### PR TITLE
feat(web): complete i18n coverage for marketing site

### DIFF
--- a/turbo/apps/web/app/[locale]/blog/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/page.tsx
@@ -13,7 +13,7 @@ import { BlogContent } from "../../components/blog";
 import Footer from "../../components/Footer";
 import { isBlogEnabled } from "../../../src/env";
 
-const BASE_URL = "https://vm0.ai";
+const BASE_URL = "https://www.vm0.ai";
 
 function getBreadcrumbJsonLd(locale: string) {
   return {

--- a/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
@@ -125,13 +125,13 @@ export default async function BlogPostPage({ params }: PageProps) {
         "@type": "ListItem",
         position: 1,
         name: "Home",
-        item: `https://vm0.ai/${locale}`,
+        item: `https://www.vm0.ai/${locale}`,
       },
       {
         "@type": "ListItem",
         position: 2,
         name: "Blog",
-        item: `https://vm0.ai/${locale}/blog`,
+        item: `https://www.vm0.ai/${locale}/blog`,
       },
       {
         "@type": "ListItem",
@@ -159,7 +159,7 @@ export default async function BlogPostPage({ params }: PageProps) {
       name: "VM0",
       logo: {
         "@type": "ImageObject",
-        url: "https://vm0.ai/assets/vm0-logo.svg",
+        url: "https://www.vm0.ai/assets/vm0-logo.svg",
       },
     },
   };

--- a/turbo/apps/web/app/[locale]/layout.tsx
+++ b/turbo/apps/web/app/[locale]/layout.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     ja: "ja_JP",
   };
 
-  const baseUrl = "https://vm0.ai";
+  const baseUrl = "https://www.vm0.ai";
   const languages: Record<string, string> = {};
 
   locales.forEach((loc) => {

--- a/turbo/apps/web/app/[locale]/page.tsx
+++ b/turbo/apps/web/app/[locale]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { auth } from "@clerk/nextjs/server";
 import LandingPage from "../components/LandingPage";
 
-const BASE_URL = "https://vm0.ai";
+const BASE_URL = "https://www.vm0.ai";
 
 interface PageProps {
   params: Promise<{ locale: string }>;

--- a/turbo/apps/web/app/[locale]/pricing/PricingPageClient.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/PricingPageClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { useTranslations } from "next-intl";
 import Footer from "../../components/Footer";
 import Particles from "../../components/Particles";
 
@@ -153,6 +154,8 @@ function PricingCard({
 }
 
 export default function PricingPageClient() {
+  const t = useTranslations("pricing");
+
   return (
     <>
       <Particles />
@@ -161,11 +164,8 @@ export default function PricingPageClient() {
       <section className="hero-section" style={{ paddingBottom: "40px" }}>
         <div className="container">
           <div>
-            <h1 className="hero-title">Pay for what you use, nothing more</h1>
-            <p className="hero-description">
-              Start free with your AI teammate. Scale when you&apos;re ready, no
-              credit card required.
-            </p>
+            <h1 className="hero-title">{t("heroTitle")}</h1>
+            <p className="hero-description">{t("heroDescription")}</p>
           </div>
         </div>
       </section>
@@ -188,16 +188,16 @@ export default function PricingPageClient() {
               <PricingCard
                 title="Free"
                 price="$0"
-                period="/month"
-                description="Get started with your AI teammate for free."
+                period={t("perMonth")}
+                description={t("free.description")}
                 features={[
-                  "10,000 starter credits",
-                  "1 concurrent run",
-                  "Unlimited total agents",
-                  "Bring your own LLM keys",
-                  "Community support",
+                  t("free.features.starterCredits"),
+                  t("free.features.concurrentRun"),
+                  t("free.features.unlimitedAgents"),
+                  t("free.features.bringOwnLLM"),
+                  t("free.features.communitySupport"),
                 ]}
-                buttonText="Get started"
+                buttonText={t("free.buttonText")}
                 buttonHref="/sign-up"
                 buttonClassName="btn-secondary-large"
               />
@@ -206,17 +206,17 @@ export default function PricingPageClient() {
               <PricingCard
                 title="Pro"
                 price="$40"
-                period="/month"
-                description="More power and seamless collaboration for your team."
+                period={t("perMonth")}
+                description={t("pro.description")}
                 features={[
-                  "20,000 credits / month",
-                  "2 concurrent runs",
-                  "Unlimited total agents",
-                  "Bring your own LLM keys",
-                  "Credits rollover (1 month)",
-                  "Email support",
+                  t("pro.features.credits"),
+                  t("pro.features.concurrentRuns"),
+                  t("pro.features.unlimitedAgents"),
+                  t("pro.features.bringOwnLLM"),
+                  t("pro.features.creditsRollover"),
+                  t("pro.features.emailSupport"),
                 ]}
-                buttonText="Start with Pro"
+                buttonText={t("pro.buttonText")}
                 buttonHref="/sign-up?plan=pro"
                 buttonClassName="btn-primary-large"
               />
@@ -225,17 +225,17 @@ export default function PricingPageClient() {
               <PricingCard
                 title="Team"
                 price="$200"
-                period="/month"
-                description="Scale fast with zero friction and full flexibility."
+                period={t("perMonth")}
+                description={t("team.description")}
                 features={[
-                  "120,000 credits / month",
-                  "5 concurrent runs",
-                  "Unlimited total agents",
-                  "Bring your own LLM keys",
-                  "Credits rollover (1 month)",
-                  "Priority support",
+                  t("team.features.credits"),
+                  t("team.features.concurrentRuns"),
+                  t("team.features.unlimitedAgents"),
+                  t("team.features.bringOwnLLM"),
+                  t("team.features.creditsRollover"),
+                  t("team.features.prioritySupport"),
                 ]}
-                buttonText="Start with Team"
+                buttonText={t("team.buttonText")}
                 buttonHref="/sign-up?plan=team"
                 buttonClassName="btn-secondary-large"
               />
@@ -266,7 +266,7 @@ export default function PricingPageClient() {
                   letterSpacing: "-0.3px",
                 }}
               >
-                Need more credits?
+                {t("needMoreCredits")}
               </h2>
               <p
                 style={{
@@ -278,15 +278,13 @@ export default function PricingPageClient() {
                   maxWidth: "600px",
                 }}
               >
-                Top up anytime at{" "}
+                {t("topUpDescription")}{" "}
                 <strong
                   style={{ color: "var(--text-primary)", fontWeight: 500 }}
                 >
-                  1,000 credits per $1
+                  {t("topUpRate")}
                 </strong>
-                . Set up auto-recharge so your agents never stop — when your
-                balance drops below a threshold, credits are purchased
-                automatically.
+                . {t("topUpAutoRecharge")}
               </p>
             </div>
             <div
@@ -316,7 +314,7 @@ export default function PricingPageClient() {
                   color: "var(--text-muted)",
                 }}
               >
-                per 1,000 credits
+                {t("perCredits")}
               </div>
             </div>
           </div>
@@ -333,7 +331,7 @@ export default function PricingPageClient() {
                 letterSpacing: "-0.5px",
               }}
             >
-              Compare plans
+              {t("comparePlans")}
             </h2>
             <div style={{ overflowX: "auto" }}>
               <table
@@ -358,7 +356,7 @@ export default function PricingPageClient() {
                         borderBottom: "1px solid var(--border-light)",
                       }}
                     >
-                      Features
+                      {t("featuresHeader")}
                     </th>
                     <th
                       style={{
@@ -402,130 +400,132 @@ export default function PricingPageClient() {
                   </tr>
                 </thead>
                 <tbody>
-                  <TableSection title="Credits & Agents" />
+                  <TableSection title={t("sections.creditsAndAgents")} />
                   <TableRow
-                    feature="Credits per month"
-                    description="Credits consumed by AI model usage across all agents"
-                    free="10,000 starter"
-                    pro="20,000"
-                    team="120,000"
+                    feature={t("tableFeatures.creditsPerMonth")}
+                    description={t("tableFeatures.creditsPerMonthDesc")}
+                    free={t("tableValues.starter")}
+                    pro={t("tableValues.20k")}
+                    team={t("tableValues.120k")}
                   />
                   <TableRow
-                    feature="Concurrent runs"
-                    description="Number of agents that can run concurrently"
+                    feature={t("tableFeatures.concurrentRuns")}
+                    description={t("tableFeatures.concurrentRunsDesc")}
                     free="1"
                     pro="2"
                     team="5"
                   />
                   <TableRow
-                    feature="Total agents"
-                    description="Maximum number of agents you can create"
-                    free="Unlimited"
-                    pro="Unlimited"
-                    team="Unlimited"
+                    feature={t("tableFeatures.totalAgents")}
+                    description={t("tableFeatures.totalAgentsDesc")}
+                    free={t("tableValues.unlimited")}
+                    pro={t("tableValues.unlimited")}
+                    team={t("tableValues.unlimited")}
                   />
                   <TableRow
-                    feature="Credits rollover"
-                    description="Unused credits carry over to the next billing period"
+                    feature={t("tableFeatures.creditsRollover")}
+                    description={t("tableFeatures.creditsRolloverDesc")}
                     free={false}
-                    pro="1 month"
-                    team="1 month"
+                    pro={t("tableValues.oneMonth")}
+                    team={t("tableValues.oneMonth")}
                   />
                   <TableRow
-                    feature="Credit top-up"
-                    description="Purchase additional credits anytime at $1 per 1,000 credits"
-                    free={false}
-                    pro={true}
-                    team={true}
-                  />
-                  <TableRow
-                    feature="Auto-recharge"
-                    description="Automatically purchase credits when balance falls below a threshold"
-                    free={false}
-                    pro={true}
-                    team={true}
-                  />
-
-                  <TableSection title="Connectors & Integrations" />
-                  <TableRow
-                    feature="Connectors"
-                    description="Connect your tools like Slack, GitHub, Notion, and more"
-                    free="All connectors"
-                    pro="All connectors"
-                    team="All connectors"
-                  />
-                  <TableRow
-                    feature="Bring your own LLM"
-                    description="Use your own model provider API keys"
-                    free={true}
-                    pro={true}
-                    team={true}
-                  />
-
-                  <TableSection title="Security & Compliance" />
-                  <TableRow
-                    feature="Sandboxed execution"
-                    description="Firecracker microVMs with hardware-level KVM isolation"
-                    free={true}
-                    pro={true}
-                    team={true}
-                  />
-                  <TableRow
-                    feature="Full audit trail"
-                    description="Agent HTTP/HTTPS traffic logged with SHA-256 integrity per run"
-                    free={true}
-                    pro={true}
-                    team={true}
-                  />
-                  <TableRow
-                    feature="No credential exposure"
-                    description="Secrets injected at network layer, never visible to agent code"
-                    free={true}
-                    pro={true}
-                    team={true}
-                  />
-
-                  <TableSection title="Collaboration" />
-                  <TableRow
-                    feature="Team members"
-                    description="Number of people in your workspace"
-                    free="Unlimited"
-                    pro="Unlimited"
-                    team="Unlimited"
-                  />
-                  <TableRow
-                    feature="Per-member credit caps"
-                    description="Set spending limits for individual team members"
+                    feature={t("tableFeatures.creditTopUp")}
+                    description={t("tableFeatures.creditTopUpDesc")}
                     free={false}
                     pro={true}
                     team={true}
                   />
                   <TableRow
-                    feature="Auto-recharge"
-                    description="Automatically purchase credits when balance falls below a threshold"
+                    feature={t("tableFeatures.autoRecharge")}
+                    description={t("tableFeatures.autoRechargeDesc")}
                     free={false}
                     pro={true}
                     team={true}
                   />
 
-                  <TableSection title="Support" />
+                  <TableSection
+                    title={t("sections.connectorsAndIntegrations")}
+                  />
                   <TableRow
-                    feature="Community support"
-                    description="Access to Discord community and documentation"
+                    feature={t("tableFeatures.connectors")}
+                    description={t("tableFeatures.connectorsDesc")}
+                    free={t("tableValues.allConnectors")}
+                    pro={t("tableValues.allConnectors")}
+                    team={t("tableValues.allConnectors")}
+                  />
+                  <TableRow
+                    feature={t("tableFeatures.bringOwnLLM")}
+                    description={t("tableFeatures.bringOwnLLMDesc")}
+                    free={true}
+                    pro={true}
+                    team={true}
+                  />
+
+                  <TableSection title={t("sections.securityAndCompliance")} />
+                  <TableRow
+                    feature={t("tableFeatures.sandboxedExecution")}
+                    description={t("tableFeatures.sandboxedExecutionDesc")}
                     free={true}
                     pro={true}
                     team={true}
                   />
                   <TableRow
-                    feature="Email support"
-                    description="Direct email support from the VM0 team"
+                    feature={t("tableFeatures.fullAuditTrail")}
+                    description={t("tableFeatures.fullAuditTrailDesc")}
+                    free={true}
+                    pro={true}
+                    team={true}
+                  />
+                  <TableRow
+                    feature={t("tableFeatures.noCredentialExposure")}
+                    description={t("tableFeatures.noCredentialExposureDesc")}
+                    free={true}
+                    pro={true}
+                    team={true}
+                  />
+
+                  <TableSection title={t("sections.collaboration")} />
+                  <TableRow
+                    feature={t("tableFeatures.teamMembers")}
+                    description={t("tableFeatures.teamMembersDesc")}
+                    free={t("tableValues.unlimited")}
+                    pro={t("tableValues.unlimited")}
+                    team={t("tableValues.unlimited")}
+                  />
+                  <TableRow
+                    feature={t("tableFeatures.perMemberCreditCaps")}
+                    description={t("tableFeatures.perMemberCreditCapsDesc")}
                     free={false}
                     pro={true}
                     team={true}
                   />
                   <TableRow
-                    feature="Priority support"
-                    description="Dedicated support with faster response times"
+                    feature={t("tableFeatures.autoRecharge")}
+                    description={t("tableFeatures.autoRechargeDesc")}
+                    free={false}
+                    pro={true}
+                    team={true}
+                  />
+
+                  <TableSection title={t("sections.support")} />
+                  <TableRow
+                    feature={t("tableFeatures.communitySupport")}
+                    description={t("tableFeatures.communitySupportDesc")}
+                    free={true}
+                    pro={true}
+                    team={true}
+                  />
+                  <TableRow
+                    feature={t("tableFeatures.emailSupport")}
+                    description={t("tableFeatures.emailSupportDesc")}
+                    free={false}
+                    pro={true}
+                    team={true}
+                  />
+                  <TableRow
+                    feature={t("tableFeatures.prioritySupport")}
+                    description={t("tableFeatures.prioritySupportDesc")}
                     free={false}
                     pro={false}
                     team={true}
@@ -547,7 +547,7 @@ export default function PricingPageClient() {
                 letterSpacing: "-0.5px",
               }}
             >
-              Frequently asked questions
+              {t("faq.title")}
             </h2>
             <div
               style={{
@@ -556,32 +556,32 @@ export default function PricingPageClient() {
               }}
             >
               <FAQItem
-                question="What are credits?"
-                answer="Credits are consumed when your agents use AI models. Different models consume credits at different rates. For example, a simple task might use a few credits, while a complex multi-step workflow uses more."
+                question={t("faq.whatAreCredits")}
+                answer={t("faq.whatAreCreditsAnswer")}
               />
               <FAQItem
-                question="Can I change plans at any time?"
-                answer="Yes! You can upgrade or downgrade your plan at any time. Changes take effect immediately, and we'll prorate charges accordingly."
+                question={t("faq.changePlans")}
+                answer={t("faq.changePlansAnswer")}
               />
               <FAQItem
-                question="What happens when I run out of credits?"
-                answer="When your credits are depleted, your agents will stop running. You can purchase additional credits via auto-recharge, or upgrade to a higher plan for more monthly credits."
+                question={t("faq.runOutOfCredits")}
+                answer={t("faq.runOutOfCreditsAnswer")}
               />
               <FAQItem
-                question="Do unused credits roll over?"
-                answer="On the Free plan, starter credits don't expire but don't replenish. On Pro, unused credits roll over for 1 month. On Team, credits roll over for 1 month."
+                question={t("faq.doCreditsRollOver")}
+                answer={t("faq.doCreditsRollOverAnswer")}
               />
               <FAQItem
-                question="Can I bring my own model provider?"
-                answer="Yes! All plans support bringing your own LLM API keys (Anthropic, etc.). When using your own keys, no VM0 credits are consumed for model usage."
+                question={t("faq.bringOwnModel")}
+                answer={t("faq.bringOwnModelAnswer")}
               />
               <FAQItem
-                question="How secure is VM0?"
-                answer="Every agent run executes in an isolated Firecracker microVM with hardware-level KVM isolation. Credentials are injected at the network layer and never exposed to agent code. All agent HTTP/HTTPS traffic is logged with SHA-256 integrity per run."
+                question={t("faq.howSecure")}
+                answer={t("faq.howSecureAnswer")}
               />
               <FAQItem
-                question="Do you offer annual billing or discounts?"
-                answer="Contact us to discuss volume pricing, annual billing discounts, and custom arrangements for your team."
+                question={t("faq.annualBilling")}
+                answer={t("faq.annualBillingAnswer")}
               />
             </div>
           </div>

--- a/turbo/apps/web/app/[locale]/pricing/page.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Script from "next/script";
 import PricingPageClient from "./PricingPageClient";
 
-const BASE_URL = "https://vm0.ai";
+const BASE_URL = "https://www.vm0.ai";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -113,7 +113,7 @@ const pricingJsonLd = {
   name: "VM0",
   applicationCategory: "DeveloperApplication",
   operatingSystem: "Web, Linux, macOS, Windows",
-  url: "https://vm0.ai",
+  url: "https://www.vm0.ai",
   offers: [
     {
       "@type": "Offer",

--- a/turbo/apps/web/app/[locale]/security/SecurityPage.tsx
+++ b/turbo/apps/web/app/[locale]/security/SecurityPage.tsx
@@ -1,71 +1,42 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import Footer from "../../components/Footer";
 
-const SECTIONS = [
-  {
-    title: "Isolated execution",
-    description:
-      "Every agent run happens inside a completely isolated private environment. When the run finishes, the environment is destroyed automatically, nothing is left behind. Think of it like a disposable glove: clean, safe, and reliable.",
-    detail:
-      "Powered by Firecracker microVMs with hardware-level KVM isolation, not containers. Each run gets its own network namespace from a pre-allocated pool of 16,000+.",
-  },
-  {
-    title: "Secrets never exposed",
-    description:
-      "Connecting Gmail, Slack, or GitHub? Your tokens and credentials are securely managed for you. The agent can use them, but it can never see or extract them. Even if something goes wrong in the agent's code, your accounts stay safe.",
-    detail:
-      "Credentials are injected at the network layer via transparent MITM proxy. Agent code never touches raw tokens. Outbound requests are scanned to prevent secret leakage.",
-  },
-  {
-    title: "Starts in seconds",
-    description:
-      "We've done extensive optimization under the hood so your agent goes from trigger to running in tens of milliseconds. Fast, because we put in the hard work at the infrastructure level. You just experience the result.",
-    detail:
-      "Overlayfs with shared read-only rootfs for zero-copy boot. VM memory snapshots pre-warm the entire runtime stack, restore instead of cold start.",
-  },
-  {
-    title: "Full audit trail",
-    description:
-      "Every action the agent takes, which services it accessed, which APIs it called, what it produced, is logged. If something goes wrong, there's a clear record. If nothing goes wrong, you still have peace of mind.",
-    detail:
-      "Complete HTTP/HTTPS traffic logged per run (JSONL). Immutable, content-addressed artifacts stored on Cloudflare R2 with SHA-256 integrity.",
-  },
-  {
-    title: "Open source",
-    description:
-      "The core platform is open source. You can inspect the code, audit the security model, and contribute. Transparent by default.",
-    detail:
-      "Core platform on GitHub. Regular third-party penetration testing. SOC 2 Type II compliance in progress.",
-  },
-];
+const SECTION_KEYS = [
+  "isolatedExecution",
+  "secretsNeverExposed",
+  "startsInSeconds",
+  "fullAuditTrail",
+  "openSource",
+] as const;
 
 export default function SecurityPage() {
+  const t = useTranslations("securityPage");
+
   return (
     <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
       <main className="px-6 pb-20 pt-[calc(var(--total-header-height)+48px)] md:pb-28 md:pt-[calc(var(--total-header-height)+72px)]">
         <div className="mx-auto max-w-2xl">
           <h1 className="text-[32px] font-semibold leading-[1.2] tracking-tight sm:text-[40px]">
-            Security
+            {t("title")}
           </h1>
           <p className="mt-4 text-[15px] leading-relaxed text-[hsl(var(--muted-foreground))]">
-            When you hand work to an AI agent, your biggest concerns are data
-            safety, privacy, and staying in control. VM0 was designed from day
-            one with all of this in mind.
+            {t("intro")}
           </p>
 
           <div className="mt-12 space-y-10">
-            {SECTIONS.map(({ title, description, detail }) => {
+            {SECTION_KEYS.map((key) => {
               return (
-                <div key={title}>
+                <div key={key}>
                   <h2 className="text-[15px] font-semibold text-[hsl(var(--foreground))]">
-                    {title}
+                    {t(`${key}.title`)}
                   </h2>
                   <p className="mt-2 text-[15px] leading-relaxed text-[hsl(var(--muted-foreground))]">
-                    {description}
+                    {t(`${key}.description`)}
                   </p>
                   <p className="mt-2 text-[13px] leading-relaxed text-[hsl(var(--muted-foreground))]/50">
-                    {detail}
+                    {t(`${key}.detail`)}
                   </p>
                 </div>
               );
@@ -74,12 +45,12 @@ export default function SecurityPage() {
 
           <div className="mt-16 border-t border-[hsl(var(--gray-200))] pt-8">
             <p className="text-[15px] leading-relaxed text-[hsl(var(--muted-foreground))]">
-              Questions about security?{" "}
+              {t("questionsAboutSecurity")}{" "}
               <a
                 href="mailto:contact@vm0.ai"
                 className="text-[hsl(var(--foreground))] underline underline-offset-4"
               >
-                Contact us
+                {t("contactUs")}
               </a>
             </p>
           </div>

--- a/turbo/apps/web/app/[locale]/security/page.tsx
+++ b/turbo/apps/web/app/[locale]/security/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Script from "next/script";
 import SecurityPage from "./SecurityPage";
 
-const BASE_URL = "https://vm0.ai";
+const BASE_URL = "https://www.vm0.ai";
 
 interface PageProps {
   params: Promise<{ locale: string }>;

--- a/turbo/apps/web/app/[locale]/use-cases/UseCasesGalleryClient.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/UseCasesGalleryClient.tsx
@@ -58,7 +58,15 @@ function ConnectorIcon({ connector }: { connector: ConnectorRef }) {
   );
 }
 
-function UseCaseCard({ useCase }: { useCase: UseCase }) {
+function UseCaseCard({
+  useCase,
+  title,
+  description,
+}: {
+  useCase: UseCase;
+  title: string;
+  description: string;
+}) {
   return (
     <Link
       href={`/use-cases/${useCase.slug}`}
@@ -93,10 +101,10 @@ function UseCaseCard({ useCase }: { useCase: UseCase }) {
       {/* Content */}
       <div className="flex flex-col gap-3 px-6 pb-7 pt-5">
         <h3 className="text-lg font-medium leading-snug tracking-[-0.2px] text-[hsl(var(--foreground))] group-hover:text-[#ed4e01]">
-          {useCase.title}
+          {title}
         </h3>
         <p className="line-clamp-3 text-[15px] font-light leading-relaxed text-[hsl(var(--muted-foreground))]">
-          {useCase.description}
+          {description}
         </p>
       </div>
     </Link>
@@ -122,24 +130,31 @@ export default function UseCasesGalleryClient() {
       <section style={{ paddingBottom: "120px" }}>
         <div className="uc-grid">
           {USE_CASES.map((uc) => {
-            return <UseCaseCard key={uc.slug} useCase={uc} />;
+            return (
+              <UseCaseCard
+                key={uc.slug}
+                useCase={uc}
+                title={t(`content.${uc.slug}.title`)}
+                description={t(`content.${uc.slug}.description`)}
+              />
+            );
           })}
 
           {/* Coming soon */}
           <div className="flex flex-col justify-between overflow-hidden rounded-[20px] bg-white px-6 pb-7 pt-5">
             <div className="flex flex-col gap-2">
               <h3 className="text-lg font-medium leading-snug tracking-[-0.2px] text-[hsl(var(--foreground))]">
-                More to come
+                {t("gallery.moreToCome")}
               </h3>
               <p className="text-[15px] font-light leading-relaxed text-[hsl(var(--muted-foreground))]">
-                Have a smart way to use Zero?
+                {t("gallery.moreToComeDesc")}
               </p>
             </div>
             <a
               href="mailto:contact@vm0.ai"
               className="mt-4 inline-flex items-center gap-1 text-[14px] font-medium text-[#ed4e01] transition-all hover:gap-2"
             >
-              Submit your case &rarr;
+              {t("gallery.submitYourCase")}
             </a>
           </div>
         </div>

--- a/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
@@ -8,6 +8,11 @@ import Footer from "../../../components/Footer";
 import Particles from "../../../components/Particles";
 import type { UseCase, ConnectorRef } from "../data";
 
+interface PromptVariant {
+  label: string;
+  prompt: string;
+}
+
 function ConnectorBadge({ connector }: { connector: ConnectorRef }) {
   if (!connector.icon) return null;
   return (
@@ -40,7 +45,7 @@ function Section({
   );
 }
 
-function PromptVariants({ variants }: { variants: UseCase["promptVariants"] }) {
+function PromptVariants({ variants }: { variants: PromptVariant[] }) {
   const [activeTab, setActiveTab] = useState(0);
 
   return (
@@ -67,6 +72,23 @@ function PromptVariants({ variants }: { variants: UseCase["promptVariants"] }) {
 
 export default function UseCaseDetailClient({ useCase }: { useCase: UseCase }) {
   const t = useTranslations("useCases");
+  const slug = useCase.slug;
+
+  const promptVariants = t.raw(
+    `content.${slug}.promptVariants`,
+  ) as PromptVariant[];
+  const steps = t.raw(`content.${slug}.steps`) as {
+    title: string;
+    description: string;
+  }[];
+  const nextActions = t.raw(`content.${slug}.nextActions`) as {
+    title: string;
+    description: string;
+    examplePrompt: string;
+  }[];
+  const tips = t.raw(`content.${slug}.tips`) as string[];
+
+  const title = t(`content.${slug}.title`);
 
   return (
     <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
@@ -82,10 +104,10 @@ export default function UseCaseDetailClient({ useCase }: { useCase: UseCase }) {
           {/* Header */}
           <header style={{ marginBottom: 48 }}>
             <h1 className="text-[32px] font-semibold leading-[1.2] tracking-tight sm:text-[40px]">
-              {useCase.title}
+              {title}
             </h1>
             <p className="mt-4 text-[15px] font-light leading-relaxed text-[hsl(var(--muted-foreground))]">
-              {useCase.description}
+              {t(`content.${slug}.description`)}
             </p>
 
             <div className="mt-5 flex flex-wrap items-center gap-2 text-[14px] text-[hsl(var(--muted-foreground))]">
@@ -103,7 +125,7 @@ export default function UseCaseDetailClient({ useCase }: { useCase: UseCase }) {
             <div className="uc-video-embed" style={{ marginBottom: 48 }}>
               <iframe
                 src={`https://www.youtube.com/embed/${useCase.videoId}`}
-                title={useCase.title}
+                title={title}
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                 allowFullScreen
                 className="aspect-video w-full rounded-[12px]"
@@ -113,19 +135,19 @@ export default function UseCaseDetailClient({ useCase }: { useCase: UseCase }) {
           )}
 
           {/* Scenario */}
-          <Section title={useCase.headings.scenario}>
-            <p className="uc-section-body">{useCase.scenario}</p>
+          <Section title={t(`content.${slug}.headings.scenario`)}>
+            <p className="uc-section-body">{t(`content.${slug}.scenario`)}</p>
           </Section>
 
           {/* Prompt */}
-          <Section title={useCase.headings.prompt}>
-            <PromptVariants variants={useCase.promptVariants} />
+          <Section title={t(`content.${slug}.headings.prompt`)}>
+            <PromptVariants variants={promptVariants} />
           </Section>
 
           {/* Steps */}
-          <Section title={useCase.headings.steps}>
+          <Section title={t(`content.${slug}.headings.steps`)}>
             <div className="uc-steps">
-              {useCase.steps.map((step, i) => {
+              {steps.map((step, i) => {
                 return (
                   <div key={i} className="uc-step">
                     <div className="uc-step-title">{step.title}</div>
@@ -137,9 +159,9 @@ export default function UseCaseDetailClient({ useCase }: { useCase: UseCase }) {
           </Section>
 
           {/* Next actions */}
-          <Section title={useCase.headings.nextActions}>
+          <Section title={t(`content.${slug}.headings.nextActions`)}>
             <div className="uc-next-actions">
-              {useCase.nextActions.map((action, i) => {
+              {nextActions.map((action, i) => {
                 return (
                   <div key={i} className="uc-next-action">
                     <div className="uc-next-action-title">{action.title}</div>
@@ -156,7 +178,7 @@ export default function UseCaseDetailClient({ useCase }: { useCase: UseCase }) {
           </Section>
 
           {/* Integrations */}
-          <Section title={useCase.headings.integrations}>
+          <Section title={t(`content.${slug}.headings.integrations`)}>
             <div className="uc-integrations">
               {useCase.integrations.map((integration, i) => {
                 return (
@@ -179,7 +201,7 @@ export default function UseCaseDetailClient({ useCase }: { useCase: UseCase }) {
                         {integration.connector.label}
                       </div>
                       <div className="uc-integration-desc">
-                        {integration.description}
+                        {t(`content.${slug}.integrations.${i}.description`)}
                       </div>
                     </div>
                     <span
@@ -200,10 +222,10 @@ export default function UseCaseDetailClient({ useCase }: { useCase: UseCase }) {
           {/* Tips */}
           <div className="uc-section">
             <h2 className="uc-section-title" style={{ marginBottom: 16 }}>
-              {useCase.headings.tips}
+              {t(`content.${slug}.headings.tips`)}
             </h2>
             <div className="uc-tips">
-              {useCase.tips.map((tip, i) => {
+              {tips.map((tip, i) => {
                 return (
                   <div key={i} className="uc-tip">
                     <span className="uc-tip-icon">&#9679;</span>

--- a/turbo/apps/web/app/[locale]/use-cases/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/[slug]/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 import UseCaseDetailClient from "./UseCaseDetailClient";
 import { USE_CASES, getUseCaseBySlug } from "../data";
 import { locales } from "../../../../i18n";
 
-const BASE_URL = "https://vm0.ai";
+const BASE_URL = "https://www.vm0.ai";
 
 interface PageProps {
   params: Promise<{ slug: string; locale: string }>;
@@ -20,17 +21,21 @@ export async function generateMetadata({
     return { title: "Not Found" };
   }
 
+  const t = await getTranslations({ locale, namespace: "useCases" });
+  const title = t(`content.${slug}.title`);
+  const description = t(`content.${slug}.description`);
+
   const url = `${BASE_URL}/${locale}/use-cases/${slug}`;
 
   return {
-    title: `${useCase.title} — VM0 Use Case`,
-    description: useCase.description,
+    title: `${title} — VM0 Use Case`,
+    description,
     alternates: {
       canonical: url,
     },
     openGraph: {
-      title: `${useCase.title} — VM0 Use Case`,
-      description: useCase.description,
+      title: `${title} — VM0 Use Case`,
+      description,
       url,
       type: "article",
       images: [
@@ -38,14 +43,14 @@ export async function generateMetadata({
           url: "/og-image.png",
           width: 1200,
           height: 630,
-          alt: useCase.title,
+          alt: title,
         },
       ],
     },
     twitter: {
       card: "summary_large_image",
-      title: `${useCase.title} — VM0 Use Case`,
-      description: useCase.description,
+      title: `${title} — VM0 Use Case`,
+      description,
       images: ["/og-image.png"],
       creator: "@vm0_ai",
       site: "@vm0_ai",
@@ -66,19 +71,25 @@ export function generateStaticParams() {
 }
 
 export default async function UseCaseDetailPage({ params }: PageProps) {
-  const { slug } = await params;
+  const { slug, locale } = await params;
   const useCase = getUseCaseBySlug(slug);
 
   if (!useCase) {
     notFound();
   }
 
+  const t = await getTranslations({ locale, namespace: "useCases" });
+  const steps = t.raw(`content.${slug}.steps`) as {
+    title: string;
+    description: string;
+  }[];
+
   const howToJsonLd = {
     "@context": "https://schema.org",
     "@type": "HowTo",
-    name: useCase.title,
-    description: useCase.description,
-    step: useCase.steps.map((s, i) => {
+    name: t(`content.${slug}.title`),
+    description: t(`content.${slug}.description`),
+    step: steps.map((s, i) => {
       return {
         "@type": "HowToStep",
         position: i + 1,

--- a/turbo/apps/web/app/[locale]/use-cases/data.ts
+++ b/turbo/apps/web/app/[locale]/use-cases/data.ts
@@ -12,36 +12,9 @@ export interface ConnectorRef {
   darkIcon?: string;
 }
 
-export interface SlackMessage {
-  role: "user" | "zero";
-  name: string;
-  text: string;
-}
-
-export interface PromptVariant {
-  label: string;
-  prompt: string;
-}
-
-export interface NextAction {
-  title: string;
-  description: string;
-  examplePrompt: string;
-}
-
-export interface Integration {
+export interface IntegrationData {
   connector: ConnectorRef;
-  description: string;
   required: boolean;
-}
-
-export interface UseCaseSectionHeadings {
-  scenario: string;
-  prompt: string;
-  steps: string;
-  nextActions: string;
-  integrations: string;
-  tips: string;
 }
 
 export interface AvatarConfig {
@@ -55,25 +28,21 @@ export interface AvatarConfig {
 
 export interface UseCase {
   slug: string;
-  title: string;
-  description: string;
   color: string;
   avatar: AvatarConfig;
   roles: Role[];
   capability: Capability;
-  timeSaved: string;
   model: string;
   videoId?: string;
   connectors: ConnectorRef[];
-  slackPreview: SlackMessage[];
-  headings: UseCaseSectionHeadings;
-  scenario: string;
-  promptVariants: PromptVariant[];
-  steps: { title: string; description: string }[];
-  nextActions: NextAction[];
-  integrations: Integration[];
-  tips: string[];
+  integrations: IntegrationData[];
   relatedSlugs: string[];
+  stepCount: number;
+  nextActionCount: number;
+  integrationCount: number;
+  tipCount: number;
+  promptVariantCount: number;
+  slackPreviewCount: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -140,12 +109,6 @@ const V0: ConnectorRef = {
   icon: "/assets/connectors/v0.svg",
 };
 
-const VERCEL: ConnectorRef = {
-  id: "vercel",
-  label: "Vercel",
-  icon: "/assets/connectors/vercel.svg",
-};
-
 // ---------------------------------------------------------------------------
 // Full use cases
 // ---------------------------------------------------------------------------
@@ -153,9 +116,6 @@ const VERCEL: ConnectorRef = {
 export const USE_CASES: UseCase[] = [
   {
     slug: "sentry-triage",
-    title: "Turn Sentry noise into a prioritized action list",
-    description:
-      "Ask Zero to pull your top unresolved Sentry errors, ranked by frequency. Zero reads the stack traces, explains the root cause in plain language, and tells you which file to fix first.",
     color: "#d4a96a",
     videoId: "iTYhvVp5z5k",
     avatar: {
@@ -168,115 +128,27 @@ export const USE_CASES: UseCase[] = [
     },
     roles: ["engineering"],
     capability: "multi-tool",
-    timeSaved: "~25 min saved",
     model: "Claude 4 Sonnet",
     connectors: [SLACK, SENTRY, AXIOM, GITHUB],
-    slackPreview: [
-      {
-        role: "user",
-        name: "Yuma",
-        text: "@Zero look at recent failures on Sentry. Rank by frequency. Top 3 with detailed error stacks.",
-      },
-      {
-        role: "zero",
-        name: "Zero",
-        text: "Here's the full Sentry failure report.\n\n#\tIssue\tCount\tPriority\n1\tSlack missing_scope\t57\tHigh\n2\tUnknown Stripe price ID\t15\tHigh\n3\tZeroSidebar .map()\t10\tMed",
-      },
-    ],
-    headings: {
-      scenario: "Why Sentry triage wastes engineering time",
-      prompt: "How to ask Zero to triage Sentry errors",
-      steps: "How Zero analyzes and ranks your Sentry errors",
-      nextActions: "Turn Sentry triage into GitHub issues and daily automation",
-      integrations: "Required integrations: Sentry and GitHub",
-      tips: "Best practices for automated Sentry triage",
-    },
-    scenario:
-      "Monday morning. You open Slack and there are a dozen Sentry alerts in #dev. Most of them are noise, flaky tests, known issues, transient errors that resolve themselves. But somewhere in there might be something real: a broken integration, a billing bug, a crash that's hitting actual users. You don't want to open Sentry's dashboard and click through issues one by one. You just want to know: which ones matter, how bad are they, and what's causing them.",
-    promptVariants: [
-      {
-        label: "Detailed",
-        prompt:
-          "@Zero take a look at the recent failures on Sentry. Please rank the failures from the last 24 hours by their occurrence frequency.\n\nFor the top three failures, provide me with a report that includes the expanded, detailed error stacks.",
-      },
-      {
-        label: "Quick",
-        prompt: "@Zero top 3 Sentry errors in the last 24h, ranked by count.",
-      },
-      {
-        label: "Scheduled",
-        prompt:
-          "@Zero every weekday at 9am, run this same Sentry check and post results to #dev. Only include errors with 5+ occurrences.",
-      },
-    ],
-    steps: [
-      {
-        title: "Zero connects to Sentry",
-        description:
-          "Zero pulls unresolved issues from your Sentry project for the specified time window and ranks them by occurrence count.",
-      },
-      {
-        title: "Summary table",
-        description:
-          "Zero replies in the same Slack thread with a quick summary table, issue name, occurrence count, and priority level, that you can scan in 5 seconds.",
-      },
-      {
-        title: "Detailed analysis",
-        description:
-          'For each top issue, Zero provides annotated stack traces and plain-language root cause explanations. For example, it doesn\'t just say "Unknown Stripe price ID", it explains that a new price was likely created in Stripe but the corresponding mapping was not updated.',
-      },
-    ],
-    nextActions: [
-      {
-        title: "Turn findings into action",
-        description: "Create GitHub issues from the report",
-        examplePrompt:
-          "@Zero create GitHub issues for #1 and #2. Assign #1 to Lancy (Slack scope fix) and #2 to James (Stripe mapping). Label both as bug, priority high.",
-      },
-      {
-        title: "Go deeper",
-        description: "Ask Zero to investigate a specific error",
-        examplePrompt:
-          "@Zero for issue #1, what exact Slack OAuth scope is missing? Check our app manifest and tell me what to add.",
-      },
-      {
-        title: "Make it a routine",
-        description: "Schedule this as a daily check",
-        examplePrompt:
-          "@Zero every weekday at 9am, run this same Sentry check and post results to #dev. Only include errors with 5+ occurrences.",
-      },
-    ],
     integrations: [
-      {
-        connector: SENTRY,
-        description:
-          "OAuth connection to your Sentry org. Zero needs read access to issues and events.",
-        required: true,
-      },
-      {
-        connector: GITHUB,
-        description:
-          "Only needed if you want Zero to create issues from the report. Read/write access to issues.",
-        required: false,
-      },
-    ],
-    tips: [
-      'Be specific about the time window. "last 24 hours" for daily triage, "errors since the last deploy" for post-deploy checks.',
-      "Add a severity filter to reduce noise, only show errors with 10+ occurrences or skip errors tagged as known-issue.",
-      "Chain it into your standup, combine with the standup use case for a morning brief that includes both your task summary and the Sentry report.",
+      { connector: SENTRY, required: true },
+      { connector: GITHUB, required: false },
     ],
     relatedSlugs: [
       "file-bugs-from-slack",
       "kol-cold-outreach",
       "standup-summary",
     ],
+    stepCount: 3,
+    nextActionCount: 3,
+    integrationCount: 2,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
   },
 
   {
     slug: "standup-summary",
-    title: "Get your standup ready without opening 5 apps",
-    description:
-      "Zero pulls from calendar, email, and Linear, then writes a shareable summary you can paste straight into the team thread.",
     color: "#c89090",
     videoId: "0D7ScfH4fwk",
     avatar: {
@@ -289,120 +161,28 @@ export const USE_CASES: UseCase[] = [
     },
     roles: ["everyone"],
     capability: "multi-tool",
-    timeSaved: "~20 min saved",
     model: "GPT-4o",
     connectors: [GOOGLE_CALENDAR, GMAIL, LINEAR, NOTION],
-    slackPreview: [
-      {
-        role: "user",
-        name: "Alex",
-        text: "@Zero check my calendar, emails, and Linear tasks since yesterday and write me a work summary",
-      },
-      {
-        role: "zero",
-        name: "Zero",
-        text: "Work Summary: Mar 23\u201324\n\nMeetings\n\u2022 Daily standups (10\u201310:30 AM)\n\u2022 VM0 User Interview w/ Daniel Miller\n\nEngineering\n\u2022 PR #5467 merged, firewall permissions\n\u2022 PR #6277 in review. Lighthouse at 36",
-      },
-    ],
-    headings: {
-      scenario: "The daily standup scramble across Calendar, Gmail, and Linear",
-      prompt: "How to ask Zero for a standup summary",
-      steps: "How Zero compiles your work summary from 3 tools",
-      nextActions: "Post to Slack, add blockers, or automate daily",
-      integrations: "Required integrations: Google Calendar, Gmail, and Linear",
-      tips: "Best practices for AI-generated standup summaries",
-    },
-    scenario:
-      "It's 9:50 AM and standup starts in 10 minutes. You haven't checked your calendar yet. You ask Zero to pull yesterday's meetings, emails, and Linear tasks, it writes a summary you can paste straight into the team thread.",
-    promptVariants: [
-      {
-        label: "Detailed",
-        prompt:
-          "@Zero check my calendar, emails, and Linear tasks since yesterday and write me a work summary. Include meeting highlights and PR status.",
-      },
-      {
-        label: "Quick",
-        prompt: "@Zero what did I do yesterday? Check calendar and Linear.",
-      },
-      {
-        label: "Scheduled",
-        prompt:
-          "@Zero every weekday at 9:45am, write my standup summary and DM it to me.",
-      },
-    ],
-    steps: [
-      {
-        title: "Zero checks your calendar",
-        description:
-          "Zero reads your Google Calendar events from the past 24 hours and extracts meeting names, times, and attendees.",
-      },
-      {
-        title: "Zero scans email and tasks",
-        description:
-          "Zero checks Gmail for relevant threads and Linear for tasks you updated, completed, or were assigned since yesterday.",
-      },
-      {
-        title: "Formatted summary",
-        description:
-          "Zero compiles everything into a clean, copy-paste-ready summary organized by Meetings, Engineering work, and action items.",
-      },
-    ],
-    nextActions: [
-      {
-        title: "Post directly to a channel",
-        description: "Have Zero post the summary to #standup",
-        examplePrompt: "@Zero post this summary to #standup and tag @team-eng.",
-      },
-      {
-        title: "Add context",
-        description: "Ask Zero to include blockers or priorities",
-        examplePrompt:
-          "@Zero also check my Linear for any blocked tasks and add them as blockers in the summary.",
-      },
-      {
-        title: "Make it daily",
-        description: "Automate your morning prep",
-        examplePrompt:
-          "@Zero every weekday at 9:45am, write my standup summary and DM it to me.",
-      },
-    ],
     integrations: [
-      {
-        connector: GOOGLE_CALENDAR,
-        description:
-          "OAuth connection to Google Calendar. Zero needs read access to your events.",
-        required: true,
-      },
-      {
-        connector: GMAIL,
-        description:
-          "OAuth connection to Gmail. Zero needs read access to scan recent threads.",
-        required: true,
-      },
-      {
-        connector: LINEAR,
-        description:
-          "OAuth connection to Linear. Zero reads your assigned and updated tasks.",
-        required: true,
-      },
-    ],
-    tips: [
-      'Tell Zero your standup format if it differs from the default. "use the format: Yesterday / Today / Blockers".',
-      'Specify the time window. "since yesterday 5pm" if you work late.',
-      "Combine with Sentry triage for a complete engineering morning brief.",
+      { connector: GOOGLE_CALENDAR, required: true },
+      { connector: GMAIL, required: true },
+      { connector: LINEAR, required: true },
     ],
     relatedSlugs: [
       "sentry-triage",
       "kol-cold-outreach",
       "file-bugs-from-slack",
     ],
+    stepCount: 3,
+    nextActionCount: 3,
+    integrationCount: 3,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
   },
 
   {
     slug: "kol-cold-outreach",
-    title: "Research a KOL on X and draft a personalized cold email",
-    description:
-      "Give Zero an X handle. It reads their last 30 posts, understands their style and interests, writes a personalized outreach email under 150 words, and saves it as a Gmail draft.",
     color: "#c4a08a",
     videoId: "aignt_fZSVo",
     avatar: {
@@ -415,112 +195,24 @@ export const USE_CASES: UseCase[] = [
     },
     roles: ["product"],
     capability: "multi-tool",
-    timeSaved: "~20 min saved",
     model: "Claude 4 Sonnet",
     connectors: [X_TWITTER, GMAIL, NOTION, SLACK],
-    slackPreview: [
-      {
-        role: "user",
-        name: "Scarlett",
-        text: "@Zero read @swyx's last 30 X posts, understand his style, and draft a cold outreach email for a VM0 partnership. Save as Gmail draft.",
-      },
-      {
-        role: "zero",
-        name: "Zero",
-        text: "Done. Analyzed @swyx's recent content:\n\u2022 Focus: AI agents, developer tools, open source\n\u2022 Tone: Technical but conversational\n\u2022 Audience fit: High (9/10)\n\nGmail draft saved: \"Agents that ship real work, thought you'd find this interesting\"",
-      },
-    ],
-    headings: {
-      scenario: "Why generic cold outreach gets ignored",
-      prompt: "How to research a KOL and draft personalized outreach",
-      steps: "How Zero analyzes X profiles and crafts tailored emails",
-      nextActions:
-        "Score KOL fit, batch multiple outreach drafts, or track in Notion CRM",
-      integrations: "Required integrations: X, Gmail, and Notion",
-      tips: "Best practices for AI-assisted KOL outreach",
-    },
-    scenario:
-      "You found a KOL who'd be perfect for a partnership, but writing a cold email that doesn't feel generic takes 20 minutes of research, reading their posts, understanding what they care about, finding the right angle. You give Zero their X handle and get a personalized draft in seconds.",
-    promptVariants: [
-      {
-        label: "Detailed",
-        prompt:
-          "@Zero read @swyx's last 30 X posts to understand their style and interests. Write a personalized cold outreach email under 150 words about a VM0 partnership. Reference something specific they posted recently. Save it as a Gmail draft.",
-      },
-      {
-        label: "Quick",
-        prompt:
-          "@Zero draft a cold email to @swyx about VM0, based on their X posts. Save as Gmail draft.",
-      },
-      {
-        label: "Batch",
-        prompt:
-          '@Zero for each handle in my Notion KOL list marked as "Not contacted", research their X profile and draft a personalized outreach email. Save all as Gmail drafts.',
-      },
-    ],
-    steps: [
-      {
-        title: "Zero reads the KOL's X profile",
-        description:
-          "Zero pulls the last 30 posts, analyzes content themes, tone, audience, and engagement patterns to build a profile of what this person cares about.",
-      },
-      {
-        title: "Personalized email drafted",
-        description:
-          "Zero writes a concise outreach email that references specific content the KOL posted, explains the relevance of your product, and uses a tone that matches their style.",
-      },
-      {
-        title: "Draft saved to Gmail",
-        description:
-          "The email is saved as a Gmail draft ready for your review. Zero also updates the KOL's status in your Notion CRM if connected.",
-      },
-    ],
-    nextActions: [
-      {
-        title: "Score KOL fit",
-        description: "Rate how well a KOL matches your audience",
-        examplePrompt:
-          "@Zero analyze @swyx's audience overlap with VM0's ICP. Score 1-10 with reasoning and save to Notion.",
-      },
-      {
-        title: "Batch outreach",
-        description: "Draft emails for multiple KOLs at once",
-        examplePrompt:
-          "@Zero for the top 10 KOLs in my Notion list, research each and draft personalized outreach emails.",
-      },
-    ],
     integrations: [
-      {
-        connector: X_TWITTER,
-        description:
-          "Zero reads public posts to understand the KOL's style and interests.",
-        required: true,
-      },
-      {
-        connector: GMAIL,
-        description: "Zero saves the drafted email to your Gmail drafts.",
-        required: true,
-      },
-      {
-        connector: NOTION,
-        description:
-          "Optional, track KOL status and fit scores in your Notion CRM.",
-        required: false,
-      },
-    ],
-    tips: [
-      'Give Zero context about your product angle. "focus on how VM0 helps developer tool companies".',
-      'Ask for multiple variants. "draft 2 versions: one casual, one professional".',
-      "Always review before sending. Zero gets the research right, but the final voice should be yours.",
+      { connector: X_TWITTER, required: true },
+      { connector: GMAIL, required: true },
+      { connector: NOTION, required: false },
     ],
     relatedSlugs: ["file-bugs-from-slack", "slack-triage", "standup-summary"],
+    stepCount: 3,
+    nextActionCount: 2,
+    integrationCount: 3,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
   },
 
   {
     slug: "file-bugs-from-slack",
-    title: "File bugs from Slack without switching context",
-    description:
-      "Describe the issue in plain language. Zero creates a formatted GitHub issue, labels it, and assigns the right person.",
     color: "#c08050",
     videoId: "E08Bc02tDIM",
     avatar: {
@@ -533,111 +225,23 @@ export const USE_CASES: UseCase[] = [
     },
     roles: ["engineering", "product"],
     capability: "instant",
-    timeSaved: "Instant",
     model: "GPT-4o mini",
     connectors: [SLACK, GITHUB, LINEAR],
-    slackPreview: [
-      {
-        role: "user",
-        name: "Alex",
-        text: "@Zero create issue: pressing ESC in the schedule dialog closes it immediately even with unsaved edits. Should ask for confirmation first. Assign to Lancy.",
-      },
-      {
-        role: "zero",
-        name: "Zero",
-        text: "Issue created:\n#6260: bug: ESC key closes schedule dialog without confirming\nAssigned to Lancy \u00b7 Priority: Medium",
-      },
-    ],
-    headings: {
-      scenario: "Why filing GitHub issues from Slack saves context switching",
-      prompt: "How to create GitHub issues from a Slack message",
-      steps: "How Zero parses your message and creates a formatted issue",
-      nextActions: "Add details, batch file issues, or automate triage",
-      integrations: "Required integrations: GitHub and Slack",
-      tips: "Best practices for filing bugs via Slack",
-    },
-    scenario:
-      "You just noticed a UX bug during a demo. Instead of opening GitHub, finding the repo, writing a formatted issue, and assigning someone, you describe it in Slack. Zero creates the issue, adds labels, and assigns the right person. You never leave the conversation.",
-    promptVariants: [
-      {
-        label: "Detailed",
-        prompt:
-          "@Zero create issue: pressing ESC in the schedule dialog closes it immediately even with unsaved edits. Should ask for confirmation first. Assign to Lancy. Label as bug, platform. Priority medium.",
-      },
-      {
-        label: "Quick",
-        prompt:
-          "@Zero bug: ESC closes schedule dialog without save confirmation. Assign Lancy.",
-      },
-      {
-        label: "Scheduled",
-        prompt:
-          "@Zero every Friday at 4pm, check #bugs channel for any unresolved bug reports and create GitHub issues for each one.",
-      },
-    ],
-    steps: [
-      {
-        title: "Zero parses the request",
-        description:
-          "Zero understands the bug description, identifies the assignee, and infers appropriate labels (bug, platform) and priority from context.",
-      },
-      {
-        title: "Issue created on GitHub",
-        description:
-          "Zero creates a properly formatted GitHub issue with a clear title, description, labels, and assignment, all from your natural-language Slack message.",
-      },
-      {
-        title: "Confirmation in Slack",
-        description:
-          "Zero replies in the same thread with the issue number, title, assignee, and a direct link so you can verify without leaving Slack.",
-      },
-    ],
-    nextActions: [
-      {
-        title: "Add more detail",
-        description: "Attach screenshots or steps to reproduce",
-        examplePrompt:
-          "@Zero add to #6260: steps to reproduce. 1. Open schedule dialog 2. Type something 3. Press ESC. Expected: confirmation dialog.",
-      },
-      {
-        title: "Batch file issues",
-        description: "Create multiple issues at once",
-        examplePrompt:
-          "@Zero create 3 issues from these bugs:\n1. ESC dialog close (Lancy)\n2. Date picker off by one day (James)\n3. Avatar upload fails on Safari (Yuma)",
-      },
-      {
-        title: "Automate triage",
-        description: "Auto-create issues from a channel",
-        examplePrompt:
-          '@Zero watch #bugs, when someone posts a message starting with "bug:", auto-create a GitHub issue and reply with the link.',
-      },
-    ],
     integrations: [
-      {
-        connector: GITHUB,
-        description:
-          "OAuth connection to GitHub. Zero needs read/write access to create and manage issues.",
-        required: true,
-      },
-      {
-        connector: SLACK,
-        description: "Zero reads your message and replies in the same thread.",
-        required: true,
-      },
-    ],
-    tips: [
-      "Include the assignee name. Zero matches Slack display names to GitHub usernames.",
-      "Mention labels explicitly if you want specific ones, otherwise Zero infers from context.",
-      'Works for feature requests too, just say "feature request" instead of "bug".',
+      { connector: GITHUB, required: true },
+      { connector: SLACK, required: true },
     ],
     relatedSlugs: ["sentry-triage", "standup-summary", "kol-cold-outreach"],
+    stepCount: 3,
+    nextActionCount: 3,
+    integrationCount: 2,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
   },
 
   {
     slug: "slack-triage",
-    title: "Cut through Slack noise and surface what needs your attention",
-    description:
-      "Zero scans your unread Slack messages, filters out bots and noise, and shows you only the messages that actually need your action today, sorted by urgency.",
     color: "#7c9885",
     videoId: "XcqnMX1U0xY",
     avatar: {
@@ -650,110 +254,24 @@ export const USE_CASES: UseCase[] = [
     },
     roles: ["everyone"],
     capability: "instant",
-    timeSaved: "~10 min saved",
     model: "Claude 4 Sonnet",
     connectors: [SLACK, LINEAR, GOOGLE_CALENDAR],
-    slackPreview: [
-      {
-        role: "user",
-        name: "Lancy",
-        text: "@Zero scan my unread Slack from the last 12 hours. Filter out bots and noise. Show me only what needs my action today.",
-      },
-      {
-        role: "zero",
-        name: "Zero",
-        text: "Found 47 unread messages. 5 need your action:\n\n1. @Ethan asked for your design review on PR #6312\n2. @James needs approval on the Stripe migration plan\n3. #support has a P0 from a customer mentioning churn\n4. @Scarlett tagged you in a KOL outreach decision\n5. Sprint review moved to 3pm (was 2pm)",
-      },
-    ],
-    headings: {
-      scenario: "Why Slack overload causes missed action items",
-      prompt: "How to ask Zero to triage your unread Slack messages",
-      steps: "How Zero filters noise and surfaces actionable messages",
-      nextActions: "Reply directly, create tasks, or automate daily triage",
-      integrations: "Required integrations: Slack",
-      tips: "Best practices for Slack message triage",
-    },
-    scenario:
-      "You open Slack after a 2-hour focus block and there are 47 unread messages across 12 channels. Most are bot notifications, automated alerts, and conversations that don't need you. Somewhere in the noise are 3 things that actually need your response. Instead of scrolling through everything, you ask Zero to find what matters.",
-    promptVariants: [
-      {
-        label: "Detailed",
-        prompt:
-          "@Zero scan my unread Slack messages from the last 12 hours. Filter out bots, automated notifications, and threads I'm not tagged in. Show me only messages that need my action today, sorted by urgency. For each one, tell me who's waiting and what they need.",
-      },
-      {
-        label: "Quick",
-        prompt: "@Zero what needs my attention in Slack right now?",
-      },
-      {
-        label: "Scheduled",
-        prompt:
-          "@Zero every morning at 9am and after lunch at 1pm, scan my unreads and DM me what needs action.",
-      },
-    ],
-    steps: [
-      {
-        title: "Zero scans your channels",
-        description:
-          "Zero reads your unread messages across all channels, filtering out bot messages, automated CI/CD alerts, and threads where you're not mentioned or needed.",
-      },
-      {
-        title: "Messages classified by urgency",
-        description:
-          "Each remaining message is assessed: is someone waiting on you? Is there a deadline? Is it a decision that's blocking others? Zero ranks them by how urgently they need your response.",
-      },
-      {
-        title: "Actionable summary delivered",
-        description:
-          "Zero DMs you a numbered list of what needs attention, with who's asking, what they need, and a direct link to each thread. Everything else is safely ignored.",
-      },
-    ],
-    nextActions: [
-      {
-        title: "Reply through Zero",
-        description: "Respond without opening each thread",
-        examplePrompt:
-          '@Zero reply to #1: "Looks good, approved. Ship it." And for #3, create a P0 Linear issue and assign to James.',
-      },
-      {
-        title: "Make it a routine",
-        description: "Auto-triage every morning",
-        examplePrompt:
-          "@Zero every weekday at 9am, scan my unreads from overnight and DM me the action items.",
-      },
-    ],
     integrations: [
-      {
-        connector: SLACK,
-        description:
-          "Zero reads your unread messages and DMs you the triage summary.",
-        required: true,
-      },
-      {
-        connector: LINEAR,
-        description: "Optional: create tasks directly from triaged messages.",
-        required: false,
-      },
-      {
-        connector: GOOGLE_CALENDAR,
-        description:
-          "Optional: Zero checks your calendar to flag meeting-related messages.",
-        required: false,
-      },
-    ],
-    tips: [
-      "Tell Zero which channels matter most to you so it can prioritize accordingly.",
-      'Ask Zero to learn your noise patterns over time: "always skip messages from @github-bot and @vercel-bot".',
-      "Combine with the standup use case: triage first, then generate your standup from the action items.",
+      { connector: SLACK, required: true },
+      { connector: LINEAR, required: false },
+      { connector: GOOGLE_CALENDAR, required: false },
     ],
     relatedSlugs: ["standup-summary", "file-bugs-from-slack", "sentry-triage"],
+    stepCount: 3,
+    nextActionCount: 2,
+    integrationCount: 3,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
   },
 
   {
     slug: "employee-onboarding",
-    title: "Onboard new teammates with one Slack message",
-    description:
-      "Tell Zero who's joining and when. It creates their Notion onboarding page, schedules welcome meetings on Google Calendar, posts a Slack intro, and DMs them their first-week agenda.",
     color: "#6b8cae",
     videoId: "2YA7Iff4XHs",
     avatar: {
@@ -766,115 +284,25 @@ export const USE_CASES: UseCase[] = [
     },
     roles: ["ops", "everyone"],
     capability: "multi-tool",
-    timeSaved: "~45 min saved",
     model: "Claude 4 Sonnet",
     connectors: [SLACK, NOTION, GOOGLE_CALENDAR, GMAIL],
-    slackPreview: [
-      {
-        role: "user",
-        name: "Lancy",
-        text: "@Zero onboard Sarah Chen, joining as Product Designer on April 14. Set up everything.",
-      },
-      {
-        role: "zero",
-        name: "Zero",
-        text: "Onboarding for Sarah Chen is ready:\n\n\u2714 Notion page created from template\n\u2714 Week-1 intro meetings scheduled\n\u2714 30-day check-in on May 14\n\u2714 Welcome posted to #general\n\u2714 DM sent with first-week agenda",
-      },
-    ],
-    headings: {
-      scenario: "Why manual onboarding checklists always miss something",
-      prompt: "How to automate new hire onboarding with Zero",
-      steps: "How Zero sets up Notion, Calendar, and Slack for a new teammate",
-      nextActions: "Add access provisioning or customize by role",
-      integrations:
-        "Required integrations: Slack, Notion, Google Calendar, and Gmail",
-      tips: "Best practices for automated employee onboarding",
-    },
-    scenario:
-      "A new teammate starts next Monday. Someone needs to create their onboarding doc, schedule intro meetings with 5 people, post a welcome message, and send them a first-week agenda. It's 45 minutes of coordination that happens the same way every time. You tell Zero once and it handles everything.",
-    promptVariants: [
-      {
-        label: "Detailed",
-        prompt:
-          "@Zero onboard Sarah Chen joining as Product Designer on April 14. Duplicate the Notion onboarding template, schedule week-1 intro meetings with Ethan, Lancy, James, Yuma, and Scarlett on Google Calendar. Schedule a 30-day check-in. Post a welcome to #general and DM Sarah her first-week agenda.",
-      },
-      {
-        label: "Quick",
-        prompt:
-          "@Zero onboard Sarah Chen, Product Designer, starting April 14. Full setup.",
-      },
-      {
-        label: "Template",
-        prompt:
-          '@Zero when someone posts in #new-hires with format "Name / Role / Start Date", auto-run the full onboarding workflow.',
-      },
-    ],
-    steps: [
-      {
-        title: "Notion onboarding page created",
-        description:
-          "Zero duplicates your onboarding template in Notion, fills in the new hire's name, role, start date, and manager. Links to relevant docs and team resources.",
-      },
-      {
-        title: "Meetings scheduled",
-        description:
-          "Zero creates intro meetings with specified teammates on Google Calendar during the first week, plus a 30-day check-in. All calendar invites include context about what to discuss.",
-      },
-      {
-        title: "Slack welcome and DM sent",
-        description:
-          "Zero posts a welcome message to #general introducing the new hire, then DMs them directly with their first-week agenda, links to their Notion page, and key contacts.",
-      },
-    ],
-    nextActions: [
-      {
-        title: "Customize by role",
-        description: "Different onboarding for different roles",
-        examplePrompt:
-          "@Zero for engineers, also add a pairing session with the tech lead and link to the architecture docs in the onboarding page.",
-      },
-      {
-        title: "Automate triggers",
-        description: "Run onboarding from a channel post",
-        examplePrompt:
-          '@Zero whenever someone posts in #new-hires with the format "Name / Role / Start Date", run the full onboarding automatically.',
-      },
-    ],
     integrations: [
-      {
-        connector: SLACK,
-        description: "Zero posts the welcome message and DMs the new hire.",
-        required: true,
-      },
-      {
-        connector: NOTION,
-        description: "Zero creates the onboarding page from your template.",
-        required: true,
-      },
-      {
-        connector: GOOGLE_CALENDAR,
-        description: "Zero schedules intro meetings and check-ins.",
-        required: true,
-      },
-      {
-        connector: GMAIL,
-        description: "Optional, send a welcome email with logistics and links.",
-        required: false,
-      },
-    ],
-    tips: [
-      "Create a Notion onboarding template first. Zero duplicates it and fills in the details.",
-      "List the people who should have intro meetings. Zero handles the calendar coordination.",
-      "Works for contractors and interns too, just adjust the template and meeting list.",
+      { connector: SLACK, required: true },
+      { connector: NOTION, required: true },
+      { connector: GOOGLE_CALENDAR, required: true },
+      { connector: GMAIL, required: false },
     ],
     relatedSlugs: ["slack-triage", "standup-summary", "file-bugs-from-slack"],
+    stepCount: 3,
+    nextActionCount: 2,
+    integrationCount: 4,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
   },
 
   {
     slug: "build-with-v0",
-    title: "Turn a Slack idea into an interactive prototype instantly",
-    description:
-      "When an idea sparks mid-conversation, describe it to Zero. It uses v0 to generate a clickable React prototype and posts the live preview link back in the thread — before the discussion moves on.",
     color: "#7c8cbe",
     avatar: {
       rotation: 3,
@@ -886,109 +314,23 @@ export const USE_CASES: UseCase[] = [
     },
     roles: ["engineering", "product"],
     capability: "instant",
-    timeSaved: "Hours → seconds",
     model: "Claude 4 Sonnet",
     connectors: [SLACK, V0],
-    slackPreview: [
-      {
-        role: "user",
-        name: "Ethan",
-        text: "@Zero prototype this: a command palette that lets users search agents, recent runs, and connectors. Keyboard-navigable, fuzzy search, shows a preview on the right.",
-      },
-      {
-        role: "zero",
-        name: "Zero",
-        text: "Here's the interactive prototype:\nv0.dev/r/cmd-palette-preview\n\nIncludes fuzzy search across agents, runs, and connectors. Arrow-key navigation. Right-side preview panel updates on hover. Click to open.",
-      },
-    ],
-    headings: {
-      scenario: "Why ideas get lost before anyone can see them",
-      prompt: "How to turn a Slack idea into a prototype with Zero",
-      steps: "How Zero goes from your description to a live, clickable UI",
-      nextActions: "Refine, share, or hand off to engineering",
-      integrations: "Required integrations: v0",
-      tips: "Best practices for rapid idea prototyping with v0",
-    },
-    scenario:
-      "You're in a Slack thread debating how a feature should work. Someone proposes a new UI pattern — a command palette, a settings panel, a multi-step wizard. Words aren't landing. Sketching on a whiteboard isn't an option. Scheduling a Figma session pushes the decision to next week. You describe the idea to Zero in plain language. It calls v0, generates a fully interactive React prototype, and posts the live preview link right back in the thread — in under a minute. Everyone can click through it before the conversation moves on.",
-    promptVariants: [
-      {
-        label: "New UI idea",
-        prompt:
-          "@Zero prototype this: a command palette that lets users search agents, recent runs, and connectors. Keyboard-navigable, fuzzy search, shows a preview panel on the right side.",
-      },
-      {
-        label: "From thread context",
-        prompt:
-          "@Zero based on the flow we just described above, build a quick v0 prototype so the team can see it before we decide.",
-      },
-      {
-        label: "Iterate",
-        prompt:
-          "@Zero update the prototype — add a filter tab at the top for 'Agents / Runs / Connectors' and highlight the active item in orange. Regenerate.",
-      },
-    ],
-    steps: [
-      {
-        title: "Describe the idea in plain language",
-        description:
-          "No spec, no wireframe required. Tell Zero what the UI should do — the components, the interactions, the data it surfaces. Paste a rough sketch description or just riff from the thread.",
-      },
-      {
-        title: "Zero generates the prototype via v0",
-        description:
-          "Zero translates your description into a structured v0 prompt and calls the v0 API. v0 produces a fully interactive React component — real buttons, real states, real navigation.",
-      },
-      {
-        title: "Live preview link posted in Slack",
-        description:
-          "Zero posts the v0 preview URL back in the same thread. Teammates can click through the prototype immediately, on any device, without installing anything or checking out code.",
-      },
-    ],
-    nextActions: [
-      {
-        title: "Refine in the thread",
-        description: "Keep iterating without leaving Slack",
-        examplePrompt:
-          "@Zero update the prototype — the search input should have an icon on the left, and empty state should show recent items instead of nothing.",
-      },
-      {
-        title: "Share for async feedback",
-        description: "Post to a broader channel or DM stakeholders",
-        examplePrompt:
-          "@Zero share the v0 prototype link to #product with the message: 'Quick prototype of the command palette idea — feedback welcome before Thursday.'",
-      },
-      {
-        title: "Hand off to engineering",
-        description: "Export the generated code into the repo",
-        examplePrompt:
-          "@Zero take the v0 prototype code and open a PR in vm0-ai/vm0 under turbo/apps/platform/src/components/CommandPalette.tsx for the team to build on.",
-      },
-    ],
     integrations: [
-      {
-        connector: V0,
-        description:
-          "Zero sends your idea as a generation prompt to v0 and retrieves the interactive prototype URL. Connect your v0 account to enable this.",
-        required: true,
-      },
-      {
-        connector: SLACK,
-        description:
-          "Zero reads your idea from the Slack thread and posts the prototype link back in the same conversation.",
-        required: false,
-      },
-    ],
-    tips: [
-      "Describe behavior, not just appearance. 'Clicking a row expands details below it' gets a more accurate prototype than 'expandable rows'.",
-      "Reference existing UI patterns by name — 'like a VS Code command palette' or 'like Notion's slash menu' — to anchor v0's generation.",
-      "Use the iterate prompt immediately after the first result. One round of refinement usually gets you 90% of the way there.",
+      { connector: V0, required: true },
+      { connector: SLACK, required: false },
     ],
     relatedSlugs: [
       "file-bugs-from-slack",
       "standup-summary",
       "employee-onboarding",
     ],
+    stepCount: 3,
+    nextActionCount: 3,
+    integrationCount: 2,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
   },
 ];
 

--- a/turbo/apps/web/app/[locale]/use-cases/page.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import UseCasesGalleryClient from "./UseCasesGalleryClient";
 import { USE_CASES } from "./data";
 
-const BASE_URL = "https://vm0.ai";
+const BASE_URL = "https://www.vm0.ai";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -48,23 +49,26 @@ export async function generateMetadata({
   };
 }
 
-const itemListJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "ItemList",
-  name: "VM0 Zero Use Cases",
-  description: "Real workflows from teams using Zero as their AI teammate.",
-  itemListElement: USE_CASES.map((uc, i) => {
-    return {
-      "@type": "ListItem",
-      position: i + 1,
-      url: `${BASE_URL}/en/use-cases/${uc.slug}`,
-      name: uc.title,
-      description: uc.description,
-    };
-  }),
-};
+export default async function UseCasesPage({ params }: PageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "useCases" });
 
-export default function UseCasesPage() {
+  const itemListJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "VM0 Zero Use Cases",
+    description: "Real workflows from teams using Zero as their AI teammate.",
+    itemListElement: USE_CASES.map((uc, i) => {
+      return {
+        "@type": "ListItem",
+        position: i + 1,
+        url: `${BASE_URL}/en/use-cases/${uc.slug}`,
+        name: t(`content.${uc.slug}.title`),
+        description: t(`content.${uc.slug}.description`),
+      };
+    }),
+  };
+
   return (
     <>
       <script type="application/ld+json" suppressHydrationWarning>

--- a/turbo/apps/web/app/components/AvatarCustomizer.tsx
+++ b/turbo/apps/web/app/components/AvatarCustomizer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import Image from "next/image";
 
 type Step =
@@ -11,19 +12,19 @@ type Step =
   | "expression"
   | "intensity";
 
-const STEPS: { key: Step; label: string }[] = [
-  { key: "rotation", label: "Angle" },
-  { key: "skin", label: "Skin" },
-  { key: "hairStyle", label: "Hair" },
-  { key: "hairColor", label: "Color" },
-  { key: "expression", label: "Face" },
-  { key: "intensity", label: "Mood" },
+const STEP_KEYS: Step[] = [
+  "rotation",
+  "skin",
+  "hairStyle",
+  "hairColor",
+  "expression",
+  "intensity",
 ];
 
-const INTENSITY_LABELS: Record<string, string> = {
-  d: "Chill",
-  m: "Normal",
-  h: "Hyped",
+const INTENSITY_LABEL_KEYS: Record<string, string> = {
+  d: "chill",
+  m: "normal",
+  h: "hyped",
 };
 
 interface AvatarConfig {
@@ -229,12 +230,11 @@ export default function AvatarCustomizer() {
   const [step, setStep] = useState<Step>("rotation");
   const [justPicked, setJustPicked] = useState<string | null>(null);
   const [showSparkles, setShowSparkles] = useState(false);
+  const t = useTranslations("avatar");
   // Tooltip hint that disappears after first interaction
 
   const current = editing !== null ? chars[editing] : null;
-  const stepIdx = STEPS.findIndex((s) => {
-    return s.key === step;
-  });
+  const stepIdx = STEP_KEYS.indexOf(step);
 
   const toggle = useCallback(
     (i: number) => {
@@ -261,12 +261,10 @@ export default function AvatarCustomizer() {
       const timer = setTimeout(() => {
         setJustPicked(null);
         setShowSparkles(false);
-        const idx = STEPS.findIndex((s) => {
-          return s.key === field;
-        });
+        const idx = STEP_KEYS.indexOf(field);
         const nextIdx = idx + 1;
-        if (nextIdx < STEPS.length) {
-          setStep(STEPS[nextIdx]!.key);
+        if (nextIdx < STEP_KEYS.length) {
+          setStep(STEP_KEYS[nextIdx]!);
         } else {
           setEditing(null);
         }
@@ -280,7 +278,7 @@ export default function AvatarCustomizer() {
 
   const goBack = useCallback(() => {
     if (stepIdx > 0) {
-      setStep(STEPS[stepIdx - 1]!.key);
+      setStep(STEP_KEYS[stepIdx - 1]!);
     }
   }, [stepIdx]);
 
@@ -305,7 +303,7 @@ export default function AvatarCustomizer() {
           >
             <AvatarPreview config={preview} size={56} />
             <span className="text-[10px] text-[#525b68]">
-              {INTENSITY_LABELS[val]}
+              {t(`intensityLabels.${INTENSITY_LABEL_KEYS[val]}`)}
             </span>
           </button>
         );
@@ -392,10 +390,10 @@ export default function AvatarCustomizer() {
 
             {/* Step progress */}
             <div className="flex items-center gap-1">
-              {STEPS.map((s, i) => {
+              {STEP_KEYS.map((s, i) => {
                 return (
                   <div
-                    key={s.key}
+                    key={s}
                     className={`h-1.5 rounded-full transition-all duration-300 ${
                       i === stepIdx
                         ? "w-5 bg-[#ed4e01]"
@@ -414,7 +412,7 @@ export default function AvatarCustomizer() {
               key={step} // re-mount on step change for animation
               style={{ animation: "optionAppear 0.15s ease-out" }}
             >
-              {STEPS[stepIdx]?.label}
+              {STEP_KEYS[stepIdx] ? t(`steps.${STEP_KEYS[stepIdx]}`) : ""}
             </p>
 
             {/* Options with staggered entrance */}
@@ -428,7 +426,7 @@ export default function AvatarCustomizer() {
                   className="text-xs text-[#525b68] hover:text-[#14171d]"
                   onClick={goBack}
                 >
-                  ← Back
+                  {t("back")}
                 </button>
               ) : (
                 <span />

--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import NextLink from "next/link";
 import { useUser } from "@clerk/nextjs";
+import { useTranslations } from "next-intl";
 import { getAppUrl } from "../../src/lib/zero/url";
 import Footer from "./Footer";
 import Image from "next/image";
@@ -381,7 +382,7 @@ function SlackMockup() {
   );
 }
 
-function SlackCard() {
+function SlackCard({ t }: { t: (key: string) => string }) {
   return (
     <div className="overflow-hidden rounded-[20px] bg-white">
       <div className="flex flex-col md:flex-row">
@@ -389,20 +390,18 @@ function SlackCard() {
         <div className="flex w-full flex-col justify-between gap-4 p-10 md:w-[421px] md:shrink-0">
           <div className="flex flex-col gap-4">
             <h3 className="text-2xl font-medium leading-8 text-[hsl(var(--foreground))]">
-              Ask in Slack, get answers from all your tools.
+              {t("slackCard.title")}
             </h3>
             <p className="text-base leading-6 text-[hsl(var(--muted-foreground))]">
-              @Zero in any channel. It pulls from your calendar, email, Linear,
-              GitHub — and replies with a summary your team can actually use. No
-              tab-switching, no dashboards.
+              {t("slackCard.description")}
             </p>
           </div>
           <div className="flex items-center gap-2">
             <span className="rounded-lg bg-[hsl(var(--gray-100))] px-4 py-1.5 text-sm font-medium text-[hsl(var(--muted-foreground))]">
-              Slack
+              {t("slackCard.tagSlack")}
             </span>
             <span className="rounded-lg bg-[hsl(var(--gray-100))] px-4 py-1.5 text-sm font-medium text-[hsl(var(--muted-foreground))]">
-              Team Sync
+              {t("slackCard.tagTeamSync")}
             </span>
           </div>
         </div>
@@ -534,7 +533,7 @@ function SyncedToolsMockup() {
   );
 }
 
-function SyncedToolsCard() {
+function SyncedToolsCard({ t }: { t: (key: string) => string }) {
   return (
     <div className="overflow-hidden rounded-[20px] bg-white">
       <div className="flex flex-col md:flex-row">
@@ -542,20 +541,18 @@ function SyncedToolsCard() {
         <div className="flex w-full flex-col justify-between gap-4 p-10 md:w-[421px] md:shrink-0">
           <div className="flex flex-col gap-4">
             <h3 className="text-2xl font-medium leading-8 text-[hsl(var(--foreground))]">
-              From discovery to outreach, agents do the legwork.
+              {t("syncedToolsCard.title")}
             </h3>
             <p className="text-base leading-6 text-[hsl(var(--muted-foreground))]">
-              Tell Zero who you&apos;re looking for. Its agents crawl social
-              platforms, build prospect lists, and draft personalized outreach
-              so your team focuses on closing, not searching.
+              {t("syncedToolsCard.description")}
             </p>
           </div>
           <div className="flex items-center gap-2">
             <span className="rounded-lg bg-[hsl(var(--gray-100))] px-4 py-1.5 text-sm font-medium text-[hsl(var(--muted-foreground))]">
-              Marketing Outreach
+              {t("syncedToolsCard.tagMarketing")}
             </span>
             <span className="rounded-lg bg-[hsl(var(--gray-100))] px-4 py-1.5 text-sm font-medium text-[hsl(var(--muted-foreground))]">
-              Cross-platform
+              {t("syncedToolsCard.tagCrossPlatform")}
             </span>
           </div>
         </div>
@@ -568,13 +565,25 @@ function SyncedToolsCard() {
 
 /* ── App UI carousel for "Teammate" card ── */
 
-const WEB_UI_CASES = [
-  { label: "Summarize my work week", src: "/assets/mockup/web-ui-1.png" },
-  { label: "Find and email leads", src: "/assets/mockup/web-ui-2.png" },
-  { label: "Triage Sentry errors", src: "/assets/mockup/web-ui-3.png" },
+const WEB_UI_CASES_SRCS = [
+  "/assets/mockup/web-ui-1.png",
+  "/assets/mockup/web-ui-2.png",
+  "/assets/mockup/web-ui-3.png",
 ];
 
-function AppMockupCarousel() {
+const WEB_UI_LABEL_KEYS = [
+  "teammateCard.tabSummarize",
+  "teammateCard.tabLeads",
+  "teammateCard.tabTriage",
+] as const;
+
+const WEB_UI_ARIA_KEYS = [
+  "teammateCard.ariaDaily",
+  "teammateCard.ariaLeads",
+  "teammateCard.ariaSentry",
+] as const;
+
+function AppMockupCarousel({ t }: { t: (key: string) => string }) {
   const [active, setActive] = useState(0);
   const ref = useInView();
 
@@ -582,11 +591,12 @@ function AppMockupCarousel() {
     <div className="flex flex-col">
       {/* Tabs */}
       <div className="flex items-center gap-1 px-2 sm:px-6">
-        {WEB_UI_CASES.map((c, i) => {
+        {WEB_UI_LABEL_KEYS.map((key, i) => {
           const isActive = i === active;
+          const label = t(key);
           return (
             <button
-              key={c.label}
+              key={key}
               type="button"
               onClick={() => {
                 return setActive(i);
@@ -597,7 +607,7 @@ function AppMockupCarousel() {
                   : "text-white/60 hover:text-white/90"
               }`}
             >
-              {c.label}
+              {label}
             </button>
           );
         })}
@@ -608,12 +618,12 @@ function AppMockupCarousel() {
         ref={ref}
         className="relative mt-2 w-full overflow-hidden rounded-t-xl sm:mt-3"
       >
-        {WEB_UI_CASES.map((c, i) => {
+        {WEB_UI_CASES_SRCS.map((src, i) => {
           return (
             <Image
-              key={c.src}
-              alt={c.label}
-              src={c.src}
+              key={src}
+              alt={t(WEB_UI_LABEL_KEYS[i]!)}
+              src={src}
               width={855}
               height={600}
               className={`webui-pop w-full select-none ${i === active ? "relative" : "absolute inset-0 opacity-0"}`}
@@ -625,7 +635,7 @@ function AppMockupCarousel() {
         <div className="absolute inset-0 z-20">
           <button
             type="button"
-            aria-label="Daily Report"
+            aria-label={t("teammateCard.ariaDaily")}
             onClick={() => {
               return setActive(0);
             }}
@@ -634,7 +644,7 @@ function AppMockupCarousel() {
           />
           <button
             type="button"
-            aria-label="Email Leads"
+            aria-label={t("teammateCard.ariaLeads")}
             onClick={() => {
               return setActive(1);
             }}
@@ -643,7 +653,7 @@ function AppMockupCarousel() {
           />
           <button
             type="button"
-            aria-label="Sentry Report"
+            aria-label={t("teammateCard.ariaSentry")}
             onClick={() => {
               return setActive(2);
             }}
@@ -666,21 +676,19 @@ function AppMockupCarousel() {
   );
 }
 
-function TeammateCard() {
+function TeammateCard({ t }: { t: (key: string) => string }) {
   return (
     <div className="overflow-hidden rounded-[20px] bg-white">
       <div className="flex flex-col gap-4 p-8 sm:p-10">
         <h3 className="text-2xl font-medium leading-8 text-[hsl(var(--foreground))]">
-          A teammate that reads, thinks, and delivers.
+          {t("teammateCard.title")}
         </h3>
         <p className="text-sm leading-6 text-[hsl(var(--muted-foreground))] sm:text-base">
-          &ldquo;Summarize my week from Calendar, Linear, and Slack.&rdquo; Zero
-          pulls context from your tools, connects the dots, and hands you a
-          finished report. Like briefing a colleague, except it takes seconds.
+          {t("teammateCard.description")}
         </p>
       </div>
       <div className="bg-[#d58341] px-2 pb-0 pt-3 sm:px-6 sm:pt-6">
-        <AppMockupCarousel />
+        <AppMockupCarousel t={t} />
       </div>
     </div>
   );
@@ -1293,8 +1301,9 @@ export default function LandingPage({
   const { isSignedIn: clerkIsSignedIn, isLoaded } = useUser();
   const isSignedIn = isLoaded ? clerkIsSignedIn : initialIsSignedIn;
   const revealRef = useScrollReveal();
+  const t = useTranslations("landing");
 
-  const ctaText = isSignedIn ? "Open app" : "Get started";
+  const ctaText = isSignedIn ? t("hero.ctaOpenApp") : t("hero.ctaGetStarted");
   const ctaHref = isSignedIn ? getAppUrl() : "/sign-up";
 
   return (
@@ -1369,7 +1378,7 @@ export default function LandingPage({
                   height={16}
                   className="h-4 w-[22px]"
                 />
-                <span>Check out our $14M seed round fundraising blog.</span>
+                <span>{t("hero.seedBanner")}</span>
                 <svg
                   width="16"
                   height="16"
@@ -1393,13 +1402,10 @@ export default function LandingPage({
               {/* Heading + Subtitle */}
               <div className="flex w-full flex-col items-center gap-[15px] text-center">
                 <h1 className="w-full text-[32px] font-medium leading-[1.4] tracking-[-1.12px] text-[hsl(var(--foreground))] sm:text-[42px] md:text-[51px]">
-                  Zero, your trustworthy AI teammate{" "}
-                  <br className="hidden sm:inline" />
-                  for real work.
+                  {t("hero.title")}
                 </h1>
                 <p className="max-w-2xl text-[16px] leading-7 text-[hsl(var(--muted-foreground))] sm:text-[18px]">
-                  Zero connects to 100+ tools and does the work. Reports,
-                  triage, outreach, research. In Slack or on the web.
+                  {t("hero.subtitle")}
                 </p>
               </div>
             </div>
@@ -1415,7 +1421,7 @@ export default function LandingPage({
                 href="/use-cases"
                 className="inline-flex items-center justify-center rounded-xl px-8 py-3.5 text-base font-medium text-[hsl(var(--foreground))] transition-all border border-[hsl(var(--gray-300))] hover:bg-[hsl(var(--gray-100))]"
               >
-                See use cases
+                {t("hero.seeUseCases")}
               </NextLink>
             </div>
           </div>
@@ -1425,18 +1431,18 @@ export default function LandingPage({
         <section className="px-5 py-10 sm:px-6 sm:py-12 md:py-16">
           <div className="mx-auto max-w-[1152px]">
             <div className="reveal">
-              <SectionHeading>What Zero actually does for you</SectionHeading>
+              <SectionHeading>{t("worksForYou.heading")}</SectionHeading>
             </div>
 
             <div className="mt-12 space-y-8 sm:mt-16">
               <div className="reveal">
-                <TeammateCard />
+                <TeammateCard t={t} />
               </div>
               <div className="reveal">
-                <SlackCard />
+                <SlackCard t={t} />
               </div>
               <div className="reveal">
-                <SyncedToolsCard />
+                <SyncedToolsCard t={t} />
               </div>
 
               {/* More use cases link */}
@@ -1445,7 +1451,7 @@ export default function LandingPage({
                   href="/use-cases"
                   className="inline-flex items-center gap-2 rounded-xl px-6 py-3 text-base font-medium text-[hsl(var(--foreground))] transition-all border border-[hsl(var(--gray-300))] hover:bg-[hsl(var(--gray-100))]"
                 >
-                  Explore more use cases
+                  {t("worksForYou.exploreMore")}
                   <svg
                     width="16"
                     height="16"
@@ -1473,11 +1479,10 @@ export default function LandingPage({
             {/* Title block */}
             <div className="reveal flex flex-col items-center gap-4 rounded-[32px] px-2 pb-2 pt-6">
               <h2 className="landing-heading text-center text-[28px] font-medium leading-[1.2] tracking-[-0.88px] text-[hsl(var(--foreground))] sm:text-[34px] md:text-[40px]">
-                Works with 100+ tools you already use
+                {t("connectors.heading")}
               </h2>
               <p className="max-w-[856px] text-center text-base leading-6 text-[hsl(var(--muted-foreground))]">
-                Slack, GitHub, Gmail, Notion, Linear, Sentry, and more. Zero
-                connects to your stack so it can act, not just answer.
+                {t("connectors.description")}
               </p>
             </div>
 
@@ -1584,7 +1589,7 @@ export default function LandingPage({
           <div className="mx-auto max-w-[1152px]">
             <div className="reveal">
               <h2 className="landing-heading text-center text-[28px] font-medium leading-[1.2] tracking-[-0.88px] text-[hsl(var(--foreground))] sm:text-[34px] md:text-[40px]">
-                Your data stays yours
+                {t("security.heading")}
               </h2>
             </div>
 
@@ -1593,11 +1598,10 @@ export default function LandingPage({
               <div className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] bg-white">
                 <div className="flex flex-1 flex-col gap-4 p-10">
                   <h3 className="text-2xl font-medium leading-8 text-[hsl(var(--foreground))]">
-                    You control what Zero can access
+                    {t("security.permissionTitle")}
                   </h3>
                   <p className="text-base leading-6 text-[hsl(var(--muted-foreground))]">
-                    Set read and write permissions per tool, per agent. Zero
-                    only touches what you explicitly allow.
+                    {t("security.permissionDesc")}
                   </p>
                 </div>
                 <div className="flex h-[300px] items-center justify-center rounded-b-[20px] bg-[hsl(var(--gray-100))] px-10">
@@ -1617,20 +1621,19 @@ export default function LandingPage({
               <div className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] bg-white">
                 <div className="flex flex-col gap-4 p-10">
                   <h3 className="text-2xl font-medium leading-8 text-[hsl(var(--foreground))]">
-                    Isolated execution, every time
+                    {t("security.isolatedTitle")}
                   </h3>
                   <p className="min-h-[72px] text-base leading-6 text-[hsl(var(--muted-foreground))]">
-                    Every task runs in its own microVM. Credentials never leave
-                    the sandbox. Fully auditable. And{" "}
+                    {t("security.isolatedDescPart1")}
                     <a
                       href="https://github.com/vm0-ai/vm0"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="font-medium text-[#45A7A8] underline underline-offset-2 hover:text-[#3a8e8f]"
                     >
-                      open source
+                      {t("security.isolatedDescLink")}
                     </a>
-                    .
+                    {t("security.isolatedDescPart2")}
                   </p>
                 </div>
                 <div className="flex h-[300px] items-center justify-center rounded-b-[20px] bg-[hsl(var(--gray-100))] px-10">
@@ -1647,7 +1650,7 @@ export default function LandingPage({
             {/* Section title */}
             <div className="reveal">
               <h2 className="landing-heading max-w-[740px] text-center text-[28px] font-medium leading-[1.2] tracking-[-0.88px] text-[hsl(var(--foreground))] sm:text-[34px] md:text-[40px]">
-                Gets smarter the more you use it
+                {t("intelligence.heading")}
               </h2>
             </div>
 
@@ -1664,12 +1667,10 @@ export default function LandingPage({
                     className="h-[22px] w-[24px] landing-icon-invert"
                   />
                   <h3 className="text-2xl font-medium leading-8 text-[hsl(var(--foreground))]">
-                    Remembers your context
+                    {t("intelligence.memoryTitle")}
                   </h3>
                   <p className="text-base leading-6 text-[hsl(var(--muted-foreground))]">
-                    Past decisions, project context, your preferences — Zero
-                    carries it all forward. No re-explaining, no lost context
-                    between sessions.
+                    {t("intelligence.memoryDesc")}
                   </p>
                 </div>
                 <MemoryMockupArea />
@@ -1686,11 +1687,10 @@ export default function LandingPage({
                     className="size-[24px] landing-icon-invert"
                   />
                   <h3 className="text-2xl font-medium leading-8 text-[hsl(var(--foreground))]">
-                    Scheduled intelligence
+                    {t("intelligence.scheduleTitle")}
                   </h3>
                   <p className="text-base leading-6 text-[hsl(var(--muted-foreground))]">
-                    Zero runs autonomous recurring tasks, daily error scans,
-                    tech debt reports, morning briefs, without being prompted.
+                    {t("intelligence.scheduleDesc")}
                   </p>
                 </div>
                 <ScheduleMockupArea />
@@ -1699,30 +1699,29 @@ export default function LandingPage({
 
             {/* Three bottom benefit items */}
             <div className="reveal grid w-full gap-8 sm:grid-cols-3">
-              {[
-                {
-                  title: "Specialized sub-agents",
-                  description:
-                    "Create agents for specific jobs. One for research, one for triage, one for outreach. They work in parallel so you don't.",
-                },
-                {
-                  title: "Tool orchestration",
-                  description:
-                    "Zero selects and chains the right tools from 100+ available integrations. You describe the goal; Zero figures out the steps.",
-                },
-                {
-                  title: "Knows who you are",
-                  description:
-                    '"My PRs," "assign to me." Zero resolves your identity across GitHub, Slack, and Linear automatically. No setup required.',
-                },
-              ].map((item) => {
+              {(
+                [
+                  {
+                    titleKey: "intelligence.subAgentsTitle",
+                    descKey: "intelligence.subAgentsDesc",
+                  },
+                  {
+                    titleKey: "intelligence.toolOrchTitle",
+                    descKey: "intelligence.toolOrchDesc",
+                  },
+                  {
+                    titleKey: "intelligence.identityTitle",
+                    descKey: "intelligence.identityDesc",
+                  },
+                ] as const
+              ).map((item) => {
                 return (
-                  <div key={item.title} className="flex flex-col gap-2">
+                  <div key={item.titleKey} className="flex flex-col gap-2">
                     <h3 className="text-base font-bold leading-6 text-[hsl(var(--foreground))]">
-                      {item.title}
+                      {t(item.titleKey)}
                     </h3>
                     <p className="text-base leading-6 text-[hsl(var(--muted-foreground))]">
-                      {item.description}
+                      {t(item.descKey)}
                     </p>
                   </div>
                 );
@@ -1737,11 +1736,10 @@ export default function LandingPage({
             <div className="flex flex-col items-start gap-6 rounded-[20px] bg-white px-6 py-8 sm:flex-row sm:items-center sm:justify-between sm:gap-8 sm:px-10">
               <div className="flex flex-col gap-2">
                 <h3 className="landing-heading text-[22px] font-medium leading-[1.3] tracking-[-0.5px] text-[hsl(var(--foreground))] sm:text-[26px]">
-                  You decide what matters. Zero handles the rest.
+                  {t("cta.title")}
                 </h3>
                 <p className="text-base leading-6 text-[hsl(var(--muted-foreground))]">
-                  Start free. Use it in Slack or on the web. No credit card
-                  required.
+                  {t("cta.subtitle")}
                 </p>
               </div>
               <CtaButton

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -80,13 +80,13 @@ export default function Navbar({ initialIsSignedIn = false }: NavbarProps) {
             style={{ display: "flex", gap: "32px" }}
           >
             <Link href="/pricing" className="nav-link">
-              Pricing
+              {t("pricing")}
             </Link>
             <Link href="/security" className="nav-link">
-              Security
+              {t("security")}
             </Link>
             <Link href="/use-cases" className="nav-link">
-              Use Cases
+              {t("useCases")}
             </Link>
             {isBlogEnabled() && (
               <Link href="/blog" className="nav-link">
@@ -126,7 +126,7 @@ export default function Navbar({ initialIsSignedIn = false }: NavbarProps) {
                   onClick={handleSignOut}
                   className="btn-try-demo nav-desktop"
                 >
-                  Sign out
+                  {t("signOut")}
                 </button>
                 <a
                   href={getAppUrl()}
@@ -134,7 +134,7 @@ export default function Navbar({ initialIsSignedIn = false }: NavbarProps) {
                   rel="noopener noreferrer"
                   className="btn-get-access nav-desktop group"
                 >
-                  <span>Open app</span>
+                  <span>{t("openApp")}</span>
                   <IconArrowRight
                     size={16}
                     className="transition-transform group-hover:translate-x-0.5"
@@ -177,7 +177,7 @@ export default function Navbar({ initialIsSignedIn = false }: NavbarProps) {
                 return setMobileMenuOpen(false);
               }}
             >
-              Security
+              {t("security")}
             </Link>
             <Link
               href="/use-cases"
@@ -186,7 +186,7 @@ export default function Navbar({ initialIsSignedIn = false }: NavbarProps) {
                 return setMobileMenuOpen(false);
               }}
             >
-              Use Cases
+              {t("useCases")}
             </Link>
             {isBlogEnabled() && (
               <Link
@@ -231,7 +231,7 @@ export default function Navbar({ initialIsSignedIn = false }: NavbarProps) {
                   className="mobile-menu-link"
                   style={{ textAlign: "left", width: "100%" }}
                 >
-                  Sign out
+                  {t("signOut")}
                 </button>
                 <a
                   href={getAppUrl()}
@@ -243,7 +243,7 @@ export default function Navbar({ initialIsSignedIn = false }: NavbarProps) {
                   }}
                   style={{ display: "flex", alignItems: "center", gap: "8px" }}
                 >
-                  <span>Open app</span>
+                  <span>{t("openApp")}</span>
                   <IconArrowRight
                     size={16}
                     className="transition-transform group-hover:translate-x-0.5"

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -52,7 +52,7 @@ const jetBrainsMono = JetBrains_Mono({
 
 export function generateMetadata(): Metadata {
   return {
-    metadataBase: new URL("https://vm0.ai"),
+    metadataBase: new URL("https://www.vm0.ai"),
     title: {
       default: "VM0 - Your Trustworthy AI Teammate",
       template: "%s | VM0",
@@ -73,7 +73,7 @@ export function generateMetadata(): Metadata {
       "AI productivity",
       "workflow automation",
     ],
-    authors: [{ name: "VM0", url: "https://vm0.ai" }],
+    authors: [{ name: "VM0", url: "https://www.vm0.ai" }],
     creator: "VM0",
     publisher: "VM0",
     applicationName: "VM0",
@@ -90,7 +90,7 @@ export function generateMetadata(): Metadata {
     openGraph: {
       type: "website",
       locale: "en_US",
-      url: "https://vm0.ai",
+      url: "https://www.vm0.ai",
       title: "VM0 - Your Trustworthy AI Teammate",
       description:
         "Meet Zero, your AI teammate that works in Slack and on the web. Secure, intelligent, and built for individuals and teams to do more together.",
@@ -185,8 +185,8 @@ export default function RootLayout({
                 "@context": "https://schema.org",
                 "@type": "Organization",
                 name: "VM0",
-                url: "https://vm0.ai",
-                logo: "https://vm0.ai/assets/vm0-logo.svg",
+                url: "https://www.vm0.ai",
+                logo: "https://www.vm0.ai/assets/vm0-logo.svg",
                 description:
                   "Your trustworthy AI teammate. Works in Slack and on the web, for individuals and team collaboration.",
                 email: "contact@vm0.ai",
@@ -212,7 +212,7 @@ export default function RootLayout({
                 "@context": "https://schema.org",
                 "@type": "WebSite",
                 name: "VM0",
-                url: "https://vm0.ai",
+                url: "https://www.vm0.ai",
                 description:
                   "Your trustworthy AI teammate. Works in Slack and on the web, for individuals and team collaboration.",
               }),
@@ -235,8 +235,8 @@ export default function RootLayout({
                 },
                 description:
                   "Your trustworthy AI teammate. Works in Slack and on the web, for individuals and team collaboration.",
-                url: "https://vm0.ai",
-                image: "https://vm0.ai/og-image.png",
+                url: "https://www.vm0.ai",
+                image: "https://www.vm0.ai/og-image.png",
               }),
             }}
           />

--- a/turbo/apps/web/app/privacy-policy/layout.tsx
+++ b/turbo/apps/web/app/privacy-policy/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   description:
     "VM0 Privacy Policy — how we collect, use, and protect your data.",
   alternates: {
-    canonical: "https://vm0.ai/privacy-policy",
+    canonical: "https://www.vm0.ai/privacy-policy",
   },
   robots: {
     index: true,

--- a/turbo/apps/web/app/privacy-policy/page.tsx
+++ b/turbo/apps/web/app/privacy-policy/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
   description:
     "VM0 Privacy Policy — how we collect, use, and protect your data.",
   alternates: {
-    canonical: "https://vm0.ai/privacy-policy",
+    canonical: "https://www.vm0.ai/privacy-policy",
   },
   robots: {
     index: true,

--- a/turbo/apps/web/app/robots.ts
+++ b/turbo/apps/web/app/robots.ts
@@ -17,6 +17,6 @@ export default function robots(): MetadataRoute.Robots {
         ],
       },
     ],
-    sitemap: "https://vm0.ai/sitemap.xml",
+    sitemap: "https://www.vm0.ai/sitemap.xml",
   };
 }

--- a/turbo/apps/web/app/sitemap.ts
+++ b/turbo/apps/web/app/sitemap.ts
@@ -4,7 +4,7 @@ import { getPosts } from "./lib/blog/data-source";
 import { getBlogBaseUrl } from "./lib/blog/config";
 
 const locales = ["en", "de", "es", "ja"];
-const baseUrl = "https://vm0.ai";
+const baseUrl = "https://www.vm0.ai";
 
 // Static dates per route category — avoids false "always modified" signals
 const STATIC_DATE = new Date("2025-01-01");

--- a/turbo/apps/web/app/terms-of-use/layout.tsx
+++ b/turbo/apps/web/app/terms-of-use/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   description:
     "VM0 Terms of Use — the rules and conditions governing use of our platform.",
   alternates: {
-    canonical: "https://vm0.ai/terms-of-use",
+    canonical: "https://www.vm0.ai/terms-of-use",
   },
   robots: {
     index: true,

--- a/turbo/apps/web/app/terms-of-use/page.tsx
+++ b/turbo/apps/web/app/terms-of-use/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
   description:
     "VM0 Terms of Use — the rules and conditions governing use of our platform.",
   alternates: {
-    canonical: "https://vm0.ai/terms-of-use",
+    canonical: "https://www.vm0.ai/terms-of-use",
   },
   robots: {
     index: true,

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -78,21 +78,135 @@
     "button": "Warteliste beitreten"
   },
   "nav": {
-    "docs": "Docs",
+    "docs": "Dokumente",
     "blog": "Blog",
     "skills": "Skills",
-    "glossary": "Glossar",
     "pricing": "Preise",
     "github": "GitHub",
     "contact": "Demo vereinbaren",
-    "joinWaitlist": "Registrieren"
+    "joinWaitlist": "Registrieren",
+    "security": "Sicherheit",
+    "useCases": "Anwendungsfälle",
+    "signOut": "Abmelden",
+    "openApp": "App öffnen"
   },
   "pricing": {
     "title": "Wählen Sie Ihren Plan",
-    "subtitle": "Starten Sie kostenlos und skalieren Sie nach Bedarf. Keine Kreditkarte erforderlich."
+    "subtitle": "Starten Sie kostenlos und skalieren Sie nach Bedarf. Keine Kreditkarte erforderlich.",
+    "heroTitle": "Zahlen Sie nur, was Sie nutzen, nicht mehr",
+    "heroDescription": "Starten Sie kostenlos mit Ihrem KI-Teamkollegen. Skalieren Sie, wenn Sie bereit sind, keine Kreditkarte erforderlich.",
+    "free": {
+      "description": "Starten Sie kostenlos mit Ihrem KI-Teamkollegen.",
+      "features": {
+        "starterCredits": "10.000 Starter-Credits",
+        "concurrentRun": "1 gleichzeitige Ausführung",
+        "unlimitedAgents": "Unbegrenzte Agenten insgesamt",
+        "bringOwnLLM": "Eigene LLM-Schlüssel verwenden",
+        "communitySupport": "Community-Support"
+      },
+      "buttonText": "Jetzt starten"
+    },
+    "pro": {
+      "description": "Mehr Leistung und nahtlose Zusammenarbeit für Ihr Team.",
+      "features": {
+        "credits": "20.000 Credits / Monat",
+        "concurrentRuns": "2 gleichzeitige Ausführungen",
+        "unlimitedAgents": "Unbegrenzte Agenten insgesamt",
+        "bringOwnLLM": "Eigene LLM-Schlüssel verwenden",
+        "creditsRollover": "Credits-Übertrag (1 Monat)",
+        "emailSupport": "E-Mail-Support"
+      },
+      "buttonText": "Mit Pro starten"
+    },
+    "team": {
+      "description": "Skalieren Sie schnell, ohne Reibung und mit voller Flexibilität.",
+      "features": {
+        "credits": "120.000 Credits / Monat",
+        "concurrentRuns": "5 gleichzeitige Ausführungen",
+        "unlimitedAgents": "Unbegrenzte Agenten insgesamt",
+        "bringOwnLLM": "Eigene LLM-Schlüssel verwenden",
+        "creditsRollover": "Credits-Übertrag (1 Monat)",
+        "prioritySupport": "Prioritäts-Support"
+      },
+      "buttonText": "Mit Team starten"
+    },
+    "needMoreCredits": "Mehr Credits benötigt?",
+    "topUpDescription": "Jederzeit aufladen für",
+    "topUpRate": "1.000 Credits pro 1 $",
+    "topUpAutoRecharge": "Richten Sie automatisches Aufladen ein, damit Ihre Agenten nie stoppen – wenn Ihr Guthaben unter einen Schwellenwert fällt, werden Credits automatisch gekauft.",
+    "perCredits": "pro 1.000 Credits",
+    "comparePlans": "Pläne vergleichen",
+    "featuresHeader": "Funktionen",
+    "sections": {
+      "creditsAndAgents": "Credits & Agenten",
+      "connectorsAndIntegrations": "Konnektoren & Integrationen",
+      "securityAndCompliance": "Sicherheit & Compliance",
+      "collaboration": "Zusammenarbeit",
+      "support": "Support"
+    },
+    "tableFeatures": {
+      "creditsPerMonth": "Credits pro Monat",
+      "creditsPerMonthDesc": "Credits, die durch KI-Modellnutzung über alle Agenten verbraucht werden",
+      "concurrentRuns": "Gleichzeitige Ausführungen",
+      "concurrentRunsDesc": "Anzahl der Agenten, die gleichzeitig laufen können",
+      "totalAgents": "Agenten insgesamt",
+      "totalAgentsDesc": "Maximale Anzahl der Agenten, die Sie erstellen können",
+      "creditsRollover": "Credits-Übertrag",
+      "creditsRolloverDesc": "Ungenutzte Credits werden in die nächste Abrechnungsperiode übertragen",
+      "creditTopUp": "Credit-Aufladung",
+      "creditTopUpDesc": "Zusätzliche Credits jederzeit kaufen für 1 $ pro 1.000 Credits",
+      "autoRecharge": "Automatisches Aufladen",
+      "autoRechargeDesc": "Automatischer Credit-Kauf, wenn das Guthaben unter einen Schwellenwert fällt",
+      "connectors": "Konnektoren",
+      "connectorsDesc": "Verbinden Sie Ihre Tools wie Slack, GitHub, Notion und mehr",
+      "bringOwnLLM": "Eigenes LLM mitbringen",
+      "bringOwnLLMDesc": "Verwenden Sie Ihre eigenen Modellanbieter-API-Schlüssel",
+      "sandboxedExecution": "Sandbox-Ausführung",
+      "sandboxedExecutionDesc": "Firecracker-microVMs mit Hardware-Level-KVM-Isolation",
+      "fullAuditTrail": "Vollständiger Audit-Trail",
+      "fullAuditTrailDesc": "Agent-HTTP/HTTPS-Verkehr pro Ausführung mit SHA-256-Integrität protokolliert",
+      "noCredentialExposure": "Keine Credential-Offenlegung",
+      "noCredentialExposureDesc": "Secrets werden auf Netzwerkebene injiziert, nie für Agenten-Code sichtbar",
+      "teamMembers": "Teammitglieder",
+      "teamMembersDesc": "Anzahl der Personen in Ihrem Workspace",
+      "perMemberCreditCaps": "Credit-Limits pro Mitglied",
+      "perMemberCreditCapsDesc": "Ausgabenlimits für einzelne Teammitglieder festlegen",
+      "communitySupport": "Community-Support",
+      "communitySupportDesc": "Zugang zur Discord-Community und Dokumentation",
+      "emailSupport": "E-Mail-Support",
+      "emailSupportDesc": "Direkter E-Mail-Support vom VM0-Team",
+      "prioritySupport": "Prioritäts-Support",
+      "prioritySupportDesc": "Dedizierter Support mit schnelleren Reaktionszeiten"
+    },
+    "tableValues": {
+      "starter": "10.000 Starter",
+      "20k": "20.000",
+      "120k": "120.000",
+      "unlimited": "Unbegrenzt",
+      "oneMonth": "1 Monat",
+      "allConnectors": "Alle Konnektoren"
+    },
+    "faq": {
+      "title": "Häufig gestellte Fragen",
+      "whatAreCredits": "Was sind Credits?",
+      "whatAreCreditsAnswer": "Credits werden verbraucht, wenn Ihre Agenten KI-Modelle nutzen. Verschiedene Modelle verbrauchen Credits mit unterschiedlichen Raten. Zum Beispiel verbraucht eine einfache Aufgabe wenige Credits, während ein komplexer mehrstufiger Workflow mehr benötigt.",
+      "changePlans": "Kann ich den Plan jederzeit wechseln?",
+      "changePlansAnswer": "Ja! Sie können Ihren Plan jederzeit upgraden oder downgraden. Änderungen werden sofort wirksam, und wir berechnen die Kosten anteilig.",
+      "runOutOfCredits": "Was passiert, wenn meine Credits aufgebraucht sind?",
+      "runOutOfCreditsAnswer": "Wenn Ihre Credits aufgebraucht sind, stoppen Ihre Agenten. Sie können zusätzliche Credits per automatischem Aufladen kaufen oder auf einen höheren Plan upgraden.",
+      "doCreditsRollOver": "Werden ungenutzte Credits übertragen?",
+      "doCreditsRollOverAnswer": "Beim Free-Plan verfallen Starter-Credits nicht, werden aber nicht aufgefüllt. Bei Pro werden ungenutzte Credits 1 Monat übertragen. Bei Team werden Credits 1 Monat übertragen.",
+      "bringOwnModel": "Kann ich meinen eigenen Modellanbieter verwenden?",
+      "bringOwnModelAnswer": "Ja! Alle Pläne unterstützen eigene LLM-API-Schlüssel (Anthropic usw.). Bei Verwendung eigener Schlüssel werden keine VM0-Credits für die Modellnutzung verbraucht.",
+      "howSecure": "Wie sicher ist VM0?",
+      "howSecureAnswer": "Jeder Agentenlauf wird in einer isolierten Firecracker-microVM mit Hardware-Level-KVM-Isolation ausgeführt. Credentials werden auf Netzwerkebene injiziert und nie dem Agenten-Code ausgesetzt. Sämtlicher Agent-HTTP/HTTPS-Verkehr wird pro Lauf mit SHA-256-Integrität protokolliert.",
+      "annualBilling": "Bieten Sie Jahresabrechnung oder Rabatte an?",
+      "annualBillingAnswer": "Kontaktieren Sie uns, um Mengenpreise, Jahresabrechnungsrabatte und individuelle Vereinbarungen für Ihr Team zu besprechen."
+    },
+    "perMonth": "/Monat"
   },
   "footer": {
-    "tagline": "Zero, your trustworthy AI teammate.",
+    "tagline": "Zero, Ihr vertrauenswürdiger KI-Teamkollege.",
     "copyright": "© 2026 VM0.ai Alle Rechte vorbehalten.",
     "language": "Sprache",
     "status": "Status",
@@ -135,142 +249,6 @@
       "Other": "Sonstiges"
     }
   },
-  "glossary": {
-    "hero": {
-      "title": "Glossar für Agenten-Entwicklung",
-      "description": "Beherrschen Sie die Sprache von KI-Agenten. Erkunden Sie wichtige Konzepte, Terminologie und VM0-spezifische Funktionen, um Ihre Agenten-Entwicklungsreise zu beschleunigen."
-    },
-    "search": {
-      "placeholder": "Begriffe durchsuchen...",
-      "allCategories": "Alle Kategorien",
-      "showingAll": "Zeige alle Begriffe",
-      "found": "Gefunden",
-      "results": "Begriffe",
-      "noResults": "Keine Begriffe gefunden, die Ihrer Suche entsprechen"
-    },
-    "relatedTerms": "Verwandte Begriffe",
-    "categories": {
-      "Core Concepts": "Kernkonzepte",
-      "Execution": "Ausführung",
-      "Infrastructure": "Infrastruktur",
-      "VM0 Features": "VM0-Funktionen",
-      "Development": "Entwicklung"
-    },
-    "terms": {
-      "agent": {
-        "name": "Agent",
-        "definition": "Ein autonomes KI-Programm, das Anweisungen verstehen, Entscheidungen treffen, Werkzeuge verwenden und Aufgaben selbstständig ausführen kann. Im Gegensatz zu traditionellen Skripten können Agenten ihren Ansatz basierend auf dem Kontext anpassen und iterativ auf Ziele hinarbeiten."
-      },
-      "skill": {
-        "name": "Skill",
-        "definition": "Eine vorgefertigte Integration oder Fähigkeit, die Agenten nutzen können, um mit externen Diensten zu interagieren. Skills bieten Agenten sofort einsetzbare Funktionalität wie den Zugriff auf Slack, GitHub, Notion oder andere APIs, ohne dass eine benutzerdefinierte Implementierung erforderlich ist."
-      },
-      "tool": {
-        "name": "Tool",
-        "definition": "Eine Funktion oder API, die ein Agent aufrufen kann, um bestimmte Aktionen auszuführen. Tools sind die Bausteine der Agentenfähigkeiten und ermöglichen es ihnen, Dateien zu lesen, HTTP-Anfragen zu stellen, Datenbanken abzufragen oder mit jedem externen System zu interagieren."
-      },
-      "prompt": {
-        "name": "Prompt",
-        "definition": "Natürlichsprachliche Anweisungen, die einem Agenten gegeben werden, um seine Aufgabe, sein Verhalten oder sein Ziel zu definieren. Prompts können von einfachen Befehlen bis hin zu komplexen Systemanweisungen reichen, die bestimmen, wie ein Agent denkt und arbeitet."
-      },
-      "context": {
-        "name": "Kontext",
-        "definition": "Die Informationen, die einem Agenten während der Ausführung zur Verfügung stehen, einschließlich Gesprächsverlauf, Speicher, Tool-Ausgaben und Umgebungszustand. Der Kontext hilft Agenten, Kohärenz über Interaktionen hinweg zu wahren und fundierte Entscheidungen zu treffen."
-      },
-      "session": {
-        "name": "Sitzung",
-        "definition": "Ein kontinuierlicher Zeitraum der Agentenausführung, der Zustand, Speicher und Kontext bewahrt. Sitzungen ermöglichen es Agenten, das Bewusstsein über mehrere Interaktionen hinweg aufrechtzuerhalten und die Arbeit fortzusetzen, ohne Fortschritte zu verlieren."
-      },
-      "checkpoint": {
-        "name": "Checkpoint",
-        "definition": "Ein Snapshot des Zustands eines Agenten zu einem bestimmten Zeitpunkt, der seinen Speicher, Kontext und Ausführungsfortschritt erfasst. Checkpoints ermöglichen Reproduzierbarkeit und erlauben es Ihnen, Agentendurchläufe wiederherzustellen, zu forken oder zu wiederholen."
-      },
-      "artifact": {
-        "name": "Artefakt",
-        "definition": "Dateien, Daten oder Ausgaben, die von einem Agenten während der Ausführung erzeugt werden. Artefakte bleiben über Durchläufe hinweg bestehen und können Code, Dokumente, Analyseergebnisse oder andere vom Agenten produzierte Ergebnisse umfassen."
-      },
-      "observability": {
-        "name": "Beobachtbarkeit",
-        "definition": "Die Fähigkeit, das Verhalten von Agenten durch Logs, Metriken und Ausführungstraces zu inspizieren, zu überwachen und zu verstehen. Beobachtbarkeit ist wesentlich für Debugging, Optimierung und die Gewährleistung transparenter KI-Operationen."
-      },
-      "sandbox": {
-        "name": "Sandbox",
-        "definition": "Eine isolierte Ausführungsumgebung, in der Agenten sicher laufen, ohne Produktionssysteme zu beeinträchtigen. Sandboxes bieten Sicherheitsgrenzen und stellen sicher, dass Agentenaktionen eingedämmt und kontrolliert werden."
-      },
-      "memory": {
-        "name": "Speicher",
-        "definition": "Informationen, die ein Agent über Interaktionen hinweg behält und es ihm ermöglichen, aus vergangenen Erfahrungen zu lernen und den Kontext über die Zeit aufrechtzuerhalten. Der Speicher kann Fakten, Präferenzen, Gesprächsverläufe und gelernte Muster umfassen."
-      },
-      "workflow": {
-        "name": "Workflow",
-        "definition": "Eine Abfolge von Aufgaben oder Operationen, die ein Agent ausführt, um ein Ziel zu erreichen. Im Gegensatz zu starren Automatisierungsskripten können Agenten-Workflows sich anpassen und basierend auf Zwischenergebnissen und sich ändernden Bedingungen justieren."
-      },
-      "llm": {
-        "name": "LLM (Large Language Model)",
-        "definition": "Das zugrunde liegende KI-Modell, das das Reasoning und die Entscheidungsfindung des Agenten antreibt. Beispiele sind Claude, GPT-4 und Gemini. Verschiedene LLMs haben unterschiedliche Stärken, Kosten und Fähigkeiten."
-      },
-      "skillMd": {
-        "name": "SKILL.md",
-        "definition": "Eine Markdown-Konfigurationsdatei, die das Verhalten, die Eingaben, Ausgaben und Implementierungslogik einer Skill definiert. Die SKILL.md-Datei ermöglicht es Ihnen, benutzerdefinierte Skills mit natürlicher Sprache und strukturierten Metadaten zu erstellen, wodurch es einfach wird, Agentenfähigkeiten zu erweitern, ohne komplexen Code zu schreiben."
-      },
-      "agentMd": {
-        "name": "AGENTS.md",
-        "definition": "Eine Markdown-Konfigurationsdatei, die das Verhalten, die Persönlichkeit, die Ziele und die verfügbaren Tools eines Agenten definiert. Die AGENTS.md-Datei dient als Blaupause des Agenten und spezifiziert, wie er denken sollte, was er tun kann und wie er mit Benutzern und Systemen interagieren sollte."
-      },
-      "volume": {
-        "name": "Volume",
-        "definition": "Ein persistenter Speicherplatz, der Dateien und Daten über Agentendurchläufe hinweg bewahrt. Volumes bieten Agenten ein Dateisystem, das über einzelne Ausführungen hinaus besteht und es ihnen ermöglicht, Zustände zu speichern, Daten zu cachen und langfristige Artefakte zu pflegen."
-      },
-      "action": {
-        "name": "Aktion",
-        "definition": "Eine konkrete Operation oder Aufgabe, die ein Agent ausführt, um seine Ziele zu erreichen. Aktionen können API-Aufrufe, das Lesen von Dateien, die Verarbeitung von Daten oder die Interaktion mit externen Systemen umfassen. Jede Aktion repräsentiert einen einzelnen Schritt im Ausführungsfluss des Agenten."
-      },
-      "runtime": {
-        "name": "Runtime",
-        "definition": "Die Ausführungsumgebung, in der Agenten laufen und die notwendige Infrastruktur, Ressourcen und APIs bereitstellt. Die Runtime verwaltet den Agentenlebenszyklus, handhabt die Ressourcenzuweisung und gewährleistet die ordnungsgemäße Isolation zwischen verschiedenen Agentenausführungen."
-      },
-      "orchestration": {
-        "name": "Orchestrierung",
-        "definition": "Die Koordination und Verwaltung mehrerer Agenten, Workflows oder Aufgaben, um komplexe Ziele zu erreichen. Die Orchestrierung handhabt Abhängigkeiten, Sequenzierung, parallele Ausführung und Ressourcenzuweisung über verteilte Agentenoperationen hinweg."
-      },
-      "mcp": {
-        "name": "MCP (Model Context Protocol)",
-        "definition": "Ein offenes Protokoll, das von Anthropic entwickelt wurde und es KI-Assistenten ermöglicht, sich sicher mit externen Datenquellen und Tools zu verbinden. MCP bietet eine standardisierte Möglichkeit für Agenten, auf Ressourcen wie Datenbanken, APIs und Dateisysteme zuzugreifen, während Sicherheit und Kontextbewusstsein gewahrt bleiben."
-      },
-      "image": {
-        "name": "Image",
-        "definition": "Ein gepackter Container, der den Code, die Runtime, die Abhängigkeiten und die Konfiguration enthält, die zum Ausführen eines Agenten erforderlich sind. Images bieten eine konsistente und reproduzierbare Ausführungsumgebung und stellen sicher, dass Agenten sich über verschiedene Deployments hinweg gleich verhalten."
-      },
-      "secrets": {
-        "name": "Secrets",
-        "definition": "Sensible Informationen wie API-Schlüssel, Passwörter und Tokens, die Agenten benötigen, um auf externe Dienste zuzugreifen. Secrets werden sicher gespeichert und zur Ausführungszeit in die Agenten-Runtime injiziert, wodurch eine Offenlegung im Code oder in Konfigurationsdateien verhindert wird."
-      },
-      "environmentVariable": {
-        "name": "Umgebungsvariable",
-        "definition": "Ein Konfigurationswert, der einem Agenten zur Laufzeit übergeben wird und es Ihnen ermöglicht, das Verhalten anzupassen, ohne Code zu ändern. Umgebungsvariablen werden häufig für API-Endpunkte, Feature-Flags und nicht sensible Konfigurationseinstellungen verwendet."
-      },
-      "virtualMachine": {
-        "name": "Virtuelle Maschine",
-        "definition": "Eine isolierte, softwarebasierte Rechenumgebung, die einen physischen Computer emuliert. Virtuelle Maschinen bieten vollständige Isolation zwischen Agentenausführungen und gewährleisten Sicherheit und verhindern Interferenzen. VM0 verwendet leichtgewichtige virtuelle Maschinen, um Agenten mit ihrem eigenen Betriebssystem, Dateisystem und Netzwerk-Stack auszuführen."
-      },
-      "cli": {
-        "name": "CLI (Command Line Interface)",
-        "definition": "Eine textbasierte Schnittstelle zur Interaktion mit Agenten und der VM0-Plattform. Die CLI ermöglicht es Entwicklern, Agenten über Terminal-Befehle zu erstellen, bereitzustellen und zu verwalten, und bietet leistungsstarke Skripting- und Automatisierungsfähigkeiten, ohne eine grafische Benutzeroberfläche zu benötigen."
-      },
-      "cliAgent": {
-        "name": "CLI-Agent",
-        "definition": "Ein Agent, der speziell dafür entwickelt wurde, über Befehlszeilenschnittstellen aufgerufen und gesteuert zu werden. CLI-Agenten können in Skripte, CI/CD-Pipelines und Terminal-Workflows integriert werden, was sie ideal für Automatisierungsaufgaben und Entwicklerwerkzeuge macht."
-      },
-      "agentRouter": {
-        "name": "Agent-Router",
-        "definition": "Ein System, das Agentenanfragen intelligent an das am besten geeignete KI-Modell weiterleitet, basierend auf Aufgabenanforderungen, Kostenbeschränkungen und Leistungsbedürfnissen. Der Agent-Router kann dynamisch zwischen verschiedenen LLMs (Claude, GPT, Gemini) wählen oder an spezialisierte Modelle für bestimmte Fähigkeiten weiterleiten."
-      },
-      "claudeCode": {
-        "name": "Claude Code",
-        "definition": "Anthropics offizielles Befehlszeilenwerkzeug zum Erstellen und Bereitstellen von KI-Agenten. Claude Code bietet eine entwicklerfreundliche Schnittstelle zum Erstellen von Agenten, Verwalten von Skills und zur Integration mit der Claude API. Es rationalisiert den Agenten-Entwicklungsworkflow mit Funktionen wie Live-Reloading, Debugging-Tools und Deployment-Automatisierung."
-      }
-    }
-  },
   "blog": {
     "title": "Blog",
     "description": "Einblicke, Tutorials und Updates zur agentenzentrierten Entwicklung und der Zukunft der KI-Infrastruktur.",
@@ -290,31 +268,725 @@
     "link": "Details anzeigen"
   },
   "useCases": {
-    "title": "Use Cases",
-    "metaDescription": "Real workflows from teams using Zero as their AI teammate. See the exact prompts, outputs, and integrations.",
-    "heroTitle": "See what Zero can do for your team",
-    "heroSubtitle": "Real workflows from teams using Zero as their AI teammate. Each use case includes the exact prompt, Zero's output, and how to extend it.",
-    "role": "Role",
-    "capability": "Capability",
-    "all": "All",
-    "seeHow": "See how",
-    "comingSoon": "Coming soon",
-    "moreComingSoon": "More use cases coming",
-    "noResults": "No use cases match these filters.",
-    "whenThisHappens": "When this happens",
-    "whatYouSay": "What you say to Zero",
-    "whatZeroDoes": "What Zero does",
-    "whatsNext": "What's next",
-    "whatYouNeed": "What you need",
-    "required": "Required",
+    "title": "Anwendungsfälle",
+    "metaDescription": "Reale Workflows von Teams, die Zero als KI-Teamkollegen nutzen. Sehen Sie die genauen Prompts, Ausgaben und Integrationen.",
+    "heroTitle": "Sehen Sie, was Zero für Ihr Team tun kann",
+    "heroSubtitle": "Reale Workflows von Teams, die Zero als KI-Teamkollegen nutzen. Jeder Anwendungsfall enthält den genauen Prompt, Zeros Ausgabe und wie Sie ihn erweitern können.",
+    "role": "Rolle",
+    "capability": "Funktion",
+    "all": "Alle",
+    "seeHow": "So geht's",
+    "comingSoon": "Demnächst verfügbar",
+    "moreComingSoon": "Weitere Anwendungsfälle folgen",
+    "noResults": "Keine Anwendungsfälle entsprechen diesen Filtern.",
+    "whenThisHappens": "Wenn dies passiert",
+    "whatYouSay": "Was Sie Zero sagen",
+    "whatZeroDoes": "Was Zero tut",
+    "whatsNext": "Was kommt als Nächstes",
+    "whatYouNeed": "Was Sie benötigen",
+    "required": "Erforderlich",
     "optional": "Optional",
-    "tips": "Tips and best practices",
-    "relatedUseCases": "Related use cases",
-    "backToAll": "All use cases",
-    "zeroConnects": "Zero connects:",
-    "ctaTitle": "Zero works where your team works",
-    "ctaSubtitle": "Add Zero to Slack and start delegating in plain language. No setup wizards. No workflow builders. Just ask.",
-    "addToSlack": "Add Zero to Slack",
-    "bookDemo": "Book a demo"
+    "tips": "Tipps und bewährte Methoden",
+    "relatedUseCases": "Ähnliche Anwendungsfälle",
+    "backToAll": "Alle Anwendungsfälle",
+    "zeroConnects": "Zero verbindet:",
+    "ctaTitle": "Zero arbeitet dort, wo Ihr Team arbeitet",
+    "ctaSubtitle": "Fügen Sie Zero zu Slack hinzu und beginnen Sie mit dem Delegieren in natürlicher Sprache. Keine Einrichtungsassistenten. Keine Workflow-Builder. Einfach fragen.",
+    "addToSlack": "Zero zu Slack hinzufügen",
+    "bookDemo": "Demo buchen",
+    "gallery": {
+      "moreToCome": "Mehr kommt bald",
+      "moreToComeDesc": "Haben Sie eine clevere Nutzung für Zero?",
+      "submitYourCase": "Ihren Fall einreichen →"
+    },
+    "content": {
+      "sentry-triage": {
+        "title": "Sentry-Rauschen in eine priorisierte Aufgabenliste verwandeln",
+        "description": "Bitten Sie Zero, Ihre wichtigsten ungelösten Sentry-Fehler nach Häufigkeit geordnet abzurufen. Zero liest die Stack Traces, erklärt die Ursache in verständlicher Sprache und sagt Ihnen, welche Datei Sie zuerst beheben sollten.",
+        "timeSaved": "~25 Min. gespart",
+        "headings": {
+          "scenario": "Warum Sentry-Triage Engineering-Zeit verschwendet",
+          "prompt": "So bitten Sie Zero, Sentry-Fehler zu priorisieren",
+          "steps": "Wie Zero Ihre Sentry-Fehler analysiert und einstuft",
+          "nextActions": "Sentry-Triage in GitHub Issues und tägliche Automatisierung umwandeln",
+          "integrations": "Erforderliche Integrationen: Sentry und GitHub",
+          "tips": "Best Practices für automatisierte Sentry-Triage"
+        },
+        "scenario": "Montagmorgen. Sie öffnen Slack und finden ein Dutzend Sentry-Alarme in #dev. Die meisten davon sind Rauschen – instabile Tests, bekannte Probleme, vorübergehende Fehler, die sich von selbst lösen. Aber irgendwo darin könnte etwas Wichtiges stecken: eine defekte Integration, ein Abrechnungsfehler, ein Absturz, der echte Benutzer betrifft. Sie möchten nicht Sentrys Dashboard öffnen und Issues einzeln durchklicken. Sie wollen einfach wissen: welche sind wichtig, wie schlimm sind sie, und was verursacht sie.",
+        "promptVariants": [
+          {
+            "label": "Detailliert",
+            "prompt": "@Zero schau dir die letzten Fehler auf Sentry an. Bitte sortiere die Fehler der letzten 24 Stunden nach ihrer Häufigkeit.\n\nFür die drei häufigsten Fehler erstelle mir einen Bericht mit den vollständigen, detaillierten Error Stacks."
+          },
+          {
+            "label": "Schnell",
+            "prompt": "@Zero Top 3 Sentry-Fehler der letzten 24h, sortiert nach Anzahl."
+          },
+          {
+            "label": "Geplant",
+            "prompt": "@Zero führe jeden Werktag um 9 Uhr dieselbe Sentry-Prüfung durch und poste die Ergebnisse in #dev. Nur Fehler mit 5+ Vorkommen einbeziehen."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Yuma",
+            "text": "@Zero schau dir die aktuellen Fehler auf Sentry an. Nach Häufigkeit sortieren. Top 3 mit detaillierten Error Stacks."
+          },
+          {
+            "name": "Zero",
+            "text": "Hier ist der vollständige Sentry-Fehlerbericht.\n\n#\tProblem\tAnzahl\tPriorität\n1\tSlack missing_scope\t57\tHoch\n2\tUnbekannte Stripe-Preis-ID\t15\tHoch\n3\tZeroSidebar .map()\t10\tMittel"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero verbindet sich mit Sentry",
+            "description": "Zero ruft ungelöste Issues aus Ihrem Sentry-Projekt für den angegebenen Zeitraum ab und sortiert sie nach Vorkommenszahl."
+          },
+          {
+            "title": "Übersichtstabelle",
+            "description": "Zero antwortet im selben Slack-Thread mit einer schnellen Übersichtstabelle – Issue-Name, Vorkommenszahl und Prioritätsstufe –, die Sie in 5 Sekunden erfassen können."
+          },
+          {
+            "title": "Detaillierte Analyse",
+            "description": "Für jedes Top-Issue liefert Zero annotierte Stack Traces und Ursachenerklärungen in verständlicher Sprache. Zum Beispiel sagt es nicht nur „Unbekannte Stripe-Preis-ID“, sondern erklärt, dass wahrscheinlich ein neuer Preis in Stripe erstellt, aber das entsprechende Mapping nicht aktualisiert wurde."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Ergebnisse in Aktionen umwandeln",
+            "description": "GitHub Issues aus dem Bericht erstellen",
+            "examplePrompt": "@Zero erstelle GitHub Issues für #1 und #2. Weise #1 Lancy zu (Slack-Scope-Fix) und #2 James (Stripe-Mapping). Beide als Bug mit hoher Priorität labeln."
+          },
+          {
+            "title": "Tiefer einsteigen",
+            "description": "Zero einen bestimmten Fehler untersuchen lassen",
+            "examplePrompt": "@Zero welcher genaue Slack-OAuth-Scope fehlt bei Issue #1? Prüfe unser App-Manifest und sag mir, was hinzugefügt werden muss."
+          },
+          {
+            "title": "Zur Routine machen",
+            "description": "Als tägliche Prüfung einplanen",
+            "examplePrompt": "@Zero führe jeden Werktag um 9 Uhr dieselbe Sentry-Prüfung durch und poste die Ergebnisse in #dev. Nur Fehler mit 5+ Vorkommen einbeziehen."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "OAuth-Verbindung zu Ihrer Sentry-Organisation. Zero benötigt Lesezugriff auf Issues und Events."
+          },
+          {
+            "description": "Nur erforderlich, wenn Zero Issues aus dem Bericht erstellen soll. Lese-/Schreibzugriff auf Issues."
+          }
+        ],
+        "tips": [
+          "Seien Sie spezifisch beim Zeitfenster. „Letzte 24 Stunden“ für die tägliche Triage, „Fehler seit dem letzten Deploy“ für Post-Deploy-Prüfungen.",
+          "Fügen Sie einen Schweregrad-Filter hinzu, um Rauschen zu reduzieren – nur Fehler mit 10+ Vorkommen anzeigen oder als known-issue getaggte Fehler überspringen.",
+          "Verknüpfen Sie es mit Ihrem Standup – kombinieren Sie es mit dem Standup-Anwendungsfall für ein Morgen-Briefing, das sowohl Ihre Aufgabenübersicht als auch den Sentry-Bericht enthält."
+        ]
+      },
+      "standup-summary": {
+        "title": "Standup vorbereiten, ohne 5 Apps zu öffnen",
+        "description": "Zero ruft Daten aus Kalender, E-Mail und Linear ab und schreibt dann eine teilbare Zusammenfassung, die Sie direkt in den Team-Thread einfügen können.",
+        "timeSaved": "~20 Min. gespart",
+        "headings": {
+          "scenario": "Das tägliche Standup-Chaos zwischen Calendar, Gmail und Linear",
+          "prompt": "So bitten Sie Zero um eine Standup-Zusammenfassung",
+          "steps": "Wie Zero Ihre Arbeitszusammenfassung aus 3 Tools erstellt",
+          "nextActions": "In Slack posten, Blocker hinzufügen oder täglich automatisieren",
+          "integrations": "Erforderliche Integrationen: Google Calendar, Gmail und Linear",
+          "tips": "Best Practices für KI-generierte Standup-Zusammenfassungen"
+        },
+        "scenario": "Es ist 9:50 Uhr und das Standup beginnt in 10 Minuten. Sie haben Ihren Kalender noch nicht geprüft. Sie bitten Zero, die gestrigen Meetings, E-Mails und Linear-Aufgaben abzurufen – Zero schreibt eine Zusammenfassung, die Sie direkt in den Team-Thread einfügen können.",
+        "promptVariants": [
+          {
+            "label": "Detailliert",
+            "prompt": "@Zero prüfe meinen Kalender, E-Mails und Linear-Aufgaben seit gestern und schreibe mir eine Arbeitszusammenfassung. Inklusive Meeting-Highlights und PR-Status."
+          },
+          {
+            "label": "Schnell",
+            "prompt": "@Zero was habe ich gestern gemacht? Kalender und Linear prüfen."
+          },
+          {
+            "label": "Geplant",
+            "prompt": "@Zero schreibe jeden Werktag um 9:45 Uhr meine Standup-Zusammenfassung und schicke sie mir per DM."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero prüfe meinen Kalender, E-Mails und Linear-Aufgaben seit gestern und schreibe mir eine Arbeitszusammenfassung"
+          },
+          {
+            "name": "Zero",
+            "text": "Arbeitszusammenfassung: 23.–24. März\n\nMeetings\n• Tägliche Standups (10–10:30 Uhr)\n• VM0 User Interview mit Daniel Miller\n\nEngineering\n• PR #5467 gemergt, Firewall-Berechtigungen\n• PR #6277 im Review. Lighthouse bei 36"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero prüft Ihren Kalender",
+            "description": "Zero liest Ihre Google-Calendar-Termine der letzten 24 Stunden und extrahiert Meeting-Namen, Zeiten und Teilnehmer."
+          },
+          {
+            "title": "Zero durchsucht E-Mails und Aufgaben",
+            "description": "Zero prüft Gmail auf relevante Threads und Linear auf Aufgaben, die Sie seit gestern aktualisiert, abgeschlossen oder zugewiesen bekommen haben."
+          },
+          {
+            "title": "Formatierte Zusammenfassung",
+            "description": "Zero erstellt alles als saubere, kopierfertige Zusammenfassung, gegliedert nach Meetings, Engineering-Arbeit und Aktionspunkten."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Direkt in einen Channel posten",
+            "description": "Zero die Zusammenfassung in #standup posten lassen",
+            "examplePrompt": "@Zero poste diese Zusammenfassung in #standup und tagge @team-eng."
+          },
+          {
+            "title": "Kontext hinzufügen",
+            "description": "Zero nach Blockern oder Prioritäten fragen",
+            "examplePrompt": "@Zero prüfe auch mein Linear auf blockierte Aufgaben und füge sie als Blocker in die Zusammenfassung ein."
+          },
+          {
+            "title": "Täglich machen",
+            "description": "Morgendliche Vorbereitung automatisieren",
+            "examplePrompt": "@Zero schreibe jeden Werktag um 9:45 Uhr meine Standup-Zusammenfassung und schicke sie mir per DM."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "OAuth-Verbindung zu Google Calendar. Zero benötigt Lesezugriff auf Ihre Termine."
+          },
+          {
+            "description": "OAuth-Verbindung zu Gmail. Zero benötigt Lesezugriff zum Durchsuchen aktueller Threads."
+          },
+          {
+            "description": "OAuth-Verbindung zu Linear. Zero liest Ihre zugewiesenen und aktualisierten Aufgaben."
+          }
+        ],
+        "tips": [
+          "Teilen Sie Zero Ihr Standup-Format mit, falls es vom Standard abweicht. „Verwende das Format: Gestern / Heute / Blocker“.",
+          "Geben Sie das Zeitfenster an. „Seit gestern 17 Uhr“, wenn Sie spät arbeiten.",
+          "Kombinieren Sie es mit Sentry-Triage für ein vollständiges Engineering-Morgen-Briefing."
+        ]
+      },
+      "kol-cold-outreach": {
+        "title": "KOL auf X recherchieren und eine personalisierte Cold-E-Mail verfassen",
+        "description": "Geben Sie Zero einen X-Handle. Zero liest die letzten 30 Posts, versteht Stil und Interessen, schreibt eine personalisierte Outreach-E-Mail unter 150 Wörtern und speichert sie als Gmail-Entwurf.",
+        "timeSaved": "~20 Min. gespart",
+        "headings": {
+          "scenario": "Warum generische Cold-Outreach ignoriert wird",
+          "prompt": "So recherchieren Sie einen KOL und verfassen personalisierte Outreach-Mails",
+          "steps": "Wie Zero X-Profile analysiert und maßgeschneiderte E-Mails erstellt",
+          "nextActions": "KOL-Fit bewerten, Batch-Outreach starten oder im Notion-CRM verfolgen",
+          "integrations": "Erforderliche Integrationen: X, Gmail und Notion",
+          "tips": "Best Practices für KI-gestützte KOL-Outreach"
+        },
+        "scenario": "Sie haben einen KOL gefunden, der perfekt für eine Partnerschaft wäre, aber eine Cold-E-Mail zu schreiben, die nicht generisch wirkt, dauert 20 Minuten Recherche – Posts lesen, verstehen, was ihnen wichtig ist, den richtigen Ansatz finden. Sie geben Zero den X-Handle und erhalten in Sekunden einen personalisierten Entwurf.",
+        "promptVariants": [
+          {
+            "label": "Detailliert",
+            "prompt": "@Zero lies die letzten 30 X-Posts von @swyx, um seinen Stil und seine Interessen zu verstehen. Schreibe eine personalisierte Cold-Outreach-E-Mail unter 150 Wörtern über eine VM0-Partnerschaft. Beziehe dich auf etwas Konkretes, das er kürzlich gepostet hat. Speichere sie als Gmail-Entwurf."
+          },
+          {
+            "label": "Schnell",
+            "prompt": "@Zero verfasse eine Cold-E-Mail an @swyx über VM0, basierend auf seinen X-Posts. Als Gmail-Entwurf speichern."
+          },
+          {
+            "label": "Batch",
+            "prompt": "@Zero recherchiere für jeden Handle in meiner Notion-KOL-Liste mit Status „Nicht kontaktiert“ das X-Profil und verfasse eine personalisierte Outreach-E-Mail. Alle als Gmail-Entwürfe speichern."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero lies die letzten 30 X-Posts von @swyx, verstehe seinen Stil und verfasse eine Cold-Outreach-E-Mail für eine VM0-Partnerschaft. Als Gmail-Entwurf speichern."
+          },
+          {
+            "name": "Zero",
+            "text": "Erledigt. @swyxs aktuelle Inhalte analysiert:\n• Fokus: KI-Agenten, Entwicklertools, Open Source\n• Ton: Technisch, aber gesprächig\n• Zielgruppen-Fit: Hoch (9/10)\n\nGmail-Entwurf gespeichert: „Agenten, die echte Arbeit liefern – dachte, das könnte dich interessieren“"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero liest das X-Profil des KOL",
+            "description": "Zero ruft die letzten 30 Posts ab, analysiert Inhaltsthemen, Ton, Zielgruppe und Engagement-Muster, um ein Profil dessen zu erstellen, was dieser Person wichtig ist."
+          },
+          {
+            "title": "Personalisierte E-Mail verfasst",
+            "description": "Zero schreibt eine prägnante Outreach-E-Mail, die auf spezifische Inhalte des KOL verweist, die Relevanz Ihres Produkts erklärt und einen zum Stil passenden Ton verwendet."
+          },
+          {
+            "title": "Entwurf in Gmail gespeichert",
+            "description": "Die E-Mail wird als Gmail-Entwurf gespeichert und ist bereit für Ihre Überprüfung. Zero aktualisiert auch den KOL-Status in Ihrem Notion-CRM, falls verbunden."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "KOL-Fit bewerten",
+            "description": "Bewerten, wie gut ein KOL zu Ihrer Zielgruppe passt",
+            "examplePrompt": "@Zero analysiere die Zielgruppenüberschneidung von @swyx mit VM0s ICP. Bewerte 1-10 mit Begründung und speichere in Notion."
+          },
+          {
+            "title": "Batch-Outreach",
+            "description": "E-Mails für mehrere KOLs gleichzeitig verfassen",
+            "examplePrompt": "@Zero recherchiere für die Top 10 KOLs in meiner Notion-Liste jeden einzelnen und verfasse personalisierte Outreach-E-Mails."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero liest öffentliche Posts, um den Stil und die Interessen des KOL zu verstehen."
+          },
+          {
+            "description": "Zero speichert die verfasste E-Mail in Ihren Gmail-Entwürfen."
+          },
+          {
+            "description": "Optional – KOL-Status und Fit-Scores in Ihrem Notion-CRM verfolgen."
+          }
+        ],
+        "tips": [
+          "Geben Sie Zero Kontext zu Ihrem Produktansatz. „Fokussiere darauf, wie VM0 Developer-Tool-Unternehmen hilft“.",
+          "Bitten Sie um mehrere Varianten. „Verfasse 2 Versionen: eine locker, eine professionell“.",
+          "Überprüfen Sie immer vor dem Versand. Zero recherchiert korrekt, aber die finale Stimme sollte Ihre sein."
+        ]
+      },
+      "file-bugs-from-slack": {
+        "title": "Bugs direkt aus Slack melden, ohne den Kontext zu wechseln",
+        "description": "Beschreiben Sie das Problem in natürlicher Sprache. Zero erstellt ein formatiertes GitHub Issue, vergibt Labels und weist die richtige Person zu.",
+        "timeSaved": "Sofort",
+        "headings": {
+          "scenario": "Warum GitHub Issues aus Slack heraus erstellen Kontextwechsel spart",
+          "prompt": "So erstellen Sie GitHub Issues aus einer Slack-Nachricht",
+          "steps": "Wie Zero Ihre Nachricht analysiert und ein formatiertes Issue erstellt",
+          "nextActions": "Details hinzufügen, Issues im Batch erstellen oder Triage automatisieren",
+          "integrations": "Erforderliche Integrationen: GitHub und Slack",
+          "tips": "Best Practices für das Melden von Bugs über Slack"
+        },
+        "scenario": "Sie haben gerade einen UX-Bug während einer Demo bemerkt. Statt GitHub zu öffnen, das Repo zu finden, ein formatiertes Issue zu schreiben und jemanden zuzuweisen, beschreiben Sie es in Slack. Zero erstellt das Issue, fügt Labels hinzu und weist die richtige Person zu. Sie verlassen nie das Gespräch.",
+        "promptVariants": [
+          {
+            "label": "Detailliert",
+            "prompt": "@Zero erstelle Issue: ESC im Planungsdialog drücken schließt ihn sofort, auch bei ungespeicherten Änderungen. Sollte zuerst nach Bestätigung fragen. Lancy zuweisen. Label als Bug, Platform. Priorität Mittel."
+          },
+          {
+            "label": "Schnell",
+            "prompt": "@Zero Bug: ESC schließt Planungsdialog ohne Speicherbestätigung. Lancy zuweisen."
+          },
+          {
+            "label": "Geplant",
+            "prompt": "@Zero prüfe jeden Freitag um 16 Uhr den #bugs-Channel auf ungelöste Bug-Meldungen und erstelle für jede ein GitHub Issue."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero erstelle Issue: ESC im Planungsdialog drücken schließt ihn sofort, auch bei ungespeicherten Änderungen. Sollte zuerst nach Bestätigung fragen. Lancy zuweisen."
+          },
+          {
+            "name": "Zero",
+            "text": "Issue erstellt:\n#6260: Bug: ESC-Taste schließt Planungsdialog ohne Bestätigung\nZugewiesen an Lancy · Priorität: Mittel"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero analysiert die Anfrage",
+            "description": "Zero versteht die Bug-Beschreibung, identifiziert den Zugewiesenen und leitet passende Labels (Bug, Platform) und Priorität aus dem Kontext ab."
+          },
+          {
+            "title": "Issue auf GitHub erstellt",
+            "description": "Zero erstellt ein ordentlich formatiertes GitHub Issue mit klarem Titel, Beschreibung, Labels und Zuweisung – alles aus Ihrer natürlichsprachlichen Slack-Nachricht."
+          },
+          {
+            "title": "Bestätigung in Slack",
+            "description": "Zero antwortet im selben Thread mit Issue-Nummer, Titel, Zugewiesenem und einem direkten Link, damit Sie es überprüfen können, ohne Slack zu verlassen."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Mehr Details hinzufügen",
+            "description": "Screenshots oder Reproduktionsschritte anhängen",
+            "examplePrompt": "@Zero zu #6260 hinzufügen: Reproduktionsschritte. 1. Planungsdialog öffnen 2. Etwas eingeben 3. ESC drücken. Erwartet: Bestätigungsdialog."
+          },
+          {
+            "title": "Issues im Batch erstellen",
+            "description": "Mehrere Issues auf einmal erstellen",
+            "examplePrompt": "@Zero erstelle 3 Issues aus diesen Bugs:\n1. ESC-Dialog-Schließen (Lancy)\n2. Datumsauswahl einen Tag daneben (James)\n3. Avatar-Upload schlägt auf Safari fehl (Yuma)"
+          },
+          {
+            "title": "Triage automatisieren",
+            "description": "Issues automatisch aus einem Channel erstellen",
+            "examplePrompt": "@Zero beobachte #bugs. Wenn jemand eine Nachricht mit „Bug:“ postet, erstelle automatisch ein GitHub Issue und antworte mit dem Link."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "OAuth-Verbindung zu GitHub. Zero benötigt Lese-/Schreibzugriff zum Erstellen und Verwalten von Issues."
+          },
+          {
+            "description": "Zero liest Ihre Nachricht und antwortet im selben Thread."
+          }
+        ],
+        "tips": [
+          "Nennen Sie den Namen des Zugewiesenen. Zero ordnet Slack-Anzeigenamen GitHub-Benutzernamen zu.",
+          "Erwähnen Sie Labels explizit, wenn Sie bestimmte möchten – sonst leitet Zero sie aus dem Kontext ab.",
+          "Funktioniert auch für Feature-Requests – sagen Sie einfach „Feature Request“ statt „Bug“."
+        ]
+      },
+      "slack-triage": {
+        "title": "Slack-Rauschen durchdringen und herausfiltern, was Ihre Aufmerksamkeit erfordert",
+        "description": "Zero scannt Ihre ungelesenen Slack-Nachrichten, filtert Bots und Rauschen heraus und zeigt Ihnen nur die Nachrichten, die heute wirklich Ihre Aktion erfordern – sortiert nach Dringlichkeit.",
+        "timeSaved": "~10 Min. gespart",
+        "headings": {
+          "scenario": "Warum Slack-Überflutung zu verpassten Aufgaben führt",
+          "prompt": "So bitten Sie Zero, Ihre ungelesenen Slack-Nachrichten zu priorisieren",
+          "steps": "Wie Zero Rauschen filtert und handlungsrelevante Nachrichten hervorhebt",
+          "nextActions": "Direkt antworten, Aufgaben erstellen oder tägliche Triage automatisieren",
+          "integrations": "Erforderliche Integrationen: Slack",
+          "tips": "Best Practices für Slack-Nachrichten-Triage"
+        },
+        "scenario": "Sie öffnen Slack nach einem 2-stündigen Fokusblock und es gibt 47 ungelesene Nachrichten in 12 Channels. Die meisten sind Bot-Benachrichtigungen, automatische Alarme und Gespräche, die Sie nicht betreffen. Irgendwo im Rauschen stecken 3 Dinge, die wirklich Ihre Antwort erfordern. Statt alles durchzuscrollen, bitten Sie Zero, das Wichtige zu finden.",
+        "promptVariants": [
+          {
+            "label": "Detailliert",
+            "prompt": "@Zero scanne meine ungelesenen Slack-Nachrichten der letzten 12 Stunden. Filtere Bots, automatische Benachrichtigungen und Threads heraus, in denen ich nicht getaggt bin. Zeige mir nur Nachrichten, die heute mein Handeln erfordern, sortiert nach Dringlichkeit. Sag mir bei jeder, wer wartet und was gebraucht wird."
+          },
+          {
+            "label": "Schnell",
+            "prompt": "@Zero was braucht gerade meine Aufmerksamkeit in Slack?"
+          },
+          {
+            "label": "Geplant",
+            "prompt": "@Zero scanne jeden Morgen um 9 Uhr und nach dem Mittagessen um 13 Uhr meine ungelesenen Nachrichten und schicke mir per DM, was Handlung erfordert."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero scanne meine ungelesenen Slack-Nachrichten der letzten 12 Stunden. Filtere Bots und Rauschen heraus. Zeige mir nur, was heute mein Handeln erfordert."
+          },
+          {
+            "name": "Zero",
+            "text": "47 ungelesene Nachrichten gefunden. 5 erfordern Ihre Aktion:\n\n1. @Ethan bittet um Ihr Design-Review zu PR #6312\n2. @James braucht Freigabe für den Stripe-Migrationsplan\n3. #support hat ein P0 von einem Kunden, der Abwanderung erwähnt\n4. @Scarlett hat Sie in einer KOL-Outreach-Entscheidung getaggt\n5. Sprint-Review verschoben auf 15 Uhr (war 14 Uhr)"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero scannt Ihre Channels",
+            "description": "Zero liest Ihre ungelesenen Nachrichten über alle Channels hinweg und filtert Bot-Nachrichten, automatische CI/CD-Alarme und Threads heraus, in denen Sie nicht erwähnt oder gebraucht werden."
+          },
+          {
+            "title": "Nachrichten nach Dringlichkeit klassifiziert",
+            "description": "Jede verbleibende Nachricht wird bewertet: Wartet jemand auf Sie? Gibt es eine Frist? Blockiert eine Entscheidung andere? Zero stuft sie danach ein, wie dringend sie Ihre Antwort brauchen."
+          },
+          {
+            "title": "Handlungsrelevante Zusammenfassung geliefert",
+            "description": "Zero schickt Ihnen eine nummerierte Liste mit allem, was Aufmerksamkeit erfordert – wer fragt, was gebraucht wird und ein direkter Link zu jedem Thread. Alles andere kann sicher ignoriert werden."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Über Zero antworten",
+            "description": "Antworten, ohne jeden Thread zu öffnen",
+            "examplePrompt": "@Zero antworte auf #1: „Sieht gut aus, genehmigt. Ausliefern.“ Und für #3 erstelle ein P0 Linear-Issue und weise es James zu."
+          },
+          {
+            "title": "Zur Routine machen",
+            "description": "Jeden Morgen automatisch priorisieren",
+            "examplePrompt": "@Zero scanne jeden Werktag um 9 Uhr meine nächtlichen ungelesenen Nachrichten und schicke mir die Aktionspunkte per DM."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero liest Ihre ungelesenen Nachrichten und schickt Ihnen die Triage-Zusammenfassung per DM."
+          },
+          {
+            "description": "Optional: Aufgaben direkt aus priorisierten Nachrichten erstellen."
+          },
+          {
+            "description": "Optional: Zero prüft Ihren Kalender, um Meeting-bezogene Nachrichten zu kennzeichnen."
+          }
+        ],
+        "tips": [
+          "Sagen Sie Zero, welche Channels Ihnen am wichtigsten sind, damit es entsprechend priorisieren kann.",
+          "Bitten Sie Zero, Ihre Rauschen-Muster im Laufe der Zeit zu lernen: „Überspringe immer Nachrichten von @github-bot und @vercel-bot“.",
+          "Kombinieren Sie es mit dem Standup-Anwendungsfall: erst priorisieren, dann Ihr Standup aus den Aktionspunkten generieren."
+        ]
+      },
+      "employee-onboarding": {
+        "title": "Neue Teammitglieder mit einer Slack-Nachricht onboarden",
+        "description": "Sagen Sie Zero, wer wann anfängt. Zero erstellt die Notion-Onboarding-Seite, plant Willkommensmeetings im Google Calendar, postet eine Slack-Vorstellung und schickt dem neuen Teammitglied die Agenda für die erste Woche per DM.",
+        "timeSaved": "~45 Min. gespart",
+        "headings": {
+          "scenario": "Warum manuelle Onboarding-Checklisten immer etwas vergessen",
+          "prompt": "So automatisieren Sie das Onboarding neuer Mitarbeiter mit Zero",
+          "steps": "Wie Zero Notion, Calendar und Slack für ein neues Teammitglied einrichtet",
+          "nextActions": "Zugangsvergabe hinzufügen oder nach Rolle anpassen",
+          "integrations": "Erforderliche Integrationen: Slack, Notion, Google Calendar und Gmail",
+          "tips": "Best Practices für automatisiertes Mitarbeiter-Onboarding"
+        },
+        "scenario": "Ein neues Teammitglied fängt nächsten Montag an. Jemand muss das Onboarding-Dokument erstellen, Kennenlerngespräche mit 5 Leuten planen, eine Willkommensnachricht posten und eine Agenda für die erste Woche senden. Es sind 45 Minuten Koordination, die jedes Mal gleich ablaufen. Sie sagen es Zero einmal und es erledigt alles.",
+        "promptVariants": [
+          {
+            "label": "Detailliert",
+            "prompt": "@Zero onboarde Sarah Chen als Product Designer ab dem 14. April. Dupliziere die Notion-Onboarding-Vorlage, plane Woche-1-Kennenlerngespräche mit Ethan, Lancy, James, Yuma und Scarlett im Google Calendar. Plane einen 30-Tage-Check-in. Poste eine Begrüßung in #general und schicke Sarah ihre Erste-Woche-Agenda per DM."
+          },
+          {
+            "label": "Schnell",
+            "prompt": "@Zero onboarde Sarah Chen, Product Designer, Start am 14. April. Vollständiges Setup."
+          },
+          {
+            "label": "Vorlage",
+            "prompt": "@Zero wenn jemand in #new-hires mit dem Format „Name / Rolle / Startdatum“ postet, führe automatisch den vollständigen Onboarding-Workflow aus."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero onboarde Sarah Chen, kommt als Product Designer am 14. April. Alles einrichten."
+          },
+          {
+            "name": "Zero",
+            "text": "Onboarding für Sarah Chen ist bereit:\n\n✔ Notion-Seite aus Vorlage erstellt\n✔ Woche-1-Kennenlerngespräche geplant\n✔ 30-Tage-Check-in am 14. Mai\n✔ Begrüßung in #general gepostet\n✔ DM mit Erste-Woche-Agenda gesendet"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Notion-Onboarding-Seite erstellt",
+            "description": "Zero dupliziert Ihre Onboarding-Vorlage in Notion, füllt Name, Rolle, Startdatum und Vorgesetzten des neuen Mitarbeiters ein. Verlinkt relevante Dokumente und Team-Ressourcen."
+          },
+          {
+            "title": "Meetings geplant",
+            "description": "Zero erstellt Kennenlerngespräche mit den angegebenen Teammitgliedern im Google Calendar während der ersten Woche, plus einen 30-Tage-Check-in. Alle Kalendereinladungen enthalten Kontext darüber, was besprochen werden soll."
+          },
+          {
+            "title": "Slack-Begrüßung und DM gesendet",
+            "description": "Zero postet eine Willkommensnachricht in #general, die das neue Teammitglied vorstellt, und schickt ihm dann direkt per DM die Erste-Woche-Agenda, Links zur Notion-Seite und wichtige Kontakte."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Nach Rolle anpassen",
+            "description": "Unterschiedliches Onboarding für verschiedene Rollen",
+            "examplePrompt": "@Zero für Ingenieure zusätzlich eine Pairing-Session mit dem Tech Lead hinzufügen und einen Link zu den Architektur-Docs in die Onboarding-Seite einfügen."
+          },
+          {
+            "title": "Trigger automatisieren",
+            "description": "Onboarding aus einem Channel-Post starten",
+            "examplePrompt": "@Zero wenn jemand in #new-hires mit dem Format „Name / Rolle / Startdatum“ postet, führe automatisch das vollständige Onboarding durch."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero postet die Willkommensnachricht und schickt dem neuen Mitarbeiter eine DM."
+          },
+          {
+            "description": "Zero erstellt die Onboarding-Seite aus Ihrer Vorlage."
+          },
+          {
+            "description": "Zero plant Kennenlerngespräche und Check-ins."
+          },
+          {
+            "description": "Optional – eine Willkommens-E-Mail mit Logistik und Links senden."
+          }
+        ],
+        "tips": [
+          "Erstellen Sie zuerst eine Notion-Onboarding-Vorlage. Zero dupliziert sie und füllt die Details aus.",
+          "Listen Sie die Personen auf, die Kennenlerngespräche haben sollen. Zero übernimmt die Kalenderkoordination.",
+          "Funktioniert auch für Freelancer und Praktikanten – passen Sie einfach Vorlage und Meeting-Liste an."
+        ]
+      },
+      "build-with-v0": {
+        "title": "Eine Slack-Idee sofort in einen interaktiven Prototyp verwandeln",
+        "description": "Wenn mitten im Gespräch eine Idee aufkommt, beschreiben Sie sie Zero. Es nutzt v0, um einen klickbaren React-Prototyp zu generieren und postet den Live-Preview-Link zurück in den Thread – bevor die Diskussion weitergeht.",
+        "timeSaved": "Stunden → Sekunden",
+        "headings": {
+          "scenario": "Warum Ideen verloren gehen, bevor sie jemand sehen kann",
+          "prompt": "So verwandeln Sie eine Slack-Idee mit Zero in einen Prototyp",
+          "steps": "Wie Zero von Ihrer Beschreibung zu einer live klickbaren UI kommt",
+          "nextActions": "Verfeinern, teilen oder an Engineering übergeben",
+          "integrations": "Erforderliche Integrationen: v0",
+          "tips": "Best Practices für schnelles Ideen-Prototyping mit v0"
+        },
+        "scenario": "Sie sind in einem Slack-Thread und diskutieren, wie ein Feature funktionieren soll. Jemand schlägt ein neues UI-Muster vor – eine Befehlspalette, ein Einstellungspanel, einen mehrstufigen Assistenten. Worte allein reichen nicht. Auf einem Whiteboard skizzieren ist keine Option. Eine Figma-Session zu planen verschiebt die Entscheidung auf nächste Woche. Sie beschreiben die Idee Zero in natürlicher Sprache. Es ruft v0 auf, generiert einen vollständig interaktiven React-Prototyp und postet den Live-Preview-Link direkt zurück in den Thread – in unter einer Minute. Alle können ihn durchklicken, bevor das Gespräch weitergeht.",
+        "promptVariants": [
+          {
+            "label": "Neue UI-Idee",
+            "prompt": "@Zero erstelle einen Prototyp: eine Befehlspalette, mit der Benutzer Agenten, letzte Läufe und Konnektoren suchen können. Tastaturgesteuert, Fuzzy-Suche, zeigt ein Vorschau-Panel auf der rechten Seite."
+          },
+          {
+            "label": "Aus Thread-Kontext",
+            "prompt": "@Zero baue basierend auf dem Flow, den wir oben beschrieben haben, einen schnellen v0-Prototyp, damit das Team ihn sehen kann, bevor wir entscheiden."
+          },
+          {
+            "label": "Iterieren",
+            "prompt": "@Zero aktualisiere den Prototyp – füge oben einen Filter-Tab für ‚Agenten / Läufe / Konnektoren‘ hinzu und markiere das aktive Element in Orange. Neu generieren."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Ethan",
+            "text": "@Zero erstelle einen Prototyp: eine Befehlspalette, mit der Benutzer Agenten, letzte Läufe und Konnektoren suchen können. Tastaturgesteuert, Fuzzy-Suche, zeigt eine Vorschau rechts."
+          },
+          {
+            "name": "Zero",
+            "text": "Hier ist der interaktive Prototyp:\nv0.dev/r/cmd-palette-preview\n\nEnthält Fuzzy-Suche über Agenten, Läufe und Konnektoren. Pfeiltasten-Navigation. Rechtes Vorschau-Panel aktualisiert sich beim Hover. Klicken zum Öffnen."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Die Idee in natürlicher Sprache beschreiben",
+            "description": "Keine Spezifikation, kein Wireframe nötig. Sagen Sie Zero, was die UI tun soll – die Komponenten, die Interaktionen, die Daten, die angezeigt werden. Fügen Sie eine grobe Skizzenbeschreibung ein oder improvisieren Sie aus dem Thread."
+          },
+          {
+            "title": "Zero generiert den Prototyp über v0",
+            "description": "Zero übersetzt Ihre Beschreibung in einen strukturierten v0-Prompt und ruft die v0-API auf. v0 erzeugt eine vollständig interaktive React-Komponente – echte Buttons, echte Zustände, echte Navigation."
+          },
+          {
+            "title": "Live-Preview-Link in Slack gepostet",
+            "description": "Zero postet die v0-Preview-URL zurück in denselben Thread. Teammitglieder können den Prototyp sofort durchklicken, auf jedem Gerät, ohne etwas zu installieren oder Code auszuchecken."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Im Thread verfeinern",
+            "description": "Weiter iterieren, ohne Slack zu verlassen",
+            "examplePrompt": "@Zero aktualisiere den Prototyp – das Suchfeld sollte links ein Icon haben, und der leere Zustand sollte letzte Elemente statt nichts anzeigen."
+          },
+          {
+            "title": "Für asynchrones Feedback teilen",
+            "description": "In einen breiteren Channel posten oder Stakeholdern per DM senden",
+            "examplePrompt": "@Zero teile den v0-Prototyp-Link in #product mit der Nachricht: ‚Schneller Prototyp der Befehlspaletten-Idee – Feedback willkommen bis Donnerstag.‘"
+          },
+          {
+            "title": "An Engineering übergeben",
+            "description": "Den generierten Code ins Repository exportieren",
+            "examplePrompt": "@Zero nimm den v0-Prototyp-Code und eröffne einen PR in vm0-ai/vm0 unter turbo/apps/platform/src/components/CommandPalette.tsx, damit das Team darauf aufbauen kann."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero sendet Ihre Idee als Generierungsprompt an v0 und ruft die interaktive Prototyp-URL ab. Verbinden Sie Ihr v0-Konto, um dies zu aktivieren."
+          },
+          {
+            "description": "Zero liest Ihre Idee aus dem Slack-Thread und postet den Prototyp-Link zurück in dieselbe Konversation."
+          }
+        ],
+        "tips": [
+          "Beschreiben Sie Verhalten, nicht nur Aussehen. ‚Klick auf eine Zeile klappt Details darunter auf‘ liefert einen genaueren Prototyp als ‚aufklappbare Zeilen‘.",
+          "Referenzieren Sie bestehende UI-Muster beim Namen – ‚wie die VS Code Befehlspalette‘ oder ‚wie Notions Slash-Menü‘ – um v0s Generierung zu verankern.",
+          "Nutzen Sie den Iterieren-Prompt direkt nach dem ersten Ergebnis. Eine Runde Verfeinerung bringt Sie meistens 90 % ans Ziel."
+        ]
+      }
+    }
+  },
+  "landing": {
+    "hero": {
+      "title": "Zero, Ihr vertrauenswürdiger KI-Teamkollege für echte Arbeit.",
+      "subtitle": "Zero verbindet sich mit über 100 Tools und erledigt die Arbeit. Berichte, Triage, Outreach, Recherche. In Slack oder im Web.",
+      "ctaGetStarted": "Jetzt starten",
+      "ctaOpenApp": "App öffnen",
+      "seeUseCases": "Anwendungsfälle ansehen",
+      "seedBanner": "Lesen Sie unseren Blog über unsere $14M Seed-Runde."
+    },
+    "worksForYou": {
+      "heading": "Was Zero wirklich für Sie tut",
+      "exploreMore": "Weitere Anwendungsfälle entdecken"
+    },
+    "teammateCard": {
+      "title": "Ein Teamkollege, der liest, denkt und liefert.",
+      "description": "„Fasse meine Woche aus Kalender, Linear und Slack zusammen.“ Zero holt den Kontext aus Ihren Tools, verbindet die Punkte und liefert Ihnen einen fertigen Bericht. Wie ein Kollegen-Briefing, nur in Sekunden.",
+      "tabSummarize": "Meine Arbeitswoche zusammenfassen",
+      "tabLeads": "Leads finden und per E-Mail kontaktieren",
+      "tabTriage": "Sentry-Fehler triagieren",
+      "ariaDaily": "Tagesbericht",
+      "ariaLeads": "E-Mail-Leads",
+      "ariaSentry": "Sentry-Bericht"
+    },
+    "slackCard": {
+      "title": "Fragen Sie in Slack, erhalten Sie Antworten aus all Ihren Tools.",
+      "description": "@Zero in jedem Channel. Es greift auf Ihren Kalender, E-Mail, Linear, GitHub zu – und antwortet mit einer Zusammenfassung, die Ihr Team tatsächlich nutzen kann. Kein Tab-Wechsel, keine Dashboards.",
+      "tagSlack": "Slack",
+      "tagTeamSync": "Team-Sync"
+    },
+    "syncedToolsCard": {
+      "title": "Von der Entdeckung bis zur Ansprache – Agenten erledigen die Vorarbeit.",
+      "description": "Sagen Sie Zero, wen Sie suchen. Die Agenten durchsuchen soziale Plattformen, erstellen Interessentenlisten und entwerfen personalisierte Ansprachen, damit sich Ihr Team auf den Abschluss konzentriert, nicht auf die Suche.",
+      "tagMarketing": "Marketing-Outreach",
+      "tagCrossPlatform": "Plattformübergreifend"
+    },
+    "connectors": {
+      "heading": "Funktioniert mit über 100 Tools, die Sie bereits nutzen",
+      "description": "Slack, GitHub, Gmail, Notion, Linear, Sentry und mehr. Zero verbindet sich mit Ihrem Stack, um zu handeln, nicht nur zu antworten."
+    },
+    "security": {
+      "heading": "Ihre Daten bleiben Ihre",
+      "permissionTitle": "Sie kontrollieren, worauf Zero zugreifen kann",
+      "permissionDesc": "Legen Sie Lese- und Schreibberechtigungen pro Tool und pro Agent fest. Zero greift nur auf das zu, was Sie ausdrücklich erlauben.",
+      "isolatedTitle": "Isolierte Ausführung, jedes Mal",
+      "isolatedDescPart1": "Jede Aufgabe läuft in ihrer eigenen microVM. Anmeldedaten verlassen nie die Sandbox. Vollständig überprüfbar. Und ",
+      "isolatedDescLink": "Open Source",
+      "isolatedDescPart2": "."
+    },
+    "intelligence": {
+      "heading": "Wird intelligenter, je mehr Sie es nutzen",
+      "memoryTitle": "Erinnert sich an Ihren Kontext",
+      "memoryDesc": "Vergangene Entscheidungen, Projektkontext, Ihre Präferenzen – Zero trägt alles weiter. Kein erneutes Erklären, kein verlorener Kontext zwischen Sitzungen.",
+      "scheduleTitle": "Geplante Intelligenz",
+      "scheduleDesc": "Zero führt autonome wiederkehrende Aufgaben aus – tägliche Fehlerscans, Tech-Debt-Berichte, Morgenbriefings – ohne Aufforderung.",
+      "subAgentsTitle": "Spezialisierte Sub-Agenten",
+      "subAgentsDesc": "Erstellen Sie Agenten für bestimmte Aufgaben. Einen für Recherche, einen für Triage, einen für Outreach. Sie arbeiten parallel, damit Sie es nicht müssen.",
+      "toolOrchTitle": "Tool-Orchestrierung",
+      "toolOrchDesc": "Zero wählt und verkettet die richtigen Tools aus über 100 verfügbaren Integrationen. Sie beschreiben das Ziel; Zero ermittelt die Schritte.",
+      "identityTitle": "Weiß, wer Sie sind",
+      "identityDesc": "\"Meine PRs\", \"mir zuweisen.\" Zero löst Ihre Identität über GitHub, Slack und Linear automatisch auf. Keine Einrichtung erforderlich."
+    },
+    "cta": {
+      "title": "Sie entscheiden, was wichtig ist. Zero erledigt den Rest.",
+      "subtitle": "Starten Sie kostenlos. Nutzen Sie es in Slack oder im Web. Keine Kreditkarte erforderlich."
+    }
+  },
+  "securityPage": {
+    "title": "Sicherheit",
+    "intro": "Wenn Sie Arbeit an einen KI-Agenten übergeben, sind Ihre größten Bedenken Datensicherheit, Datenschutz und Kontrolle. VM0 wurde von Anfang an mit all dem im Sinn entwickelt.",
+    "isolatedExecution": {
+      "title": "Isolierte Ausführung",
+      "description": "Jeder Agentenlauf findet in einer vollständig isolierten privaten Umgebung statt. Wenn der Lauf beendet ist, wird die Umgebung automatisch zerstört – nichts bleibt zurück. Stellen Sie es sich wie einen Einweghandschuh vor: sauber, sicher und zuverlässig.",
+      "detail": "Betrieben durch Firecracker-microVMs mit Hardware-Level-KVM-Isolation, keine Container. Jeder Lauf erhält seinen eigenen Netzwerk-Namespace aus einem vorab zugewiesenen Pool von über 16.000."
+    },
+    "secretsNeverExposed": {
+      "title": "Secrets nie offengelegt",
+      "description": "Gmail, Slack oder GitHub verbinden? Ihre Tokens und Anmeldedaten werden sicher für Sie verwaltet. Der Agent kann sie verwenden, aber niemals einsehen oder extrahieren. Selbst wenn etwas im Code des Agenten schiefgeht, bleiben Ihre Konten sicher.",
+      "detail": "Anmeldedaten werden auf Netzwerkebene über transparenten MITM-Proxy injiziert. Agenten-Code berührt niemals rohe Tokens. Ausgehende Anfragen werden gescannt, um Secret-Leaks zu verhindern."
+    },
+    "startsInSeconds": {
+      "title": "Startet in Sekunden",
+      "description": "Wir haben umfangreiche Optimierungen unter der Haube vorgenommen, damit Ihr Agent in Zehntel von Millisekunden vom Auslöser zur Ausführung kommt. Schnell, weil wir die harte Arbeit auf Infrastrukturebene geleistet haben. Sie erleben nur das Ergebnis.",
+      "detail": "Overlayfs mit gemeinsam genutztem schreibgeschütztem rootfs für Zero-Copy-Boot. VM-Speicher-Snapshots wärmen den gesamten Runtime-Stack vor – Wiederherstellung statt Kaltstart."
+    },
+    "fullAuditTrail": {
+      "title": "Vollständiger Audit-Trail",
+      "description": "Jede Aktion, die der Agent ausführt – welche Dienste er aufgerufen hat, welche APIs er verwendet hat, was er produziert hat – wird protokolliert. Wenn etwas schiefgeht, gibt es einen klaren Nachweis. Wenn nichts schiefgeht, haben Sie trotzdem Gewissheit.",
+      "detail": "Vollständiger HTTP/HTTPS-Verkehr pro Lauf protokolliert (JSONL). Unveränderliche, inhaltsadressierte Artefakte auf Cloudflare R2 mit SHA-256-Integrität gespeichert."
+    },
+    "openSource": {
+      "title": "Open Source",
+      "description": "Die Kernplattform ist Open Source. Sie können den Code einsehen, das Sicherheitsmodell prüfen und beitragen. Standardmäßig transparent.",
+      "detail": "Kernplattform auf GitHub. Regelmäßige Penetrationstests durch Drittanbieter. SOC 2 Type II-Compliance in Bearbeitung."
+    },
+    "questionsAboutSecurity": "Fragen zur Sicherheit?",
+    "contactUs": "Kontaktieren Sie uns"
+  },
+  "avatar": {
+    "steps": {
+      "rotation": "Winkel",
+      "skin": "Haut",
+      "hairStyle": "Haare",
+      "hairColor": "Farbe",
+      "expression": "Gesicht",
+      "intensity": "Stimmung"
+    },
+    "intensityLabels": {
+      "chill": "Entspannt",
+      "normal": "Normal",
+      "hyped": "Aufgedreht"
+    },
+    "back": "← Zurück"
   }
 }

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -81,15 +81,129 @@
     "docs": "Docs",
     "blog": "Blog",
     "skills": "Skills",
-    "glossary": "Glossary",
     "pricing": "Pricing",
     "github": "GitHub",
     "contact": "Schedule a demo",
-    "joinWaitlist": "Sign up"
+    "joinWaitlist": "Sign up",
+    "security": "Security",
+    "useCases": "Use Cases",
+    "signOut": "Sign out",
+    "openApp": "Open app"
   },
   "pricing": {
     "title": "Choose Your Plan",
-    "subtitle": "Start free and scale as you grow. No credit card required."
+    "subtitle": "Start free and scale as you grow. No credit card required.",
+    "heroTitle": "Pay for what you use, nothing more",
+    "heroDescription": "Start free with your AI teammate. Scale when you're ready, no credit card required.",
+    "free": {
+      "description": "Get started with your AI teammate for free.",
+      "features": {
+        "starterCredits": "10,000 starter credits",
+        "concurrentRun": "1 concurrent run",
+        "unlimitedAgents": "Unlimited total agents",
+        "bringOwnLLM": "Bring your own LLM keys",
+        "communitySupport": "Community support"
+      },
+      "buttonText": "Get started"
+    },
+    "pro": {
+      "description": "More power and seamless collaboration for your team.",
+      "features": {
+        "credits": "20,000 credits / month",
+        "concurrentRuns": "2 concurrent runs",
+        "unlimitedAgents": "Unlimited total agents",
+        "bringOwnLLM": "Bring your own LLM keys",
+        "creditsRollover": "Credits rollover (1 month)",
+        "emailSupport": "Email support"
+      },
+      "buttonText": "Start with Pro"
+    },
+    "team": {
+      "description": "Scale fast with zero friction and full flexibility.",
+      "features": {
+        "credits": "120,000 credits / month",
+        "concurrentRuns": "5 concurrent runs",
+        "unlimitedAgents": "Unlimited total agents",
+        "bringOwnLLM": "Bring your own LLM keys",
+        "creditsRollover": "Credits rollover (1 month)",
+        "prioritySupport": "Priority support"
+      },
+      "buttonText": "Start with Team"
+    },
+    "needMoreCredits": "Need more credits?",
+    "topUpDescription": "Top up anytime at",
+    "topUpRate": "1,000 credits per $1",
+    "topUpAutoRecharge": "Set up auto-recharge so your agents never stop — when your balance drops below a threshold, credits are purchased automatically.",
+    "perCredits": "per 1,000 credits",
+    "comparePlans": "Compare plans",
+    "featuresHeader": "Features",
+    "sections": {
+      "creditsAndAgents": "Credits & Agents",
+      "connectorsAndIntegrations": "Connectors & Integrations",
+      "securityAndCompliance": "Security & Compliance",
+      "collaboration": "Collaboration",
+      "support": "Support"
+    },
+    "tableFeatures": {
+      "creditsPerMonth": "Credits per month",
+      "creditsPerMonthDesc": "Credits consumed by AI model usage across all agents",
+      "concurrentRuns": "Concurrent runs",
+      "concurrentRunsDesc": "Number of agents that can run concurrently",
+      "totalAgents": "Total agents",
+      "totalAgentsDesc": "Maximum number of agents you can create",
+      "creditsRollover": "Credits rollover",
+      "creditsRolloverDesc": "Unused credits carry over to the next billing period",
+      "creditTopUp": "Credit top-up",
+      "creditTopUpDesc": "Purchase additional credits anytime at $1 per 1,000 credits",
+      "autoRecharge": "Auto-recharge",
+      "autoRechargeDesc": "Automatically purchase credits when balance falls below a threshold",
+      "connectors": "Connectors",
+      "connectorsDesc": "Connect your tools like Slack, GitHub, Notion, and more",
+      "bringOwnLLM": "Bring your own LLM",
+      "bringOwnLLMDesc": "Use your own model provider API keys",
+      "sandboxedExecution": "Sandboxed execution",
+      "sandboxedExecutionDesc": "Firecracker microVMs with hardware-level KVM isolation",
+      "fullAuditTrail": "Full audit trail",
+      "fullAuditTrailDesc": "Agent HTTP/HTTPS traffic logged with SHA-256 integrity per run",
+      "noCredentialExposure": "No credential exposure",
+      "noCredentialExposureDesc": "Secrets injected at network layer, never visible to agent code",
+      "teamMembers": "Team members",
+      "teamMembersDesc": "Number of people in your workspace",
+      "perMemberCreditCaps": "Per-member credit caps",
+      "perMemberCreditCapsDesc": "Set spending limits for individual team members",
+      "communitySupport": "Community support",
+      "communitySupportDesc": "Access to Discord community and documentation",
+      "emailSupport": "Email support",
+      "emailSupportDesc": "Direct email support from the VM0 team",
+      "prioritySupport": "Priority support",
+      "prioritySupportDesc": "Dedicated support with faster response times"
+    },
+    "tableValues": {
+      "starter": "10,000 starter",
+      "20k": "20,000",
+      "120k": "120,000",
+      "unlimited": "Unlimited",
+      "oneMonth": "1 month",
+      "allConnectors": "All connectors"
+    },
+    "faq": {
+      "title": "Frequently asked questions",
+      "whatAreCredits": "What are credits?",
+      "whatAreCreditsAnswer": "Credits are consumed when your agents use AI models. Different models consume credits at different rates. For example, a simple task might use a few credits, while a complex multi-step workflow uses more.",
+      "changePlans": "Can I change plans at any time?",
+      "changePlansAnswer": "Yes! You can upgrade or downgrade your plan at any time. Changes take effect immediately, and we'll prorate charges accordingly.",
+      "runOutOfCredits": "What happens when I run out of credits?",
+      "runOutOfCreditsAnswer": "When your credits are depleted, your agents will stop running. You can purchase additional credits via auto-recharge, or upgrade to a higher plan for more monthly credits.",
+      "doCreditsRollOver": "Do unused credits roll over?",
+      "doCreditsRollOverAnswer": "On the Free plan, starter credits don't expire but don't replenish. On Pro, unused credits roll over for 1 month. On Team, credits roll over for 1 month.",
+      "bringOwnModel": "Can I bring my own model provider?",
+      "bringOwnModelAnswer": "Yes! All plans support bringing your own LLM API keys (Anthropic, etc.). When using your own keys, no VM0 credits are consumed for model usage.",
+      "howSecure": "How secure is VM0?",
+      "howSecureAnswer": "Every agent run executes in an isolated Firecracker microVM with hardware-level KVM isolation. Credentials are injected at the network layer and never exposed to agent code. All agent HTTP/HTTPS traffic is logged with SHA-256 integrity per run.",
+      "annualBilling": "Do you offer annual billing or discounts?",
+      "annualBillingAnswer": "Contact us to discuss volume pricing, annual billing discounts, and custom arrangements for your team."
+    },
+    "perMonth": "/month"
   },
   "footer": {
     "tagline": "Zero, your trustworthy AI teammate.",
@@ -133,142 +247,6 @@
       "Content": "Content",
       "Utilities": "Utilities",
       "Other": "Other"
-    }
-  },
-  "glossary": {
-    "hero": {
-      "title": "Agent Building Glossary",
-      "description": "Master the language of AI agents. Explore key concepts, terminology, and VM0-specific features to accelerate your agent development journey."
-    },
-    "search": {
-      "placeholder": "Search terms...",
-      "allCategories": "All Categories",
-      "showingAll": "Showing all terms",
-      "found": "Found",
-      "results": "terms",
-      "noResults": "No terms found matching your search"
-    },
-    "relatedTerms": "Related terms",
-    "categories": {
-      "Core Concepts": "Core Concepts",
-      "Execution": "Execution",
-      "Infrastructure": "Infrastructure",
-      "VM0 Features": "VM0 Features",
-      "Development": "Development"
-    },
-    "terms": {
-      "agent": {
-        "name": "Agent",
-        "definition": "An autonomous AI program that can understand instructions, make decisions, use tools, and execute tasks independently. Unlike traditional scripts, agents can adapt their approach based on context and iterate toward goals."
-      },
-      "skill": {
-        "name": "Skill",
-        "definition": "A pre-built integration or capability that agents can use to interact with external services. Skills provide agents with ready-made functionality like accessing Slack, GitHub, Notion, or other APIs without requiring custom implementation."
-      },
-      "tool": {
-        "name": "Tool",
-        "definition": "A function or API that an agent can call to perform specific actions. Tools are the building blocks of agent capabilities, enabling them to read files, make HTTP requests, query databases, or interact with any external system."
-      },
-      "prompt": {
-        "name": "Prompt",
-        "definition": "Natural language instructions given to an agent to define its task, behavior, or goal. Prompts can range from simple commands to complex system instructions that shape how an agent thinks and operates."
-      },
-      "context": {
-        "name": "Context",
-        "definition": "The information available to an agent during execution, including conversation history, memory, tool outputs, and environmental state. Context helps agents maintain coherence across interactions and make informed decisions."
-      },
-      "session": {
-        "name": "Session",
-        "definition": "A continuous period of agent execution that preserves state, memory, and context. Sessions allow agents to maintain awareness across multiple interactions and resume work without losing progress."
-      },
-      "checkpoint": {
-        "name": "Checkpoint",
-        "definition": "A snapshot of an agent's state at a specific point in time, capturing its memory, context, and execution progress. Checkpoints enable reproducibility, allowing you to restore, fork, or replay agent runs."
-      },
-      "artifact": {
-        "name": "Artifact",
-        "definition": "Files, data, or outputs generated by an agent during execution. Artifacts persist across runs and can include code, documents, analysis results, or any other deliverables produced by the agent."
-      },
-      "observability": {
-        "name": "Observability",
-        "definition": "The ability to inspect, monitor, and understand agent behavior through logs, metrics, and execution traces. Observability is essential for debugging, optimizing, and ensuring transparent AI operations."
-      },
-      "sandbox": {
-        "name": "Sandbox",
-        "definition": "An isolated execution environment where agents run safely without affecting production systems. Sandboxes provide security boundaries and ensure that agent actions are contained and controlled."
-      },
-      "memory": {
-        "name": "Memory",
-        "definition": "Information that an agent retains across interactions, enabling it to learn from past experiences and maintain context over time. Memory can include facts, preferences, conversation history, and learned patterns."
-      },
-      "workflow": {
-        "name": "Workflow",
-        "definition": "A sequence of tasks or operations that an agent executes to achieve a goal. Unlike rigid automation scripts, agent workflows can adapt and adjust based on intermediate results and changing conditions."
-      },
-      "llm": {
-        "name": "LLM (Large Language Model)",
-        "definition": "The underlying AI model that powers agent reasoning and decision-making. Examples include Claude, GPT-4, and Gemini. Different LLMs have different strengths, costs, and capabilities."
-      },
-      "skillMd": {
-        "name": "SKILL.md",
-        "definition": "A markdown configuration file that defines a skill's behavior, inputs, outputs, and implementation logic. The SKILL.md file allows you to create custom skills using natural language and structured metadata, making it easy to extend agent capabilities without writing complex code."
-      },
-      "agentMd": {
-        "name": "AGENTS.md",
-        "definition": "A markdown configuration file that defines an agent's behavior, personality, goals, and available tools. The AGENTS.md file serves as the agent's blueprint, specifying how it should think, what it can do, and how it should interact with users and systems."
-      },
-      "volume": {
-        "name": "Volume",
-        "definition": "A persistent storage space that preserves files and data across agent runs. Volumes provide agents with a file system that persists beyond individual executions, enabling them to store state, cache data, and maintain long-term artifacts."
-      },
-      "action": {
-        "name": "Action",
-        "definition": "A concrete operation or task that an agent performs to achieve its goals. Actions can include calling APIs, reading files, processing data, or interacting with external systems. Each action represents a single step in the agent's execution flow."
-      },
-      "runtime": {
-        "name": "Runtime",
-        "definition": "The execution environment where agents run, providing the necessary infrastructure, resources, and APIs. The runtime manages agent lifecycle, handles resource allocation, and ensures proper isolation between different agent executions."
-      },
-      "orchestration": {
-        "name": "Orchestration",
-        "definition": "The coordination and management of multiple agents, workflows, or tasks to achieve complex goals. Orchestration handles dependencies, sequencing, parallel execution, and resource allocation across distributed agent operations."
-      },
-      "mcp": {
-        "name": "MCP (Model Context Protocol)",
-        "definition": "An open protocol developed by Anthropic that enables AI assistants to securely connect to external data sources and tools. MCP provides a standardized way for agents to access resources like databases, APIs, and file systems while maintaining security and context awareness."
-      },
-      "image": {
-        "name": "Image",
-        "definition": "A packaged container that includes the code, runtime, dependencies, and configuration needed to run an agent. Images provide a consistent and reproducible execution environment, ensuring that agents behave the same way across different deployments."
-      },
-      "secrets": {
-        "name": "Secrets",
-        "definition": "Sensitive information like API keys, passwords, and tokens that agents need to access external services. Secrets are stored securely and injected into the agent runtime at execution time, preventing exposure in code or configuration files."
-      },
-      "environmentVariable": {
-        "name": "Environment Variable",
-        "definition": "A configuration value that is passed to an agent at runtime, allowing you to customize behavior without changing code. Environment variables are commonly used for API endpoints, feature flags, and non-sensitive configuration settings."
-      },
-      "virtualMachine": {
-        "name": "Virtual Machine",
-        "definition": "An isolated, software-based computing environment that emulates a physical computer. Virtual machines provide complete isolation between agent executions, ensuring security and preventing interference. VM0 uses lightweight virtual machines to run agents with their own operating system, file system, and network stack."
-      },
-      "cli": {
-        "name": "CLI (Command Line Interface)",
-        "definition": "A text-based interface for interacting with agents and the VM0 platform. The CLI allows developers to create, deploy, and manage agents through terminal commands, providing powerful scripting and automation capabilities without requiring a graphical interface."
-      },
-      "cliAgent": {
-        "name": "CLI Agent",
-        "definition": "An agent specifically designed to be invoked and controlled through command-line interfaces. CLI agents can be integrated into scripts, CI/CD pipelines, and terminal workflows, making them ideal for automation tasks and developer tooling."
-      },
-      "agentRouter": {
-        "name": "Agent Router",
-        "definition": "A system that intelligently routes agent requests to the most appropriate AI model based on task requirements, cost constraints, and performance needs. The agent router can dynamically select between different LLMs (Claude, GPT, Gemini) or route to specialized models for specific capabilities."
-      },
-      "claudeCode": {
-        "name": "Claude Code",
-        "definition": "Anthropic's official command-line tool for building and deploying AI agents. Claude Code provides a developer-friendly interface for creating agents, managing skills, and integrating with the Claude API. It streamlines the agent development workflow with features like live reloading, debugging tools, and deployment automation."
-      }
     }
   },
   "blog": {
@@ -315,6 +293,700 @@
     "ctaTitle": "Zero works where your team works",
     "ctaSubtitle": "Add Zero to Slack and start delegating in plain language. No setup wizards. No workflow builders. Just ask.",
     "addToSlack": "Add Zero to Slack",
-    "bookDemo": "Book a demo"
+    "bookDemo": "Book a demo",
+    "gallery": {
+      "moreToCome": "More to come",
+      "moreToComeDesc": "Have a smart way to use Zero?",
+      "submitYourCase": "Submit your case →"
+    },
+    "content": {
+      "sentry-triage": {
+        "title": "Turn Sentry noise into a prioritized action list",
+        "description": "Ask Zero to pull your top unresolved Sentry errors, ranked by frequency. Zero reads the stack traces, explains the root cause in plain language, and tells you which file to fix first.",
+        "timeSaved": "~25 min saved",
+        "headings": {
+          "scenario": "Why Sentry triage wastes engineering time",
+          "prompt": "How to ask Zero to triage Sentry errors",
+          "steps": "How Zero analyzes and ranks your Sentry errors",
+          "nextActions": "Turn Sentry triage into GitHub issues and daily automation",
+          "integrations": "Required integrations: Sentry and GitHub",
+          "tips": "Best practices for automated Sentry triage"
+        },
+        "scenario": "Monday morning. You open Slack and there are a dozen Sentry alerts in #dev. Most of them are noise, flaky tests, known issues, transient errors that resolve themselves. But somewhere in there might be something real: a broken integration, a billing bug, a crash that's hitting actual users. You don't want to open Sentry's dashboard and click through issues one by one. You just want to know: which ones matter, how bad are they, and what's causing them.",
+        "promptVariants": [
+          {
+            "label": "Detailed",
+            "prompt": "@Zero take a look at the recent failures on Sentry. Please rank the failures from the last 24 hours by their occurrence frequency.\n\nFor the top three failures, provide me with a report that includes the expanded, detailed error stacks."
+          },
+          {
+            "label": "Quick",
+            "prompt": "@Zero top 3 Sentry errors in the last 24h, ranked by count."
+          },
+          {
+            "label": "Scheduled",
+            "prompt": "@Zero every weekday at 9am, run this same Sentry check and post results to #dev. Only include errors with 5+ occurrences."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Yuma",
+            "text": "@Zero look at recent failures on Sentry. Rank by frequency. Top 3 with detailed error stacks."
+          },
+          {
+            "name": "Zero",
+            "text": "Here's the full Sentry failure report.\n\n#\tIssue\tCount\tPriority\n1\tSlack missing_scope\t57\tHigh\n2\tUnknown Stripe price ID\t15\tHigh\n3\tZeroSidebar .map()\t10\tMed"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero connects to Sentry",
+            "description": "Zero pulls unresolved issues from your Sentry project for the specified time window and ranks them by occurrence count."
+          },
+          {
+            "title": "Summary table",
+            "description": "Zero replies in the same Slack thread with a quick summary table, issue name, occurrence count, and priority level, that you can scan in 5 seconds."
+          },
+          {
+            "title": "Detailed analysis",
+            "description": "For each top issue, Zero provides annotated stack traces and plain-language root cause explanations. For example, it doesn't just say \"Unknown Stripe price ID\", it explains that a new price was likely created in Stripe but the corresponding mapping was not updated."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Turn findings into action",
+            "description": "Create GitHub issues from the report",
+            "examplePrompt": "@Zero create GitHub issues for #1 and #2. Assign #1 to Lancy (Slack scope fix) and #2 to James (Stripe mapping). Label both as bug, priority high."
+          },
+          {
+            "title": "Go deeper",
+            "description": "Ask Zero to investigate a specific error",
+            "examplePrompt": "@Zero for issue #1, what exact Slack OAuth scope is missing? Check our app manifest and tell me what to add."
+          },
+          {
+            "title": "Make it a routine",
+            "description": "Schedule this as a daily check",
+            "examplePrompt": "@Zero every weekday at 9am, run this same Sentry check and post results to #dev. Only include errors with 5+ occurrences."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "OAuth connection to your Sentry org. Zero needs read access to issues and events."
+          },
+          {
+            "description": "Only needed if you want Zero to create issues from the report. Read/write access to issues."
+          }
+        ],
+        "tips": [
+          "Be specific about the time window. \"last 24 hours\" for daily triage, \"errors since the last deploy\" for post-deploy checks.",
+          "Add a severity filter to reduce noise, only show errors with 10+ occurrences or skip errors tagged as known-issue.",
+          "Chain it into your standup, combine with the standup use case for a morning brief that includes both your task summary and the Sentry report."
+        ]
+      },
+      "standup-summary": {
+        "title": "Get your standup ready without opening 5 apps",
+        "description": "Zero pulls from calendar, email, and Linear, then writes a shareable summary you can paste straight into the team thread.",
+        "timeSaved": "~20 min saved",
+        "headings": {
+          "scenario": "The daily standup scramble across Calendar, Gmail, and Linear",
+          "prompt": "How to ask Zero for a standup summary",
+          "steps": "How Zero compiles your work summary from 3 tools",
+          "nextActions": "Post to Slack, add blockers, or automate daily",
+          "integrations": "Required integrations: Google Calendar, Gmail, and Linear",
+          "tips": "Best practices for AI-generated standup summaries"
+        },
+        "scenario": "It's 9:50 AM and standup starts in 10 minutes. You haven't checked your calendar yet. You ask Zero to pull yesterday's meetings, emails, and Linear tasks, it writes a summary you can paste straight into the team thread.",
+        "promptVariants": [
+          {
+            "label": "Detailed",
+            "prompt": "@Zero check my calendar, emails, and Linear tasks since yesterday and write me a work summary. Include meeting highlights and PR status."
+          },
+          {
+            "label": "Quick",
+            "prompt": "@Zero what did I do yesterday? Check calendar and Linear."
+          },
+          {
+            "label": "Scheduled",
+            "prompt": "@Zero every weekday at 9:45am, write my standup summary and DM it to me."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero check my calendar, emails, and Linear tasks since yesterday and write me a work summary"
+          },
+          {
+            "name": "Zero",
+            "text": "Work Summary: Mar 23–24\n\nMeetings\n• Daily standups (10–10:30 AM)\n• VM0 User Interview w/ Daniel Miller\n\nEngineering\n• PR #5467 merged, firewall permissions\n• PR #6277 in review. Lighthouse at 36"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero checks your calendar",
+            "description": "Zero reads your Google Calendar events from the past 24 hours and extracts meeting names, times, and attendees."
+          },
+          {
+            "title": "Zero scans email and tasks",
+            "description": "Zero checks Gmail for relevant threads and Linear for tasks you updated, completed, or were assigned since yesterday."
+          },
+          {
+            "title": "Formatted summary",
+            "description": "Zero compiles everything into a clean, copy-paste-ready summary organized by Meetings, Engineering work, and action items."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Post directly to a channel",
+            "description": "Have Zero post the summary to #standup",
+            "examplePrompt": "@Zero post this summary to #standup and tag @team-eng."
+          },
+          {
+            "title": "Add context",
+            "description": "Ask Zero to include blockers or priorities",
+            "examplePrompt": "@Zero also check my Linear for any blocked tasks and add them as blockers in the summary."
+          },
+          {
+            "title": "Make it daily",
+            "description": "Automate your morning prep",
+            "examplePrompt": "@Zero every weekday at 9:45am, write my standup summary and DM it to me."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "OAuth connection to Google Calendar. Zero needs read access to your events."
+          },
+          {
+            "description": "OAuth connection to Gmail. Zero needs read access to scan recent threads."
+          },
+          {
+            "description": "OAuth connection to Linear. Zero reads your assigned and updated tasks."
+          }
+        ],
+        "tips": [
+          "Tell Zero your standup format if it differs from the default. \"use the format: Yesterday / Today / Blockers\".",
+          "Specify the time window. \"since yesterday 5pm\" if you work late.",
+          "Combine with Sentry triage for a complete engineering morning brief."
+        ]
+      },
+      "kol-cold-outreach": {
+        "title": "Research a KOL on X and draft a personalized cold email",
+        "description": "Give Zero an X handle. It reads their last 30 posts, understands their style and interests, writes a personalized outreach email under 150 words, and saves it as a Gmail draft.",
+        "timeSaved": "~20 min saved",
+        "headings": {
+          "scenario": "Why generic cold outreach gets ignored",
+          "prompt": "How to research a KOL and draft personalized outreach",
+          "steps": "How Zero analyzes X profiles and crafts tailored emails",
+          "nextActions": "Score KOL fit, batch multiple outreach drafts, or track in Notion CRM",
+          "integrations": "Required integrations: X, Gmail, and Notion",
+          "tips": "Best practices for AI-assisted KOL outreach"
+        },
+        "scenario": "You found a KOL who'd be perfect for a partnership, but writing a cold email that doesn't feel generic takes 20 minutes of research, reading their posts, understanding what they care about, finding the right angle. You give Zero their X handle and get a personalized draft in seconds.",
+        "promptVariants": [
+          {
+            "label": "Detailed",
+            "prompt": "@Zero read @swyx's last 30 X posts to understand their style and interests. Write a personalized cold outreach email under 150 words about a VM0 partnership. Reference something specific they posted recently. Save it as a Gmail draft."
+          },
+          {
+            "label": "Quick",
+            "prompt": "@Zero draft a cold email to @swyx about VM0, based on their X posts. Save as Gmail draft."
+          },
+          {
+            "label": "Batch",
+            "prompt": "@Zero for each handle in my Notion KOL list marked as \"Not contacted\", research their X profile and draft a personalized outreach email. Save all as Gmail drafts."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero read @swyx's last 30 X posts, understand his style, and draft a cold outreach email for a VM0 partnership. Save as Gmail draft."
+          },
+          {
+            "name": "Zero",
+            "text": "Done. Analyzed @swyx's recent content:\n• Focus: AI agents, developer tools, open source\n• Tone: Technical but conversational\n• Audience fit: High (9/10)\n\nGmail draft saved: \"Agents that ship real work, thought you'd find this interesting\""
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero reads the KOL's X profile",
+            "description": "Zero pulls the last 30 posts, analyzes content themes, tone, audience, and engagement patterns to build a profile of what this person cares about."
+          },
+          {
+            "title": "Personalized email drafted",
+            "description": "Zero writes a concise outreach email that references specific content the KOL posted, explains the relevance of your product, and uses a tone that matches their style."
+          },
+          {
+            "title": "Draft saved to Gmail",
+            "description": "The email is saved as a Gmail draft ready for your review. Zero also updates the KOL's status in your Notion CRM if connected."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Score KOL fit",
+            "description": "Rate how well a KOL matches your audience",
+            "examplePrompt": "@Zero analyze @swyx's audience overlap with VM0's ICP. Score 1-10 with reasoning and save to Notion."
+          },
+          {
+            "title": "Batch outreach",
+            "description": "Draft emails for multiple KOLs at once",
+            "examplePrompt": "@Zero for the top 10 KOLs in my Notion list, research each and draft personalized outreach emails."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero reads public posts to understand the KOL's style and interests."
+          },
+          {
+            "description": "Zero saves the drafted email to your Gmail drafts."
+          },
+          {
+            "description": "Optional, track KOL status and fit scores in your Notion CRM."
+          }
+        ],
+        "tips": [
+          "Give Zero context about your product angle. \"focus on how VM0 helps developer tool companies\".",
+          "Ask for multiple variants. \"draft 2 versions: one casual, one professional\".",
+          "Always review before sending. Zero gets the research right, but the final voice should be yours."
+        ]
+      },
+      "file-bugs-from-slack": {
+        "title": "File bugs from Slack without switching context",
+        "description": "Describe the issue in plain language. Zero creates a formatted GitHub issue, labels it, and assigns the right person.",
+        "timeSaved": "Instant",
+        "headings": {
+          "scenario": "Why filing GitHub issues from Slack saves context switching",
+          "prompt": "How to create GitHub issues from a Slack message",
+          "steps": "How Zero parses your message and creates a formatted issue",
+          "nextActions": "Add details, batch file issues, or automate triage",
+          "integrations": "Required integrations: GitHub and Slack",
+          "tips": "Best practices for filing bugs via Slack"
+        },
+        "scenario": "You just noticed a UX bug during a demo. Instead of opening GitHub, finding the repo, writing a formatted issue, and assigning someone, you describe it in Slack. Zero creates the issue, adds labels, and assigns the right person. You never leave the conversation.",
+        "promptVariants": [
+          {
+            "label": "Detailed",
+            "prompt": "@Zero create issue: pressing ESC in the schedule dialog closes it immediately even with unsaved edits. Should ask for confirmation first. Assign to Lancy. Label as bug, platform. Priority medium."
+          },
+          {
+            "label": "Quick",
+            "prompt": "@Zero bug: ESC closes schedule dialog without save confirmation. Assign Lancy."
+          },
+          {
+            "label": "Scheduled",
+            "prompt": "@Zero every Friday at 4pm, check #bugs channel for any unresolved bug reports and create GitHub issues for each one."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero create issue: pressing ESC in the schedule dialog closes it immediately even with unsaved edits. Should ask for confirmation first. Assign to Lancy."
+          },
+          {
+            "name": "Zero",
+            "text": "Issue created:\n#6260: bug: ESC key closes schedule dialog without confirming\nAssigned to Lancy · Priority: Medium"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero parses the request",
+            "description": "Zero understands the bug description, identifies the assignee, and infers appropriate labels (bug, platform) and priority from context."
+          },
+          {
+            "title": "Issue created on GitHub",
+            "description": "Zero creates a properly formatted GitHub issue with a clear title, description, labels, and assignment, all from your natural-language Slack message."
+          },
+          {
+            "title": "Confirmation in Slack",
+            "description": "Zero replies in the same thread with the issue number, title, assignee, and a direct link so you can verify without leaving Slack."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Add more detail",
+            "description": "Attach screenshots or steps to reproduce",
+            "examplePrompt": "@Zero add to #6260: steps to reproduce. 1. Open schedule dialog 2. Type something 3. Press ESC. Expected: confirmation dialog."
+          },
+          {
+            "title": "Batch file issues",
+            "description": "Create multiple issues at once",
+            "examplePrompt": "@Zero create 3 issues from these bugs:\n1. ESC dialog close (Lancy)\n2. Date picker off by one day (James)\n3. Avatar upload fails on Safari (Yuma)"
+          },
+          {
+            "title": "Automate triage",
+            "description": "Auto-create issues from a channel",
+            "examplePrompt": "@Zero watch #bugs, when someone posts a message starting with \"bug:\", auto-create a GitHub issue and reply with the link."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "OAuth connection to GitHub. Zero needs read/write access to create and manage issues."
+          },
+          {
+            "description": "Zero reads your message and replies in the same thread."
+          }
+        ],
+        "tips": [
+          "Include the assignee name. Zero matches Slack display names to GitHub usernames.",
+          "Mention labels explicitly if you want specific ones, otherwise Zero infers from context.",
+          "Works for feature requests too, just say \"feature request\" instead of \"bug\"."
+        ]
+      },
+      "slack-triage": {
+        "title": "Cut through Slack noise and surface what needs your attention",
+        "description": "Zero scans your unread Slack messages, filters out bots and noise, and shows you only the messages that actually need your action today, sorted by urgency.",
+        "timeSaved": "~10 min saved",
+        "headings": {
+          "scenario": "Why Slack overload causes missed action items",
+          "prompt": "How to ask Zero to triage your unread Slack messages",
+          "steps": "How Zero filters noise and surfaces actionable messages",
+          "nextActions": "Reply directly, create tasks, or automate daily triage",
+          "integrations": "Required integrations: Slack",
+          "tips": "Best practices for Slack message triage"
+        },
+        "scenario": "You open Slack after a 2-hour focus block and there are 47 unread messages across 12 channels. Most are bot notifications, automated alerts, and conversations that don't need you. Somewhere in the noise are 3 things that actually need your response. Instead of scrolling through everything, you ask Zero to find what matters.",
+        "promptVariants": [
+          {
+            "label": "Detailed",
+            "prompt": "@Zero scan my unread Slack messages from the last 12 hours. Filter out bots, automated notifications, and threads I'm not tagged in. Show me only messages that need my action today, sorted by urgency. For each one, tell me who's waiting and what they need."
+          },
+          {
+            "label": "Quick",
+            "prompt": "@Zero what needs my attention in Slack right now?"
+          },
+          {
+            "label": "Scheduled",
+            "prompt": "@Zero every morning at 9am and after lunch at 1pm, scan my unreads and DM me what needs action."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero scan my unread Slack from the last 12 hours. Filter out bots and noise. Show me only what needs my action today."
+          },
+          {
+            "name": "Zero",
+            "text": "Found 47 unread messages. 5 need your action:\n\n1. @Ethan asked for your design review on PR #6312\n2. @James needs approval on the Stripe migration plan\n3. #support has a P0 from a customer mentioning churn\n4. @Scarlett tagged you in a KOL outreach decision\n5. Sprint review moved to 3pm (was 2pm)"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero scans your channels",
+            "description": "Zero reads your unread messages across all channels, filtering out bot messages, automated CI/CD alerts, and threads where you're not mentioned or needed."
+          },
+          {
+            "title": "Messages classified by urgency",
+            "description": "Each remaining message is assessed: is someone waiting on you? Is there a deadline? Is it a decision that's blocking others? Zero ranks them by how urgently they need your response."
+          },
+          {
+            "title": "Actionable summary delivered",
+            "description": "Zero DMs you a numbered list of what needs attention, with who's asking, what they need, and a direct link to each thread. Everything else is safely ignored."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Reply through Zero",
+            "description": "Respond without opening each thread",
+            "examplePrompt": "@Zero reply to #1: \"Looks good, approved. Ship it.\" And for #3, create a P0 Linear issue and assign to James."
+          },
+          {
+            "title": "Make it a routine",
+            "description": "Auto-triage every morning",
+            "examplePrompt": "@Zero every weekday at 9am, scan my unreads from overnight and DM me the action items."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero reads your unread messages and DMs you the triage summary."
+          },
+          {
+            "description": "Optional: create tasks directly from triaged messages."
+          },
+          {
+            "description": "Optional: Zero checks your calendar to flag meeting-related messages."
+          }
+        ],
+        "tips": [
+          "Tell Zero which channels matter most to you so it can prioritize accordingly.",
+          "Ask Zero to learn your noise patterns over time: \"always skip messages from @github-bot and @vercel-bot\".",
+          "Combine with the standup use case: triage first, then generate your standup from the action items."
+        ]
+      },
+      "employee-onboarding": {
+        "title": "Onboard new teammates with one Slack message",
+        "description": "Tell Zero who's joining and when. It creates their Notion onboarding page, schedules welcome meetings on Google Calendar, posts a Slack intro, and DMs them their first-week agenda.",
+        "timeSaved": "~45 min saved",
+        "headings": {
+          "scenario": "Why manual onboarding checklists always miss something",
+          "prompt": "How to automate new hire onboarding with Zero",
+          "steps": "How Zero sets up Notion, Calendar, and Slack for a new teammate",
+          "nextActions": "Add access provisioning or customize by role",
+          "integrations": "Required integrations: Slack, Notion, Google Calendar, and Gmail",
+          "tips": "Best practices for automated employee onboarding"
+        },
+        "scenario": "A new teammate starts next Monday. Someone needs to create their onboarding doc, schedule intro meetings with 5 people, post a welcome message, and send them a first-week agenda. It's 45 minutes of coordination that happens the same way every time. You tell Zero once and it handles everything.",
+        "promptVariants": [
+          {
+            "label": "Detailed",
+            "prompt": "@Zero onboard Sarah Chen joining as Product Designer on April 14. Duplicate the Notion onboarding template, schedule week-1 intro meetings with Ethan, Lancy, James, Yuma, and Scarlett on Google Calendar. Schedule a 30-day check-in. Post a welcome to #general and DM Sarah her first-week agenda."
+          },
+          {
+            "label": "Quick",
+            "prompt": "@Zero onboard Sarah Chen, Product Designer, starting April 14. Full setup."
+          },
+          {
+            "label": "Template",
+            "prompt": "@Zero when someone posts in #new-hires with format \"Name / Role / Start Date\", auto-run the full onboarding workflow."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero onboard Sarah Chen, joining as Product Designer on April 14. Set up everything."
+          },
+          {
+            "name": "Zero",
+            "text": "Onboarding for Sarah Chen is ready:\n\n✔ Notion page created from template\n✔ Week-1 intro meetings scheduled\n✔ 30-day check-in on May 14\n✔ Welcome posted to #general\n✔ DM sent with first-week agenda"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Notion onboarding page created",
+            "description": "Zero duplicates your onboarding template in Notion, fills in the new hire's name, role, start date, and manager. Links to relevant docs and team resources."
+          },
+          {
+            "title": "Meetings scheduled",
+            "description": "Zero creates intro meetings with specified teammates on Google Calendar during the first week, plus a 30-day check-in. All calendar invites include context about what to discuss."
+          },
+          {
+            "title": "Slack welcome and DM sent",
+            "description": "Zero posts a welcome message to #general introducing the new hire, then DMs them directly with their first-week agenda, links to their Notion page, and key contacts."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Customize by role",
+            "description": "Different onboarding for different roles",
+            "examplePrompt": "@Zero for engineers, also add a pairing session with the tech lead and link to the architecture docs in the onboarding page."
+          },
+          {
+            "title": "Automate triggers",
+            "description": "Run onboarding from a channel post",
+            "examplePrompt": "@Zero whenever someone posts in #new-hires with the format \"Name / Role / Start Date\", run the full onboarding automatically."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero posts the welcome message and DMs the new hire."
+          },
+          {
+            "description": "Zero creates the onboarding page from your template."
+          },
+          {
+            "description": "Zero schedules intro meetings and check-ins."
+          },
+          {
+            "description": "Optional, send a welcome email with logistics and links."
+          }
+        ],
+        "tips": [
+          "Create a Notion onboarding template first. Zero duplicates it and fills in the details.",
+          "List the people who should have intro meetings. Zero handles the calendar coordination.",
+          "Works for contractors and interns too, just adjust the template and meeting list."
+        ]
+      },
+      "build-with-v0": {
+        "title": "Turn a Slack idea into an interactive prototype instantly",
+        "description": "When an idea sparks mid-conversation, describe it to Zero. It uses v0 to generate a clickable React prototype and posts the live preview link back in the thread — before the discussion moves on.",
+        "timeSaved": "Hours → seconds",
+        "headings": {
+          "scenario": "Why ideas get lost before anyone can see them",
+          "prompt": "How to turn a Slack idea into a prototype with Zero",
+          "steps": "How Zero goes from your description to a live, clickable UI",
+          "nextActions": "Refine, share, or hand off to engineering",
+          "integrations": "Required integrations: v0",
+          "tips": "Best practices for rapid idea prototyping with v0"
+        },
+        "scenario": "You're in a Slack thread debating how a feature should work. Someone proposes a new UI pattern — a command palette, a settings panel, a multi-step wizard. Words aren't landing. Sketching on a whiteboard isn't an option. Scheduling a Figma session pushes the decision to next week. You describe the idea to Zero in plain language. It calls v0, generates a fully interactive React prototype, and posts the live preview link right back in the thread — in under a minute. Everyone can click through it before the conversation moves on.",
+        "promptVariants": [
+          {
+            "label": "New UI idea",
+            "prompt": "@Zero prototype this: a command palette that lets users search agents, recent runs, and connectors. Keyboard-navigable, fuzzy search, shows a preview panel on the right side."
+          },
+          {
+            "label": "From thread context",
+            "prompt": "@Zero based on the flow we just described above, build a quick v0 prototype so the team can see it before we decide."
+          },
+          {
+            "label": "Iterate",
+            "prompt": "@Zero update the prototype — add a filter tab at the top for 'Agents / Runs / Connectors' and highlight the active item in orange. Regenerate."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Ethan",
+            "text": "@Zero prototype this: a command palette that lets users search agents, recent runs, and connectors. Keyboard-navigable, fuzzy search, shows a preview on the right."
+          },
+          {
+            "name": "Zero",
+            "text": "Here's the interactive prototype:\nv0.dev/r/cmd-palette-preview\n\nIncludes fuzzy search across agents, runs, and connectors. Arrow-key navigation. Right-side preview panel updates on hover. Click to open."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Describe the idea in plain language",
+            "description": "No spec, no wireframe required. Tell Zero what the UI should do — the components, the interactions, the data it surfaces. Paste a rough sketch description or just riff from the thread."
+          },
+          {
+            "title": "Zero generates the prototype via v0",
+            "description": "Zero translates your description into a structured v0 prompt and calls the v0 API. v0 produces a fully interactive React component — real buttons, real states, real navigation."
+          },
+          {
+            "title": "Live preview link posted in Slack",
+            "description": "Zero posts the v0 preview URL back in the same thread. Teammates can click through the prototype immediately, on any device, without installing anything or checking out code."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Refine in the thread",
+            "description": "Keep iterating without leaving Slack",
+            "examplePrompt": "@Zero update the prototype — the search input should have an icon on the left, and empty state should show recent items instead of nothing."
+          },
+          {
+            "title": "Share for async feedback",
+            "description": "Post to a broader channel or DM stakeholders",
+            "examplePrompt": "@Zero share the v0 prototype link to #product with the message: 'Quick prototype of the command palette idea — feedback welcome before Thursday.'"
+          },
+          {
+            "title": "Hand off to engineering",
+            "description": "Export the generated code into the repo",
+            "examplePrompt": "@Zero take the v0 prototype code and open a PR in vm0-ai/vm0 under turbo/apps/platform/src/components/CommandPalette.tsx for the team to build on."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero sends your idea as a generation prompt to v0 and retrieves the interactive prototype URL. Connect your v0 account to enable this."
+          },
+          {
+            "description": "Zero reads your idea from the Slack thread and posts the prototype link back in the same conversation."
+          }
+        ],
+        "tips": [
+          "Describe behavior, not just appearance. 'Clicking a row expands details below it' gets a more accurate prototype than 'expandable rows'.",
+          "Reference existing UI patterns by name — 'like a VS Code command palette' or 'like Notion's slash menu' — to anchor v0's generation.",
+          "Use the iterate prompt immediately after the first result. One round of refinement usually gets you 90% of the way there."
+        ]
+      }
+    }
+  },
+  "landing": {
+    "hero": {
+      "title": "Zero, your trustworthy AI teammate for real work.",
+      "subtitle": "Zero connects to 100+ tools and does the work. Reports, triage, outreach, research. In Slack or on the web.",
+      "ctaGetStarted": "Get started",
+      "ctaOpenApp": "Open app",
+      "seeUseCases": "See use cases",
+      "seedBanner": "Check out our $14M seed round fundraising blog."
+    },
+    "worksForYou": {
+      "heading": "What Zero actually does for you",
+      "exploreMore": "Explore more use cases"
+    },
+    "teammateCard": {
+      "title": "A teammate that reads, thinks, and delivers.",
+      "description": "“Summarize my week from Calendar, Linear, and Slack.” Zero pulls context from your tools, connects the dots, and hands you a finished report. Like briefing a colleague, except it takes seconds.",
+      "tabSummarize": "Summarize my work week",
+      "tabLeads": "Find and email leads",
+      "tabTriage": "Triage Sentry errors",
+      "ariaDaily": "Daily Report",
+      "ariaLeads": "Email Leads",
+      "ariaSentry": "Sentry Report"
+    },
+    "slackCard": {
+      "title": "Ask in Slack, get answers from all your tools.",
+      "description": "@Zero in any channel. It pulls from your calendar, email, Linear, GitHub — and replies with a summary your team can actually use. No tab-switching, no dashboards.",
+      "tagSlack": "Slack",
+      "tagTeamSync": "Team Sync"
+    },
+    "syncedToolsCard": {
+      "title": "From discovery to outreach, agents do the legwork.",
+      "description": "Tell Zero who you’re looking for. Its agents crawl social platforms, build prospect lists, and draft personalized outreach so your team focuses on closing, not searching.",
+      "tagMarketing": "Marketing Outreach",
+      "tagCrossPlatform": "Cross-platform"
+    },
+    "connectors": {
+      "heading": "Works with 100+ tools you already use",
+      "description": "Slack, GitHub, Gmail, Notion, Linear, Sentry, and more. Zero connects to your stack so it can act, not just answer."
+    },
+    "security": {
+      "heading": "Your data stays yours",
+      "permissionTitle": "You control what Zero can access",
+      "permissionDesc": "Set read and write permissions per tool, per agent. Zero only touches what you explicitly allow.",
+      "isolatedTitle": "Isolated execution, every time",
+      "isolatedDescPart1": "Every task runs in its own microVM. Credentials never leave the sandbox. Fully auditable. And ",
+      "isolatedDescLink": "open source",
+      "isolatedDescPart2": "."
+    },
+    "intelligence": {
+      "heading": "Gets smarter the more you use it",
+      "memoryTitle": "Remembers your context",
+      "memoryDesc": "Past decisions, project context, your preferences — Zero carries it all forward. No re-explaining, no lost context between sessions.",
+      "scheduleTitle": "Scheduled intelligence",
+      "scheduleDesc": "Zero runs autonomous recurring tasks, daily error scans, tech debt reports, morning briefs, without being prompted.",
+      "subAgentsTitle": "Specialized sub-agents",
+      "subAgentsDesc": "Create agents for specific jobs. One for research, one for triage, one for outreach. They work in parallel so you don't.",
+      "toolOrchTitle": "Tool orchestration",
+      "toolOrchDesc": "Zero selects and chains the right tools from 100+ available integrations. You describe the goal; Zero figures out the steps.",
+      "identityTitle": "Knows who you are",
+      "identityDesc": "\"My PRs,\" \"assign to me.\" Zero resolves your identity across GitHub, Slack, and Linear automatically. No setup required."
+    },
+    "cta": {
+      "title": "You decide what matters. Zero handles the rest.",
+      "subtitle": "Start free. Use it in Slack or on the web. No credit card required."
+    }
+  },
+  "securityPage": {
+    "title": "Security",
+    "intro": "When you hand work to an AI agent, your biggest concerns are data safety, privacy, and staying in control. VM0 was designed from day one with all of this in mind.",
+    "isolatedExecution": {
+      "title": "Isolated execution",
+      "description": "Every agent run happens inside a completely isolated private environment. When the run finishes, the environment is destroyed automatically, nothing is left behind. Think of it like a disposable glove: clean, safe, and reliable.",
+      "detail": "Powered by Firecracker microVMs with hardware-level KVM isolation, not containers. Each run gets its own network namespace from a pre-allocated pool of 16,000+."
+    },
+    "secretsNeverExposed": {
+      "title": "Secrets never exposed",
+      "description": "Connecting Gmail, Slack, or GitHub? Your tokens and credentials are securely managed for you. The agent can use them, but it can never see or extract them. Even if something goes wrong in the agent's code, your accounts stay safe.",
+      "detail": "Credentials are injected at the network layer via transparent MITM proxy. Agent code never touches raw tokens. Outbound requests are scanned to prevent secret leakage."
+    },
+    "startsInSeconds": {
+      "title": "Starts in seconds",
+      "description": "We've done extensive optimization under the hood so your agent goes from trigger to running in tens of milliseconds. Fast, because we put in the hard work at the infrastructure level. You just experience the result.",
+      "detail": "Overlayfs with shared read-only rootfs for zero-copy boot. VM memory snapshots pre-warm the entire runtime stack, restore instead of cold start."
+    },
+    "fullAuditTrail": {
+      "title": "Full audit trail",
+      "description": "Every action the agent takes, which services it accessed, which APIs it called, what it produced, is logged. If something goes wrong, there's a clear record. If nothing goes wrong, you still have peace of mind.",
+      "detail": "Complete HTTP/HTTPS traffic logged per run (JSONL). Immutable, content-addressed artifacts stored on Cloudflare R2 with SHA-256 integrity."
+    },
+    "openSource": {
+      "title": "Open source",
+      "description": "The core platform is open source. You can inspect the code, audit the security model, and contribute. Transparent by default.",
+      "detail": "Core platform on GitHub. Regular third-party penetration testing. SOC 2 Type II compliance in progress."
+    },
+    "questionsAboutSecurity": "Questions about security?",
+    "contactUs": "Contact us"
+  },
+  "avatar": {
+    "steps": {
+      "rotation": "Angle",
+      "skin": "Skin",
+      "hairStyle": "Hair",
+      "hairColor": "Color",
+      "expression": "Face",
+      "intensity": "Mood"
+    },
+    "intensityLabels": {
+      "chill": "Chill",
+      "normal": "Normal",
+      "hyped": "Hyped"
+    },
+    "back": "← Back"
   }
 }

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -78,21 +78,135 @@
     "button": "Unirse a lista de espera"
   },
   "nav": {
-    "docs": "Docs",
+    "docs": "Documentos",
     "blog": "Blog",
     "skills": "Skills",
-    "glossary": "Glosario",
     "pricing": "Precios",
     "github": "GitHub",
     "contact": "Agendar demo",
-    "joinWaitlist": "Registrarse"
+    "joinWaitlist": "Registrarse",
+    "security": "Seguridad",
+    "useCases": "Casos de uso",
+    "signOut": "Cerrar sesión",
+    "openApp": "Abrir app"
   },
   "pricing": {
     "title": "Elige Tu Plan",
-    "subtitle": "Comienza gratis y escala según crezcas. Sin tarjeta de crédito."
+    "subtitle": "Comienza gratis y escala según crezcas. Sin tarjeta de crédito.",
+    "heroTitle": "Paga por lo que usas, nada más",
+    "heroDescription": "Comienza gratis con tu compañero de IA. Escala cuando estés listo, sin tarjeta de crédito.",
+    "free": {
+      "description": "Comienza gratis con tu compañero de IA.",
+      "features": {
+        "starterCredits": "10.000 créditos iniciales",
+        "concurrentRun": "1 ejecución simultánea",
+        "unlimitedAgents": "Agentes totales ilimitados",
+        "bringOwnLLM": "Usa tus propias claves de LLM",
+        "communitySupport": "Soporte de la comunidad"
+      },
+      "buttonText": "Comenzar"
+    },
+    "pro": {
+      "description": "Más potencia y colaboración fluida para tu equipo.",
+      "features": {
+        "credits": "20.000 créditos / mes",
+        "concurrentRuns": "2 ejecuciones simultáneas",
+        "unlimitedAgents": "Agentes totales ilimitados",
+        "bringOwnLLM": "Usa tus propias claves de LLM",
+        "creditsRollover": "Créditos acumulables (1 mes)",
+        "emailSupport": "Soporte por correo electrónico"
+      },
+      "buttonText": "Comenzar con Pro"
+    },
+    "team": {
+      "description": "Escala rápido sin fricción y con total flexibilidad.",
+      "features": {
+        "credits": "120.000 créditos / mes",
+        "concurrentRuns": "5 ejecuciones simultáneas",
+        "unlimitedAgents": "Agentes totales ilimitados",
+        "bringOwnLLM": "Usa tus propias claves de LLM",
+        "creditsRollover": "Créditos acumulables (1 mes)",
+        "prioritySupport": "Soporte prioritario"
+      },
+      "buttonText": "Comenzar con Team"
+    },
+    "needMoreCredits": "¿Necesitas más créditos?",
+    "topUpDescription": "Recarga en cualquier momento a",
+    "topUpRate": "1.000 créditos por $1",
+    "topUpAutoRecharge": "Configura la recarga automática para que tus agentes nunca se detengan: cuando tu saldo baje de un umbral, los créditos se compran automáticamente.",
+    "perCredits": "por 1.000 créditos",
+    "comparePlans": "Comparar planes",
+    "featuresHeader": "Funcionalidades",
+    "sections": {
+      "creditsAndAgents": "Créditos y agentes",
+      "connectorsAndIntegrations": "Conectores e integraciones",
+      "securityAndCompliance": "Seguridad y cumplimiento",
+      "collaboration": "Colaboración",
+      "support": "Soporte"
+    },
+    "tableFeatures": {
+      "creditsPerMonth": "Créditos por mes",
+      "creditsPerMonthDesc": "Créditos consumidos por el uso de modelos de IA en todos los agentes",
+      "concurrentRuns": "Ejecuciones simultáneas",
+      "concurrentRunsDesc": "Número de agentes que pueden ejecutarse simultáneamente",
+      "totalAgents": "Agentes totales",
+      "totalAgentsDesc": "Número máximo de agentes que puedes crear",
+      "creditsRollover": "Acumulación de créditos",
+      "creditsRolloverDesc": "Los créditos no utilizados se transfieren al siguiente período de facturación",
+      "creditTopUp": "Recarga de créditos",
+      "creditTopUpDesc": "Compra créditos adicionales en cualquier momento a $1 por 1.000 créditos",
+      "autoRecharge": "Recarga automática",
+      "autoRechargeDesc": "Compra automática de créditos cuando el saldo cae por debajo de un umbral",
+      "connectors": "Conectores",
+      "connectorsDesc": "Conecta tus herramientas como Slack, GitHub, Notion y más",
+      "bringOwnLLM": "Usa tu propio LLM",
+      "bringOwnLLMDesc": "Usa las claves API de tu propio proveedor de modelos",
+      "sandboxedExecution": "Ejecución aislada",
+      "sandboxedExecutionDesc": "Firecracker microVMs con aislamiento KVM a nivel de hardware",
+      "fullAuditTrail": "Registro de auditoría completo",
+      "fullAuditTrailDesc": "Tráfico HTTP/HTTPS del agente registrado con integridad SHA-256 por ejecución",
+      "noCredentialExposure": "Sin exposición de credenciales",
+      "noCredentialExposureDesc": "Los secretos se inyectan a nivel de red, nunca visibles para el código del agente",
+      "teamMembers": "Miembros del equipo",
+      "teamMembersDesc": "Número de personas en tu espacio de trabajo",
+      "perMemberCreditCaps": "Límites de crédito por miembro",
+      "perMemberCreditCapsDesc": "Establece límites de gasto para miembros individuales del equipo",
+      "communitySupport": "Soporte de la comunidad",
+      "communitySupportDesc": "Acceso a la comunidad de Discord y documentación",
+      "emailSupport": "Soporte por correo electrónico",
+      "emailSupportDesc": "Soporte directo por correo electrónico del equipo de VM0",
+      "prioritySupport": "Soporte prioritario",
+      "prioritySupportDesc": "Soporte dedicado con tiempos de respuesta más rápidos"
+    },
+    "tableValues": {
+      "starter": "10.000 iniciales",
+      "20k": "20.000",
+      "120k": "120.000",
+      "unlimited": "Ilimitado",
+      "oneMonth": "1 mes",
+      "allConnectors": "Todos los conectores"
+    },
+    "faq": {
+      "title": "Preguntas frecuentes",
+      "whatAreCredits": "¿Qué son los créditos?",
+      "whatAreCreditsAnswer": "Los créditos se consumen cuando tus agentes usan modelos de IA. Diferentes modelos consumen créditos a diferentes tasas. Por ejemplo, una tarea simple puede usar pocos créditos, mientras que un flujo de trabajo complejo de varios pasos usa más.",
+      "changePlans": "¿Puedo cambiar de plan en cualquier momento?",
+      "changePlansAnswer": "¡Sí! Puedes actualizar o reducir tu plan en cualquier momento. Los cambios surten efecto inmediatamente y prorrateamos los cargos en consecuencia.",
+      "runOutOfCredits": "¿Qué pasa cuando se me acaban los créditos?",
+      "runOutOfCreditsAnswer": "Cuando tus créditos se agoten, tus agentes dejarán de funcionar. Puedes comprar créditos adicionales mediante recarga automática o actualizar a un plan superior para más créditos mensuales.",
+      "doCreditsRollOver": "¿Se acumulan los créditos no utilizados?",
+      "doCreditsRollOverAnswer": "En el plan Free, los créditos iniciales no caducan pero no se reponen. En Pro, los créditos no utilizados se acumulan por 1 mes. En Team, los créditos se acumulan por 1 mes.",
+      "bringOwnModel": "¿Puedo usar mi propio proveedor de modelos?",
+      "bringOwnModelAnswer": "¡Sí! Todos los planes permiten usar tus propias claves API de LLM (Anthropic, etc.). Al usar tus propias claves, no se consumen créditos de VM0 para el uso de modelos.",
+      "howSecure": "¿Qué tan seguro es VM0?",
+      "howSecureAnswer": "Cada ejecución de agente se realiza en una microVM Firecracker aislada con aislamiento KVM a nivel de hardware. Las credenciales se inyectan a nivel de red y nunca se exponen al código del agente. Todo el tráfico HTTP/HTTPS del agente se registra con integridad SHA-256 por ejecución.",
+      "annualBilling": "¿Ofrecen facturación anual o descuentos?",
+      "annualBillingAnswer": "Contáctanos para discutir precios por volumen, descuentos de facturación anual y acuerdos personalizados para tu equipo."
+    },
+    "perMonth": "/mes"
   },
   "footer": {
-    "tagline": "Zero, your trustworthy AI teammate.",
+    "tagline": "Zero, tu compañero de IA de confianza.",
     "copyright": "© 2026 VM0.ai Todos los derechos reservados.",
     "language": "Idioma",
     "status": "Estado",
@@ -135,142 +249,6 @@
       "Other": "Otros"
     }
   },
-  "glossary": {
-    "hero": {
-      "title": "Glosario de Construcción de Agentes",
-      "description": "Domina el lenguaje de los agentes de IA. Explora conceptos clave, terminología y características específicas de VM0 para acelerar tu viaje de desarrollo de agentes."
-    },
-    "search": {
-      "placeholder": "Buscar términos...",
-      "allCategories": "Todas las Categorías",
-      "showingAll": "Mostrando todos los términos",
-      "found": "Encontrado",
-      "results": "términos",
-      "noResults": "No se encontraron términos que coincidan con tu búsqueda"
-    },
-    "relatedTerms": "Términos relacionados",
-    "categories": {
-      "Core Concepts": "Conceptos Básicos",
-      "Execution": "Ejecución",
-      "Infrastructure": "Infraestructura",
-      "VM0 Features": "Características de VM0",
-      "Development": "Desarrollo"
-    },
-    "terms": {
-      "agent": {
-        "name": "Agente",
-        "definition": "Un programa de IA autónomo que puede comprender instrucciones, tomar decisiones, usar herramientas y ejecutar tareas de forma independiente. A diferencia de los scripts tradicionales, los agentes pueden adaptar su enfoque según el contexto e iterar hacia objetivos."
-      },
-      "skill": {
-        "name": "Skill",
-        "definition": "Una integración o capacidad prediseñada que los agentes pueden usar para interactuar con servicios externos. Las skills proporcionan a los agentes funcionalidad lista para usar como acceso a Slack, GitHub, Notion u otras APIs sin necesidad de implementación personalizada."
-      },
-      "tool": {
-        "name": "Herramienta",
-        "definition": "Una función o API que un agente puede llamar para realizar acciones específicas. Las herramientas son los bloques de construcción de las capacidades del agente, permitiéndoles leer archivos, hacer solicitudes HTTP, consultar bases de datos o interactuar con cualquier sistema externo."
-      },
-      "prompt": {
-        "name": "Prompt",
-        "definition": "Instrucciones en lenguaje natural dadas a un agente para definir su tarea, comportamiento u objetivo. Los prompts pueden variar desde comandos simples hasta instrucciones de sistema complejas que dan forma a cómo piensa y opera un agente."
-      },
-      "context": {
-        "name": "Contexto",
-        "definition": "La información disponible para un agente durante la ejecución, incluido el historial de conversación, la memoria, las salidas de herramientas y el estado del entorno. El contexto ayuda a los agentes a mantener coherencia a través de las interacciones y tomar decisiones informadas."
-      },
-      "session": {
-        "name": "Sesión",
-        "definition": "Un período continuo de ejecución del agente que preserva el estado, la memoria y el contexto. Las sesiones permiten a los agentes mantener conciencia a través de múltiples interacciones y reanudar el trabajo sin perder progreso."
-      },
-      "checkpoint": {
-        "name": "Checkpoint",
-        "definition": "Una instantánea del estado de un agente en un momento específico, capturando su memoria, contexto y progreso de ejecución. Los checkpoints permiten reproducibilidad, permitiéndote restaurar, bifurcar o repetir ejecuciones del agente."
-      },
-      "artifact": {
-        "name": "Artefacto",
-        "definition": "Archivos, datos o salidas generados por un agente durante la ejecución. Los artefactos persisten a través de ejecuciones y pueden incluir código, documentos, resultados de análisis o cualquier otro entregable producido por el agente."
-      },
-      "observability": {
-        "name": "Observabilidad",
-        "definition": "La capacidad de inspeccionar, monitorear y comprender el comportamiento del agente a través de logs, métricas y trazas de ejecución. La observabilidad es esencial para depurar, optimizar y garantizar operaciones de IA transparentes."
-      },
-      "sandbox": {
-        "name": "Sandbox",
-        "definition": "Un entorno de ejecución aislado donde los agentes se ejecutan de forma segura sin afectar los sistemas de producción. Los sandboxes proporcionan límites de seguridad y garantizan que las acciones del agente estén contenidas y controladas."
-      },
-      "memory": {
-        "name": "Memoria",
-        "definition": "Información que un agente retiene a través de interacciones, permitiéndole aprender de experiencias pasadas y mantener el contexto a lo largo del tiempo. La memoria puede incluir hechos, preferencias, historial de conversación y patrones aprendidos."
-      },
-      "workflow": {
-        "name": "Flujo de trabajo",
-        "definition": "Una secuencia de tareas u operaciones que un agente ejecuta para lograr un objetivo. A diferencia de los scripts de automatización rígidos, los flujos de trabajo del agente pueden adaptarse y ajustarse según los resultados intermedios y las condiciones cambiantes."
-      },
-      "llm": {
-        "name": "LLM (Large Language Model)",
-        "definition": "El modelo de IA subyacente que impulsa el razonamiento y la toma de decisiones del agente. Los ejemplos incluyen Claude, GPT-4 y Gemini. Diferentes LLMs tienen diferentes fortalezas, costos y capacidades."
-      },
-      "skillMd": {
-        "name": "SKILL.md",
-        "definition": "Un archivo de configuración markdown que define el comportamiento, entradas, salidas y lógica de implementación de una skill. El archivo SKILL.md te permite crear skills personalizadas usando lenguaje natural y metadatos estructurados, facilitando la extensión de las capacidades del agente sin escribir código complejo."
-      },
-      "agentMd": {
-        "name": "AGENTS.md",
-        "definition": "Un archivo de configuración markdown que define el comportamiento, personalidad, objetivos y herramientas disponibles de un agente. El archivo AGENTS.md sirve como el plano del agente, especificando cómo debe pensar, qué puede hacer y cómo debe interactuar con usuarios y sistemas."
-      },
-      "volume": {
-        "name": "Volumen",
-        "definition": "Un espacio de almacenamiento persistente que preserva archivos y datos a través de ejecuciones del agente. Los volúmenes proporcionan a los agentes un sistema de archivos que persiste más allá de ejecuciones individuales, permitiéndoles almacenar estado, cachear datos y mantener artefactos a largo plazo."
-      },
-      "action": {
-        "name": "Acción",
-        "definition": "Una operación o tarea concreta que un agente realiza para lograr sus objetivos. Las acciones pueden incluir llamadas a APIs, lectura de archivos, procesamiento de datos o interacción con sistemas externos. Cada acción representa un solo paso en el flujo de ejecución del agente."
-      },
-      "runtime": {
-        "name": "Runtime",
-        "definition": "El entorno de ejecución donde se ejecutan los agentes, proporcionando la infraestructura, recursos y APIs necesarios. El runtime gestiona el ciclo de vida del agente, maneja la asignación de recursos y garantiza el aislamiento adecuado entre diferentes ejecuciones de agentes."
-      },
-      "orchestration": {
-        "name": "Orquestación",
-        "definition": "La coordinación y gestión de múltiples agentes, flujos de trabajo o tareas para lograr objetivos complejos. La orquestación maneja dependencias, secuenciación, ejecución paralela y asignación de recursos a través de operaciones de agentes distribuidos."
-      },
-      "mcp": {
-        "name": "MCP (Model Context Protocol)",
-        "definition": "Un protocolo abierto desarrollado por Anthropic que permite a los asistentes de IA conectarse de forma segura a fuentes de datos externas y herramientas. MCP proporciona una forma estandarizada para que los agentes accedan a recursos como bases de datos, APIs y sistemas de archivos mientras mantienen seguridad y conciencia del contexto."
-      },
-      "image": {
-        "name": "Imagen",
-        "definition": "Un contenedor empaquetado que incluye el código, runtime, dependencias y configuración necesarios para ejecutar un agente. Las imágenes proporcionan un entorno de ejecución consistente y reproducible, asegurando que los agentes se comporten de la misma manera en diferentes despliegues."
-      },
-      "secrets": {
-        "name": "Secretos",
-        "definition": "Información sensible como claves API, contraseñas y tokens que los agentes necesitan para acceder a servicios externos. Los secretos se almacenan de forma segura y se inyectan en el runtime del agente en el momento de ejecución, evitando la exposición en código o archivos de configuración."
-      },
-      "environmentVariable": {
-        "name": "Variable de Entorno",
-        "definition": "Un valor de configuración que se pasa a un agente en tiempo de ejecución, permitiéndote personalizar el comportamiento sin cambiar el código. Las variables de entorno se usan comúnmente para endpoints de API, feature flags y configuraciones no sensibles."
-      },
-      "virtualMachine": {
-        "name": "Máquina Virtual",
-        "definition": "Un entorno de computación aislado basado en software que emula una computadora física. Las máquinas virtuales proporcionan aislamiento completo entre ejecuciones de agentes, garantizando seguridad y previniendo interferencias. VM0 usa máquinas virtuales ligeras para ejecutar agentes con su propio sistema operativo, sistema de archivos y stack de red."
-      },
-      "cli": {
-        "name": "CLI (Command Line Interface)",
-        "definition": "Una interfaz basada en texto para interactuar con agentes y la plataforma VM0. La CLI permite a los desarrolladores crear, desplegar y gestionar agentes a través de comandos de terminal, proporcionando potentes capacidades de scripting y automatización sin requerir una interfaz gráfica."
-      },
-      "cliAgent": {
-        "name": "Agente CLI",
-        "definition": "Un agente diseñado específicamente para ser invocado y controlado a través de interfaces de línea de comandos. Los agentes CLI pueden integrarse en scripts, pipelines de CI/CD y flujos de trabajo de terminal, haciéndolos ideales para tareas de automatización y herramientas de desarrollo."
-      },
-      "agentRouter": {
-        "name": "Router de Agentes",
-        "definition": "Un sistema que enruta inteligentemente las solicitudes del agente al modelo de IA más apropiado según los requisitos de la tarea, restricciones de costos y necesidades de rendimiento. El router de agentes puede seleccionar dinámicamente entre diferentes LLMs (Claude, GPT, Gemini) o enrutar a modelos especializados para capacidades específicas."
-      },
-      "claudeCode": {
-        "name": "Claude Code",
-        "definition": "La herramienta oficial de línea de comandos de Anthropic para construir y desplegar agentes de IA. Claude Code proporciona una interfaz amigable para desarrolladores para crear agentes, gestionar skills e integrarse con la API de Claude. Optimiza el flujo de trabajo de desarrollo de agentes con características como recarga en vivo, herramientas de depuración y automatización de despliegue."
-      }
-    }
-  },
   "blog": {
     "title": "Blog",
     "description": "Perspectivas, tutoriales y actualizaciones sobre desarrollo nativo de agentes y el futuro de la infraestructura de IA.",
@@ -290,31 +268,725 @@
     "link": "Ver detalles"
   },
   "useCases": {
-    "title": "Use Cases",
-    "metaDescription": "Real workflows from teams using Zero as their AI teammate. See the exact prompts, outputs, and integrations.",
-    "heroTitle": "See what Zero can do for your team",
-    "heroSubtitle": "Real workflows from teams using Zero as their AI teammate. Each use case includes the exact prompt, Zero's output, and how to extend it.",
-    "role": "Role",
-    "capability": "Capability",
-    "all": "All",
-    "seeHow": "See how",
-    "comingSoon": "Coming soon",
-    "moreComingSoon": "More use cases coming",
-    "noResults": "No use cases match these filters.",
-    "whenThisHappens": "When this happens",
-    "whatYouSay": "What you say to Zero",
-    "whatZeroDoes": "What Zero does",
-    "whatsNext": "What's next",
-    "whatYouNeed": "What you need",
-    "required": "Required",
-    "optional": "Optional",
-    "tips": "Tips and best practices",
-    "relatedUseCases": "Related use cases",
-    "backToAll": "All use cases",
-    "zeroConnects": "Zero connects:",
-    "ctaTitle": "Zero works where your team works",
-    "ctaSubtitle": "Add Zero to Slack and start delegating in plain language. No setup wizards. No workflow builders. Just ask.",
-    "addToSlack": "Add Zero to Slack",
-    "bookDemo": "Book a demo"
+    "title": "Casos de uso",
+    "metaDescription": "Flujos de trabajo reales de equipos que usan Zero como su compañero de IA. Vea los prompts, salidas e integraciones exactos.",
+    "heroTitle": "Descubre lo que Zero puede hacer por tu equipo",
+    "heroSubtitle": "Flujos de trabajo reales de equipos que usan Zero como su compañero de IA. Cada caso de uso incluye el prompt exacto, la salida de Zero y cómo extenderlo.",
+    "role": "Rol",
+    "capability": "Capacidad",
+    "all": "Todos",
+    "seeHow": "Ver cómo",
+    "comingSoon": "Próximamente",
+    "moreComingSoon": "Más casos de uso en camino",
+    "noResults": "Ningún caso de uso coincide con estos filtros.",
+    "whenThisHappens": "Cuando esto sucede",
+    "whatYouSay": "Lo que le dices a Zero",
+    "whatZeroDoes": "Lo que hace Zero",
+    "whatsNext": "Qué sigue",
+    "whatYouNeed": "Lo que necesitas",
+    "required": "Obligatorio",
+    "optional": "Opcional",
+    "tips": "Consejos y buenas prácticas",
+    "relatedUseCases": "Casos de uso relacionados",
+    "backToAll": "Todos los casos de uso",
+    "zeroConnects": "Zero conecta:",
+    "ctaTitle": "Zero funciona donde trabaja tu equipo",
+    "ctaSubtitle": "Añade Zero a Slack y empieza a delegar en lenguaje natural. Sin asistentes de configuración. Sin creadores de flujos. Solo pregunta.",
+    "addToSlack": "Añadir Zero a Slack",
+    "bookDemo": "Reservar una demo",
+    "gallery": {
+      "moreToCome": "Más por venir",
+      "moreToComeDesc": "¿Tienes una forma inteligente de usar Zero?",
+      "submitYourCase": "Envía tu caso →"
+    },
+    "content": {
+      "sentry-triage": {
+        "title": "Convierte el ruido de Sentry en una lista de acciones priorizada",
+        "description": "Pide a Zero que obtenga los errores no resueltos de Sentry, ordenados por frecuencia. Zero lee los stack traces, explica la causa raíz en lenguaje sencillo y te dice qué archivo corregir primero.",
+        "timeSaved": "~25 min ahorrados",
+        "headings": {
+          "scenario": "Por qué la triaje de Sentry desperdicia tiempo de ingeniería",
+          "prompt": "Cómo pedir a Zero que priorice errores de Sentry",
+          "steps": "Cómo Zero analiza y clasifica tus errores de Sentry",
+          "nextActions": "Convierte la triaje de Sentry en issues de GitHub y automatización diaria",
+          "integrations": "Integraciones requeridas: Sentry y GitHub",
+          "tips": "Buenas prácticas para la triaje automatizada de Sentry"
+        },
+        "scenario": "Lunes por la mañana. Abres Slack y hay una docena de alertas de Sentry en #dev. La mayoría son ruido: tests inestables, problemas conocidos, errores transitorios que se resuelven solos. Pero en algún lugar podría haber algo real: una integración rota, un bug de facturación, un fallo que está afectando a usuarios reales. No quieres abrir el dashboard de Sentry y revisar issues uno por uno. Solo quieres saber: cuáles importan, qué tan graves son y qué los está causando.",
+        "promptVariants": [
+          {
+            "label": "Detallado",
+            "prompt": "@Zero revisa los fallos recientes en Sentry. Por favor, clasifica los fallos de las últimas 24 horas por frecuencia de ocurrencia.\n\nPara los tres fallos principales, dame un informe que incluya los stacks de error expandidos y detallados."
+          },
+          {
+            "label": "Rápido",
+            "prompt": "@Zero top 3 errores de Sentry en las últimas 24h, ordenados por cantidad."
+          },
+          {
+            "label": "Programado",
+            "prompt": "@Zero cada día laborable a las 9am, ejecuta esta misma verificación de Sentry y publica los resultados en #dev. Solo incluir errores con 5+ ocurrencias."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Yuma",
+            "text": "@Zero revisa los fallos recientes en Sentry. Ordena por frecuencia. Top 3 con stacks de error detallados."
+          },
+          {
+            "name": "Zero",
+            "text": "Aquí está el informe completo de fallos de Sentry.\n\n#\tProblema\tCantidad\tPrioridad\n1\tSlack missing_scope\t57\tAlta\n2\tID de precio Stripe desconocido\t15\tAlta\n3\tZeroSidebar .map()\t10\tMedia"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero se conecta a Sentry",
+            "description": "Zero obtiene los issues no resueltos de tu proyecto de Sentry para la ventana de tiempo especificada y los clasifica por cantidad de ocurrencias."
+          },
+          {
+            "title": "Tabla resumen",
+            "description": "Zero responde en el mismo hilo de Slack con una tabla resumen rápida: nombre del issue, cantidad de ocurrencias y nivel de prioridad, que puedes escanear en 5 segundos."
+          },
+          {
+            "title": "Análisis detallado",
+            "description": "Para cada issue principal, Zero proporciona stack traces anotados y explicaciones de la causa raíz en lenguaje sencillo. Por ejemplo, no solo dice \"ID de precio Stripe desconocido\", sino que explica que probablemente se creó un nuevo precio en Stripe pero no se actualizó el mapeo correspondiente."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Convertir hallazgos en acción",
+            "description": "Crear issues de GitHub a partir del informe",
+            "examplePrompt": "@Zero crea issues de GitHub para #1 y #2. Asigna #1 a Lancy (corrección de scope de Slack) y #2 a James (mapeo de Stripe). Etiqueta ambos como bug, prioridad alta."
+          },
+          {
+            "title": "Profundizar",
+            "description": "Pedir a Zero que investigue un error específico",
+            "examplePrompt": "@Zero para el issue #1, ¿qué scope OAuth de Slack falta exactamente? Revisa nuestro manifiesto de app y dime qué agregar."
+          },
+          {
+            "title": "Convertir en rutina",
+            "description": "Programar como verificación diaria",
+            "examplePrompt": "@Zero cada día laborable a las 9am, ejecuta esta misma verificación de Sentry y publica los resultados en #dev. Solo incluir errores con 5+ ocurrencias."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Conexión OAuth a tu organización de Sentry. Zero necesita acceso de lectura a issues y eventos."
+          },
+          {
+            "description": "Solo necesario si quieres que Zero cree issues a partir del informe. Acceso de lectura/escritura a issues."
+          }
+        ],
+        "tips": [
+          "Sé específico con la ventana de tiempo. \"Últimas 24 horas\" para triaje diario, \"errores desde el último deploy\" para verificaciones post-deploy.",
+          "Agrega un filtro de severidad para reducir el ruido: solo mostrar errores con 10+ ocurrencias u omitir errores etiquetados como known-issue.",
+          "Encadénalo con tu standup: combínalo con el caso de uso de standup para un resumen matutino que incluya tanto tu resumen de tareas como el informe de Sentry."
+        ]
+      },
+      "standup-summary": {
+        "title": "Prepara tu standup sin abrir 5 aplicaciones",
+        "description": "Zero obtiene datos del calendario, correo electrónico y Linear, luego escribe un resumen compartible que puedes pegar directamente en el hilo del equipo.",
+        "timeSaved": "~20 min ahorrados",
+        "headings": {
+          "scenario": "El caos diario del standup entre Calendar, Gmail y Linear",
+          "prompt": "Cómo pedir a Zero un resumen de standup",
+          "steps": "Cómo Zero compila tu resumen de trabajo desde 3 herramientas",
+          "nextActions": "Publicar en Slack, agregar bloqueantes o automatizar diariamente",
+          "integrations": "Integraciones requeridas: Google Calendar, Gmail y Linear",
+          "tips": "Buenas prácticas para resúmenes de standup generados por IA"
+        },
+        "scenario": "Son las 9:50 AM y el standup comienza en 10 minutos. Aún no has revisado tu calendario. Le pides a Zero que obtenga las reuniones de ayer, correos y tareas de Linear; Zero escribe un resumen que puedes pegar directamente en el hilo del equipo.",
+        "promptVariants": [
+          {
+            "label": "Detallado",
+            "prompt": "@Zero revisa mi calendario, correos y tareas de Linear desde ayer y escríbeme un resumen de trabajo. Incluye destacados de reuniones y estado de PRs."
+          },
+          {
+            "label": "Rápido",
+            "prompt": "@Zero ¿qué hice ayer? Revisa calendario y Linear."
+          },
+          {
+            "label": "Programado",
+            "prompt": "@Zero cada día laborable a las 9:45am, escribe mi resumen de standup y envíamelo por DM."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero revisa mi calendario, correos y tareas de Linear desde ayer y escríbeme un resumen de trabajo"
+          },
+          {
+            "name": "Zero",
+            "text": "Resumen de trabajo: 23–24 Mar\n\nReuniones\n• Standups diarios (10–10:30 AM)\n• Entrevista de usuario VM0 con Daniel Miller\n\nIngeniería\n• PR #5467 mergeado, permisos de firewall\n• PR #6277 en revisión. Lighthouse en 36"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero revisa tu calendario",
+            "description": "Zero lee tus eventos de Google Calendar de las últimas 24 horas y extrae nombres de reuniones, horarios y asistentes."
+          },
+          {
+            "title": "Zero escanea correos y tareas",
+            "description": "Zero revisa Gmail en busca de hilos relevantes y Linear en busca de tareas que actualizaste, completaste o te fueron asignadas desde ayer."
+          },
+          {
+            "title": "Resumen formateado",
+            "description": "Zero compila todo en un resumen limpio y listo para copiar y pegar, organizado por Reuniones, trabajo de Ingeniería y elementos de acción."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Publicar directamente en un canal",
+            "description": "Que Zero publique el resumen en #standup",
+            "examplePrompt": "@Zero publica este resumen en #standup y etiqueta a @team-eng."
+          },
+          {
+            "title": "Agregar contexto",
+            "description": "Pedir a Zero que incluya bloqueantes o prioridades",
+            "examplePrompt": "@Zero también revisa mi Linear en busca de tareas bloqueadas y agrégalas como bloqueantes en el resumen."
+          },
+          {
+            "title": "Hacerlo diario",
+            "description": "Automatizar tu preparación matutina",
+            "examplePrompt": "@Zero cada día laborable a las 9:45am, escribe mi resumen de standup y envíamelo por DM."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Conexión OAuth a Google Calendar. Zero necesita acceso de lectura a tus eventos."
+          },
+          {
+            "description": "Conexión OAuth a Gmail. Zero necesita acceso de lectura para escanear hilos recientes."
+          },
+          {
+            "description": "Conexión OAuth a Linear. Zero lee tus tareas asignadas y actualizadas."
+          }
+        ],
+        "tips": [
+          "Dile a Zero tu formato de standup si difiere del predeterminado. \"usa el formato: Ayer / Hoy / Bloqueantes\".",
+          "Especifica la ventana de tiempo. \"desde ayer a las 5pm\" si trabajas hasta tarde.",
+          "Combínalo con la triaje de Sentry para un resumen matutino de ingeniería completo."
+        ]
+      },
+      "kol-cold-outreach": {
+        "title": "Investiga un KOL en X y redacta un correo de contacto personalizado",
+        "description": "Dale a Zero un handle de X. Lee sus últimos 30 posts, entiende su estilo e intereses, redacta un correo de contacto personalizado de menos de 150 palabras y lo guarda como borrador en Gmail.",
+        "timeSaved": "~20 min ahorrados",
+        "headings": {
+          "scenario": "Por qué el contacto frío genérico es ignorado",
+          "prompt": "Cómo investigar un KOL y redactar contacto personalizado",
+          "steps": "Cómo Zero analiza perfiles de X y crea correos personalizados",
+          "nextActions": "Evaluar compatibilidad del KOL, enviar en lote o rastrear en Notion CRM",
+          "integrations": "Integraciones requeridas: X, Gmail y Notion",
+          "tips": "Buenas prácticas para contacto con KOL asistido por IA"
+        },
+        "scenario": "Encontraste un KOL perfecto para una asociación, pero escribir un correo frío que no se sienta genérico toma 20 minutos de investigación: leer sus posts, entender qué les importa, encontrar el ángulo correcto. Le das a Zero su handle de X y obtienes un borrador personalizado en segundos.",
+        "promptVariants": [
+          {
+            "label": "Detallado",
+            "prompt": "@Zero lee los últimos 30 posts de X de @swyx para entender su estilo e intereses. Escribe un correo de contacto frío personalizado de menos de 150 palabras sobre una asociación con VM0. Referencia algo específico que publicó recientemente. Guárdalo como borrador de Gmail."
+          },
+          {
+            "label": "Rápido",
+            "prompt": "@Zero redacta un correo frío a @swyx sobre VM0, basado en sus posts de X. Guardar como borrador de Gmail."
+          },
+          {
+            "label": "Lote",
+            "prompt": "@Zero para cada handle en mi lista de KOL de Notion marcado como \"No contactado\", investiga su perfil de X y redacta un correo de contacto personalizado. Guardar todos como borradores de Gmail."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero lee los últimos 30 posts de X de @swyx, entiende su estilo y redacta un correo de contacto frío para una asociación con VM0. Guardar como borrador de Gmail."
+          },
+          {
+            "name": "Zero",
+            "text": "Listo. Analicé el contenido reciente de @swyx:\n• Enfoque: agentes de IA, herramientas para desarrolladores, código abierto\n• Tono: Técnico pero conversacional\n• Compatibilidad de audiencia: Alta (9/10)\n\nBorrador de Gmail guardado: \"Agentes que entregan trabajo real, pensé que te interesaría\""
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero lee el perfil de X del KOL",
+            "description": "Zero obtiene los últimos 30 posts, analiza temas de contenido, tono, audiencia y patrones de engagement para crear un perfil de lo que le importa a esta persona."
+          },
+          {
+            "title": "Correo personalizado redactado",
+            "description": "Zero escribe un correo de contacto conciso que hace referencia a contenido específico publicado por el KOL, explica la relevancia de tu producto y usa un tono que coincide con su estilo."
+          },
+          {
+            "title": "Borrador guardado en Gmail",
+            "description": "El correo se guarda como borrador de Gmail listo para tu revisión. Zero también actualiza el estado del KOL en tu Notion CRM si está conectado."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Evaluar compatibilidad del KOL",
+            "description": "Calificar qué tan bien coincide un KOL con tu audiencia",
+            "examplePrompt": "@Zero analiza la superposición de audiencia de @swyx con el ICP de VM0. Puntúa de 1 a 10 con justificación y guarda en Notion."
+          },
+          {
+            "title": "Contacto en lote",
+            "description": "Redactar correos para múltiples KOLs a la vez",
+            "examplePrompt": "@Zero para los 10 principales KOLs en mi lista de Notion, investiga cada uno y redacta correos de contacto personalizados."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero lee posts públicos para entender el estilo e intereses del KOL."
+          },
+          {
+            "description": "Zero guarda el correo redactado en tus borradores de Gmail."
+          },
+          {
+            "description": "Opcional: rastrea el estado del KOL y puntuaciones de compatibilidad en tu Notion CRM."
+          }
+        ],
+        "tips": [
+          "Dale a Zero contexto sobre el enfoque de tu producto. \"enfócate en cómo VM0 ayuda a empresas de herramientas para desarrolladores\".",
+          "Pide múltiples variantes. \"redacta 2 versiones: una casual, una profesional\".",
+          "Siempre revisa antes de enviar. Zero investiga correctamente, pero la voz final debe ser la tuya."
+        ]
+      },
+      "file-bugs-from-slack": {
+        "title": "Reporta bugs desde Slack sin cambiar de contexto",
+        "description": "Describe el problema en lenguaje natural. Zero crea un issue de GitHub formateado, le pone etiquetas y asigna a la persona correcta.",
+        "timeSaved": "Instantáneo",
+        "headings": {
+          "scenario": "Por qué crear issues de GitHub desde Slack ahorra cambios de contexto",
+          "prompt": "Cómo crear issues de GitHub desde un mensaje de Slack",
+          "steps": "Cómo Zero analiza tu mensaje y crea un issue formateado",
+          "nextActions": "Agregar detalles, crear issues en lote o automatizar la triaje",
+          "integrations": "Integraciones requeridas: GitHub y Slack",
+          "tips": "Buenas prácticas para reportar bugs desde Slack"
+        },
+        "scenario": "Acabas de notar un bug de UX durante una demo. En lugar de abrir GitHub, buscar el repositorio, escribir un issue formateado y asignar a alguien, lo describes en Slack. Zero crea el issue, agrega etiquetas y asigna a la persona correcta. Nunca dejas la conversación.",
+        "promptVariants": [
+          {
+            "label": "Detallado",
+            "prompt": "@Zero crear issue: presionar ESC en el diálogo de programación lo cierra inmediatamente incluso con ediciones sin guardar. Debería pedir confirmación primero. Asignar a Lancy. Etiquetar como bug, platform. Prioridad media."
+          },
+          {
+            "label": "Rápido",
+            "prompt": "@Zero bug: ESC cierra diálogo de programación sin confirmación de guardado. Asignar a Lancy."
+          },
+          {
+            "label": "Programado",
+            "prompt": "@Zero cada viernes a las 4pm, revisa el canal #bugs en busca de reportes de bugs sin resolver y crea issues de GitHub para cada uno."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero crear issue: presionar ESC en el diálogo de programación lo cierra inmediatamente incluso con ediciones sin guardar. Debería pedir confirmación primero. Asignar a Lancy."
+          },
+          {
+            "name": "Zero",
+            "text": "Issue creado:\n#6260: bug: tecla ESC cierra diálogo de programación sin confirmar\nAsignado a Lancy · Prioridad: Media"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero analiza la solicitud",
+            "description": "Zero entiende la descripción del bug, identifica al asignado e infiere las etiquetas apropiadas (bug, platform) y la prioridad del contexto."
+          },
+          {
+            "title": "Issue creado en GitHub",
+            "description": "Zero crea un issue de GitHub correctamente formateado con título claro, descripción, etiquetas y asignación, todo desde tu mensaje de Slack en lenguaje natural."
+          },
+          {
+            "title": "Confirmación en Slack",
+            "description": "Zero responde en el mismo hilo con el número del issue, título, asignado y un enlace directo para que puedas verificar sin salir de Slack."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Agregar más detalle",
+            "description": "Adjuntar capturas de pantalla o pasos para reproducir",
+            "examplePrompt": "@Zero agregar a #6260: pasos para reproducir. 1. Abrir diálogo de programación 2. Escribir algo 3. Presionar ESC. Esperado: diálogo de confirmación."
+          },
+          {
+            "title": "Crear issues en lote",
+            "description": "Crear múltiples issues a la vez",
+            "examplePrompt": "@Zero crea 3 issues de estos bugs:\n1. Cierre de diálogo con ESC (Lancy)\n2. Selector de fecha desfasado un día (James)\n3. Carga de avatar falla en Safari (Yuma)"
+          },
+          {
+            "title": "Automatizar triaje",
+            "description": "Crear issues automáticamente desde un canal",
+            "examplePrompt": "@Zero vigila #bugs, cuando alguien publique un mensaje que empiece con \"bug:\", crea automáticamente un issue de GitHub y responde con el enlace."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Conexión OAuth a GitHub. Zero necesita acceso de lectura/escritura para crear y gestionar issues."
+          },
+          {
+            "description": "Zero lee tu mensaje y responde en el mismo hilo."
+          }
+        ],
+        "tips": [
+          "Incluye el nombre del asignado. Zero asocia los nombres de Slack con los usuarios de GitHub.",
+          "Menciona etiquetas explícitamente si quieres unas específicas; de lo contrario, Zero las infiere del contexto.",
+          "También funciona para solicitudes de funciones: simplemente di \"solicitud de función\" en lugar de \"bug\"."
+        ]
+      },
+      "slack-triage": {
+        "title": "Filtra el ruido de Slack y encuentra lo que necesita tu atención",
+        "description": "Zero escanea tus mensajes no leídos de Slack, filtra bots y ruido, y te muestra solo los mensajes que realmente necesitan tu acción hoy, ordenados por urgencia.",
+        "timeSaved": "~10 min ahorrados",
+        "headings": {
+          "scenario": "Por qué la sobrecarga de Slack causa que se pierdan elementos de acción",
+          "prompt": "Cómo pedir a Zero que priorice tus mensajes no leídos de Slack",
+          "steps": "Cómo Zero filtra el ruido y destaca mensajes accionables",
+          "nextActions": "Responder directamente, crear tareas o automatizar la triaje diaria",
+          "integrations": "Integraciones requeridas: Slack",
+          "tips": "Buenas prácticas para la triaje de mensajes de Slack"
+        },
+        "scenario": "Abres Slack después de un bloque de concentración de 2 horas y hay 47 mensajes no leídos en 12 canales. La mayoría son notificaciones de bots, alertas automatizadas y conversaciones que no te necesitan. En algún lugar del ruido hay 3 cosas que realmente necesitan tu respuesta. En lugar de desplazarte por todo, le pides a Zero que encuentre lo que importa.",
+        "promptVariants": [
+          {
+            "label": "Detallado",
+            "prompt": "@Zero escanea mis mensajes no leídos de Slack de las últimas 12 horas. Filtra bots, notificaciones automatizadas e hilos en los que no estoy etiquetado. Muéstrame solo mensajes que necesiten mi acción hoy, ordenados por urgencia. Para cada uno, dime quién espera y qué necesita."
+          },
+          {
+            "label": "Rápido",
+            "prompt": "@Zero ¿qué necesita mi atención en Slack ahora mismo?"
+          },
+          {
+            "label": "Programado",
+            "prompt": "@Zero cada mañana a las 9am y después del almuerzo a la 1pm, escanea mis no leídos y envíame por DM lo que necesita acción."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero escanea mis mensajes no leídos de Slack de las últimas 12 horas. Filtra bots y ruido. Muéstrame solo lo que necesita mi acción hoy."
+          },
+          {
+            "name": "Zero",
+            "text": "Encontré 47 mensajes no leídos. 5 necesitan tu acción:\n\n1. @Ethan pidió tu revisión de diseño en PR #6312\n2. @James necesita aprobación del plan de migración de Stripe\n3. #support tiene un P0 de un cliente que menciona churn\n4. @Scarlett te etiquetó en una decisión de contacto con KOL\n5. Sprint review movido a las 3pm (era a las 2pm)"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero escanea tus canales",
+            "description": "Zero lee tus mensajes no leídos en todos los canales, filtrando mensajes de bots, alertas automatizadas de CI/CD e hilos donde no te mencionan ni te necesitan."
+          },
+          {
+            "title": "Mensajes clasificados por urgencia",
+            "description": "Cada mensaje restante es evaluado: ¿alguien te espera? ¿Hay una fecha límite? ¿Es una decisión que bloquea a otros? Zero los clasifica por la urgencia con la que necesitan tu respuesta."
+          },
+          {
+            "title": "Resumen accionable entregado",
+            "description": "Zero te envía por DM una lista numerada de lo que necesita atención, con quién pregunta, qué necesita y un enlace directo a cada hilo. Todo lo demás se puede ignorar con seguridad."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Responder a través de Zero",
+            "description": "Responder sin abrir cada hilo",
+            "examplePrompt": "@Zero responde a #1: \"Se ve bien, aprobado. Envíalo.\" Y para #3, crea un issue P0 en Linear y asígnalo a James."
+          },
+          {
+            "title": "Convertir en rutina",
+            "description": "Auto-triaje cada mañana",
+            "examplePrompt": "@Zero cada día laborable a las 9am, escanea mis no leídos de la noche y envíame los elementos de acción por DM."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero lee tus mensajes no leídos y te envía el resumen de triaje por DM."
+          },
+          {
+            "description": "Opcional: crea tareas directamente desde mensajes priorizados."
+          },
+          {
+            "description": "Opcional: Zero revisa tu calendario para señalar mensajes relacionados con reuniones."
+          }
+        ],
+        "tips": [
+          "Dile a Zero qué canales te importan más para que pueda priorizar en consecuencia.",
+          "Pide a Zero que aprenda tus patrones de ruido con el tiempo: \"siempre omite mensajes de @github-bot y @vercel-bot\".",
+          "Combínalo con el caso de uso de standup: primero prioriza, luego genera tu standup a partir de los elementos de acción."
+        ]
+      },
+      "employee-onboarding": {
+        "title": "Incorpora nuevos compañeros con un mensaje de Slack",
+        "description": "Dile a Zero quién se une y cuándo. Crea su página de onboarding en Notion, programa reuniones de bienvenida en Google Calendar, publica una presentación en Slack y les envía por DM su agenda de la primera semana.",
+        "timeSaved": "~45 min ahorrados",
+        "headings": {
+          "scenario": "Por qué las listas de verificación de onboarding manual siempre olvidan algo",
+          "prompt": "Cómo automatizar el onboarding de nuevos empleados con Zero",
+          "steps": "Cómo Zero configura Notion, Calendar y Slack para un nuevo compañero",
+          "nextActions": "Agregar aprovisionamiento de acceso o personalizar por rol",
+          "integrations": "Integraciones requeridas: Slack, Notion, Google Calendar y Gmail",
+          "tips": "Buenas prácticas para el onboarding automatizado de empleados"
+        },
+        "scenario": "Un nuevo compañero empieza el próximo lunes. Alguien necesita crear su documento de onboarding, programar reuniones de presentación con 5 personas, publicar un mensaje de bienvenida y enviarle la agenda de su primera semana. Son 45 minutos de coordinación que suceden de la misma manera cada vez. Se lo dices a Zero una vez y se encarga de todo.",
+        "promptVariants": [
+          {
+            "label": "Detallado",
+            "prompt": "@Zero incorpora a Sarah Chen como Product Designer a partir del 14 de abril. Duplica la plantilla de onboarding de Notion, programa reuniones de presentación de la semana 1 con Ethan, Lancy, James, Yuma y Scarlett en Google Calendar. Programa un check-in a los 30 días. Publica una bienvenida en #general y envía a Sarah por DM su agenda de la primera semana."
+          },
+          {
+            "label": "Rápido",
+            "prompt": "@Zero incorpora a Sarah Chen, Product Designer, empezando el 14 de abril. Configuración completa."
+          },
+          {
+            "label": "Plantilla",
+            "prompt": "@Zero cuando alguien publique en #new-hires con el formato \"Nombre / Rol / Fecha de inicio\", ejecuta automáticamente el flujo completo de onboarding."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero incorpora a Sarah Chen, se une como Product Designer el 14 de abril. Configura todo."
+          },
+          {
+            "name": "Zero",
+            "text": "Onboarding para Sarah Chen listo:\n\n✔ Página de Notion creada desde plantilla\n✔ Reuniones de presentación de semana 1 programadas\n✔ Check-in de 30 días el 14 de mayo\n✔ Bienvenida publicada en #general\n✔ DM enviado con agenda de primera semana"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Página de onboarding en Notion creada",
+            "description": "Zero duplica tu plantilla de onboarding en Notion, completa el nombre del nuevo empleado, rol, fecha de inicio y gerente. Enlaza documentos relevantes y recursos del equipo."
+          },
+          {
+            "title": "Reuniones programadas",
+            "description": "Zero crea reuniones de presentación con los compañeros especificados en Google Calendar durante la primera semana, más un check-in a los 30 días. Todas las invitaciones del calendario incluyen contexto sobre qué discutir."
+          },
+          {
+            "title": "Bienvenida en Slack y DM enviado",
+            "description": "Zero publica un mensaje de bienvenida en #general presentando al nuevo compañero, luego le envía directamente por DM su agenda de la primera semana, enlaces a su página de Notion y contactos clave."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Personalizar por rol",
+            "description": "Onboarding diferente para diferentes roles",
+            "examplePrompt": "@Zero para ingenieros, también agrega una sesión de pair programming con el tech lead y enlaza los docs de arquitectura en la página de onboarding."
+          },
+          {
+            "title": "Automatizar triggers",
+            "description": "Ejecutar onboarding desde un post en un canal",
+            "examplePrompt": "@Zero cada vez que alguien publique en #new-hires con el formato \"Nombre / Rol / Fecha de inicio\", ejecuta el onboarding completo automáticamente."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero publica el mensaje de bienvenida y envía DM al nuevo empleado."
+          },
+          {
+            "description": "Zero crea la página de onboarding desde tu plantilla."
+          },
+          {
+            "description": "Zero programa reuniones de presentación y check-ins."
+          },
+          {
+            "description": "Opcional: enviar un correo de bienvenida con logística y enlaces."
+          }
+        ],
+        "tips": [
+          "Crea primero una plantilla de onboarding en Notion. Zero la duplica y completa los detalles.",
+          "Lista las personas que deben tener reuniones de presentación. Zero se encarga de la coordinación del calendario.",
+          "También funciona para contratistas y pasantes: solo ajusta la plantilla y la lista de reuniones."
+        ]
+      },
+      "build-with-v0": {
+        "title": "Convierte una idea de Slack en un prototipo interactivo al instante",
+        "description": "Cuando surge una idea en medio de una conversación, descríbela a Zero. Usa v0 para generar un prototipo React interactivo y publica el enlace de vista previa en el hilo, antes de que la discusión avance.",
+        "timeSaved": "Horas → segundos",
+        "headings": {
+          "scenario": "Por qué las ideas se pierden antes de que alguien pueda verlas",
+          "prompt": "Cómo convertir una idea de Slack en un prototipo con Zero",
+          "steps": "Cómo Zero va de tu descripción a una UI interactiva en vivo",
+          "nextActions": "Refinar, compartir o entregar a ingeniería",
+          "integrations": "Integraciones requeridas: v0",
+          "tips": "Buenas prácticas para prototipado rápido de ideas con v0"
+        },
+        "scenario": "Estás en un hilo de Slack debatiendo cómo debería funcionar una función. Alguien propone un nuevo patrón de UI: una paleta de comandos, un panel de configuración, un asistente de varios pasos. Las palabras no alcanzan. Dibujar en una pizarra no es opción. Programar una sesión de Figma pospone la decisión a la próxima semana. Describes la idea a Zero en lenguaje natural. Llama a v0, genera un prototipo React completamente interactivo y publica el enlace de vista previa en el hilo, en menos de un minuto. Todos pueden explorarlo antes de que la conversación avance.",
+        "promptVariants": [
+          {
+            "label": "Nueva idea de UI",
+            "prompt": "@Zero prototipar esto: una paleta de comandos que permite a los usuarios buscar agentes, ejecuciones recientes y conectores. Navegable por teclado, búsqueda difusa, muestra un panel de vista previa a la derecha."
+          },
+          {
+            "label": "Desde contexto del hilo",
+            "prompt": "@Zero basándote en el flujo que describimos arriba, construye un prototipo rápido en v0 para que el equipo lo vea antes de decidir."
+          },
+          {
+            "label": "Iterar",
+            "prompt": "@Zero actualiza el prototipo: agrega una pestaña de filtro arriba para 'Agentes / Ejecuciones / Conectores' y resalta el elemento activo en naranja. Regenerar."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Ethan",
+            "text": "@Zero prototipar esto: una paleta de comandos que permite a los usuarios buscar agentes, ejecuciones recientes y conectores. Navegable por teclado, búsqueda difusa, muestra una vista previa a la derecha."
+          },
+          {
+            "name": "Zero",
+            "text": "Aquí está el prototipo interactivo:\nv0.dev/r/cmd-palette-preview\n\nIncluye búsqueda difusa entre agentes, ejecuciones y conectores. Navegación con teclas de flecha. Panel de vista previa derecho se actualiza al pasar el cursor. Clic para abrir."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Describe la idea en lenguaje natural",
+            "description": "Sin especificaciones, sin wireframes. Dile a Zero qué debe hacer la UI: los componentes, las interacciones, los datos que muestra. Pega una descripción aproximada o simplemente improvisa desde el hilo."
+          },
+          {
+            "title": "Zero genera el prototipo vía v0",
+            "description": "Zero traduce tu descripción en un prompt estructurado de v0 y llama a la API de v0. v0 produce un componente React completamente interactivo: botones reales, estados reales, navegación real."
+          },
+          {
+            "title": "Enlace de vista previa publicado en Slack",
+            "description": "Zero publica la URL de vista previa de v0 en el mismo hilo. Los compañeros pueden explorar el prototipo inmediatamente, en cualquier dispositivo, sin instalar nada ni descargar código."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Refinar en el hilo",
+            "description": "Seguir iterando sin salir de Slack",
+            "examplePrompt": "@Zero actualiza el prototipo: el campo de búsqueda debería tener un icono a la izquierda, y el estado vacío debería mostrar elementos recientes en lugar de nada."
+          },
+          {
+            "title": "Compartir para feedback asíncrono",
+            "description": "Publicar en un canal más amplio o enviar DM a stakeholders",
+            "examplePrompt": "@Zero comparte el enlace del prototipo v0 en #product con el mensaje: 'Prototipo rápido de la idea de paleta de comandos — feedback bienvenido antes del jueves.'"
+          },
+          {
+            "title": "Entregar a ingeniería",
+            "description": "Exportar el código generado al repositorio",
+            "examplePrompt": "@Zero toma el código del prototipo v0 y abre un PR en vm0-ai/vm0 bajo turbo/apps/platform/src/components/CommandPalette.tsx para que el equipo lo desarrolle."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero envía tu idea como prompt de generación a v0 y obtiene la URL del prototipo interactivo. Conecta tu cuenta de v0 para habilitarlo."
+          },
+          {
+            "description": "Zero lee tu idea del hilo de Slack y publica el enlace del prototipo en la misma conversación."
+          }
+        ],
+        "tips": [
+          "Describe comportamiento, no solo apariencia. 'Al hacer clic en una fila se expanden los detalles debajo' genera un prototipo más preciso que 'filas expandibles'.",
+          "Referencia patrones de UI existentes por nombre — 'como la paleta de comandos de VS Code' o 'como el menú de barra de Notion' — para anclar la generación de v0.",
+          "Usa el prompt de iterar inmediatamente después del primer resultado. Una ronda de refinamiento generalmente te lleva al 90% del resultado."
+        ]
+      }
+    }
+  },
+  "landing": {
+    "hero": {
+      "title": "Zero, tu compañero de IA de confianza para trabajo real.",
+      "subtitle": "Zero se conecta a más de 100 herramientas y hace el trabajo. Informes, triaje, contacto, investigación. En Slack o en la web.",
+      "ctaGetStarted": "Comenzar",
+      "ctaOpenApp": "Abrir app",
+      "seeUseCases": "Ver casos de uso",
+      "seedBanner": "Lee nuestro blog sobre nuestra ronda semilla de $14M."
+    },
+    "worksForYou": {
+      "heading": "Lo que Zero realmente hace por ti",
+      "exploreMore": "Explorar más casos de uso"
+    },
+    "teammateCard": {
+      "title": "Un compañero que lee, piensa y entrega.",
+      "description": "“Resume mi semana desde Calendario, Linear y Slack.” Zero extrae el contexto de tus herramientas, conecta los puntos y te entrega un informe terminado. Como informar a un colega, excepto que toma segundos.",
+      "tabSummarize": "Resumir mi semana laboral",
+      "tabLeads": "Encontrar y enviar correos a leads",
+      "tabTriage": "Triaje de errores de Sentry",
+      "ariaDaily": "Informe diario",
+      "ariaLeads": "Correos a leads",
+      "ariaSentry": "Informe de Sentry"
+    },
+    "slackCard": {
+      "title": "Pregunta en Slack, obtén respuestas de todas tus herramientas.",
+      "description": "@Zero en cualquier canal. Consulta tu calendario, correo, Linear, GitHub y responde con un resumen que tu equipo puede usar de verdad. Sin cambiar de pestaña, sin dashboards.",
+      "tagSlack": "Slack",
+      "tagTeamSync": "Sincronización de equipo"
+    },
+    "syncedToolsCard": {
+      "title": "Del descubrimiento al contacto, los agentes hacen el trabajo pesado.",
+      "description": "Dile a Zero a quién buscas. Sus agentes rastrean plataformas sociales, crean listas de prospectos y redactan contactos personalizados para que tu equipo se enfoque en cerrar, no en buscar.",
+      "tagMarketing": "Outreach de marketing",
+      "tagCrossPlatform": "Multiplataforma"
+    },
+    "connectors": {
+      "heading": "Funciona con más de 100 herramientas que ya usas",
+      "description": "Slack, GitHub, Gmail, Notion, Linear, Sentry y más. Zero se conecta a tu stack para actuar, no solo responder."
+    },
+    "security": {
+      "heading": "Tus datos siguen siendo tuyos",
+      "permissionTitle": "Tú controlas a qué puede acceder Zero",
+      "permissionDesc": "Establece permisos de lectura y escritura por herramienta, por agente. Zero solo toca lo que tú permites explícitamente.",
+      "isolatedTitle": "Ejecución aislada, siempre",
+      "isolatedDescPart1": "Cada tarea se ejecuta en su propia microVM. Las credenciales nunca salen del sandbox. Totalmente auditable. Y ",
+      "isolatedDescLink": "código abierto",
+      "isolatedDescPart2": "."
+    },
+    "intelligence": {
+      "heading": "Se vuelve más inteligente cuanto más lo usas",
+      "memoryTitle": "Recuerda tu contexto",
+      "memoryDesc": "Decisiones pasadas, contexto del proyecto, tus preferencias — Zero lo lleva todo consigo. Sin re-explicar, sin contexto perdido entre sesiones.",
+      "scheduleTitle": "Inteligencia programada",
+      "scheduleDesc": "Zero ejecuta tareas recurrentes autónomas — escaneos diarios de errores, informes de deuda técnica, briefings matutinos — sin necesidad de solicitarlo.",
+      "subAgentsTitle": "Sub-agentes especializados",
+      "subAgentsDesc": "Crea agentes para trabajos específicos. Uno para investigación, uno para triaje, uno para contacto. Trabajan en paralelo para que tú no tengas que hacerlo.",
+      "toolOrchTitle": "Orquestación de herramientas",
+      "toolOrchDesc": "Zero selecciona y encadena las herramientas adecuadas de más de 100 integraciones disponibles. Tú describes el objetivo; Zero determina los pasos.",
+      "identityTitle": "Sabe quién eres",
+      "identityDesc": "\"Mis PRs\", \"asignarme a mí.\" Zero resuelve tu identidad en GitHub, Slack y Linear automáticamente. Sin configuración necesaria."
+    },
+    "cta": {
+      "title": "Tú decides qué importa. Zero se encarga del resto.",
+      "subtitle": "Comienza gratis. Úsalo en Slack o en la web. Sin tarjeta de crédito."
+    }
+  },
+  "securityPage": {
+    "title": "Seguridad",
+    "intro": "Cuando delegas trabajo a un agente de IA, tus mayores preocupaciones son la seguridad de los datos, la privacidad y mantener el control. VM0 fue diseñado desde el primer día con todo esto en mente.",
+    "isolatedExecution": {
+      "title": "Ejecución aislada",
+      "description": "Cada ejecución de agente ocurre dentro de un entorno privado completamente aislado. Cuando la ejecución termina, el entorno se destruye automáticamente, no queda nada. Piénsalo como un guante desechable: limpio, seguro y confiable.",
+      "detail": "Impulsado por Firecracker microVMs con aislamiento KVM a nivel de hardware, no contenedores. Cada ejecución obtiene su propio namespace de red de un pool preasignado de más de 16.000."
+    },
+    "secretsNeverExposed": {
+      "title": "Secretos nunca expuestos",
+      "description": "¿Conectando Gmail, Slack o GitHub? Tus tokens y credenciales se gestionan de forma segura. El agente puede usarlos, pero nunca puede verlos ni extraerlos. Incluso si algo sale mal en el código del agente, tus cuentas permanecen seguras.",
+      "detail": "Las credenciales se inyectan a nivel de red mediante proxy MITM transparente. El código del agente nunca toca tokens sin procesar. Las solicitudes salientes se escanean para prevenir fugas de secretos."
+    },
+    "startsInSeconds": {
+      "title": "Inicia en segundos",
+      "description": "Hemos realizado una optimización exhaustiva para que tu agente pase del disparador a la ejecución en decenas de milisegundos. Rápido, porque hicimos el trabajo duro a nivel de infraestructura. Tú solo experimentas el resultado.",
+      "detail": "Overlayfs con rootfs de solo lectura compartido para arranque sin copia. Las instantáneas de memoria de VM precalientan todo el stack de ejecución — restaurar en lugar de arranque en frío."
+    },
+    "fullAuditTrail": {
+      "title": "Registro de auditoría completo",
+      "description": "Cada acción que realiza el agente — a qué servicios accedió, qué APIs llamó, qué produjo — queda registrada. Si algo sale mal, hay un registro claro. Si nada sale mal, igualmente tienes tranquilidad.",
+      "detail": "Tráfico HTTP/HTTPS completo registrado por ejecución (JSONL). Artefactos inmutables y direccionados por contenido almacenados en Cloudflare R2 con integridad SHA-256."
+    },
+    "openSource": {
+      "title": "Código abierto",
+      "description": "La plataforma principal es de código abierto. Puedes inspeccionar el código, auditar el modelo de seguridad y contribuir. Transparente por defecto.",
+      "detail": "Plataforma principal en GitHub. Pruebas de penetración regulares por terceros. Cumplimiento SOC 2 Tipo II en proceso."
+    },
+    "questionsAboutSecurity": "¿Preguntas sobre seguridad?",
+    "contactUs": "Contáctanos"
+  },
+  "avatar": {
+    "steps": {
+      "rotation": "Ángulo",
+      "skin": "Piel",
+      "hairStyle": "Cabello",
+      "hairColor": "Color",
+      "expression": "Rostro",
+      "intensity": "Estado"
+    },
+    "intensityLabels": {
+      "chill": "Relajado",
+      "normal": "Normal",
+      "hyped": "Animado"
+    },
+    "back": "← Atrás"
   }
 }

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -81,18 +81,132 @@
     "docs": "ドキュメント",
     "blog": "ブログ",
     "skills": "Skills",
-    "glossary": "用語集",
     "pricing": "料金",
     "github": "GitHub",
     "contact": "デモを予約",
-    "joinWaitlist": "サインアップ"
+    "joinWaitlist": "サインアップ",
+    "security": "セキュリティ",
+    "useCases": "ユースケース",
+    "signOut": "サインアウト",
+    "openApp": "アプリを開く"
   },
   "pricing": {
     "title": "プランを選択",
-    "subtitle": "無料から始めて、必要に応じて拡張。クレジットカード不要。"
+    "subtitle": "無料から始めて、必要に応じて拡張。クレジットカード不要。",
+    "heroTitle": "使った分だけ支払い、それ以上はなし",
+    "heroDescription": "AIチームメイトと無料で始めましょう。準備ができたらスケールアップ。クレジットカード不要。",
+    "free": {
+      "description": "AIチームメイトと無料で始めましょう。",
+      "features": {
+        "starterCredits": "10,000スタータークレジット",
+        "concurrentRun": "1同時実行",
+        "unlimitedAgents": "エージェント数無制限",
+        "bringOwnLLM": "自分のLLMキーを使用",
+        "communitySupport": "コミュニティサポート"
+      },
+      "buttonText": "始める"
+    },
+    "pro": {
+      "description": "チームのためのより強力でシームレスなコラボレーション。",
+      "features": {
+        "credits": "20,000クレジット / 月",
+        "concurrentRuns": "2同時実行",
+        "unlimitedAgents": "エージェント数無制限",
+        "bringOwnLLM": "自分のLLMキーを使用",
+        "creditsRollover": "クレジット繰り越し（1ヶ月）",
+        "emailSupport": "メールサポート"
+      },
+      "buttonText": "Proで始める"
+    },
+    "team": {
+      "description": "摩擦ゼロ、完全な柔軟性で素早くスケール。",
+      "features": {
+        "credits": "120,000クレジット / 月",
+        "concurrentRuns": "5同時実行",
+        "unlimitedAgents": "エージェント数無制限",
+        "bringOwnLLM": "自分のLLMキーを使用",
+        "creditsRollover": "クレジット繰り越し（1ヶ月）",
+        "prioritySupport": "優先サポート"
+      },
+      "buttonText": "Teamで始める"
+    },
+    "needMoreCredits": "もっとクレジットが必要ですか？",
+    "topUpDescription": "いつでもチャージ可能",
+    "topUpRate": "1,000クレジットあたり$1",
+    "topUpAutoRecharge": "自動チャージを設定して、エージェントを止めないようにしましょう。残高がしきい値を下回ると、クレジットが自動的に購入されます。",
+    "perCredits": "1,000クレジットあたり",
+    "comparePlans": "プランを比較",
+    "featuresHeader": "機能",
+    "sections": {
+      "creditsAndAgents": "クレジットとエージェント",
+      "connectorsAndIntegrations": "コネクターと統合",
+      "securityAndCompliance": "セキュリティとコンプライアンス",
+      "collaboration": "コラボレーション",
+      "support": "サポート"
+    },
+    "tableFeatures": {
+      "creditsPerMonth": "月間クレジット",
+      "creditsPerMonthDesc": "すべてのエージェントのAIモデル使用で消費されるクレジット",
+      "concurrentRuns": "同時実行数",
+      "concurrentRunsDesc": "同時に実行できるエージェントの数",
+      "totalAgents": "エージェント総数",
+      "totalAgentsDesc": "作成可能なエージェントの最大数",
+      "creditsRollover": "クレジット繰り越し",
+      "creditsRolloverDesc": "未使用のクレジットは次の請求期間に繰り越されます",
+      "creditTopUp": "クレジットチャージ",
+      "creditTopUpDesc": "1,000クレジットあたり$1でいつでも追加クレジットを購入",
+      "autoRecharge": "自動チャージ",
+      "autoRechargeDesc": "残高がしきい値を下回ると自動的にクレジットを購入",
+      "connectors": "コネクター",
+      "connectorsDesc": "Slack、GitHub、Notionなどのツールを接続",
+      "bringOwnLLM": "自分のLLMを持ち込み",
+      "bringOwnLLMDesc": "自分のモデルプロバイダーAPIキーを使用",
+      "sandboxedExecution": "サンドボックス実行",
+      "sandboxedExecutionDesc": "ハードウェアレベルのKVM分離によるFirecracker microVM",
+      "fullAuditTrail": "完全な監査証跡",
+      "fullAuditTrailDesc": "SHA-256整合性付きで実行ごとにエージェントHTTP/HTTPSトラフィックを記録",
+      "noCredentialExposure": "クレデンシャル非公開",
+      "noCredentialExposureDesc": "シークレットはネットワーク層で注入され、エージェントコードには見えません",
+      "teamMembers": "チームメンバー",
+      "teamMembersDesc": "ワークスペースの人数",
+      "perMemberCreditCaps": "メンバーごとのクレジット上限",
+      "perMemberCreditCapsDesc": "個々のチームメンバーの利用上限を設定",
+      "communitySupport": "コミュニティサポート",
+      "communitySupportDesc": "Discordコミュニティとドキュメントへのアクセス",
+      "emailSupport": "メールサポート",
+      "emailSupportDesc": "VM0チームからの直接メールサポート",
+      "prioritySupport": "優先サポート",
+      "prioritySupportDesc": "より速い応答時間の専用サポート"
+    },
+    "tableValues": {
+      "starter": "10,000スターター",
+      "20k": "20,000",
+      "120k": "120,000",
+      "unlimited": "無制限",
+      "oneMonth": "1ヶ月",
+      "allConnectors": "すべてのコネクター"
+    },
+    "faq": {
+      "title": "よくある質問",
+      "whatAreCredits": "クレジットとは何ですか？",
+      "whatAreCreditsAnswer": "クレジットはエージェントがAIモデルを使用する際に消費されます。モデルによってクレジットの消費率は異なります。例えば、シンプルなタスクは少量のクレジットを使い、複雑なマルチステップワークフローはより多く使います。",
+      "changePlans": "いつでもプランを変更できますか？",
+      "changePlansAnswer": "はい！いつでもプランのアップグレードまたはダウングレードが可能です。変更は即座に反映され、日割り計算で請求されます。",
+      "runOutOfCredits": "クレジットがなくなったらどうなりますか？",
+      "runOutOfCreditsAnswer": "クレジットが枯渇すると、エージェントは実行を停止します。自動チャージで追加クレジットを購入するか、より上位のプランにアップグレードして月間クレジットを増やすことができます。",
+      "doCreditsRollOver": "未使用のクレジットは繰り越されますか？",
+      "doCreditsRollOverAnswer": "Freeプランでは、スタータークレジットは期限切れになりませんが補充されません。Proでは未使用クレジットが1ヶ月繰り越されます。Teamでもクレジットは1ヶ月繰り越されます。",
+      "bringOwnModel": "自分のモデルプロバイダーを使えますか？",
+      "bringOwnModelAnswer": "はい！すべてのプランで独自のLLM APIキー（Anthropicなど）の使用をサポートしています。独自のキーを使用する場合、モデル使用にVM0クレジットは消費されません。",
+      "howSecure": "VM0はどれくらい安全ですか？",
+      "howSecureAnswer": "すべてのエージェント実行は、ハードウェアレベルのKVM分離を備えた隔離されたFirecracker microVMで実行されます。クレデンシャルはネットワーク層で注入され、エージェントコードに公開されることはありません。すべてのエージェントHTTP/HTTPSトラフィックは実行ごとにSHA-256整合性で記録されます。",
+      "annualBilling": "年間請求や割引はありますか？",
+      "annualBillingAnswer": "ボリューム価格、年間請求割引、チーム向けのカスタムアレンジメントについてはお問い合わせください。"
+    },
+    "perMonth": "/月"
   },
   "footer": {
-    "tagline": "Zero, your trustworthy AI teammate.",
+    "tagline": "Zero、信頼できるAIチームメイト。",
     "copyright": "© 2026 VM0.ai 無断転載禁止",
     "language": "言語",
     "status": "ステータス",
@@ -135,141 +249,6 @@
       "Other": "その他"
     }
   },
-  "glossary": {
-    "hero": {
-      "title": "エージェント構築用語集",
-      "description": "AIエージェントの言語をマスターしましょう。主要な概念、用語、VM0固有の機能を探索して、エージェント開発の旅を加速させます。"
-    },
-    "search": {
-      "placeholder": "用語を検索...",
-      "allCategories": "すべてのカテゴリー",
-      "showingAll": "すべての用語を表示",
-      "found": "見つかりました",
-      "results": "用語",
-      "noResults": "検索に一致する用語が見つかりませんでした"
-    },
-    "relatedTerms": "関連用語",
-    "categories": {
-      "Core Concepts": "コア概念",
-      "Execution": "実行",
-      "Infrastructure": "インフラストラクチャ",
-      "Development": "開発"
-    },
-    "terms": {
-      "agent": {
-        "name": "Agent",
-        "definition": "指示を理解し、意思決定を行い、ツールを使用し、独立してタスクを実行できる自律的なAIプログラム。従来のスクリプトとは異なり、Agentはコンテキストに基づいてアプローチを適応させ、目標に向かって反復できます。"
-      },
-      "skill": {
-        "name": "Skill",
-        "definition": "Agentが外部サービスと相互作用するために使用できる事前構築統合または機能。Skillsはカスタム実装を必要とせずに、Slack、GitHub、NotionなどのAPIにアクセスするなど、Agentに既製の機能を提供します。"
-      },
-      "tool": {
-        "name": "Tool",
-        "definition": "Agentが特定のアクションを実行するために呼び出すことができる関数またはAPI。ToolsはAgent機能の構成要素であり、ファイルの読み取り、HTTPリクエストの作成、データベースのクエリ、または任意の外部システムとの相互作用を可能にします。"
-      },
-      "prompt": {
-        "name": "Prompt",
-        "definition": "Agentのタスク、動作、または目標を定義するために与えられた自然言語の指示。Promptは単純なコマンドから、Agentの思考方法と動作方法を形作る複雑なシステム指示まで様々です。"
-      },
-      "context": {
-        "name": "Context",
-        "definition": "実行中にAgentが利用可能な情報。会話履歴、メモリ、ツール出力、環境状態を含みます。Contextはエージェントが相互作用全体で一貫性を保ち、情報に基づいた決定を下すのに役立ちます。"
-      },
-      "session": {
-        "name": "Session",
-        "definition": "状態、メモリ、コンテキストを保持するAgentの実行の継続期間。Sessionsはエージェントが複数の相互作用全体で認識を維持し、進捗を失わずに作業を再開できるようにします。"
-      },
-      "checkpoint": {
-        "name": "Checkpoint",
-        "definition": "特定の時点でのAgentの状態のスナップショット。メモリ、コンテキスト、実行進捗をキャプチャします。Checkpointsは再現可能性を実現し、Agent実行を復元、フォーク、またはリプレイできます。"
-      },
-      "artifact": {
-        "name": "Artifact",
-        "definition": "Agent実行中に生成されたファイル、データ、または出力。Artifactsは実行全体で永続化でき、コード、ドキュメント、分析結果、またはAgentが生成した他の成果物を含むことができます。"
-      },
-      "observability": {
-        "name": "Observability",
-        "definition": "ログ、メトリクス、実行トレースを通じてAgent動作を検査、監視、理解する能力。Observabilityはデバッグ、最適化、透明で安全なAI操作を確保するために不可欠です。"
-      },
-      "sandbox": {
-        "name": "Sandbox",
-        "definition": "Agentが本番システムに影響を与えることなく安全に実行される隔離実行環境。Sandboxesはセキュリティ境界を提供し、Agentアクションが含まれ、制御されていることを確認します。"
-      },
-      "memory": {
-        "name": "Memory",
-        "definition": "Agentが相互作用全体で保持する情報。過去の経験から学び、時間をかけてコンテキストを維持できます。Memoryは事実、環境設定、会話履歴、学習されたパターンを含むことができます。"
-      },
-      "workflow": {
-        "name": "Workflow",
-        "definition": "目標を達成するためにAgentが実行する一連のタスクまたは操作。硬直した自動化スクリプトとは異なり、Agentワークフローは中間結果に基づいて適応および調整できます。"
-      },
-      "llm": {
-        "name": "LLM (Large Language Model)",
-        "definition": "Agentの推論と意思決定に力を与える基盤となるAIモデル。Claude、GPT-4、Geminiなどが例です。異なるLLMは異なる強度、コスト、機能を持っています。"
-      },
-      "skillMd": {
-        "name": "SKILLS.MD",
-        "definition": "Skillの動作、入力、出力、実装ロジックを定義するMarkdown設定ファイル。SKILLS.MDファイルは自然言語と構造化メタデータを使用してカスタムSkillsを作成できます。複雑なコードを書くことなくAgent機能を拡張できます。"
-      },
-      "agentMd": {
-        "name": "AGENTS.MD",
-        "definition": "Agentの動作、個性、目標、利用可能なツールを定義するMarkdown設定ファイル。AGENTS.MDファイルはAgentのブループリントとして機能し、どのように考えるべきか、何ができるか、ユーザーとシステムとどのように相互作用するべきかを指定します。"
-      },
-      "volume": {
-        "name": "Volume",
-        "definition": "Agent実行全体でファイルとデータを保持する永続ストレージスペース。Volumesはエージェントに個々の実行を超えて永続化するファイルシステムを提供し、状態を保存し、データをキャッシュし、長期的なアーティファクトを維持できます。"
-      },
-      "action": {
-        "name": "Action",
-        "definition": "目標を達成するためにAgentが実行する具体的な操作またはタスク。ActionsはAPIの呼び出し、ファイルの読み取り、データの処理、または外部システムとの相互作用を含むことができます。Agent実行フローの各ステップを表します。"
-      },
-      "runtime": {
-        "name": "Runtime",
-        "definition": "Agentが実行される実行環境。必要なインフラストラクチャ、リソース、APIを提供します。Runtimeはagentのライフサイクルを管理し、リソース割り当てを処理し、異なるAgent実行間の適切な分離を確保します。"
-      },
-      "orchestration": {
-        "name": "Orchestration",
-        "definition": "複雑な目標を達成するための複数のAgent、ワークフロー、またはタスクの調整と管理。Orchestrationは依存関係、シーケンス、分散Agent操作全体での並列実行、リソース割り当てを処理します。"
-      },
-      "mcp": {
-        "name": "MCP (Model Context Protocol)",
-        "definition": "Anthropicによって開発されたオープンプロトコル。AIアシスタントが外部データソースとツールに安全に接続できます。MCPはエージェントがデータベース、API、ファイルシステムなどのリソースにアクセスし、セキュリティとコンテキスト認識を維持できる標準化された方法を提供します。"
-      },
-      "image": {
-        "name": "Image",
-        "definition": "Agentを実行するために必要なコード、ランタイム、依存関係、設定を含むパッケージ化されたコンテナ。Imagesは一貫性のある再現可能な実行環境を提供し、異なるデプロイメント間でエージェントが同じように動作することを確保します。"
-      },
-      "secrets": {
-        "name": "Secrets",
-        "definition": "APIキー、パスワード、トークンなど、Agentが外部サービスにアクセスする必要があるセンシティブ情報。Secretsは安全に保存され、実行時にAgent runtimeに注入され、コードまたは設定ファイルでの露出を防ぎます。"
-      },
-      "environmentVariable": {
-        "name": "Environment Variable",
-        "definition": "実行時にAgentに渡される設定値。コードを変更することなく動作をカスタマイズできます。Environment Variablesは一般的にAPIエンドポイント、機能フラグ、非センシティブ設定に使用されます。"
-      },
-      "virtualMachine": {
-        "name": "Virtual Machine",
-        "definition": "物理コンピューターをエミュレートする隔離されたソフトウェアベースのコンピューティング環境。仮想マシンはAgent実行間の完全な分離を提供し、セキュリティを確保し、干渉を防ぎます。VM0は独自のオペレーティングシステム、ファイルシステム、ネットワークスタックを持つ軽量の仮想マシンを使用してエージェントを実行します。"
-      },
-      "cli": {
-        "name": "CLI (Command Line Interface)",
-        "definition": "AgentとVM0プラットフォームと相互作用するためのテキストベースのインターフェース。CLIは開発者がターミナルコマンドを通じてAgentを作成、デプロイ、管理できます。グラフィカルインターフェースがなくても強力なスクリプトと自動化機能を提供します。"
-      },
-      "cliAgent": {
-        "name": "CLI Agent",
-        "definition": "コマンドラインインターフェースを通じて呼び出しおよび制御されるように設計されたAgent。CLI Agentsはスクリプト、CI/CDパイプライン、ターミナルワークフローに統合でき、自動化タスクと開発者ツーリングに理想的です。"
-      },
-      "agentRouter": {
-        "name": "Agent Router",
-        "definition": "タスク要件、コスト制約、パフォーマンスニーズに基づいて、Agent要求を最も適切なAIモデルにインテリジェントにルーティングするシステム。Agent Routerは異なるLLMs(Claude、GPT、Gemini)の間で動的に選択するか、特定の機能の専門モデルにルーティングできます。"
-      },
-      "claudeCode": {
-        "name": "Claude Code",
-        "definition": "AnthropicのAI Agentを構築および展開するための公式コマンドラインツール。Claude CodeはAgentの作成、Skillsの管理、Claude APIとの統合のためのデベロッパーフレンドリーなインターフェースを提供します。ライブリロード、デバッグツール、展開自動化などの機能でagent開発ワークフローを簡素化します。"
-      }
-    }
-  },
   "blog": {
     "title": "ブログ",
     "description": "エージェントネイティブ開発とAIインフラの未来に関する洞察、チュートリアル、最新情報。",
@@ -289,31 +268,725 @@
     "link": "詳細を見る"
   },
   "useCases": {
-    "title": "Use Cases",
-    "metaDescription": "Real workflows from teams using Zero as their AI teammate. See the exact prompts, outputs, and integrations.",
-    "heroTitle": "See what Zero can do for your team",
-    "heroSubtitle": "Real workflows from teams using Zero as their AI teammate. Each use case includes the exact prompt, Zero's output, and how to extend it.",
-    "role": "Role",
-    "capability": "Capability",
-    "all": "All",
-    "seeHow": "See how",
-    "comingSoon": "Coming soon",
-    "moreComingSoon": "More use cases coming",
-    "noResults": "No use cases match these filters.",
-    "whenThisHappens": "When this happens",
-    "whatYouSay": "What you say to Zero",
-    "whatZeroDoes": "What Zero does",
-    "whatsNext": "What's next",
-    "whatYouNeed": "What you need",
-    "required": "Required",
-    "optional": "Optional",
-    "tips": "Tips and best practices",
-    "relatedUseCases": "Related use cases",
-    "backToAll": "All use cases",
-    "zeroConnects": "Zero connects:",
-    "ctaTitle": "Zero works where your team works",
-    "ctaSubtitle": "Add Zero to Slack and start delegating in plain language. No setup wizards. No workflow builders. Just ask.",
-    "addToSlack": "Add Zero to Slack",
-    "bookDemo": "Book a demo"
+    "title": "ユースケース",
+    "metaDescription": "ZeroをAIチームメイトとして活用するチームの実際のワークフロー。具体的なプロンプト、出力、連携機能をご覧ください。",
+    "heroTitle": "Zeroがあなたのチームにできることを確認",
+    "heroSubtitle": "ZeroをAIチームメイトとして活用するチームの実際のワークフロー。各ユースケースには、具体的なプロンプト、Zeroの出力、拡張方法が含まれます。",
+    "role": "役割",
+    "capability": "機能",
+    "all": "すべて",
+    "seeHow": "詳しく見る",
+    "comingSoon": "近日公開",
+    "moreComingSoon": "さらにユースケースを追加予定",
+    "noResults": "これらのフィルターに一致するユースケースはありません。",
+    "whenThisHappens": "このようなときに",
+    "whatYouSay": "Zeroに伝えること",
+    "whatZeroDoes": "Zeroが行うこと",
+    "whatsNext": "次のステップ",
+    "whatYouNeed": "必要なもの",
+    "required": "必須",
+    "optional": "オプション",
+    "tips": "ヒントとベストプラクティス",
+    "relatedUseCases": "関連ユースケース",
+    "backToAll": "すべてのユースケース",
+    "zeroConnects": "Zeroの接続先:",
+    "ctaTitle": "Zeroはチームが働く場所で動作します",
+    "ctaSubtitle": "ZeroをSlackに追加して、自然な言葉で作業を委任しましょう。セットアップウィザードもワークフロービルダーも不要。ただ頼むだけです。",
+    "addToSlack": "ZeroをSlackに追加",
+    "bookDemo": "デモを予約",
+    "gallery": {
+      "moreToCome": "さらに追加予定",
+      "moreToComeDesc": "Zeroの活用アイデアはありますか？",
+      "submitYourCase": "ケースを提出 →"
+    },
+    "content": {
+      "sentry-triage": {
+        "title": "Sentryのノイズを優先順位付きアクションリストに変換",
+        "description": "Zeroに未解決のSentryエラーを頻度順に取得するよう依頼します。Zeroがスタックトレースを読み、根本原因を分かりやすく説明し、最初に修正すべきファイルを教えてくれます。",
+        "timeSaved": "約25分の節約",
+        "headings": {
+          "scenario": "Sentryトリアージがエンジニアリング時間を浪費する理由",
+          "prompt": "ZeroにSentryエラーのトリアージを依頼する方法",
+          "steps": "ZeroがSentryエラーを分析・ランク付けする仕組み",
+          "nextActions": "SentryトリアージをGitHub Issueと日次自動化に変換",
+          "integrations": "必要な連携: SentryとGitHub",
+          "tips": "自動Sentryトリアージのベストプラクティス"
+        },
+        "scenario": "月曜の朝。Slackを開くと#devに十数件のSentryアラートが届いています。ほとんどはノイズ — 不安定なテスト、既知の問題、自然に解消する一時的なエラー。しかしその中には本物があるかもしれません：壊れた連携、課金バグ、実際のユーザーに影響するクラッシュ。Sentryのダッシュボードを開いてIssueを一つずつクリックしたくはありません。知りたいのは：どれが重要で、どれくらい深刻で、何が原因なのか。",
+        "promptVariants": [
+          {
+            "label": "詳細",
+            "prompt": "@Zero Sentryの最近の障害を確認してください。過去24時間の障害を発生頻度順にランク付けしてください。\n\n上位3件の障害について、展開された詳細なエラースタックを含むレポートを作成してください。"
+          },
+          {
+            "label": "クイック",
+            "prompt": "@Zero 過去24時間のSentryエラーTop 3を件数順に。"
+          },
+          {
+            "label": "スケジュール",
+            "prompt": "@Zero 平日毎朝9時にこのSentryチェックを実行し、結果を#devに投稿。5回以上発生したエラーのみ含める。"
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Yuma",
+            "text": "@Zero Sentryの最近の障害を確認。頻度順にランク付け。Top 3を詳細なエラースタック付きで。"
+          },
+          {
+            "name": "Zero",
+            "text": "Sentryの障害レポートです。\n\n#\tIssue\t件数\t優先度\n1\tSlack missing_scope\t57\t高\n2\t不明なStripe価格ID\t15\t高\n3\tZeroSidebar .map()\t10\t中"
+          }
+        ],
+        "steps": [
+          {
+            "title": "ZeroがSentryに接続",
+            "description": "Zeroが指定された時間枚でSentryプロジェクトの未解決Issueを取得し、発生回数でランク付けします。"
+          },
+          {
+            "title": "サマリーテーブル",
+            "description": "Zeroが同じSlackスレッドにクイックサマリーテーブル（Issue名、発生回数、優先度レベル）を返信し、5秒で確認できます。"
+          },
+          {
+            "title": "詳細分析",
+            "description": "各トップIssueについて、Zeroがアノテーション付きスタックトレースと分かりやすい根本原因の説明を提供します。例えば「不明なStripe価格ID」とだけ言うのではなく、Stripeで新しい価格が作成されたが対応するマッピングが更新されていない可能性が高いと説明します。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "発見をアクションに変換",
+            "description": "レポートからGitHub Issueを作成",
+            "examplePrompt": "@Zero #1と#2のGitHub Issueを作成。#1はLancyに割り当て（Slackスコープ修正）、#2はJamesに（Stripeマッピング）。両方ともbug、優先度高でラベル付け。"
+          },
+          {
+            "title": "さらに深掘り",
+            "description": "Zeroに特定のエラーを調査させる",
+            "examplePrompt": "@Zero Issue #1について、どのSlack OAuthスコープが不足しているか正確に教えて。アプリマニフェストを確認して何を追加すべきか教えて。"
+          },
+          {
+            "title": "ルーティンにする",
+            "description": "日次チェックとしてスケジュール",
+            "examplePrompt": "@Zero 平日毎朝9時にこのSentryチェックを実行し、結果を#devに投稿。5回以上発生したエラーのみ含める。"
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Sentry組織へのOAuth接続。ZeroにはIssueとイベントへの読み取りアクセスが必要です。"
+          },
+          {
+            "description": "ZeroにレポートからIssueを作成させたい場合のみ必要。Issueへの読み書きアクセス。"
+          }
+        ],
+        "tips": [
+          "時間枚を具体的に指定しましょう。日次トリアージには「過去24時間」、デプロイ後チェックには「最後のデプロイ以降のエラー」。",
+          "ノイズを減らすために重要度フィルターを追加 — 10回以上発生したエラーのみ表示、またはknown-issueとタグ付けされたエラーをスキップ。",
+          "スタンドアップと連携させましょう — スタンドアップのユースケースと組み合わせて、タスクサマリーとSentryレポートの両方を含む朝のブリーフィングに。"
+        ]
+      },
+      "standup-summary": {
+        "title": "5つのアプリを開かずにスタンドアップを準備",
+        "description": "Zeroがカレンダー、メール、Linearからデータを取得し、チームスレッドにそのまま貼り付けられる共有可能なサマリーを作成します。",
+        "timeSaved": "約20分の節約",
+        "headings": {
+          "scenario": "Calendar、Gmail、Linearを行き来する毎日のスタンドアップの混乱",
+          "prompt": "Zeroにスタンドアップサマリーを依頼する方法",
+          "steps": "Zeroが3つのツールから作業サマリーをまとめる仕組み",
+          "nextActions": "Slackに投稿、ブロッカー追加、または毎日自動化",
+          "integrations": "必要な連携: Google Calendar、Gmail、Linear",
+          "tips": "AI生成スタンドアップサマリーのベストプラクティス"
+        },
+        "scenario": "午前9時50分、スタンドアップまでああ10分。まだカレンダーを確認していません。Zeroに昨日の会議、メール、Linearタスクを取得するよう頼むと、チームスレッドにそのまま貼り付けられるサマリーを書いてくれます。",
+        "promptVariants": [
+          {
+            "label": "詳細",
+            "prompt": "@Zero 昨日からのカレンダー、メール、Linearタスクを確認して作業サマリーを書いて。会議のハイライトとPRステータスを含めて。"
+          },
+          {
+            "label": "クイック",
+            "prompt": "@Zero 昨日何をした？カレンダーとLinearを確認して。"
+          },
+          {
+            "label": "スケジュール",
+            "prompt": "@Zero 平日毎朝9:45に、スタンドアップサマリーを書いてDMで送って。"
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero 昨日からのカレンダー、メール、Linearタスクを確認して作業サマリーを書いて"
+          },
+          {
+            "name": "Zero",
+            "text": "作業サマリー: 3月23〜24日\n\n会議\n• デイリースタンドアップ（10〜10:30 AM）\n• VM0ユーザーインタビュー w/ Daniel Miller\n\nエンジニアリング\n• PR #5467マージ済み、ファイアウォール権限\n• PR #6277レビュー中。Lighthouseスコア36"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zeroがカレンダーを確認",
+            "description": "Zeroが過去24時間のGoogle Calendarイベントを読み取り、会議名、時間、参加者を抽出します。"
+          },
+          {
+            "title": "Zeroがメールとタスクをスキャン",
+            "description": "ZeroがGmailの関連スレッドとLinearの昨日以降に更新、完了、または割り当てられたタスクを確認します。"
+          },
+          {
+            "title": "フォーマット済みサマリー",
+            "description": "Zeroが全てを会議、エンジニアリング作業、アクションアイテムで整理された、クリーンでコピー＆ペースト可能なサマリーにまとめます。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "チャンネルに直接投稿",
+            "description": "Zeroにサマリーを#standupに投稿させる",
+            "examplePrompt": "@Zero このサマリーを#standupに投稿して@team-engをタグ付けして。"
+          },
+          {
+            "title": "コンテキストを追加",
+            "description": "Zeroにブロッカーや優先事項を含めるよう依頼",
+            "examplePrompt": "@Zero Linearでブロックされているタスクも確認して、サマリーにブロッカーとして追加して。"
+          },
+          {
+            "title": "毎日にする",
+            "description": "朝の準備を自動化",
+            "examplePrompt": "@Zero 平日毎朝9:45に、スタンドアップサマリーを書いてDMで送って。"
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Google CalendarへのOAuth接続。Zeroにはイベントへの読み取りアクセスが必要です。"
+          },
+          {
+            "description": "GmailへのOAuth接続。Zeroには最近のスレッドをスキャンするための読み取りアクセスが必要です。"
+          },
+          {
+            "description": "LinearへのOAuth接続。Zeroが割り当て済みおよび更新済みタスクを読み取ります。"
+          }
+        ],
+        "tips": [
+          "デフォルトと異なる場合はスタンドアップフォーマットをZeroに伝えましょう。「次のフォーマットを使用: 昨日 / 今日 / ブロッカー」。",
+          "時間枚を指定しましょう。遅くまで働く場合は「昨日午後5時以降」。",
+          "Sentryトリアージと組み合わせて、完全なエンジニアリングモーニングブリーフィングに。"
+        ]
+      },
+      "kol-cold-outreach": {
+        "title": "XでKOLをリサーチし、パーソナライズされたコールドメールを作成",
+        "description": "ZeroにXのハンドルを伝えます。直近30件の投稿を読み、スタイルと関心を理解し、150語以下のパーソナライズされたアウトリーチメールを作成してGmailの下書きに保存します。",
+        "timeSaved": "約20分の節約",
+        "headings": {
+          "scenario": "一般的なコールドアウトリーチが無視される理由",
+          "prompt": "KOLをリサーチしパーソナライズされたアウトリーチを作成する方法",
+          "steps": "ZeroがXプロフィールを分析しカスタムメールを作成する仕組み",
+          "nextActions": "KOL適合度を評価、一括アウトリーチ、またはNotion CRMで追跡",
+          "integrations": "必要な連携: X、Gmail、Notion",
+          "tips": "AI支援KOLアウトリーチのベストプラクティス"
+        },
+        "scenario": "パートナーシップにぴったりのKOLを見つけましたが、ありきたりに感じないコールドメールを書くには20分のリサーチが必要 — 投稿を読み、何に関心があるか理解し、適切な切り口を見つける。ZeroにXハンドルを伝えれば、数秒でパーソナライズされた下書きが得られます。",
+        "promptVariants": [
+          {
+            "label": "詳細",
+            "prompt": "@Zero @swyxの直近30件のX投稿を読んでスタイルと関心を把握して。VM0パートナーシップについて150語以下のパーソナライズされたコールドアウトリーチメールを書いて。最近投稿した具体的な内容に言及して。Gmailの下書きとして保存。"
+          },
+          {
+            "label": "クイック",
+            "prompt": "@Zero @swyxのX投稿を基にVM0についてのコールドメールを下書き。Gmailの下書きとして保存。"
+          },
+          {
+            "label": "一括",
+            "prompt": "@Zero NotionのKOLリストで「未連絡」とマークされた各ハンドルについて、Xプロフィールをリサーチしパーソナライズされたアウトリーチメールを作成。すべてGmailの下書きとして保存。"
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero @swyxの直近30件のX投稿を読んで、スタイルを理解し、VM0パートナーシップ向けのコールドアウトリーチメールを作成。Gmailの下書きとして保存。"
+          },
+          {
+            "name": "Zero",
+            "text": "完了。@swyxの最近のコンテンツを分析:\n• フォーカス: AIエージェント、開発者ツール、オープンソース\n• トーン: テクニカルだが会話的\n• オーディエンス適合度: 高（9/10）\n\nGmail下書き保存済み: 「実務をこなすエージェント — 興味を持っていただけると思い」"
+          }
+        ],
+        "steps": [
+          {
+            "title": "ZeroがKOLのXプロフィールを読む",
+            "description": "Zeroが直近30件の投稿を取得し、コンテンツテーマ、トーン、オーディエンス、エンゲージメントパターンを分析して、この人が何に関心を持っているかのプロフィールを構築します。"
+          },
+          {
+            "title": "パーソナライズされたメール作成",
+            "description": "ZeroがKOLが投稿した具体的なコンテンツに言及し、製品の関連性を説明し、相手のスタイルに合ったトーンを使用した簡潔なアウトリーチメールを作成します。"
+          },
+          {
+            "title": "Gmailに下書き保存",
+            "description": "メールはレビュー可能なGmail下書きとして保存されます。接続されていれば、ZeroはNotion CRMのKOLステータスも更新します。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "KOL適合度を評価",
+            "description": "KOLがオーディエンスにどの程度マッチするか評価",
+            "examplePrompt": "@Zero @swyxのオーディエンスとVM0のICPの重複を分析。1-10でスコアリングし理由付きでNotionに保存。"
+          },
+          {
+            "title": "一括アウトリーチ",
+            "description": "複数のKOLのメールを一度に作成",
+            "examplePrompt": "@Zero Notionリストのトップ10 KOLについて、それぞれリサーチしパーソナライズされたアウトリーチメールを作成。"
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zeroが公開投稿を読み、KOLのスタイルと関心を把握します。"
+          },
+          {
+            "description": "Zeroが作成したメールをGmailの下書きに保存します。"
+          },
+          {
+            "description": "オプション：Notion CRMでKOLステータスと適合度スコアを追跡。"
+          }
+        ],
+        "tips": [
+          "製品の切り口についてZeroにコンテキストを伝えましょう。「VM0が開発者ツール企業にどう役立つかに焦点を当てて」。",
+          "複数のバリアントを依頼しましょう。「2バージョン作成: カジュアルなものとプロフェッショナルなもの」。",
+          "送信前に必ずレビューしましょう。Zeroのリサーチは正確ですが、最終的な表現はあなた自身のものであるべきです。"
+        ]
+      },
+      "file-bugs-from-slack": {
+        "title": "コンテキストを切り替えずにSlackからバグを報告",
+        "description": "自然言語で問題を説明するだけ。Zeroがフォーマット済みのGitHub Issueを作成し、ラベルを付け、適切な人に割り当てます。",
+        "timeSaved": "即座",
+        "headings": {
+          "scenario": "SlackからGitHub Issueを作成するとコンテキスト切り替えが節約される理由",
+          "prompt": "SlackメッセージからGitHub Issueを作成する方法",
+          "steps": "Zeroがメッセージを解析しフォーマット済みIssueを作成する仕組み",
+          "nextActions": "詳細を追加、一括Issue作成、またはトリアージを自動化",
+          "integrations": "必要な連携: GitHubとSlack",
+          "tips": "Slack経由でバグを報告するベストプラクティス"
+        },
+        "scenario": "デモ中にUXバグに気づきました。GitHubを開いてリポジトリを探し、フォーマット済みのIssueを書いて誰かに割り当てる代わりに、Slackで説明します。ZeroがIssueを作成し、ラベルを追加し、適切な人を割り当てます。会話を離れる必要はありません。",
+        "promptVariants": [
+          {
+            "label": "詳細",
+            "prompt": "@Zero Issue作成: スケジュールダイアログでESCを押すと、未保存の編集があっても即座に閉じてしまう。最初に確認を求めるべき。Lancyに割り当て。bug、platformのラベル。優先度中。"
+          },
+          {
+            "label": "クイック",
+            "prompt": "@Zero バグ: ESCがスケジュールダイアログを保存確認なしで閉じる。Lancyに割り当て。"
+          },
+          {
+            "label": "スケジュール",
+            "prompt": "@Zero 毎週金曜16時に#bugsチャンネルで未解決のバグレポートを確認し、それぞれにGitHub Issueを作成。"
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero Issue作成: スケジュールダイアログでESCを押すと、未保存の編集があっても即座に閉じてしまう。最初に確認を求めるべき。Lancyに割り当て。"
+          },
+          {
+            "name": "Zero",
+            "text": "Issue作成済み:\n#6260: bug: ESCキーがスケジュールダイアログを確認なしで閉じる\nLancyに割り当て · 優先度: 中"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zeroがリクエストを解析",
+            "description": "Zeroがバグの説明を理解し、担当者を特定し、コンテキストから適切なラベル（bug、platform）と優先度を推定します。"
+          },
+          {
+            "title": "GitHubにIssue作成",
+            "description": "Zeroが自然言語のSlackメッセージから、明確なタイトル、説明、ラベル、割り当てを含む適切にフォーマットされたGitHub Issueを作成します。"
+          },
+          {
+            "title": "Slackで確認",
+            "description": "Zeroが同じスレッドにIssue番号、タイトル、担当者、直接リンクを返信するので、Slackを離れずに確認できます。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "詳細を追加",
+            "description": "スクリーンショットや再現手順を添付",
+            "examplePrompt": "@Zero #6260に追加: 再現手順。1. スケジュールダイアログを開く 2. 何か入力 3. ESCを押す。期待: 確認ダイアログ。"
+          },
+          {
+            "title": "一括Issue作成",
+            "description": "複数のIssueを一度に作成",
+            "examplePrompt": "@Zero これらのバグから3つのIssueを作成:\n1. ESCダイアログ閉じ（Lancy）\n2. 日付ピッカーが1日ずれる（James）\n3. Safariでアバターアップロードが失敗（Yuma）"
+          },
+          {
+            "title": "トリアージを自動化",
+            "description": "チャンネルからIssueを自動作成",
+            "examplePrompt": "@Zero #bugsを監視、誰かが「bug:」で始まるメッセージを投稿したら、自動的にGitHub Issueを作成してリンクで返信。"
+          }
+        ],
+        "integrations": [
+          {
+            "description": "GitHubへのOAuth接続。ZeroにはIssueの作成・管理のための読み書きアクセスが必要です。"
+          },
+          {
+            "description": "Zeroがメッセージを読み、同じスレッドに返信します。"
+          }
+        ],
+        "tips": [
+          "担当者名を含めましょう。ZeroがSlackの表示名をGitHubユーザー名にマッチングします。",
+          "特定のラベルが必要な場合は明示的に指定してください。そうでなければZeroがコンテキストから推定します。",
+          "機能リクエストにも使えます — 「bug」の代わりに「機能リクエスト」と言うだけです。"
+        ]
+      },
+      "slack-triage": {
+        "title": "Slackのノイズを突破し、注意が必要なものを表面化",
+        "description": "Zeroが未読のSlackメッセージをスキャンし、ボットとノイズをフィルタリングして、今日実際にアクションが必要なメッセージだけを緊急度順に表示します。",
+        "timeSaved": "約10分の節約",
+        "headings": {
+          "scenario": "Slackの過負荷がアクションアイテムの見落としを引き起こす理由",
+          "prompt": "Zeroに未読Slackメッセージのトリアージを依頼する方法",
+          "steps": "Zeroがノイズをフィルタリングしアクション可能なメッセージを抽出する仕組み",
+          "nextActions": "直接返信、タスク作成、または日次トリアージを自動化",
+          "integrations": "必要な連携: Slack",
+          "tips": "Slackメッセージトリアージのベストプラクティス"
+        },
+        "scenario": "2時間の集中ブロック後にSlackを開くと、12チャンネルに47件の未読メッセージがあります。ほとんどはボット通知、自動アラート、自分に関係のない会話です。ノイズの中に実際に返信が必要な3つのことがあります。全てをスクロールする代わりに、Zeroに重要なものを見つけてもらいます。",
+        "promptVariants": [
+          {
+            "label": "詳細",
+            "prompt": "@Zero 過去12時間の未読Slackメッセージをスキャン。ボット、自動通知、タグされていないスレッドをフィルタリング。今日アクションが必要なメッセージだけを緊急度順に表示。それぞれ誰が待っていて何が必要か教えて。"
+          },
+          {
+            "label": "クイック",
+            "prompt": "@Zero 今 Slackで私の注意が必要なものは？"
+          },
+          {
+            "label": "スケジュール",
+            "prompt": "@Zero 毎朝9時と昇食後の13時に未読をスキャンしてアクションが必要なものをDMで送って。"
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero 過去12時間の未読Slackをスキャン。ボットとノイズをフィルタリング。今日アクションが必要なものだけ表示。"
+          },
+          {
+            "name": "Zero",
+            "text": "47件の未読メッセージを発見。5件がアクション必要:\n\n1. @Ethanが PR #6312のデザインレビューを依頼\n2. @JamesがStripe移行プランの承認を必要\n3. #supportにチャーンに言及する顧客からのP0\n4. @ScarlettがKOLアウトリーチの判断であなたをタグ\n5. スプリントレビューが15時に変更（14時から）"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zeroがチャンネルをスキャン",
+            "description": "Zeroが全チャンネルの未読メッセージを読み、ボットメッセージ、自動CI/CDアラート、メンションや必要性のないスレッドをフィルタリングします。"
+          },
+          {
+            "title": "メッセージを緊急度で分類",
+            "description": "残りの各メッセージを評価: 誰かがあなたを待っている？期限がある？他の人をブロックしている判断？Zeroが返信の緊急度でランク付けします。"
+          },
+          {
+            "title": "アクション可能なサマリーを配信",
+            "description": "Zeroが注意が必要なもののナンバリングリストをDMで送ります — 誰が聞いているか、何が必要か、各スレッドへの直接リンク付き。それ以外は安全に無視できます。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Zeroを通じて返信",
+            "description": "各スレッドを開かずに返信",
+            "examplePrompt": "@Zero #1に返信: 「問題なし、承認。出荷して。」そして#3は、P0 Linear Issueを作成してJamesに割り当て。"
+          },
+          {
+            "title": "ルーティンにする",
+            "description": "毎朝自動トリアージ",
+            "examplePrompt": "@Zero 平日毎朝9時に夜間の未読をスキャンしてアクションアイテムをDMで送って。"
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zeroが未読メッセージを読み、トリアージサマリーをDMで送ります。"
+          },
+          {
+            "description": "オプション: トリアージされたメッセージから直接タスクを作成。"
+          },
+          {
+            "description": "オプション: Zeroがカレンダーを確認して会議関連のメッセージにフラグを付けます。"
+          }
+        ],
+        "tips": [
+          "最も重要なチャンネルをZeroに伝えて、それに応じて優先順位付けできるようにしましょう。",
+          "Zeroにノイズパターンを学習させましょう:「@github-botと@vercel-botからのメッセージは常にスキップ」。",
+          "スタンドアップのユースケースと組み合わせましょう: まずトリアージ、次にアクションアイテムからスタンドアップを生成。"
+        ]
+      },
+      "employee-onboarding": {
+        "title": "Slackメッセージ1つで新しいチームメイトをオンボーディング",
+        "description": "Zeroに誰がいつ入社するか伝えます。Notionのオンボーディングページを作成し、Google Calendarでウェルカムミーティングをスケジュールし、Slackで紹介を投稿し、初週のアジェンダをDMで送ります。",
+        "timeSaved": "約45分の節約",
+        "headings": {
+          "scenario": "手動のオンボーディングチェックリストが常に何かを見落とす理由",
+          "prompt": "Zeroで新入社員のオンボーディングを自動化する方法",
+          "steps": "Zeroが新しいチームメイトのためにNotion、Calendar、Slackを設定する仕組み",
+          "nextActions": "アクセス設定を追加またはロール別にカスタマイズ",
+          "integrations": "必要な連携: Slack、Notion、Google Calendar、Gmail",
+          "tips": "自動従業員オンボーディングのベストプラクティス"
+        },
+        "scenario": "新しいチームメイトが来週月曜に入社します。誰かがオンボーディングドキュメントを作成し、5人との紹介ミーティングをスケジュールし、ウェルカムメッセージを投稿し、初週のアジェンダを送る必要があります。毎回同じように行われる45分の調整作業です。Zeroに一度伝えれば全て対応してくれます。",
+        "promptVariants": [
+          {
+            "label": "詳細",
+            "prompt": "@Zero 4月14日にProduct Designerとして入社するSarah Chenをオンボーディング。Notionのオンボーディングテンプレートを複製し、Google CalendarでEthan、Lancy、James、Yuma、Scarlettとの第1週紹介ミーティングをスケジュール。30日チェックインをスケジュール。#generalにウェルカムを投稿しSarahに初週アジェンダをDM。"
+          },
+          {
+            "label": "クイック",
+            "prompt": "@Zero Sarah Chen、Product Designer、4月14日開始をオンボーディング。フルセットアップ。"
+          },
+          {
+            "label": "テンプレート",
+            "prompt": "@Zero 誰かが#new-hiresに「名前 / ロール / 開始日」形式で投稿したら、フルオンボーディングワークフローを自動実行。"
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero Sarah Chenをオンボーディング、4月14日にProduct Designerとして入社。全て設定して。"
+          },
+          {
+            "name": "Zero",
+            "text": "Sarah Chenのオンボーディング準備完了:\n\n✔ テンプレートからNotionページ作成\n✔ 第1週紹介ミーティングスケジュール済み\n✔ 5月14日に30日チェックイン\n✔ #generalにウェルカム投稿済み\n✔ 初週アジェンダのDM送信済み"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Notionオンボーディングページ作成",
+            "description": "ZeroがNotionのオンボーディングテンプレートを複製し、新入社員の名前、ロール、開始日、マネージャーを記入します。関連ドキュメントとチームリソースにリンクします。"
+          },
+          {
+            "title": "ミーティングスケジュール済み",
+            "description": "Zeroが第1週中に指定されたチームメイトとの紹介ミーティングをGoogle Calendarに作成し、30日チェックインも設定します。全てのカレンダー招待には議題のコンテキストが含まれます。"
+          },
+          {
+            "title": "Slackウェルカムとdm送信",
+            "description": "Zeroが#generalに新入社員を紹介するウェルカムメッセージを投稿し、初週アジェンダ、Notionページへのリンク、主要連絡先をDMで直接送ります。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "ロール別にカスタマイズ",
+            "description": "異なるロールに異なるオンボーディング",
+            "examplePrompt": "@Zero エンジニア向けには、テックリードとのペアリングセッションも追加し、オンボーディングページにアーキテクチャドキュメントへのリンクを入れて。"
+          },
+          {
+            "title": "トリガーを自動化",
+            "description": "チャンネル投稿からオンボーディングを実行",
+            "examplePrompt": "@Zero 誰かが#new-hiresに「名前 / ロール / 開始日」形式で投稿したら、自動的にフルオンボーディングを実行。"
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zeroがウェルカムメッセージを投稿し、新入社員にDMを送ります。"
+          },
+          {
+            "description": "Zeroがテンプレートからオンボーディングページを作成します。"
+          },
+          {
+            "description": "Zeroが紹介ミーティングとチェックインをスケジュールします。"
+          },
+          {
+            "description": "オプション：ロジスティクスとリンクを含むウェルカムメールを送信。"
+          }
+        ],
+        "tips": [
+          "まずNotionのオンボーディングテンプレートを作成しましょう。Zeroが複製して詳細を記入します。",
+          "紹介ミーティングを行うべき人をリストアップしましょう。Zeroがカレンダー調整を行います。",
+          "契約社員やインターンにも使えます — テンプレートとミーティングリストを調整するだけです。"
+        ]
+      },
+      "build-with-v0": {
+        "title": "Slackのアイデアを即座にインタラクティブなプロトタイプに変換",
+        "description": "会話の途中でアイデアが浮かんだら、Zeroに説明します。v0を使ってクリック可能なReactプロトタイプを生成し、ライブプレビューリンクをスレッドに投稿します — ディスカッションが先に進む前に。",
+        "timeSaved": "数時間 → 数秒",
+        "headings": {
+          "scenario": "誰にも見せられないままアイデアが消えてしまう理由",
+          "prompt": "ZeroでSlackのアイデアをプロトタイプに変える方法",
+          "steps": "Zeroがあなたの説明からライブでクリック可能なUIを作る仕組み",
+          "nextActions": "改良、共有、またはエンジニアリングに引き継ぎ",
+          "integrations": "必要な連携: v0",
+          "tips": "v0を使った迅速なアイデアプロトタイピングのベストプラクティス"
+        },
+        "scenario": "Slackスレッドで機能の動作方法を議論しています。誰かが新しいUIパターンを提案 — コマンドパレット、設定パネル、マルチステップウィザード。言葉では伝わりません。ホワイトボードに描くオプションもありません。Figmaセッションをスケジュールすると決定が来週に延期されます。Zeroに自然言語でアイデアを説明します。v0を呼び出し、完全にインタラクティブなReactプロトタイプを生成し、ライブプレビューリンクをスレッドに投稿します — 1分以内に。会話が先に進む前に全員がクリックスルーできます。",
+        "promptVariants": [
+          {
+            "label": "新しいUIアイデア",
+            "prompt": "@Zero これをプロトタイプ化: ユーザーがエージェント、最近の実行、コネクターを検索できるコマンドパレット。キーボード操作可能、ファジー検索、右側にプレビューパネルを表示。"
+          },
+          {
+            "label": "スレッドコンテキストから",
+            "prompt": "@Zero 上で説明したフローに基づいて、チームが判断前に確認できるようクイックv0プロトタイプを作って。"
+          },
+          {
+            "label": "イテレーション",
+            "prompt": "@Zero プロトタイプを更新 — 上部に「エージェント / 実行 / コネクター」のフィルタータブを追加し、アクティブアイテムをオレンジでハイライト。再生成。"
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Ethan",
+            "text": "@Zero これをプロトタイプ化: ユーザーがエージェント、最近の実行、コネクターを検索できるコマンドパレット。キーボード操作可能、ファジー検索、右側にプレビューを表示。"
+          },
+          {
+            "name": "Zero",
+            "text": "インタラクティブなプロトタイプです:\nv0.dev/r/cmd-palette-preview\n\nエージェント、実行、コネクター間のファジー検索を搭載。矢印キーナビゲーション。右側プレビューパネルがホバーで更新。クリックして開く。"
+          }
+        ],
+        "steps": [
+          {
+            "title": "自然言語でアイデアを説明",
+            "description": "仕様書もワイヤーフレームも不要。UIが何をすべきか — コンポーネント、インタラクション、表示するデータをZeroに伝えます。大まかなスケッチ説明を貼り付けるか、スレッドから即興で。"
+          },
+          {
+            "title": "Zeroがv0でプロトタイプを生成",
+            "description": "Zeroがあなたの説明を構造化されたv0プロンプトに変換し、v0 APIを呼び出します。v0が完全にインタラクティブなReactコンポーネント — 本物のボタン、本物の状態、本物のナビゲーション — を生成します。"
+          },
+          {
+            "title": "ライブプレビューリンクをSlackに投稿",
+            "description": "Zeroがv0プレビューURLを同じスレッドに投稿します。チームメイトはあらゆるデバイスで、何もインストールしたりコードをチェックアウトすることなく、すぐにプロトタイプをクリックスルーできます。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "スレッドで改良",
+            "description": "Slackを離れずにイテレーションを続ける",
+            "examplePrompt": "@Zero プロトタイプを更新 — 検索入力の左にアイコンを付けて、空の状態では何も表示しない代わりに最近のアイテムを表示。"
+          },
+          {
+            "title": "非同期フィードバックのために共有",
+            "description": "より広いチャンネルに投稿またはステークホルダーにDM",
+            "examplePrompt": "@Zero v0プロトタイプリンクを#productに共有、メッセージ: 「コマンドパレットアイデアのクイックプロトタイプ — 木曜までにフィードバックお願いします。」"
+          },
+          {
+            "title": "エンジニアリングに引き継ぎ",
+            "description": "生成されたコードをリポジトリにエクスポート",
+            "examplePrompt": "@Zero v0プロトタイプコードを取得してvm0-ai/vm0のturbo/apps/platform/src/components/CommandPalette.tsxにPRを開いて、チームが開発を進められるようにして。"
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zeroがアイデアを生成プロンプトとしてv0に送信し、インタラクティブなプロトタイプURLを取得します。v0アカウントを接続して有効にしてください。"
+          },
+          {
+            "description": "ZeroがSlackスレッドからアイデアを読み取り、同じ会話にプロトタイプリンクを投稿します。"
+          }
+        ],
+        "tips": [
+          "外見だけでなく振る舞いを説明しましょう。「行をクリックするとその下に詳細が展開」は「展開可能な行」よりも正確なプロトタイプを生成します。",
+          "既存のUIパターンを名前で参照 — 「VS Codeのコマンドパレットのように」や「Notionのスラッシュメニューのように」 — v0の生成を導きます。",
+          "最初の結果の直後にイテレーションプロンプトを使いましょう。1回の改良で通常90%の完成度に達します。"
+        ]
+      }
+    }
+  },
+  "landing": {
+    "hero": {
+      "title": "Zero、実務のための信頼できるAIチームメイト。",
+      "subtitle": "Zeroは100以上のツールと連携し、仕事をこなします。レポート、トリアージ、アウトリーチ、リサーチ。Slackまたはウェブで。",
+      "ctaGetStarted": "始める",
+      "ctaOpenApp": "アプリを開く",
+      "seeUseCases": "ユースケースを見る",
+      "seedBanner": "$14Mシードラウンドの資金調達ブログをご覧ください。"
+    },
+    "worksForYou": {
+      "heading": "Zeroがあなたのために実際にすること",
+      "exploreMore": "さらにユースケースを探す"
+    },
+    "teammateCard": {
+      "title": "読んで、考えて、成果を出すチームメイト。",
+      "description": "“カレンダー、Linear、Slackから今週のまとめを作って。” Zeroはツールからコンテキストを引き出し、点と点をつなぎ、完成したレポートを渡します。同僚にブリーフィングするように、ただし数秒で。",
+      "tabSummarize": "仕事の週間サマリー",
+      "tabLeads": "リードを見つけてメール送信",
+      "tabTriage": "Sentryエラーのトリアージ",
+      "ariaDaily": "日次レポート",
+      "ariaLeads": "メールリード",
+      "ariaSentry": "Sentryレポート"
+    },
+    "slackCard": {
+      "title": "Slackで質問し、すべてのツールから回答を取得。",
+      "description": "任意のチャンネルで@Zero。カレンダー、メール、Linear、GitHubから情報を取得し、チームが実際に使えるサマリーで返信します。タブ切り替え不要、ダッシュボード不要。",
+      "tagSlack": "Slack",
+      "tagTeamSync": "チーム同期"
+    },
+    "syncedToolsCard": {
+      "title": "発見からアウトリーチまで、エージェントが下準備をします。",
+      "description": "Zeroに探している人を伝えてください。エージェントがソーシャルプラットフォームを巡回し、見込み客リストを作成し、パーソナライズされたアウトリーチを下書きします。チームは検索ではなく、クロージングに集中できます。",
+      "tagMarketing": "マーケティングアウトリーチ",
+      "tagCrossPlatform": "クロスプラットフォーム"
+    },
+    "connectors": {
+      "heading": "既に使っている100以上のツールと連携",
+      "description": "Slack、GitHub、Gmail、Notion、Linear、Sentryなど。Zeroはあなたのスタックに接続して、回答するだけでなく行動します。"
+    },
+    "security": {
+      "heading": "あなたのデータはあなたのもの",
+      "permissionTitle": "Zeroがアクセスできるものをあなたが制御",
+      "permissionDesc": "ツールごと、エージェントごとに読み取り・書き込み権限を設定。Zeroは明示的に許可されたものだけにアクセスします。",
+      "isolatedTitle": "常に隔離された実行環境",
+      "isolatedDescPart1": "すべてのタスクは独自のmicroVMで実行されます。クレデンシャルはサンドボックスの外に出ません。完全に監査可能。そして",
+      "isolatedDescLink": "オープンソース",
+      "isolatedDescPart2": "。"
+    },
+    "intelligence": {
+      "heading": "使えば使うほど賢くなる",
+      "memoryTitle": "コンテキストを記憶",
+      "memoryDesc": "過去の決定、プロジェクトコンテキスト、あなたの好み — Zeroはすべてを引き継ぎます。再説明不要、セッション間でコンテキストが失われません。",
+      "scheduleTitle": "スケジュールされたインテリジェンス",
+      "scheduleDesc": "Zeroは自律的な定期タスクを実行します — 毎日のエラースキャン、技術的負債レポート、朝のブリーフィング — プロンプト不要で。",
+      "subAgentsTitle": "特化型サブエージェント",
+      "subAgentsDesc": "特定の仕事用にエージェントを作成。リサーチ用、トリアージ用、アウトリーチ用。並行して動くので、あなたがする必要はありません。",
+      "toolOrchTitle": "ツールオーケストレーション",
+      "toolOrchDesc": "Zeroは100以上の利用可能な連携から適切なツールを選択し連鎖させます。あなたが目標を述べれば、Zeroが手順を考えます。",
+      "identityTitle": "あなたが誰かを知っている",
+      "identityDesc": "\"自分のPR\"、\"自分にアサイン\"。ZeroはGitHub、Slack、Linearでのあなたのアイデンティティを自動的に解決します。セットアップ不要。"
+    },
+    "cta": {
+      "title": "何が大事かはあなたが決める。残りはZeroにお任せ。",
+      "subtitle": "無料で始められます。SlackまたはWebで使えます。クレジットカード不要。"
+    }
+  },
+  "securityPage": {
+    "title": "セキュリティ",
+    "intro": "AIエージェントに仕事を任せる際、最大の懸念はデータの安全性、プライバシー、そしてコントロールの維持です。VM0は初日からこれらすべてを念頭に設計されました。",
+    "isolatedExecution": {
+      "title": "隔離された実行環境",
+      "description": "すべてのエージェント実行は完全に隔離されたプライベート環境内で行われます。実行が終了すると、環境は自動的に破棄され、何も残りません。使い捨ての手袋のようなものです：清潔、安全、信頼性。",
+      "detail": "コンテナではなく、ハードウェアレベルのKVM分離を備えたFirecracker microVMで駆動。各実行は16,000以上の事前割り当てプールから独自のネットワーク名前空間を取得。"
+    },
+    "secretsNeverExposed": {
+      "title": "シークレットは決して公開されない",
+      "description": "Gmail、Slack、GitHubを接続？あなたのトークンとクレデンシャルは安全に管理されます。エージェントはそれらを使用できますが、見たり抽出したりすることはできません。エージェントのコードに何か問題が起きても、あなたのアカウントは安全です。",
+      "detail": "クレデンシャルは透過的MITMプロキシを介してネットワーク層で注入。エージェントコードは生のトークンに触れません。外向きリクエストはシークレット漏洩防止のためスキャンされます。"
+    },
+    "startsInSeconds": {
+      "title": "秒で起動",
+      "description": "エージェントがトリガーから数十ミリ秒で実行に移れるよう、内部で広範な最適化を行いました。インフラレベルでの努力により高速です。あなたは結果を体験するだけです。",
+      "detail": "ゼロコピーブートのための共有読み取り専用rootfsを使用したoverlayfs。VMメモリスナップショットがランタイムスタック全体をプリウォーム — コールドスタートではなくリストア。"
+    },
+    "fullAuditTrail": {
+      "title": "完全な監査証跡",
+      "description": "エージェントが行うすべてのアクション — どのサービスにアクセスしたか、どのAPIを呼び出したか、何を生成したか — が記録されます。問題が発生すれば明確な記録があります。問題がなくても安心できます。",
+      "detail": "実行ごとに完全なHTTP/HTTPSトラフィックを記録（JSONL）。SHA-256整合性でCloudflare R2に保存された不変のコンテンツアドレスアーティファクト。"
+    },
+    "openSource": {
+      "title": "オープンソース",
+      "description": "コアプラットフォームはオープンソースです。コードを検査し、セキュリティモデルを監査し、貢献できます。デフォルトで透明。",
+      "detail": "GitHub上のコアプラットフォーム。定期的なサードパーティペネトレーションテスト。SOC 2 Type IIコンプライアンス進行中。"
+    },
+    "questionsAboutSecurity": "セキュリティについて質問がありますか？",
+    "contactUs": "お問い合わせ"
+  },
+  "avatar": {
+    "steps": {
+      "rotation": "角度",
+      "skin": "肌",
+      "hairStyle": "髪型",
+      "hairColor": "色",
+      "expression": "表情",
+      "intensity": "ムード"
+    },
+    "intensityLabels": {
+      "chill": "リラックス",
+      "normal": "ノーマル",
+      "hyped": "ハイテンション"
+    },
+    "back": "← 戻る"
   }
 }

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -20,7 +20,6 @@ import { handleCors } from "./proxy.cors";
 const isPublicRoute = createRouteMatcher([
   "/",
   "/:locale",
-  "/:locale/glossary",
   "/:locale/pricing",
   "/terms-of-use",
   "/privacy-policy",


### PR DESCRIPTION
## Summary

Localize the entire marketing site (landing, pricing, security, use cases, navbar) into German, Spanish, and Japanese. Previously only a small share of strings were translated; most UI copy, feature descriptions, and the full use-cases module rendered English on every locale.

Also bundles a few related technical SEO fixes that were already in this branch.

## What changed

**Translation coverage (the big one)**
- Extract all hardcoded user-facing strings from [LandingPage](turbo/apps/web/app/components/LandingPage.tsx), [PricingPageClient](turbo/apps/web/app/[locale]/pricing/PricingPageClient.tsx), [SecurityPage](turbo/apps/web/app/[locale]/security/SecurityPage.tsx), [AvatarCustomizer](turbo/apps/web/app/components/AvatarCustomizer.tsx), [Navbar](turbo/apps/web/app/components/Navbar.tsx), and the Use Cases gallery + detail into `messages/{en,de,es,ja}.json`.
- Move the use-cases content (titles, scenarios, prompt variants, Slack previews, steps, next actions, tips, integration descriptions) out of [data.ts](turbo/apps/web/app/[locale]/use-cases/data.ts) into `useCases.content.<slug>.*`. `data.ts` is now pure structural data (slug, color, avatar, roles, connectors refs, relatedSlugs).
- Fully localize Slack preview messages and example prompts; keep brand names (VM0, Zero, Slack, Sentry, GitHub, etc.), connector labels, plan tiers (Free/Pro/Team), and tech tokens (`#dev`, `@Zero`, `PR #N`) verbatim.
- Drop the already-removed `/glossary` route from the proxy public matcher and purge the dead `glossary` namespace from every message file.
- Final state: **406 keys** per locale, **0 missing / 0 extra** for de/es/ja.

**Technical SEO fixes bundled in (carryover from earlier in this branch)**
- Unify metadata base URL from `https://vm0.ai` to `https://www.vm0.ai` across canonical / OG / JSON-LD / sitemap / robots so www vs. non-www no longer compete as indexing signals.
- Add non-localized `/blog` and `/blog/posts/:slug` to [`isPublicRoute`](turbo/apps/web/proxy.ts) so Googlebot hitting a no-locale blog URL lands on the i18n 308 redirect instead of a Clerk `/sign-in` redirect (the reason GSC flagged "Indexed, though blocked by robots.txt").

## What intentionally stays English

- Slack/Memory/Schedule demo mockup content in LandingPage (fake Slack thread screenshot — translating it looks machine-translated)
- Brand and connector names (Slack, Sentry, Linear, GitHub, Notion, Gmail, …)
- Plan tier names (Free / Pro / Team) and currency values
- Tech tokens in example prompts (`@Zero`, `#dev`, `24h`, `PR #6312`)
- Fictional character names in Slack previews (Yuma, Alex, Lancy, …)

## Test plan
- [ ] Visit `/de`, `/es`, `/ja` and spot-check hero, feature cards, CTA, security, pricing, use cases gallery, and one use-case detail page in each locale
- [ ] Verify Navbar + Footer render fully translated (Pricing / Security / Use Cases / Sign out / Open app / Status / Terms / Privacy)
- [ ] Confirm Use Cases detail page translates: section headings, Slack preview, prompt variants (Detailed/Quick/Scheduled tabs), steps, next actions, integrations, tips
- [ ] `curl -I https://www.vm0.ai/blog/posts/building-in-public` after deploy should 308 to `/en/blog/posts/...`, not redirect to `/sign-in`
- [ ] Submit "Validate Fix" in GSC for the previously flagged URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)