### PR TITLE
feat(web): reorder voice chat model tabs to put default first

### DIFF
--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -368,11 +368,11 @@ export function VoiceChatPage() {
           }}
         >
           <TabsList>
-            <TabsTrigger value="gpt-realtime" className="text-xs px-3">
-              GPT Realtime
-            </TabsTrigger>
             <TabsTrigger value="gpt-realtime-mini" className="text-xs px-3">
               GPT Realtime Mini
+            </TabsTrigger>
+            <TabsTrigger value="gpt-realtime" className="text-xs px-3">
+              GPT Realtime
             </TabsTrigger>
           </TabsList>
         </Tabs>


### PR DESCRIPTION
## Summary
- Move GPT Realtime Mini tab to the left (first) position in the voice chat model selector
- GPT Realtime Mini is the default model, so placing it first is more intuitive for users

## Test plan
- [ ] Open /voice-chat page and verify GPT Realtime Mini tab appears on the left
- [ ] Verify GPT Realtime Mini is still selected by default
- [ ] Verify switching between tabs still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)