### PR TITLE
chore(ci): update toolchain containers to 20260404

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -17,7 +17,7 @@ jobs:
   cleanup-neon-branches:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     steps:
       - name: Install neonctl
         run: npm install -g neonctl@2.15.0

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -82,7 +82,7 @@ jobs:
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -58,7 +58,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260404
     outputs:
       any-changed: ${{ steps.detect.outputs.any-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
@@ -162,7 +162,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260404
     needs: [detect]
     if: needs.detect.outputs.any-changed == 'true'
     steps:
@@ -237,7 +237,7 @@ jobs:
   nbd-cow-test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260404
     needs: [detect]
     if: |
       needs.detect.outputs.ci-changed == 'true' ||
@@ -284,7 +284,7 @@ jobs:
   runner-build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260404
     needs: [detect]
     if: |
       needs.detect.outputs.ci-changed == 'true' ||

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,7 +72,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     permissions:
       contents: read
     environment: production
@@ -170,7 +170,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     outputs:
       deployment_url: ${{ steps.deploy.outputs.url }}
       vercel_dashboard_url: ${{ steps.vercel-dashboard.outputs.url }}
@@ -403,7 +403,7 @@ jobs:
       needs.release-please.outputs.app_release_created == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     outputs:
       deployment_url: ${{ steps.deploy.outputs.url }}
       vercel_dashboard_url: ${{ steps.vercel-dashboard.outputs.url }}
@@ -847,7 +847,7 @@ jobs:
       needs.release-please.outputs.runner_rs_release_created == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260404
     permissions:
       contents: write
     environment: production
@@ -1102,7 +1102,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     permissions:
       contents: read
     environment: production
@@ -1126,7 +1126,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     permissions:
       contents: read
     steps:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -67,7 +67,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     outputs:
       job-ref: ${{ steps.set-job-ref.outputs.job-ref }}
       web-preview-url: ${{ steps.preview-urls.outputs.web-url }}
@@ -288,7 +288,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -311,7 +311,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -325,7 +325,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -339,7 +339,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -355,7 +355,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     services:
       postgres:
         image: postgres:17-alpine
@@ -401,7 +401,7 @@ jobs:
     # Only run when migration or schema files changed
     if: needs.prepare.outputs.migration-changed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     services:
       postgres:
         image: postgres:17-alpine
@@ -458,7 +458,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -490,7 +490,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -519,7 +519,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260404
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -549,7 +549,7 @@ jobs:
       group: deploy-web-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and web, CLI, runner, or platform changed
     if: |
@@ -1012,7 +1012,7 @@ jobs:
       group: deploy-app-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and platform/e2e/ci changed
     if: >-
@@ -1166,7 +1166,7 @@ jobs:
   build-cli:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     needs: [prepare]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1344,7 +1344,7 @@ jobs:
       group: deploy-runner-prepare-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260404
     needs: [prepare]
     timeout-minutes: 20
     env:
@@ -1883,7 +1883,7 @@ jobs:
   build-e2b-template:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260404
     needs: [prepare]
     # Build on PR or main push when E2B templates changed, skip release-please commits
     if: |


### PR DESCRIPTION
## Summary
- Update all `vm0-toolchain` and `vm0-toolchain-rust` container references from `20260320`/`20260324` to `20260404` (latest)
- Aligns all 5 workflows: `turbo.yml`, `crates.yml`, `release-please.yml`, `cleanup.yml`, `cleanup-stale.yml`
- Ensures identical compiler versions across all pipelines, which is required for R2 image cache hits between CI and production deploys

## Test plan
- [ ] CI passes with new container version
- [ ] R2 cache hits work across pipelines (crates.yml build → release-please.yml deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)