### PR TITLE
fix(voice-io): wire abort signals and improve cleanup edge cases

### DIFF
--- a/turbo/apps/platform/src/lib/voice-io/tts-fetch.ts
+++ b/turbo/apps/platform/src/lib/voice-io/tts-fetch.ts
@@ -8,11 +8,13 @@
 export async function fetchTtsAudio(
   fetchFn: (url: string, init?: RequestInit) => Promise<Response>,
   text: string,
+  signal?: AbortSignal,
 ): Promise<Blob | null> {
   const response = await fetchFn("/api/zero/voice-io/tts", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ text: text.slice(0, 4096) }),
+    signal,
   });
 
   if (!response.ok) {

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -3,6 +3,7 @@ import { FeatureSwitchKey } from "@vm0/core";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { fetch$ } from "../fetch.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
+import { stopTts$ } from "./voice-io-tts.ts";
 
 // ── Private state ──
 
@@ -59,11 +60,14 @@ function stopAllTracks(stream: MediaStream | null) {
 // ── Commands ──
 
 export const startRecording$ = command(
-  async ({ get, set }, _signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     // Guard: if already recording or transcribing, return
     if (get(internalRecording$) || get(internalTranscribing$)) {
       return;
     }
+
+    // Stop any ongoing TTS playback to prevent recording AI voice
+    set(stopTts$);
 
     const stream = await navigator.mediaDevices
       .getUserMedia({
@@ -76,6 +80,7 @@ export const startRecording$ = command(
       .catch(() => {
         return null;
       });
+    signal.throwIfAborted();
 
     if (!stream) {
       toast.error("Microphone access denied");
@@ -104,7 +109,7 @@ export const startRecording$ = command(
 );
 
 export const stopAndTranscribe$ = command(
-  async ({ get, set }, _signal: AbortSignal): Promise<string> => {
+  async ({ get, set }, signal: AbortSignal): Promise<string> => {
     if (!get(internalRecording$)) {
       return "";
     }
@@ -156,9 +161,11 @@ export const stopAndTranscribe$ = command(
     const response = await fetchFn("/api/zero/voice-io/stt", {
       method: "POST",
       body: formData,
+      signal,
     }).catch(() => {
       return null;
     });
+    signal.throwIfAborted();
 
     if (!response || !response.ok) {
       const errorBody = response

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
@@ -13,6 +13,7 @@ const L = logger("VoiceIO:TTS");
 const internalPlayingMessageId$ = state<string | null>(null);
 const internalAudioElement$ = state<HTMLAudioElement | null>(null);
 const internalBlobUrl$ = state<string | null>(null);
+const internalCleanupFn$ = state<(() => void) | null>(null);
 
 // Auto-read tracking
 const internalSeenLoading$ = state<Set<string>>(new Set());
@@ -55,6 +56,11 @@ function stripMarkdown(text: string): string {
 // ---------------------------------------------------------------------------
 
 const cleanupAudio$ = command(({ get, set }) => {
+  const cleanupFn = get(internalCleanupFn$);
+  if (cleanupFn) {
+    cleanupFn();
+  }
+
   const audio = get(internalAudioElement$);
   if (audio) {
     audio.pause();
@@ -62,14 +68,10 @@ const cleanupAudio$ = command(({ get, set }) => {
     audio.load();
   }
 
-  const blobUrl = get(internalBlobUrl$);
-  if (blobUrl) {
-    URL.revokeObjectURL(blobUrl);
-  }
-
   set(internalPlayingMessageId$, null);
   set(internalAudioElement$, null);
   set(internalBlobUrl$, null);
+  set(internalCleanupFn$, null);
 });
 
 const fetchAndPlay$ = command(
@@ -77,7 +79,7 @@ const fetchAndPlay$ = command(
     { get, set },
     messageId: string,
     text: string,
-    _signal: AbortSignal,
+    signal: AbortSignal,
   ) => {
     set(cleanupAudio$);
 
@@ -91,7 +93,7 @@ const fetchAndPlay$ = command(
     let blob: Blob | null;
     // eslint-disable-next-line no-restricted-syntax -- raw fetch for binary audio (not a ts-rest contract)
     try {
-      blob = await fetchTtsAudio(fetchFn, plainText);
+      blob = await fetchTtsAudio(fetchFn, plainText, signal);
     } catch (error) {
       L.error("TTS fetch failed", error);
       return;
@@ -105,29 +107,38 @@ const fetchAndPlay$ = command(
     const blobUrl = URL.createObjectURL(blob);
     const audio = new Audio(blobUrl);
 
-    set(internalBlobUrl$, blobUrl);
-    set(internalAudioElement$, audio);
-    set(internalPlayingMessageId$, messageId);
-
-    const cleanup = () => {
+    const onEnded = () => {
       URL.revokeObjectURL(blobUrl);
       set(internalPlayingMessageId$, null);
       set(internalAudioElement$, null);
       set(internalBlobUrl$, null);
+      set(internalCleanupFn$, null);
     };
 
-    audio.addEventListener("ended", cleanup);
-    audio.addEventListener("error", () => {
+    const onError = () => {
       L.error("Audio playback error");
-      cleanup();
+      onEnded();
+    };
+
+    audio.addEventListener("ended", onEnded);
+    audio.addEventListener("error", onError);
+
+    set(internalCleanupFn$, () => {
+      audio.removeEventListener("ended", onEnded);
+      audio.removeEventListener("error", onError);
+      URL.revokeObjectURL(blobUrl);
     });
+
+    set(internalBlobUrl$, blobUrl);
+    set(internalAudioElement$, audio);
+    set(internalPlayingMessageId$, messageId);
 
     // eslint-disable-next-line no-restricted-syntax -- audio.play() rejects on browser autoplay restrictions
     try {
       await audio.play();
     } catch (error) {
       L.error("Audio play failed", error);
-      cleanup();
+      onEnded();
     }
   },
 );


### PR DESCRIPTION
## Summary

Closes #9121

- Pass `AbortSignal` to `fetchTtsAudio` and STT fetch calls so in-flight requests are cancelled on page navigation
- Store a cleanup function with closure over named listener refs to explicitly remove audio `ended`/`error` event listeners on cleanup
- Stop TTS playback when recording starts to prevent the microphone from capturing AI voice output

## Changes

| File | What changed |
|------|-------------|
| `tts-fetch.ts` | Added optional `signal` parameter, forwarded to `fetchFn` |
| `voice-io-tts.ts` | Wired signal to `fetchTtsAudio`, added `internalCleanupFn$` state for explicit listener removal, refactored `fetchAndPlay$` to use named `onEnded`/`onError` listeners |
| `voice-io-stt.ts` | Wired signal to STT fetch, added `signal.throwIfAborted()` after awaits, imported and called `stopTts$` at start of `startRecording$` |

## Test plan

- [ ] Navigate away from chat page while TTS is loading → fetch should be aborted (network tab)
- [ ] Navigate away while STT transcription is in progress → fetch should be aborted
- [ ] Start recording while TTS is playing → TTS stops immediately
- [ ] Play TTS, stop manually → no stale listener warnings in console
- [ ] Auto-read toggle still works end-to-end
- [ ] All existing tests pass (`pnpm vitest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)