### PR TITLE
feat: upgrade stt model from whisper-1 to gpt-4o-mini-transcribe

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -507,7 +507,7 @@ const setupWebRTC$ = command(
           session: {
             modalities: ["text", "audio"],
             instructions: FAST_BRAIN_INSTRUCTIONS,
-            input_audio_transcription: { model: "whisper-1" },
+            input_audio_transcription: { model: "gpt-4o-mini-transcribe" },
             input_audio_noise_reduction: { type: "far_field" },
             turn_detection: turnDetection,
             tools: SESSION_TOOLS,

--- a/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
@@ -105,10 +105,10 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  // 7. Call OpenAI Whisper API
+  // 7. Call OpenAI STT API
   const openaiForm = new FormData();
   openaiForm.append("file", file, file.name || "audio.webm");
-  openaiForm.append("model", "whisper-1");
+  openaiForm.append("model", "gpt-4o-mini-transcribe");
   openaiForm.append("response_format", "json");
 
   const openaiResponse = await fetch(
@@ -121,7 +121,7 @@ export async function POST(request: Request): Promise<Response> {
   );
 
   if (!openaiResponse.ok) {
-    log.error("OpenAI Whisper API error", {
+    log.error("OpenAI STT API error", {
       status: openaiResponse.status,
       statusText: openaiResponse.statusText,
     });


### PR DESCRIPTION
## Summary

- Replace `whisper-1` with `gpt-4o-mini-transcribe` in standalone STT endpoint (`stt/route.ts`) and realtime voice chat session (`voice-chat-session.ts`)
- Update associated comments and log messages from "Whisper" to "STT"
- Provides 50% cost reduction ($0.003/min vs $0.006/min) and 89% fewer hallucinations

Closes #9164

## Test plan

- [x] Existing STT route tests pass (9/9)
- [x] Lint passes (0 errors)
- [x] Format check passes
- [x] No remaining `whisper-1` references in production code
- [ ] CI pipeline passes
- [ ] Manual verification: voice chat transcription works in platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)