### PR TITLE
feat(insights): abbreviate credit numbers with k/m suffix

### DIFF
--- a/turbo/apps/platform/src/lib/format-credits.ts
+++ b/turbo/apps/platform/src/lib/format-credits.ts
@@ -1,0 +1,16 @@
+/**
+ * Format a credit count with K/M abbreviation for compact display.
+ *
+ * - >= 1,000,000 → "x.x M" (e.g. 2,300,000 → "2.3 M")
+ * - >= 1,000     → "x.x K" (e.g. 12,400    → "12.4 K")
+ * - <  1,000     → exact integer string  (e.g. 999      → "999")
+ */
+export function formatCredits(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)} M`;
+  }
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(1)} K`;
+  }
+  return String(n);
+}

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
@@ -169,6 +169,83 @@ describe("network insights page - data rendering", () => {
     });
   });
 
+  it("should abbreviate credit amounts >= 1,000 with K suffix", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        creditsUsed: 12_400,
+        creditBalance: 9500,
+        teamUsage: [
+          {
+            userId: "user-alice",
+            name: "alice",
+            credits: 12_400,
+            agentNames: ["Alpha Bot"],
+            agentCredits: { "Alpha Bot": 12_400 },
+          },
+        ],
+      }),
+    ]);
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("12.4 K").length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText("9.5 K")).toBeInTheDocument();
+  });
+
+  it("should abbreviate credit amounts >= 1,000,000 with M suffix", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        creditsUsed: 2_300_000,
+        creditBalance: 5_000_000,
+        teamUsage: [
+          {
+            userId: "user-alice",
+            name: "alice",
+            credits: 2_300_000,
+            agentNames: ["Alpha Bot"],
+            agentCredits: { "Alpha Bot": 2_300_000 },
+          },
+        ],
+      }),
+    ]);
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("2.3 M").length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText("5.0 M")).toBeInTheDocument();
+  });
+
+  it("should expose exact credit value via title attribute on hover", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        creditsUsed: 12_400,
+        creditBalance: 9500,
+        teamUsage: [
+          {
+            userId: "user-alice",
+            name: "alice",
+            credits: 12_400,
+            agentNames: ["Alpha Bot"],
+            agentCredits: { "Alpha Bot": 12_400 },
+          },
+        ],
+      }),
+    ]);
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("12.4 K").length).toBeGreaterThan(0);
+    });
+    // Hover tooltip via native title attribute exposes the exact value.
+    const abbreviated = screen.getAllByText("12.4 K");
+    expect(abbreviated[0]).toHaveAttribute("title", "12,400");
+  });
+
   it("should display most-used service with proper connector label", async () => {
     mockInsightsAPI([sampleDay(day1Ago)]);
 
@@ -479,7 +556,7 @@ describe("network insights page - team credit usage card", () => {
     detachedSetupPage({ context, path: "/insights" });
 
     await waitFor(() => {
-      expect(screen.getByText("9,800")).toBeInTheDocument();
+      expect(screen.getByText("9.8 K")).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -36,6 +36,7 @@ import {
 import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { user$ } from "../../signals/auth.ts";
+import { formatCredits } from "../../lib/format-credits.ts";
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 
 // ---------------------------------------------------------------------------
@@ -407,8 +408,8 @@ function buildSummaryQuote(day: DayInsight): {
     quote = `${totalCalls} service calls across ${day.services.length} services. High traffic day.`;
     caption = `${totalCalls} calls · ${day.services.length} services`;
   } else if (day.agents.length >= 4) {
-    quote = `${day.agents.length} agents active, using ${day.creditsUsed} credits total. A well-distributed workload.`;
-    caption = `${day.agents.length} agents · ${day.creditsUsed} credits`;
+    quote = `${day.agents.length} agents active, using ${formatCredits(day.creditsUsed)} credits total. A well-distributed workload.`;
+    caption = `${day.agents.length} agents · ${formatCredits(day.creditsUsed)} credits`;
   } else if (totalRuns <= 2 && totalCalls < 30) {
     quote = `Light activity — ${totalRuns === 0 ? "no runs" : `only ${totalRuns} ${totalRuns === 1 ? "run" : "runs"}`} and ${totalCalls} calls. A quiet day.`;
     caption = `${totalRuns} ${totalRuns === 1 ? "run" : "runs"} · a quiet day`;
@@ -591,8 +592,11 @@ function TeamCreditUsageCard({
       >
         Team Credit Usage
       </p>
-      <p className="text-5xl font-black leading-none tabular-nums font-serif transition-all duration-150">
-        {displayCredits.toLocaleString()}
+      <p
+        className="text-5xl font-black leading-none tabular-nums font-serif transition-all duration-150"
+        title={displayCredits.toLocaleString()}
+      >
+        {formatCredits(displayCredits)}
       </p>
       <p className="text-sm opacity-60 mt-2">
         {hoveredAgentData
@@ -602,8 +606,11 @@ function TeamCreditUsageCard({
 
       <div className="flex items-center justify-between mt-4">
         <span className="text-sm opacity-60">Balance</span>
-        <span className="text-sm font-semibold tabular-nums">
-          {day.creditBalance.toLocaleString()}
+        <span
+          className="text-sm font-semibold tabular-nums"
+          title={day.creditBalance.toLocaleString()}
+        >
+          {formatCredits(day.creditBalance)}
         </span>
       </div>
 
@@ -643,8 +650,11 @@ function TeamCreditUsageCard({
                       }}
                     />
                   </div>
-                  <span className="text-xs opacity-60 w-10 text-right shrink-0 tabular-nums">
-                    {memberCredits}
+                  <span
+                    className="text-xs opacity-60 w-10 text-right shrink-0 tabular-nums"
+                    title={memberCredits.toLocaleString()}
+                  >
+                    {formatCredits(memberCredits)}
                   </span>
                 </div>
               );
@@ -695,8 +705,11 @@ function YourCreditUsageCard({
       >
         Your Credit Usage
       </p>
-      <p className="text-5xl font-black leading-none tabular-nums font-serif transition-all duration-150">
-        {displayCredits.toLocaleString()}
+      <p
+        className="text-5xl font-black leading-none tabular-nums font-serif transition-all duration-150"
+        title={displayCredits.toLocaleString()}
+      >
+        {formatCredits(displayCredits)}
       </p>
       <p className="text-sm opacity-60 mt-2">
         {hoveredAgentData


### PR DESCRIPTION
Closes #9136

## Summary

- Add shared `formatCredits` helper at `apps/platform/src/lib/format-credits.ts` that abbreviates large numbers using SI suffixes (`12,400` → `12.4 K`, `2,300,000` → `2.3 M`, values < 1000 stay as-is)
- Apply it on the Insights page for: Team total, Balance, per-member bar, Your total, and the textual quote/caption
- Surface the exact value via the native `title` attribute so hovering reveals full precision (e.g. `12,400`)

## Test plan

- [x] `network-insights-page-interaction.test.tsx` — added cases for K-suffix, M-suffix, and `title` attribute exposure; updated existing `creditBalance` assertion that previously relied on `toLocaleString()`
- [x] All 36 tests in the suite pass
- [x] `pnpm turbo run lint check-types --filter=@vm0/app` clean