### PR TITLE
fix(voice-chat): change default model back to gpt-realtime

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -220,7 +220,7 @@ const internalPrepStartTime$ = state<number | null>(null);
 const internalPrepElapsedMs$ = state(0);
 const internalReconnectAttempt$ = state(0);
 const internalInputMode$ = state<"hands-free" | "push-to-talk">("hands-free");
-const internalModel$ = state<RealtimeModel>("gpt-realtime-mini");
+const internalModel$ = state<RealtimeModel>("gpt-realtime");
 
 const internalParentSignal$ = state<AbortSignal | null>(null);
 const internalWakeLock$ = state<WakeLockSentinel | null>(null);
@@ -1413,7 +1413,7 @@ export const endVoiceChat$ = command(({ get, set }) => {
   set(internalPrepElapsedMs$, 0);
   set(internalReconnectAttempt$, 0);
   set(internalInputMode$, "hands-free");
-  set(internalModel$, "gpt-realtime-mini");
+  set(internalModel$, "gpt-realtime");
   set(internalParentSignal$, null);
   set(internalStatus$, "idle");
 });


### PR DESCRIPTION
## Summary
- Switch voice chat default model from `gpt-realtime-mini` back to `gpt-realtime`
- Updated both initial state and session reset to use `gpt-realtime`

## Test plan
- [ ] Open voice chat and verify the default selected model is GPT Realtime (not Mini)
- [ ] Start a voice session and confirm it connects with the correct model
- [ ] Reset a session and verify it defaults back to GPT Realtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)