### PR TITLE
feat(voice-chat): integrate preparation cache into session creation

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -1083,18 +1083,39 @@ export const startVoiceChat$ = command(
     }
 
     const { session } = (await sessionRes.json()) as {
-      session: { id: string };
+      session: { id: string; prepared?: boolean };
     };
     signal.throwIfAborted();
     set(internalSessionId$, session.id);
 
-    await set(
-      prepareActivateConnect$,
-      session.id,
-      sessionSignal,
-      PREP_TIMEOUT_CHAT_MS,
-      signal,
-    );
+    if (session.prepared) {
+      const heartbeatPromise = set(startHeartbeat$, sessionSignal);
+
+      const activateRes = await fetchFn(
+        `/api/zero/voice-chat/${session.id}/activate`,
+        { method: "POST" },
+      );
+      signal.throwIfAborted();
+
+      if (!activateRes.ok) {
+        set(internalError$, "Failed to activate session");
+        set(internalStatus$, "error");
+        return;
+      }
+
+      await Promise.allSettled([
+        heartbeatPromise,
+        set(connectVoiceSession$, sessionSignal),
+      ]);
+    } else {
+      await set(
+        prepareActivateConnect$,
+        session.id,
+        sessionSignal,
+        PREP_TIMEOUT_CHAT_MS,
+        signal,
+      );
+    }
   },
 );
 
@@ -1151,18 +1172,39 @@ export const startVoiceMeeting$ = command(
     }
 
     const { session } = (await sessionRes.json()) as {
-      session: { id: string };
+      session: { id: string; prepared?: boolean };
     };
     signal.throwIfAborted();
     set(internalSessionId$, session.id);
 
-    await set(
-      prepareActivateConnect$,
-      session.id,
-      sessionSignal,
-      PREP_TIMEOUT_MEETING_MS,
-      signal,
-    );
+    if (session.prepared) {
+      const heartbeatPromise = set(startHeartbeat$, sessionSignal);
+
+      const activateRes = await fetchFn(
+        `/api/zero/voice-chat/${session.id}/activate`,
+        { method: "POST" },
+      );
+      signal.throwIfAborted();
+
+      if (!activateRes.ok) {
+        set(internalError$, "Failed to activate session");
+        set(internalStatus$, "error");
+        return;
+      }
+
+      await Promise.allSettled([
+        heartbeatPromise,
+        set(connectVoiceSession$, sessionSignal),
+      ]);
+    } else {
+      await set(
+        prepareActivateConnect$,
+        session.id,
+        sessionSignal,
+        PREP_TIMEOUT_MEETING_MS,
+        signal,
+      );
+    }
   },
 );
 

--- a/turbo/apps/web/app/api/zero/voice-chat/__tests__/create-session.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/__tests__/create-session.test.ts
@@ -5,6 +5,8 @@ import {
   createTestVoiceChatSession,
   createTestCompose,
   findTestZeroRun,
+  insertTestVoiceChatPreparation,
+  getTestVoiceChatEvents,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -185,5 +187,134 @@ describe("POST /api/zero/voice-chat (create session)", () => {
     const body = await response.json();
     expect(response.status).toBe(409);
     expect(body.error.code).toBe("CONFLICT");
+  });
+
+  it("should return prepared: true when fresh preparation cache exists", async () => {
+    const { agentId } = await createTestCompose(uniqueId("vc-cache-hit"));
+
+    await insertTestVoiceChatPreparation({
+      orgId,
+      userId,
+      agentId,
+      mode: "chat",
+      status: "ready",
+      directiveContent: "Cached directive for the fast-brain.",
+    });
+
+    const response = await POST(createRequest({ agentId }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.session.prepared).toBe(true);
+    expect(body.session.runId).toBeDefined();
+
+    // Verify cached events were written (thinking + directive + preparation-ready + session-start)
+    const events = await getTestVoiceChatEvents(body.session.id);
+    expect(events).toHaveLength(4);
+    expect(events[0]).toMatchObject({
+      source: "slow-brain",
+      type: "thinking",
+    });
+    expect(events[1]).toMatchObject({
+      source: "slow-brain",
+      type: "directive",
+      content: "Cached directive for the fast-brain.",
+    });
+    expect(events[2]).toMatchObject({
+      source: "slow-brain",
+      type: "preparation-ready",
+    });
+    expect(events[3]).toMatchObject({
+      source: "system",
+      type: "session-start",
+    });
+  });
+
+  it("should return prepared: false when no preparation cache exists", async () => {
+    const { agentId } = await createTestCompose(uniqueId("vc-cache-miss"));
+
+    const response = await POST(createRequest({ agentId }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.session.prepared).toBe(false);
+    expect(body.session.runId).toBeDefined();
+
+    // Verify only session-start event (normal flow)
+    const events = await getTestVoiceChatEvents(body.session.id);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      source: "system",
+      type: "session-start",
+    });
+  });
+
+  it("should return prepared: false when preparation is stale", async () => {
+    const { agentId } = await createTestCompose(uniqueId("vc-stale"));
+
+    await insertTestVoiceChatPreparation({
+      orgId,
+      userId,
+      agentId,
+      mode: "chat",
+      status: "ready",
+      directiveContent: "Old cached directive.",
+      createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000), // 2 hours ago
+    });
+
+    const response = await POST(createRequest({ agentId }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.session.prepared).toBe(false);
+  });
+
+  it("should return prepared: true for meeting mode with matching prompt", async () => {
+    const { agentId } = await createTestCompose(uniqueId("vc-meeting-hit"));
+    const meetingPrompt = "Review PR #456 changes";
+
+    await insertTestVoiceChatPreparation({
+      orgId,
+      userId,
+      agentId,
+      mode: "meeting",
+      prompt: meetingPrompt,
+      status: "ready",
+      directiveContent: "Meeting preparation summary.",
+    });
+
+    const response = await POST(
+      createRequest({ agentId, mode: "meeting", prompt: meetingPrompt }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.session.prepared).toBe(true);
+  });
+
+  it("should return prepared: false for meeting mode with different prompt", async () => {
+    const { agentId } = await createTestCompose(uniqueId("vc-meeting-miss"));
+
+    await insertTestVoiceChatPreparation({
+      orgId,
+      userId,
+      agentId,
+      mode: "meeting",
+      prompt: "Review PR #123",
+      status: "ready",
+      directiveContent: "Different meeting preparation.",
+    });
+
+    const response = await POST(
+      createRequest({
+        agentId,
+        mode: "meeting",
+        prompt: "Review PR #789",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.session.prepared).toBe(false);
   });
 });

--- a/turbo/apps/web/app/api/zero/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/route.ts
@@ -7,7 +7,10 @@ import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
 import {
   createSession,
   dispatchSlowBrain,
+  dispatchObservationSlowBrain,
+  writeCachedPreparationEvents,
 } from "../../../../src/lib/zero/voice-chat/session-service";
+import { findFreshPreparation } from "../../../../src/lib/zero/voice-chat/preparation-service";
 import { isApiError } from "../../../../src/lib/shared/errors";
 import { logger } from "../../../../src/lib/shared/logger";
 import { loadFeatureSwitchOverrides } from "../../../../src/lib/zero/user/feature-switches-service";
@@ -79,6 +82,38 @@ export async function POST(request: Request) {
       mode,
       prompt,
     });
+
+    const preparation = await findFreshPreparation(
+      userId,
+      agentId,
+      mode,
+      prompt,
+    );
+
+    if (preparation) {
+      await writeCachedPreparationEvents(
+        session.id,
+        preparation.directiveContent,
+      );
+      const run = await dispatchObservationSlowBrain(
+        session,
+        org.orgId,
+        userId,
+        agentId,
+      );
+
+      return NextResponse.json({
+        session: {
+          id: session.id,
+          mode: session.mode,
+          status: session.status,
+          runId: run.runId,
+          createdAt: session.createdAt,
+          prepared: true,
+        },
+      });
+    }
+
     const run = await dispatchSlowBrain(session, org.orgId, userId, agentId, {
       mode,
       prompt,
@@ -91,6 +126,7 @@ export async function POST(request: Request) {
         status: session.status,
         runId: run.runId,
         createdAt: session.createdAt,
+        prepared: false,
       },
     });
   } catch (error) {

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -187,6 +187,25 @@ Write events:
 - **preparation-ready**: Signal that preparation is complete (no content needed).
 ${SHARED_OBSERVATION_PROMPT}`.trim();
 
+const VOICE_CHAT_OBSERVATION_ONLY_PROMPT = `
+# Zero — Slow-Brain Observation Mode
+
+You are Zero's slow-brain. Preparation was already completed from a cached run. The fast-brain has initial context. Start observing the conversation immediately.
+${SHARED_OBSERVATION_PROMPT}`.trim();
+
+/**
+ * Build the full appendSystemPrompt for Voice-Chat observation-only mode.
+ * Used when a cached preparation exists — skips Phase 1 entirely.
+ */
+export function buildVoiceChatObservationOnlyPrompt(sessionId: string): string {
+  const header = buildIntegrationPrompt("Voice-Chat");
+  const prompt = VOICE_CHAT_OBSERVATION_ONLY_PROMPT.replaceAll(
+    "<SESSION_ID>",
+    sessionId,
+  );
+  return [header, prompt].join("\n\n");
+}
+
 /**
  * Build the full appendSystemPrompt for Voice-Chat quick preparation mode.
  * Combines the integration header with the quick preparation prompt.

--- a/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
@@ -1,8 +1,47 @@
-import { lt } from "drizzle-orm";
+import { eq, and, gt, lt, desc, isNull } from "drizzle-orm";
 import { voiceChatPreparations } from "../../../db/schema/voice-chat";
 import { logger } from "../../shared/logger";
 
 const log = logger("zero:voice-chat:preparation");
+
+const PREPARATION_FRESHNESS_MS = 60 * 60 * 1000; // 1 hour
+
+export async function findFreshPreparation(
+  userId: string,
+  agentId: string,
+  mode: string,
+  prompt?: string,
+): Promise<{ id: string; directiveContent: string } | null> {
+  const db = globalThis.services.db;
+  const threshold = new Date(Date.now() - PREPARATION_FRESHNESS_MS);
+
+  const conditions = [
+    eq(voiceChatPreparations.userId, userId),
+    eq(voiceChatPreparations.agentId, agentId),
+    eq(voiceChatPreparations.mode, mode),
+    eq(voiceChatPreparations.status, "ready"),
+    gt(voiceChatPreparations.createdAt, threshold),
+  ];
+
+  if (prompt) {
+    conditions.push(eq(voiceChatPreparations.prompt, prompt));
+  } else {
+    conditions.push(isNull(voiceChatPreparations.prompt));
+  }
+
+  const [result] = await db
+    .select({
+      id: voiceChatPreparations.id,
+      directiveContent: voiceChatPreparations.directiveContent,
+    })
+    .from(voiceChatPreparations)
+    .where(and(...conditions))
+    .orderBy(desc(voiceChatPreparations.createdAt))
+    .limit(1);
+
+  if (!result?.directiveContent) return null;
+  return { id: result.id, directiveContent: result.directiveContent };
+}
 
 export async function deleteExpiredPreparations(ttlMs: number) {
   const db = globalThis.services.db;

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -8,6 +8,7 @@ import { cancelRun } from "../zero-run-cancel";
 import {
   buildVoiceChatQuickPrepPrompt,
   buildVoiceChatMeetingPrompt,
+  buildVoiceChatObservationOnlyPrompt,
 } from "../integration-prompt";
 import { conflict, notFound, badRequest, forbidden } from "../../shared/errors";
 import { logger } from "../../shared/logger";
@@ -194,6 +195,83 @@ export async function dispatchSlowBrain(
     .where(eq(voiceChatSessions.id, session.id));
 
   // Write session-start event
+  await db.insert(voiceChatEvents).values({
+    sessionId: session.id,
+    source: "system",
+    type: "session-start",
+  });
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Cached Preparation Events
+// ---------------------------------------------------------------------------
+
+export async function writeCachedPreparationEvents(
+  sessionId: string,
+  directiveContent: string,
+) {
+  const db = globalThis.services.db;
+  await db.insert(voiceChatEvents).values([
+    {
+      sessionId,
+      source: "slow-brain",
+      type: "thinking",
+      content: "Reviewing agent context and preparing initial guidance...",
+    },
+    {
+      sessionId,
+      source: "slow-brain",
+      type: "directive",
+      content: directiveContent,
+    },
+    {
+      sessionId,
+      source: "slow-brain",
+      type: "preparation-ready",
+    },
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Observation-Only Slow-Brain Dispatch
+// ---------------------------------------------------------------------------
+
+export async function dispatchObservationSlowBrain(
+  session: { id: string },
+  orgId: string,
+  userId: string,
+  agentId: string,
+) {
+  const db = globalThis.services.db;
+  const appendSystemPrompt = buildVoiceChatObservationOnlyPrompt(session.id);
+  const prompt = `You are Zero's slow-brain for voice-chat session ${session.id}. Preparation is complete. Start observing the conversation.`;
+
+  const callbackPayload: VoiceChatCallbackPayload = {
+    sessionId: session.id,
+  };
+
+  const result = await createZeroRun({
+    userId,
+    agentId,
+    prompt,
+    appendSystemPrompt,
+    triggerSource: "voice-chat",
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/voice-chat`,
+        secret: generateCallbackSecret(),
+        payload: callbackPayload,
+      },
+    ],
+  });
+
+  await db
+    .update(voiceChatSessions)
+    .set({ runId: result.runId })
+    .where(eq(voiceChatSessions.id, session.id));
+
   await db.insert(voiceChatEvents).values({
     sessionId: session.id,
     source: "system",


### PR DESCRIPTION
## Summary

- Check for cached preparations when creating voice chat sessions; on cache HIT, inject cached events (thinking + directive + preparation-ready) and dispatch observation-only slow-brain (Phase 2 only)
- On cache MISS, fall back to existing full slow-brain flow with `prepared: false`
- Frontend skips preparation polling when `prepared: true`, going directly to activate + connect for near-instant voice startup

## Changes

| File | Change |
|------|--------|
| `preparation-service.ts` | Add `findFreshPreparation()` — queries for "ready" preparations within 1h freshness window |
| `integration-prompt.ts` | Add `buildVoiceChatObservationOnlyPrompt()` — Phase 2 only prompt for observation mode |
| `session-service.ts` | Add `writeCachedPreparationEvents()` and `dispatchObservationSlowBrain()` |
| `route.ts` (voice-chat) | Add cache check after session creation, conditional dispatch, `prepared` flag in response |
| `voice-chat-session.ts` (platform) | Handle `prepared` flag in `startVoiceChat$` and `startVoiceMeeting$` — skip polling on cache HIT |
| `create-session.test.ts` | Add 5 integration tests: cache HIT, cache MISS, stale preparation, meeting HIT, meeting prompt mismatch |

Closes #9086

## Test plan

- [x] Cache HIT: fresh "ready" preparation exists → `prepared: true`, 4 events written
- [x] Cache MISS: no preparation → `prepared: false`, normal flow
- [x] Stale preparation (>1h) → treated as cache MISS
- [x] Meeting mode cache HIT with matching prompt
- [x] Meeting mode prompt mismatch → cache MISS
- [x] All 14 tests pass (7 existing + 5 new cache tests + 2 existing)
- [x] Lint, type-check, format, knip pass
- [ ] E2E: manual verification of voice chat with cached preparation

🤖 Generated with [Claude Code](https://claude.com/claude-code)