### PR TITLE
fix(voice-io): resume audio context to fix silent TTS playback

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
+++ b/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
@@ -14,6 +14,7 @@ function mockWebAudio() {
   const mockAudioContext = {
     currentTime: 0,
     destination: {},
+    resume: vi.fn().mockResolvedValue(undefined),
     createBuffer: vi.fn(
       (_channels: number, length: number, sampleRate: number) => {
         return {
@@ -30,6 +31,7 @@ function mockWebAudio() {
         onended: null as (() => void) | null,
         connect: vi.fn(),
         start: vi.fn(),
+        addEventListener: vi.fn(),
       };
       sources.push(source);
       return source;

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
@@ -109,6 +109,8 @@ const fetchAndPlay$ = command(
     }
 
     const audioCtx = new AudioContext({ sampleRate: 24_000 });
+    await audioCtx.resume();
+    signal.throwIfAborted();
     const reader = body.getReader();
     let nextStartTime = audioCtx.currentTime;
     let lastSource: AudioBufferSourceNode | null = null;


### PR DESCRIPTION
## Summary

- Add `await audioCtx.resume()` after `AudioContext` creation to fix silent TTS playback caused by browser autoplay policy suspending the context after async fetch
- Add `signal.throwIfAborted()` after resume for proper cancellation handling
- Update test mocks with `resume` and `addEventListener` methods

Closes #9230

## Test plan

- [x] All 3 existing TTS tests pass
- [x] Lint passes (including `ccstate/signal-check-await` rule)
- [x] Knip passes (no unused exports)
- [ ] Manual: Click "Read Aloud" on a message → audio plays
- [ ] Manual: Auto-read produces audio for new messages
- [ ] Manual: No `AudioContext was not allowed to start` warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)