### PR TITLE
fix(web): render navbar auth state on the server to avoid refresh flicker

### DIFF
--- a/turbo/apps/web/app/[locale]/blog/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/page.tsx
@@ -10,7 +10,6 @@ import {
   getBlogBaseUrl,
 } from "../../lib/blog";
 import { BlogContent } from "../../components/blog";
-import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
 import { isBlogEnabled } from "../../../src/env";
 
@@ -101,9 +100,6 @@ export default async function BlogPage({ params }: BlogPageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
-      <div className="header-container">
-        <Navbar />
-      </div>
       <Suspense
         fallback={
           <div

--- a/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
@@ -8,7 +8,6 @@ import rehypeHighlight from "rehype-highlight";
 import { getTranslations } from "next-intl/server";
 import { Link } from "../../../../../navigation";
 import Particles from "../../../../components/Particles";
-import Navbar from "../../../../components/Navbar";
 import Footer from "../../../../components/Footer";
 import { ShareButtons } from "../../../../components/blog";
 import { getPost, getPosts, getBlogBaseUrl } from "../../../../lib/blog";
@@ -177,9 +176,6 @@ export default async function BlogPostPage({ params }: PageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
       />
-      <div className="header-container">
-        <Navbar />
-      </div>
       <Particles />
 
       {/* Post Header */}

--- a/turbo/apps/web/app/[locale]/layout.tsx
+++ b/turbo/apps/web/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import { NextIntlClientProvider } from "next-intl";
 import { notFound } from "next/navigation";
 import { locales, type Locale } from "../../i18n";
+import SiteHeader from "../components/SiteHeader";
 import type { Metadata } from "next";
 
 type Props = {
@@ -76,6 +77,7 @@ export default async function LocaleLayout(props: Props) {
 
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
+      <SiteHeader />
       {props.children}
     </NextIntlClientProvider>
   );

--- a/turbo/apps/web/app/[locale]/page.tsx
+++ b/turbo/apps/web/app/[locale]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { auth } from "@clerk/nextjs/server";
 import LandingPage from "../components/LandingPage";
 
 const BASE_URL = "https://vm0.ai";
@@ -34,6 +35,7 @@ export async function generateMetadata({
   };
 }
 
-export default function Home() {
-  return <LandingPage />;
+export default async function Home() {
+  const { userId } = await auth();
+  return <LandingPage initialIsSignedIn={!!userId} />;
 }

--- a/turbo/apps/web/app/[locale]/pricing/PricingPageClient.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/PricingPageClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
 import Particles from "../../components/Particles";
 
@@ -157,7 +156,6 @@ export default function PricingPageClient() {
   return (
     <>
       <Particles />
-      <Navbar />
 
       {/* Hero Section */}
       <section className="hero-section" style={{ paddingBottom: "40px" }}>

--- a/turbo/apps/web/app/[locale]/security/SecurityPage.tsx
+++ b/turbo/apps/web/app/[locale]/security/SecurityPage.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
 
 const SECTIONS = [
@@ -44,10 +43,6 @@ const SECTIONS = [
 export default function SecurityPage() {
   return (
     <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
-      <div className="header-container">
-        <Navbar />
-      </div>
-
       <main className="px-6 pb-20 pt-[calc(var(--total-header-height)+48px)] md:pb-28 md:pt-[calc(var(--total-header-height)+72px)]">
         <div className="mx-auto max-w-2xl">
           <h1 className="text-[32px] font-semibold leading-[1.2] tracking-tight sm:text-[40px]">

--- a/turbo/apps/web/app/[locale]/use-cases/UseCasesGalleryClient.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/UseCasesGalleryClient.tsx
@@ -3,7 +3,6 @@
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Link } from "../../../navigation";
-import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
 import Particles from "../../components/Particles";
 import { USE_CASES } from "./data";
@@ -110,9 +109,6 @@ export default function UseCasesGalleryClient() {
   return (
     <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
       <Particles />
-      <div className="header-container">
-        <Navbar />
-      </div>
 
       {/* Hero */}
       <section className="hero-section" style={{ paddingBottom: "40px" }}>

--- a/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Link } from "../../../../navigation";
-import Navbar from "../../../components/Navbar";
 import Footer from "../../../components/Footer";
 import Particles from "../../../components/Particles";
 import type { UseCase, ConnectorRef } from "../data";
@@ -72,9 +71,6 @@ export default function UseCaseDetailClient({ useCase }: { useCase: UseCase }) {
   return (
     <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
       <Particles />
-      <div className="header-container">
-        <Navbar />
-      </div>
 
       <main className="px-6 pb-20 pt-[calc(var(--total-header-height)+48px)] md:pb-28 md:pt-[calc(var(--total-header-height)+72px)]">
         <article className="mx-auto max-w-[800px]">

--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef, useState } from "react";
 import NextLink from "next/link";
 import { useUser } from "@clerk/nextjs";
 import { getAppUrl } from "../../src/lib/zero/url";
-import Navbar from "./Navbar";
 import Footer from "./Footer";
 import Image from "next/image";
 import AvatarCustomizer from "./AvatarCustomizer";
@@ -1284,8 +1283,15 @@ function CubeShieldIllustration() {
   );
 }
 
-export default function LandingPage() {
-  const { isSignedIn } = useUser();
+interface LandingPageProps {
+  initialIsSignedIn?: boolean;
+}
+
+export default function LandingPage({
+  initialIsSignedIn = false,
+}: LandingPageProps) {
+  const { isSignedIn: clerkIsSignedIn, isLoaded } = useUser();
+  const isSignedIn = isLoaded ? clerkIsSignedIn : initialIsSignedIn;
   const revealRef = useScrollReveal();
 
   const ctaText = isSignedIn ? "Open app" : "Get started";
@@ -1327,10 +1333,6 @@ export default function LandingPage() {
             "radial-gradient(ellipse 70% 65% at 50% 50%, transparent 50%, black 100%)",
         }}
       />
-
-      <div className="header-container">
-        <Navbar />
-      </div>
 
       <main>
         {/* ===== HERO SECTION ===== */}

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -12,10 +12,15 @@ import LanguageSwitcher from "./LanguageSwitcher";
 import { useUser, useClerk } from "@clerk/nextjs";
 import { getAppUrl } from "../../src/lib/zero/url";
 import { isBlogEnabled } from "../../src/env";
-export default function Navbar() {
+interface NavbarProps {
+  initialIsSignedIn?: boolean;
+}
+
+export default function Navbar({ initialIsSignedIn = false }: NavbarProps) {
   const { theme } = useTheme();
   const t = useTranslations("nav");
-  const { isSignedIn } = useUser();
+  const { isSignedIn: clerkIsSignedIn, isLoaded } = useUser();
+  const isSignedIn = isLoaded ? clerkIsSignedIn : initialIsSignedIn;
   const { signOut } = useClerk();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 

--- a/turbo/apps/web/app/components/SiteHeader.tsx
+++ b/turbo/apps/web/app/components/SiteHeader.tsx
@@ -1,0 +1,12 @@
+import { auth } from "@clerk/nextjs/server";
+import Navbar from "./Navbar";
+
+export default async function SiteHeader() {
+  const { userId } = await auth();
+
+  return (
+    <div className="header-container">
+      <Navbar initialIsSignedIn={!!userId} />
+    </div>
+  );
+}

--- a/turbo/apps/web/app/privacy-policy/PrivacyPolicyClient.tsx
+++ b/turbo/apps/web/app/privacy-policy/PrivacyPolicyClient.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { NextIntlClientProvider } from "next-intl";
-import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
-import enMessages from "../../messages/en.json";
 
 export default function PrivacyPolicyClient() {
   useEffect(() => {
@@ -16,25 +13,19 @@ export default function PrivacyPolicyClient() {
   }, []);
 
   return (
-    <NextIntlClientProvider locale="en" messages={enMessages}>
-      <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
-        <div className="header-container">
-          <Navbar />
+    <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
+      <main className="px-6 pb-20 pt-[calc(var(--total-header-height)+48px)] md:pb-28 md:pt-[calc(var(--total-header-height)+72px)]">
+        <div className="termly-embed-wrapper mx-auto max-w-2xl">
+          <div
+            {...({
+              name: "termly-embed",
+            } as React.HTMLAttributes<HTMLDivElement>)}
+            data-id="e2483c7f-905a-4618-b026-94f823ff2332"
+          />
         </div>
+      </main>
 
-        <main className="px-6 pb-20 pt-[calc(var(--total-header-height)+48px)] md:pb-28 md:pt-[calc(var(--total-header-height)+72px)]">
-          <div className="termly-embed-wrapper mx-auto max-w-2xl">
-            <div
-              {...({
-                name: "termly-embed",
-              } as React.HTMLAttributes<HTMLDivElement>)}
-              data-id="e2483c7f-905a-4618-b026-94f823ff2332"
-            />
-          </div>
-        </main>
-
-        <Footer />
-      </div>
-    </NextIntlClientProvider>
+      <Footer />
+    </div>
   );
 }

--- a/turbo/apps/web/app/privacy-policy/layout.tsx
+++ b/turbo/apps/web/app/privacy-policy/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { NextIntlClientProvider } from "next-intl";
+import SiteHeader from "../components/SiteHeader";
+import enMessages from "../../messages/en.json";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
@@ -19,5 +22,10 @@ export default function PrivacyPolicyLayout({
 }: {
   children: ReactNode;
 }) {
-  return children;
+  return (
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <SiteHeader />
+      {children}
+    </NextIntlClientProvider>
+  );
 }

--- a/turbo/apps/web/app/terms-of-use/TermsOfUseClient.tsx
+++ b/turbo/apps/web/app/terms-of-use/TermsOfUseClient.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { NextIntlClientProvider } from "next-intl";
-import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
-import enMessages from "../../messages/en.json";
 
 export default function TermsOfUseClient() {
   useEffect(() => {
@@ -16,25 +13,19 @@ export default function TermsOfUseClient() {
   }, []);
 
   return (
-    <NextIntlClientProvider locale="en" messages={enMessages}>
-      <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
-        <div className="header-container">
-          <Navbar />
+    <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
+      <main className="px-6 pb-20 pt-[calc(var(--total-header-height)+48px)] md:pb-28 md:pt-[calc(var(--total-header-height)+72px)]">
+        <div className="termly-embed-wrapper mx-auto max-w-2xl">
+          <div
+            {...({
+              name: "termly-embed",
+            } as React.HTMLAttributes<HTMLDivElement>)}
+            data-id="2d4a38d0-0baf-410c-a39d-86976b13052d"
+          />
         </div>
+      </main>
 
-        <main className="px-6 pb-20 pt-[calc(var(--total-header-height)+48px)] md:pb-28 md:pt-[calc(var(--total-header-height)+72px)]">
-          <div className="termly-embed-wrapper mx-auto max-w-2xl">
-            <div
-              {...({
-                name: "termly-embed",
-              } as React.HTMLAttributes<HTMLDivElement>)}
-              data-id="2d4a38d0-0baf-410c-a39d-86976b13052d"
-            />
-          </div>
-        </main>
-
-        <Footer />
-      </div>
-    </NextIntlClientProvider>
+      <Footer />
+    </div>
   );
 }

--- a/turbo/apps/web/app/terms-of-use/layout.tsx
+++ b/turbo/apps/web/app/terms-of-use/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { NextIntlClientProvider } from "next-intl";
+import SiteHeader from "../components/SiteHeader";
+import enMessages from "../../messages/en.json";
 
 export const metadata: Metadata = {
   title: "Terms of Use",
@@ -19,5 +22,10 @@ export default function TermsOfUseLayout({
 }: {
   children: ReactNode;
 }) {
-  return children;
+  return (
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <SiteHeader />
+      {children}
+    </NextIntlClientProvider>
+  );
 }


### PR DESCRIPTION
## Summary

- Move Navbar's signed-in state from client-side `useUser()` to server-side `auth()` injection, eliminating the button flicker on refresh (Contact / Join Waitlist ↔ Sign out / Open app).
- Extract a shared `SiteHeader` server component that centralizes the `auth()` call and renders `header-container + Navbar`. Reused across the `[locale]`, `/privacy-policy`, and `/terms-of-use` layouts, removing duplicated `<Navbar />` from each page-level client container.
- The LandingPage hero CTA ("Get started" / "Open app") uses the same `initialIsSignedIn` prop chain, threaded down from `auth()` in `[locale]/page.tsx`.

## Implementation notes

- `Navbar` and `LandingPage` accept `initialIsSignedIn?: boolean`. At runtime they switch on `useUser().isLoaded`: before Clerk hydrates they use the server-provided initial value; after hydration they fall back to Clerk's live value, preserving runtime responsiveness to sign-in / sign-out.
- Hoisted `NextIntlClientProvider` from `PrivacyPolicyClient` / `TermsOfUseClient` into their respective layouts (it was previously wrapped inside the client container, an extra layer).

## Trade-off

- Calling `auth()` in `[locale]/layout.tsx` makes the entire `[locale]/*` subtree dynamically rendered. `[locale]/blog/page.tsx`'s `revalidate = 3600` (ISR) no longer takes effect. If blog SEO/performance matters, a follow-up could split blog into its own layout route group, or wrap `SiteHeader` in `<Suspense>` to stream the dynamic part separately.

## Test plan

- [x] `pnpm -F web exec tsc --noEmit`
- [x] `pnpm -F web exec eslint <changed files>`
- [x] `pnpm -F web exec vitest run app/components/__tests__/` (navbar / footer tests pass)
- [x] `pnpm format`
- [x] `pnpm knip` (run automatically by the pre-commit hook)
- [ ] Manual: while signed in, refresh home / pricing / security / use-cases / blog / privacy-policy / terms-of-use — buttons no longer flicker
- [ ] Manual: while signed out, refresh the same pages — buttons start as "Contact / Join Waitlist"
- [ ] Manual: after signing out from the navbar, it immediately switches back to the signed-out state (runtime reactivity still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)