### PR TITLE
fix(credit): skip proxy usage alert when client data is all zeros

### DIFF
--- a/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
@@ -240,6 +240,54 @@ describe("compareRecentRunsProxyUsage", () => {
     expect(entries[0]!.meta).toMatchObject({ runId });
   });
 
+  // ── Zero-usage runs (no LLM call) ──────────────────────────────────
+
+  it("does not log 'missing proxy' when client data is all zeros", async () => {
+    const { orgId, userId } = await context.setupUser({
+      prefix: "zero-client",
+    });
+    const runId = await createCompletedRun(
+      orgId,
+      userId,
+      new Date(Date.now() - 120_000),
+    );
+    // Client reported usage but all token counts are zero (no LLM call)
+    await insertTestClientCreditUsage(orgId, {
+      userId,
+      runId,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      webSearchRequests: 0,
+    });
+
+    await compareRecentRunsProxyUsage();
+
+    expect(errorMessagesForOrg(logSpy, orgId)).toHaveLength(0);
+  });
+
+  it("does not log 'missing client' when proxy data is all zeros", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "zero-proxy" });
+    const runId = await createCompletedRun(
+      orgId,
+      userId,
+      new Date(Date.now() - 120_000),
+    );
+    // Proxy recorded usage but all token counts are zero
+    await insertTestCreditUsageForRun({
+      runId,
+      orgId,
+      userId,
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+
+    await compareRecentRunsProxyUsage();
+
+    expect(errorMessagesForOrg(logSpy, orgId)).toHaveLength(0);
+  });
+
   // ── Multi-row proxy aggregates subagent usage ──────────────────────
 
   it("aggregates multiple proxy rows (subagents) per run for comparison", async () => {

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
@@ -281,6 +281,9 @@ describe("compareRecentRunsProxyUsage", () => {
       userId,
       inputTokens: 0,
       outputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      webSearchRequests: 0,
     });
 
     await compareRecentRunsProxyUsage();

--- a/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
@@ -164,17 +164,31 @@ async function compareProxyUsage(
     const client = clientByRun.get(runId);
 
     if (!proxy) {
-      log.error("Proxy usage missing for run with client data", {
-        orgId,
-        runId,
-      });
+      const hasNonZero = client
+        ? fields.some((f) => {
+            return (client[f] ?? 0) > 0;
+          })
+        : false;
+      if (hasNonZero) {
+        log.error("Proxy usage missing for run with client data", {
+          orgId,
+          runId,
+        });
+      }
       continue;
     }
     if (!client) {
-      log.error("Client usage missing for run with proxy data", {
-        orgId,
-        runId,
-      });
+      const hasNonZero = proxy
+        ? fields.some((f) => {
+            return (proxy[f] ?? 0) > 0;
+          })
+        : false;
+      if (hasNonZero) {
+        log.error("Client usage missing for run with proxy data", {
+          orgId,
+          runId,
+        });
+      }
       continue;
     }
 

--- a/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
@@ -143,9 +143,10 @@ async function compareProxyUsage(
   );
 
   // Walk the union of runIds.  Any asymmetry is an error:
-  //   proxy missing entirely → mitmproxy lost all reports for this run
-  //   client missing entirely → events webhook never delivered result events
+  //   proxy missing + client non-zero → mitmproxy lost all reports for this run
+  //   client missing + proxy non-zero → events webhook never delivered result events
   //   both present but proxy < client on any field → partial proxy data loss
+  // Runs where the present side is all-zero are silently skipped (no LLM call).
   const allRunIds = new Set<string>([
     ...proxyByRun.keys(),
     ...clientByRun.keys(),


### PR DESCRIPTION
## Summary

- Skip "proxy usage missing" and "client usage missing" alerts when the counterpart's data is all zeros
- Fixes false positives from runs that complete without any LLM call (e.g. unknown skill, immediate exit)

## Root Cause

Run `ed08ee72` completed in 1 second with `Unknown skill: pr-review-merge` — no `/v1/messages` call was made. Claude Code still reported a client usage record with all-zero token counts. The comparison service flagged this as "proxy usage missing" because it only checked for row existence, not whether values were non-zero.

## Changes

| File | Change |
|------|--------|
| `proxy-usage-comparison-service.ts` | Both `!proxy` and `!client` branches now check if the counterpart has non-zero values before logging an error |

## Test plan

- [ ] CI passes
- [ ] Verify false positive no longer triggers for zero-usage runs

Closes #9293

🤖 Generated with [Claude Code](https://claude.com/claude-code)