### PR TITLE
fix(platform): clear active org before leaving or deleting workspace

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
+import { mockedClerk } from "../../../__tests__/mock-auth.ts";
 
 const context = testContext();
 
@@ -271,5 +272,162 @@ describe("org general tab - profile section", () => {
     await vi.waitFor(() => {
       expect(requestBody).toHaveBeenCalledWith({ name: "New Name" });
     });
+  });
+});
+
+describe("org general tab - danger zone", () => {
+  afterEach(() => {
+    // These tests intentionally navigate to /select-org, so always reset the
+    // pathname before the next test runs.
+    if (window.location.pathname !== "/") {
+      window.location.href = "http://localhost/";
+    }
+  });
+
+  it("leaves workspace: clears active org then navigates to /select-org", async () => {
+    const user = userEvent.setup();
+    const leaveCalled = vi.fn();
+    mockAPIs({ role: "member", slug: "my-org" });
+    server.use(
+      http.post("*/api/zero/org/leave", () => {
+        leaveCalled();
+        return HttpResponse.json({ message: "ok" });
+      }),
+    );
+
+    await openGeneralTab();
+
+    const leaveTrigger = await waitFor(() => {
+      const btn = screen.getAllByRole("button").find((el) => {
+        return el.textContent?.trim() === "Leave";
+      });
+      expect(btn).toBeInTheDocument();
+      return btn as HTMLElement;
+    });
+    await user.click(leaveTrigger);
+
+    const confirmBtn = await waitFor(() => {
+      const buttons = screen.getAllByRole("button");
+      const btn = buttons.find((el) => {
+        return (
+          el.textContent?.trim() === "Leave" && el.closest('[role="dialog"]')
+        );
+      });
+      expect(btn).toBeInTheDocument();
+      return btn as HTMLElement;
+    });
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(leaveCalled).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(mockedClerk.setActive).toHaveBeenCalledWith({
+        organization: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/select-org");
+    });
+  });
+
+  it("deletes workspace: clears active org then navigates to /select-org", async () => {
+    const user = userEvent.setup();
+    const deleteCalled = vi.fn();
+    mockAPIs({ role: "admin", slug: "my-org" });
+    server.use(
+      http.post("*/api/zero/org/delete", () => {
+        deleteCalled();
+        return HttpResponse.json({ message: "ok" });
+      }),
+    );
+
+    await openGeneralTab();
+
+    const deleteTrigger = await waitFor(() => {
+      const btn = screen.getAllByRole("button").find((el) => {
+        return el.textContent?.trim() === "Delete";
+      });
+      expect(btn).toBeInTheDocument();
+      return btn as HTMLElement;
+    });
+    await user.click(deleteTrigger);
+
+    const slugInput = await screen.findByPlaceholderText("my-org");
+    await fill(slugInput, "my-org");
+
+    const confirmBtn = await waitFor(() => {
+      const buttons = screen.getAllByRole("button");
+      const btn = buttons.find((el) => {
+        return el.textContent?.trim() === "Delete workspace";
+      });
+      expect(btn).toBeInTheDocument();
+      expect(btn).not.toBeDisabled();
+      return btn as HTMLElement;
+    });
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(deleteCalled).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(mockedClerk.setActive).toHaveBeenCalledWith({
+        organization: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/select-org");
+    });
+  });
+
+  it("does not clear active org or navigate when leave API fails", async () => {
+    const user = userEvent.setup();
+    const leaveCalled = vi.fn();
+    mockAPIs({ role: "member", slug: "my-org" });
+    server.use(
+      http.post("*/api/zero/org/leave", () => {
+        leaveCalled();
+        return HttpResponse.json(
+          { error: { message: "boom", code: "INTERNAL_SERVER_ERROR" } },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await openGeneralTab();
+
+    const leaveTrigger = await waitFor(() => {
+      const btn = screen.getAllByRole("button").find((el) => {
+        return el.textContent?.trim() === "Leave";
+      });
+      expect(btn).toBeInTheDocument();
+      return btn as HTMLElement;
+    });
+    await user.click(leaveTrigger);
+
+    const confirmBtn = await waitFor(() => {
+      const buttons = screen.getAllByRole("button");
+      const btn = buttons.find((el) => {
+        return (
+          el.textContent?.trim() === "Leave" && el.closest('[role="dialog"]')
+        );
+      });
+      expect(btn).toBeInTheDocument();
+      return btn as HTMLElement;
+    });
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(leaveCalled).toHaveBeenCalledTimes(1);
+    });
+
+    // Session must not be touched on failure — otherwise a transient 5xx
+    // could silently log the user out of their current workspace.
+    expect(mockedClerk.setActive).not.toHaveBeenCalled();
+    expect(window.location.pathname).not.toBe("/select-org");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -378,6 +378,9 @@ function DangerZoneSection({
   isAdmin: boolean;
 }) {
   const createClient = useGet(zeroClient$);
+  const clerkLoadable = useLoadable(clerk$);
+  const clerk =
+    clerkLoadable.state === "hasData" ? clerkLoadable.data : undefined;
   const canLeave = !isAdmin;
 
   const leaving = useGet(leaving$);
@@ -398,10 +401,14 @@ function DangerZoneSection({
     detach(
       client
         .leave({ body: {} })
-        .then((result) => {
+        .then(async (result) => {
           if (result.status === 200) {
+            // Clear the active organization before navigating so the session
+            // JWT no longer references an org the user is no longer a member
+            // of; otherwise Clerk may revoke the session and log the user out.
+            await clerk?.setActive({ organization: null });
             toast.success("You have left the workspace");
-            window.location.reload();
+            window.location.href = "/select-org";
           } else {
             toast.error(
               extractErrorMessage(result, `Failed to leave (${result.status})`),
@@ -424,8 +431,12 @@ function DangerZoneSection({
     detach(
       client
         .delete({ body: { slug: org.slug } })
-        .then((result) => {
+        .then(async (result) => {
           if (result.status === 200) {
+            // Clear the active organization before navigating so the session
+            // JWT no longer references the deleted org; otherwise Clerk may
+            // revoke the session and log the user out.
+            await clerk?.setActive({ organization: null });
             toast.success("Workspace deleted");
             window.location.href = "/select-org";
           } else {


### PR DESCRIPTION
## Summary

- Both **Leave workspace** and **Delete workspace** flows navigated away without first clearing the Clerk active organization. The session JWT's `org_id` claim then referenced a now-invalid org (deleted, or the user is no longer a member), so Clerk's Frontend API revoked the whole session and logged the user out instead of landing them on `/select-org`.
- Call `clerk.setActive({ organization: null })` **before** navigation in both `handleLeave` and `handleDelete`, so the session no longer references the stale org when the page reloads.
- Unify the post-`leave` navigation to `/select-org` (previously `window.location.reload()`), matching the delete flow — users who just left the workspace should land on the picker, not on the page of the workspace they no longer have access to.
- Guard `setActive` against API failures: if leave/delete returns non-200, we do not touch the session. Otherwise a transient 5xx could silently drop the user out of their current workspace.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-general-tab.test.tsx` — 13/13 passing, including 3 new danger-zone tests
- [x] Lint clean (`oxlint`)
- [x] Format applied (`pnpm format`)
- [ ] Manual: as a member, Leave a workspace → land on `/select-org`, still signed in
- [ ] Manual: as an admin with no other orgs, Delete the only workspace → land on `/select-org`, still signed in
- [ ] Manual: force a 5xx on `/api/zero/org/leave` → toast appears, user stays on current workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)