### PR TITLE
fix(voice-io): prevent double tts playback on rapid read-aloud clicks

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
+++ b/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { playTts$, ttsPlayingMessageId$ } from "../voice-io-tts.ts";
+
+class MockAudio {
+  play = (): Promise<void> => {
+    return Promise.resolve();
+  };
+  pause = () => {};
+  load = () => {};
+  removeAttribute = (_name: string) => {};
+  addEventListener = (_type: string, _listener: unknown) => {};
+  removeEventListener = (_type: string, _listener: unknown) => {};
+}
+
+function mockAudio() {
+  const instances: MockAudio[] = [];
+
+  vi.stubGlobal(
+    "Audio",
+    vi.fn(function (this: MockAudio) {
+      Object.assign(this, new MockAudio());
+      vi.spyOn(this, "play").mockResolvedValue(undefined);
+      instances.push(this);
+    }),
+  );
+
+  vi.stubGlobal(
+    "URL",
+    Object.assign(globalThis.URL, {
+      createObjectURL: vi.fn().mockReturnValue("blob:mock"),
+      revokeObjectURL: vi.fn(),
+    }),
+  );
+
+  return { instances };
+}
+
+function mockTtsEndpoint() {
+  let fetchCount = 0;
+
+  server.use(
+    http.post("http://localhost:3000/api/zero/voice-io/tts", () => {
+      fetchCount++;
+      const body = new Uint8Array([0]);
+      return new HttpResponse(body, {
+        headers: { "Content-Type": "audio/mpeg" },
+      });
+    }),
+  );
+
+  return {
+    getFetchCount: () => {
+      return fetchCount;
+    },
+  };
+}
+
+describe("playTts$", () => {
+  const context = testContext();
+
+  it("should not trigger a second fetch when called twice with the same messageId", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+    const { instances } = mockAudio();
+    const { getFetchCount } = mockTtsEndpoint();
+
+    const p1 = context.store.set(
+      playTts$,
+      "msg-1",
+      "Hello world",
+      context.signal,
+    );
+    const p2 = context.store.set(
+      playTts$,
+      "msg-1",
+      "Hello world",
+      context.signal,
+    );
+    await Promise.all([p1, p2]);
+
+    expect(getFetchCount()).toBe(1);
+    expect(instances).toHaveLength(1);
+  });
+
+  it("should allow playback for a different messageId", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+    mockAudio();
+    const { getFetchCount } = mockTtsEndpoint();
+
+    await context.store.set(playTts$, "msg-1", "Hello", context.signal);
+    await context.store.set(playTts$, "msg-2", "World", context.signal);
+
+    expect(getFetchCount()).toBe(2);
+  });
+
+  it("should reset playingMessageId on fetch failure", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+    mockAudio();
+
+    // Allow expected TTS error logs without throwing
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    server.use(
+      http.post("http://localhost:3000/api/zero/voice-io/tts", () => {
+        return HttpResponse.json({ error: "fail" }, { status: 500 });
+      }),
+    );
+
+    await context.store.set(playTts$, "msg-1", "Hello world", context.signal);
+
+    const playingId = context.store.get(ttsPlayingMessageId$);
+    expect(playingId).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
@@ -82,9 +82,11 @@ const fetchAndPlay$ = command(
     signal: AbortSignal,
   ) => {
     set(cleanupAudio$);
+    set(internalPlayingMessageId$, messageId);
 
     const plainText = stripMarkdown(text);
     if (!plainText) {
+      set(internalPlayingMessageId$, null);
       return;
     }
 
@@ -96,11 +98,13 @@ const fetchAndPlay$ = command(
       blob = await fetchTtsAudio(fetchFn, plainText, signal);
     } catch (error) {
       L.error("TTS fetch failed", error);
+      set(internalPlayingMessageId$, null);
       return;
     }
 
     if (!blob) {
       L.error("TTS API returned error");
+      set(internalPlayingMessageId$, null);
       return;
     }
 
@@ -131,7 +135,6 @@ const fetchAndPlay$ = command(
 
     set(internalBlobUrl$, blobUrl);
     set(internalAudioElement$, audio);
-    set(internalPlayingMessageId$, messageId);
 
     // eslint-disable-next-line no-restricted-syntax -- audio.play() rejects on browser autoplay restrictions
     try {
@@ -152,7 +155,15 @@ export const stopTts$ = command(({ set }) => {
 });
 
 export const playTts$ = command(
-  async ({ set }, messageId: string, text: string, signal: AbortSignal) => {
+  async (
+    { get, set },
+    messageId: string,
+    text: string,
+    signal: AbortSignal,
+  ) => {
+    if (get(internalPlayingMessageId$) === messageId) {
+      return;
+    }
     await set(fetchAndPlay$, messageId, text, signal);
   },
 );


### PR DESCRIPTION
## Summary

- Add guard in `playTts$` to skip duplicate calls for the same message
- Eagerly set `internalPlayingMessageId$` at the start of `fetchAndPlay$` (before async fetch) to close the race window where two rapid clicks both pass through
- Reset `internalPlayingMessageId$` on all error paths (empty text, fetch failure, non-ok response)

Closes #9153

## Test plan

- [x] New test: double invocation with same messageId only triggers one fetch
- [x] New test: different messageId triggers new playback
- [x] New test: failed fetch resets playingMessageId to null
- [x] All existing tests pass
- [x] Lint, type-check, format, knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)