### PR TITLE
feat(web): add daily-engineering-brief use case

### DIFF
--- a/turbo/apps/web/app/[locale]/use-cases/data.ts
+++ b/turbo/apps/web/app/[locale]/use-cases/data.ts
@@ -185,6 +185,12 @@ const STRAPI: ConnectorRef = {
   icon: "/assets/connectors/strapi.svg",
 };
 
+const PLAUSIBLE: ConnectorRef = {
+  id: "plausible",
+  label: "Plausible",
+  icon: "/assets/connectors/plausible.svg",
+};
+
 // ---------------------------------------------------------------------------
 // Full use cases
 // ---------------------------------------------------------------------------
@@ -552,6 +558,41 @@ export const USE_CASES: UseCase[] = [
     stepCount: 3,
     nextActionCount: 3,
     integrationCount: 3,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
+  },
+
+  {
+    slug: "daily-engineering-brief",
+    color: "#7c9ebe",
+    avatar: {
+      rotation: 2,
+      skin: 4,
+      hairStyle: 5,
+      hairColor: 2,
+      expression: 3,
+      intensity: "h",
+    },
+    roles: ["engineering", "product"],
+    capability: "scheduled",
+    model: "Claude 4 Sonnet",
+    connectors: [SLACK, GITHUB, LINEAR, SENTRY, PLAUSIBLE],
+    integrations: [
+      { connector: GITHUB, required: true },
+      { connector: SLACK, required: true },
+      { connector: LINEAR, required: false },
+      { connector: SENTRY, required: false },
+      { connector: PLAUSIBLE, required: false },
+    ],
+    relatedSlugs: [
+      "product-health-briefing",
+      "sentry-triage",
+      "error-triage-daily",
+    ],
+    stepCount: 4,
+    nextActionCount: 3,
+    integrationCount: 5,
     tipCount: 3,
     promptVariantCount: 3,
     slackPreviewCount: 2,

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -1551,29 +1551,29 @@
         ]
       },
       "daily-engineering-brief": {
-        "title": "Daily engineering brief with anomaly detection",
-        "description": "Ask Zero to pull live data from GitHub, Linear, Sentry, and Plausible every morning, compute 7-day rolling averages, flag any anomalies, and post a formatted four-section brief to your Slack channel automatically.",
-        "timeSaved": "~20 min saved daily",
+        "title": "Tägliches Engineering-Briefing mit Anomalieerkennung",
+        "description": "Lass Zero jeden Morgen Live-Daten aus GitHub, Linear, Sentry und Plausible abrufen, gleitende 7-Tage-Durchschnitte berechnen, Anomalien markieren und ein formatiertes Briefing mit vier Abschnitten automatisch in deinen Slack-Channel posten.",
+        "timeSaved": "~20 Min. täglich gespart",
         "headings": {
-          "scenario": "Why scattered dashboards slow down your morning sync",
-          "prompt": "How to set up a daily cross-tool engineering brief with Zero",
-          "steps": "How Zero pulls live data, computes baselines, and flags anomalies",
-          "nextActions": "Drill into anomalies, fix broken connectors, or expand the brief",
-          "integrations": "Required integrations: GitHub and Slack. Optional: Linear, Sentry, Plausible",
-          "tips": "Best practices for scheduled multi-tool engineering briefings"
+          "scenario": "Warum verteilte Dashboards dein Morning-Sync verlangsamen",
+          "prompt": "So richtest du ein tägliches, toolübergreifendes Engineering-Briefing mit Zero ein",
+          "steps": "So ruft Zero Live-Daten ab, berechnet Baselines und erkennt Anomalien",
+          "nextActions": "Anomalien untersuchen, defekte Konnektoren reparieren oder das Briefing erweitern",
+          "integrations": "Erforderliche Integrationen: GitHub und Slack. Optional: Linear, Sentry, Plausible",
+          "tips": "Best Practices für geplante, toolübergreifende Engineering-Briefings"
         },
-        "scenario": "Every morning someone opens four different tabs: GitHub for PR activity, Linear for sprint progress, Sentry for overnight errors, and Plausible for traffic trends. They manually compare today's numbers to what they remember from last week and try to spot anything unusual before the standup. That cross-referencing takes 15 to 20 minutes and relies on memory. Zero runs before standup, pulls live data from all four sources, computes 7-day rolling averages, flags anything that deviates significantly, and posts a clean four-section brief to Slack before anyone opens their laptop.",
+        "scenario": "Jeden Morgen öffnet jemand vier verschiedene Tabs: GitHub für PR-Aktivität, Linear für den Sprint-Fortschritt, Sentry für nächtliche Fehler und Plausible für Traffic-Trends. Man vergleicht die heutigen Zahlen manuell mit dem, was man von letzter Woche in Erinnerung hat, und versucht, vor dem Standup etwas Auffälliges zu erkennen. Dieses Abgleichen dauert 15 bis 20 Minuten und beruht auf dem Gedächtnis. Zero läuft vor dem Standup, ruft Live-Daten aus allen vier Quellen ab, berechnet gleitende 7-Tage-Durchschnitte, markiert alles, was signifikant abweicht, und postet ein sauberes Briefing mit vier Abschnitten in Slack, bevor jemand den Laptop aufklappt.",
         "promptVariants": [
           {
-            "label": "Full daily brief",
+            "label": "Vollständiges tägliches Briefing",
             "prompt": "@Zero every weekday at 8:30am, pull live data from Plausible, Sentry, GitHub, and Linear, flag anomalies vs the 7-day rolling average, and post a formatted 4-section daily brief to #engineering."
           },
           {
-            "label": "GitHub and Linear only",
+            "label": "Nur GitHub und Linear",
             "prompt": "@Zero every morning at 9am, pull today's GitHub PR and issue stats for vm0-ai/vm0 and Linear sprint progress. Flag anything more than 2x above the 7-day average and post to #standup."
           },
           {
-            "label": "On demand",
+            "label": "Auf Abruf",
             "prompt": "@Zero pull live data from GitHub and Linear right now, compare to the 7-day rolling average, and tell me what looks unusual today."
           }
         ],
@@ -1589,60 +1589,60 @@
         ],
         "steps": [
           {
-            "title": "Zero pulls live data from each source",
-            "description": "Zero queries GitHub for PRs merged, issues opened and closed, and commits. It pulls Linear for issues created, in-progress work, and backlog count. If configured, it also queries Sentry for error counts and Plausible for visitor and pageview metrics."
+            "title": "Zero ruft Live-Daten aus jeder Quelle ab",
+            "description": "Zero fragt GitHub nach zusammengeführten PRs, geöffneten und geschlossenen Issues sowie Commits ab. Es ruft von Linear erstellte Issues, laufende Arbeiten und den Backlog-Stand ab. Falls konfiguriert, fragt es auch Sentry nach Fehlerzahlen und Plausible nach Besucher- und Seitenaufruf-Metriken ab."
           },
           {
-            "title": "7-day rolling averages computed",
-            "description": "For each metric, Zero fetches the same data for the prior seven days and computes a daily average. This gives a stable baseline that accounts for weekends, deploys, and team size changes."
+            "title": "Gleitende 7-Tage-Durchschnitte werden berechnet",
+            "description": "Für jede Metrik ruft Zero dieselben Daten der letzten sieben Tage ab und berechnet einen Tagesdurchschnitt. Das ergibt eine stabile Baseline, die Wochenenden, Deployments und Teamgrößenänderungen berücksichtigt."
           },
           {
-            "title": "Anomalies flagged automatically",
-            "description": "Zero compares today's numbers to the rolling average and flags anything that deviates significantly. A spike in merged PRs might indicate a coordinated refactor; a drop in Plausible traffic might signal a deploy issue; a surge in issues opened might mean a new bug surface was discovered."
+            "title": "Anomalien werden automatisch markiert",
+            "description": "Zero vergleicht die heutigen Zahlen mit dem gleitenden Durchschnitt und markiert alles, was signifikant abweicht. Ein Anstieg bei zusammengeführten PRs kann auf ein koordiniertes Refactoring hindeuten; ein Rückgang des Plausible-Traffics kann auf ein Deployment-Problem hinweisen; ein Anstieg bei geöffneten Issues kann bedeuten, dass eine neue Fehlerquelle entdeckt wurde."
           },
           {
-            "title": "Four-section brief posted to Slack",
-            "description": "Zero posts a structured message with one section per source: Web Traffic, Errors and Reliability, Engineering Activity, and Project Tracker. Each section lists today's numbers, the 7-day average, and a plain-language anomaly note where applicable."
+            "title": "Briefing mit vier Abschnitten wird in Slack gepostet",
+            "description": "Zero postet eine strukturierte Nachricht mit einem Abschnitt pro Quelle: Web-Traffic, Fehler und Zuverlässigkeit, Engineering-Aktivität und Projekt-Tracker. Jeder Abschnitt listet die heutigen Zahlen, den 7-Tage-Durchschnitt und gegebenenfalls eine Anomalie-Anmerkung im Klartext auf."
           }
         ],
         "nextActions": [
           {
-            "title": "Drill into an anomaly",
-            "description": "Ask Zero to investigate a spike directly from the brief thread",
+            "title": "Eine Anomalie untersuchen",
+            "description": "Bitte Zero, einen Ausschlag direkt aus dem Briefing-Thread heraus zu untersuchen",
             "examplePrompt": "@Zero the 572% PR spike in today's brief — list all those PRs and group them by label or title prefix so I can see what the team was shipping."
           },
           {
-            "title": "Fix a broken connector",
-            "description": "Resolve a missing token so all four sections have live data",
+            "title": "Defekten Konnektor reparieren",
+            "description": "Ein fehlendes Token beheben, damit alle vier Abschnitte Live-Daten enthalten",
             "examplePrompt": "@Zero check which connectors are missing or misconfigured for the daily brief and tell me what tokens I need to set."
           },
           {
-            "title": "Add a custom threshold",
-            "description": "Only get alerted when a metric crosses a meaningful threshold",
+            "title": "Benutzerdefinierten Schwellenwert hinzufügen",
+            "description": "Nur bei Metriken benachrichtigt werden, die einen aussagekräftigen Schwellenwert überschreiten",
             "examplePrompt": "@Zero update the daily brief schedule to only flag anomalies that are more than 3x the 7-day average. For smaller deviations, just include the number without a flag."
           }
         ],
         "integrations": [
           {
-            "description": "Zero reads PRs merged, issues opened and closed, and commit counts. Required for the Engineering Activity section."
+            "description": "Zero liest zusammengeführte PRs, geöffnete und geschlossene Issues sowie Commit-Zahlen. Erforderlich für den Abschnitt Engineering-Aktivität."
           },
           {
-            "description": "Zero posts the formatted brief and threads any follow-up analysis into the same message. Required for delivery."
+            "description": "Zero postet das formatierte Briefing und führt Folgeanalysen als Thread in derselben Nachricht fort. Erforderlich für die Zustellung."
           },
           {
-            "description": "Zero reads issue creation, in-progress work, and backlog count for the Project Tracker section. Optional."
+            "description": "Zero liest erstellte Issues, laufende Arbeiten und den Backlog-Stand für den Abschnitt Projekt-Tracker. Optional."
           },
           {
-            "description": "Zero reads unresolved error counts and new issue volume for the Errors and Reliability section. Optional."
+            "description": "Zero liest ungelöste Fehlerzahlen und das Volumen neuer Issues für den Abschnitt Fehler und Zuverlässigkeit. Optional."
           },
           {
-            "description": "Zero reads visitor counts, pageviews, and bounce rate for the Web Traffic section. Optional."
+            "description": "Zero liest Besucherzahlen, Seitenaufrufe und Absprungrate für den Abschnitt Web-Traffic. Optional."
           }
         ],
         "tips": [
-          "Schedule the brief 15 to 20 minutes before your standup so the team can see it before the meeting starts.",
-          "Start with GitHub and Slack only. Once the brief is running reliably, add Sentry and Plausible one at a time to validate each connector before expanding.",
-          "Add a custom threshold note to your prompt to reduce noise. For example, only flag metrics that are more than 2x the rolling average so minor day-to-day variation does not trigger alerts."
+          "Plane das Briefing 15 bis 20 Minuten vor deinem Standup, damit das Team es vor dem Meeting sehen kann.",
+          "Starte nur mit GitHub und Slack. Sobald das Briefing zuverlässig läuft, füge Sentry und Plausible nacheinander hinzu, um jeden Konnektor einzeln zu validieren, bevor du erweiterst.",
+          "Füge einen benutzerdefinierten Schwellenwert-Hinweis in deinen Prompt ein, um Rauschen zu reduzieren. Markiere zum Beispiel nur Metriken, die mehr als das 2-Fache des gleitenden Durchschnitts betragen, damit geringfügige tägliche Schwankungen keine Warnungen auslösen."
         ]
       }
     }

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -1549,6 +1549,101 @@
           "Halte jeden Agent fokussiert auf eine Aufgabe. Ein Worker, der PRs reviewt und gleichzeitig Tests laufen lässt, verliert bei beidem an Schärfe. Enge System-Prompts ergeben klarere Ergebnisse und sauberere Orchestrierung.",
           "Verkette Worker mit bedingten Prompts — 'wenn X fertig ist, starte Y mit dem Ergebnis'. Eine Flotte fokussierter Agents wird so ganz ohne Extra-Infrastruktur zu einer Pipeline."
         ]
+      },
+      "daily-engineering-brief": {
+        "title": "Daily engineering brief with anomaly detection",
+        "description": "Ask Zero to pull live data from GitHub, Linear, Sentry, and Plausible every morning, compute 7-day rolling averages, flag any anomalies, and post a formatted four-section brief to your Slack channel automatically.",
+        "timeSaved": "~20 min saved daily",
+        "headings": {
+          "scenario": "Why scattered dashboards slow down your morning sync",
+          "prompt": "How to set up a daily cross-tool engineering brief with Zero",
+          "steps": "How Zero pulls live data, computes baselines, and flags anomalies",
+          "nextActions": "Drill into anomalies, fix broken connectors, or expand the brief",
+          "integrations": "Required integrations: GitHub and Slack. Optional: Linear, Sentry, Plausible",
+          "tips": "Best practices for scheduled multi-tool engineering briefings"
+        },
+        "scenario": "Every morning someone opens four different tabs: GitHub for PR activity, Linear for sprint progress, Sentry for overnight errors, and Plausible for traffic trends. They manually compare today's numbers to what they remember from last week and try to spot anything unusual before the standup. That cross-referencing takes 15 to 20 minutes and relies on memory. Zero runs before standup, pulls live data from all four sources, computes 7-day rolling averages, flags anything that deviates significantly, and posts a clean four-section brief to Slack before anyone opens their laptop.",
+        "promptVariants": [
+          {
+            "label": "Full daily brief",
+            "prompt": "@Zero every weekday at 8:30am, pull live data from Plausible, Sentry, GitHub, and Linear, flag anomalies vs the 7-day rolling average, and post a formatted 4-section daily brief to #engineering."
+          },
+          {
+            "label": "GitHub and Linear only",
+            "prompt": "@Zero every morning at 9am, pull today's GitHub PR and issue stats for vm0-ai/vm0 and Linear sprint progress. Flag anything more than 2x above the 7-day average and post to #standup."
+          },
+          {
+            "label": "On demand",
+            "prompt": "@Zero pull live data from GitHub and Linear right now, compare to the 7-day rolling average, and tell me what looks unusual today."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero every weekday at 8:30am pull live data from Plausible, Sentry, GitHub, and Linear, flag anomalies vs the 7-day rolling average, and post a 4-section brief to #engineering."
+          },
+          {
+            "name": "Zero",
+            "text": "Scheduled. Running weekdays at 08:30.\n\nRun from this morning:\n*GitHub* — 96 PRs merged today vs 14.3 avg 🔴 572% spike (coordinated test refactor). Issues closed: 71 vs 28.6 avg 🟢.\n*Linear* — 0 issues created this week, 3 in backlog.\n*Sentry* — connector not configured.\n*Plausible* — connector not configured."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero pulls live data from each source",
+            "description": "Zero queries GitHub for PRs merged, issues opened and closed, and commits. It pulls Linear for issues created, in-progress work, and backlog count. If configured, it also queries Sentry for error counts and Plausible for visitor and pageview metrics."
+          },
+          {
+            "title": "7-day rolling averages computed",
+            "description": "For each metric, Zero fetches the same data for the prior seven days and computes a daily average. This gives a stable baseline that accounts for weekends, deploys, and team size changes."
+          },
+          {
+            "title": "Anomalies flagged automatically",
+            "description": "Zero compares today's numbers to the rolling average and flags anything that deviates significantly. A spike in merged PRs might indicate a coordinated refactor; a drop in Plausible traffic might signal a deploy issue; a surge in issues opened might mean a new bug surface was discovered."
+          },
+          {
+            "title": "Four-section brief posted to Slack",
+            "description": "Zero posts a structured message with one section per source: Web Traffic, Errors and Reliability, Engineering Activity, and Project Tracker. Each section lists today's numbers, the 7-day average, and a plain-language anomaly note where applicable."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Drill into an anomaly",
+            "description": "Ask Zero to investigate a spike directly from the brief thread",
+            "examplePrompt": "@Zero the 572% PR spike in today's brief — list all those PRs and group them by label or title prefix so I can see what the team was shipping."
+          },
+          {
+            "title": "Fix a broken connector",
+            "description": "Resolve a missing token so all four sections have live data",
+            "examplePrompt": "@Zero check which connectors are missing or misconfigured for the daily brief and tell me what tokens I need to set."
+          },
+          {
+            "title": "Add a custom threshold",
+            "description": "Only get alerted when a metric crosses a meaningful threshold",
+            "examplePrompt": "@Zero update the daily brief schedule to only flag anomalies that are more than 3x the 7-day average. For smaller deviations, just include the number without a flag."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero reads PRs merged, issues opened and closed, and commit counts. Required for the Engineering Activity section."
+          },
+          {
+            "description": "Zero posts the formatted brief and threads any follow-up analysis into the same message. Required for delivery."
+          },
+          {
+            "description": "Zero reads issue creation, in-progress work, and backlog count for the Project Tracker section. Optional."
+          },
+          {
+            "description": "Zero reads unresolved error counts and new issue volume for the Errors and Reliability section. Optional."
+          },
+          {
+            "description": "Zero reads visitor counts, pageviews, and bounce rate for the Web Traffic section. Optional."
+          }
+        ],
+        "tips": [
+          "Schedule the brief 15 to 20 minutes before your standup so the team can see it before the meeting starts.",
+          "Start with GitHub and Slack only. Once the brief is running reliably, add Sentry and Plausible one at a time to validate each connector before expanding.",
+          "Add a custom threshold note to your prompt to reduce noise. For example, only flag metrics that are more than 2x the rolling average so minor day-to-day variation does not trigger alerts."
+        ]
       }
     }
   },

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -1631,6 +1631,101 @@
           "Review before publishing. Zero creates Drafts by default — use the Strapi admin link Zero returns to spot-check each locale before going live.",
           "Feed Zero brand context. Paste your brand voice guidelines or a sample post from the target locale — the output will be noticeably more on-brand."
         ]
+      },
+      "daily-engineering-brief": {
+        "title": "Daily engineering brief with anomaly detection",
+        "description": "Ask Zero to pull live data from GitHub, Linear, Sentry, and Plausible every morning, compute 7-day rolling averages, flag any anomalies, and post a formatted four-section brief to your Slack channel automatically.",
+        "timeSaved": "~20 min saved daily",
+        "headings": {
+          "scenario": "Why scattered dashboards slow down your morning sync",
+          "prompt": "How to set up a daily cross-tool engineering brief with Zero",
+          "steps": "How Zero pulls live data, computes baselines, and flags anomalies",
+          "nextActions": "Drill into anomalies, fix broken connectors, or expand the brief",
+          "integrations": "Required integrations: GitHub and Slack. Optional: Linear, Sentry, Plausible",
+          "tips": "Best practices for scheduled multi-tool engineering briefings"
+        },
+        "scenario": "Every morning someone opens four different tabs: GitHub for PR activity, Linear for sprint progress, Sentry for overnight errors, and Plausible for traffic trends. They manually compare today's numbers to what they remember from last week and try to spot anything unusual before the standup. That cross-referencing takes 15 to 20 minutes and relies on memory. Zero runs before standup, pulls live data from all four sources, computes 7-day rolling averages, flags anything that deviates significantly, and posts a clean four-section brief to Slack before anyone opens their laptop.",
+        "promptVariants": [
+          {
+            "label": "Full daily brief",
+            "prompt": "@Zero every weekday at 8:30am, pull live data from Plausible, Sentry, GitHub, and Linear, flag anomalies vs the 7-day rolling average, and post a formatted 4-section daily brief to #engineering."
+          },
+          {
+            "label": "GitHub and Linear only",
+            "prompt": "@Zero every morning at 9am, pull today's GitHub PR and issue stats for vm0-ai/vm0 and Linear sprint progress. Flag anything more than 2x above the 7-day average and post to #standup."
+          },
+          {
+            "label": "On demand",
+            "prompt": "@Zero pull live data from GitHub and Linear right now, compare to the 7-day rolling average, and tell me what looks unusual today."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero every weekday at 8:30am pull live data from Plausible, Sentry, GitHub, and Linear, flag anomalies vs the 7-day rolling average, and post a 4-section brief to #engineering."
+          },
+          {
+            "name": "Zero",
+            "text": "Scheduled. Running weekdays at 08:30.\n\nRun from this morning:\n*GitHub* — 96 PRs merged today vs 14.3 avg 🔴 572% spike (coordinated test refactor). Issues closed: 71 vs 28.6 avg 🟢.\n*Linear* — 0 issues created this week, 3 in backlog.\n*Sentry* — connector not configured.\n*Plausible* — connector not configured."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero pulls live data from each source",
+            "description": "Zero queries GitHub for PRs merged, issues opened and closed, and commits. It pulls Linear for issues created, in-progress work, and backlog count. If configured, it also queries Sentry for error counts and Plausible for visitor and pageview metrics."
+          },
+          {
+            "title": "7-day rolling averages computed",
+            "description": "For each metric, Zero fetches the same data for the prior seven days and computes a daily average. This gives a stable baseline that accounts for weekends, deploys, and team size changes."
+          },
+          {
+            "title": "Anomalies flagged automatically",
+            "description": "Zero compares today's numbers to the rolling average and flags anything that deviates significantly. A spike in merged PRs might indicate a coordinated refactor; a drop in Plausible traffic might signal a deploy issue; a surge in issues opened might mean a new bug surface was discovered."
+          },
+          {
+            "title": "Four-section brief posted to Slack",
+            "description": "Zero posts a structured message with one section per source: Web Traffic, Errors and Reliability, Engineering Activity, and Project Tracker. Each section lists today's numbers, the 7-day average, and a plain-language anomaly note where applicable."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Drill into an anomaly",
+            "description": "Ask Zero to investigate a spike directly from the brief thread",
+            "examplePrompt": "@Zero the 572% PR spike in today's brief — list all those PRs and group them by label or title prefix so I can see what the team was shipping."
+          },
+          {
+            "title": "Fix a broken connector",
+            "description": "Resolve a missing token so all four sections have live data",
+            "examplePrompt": "@Zero check which connectors are missing or misconfigured for the daily brief and tell me what tokens I need to set."
+          },
+          {
+            "title": "Add a custom threshold",
+            "description": "Only get alerted when a metric crosses a meaningful threshold",
+            "examplePrompt": "@Zero update the daily brief schedule to only flag anomalies that are more than 3x the 7-day average. For smaller deviations, just include the number without a flag."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero reads PRs merged, issues opened and closed, and commit counts. Required for the Engineering Activity section."
+          },
+          {
+            "description": "Zero posts the formatted brief and threads any follow-up analysis into the same message. Required for delivery."
+          },
+          {
+            "description": "Zero reads issue creation, in-progress work, and backlog count for the Project Tracker section. Optional."
+          },
+          {
+            "description": "Zero reads unresolved error counts and new issue volume for the Errors and Reliability section. Optional."
+          },
+          {
+            "description": "Zero reads visitor counts, pageviews, and bounce rate for the Web Traffic section. Optional."
+          }
+        ],
+        "tips": [
+          "Schedule the brief 15 to 20 minutes before your standup so the team can see it before the meeting starts.",
+          "Start with GitHub and Slack only. Once the brief is running reliably, add Sentry and Plausible one at a time to validate each connector before expanding.",
+          "Add a custom threshold note to your prompt to reduce noise. For example, only flag metrics that are more than 2x the rolling average so minor day-to-day variation does not trigger alerts."
+        ]
       }
     }
   },

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -1549,6 +1549,101 @@
           "Mantén cada agente con un único propósito. Un worker que hace review de PRs y también corre tests pierde foco en ambos. System prompts estrechos producen salidas más nítidas y una orquestación más limpia.",
           "Encadena workers con prompts condicionales: 'cuando termine X, lanza Y sobre su salida'. Una flota de agentes enfocados se convierte en un pipeline sin infraestructura adicional."
         ]
+      },
+      "daily-engineering-brief": {
+        "title": "Daily engineering brief with anomaly detection",
+        "description": "Ask Zero to pull live data from GitHub, Linear, Sentry, and Plausible every morning, compute 7-day rolling averages, flag any anomalies, and post a formatted four-section brief to your Slack channel automatically.",
+        "timeSaved": "~20 min saved daily",
+        "headings": {
+          "scenario": "Why scattered dashboards slow down your morning sync",
+          "prompt": "How to set up a daily cross-tool engineering brief with Zero",
+          "steps": "How Zero pulls live data, computes baselines, and flags anomalies",
+          "nextActions": "Drill into anomalies, fix broken connectors, or expand the brief",
+          "integrations": "Required integrations: GitHub and Slack. Optional: Linear, Sentry, Plausible",
+          "tips": "Best practices for scheduled multi-tool engineering briefings"
+        },
+        "scenario": "Every morning someone opens four different tabs: GitHub for PR activity, Linear for sprint progress, Sentry for overnight errors, and Plausible for traffic trends. They manually compare today's numbers to what they remember from last week and try to spot anything unusual before the standup. That cross-referencing takes 15 to 20 minutes and relies on memory. Zero runs before standup, pulls live data from all four sources, computes 7-day rolling averages, flags anything that deviates significantly, and posts a clean four-section brief to Slack before anyone opens their laptop.",
+        "promptVariants": [
+          {
+            "label": "Full daily brief",
+            "prompt": "@Zero every weekday at 8:30am, pull live data from Plausible, Sentry, GitHub, and Linear, flag anomalies vs the 7-day rolling average, and post a formatted 4-section daily brief to #engineering."
+          },
+          {
+            "label": "GitHub and Linear only",
+            "prompt": "@Zero every morning at 9am, pull today's GitHub PR and issue stats for vm0-ai/vm0 and Linear sprint progress. Flag anything more than 2x above the 7-day average and post to #standup."
+          },
+          {
+            "label": "On demand",
+            "prompt": "@Zero pull live data from GitHub and Linear right now, compare to the 7-day rolling average, and tell me what looks unusual today."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero every weekday at 8:30am pull live data from Plausible, Sentry, GitHub, and Linear, flag anomalies vs the 7-day rolling average, and post a 4-section brief to #engineering."
+          },
+          {
+            "name": "Zero",
+            "text": "Scheduled. Running weekdays at 08:30.\n\nRun from this morning:\n*GitHub* — 96 PRs merged today vs 14.3 avg 🔴 572% spike (coordinated test refactor). Issues closed: 71 vs 28.6 avg 🟢.\n*Linear* — 0 issues created this week, 3 in backlog.\n*Sentry* — connector not configured.\n*Plausible* — connector not configured."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero pulls live data from each source",
+            "description": "Zero queries GitHub for PRs merged, issues opened and closed, and commits. It pulls Linear for issues created, in-progress work, and backlog count. If configured, it also queries Sentry for error counts and Plausible for visitor and pageview metrics."
+          },
+          {
+            "title": "7-day rolling averages computed",
+            "description": "For each metric, Zero fetches the same data for the prior seven days and computes a daily average. This gives a stable baseline that accounts for weekends, deploys, and team size changes."
+          },
+          {
+            "title": "Anomalies flagged automatically",
+            "description": "Zero compares today's numbers to the rolling average and flags anything that deviates significantly. A spike in merged PRs might indicate a coordinated refactor; a drop in Plausible traffic might signal a deploy issue; a surge in issues opened might mean a new bug surface was discovered."
+          },
+          {
+            "title": "Four-section brief posted to Slack",
+            "description": "Zero posts a structured message with one section per source: Web Traffic, Errors and Reliability, Engineering Activity, and Project Tracker. Each section lists today's numbers, the 7-day average, and a plain-language anomaly note where applicable."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Drill into an anomaly",
+            "description": "Ask Zero to investigate a spike directly from the brief thread",
+            "examplePrompt": "@Zero the 572% PR spike in today's brief — list all those PRs and group them by label or title prefix so I can see what the team was shipping."
+          },
+          {
+            "title": "Fix a broken connector",
+            "description": "Resolve a missing token so all four sections have live data",
+            "examplePrompt": "@Zero check which connectors are missing or misconfigured for the daily brief and tell me what tokens I need to set."
+          },
+          {
+            "title": "Add a custom threshold",
+            "description": "Only get alerted when a metric crosses a meaningful threshold",
+            "examplePrompt": "@Zero update the daily brief schedule to only flag anomalies that are more than 3x the 7-day average. For smaller deviations, just include the number without a flag."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero reads PRs merged, issues opened and closed, and commit counts. Required for the Engineering Activity section."
+          },
+          {
+            "description": "Zero posts the formatted brief and threads any follow-up analysis into the same message. Required for delivery."
+          },
+          {
+            "description": "Zero reads issue creation, in-progress work, and backlog count for the Project Tracker section. Optional."
+          },
+          {
+            "description": "Zero reads unresolved error counts and new issue volume for the Errors and Reliability section. Optional."
+          },
+          {
+            "description": "Zero reads visitor counts, pageviews, and bounce rate for the Web Traffic section. Optional."
+          }
+        ],
+        "tips": [
+          "Schedule the brief 15 to 20 minutes before your standup so the team can see it before the meeting starts.",
+          "Start with GitHub and Slack only. Once the brief is running reliably, add Sentry and Plausible one at a time to validate each connector before expanding.",
+          "Add a custom threshold note to your prompt to reduce noise. For example, only flag metrics that are more than 2x the rolling average so minor day-to-day variation does not trigger alerts."
+        ]
       }
     }
   },

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -1551,29 +1551,29 @@
         ]
       },
       "daily-engineering-brief": {
-        "title": "Daily engineering brief with anomaly detection",
-        "description": "Ask Zero to pull live data from GitHub, Linear, Sentry, and Plausible every morning, compute 7-day rolling averages, flag any anomalies, and post a formatted four-section brief to your Slack channel automatically.",
-        "timeSaved": "~20 min saved daily",
+        "title": "Resumen diario de ingeniería con detección de anomalías",
+        "description": "Pide a @Zero que extraiga datos en tiempo real de GitHub, Linear, Sentry y Plausible cada mañana, calcule promedios móviles de 7 días, marque cualquier anomalía y publique automáticamente un resumen de cuatro secciones en tu canal de Slack.",
+        "timeSaved": "~20 min ahorrados al día",
         "headings": {
-          "scenario": "Why scattered dashboards slow down your morning sync",
-          "prompt": "How to set up a daily cross-tool engineering brief with Zero",
-          "steps": "How Zero pulls live data, computes baselines, and flags anomalies",
-          "nextActions": "Drill into anomalies, fix broken connectors, or expand the brief",
-          "integrations": "Required integrations: GitHub and Slack. Optional: Linear, Sentry, Plausible",
-          "tips": "Best practices for scheduled multi-tool engineering briefings"
+          "scenario": "Por qué los dashboards dispersos ralentizan tu sincronización matutina",
+          "prompt": "Cómo configurar un resumen diario de ingeniería multi-herramienta con @Zero",
+          "steps": "Cómo @Zero extrae datos en tiempo real, calcula líneas base y marca anomalías",
+          "nextActions": "Profundiza en anomalías, corrige conectores rotos o amplía el resumen",
+          "integrations": "Integraciones requeridas: GitHub y Slack. Opcionales: Linear, Sentry, Plausible",
+          "tips": "Mejores prácticas para reportes de ingeniería programados con múltiples herramientas"
         },
-        "scenario": "Every morning someone opens four different tabs: GitHub for PR activity, Linear for sprint progress, Sentry for overnight errors, and Plausible for traffic trends. They manually compare today's numbers to what they remember from last week and try to spot anything unusual before the standup. That cross-referencing takes 15 to 20 minutes and relies on memory. Zero runs before standup, pulls live data from all four sources, computes 7-day rolling averages, flags anything that deviates significantly, and posts a clean four-section brief to Slack before anyone opens their laptop.",
+        "scenario": "Cada mañana alguien abre cuatro pestañas diferentes: GitHub para la actividad de PRs, Linear para el progreso del sprint, Sentry para los errores nocturnos y Plausible para las tendencias de tráfico. Comparan manualmente los números de hoy con lo que recuerdan de la semana pasada e intentan detectar algo inusual antes del standup. Esa verificación cruzada toma de 15 a 20 minutos y depende de la memoria. @Zero se ejecuta antes del standup, extrae datos en tiempo real de las cuatro fuentes, calcula promedios móviles de 7 días, marca cualquier desviación significativa y publica un resumen limpio de cuatro secciones en Slack antes de que alguien abra su laptop.",
         "promptVariants": [
           {
-            "label": "Full daily brief",
+            "label": "Resumen diario completo",
             "prompt": "@Zero every weekday at 8:30am, pull live data from Plausible, Sentry, GitHub, and Linear, flag anomalies vs the 7-day rolling average, and post a formatted 4-section daily brief to #engineering."
           },
           {
-            "label": "GitHub and Linear only",
+            "label": "Solo GitHub y Linear",
             "prompt": "@Zero every morning at 9am, pull today's GitHub PR and issue stats for vm0-ai/vm0 and Linear sprint progress. Flag anything more than 2x above the 7-day average and post to #standup."
           },
           {
-            "label": "On demand",
+            "label": "Bajo demanda",
             "prompt": "@Zero pull live data from GitHub and Linear right now, compare to the 7-day rolling average, and tell me what looks unusual today."
           }
         ],
@@ -1589,60 +1589,60 @@
         ],
         "steps": [
           {
-            "title": "Zero pulls live data from each source",
-            "description": "Zero queries GitHub for PRs merged, issues opened and closed, and commits. It pulls Linear for issues created, in-progress work, and backlog count. If configured, it also queries Sentry for error counts and Plausible for visitor and pageview metrics."
+            "title": "@Zero extrae datos en tiempo real de cada fuente",
+            "description": "@Zero consulta GitHub para PRs fusionados, issues abiertos y cerrados, y commits. Extrae de Linear los issues creados, el trabajo en progreso y el conteo del backlog. Si están configurados, también consulta Sentry para el conteo de errores y Plausible para métricas de visitantes y páginas vistas."
           },
           {
-            "title": "7-day rolling averages computed",
-            "description": "For each metric, Zero fetches the same data for the prior seven days and computes a daily average. This gives a stable baseline that accounts for weekends, deploys, and team size changes."
+            "title": "Se calculan los promedios móviles de 7 días",
+            "description": "Para cada métrica, @Zero obtiene los mismos datos de los siete días anteriores y calcula un promedio diario. Esto proporciona una línea base estable que tiene en cuenta fines de semana, despliegues y cambios en el tamaño del equipo."
           },
           {
-            "title": "Anomalies flagged automatically",
-            "description": "Zero compares today's numbers to the rolling average and flags anything that deviates significantly. A spike in merged PRs might indicate a coordinated refactor; a drop in Plausible traffic might signal a deploy issue; a surge in issues opened might mean a new bug surface was discovered."
+            "title": "Las anomalías se marcan automáticamente",
+            "description": "@Zero compara los números de hoy con el promedio móvil y marca cualquier desviación significativa. Un pico en PRs fusionados podría indicar un refactoreo coordinado; una caída en el tráfico de Plausible podría señalar un problema de despliegue; un aumento en issues abiertos podría significar que se descubrió una nueva superficie de errores."
           },
           {
-            "title": "Four-section brief posted to Slack",
-            "description": "Zero posts a structured message with one section per source: Web Traffic, Errors and Reliability, Engineering Activity, and Project Tracker. Each section lists today's numbers, the 7-day average, and a plain-language anomaly note where applicable."
+            "title": "Se publica el resumen de cuatro secciones en Slack",
+            "description": "@Zero publica un mensaje estructurado con una sección por fuente: Tráfico Web, Errores y Confiabilidad, Actividad de Ingeniería y Seguimiento de Proyecto. Cada sección lista los números de hoy, el promedio de 7 días y una nota de anomalía en lenguaje claro cuando corresponda."
           }
         ],
         "nextActions": [
           {
-            "title": "Drill into an anomaly",
-            "description": "Ask Zero to investigate a spike directly from the brief thread",
+            "title": "Profundizar en una anomalía",
+            "description": "Pide a @Zero que investigue un pico directamente desde el hilo del resumen",
             "examplePrompt": "@Zero the 572% PR spike in today's brief — list all those PRs and group them by label or title prefix so I can see what the team was shipping."
           },
           {
-            "title": "Fix a broken connector",
-            "description": "Resolve a missing token so all four sections have live data",
+            "title": "Corregir un conector roto",
+            "description": "Resuelve un token faltante para que las cuatro secciones tengan datos en tiempo real",
             "examplePrompt": "@Zero check which connectors are missing or misconfigured for the daily brief and tell me what tokens I need to set."
           },
           {
-            "title": "Add a custom threshold",
-            "description": "Only get alerted when a metric crosses a meaningful threshold",
+            "title": "Agregar un umbral personalizado",
+            "description": "Recibe alertas solo cuando una métrica cruza un umbral significativo",
             "examplePrompt": "@Zero update the daily brief schedule to only flag anomalies that are more than 3x the 7-day average. For smaller deviations, just include the number without a flag."
           }
         ],
         "integrations": [
           {
-            "description": "Zero reads PRs merged, issues opened and closed, and commit counts. Required for the Engineering Activity section."
+            "description": "@Zero lee PRs fusionados, issues abiertos y cerrados, y conteo de commits. Requerido para la sección de Actividad de Ingeniería."
           },
           {
-            "description": "Zero posts the formatted brief and threads any follow-up analysis into the same message. Required for delivery."
+            "description": "@Zero publica el resumen formateado y agrupa cualquier análisis de seguimiento en el mismo mensaje. Requerido para la entrega."
           },
           {
-            "description": "Zero reads issue creation, in-progress work, and backlog count for the Project Tracker section. Optional."
+            "description": "@Zero lee la creación de issues, el trabajo en progreso y el conteo del backlog para la sección de Seguimiento de Proyecto. Opcional."
           },
           {
-            "description": "Zero reads unresolved error counts and new issue volume for the Errors and Reliability section. Optional."
+            "description": "@Zero lee los conteos de errores no resueltos y el volumen de nuevos issues para la sección de Errores y Confiabilidad. Opcional."
           },
           {
-            "description": "Zero reads visitor counts, pageviews, and bounce rate for the Web Traffic section. Optional."
+            "description": "@Zero lee el conteo de visitantes, páginas vistas y tasa de rebote para la sección de Tráfico Web. Opcional."
           }
         ],
         "tips": [
-          "Schedule the brief 15 to 20 minutes before your standup so the team can see it before the meeting starts.",
-          "Start with GitHub and Slack only. Once the brief is running reliably, add Sentry and Plausible one at a time to validate each connector before expanding.",
-          "Add a custom threshold note to your prompt to reduce noise. For example, only flag metrics that are more than 2x the rolling average so minor day-to-day variation does not trigger alerts."
+          "Programa el resumen de 15 a 20 minutos antes de tu standup para que el equipo pueda verlo antes de que comience la reunión.",
+          "Comienza solo con GitHub y Slack. Una vez que el resumen funcione de manera confiable, agrega Sentry y Plausible uno a la vez para validar cada conector antes de expandir.",
+          "Agrega una nota de umbral personalizado a tu prompt para reducir el ruido. Por ejemplo, marca solo métricas que superen 2x el promedio móvil para que la variación menor del día a día no genere alertas."
         ]
       }
     }

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -1633,29 +1633,29 @@
         ]
       },
       "daily-engineering-brief": {
-        "title": "Daily engineering brief with anomaly detection",
-        "description": "Ask Zero to pull live data from GitHub, Linear, Sentry, and Plausible every morning, compute 7-day rolling averages, flag any anomalies, and post a formatted four-section brief to your Slack channel automatically.",
-        "timeSaved": "~20 min saved daily",
+        "title": "異常検知付きデイリーエンジニアリングブリーフ",
+        "description": "@Zeroに毎朝GitHub、Linear、Sentry、Plausibleからリアルタイムデータを取得させ、7日間の移動平均を算出し、異常値をフラグ付けして、フォーマットされた4セクションのブリーフをSlackチャンネルに自動投稿します。",
+        "timeSaved": "毎日約20分の時間削減",
         "headings": {
-          "scenario": "Why scattered dashboards slow down your morning sync",
-          "prompt": "How to set up a daily cross-tool engineering brief with Zero",
-          "steps": "How Zero pulls live data, computes baselines, and flags anomalies",
-          "nextActions": "Drill into anomalies, fix broken connectors, or expand the brief",
-          "integrations": "Required integrations: GitHub and Slack. Optional: Linear, Sentry, Plausible",
-          "tips": "Best practices for scheduled multi-tool engineering briefings"
+          "scenario": "分散したダッシュボードが朝の同期を遅らせる理由",
+          "prompt": "@Zeroでクロスツールのデイリーエンジニアリングブリーフを設定する方法",
+          "steps": "@Zeroがリアルタイムデータを取得し、ベースラインを算出し、異常を検知する仕組み",
+          "nextActions": "異常の深掘り、壊れたコネクタの修復、またはブリーフの拡張",
+          "integrations": "必須連携: GitHubとSlack。オプション: Linear、Sentry、Plausible",
+          "tips": "スケジュール型マルチツールエンジニアリングブリーフのベストプラクティス"
         },
-        "scenario": "Every morning someone opens four different tabs: GitHub for PR activity, Linear for sprint progress, Sentry for overnight errors, and Plausible for traffic trends. They manually compare today's numbers to what they remember from last week and try to spot anything unusual before the standup. That cross-referencing takes 15 to 20 minutes and relies on memory. Zero runs before standup, pulls live data from all four sources, computes 7-day rolling averages, flags anything that deviates significantly, and posts a clean four-section brief to Slack before anyone opens their laptop.",
+        "scenario": "毎朝誰かが4つのタブを開きます。GitHubでPRアクティビティ、Linearでスプリント進捗、Sentryで夜間エラー、Plausibleでトラフィック傾向を確認します。今日の数値を先週の記憶と手動で比較し、スタンドアップ前に異常がないか見つけようとします。この照合作業には15〜20分かかり、記憶に頼っています。@Zeroはスタンドアップ前に実行され、4つすべてのソースからリアルタイムデータを取得し、7日間の移動平均を算出し、大幅な偏差をフラグ付けし、誰もラップトップを開く前にSlackに整理された4セクションのブリーフを投稿します。",
         "promptVariants": [
           {
-            "label": "Full daily brief",
+            "label": "フルデイリーブリーフ",
             "prompt": "@Zero every weekday at 8:30am, pull live data from Plausible, Sentry, GitHub, and Linear, flag anomalies vs the 7-day rolling average, and post a formatted 4-section daily brief to #engineering."
           },
           {
-            "label": "GitHub and Linear only",
+            "label": "GitHubとLinearのみ",
             "prompt": "@Zero every morning at 9am, pull today's GitHub PR and issue stats for vm0-ai/vm0 and Linear sprint progress. Flag anything more than 2x above the 7-day average and post to #standup."
           },
           {
-            "label": "On demand",
+            "label": "オンデマンド",
             "prompt": "@Zero pull live data from GitHub and Linear right now, compare to the 7-day rolling average, and tell me what looks unusual today."
           }
         ],
@@ -1671,60 +1671,60 @@
         ],
         "steps": [
           {
-            "title": "Zero pulls live data from each source",
-            "description": "Zero queries GitHub for PRs merged, issues opened and closed, and commits. It pulls Linear for issues created, in-progress work, and backlog count. If configured, it also queries Sentry for error counts and Plausible for visitor and pageview metrics."
+            "title": "@Zeroが各ソースからリアルタイムデータを取得",
+            "description": "@ZeroはGitHubからマージされたPR、オープン・クローズされたissue、コミットを取得します。Linearからは作成されたissue、進行中の作業、バックログ数を取得します。設定されている場合、Sentryのエラー数やPlausibleの訪問者数・ページビュー指標も取得します。"
           },
           {
-            "title": "7-day rolling averages computed",
-            "description": "For each metric, Zero fetches the same data for the prior seven days and computes a daily average. This gives a stable baseline that accounts for weekends, deploys, and team size changes."
+            "title": "7日間の移動平均を算出",
+            "description": "各指標について、@Zeroは過去7日間の同じデータを取得し、日次平均を算出します。これにより、週末、デプロイ、チーム規模の変更を考慮した安定したベースラインが得られます。"
           },
           {
-            "title": "Anomalies flagged automatically",
-            "description": "Zero compares today's numbers to the rolling average and flags anything that deviates significantly. A spike in merged PRs might indicate a coordinated refactor; a drop in Plausible traffic might signal a deploy issue; a surge in issues opened might mean a new bug surface was discovered."
+            "title": "異常を自動的にフラグ付け",
+            "description": "@Zeroは今日の数値を移動平均と比較し、大幅な偏差をフラグ付けします。マージされたPRの急増は協調的なリファクタリングを示す可能性があり、Plausibleのトラフィック低下はデプロイの問題を示す可能性があり、オープンされたissueの急増は新たなバグ領域の発見を意味する可能性があります。"
           },
           {
-            "title": "Four-section brief posted to Slack",
-            "description": "Zero posts a structured message with one section per source: Web Traffic, Errors and Reliability, Engineering Activity, and Project Tracker. Each section lists today's numbers, the 7-day average, and a plain-language anomaly note where applicable."
+            "title": "4セクションのブリーフをSlackに投稿",
+            "description": "@Zeroはソースごとに1セクションの構造化されたメッセージを投稿します：Webトラフィック、エラーと信頼性、エンジニアリングアクティビティ、プロジェクトトラッカー。各セクションには今日の数値、7日間の平均、該当する場合は平易な言葉での異常ノートが記載されます。"
           }
         ],
         "nextActions": [
           {
-            "title": "Drill into an anomaly",
-            "description": "Ask Zero to investigate a spike directly from the brief thread",
+            "title": "異常を深掘りする",
+            "description": "ブリーフのスレッドから直接@Zeroにスパイクの調査を依頼",
             "examplePrompt": "@Zero the 572% PR spike in today's brief — list all those PRs and group them by label or title prefix so I can see what the team was shipping."
           },
           {
-            "title": "Fix a broken connector",
-            "description": "Resolve a missing token so all four sections have live data",
+            "title": "壊れたコネクタを修復する",
+            "description": "不足しているトークンを解決して4つすべてのセクションにライブデータを反映",
             "examplePrompt": "@Zero check which connectors are missing or misconfigured for the daily brief and tell me what tokens I need to set."
           },
           {
-            "title": "Add a custom threshold",
-            "description": "Only get alerted when a metric crosses a meaningful threshold",
+            "title": "カスタム閾値を追加する",
+            "description": "指標が意味のある閾値を超えた場合のみアラートを受け取る",
             "examplePrompt": "@Zero update the daily brief schedule to only flag anomalies that are more than 3x the 7-day average. For smaller deviations, just include the number without a flag."
           }
         ],
         "integrations": [
           {
-            "description": "Zero reads PRs merged, issues opened and closed, and commit counts. Required for the Engineering Activity section."
+            "description": "@ZeroはマージされたPR、オープン・クローズされたissue、コミット数を読み取ります。エンジニアリングアクティビティセクションに必須です。"
           },
           {
-            "description": "Zero posts the formatted brief and threads any follow-up analysis into the same message. Required for delivery."
+            "description": "@Zeroはフォーマットされたブリーフを投稿し、フォローアップの分析を同じメッセージのスレッドにまとめます。配信に必須です。"
           },
           {
-            "description": "Zero reads issue creation, in-progress work, and backlog count for the Project Tracker section. Optional."
+            "description": "@Zeroはissueの作成、進行中の作業、バックログ数をプロジェクトトラッカーセクション用に読み取ります。オプションです。"
           },
           {
-            "description": "Zero reads unresolved error counts and new issue volume for the Errors and Reliability section. Optional."
+            "description": "@Zeroは未解決のエラー数と新規issue数をエラーと信頼性セクション用に読み取ります。オプションです。"
           },
           {
-            "description": "Zero reads visitor counts, pageviews, and bounce rate for the Web Traffic section. Optional."
+            "description": "@Zeroは訪問者数、ページビュー、直帰率をWebトラフィックセクション用に読み取ります。オプションです。"
           }
         ],
         "tips": [
-          "Schedule the brief 15 to 20 minutes before your standup so the team can see it before the meeting starts.",
-          "Start with GitHub and Slack only. Once the brief is running reliably, add Sentry and Plausible one at a time to validate each connector before expanding.",
-          "Add a custom threshold note to your prompt to reduce noise. For example, only flag metrics that are more than 2x the rolling average so minor day-to-day variation does not trigger alerts."
+          "スタンドアップの15〜20分前にブリーフをスケジュールして、ミーティング開始前にチームが確認できるようにしましょう。",
+          "まずGitHubとSlackだけで始めましょう。ブリーフが安定して動作するようになったら、SentryとPlausibleを1つずつ追加して、拡張前に各コネクタを検証しましょう。",
+          "ノイズを減らすために、プロンプトにカスタム閾値の指示を追加しましょう。例えば、移動平均の2倍を超える指標のみフラグ付けすることで、日常的な小さな変動によるアラートを防げます。"
         ]
       }
     }

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -1631,6 +1631,101 @@
           "公開前に確認しましょう。Zeroはデフォルトでドラフトを作成します — Zeroが返すStrapiアドミンのリンクを使って、本公開前に各ロケールをチェックしてください。",
           "ブランドコンテキストをZeroに渡しましょう。ブランドボイスガイドラインや対象ロケールのサンプル記事を貼り付けると、出力が格段にブランドらしくなります。"
         ]
+      },
+      "daily-engineering-brief": {
+        "title": "Daily engineering brief with anomaly detection",
+        "description": "Ask Zero to pull live data from GitHub, Linear, Sentry, and Plausible every morning, compute 7-day rolling averages, flag any anomalies, and post a formatted four-section brief to your Slack channel automatically.",
+        "timeSaved": "~20 min saved daily",
+        "headings": {
+          "scenario": "Why scattered dashboards slow down your morning sync",
+          "prompt": "How to set up a daily cross-tool engineering brief with Zero",
+          "steps": "How Zero pulls live data, computes baselines, and flags anomalies",
+          "nextActions": "Drill into anomalies, fix broken connectors, or expand the brief",
+          "integrations": "Required integrations: GitHub and Slack. Optional: Linear, Sentry, Plausible",
+          "tips": "Best practices for scheduled multi-tool engineering briefings"
+        },
+        "scenario": "Every morning someone opens four different tabs: GitHub for PR activity, Linear for sprint progress, Sentry for overnight errors, and Plausible for traffic trends. They manually compare today's numbers to what they remember from last week and try to spot anything unusual before the standup. That cross-referencing takes 15 to 20 minutes and relies on memory. Zero runs before standup, pulls live data from all four sources, computes 7-day rolling averages, flags anything that deviates significantly, and posts a clean four-section brief to Slack before anyone opens their laptop.",
+        "promptVariants": [
+          {
+            "label": "Full daily brief",
+            "prompt": "@Zero every weekday at 8:30am, pull live data from Plausible, Sentry, GitHub, and Linear, flag anomalies vs the 7-day rolling average, and post a formatted 4-section daily brief to #engineering."
+          },
+          {
+            "label": "GitHub and Linear only",
+            "prompt": "@Zero every morning at 9am, pull today's GitHub PR and issue stats for vm0-ai/vm0 and Linear sprint progress. Flag anything more than 2x above the 7-day average and post to #standup."
+          },
+          {
+            "label": "On demand",
+            "prompt": "@Zero pull live data from GitHub and Linear right now, compare to the 7-day rolling average, and tell me what looks unusual today."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero every weekday at 8:30am pull live data from Plausible, Sentry, GitHub, and Linear, flag anomalies vs the 7-day rolling average, and post a 4-section brief to #engineering."
+          },
+          {
+            "name": "Zero",
+            "text": "Scheduled. Running weekdays at 08:30.\n\nRun from this morning:\n*GitHub* — 96 PRs merged today vs 14.3 avg 🔴 572% spike (coordinated test refactor). Issues closed: 71 vs 28.6 avg 🟢.\n*Linear* — 0 issues created this week, 3 in backlog.\n*Sentry* — connector not configured.\n*Plausible* — connector not configured."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero pulls live data from each source",
+            "description": "Zero queries GitHub for PRs merged, issues opened and closed, and commits. It pulls Linear for issues created, in-progress work, and backlog count. If configured, it also queries Sentry for error counts and Plausible for visitor and pageview metrics."
+          },
+          {
+            "title": "7-day rolling averages computed",
+            "description": "For each metric, Zero fetches the same data for the prior seven days and computes a daily average. This gives a stable baseline that accounts for weekends, deploys, and team size changes."
+          },
+          {
+            "title": "Anomalies flagged automatically",
+            "description": "Zero compares today's numbers to the rolling average and flags anything that deviates significantly. A spike in merged PRs might indicate a coordinated refactor; a drop in Plausible traffic might signal a deploy issue; a surge in issues opened might mean a new bug surface was discovered."
+          },
+          {
+            "title": "Four-section brief posted to Slack",
+            "description": "Zero posts a structured message with one section per source: Web Traffic, Errors and Reliability, Engineering Activity, and Project Tracker. Each section lists today's numbers, the 7-day average, and a plain-language anomaly note where applicable."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Drill into an anomaly",
+            "description": "Ask Zero to investigate a spike directly from the brief thread",
+            "examplePrompt": "@Zero the 572% PR spike in today's brief — list all those PRs and group them by label or title prefix so I can see what the team was shipping."
+          },
+          {
+            "title": "Fix a broken connector",
+            "description": "Resolve a missing token so all four sections have live data",
+            "examplePrompt": "@Zero check which connectors are missing or misconfigured for the daily brief and tell me what tokens I need to set."
+          },
+          {
+            "title": "Add a custom threshold",
+            "description": "Only get alerted when a metric crosses a meaningful threshold",
+            "examplePrompt": "@Zero update the daily brief schedule to only flag anomalies that are more than 3x the 7-day average. For smaller deviations, just include the number without a flag."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero reads PRs merged, issues opened and closed, and commit counts. Required for the Engineering Activity section."
+          },
+          {
+            "description": "Zero posts the formatted brief and threads any follow-up analysis into the same message. Required for delivery."
+          },
+          {
+            "description": "Zero reads issue creation, in-progress work, and backlog count for the Project Tracker section. Optional."
+          },
+          {
+            "description": "Zero reads unresolved error counts and new issue volume for the Errors and Reliability section. Optional."
+          },
+          {
+            "description": "Zero reads visitor counts, pageviews, and bounce rate for the Web Traffic section. Optional."
+          }
+        ],
+        "tips": [
+          "Schedule the brief 15 to 20 minutes before your standup so the team can see it before the meeting starts.",
+          "Start with GitHub and Slack only. Once the brief is running reliably, add Sentry and Plausible one at a time to validate each connector before expanding.",
+          "Add a custom threshold note to your prompt to reduce noise. For example, only flag metrics that are more than 2x the rolling average so minor day-to-day variation does not trigger alerts."
+        ]
       }
     }
   },


### PR DESCRIPTION
## Summary

- Adds a new **`daily-engineering-brief`** use case to the Use Cases page
- Zero pulls live data from GitHub, Linear, Sentry, and Plausible, computes 7-day rolling averages, flags anomalies, and posts a formatted 4-section brief to Slack
- Adds a `PLAUSIBLE` connector ref constant to `data.ts`
- Locale files updated for `en`, `de`, `es`, `ja` (non-EN locales use EN copy pending professional translation)

## Inspired by

This use case was run live in Slack today — Zero posted a real daily brief to #engineering with GitHub anomaly detection (96 PRs merged vs 14.3 avg, flagged as a coordinated test architecture refactor).

## Test plan
- [ ] Visit `/en/use-cases` — confirm new card appears in the gallery
- [ ] Visit `/en/use-cases/daily-engineering-brief` — confirm detail page renders correctly
- [ ] Confirm connector icons render (GitHub, Linear, Sentry, Slack shown; Plausible shown once icon asset is added)
- [ ] Run `pnpm test` in `turbo/apps/web` — connector ID validation test should pass

## Notes
- A `plausible.svg` connector icon asset should be added to `/public/assets/connectors/` before this ships (tracked separately)
- Non-EN translations are EN placeholders — flag for localization team

🤖 Generated with [Claude Code](https://claude.ai/claude-code)