### PR TITLE
feat(core): split agent:delete capability from agent:write and exclude from agent tokens

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
@@ -20,11 +20,6 @@ import {
 
 const context = testContext();
 
-interface LoopCallbackPayload {
-  scheduleId: string;
-  intervalSeconds: number;
-}
-
 describe("POST /api/internal/callbacks/schedule/loop", () => {
   let composeId: string;
   let userId: string;
@@ -51,7 +46,6 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
       url: "http://localhost/api/internal/callbacks/schedule/loop",
       payload: {
         scheduleId: schedule.id,
-        intervalSeconds: 300,
       },
     });
     return { schedule, runId, callbackId, secret };
@@ -66,7 +60,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
         {
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
         { invalidSignature: true },
@@ -84,7 +78,6 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
           status: "completed",
           payload: {
             scheduleId: "00000000-0000-0000-0000-000000000000",
-            intervalSeconds: 300,
           },
         },
         "fake-secret",
@@ -103,7 +96,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
           callbackId,
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -136,7 +129,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
           callbackId,
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -163,7 +156,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
         {
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -191,7 +184,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
           runId,
           status: "failed",
           error: "Agent crashed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -218,7 +211,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
           runId,
           status: "failed",
           error: "Third failure",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -242,7 +235,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
         {
           runId,
           status: "progress",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -270,7 +263,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
         {
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -292,7 +285,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
         {
           runId,
           status: "completed",
-          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+          payload: { scheduleId: schedule.id },
         },
         secret,
       );
@@ -301,6 +294,37 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.skipped).toBe(true);
+    });
+
+    it("should use current DB interval, not stale value from run creation time", async () => {
+      const { schedule, runId, secret } = await setupLoopSchedule();
+
+      // User changes interval from 300 to 600 while run is in progress
+      await updateTestScheduleState(schedule.id, { intervalSeconds: 600 });
+
+      const request = createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/schedule/loop",
+        {
+          runId,
+          status: "completed",
+          payload: { scheduleId: schedule.id },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      const updated = await findTestScheduleById(schedule.id);
+      // nextRunAt should be ~600s from now, not the original 300s
+      const expectedMin = new Date(Date.now() + 599 * 1000);
+      const expectedMax = new Date(Date.now() + 601 * 1000);
+      expect(updated!.nextRunAt!.getTime()).toBeGreaterThanOrEqual(
+        expectedMin.getTime(),
+      );
+      expect(updated!.nextRunAt!.getTime()).toBeLessThanOrEqual(
+        expectedMax.getTime(),
+      );
     });
   });
 });

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
@@ -16,10 +16,7 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 function parsePayload(payload: unknown): ScheduleLoopCallbackPayload | null {
   if (!payload || typeof payload !== "object") return null;
   const p = payload as Record<string, unknown>;
-  if (
-    typeof p.scheduleId !== "string" ||
-    typeof p.intervalSeconds !== "number"
-  ) {
+  if (typeof p.scheduleId !== "string") {
     return null;
   }
   return p as unknown as ScheduleLoopCallbackPayload;
@@ -45,7 +42,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return errorResponse("Invalid or missing payload", 400);
   }
 
-  const { scheduleId, intervalSeconds } = payload;
+  const { scheduleId } = payload;
 
   // Ignore progress notifications — only act on terminal states
   if (status === "progress") {
@@ -83,7 +80,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const shouldDisable = newFailureCount >= MAX_CONSECUTIVE_FAILURES;
   const nextRunAt = shouldDisable
     ? null
-    : new Date(now.getTime() + intervalSeconds * 1000);
+    : new Date(now.getTime() + schedule.intervalSeconds! * 1000);
 
   await globalThis.services.db
     .update(zeroAgentSchedules)

--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -310,7 +310,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
-      requiredCapability: "agent:write",
+      requiredCapability: "agent:delete",
     });
     if (isAuthError(authCtx)) return authCtx;
 

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -40,6 +40,7 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { generateZeroToken } from "../../../../../src/lib/auth/sandbox-token";
 import { POST as runSchedule } from "../../schedules/run/route";
 
 const context = testContext();
@@ -1075,6 +1076,28 @@ describe("Zero Agents API", () => {
         "no-token",
       );
       expect(response.status).toBe(401);
+    });
+
+    it("should reject agent run token (agent:delete is agent-excluded)", async () => {
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      await insertOrgMembersCacheEntry({
+        userId: user.userId,
+        orgId: user.orgId,
+        role: "admin",
+      });
+
+      // Switch to zero token auth (agent run) — no Clerk session
+      mockClerk({ userId: null });
+      const token = await generateZeroToken(user.userId, "run-123", user.orgId);
+
+      const response = await deleteAgent(created.agentId, token);
+
+      expect(response.status).toBe(403);
+      const data = await response.json();
+      expect(data.error.message).toBe(
+        "Missing required capability: agent:delete",
+      );
     });
   });
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
@@ -197,6 +197,7 @@ export async function updateTestScheduleState(
     enabled?: boolean;
     nextRunAt?: Date | null;
     lastRunId?: string;
+    intervalSeconds?: number;
   },
 ): Promise<void> {
   await globalThis.services.db

--- a/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
@@ -373,5 +373,6 @@ describe("getAuthContext with zero token and acceptAnySandboxCapability", () => 
       ]),
     );
     expect(result?.capabilities).not.toContain("agent-run:write");
+    expect(result?.capabilities).not.toContain("agent:delete");
   });
 });

--- a/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
@@ -191,6 +191,22 @@ describe("requireAuth", () => {
       );
     }
   });
+
+  it("should return 403 for zero token missing agent-excluded capability (agent:delete)", async () => {
+    const token = await generateZeroToken("user-1", "run-1", "org-1");
+
+    const result = await requireAuth(`Bearer ${token}`, {
+      requiredCapability: "agent:delete",
+    });
+
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.status).toBe(403);
+      expect(result.body.error.message).toBe(
+        "Missing required capability: agent:delete",
+      );
+    }
+  });
 });
 
 describe("isAuthError", () => {

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -302,6 +302,7 @@ describe("sandbox-token", () => {
       const auth = verifyZeroToken(token);
 
       expect(auth?.capabilities).not.toContain("schedule:delete");
+      expect(auth?.capabilities).not.toContain("agent:delete");
       expect(auth?.capabilities).toContain("schedule:write");
     });
 

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -28,6 +28,7 @@ const CONDITIONAL_CAPABILITIES: ReadonlyMap<ZeroCapability, FeatureSwitchKey> =
 const AGENT_EXCLUDED_CAPABILITIES: ReadonlySet<ZeroCapability> = new Set([
   "schedule:delete",
   "agent-run:write",
+  "agent:delete",
 ]);
 
 const log = logger("auth:sandbox");

--- a/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
+++ b/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
@@ -53,7 +53,6 @@ export interface EmailReplyCallbackPayload {
 
 export interface ScheduleLoopCallbackPayload {
   scheduleId: string;
-  intervalSeconds: number;
 }
 
 export interface ScheduleCronCallbackPayload {

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -860,7 +860,6 @@ export async function executeSchedule(
   if (schedule.triggerType === "loop") {
     const loopPayload: ScheduleLoopCallbackPayload = {
       scheduleId: schedule.id,
-      intervalSeconds: schedule.intervalSeconds!,
     };
     callbacks.push({
       url: `${getApiUrl()}/api/internal/callbacks/schedule/loop`,

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -23,8 +23,8 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 11 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(11);
+  it("should have exactly 12 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(12);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -29,6 +29,7 @@ export const AGENT_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/;
 export const ZERO_CAPABILITIES = [
   "agent:read",
   "agent:write",
+  "agent:delete",
   "agent-run:read",
   "agent-run:write",
   "schedule:read",
@@ -57,7 +58,8 @@ export interface ZeroCapabilityMeta {
 export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
   {
     "agent:read": { group: "Agent", label: "Read agents" },
-    "agent:write": { group: "Agent", label: "Create, update & delete agents" },
+    "agent:write": { group: "Agent", label: "Create & update agents" },
+    "agent:delete": { group: "Agent", label: "Delete agents" },
     "agent-run:read": { group: "Agent Runs", label: "View runs & telemetry" },
     "agent-run:write": { group: "Agent Runs", label: "Create & cancel runs" },
     "schedule:read": { group: "Schedules", label: "View schedules" },


### PR DESCRIPTION
## Summary

- Add new `agent:delete` capability to `ZERO_CAPABILITIES`, separate from `agent:write`
- Add `agent:delete` to `AGENT_EXCLUDED_CAPABILITIES` so agent run (zero) tokens never receive it
- Change the DELETE handler in `/api/zero/agents/[id]` to require `agent:delete` instead of `agent:write`

This follows the exact same pattern as the existing `schedule:delete` capability exclusion. CLI (PAT) tokens are unaffected — human users can still delete agents normally.

Closes #9309
Closes #9187

## Test plan

- [x] New integration test: zero token DELETE request returns 403 with "Missing required capability: agent:delete"
- [x] New unit test: `requireAuth` returns 403 for `agent:delete` on zero tokens
- [x] Updated assertions: `agent:delete` excluded from zero token capabilities in sandbox-token and get-auth-context tests
- [x] All existing delete tests (CLI token) continue to pass with 204
- [x] TypeScript type check passes (exhaustive `Record<ZeroCapability, ...>` enforced)
- [x] Lint, format, and knip all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)