### PR TITLE
feat(voice-chat): add prepare pipeline, dispatch, and callback

### DIFF
--- a/turbo/apps/cli/src/commands/zero/voice-chat/context/index.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/context/index.ts
@@ -1,9 +1,11 @@
 import { Command } from "commander";
 import { voiceChatContextGetCommand } from "./get";
 import { voiceChatContextAppendCommand } from "./append";
+import { voiceChatContextPrepareCommand } from "./prepare";
 
 export const voiceChatContextCommand = new Command()
   .name("context")
   .description("Read and write voice-chat shared context")
   .addCommand(voiceChatContextGetCommand)
-  .addCommand(voiceChatContextAppendCommand);
+  .addCommand(voiceChatContextAppendCommand)
+  .addCommand(voiceChatContextPrepareCommand);

--- a/turbo/apps/cli/src/commands/zero/voice-chat/context/prepare.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/context/prepare.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "fs";
+import { Command } from "commander";
+import { withErrorHandler } from "../../../../lib/command";
+import { completeVoiceChatPreparation } from "../../../../lib/api";
+
+export const voiceChatContextPrepareCommand = new Command()
+  .name("prepare")
+  .description("Submit preparation directive content for a voice-chat run")
+  .option(
+    "--content <content>",
+    "Directive content (reads from stdin if not provided)",
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  With content:    zero voice-chat context prepare --content "User is a backend engineer..."
+  Pipe from stdin: echo "User is a backend engineer..." | zero voice-chat context prepare`,
+  )
+  .action(
+    withErrorHandler(async (options: { content?: string }) => {
+      let content = options.content;
+
+      // Read from stdin if content not provided and stdin is piped
+      if (!content && process.stdin.isTTY === false) {
+        content = readFileSync("/dev/stdin", "utf8").trim();
+      }
+
+      if (!content) {
+        throw new Error(
+          "Content is required. Provide --content or pipe via stdin.",
+        );
+      }
+
+      const data = await completeVoiceChatPreparation(content);
+      console.log(JSON.stringify(data, null, 2));
+    }),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-voice-chat-prepare.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-voice-chat-prepare.ts
@@ -1,0 +1,24 @@
+import { initClient } from "@ts-rest/core";
+import {
+  zeroVoiceChatPrepareCompleteContract,
+  type PrepareCompleteResponse,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+export async function completeVoiceChatPreparation(
+  content: string,
+): Promise<PrepareCompleteResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVoiceChatPrepareCompleteContract, config);
+
+  const result = await client.complete({
+    body: { content },
+    headers: {},
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to complete voice-chat preparation");
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -193,3 +193,6 @@ export {
   getVoiceChatContextEvents,
   appendVoiceChatContextEvent,
 } from "./domains/zero-voice-chat-context";
+
+// Domain modules - Zero Voice Chat Prepare
+export { completeVoiceChatPreparation } from "./domains/zero-voice-chat-prepare";

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-prepare/__tests__/route.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestCallback,
+  createTestRunInDb,
+  createSignedCallbackRequest,
+  getTestZeroAgentId,
+  insertTestVoiceChatPreparation,
+  getTestVoiceChatPreparation,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { POST } from "../route";
+
+const context = testContext();
+
+describe("POST /api/internal/callbacks/voice-chat-prepare", () => {
+  let user: UserContext;
+  let agentId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    const compose = await createTestCompose(uniqueId("vcp-cb"));
+    agentId = await getTestZeroAgentId(user.orgId, compose.name);
+  });
+
+  async function setupPreparationAndRun(options?: {
+    preparationStatus?: string;
+    runStatus?: "completed" | "failed";
+  }) {
+    const { preparationStatus = "preparing", runStatus = "completed" } =
+      options ?? {};
+
+    const { runId } = await createTestRunInDb(user.userId, agentId, {
+      status: runStatus,
+    });
+
+    const preparationId = await insertTestVoiceChatPreparation({
+      orgId: user.orgId,
+      userId: user.userId,
+      agentId,
+      runId,
+      status: preparationStatus,
+    });
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/voice-chat-prepare",
+      payload: { preparationId },
+    });
+
+    return { preparationId, runId, secret };
+  }
+
+  it("should return 200 for progress status without changing preparation", async () => {
+    const { preparationId, runId, secret } = await setupPreparationAndRun();
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/voice-chat-prepare",
+        {
+          runId,
+          status: "progress",
+          payload: { preparationId },
+        },
+        secret,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+
+    // Preparation should still be "preparing"
+    const prep = await getTestVoiceChatPreparation(preparationId);
+    expect(prep?.status).toBe("preparing");
+  });
+
+  it("should mark preparation as failed on non-completed terminal state", async () => {
+    const { preparationId, runId, secret } = await setupPreparationAndRun({
+      runStatus: "failed",
+    });
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/voice-chat-prepare",
+        {
+          runId,
+          status: "failed",
+          error: "Run crashed",
+          payload: { preparationId },
+        },
+        secret,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+
+    // Preparation should now be "failed"
+    const prep = await getTestVoiceChatPreparation(preparationId);
+    expect(prep?.status).toBe("failed");
+  });
+
+  it("should not change preparation on completed status (CLI handles success)", async () => {
+    const { preparationId, runId, secret } = await setupPreparationAndRun();
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/voice-chat-prepare",
+        {
+          runId,
+          status: "completed",
+          payload: { preparationId },
+        },
+        secret,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+
+    // On "completed", the callback is a no-op — the CLI `prepare` command
+    // already marked the preparation as "ready" via the complete endpoint.
+    const prep = await getTestVoiceChatPreparation(preparationId);
+    expect(prep?.status).toBe("preparing");
+  });
+
+  it("should return 400 for invalid payload", async () => {
+    const { runId, secret } = await setupPreparationAndRun();
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/voice-chat-prepare",
+        {
+          runId,
+          status: "completed",
+          payload: { invalid: true },
+        },
+        secret,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("should return 401 for invalid signature", async () => {
+    const { preparationId, runId, secret } = await setupPreparationAndRun();
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/voice-chat-prepare",
+        {
+          runId,
+          status: "completed",
+          payload: { preparationId },
+        },
+        secret,
+        { invalidSignature: true },
+      ),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-prepare/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-prepare/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { initServices } from "../../../../../src/lib/init-services";
+import { verifyCallback } from "../../../../../src/lib/infra/callback";
+import { updatePreparationStatus } from "../../../../../src/lib/zero/voice-chat/preparation-service";
+import type { VoiceChatPrepareCallbackPayload } from "../../../../../src/lib/infra/callback/callback-payloads";
+import { logger } from "../../../../../src/lib/shared/logger";
+
+const log = logger("callback:voice-chat-prepare");
+
+function parsePayload(
+  payload: unknown,
+): VoiceChatPrepareCallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  if (typeof p.preparationId !== "string") return null;
+  return { preparationId: p.preparationId };
+}
+
+/**
+ * POST /api/internal/callbacks/voice-chat-prepare
+ *
+ * Callback handler for standalone preparation runs.
+ * When the run reaches a terminal failure state, marks the preparation as
+ * "failed" so the client knows it will not complete.
+ *
+ * Successful completion is handled by the CLI `zero voice-chat context prepare`
+ * command which calls the /api/zero/voice-chat/prepare/complete endpoint.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+
+  const result = await verifyCallback<VoiceChatPrepareCallbackPayload>(
+    request,
+    log,
+  );
+  if (!result.ok) return result.response;
+
+  const { runId, status } = result.data;
+  const payload = parsePayload(result.data.payload);
+  if (!payload) {
+    return NextResponse.json(
+      { error: "Invalid or missing payload" },
+      { status: 400 },
+    );
+  }
+
+  // Ignore progress notifications — only act on terminal states
+  if (status === "progress") {
+    return NextResponse.json({ success: true });
+  }
+
+  const { preparationId } = payload;
+
+  log.debug("Processing voice-chat-prepare callback", {
+    runId,
+    status,
+    preparationId,
+  });
+
+  // On failure/cancellation, mark the preparation as failed
+  if (status !== "completed") {
+    await updatePreparationStatus(preparationId, "failed");
+    log.info("Preparation marked as failed", {
+      preparationId,
+      runId,
+      status,
+    });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/__tests__/route.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createTestRequest,
+  createTestOrg,
+  createTestCompose,
+  findTestZeroRun,
+  insertTestVoiceChatPreparation,
+  getTestZeroAgentId,
+  getTestVoiceChatPreparation,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+vi.mock("@vm0/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vm0/core")>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn().mockReturnValue(true),
+  };
+});
+
+const { isFeatureEnabled } = await import("@vm0/core");
+const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
+
+const { POST } = await import("../route");
+
+const context = testContext();
+
+const BASE_URL = "http://localhost:3000/api/zero/voice-chat/prepare";
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("vcp");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function createRequest(body?: unknown) {
+  return createTestRequest(BASE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("POST /api/zero/voice-chat/prepare", () => {
+  let orgId: string;
+  let userId: string;
+  let agentId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    userId = user.userId;
+    const org = await setupOrg(userId);
+    orgId = org.orgId;
+    mockIsFeatureEnabled.mockReturnValue(true);
+    const compose = await createTestCompose(uniqueId("vcp-agent"));
+    agentId = await getTestZeroAgentId(orgId, compose.name);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+    const response = await POST(createRequest({ agentId: "any" }));
+    const body = await response.json();
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 403 when feature flag is disabled", async () => {
+    mockIsFeatureEnabled.mockReturnValue(false);
+    const response = await POST(createRequest({ agentId }));
+    const body = await response.json();
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should return 400 when agentId is missing", async () => {
+    const response = await POST(createRequest({}));
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should return 400 when agentId is empty string", async () => {
+    const response = await POST(createRequest({ agentId: "" }));
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should return 400 when meeting mode lacks prompt", async () => {
+    const response = await POST(createRequest({ agentId, mode: "meeting" }));
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should return cached preparation when a fresh one exists", async () => {
+    const preparationId = await insertTestVoiceChatPreparation({
+      orgId,
+      userId,
+      agentId,
+      mode: "chat",
+      status: "ready",
+      directiveContent: "cached directive",
+    });
+
+    const response = await POST(createRequest({ agentId }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.preparation.id).toBe(preparationId);
+    expect(body.preparation.status).toBe("ready");
+  });
+
+  it("should return in-flight preparation for dedup", async () => {
+    const preparationId = await insertTestVoiceChatPreparation({
+      orgId,
+      userId,
+      agentId,
+      mode: "chat",
+      status: "preparing",
+    });
+
+    const response = await POST(createRequest({ agentId }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.preparation.id).toBe(preparationId);
+    expect(body.preparation.status).toBe("preparing");
+  });
+
+  it("should create new preparation and dispatch run", async () => {
+    const response = await POST(createRequest({ agentId }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.preparation).toBeDefined();
+    expect(body.preparation.id).toBeDefined();
+    expect(body.preparation.status).toBe("preparing");
+    expect(body.preparation.runId).toBeDefined();
+
+    // Verify preparation was created in database
+    const prep = await getTestVoiceChatPreparation(body.preparation.id);
+    expect(prep).toBeDefined();
+    expect(prep?.status).toBe("preparing");
+    expect(prep?.runId).toBe(body.preparation.runId);
+
+    // Verify a zero run was dispatched
+    const run = await findTestZeroRun(body.preparation.runId);
+    expect(run).toBeDefined();
+    expect(run?.triggerSource).toBe("voice-chat");
+  });
+
+  it("should create meeting preparation with prompt", async () => {
+    const response = await POST(
+      createRequest({
+        agentId,
+        mode: "meeting",
+        prompt: "Review PR #42",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.preparation.status).toBe("preparing");
+
+    const prep = await getTestVoiceChatPreparation(body.preparation.id);
+    expect(prep?.mode).toBe("meeting");
+    expect(prep?.prompt).toBe("Review PR #42");
+  });
+});

--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/__tests__/route.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestRunInDb,
+  createTestSandboxToken,
+  getTestZeroAgentId,
+  insertTestVoiceChatPreparation,
+  getTestVoiceChatPreparation,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import { POST } from "../route";
+
+const context = testContext();
+
+function makeRequest(token: string, body?: Record<string, unknown>) {
+  return new Request(
+    "http://localhost:3000/api/zero/voice-chat/prepare/complete",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body ?? {}),
+    },
+  );
+}
+
+describe("POST /api/zero/voice-chat/prepare/complete", () => {
+  let user: UserContext;
+  let agentId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    const compose = await createTestCompose(uniqueId("vcp-cmp"));
+    agentId = await getTestZeroAgentId(user.orgId, compose.name);
+  });
+
+  async function setupPreparationWithRun(options?: {
+    preparationStatus?: string;
+  }) {
+    const { preparationStatus = "preparing" } = options ?? {};
+
+    const { runId } = await createTestRunInDb(user.userId, agentId, {
+      status: "running",
+    });
+
+    const preparationId = await insertTestVoiceChatPreparation({
+      orgId: user.orgId,
+      userId: user.userId,
+      agentId,
+      runId,
+      status: preparationStatus,
+    });
+
+    const token = await createTestSandboxToken(user.userId, runId);
+
+    return { preparationId, runId, token };
+  }
+
+  it("should reject non-sandbox callers with 400 (no runId)", async () => {
+    // When Clerk authenticates a regular user, authCtx.runId is undefined.
+    // The endpoint returns 400 "must be called from a sandbox run".
+    const response = await POST(
+      makeRequest("invalid-token", { content: "test" }),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should return 400 when content is missing", async () => {
+    const { token } = await setupPreparationWithRun();
+
+    const response = await POST(makeRequest(token, {}));
+    expect(response.status).toBe(400);
+  });
+
+  it("should return 400 when content is empty", async () => {
+    const { token } = await setupPreparationWithRun();
+
+    const response = await POST(makeRequest(token, { content: "" }));
+    expect(response.status).toBe(400);
+  });
+
+  it("should return 404 when no preparation found for run", async () => {
+    // Create a run with no linked preparation
+    const { runId } = await createTestRunInDb(user.userId, agentId, {
+      status: "running",
+    });
+    const token = await createTestSandboxToken(user.userId, runId);
+
+    const response = await POST(
+      makeRequest(token, { content: "test directive" }),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 400 when preparation is not in preparing status", async () => {
+    const { token } = await setupPreparationWithRun({
+      preparationStatus: "ready",
+    });
+
+    const response = await POST(
+      makeRequest(token, { content: "test directive" }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("should complete preparation successfully", async () => {
+    const { preparationId, token } = await setupPreparationWithRun();
+
+    const response = await POST(
+      makeRequest(token, { content: "User is a backend engineer..." }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.id).toBe(preparationId);
+    expect(data.status).toBe("ready");
+
+    // Verify database state
+    const prep = await getTestVoiceChatPreparation(preparationId);
+    expect(prep?.status).toBe("ready");
+    expect(prep?.directiveContent).toBe("User is a backend engineer...");
+  });
+});

--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
+import { voiceChatPreparations } from "../../../../../../src/db/schema/voice-chat";
+import { updatePreparationStatus } from "../../../../../../src/lib/zero/voice-chat/preparation-service";
+import { logger } from "../../../../../../src/lib/shared/logger";
+
+const bodySchema = z.object({
+  content: z.string().min(1),
+});
+
+const log = logger("api:zero:voice-chat:prepare:complete");
+
+export async function POST(request: Request) {
+  initServices();
+
+  const authCtx = await getAuthContext(
+    request.headers.get("authorization") ?? undefined,
+    { acceptAnySandboxCapability: true },
+  );
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { runId } = authCtx;
+  if (!runId) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "This endpoint must be called from a sandbox run",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const parsed = bodySchema.safeParse(await request.json());
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return NextResponse.json(
+      {
+        error: {
+          message: issue?.message ?? "Invalid request body",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+  const { content } = parsed.data;
+
+  // Find the preparation associated with this run
+  const [preparation] = await globalThis.services.db
+    .select({
+      id: voiceChatPreparations.id,
+      status: voiceChatPreparations.status,
+    })
+    .from(voiceChatPreparations)
+    .where(eq(voiceChatPreparations.runId, runId))
+    .limit(1);
+
+  if (!preparation) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "No preparation found for this run",
+          code: "NOT_FOUND",
+        },
+      },
+      { status: 404 },
+    );
+  }
+
+  if (preparation.status !== "preparing") {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Preparation is not in preparing status",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const updated = await updatePreparationStatus(
+    preparation.id,
+    "ready",
+    content,
+  );
+
+  log.info("Preparation completed", { preparationId: preparation.id, runId });
+
+  return NextResponse.json({
+    id: updated!.id,
+    status: updated!.status,
+  });
+}

--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/route.ts
@@ -1,0 +1,129 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
+import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
+import {
+  findFreshPreparation,
+  findInFlightPreparation,
+  createPreparation,
+  dispatchPreparationRun,
+} from "../../../../../src/lib/zero/voice-chat/preparation-service";
+import { isApiError } from "../../../../../src/lib/shared/errors";
+import { logger } from "../../../../../src/lib/shared/logger";
+import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
+
+const bodySchema = z
+  .object({
+    agentId: z.string().min(1),
+    mode: z.enum(["chat", "meeting"]).default("chat"),
+    prompt: z.string().min(1).optional(),
+  })
+  .refine(
+    (data) => {
+      return data.mode !== "meeting" || data.prompt;
+    },
+    {
+      message: "prompt is required for meeting mode",
+      path: ["prompt"],
+    },
+  );
+
+const log = logger("api:zero:voice-chat:prepare");
+
+export async function POST(request: Request) {
+  initServices();
+
+  const authCtx = await getAuthContext(
+    request.headers.get("authorization") ?? undefined,
+  );
+  if (!authCtx?.orgId) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { org } = await resolveOrg(authCtx);
+  const { userId } = authCtx;
+
+  const overrides = await loadFeatureSwitchOverrides(org.orgId, userId);
+  const enabled = isFeatureEnabled(FeatureSwitchKey.VoiceChat, {
+    orgId: org.orgId,
+    userId,
+    overrides,
+  });
+  if (!enabled) {
+    return NextResponse.json(
+      { error: { message: "Voice chat is not enabled", code: "FORBIDDEN" } },
+      { status: 403 },
+    );
+  }
+
+  const parsed = bodySchema.safeParse(await request.json());
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return NextResponse.json(
+      {
+        error: {
+          message: issue?.message ?? "Invalid request body",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+  const { agentId, mode, prompt } = parsed.data;
+
+  // Check for a fresh cached preparation (cache hit)
+  const fresh = await findFreshPreparation(userId, agentId, mode, prompt);
+  if (fresh) {
+    return NextResponse.json({
+      preparation: { id: fresh.id, status: "ready" },
+    });
+  }
+
+  // Check for an in-flight preparation (dedup)
+  const inflight = await findInFlightPreparation(userId, agentId, mode);
+  if (inflight) {
+    return NextResponse.json({
+      preparation: { id: inflight.id, status: "preparing" },
+    });
+  }
+
+  // Create a new preparation and dispatch the run
+  try {
+    const preparation = await createPreparation(
+      org.orgId,
+      userId,
+      agentId,
+      mode,
+      prompt,
+    );
+    const run = await dispatchPreparationRun(
+      preparation.id,
+      org.orgId,
+      userId,
+      agentId,
+      { mode: mode as "chat" | "meeting", prompt },
+    );
+
+    return NextResponse.json({
+      preparation: {
+        id: preparation.id,
+        status: preparation.status,
+        runId: run.runId,
+      },
+    });
+  } catch (error) {
+    if (isApiError(error)) {
+      return NextResponse.json(
+        { error: { message: error.message, code: error.code } },
+        { status: error.statusCode },
+      );
+    }
+    log.error("Failed to create voice-chat preparation", error);
+    throw error;
+  }
+}

--- a/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
@@ -357,6 +357,7 @@ export async function insertTestVoiceChatPreparation(overrides: {
   agentId?: string;
   mode?: string;
   prompt?: string;
+  runId?: string;
   status?: string;
   directiveContent?: string;
   createdAt?: Date;
@@ -370,6 +371,7 @@ export async function insertTestVoiceChatPreparation(overrides: {
       agentId: overrides.agentId,
       mode: overrides.mode ?? "chat",
       prompt: overrides.prompt ?? null,
+      runId: overrides.runId ?? null,
       status: overrides.status ?? "preparing",
       directiveContent: overrides.directiveContent ?? null,
       createdAt: overrides.createdAt ?? new Date(),

--- a/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
+++ b/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
@@ -82,6 +82,10 @@ export interface VoiceChatCallbackPayload {
   sessionId: string;
 }
 
+export interface VoiceChatPrepareCallbackPayload {
+  preparationId: string;
+}
+
 export interface PhoneCallbackPayload {
   callId: string;
   userId: string;

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -277,6 +277,93 @@ export function buildVoiceChatMeetingPrompt(
   return [header, meetingPrompt].join("\n\n");
 }
 
+// ---------------------------------------------------------------------------
+// Prepare-only prompts (standalone preparation runs, no observation phase)
+// ---------------------------------------------------------------------------
+
+const VOICE_CHAT_PREPARE_ONLY_PROMPT = `
+# Zero — Standalone Preparation Run
+
+You are Zero preparing for a voice chat. Your job is to review the agent context and user identity, then output an initial directive.
+
+## Steps
+
+1. **Review context** — Read the agent's system prompt, instructions, and memory. Note the user's identity (name, role, timezone).
+2. **Prepare a directive** — Summarize the key context:
+   - Who the user is (name, role if known)
+   - What the agent specializes in
+   - Any relevant recent context from memory
+3. **Output the directive** — Write the final directive using the CLI command below.
+
+## Output Command
+
+When your directive is ready, output it using:
+
+\`zero voice-chat context prepare --content "<YOUR_DIRECTIVE>"\`
+
+This writes your preparation to the cache so future voice chat sessions can start instantly.
+
+## Important
+
+- This should only take a few seconds. Do NOT do deep research — just review what you already know.
+- You are NOT in a live session. There is no shared context to poll. Just prepare and output.
+`.trim();
+
+/**
+ * Build the appendSystemPrompt for a standalone chat preparation run.
+ * Phase 1 only — outputs via `zero voice-chat context prepare`.
+ */
+export function buildVoiceChatPrepareOnlyPrompt(): string {
+  const header = buildIntegrationPrompt("Voice-Chat");
+  return [header, VOICE_CHAT_PREPARE_ONLY_PROMPT].join("\n\n");
+}
+
+const VOICE_CHAT_MEETING_PREPARE_ONLY_PROMPT = `
+# Zero — Standalone Meeting Preparation Run
+
+You are Zero preparing for a voice meeting. A meeting has been requested and you need to prepare in advance.
+
+## The User's Meeting Prompt
+
+<MEETING_PROMPT>
+
+## Steps
+
+1. **Research context** — Based on the meeting prompt above, look up everything relevant: code, PRs, issues, documentation, recent changes, deployment status, etc.
+2. **Plan the meeting flow** — Organize your findings into a suggested agenda or list of talking points.
+3. **Prepare a directive** — When preparation is complete, write a directive containing:
+   - Summary of what you found
+   - Suggested meeting flow / talking points
+   - Key data and references
+4. **Output the directive** — Write the final directive using the CLI command below.
+
+## Output Command
+
+When your directive is ready, output it using:
+
+\`zero voice-chat context prepare --content "<YOUR_DIRECTIVE>"\`
+
+This writes your preparation to the cache so the meeting session can start instantly.
+
+## Important
+
+- You have full tool access. Use your sandbox, CLI, and APIs to research and prepare.
+- You are NOT in a live session. There is no shared context to poll. Just prepare and output.
+`.trim();
+
+/**
+ * Build the appendSystemPrompt for a standalone meeting preparation run.
+ * Deep research based on the meeting prompt, outputs via `zero voice-chat context prepare`.
+ */
+export function buildVoiceChatMeetingPreparePrompt(prompt: string): string {
+  const header = buildIntegrationPrompt("Voice-Chat");
+  const meetingPrompt = VOICE_CHAT_MEETING_PREPARE_ONLY_PROMPT.replaceAll(
+    "<MEETING_PROMPT>",
+    prompt,
+  );
+  return [header, meetingPrompt].join("\n\n");
+}
+
 /**
  * Build the full appendSystemPrompt for Slack integration.
  */

--- a/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
@@ -1,5 +1,12 @@
 import { eq, and, gt, lt, desc, isNull } from "drizzle-orm";
 import { voiceChatPreparations } from "../../../db/schema/voice-chat";
+import { createZeroRun } from "../zero-run-service";
+import {
+  buildVoiceChatPrepareOnlyPrompt,
+  buildVoiceChatMeetingPreparePrompt,
+} from "../integration-prompt";
+import { generateCallbackSecret, getApiUrl } from "../../infra/callback";
+import type { VoiceChatPrepareCallbackPayload } from "../../infra/callback/callback-payloads";
 import { logger } from "../../shared/logger";
 
 const log = logger("zero:voice-chat:preparation");
@@ -42,6 +49,124 @@ export async function findFreshPreparation(
   if (!result?.directiveContent) return null;
   return { id: result.id, directiveContent: result.directiveContent };
 }
+
+// ---------------------------------------------------------------------------
+// CRUD Operations
+// ---------------------------------------------------------------------------
+
+export async function createPreparation(
+  orgId: string,
+  userId: string,
+  agentId: string,
+  mode: string,
+  prompt?: string,
+) {
+  const db = globalThis.services.db;
+  const [row] = await db
+    .insert(voiceChatPreparations)
+    .values({
+      orgId,
+      userId,
+      agentId,
+      mode,
+      prompt: prompt ?? null,
+      status: "preparing",
+    })
+    .returning();
+  return row!;
+}
+
+export async function updatePreparationStatus(
+  id: string,
+  status: string,
+  directiveContent?: string,
+) {
+  const db = globalThis.services.db;
+  const updates: Record<string, unknown> = { status };
+  if (directiveContent !== undefined) {
+    updates.directiveContent = directiveContent;
+  }
+  const [row] = await db
+    .update(voiceChatPreparations)
+    .set(updates)
+    .where(eq(voiceChatPreparations.id, id))
+    .returning();
+  return row ?? null;
+}
+
+export async function findInFlightPreparation(
+  userId: string,
+  agentId: string,
+  mode: string,
+) {
+  const db = globalThis.services.db;
+  const [row] = await db
+    .select()
+    .from(voiceChatPreparations)
+    .where(
+      and(
+        eq(voiceChatPreparations.userId, userId),
+        eq(voiceChatPreparations.agentId, agentId),
+        eq(voiceChatPreparations.mode, mode),
+        eq(voiceChatPreparations.status, "preparing"),
+      ),
+    )
+    .orderBy(desc(voiceChatPreparations.createdAt))
+    .limit(1);
+  return row ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+export async function dispatchPreparationRun(
+  preparationId: string,
+  orgId: string,
+  userId: string,
+  agentId: string,
+  options?: { mode?: "chat" | "meeting"; prompt?: string },
+) {
+  const db = globalThis.services.db;
+  const meetingPrompt =
+    options?.mode === "meeting" ? options.prompt : undefined;
+
+  const appendSystemPrompt = meetingPrompt
+    ? buildVoiceChatMeetingPreparePrompt(meetingPrompt)
+    : buildVoiceChatPrepareOnlyPrompt();
+
+  const prompt = meetingPrompt
+    ? "You are Zero preparing for a voice meeting. Research the meeting topic and prepare a comprehensive briefing."
+    : "You are Zero preparing for a voice chat. Review the agent configuration and user context, then output an initial directive.";
+
+  const callbackPayload: VoiceChatPrepareCallbackPayload = { preparationId };
+
+  const result = await createZeroRun({
+    userId,
+    agentId,
+    prompt,
+    appendSystemPrompt,
+    triggerSource: "voice-chat",
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/voice-chat-prepare`,
+        secret: generateCallbackSecret(),
+        payload: callbackPayload,
+      },
+    ],
+  });
+
+  await db
+    .update(voiceChatPreparations)
+    .set({ runId: result.runId })
+    .where(eq(voiceChatPreparations.id, preparationId));
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
 
 export async function deleteExpiredPreparations(ttlMs: number) {
   const db = globalThis.services.db;

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -808,6 +808,12 @@ export {
   type AppendContextEventBody,
 } from "./zero-voice-chat-context";
 export {
+  zeroVoiceChatPrepareCompleteContract,
+  type ZeroVoiceChatPrepareCompleteContract,
+  type PrepareCompleteBody,
+  type PrepareCompleteResponse,
+} from "./zero-voice-chat-prepare";
+export {
   tasksContract,
   taskItemSchema,
   taskTypeSchema,

--- a/turbo/packages/core/src/contracts/zero-voice-chat-prepare.ts
+++ b/turbo/packages/core/src/contracts/zero-voice-chat-prepare.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const prepareCompleteBodySchema = z.object({
+  content: z.string().min(1),
+});
+
+const prepareCompleteResponseSchema = z.object({
+  id: z.string(),
+  status: z.string(),
+});
+
+export const zeroVoiceChatPrepareCompleteContract = c.router({
+  complete: {
+    method: "POST",
+    path: "/api/zero/voice-chat/prepare/complete",
+    headers: authHeadersSchema,
+    body: prepareCompleteBodySchema,
+    responses: {
+      200: prepareCompleteResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary:
+      "Complete a voice-chat preparation run by submitting the directive content",
+  },
+});
+
+export type ZeroVoiceChatPrepareCompleteContract =
+  typeof zeroVoiceChatPrepareCompleteContract;
+export type PrepareCompleteBody = z.infer<typeof prepareCompleteBodySchema>;
+export type PrepareCompleteResponse = z.infer<
+  typeof prepareCompleteResponseSchema
+>;


### PR DESCRIPTION
## Summary

- Add `POST /api/zero/voice-chat/prepare` trigger endpoint with cache-hit detection and in-flight dedup
- Add `POST /api/zero/voice-chat/prepare/complete` sandbox endpoint for CLI to submit directive content
- Add `POST /api/internal/callbacks/voice-chat-prepare` callback handler that marks preparations as "failed" on run failure
- Add `zero voice-chat context prepare` CLI command with ts-rest contract in `@vm0/core`
- Add prepare-only and meeting-prepare prompt templates in `integration-prompt.ts`
- Add `dispatchPreparationRun` to preparation-service for creating zero runs with callbacks
- Add `VoiceChatPrepareCallbackPayload` to callback payload types
- Remove unused `findPreparationById` (flagged by knip)
- Integration tests for all three endpoints (20 tests)

Closes #9085

## Test plan

- [x] Integration tests for prepare trigger endpoint (auth, feature flag, validation, cache hit, dedup, dispatch)
- [x] Integration tests for prepare/complete endpoint (sandbox auth, validation, status check, completion)
- [x] Integration tests for callback handler (progress no-op, failure marking, completion no-op, payload validation, signature check)
- [x] All pre-commit checks pass (format, lint, knip, prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)