### PR TITLE
refactor(test): migrate users.ts voice chat helpers to three-tier architecture

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
@@ -1,16 +1,8 @@
-import { eq } from "drizzle-orm";
-import { initServices } from "../../lib/init-services";
 import {
   consumeCaptureNetworkBodies,
   getUserPreferences,
   updateUserPreferences,
 } from "../../lib/zero/user/user-preferences-service";
-import { pushSubscriptions } from "../../db/schema/push-subscription";
-import {
-  voiceChatSessions,
-  voiceChatEvents,
-  voiceChatPreparations,
-} from "../../db/schema/voice-chat";
 import { getVm0ApiKey } from "../../lib/zero/vm0-key/vm0-key-service";
 import { POST as registerPushSubscriptionRoute } from "../../../app/api/zero/push-subscriptions/route";
 import { randomUUID } from "crypto";
@@ -24,10 +16,21 @@ export {
   seedUserCacheEntry,
   insertUserCacheEntry,
   insertVm0ApiKeys,
+  createTestVoiceChatSession,
+  insertTestVoiceChatSession,
+  insertTestVoiceChatPreparation,
 } from "../db-test-seeders/users";
 
 // Re-exports: read-only assertions
-export { getUserRow, countUserRows } from "../db-test-assertions/users";
+export {
+  getUserRow,
+  countUserRows,
+  getPushSubscriptionsByEndpoint,
+  getTestVoiceChatSessionStatus,
+  getTestVoiceChatSessionHeartbeat,
+  getTestVoiceChatEvents,
+  getTestVoiceChatPreparation,
+} from "../db-test-assertions/users";
 
 /**
  * Get a VM0 API key from the pool for a vendor.
@@ -68,141 +71,6 @@ export async function createTestPushSubscription(
   }
 
   return { endpoint: ep };
-}
-
-/**
- * Query push subscriptions for the given endpoint directly from the DB.
- * Returns the matching rows (empty array means the subscription was deleted).
- */
-export async function getPushSubscriptionsByEndpoint(
-  endpoint: string,
-): Promise<Array<{ id: string; endpoint: string }>> {
-  initServices();
-  return globalThis.services.db
-    .select({ id: pushSubscriptions.id, endpoint: pushSubscriptions.endpoint })
-    .from(pushSubscriptions)
-    .where(eq(pushSubscriptions.endpoint, endpoint));
-}
-
-// ============================================================================
-// Voice Chat Helpers
-// ============================================================================
-
-/**
- * Create a voice-chat session directly in the database.
- */
-export async function createTestVoiceChatSession(
-  orgId: string,
-  userId: string,
-  status = "active",
-): Promise<{ id: string }> {
-  initServices();
-  const [session] = await globalThis.services.db
-    .insert(voiceChatSessions)
-    .values({ orgId, userId, status })
-    .returning({ id: voiceChatSessions.id });
-  return session!;
-}
-
-export async function insertTestVoiceChatSession(overrides: {
-  orgId: string;
-  userId: string;
-  agentId?: string;
-  status?: string;
-  runId?: string;
-  createdAt?: Date;
-  lastHeartbeatAt?: Date;
-}): Promise<string> {
-  initServices();
-  const now = new Date();
-  const [row] = await globalThis.services.db
-    .insert(voiceChatSessions)
-    .values({
-      orgId: overrides.orgId,
-      userId: overrides.userId,
-      agentId: overrides.agentId,
-      status: overrides.status ?? "active",
-      runId: overrides.runId,
-      createdAt: overrides.createdAt ?? now,
-      lastHeartbeatAt: overrides.lastHeartbeatAt ?? now,
-    })
-    .returning({ id: voiceChatSessions.id });
-  return row!.id;
-}
-
-export async function getTestVoiceChatSessionStatus(
-  id: string,
-): Promise<string | undefined> {
-  initServices();
-  const [row] = await globalThis.services.db
-    .select({ status: voiceChatSessions.status })
-    .from(voiceChatSessions)
-    .where(eq(voiceChatSessions.id, id));
-  return row?.status;
-}
-
-export async function getTestVoiceChatSessionHeartbeat(
-  id: string,
-): Promise<Date | undefined> {
-  initServices();
-  const [row] = await globalThis.services.db
-    .select({ lastHeartbeatAt: voiceChatSessions.lastHeartbeatAt })
-    .from(voiceChatSessions)
-    .where(eq(voiceChatSessions.id, id));
-  return row?.lastHeartbeatAt;
-}
-
-export async function getTestVoiceChatEvents(
-  sessionId: string,
-): Promise<Array<{ type: string; source: string; content: string | null }>> {
-  initServices();
-  return globalThis.services.db
-    .select({
-      type: voiceChatEvents.type,
-      source: voiceChatEvents.source,
-      content: voiceChatEvents.content,
-    })
-    .from(voiceChatEvents)
-    .where(eq(voiceChatEvents.sessionId, sessionId));
-}
-
-export async function insertTestVoiceChatPreparation(overrides: {
-  orgId: string;
-  userId: string;
-  agentId?: string;
-  mode?: string;
-  prompt?: string;
-  runId?: string;
-  status?: string;
-  directiveContent?: string;
-  createdAt?: Date;
-}): Promise<string> {
-  initServices();
-  const [row] = await globalThis.services.db
-    .insert(voiceChatPreparations)
-    .values({
-      orgId: overrides.orgId,
-      userId: overrides.userId,
-      agentId: overrides.agentId,
-      mode: overrides.mode ?? "chat",
-      prompt: overrides.prompt ?? null,
-      runId: overrides.runId ?? null,
-      status: overrides.status ?? "preparing",
-      directiveContent: overrides.directiveContent ?? null,
-      createdAt: overrides.createdAt ?? new Date(),
-    })
-    .returning({ id: voiceChatPreparations.id });
-  return row!.id;
-}
-
-export async function getTestVoiceChatPreparation(id: string) {
-  initServices();
-  const [row] = await globalThis.services.db
-    .select()
-    .from(voiceChatPreparations)
-    .where(eq(voiceChatPreparations.id, id))
-    .limit(1);
-  return row;
 }
 
 /**

--- a/turbo/apps/web/src/__tests__/db-test-assertions/users.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/users.ts
@@ -1,6 +1,12 @@
 import { eq, sql } from "drizzle-orm";
 import { initServices } from "../../lib/init-services";
 import { users } from "../../db/schema/user";
+import { pushSubscriptions } from "../../db/schema/push-subscription";
+import {
+  voiceChatSessions,
+  voiceChatEvents,
+  voiceChatPreparations,
+} from "../../db/schema/voice-chat";
 
 /**
  * Read a full users row by userId.
@@ -48,4 +54,76 @@ export async function countUserRows(
     sql`SELECT COUNT(*)::int AS count FROM ${sql.identifier(tableName)} WHERE ${sql.identifier(columnName)} = ${userId}`,
   );
   return (rows.rows[0] as { count: number }).count;
+}
+
+/**
+ * Query push subscriptions for the given endpoint directly from the DB.
+ * Returns the matching rows (empty array means the subscription was deleted).
+ */
+export async function getPushSubscriptionsByEndpoint(
+  endpoint: string,
+): Promise<Array<{ id: string; endpoint: string }>> {
+  initServices();
+  return globalThis.services.db
+    .select({ id: pushSubscriptions.id, endpoint: pushSubscriptions.endpoint })
+    .from(pushSubscriptions)
+    .where(eq(pushSubscriptions.endpoint, endpoint));
+}
+
+/**
+ * Read a voice-chat session's status field.
+ */
+export async function getTestVoiceChatSessionStatus(
+  id: string,
+): Promise<string | undefined> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ status: voiceChatSessions.status })
+    .from(voiceChatSessions)
+    .where(eq(voiceChatSessions.id, id));
+  return row?.status;
+}
+
+/**
+ * Read a voice-chat session's lastHeartbeatAt timestamp.
+ */
+export async function getTestVoiceChatSessionHeartbeat(
+  id: string,
+): Promise<Date | undefined> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ lastHeartbeatAt: voiceChatSessions.lastHeartbeatAt })
+    .from(voiceChatSessions)
+    .where(eq(voiceChatSessions.id, id));
+  return row?.lastHeartbeatAt;
+}
+
+/**
+ * Read voice-chat events for a session.
+ */
+export async function getTestVoiceChatEvents(
+  sessionId: string,
+): Promise<Array<{ type: string; source: string; content: string | null }>> {
+  initServices();
+  return globalThis.services.db
+    .select({
+      type: voiceChatEvents.type,
+      source: voiceChatEvents.source,
+      content: voiceChatEvents.content,
+    })
+    .from(voiceChatEvents)
+    .where(eq(voiceChatEvents.sessionId, sessionId));
+}
+
+/**
+ * Read a full voice-chat preparation record.
+ */
+export async function getTestVoiceChatPreparation(id: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(voiceChatPreparations)
+    .where(eq(voiceChatPreparations.id, id))
+    .limit(1);
+  return row;
 }

--- a/turbo/apps/web/src/__tests__/db-test-seeders/users.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/users.ts
@@ -3,6 +3,10 @@ import { initServices } from "../../lib/init-services";
 import { users } from "../../db/schema/user";
 import { userCache } from "../../db/schema/user-cache";
 import { vm0ApiKeys } from "../../db/schema/vm0-api-key";
+import {
+  voiceChatSessions,
+  voiceChatPreparations,
+} from "../../db/schema/voice-chat";
 
 /**
  * Insert a user row for testing.
@@ -90,4 +94,84 @@ export async function insertVm0ApiKeys(
 ) {
   initServices();
   await globalThis.services.db.insert(vm0ApiKeys).values(keys);
+}
+
+/**
+ * Create a voice-chat session directly in the database.
+ * @why-db-direct Voice chat sessions are created by the voice-chat API which requires WebSocket infrastructure not available in tests
+ */
+export async function createTestVoiceChatSession(
+  orgId: string,
+  userId: string,
+  status = "active",
+): Promise<{ id: string }> {
+  initServices();
+  const [session] = await globalThis.services.db
+    .insert(voiceChatSessions)
+    .values({ orgId, userId, status })
+    .returning({ id: voiceChatSessions.id });
+  return session!;
+}
+
+/**
+ * Insert a voice-chat session with full override support.
+ * @why-db-direct Voice chat sessions require WebSocket infrastructure; full override enables impossible-state testing (e.g., stale heartbeats)
+ */
+export async function insertTestVoiceChatSession(overrides: {
+  orgId: string;
+  userId: string;
+  agentId?: string;
+  status?: string;
+  runId?: string;
+  createdAt?: Date;
+  lastHeartbeatAt?: Date;
+}): Promise<string> {
+  initServices();
+  const now = new Date();
+  const [row] = await globalThis.services.db
+    .insert(voiceChatSessions)
+    .values({
+      orgId: overrides.orgId,
+      userId: overrides.userId,
+      agentId: overrides.agentId,
+      status: overrides.status ?? "active",
+      runId: overrides.runId,
+      createdAt: overrides.createdAt ?? now,
+      lastHeartbeatAt: overrides.lastHeartbeatAt ?? now,
+    })
+    .returning({ id: voiceChatSessions.id });
+  return row!.id;
+}
+
+/**
+ * Insert a voice-chat preparation record.
+ * @why-db-direct Voice chat preparations are created by the prepare endpoint which requires real-time infrastructure
+ */
+export async function insertTestVoiceChatPreparation(overrides: {
+  orgId: string;
+  userId: string;
+  agentId?: string;
+  mode?: string;
+  prompt?: string;
+  runId?: string;
+  status?: string;
+  directiveContent?: string;
+  createdAt?: Date;
+}): Promise<string> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .insert(voiceChatPreparations)
+    .values({
+      orgId: overrides.orgId,
+      userId: overrides.userId,
+      agentId: overrides.agentId,
+      mode: overrides.mode ?? "chat",
+      prompt: overrides.prompt ?? null,
+      runId: overrides.runId ?? null,
+      status: overrides.status ?? "preparing",
+      directiveContent: overrides.directiveContent ?? null,
+      createdAt: overrides.createdAt ?? new Date(),
+    })
+    .returning({ id: voiceChatPreparations.id });
+  return row!.id;
 }


### PR DESCRIPTION
## Summary

- Move 3 DB-direct seeder functions (`createTestVoiceChatSession`, `insertTestVoiceChatSession`, `insertTestVoiceChatPreparation`) to `db-test-seeders/users.ts`
- Move 5 DB-direct assertion functions (`getPushSubscriptionsByEndpoint`, `getTestVoiceChatSessionStatus`, `getTestVoiceChatSessionHeartbeat`, `getTestVoiceChatEvents`, `getTestVoiceChatPreparation`) to `db-test-assertions/users.ts`
- Refactor `api-test-helpers/users.ts` to re-export moved functions, removing all `globalThis.services.db` calls and `db/schema/*` imports

Zero consumer test changes — re-exports preserve all public APIs through the barrel.

Part of Epic #9321.

Closes #9376

## Test plan

- [x] All voice-chat tests pass (9 test files, 81 tests)
- [x] `grep` confirms zero `globalThis.services.db`, `db/schema`, and `initServices` in `api-test-helpers/users.ts`
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [x] Note: `callbacks/chat` route.test.ts has 19 pre-existing failures on main (unrelated to this change)
- [x] Note: `tasks/route.test.ts` has 11 pre-existing failures on main (chat_threads schema mismatch, unrelated)
- [x] Note: `check-types` has 1 pre-existing failure on main (`usage/runs/route.ts` implicit any, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)