### PR TITLE
fix(security): strengthen Slack download URL validation against SSRF

### DIFF
--- a/turbo/apps/web/src/lib/zero/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/zero/slack/__tests__/context.test.ts
@@ -1331,6 +1331,65 @@ describe("Feature: Format Current Message Files", () => {
       expect(result).toContain("URL: https://slack.com/files/bad.png");
       expect(result).not.toContain("Download: curl");
     });
+
+    it("should reject arbitrary subdomain of slack.com (regression: old endsWith check)", async () => {
+      const files = [
+        {
+          id: "F105",
+          name: "file.png",
+          mimetype: "image/png",
+          url_private_download: "https://arbitrary.slack.com/file.png",
+          permalink: "https://slack.com/files/file.png",
+        },
+      ];
+
+      const result = await formatCurrentMessageFiles(
+        files,
+        "xoxb-test-token",
+        "test-session-ssrf",
+      );
+
+      expect(context.mocks.s3.uploadS3Buffer).not.toHaveBeenCalled();
+      expect(result).toContain("URL: https://slack.com/files/file.png");
+      expect(result).not.toContain("Download: curl");
+    });
+
+    it("should accept cdn.slack.com download URL", async () => {
+      const pngMagic = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      const imageBuffer = Buffer.concat([
+        pngMagic,
+        Buffer.from("fake-content"),
+      ]);
+
+      const downloadHandler = http.get(
+        "https://cdn.slack.com/files/image.png",
+        () => {
+          return new HttpResponse(imageBuffer, {
+            headers: { "content-type": "image/png" },
+          });
+        },
+      );
+      server.use(downloadHandler.handler);
+
+      const files = [
+        {
+          id: "F106",
+          name: "image.png",
+          mimetype: "image/png",
+          url_private_download: "https://cdn.slack.com/files/image.png",
+          permalink: "https://slack.com/files/image.png",
+        },
+      ];
+
+      const result = await formatCurrentMessageFiles(
+        files,
+        "xoxb-test-token",
+        "test-session-ssrf",
+      );
+
+      expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalled();
+      expect(result).toContain("Download: curl");
+    });
   });
 });
 

--- a/turbo/apps/web/src/lib/zero/slack/context.ts
+++ b/turbo/apps/web/src/lib/zero/slack/context.ts
@@ -7,13 +7,25 @@ import { type SlackUserInfo, formatSenderBlock } from "./client";
 const log = logger("slack:context");
 
 /**
+ * Trusted Slack file download hostnames.
+ * Using an explicit allowlist rather than endsWith(".slack.com") to prevent
+ * SSRF via unintended subdomains.
+ */
+const ALLOWED_SLACK_DOWNLOAD_HOSTNAMES = new Set([
+  "files.slack.com",
+  "files-pri.slack.com",
+  "cdn.slack.com",
+]);
+
+/**
  * Validate that a Slack file download URL is from a trusted Slack domain.
  */
 function isValidSlackDownloadUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     return (
-      parsed.protocol === "https:" && parsed.hostname.endsWith(".slack.com")
+      parsed.protocol === "https:" &&
+      ALLOWED_SLACK_DOWNLOAD_HOSTNAMES.has(parsed.hostname)
     );
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- Replaces `hostname.endsWith('.slack.com')` with an explicit allowlist of trusted Slack file download hostnames
- Addresses CodeQL alert #177 (js/request-forgery, critical severity)

## Root cause
The previous validation accepted any subdomain of `slack.com`. While Slack controls the `slack.com` namespace, an explicit allowlist is more defensible and eliminates the static analysis warning.

## Change
In `isValidSlackDownloadUrl()` — replaced the broad `endsWith` check with a `Set` of known trusted Slack file hostnames:
- `files.slack.com`
- `files-pri.slack.com`  
- `cdn.slack.com`

## Test plan
- [ ] Verify Slack file downloads still work in staging
- [ ] Confirm CodeQL alert #177 resolves after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)