### PR TITLE
chore(test): expand eslint no-direct-db-in-tests rule to api-test-helpers

### DIFF
--- a/turbo/apps/web/custom-eslint/__tests__/no-direct-db-in-tests.test.ts
+++ b/turbo/apps/web/custom-eslint/__tests__/no-direct-db-in-tests.test.ts
@@ -23,6 +23,14 @@ ruleTester.run("no-direct-db-in-tests", rule, {
       // services.db without globalThis prefix is fine (different variable)
       code: "const x = services.db;",
     },
+    {
+      // Importing from db-test-seeders is fine
+      code: 'import { insertTestUser } from "../db-test-seeders/users";',
+    },
+    {
+      // Importing from non-schema paths is fine
+      code: 'import { foo } from "../../lib/services";',
+    },
   ],
   invalid: [
     {
@@ -53,6 +61,14 @@ ruleTester.run("no-direct-db-in-tests", rule, {
         });
       `,
       errors: [{ messageId: "noInitServices" }],
+    },
+    {
+      code: 'import { users } from "../../db/schema/user";',
+      errors: [{ messageId: "noDbSchemaImport" }],
+    },
+    {
+      code: 'import { agentRuns } from "../../db/schema/agent-run";',
+      errors: [{ messageId: "noDbSchemaImport" }],
     },
   ],
 });

--- a/turbo/apps/web/custom-eslint/rules/no-direct-db-in-tests.ts
+++ b/turbo/apps/web/custom-eslint/rules/no-direct-db-in-tests.ts
@@ -38,10 +38,23 @@ export default createRule({
         "Do not use globalThis.services.db in test files. Use API helpers instead. See docs/testing/web-testing.md#avoid-db-operations",
       noInitServices:
         "Do not call initServices() in test files. Route handlers call it internally. See docs/testing/web-testing.md#no-initservices-in-route-tests",
+      noDbSchemaImport:
+        "Do not import from db/schema/* in test files. Use db-test-seeders or db-test-assertions instead.",
     },
   },
   create(context) {
     return {
+      // Detect imports from db/schema/*
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        const source = node.source.value;
+        if (typeof source === "string" && /\/db\/schema\//.test(source)) {
+          context.report({
+            node,
+            messageId: "noDbSchemaImport",
+          });
+        }
+      },
+
       // Detect globalThis.services.db
       MemberExpression(node: TSESTree.MemberExpression) {
         if (

--- a/turbo/apps/web/eslint.config.js
+++ b/turbo/apps/web/eslint.config.js
@@ -78,6 +78,15 @@ export default [
     },
   },
   {
+    files: ["**/api-test-helpers/**/*.ts"],
+    plugins: {
+      web: webPlugin,
+    },
+    rules: {
+      "web/no-direct-db-in-tests": "error",
+    },
+  },
+  {
     ignores: [
       "custom-eslint/**",
       "scripts/migrations/001-backfill-clerk-orgs/**",

--- a/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
@@ -1,10 +1,3 @@
-import { initServices } from "../../lib/init-services";
-import { grantOrgCredits } from "../../lib/zero/org/org-service";
-import {
-  deductFromExpiresRecords,
-  expireCredits,
-} from "../../lib/zero/credit/credit-expires-service";
-
 // ---------------------------------------------------------------------------
 // Re-exports: DB-direct seeders.
 //
@@ -26,6 +19,9 @@ export {
   seedCreditUsageRecord,
   seedInsightsDaily,
   createCompletedRun,
+  grantCreditsToOrg,
+  testDeductFromExpiresRecords,
+  testExpireCredits,
 } from "../db-test-seeders/credits";
 
 // ---------------------------------------------------------------------------
@@ -42,49 +38,3 @@ export {
   findUsageDaily,
   findInsightsDaily,
 } from "../db-test-assertions/credits";
-
-// ---------------------------------------------------------------------------
-// Service-layer wrappers.
-//
-// These call production service functions (not raw DB) and are valid
-// API-based helpers.
-// ---------------------------------------------------------------------------
-
-/**
- * Grant credits to an org atomically. Wraps grantOrgCredits in a transaction.
- */
-export async function grantCreditsToOrg(
-  orgId: string,
-  amount: number,
-): Promise<void> {
-  initServices();
-  await globalThis.services.db.transaction(async (tx) => {
-    await grantOrgCredits(tx, orgId, amount);
-  });
-}
-
-/**
- * Deduct from expires records within a transaction (test helper).
- */
-export async function testDeductFromExpiresRecords(
-  orgId: string,
-  amount: number,
-): Promise<void> {
-  initServices();
-  await globalThis.services.db.transaction(async (tx) => {
-    await deductFromExpiresRecords(tx, orgId, amount);
-  });
-}
-
-/**
- * Expire credits within a transaction (test helper).
- * Returns the total expired amount.
- */
-export async function testExpireCredits(orgId: string): Promise<number> {
-  initServices();
-  let result = 0;
-  await globalThis.services.db.transaction(async (tx) => {
-    result = await expireCredits(tx, orgId);
-  });
-  return result;
-}

--- a/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/schedules.ts
@@ -1,7 +1,3 @@
-import { and, eq } from "drizzle-orm";
-import { initServices } from "../../lib/init-services";
-import { agentComposes } from "../../db/schema/agent-compose";
-import { zeroAgents } from "../../db/schema/zero-agent";
 import type { ScheduleResponse } from "../../lib/zero/schedule/schedule-service";
 import {
   deploySchedule,
@@ -12,33 +8,7 @@ import {
   getScheduleRecentRuns,
 } from "../../lib/zero/schedule";
 import { getTestAuthContext } from "./core";
-
-/**
- * Resolve composeId to agentId for test helpers.
- * Looks up the compose to get org/name, then finds the corresponding zero agent.
- */
-async function resolveAgentIdFromCompose(composeId: string): Promise<string> {
-  const [compose] = await globalThis.services.db
-    .select({ orgId: agentComposes.orgId, name: agentComposes.name })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, composeId))
-    .limit(1);
-  if (!compose) throw new Error(`Compose ${composeId} not found`);
-
-  const [agent] = await globalThis.services.db
-    .select({ id: zeroAgents.id })
-    .from(zeroAgents)
-    .where(
-      and(
-        eq(zeroAgents.orgId, compose.orgId),
-        eq(zeroAgents.name, compose.name),
-      ),
-    )
-    .limit(1);
-  if (!agent) throw new Error(`Zero agent not found for compose ${composeId}`);
-
-  return agent.id;
-}
+import { resolveAgentIdFromCompose } from "../db-test-seeders/schedules";
 
 /**
  * Create a test schedule via the schedule service.
@@ -57,7 +27,6 @@ export async function createTestSchedule(
     appendSystemPrompt?: string;
   },
 ): Promise<ScheduleResponse> {
-  initServices();
   const { userId, orgId } = await getTestAuthContext();
   const agentId = await resolveAgentIdFromCompose(composeId);
 
@@ -92,7 +61,6 @@ export async function getTestSchedule(
   composeId: string,
   name: string,
 ): Promise<ScheduleResponse> {
-  initServices();
   const { userId, orgId } = await getTestAuthContext();
   const agentId = await resolveAgentIdFromCompose(composeId);
   return getScheduleByName(userId, orgId, agentId, name);
@@ -109,7 +77,6 @@ export async function enableTestSchedule(
   composeId: string,
   name: string,
 ): Promise<ScheduleResponse> {
-  initServices();
   const { userId, orgId } = await getTestAuthContext();
   const agentId = await resolveAgentIdFromCompose(composeId);
   return enableSchedule(userId, orgId, agentId, name);
@@ -126,7 +93,6 @@ export async function disableTestSchedule(
   composeId: string,
   name: string,
 ): Promise<ScheduleResponse> {
-  initServices();
   const { userId, orgId } = await getTestAuthContext();
   const agentId = await resolveAgentIdFromCompose(composeId);
   return disableSchedule(userId, orgId, agentId, name);
@@ -142,7 +108,6 @@ export async function deleteTestSchedule(
   composeId: string,
   name: string,
 ): Promise<void> {
-  initServices();
   const { userId, orgId } = await getTestAuthContext();
   const agentId = await resolveAgentIdFromCompose(composeId);
   await deleteSchedule(userId, orgId, agentId, name);
@@ -169,7 +134,6 @@ export async function getTestScheduleRuns(
     error: string | null;
   }>;
 }> {
-  initServices();
   const { userId, orgId } = await getTestAuthContext();
   const agentId = await resolveAgentIdFromCompose(composeId);
   const runs = await getScheduleRecentRuns(

--- a/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
@@ -12,6 +12,11 @@ import {
   agentComposeVersions,
 } from "../../db/schema/agent-compose";
 import { agentRuns } from "../../db/schema/agent-run";
+import { grantOrgCredits } from "../../lib/zero/org/org-service";
+import {
+  deductFromExpiresRecords,
+  expireCredits,
+} from "../../lib/zero/credit/credit-expires-service";
 
 // ---------------------------------------------------------------------------
 // DB-direct seeders for billing / Stripe test setup.
@@ -504,4 +509,59 @@ export async function createCompletedRun(
     })
     .returning();
   return run!.id;
+}
+
+// ---------------------------------------------------------------------------
+// Transaction wrappers.
+//
+// These functions wrap production service functions that expect a transaction
+// parameter (tx). They provide the transaction context for test usage.
+// ---------------------------------------------------------------------------
+
+/**
+ * Grant credits to an org atomically. Wraps grantOrgCredits in a transaction.
+ *
+ * @why-db-direct Requires a database transaction wrapper to call grantOrgCredits
+ * service; no API endpoint provides atomic credit grants
+ */
+export async function grantCreditsToOrg(
+  orgId: string,
+  amount: number,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db.transaction(async (tx) => {
+    await grantOrgCredits(tx, orgId, amount);
+  });
+}
+
+/**
+ * Deduct from expires records within a transaction (test helper).
+ *
+ * @why-db-direct Requires a database transaction wrapper to call
+ * deductFromExpiresRecords service; service expects tx parameter
+ */
+export async function testDeductFromExpiresRecords(
+  orgId: string,
+  amount: number,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db.transaction(async (tx) => {
+    await deductFromExpiresRecords(tx, orgId, amount);
+  });
+}
+
+/**
+ * Expire credits within a transaction (test helper).
+ * Returns the total expired amount.
+ *
+ * @why-db-direct Requires a database transaction wrapper to call expireCredits
+ * service; service expects tx parameter
+ */
+export async function testExpireCredits(orgId: string): Promise<number> {
+  initServices();
+  let result = 0;
+  await globalThis.services.db.transaction(async (tx) => {
+    result = await expireCredits(tx, orgId);
+  });
+  return result;
 }

--- a/turbo/apps/web/src/__tests__/db-test-seeders/schedules.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/schedules.ts
@@ -1,6 +1,8 @@
 import { and, eq } from "drizzle-orm";
 import { initServices } from "../../lib/init-services";
 import { zeroAgentSchedules } from "../../db/schema/zero-agent-schedule";
+import { agentComposes } from "../../db/schema/agent-compose";
+import { zeroAgents } from "../../db/schema/zero-agent";
 
 // ============================================================================
 // Schedule Seeders
@@ -75,4 +77,37 @@ export async function setScheduleConsecutiveFailures(
         eq(zeroAgentSchedules.name, name),
       ),
     );
+}
+
+/**
+ * Resolve composeId to agentId for test helpers.
+ * Looks up the compose to get org/name, then finds the corresponding zero agent.
+ *
+ * @why-db-direct Resolves compose → zero_agent mapping; no API endpoint
+ * provides composeId→agentId resolution
+ */
+export async function resolveAgentIdFromCompose(
+  composeId: string,
+): Promise<string> {
+  initServices();
+  const [compose] = await globalThis.services.db
+    .select({ orgId: agentComposes.orgId, name: agentComposes.name })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  if (!compose) throw new Error(`Compose ${composeId} not found`);
+
+  const [agent] = await globalThis.services.db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.orgId, compose.orgId),
+        eq(zeroAgents.name, compose.name),
+      ),
+    )
+    .limit(1);
+  if (!agent) throw new Error(`Zero agent not found for compose ${composeId}`);
+
+  return agent.id;
 }


### PR DESCRIPTION
## Summary

- Move 3 transaction-wrapper functions from `api-test-helpers/credits.ts` to `db-test-seeders/credits.ts` with `@why-db-direct` annotations
- Move `resolveAgentIdFromCompose` from `api-test-helpers/schedules.ts` to `db-test-seeders/schedules.ts`
- Remove all `initServices()` calls from schedule service wrappers (test context handles initialization)
- Add `db/schema/*` import detection to the `no-direct-db-in-tests` ESLint rule
- Expand ESLint rule scope to cover `api-test-helpers/**/*.ts`

After this change, all files under `api-test-helpers/` have zero `globalThis.services.db`, `db/schema/*`, and `initServices()` references.

Final issue of Epic #9321.

Closes #9381

## Test plan

- [x] ESLint rule tests pass (13 tests — 6 valid, 7 invalid including 2 new db/schema cases)
- [x] All schedule tests pass (39 tests across 3 files)
- [x] All credit/billing tests pass (41 tests across 4 files)
- [x] `grep` confirms zero violations in `api-test-helpers/`
- [x] ESLint passes on `api-test-helpers/` with new rule scope
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)