### PR TITLE
refactor(test): migrate slack.ts helpers to three-tier structure

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -7,12 +7,14 @@ import {
 import {
   createTestCompose,
   createTestCallback,
-  createTestSlackOrgInstallation,
   createTestRequest,
-  seedTestSlackOrgConnection,
   completeTestRun,
   createSignedCallbackRequest,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestSlackOrgInstallation,
+  seedTestSlackOrgConnection,
+} from "../../../../../../../src/__tests__/db-test-seeders/slack";
 import { POST } from "../route";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 

--- a/turbo/apps/web/app/api/webhooks/clerk/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/clerk/__tests__/route.test.ts
@@ -21,11 +21,8 @@ import {
   insertTestExportJob,
   insertOrgMembersCacheEntry,
   insertOrgMembersEntry,
-  insertTestSlackOrgInstallation,
-  insertTestSlackOrgConnection,
   countOrgRows,
   countUserRows,
-  countSlackConnectionRows,
   countGithubUserLinkRows,
   countTelegramUserLinkRows,
   updateOrgStripeSubscription,
@@ -39,8 +36,13 @@ import {
   insertTestTelegramUserLink,
   insertUserCacheEntry,
   insertOrgCacheEntry,
-  insertTestSlackOrgThreadSession,
 } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  insertTestSlackOrgInstallation,
+  insertTestSlackOrgConnection,
+  insertTestSlackOrgThreadSession,
+} from "../../../../../src/__tests__/db-test-seeders/slack";
+import { countSlackConnectionRows } from "../../../../../src/__tests__/db-test-assertions/slack";
 import {
   createTestZeroAgent,
   updateAgentComposeOrg,

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -23,15 +23,17 @@ import {
   createTestSchedule,
   enableTestSchedule,
   createTestSessionWithConversation,
-  insertTestSlackOrgInstallation,
-  insertTestSlackOrgConnection,
-  insertTestSlackOrgThreadSession,
   setDefaultAgentByComposeId,
   clearOrgMembersCacheEntry,
   insertOrgMembersCacheEntry,
   createTestTarFile,
   createTestZeroSkill,
 } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  insertTestSlackOrgInstallation,
+  insertTestSlackOrgConnection,
+  insertTestSlackOrgThreadSession,
+} from "../../../../../src/__tests__/db-test-seeders/slack";
 import { getTestComposeVersionContent } from "../../../../../src/__tests__/db-test-assertions/agents";
 import { getInstructionsStorageName } from "@vm0/core";
 import {

--- a/turbo/apps/web/app/api/zero/integrations/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/__tests__/route.test.ts
@@ -6,14 +6,16 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { createTestOrg } from "../../../../../../src/__tests__/api-test-helpers";
 import {
-  createTestOrg,
   createTestSlackOrgInstallation,
   createTestSlackOrgConnection,
+} from "../../../../../../src/__tests__/db-test-seeders/slack";
+import {
   findTestSlackOrgConnection,
   findTestSlackOrgInstallation,
-  SLACK_BOT_SCOPES,
-} from "../../../../../../src/__tests__/api-test-helpers";
+} from "../../../../../../src/__tests__/db-test-assertions/slack";
+import { SLACK_BOT_SCOPES } from "../../../../../../src/lib/zero/slack-org/scopes";
 
 const context = testContext();
 

--- a/turbo/apps/web/app/api/zero/integrations/slack/connect/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/connect/__tests__/route.test.ts
@@ -7,12 +7,14 @@ import {
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import {
   createTestOrg,
-  createTestSlackOrgInstallation,
-  createTestSlackOrgConnection,
   createTestRequest,
-  findTestSlackOrgConnection,
   insertOrgCacheEntry,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestSlackOrgInstallation,
+  createTestSlackOrgConnection,
+} from "../../../../../../../src/__tests__/db-test-seeders/slack";
+import { findTestSlackOrgConnection } from "../../../../../../../src/__tests__/db-test-assertions/slack";
 
 const context = testContext();
 

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
@@ -4,11 +4,13 @@ import { POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  createTestSlackOrgInstallation,
   insertOrgMembersCacheEntry,
   createTestSchedule,
-  seedTestSlackOrgConnection,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestSlackOrgInstallation,
+  seedTestSlackOrgConnection,
+} from "../../../../../../../src/__tests__/db-test-seeders/slack";
 import { createTestZeroAgent } from "../../../../../../../src/__tests__/db-test-seeders/agents";
 import {
   testContext,

--- a/turbo/apps/web/app/api/zero/slack/channels/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/channels/__tests__/route.test.ts
@@ -6,10 +6,8 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
-import {
-  createTestOrg,
-  createTestSlackOrgInstallation,
-} from "../../../../../../src/__tests__/api-test-helpers";
+import { createTestOrg } from "../../../../../../src/__tests__/api-test-helpers";
+import { createTestSlackOrgInstallation } from "../../../../../../src/__tests__/db-test-seeders/slack";
 
 const context = testContext();
 

--- a/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
@@ -7,11 +7,13 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
+  updateOrgDefaultAgent,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
   createTestSlackOrgInstallation,
   seedTestSlackOrgConnection,
-  updateOrgDefaultAgent,
-  countSlackOrgConnections,
-} from "../../../../../../src/__tests__/api-test-helpers";
+} from "../../../../../../src/__tests__/db-test-seeders/slack";
+import { countSlackOrgConnections } from "../../../../../../src/__tests__/db-test-assertions/slack";
 import { reloadEnv } from "../../../../../../src/env";
 
 import { POST } from "../route";

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -7,12 +7,16 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
+  updateOrgDefaultAgent,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
   createTestSlackOrgInstallation,
   seedTestSlackOrgConnection,
-  updateOrgDefaultAgent,
+} from "../../../../../../src/__tests__/db-test-seeders/slack";
+import {
   countSlackOrgInstallations,
   countSlackOrgConnections,
-} from "../../../../../../src/__tests__/api-test-helpers";
+} from "../../../../../../src/__tests__/db-test-assertions/slack";
 import {
   seedOrphanCompose,
   clearComposeHeadVersion,

--- a/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
@@ -8,8 +8,8 @@ import {
 import {
   createTestSlackOrgInstallation,
   seedTestSlackOrgConnection,
-  countSlackOrgConnections,
-} from "../../../../../../src/__tests__/api-test-helpers";
+} from "../../../../../../src/__tests__/db-test-seeders/slack";
+import { countSlackOrgConnections } from "../../../../../../src/__tests__/db-test-assertions/slack";
 import { reloadEnv } from "../../../../../../src/env";
 
 import { POST } from "../route";

--- a/turbo/apps/web/app/api/zero/slack/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/oauth/callback/__tests__/route.test.ts
@@ -4,10 +4,12 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestOrg,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
   findTestSlackOrgInstallation,
   findTestSlackOrgConnection,
   findTestSlackOrgConnections,
-} from "../../../../../../../src/__tests__/api-test-helpers";
+} from "../../../../../../../src/__tests__/db-test-assertions/slack";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/app/api/zero/slack/oauth/connect/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/oauth/connect/__tests__/route.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET } from "../route";
-import {
-  createTestRequest,
-  createTestSlackOrgInstallation,
-} from "../../../../../../../src/__tests__/api-test-helpers";
+import { createTestRequest } from "../../../../../../../src/__tests__/api-test-helpers";
+import { createTestSlackOrgInstallation } from "../../../../../../../src/__tests__/db-test-seeders/slack";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
@@ -11,7 +11,6 @@ export * from "./secrets";
 export * from "./connectors";
 export * from "./callbacks";
 export * from "./email";
-export * from "./slack";
 export * from "./github";
 export * from "./telegram";
 export * from "./phone";

--- a/turbo/apps/web/src/__tests__/db-test-assertions/slack.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/slack.ts
@@ -1,0 +1,93 @@
+import { and, eq, sql } from "drizzle-orm";
+import { initServices } from "../../lib/init-services";
+import { slackOrgInstallations } from "../../db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../db/schema/slack-org-connection";
+
+export async function findTestSlackOrgInstallation(workspaceId: string) {
+  const [row] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+  return row;
+}
+
+export async function findTestSlackOrgConnections(
+  slackUserId: string,
+  workspaceId: string,
+) {
+  return globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, slackUserId),
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+      ),
+    );
+}
+
+export async function findTestSlackOrgConnection(
+  slackUserId: string,
+  workspaceId: string,
+) {
+  const [row] = await globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, slackUserId),
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+      ),
+    );
+  return row;
+}
+
+export async function findTestSlackOrgConnectionsByVm0UserId(
+  vm0UserId: string,
+) {
+  return globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.vm0UserId, vm0UserId));
+}
+
+/**
+ * Count Slack org installations for a workspace.
+ */
+export async function countSlackOrgInstallations(
+  workspaceId: string,
+): Promise<number> {
+  initServices();
+  const rows = await globalThis.services.db
+    .select({ id: slackOrgInstallations.slackWorkspaceId })
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
+  return rows.length;
+}
+
+/**
+ * Count Slack org connections for a workspace.
+ */
+export async function countSlackOrgConnections(
+  workspaceId: string,
+): Promise<number> {
+  initServices();
+  const rows = await globalThis.services.db
+    .select({ id: slackOrgConnections.id })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
+  return rows.length;
+}
+
+/**
+ * Count rows in slack_org_connections where vm0_user_id matches.
+ */
+export async function countSlackConnectionRows(
+  vm0UserId: string,
+): Promise<number> {
+  const rows = await globalThis.services.db.execute(
+    sql`SELECT COUNT(*)::int AS count FROM slack_org_connections WHERE vm0_user_id = ${vm0UserId}`,
+  );
+  return (rows.rows[0] as { count: number }).count;
+}

--- a/turbo/apps/web/src/__tests__/db-test-assertions/slack.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/slack.ts
@@ -1,9 +1,10 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, count } from "drizzle-orm";
 import { initServices } from "../../lib/init-services";
 import { slackOrgInstallations } from "../../db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../db/schema/slack-org-connection";
 
 export async function findTestSlackOrgInstallation(workspaceId: string) {
+  initServices();
   const [row] = await globalThis.services.db
     .select()
     .from(slackOrgInstallations)
@@ -16,6 +17,7 @@ export async function findTestSlackOrgConnections(
   slackUserId: string,
   workspaceId: string,
 ) {
+  initServices();
   return globalThis.services.db
     .select()
     .from(slackOrgConnections)
@@ -31,6 +33,7 @@ export async function findTestSlackOrgConnection(
   slackUserId: string,
   workspaceId: string,
 ) {
+  initServices();
   const [row] = await globalThis.services.db
     .select()
     .from(slackOrgConnections)
@@ -46,6 +49,7 @@ export async function findTestSlackOrgConnection(
 export async function findTestSlackOrgConnectionsByVm0UserId(
   vm0UserId: string,
 ) {
+  initServices();
   return globalThis.services.db
     .select()
     .from(slackOrgConnections)
@@ -86,8 +90,10 @@ export async function countSlackOrgConnections(
 export async function countSlackConnectionRows(
   vm0UserId: string,
 ): Promise<number> {
-  const rows = await globalThis.services.db.execute(
-    sql`SELECT COUNT(*)::int AS count FROM slack_org_connections WHERE vm0_user_id = ${vm0UserId}`,
-  );
-  return (rows.rows[0] as { count: number }).count;
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ count: count() })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.vm0UserId, vm0UserId));
+  return row?.count ?? 0;
 }

--- a/turbo/apps/web/src/__tests__/db-test-seeders/slack.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/slack.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
 import { initServices } from "../../lib/init-services";
 import { slackOrgInstallations } from "../../db/schema/slack-org-installation";
@@ -6,13 +6,12 @@ import { slackOrgConnections } from "../../db/schema/slack-org-connection";
 import { slackOrgThreadSessions } from "../../db/schema/slack-org-thread-session";
 import { encryptSecretValue } from "../../lib/shared/crypto/secrets-encryption";
 import { uniqueId } from "../test-helpers";
-export { SLACK_BOT_SCOPES } from "../../lib/zero/slack-org/scopes";
 
 /**
- * Create an org-aware Slack installation for testing.
+ * @why-db-direct Slack OAuth callback requires real API interaction to exchange
+ * authorization code for bot token; no test-friendly API endpoint exists.
  *
- * Direct DB insert is required because the org Slack OAuth callback
- * requires real Slack API interaction that cannot be easily mocked.
+ * Creates an org-aware Slack installation with encrypted bot token.
  */
 export async function createTestSlackOrgInstallation(opts: {
   workspaceId?: string;
@@ -59,10 +58,10 @@ export async function createTestSlackOrgInstallation(opts: {
 }
 
 /**
- * Create an org-aware Slack connection for testing.
+ * @why-db-direct Connect API calls Slack to send DM notifications; test setup
+ * needs connections without Slack API side effects.
  *
- * Direct DB insert is required because the connect API requires
- * Slack workspace context that is only available during real OAuth.
+ * Creates an org-aware Slack connection, validating the installation has an orgId.
  */
 export async function createTestSlackOrgConnection(opts: {
   slackUserId?: string;
@@ -97,51 +96,9 @@ export async function createTestSlackOrgConnection(opts: {
   return { slackUserId, connectionId: connection!.id };
 }
 
-export async function findTestSlackOrgInstallation(workspaceId: string) {
-  const [row] = await globalThis.services.db
-    .select()
-    .from(slackOrgInstallations)
-    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId))
-    .limit(1);
-  return row;
-}
-
-export async function findTestSlackOrgConnections(
-  slackUserId: string,
-  workspaceId: string,
-) {
-  return globalThis.services.db
-    .select()
-    .from(slackOrgConnections)
-    .where(
-      and(
-        eq(slackOrgConnections.slackUserId, slackUserId),
-        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
-      ),
-    );
-}
-
-export async function findTestSlackOrgConnection(
-  slackUserId: string,
-  workspaceId: string,
-) {
-  const [row] = await globalThis.services.db
-    .select()
-    .from(slackOrgConnections)
-    .where(
-      and(
-        eq(slackOrgConnections.slackUserId, slackUserId),
-        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
-      ),
-    );
-  return row;
-}
-
 /**
- * Seed a Slack org connection directly for testing cleanup scenarios.
- *
- * Unlike createTestSlackOrgConnection, this does not require the
- * installation to have an orgId.
+ * @why-db-direct Direct insert without installation-orgId validation; needed
+ * for cleanup/disconnect tests where installation may lack orgId.
  */
 export async function seedTestSlackOrgConnection(opts: {
   slackUserId: string;
@@ -164,7 +121,8 @@ export async function seedTestSlackOrgConnection(opts: {
 }
 
 /**
- * Create a Slack org installation for a specific org.
+ * @why-db-direct Minimal installation for external cleanup tests; no API path
+ * creates installations without real OAuth.
  */
 export async function createSlackInstallationForOrg(
   orgId: string,
@@ -183,6 +141,10 @@ export async function createSlackInstallationForOrg(
     .onConflictDoNothing();
 }
 
+/**
+ * @why-db-direct Simple installation without encrypted tokens for
+ * deletion/cascade tests.
+ */
 export async function insertTestSlackOrgInstallation(params: {
   slackWorkspaceId: string;
   slackWorkspaceName: string;
@@ -199,6 +161,9 @@ export async function insertTestSlackOrgInstallation(params: {
   });
 }
 
+/**
+ * @why-db-direct Direct connection insert for deletion/cascade tests.
+ */
 export async function insertTestSlackOrgConnection(params: {
   slackUserId: string;
   slackWorkspaceId: string;
@@ -215,6 +180,10 @@ export async function insertTestSlackOrgConnection(params: {
   return row!;
 }
 
+/**
+ * @why-db-direct Thread session requires pre-existing connection ID; no API
+ * creates thread sessions directly.
+ */
 export async function insertTestSlackOrgThreadSession(params: {
   connectionId: string;
   agentSessionId?: string;
@@ -229,53 +198,4 @@ export async function insertTestSlackOrgThreadSession(params: {
     })
     .returning({ id: slackOrgThreadSessions.id });
   return row!;
-}
-
-/**
- * Count Slack org installations for a workspace.
- */
-export async function countSlackOrgInstallations(
-  workspaceId: string,
-): Promise<number> {
-  initServices();
-  const rows = await globalThis.services.db
-    .select({ id: slackOrgInstallations.slackWorkspaceId })
-    .from(slackOrgInstallations)
-    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
-  return rows.length;
-}
-
-/**
- * Count Slack org connections for a workspace.
- */
-export async function countSlackOrgConnections(
-  workspaceId: string,
-): Promise<number> {
-  initServices();
-  const rows = await globalThis.services.db
-    .select({ id: slackOrgConnections.id })
-    .from(slackOrgConnections)
-    .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
-  return rows.length;
-}
-
-/**
- * Count rows in slack_org_connections where vm0_user_id matches.
- */
-export async function countSlackConnectionRows(
-  vm0UserId: string,
-): Promise<number> {
-  const rows = await globalThis.services.db.execute(
-    sql`SELECT COUNT(*)::int AS count FROM slack_org_connections WHERE vm0_user_id = ${vm0UserId}`,
-  );
-  return (rows.rows[0] as { count: number }).count;
-}
-
-export async function findTestSlackOrgConnectionsByVm0UserId(
-  vm0UserId: string,
-) {
-  return globalThis.services.db
-    .select()
-    .from(slackOrgConnections)
-    .where(eq(slackOrgConnections.vm0UserId, vm0UserId));
 }

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
@@ -10,9 +10,6 @@ import {
   findTestQueueEntry,
   insertOrgDefaultModelProvider,
   insertTestQueueEntry,
-  insertTestSlackOrgInstallation,
-  insertTestSlackOrgConnection,
-  insertTestSlackOrgThreadSession,
   insertTestCreditUsageForRun,
   insertTestConversation,
   insertTestStorage,
@@ -21,12 +18,17 @@ import {
   insertTestExportJob,
   insertOrgMembersCacheEntry,
   insertOrgMembersEntry,
-  findTestSlackOrgInstallation,
   countOrgRows,
   insertTestOrgSentinelSecret,
   insertTestOrgSentinelVariable,
   createTestSchedule,
 } from "../../../../__tests__/api-test-helpers";
+import {
+  insertTestSlackOrgInstallation,
+  insertTestSlackOrgConnection,
+  insertTestSlackOrgThreadSession,
+} from "../../../../__tests__/db-test-seeders/slack";
+import { findTestSlackOrgInstallation } from "../../../../__tests__/db-test-assertions/slack";
 import { createTestZeroAgent } from "../../../../__tests__/db-test-seeders/agents";
 import { deleteOrgData } from "../org-deletion-service";
 import { seedTestRun } from "../../../../__tests__/db-test-seeders/runs";

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-external-cleanup.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-external-cleanup.test.ts
@@ -8,9 +8,9 @@ import { reloadEnv } from "../../../../env";
 import {
   updateOrgStripeSubscription,
   createTelegramInstallationForCompose,
-  createSlackInstallationForOrg,
-  findTestSlackOrgInstallation,
 } from "../../../../__tests__/api-test-helpers";
+import { createSlackInstallationForOrg } from "../../../../__tests__/db-test-seeders/slack";
+import { findTestSlackOrgInstallation } from "../../../../__tests__/db-test-assertions/slack";
 import { updateAgentComposeOrg } from "../../../../__tests__/db-test-seeders/agents";
 import { cleanupOrgExternalServices } from "../org-external-cleanup";
 

--- a/turbo/apps/web/src/lib/zero/slack-org/__tests__/connect-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/__tests__/connect-service.test.ts
@@ -7,9 +7,11 @@ import {
 import {
   createTestSlackOrgInstallation,
   seedTestSlackOrgConnection,
+} from "../../../../__tests__/db-test-seeders/slack";
+import {
   countSlackOrgInstallations,
   countSlackOrgConnections,
-} from "../../../../__tests__/api-test-helpers";
+} from "../../../../__tests__/db-test-assertions/slack";
 import {
   adminConnect,
   memberConnect,

--- a/turbo/apps/web/src/lib/zero/user/__tests__/user-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/user/__tests__/user-deletion-service.test.ts
@@ -12,9 +12,6 @@ import {
   findTestRunRecord,
   findTestQueueEntry,
   insertTestQueueEntry,
-  insertTestSlackOrgInstallation,
-  insertTestSlackOrgConnection,
-  insertTestSlackOrgThreadSession,
   insertTestCreditUsageForRun,
   insertTestConversation,
   insertTestStorage,
@@ -25,7 +22,6 @@ import {
   insertOrgMembersEntry,
   insertUserCacheEntry,
   countUserRows,
-  countSlackConnectionRows,
   countGithubUserLinkRows,
   countTelegramUserLinkRows,
   insertTestGithubInstallation,
@@ -33,6 +29,12 @@ import {
   insertTestTelegramInstallation,
   insertTestTelegramUserLink,
 } from "../../../../__tests__/api-test-helpers";
+import {
+  insertTestSlackOrgInstallation,
+  insertTestSlackOrgConnection,
+  insertTestSlackOrgThreadSession,
+} from "../../../../__tests__/db-test-seeders/slack";
+import { countSlackConnectionRows } from "../../../../__tests__/db-test-assertions/slack";
 import { insertTestComposeJob } from "../../../../__tests__/db-test-seeders/agents";
 import { deleteUserData } from "../user-deletion-service";
 import { seedTestRun } from "../../../../__tests__/db-test-seeders/runs";

--- a/turbo/apps/web/src/lib/zero/user/__tests__/user-external-cleanup.test.ts
+++ b/turbo/apps/web/src/lib/zero/user/__tests__/user-external-cleanup.test.ts
@@ -4,13 +4,15 @@ import {
   insertTestGitHubUserLink,
   insertTestGitHubInstallation,
   createTestTelegramInstallation,
+  findTestGitHubUserLinksByVm0UserId,
+  findTestTelegramUserLinksByVm0UserId,
+} from "../../../../__tests__/api-test-helpers";
+import {
   insertTestSlackOrgInstallation,
   insertTestSlackOrgConnection,
   insertTestSlackOrgThreadSession,
-  findTestGitHubUserLinksByVm0UserId,
-  findTestTelegramUserLinksByVm0UserId,
-  findTestSlackOrgConnectionsByVm0UserId,
-} from "../../../../__tests__/api-test-helpers";
+} from "../../../../__tests__/db-test-seeders/slack";
+import { findTestSlackOrgConnectionsByVm0UserId } from "../../../../__tests__/db-test-assertions/slack";
 import { cleanupUserExternalServices } from "../user-external-cleanup";
 
 const context = testContext();


### PR DESCRIPTION
## Summary

Closes #9351

- Moved all DB-direct helpers from `api-test-helpers/slack.ts` into the three-tier structure:
  - **`db-test-seeders/slack.ts`**: 7 seeder functions with `@why-db-direct` JSDoc
  - **`db-test-assertions/slack.ts`**: 7 read-only assertion/find/count functions
- Deleted `api-test-helpers/slack.ts` entirely and removed barrel re-export
- Updated `SLACK_BOT_SCOPES` to import directly from source (`lib/zero/slack-org/scopes`)
- Updated imports across 17 consumer test files

## Test plan

- [x] All pre-commit checks pass (prettier, knip, commitlint)
- [x] Type-check passes for web app (only pre-existing errors in cli/platform)
- [x] Lint passes with zero errors
- [ ] CI pipeline validates all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)