### PR TITLE
feat: add competitor-pricing-monitor use case

### DIFF
--- a/turbo/apps/web/app/[locale]/use-cases/data.ts
+++ b/turbo/apps/web/app/[locale]/use-cases/data.ts
@@ -599,6 +599,38 @@ export const USE_CASES: UseCase[] = [
   },
 
   {
+    slug: "competitor-pricing-monitor",
+    color: "#7cbeab",
+    avatar: {
+      rotation: 5,
+      skin: 2,
+      hairStyle: 4,
+      hairColor: 1,
+      expression: 4,
+      intensity: "d",
+    },
+    roles: ["product", "ops"],
+    capability: "scheduled",
+    model: "Claude 4 Sonnet",
+    connectors: [NOTION, SLACK],
+    integrations: [
+      { connector: NOTION, required: true },
+      { connector: SLACK, required: false },
+    ],
+    relatedSlugs: [
+      "competitor-audit",
+      "kol-cold-outreach",
+      "product-health-briefing",
+    ],
+    stepCount: 3,
+    nextActionCount: 3,
+    integrationCount: 2,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
+  },
+
+  {
     slug: "error-triage-daily",
     color: "#9abe7c",
     avatar: {

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -1644,6 +1644,88 @@
           "Starte nur mit GitHub und Slack. Sobald das Briefing zuverlässig läuft, füge Sentry und Plausible nacheinander hinzu, um jeden Konnektor einzeln zu validieren, bevor du erweiterst.",
           "Füge einen benutzerdefinierten Schwellenwert-Hinweis in deinen Prompt ein, um Rauschen zu reduzieren. Markiere zum Beispiel nur Metriken, die mehr als das 2-Fache des gleitenden Durchschnitts betragen, damit geringfügige tägliche Schwankungen keine Warnungen auslösen."
         ]
+      },
+      "competitor-pricing-monitor": {
+        "title": "Preisseiten von Wettbewerbern überwachen und Änderungen wöchentlich melden",
+        "description": "Gib Zero eine Liste von Preisseiten-URLs deiner Wettbewerber. Es scrapt jede Seite jeden Montag, vergleicht sie mit dem Notion-Snapshot der letzten Woche, schreibt eine Auswirkungsanalyse für jede gefundene Änderung, speichert den vollständigen Bericht in Notion und postet eine Zusammenfassung in Slack.",
+        "timeSaved": "~2 Std. pro Woche gespart",
+        "headings": {
+          "scenario": "Warum Preisänderungen Teams überraschen",
+          "prompt": "So richtest du eine wöchentliche Wettbewerber-Preisüberwachung mit Zero ein",
+          "steps": "So scrapt, vergleicht und meldet Zero Preisänderungen",
+          "nextActions": "Einzelne Änderung vertiefen, Watchlist anpassen oder Ergebnisse mit der Führungsebene teilen",
+          "integrations": "Erforderliche Integrationen: Notion und Slack",
+          "tips": "Best Practices für automatisierte Preis-Intelligence"
+        },
+        "scenario": "Ein Wettbewerber streicht stillschweigend sein kostenloses Angebot. Ein anderer führt einen neuen Enterprise-Plan ein. Du erfährst es drei Wochen später von einem Interessenten, der sich bereits für sie entschieden hat. Zero prüft jeden Montag deine Wettbewerber-Preisseiten, vergleicht, was sich seit letzter Woche geändert hat, schreibt eine klare Auswirkungsanalyse für jede gefundene Änderung und postet eine Zusammenfassung in Slack, bevor die Woche deines Teams richtig losgeht.",
+        "promptVariants": [
+          {
+            "label": "Wöchentliche Überwachung einrichten",
+            "prompt": "@Zero every Monday at 9am, scrape the pricing pages of e2b.dev, daytona.io, cursor.com, and replit.com. Compare against last week's Notion snapshot. Flag any changes to tiers, prices, or CTAs, write a 2–3 sentence impact summary for each, save the full report to Notion under Competitor Pricing Log, and post a digest to #competitive."
+          },
+          {
+            "label": "Einmalige Prüfung durchführen",
+            "prompt": "@Zero scrape the pricing pages of e2b.dev and daytona.io right now. Compare against the last saved Notion snapshot and tell me what changed."
+          },
+          {
+            "label": "Deep Dive zu einem Wettbewerber",
+            "prompt": "@Zero pull the full pricing history for cursor.com from the Competitor Pricing Log in Notion. Summarize how their tiers and CTAs have evolved over time."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero every Monday at 9am, scrape competitor pricing pages and compare against last week's Notion snapshot. Post a digest to #competitive."
+          },
+          {
+            "name": "Zero",
+            "text": "Competitor Pricing Digest — Apr 14\n\nCursor: Added new Ultra tier at $200/month. Signals growing confidence in a high-willingness-to-pay power-user segment.\nDaytona: Increased startup credit offer from $25K to $50K. Signals aggressive developer acquisition push.\n\nNo changes detected: E2B, Replit\n\nFull report saved to Notion."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero scrapt jede Preisseite",
+            "description": "Zero ruft den aktuellen Inhalt jeder angegebenen Preis-URL ab und extrahiert Tarifnamen, Preise, Feature-Listen, Testangebote und CTAs."
+          },
+          {
+            "title": "Zero vergleicht mit dem Notion-Snapshot der Vorwoche",
+            "description": "Zero vergleicht den heutigen Inhalt mit der letzte Woche in Notion gespeicherten Version. Es markiert jede Änderung an Preisstufen, Plannamen, enthaltenen Features, Testbedingungen oder Handlungsaufforderungen."
+          },
+          {
+            "title": "Auswirkungsanalysen gespeichert und Zusammenfassung gepostet",
+            "description": "Für jede gefundene Änderung schreibt Zero eine 2–3-Satz-Auswirkungsanalyse, die beschreibt, was sich geändert hat, was es signalisiert und was zu beachten ist. Der vollständige Bericht wird in Notion gespeichert und eine kompakte Zusammenfassung in Slack gepostet."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Einzelne Änderung vertiefen",
+            "description": "Mehr Kontext zu einem bestimmten Wettbewerber-Schritt erhalten",
+            "examplePrompt": "@Zero pull up everything we have on Cursor's pricing history in Notion. Summarize how they've repositioned their tiers since Q1."
+          },
+          {
+            "title": "Neuen Wettbewerber zur Watchlist hinzufügen",
+            "description": "Die überwachten Seiten erweitern",
+            "examplePrompt": "@Zero add replit.com/pricing to the weekly pricing monitor and run an initial scrape now to set the baseline."
+          },
+          {
+            "title": "Zusammenfassung mit der Führungsebene teilen",
+            "description": "Eine Quartalszusammenfassung der Preisänderungen senden",
+            "examplePrompt": "@Zero summarize all competitor pricing changes logged in Notion this quarter and post a report to #leadership."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero speichert wöchentliche Preis-Snapshots und Änderungsberichte in deinem Notion-Workspace für langfristiges Tracking und Vergleiche."
+          },
+          {
+            "description": "Zero postet eine kompakte wöchentliche Zusammenfassung in den von dir angegebenen Slack-Channel."
+          }
+        ],
+        "tips": [
+          "Führe zuerst einen initialen Scrape durch, um den Baseline-Snapshot in Notion zu erstellen. Ohne diesen hat Zero nichts zum Vergleichen und behandelt alles als Änderung.",
+          "Sei konkret, was markiert werden soll. 'Achte auf Änderungen bei Preisstufen, Plannamen, Testangeboten und CTAs' liefert präzisere Ergebnisse als eine allgemeine Übersicht.",
+          "Strukturiere dein Notion-Log mit Eigenschaften wie Wettbewerber, Änderungstyp und Datum, damit du über die gesamte Historie filtern kannst, was sich wann geändert hat."
+        ]
       }
     }
   },

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -1295,6 +1295,88 @@
           "Run a catch-up scan first to seed the database with baseline data before setting up the recurring schedule."
         ]
       },
+      "competitor-pricing-monitor": {
+        "title": "Monitor competitor pricing pages and flag changes weekly",
+        "description": "Give Zero a list of competitor pricing URLs. It scrapes each page every Monday, diffs it against last week's Notion snapshot, writes an impact summary for every change found, saves the full report to Notion, and posts a digest to Slack.",
+        "timeSaved": "~2 hrs saved per week",
+        "headings": {
+          "scenario": "Why pricing changes catch teams off guard",
+          "prompt": "How to set up weekly competitor pricing monitoring with Zero",
+          "steps": "How Zero scrapes, diffs, and reports pricing changes",
+          "nextActions": "Drill into a specific change, adjust the watchlist, or share with leadership",
+          "integrations": "Required integrations: Notion and Slack",
+          "tips": "Best practices for automated pricing intelligence"
+        },
+        "scenario": "A competitor quietly drops their free tier. Another one adds a new enterprise plan. You find out three weeks later from a prospect who already chose them. Zero checks your competitor pricing pages every Monday, compares what changed since last week, writes a clear impact summary for every change found, and posts a digest to Slack before your team's week kicks off.",
+        "promptVariants": [
+          {
+            "label": "Set up weekly monitoring",
+            "prompt": "@Zero every Monday at 9am, scrape the pricing pages of e2b.dev, daytona.io, cursor.com, and replit.com. Compare against last week's Notion snapshot. Flag any changes to tiers, prices, or CTAs, write a 2–3 sentence impact summary for each, save the full report to Notion under Competitor Pricing Log, and post a digest to #competitive."
+          },
+          {
+            "label": "Run a one-off check",
+            "prompt": "@Zero scrape the pricing pages of e2b.dev and daytona.io right now. Compare against the last saved Notion snapshot and tell me what changed."
+          },
+          {
+            "label": "Deep dive on one competitor",
+            "prompt": "@Zero pull the full pricing history for cursor.com from the Competitor Pricing Log in Notion. Summarize how their tiers and CTAs have evolved over time."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero every Monday at 9am, scrape competitor pricing pages and compare against last week's Notion snapshot. Post a digest to #competitive."
+          },
+          {
+            "name": "Zero",
+            "text": "Competitor Pricing Digest — Apr 14\n\nCursor: Added new Ultra tier at $200/month. Signals growing confidence in a high-willingness-to-pay power-user segment.\nDaytona: Increased startup credit offer from $25K to $50K. Signals aggressive developer acquisition push.\n\nNo changes detected: E2B, Replit\n\nFull report saved to Notion."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero scrapes each pricing page",
+            "description": "Zero fetches the current content of every pricing URL you specified, extracting tier names, prices, feature lists, trial offers, and CTAs."
+          },
+          {
+            "title": "Zero diffs against last week's Notion snapshot",
+            "description": "Zero compares today's content against the version saved in Notion last week. It flags any change to pricing tiers, plan names, included features, trial terms, or calls to action."
+          },
+          {
+            "title": "Impact summaries saved and digest posted",
+            "description": "For each change found, Zero writes a 2–3 sentence impact summary covering what changed, what it signals, and what to consider. The full report is saved to Notion and a concise digest is posted to Slack."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Drill into a specific change",
+            "description": "Get more context on a single competitor move",
+            "examplePrompt": "@Zero pull up everything we have on Cursor's pricing history in Notion. Summarize how they've repositioned their tiers since Q1."
+          },
+          {
+            "title": "Add a new competitor to the watchlist",
+            "description": "Expand the pages being monitored",
+            "examplePrompt": "@Zero add replit.com/pricing to the weekly pricing monitor and run an initial scrape now to set the baseline."
+          },
+          {
+            "title": "Share a rollup with leadership",
+            "description": "Send a quarterly summary of pricing shifts",
+            "examplePrompt": "@Zero summarize all competitor pricing changes logged in Notion this quarter and post a report to #leadership."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero saves weekly pricing snapshots and change reports to your Notion workspace for long-term tracking and diffing."
+          },
+          {
+            "description": "Zero posts a concise weekly digest to the Slack channel you specify."
+          }
+        ],
+        "tips": [
+          "Run an initial scrape first to set the baseline snapshot in Notion. Without it, Zero has nothing to diff against and will treat everything as a change.",
+          "Be specific about what to flag. 'Watch for changes to pricing tiers, plan names, trial offers, and CTAs' gives tighter results than a general sweep.",
+          "Structure your Notion log with properties like Competitor, Change Type, and Date so you can filter by what changed and when across the full history."
+        ]
+      },
       "error-triage-daily": {
         "title": "Triage production errors every morning without touching Sentry",
         "description": "Schedule Zero to run daily. It pulls unresolved errors from Sentry and Axiom, deduplicates across sources, opens a GitHub issue with the full stack trace, and assigns it to the right engineer automatically.",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -1644,6 +1644,88 @@
           "Comienza solo con GitHub y Slack. Una vez que el resumen funcione de manera confiable, agrega Sentry y Plausible uno a la vez para validar cada conector antes de expandir.",
           "Agrega una nota de umbral personalizado a tu prompt para reducir el ruido. Por ejemplo, marca solo métricas que superen 2x el promedio móvil para que la variación menor del día a día no genere alertas."
         ]
+      },
+      "competitor-pricing-monitor": {
+        "title": "Monitorea páginas de precios de competidores y marca cambios semanalmente",
+        "description": "Dale a @Zero una lista de URLs de precios de competidores. Extrae el contenido de cada página cada lunes, lo compara con la instantánea de la semana anterior en Notion, escribe un resumen de impacto para cada cambio encontrado, guarda el reporte completo en Notion y publica un resumen en Slack.",
+        "timeSaved": "~2 hrs ahorradas por semana",
+        "headings": {
+          "scenario": "Por qué los cambios de precios toman a los equipos por sorpresa",
+          "prompt": "Cómo configurar el monitoreo semanal de precios de competidores con @Zero",
+          "steps": "Cómo @Zero extrae, compara y reporta cambios de precios",
+          "nextActions": "Profundiza en un cambio específico, ajusta la lista de seguimiento o comparte con liderazgo",
+          "integrations": "Integraciones requeridas: Notion y Slack",
+          "tips": "Mejores prácticas para inteligencia de precios automatizada"
+        },
+        "scenario": "Un competidor elimina silenciosamente su plan gratuito. Otro agrega un nuevo plan empresarial. Te enteras tres semanas después por un prospecto que ya los eligió. @Zero revisa las páginas de precios de tus competidores cada lunes, compara qué cambió desde la semana pasada, escribe un resumen de impacto claro para cada cambio encontrado y publica un resumen en Slack antes de que la semana de tu equipo comience.",
+        "promptVariants": [
+          {
+            "label": "Configurar monitoreo semanal",
+            "prompt": "@Zero every Monday at 9am, scrape the pricing pages of e2b.dev, daytona.io, cursor.com, and replit.com. Compare against last week's Notion snapshot. Flag any changes to tiers, prices, or CTAs, write a 2–3 sentence impact summary for each, save the full report to Notion under Competitor Pricing Log, and post a digest to #competitive."
+          },
+          {
+            "label": "Ejecutar una verificación puntual",
+            "prompt": "@Zero scrape the pricing pages of e2b.dev and daytona.io right now. Compare against the last saved Notion snapshot and tell me what changed."
+          },
+          {
+            "label": "Análisis profundo de un competidor",
+            "prompt": "@Zero pull the full pricing history for cursor.com from the Competitor Pricing Log in Notion. Summarize how their tiers and CTAs have evolved over time."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero every Monday at 9am, scrape competitor pricing pages and compare against last week's Notion snapshot. Post a digest to #competitive."
+          },
+          {
+            "name": "Zero",
+            "text": "Competitor Pricing Digest — Apr 14\n\nCursor: Added new Ultra tier at $200/month. Signals growing confidence in a high-willingness-to-pay power-user segment.\nDaytona: Increased startup credit offer from $25K to $50K. Signals aggressive developer acquisition push.\n\nNo changes detected: E2B, Replit\n\nFull report saved to Notion."
+          }
+        ],
+        "steps": [
+          {
+            "title": "@Zero extrae cada página de precios",
+            "description": "@Zero obtiene el contenido actual de cada URL de precios que especificaste, extrayendo nombres de planes, precios, listas de funcionalidades, ofertas de prueba y CTAs."
+          },
+          {
+            "title": "@Zero compara contra la instantánea de la semana anterior en Notion",
+            "description": "@Zero compara el contenido de hoy contra la versión guardada en Notion la semana pasada. Marca cualquier cambio en planes de precios, nombres de planes, funcionalidades incluidas, términos de prueba o llamadas a la acción."
+          },
+          {
+            "title": "Se guardan los resúmenes de impacto y se publica el resumen",
+            "description": "Para cada cambio encontrado, @Zero escribe un resumen de impacto de 2 a 3 oraciones que cubre qué cambió, qué señala y qué considerar. El reporte completo se guarda en Notion y un resumen conciso se publica en Slack."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Profundizar en un cambio específico",
+            "description": "Obtén más contexto sobre un movimiento de un competidor",
+            "examplePrompt": "@Zero pull up everything we have on Cursor's pricing history in Notion. Summarize how they've repositioned their tiers since Q1."
+          },
+          {
+            "title": "Agregar un nuevo competidor a la lista de seguimiento",
+            "description": "Amplía las páginas que se están monitoreando",
+            "examplePrompt": "@Zero add replit.com/pricing to the weekly pricing monitor and run an initial scrape now to set the baseline."
+          },
+          {
+            "title": "Compartir un resumen acumulado con liderazgo",
+            "description": "Envía un resumen trimestral de cambios de precios",
+            "examplePrompt": "@Zero summarize all competitor pricing changes logged in Notion this quarter and post a report to #leadership."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "@Zero guarda instantáneas semanales de precios y reportes de cambios en tu espacio de trabajo de Notion para seguimiento a largo plazo y comparaciones."
+          },
+          {
+            "description": "@Zero publica un resumen semanal conciso en el canal de Slack que especifiques."
+          }
+        ],
+        "tips": [
+          "Ejecuta una extracción inicial primero para establecer la instantánea base en Notion. Sin ella, @Zero no tiene nada contra qué comparar y tratará todo como un cambio.",
+          "Sé específico sobre qué marcar. 'Vigila cambios en planes de precios, nombres de planes, ofertas de prueba y CTAs' da resultados más precisos que un escaneo general.",
+          "Estructura tu registro en Notion con propiedades como Competidor, Tipo de Cambio y Fecha para que puedas filtrar por qué cambió y cuándo a lo largo de todo el historial."
+        ]
       }
     }
   },

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -1726,6 +1726,88 @@
           "まずGitHubとSlackだけで始めましょう。ブリーフが安定して動作するようになったら、SentryとPlausibleを1つずつ追加して、拡張前に各コネクタを検証しましょう。",
           "ノイズを減らすために、プロンプトにカスタム閾値の指示を追加しましょう。例えば、移動平均の2倍を超える指標のみフラグ付けすることで、日常的な小さな変動によるアラートを防げます。"
         ]
+      },
+      "competitor-pricing-monitor": {
+        "title": "競合の料金ページを監視し、変更を毎週フラグ付け",
+        "description": "@Zeroに競合の料金ページURLリストを渡します。毎週月曜日に各ページをスクレイピングし、先週のNotionスナップショットと差分を比較し、検出された各変更のインパクトサマリーを作成し、完全なレポートをNotionに保存し、ダイジェストをSlackに投稿します。",
+        "timeSaved": "週あたり約2時間の時間削減",
+        "headings": {
+          "scenario": "料金変更がチームの不意を突く理由",
+          "prompt": "@Zeroで週次の競合料金モニタリングを設定する方法",
+          "steps": "@Zeroがスクレイピング、差分比較、レポート作成を行う仕組み",
+          "nextActions": "特定の変更を深掘り、監視リストを調整、またはリーダーシップと共有",
+          "integrations": "必須連携: NotionとSlack",
+          "tips": "自動化された料金インテリジェンスのベストプラクティス"
+        },
+        "scenario": "競合がひっそりと無料プランを廃止します。別の競合が新しいエンタープライズプランを追加します。3週間後、すでにその競合を選んだ見込み客から知ることになります。@Zeroは毎週月曜日に競合の料金ページをチェックし、先週からの変更を比較し、検出された各変更の明確なインパクトサマリーを作成し、チームの週が始まる前にSlackにダイジェストを投稿します。",
+        "promptVariants": [
+          {
+            "label": "週次モニタリングを設定",
+            "prompt": "@Zero every Monday at 9am, scrape the pricing pages of e2b.dev, daytona.io, cursor.com, and replit.com. Compare against last week's Notion snapshot. Flag any changes to tiers, prices, or CTAs, write a 2–3 sentence impact summary for each, save the full report to Notion under Competitor Pricing Log, and post a digest to #competitive."
+          },
+          {
+            "label": "単発チェックを実行",
+            "prompt": "@Zero scrape the pricing pages of e2b.dev and daytona.io right now. Compare against the last saved Notion snapshot and tell me what changed."
+          },
+          {
+            "label": "特定の競合を深掘り",
+            "prompt": "@Zero pull the full pricing history for cursor.com from the Competitor Pricing Log in Notion. Summarize how their tiers and CTAs have evolved over time."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero every Monday at 9am, scrape competitor pricing pages and compare against last week's Notion snapshot. Post a digest to #competitive."
+          },
+          {
+            "name": "Zero",
+            "text": "Competitor Pricing Digest — Apr 14\n\nCursor: Added new Ultra tier at $200/month. Signals growing confidence in a high-willingness-to-pay power-user segment.\nDaytona: Increased startup credit offer from $25K to $50K. Signals aggressive developer acquisition push.\n\nNo changes detected: E2B, Replit\n\nFull report saved to Notion."
+          }
+        ],
+        "steps": [
+          {
+            "title": "@Zeroが各料金ページをスクレイピング",
+            "description": "@Zeroは指定された各料金URLの現在のコンテンツを取得し、プラン名、価格、機能リスト、トライアルオファー、CTAを抽出します。"
+          },
+          {
+            "title": "@Zeroが先週のNotionスナップショットと差分比較",
+            "description": "@Zeroは今日のコンテンツを先週Notionに保存されたバージョンと比較します。料金プラン、プラン名、含まれる機能、トライアル条件、CTAの変更をフラグ付けします。"
+          },
+          {
+            "title": "インパクトサマリーを保存しダイジェストを投稿",
+            "description": "検出された各変更について、@Zeroは何が変わったか、何を示唆しているか、何を検討すべきかを網羅する2〜3文のインパクトサマリーを作成します。完全なレポートはNotionに保存され、簡潔なダイジェストがSlackに投稿されます。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "特定の変更を深掘りする",
+            "description": "競合の動きについてより詳しいコンテキストを取得",
+            "examplePrompt": "@Zero pull up everything we have on Cursor's pricing history in Notion. Summarize how they've repositioned their tiers since Q1."
+          },
+          {
+            "title": "監視リストに新しい競合を追加する",
+            "description": "監視対象のページを拡張",
+            "examplePrompt": "@Zero add replit.com/pricing to the weekly pricing monitor and run an initial scrape now to set the baseline."
+          },
+          {
+            "title": "リーダーシップにロールアップを共有する",
+            "description": "四半期の料金変更サマリーを送信",
+            "examplePrompt": "@Zero summarize all competitor pricing changes logged in Notion this quarter and post a report to #leadership."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "@Zeroは週次の料金スナップショットと変更レポートをNotionワークスペースに保存し、長期的な追跡と差分比較に活用します。"
+          },
+          {
+            "description": "@Zeroは指定したSlackチャンネルに簡潔な週次ダイジェストを投稿します。"
+          }
+        ],
+        "tips": [
+          "まず初回スクレイピングを実行してNotionにベースラインスナップショットを設定しましょう。これがないと@Zeroは差分比較対象がなく、すべてを変更として扱います。",
+          "何をフラグ付けするか具体的に指定しましょう。「料金プラン、プラン名、トライアルオファー、CTAの変更を監視」は、一般的なスキャンよりも精度の高い結果を得られます。",
+          "Notionログに競合名、変更タイプ、日付などのプロパティを設定して、履歴全体で何がいつ変わったかをフィルタリングできるようにしましょう。"
+        ]
       }
     }
   },


### PR DESCRIPTION
## Summary

- Adds a new `competitor-pricing-monitor` use case to the use cases gallery
- Scheduled capability (runs weekly), targeting `product` and `ops` roles
- Connectors: Notion (required) and Slack (optional)
- Distinct from the existing `competitor-audit` use case, which monitors X/social; this one is focused specifically on scraping and diffing **pricing pages**

## Changes

- `turbo/apps/web/app/[locale]/use-cases/data.ts` — new `UseCase` entry with slug `competitor-pricing-monitor`
- `turbo/apps/web/messages/en.json` — full English content: title, description, scenario, 3 prompt variants, 3 steps, 3 next actions, 2 integration descriptions, 3 tips, 2 Slack preview messages

## Test plan

- [ ] Use case appears in the gallery at `/use-cases`
- [ ] Detail page renders at `/use-cases/competitor-pricing-monitor`
- [ ] All connector IDs (`notion`, `slack`) pass the existing `use-cases-data.test.ts` validation
- [ ] Step/tip/integration counts in `data.ts` match the content arrays in `en.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)