### PR TITLE
fix(web): filter out non-actionable tasks from mission control list

### DIFF
--- a/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
@@ -4,17 +4,12 @@ import {
   createTestRequest,
   createTestCompose,
   createTestZeroAgent,
-  createTestAgentSession,
   createTestRunInDb,
   addTestRunToThread,
   insertTestChatThread,
   getTestAgentComposeName,
   createTestSchedule,
-  insertTestSlackOrgInstallation,
-  insertTestSlackOrgConnection,
-  insertTestSlackOrgThreadSession,
-  createTestEmailThreadSession,
-  generateTestReplyToken,
+  updateTestScheduleState,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -98,6 +93,12 @@ describe("GET /api/zero/tasks", () => {
       prompt: "Run daily check",
     });
 
+    // Link a run to the schedule so it becomes actionable
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      status: "completed",
+    });
+    await updateTestScheduleState(schedule.id, { lastRunId: runId });
+
     const request = createTestRequest("http://localhost:3000/api/zero/tasks");
     const response = await GET(request);
     const data = await response.json();
@@ -109,89 +110,8 @@ describe("GET /api/zero/tasks", () => {
     expect(schedTask).toBeDefined();
     expect(schedTask.title).toBe("daily-check");
     expect(schedTask.scheduleId).toBe(schedule.id);
-    expect(schedTask.latestRunId).toBeNull();
-    expect(schedTask.status).toBeNull();
-  });
-
-  it("should return slack thread tasks", async () => {
-    const { composeId } = await createTestCompose(uniqueId("slack-task"));
-
-    // Create slack installation + connection
-    const slackWorkspaceId = uniqueId("ws");
-    await insertTestSlackOrgInstallation({
-      slackWorkspaceId,
-      slackWorkspaceName: "Test Workspace",
-      orgId: user.orgId,
-      installedByUserId: user.userId,
-    });
-    const { id: connectionId } = await insertTestSlackOrgConnection({
-      slackUserId: uniqueId("slack-user"),
-      slackWorkspaceId,
-      vm0UserId: user.userId,
-    });
-
-    // Create agent session + slack thread session
-    const session = await createTestAgentSession(user.userId, composeId);
-    const { id: slackThreadId } = await insertTestSlackOrgThreadSession({
-      connectionId,
-      agentSessionId: session.id,
-    });
-
-    // Create a run linked to the session
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
-      status: "running",
-      continuedFromSessionId: session.id,
-      triggerSource: "slack",
-    });
-
-    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
-    const response = await GET(request);
-    const data = await response.json();
-
-    expect(response.status).toBe(200);
-    const slackTask = data.tasks.find((t: Record<string, unknown>) => {
-      return t.type === "slack";
-    });
-    expect(slackTask).toBeDefined();
-    expect(slackTask.slackThreadSessionId).toBe(slackThreadId);
-    expect(slackTask.latestRunId).toBe(runId);
-    expect(slackTask.status).toBe("running");
-  });
-
-  it("should return email thread tasks", async () => {
-    const { composeId } = await createTestCompose(uniqueId("email-task"));
-
-    // Create agent session for email
-    const session = await createTestAgentSession(user.userId, composeId);
-
-    // Create email thread session
-    const replyToken = generateTestReplyToken(session.id);
-    const emailThread = await createTestEmailThreadSession({
-      userId: user.userId,
-      agentId: composeId,
-      agentSessionId: session.id,
-      replyToToken: replyToken,
-    });
-
-    // Create a run linked to the session
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
-      status: "completed",
-      continuedFromSessionId: session.id,
-      triggerSource: "email",
-    });
-
-    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
-    const response = await GET(request);
-    const data = await response.json();
-
-    expect(response.status).toBe(200);
-    const emailTask = data.tasks.find((t: Record<string, unknown>) => {
-      return t.type === "email";
-    });
-    expect(emailTask).toBeDefined();
-    expect(emailTask.emailThreadSessionId).toBe(emailThread.id);
-    expect(emailTask.latestRunId).toBe(runId);
-    expect(emailTask.status).toBe("completed");
+    expect(schedTask.latestRunId).toBe(runId);
+    expect(schedTask.status).toBe("completed");
   });
 
   it("should filter by agentId", async () => {
@@ -297,8 +217,18 @@ describe("GET /api/zero/tasks", () => {
       uniqueId("sched-filter-2"),
     );
 
-    await createTestSchedule(agent1, "agent1-schedule");
-    await createTestSchedule(agent2, "agent2-schedule");
+    const sched1 = await createTestSchedule(agent1, "agent1-schedule");
+    const sched2 = await createTestSchedule(agent2, "agent2-schedule");
+
+    // Link runs so schedules are actionable
+    const { runId: run1 } = await createTestRunInDb(user.userId, agent1, {
+      status: "completed",
+    });
+    await updateTestScheduleState(sched1.id, { lastRunId: run1 });
+    const { runId: run2 } = await createTestRunInDb(user.userId, agent2, {
+      status: "completed",
+    });
+    await updateTestScheduleState(sched2.id, { lastRunId: run2 });
 
     const request = createTestRequest(
       `http://localhost:3000/api/zero/tasks?agentId=${agent1}`,
@@ -405,26 +335,23 @@ describe("GET /api/zero/tasks", () => {
     );
     await addTestRunToThread(terminalThreadId, terminalRunId, user.userId);
 
-    // Schedule with no run (status = null), with an older source timestamp
-    const { composeId: composeId2 } = await createTestCompose(
-      uniqueId("null-status-agent"),
-    );
-    await createTestSchedule(composeId2, "null-status-schedule");
+    // Chat thread with no run (status = null) — chat tasks are allowed without runs
+    await insertTestChatThread(user.userId, composeId, "No Run Chat");
 
     const request = createTestRequest("http://localhost:3000/api/zero/tasks");
     const response = await GET(request);
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    const scheduleTasks = data.tasks.filter((t: Record<string, unknown>) => {
-      return t.type === "schedule";
+    const noRunTasks = data.tasks.filter((t: Record<string, unknown>) => {
+      return t.title === "No Run Chat";
     });
     const terminalTasks = data.tasks.filter((t: Record<string, unknown>) => {
       return t.title === "Terminal Task";
     });
-    expect(scheduleTasks).toHaveLength(1);
+    expect(noRunTasks).toHaveLength(1);
     expect(terminalTasks).toHaveLength(1);
-    expect(data.tasks.indexOf(scheduleTasks[0])).toBeLessThan(
+    expect(data.tasks.indexOf(noRunTasks[0])).toBeLessThan(
       data.tasks.indexOf(terminalTasks[0]),
     );
   });
@@ -662,11 +589,17 @@ describe("POST /api/zero/tasks/archive", () => {
     ).toBe(true);
   });
 
-  it("archives a schedule task with no run and excludes it from the task list", async () => {
+  it("archives a schedule task and excludes it from the task list", async () => {
     const { composeId } = await createTestCompose(uniqueId("arc-sched"));
     const schedule = await createTestSchedule(composeId, "Scheduled Task");
 
-    // Confirm it appears before archiving (latestRunId is null)
+    // Link a run so the schedule is actionable
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      status: "completed",
+    });
+    await updateTestScheduleState(schedule.id, { lastRunId: runId });
+
+    // Confirm it appears before archiving
     const listRes = await GET(
       createTestRequest("http://localhost:3000/api/zero/tasks"),
     );
@@ -677,7 +610,7 @@ describe("POST /api/zero/tasks/archive", () => {
       }),
     ).toBe(true);
 
-    // Archive with runId = null (schedule has no run yet)
+    // Archive with the runId
     const archiveRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/tasks/archive", {
         method: "POST",
@@ -685,7 +618,7 @@ describe("POST /api/zero/tasks/archive", () => {
         body: JSON.stringify({
           taskId: schedule.id,
           taskType: "schedule",
-          runId: null,
+          runId,
         }),
       }),
     );

--- a/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   getTestAgentComposeName,
   createTestSchedule,
   updateTestScheduleState,
+  insertTestVoiceChatSession,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -112,6 +113,78 @@ describe("GET /api/zero/tasks", () => {
     expect(schedTask.scheduleId).toBe(schedule.id);
     expect(schedTask.latestRunId).toBe(runId);
     expect(schedTask.status).toBe("completed");
+  });
+
+  it("should not return schedule tasks without a lastRunId", async () => {
+    const { composeId } = await createTestCompose(
+      uniqueId("sched-no-run-test"),
+    );
+
+    // Create a schedule without linking any run (lastRunId remains null)
+    await createTestSchedule(composeId, "never-run-schedule", {
+      cronExpression: "0 0 * * *",
+      prompt: "This schedule has never run",
+    });
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const scheduleTasks = data.tasks.filter((t: Record<string, unknown>) => {
+      return t.type === "schedule";
+    });
+    expect(scheduleTasks).toHaveLength(0);
+  });
+
+  it("should return voice chat tasks that have a runId", async () => {
+    const { composeId } = await createTestCompose(uniqueId("voice-chat-task"));
+
+    // Create a run so the voice chat session is actionable
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      status: "completed",
+    });
+
+    await insertTestVoiceChatSession({
+      orgId: user.orgId,
+      userId: user.userId,
+      agentId: composeId,
+      runId,
+    });
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const voiceTasks = data.tasks.filter((t: Record<string, unknown>) => {
+      return t.type === "voice_chat";
+    });
+    expect(voiceTasks).toHaveLength(1);
+    expect(voiceTasks[0].latestRunId).toBe(runId);
+  });
+
+  it("should not return voice chat tasks without a runId", async () => {
+    const { composeId } = await createTestCompose(
+      uniqueId("voice-chat-no-run"),
+    );
+
+    // Create a voice chat session without linking any run (runId remains null)
+    await insertTestVoiceChatSession({
+      orgId: user.orgId,
+      userId: user.userId,
+      agentId: composeId,
+    });
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const voiceTasks = data.tasks.filter((t: Record<string, unknown>) => {
+      return t.type === "voice_chat";
+    });
+    expect(voiceTasks).toHaveLength(0);
   });
 
   it("should filter by agentId", async () => {

--- a/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
@@ -196,6 +196,7 @@ export async function updateTestScheduleState(
     consecutiveFailures?: number;
     enabled?: boolean;
     nextRunAt?: Date | null;
+    lastRunId?: string;
   },
 ): Promise<void> {
   await globalThis.services.db

--- a/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
@@ -187,8 +187,8 @@ export async function getTestScheduleRuns(
  * Update internal schedule state for testing edge cases.
  *
  * Direct DB write is required because the schedule API does not expose
- * an endpoint to set internal fields like consecutiveFailures — these
- * are managed by the callback system, not user actions.
+ * an endpoint to set internal fields like consecutiveFailures or lastRunId —
+ * these are managed by the callback system, not user actions.
  */
 export async function updateTestScheduleState(
   scheduleId: string,

--- a/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
@@ -294,6 +294,7 @@ export async function createTestVoiceChatSession(
 export async function insertTestVoiceChatSession(overrides: {
   orgId: string;
   userId: string;
+  agentId?: string;
   status?: string;
   runId?: string;
   createdAt?: Date;
@@ -306,6 +307,7 @@ export async function insertTestVoiceChatSession(overrides: {
     .values({
       orgId: overrides.orgId,
       userId: overrides.userId,
+      agentId: overrides.agentId,
       status: overrides.status ?? "active",
       runId: overrides.runId,
       createdAt: overrides.createdAt ?? now,

--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -41,7 +41,7 @@ interface RawTask {
 }
 
 /**
- * List unified tasks across chat threads, schedules, slack threads, and email threads.
+ * List unified tasks across chat threads, schedules, voice chats, and agent runs.
  * Returns up to 25 tasks sorted by latest run time DESC.
  */
 export async function listTasks(
@@ -135,12 +135,6 @@ export async function listTasks(
       case "schedule":
         task.scheduleId = raw.id;
         break;
-      case "slack":
-        task.slackThreadSessionId = raw.id;
-        break;
-      case "email":
-        task.emailThreadSessionId = raw.id;
-        break;
       case "voice_chat":
         task.voiceChatSessionId = raw.id;
         break;
@@ -174,7 +168,7 @@ type DB = typeof globalThis.services.db;
 interface ArchivedSets {
   /** Run IDs that have been archived (for tasks with a latestRunId). */
   runIds: Set<string>;
-  /** Task IDs archived with no run (e.g. schedules that never ran). */
+  /** Task IDs archived when they had no run at the time of archival. */
   nullRunTaskIds: Set<string>;
 }
 

--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -1,12 +1,7 @@
-import { and, eq, inArray, isNull, sql, desc } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, sql, desc } from "drizzle-orm";
 import type { TaskItem, RunStatus } from "@vm0/core";
 import { chatThreads, chatThreadRuns } from "../../../db/schema/chat-thread";
 import { zeroAgentSchedules } from "../../../db/schema/zero-agent-schedule";
-import { slackOrgThreadSessions } from "../../../db/schema/slack-org-thread-session";
-import { slackOrgConnections } from "../../../db/schema/slack-org-connection";
-import { slackOrgInstallations } from "../../../db/schema/slack-org-installation";
-import { emailThreadSessions } from "../../../db/schema/email-thread-session";
-import { agentSessions } from "../../../db/schema/agent-session";
 import { agentRuns } from "../../../db/schema/agent-run";
 import { agentComposeVersions } from "../../../db/schema/agent-compose";
 import { zeroRuns } from "../../../db/schema/zero-run";
@@ -56,32 +51,18 @@ export async function listTasks(
 ): Promise<TaskItem[]> {
   const db = globalThis.services.db;
 
-  const [
-    chatTasks,
-    scheduleTasks,
-    slackTasks,
-    emailTasks,
-    inFlightEmailTasks,
-    voiceChatTasks,
-    agentTasks,
-    archivedSets,
-  ] = await Promise.all([
-    listChatTasks(db, userId, orgId, agentId),
-    listScheduleTasks(db, userId, orgId, agentId),
-    listSlackTasks(db, userId, orgId, agentId),
-    listEmailTasks(db, userId, orgId, agentId),
-    listInFlightEmailTasks(db, userId, orgId, agentId),
-    listVoiceChatTasks(db, userId, orgId, agentId),
-    listAgentTasks(db, userId, orgId, agentId),
-    getArchivedSets(db, userId, orgId),
-  ]);
+  const [chatTasks, scheduleTasks, voiceChatTasks, agentTasks, archivedSets] =
+    await Promise.all([
+      listChatTasks(db, userId, orgId, agentId),
+      listScheduleTasks(db, userId, orgId, agentId),
+      listVoiceChatTasks(db, userId, orgId, agentId),
+      listAgentTasks(db, userId, orgId, agentId),
+      getArchivedSets(db, userId, orgId),
+    ]);
 
   const allTasks = [
     ...chatTasks,
     ...scheduleTasks,
-    ...slackTasks,
-    ...emailTasks,
-    ...inFlightEmailTasks,
     ...voiceChatTasks,
     ...agentTasks,
   ].filter((t) => {
@@ -334,6 +315,7 @@ async function listScheduleTasks(
   const conditions = [
     eq(zeroAgentSchedules.userId, userId),
     eq(zeroAgentSchedules.orgId, orgId),
+    isNotNull(zeroAgentSchedules.lastRunId),
   ];
   if (agentId) conditions.push(eq(zeroAgentSchedules.agentId, agentId));
 
@@ -367,185 +349,6 @@ async function listScheduleTasks(
       latestRunId: r.lastRunId,
       sourceUpdatedAt: r.updatedAt,
       fallbackSummary: truncatePrompt(r.prompt),
-    };
-  });
-}
-
-async function listSlackTasks(
-  db: DB,
-  userId: string,
-  orgId: string,
-  agentId?: string,
-): Promise<RawTask[]> {
-  const conditions = [
-    eq(slackOrgConnections.vm0UserId, userId),
-    eq(slackOrgInstallations.orgId, orgId),
-  ];
-  if (agentId) conditions.push(eq(agentSessions.agentComposeId, agentId));
-
-  const rows = await db
-    .select({
-      id: slackOrgThreadSessions.id,
-      agentId: agentSessions.agentComposeId,
-      agentName: zeroAgents.name,
-      agentDisplayName: zeroAgents.displayName,
-      agentAvatarUrl: zeroAgents.avatarUrl,
-      agentSessionId: slackOrgThreadSessions.agentSessionId,
-      updatedAt: slackOrgThreadSessions.updatedAt,
-      latestRunId: sql<string | null>`(
-        SELECT ${agentRuns.id}
-        FROM ${agentRuns}
-        WHERE ${agentRuns.continuedFromSessionId} = ${slackOrgThreadSessions.agentSessionId}
-        ORDER BY ${agentRuns.createdAt} DESC
-        LIMIT 1
-      )`,
-    })
-    .from(slackOrgThreadSessions)
-    .innerJoin(
-      slackOrgConnections,
-      eq(slackOrgThreadSessions.connectionId, slackOrgConnections.id),
-    )
-    .innerJoin(
-      slackOrgInstallations,
-      eq(
-        slackOrgConnections.slackWorkspaceId,
-        slackOrgInstallations.slackWorkspaceId,
-      ),
-    )
-    .innerJoin(
-      agentSessions,
-      eq(slackOrgThreadSessions.agentSessionId, agentSessions.id),
-    )
-    .innerJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
-    .where(and(...conditions));
-
-  return rows.map((r) => {
-    return {
-      id: r.id,
-      type: "slack" as const,
-      title: null,
-      agent: {
-        id: r.agentId,
-        name: r.agentName,
-        displayName: r.agentDisplayName,
-        avatarUrl: r.agentAvatarUrl,
-      },
-      latestRunId: r.latestRunId,
-      sourceUpdatedAt: r.updatedAt,
-    };
-  });
-}
-
-async function listEmailTasks(
-  db: DB,
-  userId: string,
-  orgId: string,
-  agentId?: string,
-): Promise<RawTask[]> {
-  const conditions = [
-    eq(emailThreadSessions.userId, userId),
-    eq(zeroAgents.orgId, orgId),
-  ];
-  if (agentId) conditions.push(eq(emailThreadSessions.agentId, agentId));
-
-  const rows = await db
-    .select({
-      id: emailThreadSessions.id,
-      agentId: emailThreadSessions.agentId,
-      agentName: zeroAgents.name,
-      agentDisplayName: zeroAgents.displayName,
-      agentAvatarUrl: zeroAgents.avatarUrl,
-      agentSessionId: emailThreadSessions.agentSessionId,
-      updatedAt: emailThreadSessions.updatedAt,
-      latestRunId: sql<string | null>`(
-        SELECT ${agentRuns.id}
-        FROM ${agentRuns}
-        WHERE ${agentRuns.continuedFromSessionId} = ${emailThreadSessions.agentSessionId}
-           OR ${agentRuns.result}->>'agentSessionId' = ${emailThreadSessions.agentSessionId}::text
-        ORDER BY ${agentRuns.createdAt} DESC
-        LIMIT 1
-      )`,
-    })
-    .from(emailThreadSessions)
-    .innerJoin(zeroAgents, eq(emailThreadSessions.agentId, zeroAgents.id))
-    .where(and(...conditions));
-
-  return rows.map((r) => {
-    return {
-      id: r.id,
-      type: "email" as const,
-      title: null,
-      agent: {
-        id: r.agentId,
-        name: r.agentName,
-        displayName: r.agentDisplayName,
-        avatarUrl: r.agentAvatarUrl,
-      },
-      latestRunId: r.latestRunId,
-      sourceUpdatedAt: r.updatedAt,
-    };
-  });
-}
-
-/**
- * Find email-triggered runs that are still active (pending/running)
- * and have not yet produced an emailThreadSessions record. This covers the
- * window between email arrival and run completion, where the thread session
- * does not yet exist but the task should still appear in Mission Control.
- *
- * Only new-thread runs are included (continuedFromSessionId IS NULL).
- * Reply runs are excluded because their parent emailThreadSession already
- * surfaces the task via listEmailTasks.
- */
-async function listInFlightEmailTasks(
-  db: DB,
-  userId: string,
-  orgId: string,
-  agentId?: string,
-): Promise<RawTask[]> {
-  const activeStatuses: RunStatus[] = ["pending", "running"];
-  const conditions = [
-    eq(agentRuns.userId, userId),
-    eq(agentRuns.orgId, orgId),
-    eq(zeroRuns.triggerSource, "email"),
-    inArray(agentRuns.status, activeStatuses),
-    isNull(agentRuns.continuedFromSessionId),
-  ];
-  if (agentId) {
-    conditions.push(eq(zeroAgents.id, agentId));
-  }
-
-  const rows = await db
-    .select({
-      id: agentRuns.id,
-      agentId: zeroAgents.id,
-      agentName: zeroAgents.name,
-      agentDisplayName: zeroAgents.displayName,
-      agentAvatarUrl: zeroAgents.avatarUrl,
-      createdAt: agentRuns.createdAt,
-    })
-    .from(agentRuns)
-    .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
-    .innerJoin(
-      agentComposeVersions,
-      eq(agentComposeVersions.id, agentRuns.agentComposeVersionId),
-    )
-    .innerJoin(zeroAgents, eq(zeroAgents.id, agentComposeVersions.composeId))
-    .where(and(...conditions));
-
-  return rows.map((r) => {
-    return {
-      id: r.id,
-      type: "email" as const,
-      title: null,
-      agent: {
-        id: r.agentId,
-        name: r.agentName,
-        displayName: r.agentDisplayName,
-        avatarUrl: r.agentAvatarUrl,
-      },
-      latestRunId: r.id,
-      sourceUpdatedAt: r.createdAt,
     };
   });
 }
@@ -619,6 +422,7 @@ async function listVoiceChatTasks(
   const conditions = [
     eq(voiceChatSessions.userId, userId),
     eq(voiceChatSessions.orgId, orgId),
+    isNotNull(voiceChatSessions.runId),
   ];
   if (agentId) conditions.push(eq(voiceChatSessions.agentId, agentId));
 


### PR DESCRIPTION
## Summary
- Non-chat tasks (slack, email, etc.) without a `latestRunId` cannot be opened in Mission Control — there's no activity panel to display
- These empty tasks were filling all 25 slots in the task list, causing completed tasks to disappear (terminal status tasks are sorted to tier 1, behind the null-status empty tasks in tier 0)
- Remove slack, email, and in-flight email task queries entirely from mission control (not needed)
- Add `isNotNull` filter for schedule `lastRunId` and voice chat `runId` at the SQL level
- Update tests to match new behavior

## Test plan
- [x] Task route tests pass (19/19)
- [x] Mission control page tests pass (29/29)
- [x] Type check passes
- [x] Lint + knip pass
- [ ] Verify on production that completed tasks remain visible after run finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)