### PR TITLE
refactor(test): move billing helpers to db-test-seeders and db-test-assertions

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
@@ -1,11 +1,8 @@
 import { and, eq } from "drizzle-orm";
 import { randomBytes } from "crypto";
 import { initServices } from "../../lib/init-services";
-import { orgMetadata } from "../../db/schema/org-metadata";
 import { creditUsage } from "../../db/schema/credit-usage";
 import { clientCreditUsage } from "../../db/schema/client-credit-usage";
-import { creditPricing } from "../../db/schema/credit-pricing";
-import { creditExpiresRecord } from "../../db/schema/credit-expires-record";
 import { usageDaily } from "../../db/schema/usage-daily";
 import { insightsDaily } from "../../db/schema/insights-daily";
 import {
@@ -20,7 +17,32 @@ import {
 } from "../../lib/zero/credit/credit-expires-service";
 
 // ---------------------------------------------------------------------------
-// org credit helpers
+// Re-exports: DB-direct seeders and assertion helpers.
+//
+// These functions were moved to dedicated directories but are re-exported
+// here for backward compatibility — existing test files import from
+// api-test-helpers and should continue to work unchanged.
+// ---------------------------------------------------------------------------
+
+export {
+  updateOrgStripeFields,
+  updateOrgAutoRecharge,
+  updateOrgStripeSubscription,
+  insertTestCreditPricing,
+  insertCreditExpiresRecord,
+} from "../db-test-seeders/credits";
+
+export {
+  getOrgBillingFields,
+  getOrgAutoRechargeFields,
+  findCreditExpiresRecords,
+} from "../db-test-assertions/credits";
+
+// ---------------------------------------------------------------------------
+// Service-layer wrappers.
+//
+// These call production service functions (not raw DB) and are valid
+// API-based helpers.
 // ---------------------------------------------------------------------------
 
 /**
@@ -30,155 +52,41 @@ export async function grantCreditsToOrg(
   orgId: string,
   amount: number,
 ): Promise<void> {
+  initServices();
   await globalThis.services.db.transaction(async (tx) => {
     await grantOrgCredits(tx, orgId, amount);
   });
 }
 
-// ---------------------------------------------------------------------------
-// Stripe billing helpers
-// ---------------------------------------------------------------------------
-
 /**
- * Set Stripe billing fields on an org in the `org_metadata` table.
+ * Deduct from expires records within a transaction (test helper).
  */
-export async function updateOrgStripeFields(
+export async function testDeductFromExpiresRecords(
   orgId: string,
-  fields: {
-    stripeCustomerId?: string | null;
-    stripeSubscriptionId?: string | null;
-    subscriptionStatus?: string | null;
-    currentPeriodEnd?: Date | null;
-    cancelAtPeriodEnd?: boolean;
-    lastProcessedInvoiceId?: string | null;
-    tier?: string;
-  },
-): Promise<void> {
-  await globalThis.services.db
-    .update(orgMetadata)
-    .set({ ...fields, updatedAt: new Date() })
-    .where(eq(orgMetadata.orgId, orgId));
-}
-
-/**
- * Read all billing-related fields from an org in the `org_metadata` table.
- */
-export async function getOrgBillingFields(orgId: string) {
-  const [row] = await globalThis.services.db
-    .select({
-      tier: orgMetadata.tier,
-      credits: orgMetadata.credits,
-      stripeCustomerId: orgMetadata.stripeCustomerId,
-      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
-      subscriptionStatus: orgMetadata.subscriptionStatus,
-      currentPeriodEnd: orgMetadata.currentPeriodEnd,
-      cancelAtPeriodEnd: orgMetadata.cancelAtPeriodEnd,
-      lastProcessedInvoiceId: orgMetadata.lastProcessedInvoiceId,
-    })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
-  return row ?? null;
-}
-
-// ---------------------------------------------------------------------------
-// Auto-recharge helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Configure auto-recharge settings on an org.
- */
-export async function updateOrgAutoRecharge(
-  orgId: string,
-  fields: {
-    autoRechargeEnabled?: boolean;
-    autoRechargeThreshold?: number | null;
-    autoRechargeAmount?: number | null;
-    autoRechargePendingAt?: Date | null;
-  },
-): Promise<void> {
-  await globalThis.services.db
-    .update(orgMetadata)
-    .set({ ...fields, updatedAt: new Date() })
-    .where(eq(orgMetadata.orgId, orgId));
-}
-
-/**
- * Read auto-recharge fields from an org.
- */
-export async function getOrgAutoRechargeFields(orgId: string) {
-  const [row] = await globalThis.services.db
-    .select({
-      autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
-      autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
-      autoRechargeAmount: orgMetadata.autoRechargeAmount,
-      autoRechargePendingAt: orgMetadata.autoRechargePendingAt,
-    })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
-  return row ?? null;
-}
-
-/**
- * Set Stripe subscription fields on org_metadata for testing billing-related flows.
- */
-export async function updateOrgStripeSubscription(
-  orgId: string,
-  subscriptionId: string,
-  status: string,
-): Promise<void> {
-  await globalThis.services.db
-    .update(orgMetadata)
-    .set({
-      stripeSubscriptionId: subscriptionId,
-      subscriptionStatus: status,
-      updatedAt: new Date(),
-    })
-    .where(eq(orgMetadata.orgId, orgId));
-}
-
-/**
- * Insert a credit_pricing record for testing.
- * Uses upsert so tests can safely set pricing for the same model.
- */
-export async function insertTestCreditPricing(
-  model: string,
-  options?: {
-    inputTokenPrice?: number;
-    outputTokenPrice?: number;
-    cacheReadTokenPrice?: number;
-    cacheCreationTokenPrice?: number;
-    modelProvider?: string;
-  },
+  amount: number,
 ): Promise<void> {
   initServices();
-  const inputTokenPrice = options?.inputTokenPrice ?? 100;
-  const outputTokenPrice = options?.outputTokenPrice ?? 200;
-  const cacheReadTokenPrice = options?.cacheReadTokenPrice ?? 0;
-  const cacheCreationTokenPrice = options?.cacheCreationTokenPrice ?? 0;
-  const modelProvider = options?.modelProvider ?? "";
-
-  await globalThis.services.db
-    .insert(creditPricing)
-    .values({
-      model,
-      modelProvider,
-      inputTokenPrice,
-      outputTokenPrice,
-      cacheReadTokenPrice,
-      cacheCreationTokenPrice,
-    })
-    .onConflictDoUpdate({
-      target: [creditPricing.model, creditPricing.modelProvider],
-      set: {
-        inputTokenPrice,
-        outputTokenPrice,
-        cacheReadTokenPrice,
-        cacheCreationTokenPrice,
-      },
-    });
+  await globalThis.services.db.transaction(async (tx) => {
+    await deductFromExpiresRecords(tx, orgId, amount);
+  });
 }
+
+/**
+ * Expire credits within a transaction (test helper).
+ * Returns the total expired amount.
+ */
+export async function testExpireCredits(orgId: string): Promise<number> {
+  initServices();
+  let result = 0;
+  await globalThis.services.db.transaction(async (tx) => {
+    result = await expireCredits(tx, orgId);
+  });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Usage / insights helpers (Part 2 — will be migrated in a separate issue).
+// ---------------------------------------------------------------------------
 
 /**
  * Insert a credit_usage record for testing.
@@ -641,72 +549,4 @@ export async function createCompletedRun(
     })
     .returning();
   return run!.id;
-}
-
-// ---------------------------------------------------------------------------
-// Credit expires record helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Insert a credit expires record for testing.
- */
-export async function insertCreditExpiresRecord(params: {
-  orgId: string;
-  source?: string;
-  stripeInvoiceId?: string;
-  amount: number;
-  remaining?: number;
-  expiresAt: Date;
-}): Promise<string> {
-  initServices();
-  const [row] = await globalThis.services.db
-    .insert(creditExpiresRecord)
-    .values({
-      orgId: params.orgId,
-      source: params.source ?? "subscription_renewal",
-      stripeInvoiceId: params.stripeInvoiceId ?? null,
-      amount: params.amount,
-      remaining: params.remaining ?? params.amount,
-      expiresAt: params.expiresAt,
-    })
-    .returning({ id: creditExpiresRecord.id });
-  return row!.id;
-}
-
-/**
- * Find all credit expires records for an org, ordered by expires_at ASC.
- */
-export async function findCreditExpiresRecords(orgId: string) {
-  initServices();
-  return globalThis.services.db
-    .select()
-    .from(creditExpiresRecord)
-    .where(eq(creditExpiresRecord.orgId, orgId))
-    .orderBy(creditExpiresRecord.expiresAt);
-}
-
-/**
- * Deduct from expires records within a transaction (test helper).
- */
-export async function testDeductFromExpiresRecords(
-  orgId: string,
-  amount: number,
-): Promise<void> {
-  initServices();
-  await globalThis.services.db.transaction(async (tx) => {
-    await deductFromExpiresRecords(tx, orgId, amount);
-  });
-}
-
-/**
- * Expire credits within a transaction (test helper).
- * Returns the total expired amount.
- */
-export async function testExpireCredits(orgId: string): Promise<number> {
-  initServices();
-  let result = 0;
-  await globalThis.services.db.transaction(async (tx) => {
-    result = await expireCredits(tx, orgId);
-  });
-  return result;
 }

--- a/turbo/apps/web/src/__tests__/db-test-assertions/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/credits.ts
@@ -1,0 +1,60 @@
+import { eq } from "drizzle-orm";
+import { initServices } from "../../lib/init-services";
+import { orgMetadata } from "../../db/schema/org-metadata";
+import { creditExpiresRecord } from "../../db/schema/credit-expires-record";
+
+// ---------------------------------------------------------------------------
+// Read-only assertion helpers for billing / credit test verification.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read all billing-related fields from an org in the `org_metadata` table.
+ */
+export async function getOrgBillingFields(orgId: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({
+      tier: orgMetadata.tier,
+      credits: orgMetadata.credits,
+      stripeCustomerId: orgMetadata.stripeCustomerId,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      subscriptionStatus: orgMetadata.subscriptionStatus,
+      currentPeriodEnd: orgMetadata.currentPeriodEnd,
+      cancelAtPeriodEnd: orgMetadata.cancelAtPeriodEnd,
+      lastProcessedInvoiceId: orgMetadata.lastProcessedInvoiceId,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Read auto-recharge fields from an org.
+ */
+export async function getOrgAutoRechargeFields(orgId: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({
+      autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
+      autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
+      autoRechargeAmount: orgMetadata.autoRechargeAmount,
+      autoRechargePendingAt: orgMetadata.autoRechargePendingAt,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Find all credit expires records for an org, ordered by expires_at ASC.
+ */
+export async function findCreditExpiresRecords(orgId: string) {
+  initServices();
+  return globalThis.services.db
+    .select()
+    .from(creditExpiresRecord)
+    .where(eq(creditExpiresRecord.orgId, orgId))
+    .orderBy(creditExpiresRecord.expiresAt);
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
@@ -1,0 +1,163 @@
+import { eq } from "drizzle-orm";
+import { initServices } from "../../lib/init-services";
+import { orgMetadata } from "../../db/schema/org-metadata";
+import { creditPricing } from "../../db/schema/credit-pricing";
+import { creditExpiresRecord } from "../../db/schema/credit-expires-record";
+
+// ---------------------------------------------------------------------------
+// DB-direct seeders for billing / Stripe test setup.
+//
+// Each function has a @why-db-direct annotation explaining why it cannot be
+// replaced by a webhook simulation or API call.
+// ---------------------------------------------------------------------------
+
+/**
+ * Set Stripe billing fields on an org in the `org_metadata` table.
+ *
+ * @why-db-direct Sets Stripe billing preconditions (stripeCustomerId,
+ * subscriptionId, tier). These fields are normally written by Stripe
+ * Dashboard / checkout flow. No API or webhook in our codebase bootstraps
+ * these from scratch — `handleCheckoutCompleted` READS `stripeCustomerId`
+ * to find the org, so it cannot create the initial association.
+ */
+export async function updateOrgStripeFields(
+  orgId: string,
+  fields: {
+    stripeCustomerId?: string | null;
+    stripeSubscriptionId?: string | null;
+    subscriptionStatus?: string | null;
+    currentPeriodEnd?: Date | null;
+    cancelAtPeriodEnd?: boolean;
+    lastProcessedInvoiceId?: string | null;
+    tier?: string;
+  },
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(orgMetadata)
+    .set({ ...fields, updatedAt: new Date() })
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+/**
+ * Configure auto-recharge settings on an org.
+ *
+ * @why-db-direct Auto-recharge configuration is normally set via the billing
+ * settings API which requires an active paid subscription. Direct seeding
+ * avoids multi-step subscription ceremony for test setup.
+ */
+export async function updateOrgAutoRecharge(
+  orgId: string,
+  fields: {
+    autoRechargeEnabled?: boolean;
+    autoRechargeThreshold?: number | null;
+    autoRechargeAmount?: number | null;
+    autoRechargePendingAt?: Date | null;
+  },
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(orgMetadata)
+    .set({ ...fields, updatedAt: new Date() })
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+/**
+ * Set Stripe subscription fields on org_metadata for testing billing-related flows.
+ *
+ * @why-db-direct Sets subscription ID and status for cleanup / deletion tests.
+ * A subset of updateOrgStripeFields. No webhook creates subscription
+ * associations from scratch.
+ */
+export async function updateOrgStripeSubscription(
+  orgId: string,
+  subscriptionId: string,
+  status: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(orgMetadata)
+    .set({
+      stripeSubscriptionId: subscriptionId,
+      subscriptionStatus: status,
+      updatedAt: new Date(),
+    })
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+/**
+ * Insert a credit_pricing record for testing.
+ * Uses upsert so tests can safely set pricing for the same model.
+ *
+ * @why-db-direct Credit pricing is reference data managed via database
+ * migrations, not API endpoints or webhooks. No user-facing flow creates
+ * pricing records.
+ */
+export async function insertTestCreditPricing(
+  model: string,
+  options?: {
+    inputTokenPrice?: number;
+    outputTokenPrice?: number;
+    cacheReadTokenPrice?: number;
+    cacheCreationTokenPrice?: number;
+    modelProvider?: string;
+  },
+): Promise<void> {
+  initServices();
+  const inputTokenPrice = options?.inputTokenPrice ?? 100;
+  const outputTokenPrice = options?.outputTokenPrice ?? 200;
+  const cacheReadTokenPrice = options?.cacheReadTokenPrice ?? 0;
+  const cacheCreationTokenPrice = options?.cacheCreationTokenPrice ?? 0;
+  const modelProvider = options?.modelProvider ?? "";
+
+  await globalThis.services.db
+    .insert(creditPricing)
+    .values({
+      model,
+      modelProvider,
+      inputTokenPrice,
+      outputTokenPrice,
+      cacheReadTokenPrice,
+      cacheCreationTokenPrice,
+    })
+    .onConflictDoUpdate({
+      target: [creditPricing.model, creditPricing.modelProvider],
+      set: {
+        inputTokenPrice,
+        outputTokenPrice,
+        cacheReadTokenPrice,
+        cacheCreationTokenPrice,
+      },
+    });
+}
+
+/**
+ * Insert a credit expires record for testing.
+ *
+ * @why-db-direct Credit expires records are normally created by
+ * `handleInvoicePaid` during subscription renewal. Tests need precise
+ * control over amounts, remaining balances, and expiry dates that cannot
+ * be achieved through the webhook flow.
+ */
+export async function insertCreditExpiresRecord(params: {
+  orgId: string;
+  source?: string;
+  stripeInvoiceId?: string;
+  amount: number;
+  remaining?: number;
+  expiresAt: Date;
+}): Promise<string> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .insert(creditExpiresRecord)
+    .values({
+      orgId: params.orgId,
+      source: params.source ?? "subscription_renewal",
+      stripeInvoiceId: params.stripeInvoiceId ?? null,
+      amount: params.amount,
+      remaining: params.remaining ?? params.amount,
+      expiresAt: params.expiresAt,
+    })
+    .returning({ id: creditExpiresRecord.id });
+  return row!.id;
+}


### PR DESCRIPTION
## Summary

- Move 5 DB-direct billing/Stripe seeder functions from `api-test-helpers/credits.ts` to `db-test-seeders/credits.ts` with `@why-db-direct` JSDoc annotations
- Move 3 read-only assertion helpers to `db-test-assertions/credits.ts`
- Keep service-layer wrappers (`grantCreditsToOrg`, `testDeductFromExpiresRecords`, `testExpireCredits`) in `api-test-helpers/credits.ts`
- Add re-exports in `api-test-helpers/credits.ts` for backward compatibility — zero changes to any test file

Closes #9341

## Test plan

- [x] All 278 test files pass (3125 tests)
- [x] TypeScript type-check passes
- [x] Lint passes (0 errors)
- [x] Format check passes (no changes)
- [x] Knip passes (no issues)
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [x] Key affected test files verified: `stripe/route.test.ts`, `auto-recharge-service.test.ts`, `credit-expiry.test.ts`, `process-credits/route.test.ts`, `member-credit-cap-service.test.ts`, `org-metadata-service.test.ts`, `org-external-cleanup.test.ts`, `clerk/route.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)