### PR TITLE
feat(voice-chat): change default realtime model to gpt-realtime-mini

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -192,7 +192,7 @@ const internalPrepStartTime$ = state<number | null>(null);
 const internalPrepElapsedMs$ = state(0);
 const internalReconnectAttempt$ = state(0);
 const internalInputMode$ = state<"hands-free" | "push-to-talk">("hands-free");
-const internalModel$ = state<RealtimeModel>("gpt-realtime");
+const internalModel$ = state<RealtimeModel>("gpt-realtime-mini");
 
 const internalParentSignal$ = state<AbortSignal | null>(null);
 const internalWakeLock$ = state<WakeLockSentinel | null>(null);
@@ -1260,7 +1260,7 @@ export const endVoiceChat$ = command(({ get, set }) => {
   set(internalPrepElapsedMs$, 0);
   set(internalReconnectAttempt$, 0);
   set(internalInputMode$, "hands-free");
-  set(internalModel$, "gpt-realtime");
+  set(internalModel$, "gpt-realtime-mini");
   set(internalParentSignal$, null);
   set(internalStatus$, "idle");
 });

--- a/turbo/apps/web/app/api/zero/voice-chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/__tests__/route.test.ts
@@ -158,7 +158,7 @@ describe("POST /api/zero/voice-chat/token", () => {
     expect(capturedModel).toBe("gpt-realtime-mini");
   });
 
-  it("should default to gpt-realtime when no model is provided", async () => {
+  it("should default to gpt-realtime-mini when no model is provided", async () => {
     const userId = uniqueId("zvc-nomodel");
     await setupOrg(userId);
 
@@ -182,10 +182,10 @@ describe("POST /api/zero/voice-chat/token", () => {
     const response = await POST(tokenRequest());
 
     expect(response.status).toBe(200);
-    expect(capturedModel).toBe("gpt-realtime");
+    expect(capturedModel).toBe("gpt-realtime-mini");
   });
 
-  it("should fall back to gpt-realtime for invalid model", async () => {
+  it("should fall back to gpt-realtime-mini for invalid model", async () => {
     const userId = uniqueId("zvc-invalid");
     await setupOrg(userId);
 
@@ -209,6 +209,6 @@ describe("POST /api/zero/voice-chat/token", () => {
     const response = await POST(tokenRequest({ model: "invalid-model" }));
 
     expect(response.status).toBe(200);
-    expect(capturedModel).toBe("gpt-realtime");
+    expect(capturedModel).toBe("gpt-realtime-mini");
   });
 });

--- a/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
@@ -12,7 +12,7 @@ function resolveModel(input?: string): RealtimeModel {
   if (input && ALLOWED_MODELS.includes(input as RealtimeModel)) {
     return input as RealtimeModel;
   }
-  return "gpt-realtime";
+  return "gpt-realtime-mini";
 }
 
 interface EphemeralTokenResponse {


### PR DESCRIPTION
## Summary
- Change default realtime model from `gpt-realtime` to `gpt-realtime-mini` for ~70% cost reduction ($0.09/min vs $0.30/min)
- Users can still manually switch to `gpt-realtime` via the model selector (#9082)
- Updated frontend default state, reset value, backend fallback, and test expectations

Closes #9119

## Test plan
- [x] Existing voice-chat token route tests updated and passing (8/8)
- [x] Lint check passes with no new warnings
- [x] Type check — pre-existing errors only, no new issues introduced
- [x] Knip analysis clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)