### PR TITLE
refactor(test): migrate runs.ts mutation/query helpers to three-tier architecture

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
@@ -1,32 +1,5 @@
-import { and, desc, eq, like, or, sql } from "drizzle-orm";
-import type { OrgTier } from "@vm0/core";
 import { generateSandboxToken } from "../../lib/auth/sandbox-token";
-import { agentRuns } from "../../db/schema/agent-run";
-import { zeroRuns } from "../../db/schema/zero-run";
-import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
-import { agentRunQueue } from "../../db/schema/agent-run-queue";
-import { conversations } from "../../db/schema/conversation";
-import { sandboxTelemetry } from "../../db/schema/sandbox-telemetry";
-import { usageDaily } from "../../db/schema/usage-daily";
-import { initServices } from "../../lib/init-services";
-import { uniqueId } from "../test-helpers";
-import { resolveStartRunCompose } from "../../lib/zero/zero-run-validation";
-import {
-  authorizeCompose,
-  validateComposeRequirements,
-  checkRunConcurrencyLimit,
-} from "../../lib/zero/zero-run-policy";
-import { buildInfraExecutionContext } from "../../lib/infra/run/context/build-context";
-import {
-  loadCompose,
-  insertRunRecord,
-  buildAndDispatchRun,
-  markRunFailed,
-  registerCallbacks,
-  type CreateRunResult,
-} from "../../lib/infra/run/run-service";
-import { generateCallbackSecret } from "../../lib/infra/callback/hmac";
-import { encryptSecretValue } from "../../lib/shared/crypto/secrets-encryption";
+import { type CreateRunResult } from "../../lib/infra/run/run-service";
 import { enqueueRun } from "../../lib/zero/zero-run-queue-service";
 import { POST as createRunRoute } from "../../../app/api/agent/runs/route";
 import { GET as getRunByIdRoute } from "../../../app/api/agent/runs/[id]/route";
@@ -35,6 +8,37 @@ import { POST as completeWebhook } from "../../../app/api/webhooks/agent/complet
 import { createTestRequest } from "./core";
 
 export type { CreateRunResult };
+
+// Re-exports: DB-direct seeders
+export {
+  type CliRunParams,
+  createCliRun,
+  markRunningRunsAsCompleted,
+  setTestRunStatus,
+  setTestRunModelProvider,
+  setTestRunSelectedModel,
+  insertTestZeroRun,
+  expireQueueEntry,
+  insertTestQueueEntry,
+  createTestCallback,
+  linkRunToSchedule,
+  insertTestConversation,
+  insertTestSandboxTelemetry,
+  insertTestUsageDaily,
+} from "../db-test-seeders/runs";
+
+// Re-exports: read-only assertions
+export {
+  findTestRunsByUserAndPrompt,
+  findTestRunsByUserAndPromptContaining,
+  findTestRunRecord,
+  findTestZeroRun,
+  findTestRunCallbacks,
+  findTestQueueEntry,
+  findTestCallbacksByRunId,
+  findMostRecentRunForUser,
+  findTestSandboxTelemetry,
+} from "../db-test-assertions/runs";
 
 export async function createTestRun(
   agentComposeId: string,
@@ -61,121 +65,6 @@ export async function createTestRun(
   });
   const response = await createRunRoute(request);
   return response.json();
-}
-
-/**
- * Test helper that mirrors the CLI API route pipeline (resolve → authorize →
- * validate → concurrency check → insert → token → context → dispatch).
- *
- * Used by tests that need fine-grained control over run creation params
- * (e.g., version pinning, concurrency testing) without going through HTTP.
- */
-export interface CliRunParams {
-  userId: string;
-  agentComposeVersionId: string;
-  prompt: string;
-  orgTier: OrgTier;
-  appendSystemPrompt?: string;
-  vars?: Record<string, string>;
-  secrets?: Record<string, string>;
-  checkpointId?: string;
-  sessionId?: string;
-  conversationId?: string;
-  callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
-  memoryName?: string;
-  artifactName?: string;
-  artifactVersion?: string;
-  volumeVersions?: Record<string, string>;
-  debugNoMockClaude?: boolean;
-  captureNetworkBodies?: boolean;
-}
-
-export async function createCliRun(
-  params: CliRunParams,
-): Promise<CreateRunResult> {
-  const composeMeta = await resolveStartRunCompose(params);
-
-  const apiStartTime = Date.now();
-  const { composeContent, compose } = await loadCompose(
-    composeMeta.agentComposeVersionId,
-    composeMeta.composeId,
-  );
-  authorizeCompose(params.userId, compose.orgId, compose);
-  const authorizeTime = Date.now();
-
-  if (!params.checkpointId && !params.sessionId) {
-    await validateComposeRequirements(composeContent);
-  }
-
-  const orgId = compose.orgId;
-  const run = await globalThis.services.db.transaction(async (tx) => {
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
-    await checkRunConcurrencyLimit(orgId, params.orgTier, tx);
-    return insertRunRecord(tx, {
-      userId: params.userId,
-      orgId,
-      agentComposeVersionId: composeMeta.agentComposeVersionId,
-      prompt: params.prompt,
-      appendSystemPrompt: params.appendSystemPrompt,
-      vars: params.vars,
-      secrets: params.secrets,
-      resumedFromCheckpointId: params.checkpointId,
-      sessionId: params.sessionId,
-    });
-  });
-  const transactionTime = Date.now();
-
-  const sandboxToken = await generateSandboxToken(params.userId, run.id);
-  const tokenTime = Date.now();
-
-  try {
-    if (params.callbacks && params.callbacks.length > 0) {
-      await registerCallbacks(run.id, params.callbacks);
-    }
-
-    const { context } = buildInfraExecutionContext({
-      runId: run.id,
-      userId: params.userId,
-      orgId,
-      agentComposeVersionId: composeMeta.agentComposeVersionId,
-      agentCompose: composeContent,
-      prompt: params.prompt,
-      sandboxToken,
-      appendSystemPrompt: params.appendSystemPrompt,
-      vars: params.vars,
-      secrets: params.secrets,
-      artifactName: params.artifactName,
-      artifactVersion: params.artifactVersion,
-      memoryName: params.memoryName,
-      volumeVersions: params.volumeVersions,
-      agentName: composeMeta.agentName,
-      resumedFromCheckpointId: params.checkpointId,
-      continuedFromSessionId: params.sessionId,
-      debugNoMockClaude: params.debugNoMockClaude,
-      captureNetworkBodies: params.captureNetworkBodies,
-    });
-
-    const result = await buildAndDispatchRun({
-      runId: run.id,
-      context,
-      timings: {
-        apiStart: apiStartTime,
-        authorize: authorizeTime,
-        transaction: transactionTime,
-        token: tokenTime,
-      },
-    });
-
-    return {
-      runId: run.id,
-      status: result.status,
-      sandboxId: result.sandboxId,
-      createdAt: run.createdAt,
-    };
-  } catch (error) {
-    await markRunFailed(run.id, error);
-    throw error;
-  }
 }
 
 /**
@@ -334,282 +223,6 @@ export async function failTestRun(
   }
 }
 
-export async function markRunningRunsAsCompleted(userId: string) {
-  await globalThis.services.db
-    .update(agentRuns)
-    .set({ status: "completed", completedAt: new Date() })
-    .where(
-      and(
-        eq(agentRuns.userId, userId),
-        or(eq(agentRuns.status, "running"), eq(agentRuns.status, "pending")),
-      ),
-    );
-}
-
-export async function setTestRunStatus(
-  runId: string,
-  status: string,
-): Promise<void> {
-  await globalThis.services.db
-    .update(agentRuns)
-    .set({
-      status,
-      ...(["completed", "failed", "timeout", "cancelled"].includes(status)
-        ? { completedAt: new Date() }
-        : {}),
-    })
-    .where(eq(agentRuns.id, runId));
-}
-
-export async function setTestRunModelProvider(
-  runId: string,
-  modelProvider: string,
-): Promise<void> {
-  await globalThis.services.db
-    .update(zeroRuns)
-    .set({ modelProvider })
-    .where(eq(zeroRuns.id, runId));
-}
-
-export async function setTestRunSelectedModel(
-  runId: string,
-  selectedModel: string,
-): Promise<void> {
-  await globalThis.services.db
-    .update(zeroRuns)
-    .set({ selectedModel })
-    .where(eq(zeroRuns.id, runId));
-}
-
-/**
- * Find agent runs matching a given userId and prompt.
- */
-export async function findTestRunsByUserAndPrompt(
-  userId: string,
-  prompt: string,
-) {
-  return globalThis.services.db
-    .select()
-    .from(agentRuns)
-    .where(and(eq(agentRuns.userId, userId), eq(agentRuns.prompt, prompt)));
-}
-
-/**
- * Find agent runs by user ID where prompt contains the given substring.
- * Useful when the full prompt is not known (e.g., when attachments are appended).
- */
-export async function findTestRunsByUserAndPromptContaining(
-  userId: string,
-  promptSubstring: string,
-) {
-  return globalThis.services.db
-    .select()
-    .from(agentRuns)
-    .where(
-      and(
-        eq(agentRuns.userId, userId),
-        like(agentRuns.prompt, `%${promptSubstring}%`),
-      ),
-    );
-}
-
-/**
- * Look up a full agent run record by ID for verification in tests.
- *
- * Direct DB read is required because the GET /api/agent/runs/:id endpoint
- * does not expose internal fields like `vars`, `secretNames`,
- * or `lastHeartbeatAt` that integration tests need to verify.
- */
-export async function findTestRunRecord(
-  runId: string,
-): Promise<typeof agentRuns.$inferSelect | undefined> {
-  const [row] = await globalThis.services.db
-    .select()
-    .from(agentRuns)
-    .where(eq(agentRuns.id, runId))
-    .limit(1);
-  return row;
-}
-
-/**
- * Look up zero_runs record by run ID for verification in tests.
- */
-export async function findTestZeroRun(
-  runId: string,
-): Promise<typeof zeroRuns.$inferSelect | undefined> {
-  const [row] = await globalThis.services.db
-    .select()
-    .from(zeroRuns)
-    .where(eq(zeroRuns.id, runId))
-    .limit(1);
-  return row;
-}
-
-/**
- * Insert a zero_runs record for a run that already exists in agent_runs.
- * Used in tests where the run is created via enqueueRun() (which does not
- * create a zero_runs row) and the test needs to set model provider metadata
- * for credit-check scenarios.
- */
-export async function insertTestZeroRun(
-  runId: string,
-  options?: {
-    triggerSource?: string;
-    modelProvider?: string | null;
-    selectedModel?: string | null;
-  },
-): Promise<void> {
-  await globalThis.services.db.insert(zeroRuns).values({
-    id: runId,
-    triggerSource: options?.triggerSource ?? "cli",
-    modelProvider: options?.modelProvider ?? null,
-    selectedModel: options?.selectedModel ?? null,
-  });
-}
-
-/**
- * Look up agent run callback records by run ID for verification in tests.
- *
- * Direct DB read is required because no API endpoint exposes callback
- * records — they are internal implementation details of the run dispatch.
- */
-export async function findTestRunCallbacks(
-  runId: string,
-): Promise<Array<typeof agentRunCallbacks.$inferSelect>> {
-  return globalThis.services.db
-    .select()
-    .from(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, runId));
-}
-
-export async function findTestQueueEntry(runId: string) {
-  const [row] = await globalThis.services.db
-    .select()
-    .from(agentRunQueue)
-    .where(eq(agentRunQueue.runId, runId))
-    .limit(1);
-  return row;
-}
-
-export async function expireQueueEntry(runId: string) {
-  // Set expiresAt far enough in the past to avoid any timing issues in CI
-  await globalThis.services.db
-    .update(agentRunQueue)
-    .set({ expiresAt: new Date(Date.now() - 60_000) })
-    .where(eq(agentRunQueue.runId, runId));
-}
-
-/**
- * Insert a queue entry for a run that is in "queued" status.
- * Looks up the run's userId and orgId from the agent_runs table.
- *
- * @param runId - The run ID to enqueue
- * @param options - Optional overrides for createdAt and expiresAt
- */
-export async function insertTestQueueEntry(
-  runId: string,
-  options?: {
-    createdAt?: Date;
-    expiresAt?: Date;
-  },
-) {
-  const [run] = await globalThis.services.db
-    .select({ userId: agentRuns.userId, orgId: agentRuns.orgId })
-    .from(agentRuns)
-    .where(eq(agentRuns.id, runId))
-    .limit(1);
-  if (!run) {
-    throw new Error(`Run ${runId} not found`);
-  }
-  await globalThis.services.db.insert(agentRunQueue).values({
-    runId,
-    userId: run.userId,
-    orgId: run.orgId,
-    createdAt: options?.createdAt,
-    expiresAt: options?.expiresAt ?? new Date(Date.now() + 60 * 60 * 1000),
-  });
-}
-
-/**
- * Create a test callback record for agent run completion
- * Returns the callback ID and the plaintext secret for signing test requests
- */
-export async function createTestCallback(params: {
-  runId: string;
-  url: string;
-  payload?: Record<string, unknown>;
-}): Promise<{ callbackId: string; secret: string }> {
-  const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
-  const secret = generateCallbackSecret();
-  const encryptedSecret = encryptSecretValue(secret, SECRETS_ENCRYPTION_KEY);
-
-  const [callback] = await globalThis.services.db
-    .insert(agentRunCallbacks)
-    .values({
-      runId: params.runId,
-      url: params.url,
-      encryptedSecret,
-      payload: params.payload ?? null,
-    })
-    .returning({ id: agentRunCallbacks.id });
-
-  return { callbackId: callback!.id, secret };
-}
-
-/**
- * Find all callback records for a given run ID.
- */
-export async function findTestCallbacksByRunId(runId: string) {
-  return globalThis.services.db
-    .select()
-    .from(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, runId));
-}
-
-/**
- * Link an existing run to a schedule by setting its scheduleId.
- */
-export async function linkRunToSchedule(
-  runId: string,
-  scheduleId: string,
-): Promise<void> {
-  await globalThis.services.db
-    .update(zeroRuns)
-    .set({ scheduleId })
-    .where(eq(zeroRuns.id, runId));
-}
-
-/**
- * Find the most recent agent run for a user in an org.
- * Used to verify that a run was dispatched (e.g., from a phone webhook).
- */
-export async function findMostRecentRunForUser(
-  userId: string,
-  orgId: string,
-): Promise<typeof agentRuns.$inferSelect | undefined> {
-  initServices();
-  const [row] = await globalThis.services.db
-    .select()
-    .from(agentRuns)
-    .where(and(eq(agentRuns.userId, userId), eq(agentRuns.orgId, orgId)))
-    .orderBy(desc(agentRuns.createdAt))
-    .limit(1);
-  return row;
-}
-
-/**
- * Insert a test conversation record.
- */
-export async function insertTestConversation(params: {
-  runId: string;
-}): Promise<void> {
-  await globalThis.services.db.insert(conversations).values({
-    runId: params.runId,
-    cliAgentType: "claude-code",
-    cliAgentSessionId: uniqueId("session"),
-  });
-}
-
 /**
  * Enqueue a run for testing (test helper wrapping enqueueRun).
  */
@@ -625,51 +238,4 @@ export async function enqueueTestRun(params: {
     status: result.status,
     queuedAt: result.createdAt,
   };
-}
-
-/**
- * Insert sandbox telemetry record for testing.
- */
-export async function insertTestSandboxTelemetry(params: {
-  runId: string;
-}): Promise<{ id: string }> {
-  const [record] = await globalThis.services.db
-    .insert(sandboxTelemetry)
-    .values({
-      runId: params.runId,
-      data: { systemLog: "test log", metrics: [] },
-    })
-    .returning({ id: sandboxTelemetry.id });
-
-  return { id: record!.id };
-}
-
-/**
- * Find sandbox telemetry record by run ID.
- */
-export async function findTestSandboxTelemetry(
-  runId: string,
-): Promise<{ id: string } | undefined> {
-  const [row] = await globalThis.services.db
-    .select({ id: sandboxTelemetry.id })
-    .from(sandboxTelemetry)
-    .where(eq(sandboxTelemetry.runId, runId))
-    .limit(1);
-  return row;
-}
-
-/**
- * Insert a test usage_daily record.
- */
-export async function insertTestUsageDaily(params: {
-  userId: string;
-  orgId: string;
-  date: string;
-}): Promise<void> {
-  await globalThis.services.db.insert(usageDaily).values({
-    userId: params.userId,
-    orgId: params.orgId,
-    date: params.date,
-    runCount: 5,
-  });
 }

--- a/turbo/apps/web/src/__tests__/db-test-assertions/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/runs.ts
@@ -1,0 +1,148 @@
+import { and, desc, eq, like } from "drizzle-orm";
+import { initServices } from "../../lib/init-services";
+import { agentRuns } from "../../db/schema/agent-run";
+import { zeroRuns } from "../../db/schema/zero-run";
+import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
+import { agentRunQueue } from "../../db/schema/agent-run-queue";
+import { sandboxTelemetry } from "../../db/schema/sandbox-telemetry";
+
+/**
+ * Find agent runs matching a given userId and prompt.
+ */
+export async function findTestRunsByUserAndPrompt(
+  userId: string,
+  prompt: string,
+) {
+  initServices();
+  return globalThis.services.db
+    .select()
+    .from(agentRuns)
+    .where(and(eq(agentRuns.userId, userId), eq(agentRuns.prompt, prompt)));
+}
+
+/**
+ * Find agent runs by user ID where prompt contains the given substring.
+ * Useful when the full prompt is not known (e.g., when attachments are appended).
+ */
+export async function findTestRunsByUserAndPromptContaining(
+  userId: string,
+  promptSubstring: string,
+) {
+  initServices();
+  return globalThis.services.db
+    .select()
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.userId, userId),
+        like(agentRuns.prompt, `%${promptSubstring}%`),
+      ),
+    );
+}
+
+/**
+ * Look up a full agent run record by ID for verification in tests.
+ *
+ * Direct DB read is required because the GET /api/agent/runs/:id endpoint
+ * does not expose internal fields like `vars`, `secretNames`,
+ * or `lastHeartbeatAt` that integration tests need to verify.
+ */
+export async function findTestRunRecord(
+  runId: string,
+): Promise<typeof agentRuns.$inferSelect | undefined> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Look up zero_runs record by run ID for verification in tests.
+ */
+export async function findTestZeroRun(
+  runId: string,
+): Promise<typeof zeroRuns.$inferSelect | undefined> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, runId))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Look up agent run callback records by run ID for verification in tests.
+ *
+ * Direct DB read is required because no API endpoint exposes callback
+ * records — they are internal implementation details of the run dispatch.
+ */
+export async function findTestRunCallbacks(
+  runId: string,
+): Promise<Array<typeof agentRunCallbacks.$inferSelect>> {
+  initServices();
+  return globalThis.services.db
+    .select()
+    .from(agentRunCallbacks)
+    .where(eq(agentRunCallbacks.runId, runId));
+}
+
+/**
+ * Find a queue entry by run ID.
+ */
+export async function findTestQueueEntry(runId: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(agentRunQueue)
+    .where(eq(agentRunQueue.runId, runId))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Find all callback records for a given run ID.
+ */
+export async function findTestCallbacksByRunId(runId: string) {
+  initServices();
+  return globalThis.services.db
+    .select()
+    .from(agentRunCallbacks)
+    .where(eq(agentRunCallbacks.runId, runId));
+}
+
+/**
+ * Find the most recent agent run for a user in an org.
+ * Used to verify that a run was dispatched (e.g., from a phone webhook).
+ */
+export async function findMostRecentRunForUser(
+  userId: string,
+  orgId: string,
+): Promise<typeof agentRuns.$inferSelect | undefined> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(agentRuns)
+    .where(and(eq(agentRuns.userId, userId), eq(agentRuns.orgId, orgId)))
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Find sandbox telemetry record by run ID.
+ */
+export async function findTestSandboxTelemetry(
+  runId: string,
+): Promise<{ id: string } | undefined> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ id: sandboxTelemetry.id })
+    .from(sandboxTelemetry)
+    .where(eq(sandboxTelemetry.runId, runId))
+    .limit(1);
+  return row;
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -1,12 +1,36 @@
-import { eq } from "drizzle-orm";
+import { and, eq, or, sql } from "drizzle-orm";
+import type { OrgTier } from "@vm0/core";
 import { agentRuns } from "../../db/schema/agent-run";
 import { zeroRuns } from "../../db/schema/zero-run";
 import {
   agentComposes,
   agentComposeVersions,
 } from "../../db/schema/agent-compose";
+import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
+import { agentRunQueue } from "../../db/schema/agent-run-queue";
+import { conversations } from "../../db/schema/conversation";
+import { sandboxTelemetry } from "../../db/schema/sandbox-telemetry";
+import { usageDaily } from "../../db/schema/usage-daily";
 import { initServices } from "../../lib/init-services";
 import { uniqueId } from "../test-helpers";
+import { generateSandboxToken } from "../../lib/auth/sandbox-token";
+import { resolveStartRunCompose } from "../../lib/zero/zero-run-validation";
+import {
+  authorizeCompose,
+  validateComposeRequirements,
+  checkRunConcurrencyLimit,
+} from "../../lib/zero/zero-run-policy";
+import { buildInfraExecutionContext } from "../../lib/infra/run/context/build-context";
+import {
+  loadCompose,
+  insertRunRecord,
+  buildAndDispatchRun,
+  markRunFailed,
+  registerCallbacks,
+  type CreateRunResult,
+} from "../../lib/infra/run/run-service";
+import { generateCallbackSecret } from "../../lib/infra/callback/hmac";
+import { encryptSecretValue } from "../../lib/shared/crypto/secrets-encryption";
 
 /**
  * Resolve orgId from a compose version ID.
@@ -245,4 +269,378 @@ export async function seedOrphanTestRun(
     })
     .returning({ id: agentRuns.id });
   return { runId: run!.id };
+}
+
+// ---------------------------------------------------------------------------
+// Functions migrated from api-test-helpers/runs.ts (Part 2 — #9375)
+// ---------------------------------------------------------------------------
+
+/**
+ * Test helper that mirrors the CLI API route pipeline (resolve → authorize →
+ * validate → concurrency check → insert → token → context → dispatch).
+ *
+ * @why-db-direct Full CLI run pipeline with DB transaction for advisory lock +
+ * record insert; no CLI API route handler exists (CLI uses direct service calls).
+ */
+export interface CliRunParams {
+  userId: string;
+  agentComposeVersionId: string;
+  prompt: string;
+  orgTier: OrgTier;
+  appendSystemPrompt?: string;
+  vars?: Record<string, string>;
+  secrets?: Record<string, string>;
+  checkpointId?: string;
+  sessionId?: string;
+  conversationId?: string;
+  callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
+  memoryName?: string;
+  artifactName?: string;
+  artifactVersion?: string;
+  volumeVersions?: Record<string, string>;
+  debugNoMockClaude?: boolean;
+  captureNetworkBodies?: boolean;
+}
+
+export async function createCliRun(
+  params: CliRunParams,
+): Promise<CreateRunResult> {
+  initServices();
+  const composeMeta = await resolveStartRunCompose(params);
+
+  const apiStartTime = Date.now();
+  const { composeContent, compose } = await loadCompose(
+    composeMeta.agentComposeVersionId,
+    composeMeta.composeId,
+  );
+  authorizeCompose(params.userId, compose.orgId, compose);
+  const authorizeTime = Date.now();
+
+  if (!params.checkpointId && !params.sessionId) {
+    await validateComposeRequirements(composeContent);
+  }
+
+  const orgId = compose.orgId;
+  const run = await globalThis.services.db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
+    await checkRunConcurrencyLimit(orgId, params.orgTier, tx);
+    return insertRunRecord(tx, {
+      userId: params.userId,
+      orgId,
+      agentComposeVersionId: composeMeta.agentComposeVersionId,
+      prompt: params.prompt,
+      appendSystemPrompt: params.appendSystemPrompt,
+      vars: params.vars,
+      secrets: params.secrets,
+      resumedFromCheckpointId: params.checkpointId,
+      sessionId: params.sessionId,
+    });
+  });
+  const transactionTime = Date.now();
+
+  const sandboxToken = await generateSandboxToken(params.userId, run.id);
+  const tokenTime = Date.now();
+
+  try {
+    if (params.callbacks && params.callbacks.length > 0) {
+      await registerCallbacks(run.id, params.callbacks);
+    }
+
+    const { context } = buildInfraExecutionContext({
+      runId: run.id,
+      userId: params.userId,
+      orgId,
+      agentComposeVersionId: composeMeta.agentComposeVersionId,
+      agentCompose: composeContent,
+      prompt: params.prompt,
+      sandboxToken,
+      appendSystemPrompt: params.appendSystemPrompt,
+      vars: params.vars,
+      secrets: params.secrets,
+      artifactName: params.artifactName,
+      artifactVersion: params.artifactVersion,
+      memoryName: params.memoryName,
+      volumeVersions: params.volumeVersions,
+      agentName: composeMeta.agentName,
+      resumedFromCheckpointId: params.checkpointId,
+      continuedFromSessionId: params.sessionId,
+      debugNoMockClaude: params.debugNoMockClaude,
+      captureNetworkBodies: params.captureNetworkBodies,
+    });
+
+    const result = await buildAndDispatchRun({
+      runId: run.id,
+      context,
+      timings: {
+        apiStart: apiStartTime,
+        authorize: authorizeTime,
+        transaction: transactionTime,
+        token: tokenTime,
+      },
+    });
+
+    return {
+      runId: run.id,
+      status: result.status,
+      sandboxId: result.sandboxId,
+      createdAt: run.createdAt,
+    };
+  } catch (error) {
+    await markRunFailed(run.id, error);
+    throw error;
+  }
+}
+
+/**
+ * Mark all running/pending runs as completed for a user.
+ *
+ * @why-db-direct Bulk status update for cleanup; no API endpoint exists for
+ * bulk run completion — runs are completed individually via webhooks.
+ */
+export async function markRunningRunsAsCompleted(userId: string) {
+  initServices();
+  await globalThis.services.db
+    .update(agentRuns)
+    .set({ status: "completed", completedAt: new Date() })
+    .where(
+      and(
+        eq(agentRuns.userId, userId),
+        or(eq(agentRuns.status, "running"), eq(agentRuns.status, "pending")),
+      ),
+    );
+}
+
+/**
+ * Set an arbitrary status on a run.
+ *
+ * @why-db-direct Sets arbitrary run status; API only supports complete/fail
+ * transitions via webhooks. Tests need runs in specific states (e.g., "running",
+ * "timeout") without going through the full lifecycle.
+ */
+export async function setTestRunStatus(
+  runId: string,
+  status: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(agentRuns)
+    .set({
+      status,
+      ...(["completed", "failed", "timeout", "cancelled"].includes(status)
+        ? { completedAt: new Date() }
+        : {}),
+    })
+    .where(eq(agentRuns.id, runId));
+}
+
+/**
+ * Set model provider on a zero_runs record.
+ *
+ * @why-db-direct Sets model provider on zero_runs; no API for this field —
+ * it is set during dispatch pipeline.
+ */
+export async function setTestRunModelProvider(
+  runId: string,
+  modelProvider: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(zeroRuns)
+    .set({ modelProvider })
+    .where(eq(zeroRuns.id, runId));
+}
+
+/**
+ * Set selected model on a zero_runs record.
+ *
+ * @why-db-direct Sets selected model on zero_runs; no API for this field —
+ * it is set during dispatch pipeline.
+ */
+export async function setTestRunSelectedModel(
+  runId: string,
+  selectedModel: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(zeroRuns)
+    .set({ selectedModel })
+    .where(eq(zeroRuns.id, runId));
+}
+
+/**
+ * Insert a zero_runs record for a run that already exists in agent_runs.
+ *
+ * @why-db-direct Creates zero_runs record; enqueueRun() does not create this
+ * row, and tests need to set model provider metadata for credit-check scenarios.
+ */
+export async function insertTestZeroRun(
+  runId: string,
+  options?: {
+    triggerSource?: string;
+    modelProvider?: string | null;
+    selectedModel?: string | null;
+  },
+): Promise<void> {
+  initServices();
+  await globalThis.services.db.insert(zeroRuns).values({
+    id: runId,
+    triggerSource: options?.triggerSource ?? "cli",
+    modelProvider: options?.modelProvider ?? null,
+    selectedModel: options?.selectedModel ?? null,
+  });
+}
+
+/**
+ * Set expiresAt to past on a queue entry.
+ *
+ * @why-db-direct Sets expiresAt to past; no API for queue expiry manipulation.
+ * Tests for queue expiry logic need entries with controlled timestamps.
+ */
+export async function expireQueueEntry(runId: string) {
+  initServices();
+  // Set expiresAt far enough in the past to avoid any timing issues in CI
+  await globalThis.services.db
+    .update(agentRunQueue)
+    .set({ expiresAt: new Date(Date.now() - 60_000) })
+    .where(eq(agentRunQueue.runId, runId));
+}
+
+/**
+ * Insert a queue entry for a run that is in "queued" status.
+ * Looks up the run's userId and orgId from the agent_runs table.
+ *
+ * @why-db-direct Inserts queue entry with controlled timestamps; no API for
+ * direct queue manipulation — queue entries are created by the dispatch pipeline.
+ *
+ * @param runId - The run ID to enqueue
+ * @param options - Optional overrides for createdAt and expiresAt
+ */
+export async function insertTestQueueEntry(
+  runId: string,
+  options?: {
+    createdAt?: Date;
+    expiresAt?: Date;
+  },
+) {
+  initServices();
+  const [run] = await globalThis.services.db
+    .select({ userId: agentRuns.userId, orgId: agentRuns.orgId })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  if (!run) {
+    throw new Error(`Run ${runId} not found`);
+  }
+  await globalThis.services.db.insert(agentRunQueue).values({
+    runId,
+    userId: run.userId,
+    orgId: run.orgId,
+    createdAt: options?.createdAt,
+    expiresAt: options?.expiresAt ?? new Date(Date.now() + 60 * 60 * 1000),
+  });
+}
+
+/**
+ * Create a test callback record for agent run completion.
+ * Returns the callback ID and the plaintext secret for signing test requests.
+ *
+ * @why-db-direct Creates callback with encrypted secret; no standalone API for
+ * callback creation — callbacks are registered during run dispatch.
+ */
+export async function createTestCallback(params: {
+  runId: string;
+  url: string;
+  payload?: Record<string, unknown>;
+}): Promise<{ callbackId: string; secret: string }> {
+  initServices();
+  const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+  const secret = generateCallbackSecret();
+  const encryptedSecret = encryptSecretValue(secret, SECRETS_ENCRYPTION_KEY);
+
+  const [callback] = await globalThis.services.db
+    .insert(agentRunCallbacks)
+    .values({
+      runId: params.runId,
+      url: params.url,
+      encryptedSecret,
+      payload: params.payload ?? null,
+    })
+    .returning({ id: agentRunCallbacks.id });
+
+  return { callbackId: callback!.id, secret };
+}
+
+/**
+ * Link an existing run to a schedule by setting its scheduleId.
+ *
+ * @why-db-direct Sets scheduleId on zero_runs; no API for run-schedule
+ * linking — this is done during scheduled execution dispatch.
+ */
+export async function linkRunToSchedule(
+  runId: string,
+  scheduleId: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(zeroRuns)
+    .set({ scheduleId })
+    .where(eq(zeroRuns.id, runId));
+}
+
+/**
+ * Insert a test conversation record.
+ *
+ * @why-db-direct Creates conversation record; conversations are created by
+ * the checkpoint webhook, not a standalone API endpoint.
+ */
+export async function insertTestConversation(params: {
+  runId: string;
+}): Promise<void> {
+  initServices();
+  await globalThis.services.db.insert(conversations).values({
+    runId: params.runId,
+    cliAgentType: "claude-code",
+    cliAgentSessionId: uniqueId("session"),
+  });
+}
+
+/**
+ * Insert sandbox telemetry record for testing.
+ *
+ * @why-db-direct Creates telemetry record; telemetry is created by the
+ * sandbox runtime, not a user API endpoint.
+ */
+export async function insertTestSandboxTelemetry(params: {
+  runId: string;
+}): Promise<{ id: string }> {
+  initServices();
+  const [record] = await globalThis.services.db
+    .insert(sandboxTelemetry)
+    .values({
+      runId: params.runId,
+      data: { systemLog: "test log", metrics: [] },
+    })
+    .returning({ id: sandboxTelemetry.id });
+
+  return { id: record!.id };
+}
+
+/**
+ * Insert a test usage_daily record.
+ *
+ * @why-db-direct Creates usage_daily record; usage records are created by
+ * cron aggregation, not a user API endpoint.
+ */
+export async function insertTestUsageDaily(params: {
+  userId: string;
+  orgId: string;
+  date: string;
+}): Promise<void> {
+  initServices();
+  await globalThis.services.db.insert(usageDaily).values({
+    userId: params.userId,
+    orgId: params.orgId,
+    date: params.date,
+    runCount: 5,
+  });
 }


### PR DESCRIPTION
## Summary
- Move 14 DB-direct seeder functions (createCliRun, markRunningRunsAsCompleted, setTestRunStatus, setTestRunModelProvider, setTestRunSelectedModel, insertTestZeroRun, expireQueueEntry, insertTestQueueEntry, createTestCallback, linkRunToSchedule, insertTestConversation, insertTestSandboxTelemetry, insertTestUsageDaily) to `db-test-seeders/runs.ts`
- Create new `db-test-assertions/runs.ts` with 9 read-only query functions (findTestRunsByUserAndPrompt, findTestRunsByUserAndPromptContaining, findTestRunRecord, findTestZeroRun, findTestRunCallbacks, findTestQueueEntry, findTestCallbacksByRunId, findMostRecentRunForUser, findTestSandboxTelemetry)
- Refactor `api-test-helpers/runs.ts` to keep only API route wrappers (createTestRun, getTestRun, completeTestRun, failTestRun, enqueueTestRun) with re-exports for backward compatibility
- Zero `globalThis.services.db` calls, zero `db/schema` imports, zero `initServices` calls remain in api-test-helpers/runs.ts

## Test plan
- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes (0 errors)
- [x] `pnpm format` — no changes needed
- [x] `pnpm knip` — no unused exports
- [x] credit-check.test.ts (19/19 pass)
- [x] zero-run-service.test.ts (36/36 pass)
- [x] All consumer tests resolve imports via re-exports — zero test file changes needed

Closes #9375

🤖 Generated with [Claude Code](https://claude.com/claude-code)