### PR TITLE
chore(ci): upload runner binary as artifact

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -338,7 +338,7 @@ jobs:
       - name: Upload runner binary
         uses: actions/upload-artifact@v4
         with:
-          name: runner-aarch64
+          name: runner-aarch64-linux
           path: crates/target/${{ env.TARGET_TRIPLE }}/ci/runner
           retention-days: 7
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -335,6 +335,13 @@ jobs:
           GUEST_RESEED_PATH="target/$TARGET_TRIPLE/release/guest-reseed" \
           cargo build --profile ci --target "$TARGET_TRIPLE" -p runner
 
+      - name: Upload runner binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: runner-aarch64
+          path: crates/target/${{ env.TARGET_TRIPLE }}/ci/runner
+          retention-days: 7
+
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -335,10 +335,13 @@ jobs:
           GUEST_RESEED_PATH="target/$TARGET_TRIPLE/release/guest-reseed" \
           cargo build --profile ci --target "$TARGET_TRIPLE" -p runner
 
+      - id: short-sha
+        run: echo "sha=$(echo "${GITHUB_SHA:-unknown}" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
       - name: Upload runner binary
         uses: actions/upload-artifact@v4
         with:
-          name: runner-aarch64-linux
+          name: runner-${{ steps.short-sha.outputs.sha }}-aarch64-linux
           path: crates/target/${{ env.TARGET_TRIPLE }}/ci/runner
           retention-days: 7
 


### PR DESCRIPTION
## Summary
- Upload the cross-compiled runner binary (`runner-aarch64`) as a GitHub Actions artifact after build in `crates.yml`
- Allows downloading the exact CI-compiled binary for manual testing on metal hosts without local cross-compilation
- Ensures hash consistency when testing R2 cache behavior (same binary = same hash)
- 7-day retention

## Test plan
- [ ] CI passes, artifact appears in workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)