### PR TITLE
fix(ci): stop swallowing runner service stop errors

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -514,12 +514,13 @@ jobs:
 
           cleanup() {
             echo "--- Cleanup ---"
-            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force 2>/dev/null || true
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
           }
           trap cleanup EXIT
 
-          # Clean up any residual transient unit from a previous CI run
-          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force 2>/dev/null || true
+          # Clean up any residual transient unit from a previous CI run.
+          # stop() returns Ok when no service exists, so no need for || true.
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
 
           # Start transient runner service
           echo "--- Starting runner ---"
@@ -772,12 +773,13 @@ jobs:
 
           cleanup() {
             echo "--- Cleanup ---"
-            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force 2>/dev/null || true
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
           }
           trap cleanup EXIT
 
-          # Clean up any residual transient unit from a previous CI run
-          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force 2>/dev/null || true
+          # Clean up any residual transient unit from a previous CI run.
+          # stop() returns Ok when no service exists, so no need for || true.
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
 
           # Start transient runner service
           echo "--- Starting runner ---"
@@ -884,12 +886,13 @@ jobs:
 
           cleanup() {
             echo "--- Cleanup ---"
-            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force 2>/dev/null || true
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
           }
           trap cleanup EXIT
 
-          # Clean up any residual transient unit from a previous CI run
-          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force 2>/dev/null || true
+          # Clean up any residual transient unit from a previous CI run.
+          # stop() returns Ok when no service exists, so no need for || true.
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
 
           # Start transient runner service
           echo "--- Starting runner ---"
@@ -1196,12 +1199,13 @@ jobs:
 
           cleanup() {
             echo "--- Cleanup ---"
-            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force 2>/dev/null || true
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
           }
           trap cleanup EXIT
 
-          # Clean up any residual transient unit from a previous CI run
-          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force 2>/dev/null || true
+          # Clean up any residual transient unit from a previous CI run.
+          # stop() returns Ok when no service exists, so no need for || true.
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
 
           # Start transient runner service
           echo "--- Starting runner ---"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1637,9 +1637,9 @@ jobs:
               --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
             # Stop any existing service from a previous run (e.g., re-run after test failure).
-            # Ignore errors if not running.
+            # stop() returns Ok when no service exists, so no need for || true.
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "sudo ${BIN_DIR}/runner service stop --name ${RUNNER_NAME} --force" 2>/dev/null || true
+            ssh "$REMOTE" "sudo ${BIN_DIR}/runner service stop --name ${RUNNER_NAME} --force"
 
             # Start as systemd transient service
             # shellcheck disable=SC2029

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -73,9 +73,10 @@ cmd_deploy() {
   BINARY="$CRATES_DIR/target/$TARGET/release/runner"
   log "Binary: $BINARY ($(du -h "$BINARY" | cut -f1))"
 
-  # Stop old service before uploading (avoids "Text file busy")
+  # Stop old service before uploading (avoids "Text file busy").
+  # stop() returns Ok when no service exists, so no need for || true.
   log "Stopping old service..."
-  ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_NAME --force 2>/dev/null || true"
+  ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_NAME --force"
 
   # Upload
   log "Deploying to $SSH_USER@$HOST..."
@@ -159,7 +160,7 @@ cmd_exec() {
 cmd_remove() {
   log "Removing runner $RUNNER_NAME from $HOST..."
 
-  ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_NAME --force 2>/dev/null || true"
+  ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_NAME --force" || true
   ssh_cmd "sudo rm -rf $REMOTE_BIN_DIR $RUNNER_DIR"
 
   log "Done! Runner $RUNNER_NAME removed from $HOST"


### PR DESCRIPTION
## Summary

- Remove `2>/dev/null || true` from `runner service stop` calls that precede `service start` — stop failures must surface so start doesn't fail with a misleading "already running" error
- Remove `2>/dev/null` from cleanup/remove stop calls — keep `|| true` (needed in EXIT traps) but preserve diagnostic output
- Root cause of deploy-runner-start failure on dev-1 in [run #24386731227](https://github.com/vm0-ai/vm0/actions/runs/24386731227/job/71223093026)

## Context

`stop()` already returns `Ok` when no service exists (handles first-run gracefully), so `|| true` was never needed before `start`. Adding it masked real stop failures — when `systemctl stop` failed on dev-1, the error was silently swallowed, and `service start` then failed with "unit is already running".

## Test plan

- [ ] CI workflows pass — stop errors now surface instead of being hidden
- [ ] Re-run a PR with existing runner service to verify stop→start works
- [ ] First-run (no prior service) still works — `stop()` returns Ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)