### PR TITLE
fix(voice-io): show tts controls on mobile touch devices

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -5,6 +5,7 @@
 @import "@vm0/ui/styles/globals.css";
 
 @plugin "@tailwindcss/typography";
+@custom-variant pointer-coarse (@media (pointer: coarse));
 
 /* Include @vm0/ui components in Tailwind's content scanning */
 @source "../../../../../packages/ui/src/**/*.tsx";

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -6,8 +6,9 @@ import {
   useLastLoadable,
   useLastResolved,
 } from "ccstate-react";
-import { IconMenu2, IconUserPlus } from "@tabler/icons-react";
+import { IconMenu2, IconUserPlus, IconVolume2 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/core";
+import { cn } from "@vm0/ui";
 import { ZeroSidebar } from "./zero-sidebar.tsx";
 import {
   currentChatAgent$,
@@ -39,6 +40,10 @@ import {
 } from "../../signals/zero-page/settings/org-manage-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import {
+  autoReadEnabled$,
+  toggleAutoRead$,
+} from "../../signals/voice-io/voice-io-settings.ts";
 import { OrgManageDialog } from "./components/org-manage/org-manage-dialog.tsx";
 
 function AgentAvatarInTopBar() {
@@ -77,6 +82,9 @@ function MobileTopBar() {
   const features = useLastResolved(featureSwitch$);
   const mobileChatListEnabled =
     features?.[FeatureSwitchKey.MobileChatListPage] ?? false;
+  const audioIOEnabled = features?.[FeatureSwitchKey.AudioIO] ?? false;
+  const autoRead = useGet(autoReadEnabled$);
+  const toggleAutoReadFn = useSet(toggleAutoRead$);
 
   const showInvite = isChatRoute(activeId) && isAdmin;
 
@@ -128,6 +136,23 @@ function MobileTopBar() {
         </div>
       )}
       {!breadcrumb && <div className="flex-1" />}
+      {audioIOEnabled && (
+        <button
+          type="button"
+          onClick={() => {
+            toggleAutoReadFn();
+          }}
+          className={cn(
+            "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors",
+            autoRead
+              ? "text-primary bg-primary/10"
+              : "text-muted-foreground hover:text-foreground hover:bg-muted/50",
+          )}
+          aria-label="Toggle auto-read"
+        >
+          <IconVolume2 size={16} stroke={1.5} />
+        </button>
+      )}
       {showInvite && (
         <button
           type="button"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -833,7 +833,7 @@ function AssistantMessageActions({
   return (
     <div className="@[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px]">
       <div className="hidden @[900px]:block" />
-      <div className="flex items-center py-2 gap-1 -ml-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+      <div className="flex items-center py-2 gap-1 -ml-1 opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity duration-150">
         <TooltipProvider delayDuration={300}>
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

Closes #9226

- Add `pointer-coarse` custom Tailwind v4 variant (`@media (pointer: coarse)`) for touch device detection
- Make per-message action buttons (Read Aloud, Copy, View Logs) always visible on touch devices via `pointer-coarse:opacity-100` — desktop hover behavior unchanged
- Add auto-read toggle button to mobile header (`MobileTopBar`), gated behind `FeatureSwitchKey.AudioIO` feature switch

## Changes

| File | Change |
|------|--------|
| `turbo/apps/platform/src/views/css/index.css` | Add `@custom-variant pointer-coarse` |
| `turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx` | Add `pointer-coarse:opacity-100` to action buttons container |
| `turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx` | Add auto-read toggle to `MobileTopBar` |

## Test plan

- [ ] Open Chrome DevTools, toggle device toolbar, select a touch device (pointer: coarse)
- [ ] Navigate to chat thread with assistant messages
- [ ] Verify action buttons (View logs, Copy, Read Aloud) are visible below each assistant message without hover
- [ ] Verify auto-read toggle appears in mobile header when AudioIO feature is enabled
- [ ] Toggle auto-read on mobile, verify state persists on page refresh
- [ ] Switch back to desktop mode, verify hover behavior is unchanged
- [ ] Verify when AudioIO feature is off, Read Aloud button and auto-read toggle are not shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)