### PR TITLE
feat(voice-chat): add meeting preparation frontend

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-preparation.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-preparation.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setChatAgentId$ } from "../../agent-chat.ts";
+import {
+  meetingPrepStatus$,
+  meetingPrepPrompt$,
+  meetingPrepStartTime$,
+  triggerPreparation$,
+  clearPreparation$,
+} from "../voice-chat-preparation.ts";
+
+const context = testContext();
+
+const TEST_AGENT_ID = "agent-123";
+
+function setup() {
+  detachedSetupPage({
+    context,
+    path: "/",
+    withoutRender: true,
+  });
+  context.store.set(setChatAgentId$, TEST_AGENT_ID);
+}
+
+function mockPrepareEndpoint(responses: { status: string; id?: string }[]) {
+  let callIndex = 0;
+  const counter = {
+    get count() {
+      return callIndex;
+    },
+  };
+  server.use(
+    http.post("*/api/zero/voice-chat/prepare", () => {
+      const responseIndex = Math.min(callIndex, responses.length - 1);
+      const response = responses[responseIndex];
+      callIndex++;
+      return HttpResponse.json({
+        preparation: {
+          id: response.id ?? "prep-1",
+          status: response.status,
+        },
+      });
+    }),
+  );
+  return counter;
+}
+
+describe("voice-chat-preparation signals", () => {
+  it("should set status to ready when preparation is cached", async () => {
+    setup();
+    const responses = [{ status: "ready" }];
+    mockPrepareEndpoint(responses);
+
+    await context.store.set(
+      triggerPreparation$,
+      "discuss quarterly goals",
+      context.signal,
+    );
+
+    expect(context.store.get(meetingPrepStatus$)).toBe("ready");
+    expect(context.store.get(meetingPrepPrompt$)).toBe(
+      "discuss quarterly goals",
+    );
+    expect(context.store.get(meetingPrepStartTime$)).toBeTypeOf("number");
+  });
+
+  it("should poll until ready when preparation is in progress", async () => {
+    setup();
+    const responses = [
+      { status: "preparing" },
+      { status: "preparing" },
+      { status: "ready" },
+    ];
+    const counter = mockPrepareEndpoint(responses);
+
+    await context.store.set(
+      triggerPreparation$,
+      "review sprint items",
+      context.signal,
+    );
+
+    expect(context.store.get(meetingPrepStatus$)).toBe("ready");
+    // Initial call + 2 poll calls (preparing, ready)
+    expect(counter.count).toBeGreaterThanOrEqual(3);
+  });
+
+  it("should set status to failed when preparation fails during poll", async () => {
+    setup();
+    const responses = [{ status: "preparing" }, { status: "failed" }];
+    mockPrepareEndpoint(responses);
+
+    await context.store.set(
+      triggerPreparation$,
+      "team standup",
+      context.signal,
+    );
+
+    expect(context.store.get(meetingPrepStatus$)).toBe("failed");
+  });
+
+  it("should set status to failed when endpoint returns error", async () => {
+    setup();
+    server.use(
+      http.post("*/api/zero/voice-chat/prepare", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    await context.store.set(
+      triggerPreparation$,
+      "error prompt",
+      context.signal,
+    );
+
+    expect(context.store.get(meetingPrepStatus$)).toBe("failed");
+  });
+
+  it("should set status to failed when no agent is selected", async () => {
+    setup();
+    context.store.set(setChatAgentId$, null);
+
+    await context.store.set(
+      triggerPreparation$,
+      "no agent prompt",
+      context.signal,
+    );
+
+    expect(context.store.get(meetingPrepStatus$)).toBe("failed");
+  });
+
+  it("should reset all state on clearPreparation$", async () => {
+    setup();
+    const responses = [{ status: "ready" }];
+    mockPrepareEndpoint(responses);
+
+    await context.store.set(triggerPreparation$, "some prompt", context.signal);
+
+    expect(context.store.get(meetingPrepStatus$)).toBe("ready");
+
+    context.store.set(clearPreparation$);
+
+    expect(context.store.get(meetingPrepStatus$)).toBe("idle");
+    expect(context.store.get(meetingPrepPrompt$)).toBeNull();
+    expect(context.store.get(meetingPrepStartTime$)).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-preparation.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-preparation.ts
@@ -1,0 +1,108 @@
+import { command, computed, state } from "ccstate";
+import { zeroVoiceChatPrepareTriggerContract } from "@vm0/core";
+import { zeroClient$ } from "../api-client.ts";
+import { currentChatAgentId$ } from "../agent-chat.ts";
+import { accept, ApiError } from "../../lib/accept.ts";
+import { setLoop, throwIfAbort } from "../utils.ts";
+
+type PreparationStatus = "idle" | "preparing" | "ready" | "failed";
+
+const POLL_INTERVAL_MS = 5000;
+
+// --- Internal state ---
+
+const internalPrepStatus$ = state<PreparationStatus>("idle");
+const internalPrepPrompt$ = state<string | null>(null);
+const internalPrepStartTime$ = state<number | null>(null);
+
+// --- Exported computed ---
+
+export const meetingPrepStatus$ = computed((get) => {
+  return get(internalPrepStatus$);
+});
+
+export const meetingPrepPrompt$ = computed((get) => {
+  return get(internalPrepPrompt$);
+});
+
+export const meetingPrepStartTime$ = computed((get) => {
+  return get(internalPrepStartTime$);
+});
+
+// --- Commands ---
+
+export const triggerPreparation$ = command(
+  async ({ get, set }, prompt: string, signal: AbortSignal) => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroVoiceChatPrepareTriggerContract);
+    const agentId = await get(currentChatAgentId$);
+    signal.throwIfAborted();
+
+    if (!agentId) {
+      set(internalPrepStatus$, "failed");
+      return;
+    }
+
+    set(internalPrepStatus$, "preparing");
+    set(internalPrepPrompt$, prompt);
+    set(internalPrepStartTime$, Date.now());
+
+    let initialStatus: string;
+    // eslint-disable-next-line no-restricted-syntax -- accept() throws on non-200; must catch to transition to "failed" state instead of leaving "preparing" forever
+    try {
+      const res = await accept(
+        client.trigger({ body: { agentId, mode: "meeting", prompt } }),
+        [200],
+        { toast: false },
+      );
+      signal.throwIfAborted();
+      initialStatus = res.body.preparation.status;
+    } catch (error) {
+      throwIfAbort(error);
+      if (error instanceof ApiError) {
+        set(internalPrepStatus$, "failed");
+        return;
+      }
+      throw error;
+    }
+
+    if (initialStatus === "ready") {
+      set(internalPrepStatus$, "ready");
+      return;
+    }
+
+    // Poll until ready or failed.
+    // setLoop handles transient errors (including ApiError from accept())
+    // with fibonacci backoff retry.
+    await setLoop(
+      async (loopSignal: AbortSignal) => {
+        const pollRes = await accept(
+          client.trigger({ body: { agentId, mode: "meeting", prompt } }),
+          [200],
+          { toast: false },
+        );
+        loopSignal.throwIfAborted();
+
+        if (pollRes.body.preparation.status === "ready") {
+          set(internalPrepStatus$, "ready");
+          return true;
+        }
+
+        if (pollRes.body.preparation.status === "failed") {
+          set(internalPrepStatus$, "failed");
+          return true;
+        }
+
+        return false;
+      },
+      POLL_INTERVAL_MS,
+      signal,
+    );
+  },
+);
+
+export const clearPreparation$ = command(({ set }) => {
+  set(internalPrepStatus$, "idle");
+  set(internalPrepPrompt$, null);
+  set(internalPrepStartTime$, null);
+});

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-setup.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-setup.ts
@@ -7,6 +7,7 @@ import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { endVoiceChat$, vcStatus$ } from "./voice-chat-session.ts";
+import { clearPreparation$ } from "./voice-chat-preparation.ts";
 
 export const setupVoiceChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -22,12 +23,13 @@ export const setupVoiceChatPage$ = command(
 
     await set(hideAppSkeleton$, signal);
 
-    // End voice chat session when navigating away
+    // End voice chat session and clear preparation when navigating away
     signal.addEventListener("abort", () => {
       const status = get(vcStatus$);
       if (status === "connecting" || status === "connected") {
         set(endVoiceChat$);
       }
+      set(clearPreparation$);
     });
   },
 );

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -9,6 +9,7 @@ import {
   IconLoader2,
   IconRefresh,
   IconUsers,
+  IconCheck,
 } from "@tabler/icons-react";
 import type { TouchEvent as ReactTouchEvent } from "react";
 import { defaultAgentName$ } from "../../signals/agent.ts";
@@ -44,6 +45,12 @@ import {
   setTranscriptScrollContainer$,
   setEventsScrollContainer$,
 } from "../../signals/voice-chat/voice-chat-auto-scroll.ts";
+import {
+  meetingPrepStatus$,
+  meetingPrepPrompt$,
+  triggerPreparation$,
+  clearPreparation$,
+} from "../../signals/voice-chat/voice-chat-preparation.ts";
 import {
   useTranscriptAutoScroll,
   useEventsAutoScroll,
@@ -213,6 +220,91 @@ function VoiceChatFooter({
   );
 }
 
+function MeetingBox() {
+  const pageSignal = useGet(pageSignal$);
+  const agentId = useLastResolved(vcAgentId$);
+  const meetingPrompt = useGet(vcMeetingPromptInput$);
+  const setMeetingPrompt = useSet(setMeetingPromptInput$);
+  const startMeeting = useSet(startVoiceMeeting$);
+  const prepStatus = useGet(meetingPrepStatus$);
+  const prepPrompt = useGet(meetingPrepPrompt$);
+  const triggerPrep = useSet(triggerPreparation$);
+  const clearPrep = useSet(clearPreparation$);
+  const promptMatchesPrep = prepPrompt === meetingPrompt;
+
+  return (
+    <div className="w-full max-w-md rounded-lg border border-input p-5 flex flex-col gap-3">
+      <h2 className="text-lg font-semibold">Voice Meeting</h2>
+      <p className="text-sm text-muted-foreground">
+        Set a topic to guide a structured conversation.
+      </p>
+      <textarea
+        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        rows={3}
+        placeholder="What would you like to discuss?"
+        value={meetingPrompt}
+        onChange={(e) => {
+          setMeetingPrompt(e.target.value);
+          if (prepPrompt && e.target.value !== prepPrompt) {
+            clearPrep();
+          }
+        }}
+      />
+      {prepStatus === "preparing" && promptMatchesPrep && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <IconLoader2 size={16} className="animate-spin" />
+          Preparing...
+        </div>
+      )}
+      {prepStatus === "ready" && promptMatchesPrep && (
+        <div className="flex items-center gap-2 text-sm text-green-600">
+          <IconCheck size={16} />
+          Preparation ready
+        </div>
+      )}
+      {prepStatus === "failed" && promptMatchesPrep && (
+        <div className="text-sm text-destructive">Preparation failed</div>
+      )}
+      <div className="flex gap-2">
+        {!(prepStatus === "ready" && promptMatchesPrep) && (
+          <Button
+            size="lg"
+            variant="outline"
+            className="flex-1"
+            onClick={() => {
+              detach(
+                triggerPrep(meetingPrompt, pageSignal),
+                Reason.DomCallback,
+              );
+            }}
+            disabled={
+              !agentId ||
+              !meetingPrompt.trim() ||
+              (prepStatus === "preparing" && promptMatchesPrep)
+            }
+          >
+            {prepStatus === "preparing" && promptMatchesPrep
+              ? "Preparing..."
+              : "Prepare"}
+          </Button>
+        )}
+        <Button
+          size="lg"
+          variant="secondary"
+          className="flex-1"
+          onClick={() => {
+            detach(startMeeting(meetingPrompt, pageSignal), Reason.DomCallback);
+          }}
+          disabled={!agentId || !meetingPrompt.trim()}
+        >
+          <IconUsers size={18} className="mr-2" />
+          Start Meeting
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function VoiceChatPage() {
   const pageSignal = useGet(pageSignal$);
   const enabled = useLastResolved(vcEnabled$);
@@ -223,7 +315,6 @@ export function VoiceChatPage() {
   const muted = useGet(vcMuted$);
   const error = useGet(vcError$);
   const startSession = useSet(startVoiceChat$);
-  const startMeeting = useSet(startVoiceMeeting$);
   const endSession = useSet(endVoiceChat$);
   const toggleMute = useSet(toggleVoiceChatMute$);
   const reconnectAttempt = useGet(vcReconnectAttempt$);
@@ -234,8 +325,6 @@ export function VoiceChatPage() {
   const pttStop = useSet(stopPTT$);
   const prompt = useGet(vcPrompt$);
   const prepElapsedMs = useGet(vcPrepElapsedMs$);
-  const meetingPrompt = useGet(vcMeetingPromptInput$);
-  const setMeetingPrompt = useSet(setMeetingPromptInput$);
   const model = useGet(vcModel$);
   const setModel = useSet(setVcModel$);
   const agentName = useLastResolved(defaultAgentName$) ?? "Zero";
@@ -304,36 +393,7 @@ export function VoiceChatPage() {
             Start Voice Chat
           </Button>
         </div>
-        <div className="w-full max-w-md rounded-lg border border-input p-5 flex flex-col gap-3">
-          <h2 className="text-lg font-semibold">Voice Meeting</h2>
-          <p className="text-sm text-muted-foreground">
-            Set a topic to guide a structured conversation.
-          </p>
-          <textarea
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            rows={3}
-            placeholder="What would you like to discuss?"
-            value={meetingPrompt}
-            onChange={(e) => {
-              setMeetingPrompt(e.target.value);
-            }}
-          />
-          <Button
-            size="lg"
-            variant="secondary"
-            className="w-full"
-            onClick={() => {
-              detach(
-                startMeeting(meetingPrompt, pageSignal),
-                Reason.DomCallback,
-              );
-            }}
-            disabled={!agentId || !meetingPrompt.trim()}
-          >
-            <IconUsers size={18} className="mr-2" />
-            Start Voice Meeting
-          </Button>
-        </div>
+        <MeetingBox />
       </div>
     );
   }

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -808,6 +808,7 @@ export {
   type AppendContextEventBody,
 } from "./zero-voice-chat-context";
 export {
+  zeroVoiceChatPrepareTriggerContract,
   zeroVoiceChatPrepareCompleteContract,
   type ZeroVoiceChatPrepareCompleteContract,
   type PrepareCompleteBody,

--- a/turbo/packages/core/src/contracts/zero-voice-chat-prepare.ts
+++ b/turbo/packages/core/src/contracts/zero-voice-chat-prepare.ts
@@ -4,6 +4,36 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+const prepareTriggerBodySchema = z.object({
+  agentId: z.string().min(1),
+  mode: z.enum(["chat", "meeting"]).default("chat"),
+  prompt: z.string().min(1).optional(),
+});
+
+const prepareTriggerResponseSchema = z.object({
+  preparation: z.object({
+    id: z.string(),
+    status: z.string(),
+    runId: z.string().optional(),
+  }),
+});
+
+export const zeroVoiceChatPrepareTriggerContract = c.router({
+  trigger: {
+    method: "POST",
+    path: "/api/zero/voice-chat/prepare",
+    headers: authHeadersSchema,
+    body: prepareTriggerBodySchema,
+    responses: {
+      200: prepareTriggerResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "Trigger a voice-chat preparation run (with dedup and cache)",
+  },
+});
+
 const prepareCompleteBodySchema = z.object({
   content: z.string().min(1),
 });


### PR DESCRIPTION
## Summary

- Add frontend UI to the voice chat page that lets users trigger meeting preparation ahead of time. When preparation is ready, starting the meeting uses the cached preparation for near-instant voice connection.
- Add `Prepare` button alongside `Start Meeting` with inline status indicators (spinner for preparing, green checkmark for ready, error for failed)
- Add ts-rest contract (`zeroVoiceChatPrepareTriggerContract`) for the existing `POST /api/zero/voice-chat/prepare` endpoint
- Extract `MeetingBox` component to keep `VoiceChatPage` complexity under lint threshold
- Preparation state auto-invalidates when the user changes the meeting prompt
- Clear preparation state on page navigation

## Dependencies

- #9085 (prepare pipeline) — merged
- #9086 (session integration) — merged

## File Changes

| File | Change |
|------|--------|
| `turbo/apps/platform/src/signals/voice-chat/voice-chat-preparation.ts` | NEW — preparation state signals with polling |
| `turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-preparation.test.ts` | NEW — 6 integration tests |
| `turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx` | Extract MeetingBox, add preparation UI |
| `turbo/apps/platform/src/signals/voice-chat/voice-chat-setup.ts` | Clear preparation on navigation |
| `turbo/packages/core/src/contracts/zero-voice-chat-prepare.ts` | Add trigger contract |
| `turbo/packages/core/src/contracts/index.ts` | Export new contract |

## Test plan

- [x] All 6 new preparation signal tests pass
- [x] All 1674 existing platform tests pass (zero regressions)
- [x] Lint passes (0 errors)
- [x] Type check passes
- [x] Knip passes (no unused exports)
- [ ] Manual: navigate to voice chat page, enter meeting prompt, click Prepare, verify spinner appears
- [ ] Manual: wait for preparation to complete, verify green "Preparation ready" indicator
- [ ] Manual: change the prompt text, verify preparation state resets
- [ ] Manual: click Start Meeting with ready preparation, verify fast connection

Closes #9087

🤖 Generated with [Claude Code](https://claude.com/claude-code)