### PR TITLE
refactor(vsock-guest): remove unnecessary libc::sync() from shutdown handler

### DIFF
--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -437,15 +437,15 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool) -> (bool, Strin
     (true, String::new())
 }
 
-/// Handle shutdown message - sync filesystems and acknowledge
+/// Handle shutdown message — acknowledge and suppress reconnection.
+///
+/// The guest rootfs is ext4 on an ephemeral COW device that is destroyed
+/// when the VM is killed, so there is nothing to sync. The primary purpose
+/// of this handler is to set `SHUTDOWN_RECEIVED` so the reconnection loop
+/// in `run()` exits cleanly instead of retrying (which it would otherwise
+/// do, since reconnection is the normal path after snapshot restore).
 fn handle_shutdown(seq: u32) -> io::Result<Vec<u8>> {
-    log("INFO", "Shutdown requested, syncing filesystems...");
-    // SAFETY: libc::sync() has no preconditions — it flushes all pending filesystem writes.
-    unsafe {
-        libc::sync();
-    }
-    log("INFO", "Sync complete");
-    // Set flag so run() knows not to reconnect after connection closes
+    log("INFO", "Shutdown requested");
     SHUTDOWN_RECEIVED.store(true, Ordering::SeqCst);
     vsock_proto::encode(MSG_SHUTDOWN_ACK, seq, &[]).map_err(to_io_error)
 }


### PR DESCRIPTION
## Summary

- Remove `libc::sync()` from `handle_shutdown` — guest rootfs is ext4 on ephemeral COW device, sync flushes to a file that is destroyed on VM kill
- Keep the MSG_SHUTDOWN handshake — `SHUTDOWN_RECEIVED` flag distinguishes "shutdown" from "snapshot restore" in the guest reconnection loop
- Remove `unsafe` block

## Context

Discovered during #9152 (vCPU pause for idle sandboxes). The original `sync()` was added in #2118 as best-effort, with the author noting "SIGKILL approach works fine since overlay filesystem is temporary."

The reconnection loop (`MAX_RECONNECT_ATTEMPTS = 50`, 10ms delay) is designed for snapshot restore scenarios. Without `SHUTDOWN_RECEIVED`, every `stop()` would trigger 50 reconnection attempts with warning logs before SIGKILL arrives.

## Test plan

- [x] `cargo test -p vsock-guest` — 31 passed
- [x] `cargo clippy` — clean

Closes #9295

🤖 Generated with [Claude Code](https://claude.com/claude-code)