### PR TITLE
fix(voice-io): use pcm + web audio api for tts playback

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
+++ b/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
@@ -5,38 +5,46 @@ import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { playTts$, ttsPlayingMessageId$ } from "../voice-io-tts.ts";
 
-class MockAudio {
-  play = (): Promise<void> => {
-    return Promise.resolve();
+function mockWebAudio() {
+  const sources: {
+    onended: (() => void) | null;
+    start: ReturnType<typeof vi.fn>;
+  }[] = [];
+
+  const mockAudioContext = {
+    currentTime: 0,
+    destination: {},
+    createBuffer: vi.fn(
+      (_channels: number, length: number, sampleRate: number) => {
+        return {
+          getChannelData: vi.fn(() => {
+            return new Float32Array(length);
+          }),
+          duration: length / sampleRate,
+        };
+      },
+    ),
+    createBufferSource: vi.fn(() => {
+      const source = {
+        buffer: null as unknown,
+        onended: null as (() => void) | null,
+        connect: vi.fn(),
+        start: vi.fn(),
+      };
+      sources.push(source);
+      return source;
+    }),
+    close: vi.fn().mockResolvedValue(undefined),
   };
-  pause = () => {};
-  load = () => {};
-  removeAttribute = (_name: string) => {};
-  addEventListener = (_type: string, _listener: unknown) => {};
-  removeEventListener = (_type: string, _listener: unknown) => {};
-}
-
-function mockAudio() {
-  const instances: MockAudio[] = [];
 
   vi.stubGlobal(
-    "Audio",
-    vi.fn(function (this: MockAudio) {
-      Object.assign(this, new MockAudio());
-      vi.spyOn(this, "play").mockResolvedValue(undefined);
-      instances.push(this);
+    "AudioContext",
+    vi.fn(function () {
+      return mockAudioContext;
     }),
   );
 
-  vi.stubGlobal(
-    "URL",
-    Object.assign(globalThis.URL, {
-      createObjectURL: vi.fn().mockReturnValue("blob:mock"),
-      revokeObjectURL: vi.fn(),
-    }),
-  );
-
-  return { instances };
+  return { mockAudioContext, sources };
 }
 
 function mockTtsEndpoint() {
@@ -45,9 +53,14 @@ function mockTtsEndpoint() {
   server.use(
     http.post("http://localhost:3000/api/zero/voice-io/tts", () => {
       fetchCount++;
-      const body = new Uint8Array([0]);
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([0x00, 0x01, 0x00, 0x02]));
+          controller.close();
+        },
+      });
       return new HttpResponse(body, {
-        headers: { "Content-Type": "audio/mpeg" },
+        headers: { "Content-Type": "application/octet-stream" },
       });
     }),
   );
@@ -64,7 +77,7 @@ describe("playTts$", () => {
 
   it("should not trigger a second fetch when called twice with the same messageId", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
-    const { instances } = mockAudio();
+    mockWebAudio();
     const { getFetchCount } = mockTtsEndpoint();
 
     const p1 = context.store.set(
@@ -82,12 +95,12 @@ describe("playTts$", () => {
     await Promise.all([p1, p2]);
 
     expect(getFetchCount()).toBe(1);
-    expect(instances).toHaveLength(1);
+    expect(AudioContext).toHaveBeenCalledTimes(1);
   });
 
   it("should allow playback for a different messageId", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
-    mockAudio();
+    mockWebAudio();
     const { getFetchCount } = mockTtsEndpoint();
 
     await context.store.set(playTts$, "msg-1", "Hello", context.signal);
@@ -98,7 +111,7 @@ describe("playTts$", () => {
 
   it("should reset playingMessageId on fetch failure", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
-    mockAudio();
+    mockWebAudio();
 
     // Allow expected TTS error logs without throwing
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
@@ -11,8 +11,6 @@ const L = logger("VoiceIO:TTS");
 // ---------------------------------------------------------------------------
 
 const internalPlayingMessageId$ = state<string | null>(null);
-const internalAudioElement$ = state<HTMLAudioElement | null>(null);
-const internalObjectUrl$ = state<string | null>(null);
 const internalCleanupFn$ = state<(() => void) | null>(null);
 
 // Auto-read tracking
@@ -51,74 +49,6 @@ function stripMarkdown(text: string): string {
     .trim();
 }
 
-function supportsMediaSourceMpeg(): boolean {
-  return (
-    typeof MediaSource !== "undefined" &&
-    MediaSource.isTypeSupported("audio/mpeg")
-  );
-}
-
-function noop() {}
-
-/**
- * Read all chunks from a ReadableStream and append them to a SourceBuffer for
- * progressive audio playback. Returns a promise that resolves when the stream
- * is fully consumed and all chunks have been flushed to the buffer.
- */
-function drainStreamIntoSourceBuffer(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  sourceBuffer: SourceBuffer,
-  signal: AbortSignal,
-): Promise<void> {
-  const queue: Uint8Array<ArrayBuffer>[] = [];
-  let draining = false;
-
-  function flush() {
-    if (draining || queue.length === 0 || sourceBuffer.updating) {
-      return;
-    }
-    draining = true;
-    const chunk = queue.shift()!;
-    sourceBuffer.appendBuffer(chunk);
-  }
-
-  sourceBuffer.addEventListener("updateend", () => {
-    draining = false;
-    flush();
-  });
-
-  return (async () => {
-    for (;;) {
-      if (signal.aborted) {
-        break;
-      }
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-      queue.push(value.slice());
-      flush();
-    }
-
-    // Wait for remaining buffered data to finish appending
-    await new Promise<void>((resolve) => {
-      const finish = () => {
-        if (queue.length > 0) {
-          flush();
-          return;
-        }
-        if (sourceBuffer.updating) {
-          return;
-        }
-        sourceBuffer.removeEventListener("updateend", finish);
-        resolve();
-      };
-      sourceBuffer.addEventListener("updateend", finish);
-      finish();
-    });
-  })();
-}
-
 // ---------------------------------------------------------------------------
 // Internal commands
 // ---------------------------------------------------------------------------
@@ -129,23 +59,12 @@ const cleanupAudio$ = command(({ get, set }) => {
     cleanupFn();
   }
 
-  const audio = get(internalAudioElement$);
-  if (audio) {
-    audio.pause();
-    audio.removeAttribute("src");
-    audio.load();
-  }
-
   set(internalPlayingMessageId$, null);
-  set(internalAudioElement$, null);
-  set(internalObjectUrl$, null);
   set(internalCleanupFn$, null);
 });
 
 const resetPlaybackState$ = command(({ set }) => {
   set(internalPlayingMessageId$, null);
-  set(internalAudioElement$, null);
-  set(internalObjectUrl$, null);
   set(internalCleanupFn$, null);
 });
 
@@ -183,110 +102,87 @@ const fetchAndPlay$ = command(
       return;
     }
 
-    if (supportsMediaSourceMpeg() && response.body) {
-      // Streaming path: pipe response stream into MediaSource for progressive playback
-      const mediaSource = new MediaSource();
-      const audio = new Audio();
-      const objectUrl = URL.createObjectURL(mediaSource);
-      audio.src = objectUrl;
+    const body = response.body;
+    if (!body) {
+      set(internalPlayingMessageId$, null);
+      return;
+    }
 
-      const reader = response.body.getReader();
+    const audioCtx = new AudioContext({ sampleRate: 24_000 });
+    const reader = body.getReader();
+    let nextStartTime = audioCtx.currentTime;
+    let lastSource: AudioBufferSourceNode | null = null;
+    let carry: Uint8Array | null = null;
 
-      const onEnded = () => {
-        set(resetPlaybackState$);
-      };
-      const onError = () => {
-        L.error("Audio playback error");
-        set(resetPlaybackState$);
-      };
-
-      audio.addEventListener("ended", onEnded);
-      audio.addEventListener("error", onError);
-
-      set(internalCleanupFn$, () => {
-        reader.cancel().catch(noop);
-        audio.removeEventListener("ended", onEnded);
-        audio.removeEventListener("error", onError);
-        if (mediaSource.readyState === "open") {
-          mediaSource.endOfStream();
-        }
-        URL.revokeObjectURL(objectUrl);
+    set(internalCleanupFn$, () => {
+      reader.cancel().catch((error: unknown) => {
+        L.debug("reader cancel error", error);
       });
+      audioCtx.close().catch((error: unknown) => {
+        L.debug("audioCtx close error", error);
+      });
+    });
 
-      set(internalObjectUrl$, objectUrl);
-      set(internalAudioElement$, audio);
+    for (;;) {
+      if (signal.aborted) {
+        break;
+      }
+      const { done, value } = await reader.read();
+      signal.throwIfAborted();
+      if (done) {
+        break;
+      }
 
-      await new Promise<void>((resolve) => {
-        mediaSource.addEventListener(
-          "sourceopen",
-          () => {
-            const sourceBuffer = mediaSource.addSourceBuffer("audio/mpeg");
-            let playStarted = false;
+      // Handle byte alignment (PCM = 2 bytes per sample)
+      let chunk = value;
+      if (carry) {
+        const merged = new Uint8Array(carry.length + chunk.length);
+        merged.set(carry);
+        merged.set(chunk, carry.length);
+        chunk = merged;
+        carry = null;
+      }
+      if (chunk.length % 2 !== 0) {
+        carry = chunk.slice(-1);
+        chunk = chunk.slice(0, -1);
+      }
+      if (chunk.length === 0) {
+        continue;
+      }
 
-            sourceBuffer.addEventListener("updateend", () => {
-              if (!playStarted) {
-                playStarted = true;
-                audio.play().catch((error: unknown) => {
-                  L.error("Audio play failed", error);
-                  set(resetPlaybackState$);
-                });
-              }
-            });
+      // Convert Int16LE PCM to Float32
+      const int16 = new Int16Array(
+        chunk.buffer,
+        chunk.byteOffset,
+        chunk.length / 2,
+      );
+      const float32 = new Float32Array(int16.length);
+      for (let i = 0; i < int16.length; i++) {
+        float32[i] = int16[i] / 32_768;
+      }
 
-            drainStreamIntoSourceBuffer(reader, sourceBuffer, signal)
-              .then(() => {
-                if (mediaSource.readyState === "open") {
-                  mediaSource.endOfStream();
-                }
-                resolve();
-              })
-              .catch((error: unknown) => {
-                if (!signal.aborted) {
-                  L.error("TTS stream error", error);
-                  set(resetPlaybackState$);
-                }
-                resolve();
-              });
-          },
-          { once: true },
-        );
+      const audioBuffer = audioCtx.createBuffer(1, float32.length, 24_000);
+      audioBuffer.getChannelData(0).set(float32);
+
+      const source = audioCtx.createBufferSource();
+      source.buffer = audioBuffer;
+      source.connect(audioCtx.destination);
+
+      if (nextStartTime < audioCtx.currentTime) {
+        nextStartTime = audioCtx.currentTime;
+      }
+      source.start(nextStartTime);
+      nextStartTime += audioBuffer.duration;
+      lastSource = source;
+    }
+
+    // Detect end of playback
+    if (lastSource) {
+      lastSource.addEventListener("ended", () => {
+        set(resetPlaybackState$);
       });
     } else {
-      // Fallback: download full blob then play (Safari/iOS or no ReadableStream)
-      const blob = await response.blob();
-      signal.throwIfAborted();
-      const blobUrl = URL.createObjectURL(blob);
-      const audio = new Audio(blobUrl);
-
-      const onEnded = () => {
-        URL.revokeObjectURL(blobUrl);
-        set(resetPlaybackState$);
-      };
-
-      const onError = () => {
-        L.error("Audio playback error");
-        onEnded();
-      };
-
-      audio.addEventListener("ended", onEnded);
-      audio.addEventListener("error", onError);
-
-      set(internalCleanupFn$, () => {
-        audio.removeEventListener("ended", onEnded);
-        audio.removeEventListener("error", onError);
-        URL.revokeObjectURL(blobUrl);
-      });
-
-      set(internalObjectUrl$, blobUrl);
-      set(internalAudioElement$, audio);
-
-      // eslint-disable-next-line no-restricted-syntax -- audio.play() rejects on browser autoplay restrictions
-      try {
-        await audio.play();
-      } catch (error) {
-        L.error("Audio play failed", error);
-        onEnded();
-      }
+      set(resetPlaybackState$);
     }
   },
 );

--- a/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
@@ -113,7 +113,7 @@ describe("POST /api/zero/voice-io/tts", () => {
     const userId = uniqueId("zvio-ok");
     await setupOrg(userId);
 
-    const fakeAudio = new Uint8Array([0xff, 0xfb, 0x90, 0x00]);
+    const fakeAudio = new Uint8Array([0x00, 0x01, 0x00, 0x02]);
 
     server.use(
       http.post(
@@ -123,10 +123,10 @@ describe("POST /api/zero/voice-io/tts", () => {
           expect(reqBody.model).toBe("gpt-4o-mini-tts");
           expect(reqBody.voice).toBe("ash");
           expect(reqBody.input).toBe("hello world");
-          expect(reqBody.response_format).toBe("mp3");
+          expect(reqBody.response_format).toBe("pcm");
 
           return new HttpResponse(fakeAudio, {
-            headers: { "Content-Type": "audio/mpeg" },
+            headers: { "Content-Type": "application/octet-stream" },
           });
         },
       ),
@@ -135,7 +135,9 @@ describe("POST /api/zero/voice-io/tts", () => {
     const response = await POST(ttsRequest({ text: "hello world" }));
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Type")).toBe("audio/mpeg");
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/octet-stream",
+    );
 
     const buffer = await response.arrayBuffer();
     expect(new Uint8Array(buffer)).toEqual(fakeAudio);

--- a/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
@@ -97,7 +97,7 @@ export async function POST(request: Request): Promise<Response> {
       model: "gpt-4o-mini-tts",
       voice: "ash",
       input: text,
-      response_format: "mp3",
+      response_format: "pcm",
     }),
   });
 
@@ -121,7 +121,7 @@ export async function POST(request: Request): Promise<Response> {
   return new Response(response.body, {
     status: 200,
     headers: {
-      "Content-Type": "audio/mpeg",
+      "Content-Type": "application/octet-stream",
     },
   });
 }


### PR DESCRIPTION
## Summary

- Replace broken MediaSource MP3 streaming with PCM format + Web Audio API for reliable, low-latency TTS playback
- Backend now requests `response_format: "pcm"` from OpenAI TTS API and returns `application/octet-stream`
- Frontend streams PCM chunks through `AudioContext` + `AudioBufferSourceNode` with gapless scheduling
- Remove all MediaSource code (`supportsMediaSourceMpeg`, `drainStreamIntoSourceBuffer`, blob fallback)

Closes #9191

## Test plan

- [x] Backend tests updated and passing (PCM format assertions, binary content type)
- [x] Frontend tests updated and passing (AudioContext mocks, dedup, error recovery)
- [x] Lint, type-check, format, knip all passing
- [ ] Manual: click "Read Aloud" on a chat message — audio plays progressively
- [ ] Manual: click "Stop" — audio stops immediately
- [ ] Manual: play different message — previous stops, new starts
- [ ] Manual: no `ERR_FILE_NOT_FOUND` or `NotSupportedError` in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)