### PR TITLE
feat(voice-chat): change push-to-talk from hold to toggle mode

### DIFF
--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -11,7 +11,6 @@ import {
   IconUsers,
   IconCheck,
 } from "@tabler/icons-react";
-import type { TouchEvent as ReactTouchEvent } from "react";
 import { defaultAgentName$ } from "../../signals/agent.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -176,28 +175,16 @@ function VoiceChatFooter({
           variant={muted ? "secondary" : "default"}
           className="h-12 w-full rounded-full select-none md:w-auto md:px-6"
           disabled={status !== "connected"}
-          onMouseDown={() => {
-            pttStart();
-          }}
-          onMouseUp={() => {
-            pttStop();
-          }}
-          onMouseLeave={() => {
-            if (!muted) {
+          onClick={() => {
+            if (muted) {
+              pttStart();
+            } else {
               pttStop();
             }
           }}
-          onTouchStart={(e: ReactTouchEvent) => {
-            e.preventDefault();
-            pttStart();
-          }}
-          onTouchEnd={(e: ReactTouchEvent) => {
-            e.preventDefault();
-            pttStop();
-          }}
         >
           <IconMicrophone size={20} className="mr-2" />
-          {muted ? "Hold to Talk" : "Recording..."}
+          {muted ? "Push to Talk" : "Recording..."}
         </Button>
       ) : (
         <Button


### PR DESCRIPTION
## Summary

- Replace hold-to-talk (press and hold) with toggle-to-talk (click to start, click to stop) for the PTT button
- Update idle button label from "Hold to Talk" to "Push to Talk"
- Remove unused `ReactTouchEvent` type import

## Changes

Single file change in `turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx`:
- Remove 5 hold-based event handlers (`onMouseDown`, `onMouseUp`, `onMouseLeave`, `onTouchStart`, `onTouchEnd`)
- Add single `onClick` handler with muted-state conditional toggle
- Net reduction of 13 lines

## Test plan

- [ ] Click PTT button once → recording starts, button shows "Recording..."
- [ ] Click PTT button again → recording stops, button shows "Push to Talk"
- [ ] Verify hands-free mode still works independently
- [ ] Verify mute button still works in hands-free mode
- [ ] Mobile: tap works the same as click
- [ ] All existing tests pass
- [x] Lint, type-check, format, knip pass

Closes #9245

🤖 Generated with [Claude Code](https://claude.com/claude-code)