### PR TITLE
feat(platform): add unread tracking for mission control tasks

### DIFF
--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
@@ -2,7 +2,7 @@ import { command, computed, state, type Command, type Computed } from "ccstate";
 import { tasksContract, type TaskItem } from "@vm0/core";
 import { zeroClient$ } from "../api-client";
 import { accept } from "../../lib/accept";
-import { onRef, setLoop } from "../utils.ts";
+import { jsonParseOr, onRef, setLoop } from "../utils.ts";
 import {
   createChatThreadSignals,
   ensureDraft$,
@@ -13,6 +13,23 @@ import {
   type ActivitySignals,
 } from "./create-activity-signals.ts";
 import { maximizedTaskId$ } from "./mission-control-panels.ts";
+import { localStorageSignals } from "../external/local-storage.ts";
+
+// ---------------------------------------------------------------------------
+// Unread tracking — localStorage-backed map of taskId → lastSeenRunId
+// ---------------------------------------------------------------------------
+
+const lastSeenRunIdsStorage = localStorageSignals(
+  "missionControlLastSeenRunIds",
+);
+
+const lastSeenRunIds$ = computed((get) => {
+  const raw = get(lastSeenRunIdsStorage.get$);
+  if (!raw) {
+    return {} as Record<string, string>;
+  }
+  return jsonParseOr<Record<string, string>>(raw, {});
+});
 
 const OPTIMISTIC_TTL_MS = 30_000;
 
@@ -29,7 +46,10 @@ export type TaskPanelEntry =
 // ---------------------------------------------------------------------------
 
 export interface TaskSignals {
-  task: TaskItem;
+  taskId: string;
+  task$: Computed<TaskItem>;
+  updateTask$: Command<void, [TaskItem]>;
+  unread$: Computed<boolean>;
   optimistic: boolean;
   optimisticInsertedAt: number | null;
   open$: Computed<boolean>;
@@ -49,7 +69,42 @@ export interface TaskSignals {
 // Factory
 // ---------------------------------------------------------------------------
 
+const markRead$ = command(
+  ({ get, set }, taskId: string, latestRunId: string | null) => {
+    if (!latestRunId) {
+      return;
+    }
+    const seen = get(lastSeenRunIds$);
+    if (seen[taskId] === latestRunId) {
+      return;
+    }
+    set(
+      lastSeenRunIdsStorage.set$,
+      JSON.stringify({ ...seen, [taskId]: latestRunId }),
+    );
+  },
+);
+
 function createTaskSignals(initialTask: TaskItem): TaskSignals {
+  const internalTask$ = state(initialTask);
+
+  const task$ = computed((get) => {
+    return get(internalTask$);
+  });
+
+  const updateTask$ = command(({ set }, task: TaskItem) => {
+    set(internalTask$, task);
+  });
+
+  const unread$ = computed((get) => {
+    const task = get(internalTask$);
+    if (!task.latestRunId) {
+      return false;
+    }
+    const seen = get(lastSeenRunIds$);
+    return seen[initialTask.id] !== task.latestRunId;
+  });
+
   const internalOpen$ = state(false);
   const internalOpenedAt$ = state<number | null>(null);
   const internalPanelEntry$ = state<TaskPanelEntry | null>(null);
@@ -73,8 +128,6 @@ function createTaskSignals(initialTask: TaskItem): TaskSignals {
     set(internalInputFocused$, false);
   });
 
-  // Mutable ref so openTask$ always reads the latest API data
-  const taskRef = { value: initialTask };
   const optimisticRef = { value: false };
   const optimisticInsertedAtRef = { value: null as number | null };
 
@@ -84,7 +137,10 @@ function createTaskSignals(initialTask: TaskItem): TaskSignals {
         return;
       }
 
-      const task = taskRef.value;
+      const task = get(internalTask$);
+
+      // Mark as read when opening
+      set(markRead$, initialTask.id, task.latestRunId);
 
       if (task.type === "chat" && task.chatThreadId) {
         const draft = set(ensureDraft$, task.chatThreadId);
@@ -142,12 +198,10 @@ function createTaskSignals(initialTask: TaskItem): TaskSignals {
   });
 
   return {
-    get task() {
-      return taskRef.value;
-    },
-    set task(t: TaskItem) {
-      taskRef.value = t;
-    },
+    taskId: initialTask.id,
+    task$,
+    updateTask$,
+    unread$,
     get optimistic() {
       return optimisticRef.value;
     },
@@ -230,9 +284,13 @@ export const setupTasksLoop$ = command(
         for (const task of tasks) {
           const existing = taskSignals.get(task.id);
           if (existing) {
-            existing.task = task;
+            set(existing.updateTask$, task);
             existing.optimistic = false;
             existing.optimisticInsertedAt = null;
+            // Auto-mark read when task panel is already open
+            if (get(existing.open$)) {
+              set(markRead$, task.id, task.latestRunId);
+            }
           } else {
             taskSignals.set(task.id, createTaskSignals(task));
           }
@@ -277,7 +335,7 @@ export const taskSignals$ = computed(async (get) => {
 
   // Optimistic entries not yet confirmed by server — prepend at top
   const optimisticEntries = [...signals.values()].filter((ts) => {
-    return ts.optimistic && !serverIds.has(ts.task.id);
+    return ts.optimistic && !serverIds.has(ts.taskId);
   });
 
   // Server-confirmed entries in server order
@@ -304,7 +362,7 @@ export const archiveTask$ = command(
       return;
     }
 
-    const { task } = ts;
+    const task = get(ts.task$);
     const client = get(zeroClient$)(tasksContract);
 
     await accept(
@@ -387,7 +445,7 @@ export const closeAndFocusNextInput$ = command(
   async ({ get, set }, taskId: string, _signal: AbortSignal) => {
     const tasks = await get(taskSignals$);
     const currentIndex = tasks.findIndex((ts) => {
-      return ts.task.id === taskId;
+      return ts.taskId === taskId;
     });
     if (currentIndex === -1) {
       return;
@@ -426,7 +484,7 @@ export const visibleTasks$ = computed(async (get) => {
   const maximizedId = get(maximizedTaskId$);
   if (maximizedId !== null) {
     const maximized = open.find((ts) => {
-      return ts.task.id === maximizedId;
+      return ts.taskId === maximizedId;
     });
     return maximized ? [maximized] : open;
   }
@@ -441,4 +499,40 @@ export const visibleTasks$ = computed(async (get) => {
 export const missionControlPanelVisible$ = computed(async (get) => {
   const visible = await get(visibleTasks$);
   return visible.length > 0;
+});
+
+// ---------------------------------------------------------------------------
+// Unread commands
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether any task in the list is unread.
+ */
+export const hasUnreadTasks$ = computed(async (get) => {
+  const tasks = await get(taskSignals$);
+  return tasks.some((ts) => {
+    return get(ts.unread$);
+  });
+});
+
+/**
+ * Mark all current tasks as read.
+ */
+export const markAllTasksRead$ = command(({ get, set }) => {
+  const taskSignals = get(internalTaskSignals$);
+  const current = get(lastSeenRunIds$);
+  const updated = { ...current };
+  let changed = false;
+
+  for (const [id, ts] of taskSignals) {
+    const task = get(ts.task$);
+    if (task.latestRunId && updated[id] !== task.latestRunId) {
+      updated[id] = task.latestRunId;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    set(lastSeenRunIdsStorage.set$, JSON.stringify(updated));
+  }
 });

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -404,7 +404,7 @@ describe("mission control page", () => {
     const signalsBefore = await context.store.get(taskSignals$);
     expect(
       signalsBefore.some((ts) => {
-        return ts.task.id === "stale-thread-ttl";
+        return ts.taskId === "stale-thread-ttl";
       }),
     ).toBeTruthy();
 
@@ -417,7 +417,7 @@ describe("mission control page", () => {
       const signals = await context.store.get(taskSignals$);
       expect(
         signals.some((ts) => {
-          return ts.task.id === "stale-thread-ttl";
+          return ts.taskId === "stale-thread-ttl";
         }),
       ).toBeFalsy();
     });

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -842,4 +842,218 @@ describe("mission control page", () => {
       expect(screen.getByText("Talk to")).toBeInTheDocument();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Unread tracking tests
+  // ---------------------------------------------------------------------------
+
+  it("should show Read all button when a task has an unseen latestRunId", async () => {
+    mockTasksAPI([
+      {
+        id: "task-unread",
+        type: "schedule",
+        title: "Unread Task",
+        summary: null,
+        agent: createAgent(),
+        latestRunId: "run-new-1",
+        status: "completed",
+        scheduleId: "sched-u1",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Unread Task")).toBeInTheDocument();
+    });
+
+    // latestRunId is set and not in localStorage → task is unread → button shown
+    expect(screen.getByText("Read all")).toBeInTheDocument();
+  });
+
+  it("should not show Read all button when task has no latestRunId", async () => {
+    mockTasksAPI([
+      {
+        id: "task-no-run",
+        type: "chat",
+        title: "Chat Without Run",
+        summary: null,
+        agent: createAgent(),
+        latestRunId: null,
+        status: null,
+        chatThreadId: "thread-no-run",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Chat Without Run")).toBeInTheDocument();
+    });
+
+    // latestRunId is null → unread$ returns false → no "Read all" button
+    expect(screen.queryByText("Read all")).not.toBeInTheDocument();
+  });
+
+  it("should hide Read all button after clicking it", async () => {
+    mockTasksAPI([
+      {
+        id: "task-mark-all",
+        type: "schedule",
+        title: "Mark All Read Task",
+        summary: null,
+        agent: createAgent(),
+        latestRunId: "run-mark-all-1",
+        status: "completed",
+        scheduleId: "sched-mark-all",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    const readAllBtn = await waitFor(() => {
+      return screen.getByText("Read all");
+    });
+
+    await user.click(readAllBtn);
+
+    // After marking all read, the button should disappear
+    await waitFor(() => {
+      expect(screen.queryByText("Read all")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should mark task as read when its panel is opened", async () => {
+    mockTasksAPI([
+      {
+        id: "task-open-read",
+        type: "schedule",
+        title: "Open To Read Task",
+        summary: null,
+        agent: createAgent(),
+        latestRunId: "run-open-read-1",
+        status: "completed",
+        scheduleId: "sched-open-read",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    mockActivityAPIs("run-open-read-1");
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    // Confirm task is unread before opening
+    await waitFor(() => {
+      expect(screen.getByText("Read all")).toBeInTheDocument();
+    });
+
+    // Open the task panel
+    const title = await waitFor(() => {
+      return screen.getByText("Open To Read Task");
+    });
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Close task")).toBeInTheDocument();
+    });
+
+    // Opening the panel calls markRead$ → hasUnreadTasks$ becomes false → button hidden
+    await waitFor(() => {
+      expect(screen.queryByText("Read all")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should mark open task as read on next poll loop iteration", async () => {
+    // First poll: task has latestRunId "run-v1" (unread)
+    let pollCount = 0;
+    server.use(
+      http.get("*/api/zero/tasks", () => {
+        pollCount++;
+        const latestRunId = pollCount === 1 ? "run-v1" : "run-v2";
+        return HttpResponse.json({
+          tasks: [
+            {
+              id: "task-poll-read",
+              type: "schedule",
+              title: "Poll Read Task",
+              summary: null,
+              agent: createAgent(),
+              latestRunId,
+              status: "completed",
+              scheduleId: "sched-poll-read",
+              createdAt: "2026-04-10T10:00:00Z",
+              updatedAt: "2026-04-10T10:00:00Z",
+            },
+          ],
+        });
+      }),
+    );
+
+    mockActivityAPIs("run-v1");
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    // Wait for unread indicator
+    await waitFor(() => {
+      expect(screen.getByText("Read all")).toBeInTheDocument();
+    });
+
+    // Open the panel — markRead$ records run-v1 as seen
+    const title = screen.getByText("Poll Read Task");
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Close task")).toBeInTheDocument();
+    });
+
+    // run-v1 is now seen → no unread
+    await waitFor(() => {
+      expect(screen.queryByText("Read all")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should compute hasUnreadTasks$ as false when all tasks are read", async () => {
+    mockTasksAPI([
+      {
+        id: "task-all-read",
+        type: "schedule",
+        title: "Already Read Task",
+        summary: null,
+        agent: createAgent(),
+        latestRunId: "run-already-read-1",
+        status: "completed",
+        scheduleId: "sched-all-read",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    // Initially unread
+    const readAllBtn = await waitFor(() => {
+      return screen.getByText("Read all");
+    });
+
+    // Mark all read
+    await user.click(readAllBtn);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Read all")).not.toBeInTheDocument();
+    });
+
+    // Task card still renders (the task itself is still in the list)
+    expect(screen.getByText("Already Read Task")).toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
@@ -5,7 +5,11 @@ import {
   Separator,
   useDefaultLayout,
 } from "react-resizable-panels";
-import { missionControlPanelVisible$ } from "../../signals/mission-control-page/mission-control-tasks.ts";
+import {
+  missionControlPanelVisible$,
+  markAllTasksRead$,
+  hasUnreadTasks$,
+} from "../../signals/mission-control-page/mission-control-tasks.ts";
 import {
   taskListCollapsed$,
   setTaskListPanelRef$,
@@ -38,6 +42,8 @@ export function MissionControlPage() {
   const displayName = useLastResolved(defaultAgentName$) ?? "Zero";
   const createAndShowChatTask = useSet(createAndShowChatTask$);
   const pageSignal = useGet(pageSignal$);
+  const markAllRead = useSet(markAllTasksRead$);
+  const hasUnread = useLastResolved(hasUnreadTasks$) ?? false;
 
   const onNewChat = (agentId: string | null) => {
     setNewChatOpen(false);
@@ -81,7 +87,20 @@ export function MissionControlPage() {
                     Active tasks across all channels
                   </p>
                 </div>
-                <VoiceButton />
+                <div className="flex items-center gap-2">
+                  {hasUnread && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        markAllRead();
+                      }}
+                      className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      Read all
+                    </button>
+                  )}
+                  <VoiceButton />
+                </div>
               </div>
             </div>
             <VoiceBanner />

--- a/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
@@ -94,8 +94,8 @@ export function TaskCard({ taskSignals }: { taskSignals: TaskSignals }) {
   const openTask = useSet(taskSignals.openTask$);
   const pageSignal = useGet(pageSignal$);
   const isOpen = useGet(taskSignals.open$);
-
-  const { task } = taskSignals;
+  const task = useGet(taskSignals.task$);
+  const unread = useGet(taskSignals.unread$);
 
   const closeTask = useSet(taskSignals.closeTask$);
   const archiveTask = useSet(archiveTask$);
@@ -147,7 +147,7 @@ export function TaskCard({ taskSignals }: { taskSignals: TaskSignals }) {
         data-task-id={task.id}
         onClick={openOrFocusInput}
         className={`group p-4 cursor-pointer transition-colors hover:bg-accent/50 focus:outline focus:outline-2 focus:outline-primary ${
-          inputFocused ? "bg-accent" : ""
+          inputFocused ? "bg-accent" : unread ? "bg-primary/5" : ""
         } ${isOpen ? "border-primary" : ""}`}
       >
         <div className="flex flex-col gap-1.5">

--- a/turbo/apps/platform/src/views/mission-control-page/task-list.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-list.tsx
@@ -57,7 +57,7 @@ export function TaskList() {
   return (
     <div className="flex flex-col gap-2 mt-2">
       {tasks.map((ts) => {
-        return <TaskCard key={ts.task.id} taskSignals={ts} />;
+        return <TaskCard key={ts.taskId} taskSignals={ts} />;
       })}
     </div>
   );

--- a/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
@@ -28,7 +28,7 @@ export function TaskPanel() {
   return (
     <div className="flex h-full min-h-0">
       {entries.flatMap((ts, index) => {
-        const taskId = ts.task.id;
+        const taskId = ts.taskId;
         const elements = [];
         if (index > 0) {
           elements.push(
@@ -56,7 +56,7 @@ function TaskPanelCard({ taskSignals }: { taskSignals: TaskSignals }) {
   const pageSignal = useGet(pageSignal$);
   const maximizedId = useGet(maximizedTaskId$);
 
-  const taskId = taskSignals.task.id;
+  const taskId = taskSignals.taskId;
   const isMaximized = maximizedId === taskId;
 
   return (
@@ -137,7 +137,7 @@ function TaskPanelCard({ taskSignals }: { taskSignals: TaskSignals }) {
 }
 
 function TaskPanelTitle({ taskSignals }: { taskSignals: TaskSignals }) {
-  const { task } = taskSignals;
+  const task = useGet(taskSignals.task$);
   const agentName = task.agent.displayName ?? task.agent.name;
 
   return (


### PR DESCRIPTION
## Summary
- Add localStorage-backed unread tracking for mission control tasks using `lastSeenRunId` per task
- Refactor task state from mutable refs to reactive ccstate signals (`task$`, `updateTask$`, `unread$`) for proper reactivity
- Highlight unread task cards with subtle background color (`bg-primary/5`) and add a "Read all" button in the header
- Auto-mark tasks as read when opened or when their panel is already open during polling updates

## Test plan
- [ ] Verify unread tasks get highlighted when a new run appears
- [ ] Verify opening a task card marks it as read and removes highlight
- [ ] Verify "Read all" button appears when unread tasks exist and marks all as read
- [ ] Verify optimistic task insertion still works correctly
- [ ] Verify TTL pruning of stale optimistic entries still works
- [ ] Verify existing mission-control-page tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)