### PR TITLE
perf(voice-io): stream tts audio for faster time-to-first-sound

### DIFF
--- a/turbo/apps/platform/src/lib/voice-io/tts-fetch.ts
+++ b/turbo/apps/platform/src/lib/voice-io/tts-fetch.ts
@@ -9,7 +9,7 @@ export async function fetchTtsAudio(
   fetchFn: (url: string, init?: RequestInit) => Promise<Response>,
   text: string,
   signal?: AbortSignal,
-): Promise<Blob | null> {
+): Promise<Response | null> {
   const response = await fetchFn("/api/zero/voice-io/tts", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -21,5 +21,5 @@ export async function fetchTtsAudio(
     return null;
   }
 
-  return response.blob();
+  return response;
 }

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
@@ -12,7 +12,7 @@ const L = logger("VoiceIO:TTS");
 
 const internalPlayingMessageId$ = state<string | null>(null);
 const internalAudioElement$ = state<HTMLAudioElement | null>(null);
-const internalBlobUrl$ = state<string | null>(null);
+const internalObjectUrl$ = state<string | null>(null);
 const internalCleanupFn$ = state<(() => void) | null>(null);
 
 // Auto-read tracking
@@ -51,6 +51,74 @@ function stripMarkdown(text: string): string {
     .trim();
 }
 
+function supportsMediaSourceMpeg(): boolean {
+  return (
+    typeof MediaSource !== "undefined" &&
+    MediaSource.isTypeSupported("audio/mpeg")
+  );
+}
+
+function noop() {}
+
+/**
+ * Read all chunks from a ReadableStream and append them to a SourceBuffer for
+ * progressive audio playback. Returns a promise that resolves when the stream
+ * is fully consumed and all chunks have been flushed to the buffer.
+ */
+function drainStreamIntoSourceBuffer(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  sourceBuffer: SourceBuffer,
+  signal: AbortSignal,
+): Promise<void> {
+  const queue: Uint8Array<ArrayBuffer>[] = [];
+  let draining = false;
+
+  function flush() {
+    if (draining || queue.length === 0 || sourceBuffer.updating) {
+      return;
+    }
+    draining = true;
+    const chunk = queue.shift()!;
+    sourceBuffer.appendBuffer(chunk);
+  }
+
+  sourceBuffer.addEventListener("updateend", () => {
+    draining = false;
+    flush();
+  });
+
+  return (async () => {
+    for (;;) {
+      if (signal.aborted) {
+        break;
+      }
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      queue.push(value.slice());
+      flush();
+    }
+
+    // Wait for remaining buffered data to finish appending
+    await new Promise<void>((resolve) => {
+      const finish = () => {
+        if (queue.length > 0) {
+          flush();
+          return;
+        }
+        if (sourceBuffer.updating) {
+          return;
+        }
+        sourceBuffer.removeEventListener("updateend", finish);
+        resolve();
+      };
+      sourceBuffer.addEventListener("updateend", finish);
+      finish();
+    });
+  })();
+}
+
 // ---------------------------------------------------------------------------
 // Internal commands
 // ---------------------------------------------------------------------------
@@ -70,7 +138,14 @@ const cleanupAudio$ = command(({ get, set }) => {
 
   set(internalPlayingMessageId$, null);
   set(internalAudioElement$, null);
-  set(internalBlobUrl$, null);
+  set(internalObjectUrl$, null);
+  set(internalCleanupFn$, null);
+});
+
+const resetPlaybackState$ = command(({ set }) => {
+  set(internalPlayingMessageId$, null);
+  set(internalAudioElement$, null);
+  set(internalObjectUrl$, null);
   set(internalCleanupFn$, null);
 });
 
@@ -92,56 +167,126 @@ const fetchAndPlay$ = command(
 
     const fetchFn = get(fetch$);
 
-    let blob: Blob | null;
+    let response: Response | null;
     // eslint-disable-next-line no-restricted-syntax -- raw fetch for binary audio (not a ts-rest contract)
     try {
-      blob = await fetchTtsAudio(fetchFn, plainText, signal);
+      response = await fetchTtsAudio(fetchFn, plainText, signal);
     } catch (error) {
       L.error("TTS fetch failed", error);
       set(internalPlayingMessageId$, null);
       return;
     }
 
-    if (!blob) {
+    if (!response) {
       L.error("TTS API returned error");
       set(internalPlayingMessageId$, null);
       return;
     }
 
-    const blobUrl = URL.createObjectURL(blob);
-    const audio = new Audio(blobUrl);
+    if (supportsMediaSourceMpeg() && response.body) {
+      // Streaming path: pipe response stream into MediaSource for progressive playback
+      const mediaSource = new MediaSource();
+      const audio = new Audio();
+      const objectUrl = URL.createObjectURL(mediaSource);
+      audio.src = objectUrl;
 
-    const onEnded = () => {
-      URL.revokeObjectURL(blobUrl);
-      set(internalPlayingMessageId$, null);
-      set(internalAudioElement$, null);
-      set(internalBlobUrl$, null);
-      set(internalCleanupFn$, null);
-    };
+      const reader = response.body.getReader();
 
-    const onError = () => {
-      L.error("Audio playback error");
-      onEnded();
-    };
+      const onEnded = () => {
+        set(resetPlaybackState$);
+      };
+      const onError = () => {
+        L.error("Audio playback error");
+        set(resetPlaybackState$);
+      };
 
-    audio.addEventListener("ended", onEnded);
-    audio.addEventListener("error", onError);
+      audio.addEventListener("ended", onEnded);
+      audio.addEventListener("error", onError);
 
-    set(internalCleanupFn$, () => {
-      audio.removeEventListener("ended", onEnded);
-      audio.removeEventListener("error", onError);
-      URL.revokeObjectURL(blobUrl);
-    });
+      set(internalCleanupFn$, () => {
+        reader.cancel().catch(noop);
+        audio.removeEventListener("ended", onEnded);
+        audio.removeEventListener("error", onError);
+        if (mediaSource.readyState === "open") {
+          mediaSource.endOfStream();
+        }
+        URL.revokeObjectURL(objectUrl);
+      });
 
-    set(internalBlobUrl$, blobUrl);
-    set(internalAudioElement$, audio);
+      set(internalObjectUrl$, objectUrl);
+      set(internalAudioElement$, audio);
 
-    // eslint-disable-next-line no-restricted-syntax -- audio.play() rejects on browser autoplay restrictions
-    try {
-      await audio.play();
-    } catch (error) {
-      L.error("Audio play failed", error);
-      onEnded();
+      await new Promise<void>((resolve) => {
+        mediaSource.addEventListener(
+          "sourceopen",
+          () => {
+            const sourceBuffer = mediaSource.addSourceBuffer("audio/mpeg");
+            let playStarted = false;
+
+            sourceBuffer.addEventListener("updateend", () => {
+              if (!playStarted) {
+                playStarted = true;
+                audio.play().catch((error: unknown) => {
+                  L.error("Audio play failed", error);
+                  set(resetPlaybackState$);
+                });
+              }
+            });
+
+            drainStreamIntoSourceBuffer(reader, sourceBuffer, signal)
+              .then(() => {
+                if (mediaSource.readyState === "open") {
+                  mediaSource.endOfStream();
+                }
+                resolve();
+              })
+              .catch((error: unknown) => {
+                if (!signal.aborted) {
+                  L.error("TTS stream error", error);
+                  set(resetPlaybackState$);
+                }
+                resolve();
+              });
+          },
+          { once: true },
+        );
+      });
+    } else {
+      // Fallback: download full blob then play (Safari/iOS or no ReadableStream)
+      const blob = await response.blob();
+      signal.throwIfAborted();
+      const blobUrl = URL.createObjectURL(blob);
+      const audio = new Audio(blobUrl);
+
+      const onEnded = () => {
+        URL.revokeObjectURL(blobUrl);
+        set(resetPlaybackState$);
+      };
+
+      const onError = () => {
+        L.error("Audio playback error");
+        onEnded();
+      };
+
+      audio.addEventListener("ended", onEnded);
+      audio.addEventListener("error", onError);
+
+      set(internalCleanupFn$, () => {
+        audio.removeEventListener("ended", onEnded);
+        audio.removeEventListener("error", onError);
+        URL.revokeObjectURL(blobUrl);
+      });
+
+      set(internalObjectUrl$, blobUrl);
+      set(internalAudioElement$, audio);
+
+      // eslint-disable-next-line no-restricted-syntax -- audio.play() rejects on browser autoplay restrictions
+      try {
+        await audio.play();
+      } catch (error) {
+        L.error("Audio play failed", error);
+        onEnded();
+      }
     }
   },
 );

--- a/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
@@ -118,13 +118,10 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  const audioBuffer = await response.arrayBuffer();
-
-  return new Response(audioBuffer, {
+  return new Response(response.body, {
     status: 200,
     headers: {
       "Content-Type": "audio/mpeg",
-      "Content-Length": String(audioBuffer.byteLength),
     },
   });
 }


### PR DESCRIPTION
## Summary

- Stream OpenAI TTS response body directly instead of buffering with `arrayBuffer()` on the backend
- Use `MediaSource` API on the frontend to pipe audio chunks into the `<audio>` element as they arrive, starting playback after the first chunk
- Fall back to the existing blob-based approach when `MediaSource.isTypeSupported('audio/mpeg')` is false (Safari/iOS)

Closes #9154

## Changes

| File | Change |
|------|--------|
| `turbo/apps/web/app/api/zero/voice-io/tts/route.ts` | Stream `response.body` instead of buffering `arrayBuffer()` |
| `turbo/apps/platform/src/lib/voice-io/tts-fetch.ts` | Return `Response` instead of `Blob` |
| `turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts` | Add MediaSource streaming path with blob fallback, refactor cleanup |

## Test plan

- [x] All existing backend TTS tests pass (7/7)
- [x] Lint, type-check, format, knip all pass
- [ ] Manual: Chrome — verify streaming playback starts within ~200-500ms
- [ ] Manual: Safari — verify blob fallback works (no regression)
- [ ] Manual: click stop during streaming — verify clean abort
- [ ] Manual: auto-read feature — verify streaming works with auto-read
- [ ] Manual: long text (near 4096 chars) — verify complete playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)