### PR TITLE
fix(platform): center voice-chat footer controls on desktop

### DIFF
--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -137,7 +137,7 @@ function VoiceChatFooter({
   onRetry: () => void;
 }) {
   return (
-    <div className="border-t px-4 py-3 flex flex-col items-center gap-3 md:flex-row md:justify-between md:gap-4">
+    <div className="border-t px-4 py-3 flex flex-col items-center gap-3 md:flex-row md:justify-center md:gap-4">
       {/* Left: Segmented Control */}
       <Tabs
         value={inputMode}


### PR DESCRIPTION
## Summary
- Center the segment control and action button in the voice-chat footer on desktop instead of pushing them to opposite edges
- Changes `md:justify-between` to `md:justify-center` on the footer container
- Mobile layout (vertical stacking with centered items) is unaffected

## Test plan
- [ ] Open `/voice-chat` on desktop — segment control and button should be centered together
- [ ] Open `/voice-chat` on mobile — layout should remain unchanged (stacked vertically, centered)
- [ ] Test all three button states: Mute/Unmute (hands-free), Hold to Talk (push-to-talk), Retry (disconnected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)