### PR TITLE
refactor(runner): deduplicate guest state restore in executor

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -397,7 +397,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             profile_config,
             &home,
         );
-        let use_snapshot = factory_config.snapshot.is_some();
+        let restore_guest_state = factory_config.snapshot.is_some();
         let factory_result = runtime.create_factory(factory_config).await;
         let factory = match factory_result {
             Ok(f) => f,
@@ -406,7 +406,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 return Err(e.into());
             }
         };
-        factories.insert(profile_name.clone(), (Arc::new(factory), use_snapshot));
+        factories.insert(
+            profile_name.clone(),
+            (Arc::new(factory), restore_guest_state),
+        );
         info!(profile = %profile_name, "factory started");
     }
 
@@ -572,7 +575,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let job_vcpu = profile_config.vcpu;
                 let job_memory = profile_config.memory_mb;
                 // Look up factory for this profile.
-                let Some((factory, use_snapshot)) = factories.get(&profile_name) else {
+                let Some((factory, restore_guest_state)) = factories.get(&profile_name) else {
                     warn!(run_id = %run_id, profile = %profile_name, "no factory for profile, skipping");
                     continue;
                 };
@@ -680,7 +683,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     profile_name: profile_name.clone(),
                     vcpu: job_vcpu,
                     memory_mb: job_memory,
-                    use_snapshot: *use_snapshot,
+                    restore_guest_state: *restore_guest_state,
                     factory: Arc::clone(factory),
                     cancel: job_cancel,
                 };
@@ -849,7 +852,7 @@ struct JobProfile {
     profile_name: String,
     vcpu: u32,
     memory_mb: u32,
-    use_snapshot: bool,
+    restore_guest_state: bool,
     factory: SharedFactory,
     cancel: CancellationToken,
 }
@@ -915,7 +918,7 @@ fn spawn_job(
     let params = executor::JobParams {
         vcpu,
         memory_mb,
-        use_snapshot: job_profile.use_snapshot,
+        restore_guest_state: job_profile.restore_guest_state,
     };
 
     let storage_fingerprints = context

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -38,7 +38,7 @@ pub struct ExecutorConfig {
 pub struct JobParams {
     pub vcpu: u32,
     pub memory_mb: u32,
-    pub use_snapshot: bool,
+    pub restore_guest_state: bool,
 }
 
 /// Outcome of a job execution, including the sandbox for possible reuse.
@@ -203,7 +203,7 @@ async fn execute_new_sandbox(
         sandbox.as_ref(),
         context,
         config,
-        params.use_snapshot,
+        params.restore_guest_state,
         None,
         telemetry,
         cancel,
@@ -2258,7 +2258,7 @@ mod tests {
         JobParams {
             vcpu: 2,
             memory_mb: 2048,
-            use_snapshot: false,
+            restore_guest_state: false,
         }
     }
 
@@ -2306,7 +2306,7 @@ mod tests {
         factory.startup().await.unwrap();
 
         let params = JobParams {
-            use_snapshot: true,
+            restore_guest_state: true,
             ..default_params()
         };
         let (exit_code, _) = run_execute_inner(&factory, &minimal_context(), &config, &params)

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -260,37 +260,12 @@ async fn execute_reused_sandbox(
     // Re-register proxy with new run credentials
     register_proxy(config, context, source_ip).await;
 
-    // Fix clock drift and reseed entropy (always needed after idle period).
-    // On failure, return the sandbox so the caller can still stop + destroy it.
-    if let Err(e) = fix_guest_clock(sandbox.as_ref()).await {
-        warn!(run_id = %context.run_id, error = %e, "fix_guest_clock failed on reused sandbox");
-        unregister_proxy(config, context, source_ip).await;
-        return ExecuteOutcome {
-            exit_code: 1,
-            error: Some(e.to_string()),
-            sandbox: Some(sandbox),
-            source_ip: source_ip.to_string(),
-            guest_session_id: None,
-        };
-    }
-    if let Err(e) = reseed_guest_entropy(sandbox.as_ref()).await {
-        warn!(run_id = %context.run_id, error = %e, "reseed_guest_entropy failed on reused sandbox");
-        unregister_proxy(config, context, source_ip).await;
-        return ExecuteOutcome {
-            exit_code: 1,
-            error: Some(e.to_string()),
-            sandbox: Some(sandbox),
-            source_ip: source_ip.to_string(),
-            guest_session_id: None,
-        };
-    }
-
-    // Run job — clock/entropy already handled.
+    // Run job — clock/entropy fixed inside run_in_sandbox (always needed after idle).
     let result = run_in_sandbox(
         sandbox.as_ref(),
         context,
         config,
-        false, // clock/entropy already handled
+        true,
         Some(prev_storage),
         telemetry,
         cancel,
@@ -388,7 +363,7 @@ async fn run_in_sandbox(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     config: &ExecutorConfig,
-    use_snapshot: bool,
+    restore_guest_state: bool,
     prev_storage: Option<&crate::idle_pool::StorageFingerprints>,
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
@@ -399,8 +374,9 @@ async fn run_in_sandbox(
         context.run_id
     );
 
-    // 1. Fix guest clock after snapshot restore (must happen before HTTPS calls)
-    if use_snapshot {
+    // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
+    //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
+    if restore_guest_state {
         fix_guest_clock(sandbox).await?;
         reseed_guest_entropy(sandbox).await?;
     }


### PR DESCRIPTION
## Summary
- Move clock fix and entropy reseed for reused sandboxes into `run_in_sandbox` instead of duplicating the logic in `execute_reused_sandbox`
- Rename `use_snapshot` parameter to `restore_guest_state` — accurately describes its purpose: initialization needed after both snapshot restore (frozen clock) and idle reuse (drifted clock)
- Net result: -30 lines, +6 lines. Both `execute_new_sandbox` and `execute_reused_sandbox` now follow the same flow: `register_proxy → run_in_sandbox(restore_guest_state) → post_job_cleanup`

## Test plan
- [x] `cargo check -p runner` passes
- [x] All 614 runner tests pass, including `execute_job_reuse_clock_fix_failure_returns_sandbox` and `execute_job_reuse_reseed_failure_returns_sandbox`
- [x] Verified error behavior: clock fix failure on reuse path now goes through `post_job_cleanup` (same as new-sandbox path) — `copy_guest_logs` and `upload_network_logs` are no-ops when no job has run

🤖 Generated with [Claude Code](https://claude.com/claude-code)