### PR TITLE
refactor(test): migrate org.ts helpers to three-tier test architecture

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers/org.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/org.ts
@@ -1,346 +1,37 @@
-import { and, eq, sql } from "drizzle-orm";
-import { initServices } from "../../lib/init-services";
-import { orgMetadata } from "../../db/schema/org-metadata";
-import { orgCache } from "../../db/schema/org-cache";
-import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
-import { zeroAgents } from "../../db/schema/zero-agent";
-import { agentComposes } from "../../db/schema/agent-compose";
-import { modelProviders } from "../../db/schema/model-provider";
-import { ORG_SENTINEL_USER_ID } from "../../lib/zero/org/org-sentinel";
-import { getTestAuthContext } from "./core";
-import { insertOrgCacheEntry, ensureOrgRow } from "../test-helpers";
+// Re-exports: DB-direct seeders
+export {
+  createTestOrg,
+  deleteOrgRow,
+  updateOrgTier,
+  updateOrgDefaultAgent,
+  setDefaultAgentByComposeId,
+  deleteOrgCacheEntry,
+  insertOrgMembersEntry,
+  deleteOrgMembersEntry,
+  insertOrgDefaultModelProvider,
+  setOrgCredits,
+  getTestDb,
+} from "../db-test-seeders/org";
 
-export { insertOrgCacheEntry, ensureOrgRow };
+// Re-exports: read-only assertions
+export {
+  getOrgDefaultAgent,
+  getOrgCacheEntry,
+  getOrgRow,
+  getOrgMembersEntry,
+  countOrgRows,
+  getOrgCredits,
+} from "../db-test-assertions/org";
 
-/**
- * Create a test org by inserting into org_cache.
- *
- * Pre-populates org_cache so getOrgNameAndSlug() works without Clerk API calls.
- *
- * @param slug - The org slug
- * @returns The created org with id and slug
- */
-export async function createTestOrg(
-  slug: string,
-): Promise<{ id: string; slug: string }> {
-  initServices();
+// Re-exports: test-helpers infrastructure
+export { insertOrgCacheEntry, ensureOrgRow } from "../test-helpers";
 
-  // Use the mock Clerk orgId pattern from clerk-mock.ts
-  const { orgId } = await getTestAuthContext();
-
-  // Pre-populate org_cache so getOrgNameAndSlug() works without Clerk API calls
-  await globalThis.services.db
-    .insert(orgCache)
-    .values({
-      orgId,
-      slug,
-      name: slug,
-      cachedAt: new Date(),
-    })
-    .onConflictDoUpdate({
-      target: orgCache.orgId,
-      set: { slug, name: slug, cachedAt: new Date() },
-    });
-
-  // Ensure org row exists (source of truth for tier and default agent)
-  await ensureOrgRow(orgId);
-
-  return { id: orgId, slug };
-}
-
-/**
- * Delete an org row from the `org` table.
- * Useful for testing scenarios where the org row does not exist.
- */
-export async function deleteOrgRow(orgId: string): Promise<void> {
-  await globalThis.services.db
-    .delete(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId));
-}
-
-/**
- * Update the tier for an org in the `org` table.
- */
-export async function updateOrgTier(
-  orgId: string,
-  tier: string,
-): Promise<void> {
-  await globalThis.services.db
-    .update(orgMetadata)
-    .set({ tier, updatedAt: new Date() })
-    .where(eq(orgMetadata.orgId, orgId));
-}
-
-/**
- * Read the default agent ID (zero agent UUID) for an org from org_metadata.
- */
-export async function getOrgDefaultAgent(
-  orgId: string,
-): Promise<string | null> {
-  const [row] = await globalThis.services.db
-    .select({ defaultAgentId: orgMetadata.defaultAgentId })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
-  return row?.defaultAgentId ?? null;
-}
-
-/**
- * Update the default_agent_id (zero agent UUID) for an org in org_metadata.
- */
-export async function updateOrgDefaultAgent(
-  orgId: string,
-  agentId: string,
-): Promise<void> {
-  await globalThis.services.db
-    .update(orgMetadata)
-    .set({ defaultAgentId: agentId, updatedAt: new Date() })
-    .where(eq(orgMetadata.orgId, orgId));
-}
-
-/**
- * Set the org's default agent by compose ID.
- * Resolves compose → zero_agent via (orgId, name) and sets default_agent_id.
- */
-export async function setDefaultAgentByComposeId(
-  orgId: string,
-  composeId: string,
-): Promise<void> {
-  initServices();
-  const [compose] = await globalThis.services.db
-    .select({ name: agentComposes.name })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, composeId))
-    .limit(1);
-  if (!compose) throw new Error(`Compose not found: ${composeId}`);
-
-  const [agent] = await globalThis.services.db
-    .select({ id: zeroAgents.id })
-    .from(zeroAgents)
-    .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.name, compose.name)))
-    .limit(1);
-  if (!agent) throw new Error(`Zero agent not found for compose: ${composeId}`);
-
-  await globalThis.services.db
-    .update(orgMetadata)
-    .set({ defaultAgentId: agent.id, updatedAt: new Date() })
-    .where(eq(orgMetadata.orgId, orgId));
-}
-
-/**
- * Delete an org_cache row by orgId.
- * Useful for testing cache-miss behavior after createTestOrg pre-populates cache.
- */
-export async function deleteOrgCacheEntry(orgId: string): Promise<void> {
-  await globalThis.services.db
-    .delete(orgCache)
-    .where(eq(orgCache.orgId, orgId));
-}
-
-/**
- * Read an org_cache row by orgId.
- */
-export async function getOrgCacheEntry(orgId: string) {
-  const [row] = await globalThis.services.db
-    .select()
-    .from(orgCache)
-    .where(eq(orgCache.orgId, orgId))
-    .limit(1);
-  return row ?? null;
-}
-
+// Re-exports: org-members-cache seeders (already migrated)
 export {
   insertOrgMembersCacheEntry,
   findOrgMembersCacheEntry,
   clearOrgMembersCacheEntry,
 } from "../db-test-seeders/org-members-cache";
 
-/**
- * Insert an org_members entry for testing member preferences.
- */
-export async function insertOrgMembersEntry(entry: {
-  orgId: string;
-  userId: string;
-  timezone?: string | null;
-  pinnedAgentIds?: string[];
-  sendMode?: string;
-  onboardingDone?: boolean;
-  creditCap?: number | null;
-  creditEnabled?: boolean;
-}): Promise<void> {
-  initServices();
-  const now = new Date();
-  await globalThis.services.db
-    .insert(orgMembersMetadata)
-    .values({
-      orgId: entry.orgId,
-      userId: entry.userId,
-      timezone: entry.timezone ?? null,
-      pinnedAgentIds: entry.pinnedAgentIds ?? [],
-      sendMode: entry.sendMode ?? "enter",
-      onboardingDone: entry.onboardingDone ?? false,
-      creditCap: entry.creditCap ?? null,
-      creditEnabled: entry.creditEnabled ?? true,
-      createdAt: now,
-      updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
-      set: {
-        ...(entry.timezone !== undefined && { timezone: entry.timezone }),
-        ...(entry.pinnedAgentIds !== undefined && {
-          pinnedAgentIds: entry.pinnedAgentIds,
-        }),
-        ...(entry.sendMode !== undefined && { sendMode: entry.sendMode }),
-        ...(entry.onboardingDone !== undefined && {
-          onboardingDone: entry.onboardingDone,
-        }),
-        ...(entry.creditCap !== undefined && { creditCap: entry.creditCap }),
-        ...(entry.creditEnabled !== undefined && {
-          creditEnabled: entry.creditEnabled,
-        }),
-        updatedAt: now,
-      },
-    });
-}
-
-/**
- * Return the Drizzle DB instance from globalThis.services.
- * Useful for passing to script functions under test that need a db parameter.
- */
-export function getTestDb() {
-  initServices();
-  return globalThis.services.db;
-}
-
-/**
- * Read a full org_metadata row by orgId.
- * Returns undefined if no row exists.
- */
-export async function getOrgRow(orgId: string) {
-  initServices();
-  const [row] = await globalThis.services.db
-    .select()
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
-  return row;
-}
-
-/**
- * Read a full org_members_metadata row by (orgId, userId).
- * Returns undefined if no row exists.
- */
-export async function getOrgMembersEntry(orgId: string, userId: string) {
-  initServices();
-  const [row] = await globalThis.services.db
-    .select()
-    .from(orgMembersMetadata)
-    .where(
-      and(
-        eq(orgMembersMetadata.orgId, orgId),
-        eq(orgMembersMetadata.userId, userId),
-      ),
-    );
-  return row;
-}
-
-/**
- * Delete an org_members_metadata row by (orgId, userId).
- */
-export async function deleteOrgMembersEntry(
-  orgId: string,
-  userId: string,
-): Promise<void> {
-  initServices();
-  await globalThis.services.db
-    .delete(orgMembersMetadata)
-    .where(
-      and(
-        eq(orgMembersMetadata.orgId, orgId),
-        eq(orgMembersMetadata.userId, userId),
-      ),
-    );
-}
-
-/** Count rows by org_id in a given table using raw SQL to avoid type casts. */
-export async function countOrgRows(
-  tableName:
-    | "agent_runs"
-    | "agent_run_queue"
-    | "agent_composes"
-    | "storages"
-    | "secrets"
-    | "model_providers"
-    | "connectors"
-    | "variables"
-    | "usage_daily"
-    | "export_jobs"
-    | "zero_agents"
-    | "zero_agent_schedules"
-    | "credit_usage"
-    | "agent_sessions"
-    | "email_thread_sessions"
-    | "slack_org_installations"
-    | "org_members_cache"
-    | "org_members_metadata"
-    | "org_cache"
-    | "org_metadata",
-  orgId: string,
-): Promise<number> {
-  const rows = await globalThis.services.db.execute(
-    sql`SELECT COUNT(*)::int AS count FROM ${sql.identifier(tableName)} WHERE org_id = ${orgId}`,
-  );
-  return (rows.rows[0] as { count: number }).count;
-}
-
-/**
- * Insert an org-level default model provider directly in the database.
- * Useful for testing credit check behavior with different provider types.
- */
-export async function insertOrgDefaultModelProvider(
-  orgId: string,
-  type: string,
-  selectedModel?: string,
-): Promise<void> {
-  await globalThis.services.db.insert(modelProviders).values({
-    type,
-    userId: ORG_SENTINEL_USER_ID,
-    orgId,
-    isDefault: true,
-    selectedModel: selectedModel ?? null,
-  });
-}
-
-/**
- * Read the credit balance for an org from the `org` table.
- * Returns null if no row exists.
- */
-export async function getOrgCredits(orgId: string): Promise<number | null> {
-  const [row] = await globalThis.services.db
-    .select({ credits: orgMetadata.credits })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
-  return row?.credits ?? null;
-}
-
-/**
- * Set the credit balance for an org in the `org` table.
- * Ensures the org row exists first.
- */
-export async function setOrgCredits(
-  orgId: string,
-  credits: number,
-): Promise<void> {
-  await globalThis.services.db
-    .insert(orgMetadata)
-    .values({ orgId, credits })
-    .onConflictDoUpdate({
-      target: orgMetadata.orgId,
-      set: { credits, updatedAt: new Date() },
-    });
-}
-
-// Sentinel for orgId used in org-sentinel pattern
+// Re-exports: constants
 export { ORG_SENTINEL_USER_ID } from "../../lib/zero/org/org-sentinel";

--- a/turbo/apps/web/src/__tests__/db-test-assertions/org.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/org.ts
@@ -1,0 +1,113 @@
+import { and, eq, sql } from "drizzle-orm";
+import { initServices } from "../../lib/init-services";
+import { orgMetadata } from "../../db/schema/org-metadata";
+import { orgCache } from "../../db/schema/org-cache";
+import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
+
+/**
+ * Read the default agent ID (zero agent UUID) for an org from org_metadata.
+ */
+export async function getOrgDefaultAgent(
+  orgId: string,
+): Promise<string | null> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return row?.defaultAgentId ?? null;
+}
+
+/**
+ * Read an org_cache row by orgId.
+ */
+export async function getOrgCacheEntry(orgId: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(orgCache)
+    .where(eq(orgCache.orgId, orgId))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Read a full org_metadata row by orgId.
+ * Returns undefined if no row exists.
+ */
+export async function getOrgRow(orgId: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Read a full org_members_metadata row by (orgId, userId).
+ * Returns undefined if no row exists.
+ */
+export async function getOrgMembersEntry(orgId: string, userId: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, orgId),
+        eq(orgMembersMetadata.userId, userId),
+      ),
+    );
+  return row;
+}
+
+/**
+ * Count rows by org_id in a given table using raw SQL to avoid type casts.
+ */
+export async function countOrgRows(
+  tableName:
+    | "agent_runs"
+    | "agent_run_queue"
+    | "agent_composes"
+    | "storages"
+    | "secrets"
+    | "model_providers"
+    | "connectors"
+    | "variables"
+    | "usage_daily"
+    | "export_jobs"
+    | "zero_agents"
+    | "zero_agent_schedules"
+    | "credit_usage"
+    | "agent_sessions"
+    | "email_thread_sessions"
+    | "slack_org_installations"
+    | "org_members_cache"
+    | "org_members_metadata"
+    | "org_cache"
+    | "org_metadata",
+  orgId: string,
+): Promise<number> {
+  initServices();
+  const rows = await globalThis.services.db.execute(
+    sql`SELECT COUNT(*)::int AS count FROM ${sql.identifier(tableName)} WHERE org_id = ${orgId}`,
+  );
+  return (rows.rows[0] as { count: number }).count;
+}
+
+/**
+ * Read the credit balance for an org from the `org` table.
+ * Returns null if no row exists.
+ */
+export async function getOrgCredits(orgId: string): Promise<number | null> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ credits: orgMetadata.credits })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return row?.credits ?? null;
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/org.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/org.ts
@@ -1,0 +1,271 @@
+import { and, eq } from "drizzle-orm";
+import { initServices } from "../../lib/init-services";
+import { orgMetadata } from "../../db/schema/org-metadata";
+import { orgCache } from "../../db/schema/org-cache";
+import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
+import { zeroAgents } from "../../db/schema/zero-agent";
+import { agentComposes } from "../../db/schema/agent-compose";
+import { modelProviders } from "../../db/schema/model-provider";
+import { ORG_SENTINEL_USER_ID } from "../../lib/zero/org/org-sentinel";
+import { getTestAuthContext } from "../api-test-helpers/core";
+import { ensureOrgRow } from "../test-helpers";
+
+/**
+ * Create a test org by inserting into org_cache.
+ *
+ * Pre-populates org_cache so getOrgNameAndSlug() works without Clerk API calls.
+ *
+ * @why-db-direct Simulates org creation with pre-populated cache;
+ * Clerk webhook simulation not available in test infra
+ * @param slug - The org slug
+ * @returns The created org with id and slug
+ */
+export async function createTestOrg(
+  slug: string,
+): Promise<{ id: string; slug: string }> {
+  initServices();
+
+  // Use the mock Clerk orgId pattern from clerk-mock.ts
+  const { orgId } = await getTestAuthContext();
+
+  // Pre-populate org_cache so getOrgNameAndSlug() works without Clerk API calls
+  await globalThis.services.db
+    .insert(orgCache)
+    .values({
+      orgId,
+      slug,
+      name: slug,
+      cachedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: orgCache.orgId,
+      set: { slug, name: slug, cachedAt: new Date() },
+    });
+
+  // Ensure org row exists (source of truth for tier and default agent)
+  await ensureOrgRow(orgId);
+
+  return { id: orgId, slug };
+}
+
+/**
+ * Delete an org row from the `org` table.
+ * Useful for testing scenarios where the org row does not exist.
+ *
+ * @why-db-direct Deletes org row to test missing-org scenarios;
+ * no API for org deletion (Clerk webhook handles this)
+ */
+export async function deleteOrgRow(orgId: string): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .delete(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+/**
+ * Update the tier for an org in the `org` table.
+ *
+ * @why-db-direct Sets arbitrary tier; no API for direct tier changes
+ * (Stripe webhook handles this)
+ */
+export async function updateOrgTier(
+  orgId: string,
+  tier: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(orgMetadata)
+    .set({ tier, updatedAt: new Date() })
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+/**
+ * Update the default_agent_id (zero agent UUID) for an org in org_metadata.
+ *
+ * @why-db-direct Sets default agent ID directly; no API for this
+ * (compose creation sets it as side effect)
+ */
+export async function updateOrgDefaultAgent(
+  orgId: string,
+  agentId: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(orgMetadata)
+    .set({ defaultAgentId: agentId, updatedAt: new Date() })
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+/**
+ * Set the org's default agent by compose ID.
+ * Resolves compose -> zero_agent via (orgId, name) and sets default_agent_id.
+ *
+ * @why-db-direct Resolves compose->agent and sets default;
+ * no single API for this
+ */
+export async function setDefaultAgentByComposeId(
+  orgId: string,
+  composeId: string,
+): Promise<void> {
+  initServices();
+  const [compose] = await globalThis.services.db
+    .select({ name: agentComposes.name })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  if (!compose) throw new Error(`Compose not found: ${composeId}`);
+
+  const [agent] = await globalThis.services.db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.name, compose.name)))
+    .limit(1);
+  if (!agent) throw new Error(`Zero agent not found for compose: ${composeId}`);
+
+  await globalThis.services.db
+    .update(orgMetadata)
+    .set({ defaultAgentId: agent.id, updatedAt: new Date() })
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+/**
+ * Delete an org_cache row by orgId.
+ * Useful for testing cache-miss behavior after createTestOrg pre-populates cache.
+ *
+ * @why-db-direct Deletes cache to test cache-miss behavior;
+ * no API for cache deletion
+ */
+export async function deleteOrgCacheEntry(orgId: string): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .delete(orgCache)
+    .where(eq(orgCache.orgId, orgId));
+}
+
+/**
+ * Insert an org_members entry for testing member preferences.
+ *
+ * @why-db-direct Inserts member metadata with specific fields;
+ * no API for bulk member metadata creation
+ */
+export async function insertOrgMembersEntry(entry: {
+  orgId: string;
+  userId: string;
+  timezone?: string | null;
+  pinnedAgentIds?: string[];
+  sendMode?: string;
+  onboardingDone?: boolean;
+  creditCap?: number | null;
+  creditEnabled?: boolean;
+}): Promise<void> {
+  initServices();
+  const now = new Date();
+  await globalThis.services.db
+    .insert(orgMembersMetadata)
+    .values({
+      orgId: entry.orgId,
+      userId: entry.userId,
+      timezone: entry.timezone ?? null,
+      pinnedAgentIds: entry.pinnedAgentIds ?? [],
+      sendMode: entry.sendMode ?? "enter",
+      onboardingDone: entry.onboardingDone ?? false,
+      creditCap: entry.creditCap ?? null,
+      creditEnabled: entry.creditEnabled ?? true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+      set: {
+        ...(entry.timezone !== undefined && { timezone: entry.timezone }),
+        ...(entry.pinnedAgentIds !== undefined && {
+          pinnedAgentIds: entry.pinnedAgentIds,
+        }),
+        ...(entry.sendMode !== undefined && { sendMode: entry.sendMode }),
+        ...(entry.onboardingDone !== undefined && {
+          onboardingDone: entry.onboardingDone,
+        }),
+        ...(entry.creditCap !== undefined && { creditCap: entry.creditCap }),
+        ...(entry.creditEnabled !== undefined && {
+          creditEnabled: entry.creditEnabled,
+        }),
+        updatedAt: now,
+      },
+    });
+}
+
+/**
+ * Delete an org_members_metadata row by (orgId, userId).
+ *
+ * @why-db-direct Deletes member metadata row;
+ * no API for member metadata deletion
+ */
+export async function deleteOrgMembersEntry(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .delete(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, orgId),
+        eq(orgMembersMetadata.userId, userId),
+      ),
+    );
+}
+
+/**
+ * Insert an org-level default model provider directly in the database.
+ * Useful for testing credit check behavior with different provider types.
+ *
+ * @why-db-direct Inserts org-level provider bypassing API validation;
+ * tests credit check with specific provider types
+ */
+export async function insertOrgDefaultModelProvider(
+  orgId: string,
+  type: string,
+  selectedModel?: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db.insert(modelProviders).values({
+    type,
+    userId: ORG_SENTINEL_USER_ID,
+    orgId,
+    isDefault: true,
+    selectedModel: selectedModel ?? null,
+  });
+}
+
+/**
+ * Set the credit balance for an org in the `org` table.
+ * Ensures the org row exists first.
+ *
+ * @why-db-direct Sets credit balance directly; no API for direct
+ * credit manipulation (Stripe webhook handles this)
+ */
+export async function setOrgCredits(
+  orgId: string,
+  credits: number,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .insert(orgMetadata)
+    .values({ orgId, credits })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: { credits, updatedAt: new Date() },
+    });
+}
+
+/**
+ * Return the Drizzle DB instance from globalThis.services.
+ * Useful for passing to script functions under test that need a db parameter.
+ *
+ * @why-db-direct Returns raw DB instance for scripts under test
+ * that need a db parameter
+ */
+export function getTestDb() {
+  initServices();
+  return globalThis.services.db;
+}


### PR DESCRIPTION
## Summary

- Move 11 DB-direct seeder functions from `api-test-helpers/org.ts` to new `db-test-seeders/org.ts`
- Move 6 read-only assertion functions to new `db-test-assertions/org.ts`
- Refactor `api-test-helpers/org.ts` to pure re-exports (zero `globalThis.services.db`, zero `db/schema/*` imports, zero `initServices`)
- All functions retain `initServices()` calls for self-containment
- Zero consumer test file changes needed (barrel re-exports preserve all import paths)

Closes #9373

## Test plan

- [x] All 22 org-related test files pass (273 tests)
- [x] TypeScript type check passes
- [x] ESLint lint passes
- [x] Knip finds no issues
- [x] Verification: zero `globalThis.services.db` / `db/schema` / `initServices` in `api-test-helpers/org.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)