### PR TITLE
fix: harden voice-chat preparation with enum status and failed early exit

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-preparation.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-preparation.test.ts
@@ -67,6 +67,22 @@ describe("voice-chat-preparation signals", () => {
     expect(context.store.get(meetingPrepStartTime$)).toBeTypeOf("number");
   });
 
+  it("should set status to failed immediately when initial status is failed", async () => {
+    setup();
+    const responses = [{ status: "failed" }];
+    const counter = mockPrepareEndpoint(responses);
+
+    await context.store.set(
+      triggerPreparation$,
+      "already failed prompt",
+      context.signal,
+    );
+
+    expect(context.store.get(meetingPrepStatus$)).toBe("failed");
+    // Should exit immediately — only the initial call, no polling
+    expect(counter.count).toBe(1);
+  });
+
   it("should poll until ready when preparation is in progress", async () => {
     setup();
     const responses = [

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-preparation.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-preparation.ts
@@ -47,7 +47,7 @@ export const triggerPreparation$ = command(
     set(internalPrepPrompt$, prompt);
     set(internalPrepStartTime$, Date.now());
 
-    let initialStatus: string;
+    let initialStatus: "preparing" | "ready" | "failed";
     // eslint-disable-next-line no-restricted-syntax -- accept() throws on non-200; must catch to transition to "failed" state instead of leaving "preparing" forever
     try {
       const res = await accept(
@@ -68,6 +68,11 @@ export const triggerPreparation$ = command(
 
     if (initialStatus === "ready") {
       set(internalPrepStatus$, "ready");
+      return;
+    }
+
+    if (initialStatus === "failed") {
+      set(internalPrepStatus$, "failed");
       return;
     }
 

--- a/turbo/packages/core/src/contracts/zero-voice-chat-prepare.ts
+++ b/turbo/packages/core/src/contracts/zero-voice-chat-prepare.ts
@@ -13,7 +13,7 @@ const prepareTriggerBodySchema = z.object({
 const prepareTriggerResponseSchema = z.object({
   preparation: z.object({
     id: z.string(),
-    status: z.string(),
+    status: z.enum(["preparing", "ready", "failed"]),
     runId: z.string().optional(),
   }),
 });
@@ -40,7 +40,7 @@ const prepareCompleteBodySchema = z.object({
 
 const prepareCompleteResponseSchema = z.object({
   id: z.string(),
-  status: z.string(),
+  status: z.enum(["preparing", "ready", "failed"]),
 });
 
 export const zeroVoiceChatPrepareCompleteContract = c.router({


### PR DESCRIPTION
## Summary

- Tighten contract `status` field from `z.string()` to `z.enum(["preparing", "ready", "failed"])` in both `prepareTriggerResponseSchema` and `prepareCompleteResponseSchema`
- Add early exit for initial `"failed"` status to avoid entering polling loop for one wasted iteration
- Add test verifying initial failed status exits immediately without polling

Closes #9170

## Test plan

- [x] New test: initial `"failed"` status exits immediately (no polling)
- [x] All 7 existing voice-chat-preparation tests pass
- [x] TypeScript type-check passes (narrowed type propagates correctly)
- [x] Lint, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)