### PR TITLE
fix(runner): use proper url parsing for .test tld check in doctor

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2437,6 +2437,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "uuid",
  "which",
  "zstd",

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -31,6 +31,7 @@ hex = { workspace = true }
 sha2 = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
+url = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
 sentry = { workspace = true, features = ["panic"] }
 which = { workspace = true }

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -1439,6 +1439,7 @@ mod tests {
         assert!(is_test_tld("https://not-a-real-server.test/api"));
         assert!(is_test_tld("https://sub.domain.test"));
         assert!(is_test_tld("https://test"));
+        assert!(is_test_tld("https://server.test:8080/api"));
     }
 
     #[test]

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -672,12 +672,22 @@ async fn read_status(base_dir: &Path) -> Option<StatusInfo> {
 // API connectivity check
 // ---------------------------------------------------------------------------
 
+/// Returns `true` if the URL's host TLD is `.test` (RFC 2606).
+fn is_test_tld(url: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(url) else {
+        return false;
+    };
+    parsed
+        .host_str()
+        .is_some_and(|h| h.ends_with(".test") || h == "test")
+}
+
 /// Returns `None` if no server configured or URL uses `.test` TLD (RFC 2606),
 /// `Some(true)` if reachable, `Some(false)` if unreachable.
 async fn check_api(config: &RunnerConfig) -> Option<bool> {
     let server = config.server.as_ref()?;
     // Skip connectivity check for .test domains (reserved per RFC 2606, used in CI)
-    if server.url.contains(".test") {
+    if is_test_tld(&server.url) {
         return None;
     }
     let client = reqeast::builder()
@@ -1422,5 +1432,26 @@ mod tests {
         }];
         let warnings = proxy_check_warnings("running", Some(32821), &mitm_procs);
         assert!(warnings.is_empty(), "running with proxy should not warn");
+    }
+
+    #[test]
+    fn is_test_tld_matches_dot_test() {
+        assert!(is_test_tld("https://not-a-real-server.test/api"));
+        assert!(is_test_tld("https://sub.domain.test"));
+        assert!(is_test_tld("https://test"));
+    }
+
+    #[test]
+    fn is_test_tld_rejects_substring_match() {
+        assert!(!is_test_tld("https://attestation.service.internal/api"));
+        assert!(!is_test_tld("https://my.testing.company.com/api"));
+        assert!(!is_test_tld("https://contest.example.com"));
+    }
+
+    #[test]
+    fn is_test_tld_handles_edge_cases() {
+        assert!(!is_test_tld("not-a-url"));
+        assert!(!is_test_tld("https://example.com/.test"));
+        assert!(!is_test_tld("https://example.com?q=.test"));
     }
 }


### PR DESCRIPTION
## Summary
- `check_api` in `runner doctor` used `String::contains(".test")` to skip connectivity checks for RFC 2606 reserved `.test` TLD domains
- This is a substring match that silently skips the check for URLs like `https://attestation.service.internal/api` or `https://my.testing.company.com/api`
- Fix: parse the URL with the `url` crate and check the host's TLD instead

## Changes
- Extract `is_test_tld()` helper that uses `url::Url::parse` to check host TLD
- Add `url` dependency to runner (already in workspace)
- Add 3 tests covering correct matches, substring rejection, and edge cases

Closes #9193

## Test plan
- [x] `cargo test -p runner -- doctor::tests::is_test_tld` — 3 new tests pass
- [ ] CI (`crates.yml`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)