### PR TITLE
fix: log directory iteration errors instead of silently swallowing

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -565,9 +565,20 @@ async fn find_installed_services() -> Vec<InstalledService> {
     let mut services = Vec::new();
     let mut entries = match tokio::fs::read_dir("/etc/systemd/system").await {
         Ok(e) => e,
-        Err(_) => return services,
+        Err(e) => {
+            tracing::warn!("find_installed_services: cannot read /etc/systemd/system: {e}");
+            return services;
+        }
     };
-    while let Ok(Some(entry)) = entries.next_entry().await {
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(e) => {
+                tracing::warn!("find_installed_services: read entry in /etc/systemd/system: {e}");
+                break;
+            }
+        };
         let name = entry.file_name();
         let Some(name_str) = name.to_str() else {
             continue;

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -719,13 +719,20 @@ fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<PathBuf> {
     let entries = match std::fs::read_dir(locks_dir) {
         Ok(rd) => rd,
         Err(e) => {
-            tracing::debug!("workspace gc: cannot read {}: {e}", locks_dir.display());
+            warn!("workspace gc: cannot read {}: {e}", locks_dir.display());
             return Vec::new();
         }
     };
 
     let mut base_dirs = Vec::new();
-    for entry in entries.flatten() {
+    for result in entries {
+        let entry = match result {
+            Ok(entry) => entry,
+            Err(e) => {
+                warn!("workspace gc: read entry in {}: {e}", locks_dir.display());
+                continue;
+            }
+        };
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
         if !name.starts_with("base-dir-") || !name.ends_with(".lock") {

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -199,9 +199,20 @@ async fn scan_proc_cmdlines() -> Vec<(u32, String)> {
     let mut result = Vec::new();
     let mut entries = match tokio::fs::read_dir("/proc").await {
         Ok(e) => e,
-        Err(_) => return result,
+        Err(e) => {
+            tracing::warn!("scan_proc_cmdlines: cannot read /proc: {e}");
+            return result;
+        }
     };
-    while let Ok(Some(entry)) = entries.next_entry().await {
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(e) => {
+                tracing::warn!("scan_proc_cmdlines: read entry in /proc: {e}");
+                break;
+            }
+        };
         let name = entry.file_name();
         let Some(name_str) = name.to_str() else {
             continue;


### PR DESCRIPTION
## Summary
- Replace `entries.flatten()` and `while let Ok(Some(entry))` patterns with explicit `match` + `tracing::warn!` in three directory iteration sites
- Upgrade `read_dir` failure log from `debug` to `warn` in `discover_dead_runner_base_dirs`
- Sync pattern: `warn` + `continue` (per-entry error); async pattern: `warn` + `break` (stream error)

Closes #9037

## Test plan
- [x] `cargo clippy -p runner --all-targets -- -D warnings` passes
- [ ] CI crates build passes
- [ ] Existing `discover_dead_runner_base_dirs` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)