### PR TITLE
fix(voice-chat): harden preparation backend safety checks

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/route.ts
@@ -4,7 +4,6 @@ import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
 import { voiceChatPreparations } from "../../../../../../src/db/schema/voice-chat";
-import { updatePreparationStatus } from "../../../../../../src/lib/zero/voice-chat/preparation-service";
 import { logger } from "../../../../../../src/lib/shared/logger";
 
 const bodySchema = z.object({
@@ -55,50 +54,99 @@ export async function POST(request: Request) {
   }
   const { content } = parsed.data;
 
-  // Find the preparation associated with this run
-  const [preparation] = await globalThis.services.db
-    .select({
-      id: voiceChatPreparations.id,
-      status: voiceChatPreparations.status,
-    })
-    .from(voiceChatPreparations)
-    .where(eq(voiceChatPreparations.runId, runId))
-    .limit(1);
+  // Find, validate, and update preparation in a single transaction
+  const result = await globalThis.services.db.transaction(async (tx) => {
+    const [preparation] = await tx
+      .select({
+        id: voiceChatPreparations.id,
+        status: voiceChatPreparations.status,
+        orgId: voiceChatPreparations.orgId,
+      })
+      .from(voiceChatPreparations)
+      .where(eq(voiceChatPreparations.runId, runId))
+      .limit(1)
+      .for("update");
 
-  if (!preparation) {
-    return NextResponse.json(
-      {
-        error: {
-          message: "No preparation found for this run",
-          code: "NOT_FOUND",
-        },
-      },
-      { status: 404 },
-    );
+    if (!preparation) {
+      return { error: "NOT_FOUND" } as const;
+    }
+
+    if (authCtx.orgId && preparation.orgId !== authCtx.orgId) {
+      return { error: "FORBIDDEN" } as const;
+    }
+
+    if (preparation.status !== "preparing") {
+      return { error: "BAD_STATUS" } as const;
+    }
+
+    const [updated] = await tx
+      .update(voiceChatPreparations)
+      .set({ status: "ready", directiveContent: content })
+      .where(eq(voiceChatPreparations.id, preparation.id))
+      .returning({
+        id: voiceChatPreparations.id,
+        status: voiceChatPreparations.status,
+      });
+
+    if (!updated) {
+      return { error: "UPDATE_FAILED" } as const;
+    }
+
+    return { updated } as const;
+  });
+
+  if ("error" in result) {
+    switch (result.error) {
+      case "NOT_FOUND":
+        return NextResponse.json(
+          {
+            error: {
+              message: "No preparation found for this run",
+              code: "NOT_FOUND",
+            },
+          },
+          { status: 404 },
+        );
+      case "FORBIDDEN":
+        return NextResponse.json(
+          {
+            error: {
+              message: "Preparation does not belong to this organization",
+              code: "FORBIDDEN",
+            },
+          },
+          { status: 403 },
+        );
+      case "BAD_STATUS":
+        return NextResponse.json(
+          {
+            error: {
+              message: "Preparation is not in preparing status",
+              code: "BAD_REQUEST",
+            },
+          },
+          { status: 400 },
+        );
+      case "UPDATE_FAILED":
+        return NextResponse.json(
+          {
+            error: {
+              message: "Failed to update preparation",
+              code: "INTERNAL_SERVER_ERROR",
+            },
+          },
+          { status: 500 },
+        );
+    }
   }
 
-  if (preparation.status !== "preparing") {
-    return NextResponse.json(
-      {
-        error: {
-          message: "Preparation is not in preparing status",
-          code: "BAD_REQUEST",
-        },
-      },
-      { status: 400 },
-    );
-  }
-
-  const updated = await updatePreparationStatus(
-    preparation.id,
-    "ready",
-    content,
-  );
-
-  log.info("Preparation completed", { preparationId: preparation.id, runId });
+  log.info("Preparation completed", {
+    preparationId: result.updated.id,
+    runId,
+  });
 
   return NextResponse.json({
-    id: updated!.id,
-    status: updated!.status,
+    id: result.updated.id,
+    status: result.updated.status,
   });
 }

--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/route.ts
@@ -77,7 +77,13 @@ export async function POST(request: Request) {
   const { agentId, mode, prompt } = parsed.data;
 
   // Check for a fresh cached preparation (cache hit)
-  const fresh = await findFreshPreparation(userId, agentId, mode, prompt);
+  const fresh = await findFreshPreparation(
+    org.orgId,
+    userId,
+    agentId,
+    mode,
+    prompt,
+  );
   if (fresh) {
     return NextResponse.json({
       preparation: { id: fresh.id, status: "ready" },
@@ -85,7 +91,12 @@ export async function POST(request: Request) {
   }
 
   // Check for an in-flight preparation (dedup)
-  const inflight = await findInFlightPreparation(userId, agentId, mode);
+  const inflight = await findInFlightPreparation(
+    org.orgId,
+    userId,
+    agentId,
+    mode,
+  );
   if (inflight) {
     return NextResponse.json({
       preparation: { id: inflight.id, status: "preparing" },
@@ -101,13 +112,10 @@ export async function POST(request: Request) {
       mode,
       prompt,
     );
-    const run = await dispatchPreparationRun(
-      preparation.id,
-      org.orgId,
-      userId,
-      agentId,
-      { mode: mode as "chat" | "meeting", prompt },
-    );
+    const run = await dispatchPreparationRun(preparation.id, userId, agentId, {
+      mode: mode as "chat" | "meeting",
+      prompt,
+    });
 
     return NextResponse.json({
       preparation: {

--- a/turbo/apps/web/app/api/zero/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/route.ts
@@ -84,6 +84,7 @@ export async function POST(request: Request) {
     });
 
     const preparation = await findFreshPreparation(
+      org.orgId,
       userId,
       agentId,
       mode,
@@ -95,12 +96,10 @@ export async function POST(request: Request) {
         session.id,
         preparation.directiveContent,
       );
-      const run = await dispatchObservationSlowBrain(
-        session,
-        org.orgId,
-        userId,
+      const run = await dispatchObservationSlowBrain({
+        ...session,
         agentId,
-      );
+      });
 
       return NextResponse.json({
         session: {

--- a/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
@@ -14,6 +14,7 @@ const log = logger("zero:voice-chat:preparation");
 const PREPARATION_FRESHNESS_MS = 60 * 60 * 1000; // 1 hour
 
 export async function findFreshPreparation(
+  orgId: string,
   userId: string,
   agentId: string,
   mode: string,
@@ -23,6 +24,7 @@ export async function findFreshPreparation(
   const threshold = new Date(Date.now() - PREPARATION_FRESHNESS_MS);
 
   const conditions = [
+    eq(voiceChatPreparations.orgId, orgId),
     eq(voiceChatPreparations.userId, userId),
     eq(voiceChatPreparations.agentId, agentId),
     eq(voiceChatPreparations.mode, mode),
@@ -95,6 +97,7 @@ export async function updatePreparationStatus(
 }
 
 export async function findInFlightPreparation(
+  orgId: string,
   userId: string,
   agentId: string,
   mode: string,
@@ -105,6 +108,7 @@ export async function findInFlightPreparation(
     .from(voiceChatPreparations)
     .where(
       and(
+        eq(voiceChatPreparations.orgId, orgId),
         eq(voiceChatPreparations.userId, userId),
         eq(voiceChatPreparations.agentId, agentId),
         eq(voiceChatPreparations.mode, mode),
@@ -122,7 +126,6 @@ export async function findInFlightPreparation(
 
 export async function dispatchPreparationRun(
   preparationId: string,
-  orgId: string,
   userId: string,
   agentId: string,
   options?: { mode?: "chat" | "meeting"; prompt?: string },

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -238,12 +238,11 @@ export async function writeCachedPreparationEvents(
 // Observation-Only Slow-Brain Dispatch
 // ---------------------------------------------------------------------------
 
-export async function dispatchObservationSlowBrain(
-  session: { id: string },
-  orgId: string,
-  userId: string,
-  agentId: string,
-) {
+export async function dispatchObservationSlowBrain(session: {
+  id: string;
+  userId: string;
+  agentId: string;
+}) {
   const db = globalThis.services.db;
   const appendSystemPrompt = buildVoiceChatObservationOnlyPrompt(session.id);
   const prompt = `You are Zero's slow-brain for voice-chat session ${session.id}. Preparation is complete. Start observing the conversation.`;
@@ -253,8 +252,8 @@ export async function dispatchObservationSlowBrain(
   };
 
   const result = await createZeroRun({
-    userId,
-    agentId,
+    userId: session.userId,
+    agentId: session.agentId,
     prompt,
     appendSystemPrompt,
     triggerSource: "voice-chat",


### PR DESCRIPTION
## Summary

- Add `orgId` to `findFreshPreparation` and `findInFlightPreparation` queries for defense-in-depth tenant isolation
- Add org validation in `prepare/complete` endpoint — validates `preparation.orgId` matches `authCtx.orgId` when available
- Wrap status check-then-update in `prepare/complete` in a transaction with `SELECT FOR UPDATE` to prevent race conditions from concurrent completion attempts
- Replace non-null assertion (`updated!.id`) with proper null check and 500 response
- Remove unused `orgId` parameter from `dispatchPreparationRun`
- Widen session type in `dispatchObservationSlowBrain` to pull `userId`/`agentId` from session object, eliminating redundant parameters

Closes #9169

## Test plan

- [x] All 34 existing voice-chat preparation tests pass (prepare/complete, prepare, create-session, callbacks)
- [x] Lint passes (no new warnings)
- [x] Type-check passes for web app (no errors in changed files)
- [x] Format passes (prettier, no changes)
- [x] Knip passes (no unused exports/dependencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)