### PR TITLE
refactor(runner): surface r2 gc pagination invariant violations as errors

### DIFF
--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -429,17 +429,27 @@ impl R2ImageCache {
             if !resp.is_truncated().unwrap_or(false) {
                 break;
             }
-            let next_token = match resp.next_continuation_token() {
-                Some(t) => t.to_string(),
-                None => break, // truncated but no token — defensive exit
-            };
-            // Defensive: detect a server returning the same token twice
-            // (would be an S3 bug, but cheap to guard against).
+            // Both branches below validate at the S3-API boundary. They
+            // surface as `R2Error::S3` (rather than silently breaking the
+            // loop) so operators see clear errors when S3 misbehaves
+            // instead of a quietly under-deleted GC cycle. `runner gc`
+            // already logs and swallows R2 errors at the outer call site
+            // (R2 errors never fail the deploy — see #9120).
+            let next_token = resp
+                .next_continuation_token()
+                .ok_or_else(|| {
+                    R2Error::S3(
+                        "list_objects_v2: is_truncated=true with no \
+                         next_continuation_token (R2/S3 spec violation)"
+                            .into(),
+                    )
+                })?
+                .to_string();
             if continuation_token.as_deref() == Some(next_token.as_str()) {
-                tracing::warn!(
-                    "r2: list_objects_v2 returned identical continuation_token; aborting paginated scan"
-                );
-                break;
+                return Err(R2Error::S3(format!(
+                    "list_objects_v2 returned identical continuation_token \
+                     twice ({next_token}) — pagination would loop indefinitely"
+                )));
             }
             continuation_token = Some(next_token);
         }
@@ -1963,5 +1973,77 @@ mod tests {
             freed, 40,
             "proportional attribution: batch_freed=60, actual/count=2/3 → 40"
         );
+    }
+
+    /// `gc_older_than` MUST surface (not silently break) when S3 returns
+    /// `is_truncated=true` with no `next_continuation_token` — a spec
+    /// violation that, if silently accepted, would silently under-delete.
+    /// Returning `Err` lets `runner gc` log a clear cause instead of a
+    /// quietly skipped page tail.
+    #[tokio::test]
+    async fn gc_errors_on_truncated_with_no_token() {
+        use aws_sdk_s3::Client;
+        use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output;
+
+        // is_truncated=true but next_continuation_token absent.
+        let page = ListObjectsV2Output::builder().is_truncated(true).build();
+        let list = mock!(Client::list_objects_v2).then_output(move || page.clone());
+
+        let cache = mock_cache("test-bucket", &[&list]);
+        let err = cache
+            .gc_older_than(std::time::Duration::from_secs(1))
+            .await
+            .unwrap_err();
+
+        match err {
+            R2Error::S3(msg) => {
+                assert!(
+                    msg.contains("no next_continuation_token"),
+                    "want descriptive message: {msg}"
+                );
+            }
+            other => panic!("expected R2Error::S3 for missing token, got {other:?}"),
+        }
+    }
+
+    /// `gc_older_than` MUST surface (not silently break) when S3 returns
+    /// the same `next_continuation_token` twice. Without this guard, the
+    /// loop would re-issue list_objects_v2 with the repeated token forever.
+    #[tokio::test]
+    async fn gc_errors_on_repeated_continuation_token() {
+        use aws_sdk_s3::Client;
+        use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output;
+
+        // Both calls return is_truncated=true with the same token "stuck-tok".
+        let page = ListObjectsV2Output::builder()
+            .is_truncated(true)
+            .next_continuation_token("stuck-tok")
+            .build();
+        let list = mock!(Client::list_objects_v2).then_output(move || page.clone());
+
+        let cache = mock_cache("test-bucket", &[&list]);
+        let err = cache
+            .gc_older_than(std::time::Duration::from_secs(1))
+            .await
+            .unwrap_err();
+
+        match err {
+            R2Error::S3(msg) => {
+                assert!(
+                    msg.contains("identical continuation_token"),
+                    "want descriptive message: {msg}"
+                );
+                assert!(
+                    msg.contains("stuck-tok"),
+                    "want offending token in message: {msg}"
+                );
+            }
+            other => panic!("expected R2Error::S3 for repeated token, got {other:?}"),
+        }
+        // Sanity: list was called at least twice — first sets
+        // `continuation_token`, second triggers the equality check.
+        // Use `>= 2` rather than strict equality to stay robust against
+        // any future SDK retry behavior on the list operation.
+        assert!(list.num_calls() >= 2, "got {}", list.num_calls());
     }
 }


### PR DESCRIPTION
Closes #9199.

> [!NOTE]
> **Stacked on top of #9186.** The `aws-smithy-mocks` dev-dep and `mock_cache` helper come from #9186; new tests rely on them. Once #9186 merges, GitHub will auto-retarget the base of this PR to `main`.

## Summary

`R2ImageCache::gc_older_than` had two silent-`break` branches handling S3 spec violations in pagination:

- `is_truncated=true` with no `next_continuation_token`
- the same `next_continuation_token` returned twice in a row

Both now return `R2Error::S3` instead of silently breaking out of the loop. Operators see a clear cause via the existing `runner gc` error log path; deploys are unaffected (`runner gc` already swallows R2 errors per #9120).

## Why not pure removal

PR #9186 review (P2-2) suggested removing the same-token defensive code per "Avoid Defensive Programming". After investigation, **pure removal would risk an infinite loop**:

- `None` token → loop re-issues `list_objects_v2` with `continuation_token=None` → S3 returns page 1 → repeat forever.
- Same token → loop re-issues with same token → S3 returns same page → repeat forever (and burns delete-quota).

CLAUDE.md's "Avoid Defensive Programming" rule is paired with: "Only validate at system boundaries (user input, external APIs)". S3 is an external API, so the validation IS appropriate — the issue was that the validation outcome (silent break + warn) was the wrong shape. Surfacing as `Err` keeps the boundary check while removing the silent-under-deletion footgun.

Scope expanded from the reviewer's original (just same-token) to also cover the symmetric "no token" branch — both are the same shape and treating them together is more complete.

## Test plan

- [x] Two new tests in `r2_cache::tests`:
  - `gc_errors_on_truncated_with_no_token` — list returns truncated but no token → `R2Error::S3` with descriptive message
  - `gc_errors_on_repeated_continuation_token` — list returns same token twice → `R2Error::S3` with offending token in message
- [x] `cargo test -p runner` — 583 passed
- [x] `cargo clippy -p runner --tests -- -D warnings` clean
- [x] No production behavior change for well-behaved S3 (only the bug-path semantics change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)