### PR TITLE
perf(ci): restore mold linker for runner compilation

### DIFF
--- a/.github/actions/install-mold/action.yml
+++ b/.github/actions/install-mold/action.yml
@@ -1,0 +1,20 @@
+name: "Install mold linker"
+description: "Download and install the mold linker for faster linking of cross-compiled binaries"
+
+inputs:
+  version:
+    description: "mold version to install"
+    required: false
+    default: "2.41.0"
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      env:
+        MOLD_VERSION: ${{ inputs.version }}
+      run: |
+        curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz" \
+          | tar xz --strip-components=2 -C /usr/local/bin "mold-${MOLD_VERSION}-x86_64-linux/bin/mold"
+        ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
+        ln -sf /usr/local/bin/mold /usr/local/bin/aarch64-linux-gnu-ld.mold

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -319,7 +319,20 @@ jobs:
           cargo build --release --target "$TARGET_TRIPLE" \
             -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-reseed
 
+      - name: Install mold linker
+        env:
+          MOLD_VERSION: "2.41.0"
+        run: |
+          curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz" \
+            | tar xz --strip-components=2 -C /usr/local/bin "mold-${MOLD_VERSION}-x86_64-linux/bin/mold"
+          ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
+          ln -sf /usr/local/bin/mold /usr/local/bin/aarch64-linux-gnu-ld.mold
+
       - name: Cross-compile runner with embedded guests for ARM64
+        env:
+          # Override .cargo/config.toml to use mold for faster runner linking.
+          # Only runner uses this — guests use the default linker for image_hash consistency.
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=-fuse-ld=mold"
         run: |
           cd crates
           GUEST_AGENT_PATH="target/$TARGET_TRIPLE/release/guest-agent" \

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -319,14 +319,7 @@ jobs:
           cargo build --release --target "$TARGET_TRIPLE" \
             -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-reseed
 
-      - name: Install mold linker
-        env:
-          MOLD_VERSION: "2.41.0"
-        run: |
-          curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz" \
-            | tar xz --strip-components=2 -C /usr/local/bin "mold-${MOLD_VERSION}-x86_64-linux/bin/mold"
-          ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
-          ln -sf /usr/local/bin/mold /usr/local/bin/aarch64-linux-gnu-ld.mold
+      - uses: ./.github/actions/install-mold
 
       - name: Cross-compile runner with embedded guests for ARM64
         env:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1382,7 +1382,20 @@ jobs:
           cargo build --release --target "$TARGET_TRIPLE" \
             -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-reseed
 
+      - name: Install mold linker
+        env:
+          MOLD_VERSION: "2.41.0"
+        run: |
+          curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz" \
+            | tar xz --strip-components=2 -C /usr/local/bin "mold-${MOLD_VERSION}-x86_64-linux/bin/mold"
+          ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
+          ln -sf /usr/local/bin/mold /usr/local/bin/aarch64-linux-gnu-ld.mold
+
       - name: Cross-compile runner with embedded guests for ARM64
+        env:
+          # Override .cargo/config.toml to use mold for faster runner linking.
+          # Only runner uses this — guests use the default linker for image_hash consistency.
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=-fuse-ld=mold"
         run: |
           cd crates
           GUEST_AGENT_PATH="target/$TARGET_TRIPLE/release/guest-agent" \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1382,14 +1382,7 @@ jobs:
           cargo build --release --target "$TARGET_TRIPLE" \
             -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-reseed
 
-      - name: Install mold linker
-        env:
-          MOLD_VERSION: "2.41.0"
-        run: |
-          curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz" \
-            | tar xz --strip-components=2 -C /usr/local/bin "mold-${MOLD_VERSION}-x86_64-linux/bin/mold"
-          ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
-          ln -sf /usr/local/bin/mold /usr/local/bin/aarch64-linux-gnu-ld.mold
+      - uses: ./.github/actions/install-mold
 
       - name: Cross-compile runner with embedded guests for ARM64
         env:


### PR DESCRIPTION
## Summary

- Restore mold linker for runner binary compilation in CI (crates.yml, turbo.yml)
- RUSTFLAGS override is step-level only — guest binaries still use default gcc linker from `.cargo/config.toml`, preserving image_hash consistency
- Bump mold from 2.40.4 to 2.41.0

## Context

PR #9219 removed mold to unify compile settings for R2 cache reuse. PR #9297 restored `[profile.ci]` for the runner (thin LTO). This PR completes the optimization by also restoring mold for the runner link step.

Runner binary is not included in `compute_image_hash()`, so using mold for it has no effect on cache reuse.

## Test plan

- [ ] CI workflows pass (yaml syntax validated)
- [ ] Runner binary links with mold (visible in cargo output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)