### PR TITLE
fix(ci): add ssh keepalive and qos settings for cloudflare tunnel stability

### DIFF
--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -69,6 +69,10 @@ runs:
           "  UserKnownHostsFile /dev/null" \
           "  ConnectTimeout 10" \
           "  ConnectionAttempts 3" \
+          "  ServerAliveInterval 15" \
+          "  ServerAliveCountMax 4" \
+          "  TCPKeepAlive yes" \
+          "  IPQoS throughput" \
           "  IdentityFile $HOME/.ssh/runner.pem" \
           "  ProxyCommand $HOME/.ssh/cf-proxy.sh %h")"
 


### PR DESCRIPTION
## Summary
- Add `ServerAliveInterval 15` and `ServerAliveCountMax 4` — SSH application-layer heartbeats every 15s, 60s timeout before disconnect
- Add `TCPKeepAlive yes` — OS-level TCP keepalive as defense in depth
- Add `IPQoS throughput` — avoids DSCP markings that some cloud network devices may deprioritize or drop

## Context
`runner-exec` CI job intermittently fails with `client_loop: send disconnect: Broken pipe` (exit code 255) even though all tests pass. Investigation confirmed:
- sshd on the metal host shows all sessions closed normally (`disconnected by user`)
- No cloudflared errors logged server-side
- The SSH connection breaks at the Cloudflare Tunnel layer, likely due to idle connection timeout by intermediate network devices

## Test plan
- [x] Verified SSH connection to dev-2.aws.vm3.ai works with these settings
- [ ] Monitor runner-exec CI job for recurrence of broken pipe failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)