### PR TITLE
refactor: unify member and admin onboarding connector flow (#9129)

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-onboarding.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-onboarding.ts
@@ -17,7 +17,6 @@ export const apiOnboardingHandlers = [
       hasDefaultAgent: true,
       defaultAgentId: "c0000000-0000-4000-a000-000000000001",
       defaultAgentMetadata: { displayName: "Zero" },
-      defaultAgentSkills: [],
     });
   }),
 ];

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/onboard-guard.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/onboard-guard.test.ts
@@ -26,7 +26,6 @@ function mockOnboardingStatus(body: {
         defaultAgentMetadata: body.hasDefaultAgent
           ? { displayName: "Zero" }
           : null,
-        defaultAgentSkills: [],
       });
     }),
   );

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
@@ -7,8 +7,18 @@ import {
   onboardingDisplayName$,
   onboardingAddToSlack$,
   onboardingContinueWeb$,
+  onboardingEffectiveStep$,
+  onboardingVisibleSteps$,
+  onboardingStepBack$,
+  onboardingStepNext$,
 } from "../zero-onboarding-actions.ts";
-import { setZeroAgentName$, zeroOnboardingStep$ } from "../zero-onboarding.ts";
+import {
+  setZeroAgentName$,
+  setZeroStep$,
+  setZeroWorkspaceName$,
+  toggleZeroConnector$,
+  zeroOnboardingStep$,
+} from "../zero-onboarding.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createDeferredPromise } from "../../utils.ts";
 
@@ -27,7 +37,6 @@ function mockAdminOnboarding() {
         hasDefaultAgent: false,
         defaultAgentId: null,
         defaultAgentMetadata: null,
-        defaultAgentSkills: [],
       });
     }),
   );
@@ -43,7 +52,6 @@ function mockMemberOnboarding() {
         hasDefaultAgent: true,
         defaultAgentId: MOCK_MEMBER_AGENT_ID,
         defaultAgentMetadata: { displayName: "TeamBot" },
-        defaultAgentSkills: [],
       });
     }),
   );
@@ -110,7 +118,6 @@ describe("onboardingAddToSlack$", () => {
             hasDefaultAgent: false,
             defaultAgentId: null,
             defaultAgentMetadata: null,
-            defaultAgentSkills: [],
           });
         }
         return HttpResponse.json({
@@ -120,7 +127,6 @@ describe("onboardingAddToSlack$", () => {
           hasDefaultAgent: true,
           defaultAgentId: MOCK_AGENT_ID,
           defaultAgentMetadata: null,
-          defaultAgentSkills: [],
         });
       }),
     );
@@ -149,7 +155,6 @@ describe("onboardingAddToSlack$", () => {
             hasDefaultAgent: true,
             defaultAgentId: MOCK_MEMBER_AGENT_ID,
             defaultAgentMetadata: { displayName: "TeamBot" },
-            defaultAgentSkills: [],
           });
         }
         return HttpResponse.json({
@@ -159,7 +164,6 @@ describe("onboardingAddToSlack$", () => {
           hasDefaultAgent: true,
           defaultAgentId: MOCK_MEMBER_AGENT_ID,
           defaultAgentMetadata: { displayName: "TeamBot" },
-          defaultAgentSkills: [],
         });
       }),
     );
@@ -194,7 +198,6 @@ describe("onboardingContinueWeb$", () => {
             hasDefaultAgent: false,
             defaultAgentId: null,
             defaultAgentMetadata: null,
-            defaultAgentSkills: [],
           });
         }
         return HttpResponse.json({
@@ -204,7 +207,6 @@ describe("onboardingContinueWeb$", () => {
           hasDefaultAgent: true,
           defaultAgentId: MOCK_AGENT_ID,
           defaultAgentMetadata: null,
-          defaultAgentSkills: [],
         });
       }),
     );
@@ -235,7 +237,6 @@ describe("onboardingContinueWeb$", () => {
             hasDefaultAgent: true,
             defaultAgentId: MOCK_MEMBER_AGENT_ID,
             defaultAgentMetadata: { displayName: "TeamBot" },
-            defaultAgentSkills: [],
           });
         }
         return HttpResponse.json({
@@ -245,7 +246,6 @@ describe("onboardingContinueWeb$", () => {
           hasDefaultAgent: true,
           defaultAgentId: MOCK_MEMBER_AGENT_ID,
           defaultAgentMetadata: { displayName: "TeamBot" },
-          defaultAgentSkills: [],
         });
       }),
     );
@@ -282,7 +282,6 @@ describe("onboarding concurrent invocation", () => {
             hasDefaultAgent: false,
             defaultAgentId: null,
             defaultAgentMetadata: null,
-            defaultAgentSkills: [],
           });
         }
         return HttpResponse.json({
@@ -292,7 +291,6 @@ describe("onboarding concurrent invocation", () => {
           hasDefaultAgent: true,
           defaultAgentId: MOCK_AGENT_ID,
           defaultAgentMetadata: null,
-          defaultAgentSkills: [],
         });
       }),
       http.post("*/api/zero/onboarding/setup", async () => {
@@ -319,5 +317,207 @@ describe("onboarding concurrent invocation", () => {
 
     // Both invocations run (UI-level deduplication is handled by useLoadableSet)
     expect(requestCount).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unified member/admin step resolution (#9129)
+// ---------------------------------------------------------------------------
+
+describe("unified onboarding step resolution", () => {
+  it("member lands on step 2 on entry", async () => {
+    mockMemberOnboarding();
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    const step = await context.store.get(onboardingEffectiveStep$);
+    expect(step).toBe("2");
+  });
+
+  it("member with no connectors selected has visible steps [2, 4]", async () => {
+    mockMemberOnboarding();
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    const steps = await context.store.get(onboardingVisibleSteps$);
+    expect([...steps]).toStrictEqual(["2", "4"]);
+  });
+
+  it("member advancing from step 2 with no selection jumps to step 4", async () => {
+    mockMemberOnboarding();
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    await context.store.set(onboardingStepNext$, context.signal);
+
+    const step = await context.store.get(onboardingEffectiveStep$);
+    expect(step).toBe("4");
+  });
+
+  it("member toggling connectors transitions visible steps between [2, 4] and [2, 3, 4]", async () => {
+    mockMemberOnboarding();
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    context.store.set(toggleZeroConnector$, "github");
+    let steps = await context.store.get(onboardingVisibleSteps$);
+    expect([...steps]).toStrictEqual(["2", "3", "4"]);
+
+    context.store.set(toggleZeroConnector$, "github");
+    steps = await context.store.get(onboardingVisibleSteps$);
+    expect([...steps]).toStrictEqual(["2", "4"]);
+  });
+
+  it("admin with no connectors selected has visible steps [1, 2, 4]", async () => {
+    mockAdminOnboarding();
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    const steps = await context.store.get(onboardingVisibleSteps$);
+    expect([...steps]).toStrictEqual(["1", "2", "4"]);
+  });
+
+  it("admin with one connector selected has visible steps [1, 2, 3, 4]", async () => {
+    mockAdminOnboarding();
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    context.store.set(toggleZeroConnector$, "slack");
+
+    const steps = await context.store.get(onboardingVisibleSteps$);
+    expect([...steps]).toStrictEqual(["1", "2", "3", "4"]);
+  });
+
+  it("admin advancing from step 2 with no selection jumps to step 4", async () => {
+    mockAdminOnboarding();
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    context.store.set(setZeroWorkspaceName$, "Acme");
+    context.store.set(setZeroStep$, "2");
+
+    await context.store.set(onboardingStepNext$, context.signal);
+    const step = await context.store.get(onboardingEffectiveStep$);
+    expect(step).toBe("4");
+  });
+
+  it("back from step 4 returns to step 2 when no connectors are selected", async () => {
+    mockAdminOnboarding();
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    context.store.set(setZeroStep$, "4");
+    await context.store.set(onboardingStepBack$, context.signal);
+
+    const step = await context.store.get(onboardingEffectiveStep$);
+    expect(step).toBe("2");
+  });
+
+  it("back from step 4 returns to step 3 when a connector is selected", async () => {
+    mockAdminOnboarding();
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    context.store.set(toggleZeroConnector$, "slack");
+    context.store.set(setZeroStep$, "4");
+
+    await context.store.set(onboardingStepBack$, context.signal);
+
+    const step = await context.store.get(onboardingEffectiveStep$);
+    expect(step).toBe("3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Member completion sends selectedConnectors to backend (#9129 Task 11)
+// ---------------------------------------------------------------------------
+
+describe("completeMemberOnboarding$ body", () => {
+  it("sends selectedConnectors in the body when member has selected connectors", async () => {
+    mockMemberOnboarding();
+
+    let memberStatusCalls = 0;
+    server.use(
+      http.get("*/api/zero/onboarding/status", () => {
+        memberStatusCalls++;
+        if (memberStatusCalls <= 1) {
+          return HttpResponse.json({
+            needsOnboarding: true,
+            isAdmin: false,
+            hasOrg: true,
+            hasDefaultAgent: true,
+            defaultAgentId: MOCK_MEMBER_AGENT_ID,
+            defaultAgentMetadata: { displayName: "TeamBot" },
+          });
+        }
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: false,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: MOCK_MEMBER_AGENT_ID,
+          defaultAgentMetadata: { displayName: "TeamBot" },
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    let receivedBody: unknown = null;
+    server.use(
+      http.post("*/api/zero/onboarding/complete", async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    context.store.set(toggleZeroConnector$, "slack");
+    context.store.set(toggleZeroConnector$, "github");
+
+    await context.store.set(onboardingContinueWeb$, context.signal);
+
+    expect(receivedBody).toStrictEqual({
+      selectedConnectors: ["slack", "github"],
+    });
+  });
+
+  it("sends an empty body when member has no selected connectors", async () => {
+    mockMemberOnboarding();
+
+    let memberStatusCalls = 0;
+    server.use(
+      http.get("*/api/zero/onboarding/status", () => {
+        memberStatusCalls++;
+        if (memberStatusCalls <= 1) {
+          return HttpResponse.json({
+            needsOnboarding: true,
+            isAdmin: false,
+            hasOrg: true,
+            hasDefaultAgent: true,
+            defaultAgentId: MOCK_MEMBER_AGENT_ID,
+            defaultAgentMetadata: { displayName: "TeamBot" },
+          });
+        }
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: false,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: MOCK_MEMBER_AGENT_ID,
+          defaultAgentMetadata: { displayName: "TeamBot" },
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    let receivedBody: unknown = null;
+    server.use(
+      http.post("*/api/zero/onboarding/complete", async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    await context.store.set(onboardingContinueWeb$, context.signal);
+
+    expect(receivedBody).toStrictEqual({});
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -3,7 +3,6 @@ import {
   zeroNeedsOnboarding$,
   zeroNeedsMemberOnboarding$,
   zeroOnboardingStep$,
-  zeroOnboardingStatus$,
   zeroAgentName$,
   zeroWorkspaceName$,
   zeroSelectedConnectors$,
@@ -12,13 +11,11 @@ import {
   completeMemberOnboarding$,
 } from "./zero-onboarding.ts";
 import { currentChatAgentDisplayName$ } from "../agent-chat.ts";
-import { allConnectorTypes$ } from "./settings/connectors.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { slackOrgData$ } from "./zero-slack.ts";
 import { reloadBillingStatus$ } from "./billing.ts";
 import { reloadAgents$ } from "../agent.ts";
 import { showAppSkeleton$ } from "../app-skeleton.ts";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 
 // ---------------------------------------------------------------------------
 // Admin flag
@@ -30,67 +27,49 @@ export const onboardingIsAdmin$ = zeroNeedsOnboarding$;
 // Step resolution (moved from TSX)
 // ---------------------------------------------------------------------------
 
-const ADMIN_STEPS = ["1", "2", "3", "4"] as const;
-
-/** Connector types the member should see, derived from default agent skills. */
-const onboardingMemberConnectors$ = computed(async (get) => {
-  const isAdmin = await get(zeroNeedsOnboarding$);
-  if (isAdmin) {
-    return [] as ConnectorType[];
-  }
-  const status = await get(zeroOnboardingStatus$);
-  const skillUrls = status.defaultAgentSkills ?? [];
-  const all = await get(allConnectorTypes$);
-  const typeSet = new Set(
-    all.map((c) => {
-      return c.type;
-    }),
-  );
-  return (Object.keys(CONNECTOR_TYPES) as ConnectorType[]).filter((type) => {
-    const isInAgent = skillUrls.some((url) => {
-      return url.endsWith(`/${type}`);
-    });
-    return isInAgent && typeSet.has(type);
-  });
+/**
+ * Connectors shown in step 3 — just the current user selection, regardless of
+ * role. Members now drive the selection exactly like admins (#9129).
+ */
+export const onboardingEffectiveConnectors$ = computed((get) => {
+  return get(zeroSelectedConnectors$);
 });
 
-/** Connectors shown in step 3: admin's selection vs member's derived list. */
-export const onboardingEffectiveConnectors$ = computed(async (get) => {
-  const isAdmin = await get(zeroNeedsOnboarding$);
-  if (isAdmin) {
-    return get(zeroSelectedConnectors$);
-  }
-  return await get(onboardingMemberConnectors$);
-});
-
-/** The resolved step accounting for admin/member logic. */
+/**
+ * The resolved step after applying role + selection rules:
+ *   - Member never sees step 1 (admin-only workspace creation); step 1 → 2.
+ *   - Step 3 is hidden for both roles when no connector is selected; step 3 → 4.
+ */
 export const onboardingEffectiveStep$ = computed(async (get) => {
   const step = await get(zeroOnboardingStep$);
   if (!step || step === "done") {
     return undefined;
   }
   const isAdmin = await get(zeroNeedsOnboarding$);
-  if (isAdmin) {
-    return step;
+  if (!isAdmin && step === "1") {
+    return "2";
   }
-  const memberConnectors = await get(onboardingMemberConnectors$);
-  const hasMemberConnectors = memberConnectors.length > 0;
-  if (step === "1" || step === "2" || (step === "3" && !hasMemberConnectors)) {
-    return hasMemberConnectors ? "3" : "4";
+  const selected = get(zeroSelectedConnectors$);
+  if (step === "3" && selected.length === 0) {
+    return "4";
   }
   return step;
 });
 
-/** Steps shown in the progress bar. */
+/**
+ * Steps shown in the progress bar. Admin owns step 1; step 3 only appears
+ * when at least one connector is selected.
+ */
 export const onboardingVisibleSteps$ = computed(async (get) => {
   const isAdmin = await get(zeroNeedsOnboarding$);
+  const selected = get(zeroSelectedConnectors$);
+  const hasSelected = selected.length > 0;
   if (isAdmin) {
-    return ADMIN_STEPS as readonly string[];
+    return (
+      hasSelected ? ["1", "2", "3", "4"] : ["1", "2", "4"]
+    ) as readonly string[];
   }
-  const memberConnectors = await get(onboardingMemberConnectors$);
-  return (
-    memberConnectors.length > 0 ? ["3", "4"] : ["4"]
-  ) as readonly string[];
+  return (hasSelected ? ["2", "3", "4"] : ["2", "4"]) as readonly string[];
 });
 
 /** Current step index within visible steps. */
@@ -127,30 +106,14 @@ export const onboardingStepKey$ = computed(async (get) => {
 // Navigation
 // ---------------------------------------------------------------------------
 
+/** Show the back button on every step except the first visible one. */
 export const onboardingShowBack$ = computed(async (get) => {
   const step = await get(onboardingEffectiveStep$);
-  const isAdmin = await get(zeroNeedsOnboarding$);
-  switch (step) {
-    case "1": {
-      return false;
-    }
-    case "2": {
-      return true;
-    }
-    case "3": {
-      return isAdmin;
-    }
-    case "4": {
-      if (isAdmin) {
-        return true;
-      }
-      const memberConnectors = await get(onboardingMemberConnectors$);
-      return memberConnectors.length > 0;
-    }
-    default: {
-      return false;
-    }
+  if (!step) {
+    return false;
   }
+  const visibleSteps = await get(onboardingVisibleSteps$);
+  return visibleSteps.indexOf(step) > 0;
 });
 
 export const onboardingShowNext$ = computed(async (get) => {
@@ -169,6 +132,7 @@ export const onboardingNextDisabled$ = computed(async (get) => {
 export const onboardingStepBack$ = command(
   async ({ get, set }, _signal: AbortSignal) => {
     const step = await get(onboardingEffectiveStep$);
+    const hasSelected = get(zeroSelectedConnectors$).length > 0;
     switch (step) {
       case "2": {
         set(setZeroStep$, "1");
@@ -179,7 +143,7 @@ export const onboardingStepBack$ = command(
         break;
       }
       case "4": {
-        set(setZeroStep$, "3");
+        set(setZeroStep$, hasSelected ? "3" : "2");
         break;
       }
     }
@@ -189,13 +153,14 @@ export const onboardingStepBack$ = command(
 export const onboardingStepNext$ = command(
   async ({ get, set }, _signal: AbortSignal) => {
     const step = await get(onboardingEffectiveStep$);
+    const hasSelected = get(zeroSelectedConnectors$).length > 0;
     switch (step) {
       case "1": {
         set(setZeroStep$, "2");
         break;
       }
       case "2": {
-        set(setZeroStep$, "3");
+        set(setZeroStep$, hasSelected ? "3" : "4");
         break;
       }
       case "3": {

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -40,7 +40,9 @@ export const zeroNeedsMemberOnboarding$ = computed(async (get) => {
 export const completeMemberOnboarding$ = command(
   async ({ get, set }, _signal: AbortSignal): Promise<string | undefined> => {
     const client = get(zeroClient$)(onboardingCompleteContract);
-    await accept(client.complete(), [200]);
+    const selectedConnectors = get(internalSelectedConnectors$);
+    const body = selectedConnectors.length > 0 ? { selectedConnectors } : {};
+    await accept(client.complete({ body }), [200]);
     set(internalReload$, (x) => {
       return x + 1;
     });
@@ -58,7 +60,7 @@ const initialOnboardingStep$ = computed(async (get) => {
   if (!status.needsOnboarding) {
     return "done" as const;
   }
-  return (status.hasDefaultAgent ? "3" : "1") as ZeroOnboardingStep;
+  return (status.hasDefaultAgent ? "2" : "1") as ZeroOnboardingStep;
 });
 
 const internalAgentName$ = state("Zero");

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -3,6 +3,7 @@ import {
   onboardingStatusContract,
   onboardingCompleteContract,
   onboardingSetupContract,
+  type ConnectorType,
 } from "@vm0/core";
 import { clerk$ } from "../auth.ts";
 import { zeroClient$ } from "../api-client.ts";
@@ -66,7 +67,7 @@ const initialOnboardingStep$ = computed(async (get) => {
 const internalAgentName$ = state("Zero");
 const internalWorkspaceName$ = state("");
 
-const internalSelectedConnectors$ = state<string[]>([]);
+const internalSelectedConnectors$ = state<ConnectorType[]>([]);
 
 export const zeroOnboardingStep$ = computed(async (get) => {
   const userStep = get(userStep$);
@@ -115,7 +116,7 @@ export const setConnectorSearch$ = command(({ set }, value: string) => {
 });
 
 export const toggleZeroConnector$ = command(
-  ({ set }, connectorValue: string) => {
+  ({ set }, connectorValue: ConnectorType) => {
     set(internalSelectedConnectors$, (prev) => {
       return prev.includes(connectorValue)
         ? prev.filter((s) => {

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -437,7 +437,6 @@ describe("mission control page", () => {
           hasDefaultAgent: false,
           defaultAgentId: null,
           defaultAgentMetadata: null,
-          defaultAgentSkills: [],
         });
       }),
       http.get("*/api/zero/tasks", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
@@ -23,7 +23,6 @@ function mockAdminOnboarding() {
         hasDefaultAgent: false,
         defaultAgentId: null,
         defaultAgentMetadata: null,
-        defaultAgentSkills: [],
       });
     }),
     http.post("*/api/zero/onboarding/setup", () => {
@@ -42,7 +41,6 @@ function mockMemberOnboarding() {
         hasDefaultAgent: true,
         defaultAgentId: MOCK_MEMBER_AGENT_ID,
         defaultAgentMetadata: { displayName: "Zero" },
-        defaultAgentSkills: [],
       });
     }),
     http.post("*/api/zero/onboarding/complete", () => {
@@ -57,6 +55,13 @@ async function walkToWhereStep(
   isMember: boolean,
 ) {
   if (isMember) {
+    // Member lands on step 2 (Choose your tools) under the unified flow
+    await waitFor(() => {
+      expect(screen.getByText("Choose your tools")).toBeInTheDocument();
+    });
+    // Advance without selecting a connector — skips step 3, lands on step 4
+    await user.click(screen.getByText("Next"));
+
     await waitFor(() => {
       expect(
         screen.getByText(/Where would you like to work with/),
@@ -74,6 +79,8 @@ async function walkToWhereStep(
     await waitFor(() => {
       expect(screen.getByText("Choose your tools")).toBeInTheDocument();
     });
+    // Select a connector so step 3 is reachable (#9129)
+    await user.click(screen.getByTestId("connector-card-github"));
     await user.click(screen.getByText("Next"));
 
     await waitFor(() => {
@@ -107,7 +114,6 @@ describe("onboarding → chat page (no auto-intro)", () => {
           hasDefaultAgent: true,
           defaultAgentId: MOCK_AGENT_ID,
           defaultAgentMetadata: null,
-          defaultAgentSkills: [],
         });
       }),
       http.get("*/api/zero/chat-threads", () => {
@@ -145,7 +151,6 @@ describe("onboarding → chat page (no auto-intro)", () => {
           hasDefaultAgent: true,
           defaultAgentId: MOCK_MEMBER_AGENT_ID,
           defaultAgentMetadata: { displayName: "Zero" },
-          defaultAgentSkills: [],
         });
       }),
       http.get("*/api/zero/chat-threads", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
@@ -27,7 +27,6 @@ function mockMemberOnboardingDeferred() {
         hasDefaultAgent: true,
         defaultAgentId: MOCK_AGENT_ID,
         defaultAgentMetadata: { displayName: "Zero" },
-        defaultAgentSkills: [],
       });
     }),
     http.post("*/api/zero/onboarding/complete", async () => {
@@ -49,6 +48,13 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
     const mock = mockMemberOnboardingDeferred();
 
     detachedSetupPage({ context, path: "/onboarding" });
+
+    // Member lands on step 2 (Choose your tools) under the unified flow
+    await waitFor(() => {
+      expect(screen.getByText("Choose your tools")).toBeInTheDocument();
+    });
+    // Advance without selecting a connector — skips step 3, lands on step 4
+    await user.click(screen.getByText("Next"));
 
     await waitFor(() => {
       expect(
@@ -83,7 +89,6 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
           hasDefaultAgent: true,
           defaultAgentId: MOCK_AGENT_ID,
           defaultAgentMetadata: { displayName: "Zero" },
-          defaultAgentSkills: [],
         });
       }),
       http.get("*/api/zero/chat-threads", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
@@ -22,7 +22,6 @@ function mockAdminOnboarding() {
         hasDefaultAgent: false,
         defaultAgentId: null,
         defaultAgentMetadata: null,
-        defaultAgentSkills: [],
       });
     }),
     http.post("*/api/zero/onboarding/setup", () => {
@@ -41,7 +40,6 @@ function switchToAdminComplete() {
         hasDefaultAgent: true,
         defaultAgentId: MOCK_AGENT_ID,
         defaultAgentMetadata: null,
-        defaultAgentSkills: [],
       });
     }),
     http.get("*/api/zero/chat-threads", () => {
@@ -60,7 +58,6 @@ function mockMemberOnboarding() {
         hasDefaultAgent: true,
         defaultAgentId: MOCK_MEMBER_AGENT_ID,
         defaultAgentMetadata: { displayName: "Zero" },
-        defaultAgentSkills: [],
       });
     }),
     http.post("*/api/zero/onboarding/complete", () => {
@@ -79,7 +76,6 @@ function switchToMemberComplete() {
         hasDefaultAgent: true,
         defaultAgentId: MOCK_MEMBER_AGENT_ID,
         defaultAgentMetadata: { displayName: "Zero" },
-        defaultAgentSkills: [],
       });
     }),
     http.get("*/api/zero/chat-threads", () => {
@@ -100,6 +96,9 @@ async function walkAdminToWhereStep(user: ReturnType<typeof userEvent.setup>) {
   await waitFor(() => {
     expect(screen.getByText("Choose your tools")).toBeInTheDocument();
   });
+  // Select a connector so step 3 is reachable (#9129 — step 3 is
+  // conditional on at least one selected connector)
+  await user.click(screen.getByTestId("connector-card-github"));
   await user.click(screen.getByText("Next"));
 
   await waitFor(() => {
@@ -137,7 +136,13 @@ describe("onboarding continue in web → agent chat page", () => {
 
     detachedSetupPage({ context, path: "/onboarding" });
 
-    // Member with no connectors skips directly to step 4
+    // Member lands on step 2 (Choose your tools) under the unified flow
+    await waitFor(() => {
+      expect(screen.getByText("Choose your tools")).toBeInTheDocument();
+    });
+    // Advance without selecting a connector — skips step 3, lands on step 4
+    await user.click(screen.getByText("Next"));
+
     await waitFor(() => {
       expect(
         screen.getByText(/Where would you like to work with/),
@@ -181,7 +186,13 @@ describe("onboarding add to Slack → works page", () => {
 
     detachedSetupPage({ context, path: "/onboarding" });
 
-    // Member with no connectors skips directly to step 4
+    // Member lands on step 2 (Choose your tools) under the unified flow
+    await waitFor(() => {
+      expect(screen.getByText("Choose your tools")).toBeInTheDocument();
+    });
+    // Advance without selecting a connector — skips step 3, lands on step 4
+    await user.click(screen.getByText("Next"));
+
     await waitFor(() => {
       expect(
         screen.getByText(/Where would you like to work with/),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-navigation.test.tsx
@@ -21,7 +21,6 @@ function mockOnboardingNeededAdmin() {
         hasDefaultAgent: false,
         defaultAgentId: null,
         defaultAgentMetadata: null,
-        defaultAgentSkills: [],
       });
     }),
     // Single setup endpoint replaces all individual onboarding API calls
@@ -45,7 +44,6 @@ function mockOnboardingNeededMember() {
         hasDefaultAgent: true,
         defaultAgentId: "c0000000-0000-4000-a000-000000000001",
         defaultAgentMetadata: { displayName: "Zero" },
-        defaultAgentSkills: [],
       });
     }),
     // Mock complete member onboarding
@@ -92,10 +90,11 @@ describe("onboarding navigation", () => {
     await fill(input, "Test Workspace");
     await user.click(screen.getByText("Next"));
 
-    // Step 2: Choose your tools → Next
+    // Step 2: Choose your tools — select a connector so step 3 is visible
     await waitFor(() => {
       expect(screen.getByText("Choose your tools")).toBeInTheDocument();
     });
+    await user.click(screen.getByTestId("connector-card-github"));
     await user.click(screen.getByText("Next"));
 
     // Step 3: Connect your apps → Next
@@ -121,7 +120,6 @@ describe("onboarding navigation", () => {
           hasDefaultAgent: true,
           defaultAgentId: MOCK_AGENT_ID,
           defaultAgentMetadata: null,
-          defaultAgentSkills: [],
         });
       }),
     );
@@ -146,11 +144,9 @@ describe("onboarding navigation", () => {
       expect(pathname()).toBe("/onboarding");
     });
 
-    // Member goes straight to step 4 (where-to-work) with no connectors
+    // Member lands on step 2 (Choose your tools) under the unified flow
     await waitFor(() => {
-      expect(
-        screen.getByText(/Where would you like to work with/),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Choose your tools")).toBeInTheDocument();
     });
   });
 
@@ -160,7 +156,13 @@ describe("onboarding navigation", () => {
 
     detachedSetupPage({ context, path: "/onboarding" });
 
-    // Member with no connectors goes straight to step 4 (where-to-work)
+    // Member starts on step 2 — advance without selecting connectors to land
+    // on step 4 (where-to-work).
+    await waitFor(() => {
+      expect(screen.getByText("Choose your tools")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Next"));
+
     await waitFor(() => {
       expect(
         screen.getByText(/Where would you like to work with/),
@@ -177,7 +179,6 @@ describe("onboarding navigation", () => {
           hasDefaultAgent: true,
           defaultAgentId: "c0000000-0000-4000-a000-000000000001",
           defaultAgentMetadata: { displayName: "Zero" },
-          defaultAgentSkills: [],
         });
       }),
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
@@ -123,7 +123,6 @@ describe("talk navigation", () => {
             hasDefaultAgent: true,
             defaultAgentId: MOCK_AGENT_ID,
             defaultAgentMetadata: null,
-            defaultAgentSkills: [],
           });
         }
         return HttpResponse.json({
@@ -133,7 +132,6 @@ describe("talk navigation", () => {
           hasDefaultAgent: false,
           defaultAgentId: null,
           defaultAgentMetadata: null,
-          defaultAgentSkills: [],
         });
       }),
       // Single setup endpoint
@@ -158,10 +156,11 @@ describe("talk navigation", () => {
     await fill(input, "Test Workspace");
     await user.click(screen.getByText("Next"));
 
-    // Step 2: Choose your tools → Next
+    // Step 2: Choose your tools — select a connector so step 3 is reachable
     await waitFor(() => {
       expect(screen.getByText("Choose your tools")).toBeInTheDocument();
     });
+    await user.click(screen.getByTestId("connector-card-github"));
     await user.click(screen.getByText("Next"));
 
     // Step 3: Connect your apps → Next

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-to-activity-agent-retention.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-to-activity-agent-retention.test.tsx
@@ -20,7 +20,6 @@ function mockTwoAgents() {
         hasDefaultAgent: true,
         defaultAgentId: "agent-foo-id",
         defaultAgentMetadata: { displayName: "foo" },
-        defaultAgentSkills: [],
       });
     }),
     http.get("*/api/zero/team", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-about-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-about-page.test.tsx
@@ -56,7 +56,6 @@ describe("zero about page", () => {
           hasDefaultAgent: true,
           defaultAgentId: "c0000000-0000-4000-a000-000000000001",
           defaultAgentMetadata: { displayName: "MyAgent" },
-          defaultAgentSkills: [],
         });
       }),
       http.get("*/api/zero/agents/:id", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
@@ -206,7 +206,6 @@ function renderTeamPageAsMember(
         hasDefaultAgent: true,
         defaultAgentId: "compose-1",
         defaultAgentMetadata: { displayName: "Zero" },
-        defaultAgentSkills: [],
       });
     }),
     http.get("*/api/zero/org", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -18,7 +18,6 @@ function mockOnboardingNeeded() {
         hasDefaultAgent: false,
         defaultAgentId: null,
         defaultAgentMetadata: null,
-        defaultAgentSkills: [],
       });
     }),
   );
@@ -124,30 +123,38 @@ function mockMemberOnboardingNeeded() {
         hasDefaultAgent: true,
         defaultAgentId: "c0000000-0000-4000-a000-000000000001",
         defaultAgentMetadata: null,
-        defaultAgentSkills: [],
       });
     }),
   );
 }
 
 describe("member welcome - step navigation", () => {
-  it("should skip to where-to-work step for member with no connectors", async () => {
+  it("should land on step 2 (choose tools) for member on entry", async () => {
     mockMemberOnboardingNeeded();
     await renderOnboardingPage();
 
-    // Member with no defaultAgentSkills goes straight to step 4 (where-to-work)
+    // Unified flow: members skip step 1 and start on step 2 (#9129)
     await waitFor(() => {
       expect(
-        screen.getByTestId("onboarding-step-where-to-work"),
+        screen.getByTestId("onboarding-step-select-connectors"),
       ).toBeInTheDocument();
     });
   });
 
-  it("should show Slack and web options in where-to-work step", async () => {
+  it("should skip to where-to-work when member advances with no connectors", async () => {
+    const user = userEvent.setup();
     mockMemberOnboardingNeeded();
     await renderOnboardingPage();
 
-    // Member lands directly on step 4
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("onboarding-step-select-connectors"),
+      ).toBeInTheDocument();
+    });
+
+    // With no connector selected, Next jumps over step 3 to step 4
+    await user.click(screen.getByText("Next"));
+
     await waitFor(() => {
       expect(
         screen.getByTestId("onboarding-step-where-to-work"),
@@ -155,7 +162,6 @@ describe("member welcome - step navigation", () => {
     });
 
     expect(screen.getByText(/Add .+ to Slack/)).toBeInTheDocument();
-
     expect(screen.getByText(/Continue in web/)).toBeInTheDocument();
   });
 });
@@ -166,6 +172,7 @@ describe("member welcome - step navigation", () => {
 
 describe("onboarding step indicator renders (AGENT-D-056)", () => {
   it("renders a progress bar with step segments for admin flow", async () => {
+    const user = userEvent.setup();
     mockOnboardingNeeded();
     await renderOnboardingPage();
 
@@ -175,9 +182,25 @@ describe("onboarding step indicator renders (AGENT-D-056)", () => {
       ).toBeInTheDocument();
     });
 
-    // Admin flow has 4 visible steps, rendered as 4 bar segments
-    const segments = screen.getAllByTestId("progress-step");
-    expect(segments).toHaveLength(4);
+    // With no connectors selected, step 3 is hidden — 3 visible segments
+    expect(screen.getAllByTestId("progress-step")).toHaveLength(3);
+
+    // Reach step 2 and select a connector so step 3 is added back
+    const input = await screen.findByPlaceholderText("e.g. Acme Corp");
+    await fill(input, "Acme");
+    await user.click(screen.getByText("Next"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("onboarding-step-select-connectors"),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("connector-card-github"));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("progress-step")).toHaveLength(4);
+    });
   });
 });
 
@@ -234,6 +257,10 @@ describe("step-specific content renders (AGENT-D-057)", () => {
         screen.getByTestId("onboarding-step-select-connectors"),
       ).toBeInTheDocument();
     });
+
+    // Select a connector so step 3 becomes reachable (#9129: step 3 is
+    // conditional on having at least one selected connector)
+    await user.click(screen.getByTestId("connector-card-github"));
     await user.click(screen.getByText("Next"));
 
     await waitFor(() => {
@@ -410,7 +437,7 @@ describe("connect button is present in step 3 (AGENT-D-066)", () => {
 // ---------------------------------------------------------------------------
 
 describe("connector polling status shows (AGENT-D-059)", () => {
-  it("shows no connectors message when step 3 is reached without selections", async () => {
+  it("skips step 3 entirely when step 2 is advanced without selections", async () => {
     const user = userEvent.setup();
     mockOnboardingNeeded();
     await renderOnboardingPage();
@@ -425,15 +452,18 @@ describe("connector polling status shows (AGENT-D-059)", () => {
       ).toBeInTheDocument();
     });
 
-    // Skip selection and go directly to step 3
+    // With no connector selected, Next from step 2 jumps straight to step 4
+    // (#9129 — step 3 is conditional on having at least one connector).
     await user.click(screen.getByText("Next"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("onboarding-step-connect")).toBeInTheDocument();
       expect(
-        screen.getByTestId("onboarding-no-connectors"),
+        screen.getByTestId("onboarding-step-where-to-work"),
       ).toBeInTheDocument();
     });
+    expect(
+      screen.queryByTestId("onboarding-step-connect"),
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -475,8 +505,18 @@ describe("back button returns to previous step (AGENT-D-068)", () => {
 
 describe("slack/web integration setup cards render (AGENT-D-061)", () => {
   it("slack and web cards are displayed in step 4 for member", async () => {
+    const user = userEvent.setup();
     mockMemberOnboardingNeeded();
     await renderOnboardingPage();
+
+    // Member starts at step 2 under the unified flow; advance to step 4
+    // by clicking Next without selecting a connector.
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("onboarding-step-select-connectors"),
+      ).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Next"));
 
     await waitFor(() => {
       expect(screen.getByText(/Add .+ to Slack/)).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -927,10 +927,11 @@ function OnboardingStepContent() {
 
   switch (effectiveStep) {
     case "1": {
+      // Step 1 is admin-only (workspace creation).
       return isAdmin ? <WorkspaceStepContent /> : null;
     }
     case "2": {
-      return isAdmin ? <SelectConnectorsContent /> : null;
+      return <SelectConnectorsContent />;
     }
     case "3": {
       return <ConnectStepContent />;

--- a/turbo/apps/web/app/api/zero/onboarding/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/complete/__tests__/route.test.ts
@@ -17,7 +17,11 @@ describe("POST /api/zero/onboarding/complete", () => {
 
     const request = createTestRequest(
       "http://localhost:3000/api/zero/onboarding/complete",
-      { method: "POST" },
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+        headers: { "Content-Type": "application/json" },
+      },
     );
     const response = await POST(request);
     const data = await response.json();
@@ -54,7 +58,11 @@ describe("POST /api/zero/onboarding/complete", () => {
     // Complete onboarding
     const request = createTestRequest(
       "http://localhost:3000/api/zero/onboarding/complete",
-      { method: "POST" },
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+        headers: { "Content-Type": "application/json" },
+      },
     );
     const response = await POST(request);
     const data = await response.json();
@@ -80,6 +88,8 @@ describe("POST /api/zero/onboarding/complete", () => {
           "http://localhost:3000/api/zero/onboarding/complete",
           {
             method: "POST",
+            body: JSON.stringify({}),
+            headers: { "Content-Type": "application/json" },
           },
         ),
       );

--- a/turbo/apps/web/app/api/zero/onboarding/complete/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/complete/route.ts
@@ -1,47 +1,104 @@
-import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { onboardingCompleteContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { orgMembersMetadata } from "../../../../../src/db/schema/org-members-metadata";
+import { orgMetadata } from "../../../../../src/db/schema/org-metadata";
+import { userConnectors } from "../../../../../src/db/schema/user-connector";
 
 /**
  * POST /api/zero/onboarding/complete
  *
- * Marks the member onboarding as done by writing `onboarding_done: true`
- * to the org_members table.
+ * Marks member onboarding as done and — if the member selected any connectors
+ * during the unified step 2 — inserts `user_connectors` rows for the org's
+ * existing default agent. No new agent is created here; admins do that via
+ * /setup.
  */
-export async function POST(request: Request) {
-  initServices();
+const router = tsr.router(onboardingCompleteContract, {
+  complete: async ({ body, headers }) => {
+    initServices();
 
-  const authHeader = request.headers.get("authorization");
-  const authCtx = await getAuthContext(authHeader ?? undefined);
-  if (!authCtx) {
-    return NextResponse.json(
-      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
-      { status: 401 },
-    );
-  }
+    const authCtx = await getAuthContext(headers.authorization ?? undefined);
+    if (!authCtx) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
+    }
+    const { userId } = authCtx;
 
-  const { userId } = authCtx;
-  const { org } = await resolveOrg(authCtx);
+    const { org } = await resolveOrg(authCtx);
+    const db = globalThis.services.db;
 
-  const now = new Date();
-  await globalThis.services.db
-    .insert(orgMembersMetadata)
-    .values({
-      orgId: org.orgId,
-      userId,
-      onboardingDone: true,
-      createdAt: now,
-      updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
-      set: {
+    const now = new Date();
+    await db
+      .insert(orgMembersMetadata)
+      .values({
+        orgId: org.orgId,
+        userId,
         onboardingDone: true,
+        createdAt: now,
         updatedAt: now,
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+        set: {
+          onboardingDone: true,
+          updatedAt: now,
+        },
+      });
 
-  return NextResponse.json({ ok: true });
-}
+    const selectedConnectors = body.selectedConnectors ?? [];
+    if (selectedConnectors.length > 0) {
+      const [orgRow] = await db
+        .select({ defaultAgentId: orgMetadata.defaultAgentId })
+        .from(orgMetadata)
+        .where(eq(orgMetadata.orgId, org.orgId))
+        .limit(1);
+
+      const agentId = orgRow?.defaultAgentId;
+      if (agentId) {
+        await db.transaction(async (tx) => {
+          await tx
+            .delete(userConnectors)
+            .where(
+              and(
+                eq(userConnectors.orgId, org.orgId),
+                eq(userConnectors.userId, userId),
+                eq(userConnectors.agentId, agentId),
+              ),
+            );
+          await tx.insert(userConnectors).values(
+            selectedConnectors.map((connectorType) => {
+              return {
+                orgId: org.orgId,
+                userId,
+                agentId,
+                connectorType,
+              };
+            }),
+          );
+        });
+      }
+    }
+
+    return {
+      status: 200 as const,
+      body: { ok: true },
+    };
+  },
+});
+
+const handler = createHandler(onboardingCompleteContract, router, {
+  errorHandler: createSafeErrorHandler("onboarding-complete"),
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
@@ -48,7 +48,6 @@ describe("GET /api/zero/onboarding/status", () => {
       hasDefaultAgent: false,
       defaultAgentId: null,
       defaultAgentMetadata: null,
-      defaultAgentSkills: [],
     });
   });
 
@@ -87,7 +86,11 @@ describe("GET /api/zero/onboarding/status", () => {
     // Mark personal onboarding as done
     const completeRequest = createTestRequest(
       "http://localhost:3000/api/zero/onboarding/complete",
-      { method: "POST" },
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+        headers: { "Content-Type": "application/json" },
+      },
     );
     const completeResponse = await completeOnboarding(completeRequest);
     expect(completeResponse.status).toBe(200);
@@ -106,7 +109,6 @@ describe("GET /api/zero/onboarding/status", () => {
       hasDefaultAgent: true,
       defaultAgentId: compose.composeId,
       defaultAgentMetadata: null,
-      defaultAgentSkills: [],
     });
   });
 
@@ -136,7 +138,11 @@ describe("GET /api/zero/onboarding/status", () => {
     // Mark personal onboarding as done
     const completeRequest = createTestRequest(
       "http://localhost:3000/api/zero/onboarding/complete",
-      { method: "POST" },
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+        headers: { "Content-Type": "application/json" },
+      },
     );
     const completeResponse = await completeOnboarding(completeRequest);
     expect(completeResponse.status).toBe(200);
@@ -155,7 +161,6 @@ describe("GET /api/zero/onboarding/status", () => {
       hasDefaultAgent: true,
       defaultAgentId: compose.composeId,
       defaultAgentMetadata: { displayName: "My Agent", sound: "friendly" },
-      defaultAgentSkills: [],
     });
   });
 
@@ -238,7 +243,11 @@ describe("GET /api/zero/onboarding/status", () => {
     // Complete onboarding via POST /api/zero/onboarding/complete
     const completeRequest = createTestRequest(
       "http://localhost:3000/api/zero/onboarding/complete",
-      { method: "POST" },
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+        headers: { "Content-Type": "application/json" },
+      },
     );
     const completeResponse = await completeOnboarding(completeRequest);
     expect(completeResponse.status).toBe(200);

--- a/turbo/apps/web/app/api/zero/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/status/route.ts
@@ -8,13 +8,9 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { isBadRequest, isNotFound } from "../../../../../src/lib/shared/errors";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../../../src/db/schema/agent-compose";
+import { agentComposes } from "../../../../../src/db/schema/agent-compose";
 import { zeroAgents } from "../../../../../src/db/schema/zero-agent";
 import { eq, and } from "drizzle-orm";
-import { agentComposeApiContentSchema } from "@vm0/core";
 import { orgMembersMetadata } from "../../../../../src/db/schema/org-members-metadata";
 import { orgMetadata as orgTable } from "../../../../../src/db/schema/org-metadata";
 
@@ -44,28 +40,21 @@ interface DefaultAgentInfo {
     description?: string;
     sound?: string;
   } | null;
-  skills: string[];
 }
 
 async function resolveDefaultAgent(
-  orgId: string,
   composeId: string,
 ): Promise<DefaultAgentInfo | null> {
-  // Single query: JOIN compose + zero_agents + head version
+  // Single query: JOIN compose + zero_agents
   const [row] = await globalThis.services.db
     .select({
       name: agentComposes.name,
       displayName: zeroAgents.displayName,
       description: zeroAgents.description,
       sound: zeroAgents.sound,
-      content: agentComposeVersions.content,
     })
     .from(agentComposes)
     .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
-    .leftJoin(
-      agentComposeVersions,
-      eq(agentComposes.headVersionId, agentComposeVersions.id),
-    )
     .where(eq(agentComposes.id, composeId))
     .limit(1);
 
@@ -82,19 +71,7 @@ async function resolveDefaultAgent(
         }
       : null;
 
-  let skills: string[] = [];
-  if (row.content) {
-    const parsed = agentComposeApiContentSchema.safeParse(row.content);
-    if (parsed.success) {
-      const agentKey = Object.keys(parsed.data.agents)[0];
-      const agentDef = agentKey ? parsed.data.agents[agentKey] : undefined;
-      if (agentDef) {
-        skills = agentDef.skills ?? [];
-      }
-    }
-  }
-
-  return { name: row.name, composeId, metadata, skills };
+  return { name: row.name, composeId, metadata };
 }
 
 const router = tsr.router(onboardingStatusContract, {
@@ -132,10 +109,7 @@ const router = tsr.router(onboardingStatusContract, {
 
       if (defaultAgentId) {
         // defaultAgentId IS the composeId (zero_agents.id = agent_composes.id)
-        defaultAgent = await resolveDefaultAgent(
-          resolvedOrg.orgId,
-          defaultAgentId,
-        );
+        defaultAgent = await resolveDefaultAgent(defaultAgentId);
       }
     } catch (error) {
       if (!isNotFound(error) && !isBadRequest(error)) {
@@ -170,7 +144,6 @@ const router = tsr.router(onboardingStatusContract, {
         hasDefaultAgent: defaultAgent !== null,
         defaultAgentId: defaultAgent?.composeId ?? null,
         defaultAgentMetadata: defaultAgent?.metadata ?? null,
-        defaultAgentSkills: defaultAgent?.skills ?? [],
       },
     };
   },

--- a/turbo/packages/core/src/contracts/onboarding.ts
+++ b/turbo/packages/core/src/contracts/onboarding.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { initContract, authHeadersSchema } from "./base";
 import { apiErrorSchema } from "./errors";
+import { connectorTypeSchema } from "./connectors";
 
 const c = initContract();
 
@@ -48,7 +49,7 @@ export const onboardingCompleteContract = c.router({
     path: "/api/zero/onboarding/complete",
     headers: authHeadersSchema,
     body: z.object({
-      selectedConnectors: z.array(z.string()).optional(),
+      selectedConnectors: z.array(connectorTypeSchema).optional(),
     }),
     responses: {
       200: z.object({ ok: z.boolean() }),
@@ -68,7 +69,7 @@ export const onboardingSetupContract = c.router({
       workspaceName: z.string().optional(),
       sound: z.string().optional(),
       avatarUrl: z.string().optional(),
-      selectedConnectors: z.array(z.string()).optional(),
+      selectedConnectors: z.array(connectorTypeSchema).optional(),
       timezone: z.string().optional(),
     }),
     responses: {

--- a/turbo/packages/core/src/contracts/onboarding.ts
+++ b/turbo/packages/core/src/contracts/onboarding.ts
@@ -20,7 +20,6 @@ export const onboardingStatusResponseSchema = z.object({
       sound: z.string().optional(),
     })
     .nullable(),
-  defaultAgentSkills: z.array(z.string()),
 });
 
 export type OnboardingStatusResponse = z.infer<
@@ -48,7 +47,9 @@ export const onboardingCompleteContract = c.router({
     method: "POST",
     path: "/api/zero/onboarding/complete",
     headers: authHeadersSchema,
-    body: c.noBody(),
+    body: z.object({
+      selectedConnectors: z.array(z.string()).optional(),
+    }),
     responses: {
       200: z.object({ ok: z.boolean() }),
       401: apiErrorSchema,


### PR DESCRIPTION
## Summary

Resolves #9129. Unify the connector selection UX between admin and member onboarding so both roles share steps 2–4; only step 1 (workspace name) remains admin-only.

- Remove skill-derived member pre-selection (`onboardingMemberConnectors$`); members freely toggle connectors at step 2.
- Make step 3 (OAuth connect) conditional on `selectedConnectors.length > 0` for both roles.
- Member entry step is now `'2'` (was `'3'`).
- On member completion, `POST /api/zero/onboarding/complete` accepts `{ selectedConnectors? }` and inserts `user_connectors` rows for the org's existing default agent.
- Drop the `defaultAgentSkills` field from the onboarding status contract — no consumer remains after removing member pre-selection.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest` — 1679 platform tests pass
- [x] `pnpm -F web exec vitest run app/api/zero/onboarding/` — 11 onboarding route tests pass
- [x] `pnpm turbo run lint` — no new warnings
- [x] `pnpm check-types` — no new type errors (pre-existing CLI/org-manage errors only)
- [x] `pnpm format` — clean
- [x] `pnpm knip` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)