### PR TITLE
fix(voice-chat): re-acquire wake lock after system release

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -843,30 +843,51 @@ const reconnectVoiceSession$ = command(
 
 // --- Wake lock ---
 
+const MAX_WAKE_LOCK_REACQUIRE_ATTEMPTS = 3;
+
 const acquireWakeLock$ = command(async ({ set }, signal: AbortSignal) => {
   if (!("wakeLock" in navigator)) {
     return;
   }
 
+  let pending = false;
+  let reacquireCount = 0;
+
   const requestAndTrack = async (): Promise<void> => {
-    if (document.visibilityState !== "visible") return;
+    if (pending) {
+      return;
+    }
+    if (document.visibilityState !== "visible") {
+      return;
+    }
+    pending = true;
     let lock: WakeLockSentinel | undefined;
     // eslint-disable-next-line no-restricted-syntax -- wakeLock.request can fail if document is not visible
     try {
       lock = await navigator.wakeLock.request("screen");
     } catch {
       // Wake lock request failed — non-critical, ignore
+      pending = false;
       return;
     }
+    pending = false;
     if (signal.aborted) {
-      lock.release().catch(() => undefined);
+      lock.release().catch(() => {
+        return undefined;
+      });
       return;
     }
     set(internalWakeLock$, lock);
     // Re-acquire when the browser releases the lock (e.g. tab becomes hidden)
     lock.addEventListener("release", () => {
-      if (!signal.aborted) {
-        void requestAndTrack();
+      if (
+        !signal.aborted &&
+        reacquireCount < MAX_WAKE_LOCK_REACQUIRE_ATTEMPTS
+      ) {
+        reacquireCount++;
+        requestAndTrack().catch(() => {
+          return undefined;
+        });
       }
     });
   };
@@ -876,7 +897,11 @@ const acquireWakeLock$ = command(async ({ set }, signal: AbortSignal) => {
   // Re-acquire when the page becomes visible again after being hidden
   const onVisibilityChange = (): void => {
     if (document.visibilityState === "visible" && !signal.aborted) {
-      void requestAndTrack();
+      // Reset reacquire count on visibility change — this is user-initiated
+      reacquireCount = 0;
+      requestAndTrack().catch(() => {
+        return undefined;
+      });
     }
   };
   document.addEventListener("visibilitychange", onVisibilityChange);

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -871,6 +871,8 @@ const acquireWakeLock$ = command(async ({ set }, signal: AbortSignal) => {
     });
   };
 
+  signal.throwIfAborted();
+
   // Re-acquire when the page becomes visible again after being hidden
   const onVisibilityChange = (): void => {
     if (document.visibilityState === "visible" && !signal.aborted) {
@@ -882,7 +884,6 @@ const acquireWakeLock$ = command(async ({ set }, signal: AbortSignal) => {
     document.removeEventListener("visibilitychange", onVisibilityChange);
   });
 
-  signal.throwIfAborted();
   await requestAndTrack();
 });
 

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -847,17 +847,43 @@ const acquireWakeLock$ = command(async ({ set }, signal: AbortSignal) => {
   if (!("wakeLock" in navigator)) {
     return;
   }
-  let lock: WakeLockSentinel | undefined;
-  // eslint-disable-next-line no-restricted-syntax -- wakeLock.request can fail if document is not visible
-  try {
-    lock = await navigator.wakeLock.request("screen");
-  } catch {
-    // Wake lock request failed — non-critical, ignore
-  }
-  signal.throwIfAborted();
-  if (lock) {
+
+  const requestAndTrack = async (): Promise<void> => {
+    if (document.visibilityState !== "visible") return;
+    let lock: WakeLockSentinel | undefined;
+    // eslint-disable-next-line no-restricted-syntax -- wakeLock.request can fail if document is not visible
+    try {
+      lock = await navigator.wakeLock.request("screen");
+    } catch {
+      // Wake lock request failed — non-critical, ignore
+      return;
+    }
+    if (signal.aborted) {
+      lock.release().catch(() => undefined);
+      return;
+    }
     set(internalWakeLock$, lock);
-  }
+    // Re-acquire when the browser releases the lock (e.g. tab becomes hidden)
+    lock.addEventListener("release", () => {
+      if (!signal.aborted) {
+        void requestAndTrack();
+      }
+    });
+  };
+
+  // Re-acquire when the page becomes visible again after being hidden
+  const onVisibilityChange = (): void => {
+    if (document.visibilityState === "visible" && !signal.aborted) {
+      void requestAndTrack();
+    }
+  };
+  document.addEventListener("visibilitychange", onVisibilityChange);
+  signal.addEventListener("abort", () => {
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+  });
+
+  signal.throwIfAborted();
+  await requestAndTrack();
 });
 
 const releaseWakeLock$ = command(({ get, set }) => {


### PR DESCRIPTION
## Summary

- Adds a `release` event listener on the `WakeLockSentinel` to re-acquire the lock when the browser releases it automatically (e.g. user switches apps, screen briefly dims)
- Adds a `visibilitychange` listener to re-acquire the lock when the page becomes visible again — guards against the race where `release` fires while the document is still hidden (calling `wakeLock.request` while hidden would throw)
- Cleans up the `visibilitychange` listener when the session's `AbortSignal` fires, preventing memory leaks

## Root Cause

The `Screen Wake Lock API` automatically releases the sentinel when the `Document` becomes hidden (Web spec). Once released, the screen reverts to its normal auto-lock behavior. Since the previous implementation had no `onrelease` / re-acquisition logic, users experienced screen auto-lock mid-voice-call after briefly switching apps or pressing the power button.

## Test Plan

- [ ] Start a voice call on iOS Safari 16.4+ — confirm screen stays on through the full call
- [ ] Switch to another app mid-call and return — confirm screen stays on (lock re-acquired)
- [ ] End the call — confirm auto-lock resumes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)