### PR TITLE
feat(vsock): chunked write_file with append flag for large files

### DIFF
--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -369,14 +369,15 @@ fn handle_exec(
 }
 
 /// Handle write_file message
-fn handle_write_file(path: &str, content: &[u8], use_sudo: bool) -> (bool, String) {
+fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -> (bool, String) {
     log(
         "INFO",
         &format!(
-            "write_file: path={} size={} sudo={}",
+            "write_file: path={} size={} sudo={} append={}",
             path,
             content.len(),
-            use_sudo
+            use_sudo,
+            append,
         ),
     );
 
@@ -384,24 +385,29 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool) -> (bool, Strin
     // Use subprocess instead of direct fs::write to run as user
     const WRITE_TIMEOUT_MS: u32 = 30_000;
 
+    let escaped_path = path.replace('\'', "'\\''");
+
     // Build the write command: tee for privileged writes (build_exec_command
     // handles root elevation), cat for normal writes with parent dir creation.
     let write_cmd = if use_sudo {
-        format!("tee '{}'", path.replace('\'', "'\\''"))
+        let tee_flag = if append { "-a " } else { "" };
+        format!("tee {tee_flag}'{escaped_path}'")
+    } else if append {
+        // Append mode: parent directory already exists from the first chunk.
+        format!("cat >> '{escaped_path}'")
     } else {
         // Create parent directory if needed, then write
         if let Some(parent) = std::path::Path::new(path).parent() {
             if !parent.as_os_str().is_empty() {
                 format!(
-                    "mkdir -p '{}' && cat > '{}'",
+                    "mkdir -p '{}' && cat > '{escaped_path}'",
                     parent.display().to_string().replace('\'', "'\\''"),
-                    path.replace('\'', "'\\''")
                 )
             } else {
-                format!("cat > '{}'", path.replace('\'', "'\\''"))
+                format!("cat > '{escaped_path}'")
             }
         } else {
-            format!("cat > '{}'", path.replace('\'', "'\\''"))
+            format!("cat > '{escaped_path}'")
         }
     };
 
@@ -793,9 +799,9 @@ fn handle_message(msg: &RawMessage) -> io::Result<Option<Vec<u8>>> {
             vsock_proto::encode(MSG_PONG, msg.seq, &[]).map_err(to_io_error)?,
         )),
         MSG_WRITE_FILE => {
-            let (path, content, use_sudo) =
+            let (path, content, use_sudo, append) =
                 vsock_proto::decode_write_file(&msg.payload).map_err(to_io_error)?;
-            let (success, error) = handle_write_file(path, content, use_sudo);
+            let (success, error) = handle_write_file(path, content, use_sudo, append);
             let payload = vsock_proto::encode_write_file_result(success, &error);
             Ok(Some(
                 vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload)

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -509,9 +509,70 @@ impl VsockHost {
         })
     }
 
+    /// Maximum content per write_file message.  Leaves headroom below
+    /// [`vsock_proto::MAX_MESSAGE_SIZE`] for the path and frame overhead.
+    const WRITE_FILE_CHUNK_LIMIT: usize = 15 * 1024 * 1024;
+
     /// Write a file on the guest.
+    ///
+    /// Content larger than 15 MB is automatically split into multiple
+    /// messages using the `FLAG_APPEND` protocol flag.  Chunks are written
+    /// to a temporary file and atomically renamed to the target path after
+    /// the last chunk succeeds, so a partial transfer never leaves a
+    /// truncated file at the destination.
     pub async fn write_file(&self, path: &str, content: &[u8], sudo: bool) -> io::Result<()> {
-        let payload = vsock_proto::encode_write_file(path, content, sudo)
+        if content.len() <= Self::WRITE_FILE_CHUNK_LIMIT {
+            return self.write_file_chunk(path, content, sudo, false).await;
+        }
+
+        // Write chunks to a temp file, then atomic rename.
+        let tmp = format!("{path}.vm0tmp");
+        let escaped_tmp = tmp.replace('\'', "'\\''");
+        let rm_tmp = format!("rm -f '{escaped_tmp}'");
+
+        let result = async {
+            for (i, chunk) in content.chunks(Self::WRITE_FILE_CHUNK_LIMIT).enumerate() {
+                self.write_file_chunk(&tmp, chunk, sudo, i > 0).await?;
+            }
+            io::Result::Ok(())
+        }
+        .await;
+
+        if result.is_err() {
+            // Best-effort cleanup of the temp file.
+            let _ = self.exec(&rm_tmp, 5000, &[], sudo).await;
+            return result;
+        }
+
+        // Atomic rename temp → target.
+        let escaped_path = path.replace('\'', "'\\''");
+        let mv_cmd = format!("mv -f '{escaped_tmp}' '{escaped_path}'");
+        match self.exec(&mv_cmd, 5000, &[], sudo).await {
+            Ok(r) if r.exit_code == 0 => Ok(()),
+            Ok(r) => {
+                let _ = self.exec(&rm_tmp, 5000, &[], sudo).await;
+                Err(io::Error::other(format!(
+                    "failed to rename temp file to {path}: {}",
+                    String::from_utf8_lossy(&r.stderr),
+                )))
+            }
+            Err(e) => {
+                // Connection may be broken, but try cleanup anyway.
+                let _ = self.exec(&rm_tmp, 5000, &[], sudo).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Send a single write_file message and validate the response.
+    async fn write_file_chunk(
+        &self,
+        path: &str,
+        content: &[u8],
+        sudo: bool,
+        append: bool,
+    ) -> io::Result<()> {
+        let payload = vsock_proto::encode_write_file(path, content, sudo, append)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let timeout = Duration::from_secs(300);
         let resp = self.request(MSG_WRITE_FILE, &payload, timeout).await?;
@@ -787,10 +848,12 @@ mod tests {
             let msgs = decoder.decode(&buf[..n]).unwrap();
             assert_eq!(msgs[0].msg_type, MSG_WRITE_FILE);
 
-            let (path, content, sudo) = vsock_proto::decode_write_file(&msgs[0].payload).unwrap();
+            let (path, content, sudo, append) =
+                vsock_proto::decode_write_file(&msgs[0].payload).unwrap();
             assert_eq!(path, "/tmp/test.txt");
             assert_eq!(content, b"hello");
             assert!(!sudo);
+            assert!(!append);
 
             let payload = vsock_proto::encode_write_file_result(true, "");
             let resp = vsock_proto::encode(MSG_WRITE_FILE_RESULT, msgs[0].seq, &payload).unwrap();
@@ -801,6 +864,183 @@ mod tests {
         host.write_file("/tmp/test.txt", b"hello", false)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_file_chunked() {
+        let (host_stream, mut guest) = make_pair();
+
+        // Content just over the chunk limit → 2 write messages + 1 exec (mv)
+        let chunk_limit = VsockHost::WRITE_FILE_CHUNK_LIMIT;
+        let content = vec![0xABu8; chunk_limit + 100];
+        let content_clone = content.clone();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut chunks_received = Vec::new();
+            let mut buf = vec![0u8; chunk_limit + 4096];
+
+            // Read write_file chunks + final exec (mv) message
+            loop {
+                let n = guest.read(&mut buf).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                for msg in msgs {
+                    if msg.msg_type == MSG_WRITE_FILE {
+                        let (path, chunk, _sudo, append) =
+                            vsock_proto::decode_write_file(&msg.payload).unwrap();
+                        // Chunks go to temp file
+                        assert_eq!(path, "/tmp/big.bin.vm0tmp");
+                        chunks_received.push((append, chunk.to_vec()));
+
+                        let payload = vsock_proto::encode_write_file_result(true, "");
+                        let resp =
+                            vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
+                        guest.write_all(&resp).await.unwrap();
+                    } else if msg.msg_type == MSG_EXEC {
+                        // Atomic rename: mv temp → target
+                        let decoded = vsock_proto::decode_exec(&msg.payload).unwrap();
+                        assert!(decoded.command.contains("mv -f"));
+                        assert!(decoded.command.contains("/tmp/big.bin.vm0tmp"));
+                        assert!(decoded.command.contains("/tmp/big.bin"));
+
+                        let payload = vsock_proto::encode_exec_result(0, &[], &[]);
+                        let resp = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
+                        guest.write_all(&resp).await.unwrap();
+                        // Done — verify chunks and return
+                        assert_eq!(chunks_received.len(), 2);
+                        assert!(!chunks_received[0].0); // first: create
+                        assert_eq!(chunks_received[0].1.len(), chunk_limit);
+                        assert!(chunks_received[1].0); // second: append
+                        assert_eq!(chunks_received[1].1.len(), 100);
+                        let mut reassembled = chunks_received[0].1.clone();
+                        reassembled.extend_from_slice(&chunks_received[1].1);
+                        assert_eq!(reassembled, content_clone);
+                        return;
+                    }
+                }
+            }
+            panic!("guest loop ended without receiving exec (mv)");
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        host.write_file("/tmp/big.bin", &content, false)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_file_chunked_cleans_up_on_chunk_failure() {
+        let (host_stream, mut guest) = make_pair();
+
+        let chunk_limit = VsockHost::WRITE_FILE_CHUNK_LIMIT;
+        let content = vec![0xABu8; chunk_limit + 100];
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = vec![0u8; chunk_limit + 4096];
+            let mut chunk_count = 0u32;
+            loop {
+                let n = guest.read(&mut buf).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                for msg in msgs {
+                    if msg.msg_type == MSG_WRITE_FILE {
+                        chunk_count += 1;
+                        let (success, err) = if chunk_count == 2 {
+                            (false, "disk full")
+                        } else {
+                            (true, "")
+                        };
+                        let payload = vsock_proto::encode_write_file_result(success, err);
+                        let resp =
+                            vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
+                        guest.write_all(&resp).await.unwrap();
+                    } else if msg.msg_type == MSG_EXEC {
+                        // Cleanup: rm -f temp file
+                        let decoded = vsock_proto::decode_exec(&msg.payload).unwrap();
+                        assert!(decoded.command.contains("rm -f"));
+                        let payload = vsock_proto::encode_exec_result(0, &[], &[]);
+                        let resp = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
+                        guest.write_all(&resp).await.unwrap();
+                        return;
+                    }
+                }
+            }
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let err = host
+            .write_file("/tmp/big.bin", &content, false)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("disk full"));
+    }
+
+    #[tokio::test]
+    async fn test_write_file_chunked_cleans_up_on_mv_failure() {
+        let (host_stream, mut guest) = make_pair();
+
+        let chunk_limit = VsockHost::WRITE_FILE_CHUNK_LIMIT;
+        let content = vec![0xABu8; chunk_limit + 100];
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = vec![0u8; chunk_limit + 4096];
+            let mut exec_count = 0u32;
+            loop {
+                let n = guest.read(&mut buf).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                for msg in msgs {
+                    if msg.msg_type == MSG_WRITE_FILE {
+                        let payload = vsock_proto::encode_write_file_result(true, "");
+                        let resp =
+                            vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
+                        guest.write_all(&resp).await.unwrap();
+                    } else if msg.msg_type == MSG_EXEC {
+                        exec_count += 1;
+                        let decoded = vsock_proto::decode_exec(&msg.payload).unwrap();
+                        if decoded.command.contains("mv -f") {
+                            // mv fails
+                            let payload =
+                                vsock_proto::encode_exec_result(1, &[], b"permission denied");
+                            let resp =
+                                vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
+                            guest.write_all(&resp).await.unwrap();
+                        } else {
+                            // cleanup rm
+                            assert!(decoded.command.contains("rm -f"));
+                            let payload = vsock_proto::encode_exec_result(0, &[], &[]);
+                            let resp =
+                                vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
+                            guest.write_all(&resp).await.unwrap();
+                            assert_eq!(exec_count, 2); // mv then rm
+                            return;
+                        }
+                    }
+                }
+            }
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let err = host
+            .write_file("/tmp/big.bin", &content, false)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("permission denied"));
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -513,6 +513,13 @@ impl VsockHost {
     /// [`vsock_proto::MAX_MESSAGE_SIZE`] for the path and frame overhead.
     const WRITE_FILE_CHUNK_LIMIT: usize = 15 * 1024 * 1024;
 
+    /// Timeout (ms) for short helper commands (mv, rm) used during chunked writes.
+    const HELPER_EXEC_TIMEOUT_MS: u32 = 5000;
+
+    /// Shorter timeout (ms) for best-effort cleanup when the connection may
+    /// already be broken.  Avoids blocking for a full 5 s on a dead socket.
+    const CLEANUP_EXEC_TIMEOUT_MS: u32 = 1000;
+
     /// Write a file on the guest.
     ///
     /// Content larger than 15 MB is automatically split into multiple
@@ -540,25 +547,34 @@ impl VsockHost {
 
         if result.is_err() {
             // Best-effort cleanup of the temp file.
-            let _ = self.exec(&rm_tmp, 5000, &[], sudo).await;
+            let _ = self
+                .exec(&rm_tmp, Self::CLEANUP_EXEC_TIMEOUT_MS, &[], sudo)
+                .await;
             return result;
         }
 
         // Atomic rename temp → target.
         let escaped_path = path.replace('\'', "'\\''");
         let mv_cmd = format!("mv -f '{escaped_tmp}' '{escaped_path}'");
-        match self.exec(&mv_cmd, 5000, &[], sudo).await {
+        match self
+            .exec(&mv_cmd, Self::HELPER_EXEC_TIMEOUT_MS, &[], sudo)
+            .await
+        {
             Ok(r) if r.exit_code == 0 => Ok(()),
             Ok(r) => {
-                let _ = self.exec(&rm_tmp, 5000, &[], sudo).await;
+                let _ = self
+                    .exec(&rm_tmp, Self::CLEANUP_EXEC_TIMEOUT_MS, &[], sudo)
+                    .await;
                 Err(io::Error::other(format!(
                     "failed to rename temp file to {path}: {}",
                     String::from_utf8_lossy(&r.stderr),
                 )))
             }
             Err(e) => {
-                // Connection may be broken, but try cleanup anyway.
-                let _ = self.exec(&rm_tmp, 5000, &[], sudo).await;
+                // Connection likely broken — short timeout to avoid blocking.
+                let _ = self
+                    .exec(&rm_tmp, Self::CLEANUP_EXEC_TIMEOUT_MS, &[], sudo)
+                    .await;
                 Err(e)
             }
         }

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -20,7 +20,7 @@
 //! | 0x02 | G→H       | pong              | (empty) |
 //! | 0x03 | H→G       | exec              | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)` |
 //! | 0x04 | G→H       | exec_result       | `[4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` |
-//! | 0x05 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` |
+//! | 0x05 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
 //! | 0x06 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
 //! | 0x07 | H→G       | spawn_watch       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` |
 //! | 0x08 | G→H       | spawn_watch_result| `[4B pid]` |
@@ -60,6 +60,8 @@ pub const VSOCK_PORT: u32 = 1000;
 
 /// Flag: execute with root privileges (used in exec, spawn_watch, and write_file).
 pub const FLAG_SUDO: u8 = 0x01;
+/// Flag: append to existing file instead of truncating (used in write_file).
+pub const FLAG_APPEND: u8 = 0x02;
 
 /// Protocol error.
 #[derive(Debug, Clone)]
@@ -230,16 +232,28 @@ pub fn encode_exec_result(exit_code: i32, stdout: &[u8], stderr: &[u8]) -> Vec<u
 ///
 /// Returns `Err` if path exceeds 65535 bytes (u16 field limit).
 /// Total message size is validated by [`encode`].
-pub fn encode_write_file(path: &str, content: &[u8], sudo: bool) -> Result<Vec<u8>, ProtocolError> {
+pub fn encode_write_file(
+    path: &str,
+    content: &[u8],
+    sudo: bool,
+    append: bool,
+) -> Result<Vec<u8>, ProtocolError> {
     let path_bytes = path.as_bytes();
     if path_bytes.len() > u16::MAX as usize {
         return Err(ProtocolError::PayloadTooLarge("path", path_bytes.len()));
     }
     let path_len = path_bytes.len() as u16;
+    let mut flags = 0u8;
+    if sudo {
+        flags |= FLAG_SUDO;
+    }
+    if append {
+        flags |= FLAG_APPEND;
+    }
     let mut p = Vec::with_capacity(7 + path_len as usize + content.len());
     p.extend_from_slice(&path_len.to_be_bytes());
     p.extend_from_slice(path_bytes);
-    p.push(if sudo { FLAG_SUDO } else { 0 });
+    p.push(flags);
     p.extend_from_slice(&(content.len() as u32).to_be_bytes());
     p.extend_from_slice(content);
     Ok(p)
@@ -436,8 +450,8 @@ pub fn decode_exec_result(payload: &[u8]) -> Result<(i32, &[u8], &[u8]), Protoco
     Ok((exit_code, stdout, stderr))
 }
 
-/// Decode write_file payload. Returns `(path, content, sudo)`.
-pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool), ProtocolError> {
+/// Decode write_file payload. Returns `(path, content, sudo, append)`.
+pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool), ProtocolError> {
     let path_len = read_u16_at(payload, 0)
         .ok_or(ProtocolError::InvalidPayload("write_file too short"))? as usize;
     let path = std::str::from_utf8(
@@ -456,7 +470,12 @@ pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool), Protocol
         .ok_or(ProtocolError::InvalidPayload(
             "write_file content truncated",
         ))?;
-    Ok((path, content, (flags & FLAG_SUDO) != 0))
+    Ok((
+        path,
+        content,
+        (flags & FLAG_SUDO) != 0,
+        (flags & FLAG_APPEND) != 0,
+    ))
 }
 
 /// Decode write_file_result payload. Returns `(success, error)`.
@@ -751,33 +770,53 @@ mod tests {
 
     #[test]
     fn write_file_payload_roundtrip() {
-        let payload = encode_write_file("/tmp/test.txt", b"content", false).unwrap();
-        let (path, content, sudo) = decode_write_file(&payload).unwrap();
+        let payload = encode_write_file("/tmp/test.txt", b"content", false, false).unwrap();
+        let (path, content, sudo, append) = decode_write_file(&payload).unwrap();
         assert_eq!(path, "/tmp/test.txt");
         assert_eq!(content, b"content");
         assert!(!sudo);
+        assert!(!append);
     }
 
     #[test]
     fn write_file_with_sudo() {
-        let payload = encode_write_file("/etc/hosts", b"127.0.0.1", true).unwrap();
-        let (path, content, sudo) = decode_write_file(&payload).unwrap();
+        let payload = encode_write_file("/etc/hosts", b"127.0.0.1", true, false).unwrap();
+        let (path, content, sudo, append) = decode_write_file(&payload).unwrap();
         assert_eq!(path, "/etc/hosts");
         assert_eq!(content, b"127.0.0.1");
         assert!(sudo);
+        assert!(!append);
+    }
+
+    #[test]
+    fn write_file_with_append() {
+        let payload = encode_write_file("/tmp/out.log", b"more data", false, true).unwrap();
+        let (path, content, sudo, append) = decode_write_file(&payload).unwrap();
+        assert_eq!(path, "/tmp/out.log");
+        assert_eq!(content, b"more data");
+        assert!(!sudo);
+        assert!(append);
+    }
+
+    #[test]
+    fn write_file_with_sudo_and_append() {
+        let payload = encode_write_file("/etc/conf", b"line", true, true).unwrap();
+        let (_, _, sudo, append) = decode_write_file(&payload).unwrap();
+        assert!(sudo);
+        assert!(append);
     }
 
     #[test]
     fn write_file_path_too_long() {
         let long_path = "a".repeat(65536);
-        let err = encode_write_file(&long_path, b"", false).unwrap_err();
+        let err = encode_write_file(&long_path, b"", false, false).unwrap_err();
         assert!(matches!(err, ProtocolError::PayloadTooLarge("path", 65536)));
     }
 
     #[test]
     fn write_file_content_too_large() {
         let big = vec![0u8; MAX_MESSAGE_SIZE];
-        let payload = encode_write_file("/tmp/f", &big, false).unwrap();
+        let payload = encode_write_file("/tmp/f", &big, false, false).unwrap();
         let err = encode(MSG_WRITE_FILE, 1, &payload).unwrap_err();
         assert!(matches!(err, ProtocolError::MessageTooLarge(_)));
     }

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -798,6 +798,33 @@ async fn test_write_file_large() {
     h.finish();
 }
 
+// ── write_file (chunked — exceeds single-message limit) ────────────
+
+#[tokio::test]
+async fn test_write_file_chunked() {
+    let h = Harness::new().await;
+
+    let file_path = h.dir.join("chunked.bin");
+    let file_path_str = file_path.to_string_lossy().to_string();
+    // 16 MB content — exceeds the 15 MB chunk limit, triggers 2-chunk path + atomic rename
+    let content = vec![0xABu8; 16 * 1024 * 1024];
+
+    h.write_file(&file_path_str, &content, false)
+        .await
+        .expect("chunked write_file failed");
+
+    let written = std::fs::read(&file_path).expect("failed to read written file");
+    assert_eq!(written.len(), content.len());
+    assert_eq!(written, content);
+
+    // Temp file should not remain
+    assert!(
+        !std::path::Path::new(&format!("{file_path_str}.vm0tmp")).exists(),
+        "temp file was not cleaned up"
+    );
+    h.finish();
+}
+
 // ── shutdown ─────────────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add `FLAG_APPEND` (0x02) to vsock `write_file` protocol, enabling chunked writes for files exceeding the 16 MB single-message limit
- Host-side `write_file()` transparently splits large content into 15 MB chunks (first creates, subsequent append)
- Chunks written to temp file + atomic `mv` rename on success, cleanup `rm` on failure
- Fixes #9322 — session history >16 MB was silently crashing agent runs

## Changes

| File | What |
|------|------|
| `vsock-proto` | `FLAG_APPEND` constant, `encode/decode_write_file` accept `append` param |
| `vsock-guest` | `handle_write_file` supports append mode (`cat >>` / `tee -a`) |
| `vsock-host` | `write_file()` auto-chunks >15 MB, temp file + atomic rename |

## Design

- Reuses existing `MSG_WRITE_FILE` message type — no new message types
- Each chunk gets its own `MSG_WRITE_FILE_RESULT` response (request-response model unchanged)
- Sandbox trait interface unchanged — callers (executor) need zero changes
- Temp file (`{path}.vm0tmp`) prevents partial files on failure; cleaned up on error

## Test plan

- [x] `test_write_file` — small file, single message (existing, updated)
- [x] `test_write_file_chunked` — large file split into 2 chunks + mv
- [x] `test_write_file_chunked_cleans_up_on_chunk_failure` — chunk fails → rm temp
- [x] `test_write_file_chunked_cleans_up_on_mv_failure` — mv fails → rm temp
- [x] Proto roundtrip tests for append flag combinations
- [x] `cargo clippy` clean

Closes #9329

🤖 Generated with [Claude Code](https://claude.com/claude-code)