### PR TITLE
fix(web): validate custom skill names against org skills and connectors

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -15,6 +15,7 @@ import { zeroAgents } from "../../../../../src/db/schema/zero-agent";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
 import { eq, and } from "drizzle-orm";
 import { buildComposeContent } from "../../../../../src/lib/zero/build-compose-content";
+import { validateCustomSkills } from "../../../../../src/lib/zero/validate-custom-skills";
 import {
   requireAgentPermission,
   requireAdminPermission,
@@ -142,6 +143,12 @@ const router = tsr.router(zeroAgentsByIdContract, {
 
     // Use provided customSkills if present, otherwise keep existing
     const customSkills = body.customSkills ?? existing.customSkills ?? [];
+
+    // Validate custom skill names when explicitly provided
+    if (body.customSkills) {
+      const validation = await validateCustomSkills(customSkills, org.orgId);
+      if (!validation.valid) return validation.error;
+    }
 
     // Build compose content (all connector skills included, plus custom skills)
     const content = buildComposeContent(

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -32,6 +32,7 @@ import {
   insertOrgMembersCacheEntry,
   getTestComposeVersionContent,
   createTestTarFile,
+  createTestZeroSkill,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { getInstructionsStorageName } from "@vm0/core";
 import {
@@ -208,6 +209,9 @@ describe("Zero Agents API", () => {
     });
 
     it("should create an agent with custom skills and include them in response and compose", async () => {
+      await createTestZeroSkill(user.orgId, "my-skill");
+      await createTestZeroSkill(user.orgId, "data-tool");
+
       const response = await postAgent(
         { customSkills: ["my-skill", "data-tool"] },
         testCliToken,
@@ -230,6 +234,30 @@ describe("Zero Agents API", () => {
         name: "custom-skill@data-tool",
         version: "latest",
       });
+    });
+
+    it("should reject non-existent custom skill names", async () => {
+      const response = await postAgent(
+        { customSkills: ["does-not-exist"] },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("does-not-exist");
+      expect(data.error.message).toContain("not found");
+    });
+
+    it("should reject connector type names as custom skills", async () => {
+      const response = await postAgent(
+        { customSkills: ["github"] },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("github");
+      expect(data.error.message).toContain("connector");
     });
 
     it("should return 401 without auth", async () => {
@@ -356,6 +384,9 @@ describe("Zero Agents API", () => {
     });
 
     it("should update custom skills and reflect in compose volumes", async () => {
+      await createTestZeroSkill(user.orgId, "my-skill");
+      await createTestZeroSkill(user.orgId, "data-tool");
+
       const created = await (await postAgent({}, testCliToken)).json();
 
       const response = await putAgent(
@@ -382,6 +413,8 @@ describe("Zero Agents API", () => {
     });
 
     it("should preserve existing custom skills when not provided in update", async () => {
+      await createTestZeroSkill(user.orgId, "my-skill");
+
       // Create with custom skills
       const created = await (
         await postAgent({ customSkills: ["my-skill"] }, testCliToken)
@@ -399,6 +432,36 @@ describe("Zero Agents API", () => {
       const getRes = await getAgent(created.agentId, testCliToken);
       const fetched = await getRes.json();
       expect(fetched.customSkills).toEqual(["my-skill"]);
+    });
+
+    it("should reject non-existent custom skill names on update", async () => {
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      const response = await putAgent(
+        created.agentId,
+        { customSkills: ["does-not-exist"] },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("does-not-exist");
+      expect(data.error.message).toContain("not found");
+    });
+
+    it("should reject connector type names as custom skills on update", async () => {
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      const response = await putAgent(
+        created.agentId,
+        { customSkills: ["github"] },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("github");
+      expect(data.error.message).toContain("connector");
     });
 
     it("should return 404 for unknown agent", async () => {
@@ -482,6 +545,8 @@ describe("Zero Agents API", () => {
     });
 
     it("should preserve custom skill volumes after instructions update", async () => {
+      await createTestZeroSkill(user.orgId, "my-skill");
+
       const createResponse = await postAgent(
         { customSkills: ["my-skill"] },
         testCliToken,

--- a/turbo/apps/web/app/api/zero/agents/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/route.ts
@@ -15,6 +15,7 @@ import { zeroAgents } from "../../../../src/db/schema/zero-agent";
 import { agentComposes } from "../../../../src/db/schema/agent-compose";
 import { eq, desc } from "drizzle-orm";
 import { buildComposeContent } from "../../../../src/lib/zero/build-compose-content";
+import { validateCustomSkills } from "../../../../src/lib/zero/validate-custom-skills";
 import { logger } from "../../../../src/lib/shared/logger";
 
 const log = logger("api:zero-agents");
@@ -35,6 +36,10 @@ const router = tsr.router(zeroAgentsMainContract, {
     const agentName = crypto.randomUUID();
 
     const customSkills = body.customSkills ?? [];
+
+    // Validate custom skill names exist in the org
+    const validation = await validateCustomSkills(customSkills, org.orgId);
+    if (!validation.valid) return validation.error;
 
     // Build compose content (always includes all connector skills)
     const content = buildComposeContent(

--- a/turbo/apps/web/src/__tests__/api-test-helpers/skills.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/skills.ts
@@ -4,6 +4,7 @@ import { VOLUME_ORG_USER_ID, SYSTEM_ORG_ID } from "@vm0/core";
 import { initServices } from "../../lib/init-services";
 import { skills } from "../../db/schema/skill";
 import { zeroAgents } from "../../db/schema/zero-agent";
+import { zeroSkills } from "../../db/schema/zero-skill";
 import { storages, storageVersions } from "../../db/schema/storage";
 import { buildSeedSkillValues } from "../../lib/zero/seed-skills";
 
@@ -150,4 +151,22 @@ export async function getAgentCustomSkills(agentId: string): Promise<string[]> {
     .limit(1);
   if (!agent) throw new Error(`Agent not found: ${agentId}`);
   return agent.customSkills;
+}
+
+/**
+ * Create a custom skill record in the zero_skills table for testing.
+ */
+export async function createTestZeroSkill(
+  orgId: string,
+  name: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .insert(zeroSkills)
+    .values({
+      orgId,
+      name,
+      createdBy: "test",
+    })
+    .onConflictDoNothing();
 }

--- a/turbo/apps/web/src/lib/zero/validate-custom-skills.ts
+++ b/turbo/apps/web/src/lib/zero/validate-custom-skills.ts
@@ -1,0 +1,77 @@
+import { connectorTypeSchema } from "@vm0/core";
+import { eq, and, inArray } from "drizzle-orm";
+import { zeroSkills } from "../../db/schema/zero-skill";
+
+type ValidationSuccess = { valid: true };
+type ValidationFailure = {
+  valid: false;
+  error: {
+    status: 400;
+    body: { error: { message: string; code: string } };
+  };
+};
+type ValidationResult = ValidationSuccess | ValidationFailure;
+
+/**
+ * Validate that custom skill names are valid for an org:
+ * 1. Not a built-in connector type name
+ * 2. Exists in the org's zero_skills table
+ */
+export async function validateCustomSkills(
+  customSkills: string[],
+  orgId: string,
+): Promise<ValidationResult> {
+  if (customSkills.length === 0) return { valid: true };
+
+  // Check connector name collision
+  for (const name of customSkills) {
+    if (connectorTypeSchema.safeParse(name).success) {
+      return {
+        valid: false,
+        error: {
+          status: 400 as const,
+          body: {
+            error: {
+              message: `'${name}' is a built-in connector, not a custom skill. Enable it via connectors instead.`,
+              code: "VALIDATION_ERROR",
+            },
+          },
+        },
+      };
+    }
+  }
+
+  // Check existence in zero_skills table
+  const existing = await globalThis.services.db
+    .select({ name: zeroSkills.name })
+    .from(zeroSkills)
+    .where(
+      and(eq(zeroSkills.orgId, orgId), inArray(zeroSkills.name, customSkills)),
+    );
+
+  const existingNames = new Set(
+    existing.map((s) => {
+      return s.name;
+    }),
+  );
+  const missing = customSkills.filter((s) => {
+    return !existingNames.has(s);
+  });
+
+  if (missing.length > 0) {
+    return {
+      valid: false,
+      error: {
+        status: 400 as const,
+        body: {
+          error: {
+            message: `Custom skill '${missing[0]}' not found in this organization. Create it with 'zero skill create' first.`,
+            code: "VALIDATION_ERROR",
+          },
+        },
+      },
+    };
+  }
+
+  return { valid: true };
+}


### PR DESCRIPTION
## Summary

- Add server-side validation in agent create/update API routes to reject `--skills` values that don't exist as custom skills in the org or collide with built-in connector type names
- Previously invalid names were silently accepted (201) but caused runtime crashes (`Storage "custom-skill@plausible" not found in database`)
- Returns clear 400 errors guiding users to the correct action

## Changes

- **New**: `validate-custom-skills.ts` — shared validation helper that checks connector name collision via `connectorTypeSchema` and DB existence via `zero_skills` table
- **Modified**: `agents/route.ts` (create) and `agents/[id]/route.ts` (update) — call validation before `buildComposeContent()`
- **Modified**: Test helper `skills.ts` — add `createTestZeroSkill()` for test setup
- **Modified**: Agent route tests — fix existing tests + add 4 new validation tests

## Test plan

- [x] POST with non-existent custom skill → 400 with descriptive error
- [x] POST with connector name (e.g. `github`) → 400 with connector-specific error
- [x] PUT with non-existent custom skill → 400
- [x] PUT with connector name → 400
- [x] Existing tests updated to create skills in DB before referencing them
- [x] All 65 agent route tests pass
- [x] Lint, type check, format, knip all pass

Closes #9205

🤖 Generated with [Claude Code](https://claude.com/claude-code)