### PR TITLE
refactor(test): migrate schedules and secrets helpers to three-tier architecture

### DIFF
--- a/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
@@ -9,9 +9,11 @@ import {
   getTestSchedule,
   getTestScheduleRuns,
   getTestRun,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
   disableAllSchedules,
   setScheduleConsecutiveFailures,
-} from "../../../../../src/__tests__/api-test-helpers";
+} from "../../../../../src/__tests__/db-test-seeders/schedules";
 import {
   createTestZeroAgent,
   clearComposeHeadVersion,

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/cron/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/cron/__tests__/route.test.ts
@@ -11,10 +11,10 @@ import {
   enableTestSchedule,
   disableTestSchedule,
   deleteTestSchedule,
-  updateTestScheduleState,
-  findTestScheduleById,
   createSignedCallbackRequest,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import { updateTestScheduleState } from "../../../../../../../src/__tests__/db-test-seeders/schedules";
+import { findTestScheduleById } from "../../../../../../../src/__tests__/db-test-assertions/schedules";
 import { createTestZeroAgent } from "../../../../../../../src/__tests__/db-test-seeders/agents";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
@@ -11,10 +11,10 @@ import {
   enableTestSchedule,
   disableTestSchedule,
   deleteTestSchedule,
-  updateTestScheduleState,
-  findTestScheduleById,
   createSignedCallbackRequest,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import { updateTestScheduleState } from "../../../../../../../src/__tests__/db-test-seeders/schedules";
+import { findTestScheduleById } from "../../../../../../../src/__tests__/db-test-assertions/schedules";
 import { createTestZeroAgent } from "../../../../../../../src/__tests__/db-test-seeders/agents";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 

--- a/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
@@ -7,9 +7,9 @@ import {
   insertTestChatThread,
   getTestAgentComposeName,
   createTestSchedule,
-  updateTestScheduleState,
   insertTestVoiceChatSession,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { updateTestScheduleState } from "../../../../../src/__tests__/db-test-seeders/schedules";
 import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
 import {
   testContext,

--- a/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
@@ -1,6 +1,5 @@
 import { and, eq } from "drizzle-orm";
 import { initServices } from "../../lib/init-services";
-import { zeroAgentSchedules } from "../../db/schema/zero-agent-schedule";
 import { agentComposes } from "../../db/schema/agent-compose";
 import { zeroAgents } from "../../db/schema/zero-agent";
 import type { ScheduleResponse } from "../../lib/zero/schedule/schedule-service";
@@ -181,82 +180,4 @@ export async function getTestScheduleRuns(
     limit ?? 5,
   );
   return { runs };
-}
-
-/**
- * Update internal schedule state for testing edge cases.
- *
- * Direct DB write is required because the schedule API does not expose
- * an endpoint to set internal fields like consecutiveFailures or lastRunId —
- * these are managed by the callback system, not user actions.
- */
-export async function updateTestScheduleState(
-  scheduleId: string,
-  state: {
-    consecutiveFailures?: number;
-    enabled?: boolean;
-    nextRunAt?: Date | null;
-    lastRunId?: string;
-    intervalSeconds?: number;
-  },
-): Promise<void> {
-  await globalThis.services.db
-    .update(zeroAgentSchedules)
-    .set(state)
-    .where(eq(zeroAgentSchedules.id, scheduleId));
-}
-
-/**
- * Get internal schedule state by ID for verifying callback side-effects.
- *
- * Direct DB read is required because the schedule GET API requires
- * composeId + name, but callback tests only have the schedule ID from
- * the payload. Also exposes internal fields not in the API response.
- */
-export async function findTestScheduleById(scheduleId: string) {
-  const [row] = await globalThis.services.db
-    .select()
-    .from(zeroAgentSchedules)
-    .where(eq(zeroAgentSchedules.id, scheduleId))
-    .limit(1);
-  return row;
-}
-
-/**
- * Disable enabled schedules for a specific org.
- * Prevents stale schedules from other test files consuming the limit(10)
- * batch in executeDueSchedules, which can cause test flakiness.
- *
- * Scoped to orgId so dev-server schedules are not affected.
- */
-export async function disableAllSchedules(orgId: string): Promise<void> {
-  await globalThis.services.db
-    .update(zeroAgentSchedules)
-    .set({ enabled: false })
-    .where(
-      and(
-        eq(zeroAgentSchedules.enabled, true),
-        eq(zeroAgentSchedules.orgId, orgId),
-      ),
-    );
-}
-
-/**
- * Set the consecutiveFailures count on a schedule.
- * Useful for testing auto-disable after N failures.
- */
-export async function setScheduleConsecutiveFailures(
-  composeId: string,
-  name: string,
-  failures: number,
-): Promise<void> {
-  await globalThis.services.db
-    .update(zeroAgentSchedules)
-    .set({ consecutiveFailures: failures })
-    .where(
-      and(
-        eq(zeroAgentSchedules.agentId, composeId),
-        eq(zeroAgentSchedules.name, name),
-      ),
-    );
 }

--- a/turbo/apps/web/src/__tests__/api-test-helpers/secrets.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/secrets.ts
@@ -1,7 +1,3 @@
-import { secrets } from "../../db/schema/secret";
-import { variables } from "../../db/schema/variable";
-import { ORG_SENTINEL_USER_ID } from "../../lib/zero/org/org-sentinel";
-import { encryptSecretValue } from "../../lib/shared/crypto/secrets-encryption";
 import { POST as setSecretRoute } from "../../../app/api/zero/secrets/route";
 import { POST as setVariableRoute } from "../../../app/api/zero/variables/route";
 import { createTestRequest } from "./core";
@@ -85,34 +81,4 @@ export async function createTestVariable(
     );
   }
   return response.json();
-}
-
-export async function insertTestOrgSentinelSecret(params: {
-  orgId: string;
-  name: string;
-}): Promise<void> {
-  const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
-  const encrypted = encryptSecretValue(
-    "sentinel-test-value",
-    SECRETS_ENCRYPTION_KEY,
-  );
-  await globalThis.services.db.insert(secrets).values({
-    name: params.name,
-    encryptedValue: encrypted,
-    type: "user",
-    userId: ORG_SENTINEL_USER_ID,
-    orgId: params.orgId,
-  });
-}
-
-export async function insertTestOrgSentinelVariable(params: {
-  orgId: string;
-  name: string;
-}): Promise<void> {
-  await globalThis.services.db.insert(variables).values({
-    name: params.name,
-    value: "sentinel-test-value",
-    userId: ORG_SENTINEL_USER_ID,
-    orgId: params.orgId,
-  });
 }

--- a/turbo/apps/web/src/__tests__/db-test-assertions/schedules.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/schedules.ts
@@ -1,0 +1,24 @@
+import { eq } from "drizzle-orm";
+import { initServices } from "../../lib/init-services";
+import { zeroAgentSchedules } from "../../db/schema/zero-agent-schedule";
+
+// ============================================================================
+// Schedule Assertions
+// ============================================================================
+
+/**
+ * Get internal schedule state by ID for verifying callback side-effects.
+ *
+ * Direct DB read is required because the schedule GET API requires
+ * composeId + name, but callback tests only have the schedule ID from
+ * the payload. Also exposes internal fields not in the API response.
+ */
+export async function findTestScheduleById(scheduleId: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(zeroAgentSchedules)
+    .where(eq(zeroAgentSchedules.id, scheduleId))
+    .limit(1);
+  return row;
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/schedules.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/schedules.ts
@@ -1,0 +1,78 @@
+import { and, eq } from "drizzle-orm";
+import { initServices } from "../../lib/init-services";
+import { zeroAgentSchedules } from "../../db/schema/zero-agent-schedule";
+
+// ============================================================================
+// Schedule Seeders
+// ============================================================================
+
+/**
+ * Update internal schedule state for testing edge cases.
+ *
+ * @why-db-direct Sets internal scheduling fields (consecutiveFailures, enabled,
+ * nextRunAt, lastRunId, intervalSeconds) that are managed by the scheduler
+ * callback system, not exposed via any user-facing API.
+ */
+export async function updateTestScheduleState(
+  scheduleId: string,
+  state: {
+    consecutiveFailures?: number;
+    enabled?: boolean;
+    nextRunAt?: Date | null;
+    lastRunId?: string;
+    intervalSeconds?: number;
+  },
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(zeroAgentSchedules)
+    .set(state)
+    .where(eq(zeroAgentSchedules.id, scheduleId));
+}
+
+/**
+ * Disable enabled schedules for a specific org.
+ * Prevents stale schedules from other test files consuming the limit(10)
+ * batch in executeDueSchedules, which can cause test flakiness.
+ *
+ * Scoped to orgId so dev-server schedules are not affected.
+ *
+ * @why-db-direct Bulk disable for test cleanup; no API exists for org-wide
+ * schedule disable.
+ */
+export async function disableAllSchedules(orgId: string): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(zeroAgentSchedules)
+    .set({ enabled: false })
+    .where(
+      and(
+        eq(zeroAgentSchedules.enabled, true),
+        eq(zeroAgentSchedules.orgId, orgId),
+      ),
+    );
+}
+
+/**
+ * Set the consecutiveFailures count on a schedule.
+ * Useful for testing auto-disable after N failures.
+ *
+ * @why-db-direct Sets internal failure counter to test threshold-based
+ * disabling; the scheduler manages this field internally via callbacks.
+ */
+export async function setScheduleConsecutiveFailures(
+  composeId: string,
+  name: string,
+  failures: number,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(zeroAgentSchedules)
+    .set({ consecutiveFailures: failures })
+    .where(
+      and(
+        eq(zeroAgentSchedules.agentId, composeId),
+        eq(zeroAgentSchedules.name, name),
+      ),
+    );
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/secrets.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/secrets.ts
@@ -1,0 +1,55 @@
+import { initServices } from "../../lib/init-services";
+import { secrets } from "../../db/schema/secret";
+import { variables } from "../../db/schema/variable";
+import { ORG_SENTINEL_USER_ID } from "../../lib/zero/org/org-sentinel";
+import { encryptSecretValue } from "../../lib/shared/crypto/secrets-encryption";
+
+// ============================================================================
+// Org Sentinel Secret/Variable Seeders
+// ============================================================================
+
+/**
+ * Insert an org-level sentinel secret directly in the database.
+ *
+ * @why-db-direct The secrets API creates user-scoped secrets, not org-sentinel
+ * records. Org-sentinel secrets use a special userId (ORG_SENTINEL_USER_ID)
+ * that cannot be set through the API.
+ */
+export async function insertTestOrgSentinelSecret(params: {
+  orgId: string;
+  name: string;
+}): Promise<void> {
+  initServices();
+  const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+  const encrypted = encryptSecretValue(
+    "sentinel-test-value",
+    SECRETS_ENCRYPTION_KEY,
+  );
+  await globalThis.services.db.insert(secrets).values({
+    name: params.name,
+    encryptedValue: encrypted,
+    type: "user",
+    userId: ORG_SENTINEL_USER_ID,
+    orgId: params.orgId,
+  });
+}
+
+/**
+ * Insert an org-level sentinel variable directly in the database.
+ *
+ * @why-db-direct The variables API creates user-scoped variables, not
+ * org-sentinel records. Org-sentinel variables use a special userId
+ * (ORG_SENTINEL_USER_ID) that cannot be set through the API.
+ */
+export async function insertTestOrgSentinelVariable(params: {
+  orgId: string;
+  name: string;
+}): Promise<void> {
+  initServices();
+  await globalThis.services.db.insert(variables).values({
+    name: params.name,
+    value: "sentinel-test-value",
+    userId: ORG_SENTINEL_USER_ID,
+    orgId: params.orgId,
+  });
+}

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
@@ -18,11 +18,13 @@ import {
   insertOrgMembersCacheEntry,
   insertOrgMembersEntry,
   countOrgRows,
-  insertTestOrgSentinelSecret,
-  insertTestOrgSentinelVariable,
   createTestSchedule,
 } from "../../../../__tests__/api-test-helpers";
 import { createTestEmailThreadSession } from "../../../../__tests__/db-test-seeders/email";
+import {
+  insertTestOrgSentinelSecret,
+  insertTestOrgSentinelVariable,
+} from "../../../../__tests__/db-test-seeders/secrets";
 import {
   insertTestSlackOrgInstallation,
   insertTestSlackOrgConnection,


### PR DESCRIPTION
## Summary

- Create `db-test-seeders/schedules.ts` (3 seeders) and `db-test-assertions/schedules.ts` (1 assertion)
- Create `db-test-seeders/secrets.ts` (2 seeders)
- Remove DB functions from `api-test-helpers/schedules.ts` (keep 6 API functions + private helper)
- Remove DB functions from `api-test-helpers/secrets.ts` (keep 2 API functions)
- Add `initServices()` to all moved functions and `@why-db-direct` to all seeders
- Update 5 consumer test files to import from correct tier
- No re-exports — direct imports consistent with established pattern

## Test plan

- [x] All 4 schedule consumer tests pass (cron callback, loop callback, execute-schedules, tasks*)
- [x] Org-deletion-service tests pass (secrets consumer)
- [x] No TypeScript errors in changed files
- [x] Knip reports no unused exports
- [x] Prettier formatting clean
- [x] `api-test-helpers/schedules.ts` has zero `zeroAgentSchedules` imports
- [x] `api-test-helpers/secrets.ts` has zero DB schema/sentinel imports

*Note: `tasks/route.test.ts` has 11 pre-existing failures on main (chat_threads schema mismatch, unrelated to this PR)

Closes #9369

🤖 Generated with [Claude Code](https://claude.com/claude-code)