### PR TITLE
fix(voice-chat): pre-fetch cached preparation events before webrtc connection

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session-prepare.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session-prepare.test.ts
@@ -3,8 +3,14 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { detach, Reason } from "../../utils.ts";
 import { setupVoiceChatPage$ } from "../voice-chat-setup.ts";
-import { startVoiceChat$, vcStatus$, vcError$ } from "../voice-chat-session.ts";
+import {
+  startVoiceChat$,
+  vcStatus$,
+  vcError$,
+  vcEvents$,
+} from "../voice-chat-session.ts";
 
 const context = testContext();
 
@@ -183,6 +189,153 @@ describe("chat mode preparation cache", () => {
 
       // Session creation was still attempted
       expect(sessionCalls).toHaveLength(1);
+    });
+  });
+
+  describe("startVoiceChat$ cached preparation events", () => {
+    const MOCK_EVENTS = [
+      {
+        seq: 1,
+        source: "slow-brain",
+        type: "slow-brain/thinking",
+        content: "Reviewing agent context and preparing initial guidance...",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+      {
+        seq: 2,
+        source: "slow-brain",
+        type: "slow-brain/directive",
+        content: "You are a helpful assistant.",
+        createdAt: "2026-01-01T00:00:01Z",
+      },
+      {
+        seq: 3,
+        source: "slow-brain",
+        type: "slow-brain/preparation-ready",
+        content: null,
+        createdAt: "2026-01-01T00:00:02Z",
+      },
+    ];
+
+    function mockSessionPrepared() {
+      server.use(
+        http.post("*/api/zero/voice-chat", () => {
+          return HttpResponse.json({
+            session: { id: "sess-cached-1", prepared: true },
+          });
+        }),
+      );
+    }
+
+    function mockActivateOk() {
+      const calls: string[] = [];
+      server.use(
+        http.post("*/api/zero/voice-chat/:sessionId/activate", ({ params }) => {
+          calls.push(params["sessionId"] as string);
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+      return calls;
+    }
+
+    function mockContextEndpoint() {
+      const calls: string[] = [];
+      server.use(
+        http.get("*/api/zero/voice-chat/:sessionId/context", ({ params }) => {
+          calls.push(params["sessionId"] as string);
+          return HttpResponse.json({ events: MOCK_EVENTS });
+        }),
+      );
+      return calls;
+    }
+
+    function mockTokenEndpointError() {
+      server.use(
+        http.post("*/api/zero/voice-chat/token", () => {
+          return HttpResponse.json(
+            { error: { message: "test-token-error" } },
+            { status: 400 },
+          );
+        }),
+      );
+    }
+
+    function mockHeartbeat() {
+      server.use(
+        http.post("*/api/zero/voice-chat/:sessionId/heartbeat", () => {
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+    }
+
+    it("should pre-fetch cached events before WebRTC connection", async () => {
+      setup();
+      mockPrepareEndpoint([{ status: "ready" }]);
+      mockSessionPrepared();
+      mockActivateOk();
+      const ctxCalls = mockContextEndpoint();
+      mockTokenEndpointError();
+      mockHeartbeat();
+
+      // Fire without awaiting — heartbeat loop prevents startVoiceChat$ from settling
+      detach(
+        context.store.set(startVoiceChat$, context.signal),
+        Reason.DomCallback,
+      );
+
+      // Wait for events to be populated
+      await vi.waitFor(() => {
+        const events = context.store.get(vcEvents$);
+        expect(events).toHaveLength(3);
+      });
+
+      // Verify context API was called for the correct session
+      expect(ctxCalls).toContain("sess-cached-1");
+
+      // Verify events match the mock data
+      const events = context.store.get(vcEvents$);
+      expect(events[0]).toMatchObject({
+        seq: 1,
+        type: "slow-brain/thinking",
+      });
+      expect(events[1]).toMatchObject({
+        seq: 2,
+        type: "slow-brain/directive",
+        content: "You are a helpful assistant.",
+      });
+      expect(events[2]).toMatchObject({
+        seq: 3,
+        type: "slow-brain/preparation-ready",
+      });
+    });
+
+    it("should gracefully handle context fetch failure on cached path", async () => {
+      setup();
+      mockPrepareEndpoint([{ status: "ready" }]);
+      mockSessionPrepared();
+      mockActivateOk();
+      mockHeartbeat();
+      mockTokenEndpointError();
+
+      // Mock context endpoint to fail
+      server.use(
+        http.get("*/api/zero/voice-chat/:sessionId/context", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+
+      detach(
+        context.store.set(startVoiceChat$, context.signal),
+        Reason.DomCallback,
+      );
+
+      // Wait for the token error to propagate (connectVoiceSession$ terminates)
+      await vi.waitFor(() => {
+        expect(context.store.get(vcStatus$)).toBe("error");
+      });
+
+      // Events should remain empty when context fetch fails
+      expect(context.store.get(vcEvents$)).toHaveLength(0);
     });
   });
 });

--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session-prepare.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session-prepare.test.ts
@@ -7,6 +7,7 @@ import { detach, Reason } from "../../utils.ts";
 import { setupVoiceChatPage$ } from "../voice-chat-setup.ts";
 import {
   startVoiceChat$,
+  startVoiceMeeting$,
   vcStatus$,
   vcError$,
   vcEvents$,
@@ -336,6 +337,118 @@ describe("chat mode preparation cache", () => {
 
       // Events should remain empty when context fetch fails
       expect(context.store.get(vcEvents$)).toHaveLength(0);
+    });
+  });
+
+  describe("startVoiceMeeting$ cached preparation events", () => {
+    const MOCK_EVENTS = [
+      {
+        seq: 1,
+        source: "slow-brain",
+        type: "slow-brain/thinking",
+        content: "Reviewing agent context and preparing initial guidance...",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+      {
+        seq: 2,
+        source: "slow-brain",
+        type: "slow-brain/directive",
+        content: "You are a helpful assistant.",
+        createdAt: "2026-01-01T00:00:01Z",
+      },
+      {
+        seq: 3,
+        source: "slow-brain",
+        type: "slow-brain/preparation-ready",
+        content: null,
+        createdAt: "2026-01-01T00:00:02Z",
+      },
+    ];
+
+    function mockMeetingSessionPrepared() {
+      server.use(
+        http.post("*/api/zero/voice-chat", () => {
+          return HttpResponse.json({
+            session: { id: "sess-meeting-cached-1", prepared: true },
+          });
+        }),
+      );
+    }
+
+    function mockActivateOk() {
+      const calls: string[] = [];
+      server.use(
+        http.post("*/api/zero/voice-chat/:sessionId/activate", ({ params }) => {
+          calls.push(params["sessionId"] as string);
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+      return calls;
+    }
+
+    function mockContextEndpoint() {
+      const calls: string[] = [];
+      server.use(
+        http.get("*/api/zero/voice-chat/:sessionId/context", ({ params }) => {
+          calls.push(params["sessionId"] as string);
+          return HttpResponse.json({ events: MOCK_EVENTS });
+        }),
+      );
+      return calls;
+    }
+
+    function mockTokenEndpointError() {
+      server.use(
+        http.post("*/api/zero/voice-chat/token", () => {
+          return HttpResponse.json(
+            { error: { message: "test-token-error" } },
+            { status: 400 },
+          );
+        }),
+      );
+    }
+
+    function mockHeartbeat() {
+      server.use(
+        http.post("*/api/zero/voice-chat/:sessionId/heartbeat", () => {
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+    }
+
+    it("should pre-fetch cached events before WebRTC connection", async () => {
+      setup();
+      mockMeetingSessionPrepared();
+      mockActivateOk();
+      const ctxCalls = mockContextEndpoint();
+      mockTokenEndpointError();
+      mockHeartbeat();
+
+      // startVoiceMeeting$ takes a prompt and signal (no preparation trigger)
+      detach(
+        context.store.set(startVoiceMeeting$, "test prompt", context.signal),
+        Reason.DomCallback,
+      );
+
+      // Wait for events to be populated
+      await vi.waitFor(() => {
+        const events = context.store.get(vcEvents$);
+        expect(events).toHaveLength(3);
+      });
+
+      // Verify context API was called for the correct session
+      expect(ctxCalls).toContain("sess-meeting-cached-1");
+
+      // Verify events match the mock data
+      const events = context.store.get(vcEvents$);
+      expect(events[0]).toMatchObject({
+        seq: 1,
+        type: "slow-brain/thinking",
+      });
+      expect(events[2]).toMatchObject({
+        seq: 3,
+        type: "slow-brain/preparation-ready",
+      });
     });
   });
 });

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -1156,6 +1156,22 @@ export const startVoiceChat$ = command(
         return;
       }
 
+      // Pre-fetch cached preparation events so they're available when DC opens
+      const ctxRes = await fetchFn(
+        `/api/zero/voice-chat/${session.id}/context?after=0`,
+      );
+      signal.throwIfAborted();
+      if (ctxRes.ok) {
+        const data = (await ctxRes.json()) as { events: ContextEvent[] };
+        if (data.events.length > 0) {
+          set(internalEvents$, data.events);
+          const lastEvent = data.events[data.events.length - 1];
+          if (lastEvent) {
+            set(internalLastSeq$, lastEvent.seq);
+          }
+        }
+      }
+
       await Promise.allSettled([
         heartbeatPromise,
         set(connectVoiceSession$, sessionSignal),
@@ -1243,6 +1259,22 @@ export const startVoiceMeeting$ = command(
         set(internalError$, "Failed to activate session");
         set(internalStatus$, "error");
         return;
+      }
+
+      // Pre-fetch cached preparation events so they're available when DC opens
+      const ctxRes = await fetchFn(
+        `/api/zero/voice-chat/${session.id}/context?after=0`,
+      );
+      signal.throwIfAborted();
+      if (ctxRes.ok) {
+        const data = (await ctxRes.json()) as { events: ContextEvent[] };
+        if (data.events.length > 0) {
+          set(internalEvents$, data.events);
+          const lastEvent = data.events[data.events.length - 1];
+          if (lastEvent) {
+            set(internalLastSeq$, lastEvent.seq);
+          }
+        }
       }
 
       await Promise.allSettled([

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -168,6 +168,26 @@ function logContextEvent(
   );
 }
 
+async function prefetchCachedEvents(
+  fetchFn: (url: string, init?: RequestInit) => Promise<Response>,
+  sessionId: string,
+  signal: AbortSignal,
+): Promise<ContextEvent[] | null> {
+  const ctxRes = await fetchFn(
+    `/api/zero/voice-chat/${sessionId}/context?after=0`,
+  );
+  signal.throwIfAborted();
+  if (!ctxRes.ok) {
+    L.warn("Failed to pre-fetch cached events", {
+      status: ctxRes.status,
+      sessionId,
+    });
+    return null;
+  }
+  const data = (await ctxRes.json()) as { events: ContextEvent[] };
+  return data.events;
+}
+
 function formatInjectionMessage(event: ContextEvent): string {
   const prefixes: Record<string, string> = {
     directive: "[Slow-brain directive]",
@@ -1157,18 +1177,16 @@ export const startVoiceChat$ = command(
       }
 
       // Pre-fetch cached preparation events so they're available when DC opens
-      const ctxRes = await fetchFn(
-        `/api/zero/voice-chat/${session.id}/context?after=0`,
+      const cachedEvents = await prefetchCachedEvents(
+        fetchFn,
+        session.id,
+        signal,
       );
-      signal.throwIfAborted();
-      if (ctxRes.ok) {
-        const data = (await ctxRes.json()) as { events: ContextEvent[] };
-        if (data.events.length > 0) {
-          set(internalEvents$, data.events);
-          const lastEvent = data.events[data.events.length - 1];
-          if (lastEvent) {
-            set(internalLastSeq$, lastEvent.seq);
-          }
+      if (cachedEvents && cachedEvents.length > 0) {
+        set(internalEvents$, cachedEvents);
+        const lastEvent = cachedEvents[cachedEvents.length - 1];
+        if (lastEvent) {
+          set(internalLastSeq$, lastEvent.seq);
         }
       }
 
@@ -1262,18 +1280,16 @@ export const startVoiceMeeting$ = command(
       }
 
       // Pre-fetch cached preparation events so they're available when DC opens
-      const ctxRes = await fetchFn(
-        `/api/zero/voice-chat/${session.id}/context?after=0`,
+      const cachedEvents = await prefetchCachedEvents(
+        fetchFn,
+        session.id,
+        signal,
       );
-      signal.throwIfAborted();
-      if (ctxRes.ok) {
-        const data = (await ctxRes.json()) as { events: ContextEvent[] };
-        if (data.events.length > 0) {
-          set(internalEvents$, data.events);
-          const lastEvent = data.events[data.events.length - 1];
-          if (lastEvent) {
-            set(internalLastSeq$, lastEvent.seq);
-          }
+      if (cachedEvents && cachedEvents.length > 0) {
+        set(internalEvents$, cachedEvents);
+        const lastEvent = cachedEvents[cachedEvents.length - 1];
+        if (lastEvent) {
+          set(internalLastSeq$, lastEvent.seq);
         }
       }
 


### PR DESCRIPTION
## Summary

- Pre-fetch cached preparation events from the context API before WebRTC connection in the `session.prepared` branch of both `startVoiceChat$` and `startVoiceMeeting$`
- Populates `internalEvents$` and `internalLastSeq$` so the DataChannel open handler can inject events into FastBrain immediately, matching the non-cached path behavior
- Adds integration tests verifying cached events are pre-fetched and graceful degradation on fetch failure

## Test plan

- [x] New test: cached path pre-fetches events into `internalEvents$` before WebRTC connection
- [x] New test: context fetch failure on cached path degrades gracefully (events remain empty)
- [x] All existing preparation tests still pass (9/9)
- [x] Lint passes
- [x] Format passes

Closes #9209

🤖 Generated with [Claude Code](https://claude.com/claude-code)