### PR TITLE
perf(ci): use thin lto for runner binary in ci pipelines

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -327,7 +327,7 @@ jobs:
           GUEST_INIT_PATH="target/$TARGET_TRIPLE/release/guest-init" \
           GUEST_MOCK_CLAUDE_PATH="target/$TARGET_TRIPLE/release/guest-mock-claude" \
           GUEST_RESEED_PATH="target/$TARGET_TRIPLE/release/guest-reseed" \
-          cargo build --release --target "$TARGET_TRIPLE" -p runner
+          cargo build --profile ci --target "$TARGET_TRIPLE" -p runner
 
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
@@ -363,7 +363,7 @@ jobs:
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
           BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"
-          TARGET_DIR="crates/target/${TARGET_TRIPLE}/release"
+          TARGET_DIR="crates/target/${TARGET_TRIPLE}/ci"
 
           # Clean previous run artifacts and upload runner (guests are embedded)
           echo "=== Deploying runner to ${HOST}:${BIN_DIR} ==="

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1390,7 +1390,7 @@ jobs:
           GUEST_INIT_PATH="target/$TARGET_TRIPLE/release/guest-init" \
           GUEST_MOCK_CLAUDE_PATH="target/$TARGET_TRIPLE/release/guest-mock-claude" \
           GUEST_RESEED_PATH="target/$TARGET_TRIPLE/release/guest-reseed" \
-          cargo build --release --target "$TARGET_TRIPLE" -p runner
+          cargo build --profile ci --target "$TARGET_TRIPLE" -p runner
 
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
@@ -1488,7 +1488,7 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_USER_STORAGES_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
         run: |
-          TARGET_DIR="crates/target/${TARGET_TRIPLE}/release"
+          TARGET_DIR="crates/target/${TARGET_TRIPLE}/ci"
 
           deploy_to_host() {
             local HOST=$1

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -86,6 +86,12 @@ lto = true
 strip = true
 codegen-units = 1
 
+# Runner-only CI profile — not used for guests (image_hash depends on --release).
+[profile.ci]
+inherits = "release"
+lto = "thin"
+codegen-units = 4
+
 [workspace.lints.rust]
 warnings = "deny"
 


### PR DESCRIPTION
## Summary

- Add `[profile.ci]` (thin LTO, codegen-units=4) for faster runner compilation in CI
- Runner binary is not part of `image_hash` — only guest binaries are, so this doesn't affect R2 cache reuse
- Guest binaries remain on `--release` (full LTO, codegen-units=1) in all pipelines
- Production builds (release-please) remain on `--release` for runner too

Reverts the runner-specific compile slowdown from #9219 while preserving its image cache fix.

## Test plan

- [ ] CI pipelines (crates.yml, turbo.yml) build and deploy successfully with `--profile ci`
- [ ] `image_hash` unchanged — guest binaries still compiled with `--release`
- [ ] release-please pipeline unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)