### PR TITLE
fix(app-skeleton): restart message cycling when skeleton is reshown

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/app-skeleton.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/app-skeleton.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+import { testContext } from "./test-helpers";
+import { setupPage } from "../../__tests__/page-helper";
+import {
+  appSkeletonVisible$,
+  hideAppSkeleton$,
+  showAppSkeleton$,
+  skeletonMessages$,
+} from "../app-skeleton";
+
+const context = testContext();
+
+describe("showAppSkeleton$ restarts cycling (regression)", () => {
+  it("after hide → show, the message cycle advances so the typewriter animation re-fires", async () => {
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    // Forcibly stop the bootstrap cycling loop so we have a stable baseline.
+    await context.store.set(hideAppSkeleton$, context.signal);
+    expect(context.store.get(appSkeletonVisible$)).toBeFalsy();
+
+    const cycleAfterHide = context.store.get(skeletonMessages$).cycle;
+
+    // Show again — this must restart the cycling loop so <div key={cycle}>
+    // remounts and the typewriter animation re-fires. Without the restart in
+    // showAppSkeleton$ the loop stays aborted from the prior hide and the
+    // cycle index is frozen forever.
+    context.store.set(showAppSkeleton$);
+    expect(context.store.get(appSkeletonVisible$)).toBeTruthy();
+
+    await vi.waitFor(() => {
+      expect(context.store.get(skeletonMessages$).cycle).toBeGreaterThan(
+        cycleAfterHide,
+      );
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -1,9 +1,10 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { currentChatAgent$ } from "./agent-chat.ts";
 import { resolveAvatarUrl } from "../views/zero-page/avatar-utils.ts";
-import { resetSignal, bestEffort, setLoop } from "./utils.ts";
+import { resetSignal, bestEffort, setLoop, throwIfNotAbort } from "./utils.ts";
 import { agents$ } from "./agent.ts";
 import { getAvatarPresets } from "../views/zero-page/zero-avatars.ts";
+import { rootSignal$ } from "./root-signal.ts";
 
 // ---------------------------------------------------------------------------
 // Visibility
@@ -84,8 +85,20 @@ export const appSkeletonVisible$ = computed((get) => {
   return get(internalVisible$);
 });
 
-export const showAppSkeleton$ = command(({ set }) => {
+/**
+ * Reveal the skeleton and (re)start the message-cycling loop so the
+ * typewriter animation plays again. `hideAppSkeleton$` aborts the cycling
+ * loop via `resetSkeletonCycling$`, so any subsequent show — for example
+ * the brief skeleton between onboarding completion and the chat page — must
+ * restart it. We also reset `skeletonFirstCycle$` so the first frame after
+ * showing replays the static → typewriter intro instead of jumping straight
+ * to the cursor-only state the previous run ended on.
+ */
+export const showAppSkeleton$ = command(({ get, set }) => {
   set(internalVisible$, true);
+  set(skeletonFirstCycle$, true);
+  const { signal } = get(rootSignal$);
+  void set(startSkeletonCycling$, signal).catch(throwIfNotAbort);
 });
 
 const prefetch$ = command(


### PR DESCRIPTION
## Summary

Fixes the missing typewriter animation on the loading skeleton shown right after onboarding completes (and any other reshow of the skeleton).

The skeleton's typewriter effect depends on a 4 s loop that increments `skeletonMsgIndex$`, forcing the message `<div key={cycle}>` to remount so the CSS animation re-fires. The loop is started exactly once at bootstrap (`bootstrap.ts:281`) and is permanently aborted by `hideAppSkeleton$` via `resetSkeletonCycling$` when the first page loads.

`showAppSkeleton$` only flipped `internalVisible$` back to `true` — it never restarted the loop. So when onboarding completion reshows the skeleton (`zero-onboarding-actions.ts:217,241`), the user sees a fully-typed message with only the cursor blinking: no typewriter, no message rotation.

### Fix

- `showAppSkeleton$` now restarts the cycling loop using `rootSignal$` so its lifetime is tied to the app root, not the (unavailable) caller signal.
- `skeletonFirstCycle$` is reset to `true` so the reshown skeleton replays the static → typewriter intro instead of starting in the cursor-only state the prior run ended on.

The change is symmetric to `hideAppSkeleton$` (which stops the loop) and idempotent — every call resets and reseats the loop's controller via `resetSignal()`.

### Surface area

- `apps/platform/src/signals/app-skeleton.ts` — the fix (one command body).
- `apps/platform/src/signals/__tests__/app-skeleton.test.ts` — new regression test asserting the message cycle advances after `hide → show`.

No callers of `showAppSkeleton$` change.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest` — 1672 platform tests pass (1671 pre-existing + 1 new regression test)
- [x] `pnpm turbo run lint --filter=@vm0/app` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — only pre-existing config hints, no new issues
- [ ] Manual verification on a fresh onboarding: complete onboarding (admin or member), confirm the skeleton between step 4 and the chat page rotates messages with the typewriter animation playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)