### PR TITLE
fix(runner): include host kernel version in image hash

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1566,7 +1566,7 @@ jobs:
               rm -rf "$LOG_DIR"
               exit 1
             fi
-            HASH_MAP=$(echo "$HASH_MAP" | jq --arg h "$HOST" --arg v "$HASH" '. + {($h): $v}')
+            HASH_MAP=$(echo "$HASH_MAP" | jq -c --arg h "$HOST" --arg v "$HASH" '. + {($h): $v}')
           done
           rm -rf "$LOG_DIR"
           echo "image-hash-map=${HASH_MAP}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1363,7 +1363,7 @@ jobs:
       runner-dir: ${{ steps.host.outputs.runner-dir }}
       runner-matrix: ${{ steps.runner-matrix.outputs.matrix }}
       chunk-count: ${{ steps.runner-matrix.outputs.chunk-count }}
-      default-image-hash: ${{ steps.deploy.outputs.default-image-hash }}
+      image-hash-map: ${{ steps.deploy.outputs.image-hash-map }}
     steps:
       - uses: actions/checkout@v6
 
@@ -1556,15 +1556,27 @@ jobs:
             exit 1
           fi
 
-          # Extract build hashes from any host's log (all hosts produce identical hashes).
-          FIRST_LOG=$(find "$LOG_DIR" -name '*.log' | head -1)
-          DEFAULT_IMAGE_HASH=$(grep '^image_hash=' "$FIRST_LOG" | cut -d= -f2)
+          # Extract per-host build hashes — they may differ across hosts
+          # because the image hash includes the host kernel version and CPU model.
+          HASH_MAP="{"
+          FIRST=true
+          for HOST in "${HOSTS[@]}"; do
+            HASH=$(grep '^image_hash=' "${LOG_DIR}/${HOST}.log" | cut -d= -f2)
+            if [ -z "$HASH" ]; then
+              echo "::error::Failed to extract image hash from ${HOST} log"
+              rm -rf "$LOG_DIR"
+              exit 1
+            fi
+            if [ "$FIRST" = true ]; then
+              FIRST=false
+            else
+              HASH_MAP+=","
+            fi
+            HASH_MAP+="\"${HOST}\":\"${HASH}\""
+          done
+          HASH_MAP+="}"
           rm -rf "$LOG_DIR"
-          if [ -z "$DEFAULT_IMAGE_HASH" ]; then
-            echo "::error::Failed to extract default image hash from log"
-            exit 1
-          fi
-          echo "default-image-hash=${DEFAULT_IMAGE_HASH}" >> "$GITHUB_OUTPUT"
+          echo "image-hash-map=${HASH_MAP}" >> "$GITHUB_OUTPUT"
 
   # Deploy runner start: generate config with real preview URL and start service
   # Waits for both deploy-runner-prepare (binaries + image) and deploy-web (preview URL)
@@ -1606,7 +1618,7 @@ jobs:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
-          DEFAULT_IMAGE_HASH: ${{ needs.deploy-runner-prepare.outputs.default-image-hash }}
+          IMAGE_HASH_MAP: ${{ needs.deploy-runner-prepare.outputs.image-hash-map }}
           PREVIEW_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
@@ -1616,6 +1628,14 @@ jobs:
             local RUNNER_NAME="${JOB_REF}-${HOST_INDEX}"
             local REMOTE="${METAL_USER}@${HOST}"
             echo "=== Starting runner ${RUNNER_NAME} on ${HOST} ==="
+
+            # Look up per-host image hash (differs across kernel versions)
+            local IMAGE_HASH
+            IMAGE_HASH=$(echo "$IMAGE_HASH_MAP" | jq -r --arg h "$HOST" '.[$h]')
+            if [ -z "$IMAGE_HASH" ] || [ "$IMAGE_HASH" = "null" ]; then
+              echo "::error::No image hash found for ${HOST} in hash map"
+              return 1
+            fi
 
             # Guard: ensure binary exists (fails fast on "Re-run failed jobs" without prepare)
             # shellcheck disable=SC2029
@@ -1628,7 +1648,7 @@ jobs:
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
               --profile vm0/default \
-              --image-hash ${DEFAULT_IMAGE_HASH} \
+              --image-hash ${IMAGE_HASH} \
               --name ${RUNNER_NAME} \
               --group vm0/development-${JOB_REF} \
               --runner-dirname ${JOB_REF} \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1558,8 +1558,7 @@ jobs:
 
           # Extract per-host build hashes — they may differ across hosts
           # because the image hash includes the host kernel version and CPU model.
-          HASH_MAP="{"
-          FIRST=true
+          HASH_MAP=$(jq -n '{}')
           for HOST in "${HOSTS[@]}"; do
             HASH=$(grep '^image_hash=' "${LOG_DIR}/${HOST}.log" | cut -d= -f2)
             if [ -z "$HASH" ]; then
@@ -1567,14 +1566,8 @@ jobs:
               rm -rf "$LOG_DIR"
               exit 1
             fi
-            if [ "$FIRST" = true ]; then
-              FIRST=false
-            else
-              HASH_MAP+=","
-            fi
-            HASH_MAP+="\"${HOST}\":\"${HASH}\""
+            HASH_MAP=$(echo "$HASH_MAP" | jq --arg h "$HOST" --arg v "$HASH" '. + {($h): $v}')
           done
-          HASH_MAP+="}"
           rm -rf "$LOG_DIR"
           echo "image-hash-map=${HASH_MAP}" >> "$GITHUB_OUTPUT"
 

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -541,10 +541,13 @@ async fn compute_image_hash(
     hasher.update(b"cpu_microcode:");
     hasher.update(read_cpu_microcode().unwrap_or_default().as_bytes());
 
-    // BIOS/firmware version — firmware updates can change ACPI tables, CPU feature
-    // advertisement, and memory map, affecting KVM register state in snapshots.
+    // BIOS/firmware version and revision — firmware updates can change ACPI tables,
+    // CPU feature advertisement, and memory map, affecting KVM register state in
+    // snapshots. Both fields can change independently.
     hasher.update(b"bios_version:");
     hasher.update(read_sysfs_trimmed("/sys/devices/virtual/dmi/id/bios_version").as_bytes());
+    hasher.update(b"bios_release:");
+    hasher.update(read_sysfs_trimmed("/sys/devices/virtual/dmi/id/bios_release").as_bytes());
 
     Ok(hex::encode(hasher.finalize()))
 }

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -463,6 +463,13 @@ async fn compute_image_hash(
     hasher.update(b"memory_mb:");
     hasher.update(memory_mb.to_le_bytes());
 
+    // Host kernel version — snapshots are not portable across kernel versions
+    // because KVM exposes different registers (e.g. ARM64 firmware pseudo-regs).
+    let uname =
+        nix::sys::utsname::uname().map_err(|e| RunnerError::Internal(format!("uname: {e}")))?;
+    hasher.update(b"host_kernel:");
+    hasher.update(uname.release().as_encoded_bytes());
+
     Ok(hex::encode(hasher.finalize()))
 }
 
@@ -519,27 +526,6 @@ mod tests {
         for &(input, expected) in cases {
             assert_eq!(human_bytes(input), expected, "human_bytes({input})");
         }
-    }
-
-    /// Guard against accidental changes to the hash function.
-    /// If this test fails, ALL cached images on ALL hosts are invalidated.
-    /// Only update the expected hash deliberately.
-    #[tokio::test]
-    async fn image_hash_is_stable() {
-        let dir = tempfile::tempdir().unwrap();
-        let bin = dir.path().join("agent");
-        tokio::fs::write(&bin, b"test-binary").await.unwrap();
-        let bins: &[(&Path, &str)] = &[(&bin, "/usr/local/bin/guest-agent")];
-        let provider = sandbox_mock::MockSnapshotProvider;
-
-        let hash = compute_image_hash(bins, 16384, &provider, 2, 2048)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            hash, "b56330c45192dadb0ce8cc46b0a437a04dee118ca3d29ef7ae32d164ab242871",
-            "image hash changed — this invalidates ALL cached images on ALL hosts"
-        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -153,8 +153,7 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         resolve_guest(args.guest_mock_claude, "guest-mock-claude", tmp_dir.path()).await?;
     let guest_reseed = resolve_guest(args.guest_reseed, "guest-reseed", tmp_dir.path()).await?;
 
-    // Fixed order for deterministic hashing — do NOT reorder without
-    // updating the expected value in `image_hash_is_stable`.
+    // Fixed order for deterministic hashing — do NOT reorder.
     let bins: [(&Path, &str); 5] = [
         (guest_agent.as_path(), "/usr/local/bin/guest-agent"),
         (guest_download.as_path(), "/usr/local/bin/guest-download"),
@@ -413,9 +412,14 @@ async fn is_image_complete(image: &ImagePaths) -> RunnerResult<bool> {
 
 /// Read a sysfs file, trimming whitespace. Returns empty string on failure.
 fn read_sysfs_trimmed(path: &str) -> String {
-    std::fs::read_to_string(path)
-        .map(|s| s.trim().to_owned())
-        .unwrap_or_default()
+    match std::fs::read_to_string(path) {
+        Ok(s) => s.trim().to_owned(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            tracing::warn!("failed to read {path}: {e}");
+            String::new()
+        }
+    }
 }
 
 /// Read CPU microcode/revision version.
@@ -423,22 +427,23 @@ fn read_sysfs_trimmed(path: &str) -> String {
 /// On x86_64: `/sys/devices/system/cpu/cpu0/microcode/version`
 /// On ARM64: `/sys/devices/system/cpu/cpu0/regs/identification/revidr_el1`
 fn read_cpu_microcode() -> Option<String> {
-    // x86_64
-    let x86_path = "/sys/devices/system/cpu/cpu0/microcode/version";
-    if let Ok(v) = std::fs::read_to_string(x86_path) {
-        let v = v.trim();
-        if !v.is_empty() {
-            return Some(v.to_owned());
+    let paths = [
+        "/sys/devices/system/cpu/cpu0/microcode/version",
+        "/sys/devices/system/cpu/cpu0/regs/identification/revidr_el1",
+    ];
+    for path in paths {
+        match std::fs::read_to_string(path) {
+            Ok(v) => {
+                let v = v.trim();
+                if !v.is_empty() {
+                    return Some(v.to_owned());
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => tracing::warn!("failed to read {path}: {e}"),
         }
     }
-    // ARM64
-    let arm_path = "/sys/devices/system/cpu/cpu0/regs/identification/revidr_el1";
-    if let Ok(v) = std::fs::read_to_string(arm_path) {
-        let v = v.trim();
-        if !v.is_empty() {
-            return Some(v.to_owned());
-        }
-    }
+    tracing::warn!("could not determine CPU microcode/revision version");
     None
 }
 
@@ -448,7 +453,13 @@ fn read_cpu_microcode() -> Option<String> {
 /// (e.g. "0x41:0xd40:0x1" for Neoverse V1 / Graviton 3).
 /// On x86_64 this extracts the `model name` line.
 fn read_cpu_model() -> Option<String> {
-    let cpuinfo = std::fs::read_to_string("/proc/cpuinfo").ok()?;
+    let cpuinfo = match std::fs::read_to_string("/proc/cpuinfo") {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("failed to read /proc/cpuinfo: {e}");
+            return None;
+        }
+    };
 
     // ARM64: combine implementer + part + variant
     let get = |key: &str| -> Option<&str> {
@@ -468,7 +479,12 @@ fn read_cpu_model() -> Option<String> {
     }
 
     // x86_64: use model name
-    get("model name").map(String::from)
+    if let Some(model) = get("model name") {
+        return Some(model.to_owned());
+    }
+
+    tracing::warn!("could not determine CPU model from /proc/cpuinfo");
+    None
 }
 
 /// Compute a unified hash from all rootfs + snapshot inputs.

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -411,6 +411,37 @@ async fn is_image_complete(image: &ImagePaths) -> RunnerResult<bool> {
     Ok(true)
 }
 
+/// Read a sysfs file, trimming whitespace. Returns empty string on failure.
+fn read_sysfs_trimmed(path: &str) -> String {
+    std::fs::read_to_string(path)
+        .map(|s| s.trim().to_owned())
+        .unwrap_or_default()
+}
+
+/// Read CPU microcode/revision version.
+///
+/// On x86_64: `/sys/devices/system/cpu/cpu0/microcode/version`
+/// On ARM64: `/sys/devices/system/cpu/cpu0/regs/identification/revidr_el1`
+fn read_cpu_microcode() -> Option<String> {
+    // x86_64
+    let x86_path = "/sys/devices/system/cpu/cpu0/microcode/version";
+    if let Ok(v) = std::fs::read_to_string(x86_path) {
+        let v = v.trim();
+        if !v.is_empty() {
+            return Some(v.to_owned());
+        }
+    }
+    // ARM64
+    let arm_path = "/sys/devices/system/cpu/cpu0/regs/identification/revidr_el1";
+    if let Ok(v) = std::fs::read_to_string(arm_path) {
+        let v = v.trim();
+        if !v.is_empty() {
+            return Some(v.to_owned());
+        }
+    }
+    None
+}
+
 /// Read a stable CPU model identifier from `/proc/cpuinfo`.
 ///
 /// On ARM64 this extracts `CPU implementer`, `CPU part`, and `CPU variant`
@@ -504,6 +535,16 @@ async fn compute_image_hash(
     hasher.update(b"cpu_model:");
     let cpu_id = read_cpu_model().unwrap_or_default();
     hasher.update(cpu_id.as_bytes());
+
+    // CPU microcode/revision — microcode updates can change available MSRs (x86)
+    // or CPU behavior (ARM). Gracefully defaults to empty if not available.
+    hasher.update(b"cpu_microcode:");
+    hasher.update(read_cpu_microcode().unwrap_or_default().as_bytes());
+
+    // BIOS/firmware version — firmware updates can change ACPI tables, CPU feature
+    // advertisement, and memory map, affecting KVM register state in snapshots.
+    hasher.update(b"bios_version:");
+    hasher.update(read_sysfs_trimmed("/sys/devices/virtual/dmi/id/bios_version").as_bytes());
 
     Ok(hex::encode(hasher.finalize()))
 }

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -497,6 +497,10 @@ fn read_cpu_model() -> Option<String> {
 ///   - `provider.config_hash()` — boot args, guest network config
 ///   - `FIRECRACKER_VERSION` / `KERNEL_VERSION` — binary versions
 ///   - `vcpu` / `memory_mb` — VM resource settings
+///   - host kernel version (`uname -r`)
+///   - CPU model (implementer:part:variant on ARM, model name on x86)
+///   - CPU microcode/revision version
+///   - BIOS version and release
 ///
 /// **Changing this function invalidates all cached images.**
 async fn compute_image_hash(

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -411,6 +411,35 @@ async fn is_image_complete(image: &ImagePaths) -> RunnerResult<bool> {
     Ok(true)
 }
 
+/// Read a stable CPU model identifier from `/proc/cpuinfo`.
+///
+/// On ARM64 this extracts `CPU implementer`, `CPU part`, and `CPU variant`
+/// (e.g. "0x41:0xd40:0x1" for Neoverse V1 / Graviton 3).
+/// On x86_64 this extracts the `model name` line.
+fn read_cpu_model() -> Option<String> {
+    let cpuinfo = std::fs::read_to_string("/proc/cpuinfo").ok()?;
+
+    // ARM64: combine implementer + part + variant
+    let get = |key: &str| -> Option<&str> {
+        cpuinfo.lines().find_map(|line| {
+            let (k, v) = line.split_once(':')?;
+            if k.trim() == key {
+                Some(v.trim())
+            } else {
+                None
+            }
+        })
+    };
+
+    if let (Some(implementer), Some(part)) = (get("CPU implementer"), get("CPU part")) {
+        let variant = get("CPU variant").unwrap_or("0x0");
+        return Some(format!("{implementer}:{part}:{variant}"));
+    }
+
+    // x86_64: use model name
+    get("model name").map(String::from)
+}
+
 /// Compute a unified hash from all rootfs + snapshot inputs.
 ///
 /// Inputs:
@@ -469,6 +498,12 @@ async fn compute_image_hash(
         nix::sys::utsname::uname().map_err(|e| RunnerError::Internal(format!("uname: {e}")))?;
     hasher.update(b"host_kernel:");
     hasher.update(uname.release().as_encoded_bytes());
+
+    // CPU model — different CPU models expose different registers and features,
+    // making snapshots non-portable (e.g. Graviton 2 vs 3).
+    hasher.update(b"cpu_model:");
+    let cpu_id = read_cpu_model().unwrap_or_default();
+    hasher.update(cpu_id.as_bytes());
 
     Ok(hex::encode(hasher.finalize()))
 }

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -443,7 +443,6 @@ fn read_cpu_microcode() -> Option<String> {
             Err(e) => tracing::warn!("failed to read {path}: {e}"),
         }
     }
-    tracing::warn!("could not determine CPU microcode/revision version");
     None
 }
 
@@ -645,6 +644,11 @@ mod tests {
         assert_eq!(h1.len(), 64); // SHA-256 hex
     }
 
+    /// Verify that each parameterized input changes the hash.
+    ///
+    /// Note: host-specific inputs (kernel version, CPU model, microcode, BIOS)
+    /// are read from the runtime environment and cannot be varied in tests.
+    /// Their inclusion is validated by `compute_image_hash_deterministic`.
     #[tokio::test]
     async fn compute_image_hash_sensitive_to_all_inputs() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary
- Include host kernel version (`uname -r`) in `compute_image_hash` so hosts with different kernels build and cache snapshots independently
- Fixes vCPU register restore failures when R2-cached snapshots built on kernel 6.17 are restored on kernel 6.14 (missing `KVM_REG_ARM_VENDOR_HYP_BMAP_2`)
- Remove `image_hash_is_stable` test since the hash now varies by host kernel

## Context
Firecracker snapshots capture the full KVM register state. Newer kernels expose additional registers (e.g. ARM64 firmware pseudo-regs added in 6.15+). Restoring a snapshot from a newer kernel on an older kernel fails with `ENOENT` because the register doesn't exist.

## Test plan
- [x] `compute_image_hash_deterministic` passes
- [x] `compute_image_hash_sensitive_to_all_inputs` passes
- [ ] Deploy to prod-3 (kernel 6.14) and verify fresh snapshot build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)