### PR TITLE
fix(platform): keep agent authorization list visible during refetch

### DIFF
--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -407,7 +407,11 @@ function JobPermissionsTab({
   displayName: string;
   ownerId: string;
 }) {
-  const connectorsLoadable = useLoadable(zeroJobAddedConnectors$);
+  // Use useLastLoadable so the list keeps showing the previous data while the
+  // signal refetches after a toggle/save or a permission-policy reload. This
+  // prevents the entire list from flickering to the skeleton on each change
+  // (issue #9141).
+  const connectorsLoadable = useLastLoadable(zeroJobAddedConnectors$);
   const addedConnectors =
     connectorsLoadable.state === "hasData" ? connectorsLoadable.data : [];
   const addConnector = useSet(addZeroJobConnector$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
@@ -341,4 +341,61 @@ describe("zero job detail page - interaction and state", () => {
     // Resolve the pending request
     resolvePut?.();
   });
+
+  it("should keep connector list visible during post-toggle refetch (AGENT-D-036)", async () => {
+    // Regression test for #9141: toggling a connector triggers a refetch of
+    // the user-connectors endpoint. The list must NOT flicker to the skeleton
+    // during that refetch — the rows should stay visible the whole time.
+    const user = userEvent.setup();
+
+    mockAPIs();
+
+    // Hold the post-save GET so the refetch stays pending until we release it.
+    let resolveGet: (() => void) | undefined;
+    const getPromise = new Promise<void>((resolve) => {
+      resolveGet = resolve;
+    });
+    let getCallCount = 0;
+    server.use(
+      http.put("*/api/zero/agents/:id/user-connectors", () => {
+        return HttpResponse.json({ enabledTypes: [] });
+      }),
+      http.get("*/api/zero/agents/:id/user-connectors", async () => {
+        getCallCount += 1;
+        // First call (initial seed) resolves immediately with slack enabled;
+        // second call (the post-save refetch) blocks so we can observe the
+        // in-between UI without slack enabled.
+        if (getCallCount === 1) {
+          return HttpResponse.json({ enabledTypes: ["slack"] });
+        }
+        await getPromise;
+        return HttpResponse.json({ enabledTypes: [] });
+      }),
+    );
+    detachedSetupPage({ context, path: "/agents/my-agent" });
+    await waitForPageLoad();
+
+    // Wait for connectors to load initially.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("switch", { name: /Revoke Slack access/i }),
+      ).toBeInTheDocument();
+    });
+
+    // Toggle Slack off — this triggers PUT then a GET refetch (which is held).
+    await user.click(
+      screen.getByRole("switch", { name: /Revoke Slack access/i }),
+    );
+
+    // While the refetch is in-flight, the connector rows must remain rendered
+    // (Slack and Linear are both visible — no skeleton swap).
+    await waitFor(() => {
+      expect(getCallCount).toBeGreaterThan(1);
+    });
+    expect(screen.getByText("Slack")).toBeInTheDocument();
+    expect(screen.getByText("Linear")).toBeInTheDocument();
+
+    // Release the held GET so the test cleans up.
+    resolveGet?.();
+  });
 });


### PR DESCRIPTION
## Summary

- The Authorization tab on the agent-detail page used `useLoadable` for the connectors list, which switches to `loading` on every refetch. After a connector toggle save (which triggers a `zeroJobAddedConnectors$` refetch) or a permission-policy save (which calls `reloadDetail()` and cascades into the same signal), the entire list flickered to a skeleton — losing scroll position and breaking the perception of speed.
- Switched to `useLastLoadable` so the previously resolved data stays on screen during refetches. Combined with the existing optimistic update on toggle, the row's state appears instantly and the rest of the list does not move.
- Added a regression integration test (`AGENT-D-036`) that holds the post-save GET in flight and asserts the connector rows remain visible.

Fixes #9141

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx src/signals/zero-page/__tests__/zero-job-detail.test.ts` (31 passing)
- [x] Confirmed the new test fails on this branch when `useLastLoadable` is reverted to `useLoadable` (regression coverage proven)
- [x] `pnpm turbo run lint --filter @vm0/app` passes
- [ ] Manual: toggle a connector and toggle a permission on the agent detail page — list stays put, no skeleton flash