### PR TITLE
feat(voice-io): add microphone button to chat composer for voice input

### DIFF
--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -118,7 +118,8 @@
         "src/signals/zero-page/zero-chat.ts",
         "src/signals/zero-page/chat-draft.ts",
         "src/signals/voice-chat/voice-chat-session.ts",
-        "src/signals/voice-io/voice-io-tts.ts"
+        "src/signals/voice-io/voice-io-tts.ts",
+        "src/signals/voice-io/voice-io-stt.ts"
       ],
       "rules": {
         "no-restricted-imports": [

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -130,6 +130,7 @@ export default [
       "src/signals/__tests__/fetch.test.ts",
       "src/signals/voice-chat/voice-chat-session.ts",
       "src/signals/voice-io/voice-io-tts.ts",
+      "src/signals/voice-io/voice-io-stt.ts",
       "src/views/zero-page/components/org-manage/org-general-tab.tsx",
       "src/views/agents-page/agents-page.tsx",
       "src/views/zero-page/zero-settings-tab.tsx",

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -1,0 +1,179 @@
+import { command, computed, state } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/core";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { fetch$ } from "../fetch.ts";
+import { toast } from "@vm0/ui/components/ui/sonner";
+
+// ── Private state ──
+
+const internalRecording$ = state(false);
+const internalTranscribing$ = state(false);
+const internalStream$ = state<MediaStream | null>(null);
+const internalChunks$ = state<Blob[]>([]);
+const internalRecorder$ = state<MediaRecorder | null>(null);
+
+// ── Public computed (read-only) ──
+
+export const sttRecording$ = computed((get) => {
+  return get(internalRecording$);
+});
+export const sttTranscribing$ = computed((get) => {
+  return get(internalTranscribing$);
+});
+
+export const voiceIOAvailable$ = computed(async (get) => {
+  const features = await get(featureSwitch$);
+  const featureEnabled = features[FeatureSwitchKey.VoiceIO] ?? false;
+  const hasMic =
+    typeof navigator !== "undefined" && !!navigator.mediaDevices?.getUserMedia;
+  return featureEnabled && hasMic;
+});
+
+// ── Helpers ──
+
+function getPreferredMimeType(): string {
+  if (
+    typeof MediaRecorder !== "undefined" &&
+    MediaRecorder.isTypeSupported("audio/webm")
+  ) {
+    return "audio/webm";
+  }
+  if (
+    typeof MediaRecorder !== "undefined" &&
+    MediaRecorder.isTypeSupported("audio/mp4")
+  ) {
+    return "audio/mp4";
+  }
+  return "";
+}
+
+function stopAllTracks(stream: MediaStream | null) {
+  if (!stream) {
+    return;
+  }
+  for (const track of stream.getTracks()) {
+    track.stop();
+  }
+}
+
+// ── Commands ──
+
+export const startRecording$ = command(
+  async ({ get, set }, _signal: AbortSignal) => {
+    // Guard: if already recording or transcribing, return
+    if (get(internalRecording$) || get(internalTranscribing$)) {
+      return;
+    }
+
+    const stream = await navigator.mediaDevices
+      .getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      })
+      .catch(() => {
+        return null;
+      });
+
+    if (!stream) {
+      toast.error("Microphone access denied");
+      return;
+    }
+
+    const mimeType = getPreferredMimeType();
+    const recorder = new MediaRecorder(
+      stream,
+      mimeType ? { mimeType } : undefined,
+    );
+
+    set(internalChunks$, []);
+
+    recorder.ondataavailable = (event: BlobEvent) => {
+      if (event.data.size > 0) {
+        set(internalChunks$, [...get(internalChunks$), event.data]);
+      }
+    };
+
+    recorder.start();
+    set(internalRecording$, true);
+    set(internalStream$, stream);
+    set(internalRecorder$, recorder);
+  },
+);
+
+export const stopAndTranscribe$ = command(
+  async ({ get, set }, _signal: AbortSignal): Promise<string> => {
+    if (!get(internalRecording$)) {
+      return "";
+    }
+
+    const recorder = get(internalRecorder$);
+    const stream = get(internalStream$);
+
+    set(internalRecording$, false);
+
+    // Wait for MediaRecorder to stop and flush final data
+    if (recorder && recorder.state !== "inactive") {
+      await new Promise<void>((resolve) => {
+        recorder.addEventListener(
+          "stop",
+          () => {
+            return resolve();
+          },
+          { once: true },
+        );
+        recorder.stop();
+      });
+    }
+
+    const chunks = get(internalChunks$);
+    stopAllTracks(stream);
+
+    if (chunks.length === 0) {
+      set(internalRecording$, false);
+      set(internalTranscribing$, false);
+      set(internalStream$, null);
+      set(internalChunks$, []);
+      set(internalRecorder$, null);
+      return "";
+    }
+
+    const mimeType = chunks[0]?.type || "audio/webm";
+    const blob = new Blob(chunks, { type: mimeType });
+
+    set(internalTranscribing$, true);
+    set(internalStream$, null);
+    set(internalChunks$, []);
+    set(internalRecorder$, null);
+
+    const formData = new FormData();
+    const extension = mimeType.includes("mp4") ? "mp4" : "webm";
+    formData.append("file", blob, `recording.${extension}`);
+
+    const fetchFn = get(fetch$);
+    const response = await fetchFn("/api/zero/voice-io/stt", {
+      method: "POST",
+      body: formData,
+    }).catch(() => {
+      return null;
+    });
+
+    if (!response || !response.ok) {
+      const errorBody = response
+        ? ((await response.json().catch(() => {
+            return null;
+          })) as { error?: { message?: string } } | null)
+        : null;
+      const message = errorBody?.error?.message || "Transcription failed";
+      toast.error(message);
+      set(internalTranscribing$, false);
+      return "";
+    }
+
+    const result = (await response.json()) as { text: string };
+    set(internalTranscribing$, false);
+    return (result.text ?? "").trim();
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2,11 +2,17 @@
 // oxlint-disable max-lines-per-function
 import type React from "react";
 import type { ChangeEvent, ClipboardEvent, DragEvent } from "react";
-import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import {
+  useGet,
+  useSet,
+  useLastLoadable,
+  useLastResolved,
+} from "ccstate-react";
 import { ensurePushSubscription } from "../../lib/push-notifications.ts";
 import {
   IconArrowUp,
   IconLoader2,
+  IconMicrophone,
   IconPaperclip,
   IconPlayerStop,
   IconPlug,
@@ -82,6 +88,13 @@ import {
   popoverSortOrder$,
   setPopoverSortOrder$,
 } from "../../signals/zero-page/zero-chat-composer.ts";
+import {
+  voiceIOAvailable$,
+  sttRecording$,
+  sttTranscribing$,
+  startRecording$,
+  stopAndTranscribe$,
+} from "../../signals/voice-io/voice-io-stt.ts";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -427,6 +440,85 @@ function ConnectorsPopoverButton({
 }
 
 // ---------------------------------------------------------------------------
+// Voice input mic button
+// ---------------------------------------------------------------------------
+
+function MicButton({ onSend }: { onSend: (text: string) => void }) {
+  const available = useLastResolved(voiceIOAvailable$) ?? false;
+  const recording = useGet(sttRecording$);
+  const transcribing = useGet(sttTranscribing$);
+  const startRec = useSet(startRecording$);
+  const stopAndTranscribe = useSet(stopAndTranscribe$);
+  const signal = useGet(pageSignal$);
+
+  if (!available) {
+    return null;
+  }
+
+  const handleClick = () => {
+    if (transcribing) {
+      return;
+    }
+    if (recording) {
+      detach(
+        stopAndTranscribe(signal).then((text) => {
+          if (text) {
+            onSend(text);
+          }
+        }),
+        Reason.DomCallback,
+      );
+    } else {
+      detach(startRec(signal), Reason.DomCallback);
+    }
+  };
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "inline-flex shrink-0 items-center justify-center rounded-lg h-9 w-9 transition-colors",
+              recording
+                ? "bg-red-500/15 text-red-500 hover:bg-red-500/25"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground",
+            )}
+            onClick={handleClick}
+            disabled={transcribing}
+            aria-label={
+              recording
+                ? "Stop recording"
+                : transcribing
+                  ? "Transcribing"
+                  : "Voice input"
+            }
+          >
+            {transcribing ? (
+              <IconLoader2 size={18} stroke={1.5} className="animate-spin" />
+            ) : (
+              <IconMicrophone
+                size={18}
+                stroke={1.5}
+                className={recording ? "animate-pulse" : undefined}
+              />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          {recording
+            ? "Stop recording"
+            : transcribing
+              ? "Transcribing..."
+              : "Voice input"}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Signal resolution — resolves draft/file-input with singleton fallback
 // ---------------------------------------------------------------------------
 
@@ -748,6 +840,7 @@ export function ZeroChatComposer({
                 />
               </div>
               <div className="flex items-center gap-2">
+                <MicButton onSend={onSend} />
                 {sending && onCancel ? (
                   <Button
                     size="sm"


### PR DESCRIPTION
## Summary

- Add a microphone button to the chat composer (left of Send button) that records audio via native MediaRecorder API, transcribes it through the `/api/zero/voice-io/stt` endpoint, and auto-sends the transcribed text as a chat message
- Create `voice-io-stt.ts` signals module with recording state machine (`startRecording$`, `stopAndTranscribe$`) and feature availability check (`voiceIOAvailable$`)
- Gate the entire feature behind `FeatureSwitchKey.VoiceIO` with graceful degradation when `getUserMedia` is unavailable

## Visual States

| State | Icon | Style |
|-------|------|-------|
| Idle | Microphone | Default muted foreground |
| Recording | Microphone (pulsing) | Red background tint |
| Transcribing | Loader (spinning) | Disabled |

## Test plan

- [x] All 17 existing composer tests pass (display + interaction)
- [x] All 72 signal tests pass
- [x] Lint passes (0 errors, 0 warnings)
- [x] Type check passes (no errors in changed files)
- [x] Knip passes (no unused exports)
- [ ] Manual: VoiceIO enabled → mic button appears left of Send
- [ ] Manual: Click mic → recording with red pulse indicator
- [ ] Manual: Click again → transcription → auto-send message
- [ ] Manual: VoiceIO disabled → mic button hidden
- [ ] Manual: Permission denied → error toast shown

Closes #9081

🤖 Generated with [Claude Code](https://claude.com/claude-code)