### PR TITLE
feat: sort mission control task list with active tasks before done tasks

### DIFF
--- a/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
@@ -313,6 +313,170 @@ describe("GET /api/zero/tasks", () => {
     // Least recent in the 25 should be Thread 5
     expect(data.tasks[24].title).toBe("Thread 5");
   });
+
+  it("should sort active tasks before terminal tasks even when terminal task is newer", async () => {
+    const { composeId } = await createTestCompose(uniqueId("tier-sort-test"));
+    const now = new Date("2025-06-01T00:00:00Z").getTime();
+
+    // Terminal task with a more recent timestamp (createdAt = now)
+    const terminalThreadId = await insertTestChatThread(
+      user.userId,
+      composeId,
+      "Terminal Task",
+    );
+    const { runId: terminalRunId } = await createTestRunInDb(
+      user.userId,
+      composeId,
+      { status: "completed", createdAt: new Date(now) },
+    );
+    await addTestRunToThread(terminalThreadId, terminalRunId, user.userId);
+
+    // Active task with an older timestamp (createdAt = 1 minute ago)
+    const activeThreadId = await insertTestChatThread(
+      user.userId,
+      composeId,
+      "Active Task",
+    );
+    const { runId: activeRunId } = await createTestRunInDb(
+      user.userId,
+      composeId,
+      { status: "running", createdAt: new Date(now - 60_000) },
+    );
+    await addTestRunToThread(activeThreadId, activeRunId, user.userId);
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const titles = data.tasks.map((t: Record<string, unknown>) => {
+      return t.title;
+    });
+    expect(titles.indexOf("Active Task")).toBeLessThan(
+      titles.indexOf("Terminal Task"),
+    );
+  });
+
+  it("should treat null-status tasks (no run) as active tier, appearing before terminal tasks", async () => {
+    const { composeId } = await createTestCompose(uniqueId("null-status-test"));
+    const now = new Date("2025-06-01T00:00:00Z").getTime();
+
+    // Terminal task with a very recent timestamp
+    const terminalThreadId = await insertTestChatThread(
+      user.userId,
+      composeId,
+      "Terminal Task",
+    );
+    const { runId: terminalRunId } = await createTestRunInDb(
+      user.userId,
+      composeId,
+      { status: "completed", createdAt: new Date(now) },
+    );
+    await addTestRunToThread(terminalThreadId, terminalRunId, user.userId);
+
+    // Schedule with no run (status = null), with an older source timestamp
+    const { composeId: composeId2 } = await createTestCompose(
+      uniqueId("null-status-agent"),
+    );
+    await createTestSchedule(composeId2, "null-status-schedule");
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const scheduleTasks = data.tasks.filter((t: Record<string, unknown>) => {
+      return t.type === "schedule";
+    });
+    const terminalTasks = data.tasks.filter((t: Record<string, unknown>) => {
+      return t.title === "Terminal Task";
+    });
+    expect(scheduleTasks).toHaveLength(1);
+    expect(terminalTasks).toHaveLength(1);
+    expect(data.tasks.indexOf(scheduleTasks[0])).toBeLessThan(
+      data.tasks.indexOf(terminalTasks[0]),
+    );
+  });
+
+  it("should preserve temporal order within each tier", async () => {
+    const { composeId } = await createTestCompose(
+      uniqueId("within-tier-sort-test"),
+    );
+    const now = new Date("2025-06-01T00:00:00Z").getTime();
+
+    // Two running tasks at different times
+    const runnerNewThreadId = await insertTestChatThread(
+      user.userId,
+      composeId,
+      "Runner New",
+    );
+    const { runId: runnerNewRunId } = await createTestRunInDb(
+      user.userId,
+      composeId,
+      { status: "running", createdAt: new Date(now) },
+    );
+    await addTestRunToThread(runnerNewThreadId, runnerNewRunId, user.userId);
+
+    const runnerOldThreadId = await insertTestChatThread(
+      user.userId,
+      composeId,
+      "Runner Old",
+    );
+    const { runId: runnerOldRunId } = await createTestRunInDb(
+      user.userId,
+      composeId,
+      { status: "running", createdAt: new Date(now - 10 * 60_000) },
+    );
+    await addTestRunToThread(runnerOldThreadId, runnerOldRunId, user.userId);
+
+    // Two completed tasks at different times
+    const doneNewThreadId = await insertTestChatThread(
+      user.userId,
+      composeId,
+      "Done New",
+    );
+    const { runId: doneNewRunId } = await createTestRunInDb(
+      user.userId,
+      composeId,
+      { status: "completed", createdAt: new Date(now - 5 * 60_000) },
+    );
+    await addTestRunToThread(doneNewThreadId, doneNewRunId, user.userId);
+
+    const doneOldThreadId = await insertTestChatThread(
+      user.userId,
+      composeId,
+      "Done Old",
+    );
+    const { runId: doneOldRunId } = await createTestRunInDb(
+      user.userId,
+      composeId,
+      { status: "completed", createdAt: new Date(now - 20 * 60_000) },
+    );
+    await addTestRunToThread(doneOldThreadId, doneOldRunId, user.userId);
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const titles = data.tasks.map((t: Record<string, unknown>) => {
+      return t.title;
+    });
+    const idxRunnerNew = titles.indexOf("Runner New");
+    const idxRunnerOld = titles.indexOf("Runner Old");
+    const idxDoneNew = titles.indexOf("Done New");
+    const idxDoneOld = titles.indexOf("Done Old");
+
+    // Active tier comes before terminal tier
+    expect(idxRunnerNew).toBeLessThan(idxDoneNew);
+    expect(idxRunnerOld).toBeLessThan(idxDoneNew);
+
+    // Within active tier: newer first
+    expect(idxRunnerNew).toBeLessThan(idxRunnerOld);
+
+    // Within terminal tier: newer first
+    expect(idxDoneNew).toBeLessThan(idxDoneOld);
+  });
 });
 
 describe("POST /api/zero/tasks/archive", () => {

--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray, isNull, sql, desc } from "drizzle-orm";
-import type { TaskItem } from "@vm0/core";
+import type { TaskItem, RunStatus } from "@vm0/core";
 import { chatThreads, chatThreadRuns } from "../../../db/schema/chat-thread";
 import { zeroAgentSchedules } from "../../../db/schema/zero-agent-schedule";
 import { slackOrgThreadSessions } from "../../../db/schema/slack-org-thread-session";
@@ -16,7 +16,7 @@ import { archivedTaskRuns } from "../../../db/schema/archived-task-runs";
 
 const TASKS_LIMIT = 25;
 const PROMPT_SUMMARY_MAX_LENGTH = 100;
-const TERMINAL_STATUSES = new Set<string>([
+const TERMINAL_STATUSES = new Set<RunStatus>([
   "completed",
   "failed",
   "timeout",
@@ -487,7 +487,7 @@ async function listInFlightEmailTasks(
   orgId: string,
   agentId?: string,
 ): Promise<RawTask[]> {
-  const activeStatuses = ["pending", "running", "paused"];
+  const activeStatuses: RunStatus[] = ["pending", "running"];
   const conditions = [
     eq(agentRuns.userId, userId),
     eq(agentRuns.orgId, orgId),

--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -16,6 +16,12 @@ import { archivedTaskRuns } from "../../../db/schema/archived-task-runs";
 
 const TASKS_LIMIT = 25;
 const PROMPT_SUMMARY_MAX_LENGTH = 100;
+const TERMINAL_STATUSES = new Set<string>([
+  "completed",
+  "failed",
+  "timeout",
+  "cancelled",
+]);
 
 function truncatePrompt(prompt: string): string {
   if (prompt.length <= PROMPT_SUMMARY_MAX_LENGTH) return prompt;
@@ -164,8 +170,13 @@ export async function listTasks(
     return { task, sortKey };
   });
 
-  // Sort by sortKey DESC (latest first) and take top N
+  // Sort: active tasks first (tier 0), terminal tasks second (tier 1); within each tier sort by sortKey DESC
   tasksWithSortKey.sort((a, b) => {
+    const aTier =
+      a.task.status !== null && TERMINAL_STATUSES.has(a.task.status) ? 1 : 0;
+    const bTier =
+      b.task.status !== null && TERMINAL_STATUSES.has(b.task.status) ? 1 : 0;
+    if (aTier !== bTier) return aTier - bTier;
     return b.sortKey.getTime() - a.sortKey.getTime();
   });
 


### PR DESCRIPTION
## Summary

- Add `TERMINAL_STATUSES` constant to `task-service.ts` classifying `completed`, `failed`, `timeout`, and `cancelled` as terminal
- Replace single-key temporal sort with two-tier comparator: active tasks (tier 0) always appear before terminal tasks (tier 1), with temporal ordering (newest first) preserved within each tier
- `status: null` tasks (schedules with no runs yet) are correctly treated as active tier

## Test plan

- [x] Active task appears before terminal task even when terminal task has a more recent timestamp
- [x] `status: null` tasks (no run) appear in active tier, before terminal tasks
- [x] Within-tier temporal order is preserved (newer first within active, newer first within terminal)
- [x] Existing sort/limit-25 test still passes (all completed tasks, same tier, temporal unchanged)

Closes #9109

🤖 Generated with [Claude Code](https://claude.com/claude-code)