### PR TITLE
fix(runner): switch log timestamps from elapsed-since-startup to wall-clock utc

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -27,27 +27,11 @@ mod status;
 mod telemetry;
 mod types;
 
-use std::fmt;
 use std::path::Path;
 use std::process::ExitCode;
-use std::time::Instant;
 
 use clap::{Parser, Subcommand};
-use tracing_subscriber::fmt::time::FormatTime;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
-
-struct Elapsed(Instant);
-
-impl FormatTime for Elapsed {
-    fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> fmt::Result {
-        let d = self.0.elapsed();
-        let total_secs = d.as_secs();
-        let mins = total_secs / 60;
-        let secs = total_secs % 60;
-        let millis = d.subsec_millis();
-        write!(w, "[{mins:02}:{secs:02}:{millis:03}]")
-    }
-}
 
 #[derive(Parser)]
 #[command(name = "runner", version)]
@@ -160,7 +144,6 @@ fn init_tracing_with_file(
     let writer = std::io::stderr.and(non_blocking);
 
     tracing_subscriber::fmt()
-        .with_timer(Elapsed(Instant::now()))
         .with_writer(writer)
         .with_ansi(false)
         .init();
@@ -169,9 +152,7 @@ fn init_tracing_with_file(
 }
 
 fn init_tracing_stderr() {
-    tracing_subscriber::fmt()
-        .with_timer(Elapsed(Instant::now()))
-        .init();
+    tracing_subscriber::fmt().init();
 }
 
 #[tokio::main]


### PR DESCRIPTION
## Summary
- Replace the custom `Elapsed(Instant)` timer with `tracing_subscriber`'s default `SystemTime` timer
- Log output changes from `[03:42:150]` (minutes since startup) to `2026-04-14T08:30:42.150432Z` (RFC 3339 UTC)
- Net -20 lines (deleted `Elapsed` struct, `FormatTime` impl, and unused imports)

## Why
The elapsed-since-startup format is hard to correlate with external systems (Sentry, cloud logs, DB records) and becomes unreadable for a long-running daemon after hours/days. Wall-clock UTC is the standard for production services and works with all log aggregation tools out of the box.

## Test plan
- [ ] `cargo check -p runner` passes
- [ ] `cargo clippy -p runner -- -D warnings` passes
- [ ] Manual: run `runner doctor` or any subcommand, verify log lines show UTC timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)