### PR TITLE
fix(platform): refresh pinned agents after onboarding completion

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
@@ -22,6 +22,8 @@ import {
 import { setupOnboardingPage$ } from "../../onboarding-page/onboarding-page-setup.ts";
 import { pathname, search } from "../../../signals/location.ts";
 import { createDeferredPromise } from "../../utils.ts";
+import { pinnedAgents$ } from "../zero-pinned-agents.ts";
+import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
 
 const context = testContext();
 
@@ -843,5 +845,67 @@ describe("completeMemberOnboarding$ body", () => {
     await context.store.set(onboardingContinueWeb$, context.signal);
 
     expect(receivedBody).toStrictEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pinned agents refresh after onboarding completion (#9308)
+// ---------------------------------------------------------------------------
+
+describe("pinned agents refresh after onboarding", () => {
+  it("should refresh pinnedAgents$ after onboardingContinueWeb$ completes for admin", async () => {
+    mockAdminOnboarding();
+    mockAdminCompletionApis();
+
+    let adminStatusCalls = 0;
+    server.use(
+      http.get("*/api/zero/onboarding/status", () => {
+        adminStatusCalls++;
+        if (adminStatusCalls <= 1) {
+          return HttpResponse.json({
+            needsOnboarding: true,
+            isAdmin: true,
+            hasOrg: true,
+            hasDefaultAgent: false,
+            defaultAgentId: null,
+            defaultAgentMetadata: null,
+          });
+        }
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: true,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: MOCK_AGENT_ID,
+          defaultAgentMetadata: null,
+        });
+      }),
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          {
+            id: MOCK_AGENT_ID,
+            displayName: "My Agent",
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        ]);
+      }),
+    );
+
+    setMockUserPreferences({ pinnedAgentIds: [MOCK_AGENT_ID] });
+
+    detachedSetupPage({ context, path: "/onboarding", withoutRender: true });
+
+    await context.store.set(onboardingContinueWeb$, context.signal);
+
+    const pinned = await context.store.get(pinnedAgents$);
+    expect(
+      pinned.map((a) => {
+        return a.id;
+      }),
+    ).toContain(MOCK_AGENT_ID);
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -16,6 +16,7 @@ import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { slackOrgData$ } from "./zero-slack.ts";
 import { reloadBillingStatus$ } from "./billing.ts";
 import { reloadAgents$ } from "../agent.ts";
+import { reloadPinnedAgents$ } from "./zero-pinned-agents.ts";
 import { showAppSkeleton$ } from "../app-skeleton.ts";
 import { logger } from "../log.ts";
 
@@ -232,6 +233,7 @@ const completeOnboarding$ = command(
       : await set(completeMemberOnboarding$, signal);
 
     set(reloadAgents$);
+    set(reloadPinnedAgents$);
     return agentId;
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
@@ -93,3 +93,9 @@ export const updatePinnedAgentIds$ = command(
     });
   },
 );
+
+export const reloadPinnedAgents$ = command(({ set }) => {
+  set(reloadPinned$, (x) => {
+    return x + 1;
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `reloadPinnedAgents$` command export to `zero-pinned-agents.ts` that bumps the private `reloadPinned$` counter, following the same pattern as `reloadAgents$`
- Calls `set(reloadPinnedAgents$)` inside `completeOnboarding$` after onboarding completes, ensuring `serverPinnedIds$` cache is invalidated and pinned agents reflect updated data immediately
- Adds integration test verifying `pinnedAgents$` is refreshed after `onboardingContinueWeb$` completes

Closes #9308

## Test plan

- [x] New test `pinned agents refresh after onboarding > should refresh pinnedAgents$ after onboardingContinueWeb$ completes for admin` passes
- [x] All existing `zero-onboarding-actions.test.ts` tests (31 total) pass
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)