### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -91,7 +91,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.104"
+CLAUDE_CODE_VERSION="2.1.105"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.25.4"

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -537,7 +537,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            hash, "355fc6702197b6b7956560d1c04cb3a8701bf3a214215ad85f72dcba3621d1f7",
+            hash, "7f3e8b2be83ded0550351739cb12774c0147567eddba5db1e86b5ef3d13ac92a",
             "image hash changed — this invalidates ALL cached images on ALL hosts"
         );
     }


### PR DESCRIPTION
## Summary

- Updated `CLAUDE_CODE_VERSION`: `2.1.104` → `2.1.105`
- Updated `image_hash_is_stable` expected hash in `crates/runner/src/cmd/build.rs` to reflect the new script content

## Versions checked (no update needed)

| Package | Current | Latest |
|---|---|---|
| Go | 1.26.2 | 1.26.2 ✓ |
| @googleworkspace/cli | 0.22.5 | 0.22.5 ✓ |
| @xdevplatform/xurl | 1.0.3 | 1.0.3 ✓ |
| agent-browser | 0.25.4 | 0.25.4 ✓ |

## Test results

`cargo test -p runner image_hash_is_stable` passes with the updated hash.