### PR TITLE
fix(platform): reset tts playback state on signal abort

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
+++ b/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { http, HttpResponse } from "msw";
+import { http, HttpResponse, delay } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import { playTts$, ttsPlayingMessageId$ } from "../voice-io-tts.ts";
+import { playTts$, stopTts$, ttsPlayingMessageId$ } from "../voice-io-tts.ts";
 
 function mockWebAudio() {
   const sources: {
@@ -128,5 +128,104 @@ describe("playTts$", () => {
 
     const playingId = context.store.get(ttsPlayingMessageId$);
     expect(playingId).toBeNull();
+  });
+
+  it("should reset playingMessageId after pre-aborted signal", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+    mockWebAudio();
+    mockTtsEndpoint();
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      context.store.set(playTts$, "msg-1", "Hello world", controller.signal),
+    ).rejects.toThrow();
+
+    expect(context.store.get(ttsPlayingMessageId$)).toBeNull();
+  });
+
+  it("should reset playingMessageId after signal abort during fetch", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+    mockWebAudio();
+
+    server.use(
+      http.post("http://localhost:3000/api/zero/voice-io/tts", async () => {
+        await delay(100);
+        const body = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array([0x00, 0x01, 0x00, 0x02]));
+            controller.close();
+          },
+        });
+        return new HttpResponse(body, {
+          headers: { "Content-Type": "application/octet-stream" },
+        });
+      }),
+    );
+
+    const playPromise = context.store.set(
+      playTts$,
+      "msg-2",
+      "Hello world",
+      AbortSignal.timeout(20),
+    );
+
+    await expect(playPromise).rejects.toThrow();
+    expect(context.store.get(ttsPlayingMessageId$)).toBeNull();
+  });
+
+  it("should allow replaying the same message after a previous abort", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+    mockWebAudio();
+
+    server.use(
+      http.post("http://localhost:3000/api/zero/voice-io/tts", async () => {
+        await delay(50);
+        const body = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array([0x00, 0x01, 0x00, 0x02]));
+            controller.close();
+          },
+        });
+        return new HttpResponse(body, {
+          headers: { "Content-Type": "application/octet-stream" },
+        });
+      }),
+    );
+
+    // First attempt — abort mid-flight
+    const p1 = context.store.set(
+      playTts$,
+      "msg-3",
+      "Hello",
+      AbortSignal.timeout(10),
+    );
+    try {
+      await p1;
+    } catch {
+      // expected abort
+    }
+
+    expect(context.store.get(ttsPlayingMessageId$)).toBeNull();
+
+    // Second attempt with fresh signal — must succeed
+    const { getFetchCount } = mockTtsEndpoint();
+    await context.store.set(playTts$, "msg-3", "Hello", context.signal);
+    expect(getFetchCount()).toBe(1);
+  });
+
+  it("should allow replaying after stopTts$", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+    mockWebAudio();
+    mockTtsEndpoint();
+
+    await context.store.set(playTts$, "msg-4", "Hello world", context.signal);
+    context.store.set(stopTts$);
+    expect(context.store.get(ttsPlayingMessageId$)).toBeNull();
+
+    const { getFetchCount } = mockTtsEndpoint();
+    await context.store.set(playTts$, "msg-4", "Hello again", context.signal);
+    expect(getFetchCount()).toBe(1);
   });
 });

--- a/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
+++ b/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import { http, HttpResponse, delay } from "msw";
+import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { playTts$, stopTts$, ttsPlayingMessageId$ } from "../voice-io-tts.ts";
+import { createDeferredPromise, resetSignal } from "../../utils.ts";
 
 function mockWebAudio() {
   const sources: {
@@ -135,11 +136,8 @@ describe("playTts$", () => {
     mockWebAudio();
     mockTtsEndpoint();
 
-    const controller = new AbortController();
-    controller.abort();
-
     await expect(
-      context.store.set(playTts$, "msg-1", "Hello world", controller.signal),
+      context.store.set(playTts$, "msg-1", "Hello world", AbortSignal.abort()),
     ).rejects.toThrow();
 
     expect(context.store.get(ttsPlayingMessageId$)).toBeNull();
@@ -149,27 +147,24 @@ describe("playTts$", () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
     mockWebAudio();
 
+    const fetchGate = createDeferredPromise<void>(context.signal);
     server.use(
       http.post("http://localhost:3000/api/zero/voice-io/tts", async () => {
-        await delay(100);
-        const body = new ReadableStream({
-          start(controller) {
-            controller.enqueue(new Uint8Array([0x00, 0x01, 0x00, 0x02]));
-            controller.close();
-          },
-        });
-        return new HttpResponse(body, {
-          headers: { "Content-Type": "application/octet-stream" },
-        });
+        await fetchGate.promise;
+        return HttpResponse.json({});
       }),
     );
 
+    const pageReset$ = resetSignal();
+    const pageSignal = context.store.set(pageReset$, context.signal);
     const playPromise = context.store.set(
       playTts$,
       "msg-2",
       "Hello world",
-      AbortSignal.timeout(20),
+      pageSignal,
     );
+    // Abort the signal by resetting — simulates page navigation
+    context.store.set(pageReset$, context.signal);
 
     await expect(playPromise).rejects.toThrow();
     expect(context.store.get(ttsPlayingMessageId$)).toBeNull();
@@ -179,28 +174,20 @@ describe("playTts$", () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
     mockWebAudio();
 
+    const fetchGate = createDeferredPromise<void>(context.signal);
     server.use(
       http.post("http://localhost:3000/api/zero/voice-io/tts", async () => {
-        await delay(50);
-        const body = new ReadableStream({
-          start(controller) {
-            controller.enqueue(new Uint8Array([0x00, 0x01, 0x00, 0x02]));
-            controller.close();
-          },
-        });
-        return new HttpResponse(body, {
-          headers: { "Content-Type": "application/octet-stream" },
-        });
+        await fetchGate.promise;
+        return HttpResponse.json({});
       }),
     );
 
     // First attempt — abort mid-flight
-    const p1 = context.store.set(
-      playTts$,
-      "msg-3",
-      "Hello",
-      AbortSignal.timeout(10),
-    );
+    const pageReset$ = resetSignal();
+    const pageSignal = context.store.set(pageReset$, context.signal);
+    const p1 = context.store.set(playTts$, "msg-3", "Hello", pageSignal);
+    // Abort the signal by resetting — simulates page navigation
+    context.store.set(pageReset$, context.signal);
     try {
       await p1;
     } catch {

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
@@ -107,6 +107,7 @@ const fetchAndPlay$ = command(
       if (!response) {
         L.error("TTS API returned error");
         await audioCtx.close();
+        signal.throwIfAborted();
         set(internalPlayingMessageId$, null);
         return;
       }
@@ -114,6 +115,7 @@ const fetchAndPlay$ = command(
       const body = response.body;
       if (!body) {
         await audioCtx.close();
+        signal.throwIfAborted();
         set(internalPlayingMessageId$, null);
         return;
       }

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
@@ -90,114 +90,121 @@ const fetchAndPlay$ = command(
     // grants autoplay permission (transient activation window is ~5 s).
     const audioCtx = new AudioContext({ sampleRate: 24_000 });
 
-    let response: Response | null;
-    // eslint-disable-next-line no-restricted-syntax -- raw fetch for binary audio (not a ts-rest contract)
+    // eslint-disable-next-line no-restricted-syntax -- catch-all to guarantee state cleanup on abort
     try {
-      response = await fetchTtsAudio(fetchFn, plainText, signal);
-    } catch (error) {
-      L.error("TTS fetch failed", error);
-      await audioCtx.close();
+      let response: Response | null;
+      // eslint-disable-next-line no-restricted-syntax -- raw fetch for binary audio (not a ts-rest contract)
+      try {
+        response = await fetchTtsAudio(fetchFn, plainText, signal);
+      } catch (error) {
+        L.error("TTS fetch failed", error);
+        await audioCtx.close();
+        signal.throwIfAborted();
+        set(internalPlayingMessageId$, null);
+        return;
+      }
+
+      if (!response) {
+        L.error("TTS API returned error");
+        await audioCtx.close();
+        set(internalPlayingMessageId$, null);
+        return;
+      }
+
+      const body = response.body;
+      if (!body) {
+        await audioCtx.close();
+        set(internalPlayingMessageId$, null);
+        return;
+      }
+
+      // Safety fallback: resume if the context did not auto-start (e.g. auto-read path).
+      await audioCtx.resume();
       signal.throwIfAborted();
-      set(internalPlayingMessageId$, null);
-      return;
-    }
+      const reader = body.getReader();
+      let nextStartTime = audioCtx.currentTime;
+      let lastSource: AudioBufferSourceNode | null = null;
+      let carry: Uint8Array | null = null;
 
-    if (!response) {
-      L.error("TTS API returned error");
-      await audioCtx.close();
-      signal.throwIfAborted();
-      set(internalPlayingMessageId$, null);
-      return;
-    }
-
-    const body = response.body;
-    if (!body) {
-      await audioCtx.close();
-      signal.throwIfAborted();
-      set(internalPlayingMessageId$, null);
-      return;
-    }
-
-    // Safety fallback: resume if the context did not auto-start (e.g. auto-read path).
-    await audioCtx.resume();
-    signal.throwIfAborted();
-    const reader = body.getReader();
-    let nextStartTime = audioCtx.currentTime;
-    let lastSource: AudioBufferSourceNode | null = null;
-    let carry: Uint8Array | null = null;
-
-    set(internalCleanupFn$, () => {
-      reader.cancel().catch((error: unknown) => {
-        L.debug("reader cancel error", error);
+      set(internalCleanupFn$, () => {
+        reader.cancel().catch((error: unknown) => {
+          L.debug("reader cancel error", error);
+        });
+        audioCtx.close().catch((error: unknown) => {
+          L.debug("audioCtx close error", error);
+        });
       });
-      audioCtx.close().catch((error: unknown) => {
-        L.debug("audioCtx close error", error);
-      });
-    });
 
-    for (;;) {
-      if (signal.aborted) {
-        break;
-      }
-      const { done, value } = await reader.read();
-      signal.throwIfAborted();
-      if (done) {
-        break;
+      for (;;) {
+        if (signal.aborted) {
+          break;
+        }
+        const { done, value } = await reader.read();
+        signal.throwIfAborted();
+        if (done) {
+          break;
+        }
+
+        // Handle byte alignment (PCM = 2 bytes per sample)
+        let chunk = value;
+        if (carry) {
+          const merged = new Uint8Array(carry.length + chunk.length);
+          merged.set(carry);
+          merged.set(chunk, carry.length);
+          chunk = merged;
+          carry = null;
+        }
+        if (chunk.length % 2 !== 0) {
+          carry = chunk.slice(-1);
+          chunk = chunk.slice(0, -1);
+        }
+        if (chunk.length === 0) {
+          continue;
+        }
+
+        // Convert Int16LE PCM to Float32 (use aligned buffer to avoid RangeError)
+        const aligned =
+          chunk.buffer.byteLength === chunk.length && chunk.byteOffset === 0
+            ? chunk.buffer
+            : chunk.buffer.slice(
+                chunk.byteOffset,
+                chunk.byteOffset + chunk.length,
+              );
+        const int16 = new Int16Array(aligned);
+        const float32 = new Float32Array(int16.length);
+        for (let i = 0; i < int16.length; i++) {
+          float32[i] = int16[i] / 32_768;
+        }
+
+        const audioBuffer = audioCtx.createBuffer(1, float32.length, 24_000);
+        audioBuffer.getChannelData(0).set(float32);
+
+        const source = audioCtx.createBufferSource();
+        source.buffer = audioBuffer;
+        source.connect(audioCtx.destination);
+
+        if (nextStartTime < audioCtx.currentTime) {
+          nextStartTime = audioCtx.currentTime;
+        }
+        source.start(nextStartTime);
+        nextStartTime += audioBuffer.duration;
+        lastSource = source;
       }
 
-      // Handle byte alignment (PCM = 2 bytes per sample)
-      let chunk = value;
-      if (carry) {
-        const merged = new Uint8Array(carry.length + chunk.length);
-        merged.set(carry);
-        merged.set(chunk, carry.length);
-        chunk = merged;
-        carry = null;
-      }
-      if (chunk.length % 2 !== 0) {
-        carry = chunk.slice(-1);
-        chunk = chunk.slice(0, -1);
-      }
-      if (chunk.length === 0) {
-        continue;
-      }
-
-      // Convert Int16LE PCM to Float32 (use aligned buffer to avoid RangeError)
-      const aligned =
-        chunk.buffer.byteLength === chunk.length && chunk.byteOffset === 0
-          ? chunk.buffer
-          : chunk.buffer.slice(
-              chunk.byteOffset,
-              chunk.byteOffset + chunk.length,
-            );
-      const int16 = new Int16Array(aligned);
-      const float32 = new Float32Array(int16.length);
-      for (let i = 0; i < int16.length; i++) {
-        float32[i] = int16[i] / 32_768;
-      }
-
-      const audioBuffer = audioCtx.createBuffer(1, float32.length, 24_000);
-      audioBuffer.getChannelData(0).set(float32);
-
-      const source = audioCtx.createBufferSource();
-      source.buffer = audioBuffer;
-      source.connect(audioCtx.destination);
-
-      if (nextStartTime < audioCtx.currentTime) {
-        nextStartTime = audioCtx.currentTime;
-      }
-      source.start(nextStartTime);
-      nextStartTime += audioBuffer.duration;
-      lastSource = source;
-    }
-
-    // Detect end of playback
-    if (lastSource) {
-      lastSource.addEventListener("ended", () => {
+      // Detect end of playback
+      if (lastSource) {
+        lastSource.addEventListener("ended", () => {
+          set(resetPlaybackState$);
+        });
+      } else {
         set(resetPlaybackState$);
-      });
-    } else {
-      set(resetPlaybackState$);
+      }
+    } catch (error) {
+      // Always reset playback state on any error (including AbortError)
+      // to prevent the message ID from getting stuck, which would block
+      // future playback of the same message.
+      set(cleanupAudio$);
+      throw error;
     }
   },
 );


### PR DESCRIPTION
## Summary

- Fix TTS "Read Aloud" button becoming permanently broken after a signal abort
- When `pageSignal` was aborted during fetch or PCM streaming, `fetchAndPlay$` threw `AbortError` without resetting `internalPlayingMessageId$` — the state got stuck, and `playTts$` would silently return early on future clicks of the same message
- Wrap `fetchAndPlay$` body in try/catch that calls `cleanupAudio$` on any error, ensuring the playing message ID is always reset

## Root cause

`fetchAndPlay$` sets `internalPlayingMessageId$` early (line 79), then has multiple `signal.throwIfAborted()` calls that throw `AbortError` without cleaning up. The error propagates through `playTts$` → `detach()`, which silently suppresses `AbortError`. On the next click of the same message, `playTts$` sees the stale ID match and returns immediately — no fetch, no sound, no console output.

## Test plan

- [x] New test: reset playingMessageId after pre-aborted signal
- [x] New test: reset playingMessageId after signal abort during fetch
- [x] New test: allow replaying the same message after a previous abort
- [x] New test: allow replaying after stopTts$
- [x] All 7 TTS tests pass
- [x] Type check, lint, format, knip all pass
- [ ] Manual test: click Read Aloud on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)