### PR TITLE
refactor: move org test infrastructure from api-test-helpers to proper modules

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers/org.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/org.ts
@@ -2,13 +2,15 @@ import { and, eq, sql } from "drizzle-orm";
 import { initServices } from "../../lib/init-services";
 import { orgMetadata } from "../../db/schema/org-metadata";
 import { orgCache } from "../../db/schema/org-cache";
-import { orgMembersCache } from "../../db/schema/org-members-cache";
 import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
 import { zeroAgents } from "../../db/schema/zero-agent";
 import { agentComposes } from "../../db/schema/agent-compose";
 import { modelProviders } from "../../db/schema/model-provider";
 import { ORG_SENTINEL_USER_ID } from "../../lib/zero/org/org-sentinel";
 import { getTestAuthContext } from "./core";
+import { insertOrgCacheEntry, ensureOrgRow } from "../test-helpers";
+
+export { insertOrgCacheEntry, ensureOrgRow };
 
 /**
  * Create a test org by inserting into org_cache.
@@ -44,18 +46,6 @@ export async function createTestOrg(
   await ensureOrgRow(orgId);
 
   return { id: orgId, slug };
-}
-
-/**
- * Ensure an org row exists in the `org` table.
- * Inserts with defaults if missing, does nothing if already present.
- */
-export async function ensureOrgRow(orgId: string): Promise<void> {
-  initServices();
-  await globalThis.services.db
-    .insert(orgMetadata)
-    .values({ orgId })
-    .onConflictDoNothing();
 }
 
 /**
@@ -138,34 +128,6 @@ export async function setDefaultAgentByComposeId(
 }
 
 /**
- * Insert a row into org_cache for testing cache behavior.
- */
-export async function insertOrgCacheEntry(entry: {
-  orgId: string;
-  slug: string;
-  name?: string;
-  cachedAt?: Date;
-}): Promise<void> {
-  initServices();
-  await globalThis.services.db
-    .insert(orgCache)
-    .values({
-      orgId: entry.orgId,
-      slug: entry.slug,
-      name: entry.name ?? entry.slug,
-      cachedAt: entry.cachedAt ?? new Date(),
-    })
-    .onConflictDoUpdate({
-      target: orgCache.orgId,
-      set: {
-        slug: entry.slug,
-        name: entry.name ?? entry.slug,
-        cachedAt: entry.cachedAt ?? new Date(),
-      },
-    });
-}
-
-/**
  * Delete an org_cache row by orgId.
  * Useful for testing cache-miss behavior after createTestOrg pre-populates cache.
  */
@@ -187,60 +149,11 @@ export async function getOrgCacheEntry(orgId: string) {
   return row ?? null;
 }
 
-/**
- * Insert an org_members_cache entry for testing cache behavior.
- */
-export async function insertOrgMembersCacheEntry(entry: {
-  orgId: string;
-  userId: string;
-  role?: string;
-  cachedAt?: Date;
-}): Promise<void> {
-  initServices();
-  await globalThis.services.db
-    .insert(orgMembersCache)
-    .values({
-      orgId: entry.orgId,
-      userId: entry.userId,
-      role: entry.role ?? "member",
-      cachedAt: entry.cachedAt ?? new Date(),
-    })
-    .onConflictDoUpdate({
-      target: [orgMembersCache.orgId, orgMembersCache.userId],
-      set: {
-        role: entry.role ?? "member",
-        cachedAt: entry.cachedAt ?? new Date(),
-      },
-    });
-}
-
-export async function findOrgMembersCacheEntry(orgId: string, userId: string) {
-  initServices();
-  const [row] = await globalThis.services.db
-    .select()
-    .from(orgMembersCache)
-    .where(
-      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
-    )
-    .limit(1);
-  return row;
-}
-
-/**
- * Delete a cached membership entry. Useful for tests that need to change
- * a user's role mid-test (the cache would otherwise serve the stale role).
- */
-export async function clearOrgMembersCacheEntry(
-  orgId: string,
-  userId: string,
-): Promise<void> {
-  initServices();
-  await globalThis.services.db
-    .delete(orgMembersCache)
-    .where(
-      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
-    );
-}
+export {
+  insertOrgMembersCacheEntry,
+  findOrgMembersCacheEntry,
+  clearOrgMembersCacheEntry,
+} from "../db-test-seeders/org-members-cache";
 
 /**
  * Insert an org_members entry for testing member preferences.

--- a/turbo/apps/web/src/__tests__/db-test-seeders/org-members-cache.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/org-members-cache.ts
@@ -1,0 +1,61 @@
+import { and, eq } from "drizzle-orm";
+import { initServices } from "../../lib/init-services";
+import { orgMembersCache } from "../../db/schema/org-members-cache";
+
+/**
+ * Insert an org_members_cache entry for testing cache behavior.
+ */
+export async function insertOrgMembersCacheEntry(entry: {
+  orgId: string;
+  userId: string;
+  role?: string;
+  cachedAt?: Date;
+}): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .insert(orgMembersCache)
+    .values({
+      orgId: entry.orgId,
+      userId: entry.userId,
+      role: entry.role ?? "member",
+      cachedAt: entry.cachedAt ?? new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [orgMembersCache.orgId, orgMembersCache.userId],
+      set: {
+        role: entry.role ?? "member",
+        cachedAt: entry.cachedAt ?? new Date(),
+      },
+    });
+}
+
+/**
+ * Find a cached membership entry by (orgId, userId).
+ */
+export async function findOrgMembersCacheEntry(orgId: string, userId: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(orgMembersCache)
+    .where(
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
+    )
+    .limit(1);
+  return row;
+}
+
+/**
+ * Delete a cached membership entry. Useful for tests that need to change
+ * a user's role mid-test (the cache would otherwise serve the stale role).
+ */
+export async function clearOrgMembersCacheEntry(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .delete(orgMembersCache)
+    .where(
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
+    );
+}

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -48,11 +48,12 @@ import { inArray } from "drizzle-orm";
 import { Axiom } from "@axiomhq/js";
 import { mockClerk, clearClerkMock } from "./clerk-mock";
 import { initServices } from "../lib/init-services";
-import { insertOrgCacheEntry, ensureOrgRow } from "./api-test-helpers";
 import * as s3Client from "../lib/infra/s3/s3-client";
 import * as axiomClient from "../lib/shared/axiom/client";
 import { agentComposes } from "../db/schema/agent-compose";
 import { connectors } from "../db/schema/connector";
+import { orgCache } from "../db/schema/org-cache";
+import { orgMetadata } from "../db/schema/org-metadata";
 import { userCache } from "../db/schema/user-cache";
 
 /**
@@ -184,6 +185,46 @@ interface TestContext {
 export interface UserContext {
   readonly userId: string;
   readonly orgId: string;
+}
+
+/**
+ * Insert a row into org_cache for testing cache behavior.
+ */
+export async function insertOrgCacheEntry(entry: {
+  orgId: string;
+  slug: string;
+  name?: string;
+  cachedAt?: Date;
+}): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .insert(orgCache)
+    .values({
+      orgId: entry.orgId,
+      slug: entry.slug,
+      name: entry.name ?? entry.slug,
+      cachedAt: entry.cachedAt ?? new Date(),
+    })
+    .onConflictDoUpdate({
+      target: orgCache.orgId,
+      set: {
+        slug: entry.slug,
+        name: entry.name ?? entry.slug,
+        cachedAt: entry.cachedAt ?? new Date(),
+      },
+    });
+}
+
+/**
+ * Ensure an org row exists in the `org` table.
+ * Inserts with defaults if missing, does nothing if already present.
+ */
+export async function ensureOrgRow(orgId: string): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .insert(orgMetadata)
+    .values({ orgId })
+    .onConflictDoNothing();
 }
 
 /**


### PR DESCRIPTION
## Summary

- Move `insertOrgCacheEntry` and `ensureOrgRow` from `api-test-helpers/org.ts` to `test-helpers.ts` (testContext infrastructure)
- Move `insertOrgMembersCacheEntry`, `findOrgMembersCacheEntry`, and `clearOrgMembersCacheEntry` to new `db-test-seeders/org-members-cache.ts`
- Re-exports in `api-test-helpers/org.ts` preserve backward compatibility for all existing consumers — no test files modified

## Test plan

- [x] `pnpm check-types` passes (all 6 packages)
- [x] `pnpm turbo run lint` passes (all 5 packages)
- [x] `pnpm format` — no changes needed
- [x] `pnpm knip` — no issues found
- [x] All 6 auth test files pass (68 tests): org-cache, org-membership-cache, get-auth-context, get-auth-context-zero, get-auth-context-cli, require-auth
- [x] All 5 additional test files pass: org-deletion-service, user-deletion-service, org-service, resolve-org, backfill-clerk-metadata

Closes #9338

🤖 Generated with [Claude Code](https://claude.com/claude-code)