### PR TITLE
fix(platform): restore scroll and add auto-read integration tests

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -351,6 +351,8 @@ interface MessageCommandsDeps {
   reloadThinkingMessage$: Command<void, []>;
   cancelDraftSync$: Command<void, []>;
   flushDraftClear$: Command<Promise<void>, [AbortSignal]>;
+  autoScroll$: Command<void, []>;
+  forceScrollToBottom$: Command<void, []>;
 }
 
 function createPrepareUserMessage(deps: MessageCommandsDeps) {
@@ -477,10 +479,13 @@ function createMessageCommands(deps: MessageCommandsDeps) {
         return;
       }
 
+      set(deps.forceScrollToBottom$);
+
       await setLoop(
         (sig) => {
           set(reloadChatThreads$);
           set(deps.reloadThread$);
+          set(deps.autoScroll$);
           return set(runLoop.checkFinished$, sig);
         },
         3000,
@@ -504,6 +509,7 @@ function createMessageCommands(deps: MessageCommandsDeps) {
     }
 
     set(deps.internalLocalMessages$, msgs.activeRunMessages);
+    set(deps.forceScrollToBottom$);
 
     const assistantMessages = msgs.activeRunMessages.filter(
       (m): m is AssistantChatMessage => {
@@ -529,6 +535,7 @@ function createMessageCommands(deps: MessageCommandsDeps) {
         await setLoop(
           (sig) => {
             set(deps.reloadThinkingMessage$);
+            set(deps.autoScroll$);
             return set(runLoop.checkFinished$, sig);
           },
           3000,
@@ -899,6 +906,8 @@ export function createChatThreadSignals(
     reloadThinkingMessage$,
     cancelDraftSync$,
     flushDraftClear$,
+    autoScroll$,
+    forceScrollToBottom$,
   });
 
   return {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-auto-read.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-auto-read.test.tsx
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { ttsPlayingMessageId$ } from "../../../signals/voice-io/voice-io-tts.ts";
+import { toggleAutoRead$ } from "../../../signals/voice-io/voice-io-settings.ts";
+import {
+  mockChatLifecycle,
+  sendMessageInUI,
+  PLACEHOLDER,
+} from "./chat-test-helpers.ts";
+
+const context = testContext();
+
+function mockWebAudio() {
+  vi.stubGlobal(
+    "AudioContext",
+    vi.fn(function () {
+      return {
+        currentTime: 0,
+        destination: {},
+        resume: vi.fn().mockResolvedValue(undefined),
+        createBuffer: vi.fn(
+          (_channels: number, length: number, sampleRate: number) => {
+            return {
+              getChannelData: vi.fn(() => {
+                return new Float32Array(length);
+              }),
+              duration: length / sampleRate,
+            };
+          },
+        ),
+        createBufferSource: vi.fn(() => {
+          return {
+            buffer: null as unknown,
+            onended: null as (() => void) | null,
+            connect: vi.fn(),
+            start: vi.fn(),
+            addEventListener: vi.fn(),
+          };
+        }),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+    }),
+  );
+}
+
+function mockTtsEndpoint() {
+  let fetchCount = 0;
+  server.use(
+    http.post("*/api/zero/voice-io/tts", () => {
+      fetchCount++;
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([0x00, 0x01, 0x00, 0x02]));
+          controller.close();
+        },
+      });
+      return new HttpResponse(body, {
+        headers: { "Content-Type": "application/octet-stream" },
+      });
+    }),
+  );
+  return {
+    getFetchCount: () => {
+      return fetchCount;
+    },
+  };
+}
+
+// AUTO-READ-001: checkAutoRead$ is triggered after sendMessage$ completes
+describe("chat auto-read — triggered after send", () => {
+  it("calls TTS after run completes when auto-read is enabled (AUTO-READ-001)", async () => {
+    context.store.set(toggleAutoRead$);
+    mockWebAudio();
+    const { getFetchCount } = mockTtsEndpoint();
+
+    const user = userEvent.setup();
+    const ctrl = mockChatLifecycle();
+
+    detachedSetupPage({
+      context,
+      path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
+    });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    await sendMessageInUI(user, textarea, "Hello auto-read");
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+
+    ctrl.completeRun("Auto-read response");
+
+    // Wait for TTS to be triggered after run completion
+    await waitFor(() => {
+      expect(getFetchCount()).toBeGreaterThan(0);
+    });
+  });
+});
+
+// AUTO-READ-002: checkAutoRead$ is NOT triggered when auto-read is disabled
+describe("chat auto-read — skipped when disabled", () => {
+  it("does not call TTS after run completes when auto-read is disabled (AUTO-READ-002)", async () => {
+    // auto-read disabled by default (no localStorage entry set)
+    mockWebAudio();
+    const { getFetchCount } = mockTtsEndpoint();
+
+    const user = userEvent.setup();
+    const ctrl = mockChatLifecycle();
+
+    detachedSetupPage({
+      context,
+      path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
+    });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    await sendMessageInUI(user, textarea, "Hello no auto-read");
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+
+    ctrl.completeRun("No auto-read response");
+
+    await waitFor(() => {
+      expect(screen.getByText("No auto-read response")).toBeInTheDocument();
+    });
+
+    // TTS should not be called
+    expect(getFetchCount()).toBe(0);
+    expect(context.store.get(ttsPlayingMessageId$)).toBeNull();
+  });
+});
+
+// AUTO-READ-003: markMessageLoading$ guard prevents TTS for messages not seen loading
+describe("chat auto-read — markMessageLoading$ guard", () => {
+  it("does not trigger TTS for static messages never seen loading (AUTO-READ-003)", async () => {
+    context.store.set(toggleAutoRead$);
+    mockWebAudio();
+    const { getFetchCount } = mockTtsEndpoint();
+
+    server.use(
+      http.get("*/api/zero/chat-threads/thread-static-1", () => {
+        return HttpResponse.json({
+          id: "thread-static-1",
+          title: null,
+          agentId: "c0000000-0000-4000-a000-000000000001",
+          chatMessages: [
+            {
+              role: "user",
+              content: "Static question",
+              createdAt: "2026-03-10T00:00:00Z",
+            },
+            {
+              role: "assistant",
+              content: "Static answer",
+              createdAt: "2026-03-10T00:00:01Z",
+            },
+          ],
+          latestSessionId: null,
+          unsavedRuns: [],
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-static-1" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Static answer")).toBeInTheDocument();
+    });
+
+    // Static messages were never seen loading, so TTS must not be called
+    expect(getFetchCount()).toBe(0);
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
@@ -179,8 +179,7 @@ describe("zero chat thread page - scroll container mounts on load", () => {
   });
 });
 
-// CHAT-SCROLL-005: useAutoScrollOnce resets on thread change so forceScrollToBottom$
-// fires again for the new thread
+// CHAT-SCROLL-005: forceScrollToBottom$ fires again for each new thread
 describe("zero chat thread page - scroll fires for each new thread", () => {
   it("scroll container is present after navigating to a second thread (CHAT-SCROLL-005)", async () => {
     mockThread("thread-scroll-nav-a", [
@@ -197,9 +196,8 @@ describe("zero chat thread page - scroll fires for each new thread", () => {
       expect(screen.getByText("Thread nav-A message")).toBeInTheDocument();
     });
 
-    // Navigate to thread B — a new ChatThreadSignals is created, giving
-    // useAutoScrollOnce a new scroll command reference and resetting its
-    // fired flag so it can scroll for the new thread.
+    // Navigate to thread B — a new ChatThreadSignals is created with a fresh
+    // forceScrollToBottom$ command so the signal layer scrolls for the new thread.
     context.store.set(detachedNavigateTo$, "/chats/:threadId", {
       pathParams: { threadId: "thread-scroll-nav-b" },
     });


### PR DESCRIPTION
## Summary

Follow-up fix for #9258 which was merged before these issues were caught:

- **P0 fix**: Restore auto-scroll behavior lost when `useAutoScroll` / `useAutoScrollOnce` call sites were removed — `autoScroll$` and `forceScrollToBottom$` are now passed through `MessageCommandsDeps` and called from `sendMessage$` and `loadMessages$` in the signal layer
- **P1 fix**: Add `chat-auto-read.test.tsx` integration tests covering `markMessageLoading$` + `checkAutoRead$` wiring (3 tests: enabled, disabled, and the loading-guard)
- **P2 fix**: Update stale `useAutoScrollOnce` references in `chat-scroll-behavior.test.tsx` comments

## Test plan

- [ ] `chat-auto-read.test.tsx` — 3 new tests all pass
- [ ] `chat-scroll-behavior.test.tsx` — 5 existing tests still pass
- [ ] Full platform test suite passes (100 test files)
- [ ] Lint, type-check, knip all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)