### PR TITLE
feat(runner): inflate sandbox balloon when parked in idle pool

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -611,17 +611,44 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let reuse_entry = if reuse_enabled
                     && let Some(session_id) = context.session_id()
                 {
-                    let mut pool = idle_pool.lock().await;
-                    match pool.take(session_id) {
-                        Some(entry) if entry.profile_name == profile_name => {
-                            info!(
-                                run_id = %run_id,
-                                session_id,
-                                "reusing idle VM for session"
-                            );
-                            // Idle entry already holds budget — release the new reservation.
-                            budget.release(job_vcpu, job_memory);
-                            Some(entry)
+                    // Take the entry under the pool lock, then drop the lock
+                    // before any awaits — the unpark HTTP call below must not
+                    // block other take/park operations.
+                    let taken = {
+                        let mut pool = idle_pool.lock().await;
+                        pool.take(session_id)
+                    };
+                    match taken {
+                        Some(mut entry) if entry.profile_name == profile_name => {
+                            // Deflate the balloon and respawn the reactive
+                            // controller before handing the sandbox to the
+                            // job. On failure, destroy the idle entry and
+                            // fall through to a fresh create — the run
+                            // budget reservation we made above stays in
+                            // place to cover the new sandbox.
+                            match entry.sandbox.unpark().await {
+                                Ok(()) => {
+                                    info!(
+                                        run_id = %run_id,
+                                        session_id,
+                                        "reusing idle VM for session"
+                                    );
+                                    // Idle entry already holds budget — release the new reservation.
+                                    budget.release(job_vcpu, job_memory);
+                                    Some(entry)
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        run_id = %run_id,
+                                        session_id,
+                                        error = %e,
+                                        "unpark failed, destroying idle VM and falling through to fresh create"
+                                    );
+                                    let b = Arc::clone(&budget);
+                                    destroy_tasks.spawn(destroy_idle_entry(entry, b));
+                                    None
+                                }
+                            }
                         }
                         Some(stale) => {
                             // Profile mismatch — destroy the stale VM.
@@ -947,7 +974,7 @@ fn spawn_job(
         };
 
         // Decide: park sandbox for reuse, or stop + destroy.
-        let parked = if let Some(sandbox) = sandbox {
+        let parked = if let Some(mut sandbox) = sandbox {
             let parkable_session = if reuse_enabled
                 && exit_code == 0
                 && !job_cancel.is_cancelled()
@@ -961,44 +988,65 @@ fn spawn_job(
             };
 
             if let Some(session_id) = parkable_session {
-                let mut pool = idle_pool.lock().await;
-                let idle_timeout = pool.default_timeout();
-                let entry = IdleEntry {
-                    sandbox,
-                    factory: factory_for_cleanup,
-                    session_id: session_id.to_string(),
-                    profile_name,
-                    vcpu,
-                    memory_mb,
-                    source_ip,
-                    parked_at: std::time::Instant::now(),
-                    idle_timeout,
-                    storage_fingerprints,
-                };
-                match pool.park(session_id.to_string(), entry) {
-                    ParkResult::Parked => {
-                        info!(run_id = %run_id, session_id, "VM parked for reuse");
-                        drop(pool);
-                        park_notify.notify_one();
-                        true
-                    }
-                    ParkResult::Evicted(evicted) => {
-                        info!(run_id = %run_id, session_id, "VM parked, evicting previous");
-                        drop(pool);
-                        // Notify immediately — session is already in pool.
-                        // Don't wait for stop_and_destroy which can be slow.
-                        park_notify.notify_one();
-                        let evict_vcpu = evicted.vcpu;
-                        let evict_mem = evicted.memory_mb;
-                        evicted.stop_and_destroy().await;
-                        budget.release(evict_vcpu, evict_mem);
-                        true
-                    }
-                    ParkResult::PoolFull(rejected) => {
-                        info!(run_id = %run_id, session_id, "idle pool full, destroying VM");
-                        drop(pool);
-                        rejected.stop_and_destroy().await;
-                        false
+                // Inflate the guest balloon BEFORE acquiring the pool lock —
+                // the HTTP call to Firecracker can take milliseconds, and we
+                // must not block other take/park operations on it.
+                if let Err(e) = sandbox.park().await {
+                    warn!(
+                        run_id = %run_id,
+                        session_id,
+                        error = %e,
+                        "sandbox park failed, destroying instead of parking"
+                    );
+                    stop_and_destroy_sandbox(sandbox, &**factory_for_cleanup).await;
+                    false
+                } else {
+                    let mut pool = idle_pool.lock().await;
+                    let idle_timeout = pool.default_timeout();
+                    let entry = IdleEntry {
+                        sandbox,
+                        factory: factory_for_cleanup,
+                        session_id: session_id.to_string(),
+                        profile_name,
+                        vcpu,
+                        memory_mb,
+                        source_ip,
+                        parked_at: std::time::Instant::now(),
+                        idle_timeout,
+                        storage_fingerprints,
+                    };
+                    match pool.park(session_id.to_string(), entry) {
+                        ParkResult::Parked => {
+                            info!(run_id = %run_id, session_id, "VM parked for reuse");
+                            drop(pool);
+                            park_notify.notify_one();
+                            true
+                        }
+                        ParkResult::Evicted(evicted) => {
+                            info!(run_id = %run_id, session_id, "VM parked, evicting previous");
+                            drop(pool);
+                            // Notify immediately — session is already in pool.
+                            // Don't wait for stop_and_destroy which can be slow.
+                            park_notify.notify_one();
+                            let evict_vcpu = evicted.vcpu;
+                            let evict_mem = evicted.memory_mb;
+                            // The evicted entry was park()ed when it entered the
+                            // pool; destroying a parked sandbox is safe — Drop
+                            // aborts any leftover handles and the FC process is
+                            // killed regardless of balloon state.
+                            evicted.stop_and_destroy().await;
+                            budget.release(evict_vcpu, evict_mem);
+                            true
+                        }
+                        ParkResult::PoolFull(rejected) => {
+                            info!(run_id = %run_id, session_id, "idle pool full, destroying VM");
+                            drop(pool);
+                            // The rejected sandbox was just park()ed above;
+                            // destroying a parked sandbox is safe — see Evicted
+                            // arm for rationale.
+                            rejected.stop_and_destroy().await;
+                            false
+                        }
                     }
                 }
             } else {
@@ -2946,6 +2994,260 @@ mod tests {
             "parked session should match guest_session_id"
         );
         drop(pool);
+
+        shutdown(&env, run_handle).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests 23-25: park / unpark idle-transition orchestration (#9102)
+    // -----------------------------------------------------------------------
+
+    /// Two sequential jobs on the same session produce park=2 / unpark=1:
+    /// the first job's post-exit park, plus the second job's take (unpark)
+    /// and post-exit re-park. Verifies the full reuse cycle drives the
+    /// new trait hooks symmetrically.
+    #[tokio::test(start_paused = true)]
+    async fn reuse_cycle_invokes_park_and_unpark_symmetrically() {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let counter = Arc::clone(&overrides);
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let run_handle = tokio::spawn(run(config));
+
+        // Job 1: fresh create → run → park.
+        let id1 = Uuid::new_v4();
+        push_job(
+            &env,
+            id1,
+            "vm0/default",
+            Some(context_with_session(id1, "sess-reuse-cycle")),
+        );
+        assert!(
+            env.handle
+                .wait_completion(id1, Duration::from_secs(5))
+                .await
+                .is_some()
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(counter.park_call_count(), 1);
+        assert_eq!(counter.unpark_call_count(), 0);
+
+        // Job 2: same session → take (unpark) → run → re-park.
+        let id2 = Uuid::new_v4();
+        push_job(
+            &env,
+            id2,
+            "vm0/default",
+            Some(context_with_session(id2, "sess-reuse-cycle")),
+        );
+        assert!(
+            env.handle
+                .wait_completion(id2, Duration::from_secs(5))
+                .await
+                .is_some()
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            counter.park_call_count(),
+            2,
+            "park() should fire once per job"
+        );
+        assert_eq!(
+            counter.unpark_call_count(),
+            1,
+            "unpark() should fire only for the reused job"
+        );
+        assert_eq!(idle_pool.lock().await.len(), 1);
+
+        shutdown(&env, run_handle).await;
+    }
+
+    /// A successful job with a session triggers `Sandbox::park()` exactly once
+    /// when the VM is handed off to the idle pool.
+    #[tokio::test(start_paused = true)]
+    async fn park_called_when_vm_enters_idle_pool() {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let counter = Arc::clone(&overrides);
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = Uuid::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-park-hook")),
+        );
+
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "job should complete");
+
+        // Park notification + park() are called from the post-job task; give
+        // them a moment to run before asserting.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(
+            counter.park_call_count(),
+            1,
+            "park() should have been called exactly once"
+        );
+        assert_eq!(
+            counter.unpark_call_count(),
+            0,
+            "unpark() must not be called for a fresh park"
+        );
+        assert_eq!(idle_pool.lock().await.len(), 1, "VM should be parked");
+
+        shutdown(&env, run_handle).await;
+    }
+
+    /// When `Sandbox::park()` returns an error, the runner falls back to
+    /// `stop_and_destroy_sandbox` and does NOT insert into the idle pool.
+    #[tokio::test(start_paused = true)]
+    async fn park_failure_destroys_sandbox_and_skips_pool() {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_park_result(Err(sandbox::SandboxError::IdleTransition(
+            "simulated balloon failure".into(),
+        )));
+        let counter = Arc::clone(&overrides);
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+        let budget = Arc::clone(&config.budget);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = Uuid::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-park-fail")),
+        );
+
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "job should complete normally");
+        assert_eq!(c.unwrap().exit_code, 0);
+
+        // park failure → destroy → budget fully released, pool empty.
+        wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
+        assert_eq!(
+            idle_pool.lock().await.len(),
+            0,
+            "park failure must NOT insert into pool"
+        );
+        assert_eq!(
+            counter.park_call_count(),
+            1,
+            "park() should have been attempted exactly once"
+        );
+
+        shutdown(&env, run_handle).await;
+    }
+
+    /// When the runner takes a sandbox out of the idle pool for reuse and
+    /// `Sandbox::unpark()` returns an error, the idle entry is destroyed
+    /// and the runner falls through to a fresh sandbox create.
+    #[tokio::test(start_paused = true)]
+    async fn unpark_failure_destroys_idle_entry_and_falls_through() {
+        // Both the pre-seeded sandbox and the fresh-create sandbox share
+        // the same MockSandboxOverrides set, so the unpark error queued
+        // here is consumed by the FIRST unpark call — which is the take
+        // path's call against the pre-seeded sandbox.
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let counter = Arc::clone(&overrides);
+        overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition(
+            "simulated unpark failure".into(),
+        )));
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+        let budget = Arc::clone(&config.budget);
+        let idle_pool = Arc::clone(&config.idle_pool);
+
+        // Pre-seed via the factory so the seeded MockSandbox shares the
+        // override set (and consumes the queued unpark error).
+        {
+            let mut pool = idle_pool.lock().await;
+            let runtime = sandbox_mock::MockSandboxRuntime::with_overrides(Arc::clone(&counter));
+            let mut factory = runtime
+                .create_factory(sandbox::FactoryConfig {
+                    profile: "vm0/default".into(),
+                    binary_path: PathBuf::new(),
+                    kernel_path: PathBuf::new(),
+                    rootfs_path: PathBuf::new(),
+                    base_dir: PathBuf::new(),
+                    snapshot: None,
+                })
+                .await
+                .expect("create factory");
+            factory.startup().await.expect("startup");
+            let factory_arc: Arc<Box<dyn sandbox::SandboxFactory>> = Arc::new(factory);
+            let sandbox = factory_arc
+                .create(sandbox::SandboxConfig {
+                    id: Uuid::new_v4(),
+                    resources: sandbox::ResourceLimits {
+                        cpu_count: 2,
+                        memory_mb: 4096,
+                    },
+                })
+                .await
+                .expect("create sandbox");
+            assert!(budget.try_reserve(2, 4096), "reserve seeded budget");
+            let _ = pool.park(
+                "sess-unpark-fail".to_string(),
+                IdleEntry {
+                    sandbox,
+                    factory: factory_arc,
+                    session_id: "sess-unpark-fail".to_string(),
+                    profile_name: "vm0/default".into(),
+                    vcpu: 2,
+                    memory_mb: 4096,
+                    source_ip: "10.0.0.1".into(),
+                    parked_at: std::time::Instant::now(),
+                    idle_timeout: Duration::from_secs(300),
+                    storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+                },
+            );
+        }
+        assert_eq!(idle_pool.lock().await.len(), 1, "pool seeded");
+
+        let run_handle = tokio::spawn(run(config));
+
+        // Push a job for the same session — runner will try to reuse,
+        // unpark() will fail, idle entry gets destroyed, fresh create runs.
+        let run_id = Uuid::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-unpark-fail")),
+        );
+
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "fresh-create job should still complete");
+        assert_eq!(c.unwrap().exit_code, 0);
+
+        // After the dust settles:
+        //   - unpark called exactly once (the failed take-side call);
+        //   - park called exactly once (the fresh-create's successful park).
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            counter.unpark_call_count(),
+            1,
+            "expected exactly one unpark attempt"
+        );
+        assert_eq!(
+            counter.park_call_count(),
+            1,
+            "expected exactly one park (the fresh-create's)"
+        );
 
         shutdown(&env, run_handle).await;
     }

--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -21,7 +21,10 @@ const DEFLATE_HYSTERESIS_MIB: i64 = 64;
 /// guest when a large amount of free memory is detected on the first tick.
 const MAX_INFLATE_PER_TICK_MIB: u32 = 256;
 /// Minimum guaranteed guest memory — never inflate beyond `memory_mb - MIN_GUEST_MIB`.
-const MIN_GUEST_MIB: u32 = 512;
+///
+/// Exposed to the rest of the crate so that idle-park logic in `sandbox.rs`
+/// can use the same lower bound when one-shot inflating on idle transitions.
+pub(crate) const MIN_GUEST_MIB: u32 = 512;
 /// Poll interval for balloon stats.
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// How often to emit status + host memory logs (in ticks).

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -99,6 +99,12 @@ pub struct FirecrackerSandbox {
     leak_tx: Option<tokio::sync::mpsc::Sender<crate::factory::LeakedResources>>,
     /// Set to `true` by `factory.destroy()` to suppress Drop-based leak recovery.
     pub(crate) destroyed: bool,
+    /// Tracks whether the sandbox is currently in the idle/parked state.
+    /// Set by `park()` on success (including the small-profile no-op case)
+    /// and cleared by `unpark()`. Used to make both methods idempotent and
+    /// to let `unpark()` know whether it should touch the balloon
+    /// controller or treat the call as a pure no-op.
+    is_parked: bool,
 }
 
 impl FirecrackerSandbox {
@@ -129,6 +135,7 @@ impl FirecrackerSandbox {
             balloon_controller: None,
             leak_tx,
             destroyed: false,
+            is_parked: false,
         }
     }
 
@@ -571,6 +578,11 @@ impl Sandbox for FirecrackerSandbox {
         if let Some(h) = self.control_server.take() {
             h.abort();
         }
+        // abort() without await: unlike `park_inner` (which awaits to become
+        // the sole writer to /balloon), stop() is about to kill the FC
+        // process entirely, so any in-flight controller PATCHes against the
+        // dying API socket are harmless — the subsequent kill_process call
+        // tears down FC regardless of balloon state.
         if let Some(h) = self.balloon_controller.take() {
             h.abort();
         }
@@ -599,6 +611,7 @@ impl Sandbox for FirecrackerSandbox {
         if let Some(h) = self.control_server.take() {
             h.abort();
         }
+        // abort() without await — same rationale as `stop()`.
         if let Some(h) = self.balloon_controller.take() {
             h.abort();
         }
@@ -608,6 +621,54 @@ impl Sandbox for FirecrackerSandbox {
             .store(SandboxState::Stopped as u8, Ordering::Release);
         info!(id = %self.id, "sandbox killed");
         Ok(())
+    }
+
+    // -- idle transitions --
+    //
+    // `park()` is called by the runner when a sandbox is handed off to the
+    // idle pool. It stops the reactive balloon controller, then issues a
+    // single PATCH /balloon to reclaim as much guest memory as possible
+    // (down to `MIN_GUEST_MIB` for kernel headroom).
+    //
+    // `unpark()` is called when the runner pulls the sandbox back out of
+    // the idle pool. It deflates the balloon and respawns the reactive
+    // controller so active workload is served with full memory again.
+    //
+    // Both methods propagate balloon PATCH failures as `IdleTransition`
+    // errors — on failure the caller (runner) destroys the sandbox and
+    // falls through to fresh-create. On a healthy Firecracker the PATCH
+    // /balloon API is essentially infallible; a failure here strongly
+    // indicates FC is dead or unhealthy, which destroy-and-refresh
+    // handles cleanly.
+    //
+    // For profiles where `memory_mb <= MIN_GUEST_MIB` there is nothing to
+    // reclaim, so both methods become pure no-ops — the reactive controller
+    // is left running throughout the idle period.
+    //
+    // The `is_parked` flag makes both methods idempotent and lets unpark
+    // skip the abort+respawn dance when park was a no-op.
+
+    async fn park(&mut self) -> sandbox::Result<()> {
+        park_inner(
+            &mut self.is_parked,
+            self.config.resources.memory_mb,
+            &mut self.balloon_controller,
+            &self.sock_paths.api_sock(),
+            &self.id,
+        )
+        .await
+    }
+
+    async fn unpark(&mut self) -> sandbox::Result<()> {
+        unpark_inner(
+            &mut self.is_parked,
+            self.config.resources.memory_mb,
+            &mut self.balloon_controller,
+            &self.sock_paths.api_sock(),
+            &self.crash_notify,
+            &self.id,
+        )
+        .await
     }
 
     // -- operations --
@@ -712,6 +773,119 @@ impl Sandbox for FirecrackerSandbox {
     }
 }
 
+// -- idle transition helpers --
+//
+// Extracted from `impl Sandbox for FirecrackerSandbox` as free functions so
+// that tests can drive them against a mock Unix-domain API socket without
+// building a fully-initialised `FirecrackerSandbox` (which pulls in the
+// network pool, NBD COW device, firecracker child process, etc.).
+
+async fn park_inner(
+    is_parked: &mut bool,
+    memory_mb: u32,
+    balloon_controller: &mut Option<tokio::task::JoinHandle<()>>,
+    api_sock: &std::path::Path,
+    log_id: &str,
+) -> sandbox::Result<()> {
+    if *is_parked {
+        return Ok(());
+    }
+
+    let target = memory_mb.saturating_sub(balloon::MIN_GUEST_MIB);
+    if target == 0 {
+        // Profile too small to balloon — keep the reactive controller
+        // running (it will be a no-op anyway since max_inflate == 0).
+        *is_parked = true;
+        info!(id = %log_id, memory_mb, "sandbox parked (no-op: memory below balloon threshold)");
+        return Ok(());
+    }
+
+    // Stop the reactive controller so we're the sole writer to /balloon.
+    // abort() + await ensures any in-flight PATCH from the controller
+    // completes (or is cancelled) before ours lands.
+    //
+    // Ordering note: we abort BEFORE the PATCH (rather than after) because
+    // the controller's reactive logic would otherwise see the post-inflate
+    // drop in `available_memory` as memory pressure and immediately deflate
+    // back, undoing our work.
+    //
+    // Failure-mode invariant: if patch_balloon returns Err, the controller
+    // is gone and `is_parked` stays false. This is an intentional
+    // "transient inconsistent" state — the runner's only failure handling
+    // is `stop_and_destroy_sandbox`, so the sandbox is dropped (and Drop
+    // ensures any leftover handles are aborted) before any further
+    // operations can observe the missing controller.
+    if let Some(h) = balloon_controller.take() {
+        h.abort();
+        let _ = h.await;
+    }
+
+    let client = ApiClient::new(api_sock);
+    client
+        .patch_balloon(target)
+        .await
+        .map_err(|e| SandboxError::IdleTransition(format!("balloon inflate: {e}")))?;
+
+    *is_parked = true;
+    info!(id = %log_id, target_mib = target, "sandbox parked (balloon inflated)");
+    Ok(())
+}
+
+async fn unpark_inner(
+    is_parked: &mut bool,
+    memory_mb: u32,
+    balloon_controller: &mut Option<tokio::task::JoinHandle<()>>,
+    api_sock: &std::path::Path,
+    crash_notify: &Arc<Notify>,
+    log_id: &str,
+) -> sandbox::Result<()> {
+    if !*is_parked {
+        return Ok(());
+    }
+
+    let park_touched_controller = memory_mb > balloon::MIN_GUEST_MIB;
+
+    if park_touched_controller {
+        // By construction, park_inner left the slot None when it inflated
+        // (and the is_parked guard above ensures we entered exactly one
+        // park→unpark transition). Loudly catch invariant violations in
+        // debug, and defensively take+abort in release so a violated
+        // invariant doesn't silently leak the old task (dropping a
+        // JoinHandle detaches; it does not abort).
+        debug_assert!(
+            balloon_controller.is_none(),
+            "controller slot must be None when entering unpark from a parked state",
+        );
+        if let Some(h) = balloon_controller.take() {
+            h.abort();
+        }
+
+        // Propagate deflate failure rather than swallow it. On a healthy
+        // Firecracker, PATCH /balloon doesn't return transient errors —
+        // any failure here (Connect / Http / Other) strongly suggests FC
+        // is dead or unhealthy. Symmetric with park's failure mode: the
+        // caller (runner take-site) destroys the sandbox and falls
+        // through to fresh-create. Leaving is_parked=true and controller=None
+        // is safe: the sandbox is about to be dropped; a hypothetical retry
+        // would re-enter this branch and attempt deflate again.
+        let client = ApiClient::new(api_sock);
+        client
+            .patch_balloon(0)
+            .await
+            .map_err(|e| SandboxError::IdleTransition(format!("balloon deflate: {e}")))?;
+
+        *balloon_controller = Some(balloon::spawn(
+            api_sock.to_path_buf(),
+            memory_mb,
+            Arc::clone(crash_notify),
+        ));
+    }
+
+    *is_parked = false;
+    info!(id = %log_id, "sandbox unparked");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -791,5 +965,610 @@ mod tests {
         // Signal 0 checks existence — should fail with ESRCH.
         let exists = nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None);
         assert!(exists.is_err(), "process group leader should be dead");
+    }
+
+    // -- idle transition tests --
+    //
+    // These exercise `park_inner` / `unpark_inner` against a mock Firecracker
+    // API socket. We assert on:
+    //   1. the correct sequence of PATCH /balloon requests (bodies captured);
+    //   2. whether the reactive controller handle is present / absent;
+    //   3. the is_parked flag state; and
+    //   4. idempotency on repeat calls.
+
+    use std::path::PathBuf;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixListener;
+    use tokio::sync::Mutex as TokioMutex;
+
+    /// Spawn a mock FC API server on a temporary Unix socket. It responds to
+    /// any number of PATCH /balloon calls. The response status is configurable
+    /// per call via `responses` (consumed FIFO; defaults to 204 once empty).
+    /// All received PATCH bodies are captured into `bodies`.
+    ///
+    /// Returns (sock_path, bodies_handle, tempdir) — keep the tempdir alive
+    /// until the test finishes so the socket isn't cleaned up prematurely.
+    async fn spawn_mock_fc_api(
+        mut responses: std::collections::VecDeque<u16>,
+    ) -> (PathBuf, Arc<TokioMutex<Vec<String>>>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("api.sock");
+        let listener = UnixListener::bind(&sock_path)
+            .unwrap_or_else(|e| panic!("bind {}: {e}", sock_path.display()));
+
+        let bodies: Arc<TokioMutex<Vec<String>>> = Arc::new(TokioMutex::new(Vec::new()));
+        let bodies_clone = Arc::clone(&bodies);
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let bodies_inner = Arc::clone(&bodies_clone);
+                let status = responses.pop_front().unwrap_or(204);
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n]);
+                    if let Some(pos) = req.find("\r\n\r\n") {
+                        bodies_inner.lock().await.push(req[pos + 4..].to_string());
+                    }
+                    let (reason, body) = if status == 204 {
+                        ("No Content", String::new())
+                    } else {
+                        ("Bad Request", r#"{"fault_message":"test"}"#.to_string())
+                    };
+                    let response = format!(
+                        "HTTP/1.1 {status} {reason}\r\nContent-Length: {}\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+
+        (sock_path, bodies, dir)
+    }
+
+    #[tokio::test]
+    async fn park_inflates_and_aborts_controller() {
+        let (sock, bodies, _dir) = spawn_mock_fc_api(std::collections::VecDeque::new()).await;
+
+        // Stand in for the existing reactive controller with a simple
+        // sleeping task — park_inner should abort it.
+        let mut controller: Option<tokio::task::JoinHandle<()>> = Some(tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(3600)).await
+        }));
+        let mut is_parked = false;
+
+        park_inner(&mut is_parked, 2048, &mut controller, &sock, "test-park")
+            .await
+            .unwrap();
+
+        assert!(is_parked, "is_parked should be set");
+        assert!(controller.is_none(), "controller handle should be taken");
+        let bodies = bodies.lock().await;
+        assert_eq!(
+            bodies.len(),
+            1,
+            "expected exactly one PATCH, got {bodies:?}"
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&bodies[0]).unwrap();
+        assert_eq!(parsed["amount_mib"].as_u64().unwrap(), 1536); // 2048 - 512
+    }
+
+    #[tokio::test]
+    async fn park_inflates_by_one_at_min_plus_one() {
+        // Boundary: memory_mb = MIN_GUEST_MIB + 1 → target = 1.
+        // Confirms the saturating_sub branch and the >0 check route the
+        // smallest non-trivial profile through the active-inflate path.
+        let (sock, bodies, _dir) = spawn_mock_fc_api(std::collections::VecDeque::new()).await;
+
+        let mut controller: Option<tokio::task::JoinHandle<()>> = Some(tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(3600)).await
+        }));
+        let mut is_parked = false;
+
+        park_inner(
+            &mut is_parked,
+            513,
+            &mut controller,
+            &sock,
+            "test-min-plus-1",
+        )
+        .await
+        .unwrap();
+
+        assert!(is_parked);
+        assert!(
+            controller.is_none(),
+            "513 MiB profile must take the active-inflate branch (controller aborted)"
+        );
+        let bodies = bodies.lock().await;
+        assert_eq!(bodies.len(), 1);
+        let parsed: serde_json::Value = serde_json::from_str(&bodies[0]).unwrap();
+        assert_eq!(parsed["amount_mib"].as_u64().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn park_noop_when_memory_at_min() {
+        let (sock, bodies, _dir) = spawn_mock_fc_api(std::collections::VecDeque::new()).await;
+
+        let original_controller: tokio::task::JoinHandle<()> =
+            tokio::spawn(async { tokio::time::sleep(Duration::from_secs(3600)).await });
+        let original_id = original_controller.id();
+        let mut controller = Some(original_controller);
+        let mut is_parked = false;
+
+        park_inner(
+            &mut is_parked,
+            512, // equal to MIN_GUEST_MIB
+            &mut controller,
+            &sock,
+            "test-park-small",
+        )
+        .await
+        .unwrap();
+
+        assert!(is_parked, "is_parked should still be set");
+        let still_there = controller.as_ref().expect("controller must be preserved");
+        assert_eq!(
+            still_there.id(),
+            original_id,
+            "controller must not be replaced or aborted"
+        );
+        assert!(
+            bodies.lock().await.is_empty(),
+            "no PATCH should be issued for small profiles"
+        );
+    }
+
+    #[tokio::test]
+    async fn unpark_deflates_and_respawns_controller() {
+        let (sock, bodies, _dir) = spawn_mock_fc_api(std::collections::VecDeque::new()).await;
+
+        let mut is_parked = true;
+        let mut controller: Option<tokio::task::JoinHandle<()>> = None;
+        let crash_notify = Arc::new(Notify::new());
+
+        unpark_inner(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            &sock,
+            &crash_notify,
+            "test-unpark",
+        )
+        .await
+        .unwrap();
+
+        assert!(!is_parked, "is_parked should be cleared");
+        assert!(
+            controller.is_some(),
+            "reactive controller must be respawned"
+        );
+
+        // PATCH /balloon {amount_mib: 0} from unpark, plus the first tick
+        // of the freshly spawned reactive controller may issue a GET
+        // /balloon/statistics (which we don't handle here, but that's fine —
+        // we're only checking that the deflate PATCH was observed).
+        let bodies = bodies.lock().await;
+        let deflate = bodies
+            .iter()
+            .find(|b| {
+                serde_json::from_str::<serde_json::Value>(b)
+                    .ok()
+                    .and_then(|v| v["amount_mib"].as_u64())
+                    == Some(0)
+            })
+            .expect("deflate PATCH not observed");
+        assert!(deflate.contains("amount_mib"), "body: {deflate}");
+
+        // Abort the respawned reactive controller so the test runtime
+        // doesn't leave a 5s-tick task running against the mock socket.
+        if let Some(h) = controller.take() {
+            h.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn unpark_propagates_deflate_error() {
+        // Mock returns 400 on the first PATCH (deflate). Unpark must
+        // propagate the failure as `IdleTransition` so the runner can
+        // destroy the sandbox and fall through to fresh-create. On Err,
+        // is_parked stays true and controller stays None — consistent with
+        // park_inner's failure semantics.
+        let (sock, bodies, _dir) =
+            spawn_mock_fc_api(std::collections::VecDeque::from(vec![400])).await;
+
+        let mut is_parked = true;
+        let mut controller: Option<tokio::task::JoinHandle<()>> = None;
+        let crash_notify = Arc::new(Notify::new());
+
+        let result = unpark_inner(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            &sock,
+            &crash_notify,
+            "test-unpark-err",
+        )
+        .await;
+
+        assert!(matches!(result, Err(SandboxError::IdleTransition(_))));
+        assert!(is_parked, "flag must stay true on failure");
+        assert!(
+            controller.is_none(),
+            "controller must not be respawned on failure"
+        );
+
+        // Verify a deflate PATCH was actually attempted — guards against
+        // refactors that accidentally short-circuit before the PATCH.
+        let bodies = bodies.lock().await;
+        assert_eq!(bodies.len(), 1, "expected exactly one PATCH attempt");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&bodies[0]).unwrap()["amount_mib"]
+                .as_u64()
+                .unwrap(),
+            0,
+            "deflate PATCH must target amount_mib=0"
+        );
+    }
+
+    #[tokio::test]
+    async fn unpark_on_small_vm_is_a_noop() {
+        let (sock, bodies, _dir) = spawn_mock_fc_api(std::collections::VecDeque::new()).await;
+
+        let original_controller: tokio::task::JoinHandle<()> =
+            tokio::spawn(async { tokio::time::sleep(Duration::from_secs(3600)).await });
+        let original_id = original_controller.id();
+        let mut controller = Some(original_controller);
+        let mut is_parked = true; // was parked (as a no-op) earlier
+        let crash_notify = Arc::new(Notify::new());
+
+        unpark_inner(
+            &mut is_parked,
+            512,
+            &mut controller,
+            &sock,
+            &crash_notify,
+            "test-unpark-small",
+        )
+        .await
+        .unwrap();
+
+        assert!(!is_parked);
+        let still_there = controller.as_ref().expect("controller must be preserved");
+        assert_eq!(
+            still_there.id(),
+            original_id,
+            "controller must not be replaced"
+        );
+        assert!(
+            bodies.lock().await.is_empty(),
+            "no PATCH should be issued for small profiles"
+        );
+    }
+
+    #[tokio::test]
+    async fn double_park_is_idempotent() {
+        let (sock, bodies, _dir) = spawn_mock_fc_api(std::collections::VecDeque::new()).await;
+
+        let mut controller: Option<tokio::task::JoinHandle<()>> = Some(tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(3600)).await
+        }));
+        let mut is_parked = false;
+
+        park_inner(&mut is_parked, 2048, &mut controller, &sock, "dp")
+            .await
+            .unwrap();
+        park_inner(&mut is_parked, 2048, &mut controller, &sock, "dp")
+            .await
+            .unwrap();
+
+        assert!(is_parked);
+        let bodies = bodies.lock().await;
+        assert_eq!(
+            bodies.len(),
+            1,
+            "expected exactly one PATCH despite double-park, got {bodies:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn double_unpark_is_idempotent() {
+        let (sock, bodies, _dir) = spawn_mock_fc_api(std::collections::VecDeque::new()).await;
+
+        let mut is_parked = true;
+        let mut controller: Option<tokio::task::JoinHandle<()>> = None;
+        let crash_notify = Arc::new(Notify::new());
+
+        unpark_inner(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            &sock,
+            &crash_notify,
+            "du",
+        )
+        .await
+        .unwrap();
+        let first_controller_id = controller.as_ref().unwrap().id();
+
+        unpark_inner(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            &sock,
+            &crash_notify,
+            "du",
+        )
+        .await
+        .unwrap();
+
+        assert!(!is_parked);
+        assert_eq!(
+            controller.as_ref().unwrap().id(),
+            first_controller_id,
+            "second unpark must not replace the controller"
+        );
+        // Only one deflate PATCH should have been issued.
+        let deflate_count = bodies
+            .lock()
+            .await
+            .iter()
+            .filter(|b| {
+                serde_json::from_str::<serde_json::Value>(b)
+                    .ok()
+                    .and_then(|v| v["amount_mib"].as_u64())
+                    == Some(0)
+            })
+            .count();
+        assert_eq!(deflate_count, 1, "expected exactly one deflate PATCH");
+
+        // Abort the respawned reactive controller.
+        if let Some(h) = controller.take() {
+            h.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn unpark_without_park_is_noop() {
+        let (sock, bodies, _dir) = spawn_mock_fc_api(std::collections::VecDeque::new()).await;
+
+        let original_controller: tokio::task::JoinHandle<()> =
+            tokio::spawn(async { tokio::time::sleep(Duration::from_secs(3600)).await });
+        let original_id = original_controller.id();
+        let mut controller = Some(original_controller);
+        let mut is_parked = false;
+        let crash_notify = Arc::new(Notify::new());
+
+        unpark_inner(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            &sock,
+            &crash_notify,
+            "fresh",
+        )
+        .await
+        .unwrap();
+
+        assert!(!is_parked);
+        assert_eq!(
+            controller.as_ref().unwrap().id(),
+            original_id,
+            "controller must not be touched"
+        );
+        assert!(bodies.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn park_unpark_park_cycle() {
+        // Simulates a production reuse sequence:
+        //   turn 1: sandbox created → park
+        //   turn 2: take → unpark → (job runs) → park
+        // The is_parked flag should oscillate correctly, PATCHes should
+        // follow the expected sequence (inflate, deflate, inflate), and
+        // each unpark's respawned controller must be aborted by the next
+        // park (no leak of the intermediate controller task).
+        let (sock, bodies, _dir) = spawn_mock_fc_api(std::collections::VecDeque::new()).await;
+
+        let initial: tokio::task::JoinHandle<()> =
+            tokio::spawn(async { tokio::time::sleep(Duration::from_secs(3600)).await });
+        let mut controller = Some(initial);
+        let mut is_parked = false;
+        let crash_notify = Arc::new(Notify::new());
+
+        // Turn 1: park.
+        park_inner(&mut is_parked, 2048, &mut controller, &sock, "cycle")
+            .await
+            .unwrap();
+        assert!(is_parked);
+        assert!(controller.is_none());
+
+        // Turn 2: unpark → park.
+        unpark_inner(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            &sock,
+            &crash_notify,
+            "cycle",
+        )
+        .await
+        .unwrap();
+        assert!(!is_parked);
+        assert!(controller.is_some(), "unpark must respawn the controller");
+
+        park_inner(&mut is_parked, 2048, &mut controller, &sock, "cycle")
+            .await
+            .unwrap();
+        assert!(is_parked);
+        assert!(
+            controller.is_none(),
+            "second park must abort the controller respawned by unpark"
+        );
+
+        // PATCH sequence: inflate(1536), deflate(0), inflate(1536).
+        //
+        // Fragility note: the respawned reactive controller's first tick
+        // fires immediately (tokio::time::interval burst-mode) and issues
+        // GET /balloon/statistics against this mock. `spawn_mock_fc_api`
+        // returns an empty 204 for any request, so the client's JSON parse
+        // fails and the controller tick early-returns without issuing a
+        // PATCH. The `filter_map(|v| v["amount_mib"].as_u64())` below also
+        // drops any empty GET bodies that did land in `bodies`. If the
+        // mock is ever upgraded to return a parseable stats body, this
+        // test may see an extra controller-originated PATCH and will need
+        // to be reworked.
+        let bodies = bodies.lock().await;
+        let amounts: Vec<u64> = bodies
+            .iter()
+            .filter_map(|b| serde_json::from_str::<serde_json::Value>(b).ok())
+            .filter_map(|v| v["amount_mib"].as_u64())
+            .collect();
+        assert_eq!(
+            amounts,
+            vec![1536, 0, 1536],
+            "expected inflate, deflate, inflate sequence; got {amounts:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn park_patch_failure_leaves_flag_false() {
+        // Mock returns 400 on the first PATCH.
+        let (sock, _bodies, _dir) =
+            spawn_mock_fc_api(std::collections::VecDeque::from(vec![400])).await;
+
+        let mut controller: Option<tokio::task::JoinHandle<()>> = Some(tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(3600)).await
+        }));
+        let mut is_parked = false;
+
+        let result = park_inner(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            &sock,
+            "test-park-fail",
+        )
+        .await;
+
+        assert!(matches!(result, Err(SandboxError::IdleTransition(_))));
+        assert!(!is_parked, "flag must stay false on failure");
+        // Controller was already aborted by park before the PATCH attempt.
+        assert!(controller.is_none());
+
+        // A follow-up unpark must be a clean no-op because is_parked is false.
+        let crash_notify = Arc::new(Notify::new());
+        unpark_inner(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            &sock,
+            &crash_notify,
+            "test-park-fail",
+        )
+        .await
+        .unwrap();
+        assert!(!is_parked);
+        assert!(controller.is_none());
+    }
+
+    #[tokio::test]
+    async fn park_retry_after_failure_succeeds() {
+        // First PATCH fails (400), the retry succeeds (204).
+        let (sock, bodies, _dir) =
+            spawn_mock_fc_api(std::collections::VecDeque::from(vec![400, 204])).await;
+
+        let mut controller: Option<tokio::task::JoinHandle<()>> = Some(tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(3600)).await
+        }));
+        let mut is_parked = false;
+
+        // First park attempt: PATCH returns 400, flag stays false, controller
+        // is gone (aborted before PATCH).
+        let first = park_inner(&mut is_parked, 2048, &mut controller, &sock, "retry").await;
+        assert!(matches!(first, Err(SandboxError::IdleTransition(_))));
+        assert!(!is_parked);
+        assert!(controller.is_none());
+
+        // Second park attempt: controller slot is already None (no-op
+        // .take()), PATCH succeeds (204), flag flips to true.
+        park_inner(&mut is_parked, 2048, &mut controller, &sock, "retry")
+            .await
+            .unwrap();
+        assert!(is_parked);
+        assert!(controller.is_none());
+
+        // Both PATCHes targeted the same inflate amount (2048 - 512 = 1536).
+        let bodies = bodies.lock().await;
+        assert_eq!(bodies.len(), 2, "expected two PATCH attempts");
+        for (i, body) in bodies.iter().enumerate() {
+            let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
+            assert_eq!(
+                parsed["amount_mib"].as_u64().unwrap(),
+                1536,
+                "PATCH #{i} body must inflate to 1536 MiB"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn unpark_retry_after_failure_succeeds() {
+        // Symmetric counterpart to `park_retry_after_failure_succeeds`.
+        // First PATCH (deflate) fails with 400, the retry succeeds with 204.
+        let (sock, bodies, _dir) =
+            spawn_mock_fc_api(std::collections::VecDeque::from(vec![400, 204])).await;
+
+        let mut is_parked = true;
+        let mut controller: Option<tokio::task::JoinHandle<()>> = None;
+        let crash_notify = Arc::new(Notify::new());
+
+        // First unpark attempt: PATCH 400, flag stays true, controller
+        // stays None (not respawned on failure).
+        let first = unpark_inner(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            &sock,
+            &crash_notify,
+            "retry",
+        )
+        .await;
+        assert!(matches!(first, Err(SandboxError::IdleTransition(_))));
+        assert!(is_parked, "flag must stay true on failure");
+        assert!(controller.is_none(), "controller must not be respawned");
+
+        // Second unpark attempt: PATCH 204, flag flips to false, controller
+        // is respawned.
+        unpark_inner(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            &sock,
+            &crash_notify,
+            "retry",
+        )
+        .await
+        .unwrap();
+        assert!(!is_parked);
+        assert!(controller.is_some(), "controller must be respawned");
+
+        // Both PATCHes targeted the deflate amount (0).
+        let bodies = bodies.lock().await;
+        let deflate_count = bodies
+            .iter()
+            .filter_map(|b| serde_json::from_str::<serde_json::Value>(b).ok())
+            .filter(|v| v["amount_mib"].as_u64() == Some(0))
+            .count();
+        assert_eq!(deflate_count, 2, "expected two deflate PATCHes");
+
+        // Abort the respawned reactive controller so the test runtime
+        // doesn't leave a 5s-tick task running against the mock socket.
+        if let Some(h) = controller.take() {
+            h.abort();
+        }
     }
 }

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -68,6 +68,16 @@ pub struct MockSandboxOverrides {
     /// to simulate timeout or crash. The stdout channel sender is also kept
     /// alive in `MockSandbox` so the drain task would block without the fix.
     wait_exit_error: Option<String>,
+    /// FIFO queue of park results consumed by every sandbox built with
+    /// these overrides. Empty queue → default Ok(()).
+    park_results: Mutex<VecDeque<Result<()>>>,
+    /// FIFO queue of unpark results consumed by every sandbox built with
+    /// these overrides. Empty queue → default Ok(()).
+    unpark_results: Mutex<VecDeque<Result<()>>>,
+    /// Total `park()` calls across all sandboxes built from this override set.
+    park_calls: Mutex<u32>,
+    /// Total `unpark()` calls across all sandboxes built from this override set.
+    unpark_calls: Mutex<u32>,
 }
 
 impl MockSandboxOverrides {
@@ -77,26 +87,26 @@ impl MockSandboxOverrides {
             wait_exit_code: None,
             wait_exit_gate: None,
             wait_exit_error: None,
+            park_results: Mutex::new(VecDeque::new()),
+            unpark_results: Mutex::new(VecDeque::new()),
+            park_calls: Mutex::new(0),
+            unpark_calls: Mutex::new(0),
         }
     }
 
     /// Create overrides that make `wait_exit` return a custom exit code.
     pub fn with_wait_exit_code(code: i32) -> Self {
         Self {
-            exec_matchers: Mutex::new(Vec::new()),
             wait_exit_code: Some(code),
-            wait_exit_gate: None,
-            wait_exit_error: None,
+            ..Self::new()
         }
     }
 
     /// Create overrides that block `wait_exit` until the gate is notified.
     pub fn with_wait_exit_gate(gate: Arc<tokio::sync::Notify>) -> Self {
         Self {
-            exec_matchers: Mutex::new(Vec::new()),
-            wait_exit_code: None,
             wait_exit_gate: Some(gate),
-            wait_exit_error: None,
+            ..Self::new()
         }
     }
 
@@ -105,16 +115,36 @@ impl MockSandboxOverrides {
     /// drain task blocks unless the caller aborts it.
     pub fn with_wait_exit_error(msg: impl Into<String>) -> Self {
         Self {
-            exec_matchers: Mutex::new(Vec::new()),
-            wait_exit_code: None,
-            wait_exit_gate: None,
             wait_exit_error: Some(msg.into()),
+            ..Self::new()
         }
     }
 
     /// Register a pattern matcher consumed on first match.
     pub fn add_exec_matcher(&self, matcher: ExecMatcher) {
         self.exec_matchers.lock_ignoring_poison().push(matcher);
+    }
+
+    /// Queue a `park()` result applied to the next factory-created sandbox.
+    /// Consumed FIFO across all sandboxes; empty queue → default Ok(()).
+    pub fn push_park_result(&self, result: Result<()>) {
+        self.park_results.lock_ignoring_poison().push_back(result);
+    }
+
+    /// Queue an `unpark()` result applied to the next factory-created sandbox.
+    /// Consumed FIFO across all sandboxes; empty queue → default Ok(()).
+    pub fn push_unpark_result(&self, result: Result<()>) {
+        self.unpark_results.lock_ignoring_poison().push_back(result);
+    }
+
+    /// Total `park()` calls across all sandboxes built from this override set.
+    pub fn park_call_count(&self) -> u32 {
+        *self.park_calls.lock_ignoring_poison()
+    }
+
+    /// Total `unpark()` calls across all sandboxes built from this override set.
+    pub fn unpark_call_count(&self) -> u32 {
+        *self.unpark_calls.lock_ignoring_poison()
     }
 }
 
@@ -215,6 +245,38 @@ impl Sandbox for MockSandbox {
 
     async fn kill(&mut self) -> Result<()> {
         Ok(())
+    }
+
+    /// Mock park: bumps the override `park_calls` counter on every call (so
+    /// tests can assert exact invocation counts) and consumes one queued
+    /// result (FIFO). Empty queue → `Ok(())`. The trait's idempotency
+    /// requirement is satisfied in practice because the default-Ok behavior
+    /// is side-effect-free; tests that need to exercise non-idempotent
+    /// scenarios queue explicit results.
+    async fn park(&mut self) -> Result<()> {
+        let Some(o) = &self.overrides else {
+            return Ok(());
+        };
+        *o.park_calls.lock_ignoring_poison() += 1;
+        o.park_results
+            .lock_ignoring_poison()
+            .pop_front()
+            .unwrap_or(Ok(()))
+    }
+
+    /// Mock unpark: counter + queued-result semantics mirror [`park`]
+    /// exactly. See [`park`] for details.
+    ///
+    /// [`park`]: Self::park
+    async fn unpark(&mut self) -> Result<()> {
+        let Some(o) = &self.overrides else {
+            return Ok(());
+        };
+        *o.unpark_calls.lock_ignoring_poison() += 1;
+        o.unpark_results
+            .lock_ignoring_poison()
+            .pop_front()
+            .unwrap_or(Ok(()))
     }
 
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult> {

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -12,6 +12,9 @@ pub enum SandboxError {
     #[error("execution failed: {0}")]
     ExecFailed(String),
 
+    #[error("idle transition failed: {0}")]
+    IdleTransition(String),
+
     #[error("invalid configuration: {0}")]
     InvalidConfig(String),
 

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -26,6 +26,43 @@ pub trait Sandbox: Send + Sync + Any {
     async fn stop(&mut self) -> Result<()>;
     async fn kill(&mut self) -> Result<()>;
 
+    // -- idle transitions --
+
+    /// Transition the sandbox into the idle/parked state.
+    ///
+    /// Implementations may reclaim guest memory (e.g. balloon inflate),
+    /// pause background tickers, etc. The sandbox process remains running
+    /// and vCPUs are not paused — a parked sandbox must still be able to
+    /// respond to graceful shutdown via `stop()`.
+    ///
+    /// Must be idempotent: calling `park()` on an already-parked sandbox
+    /// returns `Ok(())` without side effects.
+    ///
+    /// On `Err`, the sandbox is left in a consistent "not parked" state
+    /// (internal flags unchanged); the caller should destroy it (or
+    /// retry) rather than attempt to use it for further work.
+    async fn park(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Transition the sandbox back to the active state.
+    ///
+    /// Must be called before any further work is dispatched via `exec` /
+    /// `spawn_watch` on a previously parked sandbox. Implementations
+    /// should restore whatever state `park()` altered (balloon deflate,
+    /// respawn background tickers, etc).
+    ///
+    /// Must be idempotent: calling `unpark()` on a sandbox that was
+    /// never parked — or calling it repeatedly — returns `Ok(())`
+    /// without side effects.
+    ///
+    /// On `Err`, the sandbox is left in a consistent "still parked"
+    /// state; the caller should destroy it (or retry) rather than
+    /// attempt to use it for further work.
+    async fn unpark(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     // -- operations --
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult>;
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;


### PR DESCRIPTION
## Summary

Phase 1 of the idle-memory work (closes #9102, part of umbrella #9068).

A parked sandbox in the runner's `IdlePool` was a fully running Firecracker VM holding its full `memory_mb` as host RSS, even though the guest had no active work. With `max_idle` defaulting to unlimited, multiple parked sessions could dominate runner memory. This PR wires host-side park / unpark events into Firecracker's existing balloon device so that idle guests give their unused memory back on park and reclaim it on unpark.

## Design

- **`Sandbox` trait** gains `park()` / `unpark()` lifecycle hooks with default no-op impls. `SandboxError` gains a dedicated `IdleTransition` variant so balloon failures don't masquerade as start failures in operational logs.
- **`FirecrackerSandbox::park()`** aborts the reactive balloon controller, awaits its quiescence, then issues a single `PATCH /balloon` to inflate down to `MIN_GUEST_MIB` of guaranteed guest memory. The `abort() + await` guarantees we are the sole writer to `/balloon` — no race with the controller's own PATCHes.
- **`unpark()`** deflates and respawns the controller with the same parameters as `start()`. Both park and unpark propagate balloon PATCH failures as `IdleTransition` errors — on a healthy Firecracker the `/balloon` API is essentially infallible, so any failure strongly indicates a dead or unhealthy FC and the runner's destroy + fresh-create fallback is the right response.
- **`is_parked` flag** makes both methods truly idempotent: repeat park / repeat unpark / unpark-without-park early-return without side effects; small profiles (`memory_mb <= MIN_GUEST_MIB`) skip the balloon dance entirely, leaving the reactive controller running throughout the idle period; failures leave the flag in a consistent "still-parked" state so the caller can destroy (or retry) without inconsistent state.
- **Park / unpark core logic** lives in free functions (`park_inner` / `unpark_inner`) so it can be unit-tested against a mock Firecracker API socket without building a fully-initialised `FirecrackerSandbox`.

## Runner wiring

- **Park site (`cmd/start.rs:~990`)** calls `sandbox.park()` **before** acquiring the `idle_pool` mutex, so the HTTP call to Firecracker cannot block other take/park operations. On park failure the runner falls back to `stop_and_destroy` and skips parking entirely.
- **Take site (`~610`)** takes the entry under the pool lock, drops the lock, then awaits `unpark()`. On unpark failure the entry is destroyed via `destroy_idle_entry` and the runner falls through to a fresh-create path (the run-time budget reservation it already made covers the new sandbox).

The lock-scope refactor at the take site is the load-bearing piece — without it the `unpark` await would serialise pool accesses behind a Firecracker round-trip.

## Testing

Follows `docs/testing.md`:

- **13 sandbox-fc idle-transition tests** cover happy path, small-profile no-op, boundary case (`MIN_GUEST_MIB + 1`), deflate-error propagation, idempotency under double-park / double-unpark / unpark-without-park, flag-stays-consistent-on-failure for both park and unpark, retry-after-failure for both park and unpark, and a full `park → unpark → park` cycle.
- **4 runner integration tests** (`cmd::start`) using `MockSandbox` with shared overrides:
  - park is called exactly once when a VM enters the pool
  - park failure destroys sandbox and skips pool
  - unpark failure destroys the idle entry and falls through to fresh create
  - a two-job reuse cycle produces exactly `park=2` / `unpark=1` (symmetric hook invocation)
- **`sandbox-mock`** gains `park_calls` / `unpark_calls` counters and FIFO result queues shared across factory-built sandboxes via `MockSandboxOverrides` (mirrors the existing `exec_matchers` / `wait_exit_*` override pattern).

All 42 `cmd::start` tests pass and the full workspace suite is green.

## Self-review notes (not bugs, not blockers)

- The newly respawned reactive balloon controller's first tick may inflate by up to 256 MiB if the guest has a lot of free memory at unpark time. This matches the existing post-`start()` behaviour and is not a regression introduced here.
- `api_sock()` allocates a `PathBuf` per call and is invoked twice on the unpark path. Trivial; non-hot; deliberately not optimised.

## Test plan

- [x] `cargo test --workspace` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI green on this PR

## Follow-ups (tracked elsewhere)

- **Phase 1.5** — vCPU pause on idle (separate PR)
- **Phase 2** — KSM host-side dedup (deploy-side, umbrella #9068)
- **Phase 3** — Snapshot-to-disk suspend for long-idle sandboxes (#9103)

Closes #9102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)