### PR TITLE
fix(runner): retry dnsmasq startup on port conflict

### DIFF
--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -79,17 +79,49 @@ impl Drop for DnsProxy {
     }
 }
 
-/// Find an available UDP port by binding to port 0.
+/// Find an available port by binding to port 0.
+///
+/// Checks both TCP and UDP because dnsmasq binds both protocols.
 fn find_available_port() -> std::io::Result<u16> {
-    let socket = std::net::UdpSocket::bind("0.0.0.0:0")?;
-    Ok(socket.local_addr()?.port())
+    let tcp = std::net::TcpListener::bind("0.0.0.0:0")?;
+    let port = tcp.local_addr()?.port();
+    let _udp = std::net::UdpSocket::bind(("0.0.0.0", port))?;
+    Ok(port)
 }
 
 /// Start dnsmasq and spawn a background task to parse its query log.
 ///
 /// dnsmasq listens on a dynamically allocated port and forwards to upstream DNS.
+/// Retries up to 3 times with a fresh port if the initial bind fails (TOCTOU race).
 pub async fn start(ip_log_map: IpLogMap) -> std::io::Result<DnsProxy> {
-    let port = find_available_port()?;
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut last_err = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let port = match find_available_port() {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(attempt, error = %e, "failed to find available port");
+                last_err = Some(e);
+                continue;
+            }
+        };
+        match try_start(port, &ip_log_map).await {
+            Ok(proxy) => return Ok(proxy),
+            Err(e) => {
+                if attempt < MAX_ATTEMPTS {
+                    warn!(port, attempt, error = %e, "dnsmasq failed to start, retrying with new port");
+                } else {
+                    warn!(port, attempt, error = %e, "dnsmasq failed to start, all attempts exhausted");
+                }
+                last_err = Some(e);
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| std::io::Error::other("dnsmasq failed to start")))
+}
+
+/// Try to start dnsmasq on the given port. Returns the proxy handle on success.
+async fn try_start(port: u16, ip_log_map: &IpLogMap) -> std::io::Result<DnsProxy> {
     let port_str = port.to_string();
 
     let mut child = tokio::process::Command::new("dnsmasq")
@@ -134,6 +166,7 @@ pub async fn start(ip_log_map: IpLogMap) -> std::io::Result<DnsProxy> {
 
     let cancel = CancellationToken::new();
     let token = cancel.clone();
+    let ip_log_map = ip_log_map.clone();
     let task = tokio::spawn(async move {
         if let Err(e) = tail_stderr(stderr, &ip_log_map, token).await {
             warn!(error = %e, "dns log monitor exited");


### PR DESCRIPTION
## Summary

- Fix `find_available_port()` to check both TCP and UDP availability (dnsmasq binds both)
- Add retry (up to 3 attempts) in `dns::start()` with a fresh port on failure

## Root Cause

Production deploy failed on prod-3 ([run #24380609467](https://github.com/vm0-ai/vm0/actions/runs/24380609467/job/71203241114)): the new runner's dnsmasq couldn't bind TCP port 33628 because the old runner's dnsmasq still held it. `find_available_port()` only checked UDP, so it returned a port where UDP was free but TCP was occupied.

## Changes

`crates/runner/src/dns.rs`:
- `find_available_port()`: bind TCP first (port 0), then verify UDP on the same port
- `start()` → `start()` + `try_start()`: retry loop handles both the dual-stack mismatch and the remaining TOCTOU window between socket release and dnsmasq's bind

## Why not proxy too?

Proxy (`proxy.rs`) was considered but **not changed** — adding retry there causes spurious crash notifications via `crash_tx` (the stdout monitor from a failed spawn sends a crash signal that triggers an unnecessary restart). Proxy only uses TCP for both `find_available_port()` and mitmdump, so the dual-stack mismatch that caused prod-3's failure doesn't apply.

## Test plan

- [x] `cargo test -p runner` — 595 tests pass
- [x] `cargo clippy -p runner` — clean
- [ ] Deploy to staging with concurrent runner versions to verify no port conflict

Closes #9250

🤖 Generated with [Claude Code](https://claude.com/claude-code)