### PR TITLE
fix(runner): invalidate image cache and skip remote cache on deploy

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -53,11 +53,6 @@
       command: >
         {{ bin_dir }}/runner build
         --profile vm0/default
-      environment:
-        R2_ACCOUNT_ID: "{{ r2_account_id | default('') }}"
-        R2_ACCESS_KEY_ID: "{{ r2_access_key_id | default('') }}"
-        R2_SECRET_ACCESS_KEY: "{{ r2_secret_access_key | default('') }}"
-        R2_USER_STORAGES_BUCKET_NAME: "{{ r2_bucket | default('') }}"
       register: default_build_output
 
     - name: Parse default build hash

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -21,7 +21,7 @@ const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
 ///
 /// Bumping leaves the previous-hash R2 objects orphaned; they're swept by
 /// `runner gc` after the configured TTL (see `r2_cache::gc_older_than`).
-const IMAGE_CACHE_VERSION: u32 = 1;
+const IMAGE_CACHE_VERSION: u32 = 2;
 
 #[cfg(bundled_guests)]
 mod embedded {
@@ -537,7 +537,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            hash, "7f3e8b2be83ded0550351739cb12774c0147567eddba5db1e86b5ef3d13ac92a",
+            hash, "b56330c45192dadb0ce8cc46b0a437a04dee118ca3d29ef7ae32d164ab242871",
             "image hash changed — this invalidates ALL cached images on ALL hosts"
         );
     }


### PR DESCRIPTION
## Summary
- Bump `IMAGE_CACHE_VERSION` from 1 to 2 to invalidate all cached snapshots, forcing fresh builds
- Remove R2 environment variables from deploy build step so builds always run locally
- Fixes vCPU register restore failures (`Failed to set register 0x6030000000160003`) caused by stale cached snapshots with CPU incompatibilities on prod-3

## Test plan
- [x] `image_hash_is_stable` test updated with new expected hash
- [ ] Deploy to prod-3 and verify snapshot builds fresh and VM boots successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)