### PR TITLE
fix(onboarding): treat orphan compose as no default agent in status check

### DIFF
--- a/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
@@ -5,13 +5,12 @@ import {
   createTestCompose,
   createTestZeroAgent,
   seedOrphanCompose,
+  updateOrgDefaultAgent,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { PUT as setDefaultAgent } from "../../../default-agent/route";
 import { POST as completeOnboarding } from "../../complete/route";
-import { initServices } from "../../../../../../src/lib/init-services";
-import { orgMetadata } from "../../../../../../src/db/schema/org-metadata";
 
 const context = testContext();
 
@@ -239,14 +238,7 @@ describe("GET /api/zero/onboarding/status", () => {
     });
 
     // Directly set the orphan compose as defaultAgentId in org_metadata
-    initServices();
-    await globalThis.services.db
-      .insert(orgMetadata)
-      .values({ orgId: user.orgId, defaultAgentId: orphan.composeId })
-      .onConflictDoUpdate({
-        target: orgMetadata.orgId,
-        set: { defaultAgentId: orphan.composeId },
-      });
+    await updateOrgDefaultAgent(user.orgId, orphan.composeId);
 
     const request = createTestRequest(
       "http://localhost:3000/api/zero/onboarding/status",

--- a/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
@@ -4,11 +4,14 @@ import {
   createTestRequest,
   createTestCompose,
   createTestZeroAgent,
+  seedOrphanCompose,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { PUT as setDefaultAgent } from "../../../default-agent/route";
 import { POST as completeOnboarding } from "../../complete/route";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { orgMetadata } from "../../../../../../src/db/schema/org-metadata";
 
 const context = testContext();
 
@@ -220,6 +223,42 @@ describe("GET /api/zero/onboarding/status", () => {
     expect(response.status).toBe(200);
     expect(data.isAdmin).toBe(false);
     expect(data.hasOrg).toBe(true);
+    expect(data.needsOnboarding).toBe(true);
+  });
+
+  it("should treat orphan compose (missing zero_agents row) as no default agent", async () => {
+    const user = await context.setupUser();
+
+    // Create a compose WITHOUT a zero_agents row — simulates a partially
+    // completed onboarding where the agent_composes row was written but the
+    // zero_agents insert never ran.
+    const orphan = await seedOrphanCompose({
+      userId: user.userId,
+      name: `orphan-agent-${Date.now()}`,
+      orgId: user.orgId,
+    });
+
+    // Directly set the orphan compose as defaultAgentId in org_metadata
+    initServices();
+    await globalThis.services.db
+      .insert(orgMetadata)
+      .values({ orgId: user.orgId, defaultAgentId: orphan.composeId })
+      .onConflictDoUpdate({
+        target: orgMetadata.orgId,
+        set: { defaultAgentId: orphan.composeId },
+      });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/onboarding/status",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    // The orphan compose should NOT be reported as a valid default agent,
+    // so the admin re-enters full onboarding and creates a complete agent.
+    expect(data.hasDefaultAgent).toBe(false);
+    expect(data.defaultAgentId).toBeNull();
     expect(data.needsOnboarding).toBe(true);
   });
 

--- a/turbo/apps/web/app/api/zero/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/status/route.ts
@@ -45,7 +45,9 @@ interface DefaultAgentInfo {
 async function resolveDefaultAgent(
   composeId: string,
 ): Promise<DefaultAgentInfo | null> {
-  // Single query: JOIN compose + zero_agents
+  // INNER JOIN: both agent_composes and zero_agents must exist.
+  // An orphan compose (missing zero_agents row) is treated as non-existent
+  // so the admin re-enters full onboarding and creates a complete agent.
   const [row] = await globalThis.services.db
     .select({
       name: agentComposes.name,
@@ -54,7 +56,7 @@ async function resolveDefaultAgent(
       sound: zeroAgents.sound,
     })
     .from(agentComposes)
-    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+    .innerJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
     .where(eq(agentComposes.id, composeId))
     .limit(1);
 


### PR DESCRIPTION
## Summary
- Change `leftJoin` to `innerJoin` in `resolveDefaultAgent` so an `agent_composes` row without a matching `zero_agents` row is treated as non-existent
- This fixes a bug where partially completed onboarding (orphan compose) incorrectly reported `hasDefaultAgent=true`, preventing the admin from re-entering full onboarding
- Added integration test to verify orphan compose is treated as no default agent

## Test plan
- [ ] Existing onboarding status tests pass
- [ ] New orphan compose test verifies `hasDefaultAgent=false` and `needsOnboarding=true`
- [ ] CI checks pass (lint, typecheck, knip, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)