### PR TITLE
refactor(test): migrate storage helpers to three-tier test architecture

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers/storage.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/storage.ts
@@ -1,14 +1,40 @@
-import { and, eq } from "drizzle-orm";
-import { randomUUID } from "crypto";
-import { VOLUME_ORG_USER_ID, SYSTEM_ORG_ID } from "@vm0/core";
-import { initServices } from "../../lib/init-services";
-import { storages, storageVersions } from "../../db/schema/storage";
-import { storageVersionLineage } from "../../db/schema/storage-version-lineage";
-import { hashFileContent } from "../../lib/infra/storage/content-hash";
 import { POST as storagePrepareRoute } from "../../../app/api/storages/prepare/route";
 import { POST as storageCommitRoute } from "../../../app/api/storages/commit/route";
 import { createTestRequest } from "./core";
-import { uniqueId } from "../test-helpers";
+
+// ---------------------------------------------------------------------------
+// Re-exports: DB-direct seeders.
+//
+// These functions live in db-test-seeders/storage.ts but are re-exported
+// here for backward compatibility — existing test files import from
+// api-test-helpers and should continue to work unchanged.
+// ---------------------------------------------------------------------------
+
+export {
+  createTestVolumeForOrg,
+  insertStorageVersion,
+  insertTestArtifactStorage,
+  insertTestStorage,
+  insertTestStorageVersion,
+} from "../db-test-seeders/storage";
+
+// ---------------------------------------------------------------------------
+// Re-exports: Assertion helpers.
+// ---------------------------------------------------------------------------
+
+export {
+  findTestStorageByName,
+  findTestStorage,
+  findTestSystemStorageByName,
+  getStorageVersionLineage,
+} from "../db-test-assertions/storage";
+
+// ---------------------------------------------------------------------------
+// API-based helpers.
+//
+// These call API route handlers (prepare/commit flow) and are valid
+// API-based helpers that belong in this tier.
+// ---------------------------------------------------------------------------
 
 interface TestFile {
   path: string;
@@ -170,54 +196,6 @@ export async function createTestVolume(
 }
 
 /**
- * Create a volume storage directly in the DB for a specific org.
- * Unlike createTestVolume() which uses the mock user's org via API,
- * this allows creating storages under any org (e.g., SYSTEM_ORG_ID).
- *
- * @param orgId - The org to create the storage under
- * @param name - Storage name
- * @returns The created storage with versionId
- */
-export async function createTestVolumeForOrg(
-  orgId: string,
-  name: string,
-): Promise<{ storageId: string; versionId: string }> {
-  const versionId = randomUUID().replace(/-/g, "").repeat(2).slice(0, 64);
-  const s3Key = `${orgId}/${name}/${versionId}`;
-
-  return globalThis.services.db.transaction(async (tx) => {
-    const [storage] = await tx
-      .insert(storages)
-      .values({
-        orgId,
-        userId: VOLUME_ORG_USER_ID,
-        name,
-        type: "volume",
-        s3Prefix: `${orgId}/${name}`,
-      })
-      .returning();
-
-    const storageId = storage!.id;
-
-    await tx.insert(storageVersions).values({
-      id: versionId,
-      storageId,
-      s3Key,
-      size: 100,
-      fileCount: 1,
-      createdBy: "test",
-    });
-
-    await tx
-      .update(storages)
-      .set({ headVersionId: versionId })
-      .where(eq(storages.id, storageId));
-
-    return { storageId, versionId };
-  });
-}
-
-/**
  * Create a test memory storage via API route handlers.
  * Convenience wrapper around createTestStorage with type="memory".
  *
@@ -235,206 +213,4 @@ export async function createTestMemory(
   fileCount: number;
 }> {
   return createTestStorage(name, { ...options, type: "memory" });
-}
-
-/**
- * Insert an extra storage version record with a controlled ID.
- * Used to create deterministic ambiguous-prefix test scenarios where
- * two versions share the same prefix but the content hash is different.
- *
- * @param storageName - Name of an existing storage (must already have a version)
- * @param versionId - The 64-char hex version ID to insert
- */
-export async function insertStorageVersion(
-  storageName: string,
-  versionId: string,
-): Promise<void> {
-  const [storage] = await globalThis.services.db
-    .select()
-    .from(storages)
-    .where(eq(storages.name, storageName))
-    .limit(1);
-
-  if (!storage) {
-    throw new Error(`Storage "${storageName}" not found`);
-  }
-
-  await globalThis.services.db
-    .insert(storageVersions)
-    .values({
-      id: versionId,
-      storageId: storage.id,
-      s3Key: `test/${versionId}`,
-      size: 0,
-      fileCount: 0,
-      createdBy: "test",
-    })
-    .onConflictDoUpdate({
-      target: storageVersions.id,
-      set: { storageId: storage.id },
-    });
-}
-
-/**
- * Find a storage volume by clerk org and name.
- * Volumes use the sentinel VOLUME_ORG_USER_ID for org-level sharing.
- * Returns the storage id and name, or undefined if not found.
- */
-export async function findTestStorageByName(
-  orgId: string,
-  name: string,
-): Promise<{ id: string; name: string; s3Prefix: string } | undefined> {
-  const [result] = await globalThis.services.db
-    .select({
-      id: storages.id,
-      name: storages.name,
-      s3Prefix: storages.s3Prefix,
-    })
-    .from(storages)
-    .where(
-      and(
-        eq(storages.orgId, orgId),
-        eq(storages.userId, VOLUME_ORG_USER_ID),
-        eq(storages.name, name),
-        eq(storages.type, "volume"),
-      ),
-    )
-    .limit(1);
-  return result;
-}
-
-/**
- * Find a storage record by clerk org, name, and type.
- * Returns the storage userId and other details for verification.
- */
-export async function findTestStorage(
-  orgId: string,
-  name: string,
-  type: "volume" | "artifact" | "memory",
-): Promise<
-  { id: string; name: string; userId: string; s3Prefix: string } | undefined
-> {
-  const [result] = await globalThis.services.db
-    .select({
-      id: storages.id,
-      name: storages.name,
-      userId: storages.userId,
-      s3Prefix: storages.s3Prefix,
-    })
-    .from(storages)
-    .where(
-      and(
-        eq(storages.orgId, orgId),
-        eq(storages.name, name),
-        eq(storages.type, type),
-      ),
-    )
-    .limit(1);
-  return result;
-}
-
-/**
- * Find a single system storage by name.
- */
-export async function findTestSystemStorageByName(name: string) {
-  const [storage] = await globalThis.services.db
-    .select()
-    .from(storages)
-    .where(and(eq(storages.orgId, SYSTEM_ORG_ID), eq(storages.name, name)))
-    .limit(1);
-  return storage ?? null;
-}
-
-/**
- * Query storage version lineage records for a given versionId.
- * Used to verify lineage tracking in commit webhook tests.
- */
-export async function getStorageVersionLineage(versionId: string) {
-  initServices();
-  return globalThis.services.db
-    .select()
-    .from(storageVersionLineage)
-    .where(eq(storageVersionLineage.versionId, versionId));
-}
-
-/**
- * Insert a test artifact storage with a version for export testing.
- *
- * Direct DB insert is required because storage creation normally goes
- * through the prepare/commit flow, but we need a minimal record.
- */
-export async function insertTestArtifactStorage(
-  userId: string,
-  orgId: string,
-  name: string,
-) {
-  const versionId = hashFileContent(Buffer.from(uniqueId("sv")));
-
-  const [storage] = await globalThis.services.db
-    .insert(storages)
-    .values({
-      userId,
-      orgId,
-      name,
-      type: "artifact",
-      s3Prefix: `${userId}/artifact/${name}`,
-      size: 1024,
-      fileCount: 3,
-    })
-    .returning();
-
-  await globalThis.services.db.insert(storageVersions).values({
-    id: versionId,
-    storageId: storage!.id,
-    s3Key: `${userId}/artifact/${name}/${versionId}`,
-    size: 1024,
-    fileCount: 3,
-    createdBy: userId,
-  });
-
-  await globalThis.services.db
-    .update(storages)
-    .set({ headVersionId: versionId })
-    .where(eq(storages.id, storage!.id));
-
-  return { storageId: storage!.id, versionId };
-}
-
-/**
- * Insert a test storage record directly.
- */
-export async function insertTestStorage(params: {
-  userId: string;
-  orgId: string;
-  name: string;
-  type?: string;
-}): Promise<{ id: string }> {
-  const [row] = await globalThis.services.db
-    .insert(storages)
-    .values({
-      userId: params.userId,
-      name: params.name,
-      type: params.type ?? "volume",
-      orgId: params.orgId,
-      s3Prefix: `storages/${params.orgId}/${params.name}/`,
-    })
-    .returning({ id: storages.id });
-  return row!;
-}
-
-/**
- * Insert a test storage version record directly.
- */
-export async function insertTestStorageVersion(params: {
-  storageId: string;
-  createdBy: string;
-}): Promise<void> {
-  await globalThis.services.db.insert(storageVersions).values({
-    id: uniqueId("sv"),
-    storageId: params.storageId,
-    s3Key: "test-key",
-    size: 100,
-    fileCount: 1,
-    createdBy: params.createdBy,
-  });
 }

--- a/turbo/apps/web/src/__tests__/db-test-assertions/storage.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/storage.ts
@@ -13,6 +13,7 @@ export async function findTestStorageByName(
   orgId: string,
   name: string,
 ): Promise<{ id: string; name: string; s3Prefix: string } | undefined> {
+  initServices();
   const [result] = await globalThis.services.db
     .select({
       id: storages.id,
@@ -43,6 +44,7 @@ export async function findTestStorage(
 ): Promise<
   { id: string; name: string; userId: string; s3Prefix: string } | undefined
 > {
+  initServices();
   const [result] = await globalThis.services.db
     .select({
       id: storages.id,
@@ -66,6 +68,7 @@ export async function findTestStorage(
  * Find a single system storage by name.
  */
 export async function findTestSystemStorageByName(name: string) {
+  initServices();
   const [storage] = await globalThis.services.db
     .select()
     .from(storages)

--- a/turbo/apps/web/src/__tests__/db-test-assertions/storage.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/storage.ts
@@ -1,0 +1,87 @@
+import { and, eq } from "drizzle-orm";
+import { VOLUME_ORG_USER_ID, SYSTEM_ORG_ID } from "@vm0/core";
+import { initServices } from "../../lib/init-services";
+import { storages } from "../../db/schema/storage";
+import { storageVersionLineage } from "../../db/schema/storage-version-lineage";
+
+/**
+ * Find a storage volume by clerk org and name.
+ * Volumes use the sentinel VOLUME_ORG_USER_ID for org-level sharing.
+ * Returns the storage id and name, or undefined if not found.
+ */
+export async function findTestStorageByName(
+  orgId: string,
+  name: string,
+): Promise<{ id: string; name: string; s3Prefix: string } | undefined> {
+  const [result] = await globalThis.services.db
+    .select({
+      id: storages.id,
+      name: storages.name,
+      s3Prefix: storages.s3Prefix,
+    })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, orgId),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        eq(storages.name, name),
+        eq(storages.type, "volume"),
+      ),
+    )
+    .limit(1);
+  return result;
+}
+
+/**
+ * Find a storage record by clerk org, name, and type.
+ * Returns the storage userId and other details for verification.
+ */
+export async function findTestStorage(
+  orgId: string,
+  name: string,
+  type: "volume" | "artifact" | "memory",
+): Promise<
+  { id: string; name: string; userId: string; s3Prefix: string } | undefined
+> {
+  const [result] = await globalThis.services.db
+    .select({
+      id: storages.id,
+      name: storages.name,
+      userId: storages.userId,
+      s3Prefix: storages.s3Prefix,
+    })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, orgId),
+        eq(storages.name, name),
+        eq(storages.type, type),
+      ),
+    )
+    .limit(1);
+  return result;
+}
+
+/**
+ * Find a single system storage by name.
+ */
+export async function findTestSystemStorageByName(name: string) {
+  const [storage] = await globalThis.services.db
+    .select()
+    .from(storages)
+    .where(and(eq(storages.orgId, SYSTEM_ORG_ID), eq(storages.name, name)))
+    .limit(1);
+  return storage ?? null;
+}
+
+/**
+ * Query storage version lineage records for a given versionId.
+ * Used to verify lineage tracking in commit webhook tests.
+ */
+export async function getStorageVersionLineage(versionId: string) {
+  initServices();
+  return globalThis.services.db
+    .select()
+    .from(storageVersionLineage)
+    .where(eq(storageVersionLineage.versionId, versionId));
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/storage.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/storage.ts
@@ -1,0 +1,190 @@
+import { eq } from "drizzle-orm";
+import { randomUUID } from "crypto";
+import { VOLUME_ORG_USER_ID } from "@vm0/core";
+import { storages, storageVersions } from "../../db/schema/storage";
+import { hashFileContent } from "../../lib/infra/storage/content-hash";
+import { uniqueId } from "../test-helpers";
+
+/**
+ * Create a volume storage directly in the DB for a specific org.
+ * Unlike createTestVolume() which uses the mock user's org via API,
+ * this allows creating storages under any org (e.g., SYSTEM_ORG_ID).
+ *
+ * @why-db-direct Creates volume under arbitrary org (e.g. SYSTEM_ORG_ID);
+ * the API always uses the mock user's org from Clerk auth context, so
+ * there is no way to create a storage for a different org via API.
+ *
+ * @param orgId - The org to create the storage under
+ * @param name - Storage name
+ * @returns The created storage with versionId
+ */
+export async function createTestVolumeForOrg(
+  orgId: string,
+  name: string,
+): Promise<{ storageId: string; versionId: string }> {
+  const versionId = randomUUID().replace(/-/g, "").repeat(2).slice(0, 64);
+  const s3Key = `${orgId}/${name}/${versionId}`;
+
+  return globalThis.services.db.transaction(async (tx) => {
+    const [storage] = await tx
+      .insert(storages)
+      .values({
+        orgId,
+        userId: VOLUME_ORG_USER_ID,
+        name,
+        type: "volume",
+        s3Prefix: `${orgId}/${name}`,
+      })
+      .returning();
+
+    const storageId = storage!.id;
+
+    await tx.insert(storageVersions).values({
+      id: versionId,
+      storageId,
+      s3Key,
+      size: 100,
+      fileCount: 1,
+      createdBy: "test",
+    });
+
+    await tx
+      .update(storages)
+      .set({ headVersionId: versionId })
+      .where(eq(storages.id, storageId));
+
+    return { storageId, versionId };
+  });
+}
+
+/**
+ * Insert an extra storage version record with a controlled ID.
+ * Used to create deterministic ambiguous-prefix test scenarios where
+ * two versions share the same prefix but the content hash is different.
+ *
+ * @why-db-direct Inserts version with a controlled ID for ambiguous-prefix
+ * testing; no API endpoint exists for inserting arbitrary version IDs.
+ *
+ * @param storageName - Name of an existing storage (must already have a version)
+ * @param versionId - The 64-char hex version ID to insert
+ */
+export async function insertStorageVersion(
+  storageName: string,
+  versionId: string,
+): Promise<void> {
+  const [storage] = await globalThis.services.db
+    .select()
+    .from(storages)
+    .where(eq(storages.name, storageName))
+    .limit(1);
+
+  if (!storage) {
+    throw new Error(`Storage "${storageName}" not found`);
+  }
+
+  await globalThis.services.db
+    .insert(storageVersions)
+    .values({
+      id: versionId,
+      storageId: storage.id,
+      s3Key: `test/${versionId}`,
+      size: 0,
+      fileCount: 0,
+      createdBy: "test",
+    })
+    .onConflictDoUpdate({
+      target: storageVersions.id,
+      set: { storageId: storage.id },
+    });
+}
+
+/**
+ * Insert a test artifact storage with a version for export testing.
+ *
+ * @why-db-direct Inserts minimal artifact+version bypassing the prepare/commit
+ * flow; export testing needs a minimal storage record without S3 upload
+ * side effects.
+ */
+export async function insertTestArtifactStorage(
+  userId: string,
+  orgId: string,
+  name: string,
+) {
+  const versionId = hashFileContent(Buffer.from(uniqueId("sv")));
+
+  const [storage] = await globalThis.services.db
+    .insert(storages)
+    .values({
+      userId,
+      orgId,
+      name,
+      type: "artifact",
+      s3Prefix: `${userId}/artifact/${name}`,
+      size: 1024,
+      fileCount: 3,
+    })
+    .returning();
+
+  await globalThis.services.db.insert(storageVersions).values({
+    id: versionId,
+    storageId: storage!.id,
+    s3Key: `${userId}/artifact/${name}/${versionId}`,
+    size: 1024,
+    fileCount: 3,
+    createdBy: userId,
+  });
+
+  await globalThis.services.db
+    .update(storages)
+    .set({ headVersionId: versionId })
+    .where(eq(storages.id, storage!.id));
+
+  return { storageId: storage!.id, versionId };
+}
+
+/**
+ * Insert a test storage record directly.
+ *
+ * @why-db-direct Inserts bare storage record without version; deletion and
+ * cleanup tests need minimal records without the API prepare/commit side
+ * effects.
+ */
+export async function insertTestStorage(params: {
+  userId: string;
+  orgId: string;
+  name: string;
+  type?: string;
+}): Promise<{ id: string }> {
+  const [row] = await globalThis.services.db
+    .insert(storages)
+    .values({
+      userId: params.userId,
+      name: params.name,
+      type: params.type ?? "volume",
+      orgId: params.orgId,
+      s3Prefix: `storages/${params.orgId}/${params.name}/`,
+    })
+    .returning({ id: storages.id });
+  return row!;
+}
+
+/**
+ * Insert a test storage version record directly.
+ *
+ * @why-db-direct Inserts bare version record; deletion and cleanup tests need
+ * version records without the full prepare/commit flow and S3 upload side
+ * effects.
+ */
+export async function insertTestStorageVersion(params: {
+  storageId: string;
+  createdBy: string;
+}): Promise<void> {
+  await globalThis.services.db.insert(storageVersions).values({
+    id: uniqueId("sv"),
+    storageId: params.storageId,
+    s3Key: "test-key",
+    size: 100,
+    fileCount: 1,
+    createdBy: params.createdBy,
+  });
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/storage.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/storage.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
 import { VOLUME_ORG_USER_ID } from "@vm0/core";
+import { initServices } from "../../lib/init-services";
 import { storages, storageVersions } from "../../db/schema/storage";
 import { hashFileContent } from "../../lib/infra/storage/content-hash";
 import { uniqueId } from "../test-helpers";
@@ -22,6 +23,7 @@ export async function createTestVolumeForOrg(
   orgId: string,
   name: string,
 ): Promise<{ storageId: string; versionId: string }> {
+  initServices();
   const versionId = randomUUID().replace(/-/g, "").repeat(2).slice(0, 64);
   const s3Key = `${orgId}/${name}/${versionId}`;
 
@@ -72,6 +74,7 @@ export async function insertStorageVersion(
   storageName: string,
   versionId: string,
 ): Promise<void> {
+  initServices();
   const [storage] = await globalThis.services.db
     .select()
     .from(storages)
@@ -110,6 +113,7 @@ export async function insertTestArtifactStorage(
   orgId: string,
   name: string,
 ) {
+  initServices();
   const versionId = hashFileContent(Buffer.from(uniqueId("sv")));
 
   const [storage] = await globalThis.services.db
@@ -155,6 +159,7 @@ export async function insertTestStorage(params: {
   name: string;
   type?: string;
 }): Promise<{ id: string }> {
+  initServices();
   const [row] = await globalThis.services.db
     .insert(storages)
     .values({
@@ -179,6 +184,7 @@ export async function insertTestStorageVersion(params: {
   storageId: string;
   createdBy: string;
 }): Promise<void> {
+  initServices();
   await globalThis.services.db.insert(storageVersions).values({
     id: uniqueId("sv"),
     storageId: params.storageId,


### PR DESCRIPTION
## Summary
- Move 5 DB-direct write functions to `db-test-seeders/storage.ts` with `@why-db-direct` JSDoc
- Move 4 read-only query functions to `db-test-assertions/storage.ts`
- Keep API-based helpers (`createTestArtifact`, `createTestVolume`, `createTestMemory`) in `api-test-helpers/storage.ts`
- Add re-exports for backward compatibility — zero consumer test file changes needed

## Verification
- `api-test-helpers/storage.ts` has zero `db/schema` imports
- `api-test-helpers/storage.ts` has zero `globalThis.services.db` calls
- All existing tests pass unchanged

Closes #9354

## Test plan
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Format passes (`pnpm format`)
- [x] Knip passes (`pnpm knip`)
- [x] All 19 consumer test files pass (268 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)