### PR TITLE
refactor(test): migrate compose helpers to three-tier structure

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/[id]/metadata/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/metadata/__tests__/route.test.ts
@@ -3,9 +3,9 @@ import { PATCH } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestZeroAgent,
-  getTestZeroAgent,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../../../src/__tests__/db-test-seeders/agents";
+import { getTestZeroAgent } from "../../../../../../../src/__tests__/db-test-assertions/agents";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -20,9 +20,9 @@ import {
   insertOrgCacheEntry,
   insertOrgMembersCacheEntry,
   getOrgCacheEntry,
-  createTestZeroAgent,
   updateOrgTier,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
 import {
   generateSandboxToken,
   generateZeroToken,

--- a/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
@@ -3,7 +3,6 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestZeroAgent,
   createTestRun,
   createTestSchedule,
   enableTestSchedule,
@@ -11,9 +10,12 @@ import {
   getTestScheduleRuns,
   getTestRun,
   disableAllSchedules,
-  clearComposeHeadVersion,
   setScheduleConsecutiveFailures,
 } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestZeroAgent,
+  clearComposeHeadVersion,
+} from "../../../../../src/__tests__/db-test-seeders/agents";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/internal/callbacks/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/agent/__tests__/route.test.ts
@@ -8,10 +8,10 @@ import {
   createTestCompose,
   createTestRunInDb,
   createTestCallback,
-  createTestZeroAgent,
   createSignedCallbackRequest,
   findTestZeroRun,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../../src/__tests__/db-test-seeders/agents";
 import { reloadEnv } from "../../../../../../src/env";
 import { POST } from "../route";
 import { http } from "../../../../../../src/__tests__/msw";

--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -10,13 +10,13 @@ import {
   createTestCallback,
   createTestRunInDb,
   createTestRequest,
-  getTestZeroAgentId,
   createTestAgentSession,
   createTestPushSubscription,
   getPushSubscriptionsByEndpoint,
   createSignedCallbackRequest,
   getTestSessionChatMessages,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { getTestZeroAgentId } from "../../../../../../src/__tests__/db-test-assertions/agents";
 import { reloadEnv } from "../../../../../../src/env";
 import { POST as createThreadHandler } from "../../../../zero/chat-threads/route";
 import { POST } from "../route";

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/cron/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/cron/__tests__/route.test.ts
@@ -9,7 +9,6 @@ import {
   createTestRunInDb,
   createTestCallback,
   createTestSchedule,
-  createTestZeroAgent,
   enableTestSchedule,
   disableTestSchedule,
   deleteTestSchedule,
@@ -17,6 +16,7 @@ import {
   findTestScheduleById,
   createSignedCallbackRequest,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../../../src/__tests__/db-test-seeders/agents";
 
 const context = testContext();
 

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
@@ -9,7 +9,6 @@ import {
   createTestRunInDb,
   createTestCallback,
   createTestSchedule,
-  createTestZeroAgent,
   enableTestSchedule,
   disableTestSchedule,
   deleteTestSchedule,
@@ -17,6 +16,7 @@ import {
   findTestScheduleById,
   createSignedCallbackRequest,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../../../src/__tests__/db-test-seeders/agents";
 
 const context = testContext();
 

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-prepare/__tests__/route.test.ts
@@ -9,10 +9,10 @@ import {
   createTestCallback,
   createTestRunInDb,
   createSignedCallbackRequest,
-  getTestZeroAgentId,
   insertTestVoiceChatPreparation,
   getTestVoiceChatPreparation,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { getTestZeroAgentId } from "../../../../../../src/__tests__/db-test-assertions/agents";
 import { POST } from "../route";
 
 const context = testContext();

--- a/turbo/apps/web/app/api/user/export/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/user/export/__tests__/route.test.ts
@@ -4,11 +4,10 @@ import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import {
   createTestRequest,
+  createTestCompose,
   findTestExportJobById,
-  insertTestComposeWithVersion,
   insertTestAgentSessionWithMessages,
   insertTestArtifactStorage,
-  insertTestAgentCompose,
 } from "../../../../../src/__tests__/api-test-helpers";
 
 const context = testContext();
@@ -42,15 +41,9 @@ describe("POST /api/user/export", () => {
       mockClerk({ userId: user.userId, orgId: user.orgId });
 
       // Create test compose with version
-      const { composeId } = await insertTestComposeWithVersion(
-        user.userId,
-        user.orgId,
-        "test-agent",
-        {
-          version: "1",
-          agents: { "test-agent": { framework: "claude-code" } },
-        },
-      );
+      const { composeId } = await createTestCompose("test-agent", {
+        framework: "claude-code",
+      });
 
       // Create test session with chat messages
       await insertTestAgentSessionWithMessages(user.userId, composeId, [
@@ -184,7 +177,7 @@ describe("POST /api/user/export", () => {
       const userA = await context.setupUser();
       mockClerk({ userId: userA.userId, orgId: userA.orgId });
 
-      await insertTestAgentCompose(userA.userId, userA.orgId, "user-a-agent");
+      await createTestCompose("user-a-agent");
 
       // User B triggers export
       const userB = await context.setupUser({ prefix: "other" });

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -11,7 +11,6 @@ import {
   createTestSandboxToken,
   completeTestRun,
   createTestSchedule,
-  createTestZeroAgent,
   linkRunToSchedule,
   createTestAgentSession,
   createTestEmailThreadSession,
@@ -23,6 +22,7 @@ import {
   getTestAgentSessionWithConversation,
   generateTestReplyToken,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../../src/__tests__/db-test-seeders/agents";
 import { reloadEnv } from "../../../../../../src/env";
 import {
   testContext,

--- a/turbo/apps/web/app/api/webhooks/clerk/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/clerk/__tests__/route.test.ts
@@ -16,7 +16,6 @@ import {
   createTestAgentSession,
   createTestEmailThreadSession,
   insertOrgDefaultModelProvider,
-  createTestZeroAgent,
   insertTestStorage,
   insertTestStorageVersion,
   insertTestUsageDaily,
@@ -31,12 +30,10 @@ import {
   countGithubUserLinkRows,
   countTelegramUserLinkRows,
   updateOrgStripeSubscription,
-  updateAgentComposeOrg,
   createTelegramInstallationForCompose,
   createTestCliToken,
   createTestDeviceCode,
   createTestConnectorSession,
-  insertTestComposeJob,
   insertTestGithubInstallation,
   insertTestGithubUserLink,
   insertTestTelegramInstallation,
@@ -45,6 +42,11 @@ import {
   insertOrgCacheEntry,
   insertTestSlackOrgThreadSession,
 } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestZeroAgent,
+  updateAgentComposeOrg,
+  insertTestComposeJob,
+} from "../../../../../src/__tests__/db-test-seeders/agents";
 
 // Mock @clerk/nextjs/webhooks (external dependency)
 const mockVerifyWebhook = vi.hoisted(() => {

--- a/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/__tests__/route.test.ts
@@ -4,9 +4,9 @@ import { POST as postAgentRoute } from "../../../route";
 import {
   createTestRequest,
   createTestCliToken,
-  setComposeHeadVersion,
-  getComposeHeadVersion,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import { setComposeHeadVersion } from "../../../../../../../src/__tests__/db-test-seeders/agents";
+import { getComposeHeadVersion } from "../../../../../../../src/__tests__/db-test-assertions/agents";
 import {
   testContext,
   type UserContext,

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -30,10 +30,10 @@ import {
   setDefaultAgentByComposeId,
   clearOrgMembersCacheEntry,
   insertOrgMembersCacheEntry,
-  getTestComposeVersionContent,
   createTestTarFile,
   createTestZeroSkill,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { getTestComposeVersionContent } from "../../../../../src/__tests__/db-test-assertions/agents";
 import { getInstructionsStorageName } from "@vm0/core";
 import {
   testContext,

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -4,12 +4,12 @@ import { POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  getTestZeroAgentId,
   insertOrgDefaultModelProvider,
   findTestCallbacksByRunId,
   findTestRunRecord,
   getTestRun,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { getTestZeroAgentId } from "../../../../../../src/__tests__/db-test-assertions/agents";
 import { POST as createChatThreadPOST } from "../../../chat-threads/route";
 import {
   testContext,

--- a/turbo/apps/web/app/api/zero/default-agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/default-agent/__tests__/route.test.ts
@@ -3,10 +3,10 @@ import { PUT } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  deleteTestCompose,
   deleteOrgRow,
   getOrgDefaultAgent,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { deleteTestCompose } from "../../../../../src/__tests__/db-test-seeders/agents";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
@@ -5,12 +5,12 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRunInDb,
-  createTestZeroAgent,
   createTestSlackOrgInstallation,
   insertOrgMembersCacheEntry,
   createTestSchedule,
   seedTestSlackOrgConnection,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../../../src/__tests__/db-test-seeders/agents";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/zero/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/[id]/__tests__/route.test.ts
@@ -3,7 +3,6 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestZeroAgent,
   createTestRun,
   createTestRunInDb,
   createTestSchedule,
@@ -12,6 +11,7 @@ import {
   createOrphanTestRun,
   insertOrgMembersCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../../src/__tests__/db-test-seeders/agents";
 import {
   testContext,
   type UserContext,

--- a/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
@@ -6,11 +6,11 @@ import {
   createTestCompose,
   createTestRunInDb,
   createTestSchedule,
-  createTestZeroAgent,
   createTestRun,
   completeTestRun,
   insertOrgMembersCacheEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
 import {
   testContext,
   type UserContext,

--- a/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
@@ -3,10 +3,12 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestZeroAgent,
-  seedOrphanCompose,
   updateOrgDefaultAgent,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestZeroAgent,
+  seedOrphanCompose,
+} from "../../../../../../src/__tests__/db-test-seeders/agents";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { PUT as setDefaultAgent } from "../../../default-agent/route";

--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -3,12 +3,12 @@ import { POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  getTestZeroAgentId,
   createTestSessionWithConversation,
   createTestRunInDb,
   findTestZeroRun,
   insertOrgDefaultModelProvider,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { getTestZeroAgentId } from "../../../../../src/__tests__/db-test-assertions/agents";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
@@ -3,12 +3,12 @@ import { DELETE } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestZeroAgent,
-  getTestZeroAgentId,
   createTestOrg,
   createTestSchedule,
   insertOrgMembersCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../../src/__tests__/db-test-seeders/agents";
+import { getTestZeroAgentId } from "../../../../../../src/__tests__/db-test-assertions/agents";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/zero/schedules/[name]/disable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/disable/__tests__/route.test.ts
@@ -3,13 +3,13 @@ import { POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestZeroAgent,
-  getTestZeroAgentId,
   createTestOrg,
   createTestSchedule,
   enableTestSchedule,
   getTestSchedule,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../../../src/__tests__/db-test-seeders/agents";
+import { getTestZeroAgentId } from "../../../../../../../src/__tests__/db-test-assertions/agents";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/zero/schedules/[name]/enable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/enable/__tests__/route.test.ts
@@ -3,12 +3,12 @@ import { POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestZeroAgent,
-  getTestZeroAgentId,
   createTestOrg,
   createTestSchedule,
   getTestSchedule,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../../../src/__tests__/db-test-seeders/agents";
+import { getTestZeroAgentId } from "../../../../../../../src/__tests__/db-test-assertions/agents";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
@@ -3,11 +3,11 @@ import { POST, GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestZeroAgent,
-  getTestZeroAgentId,
   createTestOrg,
   createTestSchedule,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
+import { getTestZeroAgentId } from "../../../../../src/__tests__/db-test-assertions/agents";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/zero/schedules/run/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/run/__tests__/route.test.ts
@@ -3,11 +3,11 @@ import { POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestZeroAgent,
   createTestOrg,
   createTestSchedule,
   enableTestSchedule,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../../src/__tests__/db-test-seeders/agents";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/zero/skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/skills/__tests__/route.test.ts
@@ -9,8 +9,8 @@ import {
 import {
   createTestRequest,
   createTestCliToken,
+  createTestCompose,
   bindCustomSkillToAgent,
-  seedTestCompose,
   getAgentCustomSkills,
   insertOrgMembersCacheEntry,
   createTestTarFile,
@@ -155,12 +155,9 @@ describe("Zero Skills API (org-level)", () => {
     });
 
     it("should not bind skill to any agent", async () => {
-      const orgId = `org_mock_${user.userId}`;
-      const { agentId } = await seedTestCompose({
-        userId: user.userId,
-        name: `test-agent-${user.userId.slice(-8)}`,
-        orgId,
-      });
+      const { agentId } = await createTestCompose(
+        `test-agent-${user.userId.slice(-8)}`,
+      );
 
       await postSkillReq(
         { name: "unbound-skill", files: singleFile("# Content") },
@@ -357,17 +354,8 @@ describe("Zero Skills API (org-level)", () => {
       );
 
       // Bind to two agents
-      const orgId = `org_mock_${user.userId}`;
-      const agent1 = await seedTestCompose({
-        userId: user.userId,
-        name: `agent1-${user.userId.slice(-8)}`,
-        orgId,
-      });
-      const agent2 = await seedTestCompose({
-        userId: user.userId,
-        name: `agent2-${user.userId.slice(-8)}`,
-        orgId,
-      });
+      const agent1 = await createTestCompose(`agent1-${user.userId.slice(-8)}`);
+      const agent2 = await createTestCompose(`agent2-${user.userId.slice(-8)}`);
       await bindCustomSkillToAgent(agent1.agentId, "shared-skill");
       await bindCustomSkillToAgent(agent2.agentId, "shared-skill");
 

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -9,12 +9,14 @@ import {
   createTestCompose,
   createTestSlackOrgInstallation,
   seedTestSlackOrgConnection,
-  seedTestCompose,
-  seedOrphanCompose,
   updateOrgDefaultAgent,
   countSlackOrgInstallations,
   countSlackOrgConnections,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  seedOrphanCompose,
+  clearComposeHeadVersion,
+} from "../../../../../../src/__tests__/db-test-seeders/agents";
 import { reloadEnv } from "../../../../../../src/env";
 
 import { POST } from "../route";
@@ -326,11 +328,8 @@ describe("POST /api/zero/slack/events", () => {
 
     it("posts error when run was not created (no callback)", async () => {
       // Set up a compose WITHOUT a version → createZeroRun fails before creating the run
-      const { agentId } = await seedTestCompose({
-        userId: user.userId,
-        name: uniqueId("agent"),
-        orgId: user.orgId,
-      });
+      const { composeId, agentId } = await createTestCompose(uniqueId("agent"));
+      await clearComposeHeadVersion(composeId);
       await updateOrgDefaultAgent(user.orgId, agentId);
       const { workspaceId, slackUserId } = await setupWorkspace(user.orgId);
 
@@ -682,11 +681,8 @@ describe("POST /api/zero/slack/events", () => {
     });
 
     it("posts error when run was not created (no callback)", async () => {
-      const { agentId } = await seedTestCompose({
-        userId: user.userId,
-        name: uniqueId("agent"),
-        orgId: user.orgId,
-      });
+      const { composeId, agentId } = await createTestCompose(uniqueId("agent"));
+      await clearComposeHeadVersion(composeId);
       await updateOrgDefaultAgent(user.orgId, agentId);
       const { workspaceId, slackUserId } = await setupWorkspace(user.orgId);
 
@@ -753,11 +749,7 @@ describe("POST /api/zero/slack/events", () => {
         slackWorkspaceId: workspaceId,
         vm0UserId: user.userId,
       });
-      const { agentId } = await seedTestCompose({
-        userId: user.userId,
-        name: uniqueId("agent"),
-        orgId: user.orgId,
-      });
+      const { agentId } = await createTestCompose(uniqueId("agent"));
       await updateOrgDefaultAgent(user.orgId, agentId);
 
       const request = createSlackRetryRequest({
@@ -797,11 +789,7 @@ describe("POST /api/zero/slack/events", () => {
         slackWorkspaceId: workspaceId,
         vm0UserId: user.userId,
       });
-      const { agentId } = await seedTestCompose({
-        userId: user.userId,
-        name: uniqueId("agent"),
-        orgId: user.orgId,
-      });
+      const { agentId } = await createTestCompose(uniqueId("agent"));
       await updateOrgDefaultAgent(user.orgId, agentId);
 
       const request = createSlackRetryRequest({

--- a/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
@@ -3,7 +3,6 @@ import { GET, POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestZeroAgent,
   createTestRunInDb,
   addTestRunToThread,
   insertTestChatThread,
@@ -12,6 +11,7 @@ import {
   updateTestScheduleState,
   insertTestVoiceChatSession,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/__tests__/route.test.ts
@@ -5,9 +5,9 @@ import {
   createTestCompose,
   findTestZeroRun,
   insertTestVoiceChatPreparation,
-  getTestZeroAgentId,
   getTestVoiceChatPreparation,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { getTestZeroAgentId } from "../../../../../../src/__tests__/db-test-assertions/agents";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/__tests__/route.test.ts
@@ -8,10 +8,10 @@ import {
   createTestCompose,
   createTestRunInDb,
   createTestSandboxToken,
-  getTestZeroAgentId,
   insertTestVoiceChatPreparation,
   getTestVoiceChatPreparation,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import { getTestZeroAgentId } from "../../../../../../../src/__tests__/db-test-assertions/agents";
 import { POST } from "../route";
 
 const context = testContext();

--- a/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
@@ -1,15 +1,11 @@
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { chatThreads } from "../../db/schema/chat-thread";
-import type { RawPermissionPolicies } from "@vm0/core";
 import { initServices } from "../../lib/init-services";
 import {
   addRunToThread,
   updateChatThreadTitle,
 } from "../../lib/zero/chat-thread";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../db/schema/agent-compose";
+import { agentComposes } from "../../db/schema/agent-compose";
 import { agentRuns } from "../../db/schema/agent-run";
 import { zeroAgents } from "../../db/schema/zero-agent";
 import { agentSessions } from "../../db/schema/agent-session";
@@ -18,8 +14,6 @@ import {
   type StoredChatMessage,
 } from "../../db/schema/zero-agent-session";
 import { conversations } from "../../db/schema/conversation";
-import { composeJobs } from "../../db/schema/compose-job";
-import { hashFileContent } from "../../lib/infra/storage/content-hash";
 import { POST as createComposeRoute } from "../../../app/api/agent/composes/route";
 import { POST as upsertOrgModelProviderRoute } from "../../../app/api/zero/model-providers/route";
 import { uniqueId } from "../test-helpers";
@@ -29,6 +23,7 @@ import {
   type ComposeConfigOptions,
 } from "./core";
 import type { AgentComposeYaml } from "../../lib/infra/agent-compose/types";
+import { createTestComposeVersion } from "../db-test-seeders/agents";
 
 /**
  * Create a test compose via API route handler.
@@ -85,116 +80,6 @@ export async function createTestCompose(
   }
 
   return { ...result, agentId: result.composeId };
-}
-
-/**
- * Create or update a test zero_agents row for agent metadata.
- *
- * Since zero_agents.id = agent_composes.id (composeId), this looks up
- * the composeId by (orgId, name) and upserts the metadata row.
- *
- * @param orgId - The org ID
- * @param name - The agent name (must match compose name)
- * @param metadata - Agent metadata fields
- */
-export async function createTestZeroAgent(
-  orgId: string,
-  name: string,
-  metadata: {
-    displayName?: string;
-    description?: string;
-    sound?: string;
-    permissionPolicies?: RawPermissionPolicies;
-  },
-): Promise<void> {
-  initServices();
-
-  // Resolve composeId and userId from compose table (zero_agents.id = composeId)
-  const [compose] = await globalThis.services.db
-    .select({ id: agentComposes.id, userId: agentComposes.userId })
-    .from(agentComposes)
-    .where(and(eq(agentComposes.orgId, orgId), eq(agentComposes.name, name)))
-    .limit(1);
-
-  if (!compose) {
-    throw new Error(`Compose not found for org=${orgId} name=${name}`);
-  }
-
-  await globalThis.services.db
-    .insert(zeroAgents)
-    .values({
-      id: compose.id,
-      orgId,
-      owner: compose.userId,
-      name,
-      displayName: metadata.displayName ?? null,
-      description: metadata.description ?? null,
-      sound: metadata.sound ?? null,
-      permissionPolicies: metadata.permissionPolicies ?? null,
-    })
-    .onConflictDoUpdate({
-      target: [zeroAgents.orgId, zeroAgents.name],
-      set: {
-        displayName: metadata.displayName ?? null,
-        description: metadata.description ?? null,
-        sound: metadata.sound ?? null,
-        permissionPolicies: metadata.permissionPolicies ?? null,
-      },
-    });
-}
-
-/**
- * Get the zero_agents UUID by org + agent name.
- *
- * @param orgId - The org ID
- * @param name - The agent name
- * @returns The zero agent UUID
- */
-export async function getTestZeroAgentId(
-  orgId: string,
-  name: string,
-): Promise<string> {
-  initServices();
-  const [row] = await globalThis.services.db
-    .select({ id: zeroAgents.id })
-    .from(zeroAgents)
-    .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.name, name)))
-    .limit(1);
-  if (!row) {
-    throw new Error(`Zero agent not found: org=${orgId} name=${name}`);
-  }
-  return row.id;
-}
-
-/**
- * Read a zero_agents row by org + agent name.
- *
- * @param orgId - The org ID
- * @param name - The agent name
- * @returns The zero_agents row, or undefined if not found
- */
-export async function getTestZeroAgent(
-  orgId: string,
-  name: string,
-): Promise<
-  | {
-      displayName: string | null;
-      description: string | null;
-      sound: string | null;
-    }
-  | undefined
-> {
-  initServices();
-  const [row] = await globalThis.services.db
-    .select({
-      displayName: zeroAgents.displayName,
-      description: zeroAgents.description,
-      sound: zeroAgents.sound,
-    })
-    .from(zeroAgents)
-    .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.name, name)))
-    .limit(1);
-  return row;
 }
 
 /**
@@ -304,29 +189,6 @@ export async function createTestAgentSession(
 }
 
 /**
- * Create a compose version for a compose.
- * Internal helper for createTestSessionWithConversation.
- */
-export async function createTestComposeVersion(
-  composeId: string,
-  userId: string,
-): Promise<string> {
-  const versionId = uniqueId("version");
-  await globalThis.services.db.insert(agentComposeVersions).values({
-    id: versionId,
-    composeId,
-    content: { name: "test-agent", model: "claude-3-5-sonnet-20241022" },
-    createdBy: userId,
-  });
-  // Update compose to point to this version
-  await globalThis.services.db
-    .update(agentComposes)
-    .set({ headVersionId: versionId })
-    .where(eq(agentComposes.id, composeId));
-  return versionId;
-}
-
-/**
  * Create an agent session with a linked conversation.
  * This creates the full data chain required by validateAgentSession:
  * compose version -> run -> conversation -> session
@@ -383,57 +245,6 @@ export async function createTestSessionWithConversation(
 }
 
 /**
- * Insert an agent compose record directly in the database.
- *
- * Direct DB insert is required for schema-level tests (e.g., CASCADE behavior)
- * that need precise control over record creation without API side effects.
- */
-export async function insertTestAgentCompose(
-  userId: string,
-  orgId: string,
-  name: string,
-) {
-  const [row] = await globalThis.services.db
-    .insert(agentComposes)
-    .values({ userId, orgId, name })
-    .returning();
-  return row!;
-}
-
-/**
- * Insert a test compose with a version for export testing.
- *
- * Direct DB insert is required because the export test needs compose data
- * without going through the full compose creation API flow.
- */
-export async function insertTestComposeWithVersion(
-  userId: string,
-  orgId: string,
-  name: string,
-  content: Record<string, unknown>,
-) {
-  const [compose] = await globalThis.services.db
-    .insert(agentComposes)
-    .values({ userId, orgId, name })
-    .returning();
-
-  const versionId = hashFileContent(Buffer.from(uniqueId("ver")));
-  await globalThis.services.db.insert(agentComposeVersions).values({
-    id: versionId,
-    composeId: compose!.id,
-    content,
-    createdBy: userId,
-  });
-
-  await globalThis.services.db
-    .update(agentComposes)
-    .set({ headVersionId: versionId })
-    .where(eq(agentComposes.id, compose!.id));
-
-  return { composeId: compose!.id, versionId };
-}
-
-/**
  * Insert a test agent session with chat messages for export testing.
  *
  * Direct DB insert is required because agent sessions are created by
@@ -458,197 +269,6 @@ export async function insertTestAgentSessionWithMessages(
     .insert(zeroAgentSessions)
     .values({ id: session!.id, chatMessages });
   return session!;
-}
-
-/**
- * Insert a test compose job directly in the database.
- */
-export async function insertTestComposeJob(params: {
-  userId: string;
-  status?: string;
-  githubUrl?: string;
-}): Promise<{ id: string }> {
-  const [row] = await globalThis.services.db
-    .insert(composeJobs)
-    .values({
-      userId: params.userId,
-      status: params.status ?? "completed",
-      githubUrl: params.githubUrl ?? "https://github.com/test/repo",
-    })
-    .returning({ id: composeJobs.id });
-  return row!;
-}
-
-/**
- * Delete a compose and its matching zero agent from the database.
- * Used to simulate a user deleting an agent compose.
- */
-export async function deleteTestCompose(composeId: string): Promise<void> {
-  initServices();
-  // Resolve the compose's (orgId, name) to also delete the matching zero agent
-  const [compose] = await globalThis.services.db
-    .select({ orgId: agentComposes.orgId, name: agentComposes.name })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, composeId))
-    .limit(1);
-  await globalThis.services.db
-    .delete(agentComposes)
-    .where(eq(agentComposes.id, composeId));
-  if (compose) {
-    await globalThis.services.db
-      .delete(zeroAgents)
-      .where(
-        and(
-          eq(zeroAgents.orgId, compose.orgId),
-          eq(zeroAgents.name, compose.name),
-        ),
-      );
-  }
-}
-
-/**
- * Clear the headVersionId of a compose to simulate a compose with no versions.
- * Useful for triggering pre-run failures in executeSchedule().
- */
-export async function clearComposeHeadVersion(
-  composeId: string,
-): Promise<void> {
-  await globalThis.services.db
-    .update(agentComposes)
-    .set({ headVersionId: null })
-    .where(eq(agentComposes.id, composeId));
-}
-
-/**
- * Set the headVersionId of a compose to a specific value.
- * Useful for simulating stale compose versions in recompose tests.
- */
-export async function setComposeHeadVersion(
-  composeId: string,
-  headVersionId: string,
-): Promise<void> {
-  await globalThis.services.db
-    .update(agentComposes)
-    .set({ headVersionId })
-    .where(eq(agentComposes.id, composeId));
-}
-
-/**
- * Read the headVersionId and updatedAt of a compose record.
- * Useful for verifying recompose behavior in tests.
- */
-export async function getComposeHeadVersion(
-  composeId: string,
-): Promise<
-  { headVersionId: string | null; updatedAt: Date | null } | undefined
-> {
-  initServices();
-  const [row] = await globalThis.services.db
-    .select({
-      headVersionId: agentComposes.headVersionId,
-      updatedAt: agentComposes.updatedAt,
-    })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, composeId))
-    .limit(1);
-  return row;
-}
-
-/**
- * Read the head compose version content for a compose record.
- * Returns the resolved compose content stored in the version.
- */
-export async function getTestComposeVersionContent(
-  composeId: string,
-): Promise<Record<string, unknown> | null> {
-  initServices();
-  const [row] = await globalThis.services.db
-    .select({
-      content: agentComposeVersions.content,
-    })
-    .from(agentComposeVersions)
-    .innerJoin(
-      agentComposes,
-      eq(agentComposes.headVersionId, agentComposeVersions.id),
-    )
-    .where(eq(agentComposes.id, composeId))
-    .limit(1);
-  return (row?.content as Record<string, unknown>) ?? null;
-}
-
-/**
- * Update agent compose's orgId. Useful when tests need telegram installations
- * or other compose-linked entities to belong to a specific org.
- */
-export async function updateAgentComposeOrg(
-  composeId: string,
-  orgId: string,
-): Promise<void> {
-  await globalThis.services.db
-    .update(agentComposes)
-    .set({ orgId })
-    .where(eq(agentComposes.id, composeId));
-}
-
-/**
- * Seed an agent compose record for testing.
- */
-export async function seedTestCompose(opts: {
-  userId: string;
-  name: string;
-  orgId: string;
-}): Promise<{ composeId: string; agentId: string }> {
-  initServices();
-  const [row] = await globalThis.services.db
-    .insert(agentComposes)
-    .values({
-      userId: opts.userId,
-      name: opts.name,
-      orgId: opts.orgId,
-    })
-    .returning({ id: agentComposes.id });
-  if (!row) {
-    throw new Error("Failed to seed agent compose");
-  }
-
-  // Ensure a matching zero_agents row exists (id = composeId after PK refactor)
-  await globalThis.services.db
-    .insert(zeroAgents)
-    .values({
-      id: row.id,
-      orgId: opts.orgId,
-      owner: opts.userId,
-      name: opts.name,
-    })
-    .onConflictDoNothing();
-
-  return { composeId: row.id, agentId: row.id };
-}
-
-/**
- * Seed an agent compose record WITHOUT a corresponding zero_agents row.
- * Useful for testing "agent not found" scenarios where the compose ID exists
- * in agent_composes (satisfying FK constraints) but getWorkspaceAgent() returns
- * undefined because there is no zero_agents row.
- */
-export async function seedOrphanCompose(opts: {
-  userId: string;
-  name: string;
-  orgId: string;
-}): Promise<{ composeId: string }> {
-  initServices();
-  const [row] = await globalThis.services.db
-    .insert(agentComposes)
-    .values({
-      userId: opts.userId,
-      name: opts.name,
-      orgId: opts.orgId,
-    })
-    .returning({ id: agentComposes.id });
-  if (!row) {
-    throw new Error("Failed to seed orphan agent compose");
-  }
-  return { composeId: row.id };
 }
 
 /**

--- a/turbo/apps/web/src/__tests__/backfill-clerk-metadata.test.ts
+++ b/turbo/apps/web/src/__tests__/backfill-clerk-metadata.test.ts
@@ -13,8 +13,8 @@ import {
   insertUserRow,
   deleteUserRow,
   getTestDb,
-  seedTestCompose,
 } from "./api-test-helpers";
+import { seedTestCompose } from "./db-test-seeders/agents";
 import {
   backfillOrgMetadata,
   backfillOrgMembersMetadata,

--- a/turbo/apps/web/src/__tests__/db-test-assertions/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/agents.ts
@@ -1,0 +1,96 @@
+import { and, eq } from "drizzle-orm";
+import { initServices } from "../../lib/init-services";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../db/schema/agent-compose";
+import { zeroAgents } from "../../db/schema/zero-agent";
+
+/**
+ * Read the headVersionId and updatedAt of a compose record.
+ * Useful for verifying recompose behavior in tests.
+ */
+export async function getComposeHeadVersion(
+  composeId: string,
+): Promise<
+  { headVersionId: string | null; updatedAt: Date | null } | undefined
+> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({
+      headVersionId: agentComposes.headVersionId,
+      updatedAt: agentComposes.updatedAt,
+    })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Read the head compose version content for a compose record.
+ * Returns the resolved compose content stored in the version.
+ */
+export async function getTestComposeVersionContent(
+  composeId: string,
+): Promise<Record<string, unknown> | null> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({
+      content: agentComposeVersions.content,
+    })
+    .from(agentComposeVersions)
+    .innerJoin(
+      agentComposes,
+      eq(agentComposes.headVersionId, agentComposeVersions.id),
+    )
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  return (row?.content as Record<string, unknown>) ?? null;
+}
+
+/**
+ * Get the zero_agents UUID by org + agent name.
+ */
+export async function getTestZeroAgentId(
+  orgId: string,
+  name: string,
+): Promise<string> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.name, name)))
+    .limit(1);
+  if (!row) {
+    throw new Error(`Zero agent not found: org=${orgId} name=${name}`);
+  }
+  return row.id;
+}
+
+/**
+ * Read a zero_agents row by org + agent name.
+ */
+export async function getTestZeroAgent(
+  orgId: string,
+  name: string,
+): Promise<
+  | {
+      displayName: string | null;
+      description: string | null;
+      sound: string | null;
+    }
+  | undefined
+> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({
+      displayName: zeroAgents.displayName,
+      description: zeroAgents.description,
+      sound: zeroAgents.sound,
+    })
+    .from(zeroAgents)
+    .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.name, name)))
+    .limit(1);
+  return row;
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -1,0 +1,223 @@
+import { and, eq } from "drizzle-orm";
+import type { RawPermissionPolicies } from "@vm0/core";
+import { initServices } from "../../lib/init-services";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../db/schema/agent-compose";
+import { zeroAgents } from "../../db/schema/zero-agent";
+import { composeJobs } from "../../db/schema/compose-job";
+import { uniqueId } from "../test-helpers";
+
+/**
+ * @why-db-direct Creates compose + zero_agents WITHOUT a version — API always
+ * creates a version. Tests that need a compose with a specific userId/orgId
+ * outside of Clerk auth context (e.g., backfill scripts).
+ */
+export async function seedTestCompose(opts: {
+  userId: string;
+  name: string;
+  orgId: string;
+}): Promise<{ composeId: string; agentId: string }> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({
+      userId: opts.userId,
+      name: opts.name,
+      orgId: opts.orgId,
+    })
+    .returning({ id: agentComposes.id });
+  if (!row) {
+    throw new Error("Failed to seed agent compose");
+  }
+
+  // Ensure a matching zero_agents row exists (id = composeId after PK refactor)
+  await globalThis.services.db
+    .insert(zeroAgents)
+    .values({
+      id: row.id,
+      orgId: opts.orgId,
+      owner: opts.userId,
+      name: opts.name,
+    })
+    .onConflictDoNothing();
+
+  return { composeId: row.id, agentId: row.id };
+}
+
+/**
+ * @why-db-direct Creates compose WITHOUT zero_agents row — API always creates
+ * both. Tests "agent not found" scenarios where getWorkspaceAgent() returns
+ * undefined despite compose FK being satisfied.
+ */
+export async function seedOrphanCompose(opts: {
+  userId: string;
+  name: string;
+  orgId: string;
+}): Promise<{ composeId: string }> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({
+      userId: opts.userId,
+      name: opts.name,
+      orgId: opts.orgId,
+    })
+    .returning({ id: agentComposes.id });
+  if (!row) {
+    throw new Error("Failed to seed orphan agent compose");
+  }
+  return { composeId: row.id };
+}
+
+/**
+ * @why-db-direct Sets HEAD to an arbitrary version — API always sets HEAD to
+ * the latest created version. Tests stale-version handling in recompose flows.
+ */
+export async function setComposeHeadVersion(
+  composeId: string,
+  headVersionId: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(agentComposes)
+    .set({ headVersionId })
+    .where(eq(agentComposes.id, composeId));
+}
+
+/**
+ * @why-db-direct Sets HEAD to null — API never creates a versionless compose.
+ * Tests pre-run failure when no version exists (e.g., executeSchedule).
+ */
+export async function clearComposeHeadVersion(
+  composeId: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(agentComposes)
+    .set({ headVersionId: null })
+    .where(eq(agentComposes.id, composeId));
+}
+
+/**
+ * @why-db-direct Transfers compose between orgs — no API for org transfer.
+ * Tests org-scoped installations for composes created in other orgs.
+ */
+export async function updateAgentComposeOrg(
+  composeId: string,
+  orgId: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(agentComposes)
+    .set({ orgId })
+    .where(eq(agentComposes.id, composeId));
+}
+
+/**
+ * @why-db-direct Direct compose_jobs insert — compose jobs are created by
+ * internal pipeline, not user API. Tests compose job cleanup on deletion.
+ */
+export async function insertTestComposeJob(params: {
+  userId: string;
+  status?: string;
+  githubUrl?: string;
+}): Promise<{ id: string }> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .insert(composeJobs)
+    .values({
+      userId: params.userId,
+      status: params.status ?? "completed",
+      githubUrl: params.githubUrl ?? "https://github.com/test/repo",
+    })
+    .returning({ id: composeJobs.id });
+  return row!;
+}
+
+/**
+ * @why-db-direct Upserts zero_agents with permissionPolicies —
+ * permissionPolicies is not settable via any API route. Tests agent
+ * permission policy enforcement.
+ */
+export async function createTestZeroAgent(
+  orgId: string,
+  name: string,
+  metadata: {
+    displayName?: string;
+    description?: string;
+    sound?: string;
+    permissionPolicies?: RawPermissionPolicies;
+  },
+): Promise<void> {
+  initServices();
+
+  // Resolve composeId and userId from compose table (zero_agents.id = composeId)
+  const [compose] = await globalThis.services.db
+    .select({ id: agentComposes.id, userId: agentComposes.userId })
+    .from(agentComposes)
+    .where(and(eq(agentComposes.orgId, orgId), eq(agentComposes.name, name)))
+    .limit(1);
+
+  if (!compose) {
+    throw new Error(`Compose not found for org=${orgId} name=${name}`);
+  }
+
+  await globalThis.services.db
+    .insert(zeroAgents)
+    .values({
+      id: compose.id,
+      orgId,
+      owner: compose.userId,
+      name,
+      displayName: metadata.displayName ?? null,
+      description: metadata.description ?? null,
+      sound: metadata.sound ?? null,
+      permissionPolicies: metadata.permissionPolicies ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [zeroAgents.orgId, zeroAgents.name],
+      set: {
+        displayName: metadata.displayName ?? null,
+        description: metadata.description ?? null,
+        sound: metadata.sound ?? null,
+        permissionPolicies: metadata.permissionPolicies ?? null,
+      },
+    });
+}
+
+/**
+ * @why-db-direct Creates version with arbitrary non-content-hashed ID —
+ * API uses content-addressed versioning. Internal helper for session creation.
+ */
+export async function createTestComposeVersion(
+  composeId: string,
+  userId: string,
+): Promise<string> {
+  initServices();
+  const versionId = uniqueId("version");
+  await globalThis.services.db.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId,
+    content: { name: "test-agent", model: "claude-3-5-sonnet-20241022" },
+    createdBy: userId,
+  });
+  // Update compose to point to this version
+  await globalThis.services.db
+    .update(agentComposes)
+    .set({ headVersionId: versionId })
+    .where(eq(agentComposes.id, composeId));
+  return versionId;
+}
+
+/**
+ * @why-db-direct Deletes compose bypassing running-run check that API
+ * enforces. Tests compose deletion in cleanup flows.
+ */
+export async function deleteTestCompose(composeId: string): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .delete(agentComposes)
+    .where(eq(agentComposes.id, composeId));
+}

--- a/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
@@ -9,9 +9,9 @@ import {
   createTestSecret,
   createTestVariable,
   createTestUserConnector,
-  getTestZeroAgentId,
   findTestRunnerJobEntry,
 } from "../../../__tests__/api-test-helpers";
+import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
 import { createZeroRun } from "../zero-run-service";
 import { upsertOrgModelProvider } from "../model-provider/model-provider-service";
 import { upsertSecretByOrg } from "../secret/secret-service";

--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -7,7 +7,6 @@ import {
 import {
   createTestCompose,
   createTestRunInDb,
-  getTestZeroAgentId,
   findTestRunsByUserAndPrompt,
   findTestRunRecord,
   findTestQueueEntry,
@@ -18,6 +17,7 @@ import {
   insertOrgMembersEntry,
   insertTestZeroRun,
 } from "../../../__tests__/api-test-helpers";
+import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
 import { reloadEnv } from "../../../env";
 import { createZeroRun } from "../zero-run-service";
 import { isInsufficientCredits, isNotFound } from "../../shared/errors";

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -9,14 +9,14 @@ import {
   createTestConnector,
   createTestUserConnector,
   createTestSchedule,
-  createTestZeroAgent,
-  getTestZeroAgentId,
   findTestRunRecord,
   findTestZeroRun,
   findTestRunCallbacks,
   findTestRunnerJobEntry,
   insertUserCacheEntry,
 } from "../../../__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../__tests__/db-test-seeders/agents";
+import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
 import { createZeroRun, createZeroRunRecord } from "../zero-run-service";
 import { verifyZeroToken } from "../../auth/sandbox-token";
 import { decryptSecretsMap } from "../../shared/crypto/secrets-encryption";

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
@@ -10,7 +10,6 @@ import {
   findTestRunRecord,
   findTestQueueEntry,
   insertOrgDefaultModelProvider,
-  createTestZeroAgent,
   insertTestQueueEntry,
   insertTestSlackOrgInstallation,
   insertTestSlackOrgConnection,
@@ -29,6 +28,7 @@ import {
   insertTestOrgSentinelVariable,
   createTestSchedule,
 } from "../../../../__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../__tests__/db-test-seeders/agents";
 import { deleteOrgData } from "../org-deletion-service";
 
 const context = testContext();

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-external-cleanup.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-external-cleanup.test.ts
@@ -7,11 +7,11 @@ import { server } from "../../../../mocks/server";
 import { reloadEnv } from "../../../../env";
 import {
   updateOrgStripeSubscription,
-  updateAgentComposeOrg,
   createTelegramInstallationForCompose,
   createSlackInstallationForOrg,
   findTestSlackOrgInstallation,
 } from "../../../../__tests__/api-test-helpers";
+import { updateAgentComposeOrg } from "../../../../__tests__/db-test-seeders/agents";
 import { cleanupOrgExternalServices } from "../org-external-cleanup";
 
 // --- Stripe mock (external dependency — allowed) ---

--- a/turbo/apps/web/src/lib/zero/user/__tests__/user-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/user/__tests__/user-deletion-service.test.ts
@@ -29,12 +29,12 @@ import {
   countSlackConnectionRows,
   countGithubUserLinkRows,
   countTelegramUserLinkRows,
-  insertTestComposeJob,
   insertTestGithubInstallation,
   insertTestGithubUserLink,
   insertTestTelegramInstallation,
   insertTestTelegramUserLink,
 } from "../../../../__tests__/api-test-helpers";
+import { insertTestComposeJob } from "../../../../__tests__/db-test-seeders/agents";
 import { deleteUserData } from "../user-deletion-service";
 
 const context = testContext();


### PR DESCRIPTION
## Summary

Closes #9340

- Split `api-test-helpers/agents.ts` into a three-tier test helper structure:
  - **`db-test-seeders/agents.ts`**: 9 impossible-state seeders, each with `@why-db-direct` JSDoc explaining why the API cannot be used
  - **`db-test-assertions/agents.ts`**: 4 read-only query helpers for test assertions
  - **`api-test-helpers/agents.ts`**: Retained API-based helpers (createTestCompose, sessions, chat)
- Migrated ~30 test files to import from the correct tier
- Replaced direct DB inserts with API calls where possible (skills, export, slack/events tests)
- Removed 15 functions from api-test-helpers that moved to seeders/assertions

## Test plan

- [x] All pre-commit checks pass (prettier, knip, commitlint)
- [x] Type-check passes (only pre-existing errors from chat_threads unrelated to this PR)
- [x] Full test suite: 11 failures confirmed pre-existing on main (stash + rerun verified)
- [ ] CI pipeline validates lint, type-check, and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)