### PR TITLE
feat(platform): integrate preparation cache into chat mode session start

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session-prepare.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session-prepare.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setChatAgentId$ } from "../../agent-chat.ts";
+import { setupVoiceChatPage$ } from "../voice-chat-setup.ts";
+
+const context = testContext();
+
+const TEST_AGENT_ID = "agent-prep-123";
+
+function setup() {
+  detachedSetupPage({
+    context,
+    path: "/voice-chat",
+    withoutRender: true,
+  });
+  context.store.set(setChatAgentId$, TEST_AGENT_ID);
+}
+
+function mockPrepareEndpoint(responses: { status: string; id?: string }[]) {
+  let callIndex = 0;
+  const calls: { agentId: string; mode: string }[] = [];
+  server.use(
+    http.post("*/api/zero/voice-chat/prepare", async ({ request }) => {
+      const body = (await request.json()) as {
+        agentId: string;
+        mode: string;
+      };
+      calls.push(body);
+      const responseIndex = Math.min(callIndex, responses.length - 1);
+      const response = responses[responseIndex];
+      callIndex++;
+      return HttpResponse.json({
+        preparation: {
+          id: response.id ?? "prep-1",
+          status: response.status,
+        },
+      });
+    }),
+  );
+  return calls;
+}
+
+describe("chat mode preparation cache", () => {
+  describe("setupVoiceChatPage$ proactive preparation", () => {
+    it("should fire preparation request on page load", async () => {
+      setup();
+      const calls = mockPrepareEndpoint([{ status: "ready" }]);
+
+      await context.store.set(setupVoiceChatPage$, context.signal);
+
+      // Wait for fire-and-forget async to complete
+      await vi.waitFor(() => {
+        expect(calls.length).toBeGreaterThanOrEqual(1);
+      });
+
+      expect(calls[0]).toStrictEqual({
+        agentId: TEST_AGENT_ID,
+        mode: "chat",
+      });
+    });
+
+    it("should not block page setup when preparation fails", async () => {
+      setup();
+      server.use(
+        http.post("*/api/zero/voice-chat/prepare", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+
+      // setupVoiceChatPage$ should complete without throwing
+      await context.store.set(setupVoiceChatPage$, context.signal);
+    });
+
+    it("should send mode chat in preparation request", async () => {
+      setup();
+      const calls = mockPrepareEndpoint([{ status: "preparing" }]);
+
+      await context.store.set(setupVoiceChatPage$, context.signal);
+
+      await vi.waitFor(() => {
+        expect(calls.length).toBeGreaterThanOrEqual(1);
+      });
+
+      // Every call should use mode "chat"
+      for (const call of calls) {
+        expect(call.mode).toBe("chat");
+      }
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session-prepare.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session-prepare.test.ts
@@ -5,6 +5,7 @@ import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { setChatAgentId$ } from "../../agent-chat.ts";
 import { setupVoiceChatPage$ } from "../voice-chat-setup.ts";
+import { startVoiceChat$, vcStatus$, vcError$ } from "../voice-chat-session.ts";
 
 const context = testContext();
 
@@ -41,6 +42,26 @@ function mockPrepareEndpoint(responses: { status: string; id?: string }[]) {
     }),
   );
   return calls;
+}
+
+/**
+ * Mock the session creation endpoint to return an error so startVoiceChat$
+ * terminates cleanly after the preparation block. This lets us verify
+ * preparation behavior without mocking the entire WebRTC session flow.
+ */
+function mockSessionEndpointError() {
+  const sessionCalls: unknown[] = [];
+  server.use(
+    http.post("*/api/zero/voice-chat", async ({ request }) => {
+      const body = await request.json();
+      sessionCalls.push(body);
+      return HttpResponse.json(
+        { error: { message: "test-session-error" } },
+        { status: 400 },
+      );
+    }),
+  );
+  return sessionCalls;
 }
 
 describe("chat mode preparation cache", () => {
@@ -88,6 +109,81 @@ describe("chat mode preparation cache", () => {
       for (const call of calls) {
         expect(call.mode).toBe("chat");
       }
+    });
+  });
+
+  describe("startVoiceChat$ preparation before session", () => {
+    it("should call preparation and proceed to session when already ready", async () => {
+      setup();
+      const prepCalls = mockPrepareEndpoint([{ status: "ready" }]);
+      const sessionCalls = mockSessionEndpointError();
+
+      await context.store.set(startVoiceChat$, context.signal);
+
+      // Preparation was called
+      expect(prepCalls).toHaveLength(1);
+      expect(prepCalls[0]).toStrictEqual({
+        agentId: TEST_AGENT_ID,
+        mode: "chat",
+      });
+
+      // Session creation was attempted (proves preparation didn't block)
+      expect(sessionCalls).toHaveLength(1);
+
+      // Status should be error from our mocked session endpoint
+      expect(context.store.get(vcStatus$)).toBe("error");
+      expect(context.store.get(vcError$)).toBe("test-session-error");
+    });
+
+    it("should poll preparation until ready then proceed to session", async () => {
+      setup();
+      const prepCalls = mockPrepareEndpoint([
+        { status: "preparing" },
+        { status: "preparing" },
+        { status: "ready" },
+      ]);
+      const sessionCalls = mockSessionEndpointError();
+
+      await context.store.set(startVoiceChat$, context.signal);
+
+      // Initial call + 2 poll calls (preparing, ready)
+      expect(prepCalls.length).toBeGreaterThanOrEqual(3);
+
+      // Session creation was attempted after polling completed
+      expect(sessionCalls).toHaveLength(1);
+    });
+
+    it("should proceed to session when preparation API fails", async () => {
+      setup();
+      server.use(
+        http.post("*/api/zero/voice-chat/prepare", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+      const sessionCalls = mockSessionEndpointError();
+
+      await context.store.set(startVoiceChat$, context.signal);
+
+      // Session creation was still attempted (graceful fallback)
+      expect(sessionCalls).toHaveLength(1);
+      expect(context.store.get(vcStatus$)).toBe("error");
+    });
+
+    it("should proceed to session when preparation poll returns failed", async () => {
+      setup();
+      const prepCalls = mockPrepareEndpoint([
+        { status: "preparing" },
+        { status: "failed" },
+      ]);
+      const sessionCalls = mockSessionEndpointError();
+
+      await context.store.set(startVoiceChat$, context.signal);
+
+      // Initial call + 1 poll (failed stops the loop)
+      expect(prepCalls.length).toBeGreaterThanOrEqual(2);
+
+      // Session creation was still attempted
+      expect(sessionCalls).toHaveLength(1);
     });
   });
 });

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -1,10 +1,15 @@
 import { command, computed, state } from "ccstate";
-import { FeatureSwitchKey } from "@vm0/core";
+import {
+  FeatureSwitchKey,
+  zeroVoiceChatPrepareTriggerContract,
+} from "@vm0/core";
 import { fetch$ } from "../fetch.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
 import { delay } from "signal-timers";
 import { resetSignal, throwIfAbort, onDomEventFn, setLoop } from "../utils.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { accept } from "../../lib/accept.ts";
 
 type ConnectionStatus =
   | "idle"
@@ -1064,6 +1069,48 @@ export const startVoiceChat$ = command(
       set(internalStatus$, "error");
       return;
     }
+
+    // Ensure preparation cache is populated before session creation.
+    // If preparation is already cached ("ready"), this returns instantly.
+    // If preparation fails, we fall through to session creation which
+    // handles the unprepared case via inline slow-brain.
+    // eslint-disable-next-line no-restricted-syntax -- accept() throws on non-200; must catch to fall through gracefully
+    try {
+      const createClient = get(zeroClient$);
+      const prepClient = createClient(zeroVoiceChatPrepareTriggerContract);
+      const prepRes = await accept(
+        prepClient.trigger({ body: { agentId, mode: "chat" } }),
+        [200],
+        { toast: false },
+      );
+      signal.throwIfAborted();
+
+      if (prepRes.body.preparation.status !== "ready") {
+        // Preparation in progress — poll until ready or timeout
+        const prepStart = Date.now();
+        await setLoop(
+          async (loopSignal: AbortSignal) => {
+            if (Date.now() - prepStart > PREP_TIMEOUT_CHAT_MS) {
+              return true; // Timeout — proceed without cache
+            }
+            const pollRes = await accept(
+              prepClient.trigger({ body: { agentId, mode: "chat" } }),
+              [200],
+              { toast: false },
+            );
+            loopSignal.throwIfAborted();
+            const status = pollRes.body.preparation.status;
+            return status === "ready" || status === "failed";
+          },
+          POLL_INTERVAL_MS,
+          signal,
+        );
+      }
+    } catch (error) {
+      throwIfAbort(error);
+      // Preparation failed — fall through to session creation (graceful fallback)
+    }
+    signal.throwIfAborted();
 
     const sessionRes = await fetchFn("/api/zero/voice-chat", {
       method: "POST",

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -10,6 +10,9 @@ import { delay } from "signal-timers";
 import { resetSignal, throwIfAbort, onDomEventFn, setLoop } from "../utils.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
+import { logger } from "../log.ts";
+
+const L = logger("VoiceChat");
 
 type ConnectionStatus =
   | "idle"
@@ -1108,7 +1111,10 @@ export const startVoiceChat$ = command(
       }
     } catch (error) {
       throwIfAbort(error);
-      // Preparation failed — fall through to session creation (graceful fallback)
+      L.warn(
+        "Chat preparation failed, falling back to unprepared session",
+        error,
+      );
     }
     signal.throwIfAborted();
 

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-setup.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-setup.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { zeroVoiceChatPrepareTriggerContract } from "@vm0/core";
 import { SidebarLayout } from "../../views/zero-page/sidebar-layout.tsx";
 import { VoiceChatPage } from "../../views/voice-chat/voice-chat-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -8,6 +9,9 @@ import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { endVoiceChat$, vcStatus$ } from "./voice-chat-session.ts";
 import { clearPreparation$ } from "./voice-chat-preparation.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { currentChatAgentId$ } from "../agent-chat.ts";
+import { accept } from "../../lib/accept.ts";
 
 export const setupVoiceChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -22,6 +26,25 @@ export const setupVoiceChatPage$ = command(
     }
 
     await set(hideAppSkeleton$, signal);
+
+    // Pre-warm chat preparation cache (fire-and-forget).
+    // By the time the user clicks "Start Voice Chat", the preparation
+    // is likely already cached, reducing perceived latency.
+    (async () => {
+      const agentId = await get(currentChatAgentId$);
+      if (!agentId || signal.aborted) {
+        return;
+      }
+      const createClient = get(zeroClient$);
+      const client = createClient(zeroVoiceChatPrepareTriggerContract);
+      await accept(client.trigger({ body: { agentId, mode: "chat" } }), [200], {
+        toast: false,
+      }).catch(() => {
+        return undefined; // Swallow errors — pre-warming is best-effort
+      });
+    })().catch(() => {
+      return undefined;
+    });
 
     // End voice chat session and clear preparation when navigating away
     signal.addEventListener("abort", () => {

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-setup.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-setup.ts
@@ -12,6 +12,9 @@ import { clearPreparation$ } from "./voice-chat-preparation.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
 import { accept } from "../../lib/accept.ts";
+import { logger } from "../log.ts";
+
+const L = logger("VoiceChatSetup");
 
 export const setupVoiceChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -40,10 +43,10 @@ export const setupVoiceChatPage$ = command(
       await accept(client.trigger({ body: { agentId, mode: "chat" } }), [200], {
         toast: false,
       }).catch(() => {
-        return undefined; // Swallow errors — pre-warming is best-effort
+        return undefined; // Pre-warming is best-effort
       });
-    })().catch(() => {
-      return undefined;
+    })().catch((error: unknown) => {
+      L.warn("Preparation pre-warm failed", error);
     });
 
     // End voice chat session and clear preparation when navigating away


### PR DESCRIPTION
## Summary

Closes #9181

- Add preparation API call (`POST /api/zero/voice-chat/prepare`) before session creation in `startVoiceChat$` so that `findFreshPreparation()` finds a cached preparation on the backend, enabling `prepared: true` sessions
- Add proactive fire-and-forget preparation on page load in `setupVoiceChatPage$` to pre-warm the cache while the user is looking at the UI, reducing perceived latency when they click "Start Voice Chat"
- Graceful fallback: if preparation fails or times out, session creation proceeds as before (`prepared: false` → inline slow-brain), ensuring no regression

Backend changes: **None** — all preparation infrastructure already supports chat mode.

## Test plan

- [ ] Verify `setupVoiceChatPage$` fires preparation request on page load (covered by integration test)
- [ ] Verify preparation failure does not block page setup (covered by integration test)
- [ ] Verify preparation uses `mode: "chat"` (covered by integration test)
- [ ] Verify existing preparation tests still pass (6 tests)
- [ ] Start a voice chat in chat mode → preparation runs → session starts
- [ ] End session, start new voice chat within 1 hour → prepare API returns "ready" instantly → `session.prepared === true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)