### PR TITLE
fix(ci): replace httpbin.org with vm0.ai in runner benchmark

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -454,7 +454,7 @@ jobs:
           ssh "$REMOTE" "sudo ${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
             --profile vm0/default \
-            'curl -sf --max-time 10 https://httpbin.org/get'"
+            'curl -sf --max-time 10 https://www.vm0.ai'"
 
           echo "=== Running benchmark (browser automation) ==="
           # Retry once — snapshot restore can trigger transient Chromium


### PR DESCRIPTION
## Summary

- Replace `httpbin.org` with `www.vm0.ai` in runner benchmark curl target
- `httpbin.org` is unreliable and caused curl timeout (exit code 28) in [run #24388330329](https://github.com/vm0-ai/vm0/actions/runs/24388330329/job/71228464494)

## Test plan

- [ ] runner-benchmark CI job passes with new URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)