### PR TITLE
fix: kill child process on error paths to prevent orphans

### DIFF
--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -128,10 +128,10 @@ pub async fn start(ip_log_map: IpLogMap) -> std::io::Result<DnsProxy> {
         Ok(None) => {} // still running — good
     }
 
-    let stderr = child.stderr.take().ok_or_else(|| {
-        let _ = child.start_kill();
-        std::io::Error::other("failed to capture dnsmasq stderr")
-    })?;
+    let Some(stderr) = child.stderr.take() else {
+        let _ = child.kill().await;
+        return Err(std::io::Error::other("failed to capture dnsmasq stderr"));
+    };
 
     let cancel = CancellationToken::new();
     let token = cancel.clone();

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -120,6 +120,7 @@ pub async fn start(ip_log_map: IpLogMap) -> std::io::Result<DnsProxy> {
             )));
         }
         Err(e) => {
+            let _ = child.kill().await;
             return Err(std::io::Error::other(format!(
                 "dnsmasq process check failed: {e}"
             )));
@@ -127,10 +128,10 @@ pub async fn start(ip_log_map: IpLogMap) -> std::io::Result<DnsProxy> {
         Ok(None) => {} // still running — good
     }
 
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| std::io::Error::other("failed to capture dnsmasq stderr"))?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        let _ = child.start_kill();
+        std::io::Error::other("failed to capture dnsmasq stderr")
+    })?;
 
     let cancel = CancellationToken::new();
     let token = cancel.clone();

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -947,4 +947,55 @@ mod tests {
         // headers should be empty object
         assert_eq!(api["auth"]["headers"], serde_json::json!({}));
     }
+
+    #[tokio::test]
+    async fn wait_for_ready_returns_error_on_timeout() {
+        // `sleep` never listens on TCP — guarantees timeout.
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+
+        let raw_pid = child.id().unwrap() as i32;
+        let pid = nix::unistd::Pid::from_raw(raw_pid);
+        let port = find_available_port().unwrap();
+
+        let result = wait_for_ready(&mut child, port, Duration::from_millis(500)).await;
+        assert!(result.is_err());
+
+        // Process must still be alive — wait_for_ready does NOT kill on error.
+        // This is the scenario that caused orphaned processes before the fix:
+        // the caller (spawn_mitmdump) is responsible for killing.
+        assert!(
+            nix::sys::signal::kill(pid, None).is_ok(),
+            "process should still be alive after timeout"
+        );
+
+        // Simulate spawn_mitmdump error path: kill the child.
+        let _ = child.kill().await;
+
+        assert!(
+            nix::sys::signal::kill(pid, None).is_err(),
+            "process should be dead after kill"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_ready_returns_error_on_early_exit() {
+        // `true` exits immediately with status 0.
+        let mut child = tokio::process::Command::new("true")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+
+        // Give process time to exit before polling starts.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let port = find_available_port().unwrap();
+        let result = wait_for_ready(&mut child, port, Duration::from_secs(5)).await;
+        assert!(result.is_err());
+    }
 }

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -367,7 +367,10 @@ pub(crate) async fn spawn_mitmdump(
     }
 
     // Wait for process to be alive (poll liveness).
-    wait_for_ready(&mut child, port, READY_TIMEOUT).await?;
+    if let Err(e) = wait_for_ready(&mut child, port, READY_TIMEOUT).await {
+        let _ = child.kill().await;
+        return Err(e);
+    }
 
     Ok(child)
 }

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -991,8 +991,9 @@ mod tests {
             .spawn()
             .unwrap();
 
-        // Give process time to exit before polling starts.
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait for `true` to actually exit before calling wait_for_ready,
+        // so the first try_wait() inside the function detects it immediately.
+        let _ = child.wait().await;
 
         let port = find_available_port().unwrap();
         let result = wait_for_ready(&mut child, port, Duration::from_secs(5)).await;

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -368,6 +368,7 @@ pub(crate) async fn spawn_mitmdump(
 
     // Wait for process to be alive (poll liveness).
     if let Err(e) = wait_for_ready(&mut child, port, READY_TIMEOUT).await {
+        stopping.store(true, Ordering::Release);
         let _ = child.kill().await;
         return Err(e);
     }


### PR DESCRIPTION
## Summary

Closes #9255

- **dns.rs**: kill dnsmasq when `try_wait()` returns `Err` or `stderr.take()` returns `None`
- **proxy.rs**: kill mitmdump when `wait_for_ready()` fails (timeout or `try_wait` error)

`tokio::process::Child::Drop` does not kill the child process. On error paths after `spawn()`, the process handle was dropped but the child continued running as an orphan.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p runner` — 609 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)