### PR TITLE
fix: use db interval instead of stale callback payload value

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
@@ -20,11 +20,6 @@ import {
 
 const context = testContext();
 
-interface LoopCallbackPayload {
-  scheduleId: string;
-  intervalSeconds: number;
-}
-
 describe("POST /api/internal/callbacks/schedule/loop", () => {
   let composeId: string;
   let userId: string;
@@ -51,7 +46,6 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
       url: "http://localhost/api/internal/callbacks/schedule/loop",
       payload: {
         scheduleId: schedule.id,
-        intervalSeconds: 300,
       },
     });
     return { schedule, runId, callbackId, secret };
@@ -66,7 +60,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
         {
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
         { invalidSignature: true },
@@ -84,7 +78,6 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
           status: "completed",
           payload: {
             scheduleId: "00000000-0000-0000-0000-000000000000",
-            intervalSeconds: 300,
           },
         },
         "fake-secret",
@@ -103,7 +96,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
           callbackId,
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -136,7 +129,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
           callbackId,
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -163,7 +156,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
         {
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -191,7 +184,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
           runId,
           status: "failed",
           error: "Agent crashed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -218,7 +211,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
           runId,
           status: "failed",
           error: "Third failure",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -242,7 +235,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
         {
           runId,
           status: "progress",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -270,7 +263,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
         {
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -292,7 +285,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
         {
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -301,6 +294,37 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.skipped).toBe(true);
+    });
+
+    it("should use current DB interval, not stale value from run creation time", async () => {
+      const { schedule, runId, secret } = await setupLoopSchedule();
+
+      // User changes interval from 300 to 600 while run is in progress
+      await updateTestScheduleState(schedule.id, { intervalSeconds: 600 });
+
+      const request = createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/schedule/loop",
+        {
+          runId,
+          status: "completed",
+          payload: { scheduleId: schedule.id },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      const updated = await findTestScheduleById(schedule.id);
+      // nextRunAt should be ~600s from now, not the original 300s
+      const expectedMin = new Date(Date.now() + 599 * 1000);
+      const expectedMax = new Date(Date.now() + 601 * 1000);
+      expect(updated!.nextRunAt!.getTime()).toBeGreaterThanOrEqual(
+        expectedMin.getTime(),
+      );
+      expect(updated!.nextRunAt!.getTime()).toBeLessThanOrEqual(
+        expectedMax.getTime(),
+      );
     });
   });
 });

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
@@ -16,10 +16,7 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 function parsePayload(payload: unknown): ScheduleLoopCallbackPayload | null {
   if (!payload || typeof payload !== "object") return null;
   const p = payload as Record<string, unknown>;
-  if (
-    typeof p.scheduleId !== "string" ||
-    typeof p.intervalSeconds !== "number"
-  ) {
+  if (typeof p.scheduleId !== "string") {
     return null;
   }
   return p as unknown as ScheduleLoopCallbackPayload;
@@ -45,7 +42,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return errorResponse("Invalid or missing payload", 400);
   }
 
-  const { scheduleId, intervalSeconds } = payload;
+  const { scheduleId } = payload;
 
   // Ignore progress notifications — only act on terminal states
   if (status === "progress") {
@@ -83,7 +80,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const shouldDisable = newFailureCount >= MAX_CONSECUTIVE_FAILURES;
   const nextRunAt = shouldDisable
     ? null
-    : new Date(now.getTime() + intervalSeconds * 1000);
+    : new Date(now.getTime() + schedule.intervalSeconds! * 1000);
 
   await globalThis.services.db
     .update(zeroAgentSchedules)

--- a/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
@@ -197,6 +197,7 @@ export async function updateTestScheduleState(
     enabled?: boolean;
     nextRunAt?: Date | null;
     lastRunId?: string;
+    intervalSeconds?: number;
   },
 ): Promise<void> {
   await globalThis.services.db

--- a/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
+++ b/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
@@ -53,7 +53,6 @@ export interface EmailReplyCallbackPayload {
 
 export interface ScheduleLoopCallbackPayload {
   scheduleId: string;
-  intervalSeconds: number;
 }
 
 export interface ScheduleCronCallbackPayload {

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -860,7 +860,6 @@ export async function executeSchedule(
   if (schedule.triggerType === "loop") {
     const loopPayload: ScheduleLoopCallbackPayload = {
       scheduleId: schedule.id,
-      intervalSeconds: schedule.intervalSeconds!,
     };
     callbacks.push({
       url: `${getApiUrl()}/api/internal/callbacks/schedule/loop`,


### PR DESCRIPTION
## Summary

- Remove `intervalSeconds` from `ScheduleLoopCallbackPayload` — the callback handler already loads the full schedule from DB, so it should use `schedule.intervalSeconds` instead of a stale snapshot baked into the payload at run creation time
- Update `parsePayload()`, payload construction, and callback handler to stop using the stale field
- Add regression test verifying that mid-run interval changes are correctly reflected in `nextRunAt`

Closes #9304

## Test plan

- [x] All 11 existing + new tests pass (`vitest run app/api/internal/callbacks/schedule/loop`)
- [x] New regression test: changes `intervalSeconds` from 300 to 600 mid-run, verifies `nextRunAt` uses the DB value (600s)
- [x] Lint, format, and knip pass
- [x] No type errors in changed files
- [x] Backward compatible: old in-flight payloads with extra `intervalSeconds` field still parse (extra fields are ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)