### PR TITLE
fix: upgrade debug-level log to warn in gc read_to_string failure

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -747,7 +747,7 @@ fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<PathBuf> {
         let content = match std::fs::read_to_string(entry.path()) {
             Ok(c) => c,
             Err(e) => {
-                tracing::debug!("workspace gc: cannot read {}: {e}", entry.path().display());
+                warn!("workspace gc: cannot read {}: {e}", entry.path().display());
                 continue;
             }
         };


### PR DESCRIPTION
## Summary
- Upgrade `tracing::debug!` → `warn!` for `read_to_string` failure in `discover_dead_runner_base_dirs` (gc.rs:750)
- Consistent with #9333 which upgraded all other silent/debug-level errors in the same function

Closes #9334

🤖 Generated with [Claude Code](https://claude.com/claude-code)