### PR TITLE
perf(runner): cache built images on r2

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -390,9 +390,16 @@ jobs:
           # shellcheck disable=SC2029
           < "${TARGET_DIR}/runner" ssh "$REMOTE" "sudo install -m 755 /dev/stdin ${BIN_DIR}/runner"
 
-          # Clean up old rootfs/snapshots, keep the 3 most recent deploys
+          # Clean up old rootfs/snapshots, keep the 3 most recent deploys.
+          # R2_* env vars are inlined so `runner gc` can also sweep stale R2 image
+          # objects — without them, R2-side cleanup is silently skipped.
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "sudo ${BIN_DIR}/runner gc --keep-latest 3"
+          ssh "$REMOTE" "sudo \
+            R2_ACCOUNT_ID='${R2_ACCOUNT_ID}' \
+            R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID}' \
+            R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY}' \
+            R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME}' \
+            ${BIN_DIR}/runner gc --keep-latest 3"
 
           # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
           echo "=== Running setup ==="

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -370,6 +370,12 @@ jobs:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           HOST: ${{ needs.detect.outputs.metal-host }}
           JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
+          # R2 credentials for the runner build image cache. Inlined into the
+          # remote sudo invocation below — sudo strips env by default.
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_USER_STORAGES_BUCKET_NAME: ${{ secrets.R2_USER_STORAGES_BUCKET_NAME }}
         run: |
           set -euo pipefail
           REMOTE="${METAL_USER}@${HOST}"
@@ -393,12 +399,19 @@ jobs:
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo ${BIN_DIR}/runner setup"
 
-          # Run build (rootfs via Docker + snapshot via Firecracker)
+          # Run build (rootfs via Docker + snapshot via Firecracker).
+          # R2_* env vars are inlined after `sudo` so they reach the runner
+          # process — sudo's default `env_reset` would otherwise strip them.
           # Use tee to stream output in real-time while capturing for hash extraction
           echo "=== Building vm0/default ==="
           BUILD_LOG_DEFAULT=$(mktemp)
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "sudo ${BIN_DIR}/runner build --profile vm0/default" | tee "$BUILD_LOG_DEFAULT"
+          ssh "$REMOTE" "sudo \
+            R2_ACCOUNT_ID='${R2_ACCOUNT_ID}' \
+            R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID}' \
+            R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY}' \
+            R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME}' \
+            ${BIN_DIR}/runner build --profile vm0/default" | tee "$BUILD_LOG_DEFAULT"
           DEFAULT_IMAGE_HASH=$(grep '^image_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
           rm -f "$BUILD_LOG_DEFAULT"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -908,6 +908,11 @@ jobs:
           GRAFANA_CLOUD_PROMETHEUS_URL: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_URL }}
           GRAFANA_CLOUD_PROMETHEUS_USER: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_USER }}
           GRAFANA_CLOUD_API_KEY: ${{ secrets.GRAFANA_CLOUD_API_KEY }}
+          # R2 credentials for runner build image cache (read by runner via env)
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_USER_STORAGES_BUCKET_NAME: ${{ secrets.R2_USER_STORAGES_BUCKET_NAME }}
         run: |
           cd ansible
           ansible-playbook \
@@ -934,6 +939,10 @@ jobs:
             -e "sentry_dsn=${SENTRY_DSN_RUNNER}" \
             -e "api_url=https://www.vm0.ai" \
             -e "runner_version=${RUNNER_VERSION}" \
+            -e "r2_account_id=${R2_ACCOUNT_ID:-}" \
+            -e "r2_access_key_id=${R2_ACCESS_KEY_ID:-}" \
+            -e "r2_secret_access_key=${R2_SECRET_ACCESS_KEY:-}" \
+            -e "r2_bucket=${R2_USER_STORAGES_BUCKET_NAME:-}" \
             -v
 
       - name: Global health check (non-blocking)

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1489,6 +1489,12 @@ jobs:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ steps.host.outputs.bin-dir }}
           RUNNER_DIR: ${{ steps.host.outputs.runner-dir }}
+          # R2 credentials for the runner build image cache. Inlined into the
+          # remote sudo invocation below — sudo strips env by default.
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_USER_STORAGES_BUCKET_NAME: ${{ secrets.R2_USER_STORAGES_BUCKET_NAME }}
         run: |
           TARGET_DIR="crates/target/${TARGET_TRIPLE}/${CARGO_PROFILE}"
 
@@ -1513,9 +1519,16 @@ jobs:
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo ${BIN_DIR}/runner setup"
 
-            # Run build to create rootfs + snapshot (outputs hashes to stdout)
+            # Run build to create rootfs + snapshot (outputs hashes to stdout).
+            # R2_* env vars are inlined after `sudo` so they reach the runner
+            # process — sudo's default `env_reset` would otherwise strip them.
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "sudo ${BIN_DIR}/runner build --profile vm0/default"
+            ssh "$REMOTE" "sudo \
+              R2_ACCOUNT_ID='${R2_ACCOUNT_ID}' \
+              R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID}' \
+              R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY}' \
+              R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME}' \
+              ${BIN_DIR}/runner build --profile vm0/default"
             echo "=== Done deploying to ${HOST} ==="
           }
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1511,9 +1511,16 @@ jobs:
             # shellcheck disable=SC2029
             < "${TARGET_DIR}/runner" ssh "$REMOTE" "sudo install -m 755 /dev/stdin ${BIN_DIR}/runner"
 
-            # Clean up old rootfs/snapshots, keep the 6 most recent (3 deploys × 2 profiles)
+            # Clean up old rootfs/snapshots, keep the 6 most recent (3 deploys × 2 profiles).
+            # R2_* env vars are inlined so `runner gc` can also sweep stale R2 image
+            # objects — without them, R2-side cleanup is silently skipped.
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "sudo ${BIN_DIR}/runner gc --keep-latest 6"
+            ssh "$REMOTE" "sudo \
+              R2_ACCOUNT_ID='${R2_ACCOUNT_ID}' \
+              R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID}' \
+              R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY}' \
+              R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME}' \
+              ${BIN_DIR}/runner gc --keep-latest 6"
 
             # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
             # shellcheck disable=SC2029

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -53,6 +53,11 @@
       command: >
         {{ bin_dir }}/runner build
         --profile vm0/default
+      environment:
+        R2_ACCOUNT_ID: "{{ r2_account_id | default('') }}"
+        R2_ACCESS_KEY_ID: "{{ r2_access_key_id | default('') }}"
+        R2_SECRET_ACCESS_KEY: "{{ r2_secret_access_key | default('') }}"
+        R2_USER_STORAGES_BUCKET_NAME: "{{ r2_bucket | default('') }}"
       register: default_build_output
 
     - name: Parse default build hash

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -113,6 +113,13 @@
 
     - name: Garbage collect old artifacts
       command: "{{ bin_dir }}/runner gc --keep-latest 6"
+      environment:
+        # R2 credentials so `runner gc` can sweep stale image cache objects.
+        # Without these, R2-side cleanup is skipped (objects accumulate forever).
+        R2_ACCOUNT_ID: "{{ r2_account_id | default('') }}"
+        R2_ACCESS_KEY_ID: "{{ r2_access_key_id | default('') }}"
+        R2_SECRET_ACCESS_KEY: "{{ r2_secret_access_key | default('') }}"
+        R2_USER_STORAGES_BUCKET_NAME: "{{ r2_bucket | default('') }}"
 
     # ========================================
     # Phase 6: Final health check

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -8,14 +8,14 @@ version = "0.7.1"
 dependencies = [
  "base64",
  "futures-util",
- "hmac",
+ "hmac 0.13.0",
  "httpmock",
  "reqeast",
  "rmp-serde",
  "rmpv",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
@@ -47,6 +47,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -168,6 +174,300 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.129.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d4e8410fadbc0ee453145dd77a4958227b18b05bf67c2795d0a8b8596c9aa0f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac 0.12.1",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.10.9",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.12.1",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2 0.10.9",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.64.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6750f3dd509b0694a4377f0293ed2f9630d710b1cebe281fa8bac8f099f88bc6"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2 0.10.9",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-native-certs",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +487,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bitflags"
@@ -240,12 +550,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -391,6 +713,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc-fast"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+dependencies = [
+ "crc",
+ "digest 0.10.7",
+ "rustversion",
+ "spin",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +824,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -501,6 +851,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,7 +869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -581,6 +937,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -715,14 +1077,14 @@ dependencies = [
  "bytes",
  "guest-common",
  "hex",
- "http-body",
+ "http-body 1.0.1",
  "httpmock",
  "libc",
  "pin-project-lite",
  "reqeast",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -779,6 +1141,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -788,7 +1169,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -802,7 +1183,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -810,6 +1191,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "headers"
@@ -820,7 +1206,7 @@ dependencies = [
  "base64",
  "bytes",
  "headers-core",
- "http",
+ "http 1.4.0",
  "httpdate",
  "mime",
  "sha1",
@@ -832,7 +1218,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -849,11 +1235,31 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.2",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -868,12 +1274,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -884,8 +1301,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -917,9 +1334,9 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "headers",
- "http",
+ "http 1.4.0",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "path-tree",
  "regex",
@@ -946,6 +1363,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -954,9 +1395,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -968,17 +1409,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -992,14 +1448,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1223,6 +1679,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1756,25 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -1376,6 +1861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1904,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking"
@@ -1460,6 +1960,18 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -1608,6 +2120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,7 +2136,7 @@ name = "reqeast"
 version = "0.2.1"
 dependencies = [
  "reqwest",
- "rustls",
+ "rustls 0.23.37",
 ]
 
 [[package]]
@@ -1630,24 +2148,24 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -1705,7 +2223,9 @@ version = "0.77.1"
 dependencies = [
  "ably-subscriber",
  "async-trait",
+ "aws-sdk-s3",
  "base64",
+ "bytes",
  "chrono",
  "clap",
  "flate2",
@@ -1725,7 +2245,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -1736,6 +2256,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "which",
+ "zstd",
 ]
 
 [[package]]
@@ -1743,6 +2264,15 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1754,7 +2284,19 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -1767,7 +2309,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -1804,14 +2346,14 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.10",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1819,6 +2361,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -1876,7 +2428,7 @@ dependencies = [
  "sandbox",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1911,6 +2463,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -2082,6 +2644,17 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -2142,6 +2715,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -2149,6 +2732,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2241,7 +2830,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2346,7 +2935,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2364,11 +2953,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -2380,11 +2979,11 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tungstenite",
 ]
 
@@ -2425,8 +3024,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -2530,11 +3129,11 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -2586,7 +3185,7 @@ dependencies = [
  "flate2",
  "log",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "ureq-proto",
@@ -2601,7 +3200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
@@ -2660,6 +3259,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vsock-guest"
@@ -2866,7 +3471,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3190,6 +3795,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3297,3 +3908,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -43,6 +43,7 @@ vsock-proto = { path = "vsock-proto" }
 
 # External dependencies
 async-trait = "0.1"
+aws-sdk-s3 = { version = "1", default-features = false }
 base64 = "0.22"
 bitvec = "1"
 bytes = "1"
@@ -77,6 +78,7 @@ ureq = "3"
 url = "2"
 uuid = "1"
 which = "8"
+zstd = "0.13"
 
 [profile.release]
 lto = true

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -78,7 +78,7 @@ ureq = "3"
 url = "2"
 uuid = "1"
 which = "8"
-zstd = "0.13"
+zstd = { version = "0.13", default-features = false }
 
 [profile.release]
 lto = true

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -10,7 +10,9 @@ nbd-cow = { workspace = true }
 sandbox-fc = { workspace = true }
 
 async-trait = { workspace = true }
+aws-sdk-s3 = { workspace = true, features = ["rustls", "rt-tokio", "behavior-version-latest"] }
 base64 = { workspace = true }
+bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde", "now"] }
 clap = { workspace = true, features = ["derive", "env"] }
 nix = { workspace = true, features = ["user", "signal", "fs", "process"] }
@@ -19,7 +21,7 @@ serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs", "net", "io-util"] }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["io", "io-util"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -32,6 +34,7 @@ tempfile = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
 sentry = { workspace = true, features = ["panic"] }
 which = { workspace = true }
+zstd = { workspace = true, features = ["zstdmt"] }
 
 # These dev-dependencies exist solely for release-please version tracking:
 # cargo-workspace plugin includes dev-dependencies in its dependency graph,

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -213,6 +213,13 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
     // Try R2 download before falling back to local build. try_download manages
     // its own staging directory and atomic rename, so output_dir stays absent
     // on failure (no false-positive cache hits from partial unpack).
+    //
+    // `r2_object_is_corrupt`: set when we observed a structurally-valid
+    // download (Ok(true)) whose extracted content failed `is_image_complete`.
+    // The next `upload` call would dedup-skip on `exists() = true` and leave
+    // the bad object in place, locking the entire fleet out of this hash —
+    // so we delete it before falling through to local rebuild.
+    let mut r2_object_is_corrupt = false;
     if let Some(cache) = &r2 {
         match cache.try_download(&hash, output_dir).await {
             Ok(true) => {
@@ -221,10 +228,31 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
                     touch_mtime(output_dir);
                     return Ok(());
                 }
-                tracing::warn!("R2 download succeeded but image incomplete — will rebuild locally");
+                tracing::warn!(
+                    "R2 download for {hash} succeeded but image incomplete — \
+                     will evict bad object and rebuild locally"
+                );
+                r2_object_is_corrupt = true;
             }
             Ok(false) => tracing::info!("R2 cache miss for {hash} — building locally"),
+            // Err is ambiguous (transient network vs. content corruption);
+            // we don't auto-evict here — false eviction on a network blip
+            // would force the whole fleet into a slow rebuild cycle.
             Err(e) => tracing::warn!("R2 download failed: {e} — falling back to local build"),
+        }
+    }
+
+    // Evict the corrupt object BEFORE local build so re-upload (later) won't
+    // dedup-skip. Safe under concurrent fleet eviction (DeleteObject is
+    // idempotent). Failure here is non-fatal: worst case the upload step
+    // dedup-skips and we retry on the next deploy.
+    if r2_object_is_corrupt && let Some(cache) = &r2 {
+        match cache.delete(&hash).await {
+            Ok(()) => tracing::info!("evicted corrupt R2 object: {hash}"),
+            Err(e) => tracing::warn!(
+                "failed to evict corrupt R2 object {hash}: {e} — \
+                 next upload may dedup-skip and leave corruption in place"
+            ),
         }
     }
 

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -19,9 +19,8 @@ const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
 /// Affects both the local cache directory and the R2 object key (since the
 /// version seeds the hash that names both).
 ///
-/// Bumping leaves the previous-hash R2 objects orphaned — they're never
-/// referenced again. Cleanup relies on the bucket's lifecycle rule on the
-/// `runner-images/` prefix (see `r2_cache` module docs).
+/// Bumping leaves the previous-hash R2 objects orphaned; they're swept by
+/// `runner gc` after the configured TTL (see `r2_cache::gc_older_than`).
 const IMAGE_CACHE_VERSION: u32 = 1;
 
 #[cfg(bundled_guests)]

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -214,12 +214,15 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
     // its own staging directory and atomic rename, so output_dir stays absent
     // on failure (no false-positive cache hits from partial unpack).
     //
-    // `r2_object_is_corrupt`: set when we observed a structurally-valid
-    // download (Ok(true)) whose extracted content failed `is_image_complete`.
-    // The next `upload` call would dedup-skip on `exists() = true` and leave
-    // the bad object in place, locking the entire fleet out of this hash —
-    // so we delete it before falling through to local rebuild.
-    let mut r2_object_is_corrupt = false;
+    // `force_reupload`: set when we observed a structurally-valid download
+    // (Ok(true)) whose extracted content failed `is_image_complete`. Without
+    // it the next `upload` call would dedup-skip on `exists() = true` and
+    // leave the bad object in place, locking the entire fleet out of this
+    // hash. We pass it through as `force` to `upload` rather than calling
+    // `delete` first — force-upload is a single atomic PUT that doesn't
+    // depend on `s3:DeleteObject` permission being healthy (a persistently
+    // failing delete would otherwise leave the corruption stuck forever).
+    let mut force_reupload = false;
     if let Some(cache) = &r2 {
         match cache.try_download(&hash, output_dir).await {
             Ok(true) => {
@@ -230,29 +233,15 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
                 }
                 tracing::warn!(
                     "R2 download for {hash} succeeded but image incomplete — \
-                     will evict bad object and rebuild locally"
+                     will rebuild locally and force-overwrite the bad object"
                 );
-                r2_object_is_corrupt = true;
+                force_reupload = true;
             }
             Ok(false) => tracing::info!("R2 cache miss for {hash} — building locally"),
             // Err is ambiguous (transient network vs. content corruption);
-            // we don't auto-evict here — false eviction on a network blip
-            // would force the whole fleet into a slow rebuild cycle.
+            // we don't force-overwrite here — false overwrite on a network
+            // blip would amplify load (every host re-uploads the same hash).
             Err(e) => tracing::warn!("R2 download failed: {e} — falling back to local build"),
-        }
-    }
-
-    // Evict the corrupt object BEFORE local build so re-upload (later) won't
-    // dedup-skip. Safe under concurrent fleet eviction (DeleteObject is
-    // idempotent). Failure here is non-fatal: worst case the upload step
-    // dedup-skips and we retry on the next deploy.
-    if r2_object_is_corrupt && let Some(cache) = &r2 {
-        match cache.delete(&hash).await {
-            Ok(()) => tracing::info!("evicted corrupt R2 object: {hash}"),
-            Err(e) => tracing::warn!(
-                "failed to evict corrupt R2 object {hash}: {e} — \
-                 next upload may dedup-skip and leave corruption in place"
-            ),
         }
     }
 
@@ -394,10 +383,12 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
 
     // Synchronous R2 upload after Phase 2. Failure is non-fatal — the image is
     // already on local disk; subsequent hosts just won't get a cache hit.
-    // exists() check inside upload() avoids same-deploy N-host duplicate uploads.
+    // `exists()` dedup inside `upload()` avoids same-deploy N-host duplicate
+    // uploads; `force_reupload` bypasses dedup so a previously-detected
+    // corrupt object gets atomically overwritten.
     if let Some(cache) = &r2 {
         let files = image.expected_files().to_vec();
-        match cache.upload(&hash, &files).await {
+        match cache.upload(&hash, &files, force_reupload).await {
             Ok(()) => tracing::info!("uploaded image to R2: {hash}"),
             Err(e) => tracing::warn!("R2 upload failed: {e} — image is on local disk"),
         }

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -10,11 +10,14 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
 use crate::paths::{HomePaths, ImagePaths, touch_mtime};
 use crate::profile;
+use crate::r2_cache::R2ImageCache;
 
 const BUILD_SCRIPT: &str = include_str!("../../scripts/build-rootfs.sh");
 const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
 
 /// Bump this to invalidate all cached images without changing any input files.
+/// Affects both the local cache directory and the R2 object key (since the
+/// version seeds the hash that names both).
 const IMAGE_CACHE_VERSION: u32 = 1;
 
 #[cfg(bundled_guests)]
@@ -184,6 +187,15 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         return Ok(());
     }
 
+    // R2 cache init. Fatal on partial config (1-3 of 4 vars set) — better than
+    // silently disabling cache for a typo'd secret rotation.
+    let r2 = R2ImageCache::from_env()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("R2 cache init: {e}")))?;
+    if r2.is_none() {
+        tracing::warn!("R2 cache disabled (R2_* env vars not set) — skipping download and upload");
+    }
+
     // Acquire exclusive lock to prevent concurrent builds with the same hash.
     let _lock = lock::acquire(paths.image_lock(&hash)).await?;
 
@@ -192,6 +204,24 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         tracing::info!("[OK] image already built: {}", output_dir.display());
         touch_mtime(output_dir);
         return Ok(());
+    }
+
+    // Try R2 download before falling back to local build. try_download manages
+    // its own staging directory and atomic rename, so output_dir stays absent
+    // on failure (no false-positive cache hits from partial unpack).
+    if let Some(cache) = &r2 {
+        match cache.try_download(&hash, output_dir).await {
+            Ok(true) => {
+                if is_image_complete(&image).await? {
+                    tracing::info!("[OK] image downloaded from R2: {}", output_dir.display());
+                    touch_mtime(output_dir);
+                    return Ok(());
+                }
+                tracing::warn!("R2 download succeeded but image incomplete — will rebuild locally");
+            }
+            Ok(false) => tracing::info!("R2 cache miss for {hash} — building locally"),
+            Err(e) => tracing::warn!("R2 download failed: {e} — falling back to local build"),
+        }
     }
 
     // --- Phase 1: Build rootfs ---
@@ -329,6 +359,17 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         cow_disk = %cow_sz.1,
         "snapshot creation complete"
     );
+
+    // Synchronous R2 upload after Phase 2. Failure is non-fatal — the image is
+    // already on local disk; subsequent hosts just won't get a cache hit.
+    // exists() check inside upload() avoids same-deploy N-host duplicate uploads.
+    if let Some(cache) = &r2 {
+        let files = image.expected_files().to_vec();
+        match cache.upload(&hash, &files).await {
+            Ok(()) => tracing::info!("uploaded image to R2: {hash}"),
+            Err(e) => tracing::warn!("R2 upload failed: {e} — image is on local disk"),
+        }
+    }
 
     tracing::info!("image creation complete: {hash}");
     Ok(())

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -18,6 +18,10 @@ const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
 /// Bump this to invalidate all cached images without changing any input files.
 /// Affects both the local cache directory and the R2 object key (since the
 /// version seeds the hash that names both).
+///
+/// Bumping leaves the previous-hash R2 objects orphaned — they're never
+/// referenced again. Cleanup relies on the bucket's lifecycle rule on the
+/// `runner-images/` prefix (see `r2_cache` module docs).
 const IMAGE_CACHE_VERSION: u32 = 1;
 
 #[cfg(bundled_guests)]
@@ -193,7 +197,8 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         .await
         .map_err(|e| RunnerError::Internal(format!("R2 cache init: {e}")))?;
     if r2.is_none() {
-        tracing::warn!("R2 cache disabled (R2_* env vars not set) — skipping download and upload");
+        // Info, not warn — dev environments routinely run without R2 configured.
+        tracing::info!("R2 cache disabled (R2_* env vars not set) — skipping download and upload");
     }
 
     // Acquire exclusive lock to prevent concurrent builds with the same hash.

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -14,9 +14,11 @@ use crate::paths::{HomePaths, LogPaths};
 use crate::r2_cache::R2ImageCache;
 
 /// Default TTL for completed R2 image objects. Older objects are deleted by
-/// `gc_r2`. 7 days comfortably covers our typical release cadence; if a
-/// still-referenced image gets swept, the next `runner build` pays a
-/// one-time local rebuild + re-upload cost.
+/// `gc_r2`. 7 days comfortably covers our typical release cadence: an image
+/// from the last week's release is still useful for a host that just spun
+/// up. If a host has been offline >7 days and the cached image got swept,
+/// the next `runner build` does a one-time local rebuild + re-upload — slow
+/// but correct.
 const R2_DEFAULT_KEEP_DAYS: u64 = 7;
 
 /// Artifacts younger than this are unconditionally kept, regardless of lock
@@ -36,8 +38,9 @@ pub struct GcArgs {
     #[arg(long)]
     keep_latest: Option<usize>,
     /// TTL for R2 image cache objects (in days). Objects older than this
-    /// are deleted from `runner-images/` on R2. Default: 30 days.
-    #[arg(long, default_value_t = R2_DEFAULT_KEEP_DAYS)]
+    /// are deleted from `runner-images/` on R2. Default: 7 days.
+    /// Minimum: 1 — `0` would wipe even the just-uploaded image.
+    #[arg(long, default_value_t = R2_DEFAULT_KEEP_DAYS, value_parser = clap::value_parser!(u64).range(1..))]
     r2_keep_days: u64,
 }
 
@@ -883,6 +886,34 @@ fn human_bytes(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+
+    /// `--r2-keep-days 0` would wipe even just-uploaded images. Verify the
+    /// clap range validator rejects it (catches a regression if the
+    /// `value_parser` annotation is dropped).
+    #[derive(Parser)]
+    struct GcCli {
+        #[command(flatten)]
+        args: GcArgs,
+    }
+
+    #[test]
+    fn r2_keep_days_zero_is_rejected() {
+        let r = GcCli::try_parse_from(["gc", "--r2-keep-days", "0"]);
+        assert!(r.is_err(), "--r2-keep-days 0 must be rejected");
+    }
+
+    #[test]
+    fn r2_keep_days_one_is_accepted() {
+        let r = GcCli::try_parse_from(["gc", "--r2-keep-days", "1"]);
+        assert!(r.is_ok(), "--r2-keep-days 1 must be accepted");
+    }
+
+    #[test]
+    fn r2_keep_days_default_when_omitted() {
+        let parsed = GcCli::try_parse_from(["gc"]).unwrap();
+        assert_eq!(parsed.args.r2_keep_days, R2_DEFAULT_KEEP_DAYS);
+    }
 
     #[test]
     fn human_bytes_formats_correctly() {

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -14,10 +14,10 @@ use crate::paths::{HomePaths, LogPaths};
 use crate::r2_cache::R2ImageCache;
 
 /// Default TTL for completed R2 image objects. Older objects are deleted by
-/// `gc_r2`. 30 days easily covers any sane release cadence; a stale image
-/// staying around an extra week is harmless, but losing a still-referenced
-/// one would force a full rebuild.
-const R2_DEFAULT_KEEP_DAYS: u64 = 30;
+/// `gc_r2`. 7 days comfortably covers our typical release cadence; if a
+/// still-referenced image gets swept, the next `runner build` pays a
+/// one-time local rebuild + re-upload cost.
+const R2_DEFAULT_KEEP_DAYS: u64 = 7;
 
 /// Artifacts younger than this are unconditionally kept, regardless of lock
 /// status or `--keep-latest`. This prevents races between `runner build`

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -11,6 +11,13 @@ use crate::cmd::service;
 use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
 use crate::paths::{HomePaths, LogPaths};
+use crate::r2_cache::R2ImageCache;
+
+/// Default TTL for completed R2 image objects. Older objects are deleted by
+/// `gc_r2`. 30 days easily covers any sane release cadence; a stale image
+/// staying around an extra week is harmless, but losing a still-referenced
+/// one would force a full rebuild.
+const R2_DEFAULT_KEEP_DAYS: u64 = 30;
 
 /// Artifacts younger than this are unconditionally kept, regardless of lock
 /// status or `--keep-latest`. This prevents races between `runner build`
@@ -28,6 +35,10 @@ pub struct GcArgs {
     /// Keep the N most recent unused versions (by modification time)
     #[arg(long)]
     keep_latest: Option<usize>,
+    /// TTL for R2 image cache objects (in days). Objects older than this
+    /// are deleted from `runner-images/` on R2. Default: 30 days.
+    #[arg(long, default_value_t = R2_DEFAULT_KEEP_DAYS)]
+    r2_keep_days: u64,
 }
 
 pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
@@ -55,13 +66,16 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
 
     let debootstrap_freed = gc_debootstrap(&home, args.keep_latest, args.dry_run).await?;
 
-    let total = images_freed + job_logs_freed + debootstrap_freed + workspace_freed;
+    let (r2_deleted, r2_freed) = gc_r2(args.r2_keep_days, args.dry_run).await;
+
+    let total = images_freed + job_logs_freed + debootstrap_freed + workspace_freed + r2_freed;
     if total == 0
         && locks_removed == 0
         && job_logs_removed == 0
         && versions_removed.is_empty()
         && nbd_orphans == 0
         && workspace_orphans == 0
+        && r2_deleted == 0
     {
         info!("nothing to clean up");
     } else {
@@ -82,6 +96,54 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
     }
 
     Ok(())
+}
+
+/// Delete R2 image cache objects older than `keep_days`. Errors (R2 not
+/// configured, network blip, etc.) are logged and swallowed: GC must not
+/// fail the deploy because the cache layer is misconfigured. Returns
+/// `(deleted_count, freed_bytes)`.
+///
+/// Idempotent across the fleet — every host runs the same scan; DELETE on
+/// already-absent keys is a no-op success.
+async fn gc_r2(keep_days: u64, dry_run: bool) -> (u64, u64) {
+    let cache = match R2ImageCache::from_env().await {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            info!("r2: cache not configured, skipping R2 GC");
+            return (0, 0);
+        }
+        Err(e) => {
+            warn!("r2: init failed ({e}), skipping R2 GC");
+            return (0, 0);
+        }
+    };
+
+    if dry_run {
+        // No safe dry-run: list_objects_v2 + counting age would still cost
+        // R2 reads, and we can't filter without making the call. Surface the
+        // intent and skip the destructive part.
+        info!("[dry-run] would delete R2 image objects older than {keep_days} days");
+        return (0, 0);
+    }
+
+    let max_age = std::time::Duration::from_secs(keep_days.saturating_mul(86_400));
+    match cache.gc_older_than(max_age).await {
+        Ok((0, _)) => {
+            info!("r2: no objects older than {keep_days} days");
+            (0, 0)
+        }
+        Ok((count, bytes)) => {
+            info!(
+                "r2: deleted {count} object(s) older than {keep_days} days ({})",
+                human_bytes(bytes)
+            );
+            (count, bytes)
+        }
+        Err(e) => {
+            warn!("r2: GC failed ({e}); will retry on next gc invocation");
+            (0, 0)
+        }
+    }
 }
 
 /// An unused artifact directory whose exclusive lock is held to prevent races.

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -18,6 +18,7 @@ mod process;
 mod profile;
 mod provider;
 mod proxy;
+mod r2_cache;
 mod resource_budget;
 mod retry;
 mod status;

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -36,6 +36,30 @@
 //!
 //! Image size limit: `PART_SIZE * 10000 ≈ 160 GiB` (S3 multipart hard limit).
 //! Current images are well under 30 GiB; revisit if `PART_SIZE` decreases.
+//!
+//! ## R2-side cleanup (operator responsibility)
+//!
+//! Completed objects (`runner-images/{hash}.tar.zst`) are **never deleted by
+//! this code**. Each `IMAGE_CACHE_VERSION` bump, build-script change, guest
+//! binary rebuild, or firecracker/kernel upgrade produces a new hash and
+//! orphans the previous object.
+//!
+//! Mitigation: configure an R2 bucket lifecycle rule on the `runner-images/`
+//! prefix to delete objects older than ~30 days. R2's default 7-day rule only
+//! cleans abandoned multipart segments, not completed objects.
+//!
+//! ## Security boundary: tar path traversal
+//!
+//! `tar` 0.4 silently drops entries with `..` path components from
+//! `Archive::unpack` (verified by `unpack_rejects_path_traversal`). The
+//! defense chain that turns this into a safe failure mode:
+//! 1. unpack drops the malicious entry → staging dir ends up incomplete
+//! 2. `is_image_complete()` (in `cmd::build`) rejects the partial result
+//! 3. caller falls back to a local build
+//!
+//! **If you add a new file to the image, you MUST also extend
+//! `is_image_complete()` — otherwise an attacker-controlled tar that omits
+//! the new file would still pass the completeness check.**
 
 use std::path::{Path, PathBuf};
 
@@ -391,7 +415,7 @@ impl R2ImageCache {
                 });
                 part_number = part_number
                     .checked_add(1)
-                    .ok_or_else(|| R2Error::S3("part_number overflow".into()))?;
+                    .ok_or_else(|| R2Error::Io(io_other("part_number overflow")))?;
                 if n < PART_SIZE {
                     eof = true;
                     break;
@@ -484,8 +508,7 @@ async fn finalize_staging(staging: &Path, final_dir: &Path) -> Result<(), R2Erro
     if let Ok(meta) = tokio::fs::metadata(&cow).await {
         let len = meta.len();
         if len > 0 {
-            let cow_clone = cow.clone();
-            let result = tokio::task::spawn_blocking(move || punch_hole(&cow_clone, len))
+            let result = tokio::task::spawn_blocking(move || punch_hole(&cow, len))
                 .await
                 .map_err(|e| R2Error::Io(io_other(e)))?;
             if let Err(e) = result {
@@ -531,14 +554,14 @@ async fn read_full<R: tokio::io::AsyncRead + Unpin>(
     while total < buf.len() {
         let slice = buf
             .get_mut(total..)
-            .ok_or_else(|| R2Error::S3("buf overrun".into()))?;
+            .ok_or_else(|| R2Error::Io(io_other("buf overrun")))?;
         let n = reader.read(slice).await?;
         if n == 0 {
             break;
         }
         total = total
             .checked_add(n)
-            .ok_or_else(|| R2Error::S3("read overflow".into()))?;
+            .ok_or_else(|| R2Error::Io(io_other("read offset overflow")))?;
     }
     Ok(total)
 }
@@ -598,7 +621,8 @@ mod tests {
 
     /// `from_env` requires all-or-nothing on the four env vars.
     /// Tests use a single var with each scenario via temporary process env;
-    /// they share the global env so must run with --test-threads=1.
+    /// concurrent execution is safe — `with_clean_r2_env` serializes via
+    /// `ENV_LOCK` so the snapshot/mutate/restore window is exclusive.
     #[tokio::test]
     async fn from_env_returns_none_when_all_missing() {
         with_clean_r2_env(|| async {
@@ -611,7 +635,7 @@ mod tests {
     #[tokio::test]
     async fn from_env_returns_some_when_all_present() {
         with_clean_r2_env(|| async {
-            // SAFETY: tests are serialized via --test-threads=1.
+            // SAFETY: env mutation is serialized by ENV_LOCK in with_clean_r2_env.
             unsafe {
                 std::env::set_var("R2_ACCOUNT_ID", "test-account");
                 std::env::set_var("R2_ACCESS_KEY_ID", "test-key");
@@ -666,15 +690,24 @@ mod tests {
         .await;
     }
 
+    /// Process-wide lock that serializes env-mutating tests in this module so
+    /// they're correct even when the test harness runs threads in parallel
+    /// (CI uses `cargo llvm-cov` without `--test-threads=1`). Held across the
+    /// inner `tokio::spawn(...).await` because env vars are process-global —
+    /// without the lock, two concurrent tests would clobber each other's
+    /// snapshot/restore. Async-aware so holding across await is sound.
+    static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
     /// Helper: snapshot and clear all R2 env vars before running, restore after.
     /// Panic-safe: the closure runs in a `tokio::spawn` task so a panic doesn't
-    /// skip the restore. SAFETY of `set_var` / `remove_var`: callers must run
-    /// with `--test-threads=1` to avoid concurrent env mutation.
+    /// skip the restore. SAFETY of `set_var` / `remove_var`: serialized by
+    /// `ENV_LOCK` above, so no concurrent env mutation can occur.
     async fn with_clean_r2_env<F, Fut>(f: F)
     where
         F: FnOnce() -> Fut + Send + 'static,
         Fut: std::future::Future<Output = ()> + Send + 'static,
     {
+        let _guard = ENV_LOCK.lock().await;
         let saved: Vec<(&str, Option<String>)> = ENV_VARS
             .iter()
             .map(|v| (*v, std::env::var(v).ok()))

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -373,26 +373,7 @@ impl R2ImageCache {
             }
             let resp = req.send().await?;
 
-            // Filter expired objects in this page; build an ObjectIdentifier
-            // batch for a single DeleteObjects call (S3/R2 hard limit: 1000).
-            let mut to_delete: Vec<ObjectIdentifier> = Vec::new();
-            let mut batch_freed = 0u64;
-            for obj in resp.contents() {
-                let Some(last_modified) = obj.last_modified() else {
-                    continue;
-                };
-                if last_modified.secs() >= cutoff {
-                    continue;
-                }
-                let Some(key) = obj.key() else { continue };
-                let size = u64::try_from(obj.size().unwrap_or(0).max(0)).unwrap_or(0);
-                let oid = ObjectIdentifier::builder()
-                    .key(key)
-                    .build()
-                    .map_err(|e| R2Error::S3(format!("ObjectIdentifier build: {e:?}")))?;
-                to_delete.push(oid);
-                batch_freed = batch_freed.saturating_add(size);
-            }
+            let (to_delete, batch_freed) = select_expired_in_page(resp.contents(), cutoff)?;
 
             if !to_delete.is_empty() {
                 let count = to_delete.len() as u64;
@@ -605,6 +586,39 @@ fn key_for_hash(hash: &str) -> String {
     format!("{KEY_PREFIX}{hash}.tar.zst")
 }
 
+/// Filter a single ListObjectsV2 page down to the keys that should be
+/// deleted (`last_modified < cutoff`), and sum their reported sizes.
+/// Skips entries with no `last_modified` or no `key` (defensive — shouldn't
+/// happen for real R2 responses but the SDK type makes them Optional).
+/// Negative `size` values are clamped to 0 before being summed.
+///
+/// Boundary: an object whose `last_modified == cutoff` is **kept**
+/// (`>= cutoff` is the skip condition). This biases toward retention.
+fn select_expired_in_page(
+    objects: &[aws_sdk_s3::types::Object],
+    cutoff: i64,
+) -> Result<(Vec<ObjectIdentifier>, u64), R2Error> {
+    let mut to_delete: Vec<ObjectIdentifier> = Vec::new();
+    let mut batch_freed = 0u64;
+    for obj in objects {
+        let Some(last_modified) = obj.last_modified() else {
+            continue;
+        };
+        if last_modified.secs() >= cutoff {
+            continue;
+        }
+        let Some(key) = obj.key() else { continue };
+        let size = u64::try_from(obj.size().unwrap_or(0).max(0)).unwrap_or(0);
+        let oid = ObjectIdentifier::builder()
+            .key(key)
+            .build()
+            .map_err(|e| R2Error::S3(format!("ObjectIdentifier build: {e:?}")))?;
+        to_delete.push(oid);
+        batch_freed = batch_freed.saturating_add(size);
+    }
+    Ok((to_delete, batch_freed))
+}
+
 /// Compute the unix-seconds cutoff for "anything older than this is stale".
 /// Returns an i64 to match aws_smithy_types::DateTime::secs(). Saturates to
 /// 0 when `max_age` exceeds `now` (e.g. dev clock at epoch).
@@ -812,6 +826,92 @@ mod tests {
         let now = std::time::UNIX_EPOCH + std::time::Duration::from_secs(42);
         let zero = std::time::Duration::from_secs(0);
         assert_eq!(cutoff_unix_secs(now, zero).unwrap(), 42);
+    }
+
+    #[test]
+    fn cutoff_with_duration_max_saturates_to_zero() {
+        // Pathological input shouldn't underflow into a huge positive cutoff.
+        let now = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        assert_eq!(cutoff_unix_secs(now, std::time::Duration::MAX).unwrap(), 0);
+    }
+
+    // ---- select_expired_in_page (gc_older_than filter) ------------------
+
+    fn obj(key: &str, last_modified_secs: i64, size: i64) -> aws_sdk_s3::types::Object {
+        aws_sdk_s3::types::Object::builder()
+            .key(key)
+            .last_modified(aws_sdk_s3::primitives::DateTime::from_secs(
+                last_modified_secs,
+            ))
+            .size(size)
+            .build()
+    }
+
+    #[test]
+    fn select_expired_filters_by_cutoff() {
+        let objects = [
+            obj("old1", 100, 10),
+            obj("fresh", 200, 20),
+            obj("old2", 50, 30),
+        ];
+        let (selected, freed) = select_expired_in_page(&objects, 150).unwrap();
+        let keys: Vec<&str> = selected.iter().map(|o| o.key.as_str()).collect();
+        assert_eq!(keys.len(), 2);
+        assert!(keys.contains(&"old1"));
+        assert!(keys.contains(&"old2"));
+        assert!(!keys.contains(&"fresh"));
+        assert_eq!(freed, 40); // 10 + 30
+    }
+
+    #[test]
+    fn select_expired_keeps_object_at_exact_cutoff() {
+        // `>=` is the skip predicate, so equality biases toward retention.
+        // Important contract: an upload that just happened "right at" the
+        // GC cycle's cutoff isn't aggressively swept.
+        let objects = [obj("boundary", 100, 1)];
+        let (selected, freed) = select_expired_in_page(&objects, 100).unwrap();
+        assert_eq!(selected.len(), 0);
+        assert_eq!(freed, 0);
+    }
+
+    #[test]
+    fn select_expired_skips_object_without_last_modified() {
+        // ListObjectsV2 always sets last_modified for real R2 responses,
+        // but the SDK type is Option — guard the None branch.
+        let objects = [aws_sdk_s3::types::Object::builder()
+            .key("orphan")
+            .size(10)
+            .build()];
+        let (selected, freed) = select_expired_in_page(&objects, 100).unwrap();
+        assert_eq!(selected.len(), 0);
+        assert_eq!(freed, 0);
+    }
+
+    #[test]
+    fn select_expired_skips_object_without_key() {
+        let objects = [aws_sdk_s3::types::Object::builder()
+            .last_modified(aws_sdk_s3::primitives::DateTime::from_secs(50))
+            .size(10)
+            .build()];
+        let (selected, freed) = select_expired_in_page(&objects, 100).unwrap();
+        assert_eq!(selected.len(), 0);
+        assert_eq!(freed, 0);
+    }
+
+    #[test]
+    fn select_expired_clamps_negative_size_to_zero() {
+        // Defensive against a pathological SDK / R2 response.
+        let objects = [obj("weird", 50, -1)];
+        let (selected, freed) = select_expired_in_page(&objects, 100).unwrap();
+        assert_eq!(selected.len(), 1);
+        assert_eq!(freed, 0);
+    }
+
+    #[test]
+    fn select_expired_empty_page_returns_empty() {
+        let (selected, freed) = select_expired_in_page(&[], 100).unwrap();
+        assert!(selected.is_empty());
+        assert_eq!(freed, 0);
     }
 
     #[test]
@@ -1203,6 +1303,30 @@ mod tests {
         );
     }
 
+    /// `finalize_staging` skips `punch_hole` when `cow.img` is empty (size=0).
+    /// Different branch from `finalize_works_without_cow_img` — there the
+    /// file is absent; here it exists with zero length. Both must succeed
+    /// without invoking the fallocate syscall (which is undefined for len=0).
+    #[tokio::test]
+    async fn finalize_skips_punch_hole_on_zero_byte_cow() {
+        let dst_root = tempfile::tempdir().unwrap();
+        let final_dir = dst_root.path().join("hash");
+        let staging = staging_dir(&final_dir);
+        tokio::fs::create_dir_all(&staging).await.unwrap();
+        tokio::fs::write(staging.join("cow.img"), b"")
+            .await
+            .unwrap();
+        tokio::fs::write(staging.join("rootfs.ext4"), b"data")
+            .await
+            .unwrap();
+
+        finalize_staging(&staging, &final_dir).await.unwrap();
+
+        let cow_meta = std::fs::metadata(final_dir.join("cow.img")).unwrap();
+        assert_eq!(cow_meta.len(), 0, "0-byte cow.img preserved as-is");
+        assert!(!staging.exists(), "staging consumed by rename");
+    }
+
     /// `finalize_staging` skips `punch_hole` cleanly when `cow.img` is absent.
     /// Defends against future producers that ship without cow.img.
     #[tokio::test]
@@ -1267,6 +1391,41 @@ mod tests {
             Err(R2Error::Io(_)) => {} // expected
             other => panic!("expected R2Error::Io for missing source, got {other:?}"),
         }
+    }
+
+    /// `R2ImageCache::Debug` must not leak credentials — if logs ever capture
+    /// `{:?}` on a cache (e.g. via `tracing` instrumentation), only the
+    /// bucket name should appear, not account_id / access_key / secret.
+    #[tokio::test]
+    async fn debug_format_does_not_leak_credentials() {
+        with_clean_r2_env(|| async {
+            // SAFETY: env mutation is serialized by ENV_LOCK in with_clean_r2_env.
+            unsafe {
+                std::env::set_var("R2_ACCOUNT_ID", "secret-account-id-do-not-leak");
+                std::env::set_var("R2_ACCESS_KEY_ID", "AKIAEXAMPLEDONOTLEAK");
+                std::env::set_var("R2_SECRET_ACCESS_KEY", "secret-key-MUST-NOT-appear-in-logs");
+                std::env::set_var("R2_USER_STORAGES_BUCKET_NAME", "test-bucket");
+            }
+            let cache = R2ImageCache::from_env().await.unwrap().unwrap();
+            let dbg = format!("{cache:?}");
+            assert!(
+                !dbg.contains("secret-account-id-do-not-leak"),
+                "Debug leaked account_id: {dbg}"
+            );
+            assert!(
+                !dbg.contains("AKIAEXAMPLEDONOTLEAK"),
+                "Debug leaked access_key_id: {dbg}"
+            );
+            assert!(
+                !dbg.contains("secret-key-MUST-NOT-appear-in-logs"),
+                "Debug leaked secret_key: {dbg}"
+            );
+            assert!(
+                dbg.contains("test-bucket"),
+                "Debug should still expose bucket for diagnostic value: {dbg}"
+            );
+        })
+        .await;
     }
 
     /// Empty file list: pack succeeds and produces a valid (empty) tar.zst.

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -53,6 +53,26 @@
 //! R2's default 7-day lifecycle rule only cleans abandoned multipart
 //! segments, **not** completed objects — which is why we need our own scan.
 //!
+//! **Clock skew caveat**: `gc_older_than` uses local `SystemTime::now()` to
+//! compute the cutoff. If the host clock drifts ahead of R2 server time by
+//! more than the TTL, GC over-deletes (worst case: wipes everything older
+//! than `now_local - keep_days`, even objects that were just uploaded by
+//! peers with correct clocks). Mitigation: keep NTP healthy. A clock behind
+//! R2 is the safe direction (under-deletes, no data loss).
+//!
+//! ## Corrupt-object eviction
+//!
+//! A structurally-valid archive whose extracted content fails
+//! `is_image_complete` (e.g. uploaded by an old/buggy producer, or
+//! attacker-controlled IAM key writing a bogus tar to a predicted hash
+//! key) would otherwise dead-lock the fleet's cache for that hash: every
+//! host downloads → unpacks → fails completeness → rebuilds locally →
+//! `upload`'s `exists()` dedup-skips → the bad object stays, forever.
+//!
+//! `cmd::build::run_build` defends by calling `delete(&hash)` whenever it
+//! observes "download Ok(true) but is_image_complete=false", clearing the
+//! way for a clean re-upload after the local rebuild.
+//!
 //! ## Security boundary: tar path traversal
 //!
 //! `tar` 0.4 silently drops entries with `..` path components from
@@ -179,6 +199,22 @@ impl R2ImageCache {
         let client = aws_sdk_s3::Client::from_conf(config);
 
         Ok(Some(Self { client, bucket }))
+    }
+
+    /// Delete `runner-images/{hash}.tar.zst`. Used to evict objects detected
+    /// as corrupt (download succeeded but `is_image_complete` failed) so the
+    /// next `upload` doesn't dedup-skip and leave the corruption in place.
+    /// `DeleteObject` on a missing key is a no-op success — safe under
+    /// concurrent fleet eviction of the same key.
+    pub async fn delete(&self, hash: &str) -> Result<(), R2Error> {
+        let key = key_for_hash(hash);
+        self.client
+            .delete_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await?;
+        Ok(())
     }
 
     /// Returns `Ok(true)` if `runner-images/{hash}.tar.zst` exists.

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -88,9 +88,25 @@
 //! host downloads → unpacks → fails completeness → rebuilds locally →
 //! `upload`'s `exists()` dedup-skips → the bad object stays, forever.
 //!
-//! `cmd::build::run_build` defends by calling `delete(&hash)` whenever it
-//! observes "download Ok(true) but is_image_complete=false", clearing the
-//! way for a clean re-upload after the local rebuild.
+//! `cmd::build::run_build` defends by passing `force = true` to `upload`
+//! whenever it observes "download Ok(true) but is_image_complete=false".
+//! That bypasses the dedup check and atomically overwrites the bad object
+//! in a single PUT — robust against `s3:DeleteObject` permission being
+//! revoked or transiently failing (which a `delete + retry-upload`
+//! sequence would not be).
+//!
+//! ## Tar entry security boundary
+//!
+//! `tar::Archive::unpack` (0.4) silently drops entries with `..` path
+//! components but **accepts symlink and hardlink entries**. An attacker
+//! with R2 write access could craft a tar where each expected filename
+//! (`rootfs.ext4`, `snapshot.bin`, etc.) is a symlink to a host path
+//! (e.g. `/etc/passwd`); `is_image_complete` would pass and Firecracker
+//! would consume the linked content.
+//!
+//! Defense currently relies on the trust boundary at R2 IAM credentials.
+//! Hardening (rejecting non-regular-file tar entries) is tracked as a
+//! follow-up — out of scope for this PR.
 //!
 //! ## Security boundary: tar path traversal
 //!
@@ -220,22 +236,6 @@ impl R2ImageCache {
         Ok(Some(Self { client, bucket }))
     }
 
-    /// Delete `runner-images/{hash}.tar.zst`. Used to evict objects detected
-    /// as corrupt (download succeeded but `is_image_complete` failed) so the
-    /// next `upload` doesn't dedup-skip and leave the corruption in place.
-    /// `DeleteObject` on a missing key is a no-op success — safe under
-    /// concurrent fleet eviction of the same key.
-    pub async fn delete(&self, hash: &str) -> Result<(), R2Error> {
-        let key = key_for_hash(hash);
-        self.client
-            .delete_object()
-            .bucket(&self.bucket)
-            .key(&key)
-            .send()
-            .await?;
-        Ok(())
-    }
-
     /// Returns `Ok(true)` if `runner-images/{hash}.tar.zst` exists.
     pub async fn exists(&self, hash: &str) -> Result<bool, R2Error> {
         let key = key_for_hash(hash);
@@ -305,14 +305,25 @@ impl R2ImageCache {
     }
 
     /// Pack `files` into `tar.zst` and stream-upload to `runner-images/{hash}.tar.zst`.
-    /// Skips the upload if the object already exists (head_object dedup).
     /// No temp file: a tokio duplex pipe couples the synchronous tar+zstd
     /// producer (running on a blocking thread) to the async multipart consumer.
     ///
+    /// **`force = false`** (the common case): skip the upload if the object
+    /// already exists (head_object dedup) — saves bandwidth when peers have
+    /// already uploaded the same hash.
+    ///
+    /// **`force = true`**: skip the dedup check and always upload, atomically
+    /// replacing whatever is currently at the key. Used by `cmd::build` after
+    /// detecting a corrupt prior upload (download succeeded but
+    /// `is_image_complete` failed). Going through `delete + dedup-upload`
+    /// would deadlock the fleet's cache if `DeleteObject` permission is
+    /// missing or transiently failing — `force` is a single-round-trip atomic
+    /// overwrite that doesn't depend on `s3:DeleteObject`.
+    ///
     /// Network hangs are bounded by the AWS SDK's own per-operation timeouts;
     /// outer call sites (CI/systemd) bound total wall time.
-    pub async fn upload(&self, hash: &str, files: &[PathBuf]) -> Result<(), R2Error> {
-        if self.exists(hash).await? {
+    pub async fn upload(&self, hash: &str, files: &[PathBuf], force: bool) -> Result<(), R2Error> {
+        if !force && self.exists(hash).await? {
             tracing::info!("R2 already has {hash}, skipping upload");
             return Ok(());
         }

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -1,0 +1,1056 @@
+//! R2 cache for unified `runner build` image artifacts.
+//!
+//! Single-key bundle per image hash: `runner-images/{hash}.tar.zst` in the
+//! existing `R2_USER_STORAGES_BUCKET_NAME` bucket. The 4 files from
+//! `ImagePaths::expected_files()` are packed dense (no sparse-tar handling);
+//! `cow.img` sparseness is restored on unpack via best-effort
+//! `fallocate(FALLOC_FL_PUNCH_HOLE)`.
+//!
+//! ## Lifecycle
+//!
+//! 1. `runner build` computes hash and checks local cache (existing logic).
+//! 2. On miss, after acquiring `image_lock(hash)`, it tries `try_download`.
+//! 3. On download miss, it does the local rootfs+snapshot build (existing logic).
+//! 4. After `is_image_complete()` succeeds, it calls `upload`.
+//!
+//! Atomicity guarantees:
+//! - Multipart upload is atomic from consumer POV (object only appears after
+//!   `CompleteMultipartUpload`); abandoned segments are auto-cleaned by R2's
+//!   default 7-day lifecycle.
+//! - Download unpacks into a `{hash}.tmp/` staging directory then `rename`s
+//!   to `{hash}/` — partial unpack from a crash never produces a false-positive
+//!   `is_image_complete()` hit.
+//!
+//! Configuration semantics: `from_env` returns `Ok(None)` only when **all four**
+//! `R2_*` env vars are unset or empty (dev/test path). Setting 1-3 of 4 is a
+//! fatal `PartialConfig` error — almost certainly a typo'd secret rotation, and
+//! silently disabling cache fleet-wide is worse than failing the deploy.
+//!
+//! Streaming: both upload and download avoid temp files entirely. Upload uses a
+//! `tokio::io::duplex` pipe to couple the sync tar+zstd producer (on a blocking
+//! thread) to the async multipart consumer. Download uses `SyncIoBridge` to
+//! adapt the async S3 body into a sync `Read` for the blocking unpack thread.
+//! Memory peak per upload ≈ `(2 + CONCURRENCY + 1) × PART_SIZE` — duplex buffer,
+//! in-flight upload chunks, and the part being read — bounded regardless of
+//! image size. Currently ~112 MiB with `PART_SIZE` = 16 MiB and `CONCURRENCY` = 4.
+//!
+//! Image size limit: `PART_SIZE * 10000 ≈ 160 GiB` (S3 multipart hard limit).
+//! Current images are well under 30 GiB; revisit if `PART_SIZE` decreases.
+
+use std::path::{Path, PathBuf};
+
+use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region, SharedCredentialsProvider};
+use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::operation::head_object::HeadObjectError;
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+use tokio::io::AsyncReadExt;
+
+const KEY_PREFIX: &str = "runner-images/";
+const ZSTD_LEVEL: i32 = 3;
+
+/// Multipart part size. R2 minimum is 5 MiB (except last part); 16 MiB
+/// keeps part count reasonable for large images and fits comfortably in memory.
+const PART_SIZE: usize = 16 * 1024 * 1024;
+
+/// All four R2 env vars must be set together. Missing all four → cache disabled
+/// (dev path); missing 1-3 → fatal misconfiguration.
+const ENV_VARS: [&str; 4] = [
+    "R2_ACCOUNT_ID",
+    "R2_ACCESS_KEY_ID",
+    "R2_SECRET_ACCESS_KEY",
+    "R2_USER_STORAGES_BUCKET_NAME",
+];
+
+#[derive(Debug, thiserror::Error)]
+pub enum R2Error {
+    #[error("R2 partially configured ({}/4 set), missing: {}", present.len(), missing.join(", "))]
+    PartialConfig {
+        present: Vec<String>,
+        missing: Vec<String>,
+    },
+    #[error("s3: {0}")]
+    S3(String),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl<E, R> From<SdkError<E, R>> for R2Error
+where
+    E: std::fmt::Debug,
+    R: std::fmt::Debug,
+{
+    fn from(e: SdkError<E, R>) -> Self {
+        Self::S3(format!("{e:?}"))
+    }
+}
+
+/// Cache handle. Cheap to clone (the underlying SDK client is `Arc`-internal).
+#[derive(Clone)]
+pub struct R2ImageCache {
+    client: aws_sdk_s3::Client,
+    bucket: String,
+}
+
+impl std::fmt::Debug for R2ImageCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("R2ImageCache")
+            .field("bucket", &self.bucket)
+            .finish_non_exhaustive()
+    }
+}
+
+impl R2ImageCache {
+    /// Returns `Ok(None)` if all four env vars are unset or empty — build proceeds without R2.
+    /// Returns `Ok(Some(_))` if all four are set to non-empty values.
+    /// Returns `Err(PartialConfig { .. })` if 1-3 are set — likely a typo'd
+    /// secret rotation; surface loudly rather than silently disable.
+    ///
+    /// Empty strings count as unset: callers (Ansible, GH Actions) often
+    /// substitute `""` for missing secrets, and `""` is never a valid R2
+    /// credential — treating it as unset is more robust than failing later.
+    pub async fn from_env() -> Result<Option<Self>, R2Error> {
+        let present: Vec<String> = ENV_VARS
+            .iter()
+            .filter(|v| std::env::var(v).map(|s| !s.is_empty()).unwrap_or(false))
+            .map(|s| s.to_string())
+            .collect();
+
+        match present.len() {
+            0 => return Ok(None),
+            4 => {}
+            _ => {
+                let missing: Vec<String> = ENV_VARS
+                    .iter()
+                    .filter(|v| !present.iter().any(|p| p == *v))
+                    .map(|s| s.to_string())
+                    .collect();
+                return Err(R2Error::PartialConfig { present, missing });
+            }
+        }
+
+        // safe: all four guaranteed present (and non-empty) by the match above
+        let account_id = std::env::var("R2_ACCOUNT_ID").map_err(io_other)?;
+        let access_key = std::env::var("R2_ACCESS_KEY_ID").map_err(io_other)?;
+        let secret_key = std::env::var("R2_SECRET_ACCESS_KEY").map_err(io_other)?;
+        let bucket = std::env::var("R2_USER_STORAGES_BUCKET_NAME").map_err(io_other)?;
+
+        let endpoint = format!("https://{account_id}.r2.cloudflarestorage.com");
+        let creds = Credentials::new(access_key, secret_key, None, None, "r2-env");
+        // Build the S3 config directly without going through `aws_config::defaults()`
+        // — that's the entry point for the credential / region / endpoint discovery
+        // chain, which can hit IMDS on EC2-like hosts and waste seconds on metal.
+        // We have all four values explicitly, so skip the chain entirely.
+        let config = aws_sdk_s3::Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new("auto"))
+            .endpoint_url(endpoint)
+            .credentials_provider(SharedCredentialsProvider::new(creds))
+            .build();
+        let client = aws_sdk_s3::Client::from_conf(config);
+
+        Ok(Some(Self { client, bucket }))
+    }
+
+    /// Returns `Ok(true)` if `runner-images/{hash}.tar.zst` exists.
+    pub async fn exists(&self, hash: &str) -> Result<bool, R2Error> {
+        let key = key_for_hash(hash);
+        match self
+            .client
+            .head_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(SdkError::ServiceError(e)) if matches!(e.err(), HeadObjectError::NotFound(_)) => {
+                Ok(false)
+            }
+            Err(e) => Err(R2Error::S3(format!("head_object: {e:?}"))),
+        }
+    }
+
+    /// Try to download `runner-images/{hash}.tar.zst`, streaming directly
+    /// through zstd decode + tar unpack into a sibling staging directory,
+    /// then best-effort sparse-restore `cow.img`, then atomic rename to
+    /// `final_dir`. No temp file — bounded memory regardless of image size.
+    ///
+    /// Network hangs are bounded by the AWS SDK's own per-operation timeouts;
+    /// outer call sites (CI/systemd) bound total wall time.
+    pub async fn try_download(&self, hash: &str, final_dir: &Path) -> Result<bool, R2Error> {
+        let key = key_for_hash(hash);
+        let resp = match self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(SdkError::ServiceError(e))
+                if matches!(
+                    e.err(),
+                    aws_sdk_s3::operation::get_object::GetObjectError::NoSuchKey(_)
+                ) =>
+            {
+                return Ok(false);
+            }
+            Err(e) => return Err(R2Error::S3(format!("get_object: {e:?}"))),
+        };
+
+        // Atomic via staging dir + rename. Cleanup-on-error covers the entire
+        // staging lifecycle — a partial unpack can leave many GB on disk even
+        // though `final_dir` is never created. Without cleanup, a failed download
+        // followed by a local build could fill the disk before GC catches up.
+        let staging = staging_dir(final_dir);
+        let body_reader = resp.body.into_async_read();
+        let outcome = async {
+            let _ = tokio::fs::remove_dir_all(&staging).await;
+            tokio::fs::create_dir_all(&staging).await?;
+            unpack_into_staging(body_reader, &staging).await?;
+            finalize_staging(&staging, final_dir).await
+        }
+        .await;
+        if outcome.is_err() {
+            let _ = tokio::fs::remove_dir_all(&staging).await;
+        }
+        outcome?;
+        Ok(true)
+    }
+
+    /// Pack `files` into `tar.zst` and stream-upload to `runner-images/{hash}.tar.zst`.
+    /// Skips the upload if the object already exists (head_object dedup).
+    /// No temp file: a tokio duplex pipe couples the synchronous tar+zstd
+    /// producer (running on a blocking thread) to the async multipart consumer.
+    ///
+    /// Network hangs are bounded by the AWS SDK's own per-operation timeouts;
+    /// outer call sites (CI/systemd) bound total wall time.
+    pub async fn upload(&self, hash: &str, files: &[PathBuf]) -> Result<(), R2Error> {
+        if self.exists(hash).await? {
+            tracing::info!("R2 already has {hash}, skipping upload");
+            return Ok(());
+        }
+
+        let key = key_for_hash(hash);
+        let create = self
+            .client
+            .create_multipart_upload()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await?;
+        let upload_id = create
+            .upload_id()
+            .ok_or_else(|| R2Error::S3("create_multipart_upload: no upload_id".into()))?
+            .to_string();
+
+        // Run the full pack→stream→complete pipeline, then abort if anything
+        // failed (including Complete itself — server-side validation errors
+        // can fail Complete after all parts uploaded successfully).
+        let result = self.do_multipart_upload(&key, &upload_id, files).await;
+        if result.is_err() {
+            // Best-effort abort; R2's 7-day default lifecycle catches misses.
+            let _ = self
+                .client
+                .abort_multipart_upload()
+                .bucket(&self.bucket)
+                .key(&key)
+                .upload_id(&upload_id)
+                .send()
+                .await;
+        }
+        result
+    }
+
+    async fn do_multipart_upload(
+        &self,
+        key: &str,
+        upload_id: &str,
+        files: &[PathBuf],
+    ) -> Result<(), R2Error> {
+        let parts = self.stream_upload(key, upload_id, files).await?;
+        self.client
+            .complete_multipart_upload()
+            .bucket(&self.bucket)
+            .key(key)
+            .upload_id(upload_id)
+            .multipart_upload(
+                CompletedMultipartUpload::builder()
+                    .set_parts(Some(parts))
+                    .build(),
+            )
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    /// Stream-pack `files` and upload as multipart parts. Returns the completed
+    /// parts list ready for `CompleteMultipartUpload`. Failure of either the
+    /// producer (pack) or the consumer (upload) propagates as `Err`; the caller
+    /// is responsible for aborting the multipart upload in that case.
+    async fn stream_upload(
+        &self,
+        key: &str,
+        upload_id: &str,
+        files: &[PathBuf],
+    ) -> Result<Vec<CompletedPart>, R2Error> {
+        // Duplex buffer ≈ 2× PART_SIZE so the producer can stay one part ahead
+        // of the consumer without backpressure stalls.
+        let (writer, reader) = tokio::io::duplex(PART_SIZE * 2);
+        let files_owned: Vec<PathBuf> = files.to_vec();
+
+        // Producer: pack tar.zst into the duplex writer end, then drop everything
+        // (which closes the writer, signalling EOF to the consumer).
+        let pack_handle = tokio::task::spawn_blocking(move || -> Result<(), R2Error> {
+            let sync_writer = tokio_util::io::SyncIoBridge::new(writer);
+            pack_to_writer(sync_writer, &files_owned)
+        });
+
+        // Consumer: stream PART_SIZE chunks to S3 multipart with bounded
+        // concurrency. If this errors, dropping `reader` closes the duplex pipe
+        // and the producer will get a BrokenPipe write error.
+        let parts_result = self.upload_parts_streaming(key, upload_id, reader).await;
+
+        // Always wait for the producer to drain. A producer error matters even
+        // if the consumer "succeeded" — it means parts contain truncated data.
+        let pack_result = pack_handle.await.map_err(|e| R2Error::Io(io_other(e)))?;
+
+        // Error precedence: consumer error wins (it's the original cause; pack's
+        // BrokenPipe is downstream noise). If consumer succeeded but pack errored,
+        // surface the pack error so the caller skips Complete.
+        match (parts_result, pack_result) {
+            (Err(consumer_err), _) => Err(consumer_err),
+            (Ok(_), Err(pack_err)) => Err(pack_err),
+            (Ok(parts), Ok(())) => Ok(parts),
+        }
+    }
+
+    async fn upload_parts_streaming(
+        &self,
+        key: &str,
+        upload_id: &str,
+        mut reader: tokio::io::DuplexStream,
+    ) -> Result<Vec<CompletedPart>, R2Error> {
+        // Bounded concurrency: 4 in-flight parts gives ~75% reduction in wall
+        // time vs serial without saturating the bucket's per-prefix throughput.
+        const CONCURRENCY: usize = 4;
+
+        let mut tasks: tokio::task::JoinSet<Result<(i32, CompletedPart), R2Error>> =
+            tokio::task::JoinSet::new();
+        let mut parts: Vec<(i32, CompletedPart)> = Vec::new();
+        let mut part_number: i32 = 1;
+        let mut eof = false;
+
+        while !eof || !tasks.is_empty() {
+            // Refill the in-flight window by reading and spawning more parts.
+            while !eof && tasks.len() < CONCURRENCY {
+                let mut buf = vec![0u8; PART_SIZE];
+                let n = read_full(&mut reader, &mut buf).await?;
+                if n == 0 {
+                    eof = true;
+                    break;
+                }
+                buf.truncate(n);
+                // Vec → Bytes is zero-copy (transfers ownership). Avoids the
+                // ~16 MiB memcpy per part that `to_vec()` would do.
+                let chunk = bytes::Bytes::from(buf);
+                let pn = part_number;
+                let client = self.client.clone();
+                let bucket = self.bucket.clone();
+                let key_owned = key.to_string();
+                let upload_id_owned = upload_id.to_string();
+                tasks.spawn(async move {
+                    let resp = client
+                        .upload_part()
+                        .bucket(&bucket)
+                        .key(&key_owned)
+                        .upload_id(&upload_id_owned)
+                        .part_number(pn)
+                        .body(ByteStream::from(chunk))
+                        .send()
+                        .await?;
+                    // S3 / R2 always return ETag for a successful upload_part.
+                    // A missing ETag here would silently produce a CompletedPart
+                    // that fails Complete with "InvalidPart"; surface a clearer
+                    // error pinned to the offending part_number instead.
+                    let e_tag = resp
+                        .e_tag()
+                        .ok_or_else(|| {
+                            R2Error::S3(format!("upload_part {pn}: missing e_tag in response"))
+                        })?
+                        .to_string();
+                    Ok((
+                        pn,
+                        CompletedPart::builder()
+                            .e_tag(e_tag)
+                            .part_number(pn)
+                            .build(),
+                    ))
+                });
+                part_number = part_number
+                    .checked_add(1)
+                    .ok_or_else(|| R2Error::S3("part_number overflow".into()))?;
+                if n < PART_SIZE {
+                    eof = true;
+                    break;
+                }
+            }
+
+            // Drain at least one completion. JoinSet returns None only when
+            // empty, which our outer loop condition prevents.
+            if let Some(joined) = tasks.join_next().await {
+                let (pn, part) = joined.map_err(|e| R2Error::Io(io_other(e)))??;
+                parts.push((pn, part));
+            }
+        }
+
+        // Parts must be in part_number order for CompleteMultipartUpload.
+        parts.sort_by_key(|(pn, _)| *pn);
+        Ok(parts.into_iter().map(|(_, p)| p).collect())
+    }
+}
+
+fn key_for_hash(hash: &str) -> String {
+    format!("{KEY_PREFIX}{hash}.tar.zst")
+}
+
+/// Pack `files` as a tar.zst stream into `writer`. Each file is appended under
+/// its basename only (no path components). Sync — call from spawn_blocking.
+///
+/// zstd encoding is multi-threaded (capped at 4 workers) so encoding stays
+/// ahead of the multipart consumer instead of becoming the new bottleneck
+/// after concurrent uploads.
+fn pack_to_writer<W: std::io::Write>(writer: W, files: &[PathBuf]) -> Result<(), R2Error> {
+    let mut encoder = zstd::stream::write::Encoder::new(writer, ZSTD_LEVEL)?;
+    encoder.multithread(zstd_workers())?;
+    let mut builder = tar::Builder::new(encoder);
+    for path in files {
+        let name = path.file_name().ok_or_else(|| {
+            R2Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("file has no name: {}", path.display()),
+            ))
+        })?;
+        builder.append_path_with_name(path, name)?;
+    }
+    // Explicit finalization order:
+    //   1. tar trailer (two zero blocks)        — `into_inner` calls `finish` first
+    //   2. zstd frame footer                     — `Encoder::finish`
+    // Avoid `auto_finish()` which silently swallows errors during drop.
+    let encoder = builder.into_inner()?;
+    encoder.finish()?;
+    Ok(())
+}
+
+/// Worker count for multi-threaded zstd encoding. Capped at 4 because:
+/// - extra workers add memory (each gets its own input buffer)
+/// - upload-side concurrency is also 4, so going wider gives diminishing returns
+/// - tests run on possibly-small CI runners
+fn zstd_workers() -> u32 {
+    std::thread::available_parallelism()
+        .map(|n| n.get().min(4) as u32)
+        .unwrap_or(2)
+}
+
+/// Unpack a tar.zst stream from `reader` into `dest`. Sync — call from spawn_blocking.
+fn unpack_from_reader<R: std::io::Read>(reader: R, dest: &Path) -> Result<(), R2Error> {
+    let zr = zstd::stream::read::Decoder::new(reader)?;
+    tar::Archive::new(zr).unpack(dest)?;
+    Ok(())
+}
+
+/// Stream a tar.zst body from an async `reader` into `staging` (sync via
+/// `SyncIoBridge` on a blocking thread). Caller is responsible for creating
+/// the staging directory beforehand and for `finalize_staging` afterwards.
+async fn unpack_into_staging<R>(reader: R, staging: &Path) -> Result<(), R2Error>
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    let staging_for_blocking = staging.to_path_buf();
+    tokio::task::spawn_blocking(move || -> Result<(), R2Error> {
+        let sync_reader = tokio_util::io::SyncIoBridge::new(reader);
+        unpack_from_reader(sync_reader, &staging_for_blocking)
+    })
+    .await
+    .map_err(|e| R2Error::Io(io_other(e)))?
+}
+
+/// Finish the unpack: best-effort sparse-restore `cow.img`, then atomic rename
+/// `staging` to `final_dir`. Same-parent rename is atomic on ext4/xfs.
+async fn finalize_staging(staging: &Path, final_dir: &Path) -> Result<(), R2Error> {
+    let cow = staging.join("cow.img");
+    if let Ok(meta) = tokio::fs::metadata(&cow).await {
+        let len = meta.len();
+        if len > 0 {
+            let cow_clone = cow.clone();
+            let result = tokio::task::spawn_blocking(move || punch_hole(&cow_clone, len))
+                .await
+                .map_err(|e| R2Error::Io(io_other(e)))?;
+            if let Err(e) = result {
+                tracing::warn!("punch_hole on cow.img failed: {e}");
+            }
+        }
+    }
+
+    if let Err(e) = tokio::fs::rename(staging, final_dir).await {
+        tracing::warn!(
+            "rename {} -> {}: {e}; retrying after remove",
+            staging.display(),
+            final_dir.display()
+        );
+        let _ = tokio::fs::remove_dir_all(final_dir).await;
+        tokio::fs::rename(staging, final_dir).await?;
+    }
+    Ok(())
+}
+
+/// `images/{hash}` -> `images/{hash}.tmp` (sibling, same parent → atomic rename).
+fn staging_dir(final_dir: &Path) -> PathBuf {
+    let mut name = final_dir
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    name.push(".tmp");
+    final_dir.with_file_name(name)
+}
+
+fn io_other<E: std::fmt::Display>(e: E) -> std::io::Error {
+    std::io::Error::other(e.to_string())
+}
+
+/// Read up to `buf.len()` bytes from `reader`, returning the actual count.
+/// Returns 0 only at true EOF. Generic over any `AsyncRead` so we can use it
+/// for both `tokio::fs::File` and `tokio::io::DuplexStream`.
+async fn read_full<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut R,
+    buf: &mut [u8],
+) -> Result<usize, R2Error> {
+    let mut total = 0;
+    while total < buf.len() {
+        let slice = buf
+            .get_mut(total..)
+            .ok_or_else(|| R2Error::S3("buf overrun".into()))?;
+        let n = reader.read(slice).await?;
+        if n == 0 {
+            break;
+        }
+        total = total
+            .checked_add(n)
+            .ok_or_else(|| R2Error::S3("read overflow".into()))?;
+    }
+    Ok(total)
+}
+
+/// Best-effort `FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE` over the whole file.
+/// Logs and swallows EOPNOTSUPP (tmpfs); returns Err for other failures.
+fn punch_hole(path: &Path, len: u64) -> Result<(), R2Error> {
+    let f = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)?;
+    let len_i64 = i64::try_from(len).map_err(|_| {
+        R2Error::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("file size too large for fallocate: {len}"),
+        ))
+    })?;
+    match nix::fcntl::fallocate(
+        &f,
+        nix::fcntl::FallocateFlags::FALLOC_FL_PUNCH_HOLE
+            | nix::fcntl::FallocateFlags::FALLOC_FL_KEEP_SIZE,
+        0,
+        len_i64,
+    ) {
+        Ok(()) => Ok(()),
+        Err(nix::Error::EOPNOTSUPP) => {
+            tracing::warn!(
+                "filesystem doesn't support FALLOC_FL_PUNCH_HOLE; cow.img will remain dense \
+                 ({len} bytes on disk)"
+            );
+            Ok(())
+        }
+        Err(e) => Err(R2Error::Io(std::io::Error::other(e.to_string()))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_format() {
+        assert_eq!(key_for_hash("abc123"), "runner-images/abc123.tar.zst");
+    }
+
+    #[test]
+    fn staging_dir_is_sibling() {
+        let final_dir = Path::new("/var/lib/vm0-runner/images/abc123");
+        let staging = staging_dir(final_dir);
+        assert_eq!(
+            staging,
+            PathBuf::from("/var/lib/vm0-runner/images/abc123.tmp")
+        );
+        // Same parent — required for atomic rename.
+        assert_eq!(staging.parent(), final_dir.parent());
+    }
+
+    /// `from_env` requires all-or-nothing on the four env vars.
+    /// Tests use a single var with each scenario via temporary process env;
+    /// they share the global env so must run with --test-threads=1.
+    #[tokio::test]
+    async fn from_env_returns_none_when_all_missing() {
+        with_clean_r2_env(|| async {
+            let result = R2ImageCache::from_env().await.unwrap();
+            assert!(result.is_none(), "all four missing → None");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn from_env_returns_some_when_all_present() {
+        with_clean_r2_env(|| async {
+            // SAFETY: tests are serialized via --test-threads=1.
+            unsafe {
+                std::env::set_var("R2_ACCOUNT_ID", "test-account");
+                std::env::set_var("R2_ACCESS_KEY_ID", "test-key");
+                std::env::set_var("R2_SECRET_ACCESS_KEY", "test-secret");
+                std::env::set_var("R2_USER_STORAGES_BUCKET_NAME", "test-bucket");
+            }
+            let result = R2ImageCache::from_env().await.unwrap();
+            assert!(result.is_some(), "all four set → Some");
+            assert_eq!(result.unwrap().bucket, "test-bucket");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn from_env_treats_empty_string_as_unset() {
+        // Callers often substitute "" for missing secrets (e.g.
+        // `${R2_ACCOUNT_ID:-}` in shell, `lookup('env', ...)` in Ansible).
+        // Empty strings are never valid R2 credentials — treat as unset.
+        with_clean_r2_env(|| async {
+            unsafe {
+                for v in &ENV_VARS {
+                    std::env::set_var(v, "");
+                }
+            }
+            let result = R2ImageCache::from_env().await.unwrap();
+            assert!(result.is_none(), "all four empty → None, not Some");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn from_env_errors_on_partial_config() {
+        // Set 2 of 4 — should return PartialConfig with the right partition.
+        with_clean_r2_env(|| async {
+            unsafe {
+                std::env::set_var("R2_ACCOUNT_ID", "test");
+                std::env::set_var("R2_USER_STORAGES_BUCKET_NAME", "test");
+            }
+            let err = R2ImageCache::from_env().await.unwrap_err();
+            match err {
+                R2Error::PartialConfig { present, missing } => {
+                    assert_eq!(present.len(), 2);
+                    assert_eq!(missing.len(), 2);
+                    assert!(present.contains(&"R2_ACCOUNT_ID".to_string()));
+                    assert!(present.contains(&"R2_USER_STORAGES_BUCKET_NAME".to_string()));
+                    assert!(missing.contains(&"R2_ACCESS_KEY_ID".to_string()));
+                    assert!(missing.contains(&"R2_SECRET_ACCESS_KEY".to_string()));
+                }
+                e => panic!("expected PartialConfig, got {e:?}"),
+            }
+        })
+        .await;
+    }
+
+    /// Helper: snapshot and clear all R2 env vars before running, restore after.
+    /// Panic-safe: the closure runs in a `tokio::spawn` task so a panic doesn't
+    /// skip the restore. SAFETY of `set_var` / `remove_var`: callers must run
+    /// with `--test-threads=1` to avoid concurrent env mutation.
+    async fn with_clean_r2_env<F, Fut>(f: F)
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let saved: Vec<(&str, Option<String>)> = ENV_VARS
+            .iter()
+            .map(|v| (*v, std::env::var(v).ok()))
+            .collect();
+        unsafe {
+            for v in &ENV_VARS {
+                std::env::remove_var(v);
+            }
+        }
+        let join = tokio::spawn(f()).await;
+        unsafe {
+            for (k, v) in saved {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+        // Now propagate any panic from the test body so the test fails properly.
+        join.unwrap();
+    }
+
+    // ---- pack / unpack round-trip --------------------------------------
+
+    /// Write the four canonical image files into `dir` with the same byte
+    /// content for both packing and verification. cow.img is sparse (16 MiB
+    /// logical, only first 1 MiB written).
+    async fn write_mock_image_files(dir: &Path) -> Vec<PathBuf> {
+        let rootfs = dir.join("rootfs.ext4");
+        let snapshot = dir.join("snapshot.bin");
+        let memory = dir.join("memory.bin");
+        let cow = dir.join("cow.img");
+
+        // Distinct content per file so cross-contamination shows up as a diff.
+        tokio::fs::write(&rootfs, b"rootfs-content".repeat(1024))
+            .await
+            .unwrap();
+        tokio::fs::write(&snapshot, b"snapshot-bin").await.unwrap();
+        tokio::fs::write(&memory, vec![0u8; 4 * 1024 * 1024])
+            .await
+            .unwrap();
+
+        // Sparse cow.img: 16 MiB logical, 1 MiB at the front.
+        let cow_file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&cow)
+            .unwrap();
+        cow_file.set_len(16 * 1024 * 1024).unwrap();
+        drop(cow_file);
+        tokio::fs::write(&cow, vec![0xAB; 1024 * 1024])
+            .await
+            .unwrap();
+        // Re-truncate to logical size after writing data — write() truncates.
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&cow)
+            .unwrap()
+            .set_len(16 * 1024 * 1024)
+            .unwrap();
+
+        vec![rootfs, snapshot, memory, cow]
+    }
+
+    /// Helper: full atomic unpack from an on-disk archive (test-only path).
+    /// Mirrors what `try_download` does after the S3 GET succeeds: open file,
+    /// stream into staging, finalize. Lets the round-trip tests exercise the
+    /// same code as production without an S3 mock.
+    async fn unpack_archive_for_test(archive: &Path, final_dir: &Path) -> Result<(), R2Error> {
+        let staging = staging_dir(final_dir);
+        let _ = tokio::fs::remove_dir_all(&staging).await;
+        tokio::fs::create_dir_all(&staging).await?;
+        let f = tokio::fs::File::open(archive).await?;
+        unpack_into_staging(f, &staging).await?;
+        finalize_staging(&staging, final_dir).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pack_then_unpack_round_trips_4_files() {
+        let src_dir = tempfile::tempdir().unwrap();
+        let dst_root = tempfile::tempdir().unwrap();
+        let final_dir = dst_root.path().join("hash-abc");
+
+        let src_files = write_mock_image_files(src_dir.path()).await;
+
+        let archive = tempfile::NamedTempFile::new().unwrap();
+        let archive_path = archive.path().to_path_buf();
+        let files_for_pack = src_files.clone();
+        tokio::task::spawn_blocking(move || {
+            let f = std::fs::File::create(&archive_path).unwrap();
+            pack_to_writer(f, &files_for_pack)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        unpack_archive_for_test(archive.path(), &final_dir)
+            .await
+            .unwrap();
+
+        // All 4 file names exist and round-trip the prefix bytes.
+        for name in ["rootfs.ext4", "snapshot.bin", "memory.bin", "cow.img"] {
+            let dst = final_dir.join(name);
+            let src = src_dir.path().join(name);
+            assert!(dst.exists(), "{name} should exist after unpack");
+            let dst_meta = std::fs::metadata(&dst).unwrap();
+            let src_meta = std::fs::metadata(&src).unwrap();
+            assert_eq!(
+                dst_meta.len(),
+                src_meta.len(),
+                "{name} logical size mismatch"
+            );
+        }
+
+        // Staging directory should no longer exist after the rename.
+        assert!(!staging_dir(&final_dir).exists());
+    }
+
+    #[tokio::test]
+    async fn unpack_atomic_no_partial_final_dir_on_failure() {
+        // A truncated tar.zst (random bytes that aren't a valid zstd stream)
+        // should fail mid-unpack and leave final_dir absent.
+        let dst_root = tempfile::tempdir().unwrap();
+        let final_dir = dst_root.path().join("hash-bad");
+
+        let bad_archive = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(bad_archive.path(), b"not a valid zstd stream").unwrap();
+
+        let result = unpack_archive_for_test(bad_archive.path(), &final_dir).await;
+        assert!(result.is_err(), "unpack of garbage should fail");
+        assert!(
+            !final_dir.exists(),
+            "final_dir must NOT exist after a failed unpack — \
+             this is what prevents false-positive cache hits"
+        );
+    }
+
+    #[tokio::test]
+    async fn pack_uses_basename_only() {
+        // Files passed to pack_to_writer may have arbitrary parent paths;
+        // they should be stored under their basename in the tar so unpack
+        // produces a flat directory.
+        let src_dir = tempfile::tempdir().unwrap();
+        let nested = src_dir.path().join("deeply/nested/path");
+        tokio::fs::create_dir_all(&nested).await.unwrap();
+        let nested_file = nested.join("rootfs.ext4");
+        tokio::fs::write(&nested_file, b"hello").await.unwrap();
+
+        let archive = tempfile::NamedTempFile::new().unwrap();
+        let archive_path = archive.path().to_path_buf();
+        let files = vec![nested_file];
+        tokio::task::spawn_blocking(move || {
+            let f = std::fs::File::create(&archive_path).unwrap();
+            pack_to_writer(f, &files)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        let dst_root = tempfile::tempdir().unwrap();
+        let final_dir = dst_root.path().join("out");
+        unpack_archive_for_test(archive.path(), &final_dir)
+            .await
+            .unwrap();
+
+        assert!(final_dir.join("rootfs.ext4").exists());
+        // No nested directory in the unpacked output.
+        assert!(!final_dir.join("deeply").exists());
+    }
+
+    #[tokio::test]
+    async fn from_env_errors_on_partial_with_some_empty_strings() {
+        // Real-world misconfiguration: 2 secrets typo'd to empty, 2 set.
+        // Empty counts as unset (per from_env_treats_empty_string_as_unset),
+        // so this should be PartialConfig with present=2, missing=2 — NOT
+        // silently disabled (which would happen if all four were empty).
+        with_clean_r2_env(|| async {
+            unsafe {
+                std::env::set_var("R2_ACCOUNT_ID", "real-value");
+                std::env::set_var("R2_ACCESS_KEY_ID", ""); // typo'd to empty
+                std::env::set_var("R2_SECRET_ACCESS_KEY", ""); // typo'd to empty
+                std::env::set_var("R2_USER_STORAGES_BUCKET_NAME", "real-value");
+            }
+            let err = R2ImageCache::from_env().await.unwrap_err();
+            match err {
+                R2Error::PartialConfig { present, missing } => {
+                    assert_eq!(present.len(), 2, "two non-empty present");
+                    assert_eq!(missing.len(), 2, "two empty treated as missing");
+                    assert!(missing.contains(&"R2_ACCESS_KEY_ID".to_string()));
+                    assert!(missing.contains(&"R2_SECRET_ACCESS_KEY".to_string()));
+                }
+                e => panic!("expected PartialConfig, got {e:?}"),
+            }
+        })
+        .await;
+    }
+
+    // ---- defensive / security edge cases --------------------------------
+
+    /// Helper: pack a synchronous closure on a blocking thread.
+    async fn pack_blocking<F>(archive: &Path, f: F) -> Result<(), R2Error>
+    where
+        F: FnOnce(std::fs::File) -> Result<(), R2Error> + Send + 'static,
+    {
+        let p = archive.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            let out = std::fs::File::create(&p).unwrap();
+            f(out)
+        })
+        .await
+        .unwrap()
+    }
+
+    /// Hand-write a 512-byte ustar header so we can put `..` in the path —
+    /// `tar::Builder` defends against this on the write side too.
+    fn craft_tar_with_path(name: &[u8], data: &[u8]) -> Vec<u8> {
+        assert!(name.len() < 100);
+        let mut header = [0u8; 512];
+        header[..name.len()].copy_from_slice(name);
+        header[100..108].copy_from_slice(b"0000644\0");
+        header[108..116].copy_from_slice(b"0000000\0");
+        header[116..124].copy_from_slice(b"0000000\0");
+        let size_str = format!("{:011o}\0", data.len());
+        header[124..136].copy_from_slice(size_str.as_bytes());
+        header[136..148].copy_from_slice(b"00000000000\0");
+        // cksum is computed with these 8 bytes counted as spaces.
+        header[148..156].copy_from_slice(b"        ");
+        header[156] = b'0'; // typeflag: regular file
+        header[257..263].copy_from_slice(b"ustar\0");
+        header[263..265].copy_from_slice(b"00");
+        let cksum: u32 = header.iter().map(|&b| u32::from(b)).sum();
+        let cksum_str = format!("{cksum:06o}\0 ");
+        header[148..156].copy_from_slice(cksum_str.as_bytes());
+
+        let mut tar = Vec::with_capacity(512 + 512 + 1024);
+        tar.extend_from_slice(&header);
+        let mut data_block = [0u8; 512];
+        data_block[..data.len()].copy_from_slice(data);
+        tar.extend_from_slice(&data_block);
+        // Two zero blocks mark end-of-archive.
+        tar.extend_from_slice(&[0u8; 1024]);
+        tar
+    }
+
+    /// `tar::Archive::unpack` must reject entries whose path escapes via `..` so
+    /// attacker-controlled artifacts can't write outside the staging directory
+    /// (defense-in-depth — R2 bucket is private, but if an IAM key leaked, this
+    /// would prevent escalation).
+    #[tokio::test]
+    async fn unpack_rejects_path_traversal() {
+        let raw_tar = craft_tar_with_path(b"../escaped.txt", b"hello");
+        let archive = tempfile::NamedTempFile::new().unwrap();
+        let archive_path = archive.path().to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            let out = std::fs::File::create(&archive_path).unwrap();
+            let mut zw = zstd::stream::write::Encoder::new(out, 1).unwrap();
+            std::io::Write::write_all(&mut zw, &raw_tar).unwrap();
+            zw.finish().unwrap();
+        })
+        .await
+        .unwrap();
+
+        let dst_root = tempfile::tempdir().unwrap();
+        let final_dir = dst_root.path().join("hash");
+        // tar 0.4 silently SKIPS entries with `..` components (returns Ok(false)
+        // from Entry::unpack_in) and Archive::unpack happily continues. So the
+        // unpack succeeds with an empty staging dir → finalize_staging renames
+        // it to final_dir which exists but is empty. The security invariant is
+        // not "must error" — it is "must not write outside dst".
+        unpack_archive_for_test(archive.path(), &final_dir)
+            .await
+            .unwrap();
+
+        // Critical: nothing escaped to the parent of staging/final_dir.
+        assert!(
+            !dst_root.path().join("escaped.txt").exists(),
+            "escaped.txt MUST NOT appear at the dst_root level"
+        );
+        // The malicious entry was dropped, so final_dir is empty.
+        let entries: Vec<_> = std::fs::read_dir(&final_dir).unwrap().collect();
+        assert!(
+            entries.is_empty(),
+            "malicious entry should be dropped, final_dir empty, got {entries:?}"
+        );
+    }
+
+    /// `finalize_staging` skips `punch_hole` cleanly when `cow.img` is absent.
+    /// Defends against future producers that ship without cow.img.
+    #[tokio::test]
+    async fn finalize_works_without_cow_img() {
+        let dst_root = tempfile::tempdir().unwrap();
+        let final_dir = dst_root.path().join("hash");
+        let staging = staging_dir(&final_dir);
+        tokio::fs::create_dir_all(&staging).await.unwrap();
+        tokio::fs::write(staging.join("rootfs.ext4"), b"data")
+            .await
+            .unwrap();
+        // Intentionally: no cow.img.
+
+        finalize_staging(&staging, &final_dir).await.unwrap();
+
+        assert!(final_dir.exists());
+        assert!(final_dir.join("rootfs.ext4").exists());
+        assert!(!final_dir.join("cow.img").exists());
+        assert!(!staging.exists(), "staging consumed by rename");
+    }
+
+    /// Defensive retry path: when `final_dir` already exists, `rename` fails
+    /// once, the function removes the destination, and retries.
+    #[tokio::test]
+    async fn finalize_overwrites_existing_final_dir() {
+        let dst_root = tempfile::tempdir().unwrap();
+        let final_dir = dst_root.path().join("hash");
+
+        // Pre-populate `final_dir` with stale content the test will overwrite.
+        tokio::fs::create_dir_all(&final_dir).await.unwrap();
+        tokio::fs::write(final_dir.join("stale.txt"), b"old")
+            .await
+            .unwrap();
+
+        // Build fresh staging.
+        let staging = staging_dir(&final_dir);
+        tokio::fs::create_dir_all(&staging).await.unwrap();
+        tokio::fs::write(staging.join("fresh.txt"), b"new")
+            .await
+            .unwrap();
+
+        finalize_staging(&staging, &final_dir).await.unwrap();
+
+        assert!(final_dir.join("fresh.txt").exists(), "new content arrived");
+        assert!(
+            !final_dir.join("stale.txt").exists(),
+            "old content was wiped before rename"
+        );
+    }
+
+    /// `pack_to_writer` propagates I/O errors from `append_path_with_name` —
+    /// e.g., source file removed between `expected_files()` enumeration and pack.
+    #[tokio::test]
+    async fn pack_errors_on_missing_source_file() {
+        let archive = tempfile::NamedTempFile::new().unwrap();
+        let nonexistent = PathBuf::from("/definitely/does/not/exist/rootfs.ext4");
+        let result = pack_blocking(archive.path(), move |out| {
+            pack_to_writer(out, std::slice::from_ref(&nonexistent))
+        })
+        .await;
+        match result {
+            Err(R2Error::Io(_)) => {} // expected
+            other => panic!("expected R2Error::Io for missing source, got {other:?}"),
+        }
+    }
+
+    /// Empty file list: pack succeeds and produces a valid (empty) tar.zst.
+    /// Round-trip unpack gives an empty `final_dir`. This is degenerate but
+    /// must not panic — it's the canary for `is_image_complete()` invariants
+    /// changing in the future.
+    #[tokio::test]
+    async fn pack_unpack_empty_files_list() {
+        let archive = tempfile::NamedTempFile::new().unwrap();
+        pack_blocking(archive.path(), |out| pack_to_writer(out, &[]))
+            .await
+            .unwrap();
+
+        let dst_root = tempfile::tempdir().unwrap();
+        let final_dir = dst_root.path().join("hash");
+        unpack_archive_for_test(archive.path(), &final_dir)
+            .await
+            .unwrap();
+
+        assert!(final_dir.exists());
+        let entries: Vec<_> = std::fs::read_dir(&final_dir).unwrap().collect();
+        assert!(
+            entries.is_empty(),
+            "empty pack → empty unpack, got {entries:?}"
+        );
+    }
+}

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -296,16 +296,13 @@ impl R2ImageCache {
     /// Delete `runner-images/*` objects older than `max_age`. Returns
     /// `(deleted_count, freed_bytes)`. Idempotent under concurrent fleet
     /// execution: every host runs the same scan and `DeleteObjects` returns
-    /// success for already-absent keys. Each invocation costs ~1 LIST per 1000
-    /// objects + 1 batched DELETE per 1000 stale keys.
+    /// success for already-absent keys (S3 spec). Each invocation costs ~1
+    /// LIST + 1 batched DELETE per page (max 1000 objects/page).
+    ///
+    /// Per-key errors (e.g. AccessDenied — NOT NoSuchKey) are surfaced via
+    /// `tracing::warn!` and excluded from `deleted_count`.
     pub async fn gc_older_than(&self, max_age: std::time::Duration) -> Result<(u64, u64), R2Error> {
-        let now_secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|e| R2Error::Io(io_other(e)))?
-            .as_secs();
-        let cutoff_secs = now_secs.saturating_sub(max_age.as_secs());
-        let cutoff = i64::try_from(cutoff_secs)
-            .map_err(|_| R2Error::Io(io_other("system clock beyond i64 unix-seconds range")))?;
+        let cutoff = cutoff_unix_secs(std::time::SystemTime::now(), max_age)?;
 
         let mut continuation_token: Option<String> = None;
         let mut total_deleted = 0u64;
@@ -349,24 +346,54 @@ impl R2ImageCache {
                     .quiet(true)
                     .build()
                     .map_err(|e| R2Error::S3(format!("Delete build: {e:?}")))?;
-                self.client
+                let del_resp = self
+                    .client
                     .delete_objects()
                     .bucket(&self.bucket)
                     .delete(delete)
                     .send()
                     .await?;
-                total_deleted = total_deleted.saturating_add(count);
-                total_freed = total_freed.saturating_add(batch_freed);
+                // S3/R2 batch-delete returns per-key errors in `errors`; the
+                // request itself is 200 OK regardless. Quiet mode means
+                // successful deletes are NOT echoed, only failures are. Real
+                // failures here = AccessDenied / quota / etc. — never
+                // NoSuchKey, which the spec treats as success.
+                let err_count = del_resp.errors().len() as u64;
+                if err_count > 0 {
+                    tracing::warn!(
+                        "r2: delete_objects had {err_count} per-key failure(s); first: {:?}",
+                        del_resp.errors().first()
+                    );
+                }
+                let actual_deleted = count.saturating_sub(err_count);
+                total_deleted = total_deleted.saturating_add(actual_deleted);
+                // freed_bytes is best-effort: we don't know which specific
+                // keys failed, so attribute proportionally.
+                if count > 0 {
+                    let proportional = batch_freed
+                        .saturating_mul(actual_deleted)
+                        .checked_div(count)
+                        .unwrap_or(0);
+                    total_freed = total_freed.saturating_add(proportional);
+                }
             }
 
-            if resp.is_truncated().unwrap_or(false) {
-                match resp.next_continuation_token() {
-                    Some(t) => continuation_token = Some(t.to_string()),
-                    None => break, // truncated but no token — defensive exit
-                }
-            } else {
+            if !resp.is_truncated().unwrap_or(false) {
                 break;
             }
+            let next_token = match resp.next_continuation_token() {
+                Some(t) => t.to_string(),
+                None => break, // truncated but no token — defensive exit
+            };
+            // Defensive: detect a server returning the same token twice
+            // (would be an S3 bug, but cheap to guard against).
+            if continuation_token.as_deref() == Some(next_token.as_str()) {
+                tracing::warn!(
+                    "r2: list_objects_v2 returned identical continuation_token; aborting paginated scan"
+                );
+                break;
+            }
+            continuation_token = Some(next_token);
         }
         Ok((total_deleted, total_freed))
     }
@@ -521,6 +548,22 @@ impl R2ImageCache {
 
 fn key_for_hash(hash: &str) -> String {
     format!("{KEY_PREFIX}{hash}.tar.zst")
+}
+
+/// Compute the unix-seconds cutoff for "anything older than this is stale".
+/// Returns an i64 to match aws_smithy_types::DateTime::secs(). Saturates to
+/// 0 when `max_age` exceeds `now` (e.g. dev clock at epoch).
+fn cutoff_unix_secs(
+    now: std::time::SystemTime,
+    max_age: std::time::Duration,
+) -> Result<i64, R2Error> {
+    let now_secs = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| R2Error::Io(io_other(e)))?
+        .as_secs();
+    let cutoff_secs = now_secs.saturating_sub(max_age.as_secs());
+    i64::try_from(cutoff_secs)
+        .map_err(|_| R2Error::Io(io_other("system clock beyond i64 unix-seconds range")))
 }
 
 /// Pack `files` as a tar.zst stream into `writer`. Each file is appended under
@@ -688,6 +731,32 @@ mod tests {
     #[test]
     fn key_format() {
         assert_eq!(key_for_hash("abc123"), "runner-images/abc123.tar.zst");
+    }
+
+    // ---- cutoff math (gc_older_than helper) -----------------------------
+
+    #[test]
+    fn cutoff_subtracts_max_age_from_now() {
+        let now = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        let max_age = std::time::Duration::from_secs(1_000);
+        assert_eq!(cutoff_unix_secs(now, max_age).unwrap(), 999_000);
+    }
+
+    #[test]
+    fn cutoff_saturates_to_zero_when_age_exceeds_now() {
+        // Defensive: a dev/test clock near epoch shouldn't underflow.
+        let now = std::time::UNIX_EPOCH + std::time::Duration::from_secs(100);
+        let max_age = std::time::Duration::from_secs(1_000);
+        assert_eq!(cutoff_unix_secs(now, max_age).unwrap(), 0);
+    }
+
+    #[test]
+    fn cutoff_zero_max_age_equals_now() {
+        // `--r2-keep-days 0` is rejected at the CLI layer; this test exists
+        // so a future caller can't silently regress that contract here.
+        let now = std::time::UNIX_EPOCH + std::time::Duration::from_secs(42);
+        let zero = std::time::Duration::from_secs(0);
+        assert_eq!(cutoff_unix_secs(now, zero).unwrap(), 42);
     }
 
     #[test]

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -45,7 +45,7 @@
 //! orphans the previous object.
 //!
 //! Cleanup happens via `gc_older_than`, called from `runner gc` (which the
-//! deploy playbook runs after every release). Default TTL is 30 days. Each
+//! deploy playbook runs after every release). Default TTL is 7 days. Each
 //! host runs the same scan independently — `DeleteObjects` is idempotent for
 //! already-absent keys, so concurrent fleet execution is safe and costs
 //! ~1 LIST + 1 batched DELETE per host per gc cycle.

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -95,31 +95,29 @@
 //! revoked or transiently failing (which a `delete + retry-upload`
 //! sequence would not be).
 //!
-//! ## Tar entry security boundary
+//! ## Tar entry security
 //!
-//! `tar::Archive::unpack` (0.4) silently drops entries with `..` path
-//! components but **accepts symlink and hardlink entries**. An attacker
-//! with R2 write access could craft a tar where each expected filename
-//! (`rootfs.ext4`, `snapshot.bin`, etc.) is a symlink to a host path
-//! (e.g. `/etc/passwd`); `is_image_complete` would pass and Firecracker
-//! would consume the linked content.
+//! `tar::Archive::unpack` (0.4) has two relevant behaviors when consuming an
+//! attacker-influenced archive:
 //!
-//! Defense currently relies on the trust boundary at R2 IAM credentials.
-//! Hardening (rejecting non-regular-file tar entries) is tracked as a
-//! follow-up — out of scope for this PR.
+//! 1. **Path traversal (`..` components) is silently dropped**. Verified by
+//!    `unpack_rejects_path_traversal`. The malicious entry is skipped; the
+//!    staging dir ends up missing one or more expected files;
+//!    `is_image_complete()` (in `cmd::build`) rejects the partial result; the
+//!    caller falls back to local build. Safe.
 //!
-//! ## Security boundary: tar path traversal
+//! 2. **Symlink and hardlink entries are accepted**. An attacker with R2
+//!    write access could craft a tar where each expected filename is a
+//!    symlink to a host path (e.g. `rootfs.ext4 -> /etc/shadow`);
+//!    `is_image_complete` would pass and Firecracker would consume the
+//!    linked content. Currently relies on the R2 IAM trust boundary;
+//!    defense-in-depth (rejecting non-regular-file entries) is tracked as a
+//!    follow-up — out of scope for this PR.
 //!
-//! `tar` 0.4 silently drops entries with `..` path components from
-//! `Archive::unpack` (verified by `unpack_rejects_path_traversal`). The
-//! defense chain that turns this into a safe failure mode:
-//! 1. unpack drops the malicious entry → staging dir ends up incomplete
-//! 2. `is_image_complete()` (in `cmd::build`) rejects the partial result
-//! 3. caller falls back to a local build
-//!
-//! **If you add a new file to the image, you MUST also extend
-//! `is_image_complete()` — otherwise an attacker-controlled tar that omits
-//! the new file would still pass the completeness check.**
+//! **Maintenance note**: `is_image_complete()` is the structural check that
+//! catches case (1). If you add a new file to the image, you MUST extend
+//! `is_image_complete()` accordingly — otherwise an attacker-controlled tar
+//! that omits the new file would still pass the completeness check.
 
 use std::path::{Path, PathBuf};
 
@@ -387,7 +385,10 @@ impl R2ImageCache {
             let (to_delete, batch_freed) = select_expired_in_page(resp.contents(), cutoff)?;
 
             if !to_delete.is_empty() {
-                let count = to_delete.len() as u64;
+                // S3 bounds list/delete pages at 1000 each, so usize→u64 never
+                // saturates in practice; saturating-cast for style consistency
+                // with the `u64::try_from(obj.size()...)` pattern elsewhere.
+                let count = u64::try_from(to_delete.len()).unwrap_or(u64::MAX);
                 let delete = Delete::builder()
                     .set_objects(Some(to_delete))
                     .quiet(true)
@@ -405,7 +406,7 @@ impl R2ImageCache {
                 // successful deletes are NOT echoed, only failures are. Real
                 // failures here = AccessDenied / quota / etc. — never
                 // NoSuchKey, which the spec treats as success.
-                let err_count = del_resp.errors().len() as u64;
+                let err_count = u64::try_from(del_resp.errors().len()).unwrap_or(u64::MAX);
                 if err_count > 0 {
                     tracing::warn!(
                         "r2: delete_objects had {err_count} per-key failure(s); first: {:?}",
@@ -724,9 +725,11 @@ async fn finalize_staging(staging: &Path, final_dir: &Path) -> Result<(), R2Erro
     }
 
     if let Err(e) = tokio::fs::rename(staging, final_dir).await {
-        tracing::warn!(
-            "rename {} -> {}: {e}; retrying after remove",
-            staging.display(),
+        // Expected recovery path: a previous `runner build` for this hash
+        // crashed after creating final_dir but before is_image_complete
+        // would pass. Wipe the stale directory and retry the rename.
+        tracing::info!(
+            "{} already exists (likely stale from a partial run: {e}); replacing",
             final_dir.display()
         );
         let _ = tokio::fs::remove_dir_all(final_dir).await;

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -37,16 +37,21 @@
 //! Image size limit: `PART_SIZE * 10000 ≈ 160 GiB` (S3 multipart hard limit).
 //! Current images are well under 30 GiB; revisit if `PART_SIZE` decreases.
 //!
-//! ## R2-side cleanup (operator responsibility)
+//! ## R2-side cleanup
 //!
-//! Completed objects (`runner-images/{hash}.tar.zst`) are **never deleted by
-//! this code**. Each `IMAGE_CACHE_VERSION` bump, build-script change, guest
+//! Completed objects (`runner-images/{hash}.tar.zst`) are **never deleted on
+//! upload**. Each `IMAGE_CACHE_VERSION` bump, build-script change, guest
 //! binary rebuild, or firecracker/kernel upgrade produces a new hash and
 //! orphans the previous object.
 //!
-//! Mitigation: configure an R2 bucket lifecycle rule on the `runner-images/`
-//! prefix to delete objects older than ~30 days. R2's default 7-day rule only
-//! cleans abandoned multipart segments, not completed objects.
+//! Cleanup happens via `gc_older_than`, called from `runner gc` (which the
+//! deploy playbook runs after every release). Default TTL is 30 days. Each
+//! host runs the same scan independently — `DeleteObjects` is idempotent for
+//! already-absent keys, so concurrent fleet execution is safe and costs
+//! ~1 LIST + 1 batched DELETE per host per gc cycle.
+//!
+//! R2's default 7-day lifecycle rule only cleans abandoned multipart
+//! segments, **not** completed objects — which is why we need our own scan.
 //!
 //! ## Security boundary: tar path traversal
 //!
@@ -67,7 +72,7 @@ use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region, SharedCredentials
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart, Delete, ObjectIdentifier};
 use tokio::io::AsyncReadExt;
 
 const KEY_PREFIX: &str = "runner-images/";
@@ -286,6 +291,84 @@ impl R2ImageCache {
                 .await;
         }
         result
+    }
+
+    /// Delete `runner-images/*` objects older than `max_age`. Returns
+    /// `(deleted_count, freed_bytes)`. Idempotent under concurrent fleet
+    /// execution: every host runs the same scan and `DeleteObjects` returns
+    /// success for already-absent keys. Each invocation costs ~1 LIST per 1000
+    /// objects + 1 batched DELETE per 1000 stale keys.
+    pub async fn gc_older_than(&self, max_age: std::time::Duration) -> Result<(u64, u64), R2Error> {
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| R2Error::Io(io_other(e)))?
+            .as_secs();
+        let cutoff_secs = now_secs.saturating_sub(max_age.as_secs());
+        let cutoff = i64::try_from(cutoff_secs)
+            .map_err(|_| R2Error::Io(io_other("system clock beyond i64 unix-seconds range")))?;
+
+        let mut continuation_token: Option<String> = None;
+        let mut total_deleted = 0u64;
+        let mut total_freed = 0u64;
+        loop {
+            let mut req = self
+                .client
+                .list_objects_v2()
+                .bucket(&self.bucket)
+                .prefix(KEY_PREFIX);
+            if let Some(token) = continuation_token.as_ref() {
+                req = req.continuation_token(token);
+            }
+            let resp = req.send().await?;
+
+            // Filter expired objects in this page; build an ObjectIdentifier
+            // batch for a single DeleteObjects call (S3/R2 hard limit: 1000).
+            let mut to_delete: Vec<ObjectIdentifier> = Vec::new();
+            let mut batch_freed = 0u64;
+            for obj in resp.contents() {
+                let Some(last_modified) = obj.last_modified() else {
+                    continue;
+                };
+                if last_modified.secs() >= cutoff {
+                    continue;
+                }
+                let Some(key) = obj.key() else { continue };
+                let size = u64::try_from(obj.size().unwrap_or(0).max(0)).unwrap_or(0);
+                let oid = ObjectIdentifier::builder()
+                    .key(key)
+                    .build()
+                    .map_err(|e| R2Error::S3(format!("ObjectIdentifier build: {e:?}")))?;
+                to_delete.push(oid);
+                batch_freed = batch_freed.saturating_add(size);
+            }
+
+            if !to_delete.is_empty() {
+                let count = to_delete.len() as u64;
+                let delete = Delete::builder()
+                    .set_objects(Some(to_delete))
+                    .quiet(true)
+                    .build()
+                    .map_err(|e| R2Error::S3(format!("Delete build: {e:?}")))?;
+                self.client
+                    .delete_objects()
+                    .bucket(&self.bucket)
+                    .delete(delete)
+                    .send()
+                    .await?;
+                total_deleted = total_deleted.saturating_add(count);
+                total_freed = total_freed.saturating_add(batch_freed);
+            }
+
+            if resp.is_truncated().unwrap_or(false) {
+                match resp.next_continuation_token() {
+                    Some(t) => continuation_token = Some(t.to_string()),
+                    None => break, // truncated but no token — defensive exit
+                }
+            } else {
+                break;
+            }
+        }
+        Ok((total_deleted, total_freed))
     }
 
     async fn do_multipart_upload(

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -60,6 +60,25 @@
 //! peers with correct clocks). Mitigation: keep NTP healthy. A clock behind
 //! R2 is the safe direction (under-deletes, no data loss).
 //!
+//! ## Cancellation safety
+//!
+//! All operations in this module are safe to cancel (drop the future) at any
+//! await point — no permanent state is left in an inconsistent way:
+//!
+//! - **Local staging directory**: a hard-killed `try_download` may leave
+//!   `images/{hash}.tmp/` on disk. The next `try_download` removes it as
+//!   the first action, so the leak is bounded to one stale dir per hash
+//!   and self-heals on next attempt.
+//! - **R2 multipart upload session**: a cancelled `upload` after
+//!   `create_multipart_upload` returned but before `Complete` runs leaks
+//!   the `upload_id` server-side (Drop can't `.await` to call
+//!   `abort_multipart_upload`). R2's default 7-day lifecycle cleans
+//!   abandoned segments, capping the wasted storage cost.
+//! - **`spawn_blocking` pack / unpack tasks**: tokio cannot cancel
+//!   blocking tasks. After parent cancellation, the producer/consumer
+//!   thread runs until it hits BrokenPipe or natural EOF — wasted CPU for
+//!   a few seconds, no resource leak.
+//!
 //! ## Corrupt-object eviction
 //!
 //! A structurally-valid archive whose extracted content fails


### PR DESCRIPTION
## Summary

- Adds `R2ImageCache` module wired into `run_build` so unified image artifacts (rootfs.ext4 + snapshot.bin + memory.bin + cow.img) are shared across hosts via the existing `R2_USER_STORAGES_BUCKET_NAME` bucket under the `runner-images/` prefix.
- Streaming end-to-end: `tokio::io::duplex` couples sync tar+zstd (multi-threaded, capped at 4 workers) to a 4-way concurrent multipart upload. Download streams via `SyncIoBridge` into sync zstd+tar unpack on a blocking thread. **No temp files**; bounded memory ~112 MiB regardless of image size.
- **R2-side cleanup**: `runner gc` now also sweeps `runner-images/*` objects older than 7 days (configurable via `--r2-keep-days`). TTL-based, idempotent across the fleet — every host runs the same scan; `DeleteObjects` treats already-absent keys as success.
- Wires R2 secrets through Ansible (release-please.yml) and PR-CI workflows (turbo.yml + crates.yml) using `sudo VAR=val cmd` to bypass `sudo`'s default `env_reset` (verified on `local-1.aws.vm3.ai`).

Closes #9076.

## Pre-merge ops checklist

- [ ] Extend the existing R2 IAM token to allow on `arn:aws:s3:::{bucket}/runner-images/*`:
  - `s3:PutObject`, `s3:GetObject`, `s3:HeadObject` — for upload/download/dedup
  - `s3:DeleteObject` — for `runner gc` cleanup
  - `s3:ListBucket` (with `s3:prefix=runner-images/` condition) — for `runner gc` enumeration
  
  PR can land before the IAM update (cache + GC failures degrade gracefully); cache won't actually populate until granted.

R2's default 7-day lifecycle handles abandoned multipart segments — completed-object cleanup is now handled in-process by `runner gc`.

## Atomicity

- **Multipart upload**: atomic from consumer POV (object only appears after `CompleteMultipartUpload`). Any error path triggers `abort_multipart_upload`; orphaned segments auto-cleaned by the 7-day lifecycle.
- **Download**: unpacks into `images/{hash}.tmp/` then atomic `rename` to `images/{hash}/`. Partial unpack from a crash never produces a false-positive `is_image_complete()` hit.

## Failure modes

| Scenario | Behavior |
|---|---|
| Download error / 404 | Fall back to local build (warn) |
| Upload error / Complete failure | Abort multipart, image is on local disk; warn and continue |
| Missing all four `R2_*` env vars (or all empty) | Cache silently disabled with one info log (dev path) |
| 1-3 of 4 env vars set or non-empty | Fatal error — almost certainly a typo'd secret rotation |
| `cow.img` unpacked dense | Best-effort `fallocate(FALLOC_FL_PUNCH_HOLE)` restores sparseness; EOPNOTSUPP (tmpfs) logged and swallowed |
| Tar with `..` path components | tar 0.4 silently drops them; `is_image_complete()` rejects the resulting partial unpack and falls back to local build (security boundary documented in module docs) |
| `runner gc` against unconfigured/broken R2 | Logged and swallowed — gc never fails the deploy |

## Test plan

- [x] 15 module tests (env-mutating ones serialized via process-wide `tokio::sync::Mutex` so they're safe under parallel test execution):
  - `from_env` × 5: none/all/partial/all-empty/partial-with-empty
  - pack/unpack round-trip with sparse cow.img
  - atomic unpack: garbage tar.zst → final_dir does NOT exist
  - basename-only packing
  - empty file list edge case
  - missing source file → `R2Error::Io` propagation
  - finalize without cow.img
  - finalize overwrites existing final_dir (defensive retry)
  - path-traversal: malicious tar with `../` doesn't escape
- [x] `cargo build / test / clippy / fmt` clean (508 tests pass)
- [x] `sudo` env passthrough verified on `local-1.aws.vm3.ai`
- [ ] **Post-merge staging round-trip**: trigger a release-please staging deploy after the IAM token is updated; verify a `image downloaded from R2: ...` log line on the second host's `runner build` and an `r2: deleted N object(s)` line on a subsequent `runner gc` cycle

## Known limitations

- **Same-deploy N-host duplicate builds**: `head_object` dedups uploads but the build itself isn't serialized across hosts within a single deploy. Acceptable — matches today's baseline. Future work tracked separately.
- **GC dry-run is a no-op for R2**: listing would still cost reads; `--dry-run` logs intent and skips both the LIST and DELETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
