### PR TITLE
feat(voice-chat): extend preparation cache ttl from 1 hour to 24 hours

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-chat/__tests__/create-session.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/__tests__/create-session.test.ts
@@ -259,7 +259,7 @@ describe("POST /api/zero/voice-chat (create session)", () => {
       mode: "chat",
       status: "ready",
       directiveContent: "Old cached directive.",
-      createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000), // 2 hours ago
+      createdAt: new Date(Date.now() - 25 * 60 * 60 * 1000), // 25 hours ago
     });
 
     const response = await POST(createRequest({ agentId }));

--- a/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
@@ -11,7 +11,7 @@ import { logger } from "../../shared/logger";
 
 const log = logger("zero:voice-chat:preparation");
 
-const PREPARATION_FRESHNESS_MS = 60 * 60 * 1000; // 1 hour
+const PREPARATION_FRESHNESS_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 export async function findFreshPreparation(
   orgId: string,


### PR DESCRIPTION
## Summary
- Extend `PREPARATION_FRESHNESS_MS` from 1 hour to 24 hours so that cached meeting preparations remain usable across longer sessions
- Affects both `findFreshPreparation` (session start cache hit) and `listFreshPreparations` (Ready Meetings list on voice chat page)

## Test plan
- [ ] Start a voice chat meeting with preparation, end the session
- [ ] Wait >1 hour, start a new voice chat — verify the cached preparation is reused
- [ ] Verify Ready Meetings list shows preparations up to 24 hours old

🤖 Generated with [Claude Code](https://claude.com/claude-code)