### PR TITLE
fix(platform): add react hook imports to views allowlist

### DIFF
--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -10,7 +10,12 @@
           {
             "paths": [
               {
-                "allowImportNames": ["StrictMode", "Component"],
+                "allowImportNames": [
+                  "StrictMode",
+                  "Component",
+                  "useLayoutEffect",
+                  "useRef"
+                ],
                 "allowTypeImports": true,
                 "name": "react"
               },

--- a/turbo/apps/platform/src/views/zero-page/use-auto-scroll.ts
+++ b/turbo/apps/platform/src/views/zero-page/use-auto-scroll.ts
@@ -1,6 +1,5 @@
 // useLayoutEffect runs synchronously before paint, ensuring the scroll
 // position is applied before the user sees the content.
-// oxlint-disable-next-line no-restricted-imports
 import { useLayoutEffect, useRef } from "react";
 import { useSet } from "ccstate-react";
 import type { Command } from "ccstate";


### PR DESCRIPTION
## Summary
- Adds `useLayoutEffect` and `useRef` to the `allowImportNames` list for the `src/views/**/*.*` override in `.oxlintrc.json`
- Removes the `// oxlint-disable-next-line no-restricted-imports` comment from `use-auto-scroll.ts` that was added as a workaround

This is a follow-up to #9097 which introduced `use-auto-scroll.ts` with a lint suppression comment to work around the views layer restriction. The proper fix is to allow these hooks in the oxlint config.

## Test plan
- [ ] `oxlint` reports 0 warnings and 0 errors on the platform app
- [ ] `pnpm turbo run lint` passes
- [ ] `pnpm check-types` passes
- [ ] All 1647 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)