### PR TITLE
fix: patch follow-redirects auth header leak vulnerability

### DIFF
--- a/turbo/package.json
+++ b/turbo/package.json
@@ -50,6 +50,7 @@
       "@isaacs/brace-expansion": ">=5.0.1",
       "brace-expansion": ">=5.0.5",
       "axios": ">=1.15.0",
+      "follow-redirects": ">=1.16.0",
       "dompurify": ">=3.3.2",
       "js-yaml": ">=4.1.1",
       "lodash": ">=4.18.0",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   '@isaacs/brace-expansion': '>=5.0.1'
   brace-expansion: '>=5.0.5'
   axios: '>=1.15.0'
+  follow-redirects: '>=1.16.0'
   dompurify: '>=3.3.2'
   js-yaml: '>=4.1.1'
   lodash: '>=4.18.0'
@@ -5801,8 +5802,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -12967,7 +12968,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -13903,7 +13904,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
## Summary
- Override `follow-redirects` to `>=1.16.0` via `pnpm.overrides` to fix [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) (moderate severity)
- Vulnerability: custom authentication headers leaked to cross-domain redirect targets in `follow-redirects <=1.15.11`
- Dependency path: `@slack/web-api > axios > follow-redirects`

## Test plan
- [x] `pnpm audit` returns "No known vulnerabilities found"
- [ ] CI passes (no runtime change — only bumped a transitive dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)