### PR TITLE
chore(voice-io): switch tts model from tts-1-hd to gpt-4o-mini-tts

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
@@ -120,7 +120,7 @@ describe("POST /api/zero/voice-io/tts", () => {
         "https://api.openai.com/v1/audio/speech",
         async ({ request }) => {
           const reqBody = (await request.json()) as Record<string, unknown>;
-          expect(reqBody.model).toBe("tts-1-hd");
+          expect(reqBody.model).toBe("gpt-4o-mini-tts");
           expect(reqBody.voice).toBe("ash");
           expect(reqBody.input).toBe("hello world");
           expect(reqBody.response_format).toBe("mp3");

--- a/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
@@ -94,7 +94,7 @@ export async function POST(request: Request): Promise<Response> {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "tts-1-hd",
+      model: "gpt-4o-mini-tts",
       voice: "ash",
       input: text,
       response_format: "mp3",


### PR DESCRIPTION
## Summary
- Switch TTS model from `tts-1-hd` to `gpt-4o-mini-tts` for improved quality and latency
- Update test assertion to validate the new model name
- Drop-in replacement: same API endpoint, same parameters, same response format

Closes #9158

## Test plan
- [x] All 7 existing TTS route tests pass
- [x] Lint, type-check, format pass
- [x] Knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)