### PR TITLE
fix(voice-io): move audio context creation before async fetch for gesture activation

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
@@ -86,29 +86,39 @@ const fetchAndPlay$ = command(
 
     const fetchFn = get(fetch$);
 
+    // Create AudioContext synchronously during user gesture so the browser
+    // grants autoplay permission (transient activation window is ~5 s).
+    const audioCtx = new AudioContext({ sampleRate: 24_000 });
+
     let response: Response | null;
     // eslint-disable-next-line no-restricted-syntax -- raw fetch for binary audio (not a ts-rest contract)
     try {
       response = await fetchTtsAudio(fetchFn, plainText, signal);
     } catch (error) {
       L.error("TTS fetch failed", error);
+      await audioCtx.close();
+      signal.throwIfAborted();
       set(internalPlayingMessageId$, null);
       return;
     }
 
     if (!response) {
       L.error("TTS API returned error");
+      await audioCtx.close();
+      signal.throwIfAborted();
       set(internalPlayingMessageId$, null);
       return;
     }
 
     const body = response.body;
     if (!body) {
+      await audioCtx.close();
+      signal.throwIfAborted();
       set(internalPlayingMessageId$, null);
       return;
     }
 
-    const audioCtx = new AudioContext({ sampleRate: 24_000 });
+    // Safety fallback: resume if the context did not auto-start (e.g. auto-read path).
     await audioCtx.resume();
     signal.throwIfAborted();
     const reader = body.getReader();
@@ -152,12 +162,15 @@ const fetchAndPlay$ = command(
         continue;
       }
 
-      // Convert Int16LE PCM to Float32
-      const int16 = new Int16Array(
-        chunk.buffer,
-        chunk.byteOffset,
-        chunk.length / 2,
-      );
+      // Convert Int16LE PCM to Float32 (use aligned buffer to avoid RangeError)
+      const aligned =
+        chunk.buffer.byteLength === chunk.length && chunk.byteOffset === 0
+          ? chunk.buffer
+          : chunk.buffer.slice(
+              chunk.byteOffset,
+              chunk.byteOffset + chunk.length,
+            );
+      const int16 = new Int16Array(aligned);
       const float32 = new Float32Array(int16.length);
       for (let i = 0; i < int16.length; i++) {
         float32[i] = int16[i] / 32_768;


### PR DESCRIPTION
## Summary

- Move `AudioContext` creation before `await fetchTtsAudio()` so it's constructed within the browser's 5-second transient user activation window, fixing silent TTS playback
- Add `audioCtx.close()` in all error paths (fetch error, null response, null body) after AudioContext creation to prevent resource leaks
- Fix `Int16Array` byte alignment safety for PCM chunk decoding by using conditional `buffer.slice()` when the chunk offset is unaligned

Closes #9252

## Test plan

- [x] All 3 existing `voice-io-tts` tests pass (dedup, different messageId, fetch failure)
- [x] Lint passes (oxlint + eslint with ccstate/signal-check-await rule)
- [x] No new type errors introduced (pre-existing type errors in other files are unrelated)
- [x] Knip passes (no unused exports/deps)
- [x] Format passes (prettier)
- [ ] Manual: Click "Read Aloud" in browser — audio should play without silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)