### PR TITLE
fix(voice-io): use valid tts voice and accept mime types with codec suffix

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
@@ -120,6 +120,27 @@ describe("POST /api/zero/voice-io/stt", () => {
     expect(body.error.code).toBe("BAD_REQUEST");
   });
 
+  it("should accept MIME types with codec suffix", async () => {
+    const userId = uniqueId("stt-codec");
+    await setupOrg(userId);
+
+    server.use(
+      http.post("https://api.openai.com/v1/audio/transcriptions", () => {
+        return HttpResponse.json({ text: "Hello from codec test" });
+      }),
+    );
+
+    const file = createAudioFile(
+      1024,
+      "audio/webm;codecs=opus",
+      "recording.webm",
+    );
+    const response = await POST(createSttRequest(file));
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.text).toBe("Hello from codec test");
+  });
+
   it("should return transcribed text on success", async () => {
     const userId = uniqueId("stt-ok");
     await setupOrg(userId);

--- a/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
@@ -91,12 +91,13 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  // 6. Validate file type
-  if (!ALLOWED_MIME_TYPES.has(file.type)) {
+  // 6. Validate file type (strip codec suffix, e.g. "audio/webm;codecs=opus" → "audio/webm")
+  const baseMimeType = file.type.split(";")[0] ?? file.type;
+  if (!ALLOWED_MIME_TYPES.has(baseMimeType)) {
     return NextResponse.json(
       {
         error: {
-          message: `Unsupported audio format: ${file.type}. Supported: webm, wav, mp3, m4a, mp4, mpeg, mpga`,
+          message: `Unsupported audio format: ${baseMimeType}. Supported: webm, wav, mp3, m4a, mp4, mpeg, mpga`,
           code: "BAD_REQUEST",
         },
       },

--- a/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
@@ -121,7 +121,7 @@ describe("POST /api/zero/voice-io/tts", () => {
         async ({ request }) => {
           const reqBody = (await request.json()) as Record<string, unknown>;
           expect(reqBody.model).toBe("tts-1-hd");
-          expect(reqBody.voice).toBe("verse");
+          expect(reqBody.voice).toBe("alloy");
           expect(reqBody.input).toBe("hello world");
           expect(reqBody.response_format).toBe("mp3");
 

--- a/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
@@ -121,7 +121,7 @@ describe("POST /api/zero/voice-io/tts", () => {
         async ({ request }) => {
           const reqBody = (await request.json()) as Record<string, unknown>;
           expect(reqBody.model).toBe("tts-1-hd");
-          expect(reqBody.voice).toBe("alloy");
+          expect(reqBody.voice).toBe("ash");
           expect(reqBody.input).toBe("hello world");
           expect(reqBody.response_format).toBe("mp3");
 

--- a/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
@@ -95,7 +95,7 @@ export async function POST(request: Request): Promise<Response> {
     },
     body: JSON.stringify({
       model: "tts-1-hd",
-      voice: "verse",
+      voice: "alloy",
       input: text,
       response_format: "mp3",
     }),

--- a/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
@@ -95,7 +95,7 @@ export async function POST(request: Request): Promise<Response> {
     },
     body: JSON.stringify({
       model: "tts-1-hd",
-      voice: "alloy",
+      voice: "ash",
       input: text,
       response_format: "mp3",
     }),


### PR DESCRIPTION
## Summary

Fixes two bugs discovered during VoiceIO testing:

- **TTS 500 error**: Change voice from `verse` (unsupported by `tts-1-hd`) to `alloy`
- **STT MIME type rejection**: Strip codec suffix (e.g. `audio/webm;codecs=opus` → `audio/webm`) before validating against the allowed MIME types set

## Changes

| File | Change |
|------|--------|
| `turbo/apps/web/app/api/zero/voice-io/tts/route.ts` | `voice: "verse"` → `voice: "alloy"` |
| `turbo/apps/web/app/api/zero/voice-io/stt/route.ts` | Strip codec suffix before MIME type validation |
| `turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts` | Update voice assertion |
| `turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts` | Add codec suffix integration test |

## Test plan

- [x] TTS test updated to assert `alloy` voice
- [x] New integration test for MIME type with codec suffix (`audio/webm;codecs=opus`)
- [x] All 16 voice-io tests pass
- [x] Lint, type-check, format, and knip all pass

Closes #9127

🤖 Generated with [Claude Code](https://claude.com/claude-code)