### PR TITLE
feat(auth): remove agent-run:write capability from agent tokens

### DIFF
--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -112,7 +112,6 @@ program
     `
 Examples:
   Missing a token?       zero doctor missing-token <TOKEN_NAME>
-  Delegate to teammate?  zero run --help
   Send a Slack message?  zero slack message send --help
   Set up a schedule?     zero schedule setup --help
   Update yourself?       zero agent --help

--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -88,7 +88,7 @@ describe("POST /api/zero/runs", () => {
       expect(data.runId).toBeTruthy();
     });
 
-    it("should return 404 when sessionId does not match any session", async () => {
+    it("should return 403 when ZERO_TOKEN is used (agent-run:write excluded)", async () => {
       mockClerk({ userId: null });
       const token = await generateZeroToken(user.userId, "run-1", user.orgId);
 
@@ -106,9 +106,9 @@ describe("POST /api/zero/runs", () => {
         }),
       );
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(403);
       const data = await response.json();
-      expect(data.error.message).toBe("Session not found");
+      expect(data.error.message).toContain("agent-run:write");
     });
 
     it("should return 400 when neither agentId nor sessionId is provided", async () => {
@@ -140,7 +140,7 @@ describe("POST /api/zero/runs", () => {
       reloadEnv();
     });
 
-    it("should set triggerSource to 'agent' for ZERO_TOKEN callers", async () => {
+    it("should return 403 for ZERO_TOKEN callers (agent-run:write excluded)", async () => {
       mockClerk({ userId: null });
       const token = await generateZeroToken(user.userId, "run-1", user.orgId);
 
@@ -158,11 +158,9 @@ describe("POST /api/zero/runs", () => {
         }),
       );
 
-      expect(response.status).toBe(201);
+      expect(response.status).toBe(403);
       const data = await response.json();
-      const zeroRun = await findTestZeroRun(data.runId);
-      expect(zeroRun).toBeDefined();
-      expect(zeroRun!.triggerSource).toBe("agent");
+      expect(data.error.message).toContain("agent-run:write");
     });
 
     it("should set triggerSource to 'web' for Clerk JWT callers", async () => {
@@ -184,7 +182,7 @@ describe("POST /api/zero/runs", () => {
       expect(zeroRun!.triggerSource).toBe("web");
     });
 
-    it("should set triggerAgentId to parent compose ID for ZERO_TOKEN callers", async () => {
+    it("should return 403 for ZERO_TOKEN callers even with parent run context", async () => {
       // Create a parent agent compose and a run for it (simulates the parent agent)
       // Must happen before mockClerk({ userId: null }) since createTestCompose needs auth
       const parentCompose = await createTestCompose(uniqueId("parent-agent"));
@@ -217,11 +215,9 @@ describe("POST /api/zero/runs", () => {
         }),
       );
 
-      expect(response.status).toBe(201);
+      expect(response.status).toBe(403);
       const data = await response.json();
-      const zeroRun = await findTestZeroRun(data.runId);
-      expect(zeroRun).toBeDefined();
-      expect(zeroRun!.triggerAgentId).toBe(parentCompose.composeId);
+      expect(data.error.message).toContain("agent-run:write");
     });
 
     it("should leave triggerAgentId null for web callers", async () => {

--- a/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
@@ -367,11 +367,11 @@ describe("getAuthContext with zero token and acceptAnySandboxCapability", () => 
         "agent:read",
         "agent:write",
         "agent-run:read",
-        "agent-run:write",
         "schedule:read",
         "schedule:write",
         "slack:write",
       ]),
     );
+    expect(result?.capabilities).not.toContain("agent-run:write");
   });
 });

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -264,12 +264,12 @@ describe("sandbox-token", () => {
         "agent:read",
         "agent:write",
         "agent-run:read",
-        "agent-run:write",
         "schedule:read",
         "schedule:write",
         "slack:write",
         "connector:read",
       ]);
+      expect(auth?.capabilities).not.toContain("agent-run:write");
       expect(auth?.capabilities).not.toContain("computer-use:write");
       expect(auth?.capabilities).not.toContain("voice-chat:write");
     });
@@ -286,7 +286,6 @@ describe("sandbox-token", () => {
         "agent:read",
         "agent:write",
         "agent-run:read",
-        "agent-run:write",
         "schedule:read",
         "schedule:write",
         "slack:write",

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -27,6 +27,7 @@ const CONDITIONAL_CAPABILITIES: ReadonlyMap<ZeroCapability, FeatureSwitchKey> =
  */
 const AGENT_EXCLUDED_CAPABILITIES: ReadonlySet<ZeroCapability> = new Set([
   "schedule:delete",
+  "agent-run:write",
 ]);
 
 const log = logger("auth:sandbox");

--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -67,7 +67,6 @@ function buildAgentToolsPrompt(): string {
     "# Agent Tools",
     "You have access to the Zero CLI. Run commands with: `npx -p @vm0/cli zero <command>`",
     "- Discover available commands: `zero --help`.",
-    "- Delegate tasks to teammates: `zero run --help` and `zero agent list`.",
     "- Schedule recurring tasks: `zero schedule --help`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "- Slack messaging and file uploads: `zero slack --help`. Your replies are automatically sent to the originating thread — only use these commands for different channels/threads. Never use SLACK_TOKEN directly — it's a user OAuth token.",
     "- Diagnose missing tokens or expired connectors: `zero doctor missing-token --help`.",


### PR DESCRIPTION
## Summary

- Exclude `agent-run:write` from `AGENT_EXCLUDED_CAPABILITIES` in sandbox-token.ts to prevent agent-to-agent delegation
- Remove delegation instruction from agent system prompt (`agent-prompt.ts`)
- Remove delegation example from CLI global help text (`zero.ts`)
- Update tests to reflect the removed capability

## Motivation

Security hardening — prevent any agent from spawning unbounded runs on other agents. All legitimate agent triggering paths (schedules, Slack, Telegram, Email, Phone, Voice Chat) are server-side and bypass the capability check, so they are unaffected.

## What is NOT affected

- Server-side triggers (schedules, Slack, Telegram, Email, Phone, Voice Chat)
- Web UI and CLI users running agents (Clerk/PAT auth)
- All other agent capabilities
- Claude Code subagents (separate mechanism)
- The `zero run` CLI command itself (still works for PAT-authenticated CLI users)

## Test plan

- [x] `pnpm vitest run apps/web/src/lib/auth/__tests__/sandbox-token.test.ts` — 54/54 pass
- [x] `pnpm vitest run apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts` — 28/28 pass
- [x] `pnpm vitest run apps/cli/` — 1047/1047 pass
- [x] `pnpm turbo run lint` — 0 errors
- [x] `pnpm check-types` — pass
- [x] `pnpm knip` — no issues

Closes #9287

🤖 Generated with [Claude Code](https://claude.com/claude-code)