### PR TITLE
refactor(test): migrate run creation helpers to db-test-seeders

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
@@ -5,7 +5,6 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
-  createTestRunInDb,
   completeTestRun,
   insertOrgCacheEntry,
   insertOrgMembersCacheEntry,
@@ -21,6 +20,7 @@ import {
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -135,7 +135,7 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
     it("should return 404 for run from a different org", async () => {
       // Create a compose + run in a different org
       const otherOrg = await context.createAgentCompose(user.userId);
-      const { runId } = await createTestRunInDb(user.userId, otherOrg.id, {
+      const { runId } = await seedTestRun(user.userId, otherOrg.id, {
         status: "running",
         prompt: "Other org run",
       });
@@ -154,7 +154,7 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
     it("should return run when switching to the correct org", async () => {
       // Create a compose + run in a different org
       const otherOrg = await context.createAgentCompose(user.userId);
-      const { runId } = await createTestRunInDb(user.userId, otherOrg.id, {
+      const { runId } = await seedTestRun(user.userId, otherOrg.id, {
         status: "running",
         prompt: "Other org run",
       });

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -5,7 +5,6 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
-  createTestRunInDb,
   createTestCallback,
   findTestQueueEntry,
   findTestRunRecord,
@@ -21,6 +20,7 @@ import {
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -59,7 +59,7 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
     it("should cancel a queued run and remove queue entry", async () => {
       // Create a queued run directly (queueing is a zero-layer concern,
       // so we set up the state manually instead of going through the CLI route)
-      const { runId: queuedRunId } = await createTestRunInDb(
+      const { runId: queuedRunId } = await seedTestRun(
         user.userId,
         testComposeId,
         { status: "queued" },
@@ -92,7 +92,7 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
       expect(running.status).toBe("pending");
 
       // Create a queued run directly (queueing is a zero-layer concern)
-      const { runId: queuedRunId } = await createTestRunInDb(
+      const { runId: queuedRunId } = await seedTestRun(
         user.userId,
         testComposeId,
         { status: "queued" },
@@ -153,7 +153,7 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
   describe("Org-Scoped Filtering", () => {
     it("should return 404 for run from a different org", async () => {
       const otherOrg = await context.createAgentCompose(user.userId);
-      const { runId } = await createTestRunInDb(user.userId, otherOrg.id, {
+      const { runId } = await seedTestRun(user.userId, otherOrg.id, {
         status: "running",
         prompt: "Other org run",
       });
@@ -171,7 +171,7 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
 
     it("should cancel run when switching to the correct org", async () => {
       const otherOrg = await context.createAgentCompose(user.userId);
-      const { runId } = await createTestRunInDb(user.userId, otherOrg.id, {
+      const { runId } = await seedTestRun(user.userId, otherOrg.id, {
         status: "running",
         prompt: "Other org run",
       });

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -13,10 +13,8 @@ import {
   createTestOrgMultiAuthModelProvider,
   createTestConnector,
   createTestRun,
-  createTestRunInDb,
   getTestRun,
   completeTestRun,
-  insertStalePendingRun,
   insertOrgCacheEntry,
   insertOrgMembersCacheEntry,
   getOrgCacheEntry,
@@ -33,6 +31,10 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import {
+  seedTestRun,
+  seedStalePendingRun,
+} from "../../../../../src/__tests__/db-test-seeders/runs";
 import { reloadEnv } from "../../../../../src/env";
 
 const context = testContext();
@@ -575,7 +577,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
       // Insert a stale "pending" run (20 minutes old, past the 15-min TTL)
       // This simulates a run stuck in pending state that the cron job missed
-      await insertStalePendingRun(user.userId, versionId);
+      await seedStalePendingRun(user.userId, versionId);
 
       // New run should succeed because the stale pending run (>15min) is excluded
       const run = await createTestRun(testComposeId, "Should not be blocked");
@@ -1207,7 +1209,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       });
 
       // Create a run via DB (needs Clerk mock for compose lookup)
-      const { runId } = await createTestRunInDb(user.userId, testComposeId);
+      const { runId } = await seedTestRun(user.userId, testComposeId);
 
       // Now switch to sandbox auth (no Clerk session)
       mockClerk({ userId: null });
@@ -1312,7 +1314,7 @@ describe("GET /api/agent/runs - List Runs", () => {
   });
 
   it("should return runs belonging to the user's org", async () => {
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "running",
       prompt: "Org A run",
     });
@@ -1334,14 +1336,14 @@ describe("GET /api/agent/runs - List Runs", () => {
 
   it("should not return runs from a different org", async () => {
     // Create a run in the user's default org
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "running",
       prompt: "Default org run",
     });
 
     // Create a compose + run in a different org
     const otherOrg = await context.createAgentCompose(user.userId);
-    await createTestRunInDb(user.userId, otherOrg.id, {
+    await seedTestRun(user.userId, otherOrg.id, {
       status: "running",
       prompt: "Other org run",
     });
@@ -1364,7 +1366,7 @@ describe("GET /api/agent/runs - List Runs", () => {
   it("should filter runs by org context", async () => {
     // Create a compose + run in a different org
     const otherOrg = await context.createAgentCompose(user.userId);
-    await createTestRunInDb(user.userId, otherOrg.id, {
+    await seedTestRun(user.userId, otherOrg.id, {
       status: "running",
       prompt: "Target org run",
     });

--- a/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
@@ -3,7 +3,6 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestRunInDb,
   insertUserCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
@@ -12,6 +11,7 @@ import {
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -58,10 +58,10 @@ describe("GET /api/agent/runs/queue", () => {
 
   it("counts active runs (running + fresh pending)", async () => {
     // Create running and pending runs
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "running",
     });
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "pending",
     });
 
@@ -78,12 +78,12 @@ describe("GET /api/agent/runs/queue", () => {
   it("returns queued runs in FIFO order with correct positions", async () => {
     // Create queued runs with explicit timestamps to ensure deterministic ordering
     const now = Date.now();
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "queued",
       prompt: "first queued",
       createdAt: new Date(now - 1000),
     });
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "queued",
       prompt: "second queued",
       createdAt: new Date(now),
@@ -115,11 +115,11 @@ describe("GET /api/agent/runs/queue", () => {
     const otherUserId = uniqueId("other-user");
 
     // Both users' runs use the same compose (same org)
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "queued",
     });
     // Insert run for other user using same compose (orgId comes from compose)
-    await createTestRunInDb(otherUserId, testComposeId, {
+    await seedTestRun(otherUserId, testComposeId, {
       status: "queued",
     });
 
@@ -161,11 +161,11 @@ describe("GET /api/agent/runs/queue", () => {
   it("exposes prompt only for own runs, hides for others", async () => {
     const otherUserId = uniqueId("other-user");
 
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "queued",
       prompt: "my-prompt-content",
     });
-    await createTestRunInDb(otherUserId, testComposeId, {
+    await seedTestRun(otherUserId, testComposeId, {
       status: "queued",
       prompt: "secret-prompt-content",
     });
@@ -210,7 +210,7 @@ describe("GET /api/agent/runs/queue", () => {
 
   it("only shows runs from the requested org", async () => {
     // Create runs in the default org
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "queued",
     });
 
@@ -234,7 +234,7 @@ describe("GET /api/agent/runs/queue", () => {
   });
 
   it("resolves user emails correctly", async () => {
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "queued",
     });
 
@@ -254,10 +254,10 @@ describe("GET /api/agent/runs/queue", () => {
   });
 
   it("does not count completed or failed runs as active", async () => {
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "completed",
     });
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "failed",
     });
 
@@ -274,10 +274,10 @@ describe("GET /api/agent/runs/queue", () => {
   it("returns running tasks with privacy filtering", async () => {
     const otherUserId = uniqueId("other-user");
 
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "running",
     });
-    await createTestRunInDb(otherUserId, testComposeId, {
+    await seedTestRun(otherUserId, testComposeId, {
       status: "running",
     });
 
@@ -339,13 +339,13 @@ describe("GET /api/agent/runs/queue", () => {
     const now = Date.now();
 
     // Create two completed runs with known durations (60s and 120s)
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "completed",
       startedAt: new Date(now - 120_000),
       completedAt: new Date(now - 60_000),
     });
 
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "completed",
       startedAt: new Date(now - 180_000),
       completedAt: new Date(now - 60_000),
@@ -365,7 +365,7 @@ describe("GET /api/agent/runs/queue", () => {
   it("produces sessionLink without /zero prefix for own runs with continuedFromSessionId", async () => {
     const sessionId = crypto.randomUUID();
 
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "queued",
       continuedFromSessionId: sessionId,
     });
@@ -390,7 +390,7 @@ describe("GET /api/agent/runs/queue", () => {
   it("truncates long prompts at 200 characters for own runs", async () => {
     const longPrompt = "a".repeat(250);
 
-    await createTestRunInDb(user.userId, testComposeId, {
+    await seedTestRun(user.userId, testComposeId, {
       status: "queued",
       prompt: longPrompt,
     });

--- a/turbo/apps/web/app/api/agent/sessions/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/__tests__/route.test.ts
@@ -6,7 +6,6 @@ import {
   createTestRun,
   completeTestRun,
   insertOrgCacheEntry,
-  createTestRunInDb,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -15,6 +14,7 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -129,7 +129,7 @@ describe("GET /api/agent/sessions/:id", () => {
     await insertOrgCacheEntry({ orgId: orgBId, slug: orgBSlug });
 
     // Create a run under org-B (bypassing API to set custom orgId)
-    const { runId } = await createTestRunInDb(user.userId, testComposeId, {
+    const { runId } = await seedTestRun(user.userId, testComposeId, {
       orgId: orgBId,
     });
     const { agentSessionId } = await completeTestRun(user.userId, runId);

--- a/turbo/apps/web/app/api/cron/aggregate-insights/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-insights/__tests__/route.test.ts
@@ -6,12 +6,12 @@ import {
 } from "../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
-  createCompletedTestRun,
   ensureOrgRow,
   findInsightsDaily,
   seedCreditUsageRecord,
   seedUserCacheEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { seedCompletedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 import { reloadEnv } from "../../../../../src/env";
 
 vi.hoisted(() => {
@@ -96,7 +96,7 @@ describe("GET /api/cron/aggregate-insights", () => {
   it("should aggregate previous day agent runs", async () => {
     const { date } = recentDate();
 
-    await createCompletedTestRun({
+    await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,
@@ -106,7 +106,7 @@ describe("GET /api/cron/aggregate-insights", () => {
 
     // Second run
     const run2Start = new Date(date.getTime() + 60000);
-    await createCompletedTestRun({
+    await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: run2Start,
@@ -133,7 +133,7 @@ describe("GET /api/cron/aggregate-insights", () => {
   it("should aggregate credit usage per member", async () => {
     const { date } = recentDate();
 
-    const runId = await createCompletedTestRun({
+    const runId = await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,
@@ -171,7 +171,7 @@ describe("GET /api/cron/aggregate-insights", () => {
   it("should include credit balance from org metadata", async () => {
     const { date } = recentDate();
 
-    await createCompletedTestRun({
+    await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,
@@ -191,7 +191,7 @@ describe("GET /api/cron/aggregate-insights", () => {
   it("should include Axiom network data when available", async () => {
     const { date } = recentDate();
 
-    const runId = await createCompletedTestRun({
+    const runId = await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,
@@ -271,7 +271,7 @@ describe("GET /api/cron/aggregate-insights", () => {
   it("should record denied requests with empty firewall_permission", async () => {
     const { date } = recentDate();
 
-    const runId = await createCompletedTestRun({
+    const runId = await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,
@@ -339,7 +339,7 @@ describe("GET /api/cron/aggregate-insights", () => {
   it("should continue without network data when Axiom fails", async () => {
     const { date } = recentDate();
 
-    await createCompletedTestRun({
+    await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,
@@ -370,7 +370,7 @@ describe("GET /api/cron/aggregate-insights", () => {
   it("should include userId in teamUsage entries", async () => {
     const { date } = recentDate();
 
-    const runId = await createCompletedTestRun({
+    const runId = await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,
@@ -406,7 +406,7 @@ describe("GET /api/cron/aggregate-insights", () => {
   it("should use cached name when available in user_cache", async () => {
     const { date } = recentDate();
 
-    const runId = await createCompletedTestRun({
+    const runId = await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,
@@ -441,7 +441,7 @@ describe("GET /api/cron/aggregate-insights", () => {
   it("should fall back to email prefix when name is null in user_cache", async () => {
     const { date } = recentDate();
 
-    const runId = await createCompletedTestRun({
+    const runId = await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,
@@ -477,7 +477,7 @@ describe("GET /api/cron/aggregate-insights", () => {
   it("should be idempotent on rerun", async () => {
     const { date } = recentDate();
 
-    await createCompletedTestRun({
+    await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,

--- a/turbo/apps/web/app/api/cron/aggregate-usage/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-usage/__tests__/route.test.ts
@@ -6,9 +6,9 @@ import {
 } from "../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
-  createCompletedTestRun,
   findUsageDaily,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { seedCompletedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 import { reloadEnv } from "../../../../../src/env";
 
 vi.hoisted(() => {
@@ -80,7 +80,7 @@ describe("GET /api/cron/aggregate-usage", () => {
     const { date, dateStr } = yesterdayDate();
 
     // Run 1: 5 seconds
-    await createCompletedTestRun({
+    await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,
@@ -90,7 +90,7 @@ describe("GET /api/cron/aggregate-usage", () => {
 
     // Run 2: 8 seconds (1 min after run 1)
     const run2Start = new Date(date.getTime() + 60000);
-    await createCompletedTestRun({
+    await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: run2Start,
@@ -110,7 +110,7 @@ describe("GET /api/cron/aggregate-usage", () => {
   it("should be idempotent on rerun", async () => {
     const { date, dateStr } = yesterdayDate();
 
-    await createCompletedTestRun({
+    await seedCompletedTestRun({
       composeVersionId,
       userId,
       createdAt: date,

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
@@ -3,7 +3,6 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestRunInDb,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -11,6 +10,7 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { reloadEnv } from "../../../../../src/env";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -102,7 +102,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
 
     it("should NOT cleanup sandbox with recent heartbeat", async () => {
       // Create a run directly in pending state
-      const { runId } = await createTestRunInDb(user.userId, testComposeId);
+      const { runId } = await seedTestRun(user.userId, testComposeId);
 
       // Run cleanup immediately (heartbeat is recent)
       const request = createTestRequest(
@@ -131,7 +131,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       const runCreationTime = Date.now();
 
       // Create a run directly in pending state
-      const { runId } = await createTestRunInDb(user.userId, testComposeId);
+      const { runId } = await seedTestRun(user.userId, testComposeId);
 
       // Mock Date.now to return time 6 minutes in the future (past pending timeout of 5 minutes)
       context.mocks.dateNow.mockReturnValue(runCreationTime + 6 * 60 * 1000);
@@ -163,7 +163,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       const runCreationTime = Date.now();
 
       // Create a run directly in completed state
-      const { runId } = await createTestRunInDb(user.userId, testComposeId, {
+      const { runId } = await seedTestRun(user.userId, testComposeId, {
         status: "completed",
       });
 
@@ -196,10 +196,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       const runCreationTime = Date.now();
 
       // Create run for first user directly in pending state
-      const { runId: runId1 } = await createTestRunInDb(
-        user.userId,
-        testComposeId,
-      );
+      const { runId: runId1 } = await seedTestRun(user.userId, testComposeId);
 
       // Create another user and their compose
       const otherUser = await context.setupUser({ prefix: "other" });
@@ -208,7 +205,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       );
 
       // Create run for second user directly in pending state
-      const { runId: runId2 } = await createTestRunInDb(
+      const { runId: runId2 } = await seedTestRun(
         otherUser.userId,
         otherComposeId,
       );
@@ -243,7 +240,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       const runCreationTime = Date.now();
 
       // Create a run directly in pending state
-      const { runId } = await createTestRunInDb(user.userId, testComposeId);
+      const { runId } = await seedTestRun(user.userId, testComposeId);
 
       // Mock Date.now to return time 6 minutes in the future (past pending timeout of 5 minutes)
       context.mocks.dateNow.mockReturnValue(runCreationTime + 6 * 60 * 1000);

--- a/turbo/apps/web/app/api/internal/callbacks/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/agent/__tests__/route.test.ts
@@ -6,7 +6,6 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
-  createTestRunInDb,
   createTestCallback,
   createSignedCallbackRequest,
   findTestZeroRun,
@@ -16,6 +15,7 @@ import { reloadEnv } from "../../../../../../src/env";
 import { POST } from "../route";
 import { http } from "../../../../../../src/__tests__/msw";
 import { server } from "../../../../../../src/mocks/server";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -33,7 +33,7 @@ describe("POST /api/internal/callbacks/agent", () => {
   });
 
   async function setupAgentRun() {
-    const { runId } = await createTestRunInDb(userId, composeId, {
+    const { runId } = await seedTestRun(userId, composeId, {
       prompt: "Delegate this task to the other agent",
       triggerSource: "agent",
     });

--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -8,7 +8,6 @@ import {
 import {
   createTestCompose,
   createTestCallback,
-  createTestRunInDb,
   createTestRequest,
   createTestAgentSession,
   createTestPushSubscription,
@@ -23,6 +22,7 @@ import { POST } from "../route";
 import { http } from "../../../../../../src/__tests__/msw";
 import { server } from "../../../../../../src/mocks/server";
 import webpush, { WebPushError } from "web-push";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 vi.mock("web-push", async (importActual) => {
   const actual = await importActual<{ WebPushError: typeof WebPushError }>();
@@ -83,7 +83,7 @@ describe("POST /api/internal/callbacks/chat", () => {
     const threadId: string = threadData.id;
 
     // Create a run in DB
-    const { runId } = await createTestRunInDb(user.userId, agentId, {
+    const { runId } = await seedTestRun(user.userId, agentId, {
       status,
     });
 

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
@@ -10,7 +10,6 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
-  createTestRunInDb,
   createTestCallback,
   createTestAgentSession,
   insertTestGitHubInstallation,
@@ -19,6 +18,7 @@ import {
   createSignedCallbackRequest,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -85,7 +85,7 @@ async function givenGitHubCallbackSetup(overrides?: {
   await createTestOrg(uniqueId("gh-cb-org"));
   const { composeId } = await createTestCompose("gh-callback-agent");
 
-  const { runId } = await createTestRunInDb(userId, composeId, {
+  const { runId } = await seedTestRun(userId, composeId, {
     prompt: "Test GitHub prompt",
   });
   const installation = await insertTestGitHubInstallation(composeId);
@@ -295,7 +295,7 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       await createTestOrg(uniqueId("gh-missing-org"));
       const { composeId } = await createTestCompose("gh-missing-agent");
 
-      const { runId } = await createTestRunInDb(userId, composeId, {
+      const { runId } = await seedTestRun(userId, composeId, {
         prompt: "Test prompt",
       });
 

--- a/turbo/apps/web/app/api/internal/callbacks/phone/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/phone/__tests__/route.test.ts
@@ -5,7 +5,6 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import {
-  createTestRunInDb,
   createTestCallback,
   createTestAgentSession,
   createTestOrg,
@@ -13,6 +12,7 @@ import {
   createSignedCallbackRequest,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 vi.mock("@clerk/nextjs/server");
 vi.mock("@aws-sdk/client-s3");
@@ -36,7 +36,7 @@ async function setupPhoneCallback() {
   await createTestOrg(uniqueId("org"));
   const { composeId } = await createTestCompose("phone-test-agent");
 
-  const { runId } = await createTestRunInDb(userId, composeId, {
+  const { runId } = await seedTestRun(userId, composeId, {
     prompt: "Phone call transcript",
   });
 

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/cron/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/cron/__tests__/route.test.ts
@@ -6,7 +6,6 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
-  createTestRunInDb,
   createTestCallback,
   createTestSchedule,
   enableTestSchedule,
@@ -17,6 +16,7 @@ import {
   createSignedCallbackRequest,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import { createTestZeroAgent } from "../../../../../../../src/__tests__/db-test-seeders/agents";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -45,7 +45,7 @@ describe("POST /api/internal/callbacks/schedule/cron", () => {
       timezone: "UTC",
     });
     await enableTestSchedule(composeId, schedule.name);
-    const { runId } = await createTestRunInDb(userId, composeId, {
+    const { runId } = await seedTestRun(userId, composeId, {
       prompt: "Cron task",
     });
     const { callbackId, secret } = await createTestCallback({

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
@@ -6,7 +6,6 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
-  createTestRunInDb,
   createTestCallback,
   createTestSchedule,
   enableTestSchedule,
@@ -17,6 +16,7 @@ import {
   createSignedCallbackRequest,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import { createTestZeroAgent } from "../../../../../../../src/__tests__/db-test-seeders/agents";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -38,7 +38,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
       intervalSeconds: 300,
     });
     await enableTestSchedule(composeId, schedule.name);
-    const { runId } = await createTestRunInDb(userId, composeId, {
+    const { runId } = await seedTestRun(userId, composeId, {
       prompt: "Loop task",
     });
     const { callbackId, secret } = await createTestCallback({

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -6,7 +6,6 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
-  createTestRunInDb,
   createTestCallback,
   createTestSlackOrgInstallation,
   createTestRequest,
@@ -15,6 +14,7 @@ import {
   createSignedCallbackRequest,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import { POST } from "../route";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 // The staff org ID whose FNV-1a hash (afce210e) is listed in STAFF_ORG_ID_HASHES,
 // enabling the AuditLink feature switch for that org.
@@ -56,7 +56,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
 
   it("rejects request with invalid payload (missing required fields)", async () => {
     const { composeId } = await createTestCompose(uniqueId("agent"));
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
     });
 
@@ -90,7 +90,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
 
   it("verifyCallback returns correct payload for valid request", async () => {
     const { composeId } = await createTestCompose(uniqueId("agent"));
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
     });
 
@@ -135,7 +135,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
   it("handles progress status by setting thinking status", async () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
     });
 
@@ -176,7 +176,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
   it("posts completion message to Slack thread", async () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
     });
     await completeTestRun(user.userId, runId);
@@ -224,7 +224,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
   it("posts error message for failed status", async () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
     });
 
@@ -269,7 +269,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
 
   it("returns 404 when installation is not found (non-progress)", async () => {
     const { composeId } = await createTestCompose(uniqueId("agent"));
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
     });
 
@@ -308,7 +308,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
   it("clears thread status after posting completion", async () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
     });
     await completeTestRun(user.userId, runId);
@@ -358,7 +358,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));
     // Use a non-staff orgId so the AuditLink feature switch is disabled
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
     });
     await completeTestRun(user.userId, runId);
@@ -401,7 +401,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));
     // Use the staff orgId whose hash is in STAFF_ORG_ID_HASHES, enabling AuditLink
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
       orgId: STAFF_ORG_ID,
     });

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -6,7 +6,6 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import {
-  createTestRunInDb,
   createTestCallback,
   createTestAgentSession,
   createTestRequest,
@@ -18,6 +17,7 @@ import {
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../../src/mocks/server";
 import { http } from "../../../../../../src/__tests__/msw";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -93,7 +93,7 @@ async function setupTelegramCallback() {
     await createTelegramCallbackInstallation(composeId, userId, TEST_BOT_TOKEN);
 
   // Create run and callback (direct DB insert — avoids full API resolution)
-  const { runId } = await createTestRunInDb(userId, composeId, {
+  const { runId } = await seedTestRun(userId, composeId, {
     prompt: "Test prompt",
   });
   const chatId = `chat-${Date.now()}`;

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-prepare/__tests__/route.test.ts
@@ -7,13 +7,13 @@ import {
 import {
   createTestCompose,
   createTestCallback,
-  createTestRunInDb,
   createSignedCallbackRequest,
   insertTestVoiceChatPreparation,
   getTestVoiceChatPreparation,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { getTestZeroAgentId } from "../../../../../../src/__tests__/db-test-assertions/agents";
 import { POST } from "../route";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -35,7 +35,7 @@ describe("POST /api/internal/callbacks/voice-chat-prepare", () => {
     const { preparationStatus = "preparing", runStatus = "completed" } =
       options ?? {};
 
-    const { runId } = await createTestRunInDb(user.userId, agentId, {
+    const { runId } = await seedTestRun(user.userId, agentId, {
       status: runStatus,
     });
 

--- a/turbo/apps/web/app/api/logs/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/logs/search/__tests__/route.test.ts
@@ -4,10 +4,10 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
-  createTestRunInDb,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 
 // Only mock external services
 vi.mock("@clerk/nextjs/server");
@@ -242,7 +242,7 @@ describe("GET /api/logs/search", () => {
 
     // Create a compose + run in a different org
     const otherOrg = await context.createAgentCompose(user.userId);
-    const { runId: otherOrgRunId } = await createTestRunInDb(
+    const { runId: otherOrgRunId } = await seedTestRun(
       user.userId,
       otherOrg.id,
     );
@@ -275,7 +275,7 @@ describe("GET /api/logs/search", () => {
 
     // Create a run in a different org
     const otherOrg = await context.createAgentCompose(user.userId);
-    const { runId: otherOrgRunId } = await createTestRunInDb(
+    const { runId: otherOrgRunId } = await seedTestRun(
       user.userId,
       otherOrg.id,
     );

--- a/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
@@ -9,12 +9,12 @@ import {
   createTestArtifact,
   createTestMemory,
   createTestCompose,
-  createTestRunInDb,
   createTestCliToken,
 } from "../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
 import { generateSandboxToken } from "../../../../src/lib/auth/sandbox-token";
+import { seedTestRun } from "../../../../src/__tests__/db-test-seeders/runs";
 
 vi.hoisted(() => {
   vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
@@ -37,7 +37,7 @@ describe("Storage capability enforcement", () => {
 
     // Create a compose and run so sandbox tokens can resolve org
     const { composeId } = await createTestCompose("test-agent");
-    const result = await createTestRunInDb(userId, composeId);
+    const result = await seedTestRun(userId, composeId);
     runId = result.runId;
   });
 

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -7,7 +7,6 @@ import {
 import {
   createTestCompose,
   createTestAgentSession,
-  createTestRunInDb,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   createTelegramCallbackInstallation,
@@ -19,6 +18,7 @@ import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 import { POST } from "../[installationId]/route";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 
 // Mock Next.js after() to execute synchronously
 const afterPromises: Promise<unknown>[] = [];
@@ -518,7 +518,7 @@ describe("Telegram bot commands", () => {
       const { composeId: fillerComposeId } = await createTestCompose(
         uniqueId("filler"),
       );
-      await createTestRunInDb(userId, fillerComposeId, {
+      await seedTestRun(userId, fillerComposeId, {
         status: "running",
         startedAt: new Date(),
       });

--- a/turbo/apps/web/app/api/usage/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/usage/__tests__/route.test.ts
@@ -5,9 +5,9 @@ import {
   createTestCompose,
   createTestRun,
   completeTestRun,
-  createCompletedTestRun,
   findUsageDaily,
 } from "../../../../src/__tests__/api-test-helpers";
+import { seedCompletedTestRun } from "../../../../src/__tests__/db-test-seeders/runs";
 import {
   testContext,
   uniqueId,
@@ -172,7 +172,7 @@ describe("GET /api/usage", () => {
   });
 
   it("should calculate run times correctly with explicit timestamps", async () => {
-    // Use createCompletedTestRun to insert runs with explicit startedAt/completedAt.
+    // Use seedCompletedTestRun to insert runs with explicit startedAt/completedAt.
     // Runs created via createTestRun have startedAt=null (set later by runner claim),
     // so we must insert directly to test run_time_ms calculation.
 
@@ -180,7 +180,7 @@ describe("GET /api/usage", () => {
 
     // Run 1: 1 minute duration
     const startTime1 = new Date(now.getTime() - 3600000); // 1 hour ago
-    await createCompletedTestRun({
+    await seedCompletedTestRun({
       composeVersionId: testVersionId,
       userId: user.userId,
       createdAt: startTime1,
@@ -190,7 +190,7 @@ describe("GET /api/usage", () => {
 
     // Run 2: 2 minute duration
     const startTime2 = new Date(now.getTime() - 1800000); // 30 min ago
-    await createCompletedTestRun({
+    await seedCompletedTestRun({
       composeVersionId: testVersionId,
       userId: user.userId,
       createdAt: startTime2,
@@ -230,7 +230,7 @@ describe("GET /api/usage", () => {
 
       // Create runs on 2 different historical days
       const day1Run = new Date(fourDaysAgo.getTime() + 10 * 3600000);
-      await createCompletedTestRun({
+      await seedCompletedTestRun({
         composeVersionId,
         userId: user.userId,
         createdAt: day1Run,
@@ -239,7 +239,7 @@ describe("GET /api/usage", () => {
       });
 
       const day2Run = new Date(threeDaysAgo.getTime() + 10 * 3600000);
-      await createCompletedTestRun({
+      await seedCompletedTestRun({
         composeVersionId,
         userId: user.userId,
         createdAt: day2Run,
@@ -267,7 +267,7 @@ describe("GET /api/usage", () => {
 
       // Create a run 2 days ago at 14:00
       const partialDayStart = new Date(twoDaysAgo.getTime() + 14 * 3600000);
-      await createCompletedTestRun({
+      await seedCompletedTestRun({
         composeVersionId,
         userId: user.userId,
         createdAt: partialDayStart,
@@ -277,7 +277,7 @@ describe("GET /api/usage", () => {
 
       // Create another run 2 days ago at 08:00 (before partial boundary)
       const earlyRun = new Date(twoDaysAgo.getTime() + 8 * 3600000);
-      await createCompletedTestRun({
+      await seedCompletedTestRun({
         composeVersionId,
         userId: user.userId,
         createdAt: earlyRun,
@@ -313,7 +313,7 @@ describe("GET /api/usage", () => {
       );
 
       const runTime = new Date(fourDaysAgo.getTime() + 10 * 3600000);
-      await createCompletedTestRun({
+      await seedCompletedTestRun({
         composeVersionId,
         userId: user.userId,
         createdAt: runTime,
@@ -357,7 +357,7 @@ describe("GET /api/usage", () => {
       const runTime = new Date(now.getTime() - 3600000);
 
       // Create run in default user's org
-      await createCompletedTestRun({
+      await seedCompletedTestRun({
         composeVersionId: testVersionId,
         userId: user.userId,
         createdAt: runTime,
@@ -371,7 +371,7 @@ describe("GET /api/usage", () => {
       const { versionId: otherVersionId } = await createTestCompose(
         uniqueId("other-usage"),
       );
-      await createCompletedTestRun({
+      await seedCompletedTestRun({
         composeVersionId: otherVersionId,
         userId: otherUser.userId,
         createdAt: runTime,

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -7,7 +7,6 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
-  createTestRunInDb,
   createTestSandboxToken,
   completeTestRun,
   createTestSchedule,
@@ -32,6 +31,7 @@ import {
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
 import { POST as checkpointWebhook } from "../../checkpoints/route";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -357,7 +357,7 @@ describe("POST /api/webhooks/agent/complete", () => {
 
     it("should store error with report URL on failed completion", async () => {
       // Create run directly in DB in running state to avoid runner_job_queue issues
-      const { runId } = await createTestRunInDb(user.userId, testComposeId, {
+      const { runId } = await seedTestRun(user.userId, testComposeId, {
         status: "running",
         prompt: "Test prompt",
       });
@@ -392,7 +392,7 @@ describe("POST /api/webhooks/agent/complete", () => {
 
     it("should ignore body.error and always use report URL", async () => {
       // Create run directly in DB in running state to avoid runner_job_queue issues
-      const { runId } = await createTestRunInDb(user.userId, testComposeId, {
+      const { runId } = await seedTestRun(user.userId, testComposeId, {
         status: "running",
         prompt: "Test prompt",
       });

--- a/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
@@ -11,7 +11,6 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
-  createTestRunInDb,
   createTestSandboxToken,
   findTestClientCreditUsagesByRunId,
   findTestCreditUsagesByRunId,
@@ -26,6 +25,7 @@ import {
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
 import * as axiomModule from "../../../../../../src/lib/shared/axiom";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 // Only mock external services
 
@@ -697,7 +697,7 @@ describe("POST /api/webhooks/agent/events", () => {
 
     it("should store modelProvider and selectedModel from agent run in credit_usage", async () => {
       // Create a run with zeroRuns record (needed for modelProvider/selectedModel storage)
-      const { runId: zeroRunId } = await createTestRunInDb(
+      const { runId: zeroRunId } = await seedTestRun(
         user.userId,
         testComposeId,
       );
@@ -746,7 +746,7 @@ describe("POST /api/webhooks/agent/events", () => {
 
     it("should prefer run.selectedModel over system.init model", async () => {
       // Create a run with zeroRuns record (needed for selectedModel storage)
-      const { runId: zeroRunId } = await createTestRunInDb(
+      const { runId: zeroRunId } = await seedTestRun(
         user.userId,
         testComposeId,
       );

--- a/turbo/apps/web/app/api/webhooks/agent/usage/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/usage/__tests__/route.test.ts
@@ -4,7 +4,6 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
-  createTestRunInDb,
   createTestSandboxToken,
   findTestCreditUsagesByRunId,
   findTestClientCreditUsagesByRunId,
@@ -18,6 +17,7 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -239,7 +239,7 @@ describe("POST /api/webhooks/agent/usage", () => {
 
   describe("Model precedence", () => {
     it("prefers run.selectedModel over u.model", async () => {
-      const { runId: zeroRunId } = await createTestRunInDb(
+      const { runId: zeroRunId } = await seedTestRun(
         user.userId,
         testComposeId,
       );

--- a/turbo/apps/web/app/api/webhooks/clerk/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/clerk/__tests__/route.test.ts
@@ -10,7 +10,6 @@ import { server } from "../../../../../src/mocks/server";
 import { reloadEnv } from "../../../../../src/env";
 import {
   createTestCompose,
-  createTestRunInDb,
   createTestSecret,
   createTestVariable,
   createTestAgentSession,
@@ -78,6 +77,7 @@ vi.mock("stripe", () => {
 
 // Import route handler AFTER mocks are set up
 import { POST } from "../route";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -252,7 +252,7 @@ describe("organization.deleted e2e cleanup", () => {
     // Composes + sessions + runs
     const { composeId, agentId } = await createTestCompose("e2e-org-test");
     const session = await createTestAgentSession(userId, composeId);
-    await createTestRunInDb(userId, composeId, {
+    await seedTestRun(userId, composeId, {
       status: "running",
       startedAt: new Date(),
     });
@@ -415,7 +415,7 @@ describe("user.deleted e2e cleanup", () => {
     // Composes + sessions + runs
     const { composeId, agentId } = await createTestCompose("e2e-user-test");
     const session = await createTestAgentSession(userId, composeId);
-    await createTestRunInDb(userId, composeId, {
+    await seedTestRun(userId, composeId, {
       status: "running",
       startedAt: new Date(),
     });

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -11,7 +11,6 @@ import {
   createTestCliToken,
   createTestCompose,
   createTestRun,
-  createTestRunInDb,
   createTestOrgModelProvider,
   createTestSandboxToken,
   createTestVolume,
@@ -42,6 +41,7 @@ import {
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { generateZeroToken } from "../../../../../src/lib/auth/sandbox-token";
 import { POST as runSchedule } from "../../schedules/run/route";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -1012,7 +1012,7 @@ describe("Zero Agents API", () => {
       const created = await (await postAgent({}, testCliToken)).json();
 
       // Create a running run for this agent
-      await createTestRunInDb(user.userId, created.agentId, {
+      await seedTestRun(user.userId, created.agentId, {
         status: "running",
       });
 
@@ -1026,7 +1026,7 @@ describe("Zero Agents API", () => {
     it("should delete runs and preserve credit_usage on agent deletion", async () => {
       const created = await (await postAgent({}, testCliToken)).json();
 
-      const { runId } = await createTestRunInDb(user.userId, created.agentId, {
+      const { runId } = await seedTestRun(user.userId, created.agentId, {
         status: "completed",
       });
 
@@ -1053,7 +1053,7 @@ describe("Zero Agents API", () => {
     it("should cascade-delete run data when agent is deleted", async () => {
       const created = await (await postAgent({}, testCliToken)).json();
 
-      const { runId } = await createTestRunInDb(user.userId, created.agentId, {
+      const { runId } = await seedTestRun(user.userId, created.agentId, {
         status: "completed",
       });
 

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -5,7 +5,6 @@ import {
   createTestRequest,
   createTestCompose,
   createTestSessionWithConversation,
-  createTestRunInDb,
   appendTestChatMessages,
   addTestRunToThread,
   updateTestChatThreadTitle,
@@ -15,6 +14,7 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -110,7 +110,7 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     );
 
     // 3. Create a completed run whose result references the session
-    const { runId } = await createTestRunInDb(userId, testComposeId, {
+    const { runId } = await seedTestRun(userId, testComposeId, {
       status: "completed",
       prompt: "What files changed?",
       result: { agentSessionId: session.id },
@@ -269,7 +269,7 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     const { id: threadId } = await createRes.json();
 
     // Create a cancelled run (no agentSessionId in result)
-    const { runId } = await createTestRunInDb(testUserId, testComposeId, {
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
       status: "cancelled",
       prompt: "This was cancelled",
     });

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -21,6 +21,7 @@ import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-tok
 import { reloadEnv } from "../../../../../../src/env";
 import { server } from "../../../../../../src/mocks/server";
 import { http } from "../../../../../../src/__tests__/msw";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 
@@ -277,7 +278,7 @@ describe("POST /api/zero/chat/messages", () => {
     });
 
     it("includes the schedule name in the continue-from-schedule prompt when the source run references a real schedule", async () => {
-      const { createTestSchedule, createTestRunInDb } =
+      const { createTestSchedule } =
         await import("../../../../../../src/__tests__/api-test-helpers");
 
       const schedule = await createTestSchedule(
@@ -285,15 +286,11 @@ describe("POST /api/zero/chat/messages", () => {
         `sched-${crypto.randomUUID().slice(0, 8)}`,
         { prompt: "daily run" },
       );
-      const { runId: sourceRunId } = await createTestRunInDb(
-        user.userId,
-        agentId,
-        {
-          status: "completed",
-          scheduleId: schedule.id,
-          triggerSource: "schedule",
-        },
-      );
+      const { runId: sourceRunId } = await seedTestRun(user.userId, agentId, {
+        status: "completed",
+        scheduleId: schedule.id,
+        triggerSource: "schedule",
+      });
 
       const createThreadResponse = await createChatThreadPOST(
         createTestRequest("http://localhost:3000/api/zero/chat-threads", {

--- a/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
@@ -5,7 +5,6 @@ import { POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestRunInDb,
   insertOrgMembersCacheEntry,
   findTestOutboxItems,
 } from "../../../../../src/__tests__/api-test-helpers";
@@ -19,6 +18,7 @@ import { generateZeroToken } from "../../../../../src/lib/auth/sandbox-token";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 import { reloadEnv } from "../../../../../src/env";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 
 const PLAIN_API_URL = "https://core-api.uk.plain.com/graphql/v1";
 
@@ -35,7 +35,7 @@ async function setupRunContext(
       ? crypto.randomUUID()
       : options.continuedFromSessionId;
   const { composeId } = await createTestCompose(uniqueId("agent"));
-  const { runId } = await createTestRunInDb(user.userId, composeId, {
+  const { runId } = await seedTestRun(user.userId, composeId, {
     status: "running",
     ...(sessionId ? { continuedFromSessionId: sessionId } : {}),
   });
@@ -112,11 +112,11 @@ describe("POST /api/zero/developer-support", () => {
     const { composeId: composeId2 } = await createTestCompose(
       uniqueId("agent"),
     );
-    const { runId: runId1 } = await createTestRunInDb(user.userId, composeId1, {
+    const { runId: runId1 } = await seedTestRun(user.userId, composeId1, {
       status: "running",
       continuedFromSessionId: sessionId,
     });
-    const { runId: runId2 } = await createTestRunInDb(user.userId, composeId2, {
+    const { runId: runId2 } = await seedTestRun(user.userId, composeId2, {
       status: "running",
       continuedFromSessionId: sessionId,
     });
@@ -151,11 +151,11 @@ describe("POST /api/zero/developer-support", () => {
     const { composeId: composeId2 } = await createTestCompose(
       uniqueId("agent"),
     );
-    const { runId: runId1 } = await createTestRunInDb(user.userId, composeId1, {
+    const { runId: runId1 } = await seedTestRun(user.userId, composeId1, {
       status: "running",
       continuedFromSessionId: sessionId,
     });
-    const { runId: runId2 } = await createTestRunInDb(user.userId, composeId2, {
+    const { runId: runId2 } = await seedTestRun(user.userId, composeId2, {
       status: "running",
       continuedFromSessionId: sessionId,
     });
@@ -312,31 +312,23 @@ describe("POST /api/zero/developer-support", () => {
     const { composeId: composeId1 } = await createTestCompose(
       uniqueId("agent"),
     );
-    const { runId: firstRunId } = await createTestRunInDb(
-      user.userId,
-      composeId1,
-      {
-        status: "completed",
-        result: {
-          agentSessionId: sessionId,
-          checkpointId: "cp-1",
-          conversationId: "cv-1",
-        },
+    const { runId: firstRunId } = await seedTestRun(user.userId, composeId1, {
+      status: "completed",
+      result: {
+        agentSessionId: sessionId,
+        checkpointId: "cp-1",
+        conversationId: "cv-1",
       },
-    );
+    });
 
     // Create continuation run (the current run)
     const { composeId: composeId2 } = await createTestCompose(
       uniqueId("agent"),
     );
-    const { runId: currentRunId } = await createTestRunInDb(
-      user.userId,
-      composeId2,
-      {
-        status: "running",
-        continuedFromSessionId: sessionId,
-      },
-    );
+    const { runId: currentRunId } = await seedTestRun(user.userId, composeId2, {
+      status: "running",
+      continuedFromSessionId: sessionId,
+    });
 
     await insertOrgMembersCacheEntry({
       orgId: user.orgId,
@@ -394,7 +386,7 @@ describe("POST /api/zero/developer-support", () => {
   });
 
   it("includes user prompts as user_prompt events in chat-history.jsonl", async () => {
-    const prompt = "test prompt"; // default prompt from createTestRunInDb
+    const prompt = "test prompt"; // default prompt from seedTestRun
     const { token } = await setupRunContext(user);
 
     // Step 1: Get consent code
@@ -460,35 +452,27 @@ describe("POST /api/zero/developer-support", () => {
     const { composeId: composeId1 } = await createTestCompose(
       uniqueId("agent"),
     );
-    const { runId: firstRunId } = await createTestRunInDb(
-      user.userId,
-      composeId1,
-      {
-        status: "completed",
-        prompt: firstPrompt,
-        createdAt: new Date("2024-01-01T00:00:00Z"),
-        result: {
-          agentSessionId: sessionId,
-          checkpointId: "cp-1",
-          conversationId: "cv-1",
-        },
+    const { runId: firstRunId } = await seedTestRun(user.userId, composeId1, {
+      status: "completed",
+      prompt: firstPrompt,
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      result: {
+        agentSessionId: sessionId,
+        checkpointId: "cp-1",
+        conversationId: "cv-1",
       },
-    );
+    });
 
     // Create continuation run (current, later createdAt)
     const { composeId: composeId2 } = await createTestCompose(
       uniqueId("agent"),
     );
-    const { runId: currentRunId } = await createTestRunInDb(
-      user.userId,
-      composeId2,
-      {
-        status: "running",
-        prompt: secondPrompt,
-        createdAt: new Date("2024-01-01T01:00:00Z"),
-        continuedFromSessionId: sessionId,
-      },
-    );
+    const { runId: currentRunId } = await seedTestRun(user.userId, composeId2, {
+      status: "running",
+      prompt: secondPrompt,
+      createdAt: new Date("2024-01-01T01:00:00Z"),
+      continuedFromSessionId: sessionId,
+    });
 
     await insertOrgMembersCacheEntry({
       orgId: user.orgId,

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
@@ -4,7 +4,6 @@ import { POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestRunInDb,
   createTestSlackOrgInstallation,
   insertOrgMembersCacheEntry,
   createTestSchedule,
@@ -21,6 +20,7 @@ import {
   generateSandboxToken,
   generateZeroToken,
 } from "../../../../../../../src/lib/auth/sandbox-token";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const URL = "http://localhost:3000/api/zero/integrations/slack/message";
 
@@ -37,7 +37,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
   /** Helper: create a run and return a sandbox token */
   async function sandboxTokenWithRun() {
     const { composeId } = await createTestCompose(uniqueId("agent"));
-    const { runId } = await createTestRunInDb(user.userId, composeId);
+    const { runId } = await seedTestRun(user.userId, composeId);
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, runId);
     return { token, runId };
@@ -261,7 +261,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
     await createTestZeroAgent(user.orgId, agentName, {
       displayName: "My Assistant",
     });
-    const { runId } = await createTestRunInDb(user.userId, composeId);
+    const { runId } = await seedTestRun(user.userId, composeId);
 
     mockClerk({ userId: null });
     await insertOrgMembersCacheEntry({
@@ -316,7 +316,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
     });
 
     // Create run linked to the schedule
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       scheduleId: schedule.id,
       triggerSource: "schedule",
     });
@@ -373,7 +373,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
     await createTestZeroAgent(user.orgId, agentName, {
       displayName: "My Assistant",
     });
-    const { runId } = await createTestRunInDb(user.userId, composeId);
+    const { runId } = await seedTestRun(user.userId, composeId);
 
     // Seed a Slack connection for the user so resolveUserLabel can find the Slack user ID
     const slackUserId = uniqueId("U-slack");

--- a/turbo/apps/web/app/api/zero/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/[id]/__tests__/route.test.ts
@@ -4,11 +4,9 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
-  createTestRunInDb,
   createTestSchedule,
   completeTestRun,
   failTestRun,
-  createOrphanTestRun,
   insertOrgMembersCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { createTestZeroAgent } from "../../../../../../src/__tests__/db-test-seeders/agents";
@@ -22,6 +20,10 @@ import {
   generateZeroToken,
   generateSandboxToken,
 } from "../../../../../../src/lib/auth/sandbox-token";
+import {
+  seedTestRun,
+  seedOrphanTestRun,
+} from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 vi.mock("@e2b/code-interpreter", () => {
   return {
@@ -219,7 +221,7 @@ describe("GET /api/zero/logs/[id]", () => {
       `sched-detail-${randomUUID().slice(0, 8)}`,
     );
 
-    const { runId } = await createTestRunInDb(user.userId, testComposeId, {
+    const { runId } = await seedTestRun(user.userId, testComposeId, {
       status: "completed",
       scheduleId: schedule.id,
       triggerSource: "schedule",
@@ -255,7 +257,7 @@ describe("GET /api/zero/logs/[id]", () => {
   });
 
   it("should return run details when compose version has been deleted", async () => {
-    const { runId } = await createOrphanTestRun(user.userId, user.orgId, {
+    const { runId } = await seedOrphanTestRun(user.userId, user.orgId, {
       prompt: "Orphan run prompt",
     });
 

--- a/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
@@ -4,7 +4,6 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestRunInDb,
   createTestSchedule,
   createTestRun,
   completeTestRun,
@@ -20,6 +19,7 @@ import {
   generateZeroToken,
   generateSandboxToken,
 } from "../../../../../src/lib/auth/sandbox-token";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -398,7 +398,7 @@ describe("GET /api/zero/logs", () => {
     });
 
     it("should return explicit trigger source when set on run", async () => {
-      await createTestRunInDb(user.userId, testComposeId, {
+      await seedTestRun(user.userId, testComposeId, {
         status: "completed",
         triggerSource: "slack",
         startedAt: new Date(),
@@ -423,7 +423,7 @@ describe("GET /api/zero/logs", () => {
         `sched-${randomUUID().slice(0, 8)}`,
       );
 
-      await createTestRunInDb(user.userId, testComposeId, {
+      await seedTestRun(user.userId, testComposeId, {
         status: "completed",
         scheduleId: schedule.id,
         triggerSource: "schedule",
@@ -445,7 +445,7 @@ describe("GET /api/zero/logs", () => {
     });
 
     it("should return null scheduleId for non-schedule runs", async () => {
-      await createTestRunInDb(user.userId, testComposeId, {
+      await seedTestRun(user.userId, testComposeId, {
         status: "completed",
         triggerSource: "web",
         startedAt: new Date(),
@@ -465,7 +465,7 @@ describe("GET /api/zero/logs", () => {
     });
 
     it("should return 'web' for runs with triggerSource set to web", async () => {
-      await createTestRunInDb(user.userId, testComposeId, {
+      await seedTestRun(user.userId, testComposeId, {
         status: "completed",
         triggerSource: "web",
         continuedFromSessionId: randomUUID(),
@@ -486,7 +486,7 @@ describe("GET /api/zero/logs", () => {
     });
 
     it("should default to 'cli' for runs without explicit triggerSource", async () => {
-      await createTestRunInDb(user.userId, testComposeId, {
+      await seedTestRun(user.userId, testComposeId, {
         status: "completed",
         startedAt: new Date(),
         completedAt: new Date(),
@@ -513,7 +513,7 @@ describe("GET /api/zero/logs", () => {
 
       // Create runs with different trigger sources
       for (const source of ["web", "cli", "slack", "schedule"]) {
-        await createTestRunInDb(user.userId, testComposeId, {
+        await seedTestRun(user.userId, testComposeId, {
           status: "completed",
           triggerSource: source,
           startedAt: new Date(),
@@ -556,7 +556,7 @@ describe("GET /api/zero/logs", () => {
 
     it("should combine triggerSource with status filter", async () => {
       // Add a failed web run
-      await createTestRunInDb(user.userId, testComposeId, {
+      await seedTestRun(user.userId, testComposeId, {
         status: "failed",
         triggerSource: "web",
         startedAt: new Date(),
@@ -580,7 +580,7 @@ describe("GET /api/zero/logs", () => {
       // Create a second agent with a slack run
       const otherName = `other-agent-${randomUUID().slice(0, 8)}`;
       const { composeId: otherComposeId } = await createTestCompose(otherName);
-      await createTestRunInDb(user.userId, otherComposeId, {
+      await seedTestRun(user.userId, otherComposeId, {
         status: "completed",
         triggerSource: "slack",
         startedAt: new Date(),
@@ -632,12 +632,12 @@ describe("GET /api/zero/logs", () => {
         `filter-status-${randomUUID().slice(0, 8)}`,
       );
 
-      await createTestRunInDb(user.userId, composeId, {
+      await seedTestRun(user.userId, composeId, {
         status: "completed",
         startedAt: new Date(),
         completedAt: new Date(),
       });
-      await createTestRunInDb(user.userId, composeId, {
+      await seedTestRun(user.userId, composeId, {
         status: "failed",
         startedAt: new Date(),
         completedAt: new Date(),
@@ -657,13 +657,13 @@ describe("GET /api/zero/logs", () => {
         `filter-source-${randomUUID().slice(0, 8)}`,
       );
 
-      await createTestRunInDb(user.userId, composeId, {
+      await seedTestRun(user.userId, composeId, {
         status: "completed",
         triggerSource: "slack",
         startedAt: new Date(),
         completedAt: new Date(),
       });
-      await createTestRunInDb(user.userId, composeId, {
+      await seedTestRun(user.userId, composeId, {
         status: "completed",
         triggerSource: "web",
         startedAt: new Date(),
@@ -685,12 +685,12 @@ describe("GET /api/zero/logs", () => {
       const { composeId: composeA } = await createTestCompose(agentA);
       const { composeId: composeB } = await createTestCompose(agentB);
 
-      await createTestRunInDb(user.userId, composeA, {
+      await seedTestRun(user.userId, composeA, {
         status: "completed",
         startedAt: new Date(),
         completedAt: new Date(),
       });
-      await createTestRunInDb(user.userId, composeB, {
+      await seedTestRun(user.userId, composeB, {
         status: "completed",
         startedAt: new Date(),
         completedAt: new Date(),
@@ -711,7 +711,7 @@ describe("GET /api/zero/logs", () => {
       );
 
       // Create a run without triggerSource (will be null in DB)
-      await createTestRunInDb(user.userId, composeId, {
+      await seedTestRun(user.userId, composeId, {
         status: "completed",
         startedAt: new Date(),
         completedAt: new Date(),
@@ -733,13 +733,13 @@ describe("GET /api/zero/logs", () => {
         `filter-independent-${randomUUID().slice(0, 8)}`,
       );
 
-      await createTestRunInDb(user.userId, composeId, {
+      await seedTestRun(user.userId, composeId, {
         status: "completed",
         triggerSource: "slack",
         startedAt: new Date(),
         completedAt: new Date(),
       });
-      await createTestRunInDb(user.userId, composeId, {
+      await seedTestRun(user.userId, composeId, {
         status: "failed",
         triggerSource: "web",
         startedAt: new Date(),
@@ -781,7 +781,7 @@ describe("GET /api/zero/logs", () => {
       scheduleId = schedule.id;
 
       // Create a run linked to the schedule
-      await createTestRunInDb(user.userId, testComposeId, {
+      await seedTestRun(user.userId, testComposeId, {
         status: "completed",
         scheduleId,
         startedAt: new Date(),
@@ -789,7 +789,7 @@ describe("GET /api/zero/logs", () => {
       });
 
       // Create a run NOT linked to any schedule
-      await createTestRunInDb(user.userId, testComposeId, {
+      await seedTestRun(user.userId, testComposeId, {
         status: "completed",
         startedAt: new Date(),
         completedAt: new Date(),

--- a/turbo/apps/web/app/api/zero/logs/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/search/__tests__/route.test.ts
@@ -4,7 +4,6 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
-  createTestRunInDb,
   insertOrgMembersCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
@@ -12,6 +11,7 @@ import {
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import {
   generateZeroToken,
   generateSandboxToken,
@@ -266,7 +266,7 @@ describe("GET /api/zero/logs/search", () => {
 
     // Create a compose + run in a different org
     const otherOrg = await context.createAgentCompose(currentUser.userId);
-    const { runId: otherOrgRunId } = await createTestRunInDb(
+    const { runId: otherOrgRunId } = await seedTestRun(
       currentUser.userId,
       otherOrg.id,
     );
@@ -307,7 +307,7 @@ describe("GET /api/zero/logs/search", () => {
 
     // Create a run in a different org
     const otherOrg = await context.createAgentCompose(currentUser.userId);
-    const { runId: otherOrgRunId } = await createTestRunInDb(
+    const { runId: otherOrgRunId } = await seedTestRun(
       currentUser.userId,
       otherOrg.id,
     );

--- a/turbo/apps/web/app/api/zero/queue-position/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/queue-position/__tests__/route.test.ts
@@ -4,7 +4,6 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestRunInDb,
   insertTestQueueEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
@@ -13,6 +12,7 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -64,7 +64,7 @@ describe("GET /api/zero/queue-position", () => {
   });
 
   it("should return position 0 when run is not in queue", async () => {
-    const { runId } = await createTestRunInDb(user.userId, testComposeId, {
+    const { runId } = await seedTestRun(user.userId, testComposeId, {
       status: "running",
     });
 
@@ -84,7 +84,7 @@ describe("GET /api/zero/queue-position", () => {
     const otherOrg = await context.createAgentCompose(user.userId);
 
     // Create run in the other org
-    const { runId } = await createTestRunInDb(user.userId, otherOrg.id, {
+    const { runId } = await seedTestRun(user.userId, otherOrg.id, {
       status: "running",
     });
 
@@ -100,7 +100,7 @@ describe("GET /api/zero/queue-position", () => {
   });
 
   it("should return position when run is queued", async () => {
-    const { runId } = await createTestRunInDb(user.userId, testComposeId, {
+    const { runId } = await seedTestRun(user.userId, testComposeId, {
       status: "queued",
     });
 

--- a/turbo/apps/web/app/api/zero/report-error/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/report-error/__tests__/route.test.ts
@@ -7,7 +7,6 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
-  createTestRunInDb,
   findTestOutboxItems,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
@@ -18,6 +17,7 @@ import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 import { reloadEnv } from "../../../../../src/env";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 
 const PLAIN_API_URL = "https://core-api.uk.plain.com/graphql/v1";
 
@@ -34,7 +34,7 @@ async function setupFailedRun(
   },
 ) {
   const compose = await createTestCompose(`agent-${uniqueId("rpt")}`);
-  const { runId } = await createTestRunInDb(userId, compose.composeId, {
+  const { runId } = await seedTestRun(userId, compose.composeId, {
     status: "failed",
     ...options,
   });
@@ -97,7 +97,7 @@ describe("POST /api/zero/report-error", () => {
 
   it("should return 400 for non-failed run", async () => {
     const compose = await createTestCompose(`agent-${uniqueId("rpt")}`);
-    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+    const { runId } = await seedTestRun(userId, compose.composeId, {
       status: "completed",
     });
 
@@ -427,7 +427,7 @@ describe("POST /api/zero/report-error", () => {
 
     // First run (completed)
     const compose1 = await createTestCompose(`agent-${uniqueId("rpt")}`);
-    const { runId: firstRunId } = await createTestRunInDb(
+    const { runId: firstRunId } = await seedTestRun(
       userId,
       compose1.composeId,
       {
@@ -444,7 +444,7 @@ describe("POST /api/zero/report-error", () => {
 
     // Continuation run (failed)
     const compose2 = await createTestCompose(`agent-${uniqueId("rpt")}`);
-    const { runId: failedRunId } = await createTestRunInDb(
+    const { runId: failedRunId } = await seedTestRun(
       userId,
       compose2.composeId,
       {

--- a/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
@@ -5,7 +5,6 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
-  createTestRunInDb,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -13,6 +12,7 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -37,7 +37,7 @@ describe("GET /api/zero/runs/:id", () => {
     const userId = uniqueId("zrun-get");
     await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zrun")}`);
-    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+    const { runId } = await seedTestRun(userId, compose.composeId, {
       status: "running",
       prompt: "test prompt",
     });

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
@@ -5,7 +5,6 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
-  createTestRunInDb,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -13,6 +12,7 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -37,7 +37,7 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     const userId = uniqueId("zcanc-ok");
     await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
-    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+    const { runId } = await seedTestRun(userId, compose.composeId, {
       status: "running",
     });
 
@@ -55,7 +55,7 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     const userId = uniqueId("zcanc-done");
     await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
-    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+    const { runId } = await seedTestRun(userId, compose.composeId, {
       status: "completed",
       completedAt: new Date(),
     });

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
@@ -5,7 +5,6 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
-  createTestRunInDb,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -13,6 +12,7 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import type { RunContextSnapshot } from "../../../../../../../src/lib/shared/axiom/client";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -85,7 +85,7 @@ describe("GET /api/zero/runs/:id/context", () => {
     const userId = uniqueId("zctx-get");
     await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zctx")}`);
-    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+    const { runId } = await seedTestRun(userId, compose.composeId, {
       status: "running",
       prompt: "test prompt",
     });
@@ -128,7 +128,7 @@ describe("GET /api/zero/runs/:id/context", () => {
     const userId = uniqueId("zctx-nc");
     await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zctx")}`);
-    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+    const { runId } = await seedTestRun(userId, compose.composeId, {
       status: "running",
     });
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/network/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/network/__tests__/route.test.ts
@@ -5,13 +5,13 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
-  createTestRunInDb,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
   uniqueId,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -55,7 +55,7 @@ describe("GET /api/zero/runs/:id/network", () => {
     const userId = uniqueId("znet-get");
     await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("znet")}`);
-    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+    const { runId } = await seedTestRun(userId, compose.composeId, {
       status: "completed",
     });
 
@@ -95,7 +95,7 @@ describe("GET /api/zero/runs/:id/network", () => {
     const userId = uniqueId("znet-empty");
     await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("znet")}`);
-    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+    const { runId } = await seedTestRun(userId, compose.composeId, {
       status: "completed",
     });
 
@@ -133,7 +133,7 @@ describe("GET /api/zero/runs/:id/network", () => {
     const userId = uniqueId("znet-more");
     await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("znet")}`);
-    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+    const { runId } = await seedTestRun(userId, compose.composeId, {
       status: "completed",
     });
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -5,7 +5,6 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
-  createTestRunInDb,
 } from "../../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -13,6 +12,7 @@ import {
 } from "../../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
 import { generateSandboxToken } from "../../../../../../../../src/lib/auth/sandbox-token";
+import { seedTestRun } from "../../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -37,7 +37,7 @@ describe("GET /api/zero/runs/:id/telemetry/agent", () => {
     const userId = uniqueId("ztele-get");
     await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("ztele")}`);
-    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+    const { runId } = await seedTestRun(userId, compose.composeId, {
       status: "running",
     });
 

--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -4,7 +4,6 @@ import {
   createTestRequest,
   createTestCompose,
   createTestSessionWithConversation,
-  createTestRunInDb,
   findTestZeroRun,
   insertOrgDefaultModelProvider,
 } from "../../../../../src/__tests__/api-test-helpers";
@@ -20,6 +19,7 @@ import {
   generateZeroToken,
 } from "../../../../../src/lib/auth/sandbox-token";
 import { reloadEnv } from "../../../../../src/env";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -186,7 +186,7 @@ describe("POST /api/zero/runs", () => {
       // Create a parent agent compose and a run for it (simulates the parent agent)
       // Must happen before mockClerk({ userId: null }) since createTestCompose needs auth
       const parentCompose = await createTestCompose(uniqueId("parent-agent"));
-      const parentRun = await createTestRunInDb(
+      const parentRun = await seedTestRun(
         user.userId,
         parentCompose.composeId,
         { status: "running" },

--- a/turbo/apps/web/app/api/zero/runs/queue/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/__tests__/route.test.ts
@@ -4,7 +4,6 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
-  createTestRunInDb,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -12,6 +11,7 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -53,7 +53,7 @@ describe("GET /api/zero/runs/queue", () => {
     const userId = uniqueId("zqueue-run");
     await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zqueue")}`);
-    await createTestRunInDb(userId, compose.composeId, {
+    await seedTestRun(userId, compose.composeId, {
       status: "running",
     });
 

--- a/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
@@ -3,7 +3,6 @@ import { GET, POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestRunInDb,
   addTestRunToThread,
   insertTestChatThread,
   getTestAgentComposeName,
@@ -18,6 +17,7 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -64,7 +64,7 @@ describe("GET /api/zero/tasks", () => {
     );
 
     // Create a run and link it to the thread
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "completed",
     });
     await addTestRunToThread(threadId, runId, user.userId);
@@ -95,7 +95,7 @@ describe("GET /api/zero/tasks", () => {
     });
 
     // Link a run to the schedule so it becomes actionable
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "completed",
     });
     await updateTestScheduleState(schedule.id, { lastRunId: runId });
@@ -141,7 +141,7 @@ describe("GET /api/zero/tasks", () => {
     const { composeId } = await createTestCompose(uniqueId("voice-chat-task"));
 
     // Create a run so the voice chat session is actionable
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "completed",
     });
 
@@ -196,7 +196,7 @@ describe("GET /api/zero/tasks", () => {
       agent1,
       "Agent 1 Thread",
     );
-    const { runId: run1 } = await createTestRunInDb(user.userId, agent1, {
+    const { runId: run1 } = await seedTestRun(user.userId, agent1, {
       status: "completed",
     });
     await addTestRunToThread(thread1, run1, user.userId);
@@ -206,7 +206,7 @@ describe("GET /api/zero/tasks", () => {
       agent2,
       "Agent 2 Thread",
     );
-    const { runId: run2 } = await createTestRunInDb(user.userId, agent2, {
+    const { runId: run2 } = await seedTestRun(user.userId, agent2, {
       status: "completed",
     });
     await addTestRunToThread(thread2, run2, user.userId);
@@ -242,7 +242,7 @@ describe("GET /api/zero/tasks", () => {
       composeId,
       "User1 Thread",
     );
-    const { runId: run1 } = await createTestRunInDb(user.userId, composeId, {
+    const { runId: run1 } = await seedTestRun(user.userId, composeId, {
       status: "completed",
     });
     await addTestRunToThread(thread1, run1, user.userId);
@@ -256,7 +256,7 @@ describe("GET /api/zero/tasks", () => {
       otherComposeId,
       "User2 Thread",
     );
-    const { runId: run2 } = await createTestRunInDb(
+    const { runId: run2 } = await seedTestRun(
       otherUser.userId,
       otherComposeId,
       { status: "completed" },
@@ -294,11 +294,11 @@ describe("GET /api/zero/tasks", () => {
     const sched2 = await createTestSchedule(agent2, "agent2-schedule");
 
     // Link runs so schedules are actionable
-    const { runId: run1 } = await createTestRunInDb(user.userId, agent1, {
+    const { runId: run1 } = await seedTestRun(user.userId, agent1, {
       status: "completed",
     });
     await updateTestScheduleState(sched1.id, { lastRunId: run1 });
-    const { runId: run2 } = await createTestRunInDb(user.userId, agent2, {
+    const { runId: run2 } = await seedTestRun(user.userId, agent2, {
       status: "completed",
     });
     await updateTestScheduleState(sched2.id, { lastRunId: run2 });
@@ -329,7 +329,7 @@ describe("GET /api/zero/tasks", () => {
         `Thread ${i}`,
       );
 
-      const { runId } = await createTestRunInDb(user.userId, composeId, {
+      const { runId } = await seedTestRun(user.userId, composeId, {
         status: "completed",
         createdAt: new Date(baseTime + i * 60_000),
       });
@@ -358,11 +358,10 @@ describe("GET /api/zero/tasks", () => {
       composeId,
       "Terminal Task",
     );
-    const { runId: terminalRunId } = await createTestRunInDb(
-      user.userId,
-      composeId,
-      { status: "completed", createdAt: new Date(now) },
-    );
+    const { runId: terminalRunId } = await seedTestRun(user.userId, composeId, {
+      status: "completed",
+      createdAt: new Date(now),
+    });
     await addTestRunToThread(terminalThreadId, terminalRunId, user.userId);
 
     // Active task with an older timestamp (createdAt = 1 minute ago)
@@ -371,11 +370,10 @@ describe("GET /api/zero/tasks", () => {
       composeId,
       "Active Task",
     );
-    const { runId: activeRunId } = await createTestRunInDb(
-      user.userId,
-      composeId,
-      { status: "running", createdAt: new Date(now - 60_000) },
-    );
+    const { runId: activeRunId } = await seedTestRun(user.userId, composeId, {
+      status: "running",
+      createdAt: new Date(now - 60_000),
+    });
     await addTestRunToThread(activeThreadId, activeRunId, user.userId);
 
     const request = createTestRequest("http://localhost:3000/api/zero/tasks");
@@ -401,11 +399,10 @@ describe("GET /api/zero/tasks", () => {
       composeId,
       "Terminal Task",
     );
-    const { runId: terminalRunId } = await createTestRunInDb(
-      user.userId,
-      composeId,
-      { status: "completed", createdAt: new Date(now) },
-    );
+    const { runId: terminalRunId } = await seedTestRun(user.userId, composeId, {
+      status: "completed",
+      createdAt: new Date(now),
+    });
     await addTestRunToThread(terminalThreadId, terminalRunId, user.userId);
 
     // Chat thread with no run (status = null) — chat tasks are allowed without runs
@@ -441,7 +438,7 @@ describe("GET /api/zero/tasks", () => {
       composeId,
       "Runner New",
     );
-    const { runId: runnerNewRunId } = await createTestRunInDb(
+    const { runId: runnerNewRunId } = await seedTestRun(
       user.userId,
       composeId,
       { status: "running", createdAt: new Date(now) },
@@ -453,7 +450,7 @@ describe("GET /api/zero/tasks", () => {
       composeId,
       "Runner Old",
     );
-    const { runId: runnerOldRunId } = await createTestRunInDb(
+    const { runId: runnerOldRunId } = await seedTestRun(
       user.userId,
       composeId,
       { status: "running", createdAt: new Date(now - 10 * 60_000) },
@@ -466,11 +463,10 @@ describe("GET /api/zero/tasks", () => {
       composeId,
       "Done New",
     );
-    const { runId: doneNewRunId } = await createTestRunInDb(
-      user.userId,
-      composeId,
-      { status: "completed", createdAt: new Date(now - 5 * 60_000) },
-    );
+    const { runId: doneNewRunId } = await seedTestRun(user.userId, composeId, {
+      status: "completed",
+      createdAt: new Date(now - 5 * 60_000),
+    });
     await addTestRunToThread(doneNewThreadId, doneNewRunId, user.userId);
 
     const doneOldThreadId = await insertTestChatThread(
@@ -478,11 +474,10 @@ describe("GET /api/zero/tasks", () => {
       composeId,
       "Done Old",
     );
-    const { runId: doneOldRunId } = await createTestRunInDb(
-      user.userId,
-      composeId,
-      { status: "completed", createdAt: new Date(now - 20 * 60_000) },
-    );
+    const { runId: doneOldRunId } = await seedTestRun(user.userId, composeId, {
+      status: "completed",
+      createdAt: new Date(now - 20 * 60_000),
+    });
     await addTestRunToThread(doneOldThreadId, doneOldRunId, user.userId);
 
     const request = createTestRequest("http://localhost:3000/api/zero/tasks");
@@ -540,7 +535,7 @@ describe("POST /api/zero/tasks/archive", () => {
       composeId,
       "To Archive",
     );
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "completed",
     });
     await addTestRunToThread(threadId, runId, user.userId);
@@ -589,7 +584,7 @@ describe("POST /api/zero/tasks/archive", () => {
       composeId,
       "Idempotent",
     );
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "completed",
     });
     await addTestRunToThread(threadId, runId, user.userId);
@@ -626,7 +621,7 @@ describe("POST /api/zero/tasks/archive", () => {
       composeId,
       "Restore Me",
     );
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "completed",
     });
     await addTestRunToThread(threadId, runId, user.userId);
@@ -641,13 +636,9 @@ describe("POST /api/zero/tasks/archive", () => {
     );
 
     // Add a new run (simulates new activity)
-    const { runId: newRunId } = await createTestRunInDb(
-      user.userId,
-      composeId,
-      {
-        status: "running",
-      },
-    );
+    const { runId: newRunId } = await seedTestRun(user.userId, composeId, {
+      status: "running",
+    });
     await addTestRunToThread(threadId, newRunId, user.userId);
 
     // Task should reappear because latestRunId changed
@@ -667,7 +658,7 @@ describe("POST /api/zero/tasks/archive", () => {
     const schedule = await createTestSchedule(composeId, "Scheduled Task");
 
     // Link a run so the schedule is actionable
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "completed",
     });
     await updateTestScheduleState(schedule.id, { lastRunId: runId });
@@ -742,7 +733,7 @@ describe("POST /api/zero/tasks/unarchive", () => {
       composeId,
       "Unarchive Me",
     );
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "completed",
     });
     await addTestRunToThread(threadId, runId, user.userId);

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/end/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/end/__tests__/route.test.ts
@@ -3,7 +3,6 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
-  createTestRunInDb,
   insertTestVoiceChatSession,
   getTestVoiceChatSessionStatus,
   getTestVoiceChatEvents,
@@ -14,6 +13,7 @@ import {
   uniqueId,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const { POST } = await import("../route");
 
@@ -139,7 +139,7 @@ describe("POST /api/zero/voice-chat/[id]/end", () => {
   it("should end active session, write event, and cancel run", async () => {
     // Create a run record for FK constraint
     const compose = await createTestCompose(uniqueId("vc-agent"));
-    const testRun = await createTestRunInDb(userId, compose.composeId);
+    const testRun = await seedTestRun(userId, compose.composeId);
 
     const sessionId = await insertTestVoiceChatSession({
       orgId,

--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/__tests__/route.test.ts
@@ -6,13 +6,13 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
-  createTestRunInDb,
   createTestSandboxToken,
   insertTestVoiceChatPreparation,
   getTestVoiceChatPreparation,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import { getTestZeroAgentId } from "../../../../../../../src/__tests__/db-test-assertions/agents";
 import { POST } from "../route";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -46,7 +46,7 @@ describe("POST /api/zero/voice-chat/prepare/complete", () => {
   }) {
     const { preparationStatus = "preparing" } = options ?? {};
 
-    const { runId } = await createTestRunInDb(user.userId, agentId, {
+    const { runId } = await seedTestRun(user.userId, agentId, {
       status: "running",
     });
 
@@ -90,7 +90,7 @@ describe("POST /api/zero/voice-chat/prepare/complete", () => {
 
   it("should return 404 when no preparation found for run", async () => {
     // Create a run with no linked preparation
-    const { runId } = await createTestRunInDb(user.userId, agentId, {
+    const { runId } = await seedTestRun(user.userId, agentId, {
       status: "running",
     });
     const token = await createTestSandboxToken(user.userId, runId);

--- a/turbo/apps/web/src/__tests__/api-test-helpers/runner.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/runner.ts
@@ -5,7 +5,7 @@ import { runnerJobQueue } from "../../db/schema/runner-job-queue";
 import { runnerState } from "../../db/schema/runner-state";
 import { agentRuns } from "../../db/schema/agent-run";
 import { encryptSecretsMap } from "../../lib/shared/crypto/secrets-encryption";
-import { getOrgIdFromVersion } from "./runs";
+import { getOrgIdFromVersion } from "../db-test-seeders/runs";
 
 /**
  * Create a runner job queue entry with an associated agent run.

--- a/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
@@ -6,10 +6,6 @@ import { zeroRuns } from "../../db/schema/zero-run";
 import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
 import { agentRunQueue } from "../../db/schema/agent-run-queue";
 import { conversations } from "../../db/schema/conversation";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../db/schema/agent-compose";
 import { sandboxTelemetry } from "../../db/schema/sandbox-telemetry";
 import { usageDaily } from "../../db/schema/usage-daily";
 import { initServices } from "../../lib/init-services";
@@ -40,156 +36,6 @@ import { createTestRequest } from "./core";
 
 export type { CreateRunResult };
 
-/**
- * Resolve orgId from a compose version ID.
- * Shared by test helpers that insert agent_runs records directly.
- */
-export async function getOrgIdFromVersion(versionId: string): Promise<string> {
-  const [row] = await globalThis.services.db
-    .select({ orgId: agentComposes.orgId })
-    .from(agentComposeVersions)
-    .innerJoin(
-      agentComposes,
-      eq(agentComposes.id, agentComposeVersions.composeId),
-    )
-    .where(eq(agentComposeVersions.id, versionId))
-    .limit(1);
-  if (!row) {
-    throw new Error(`Compose version ${versionId} not found`);
-  }
-  return row.orgId;
-}
-
-/**
- * Create a run record directly in the database.
- * Internal helper - use createTestRunInDb or createOrphanTestRun.
- */
-async function createTestRunDirect(
-  userId: string,
-  versionId: string,
-  orgId: string,
-  options?: {
-    status?: string;
-    prompt?: string;
-    continuedFromSessionId?: string;
-    scheduleId?: string;
-    triggerSource?: string;
-    createdAt?: Date;
-    startedAt?: Date;
-    completedAt?: Date;
-    result?: Record<string, unknown>;
-  },
-): Promise<{ id: string }> {
-  const [run] = await globalThis.services.db
-    .insert(agentRuns)
-    .values({
-      userId,
-      orgId,
-      agentComposeVersionId: versionId,
-      status: options?.status ?? "running",
-      prompt: options?.prompt ?? "test prompt",
-      continuedFromSessionId: options?.continuedFromSessionId,
-      ...(options?.createdAt ? { createdAt: options.createdAt } : {}),
-      ...(options?.startedAt ? { startedAt: options.startedAt } : {}),
-      ...(options?.completedAt ? { completedAt: options.completedAt } : {}),
-      ...(options?.result ? { result: options.result } : {}),
-    })
-    .returning({ id: agentRuns.id });
-
-  await globalThis.services.db.insert(zeroRuns).values({
-    id: run!.id,
-    triggerSource: options?.triggerSource ?? "cli",
-    scheduleId: options?.scheduleId ?? null,
-  });
-
-  return run!;
-}
-
-/**
- * Create a run with no compose version (simulates deleted compose).
- * Useful for testing that endpoints handle orphan runs gracefully.
- */
-export async function createOrphanTestRun(
-  userId: string,
-  orgId: string,
-  options?: { status?: string; prompt?: string },
-): Promise<{ runId: string }> {
-  const [run] = await globalThis.services.db
-    .insert(agentRuns)
-    .values({
-      userId,
-      orgId,
-      agentComposeVersionId: null,
-      status: options?.status ?? "completed",
-      prompt: options?.prompt ?? "orphan run prompt",
-    })
-    .returning({ id: agentRuns.id });
-  return { runId: run!.id };
-}
-
-/**
- * Create a run record directly in the database, bypassing the API route and dispatch.
- * Use this when you need a run in a specific status without triggering dispatch logic
- * (e.g., for cron cleanup tests that need runs in pending/running state).
- */
-export async function createTestRunInDb(
-  userId: string,
-  agentComposeId: string,
-  options?: {
-    status?: string;
-    prompt?: string;
-    continuedFromSessionId?: string;
-    scheduleId?: string;
-    triggerSource?: string;
-    createdAt?: Date;
-    orgId?: string;
-    startedAt?: Date;
-    completedAt?: Date;
-    result?: Record<string, unknown>;
-  },
-): Promise<{ runId: string }> {
-  // Look up orgId from compose
-  const [compose] = await globalThis.services.db
-    .select({ orgId: agentComposes.orgId })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, agentComposeId))
-    .limit(1);
-  if (!compose) {
-    throw new Error(`Compose ${agentComposeId} not found`);
-  }
-  // Create a version for the run
-  const versionId = uniqueId("version");
-  await globalThis.services.db.insert(agentComposeVersions).values({
-    id: versionId,
-    composeId: agentComposeId,
-    content: { name: "test-agent", model: "claude-3-5-sonnet-20241022" },
-    createdBy: userId,
-  });
-  await globalThis.services.db
-    .update(agentComposes)
-    .set({ headVersionId: versionId })
-    .where(eq(agentComposes.id, agentComposeId));
-
-  // Create run directly (use provided orgId or fall back to compose orgId)
-  const run = await createTestRunDirect(
-    userId,
-    versionId,
-    options?.orgId ?? compose.orgId,
-    {
-      status: options?.status ?? "pending",
-      prompt: options?.prompt ?? "test prompt",
-      continuedFromSessionId: options?.continuedFromSessionId,
-      scheduleId: options?.scheduleId,
-      triggerSource: options?.triggerSource,
-      createdAt: options?.createdAt,
-      startedAt: options?.startedAt,
-      completedAt: options?.completedAt,
-      result: options?.result,
-    },
-  );
-  return { runId: run.id };
-}
-
 export async function createTestRun(
   agentComposeId: string,
   prompt: string,
@@ -201,6 +47,7 @@ export async function createTestRun(
     memoryName?: string;
     appendSystemPrompt?: string;
     permissionPolicies?: Record<string, Record<string, string>>;
+    triggerSource?: string;
   },
 ): Promise<{ runId: string; status: string }> {
   const request = createTestRequest("http://localhost:3000/api/agent/runs", {
@@ -485,78 +332,6 @@ export async function failTestRun(
       `Failed to fail run: ${(errorBody as { error?: { message?: string } }).error?.message || response.status}`,
     );
   }
-}
-
-/**
- * Create a completed agent run with controlled timestamps.
- *
- * Direct DB insert is required because createdAt uses PostgreSQL defaultNow()
- * which cannot be controlled via the API or JavaScript fake timers. Tests for
- * date-range logic (cron aggregation, usage API boundaries) need runs placed
- * at specific historical dates.
- */
-export async function createCompletedTestRun(options: {
-  composeVersionId: string;
-  userId: string;
-  createdAt: Date;
-  startedAt: Date;
-  completedAt: Date;
-}): Promise<string> {
-  const orgId = await getOrgIdFromVersion(options.composeVersionId);
-
-  const [row] = await globalThis.services.db
-    .insert(agentRuns)
-    .values({
-      userId: options.userId,
-      orgId,
-      agentComposeVersionId: options.composeVersionId,
-      status: "completed",
-      prompt: "test",
-      createdAt: options.createdAt,
-      startedAt: options.startedAt,
-      completedAt: options.completedAt,
-    })
-    .returning({ id: agentRuns.id });
-  return row!.id;
-}
-
-/**
- * Insert a stale pending run directly into the database.
- * This simulates a run stuck in "pending" state past the cleanup TTL,
- * which cannot be reproduced through normal API flows since the route
- * handler immediately transitions runs to "running" or "failed".
- *
- * @param userId - The user ID who owns the run
- * @param agentComposeVersionId - The compose version ID
- * @param ageMs - How old the run should be in milliseconds (default: 20 minutes)
- * @returns The inserted run ID
- */
-export async function insertStalePendingRun(
-  userId: string,
-  agentComposeVersionId: string,
-  ageMs: number = 20 * 60 * 1000,
-): Promise<string> {
-  const orgId = await getOrgIdFromVersion(agentComposeVersionId);
-
-  const staleCreatedAt = new Date(Date.now() - ageMs);
-  const [run] = await globalThis.services.db
-    .insert(agentRuns)
-    .values({
-      userId,
-      orgId,
-      agentComposeVersionId,
-      status: "pending",
-      prompt: "Stale pending run",
-      createdAt: staleCreatedAt,
-      lastHeartbeatAt: staleCreatedAt,
-    })
-    .returning({ id: agentRuns.id });
-
-  if (!run) {
-    throw new Error("Failed to insert stale pending run");
-  }
-
-  return run.id;
 }
 
 export async function markRunningRunsAsCompleted(userId: string) {

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -1,0 +1,248 @@
+import { eq } from "drizzle-orm";
+import { agentRuns } from "../../db/schema/agent-run";
+import { zeroRuns } from "../../db/schema/zero-run";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../db/schema/agent-compose";
+import { initServices } from "../../lib/init-services";
+import { uniqueId } from "../test-helpers";
+
+/**
+ * Resolve orgId from a compose version ID.
+ *
+ * @why-db-direct No API endpoint exposes orgId lookups by compose version.
+ * Used internally by seeders that insert agent_runs records.
+ */
+export async function getOrgIdFromVersion(versionId: string): Promise<string> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ orgId: agentComposes.orgId })
+    .from(agentComposeVersions)
+    .innerJoin(
+      agentComposes,
+      eq(agentComposes.id, agentComposeVersions.composeId),
+    )
+    .where(eq(agentComposeVersions.id, versionId))
+    .limit(1);
+  if (!row) {
+    throw new Error(`Compose version ${versionId} not found`);
+  }
+  return row.orgId;
+}
+
+/**
+ * Create a run record directly in the database.
+ * Internal helper used by seedTestRun.
+ */
+async function createRunDirect(
+  userId: string,
+  versionId: string,
+  orgId: string,
+  options?: {
+    status?: string;
+    prompt?: string;
+    continuedFromSessionId?: string;
+    scheduleId?: string;
+    triggerSource?: string;
+    createdAt?: Date;
+    startedAt?: Date;
+    completedAt?: Date;
+    result?: Record<string, unknown>;
+  },
+): Promise<{ id: string }> {
+  const [run] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId,
+      orgId,
+      agentComposeVersionId: versionId,
+      status: options?.status ?? "running",
+      prompt: options?.prompt ?? "test prompt",
+      continuedFromSessionId: options?.continuedFromSessionId,
+      ...(options?.createdAt ? { createdAt: options.createdAt } : {}),
+      ...(options?.startedAt ? { startedAt: options.startedAt } : {}),
+      ...(options?.completedAt ? { completedAt: options.completedAt } : {}),
+      ...(options?.result ? { result: options.result } : {}),
+    })
+    .returning({ id: agentRuns.id });
+
+  await globalThis.services.db.insert(zeroRuns).values({
+    id: run!.id,
+    triggerSource: options?.triggerSource ?? "cli",
+    scheduleId: options?.scheduleId ?? null,
+  });
+
+  return run!;
+}
+
+/**
+ * Seed a run record directly in the database, bypassing the API route and dispatch.
+ *
+ * @why-db-direct PostgreSQL defaultNow() controls createdAt/startedAt/completedAt
+ * timestamps at the DB level. vi.setSystemTime() does not affect DB defaults.
+ * Tests for date-range logic (cron aggregation, usage boundaries, cleanup TTLs)
+ * need runs placed at specific historical dates. Additionally, the API always
+ * triggers dispatch (runner_job_queue inserts, Ably notifications) which many
+ * tests do not need or want as side effects.
+ */
+export async function seedTestRun(
+  userId: string,
+  agentComposeId: string,
+  options?: {
+    status?: string;
+    prompt?: string;
+    continuedFromSessionId?: string;
+    scheduleId?: string;
+    triggerSource?: string;
+    createdAt?: Date;
+    orgId?: string;
+    startedAt?: Date;
+    completedAt?: Date;
+    result?: Record<string, unknown>;
+  },
+): Promise<{ runId: string }> {
+  initServices();
+
+  // Look up orgId from compose
+  const [compose] = await globalThis.services.db
+    .select({ orgId: agentComposes.orgId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, agentComposeId))
+    .limit(1);
+  if (!compose) {
+    throw new Error(`Compose ${agentComposeId} not found`);
+  }
+  // Create a version for the run
+  const versionId = uniqueId("version");
+  await globalThis.services.db.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId: agentComposeId,
+    content: { name: "test-agent", model: "claude-3-5-sonnet-20241022" },
+    createdBy: userId,
+  });
+  await globalThis.services.db
+    .update(agentComposes)
+    .set({ headVersionId: versionId })
+    .where(eq(agentComposes.id, agentComposeId));
+
+  // Create run directly (use provided orgId or fall back to compose orgId)
+  const run = await createRunDirect(
+    userId,
+    versionId,
+    options?.orgId ?? compose.orgId,
+    {
+      status: options?.status ?? "pending",
+      prompt: options?.prompt ?? "test prompt",
+      continuedFromSessionId: options?.continuedFromSessionId,
+      scheduleId: options?.scheduleId,
+      triggerSource: options?.triggerSource,
+      createdAt: options?.createdAt,
+      startedAt: options?.startedAt,
+      completedAt: options?.completedAt,
+      result: options?.result,
+    },
+  );
+  return { runId: run.id };
+}
+
+/**
+ * Seed a completed agent run with controlled timestamps.
+ *
+ * @why-db-direct PostgreSQL defaultNow() controls createdAt which cannot be
+ * set through the API or JavaScript fake timers. Tests for date-range logic
+ * (cron aggregation, usage API boundaries) need runs placed at specific
+ * historical dates.
+ */
+export async function seedCompletedTestRun(options: {
+  composeVersionId: string;
+  userId: string;
+  createdAt: Date;
+  startedAt: Date;
+  completedAt: Date;
+}): Promise<string> {
+  initServices();
+
+  const orgId = await getOrgIdFromVersion(options.composeVersionId);
+
+  const [row] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId: options.userId,
+      orgId,
+      agentComposeVersionId: options.composeVersionId,
+      status: "completed",
+      prompt: "test",
+      createdAt: options.createdAt,
+      startedAt: options.startedAt,
+      completedAt: options.completedAt,
+    })
+    .returning({ id: agentRuns.id });
+  return row!.id;
+}
+
+/**
+ * Seed a stale pending run directly into the database.
+ *
+ * @why-db-direct The API immediately transitions runs to "running" or "failed"
+ * during dispatch. A run stuck in "pending" state past the cleanup TTL cannot
+ * be reproduced through normal API flows. The stale lastHeartbeatAt timestamp
+ * is also a DB-controlled value that cannot be set via the API.
+ */
+export async function seedStalePendingRun(
+  userId: string,
+  agentComposeVersionId: string,
+  ageMs: number = 20 * 60 * 1000,
+): Promise<string> {
+  initServices();
+
+  const orgId = await getOrgIdFromVersion(agentComposeVersionId);
+
+  const staleCreatedAt = new Date(Date.now() - ageMs);
+  const [run] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId,
+      orgId,
+      agentComposeVersionId,
+      status: "pending",
+      prompt: "Stale pending run",
+      createdAt: staleCreatedAt,
+      lastHeartbeatAt: staleCreatedAt,
+    })
+    .returning({ id: agentRuns.id });
+
+  if (!run) {
+    throw new Error("Failed to insert stale pending run");
+  }
+
+  return run.id;
+}
+
+/**
+ * Create a run with no compose version (simulates deleted compose).
+ *
+ * @why-db-direct The API requires a valid compose version to create a run.
+ * A run whose compose has been deleted (agentComposeVersionId: null) cannot
+ * be reproduced through normal API flows. Tests for orphan-run graceful
+ * handling need this DB-direct seeder.
+ */
+export async function seedOrphanTestRun(
+  userId: string,
+  orgId: string,
+  options?: { status?: string; prompt?: string },
+): Promise<{ runId: string }> {
+  initServices();
+
+  const [run] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId,
+      orgId,
+      agentComposeVersionId: null,
+      status: options?.status ?? "completed",
+      prompt: options?.prompt ?? "orphan run prompt",
+    })
+    .returning({ id: agentRuns.id });
+  return { runId: run!.id };
+}

--- a/turbo/apps/web/src/lib/infra/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/create-run.test.ts
@@ -13,13 +13,13 @@ import {
   createTestRun,
   createCliRun,
   type CliRunParams,
-  insertStalePendingRun,
   findTestRunRecord,
   findTestRunCallbacks,
   findTestStorage,
   findTestRunnerJobEntry,
   updateOrgTier,
 } from "../../../../__tests__/api-test-helpers";
+import { seedStalePendingRun } from "../../../../__tests__/db-test-seeders/runs";
 import { POST as checkpointWebhook } from "../../../../../app/api/webhooks/agent/checkpoints/route";
 import type { AgentComposeYaml } from "../../agent-compose/types";
 import { reloadEnv } from "../../../../env";
@@ -217,7 +217,7 @@ describe("createCliRun()", () => {
 
     it("should not count stale pending runs", async () => {
       // Free tier limit is 1; stale pending run should not count
-      await insertStalePendingRun(user.userId, versionId);
+      await seedStalePendingRun(user.userId, versionId);
 
       const result = await createCliRun(baseParams());
       expect(result.status).toBe("pending");

--- a/turbo/apps/web/src/lib/infra/run/__tests__/run-status.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/run-status.test.ts
@@ -6,10 +6,10 @@ import {
 } from "../../../../__tests__/test-helpers";
 import {
   createTestCompose,
-  createTestRunInDb,
   findTestRunRecord,
 } from "../../../../__tests__/api-test-helpers";
 import { transitionRunStatus } from "../run-status";
+import { seedTestRun } from "../../../../__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -25,7 +25,7 @@ describe("transitionRunStatus", () => {
   });
 
   it("should transition from valid status", async () => {
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "pending",
     });
 
@@ -41,7 +41,7 @@ describe("transitionRunStatus", () => {
   });
 
   it("should reject transition from terminal status", async () => {
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "completed",
     });
 
@@ -57,7 +57,7 @@ describe("transitionRunStatus", () => {
   });
 
   it("should reject transition when status not in allowed list", async () => {
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "running",
     });
 
@@ -73,7 +73,7 @@ describe("transitionRunStatus", () => {
   });
 
   it("should ensure only one concurrent transition wins", async () => {
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
+    const { runId } = await seedTestRun(user.userId, composeId, {
       status: "running",
     });
 

--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -6,7 +6,6 @@ import {
 } from "../../../__tests__/test-helpers";
 import {
   createTestCompose,
-  createTestRunInDb,
   findTestRunsByUserAndPrompt,
   findTestRunRecord,
   findTestQueueEntry,
@@ -28,6 +27,7 @@ import {
   dispatchQueuedZeroRun,
 } from "../zero-run-queue-service";
 import type { TriggerSource } from "@vm0/core";
+import { seedTestRun } from "../../../__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -243,7 +243,7 @@ describe("credit check (infra queue path)", () => {
       reloadEnv();
 
       // Create a running run + a queued VM0 run
-      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
+      await seedTestRun(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(
         queueBaseParams({ prompt: "Queued VM0", modelProvider: "vm0" }),
       );
@@ -273,7 +273,7 @@ describe("credit check (infra queue path)", () => {
       reloadEnv();
 
       // Create a running run + a queued non-VM0 run
-      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
+      await seedTestRun(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(
         queueBaseParams({
           prompt: "Queued Anthropic",
@@ -301,7 +301,7 @@ describe("credit check (infra queue path)", () => {
       reloadEnv();
 
       // Create a running run
-      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
+      await seedTestRun(user.userId, composeId, { prompt: "Running" });
 
       // Enqueue two runs: first VM0, then non-VM0
       const vm0Run = await enqueueRun(
@@ -350,7 +350,7 @@ describe("credit check (infra queue path)", () => {
       });
 
       // Create a running run + a queued VM0 run
-      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
+      await seedTestRun(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(
         queueBaseParams({
           prompt: "Queued VM0 member cap",
@@ -384,7 +384,7 @@ describe("credit check (infra queue path)", () => {
       });
 
       // Create a running run + a queued non-VM0 run
-      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
+      await seedTestRun(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(
         queueBaseParams({
           prompt: "Queued Anthropic member cap",
@@ -430,7 +430,7 @@ describe("model provider check (queue dispatch path)", () => {
     // No org-level model provider configured — checkModelProviderConfigured will throw
 
     // Create a running run to force the next one into the queue
-    await createTestRunInDb(user.userId, compose.composeId, {
+    await seedTestRun(user.userId, compose.composeId, {
       prompt: "Running",
     });
 

--- a/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
@@ -6,7 +6,6 @@ import {
 } from "../../../__tests__/test-helpers";
 import {
   createTestCompose,
-  createTestRunInDb,
   findTestRunRecord,
   findTestRunCallbacks,
   findTestQueueEntry,
@@ -24,6 +23,7 @@ import {
   cleanupExpiredQueueEntries,
   dispatchQueuedZeroRun,
 } from "../zero-run-queue-service";
+import { seedTestRun } from "../../../__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -99,7 +99,7 @@ describe("run-queue-service", () => {
       reloadEnv();
 
       // Create a running run and a queued run
-      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
+      await seedTestRun(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(baseParams({ prompt: "Queued" }));
       expect(queued.status).toBe("queued");
 
@@ -120,7 +120,7 @@ describe("run-queue-service", () => {
 
     it("should register callbacks for queued zero runs on dispatch", async () => {
       // Create a run directly (simulates what dequeueNextAtomic produces)
-      const { runId } = await createTestRunInDb(user.userId, composeId, {
+      const { runId } = await seedTestRun(user.userId, composeId, {
         prompt: "With callback",
       });
 
@@ -159,7 +159,7 @@ describe("run-queue-service", () => {
       reloadEnv();
 
       // Alice creates a run → pending
-      await createTestRunInDb(user.userId, composeId, { prompt: "Alice run" });
+      await seedTestRun(user.userId, composeId, { prompt: "Alice run" });
 
       // Bob is a different user in the same org
       const bob = await context.setupUser({ prefix: "test-bob" });
@@ -199,7 +199,7 @@ describe("run-queue-service", () => {
       reloadEnv();
 
       // Create a running run and a queued run
-      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
+      await seedTestRun(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(baseParams({ prompt: "Queued" }));
       expect(queued.status).toBe("queued");
 
@@ -274,7 +274,7 @@ describe("run-queue-service", () => {
       await updateOrgTier(user.orgId, "pro");
 
       // Create 1 running run — fills free limit but not pro limit
-      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
+      await seedTestRun(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(baseParams({ prompt: "Queued" }));
 
       // With pro tier (limit=2), drain should succeed despite 1 active run
@@ -358,7 +358,7 @@ describe("run-queue-service", () => {
       reloadEnv();
 
       // user1 creates a run first (before changing Clerk mock)
-      await createTestRunInDb(user.userId, composeId, {
+      await seedTestRun(user.userId, composeId, {
         prompt: "User1 running",
       });
 
@@ -392,7 +392,7 @@ describe("run-queue-service", () => {
       reloadEnv();
 
       // user1 creates a run first (before changing Clerk mock)
-      await createTestRunInDb(user.userId, composeId, {
+      await seedTestRun(user.userId, composeId, {
         prompt: "User1 running",
       });
 

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
 import {
   createTestCompose,
-  createTestRunInDb,
   createTestSecret,
   createTestVariable,
   createTestAgentSession,
@@ -30,6 +29,7 @@ import {
 } from "../../../../__tests__/api-test-helpers";
 import { createTestZeroAgent } from "../../../../__tests__/db-test-seeders/agents";
 import { deleteOrgData } from "../org-deletion-service";
+import { seedTestRun } from "../../../../__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -48,17 +48,17 @@ describe("deleteOrgData", () => {
     const { userId, orgId } = await context.setupUser();
 
     const { composeId } = await createTestCompose("cancel-test");
-    const { runId: queuedRunId } = await createTestRunInDb(userId, composeId, {
+    const { runId: queuedRunId } = await seedTestRun(userId, composeId, {
       status: "queued",
     });
-    const { runId: pendingRunId } = await createTestRunInDb(userId, composeId, {
+    const { runId: pendingRunId } = await seedTestRun(userId, composeId, {
       status: "pending",
     });
-    const { runId: runningRunId } = await createTestRunInDb(userId, composeId, {
+    const { runId: runningRunId } = await seedTestRun(userId, composeId, {
       status: "running",
       startedAt: new Date(),
     });
-    await createTestRunInDb(userId, composeId, {
+    await seedTestRun(userId, composeId, {
       status: "completed",
       completedAt: new Date(),
     });
@@ -91,7 +91,7 @@ describe("deleteOrgData", () => {
     const { userId, orgId } = await context.setupUser();
 
     const { composeId } = await createTestCompose("cascade-run-test");
-    const { runId } = await createTestRunInDb(userId, composeId, {
+    const { runId } = await seedTestRun(userId, composeId, {
       status: "completed",
       completedAt: new Date(),
     });
@@ -210,7 +210,7 @@ describe("deleteOrgData", () => {
     // Composes, sessions, runs
     const { composeId, agentId } = await createTestCompose("full-org-test");
     const session = await createTestAgentSession(userId, composeId);
-    const { runId } = await createTestRunInDb(userId, composeId, {
+    const { runId } = await seedTestRun(userId, composeId, {
       status: "running",
       startedAt: new Date(),
     });
@@ -327,7 +327,7 @@ describe("deleteOrgData", () => {
     const { userId, orgId } = await context.setupUser();
 
     const { composeId } = await createTestCompose("idempotent-test");
-    await createTestRunInDb(userId, composeId, {
+    await seedTestRun(userId, composeId, {
       status: "running",
       startedAt: new Date(),
     });

--- a/turbo/apps/web/src/lib/zero/user/__tests__/user-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/user/__tests__/user-deletion-service.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
 import {
   createTestCompose,
-  createTestRunInDb,
   createTestSecret,
   createTestVariable,
   createTestAgentSession,
@@ -36,6 +35,7 @@ import {
 } from "../../../../__tests__/api-test-helpers";
 import { insertTestComposeJob } from "../../../../__tests__/db-test-seeders/agents";
 import { deleteUserData } from "../user-deletion-service";
+import { seedTestRun } from "../../../../__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -54,17 +54,17 @@ describe("deleteUserData", () => {
     const { userId } = await context.setupUser();
 
     const { composeId } = await createTestCompose("cancel-test");
-    const { runId: queuedRunId } = await createTestRunInDb(userId, composeId, {
+    const { runId: queuedRunId } = await seedTestRun(userId, composeId, {
       status: "queued",
     });
-    const { runId: pendingRunId } = await createTestRunInDb(userId, composeId, {
+    const { runId: pendingRunId } = await seedTestRun(userId, composeId, {
       status: "pending",
     });
-    const { runId: runningRunId } = await createTestRunInDb(userId, composeId, {
+    const { runId: runningRunId } = await seedTestRun(userId, composeId, {
       status: "running",
       startedAt: new Date(),
     });
-    await createTestRunInDb(userId, composeId, {
+    await seedTestRun(userId, composeId, {
       status: "completed",
       completedAt: new Date(),
     });
@@ -96,7 +96,7 @@ describe("deleteUserData", () => {
     const { userId, orgId } = await context.setupUser();
 
     const { composeId } = await createTestCompose("cascade-run-test");
-    const { runId } = await createTestRunInDb(userId, composeId, {
+    const { runId } = await seedTestRun(userId, composeId, {
       status: "completed",
       completedAt: new Date(),
     });
@@ -264,7 +264,7 @@ describe("deleteUserData", () => {
     // Composes, sessions, runs
     const { composeId, agentId } = await createTestCompose("full-user-test");
     const session = await createTestAgentSession(userId, composeId);
-    const { runId } = await createTestRunInDb(userId, composeId, {
+    const { runId } = await seedTestRun(userId, composeId, {
       status: "running",
       startedAt: new Date(),
     });
@@ -369,7 +369,7 @@ describe("deleteUserData", () => {
     const { userId } = await context.setupUser();
 
     const { composeId } = await createTestCompose("idempotent-test");
-    await createTestRunInDb(userId, composeId, {
+    await seedTestRun(userId, composeId, {
       status: "running",
       startedAt: new Date(),
     });


### PR DESCRIPTION
## Summary

- Move DB-direct run creation helpers (`createTestRunInDb`, `createCompletedTestRun`, `insertStalePendingRun`, `createOrphanTestRun`, `getOrgIdFromVersion`) from `api-test-helpers/runs.ts` to `db-test-seeders/runs.ts` with `@why-db-direct` justification for each function
- Update 52 test files to import `seedTestRun`, `seedCompletedTestRun`, `seedStalePendingRun`, and `seedOrphanTestRun` from the new location
- Remove ~200 lines of DB-direct code from `api-test-helpers/runs.ts`, keeping only API-based and service-based helpers
- Remove unused `createTestRunInStatus` helper (YAGNI)

Part of #9339 (parent: #9321)

## Test plan

- [x] All 268 passing test files continue to pass (10 failures are pre-existing on main)
- [x] TypeScript type checking passes (`pnpm check-types`)
- [x] Lint passes with no new warnings
- [x] Knip reports no unused exports
- [x] `grep -r "createTestRunInDb" turbo/apps/web --include="*.ts"` returns zero results
- [x] `grep -r "createCompletedTestRun" turbo/apps/web --include="*.test.ts"` returns zero results
- [x] `grep -r "insertStalePendingRun" turbo/apps/web --include="*.test.ts"` returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)