### PR TITLE
refactor(runner): unify runner-dirname and service-name validators

### DIFF
--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -119,16 +119,14 @@ const UNIT_PREFIX: &str = "vm0-runner-";
 
 /// Build the full systemd unit name from the user-supplied suffix.
 ///
-/// Validates that the suffix contains only safe characters for systemd unit
-/// names and file paths.
+/// Validates the suffix with [`crate::runner_dirname::validate_name`] so
+/// that runner directory names and service name suffixes follow the same
+/// rules (lowercase alphanumeric, hyphens, dots; no leading `.` or `-`).
 pub(crate) fn unit_name(suffix: &str) -> RunnerResult<String> {
-    if suffix.is_empty()
-        || !suffix
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'-' || b == b'_')
-    {
+    if !crate::runner_dirname::validate_name(suffix) {
         return Err(RunnerError::Config(format!(
-            "invalid service name suffix '{suffix}': only alphanumeric, '.', '-', '_' allowed"
+            "invalid service name suffix '{suffix}': must be non-empty, \
+             lowercase alphanumeric, hyphens, and dots; cannot start with '.' or '-'"
         )));
     }
     Ok(format!("{UNIT_PREFIX}{suffix}"))
@@ -673,7 +671,10 @@ mod tests {
     fn test_unit_name() {
         assert_eq!(unit_name("v0.2.0").unwrap(), "vm0-runner-v0.2.0");
         assert_eq!(unit_name("staging").unwrap(), "vm0-runner-staging");
-        assert_eq!(unit_name("my_name-1.0").unwrap(), "vm0-runner-my_name-1.0");
+        assert_eq!(
+            unit_name("pr-1234-test").unwrap(),
+            "vm0-runner-pr-1234-test"
+        );
     }
 
     #[test]
@@ -682,6 +683,19 @@ mod tests {
         assert!(unit_name("../evil").is_err());
         assert!(unit_name("has space").is_err());
         assert!(unit_name("semi;colon").is_err());
+        // Now aligned with runner_dirname: reject uppercase, underscore, leading dot/hyphen
+        assert!(unit_name("V0.2.0").is_err());
+        assert!(unit_name("my_name-1.0").is_err());
+        assert!(unit_name(".hidden").is_err());
+        assert!(unit_name("-flag").is_err());
+    }
+
+    /// Guard against someone replacing the call with `validate_or_err`
+    /// which would surface a "runner-dirname" message in a service context.
+    #[test]
+    fn test_unit_name_error_mentions_service() {
+        let msg = unit_name("UPPER").unwrap_err().to_string();
+        assert!(msg.contains("service name suffix"), "got: {msg}");
     }
 
     #[test]

--- a/crates/runner/src/runner_dirname.rs
+++ b/crates/runner/src/runner_dirname.rs
@@ -1,11 +1,13 @@
-//! Validation for runner directory names.
+//! Validation for runner instance names.
 //!
-//! Runner directory names are joined against `HomePaths::runners_dir()`
-//! to form on-disk paths (`/var/lib/vm0-runner/runners/<name>/`). Without
-//! validation, an absolute path (`/etc`) replaces the base via
+//! The same name is used as both a directory name (joined against
+//! `HomePaths::runners_dir()`) and a systemd service name suffix
+//! (e.g. `vm0-runner-<name>`). This module is the single source of
+//! truth for what counts as a valid runner instance name.
+//!
+//! Without validation, an absolute path (`/etc`) replaces the base via
 //! `Path::join`, and a bare `..` segment escapes once the kernel resolves
-//! it. This module is the single source of truth for what counts as a
-//! safe runner directory name.
+//! it.
 //!
 //! Unlike `group` and `profile`, runner directory names are not persisted
 //! in `runner.yaml` (only the resolved `RunnerConfig.base_dir: PathBuf`
@@ -31,7 +33,10 @@ pub fn validate_or_err(name: &str) -> RunnerResult<()> {
     Ok(())
 }
 
-/// Validate that `name` is a safe single-segment directory name.
+/// Validate that `name` is a safe runner instance identifier.
+///
+/// Used for both runner directory names and systemd service name suffixes
+/// to ensure a single validation rule across the codebase.
 ///
 /// Accepts `[a-z0-9.-]+` with these guards:
 /// - non-empty
@@ -42,7 +47,7 @@ pub fn validate_or_err(name: &str) -> RunnerResult<()> {
 /// name to a single path segment regardless of the host's separator
 /// conventions. The dot allowance exists for production semver dirnames
 /// produced by `ansible/playbooks/deploy-runner.yml` (e.g. `v0.3.0`).
-fn validate_name(name: &str) -> bool {
+pub(crate) fn validate_name(name: &str) -> bool {
     if name.is_empty() || name.starts_with('.') || name.starts_with('-') {
         return false;
     }


### PR DESCRIPTION
## Summary
- `service::unit_name` accepted `[a-zA-Z0-9._-]` while `runner_dirname::validate_name` enforced the stricter `[a-z0-9.-]`. Both validate the same runner instance identifier, so the divergence caused inconsistent error feedback.
- Have `unit_name` delegate to `runner_dirname::validate_name` for the boolean check while keeping its own service-context error message.
- Updated module and function docs to reflect the shared validation role.

Closes #9145

## Test plan
- [x] Existing `runner_dirname` tests pass (14 tests)
- [x] Updated `unit_name` tests reject uppercase, underscore, leading dot/hyphen
- [x] New test verifies error message says "service name suffix" (not "runner-dirname")
- [x] `cargo test -p runner` passes (616 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)