### PR TITLE
feat(voice-chat): show prepared meetings list on voice chat page

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-preparation-list.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-preparation-list.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  freshPreparations$,
+  fetchFreshPreparations$,
+} from "../voice-chat-preparation.ts";
+
+const context = testContext();
+
+function setup() {
+  detachedSetupPage({
+    context,
+    path: "/voice-chat",
+    withoutRender: true,
+  });
+}
+
+function mockListEndpoint(
+  preparations: {
+    id: string;
+    mode: string;
+    prompt: string | null;
+    agentId: string | null;
+    createdAt: string;
+  }[],
+) {
+  const calls: unknown[] = [];
+  server.use(
+    http.get("*/api/zero/voice-chat/prepare/list", () => {
+      calls.push({});
+      return HttpResponse.json({ preparations });
+    }),
+  );
+  return calls;
+}
+
+describe("fetchFreshPreparations$", () => {
+  it("should populate freshPreparations$ with API response", async () => {
+    setup();
+    const items = [
+      {
+        id: "prep-1",
+        mode: "meeting",
+        prompt: "discuss quarterly goals",
+        agentId: "agent-1",
+        createdAt: "2026-04-14T10:00:00Z",
+      },
+      {
+        id: "prep-2",
+        mode: "meeting",
+        prompt: "sprint review",
+        agentId: "agent-1",
+        createdAt: "2026-04-14T09:30:00Z",
+      },
+    ];
+    mockListEndpoint(items);
+
+    await context.store.set(fetchFreshPreparations$, context.signal);
+
+    const result = context.store.get(freshPreparations$);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toStrictEqual({
+      id: "prep-1",
+      mode: "meeting",
+      prompt: "discuss quarterly goals",
+      agentId: "agent-1",
+      createdAt: "2026-04-14T10:00:00Z",
+    });
+    expect(result[1]).toStrictEqual({
+      id: "prep-2",
+      mode: "meeting",
+      prompt: "sprint review",
+      agentId: "agent-1",
+      createdAt: "2026-04-14T09:30:00Z",
+    });
+  });
+
+  it("should return empty list when no preparations exist", async () => {
+    setup();
+    mockListEndpoint([]);
+
+    await context.store.set(fetchFreshPreparations$, context.signal);
+
+    expect(context.store.get(freshPreparations$)).toHaveLength(0);
+  });
+
+  it("should throw on API error", async () => {
+    setup();
+    server.use(
+      http.get("*/api/zero/voice-chat/prepare/list", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    await expect(
+      context.store.set(fetchFreshPreparations$, context.signal),
+    ).rejects.toThrow();
+  });
+});

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-preparation.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-preparation.ts
@@ -1,5 +1,9 @@
 import { command, computed, state } from "ccstate";
-import { zeroVoiceChatPrepareTriggerContract } from "@vm0/core";
+import {
+  zeroVoiceChatPrepareTriggerContract,
+  zeroVoiceChatPrepareListContract,
+  type FreshPreparation,
+} from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 import { defaultAgentId$ } from "../agent.ts";
 import { accept, ApiError } from "../../lib/accept.ts";
@@ -68,6 +72,10 @@ export const triggerPreparation$ = command(
 
     if (initialStatus === "ready") {
       set(internalPrepStatus$, "ready");
+      await set(fetchFreshPreparations$, signal).catch((error: unknown) => {
+        throwIfAbort(error);
+      });
+      signal.throwIfAborted();
       return;
     }
 
@@ -85,6 +93,11 @@ export const triggerPreparation$ = command(
 
         if (pollRes.body.preparation.status === "ready") {
           set(internalPrepStatus$, "ready");
+          await set(fetchFreshPreparations$, loopSignal).catch(
+            (error: unknown) => {
+              throwIfAbort(error);
+            },
+          );
           return true;
         }
 
@@ -106,3 +119,21 @@ export const clearPreparation$ = command(({ set }) => {
   set(internalPrepPrompt$, null);
   set(internalPrepStartTime$, null);
 });
+
+// --- Fresh preparations list ---
+
+const internalFreshPreparations$ = state<FreshPreparation[]>([]);
+
+export const freshPreparations$ = computed((get) => {
+  return get(internalFreshPreparations$);
+});
+
+export const fetchFreshPreparations$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroVoiceChatPrepareListContract);
+    const res = await accept(client.list({}), [200], { toast: false });
+    signal.throwIfAborted();
+    set(internalFreshPreparations$, res.body.preparations);
+  },
+);

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-setup.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-setup.ts
@@ -10,6 +10,7 @@ import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { endVoiceChat$, vcStatus$ } from "./voice-chat-session.ts";
 import {
   clearPreparation$,
+  fetchFreshPreparations$,
   meetingPrepStatus$,
 } from "./voice-chat-preparation.ts";
 import { zeroClient$ } from "../api-client.ts";
@@ -50,6 +51,11 @@ export const setupVoiceChatPage$ = command(
       });
     })().catch((error: unknown) => {
       L.warn("Preparation pre-warm failed", error);
+    });
+
+    // Fetch fresh meeting preparations list (fire-and-forget)
+    set(fetchFreshPreparations$, signal).catch((error: unknown) => {
+      L.warn("Fresh preparations list fetch failed", error);
     });
 
     // End voice chat session and clear preparation when navigating away

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -48,6 +48,7 @@ import {
 import {
   meetingPrepStatus$,
   meetingPrepPrompt$,
+  freshPreparations$,
   triggerPreparation$,
   clearPreparation$,
 } from "../../signals/voice-chat/voice-chat-preparation.ts";
@@ -305,6 +306,66 @@ function MeetingBox() {
   );
 }
 
+function formatRelativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) {
+    return "just now";
+  }
+  if (minutes < 60) {
+    return `${minutes}min ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+function ReadyMeetings() {
+  const preparations = useLastResolved(freshPreparations$);
+  const pageSignal = useGet(pageSignal$);
+  const startMeeting = useSet(startVoiceMeeting$);
+  const agentId = useLastResolved(vcAgentId$);
+
+  if (!preparations || preparations.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="w-full max-w-md flex flex-col gap-2">
+      <h2 className="text-sm font-medium text-muted-foreground">
+        Ready Meetings
+      </h2>
+      {preparations.map((prep) => {
+        return (
+          <div
+            key={prep.id}
+            className="flex items-center justify-between rounded-lg border border-input px-4 py-3"
+          >
+            <div className="flex-1 min-w-0 mr-3">
+              <p className="text-sm truncate">{prep.prompt}</p>
+              <p className="text-xs text-muted-foreground">
+                {formatRelativeTime(prep.createdAt)}
+              </p>
+            </div>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => {
+                detach(
+                  startMeeting(prep.prompt!, pageSignal),
+                  Reason.DomCallback,
+                );
+              }}
+              disabled={!agentId}
+            >
+              Start
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 export function VoiceChatPage() {
   const pageSignal = useGet(pageSignal$);
   const enabled = useLastResolved(vcEnabled$);
@@ -394,6 +455,7 @@ export function VoiceChatPage() {
           </Button>
         </div>
         <MeetingBox />
+        <ReadyMeetings />
       </div>
     );
   }

--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/list/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/list/route.ts
@@ -12,17 +12,30 @@ export async function GET(request: Request) {
   const authCtx = await getAuthContext(
     request.headers.get("authorization") ?? undefined,
   );
-  const org = await resolveOrg(authCtx);
-
-  const overrides = await loadFeatureSwitchOverrides(authCtx.userId);
-  if (!isFeatureEnabled(FeatureSwitchKey.VOICE_CHAT, overrides)) {
+  if (!authCtx?.orgId) {
     return NextResponse.json(
-      { error: { message: "Voice chat is not enabled" } },
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { org } = await resolveOrg(authCtx);
+  const { userId } = authCtx;
+
+  const overrides = await loadFeatureSwitchOverrides(org.orgId, userId);
+  const enabled = isFeatureEnabled(FeatureSwitchKey.VoiceChat, {
+    orgId: org.orgId,
+    userId,
+    overrides,
+  });
+  if (!enabled) {
+    return NextResponse.json(
+      { error: { message: "Voice chat is not enabled", code: "FORBIDDEN" } },
       { status: 403 },
     );
   }
 
-  const preparations = await listFreshPreparations(org.id, authCtx.userId);
+  const preparations = await listFreshPreparations(org.orgId, userId);
 
   return NextResponse.json({
     preparations: preparations.map((p) => {

--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/list/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/list/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../../../src/lib/zero/org/resolve-org";
+import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
+import { listFreshPreparations } from "../../../../../../src/lib/zero/voice-chat/preparation-service";
+import { loadFeatureSwitchOverrides } from "../../../../../../src/lib/zero/user/feature-switches-service";
+
+export async function GET(request: Request) {
+  initServices();
+
+  const authCtx = await getAuthContext(
+    request.headers.get("authorization") ?? undefined,
+  );
+  const org = await resolveOrg(authCtx);
+
+  const overrides = await loadFeatureSwitchOverrides(authCtx.userId);
+  if (!isFeatureEnabled(FeatureSwitchKey.VOICE_CHAT, overrides)) {
+    return NextResponse.json(
+      { error: { message: "Voice chat is not enabled" } },
+      { status: 403 },
+    );
+  }
+
+  const preparations = await listFreshPreparations(org.id, authCtx.userId);
+
+  return NextResponse.json({
+    preparations: preparations.map((p) => {
+      return {
+        id: p.id,
+        mode: p.mode,
+        prompt: p.prompt,
+        agentId: p.agentId,
+        createdAt: p.createdAt.toISOString(),
+      };
+    }),
+  });
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
@@ -52,6 +52,43 @@ export async function findFreshPreparation(
   return { id: result.id, directiveContent: result.directiveContent };
 }
 
+export async function listFreshPreparations(
+  orgId: string,
+  userId: string,
+): Promise<
+  {
+    id: string;
+    mode: string;
+    prompt: string | null;
+    agentId: string | null;
+    createdAt: Date;
+  }[]
+> {
+  const db = globalThis.services.db;
+  const threshold = new Date(Date.now() - PREPARATION_FRESHNESS_MS);
+
+  return db
+    .select({
+      id: voiceChatPreparations.id,
+      mode: voiceChatPreparations.mode,
+      prompt: voiceChatPreparations.prompt,
+      agentId: voiceChatPreparations.agentId,
+      createdAt: voiceChatPreparations.createdAt,
+    })
+    .from(voiceChatPreparations)
+    .where(
+      and(
+        eq(voiceChatPreparations.orgId, orgId),
+        eq(voiceChatPreparations.userId, userId),
+        eq(voiceChatPreparations.status, "ready"),
+        eq(voiceChatPreparations.mode, "meeting"),
+        gt(voiceChatPreparations.createdAt, threshold),
+      ),
+    )
+    .orderBy(desc(voiceChatPreparations.createdAt))
+    .limit(5);
+}
+
 // ---------------------------------------------------------------------------
 // CRUD Operations
 // ---------------------------------------------------------------------------

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -812,9 +812,11 @@ export {
 export {
   zeroVoiceChatPrepareTriggerContract,
   zeroVoiceChatPrepareCompleteContract,
+  zeroVoiceChatPrepareListContract,
   type ZeroVoiceChatPrepareCompleteContract,
   type PrepareCompleteBody,
   type PrepareCompleteResponse,
+  type FreshPreparation,
 } from "./zero-voice-chat-prepare";
 export {
   tasksContract,

--- a/turbo/packages/core/src/contracts/zero-voice-chat-prepare.ts
+++ b/turbo/packages/core/src/contracts/zero-voice-chat-prepare.ts
@@ -66,3 +66,33 @@ export type PrepareCompleteBody = z.infer<typeof prepareCompleteBodySchema>;
 export type PrepareCompleteResponse = z.infer<
   typeof prepareCompleteResponseSchema
 >;
+
+const prepareListResponseSchema = z.object({
+  preparations: z.array(
+    z.object({
+      id: z.string(),
+      mode: z.string(),
+      prompt: z.string().nullable(),
+      agentId: z.string().nullable(),
+      createdAt: z.string(),
+    }),
+  ),
+});
+
+export const zeroVoiceChatPrepareListContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/voice-chat/prepare/list",
+    headers: authHeadersSchema,
+    responses: {
+      200: prepareListResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "List fresh meeting preparations for the current user",
+  },
+});
+
+export type FreshPreparation = z.infer<
+  typeof prepareListResponseSchema
+>["preparations"][number];


### PR DESCRIPTION
## Summary

- Add a "Ready Meetings" section to the voice chat idle page displaying previously prepared voice meetings (status=ready, within 1-hour TTL)
- Users can click "Start" to immediately begin a meeting using cached preparation, skipping the prepare wait
- List refreshes on page load and after a new preparation completes

## Changes

### Backend
- `preparation-service.ts`: Add `listFreshPreparations()` query (mode=meeting, status=ready, 1-hour TTL, max 5, ordered by createdAt DESC)
- `prepare/list/route.ts`: New `GET /api/zero/voice-chat/prepare/list` endpoint with auth + feature gate

### Contract
- `zero-voice-chat-prepare.ts`: Add `zeroVoiceChatPrepareListContract` and `FreshPreparation` type

### Frontend
- `voice-chat-preparation.ts`: Add `freshPreparations$` signal + `fetchFreshPreparations$` command; refresh list when preparation becomes ready
- `voice-chat-setup.ts`: Trigger list fetch on page load (fire-and-forget)
- `voice-chat-page.tsx`: Add `ReadyMeetings` component with prompt text, relative time, and "Start" button

## Test plan

- [x] `fetchFreshPreparations$` populates state from API response
- [x] Empty list when no preparations exist
- [x] API error throws correctly
- [x] All 21 existing voice-chat tests pass (no regressions)
- [x] Lint, format, knip, commitlint all pass

Closes #9243

🤖 Generated with [Claude Code](https://claude.com/claude-code)