### PR TITLE
refactor(mission-control): fix p1 issues from pr #9325 review

### DIFF
--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
@@ -45,7 +45,7 @@ const OPTIMISTIC_TTL_MS = 30_000;
 
 export type TaskPanelEntry =
   | { kind: "chat"; signals: ChatThreadSignals }
-  | { kind: "activity"; signals: ActivitySignals; runId: string };
+  | { kind: "activity"; signals: ActivitySignals };
 
 // ---------------------------------------------------------------------------
 // TaskSignals — per-task signal bundle
@@ -131,18 +131,17 @@ function createCardSignals() {
 }
 
 interface PanelSignals {
-  internalOpen$: ReturnType<typeof state<boolean>>;
-  internalOpenedAt$: ReturnType<typeof state<number | null>>;
-  internalPanelEntry$: ReturnType<typeof state<TaskPanelEntry | null>>;
-  resetPanelPolling$: ReturnType<typeof resetSignal>;
   open$: Computed<boolean>;
   openedAt$: Computed<number | null>;
   panelEntry$: Computed<TaskPanelEntry | null>;
+  openTask$: Command<Promise<void>, [AbortSignal]>;
   closeTask$: Command<void, []>;
   refreshPanel$: Command<void, [AbortSignal]>;
+  focusInput$: Command<void, []>;
 }
 
 function createPanelSignals(
+  taskId: string,
   internalTask$: ReturnType<typeof state<TaskItem>>,
   setInputFocused$: Command<void, [boolean]>,
 ): PanelSignals {
@@ -175,31 +174,59 @@ function createPanelSignals(
       return;
     }
     const task = get(internalTask$);
-    if (!task.latestRunId || entry.runId === task.latestRunId) {
+    if (!task.latestRunId || entry.signals.runId === task.latestRunId) {
       return;
     }
     const panelSignal = set(resetPanelPolling$, signal);
     const signals = createActivitySignals(task.latestRunId);
-    set(internalPanelEntry$, {
-      kind: "activity",
-      signals,
-      runId: task.latestRunId,
-    });
+    set(internalPanelEntry$, { kind: "activity", signals });
     // Polling lifecycle is managed by resetPanelPolling$ — aborted on next
     // refresh or panel close. throwIfNotAbort swallows the expected AbortError.
     set(signals.startPolling$, panelSignal).catch(throwIfNotAbort);
   });
 
+  const openTask$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
+      if (get(internalOpen$)) {
+        return;
+      }
+      const task = get(internalTask$);
+      set(markRead$, taskId, task.latestRunId);
+      if (task.type === "chat" && task.chatThreadId) {
+        const { draft } = set(ensureDraft$, task.chatThreadId);
+        const signals = createChatThreadSignals(task.chatThreadId, draft);
+        set(internalPanelEntry$, { kind: "chat", signals });
+        set(internalOpenedAt$, Date.now());
+        set(internalOpen$, true);
+        await set(signals.loadMessages$, signal);
+        return;
+      }
+      if (task.latestRunId) {
+        const panelSignal = set(resetPanelPolling$, signal);
+        const signals = createActivitySignals(task.latestRunId);
+        set(internalPanelEntry$, { kind: "activity", signals });
+        set(internalOpenedAt$, Date.now());
+        set(internalOpen$, true);
+        await set(signals.startPolling$, panelSignal);
+      }
+    },
+  );
+
+  const focusInput$ = command(({ get, set }) => {
+    const entry = get(internalPanelEntry$);
+    if (entry) {
+      set(entry.signals.focusInput$);
+    }
+  });
+
   return {
-    internalOpen$,
-    internalOpenedAt$,
-    internalPanelEntry$,
-    resetPanelPolling$,
     open$,
     openedAt$,
     panelEntry$,
+    openTask$,
     closeTask$,
     refreshPanel$,
+    focusInput$,
   };
 }
 
@@ -232,57 +259,17 @@ function createTaskSignals(initialTask: TaskItem): TaskSignals {
   } = createCardSignals();
 
   const {
-    internalOpen$,
-    internalOpenedAt$,
-    internalPanelEntry$,
-    resetPanelPolling$,
     open$,
     openedAt$,
     panelEntry$,
+    openTask$,
     closeTask$,
     refreshPanel$,
-  } = createPanelSignals(internalTask$, setInputFocused$);
+    focusInput$,
+  } = createPanelSignals(initialTask.id, internalTask$, setInputFocused$);
 
   const optimisticRef = { value: false };
   const optimisticInsertedAtRef = { value: null as number | null };
-
-  const openTask$ = command(
-    async ({ get, set }, signal: AbortSignal): Promise<void> => {
-      if (get(internalOpen$)) {
-        return;
-      }
-      const task = get(internalTask$);
-      set(markRead$, initialTask.id, task.latestRunId);
-      if (task.type === "chat" && task.chatThreadId) {
-        const { draft } = set(ensureDraft$, task.chatThreadId);
-        const signals = createChatThreadSignals(task.chatThreadId, draft);
-        set(internalPanelEntry$, { kind: "chat", signals });
-        set(internalOpenedAt$, Date.now());
-        set(internalOpen$, true);
-        await set(signals.loadMessages$, signal);
-        return;
-      }
-      if (task.latestRunId) {
-        const panelSignal = set(resetPanelPolling$, signal);
-        const signals = createActivitySignals(task.latestRunId);
-        set(internalPanelEntry$, {
-          kind: "activity",
-          signals,
-          runId: task.latestRunId,
-        });
-        set(internalOpenedAt$, Date.now());
-        set(internalOpen$, true);
-        await set(signals.startPolling$, panelSignal);
-      }
-    },
-  );
-
-  const focusInput$ = command(({ get, set }) => {
-    const entry = get(internalPanelEntry$);
-    if (entry) {
-      set(entry.signals.focusInput$);
-    }
-  });
 
   return {
     taskId: initialTask.id,

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -1139,33 +1139,77 @@ describe("mission control page", () => {
           ],
         });
       }),
+      http.get("*/api/zero/logs/run-refresh-v1", () => {
+        return HttpResponse.json({
+          id: "00000000-0000-4000-a000-000000000010",
+          displayName: "Test Agent",
+          status: "completed",
+          agentId: "agent-1",
+          sessionId: null,
+          triggerSource: "schedule",
+          triggerAgentName: null,
+          modelProvider: null,
+          selectedModel: null,
+          framework: null,
+          scheduleId: null,
+          prompt: "Prompt from run v1",
+          appendSystemPrompt: null,
+          error: null,
+          createdAt: "2026-04-10T10:00:00Z",
+          startedAt: "2026-04-10T10:00:01Z",
+          completedAt: "2026-04-10T10:00:05Z",
+          artifact: { name: null, version: null },
+        });
+      }),
+      http.get("*/api/zero/runs/run-refresh-v1/telemetry/agent", () => {
+        return HttpResponse.json({
+          events: [],
+          hasMore: false,
+          framework: "anthropic",
+        });
+      }),
+      http.get("*/api/zero/logs/run-refresh-v2", () => {
+        return HttpResponse.json({
+          id: "00000000-0000-4000-a000-000000000011",
+          displayName: "Test Agent",
+          status: "completed",
+          agentId: "agent-1",
+          sessionId: null,
+          triggerSource: "schedule",
+          triggerAgentName: null,
+          modelProvider: null,
+          selectedModel: null,
+          framework: null,
+          scheduleId: null,
+          prompt: "Prompt from run v2",
+          appendSystemPrompt: null,
+          error: null,
+          createdAt: "2026-04-10T10:01:00Z",
+          startedAt: "2026-04-10T10:01:01Z",
+          completedAt: "2026-04-10T10:01:05Z",
+          artifact: { name: null, version: null },
+        });
+      }),
+      http.get("*/api/zero/runs/run-refresh-v2/telemetry/agent", () => {
+        return HttpResponse.json({
+          events: [],
+          hasMore: false,
+          framework: "anthropic",
+        });
+      }),
     );
-
-    mockActivityAPIs("run-refresh-v1");
-    mockActivityAPIs("run-refresh-v2");
 
     const user = userEvent.setup();
     detachedSetupPage({ context, path: "/_/mission-control" });
 
-    // Open the panel — it should show run-refresh-v1
+    // Open the panel — it should show the v1 prompt
     const title = await waitFor(() => {
       return screen.getByText("Refresh Panel Task");
     });
     await user.click(title);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Close task")).toBeInTheDocument();
-    });
-
-    // Confirm the panel entry is tracking run-refresh-v1 before the swap
-    await waitFor(async () => {
-      const signals = await context.store.get(taskSignals$);
-      const ts = signals.find((s) => {
-        return s.taskId === "task-refresh";
-      });
-      const entry = context.store.get(ts!.panelEntry$);
-      expect(entry?.kind).toBe("activity");
-      expect(entry?.kind === "activity" && entry.runId).toBe("run-refresh-v1");
+      expect(screen.getByText("Prompt from run v1")).toBeInTheDocument();
     });
 
     // Switch the task API to return run-v2, simulating a new run arriving
@@ -1192,25 +1236,10 @@ describe("mission control page", () => {
 
     // The page's background task loop will pick up the new latestRunId and
     // call refreshPanel$, swapping the panel entry to run-refresh-v2.
-    await waitFor(async () => {
-      const signals = await context.store.get(taskSignals$);
-      const ts = signals.find((s) => {
-        return s.taskId === "task-refresh";
-      });
-      const entry = context.store.get(ts!.panelEntry$);
-      return entry?.kind === "activity" && entry.runId === "run-refresh-v2";
+    // The panel now renders the v2 prompt.
+    await waitFor(() => {
+      expect(screen.getByText("Prompt from run v2")).toBeInTheDocument();
     });
-
-    // Final confirmation: panel entry is now pointing at run-refresh-v2
-    const signalsAfter = await context.store.get(taskSignals$);
-    const taskTsAfter = signalsAfter.find((ts) => {
-      return ts.taskId === "task-refresh";
-    });
-    const entryAfter = context.store.get(taskTsAfter!.panelEntry$);
-    expect(entryAfter?.kind).toBe("activity");
-    expect(entryAfter?.kind === "activity" && entryAfter.runId).toBe(
-      "run-refresh-v2",
-    );
   });
 
   it("should clear panel entry and abort polling when closeTask$ is invoked", async () => {
@@ -1276,27 +1305,15 @@ describe("mission control page", () => {
       return screen.getByLabelText("Close task");
     });
 
-    // Panel entry should be set before closing
-    const signalsBefore = await context.store.get(taskSignals$);
-    const taskTs = signalsBefore.find((ts) => {
-      return ts.taskId === "task-close";
-    });
-    expect(taskTs).toBeDefined();
-    expect(context.store.get(taskTs!.panelEntry$)).not.toBeNull();
-    expect(context.store.get(taskTs!.open$)).toBeTruthy();
-
     // Close the panel
     await user.click(closeBtn);
 
-    // Panel entry and open state should be cleared
+    // Close button should disappear once the panel is dismissed
     await waitFor(() => {
-      expect(context.store.get(taskTs!.open$)).toBeFalsy();
+      expect(screen.queryByLabelText("Close task")).not.toBeInTheDocument();
     });
-    expect(context.store.get(taskTs!.panelEntry$)).toBeNull();
 
-    // Polling is driven by resetPanelPolling$ abort — after close the signal
-    // is aborted so startPolling$ exits. waitFor above already guarantees the
-    // abort fired, so count must be greater than 0 and stable.
+    // Polling was active while the panel was open
     expect(pollCallCount).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Addresses all P1 issues identified in the PR #9325 review:

- **P1 — Remove redundant `runId` from `TaskPanelEntry` activity arm**: The `runId` field was a duplicate of `ActivitySignals.runId`. All call sites now use `entry.signals.runId` instead.
- **P1 — Stop leaking internal state atoms from `PanelSignals`**: Moved `openTask$` and `focusInput$` into `createPanelSignals` so the factory no longer exposes `internalOpen$`, `internalOpenedAt$`, `internalPanelEntry$`, and `resetPanelPolling$` through the `PanelSignals` interface. These are now properly encapsulated.
- **P1 — Replace signal-state assertions with DOM behavior assertions**: Both new tests (`refreshPanel$` swap and `closeTask$` abort) now assert what the user sees in the DOM rather than inspecting internal signal state. The refresh test uses distinct `prompt` values (`"Prompt from run v1"` / `"Prompt from run v2"`) to verify the panel actually swaps content.

Also fixes P2 issues: removes the redundant post-`waitFor` signal assertion block and the stale comment about "count must be greater than 0 and stable".

## Test plan

- [ ] All 26 mission-control-page tests pass
- [ ] TypeScript types pass (`pnpm check-types`)
- [ ] Lint passes (`pnpm -F @vm0/app exec oxlint && eslint . --max-warnings 0`)
- [ ] Knip passes (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)