### PR TITLE
feat(platform): redesign activity panel with chat-like layout for non-chat tasks

### DIFF
--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -458,6 +458,275 @@ describe("mission control page", () => {
     expect(signals).toHaveLength(0);
   });
 
+  it("should show user bubble with prompt for completed schedule task", async () => {
+    const runId = "run-chat-completed";
+    mockTasksAPI([
+      {
+        id: "task-sched-completed",
+        type: "schedule",
+        title: "Completed Schedule Task",
+        summary: null,
+        agent: createAgent(),
+        latestRunId: runId,
+        status: "completed",
+        scheduleId: "sched-done",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    server.use(
+      http.get(`*/api/zero/logs/${runId}`, () => {
+        return HttpResponse.json({
+          id: "00000000-0000-4000-a000-000000000001",
+          displayName: "Test Agent",
+          status: "completed",
+          agentId: "agent-1",
+          sessionId: null,
+          triggerSource: "schedule",
+          triggerAgentName: null,
+          modelProvider: null,
+          selectedModel: null,
+          framework: null,
+          scheduleId: null,
+          prompt: "Send the daily report",
+          appendSystemPrompt: null,
+          error: null,
+          createdAt: "2026-04-10T10:00:00Z",
+          startedAt: "2026-04-10T10:00:01Z",
+          completedAt: "2026-04-10T10:00:05Z",
+          artifact: { name: null, version: null },
+        });
+      }),
+      http.get(`*/api/zero/runs/${runId}/telemetry/agent`, () => {
+        return HttpResponse.json({
+          events: [],
+          hasMore: false,
+          framework: "anthropic",
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    const title = await waitFor(() => {
+      return screen.getByText("Completed Schedule Task");
+    });
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(screen.getByText("Send the daily report")).toBeInTheDocument();
+    });
+  });
+
+  it("should show assistant result bubble for completed task with result event", async () => {
+    const runId = "run-with-result";
+    mockTasksAPI([
+      {
+        id: "task-sched-result",
+        type: "schedule",
+        title: "Schedule Task With Result",
+        summary: null,
+        agent: createAgent(),
+        latestRunId: runId,
+        status: "completed",
+        scheduleId: "sched-result",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    server.use(
+      http.get(`*/api/zero/logs/${runId}`, () => {
+        return HttpResponse.json({
+          id: "00000000-0000-4000-a000-000000000002",
+          displayName: "Test Agent",
+          status: "completed",
+          agentId: "agent-1",
+          sessionId: null,
+          triggerSource: "schedule",
+          triggerAgentName: null,
+          modelProvider: null,
+          selectedModel: null,
+          framework: null,
+          scheduleId: null,
+          prompt: "Generate a daily report",
+          appendSystemPrompt: null,
+          error: null,
+          createdAt: "2026-04-10T10:00:00Z",
+          startedAt: "2026-04-10T10:00:01Z",
+          completedAt: "2026-04-10T10:00:05Z",
+          artifact: { name: null, version: null },
+        });
+      }),
+      http.get(`*/api/zero/runs/${runId}/telemetry/agent`, () => {
+        return HttpResponse.json({
+          events: [
+            {
+              sequenceNumber: 1,
+              eventType: "result",
+              eventData: { result: "Here is your daily report" },
+              createdAt: "2026-04-10T10:00:05Z",
+            },
+          ],
+          hasMore: false,
+          framework: "anthropic",
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    const title = await waitFor(() => {
+      return screen.getByText("Schedule Task With Result");
+    });
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(screen.getByText("Here is your daily report")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByPlaceholderText("Search steps"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show steps list for running email task, not assistant bubbles", async () => {
+    const runId = "run-running-email";
+    mockTasksAPI([
+      {
+        id: "task-running-email",
+        type: "email",
+        title: "Running Email Task",
+        summary: null,
+        agent: createAgent(),
+        latestRunId: runId,
+        status: "running",
+        emailThreadSessionId: "email-session-running",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    server.use(
+      http.get(`*/api/zero/logs/${runId}`, () => {
+        return HttpResponse.json({
+          id: "00000000-0000-4000-a000-000000000003",
+          displayName: "Test Agent",
+          status: "running",
+          agentId: "agent-1",
+          sessionId: null,
+          triggerSource: "email",
+          triggerAgentName: null,
+          modelProvider: null,
+          selectedModel: null,
+          framework: null,
+          scheduleId: null,
+          prompt: "Reply to customer inquiry",
+          appendSystemPrompt: null,
+          error: null,
+          createdAt: "2026-04-10T10:00:00Z",
+          startedAt: "2026-04-10T10:00:01Z",
+          completedAt: null,
+          artifact: { name: null, version: null },
+        });
+      }),
+      http.get(`*/api/zero/runs/${runId}/telemetry/agent`, () => {
+        return HttpResponse.json({
+          events: [],
+          hasMore: false,
+          framework: "anthropic",
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    const title = await waitFor(() => {
+      return screen.getByText("Running Email Task");
+    });
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Reply to customer inquiry").length,
+      ).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Search steps")).toBeInTheDocument();
+    });
+  });
+
+  it("should show prompt bubble but no assistant bubble when completed task has no result events", async () => {
+    const runId = "run-no-result";
+    mockTasksAPI([
+      {
+        id: "task-no-result",
+        type: "schedule",
+        title: "Task With No Result",
+        summary: null,
+        agent: createAgent(),
+        latestRunId: runId,
+        status: "completed",
+        scheduleId: "sched-no-result",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    server.use(
+      http.get(`*/api/zero/logs/${runId}`, () => {
+        return HttpResponse.json({
+          id: "00000000-0000-4000-a000-000000000004",
+          displayName: "Test Agent",
+          status: "completed",
+          agentId: "agent-1",
+          sessionId: null,
+          triggerSource: "schedule",
+          triggerAgentName: null,
+          modelProvider: null,
+          selectedModel: null,
+          framework: null,
+          scheduleId: null,
+          prompt: "Fetch news summary",
+          appendSystemPrompt: null,
+          error: null,
+          createdAt: "2026-04-10T10:00:00Z",
+          startedAt: "2026-04-10T10:00:01Z",
+          completedAt: "2026-04-10T10:00:05Z",
+          artifact: { name: null, version: null },
+        });
+      }),
+      http.get(`*/api/zero/runs/${runId}/telemetry/agent`, () => {
+        return HttpResponse.json({
+          events: [],
+          hasMore: false,
+          framework: "anthropic",
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    const title = await waitFor(() => {
+      return screen.getByText("Task With No Result");
+    });
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(screen.getByText("Fetch news summary")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByPlaceholderText("Search steps"),
+    ).not.toBeInTheDocument();
+  });
+
   it("should remove task from list when archive button is clicked", async () => {
     let archiveRequestBody: unknown = null;
 

--- a/turbo/apps/platform/src/views/mission-control-page/activity-panel-content.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/activity-panel-content.tsx
@@ -6,7 +6,7 @@ import {
 } from "ccstate-react";
 import { IconSearch } from "@tabler/icons-react";
 import { Input } from "@vm0/ui";
-import { FeatureSwitchKey } from "@vm0/core";
+import { FeatureSwitchKey, type LogStatus } from "@vm0/core";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import type { ActivitySignals } from "../../signals/mission-control-page/create-activity-signals.ts";
 import type {
@@ -26,6 +26,17 @@ import {
   groupEventsIntoMessages,
   groupedMessageMatchesSearch,
 } from "../zero-page/components/log-views/log-detail-utils.ts";
+import { Markdown } from "../components/markdown.tsx";
+import { AgentAvatarImg } from "../zero-page/zero-sidebar-shared.tsx";
+
+function isTerminalStatus(status: LogStatus): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "timeout" ||
+    status === "cancelled"
+  );
+}
 
 function ActivityPanelSkeleton() {
   return (
@@ -78,6 +89,7 @@ function prepareRenderData(
     (features?.[FeatureSwitchKey.ShowSystemPrompt] ?? false) &&
     appendSystemPrompt.trim().length > 0;
   return {
+    allMessages,
     visibleMessages,
     messages,
     showModelDetail,
@@ -85,6 +97,51 @@ function prepareRenderData(
     appendSystemPrompt,
     showSystemPrompt,
   };
+}
+
+function ActivityUserBubble({ prompt }: { prompt: string }) {
+  if (!prompt.trim()) {
+    return null;
+  }
+  return (
+    <div className="flex justify-end">
+      <div className="zero-chat-bubble-user rounded-xl max-w-[85%] px-4 py-3 text-sm leading-relaxed break-words overflow-hidden">
+        <Markdown source={prompt} />
+      </div>
+    </div>
+  );
+}
+
+function ActivityAssistantAvatar({ agentId }: { agentId: string | null }) {
+  return (
+    <div className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 shrink-0 @[900px]:mt-0.5 overflow-hidden rounded-xl">
+      <AgentAvatarImg
+        name={agentId ?? ""}
+        alt=""
+        className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 rounded-full object-cover object-top"
+      />
+    </div>
+  );
+}
+
+function ActivityAssistantBubble({
+  content,
+  agentId,
+}: {
+  content: string;
+  agentId: string | null;
+}) {
+  if (!content.trim()) {
+    return null;
+  }
+  return (
+    <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
+      <ActivityAssistantAvatar agentId={agentId} />
+      <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
+        <Markdown source={content} />
+      </div>
+    </div>
+  );
 }
 
 function ActivityPanelSteps({
@@ -109,7 +166,7 @@ function ActivityPanelSteps({
   } = prepareRenderData(detail, eventsData, stepSearch, features);
 
   return (
-    <div className="flex flex-col gap-4 pb-8 min-w-0">
+    <div className="flex flex-col gap-4 min-w-0">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div className="flex items-center gap-3">
           <span className="text-base font-medium text-foreground whitespace-nowrap">
@@ -143,6 +200,56 @@ function ActivityPanelSteps({
         stepSearch={stepSearch}
         isLoading={false}
       />
+    </div>
+  );
+}
+
+function ActivityChatLayout({
+  detail,
+  eventsData,
+  features,
+  signals,
+}: {
+  detail: LogDetail;
+  eventsData: AgentEvent[];
+  features: Record<FeatureSwitchKey, boolean> | undefined;
+  signals: ActivitySignals;
+}) {
+  const isTerminal = isTerminalStatus(detail.status);
+  const { allMessages, prompt } = prepareRenderData(
+    detail,
+    eventsData,
+    "",
+    features,
+  );
+  const resultMessages = isTerminal
+    ? allMessages.filter((m) => {
+        return m.type === "result";
+      })
+    : [];
+
+  return (
+    <div className="flex flex-col gap-6 pb-8 min-w-0">
+      <ActivityUserBubble prompt={prompt} />
+      {isTerminal ? (
+        resultMessages.map((msg) => {
+          const data = msg.eventData as { result?: string | null };
+          return (
+            <ActivityAssistantBubble
+              key={msg.sequenceNumber}
+              content={data.result ?? ""}
+              agentId={detail.agentId}
+            />
+          );
+        })
+      ) : (
+        <ActivityPanelSteps
+          detail={detail}
+          eventsData={eventsData}
+          features={features}
+          signals={signals}
+        />
+      )}
     </div>
   );
 }
@@ -184,7 +291,7 @@ export function ActivityPanelContent({
   );
 
   return (
-    <div className="h-full flex flex-col min-h-0 overflow-auto">
+    <div className="h-full flex flex-col min-h-0 overflow-auto @container">
       <div className="mx-auto w-full max-w-[900px] px-4 pt-4 pb-8">
         <ActivityHeaderCard
           displayName={displayName}
@@ -198,7 +305,7 @@ export function ActivityPanelContent({
           showModelDetail={showModelDetail}
         />
         <div className="mt-6">
-          <ActivityPanelSteps
+          <ActivityChatLayout
             detail={detail}
             eventsData={eventsLoadable.data ?? []}
             features={features}

--- a/turbo/apps/platform/src/views/mission-control-page/activity-panel-content.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/activity-panel-content.tsx
@@ -25,6 +25,7 @@ import {
 import {
   groupEventsIntoMessages,
   groupedMessageMatchesSearch,
+  type GroupingEventData,
 } from "../zero-page/components/log-views/log-detail-utils.ts";
 import { Markdown } from "../components/markdown.tsx";
 import { AgentAvatarImg } from "../zero-page/zero-sidebar-shared.tsx";
@@ -233,7 +234,7 @@ function ActivityChatLayout({
       <ActivityUserBubble prompt={prompt} />
       {isTerminal ? (
         resultMessages.map((msg) => {
-          const data = msg.eventData as { result?: string | null };
+          const data = msg.eventData as GroupingEventData;
           return (
             <ActivityAssistantBubble
               key={msg.sequenceNumber}

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -75,7 +75,7 @@ interface ToolResultMeta {
   durationMs?: number | null;
 }
 
-interface GroupingEventData {
+export interface GroupingEventData {
   subtype?: string;
   message?: {
     content: MessageContent[] | null;


### PR DESCRIPTION
## Summary

- Replaces the flat steps list in mission control activity panels (schedule, email, slack, agent tasks) with a chat-like layout
- Shows the user's `prompt` as a right-aligned user bubble with Markdown rendering
- For **completed/failed/timeout/cancelled** runs: hides the steps list and renders each `result` event as an assistant bubble with Markdown
- For **running/pending/queued** runs: keeps the existing steps list with search below the user bubble
- Adds `@container` to the panel wrapper to enable responsive grid layout for assistant bubbles

## Implementation Details

- New helper components: `ActivityUserBubble`, `ActivityAssistantAvatar`, `ActivityAssistantBubble`, `ActivityChatLayout`
- No changes to signals layer (`ActivitySignals`) or API contracts
- Borrows CSS classes (`zero-chat-bubble-user`, `zero-chat-bubble-assistant`) from the chat page but implements independently without `ChatThreadSignals` dependency

## Test plan

- [x] 15 tests pass in `mission-control-page.test.tsx` (11 existing + 4 new)
- [x] New test: completed schedule task shows user bubble with prompt
- [x] New test: completed task with result event shows assistant bubble (no steps list)
- [x] New test: running email task shows steps list with search input (not assistant bubbles)
- [x] New test: completed task with no result events shows prompt bubble only
- [x] Lint, type check, format all pass

Closes #9131

🤖 Generated with [Claude Code](https://claude.com/claude-code)