### PR TITLE
fix: add missing route files for task archive/unarchive (404 on y key)

### DIFF
--- a/turbo/apps/web/app/api/zero/tasks/archive/route.ts
+++ b/turbo/apps/web/app/api/zero/tasks/archive/route.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { archiveTask } from "../../../../../src/lib/zero/task/task-service";
+import { taskTypeSchema } from "@vm0/core";
+
+const bodySchema = z.object({
+  taskId: z.string(),
+  taskType: taskTypeSchema,
+  runId: z.string().nullable(),
+});
+
+export async function POST(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return Response.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const orgId = authCtx.orgId;
+  if (!orgId) {
+    return Response.json(
+      { error: { message: "No organization selected", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const parsed = bodySchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return Response.json(
+      { error: { message: "Invalid request body", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  const { taskId, taskType, runId } = parsed.data;
+  await archiveTask(authCtx.userId, orgId, taskId, taskType, runId);
+
+  return Response.json({ ok: true });
+}

--- a/turbo/apps/web/app/api/zero/tasks/unarchive/route.ts
+++ b/turbo/apps/web/app/api/zero/tasks/unarchive/route.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { unarchiveTask } from "../../../../../src/lib/zero/task/task-service";
+import { taskTypeSchema } from "@vm0/core";
+
+const bodySchema = z.object({
+  taskId: z.string(),
+  taskType: taskTypeSchema,
+});
+
+export async function POST(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return Response.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const orgId = authCtx.orgId;
+  if (!orgId) {
+    return Response.json(
+      { error: { message: "No organization selected", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const parsed = bodySchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return Response.json(
+      { error: { message: "Invalid request body", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  const { taskId, taskType } = parsed.data;
+  await unarchiveTask(authCtx.userId, orgId, taskId, taskType);
+
+  return Response.json({ ok: true });
+}


### PR DESCRIPTION
## Problem

#9063 added `archive` and `unarchive` handlers to `tasks/route.ts` via the ts-rest router. However, in Next.js App Router, `app/api/zero/tasks/route.ts` only handles requests to exactly `/api/zero/tasks`. Requests to `/api/zero/tasks/archive` and `/api/zero/tasks/unarchive` are 404'd by Next.js before the ts-rest handler ever sees them.

This is why pressing `y` to archive a task returns 404.

## Fix

Add the two missing Next.js route files, following the same pattern as `api/zero/schedules/run/route.ts`:

- `tasks/archive/route.ts` — handles `POST /api/zero/tasks/archive`
- `tasks/unarchive/route.ts` — handles `POST /api/zero/tasks/unarchive`

The frontend client (`archiveTask$`) and the `tasksContract` paths are correct — only the server-side routing was missing.

## Test plan

- [ ] Press `y` on a focused task card — task is removed from list (no 404)
- [ ] `POST /api/zero/tasks/archive` returns 401 for unauthenticated requests
- [ ] `POST /api/zero/tasks/unarchive` returns 401 for unauthenticated requests

Fixes regression introduced in #9063.

🤖 Generated with [Claude Code](https://claude.com/claude-code)