### PR TITLE
feat(web): add use case batch 2026-04-15

### DIFF
--- a/turbo/apps/web/app/[locale]/use-cases/data.ts
+++ b/turbo/apps/web/app/[locale]/use-cases/data.ts
@@ -115,6 +115,24 @@ const VM0: ConnectorRef = {
   icon: "/assets/connectors/vm0.svg",
 };
 
+const INTERCOM: ConnectorRef = {
+  id: "intercom",
+  label: "Intercom",
+  icon: "/assets/connectors/intercom.svg",
+};
+
+const GOOGLE_SHEETS: ConnectorRef = {
+  id: "google-sheets",
+  label: "Google Sheets",
+  icon: "/assets/connectors/google-sheets.svg",
+};
+
+const FIRECRAWL: ConnectorRef = {
+  id: "firecrawl",
+  label: "Firecrawl",
+  icon: "/assets/connectors/firecrawl.svg",
+};
+
 // ---------------------------------------------------------------------------
 // Full use cases
 // ---------------------------------------------------------------------------
@@ -515,6 +533,134 @@ export const USE_CASES: UseCase[] = [
     stepCount: 3,
     nextActionCount: 3,
     integrationCount: 3,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
+  },
+
+  {
+    slug: "i18n-gap-fixer",
+    color: "#7a9eb5",
+    avatar: {
+      rotation: 3,
+      skin: 2,
+      hairStyle: 4,
+      hairColor: 2,
+      expression: 3,
+      intensity: "m",
+    },
+    roles: ["engineering"],
+    capability: "multi-tool",
+    model: "Claude 4 Sonnet",
+    connectors: [GITHUB, NOTION, SLACK],
+    integrations: [
+      { connector: GITHUB, required: true },
+      { connector: NOTION, required: false },
+    ],
+    relatedSlugs: [
+      "tech-debt-scan",
+      "file-bugs-from-slack",
+      "product-health-briefing",
+    ],
+    stepCount: 3,
+    nextActionCount: 2,
+    integrationCount: 2,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
+  },
+
+  {
+    slug: "competitor-price-monitor",
+    color: "#b58a7a",
+    avatar: {
+      rotation: 1,
+      skin: 5,
+      hairStyle: 2,
+      hairColor: 4,
+      expression: 4,
+      intensity: "h",
+    },
+    roles: ["product"],
+    capability: "scheduled",
+    model: "Claude 4 Sonnet",
+    connectors: [FIRECRAWL, NOTION, SLACK],
+    integrations: [
+      { connector: FIRECRAWL, required: true },
+      { connector: NOTION, required: true },
+    ],
+    relatedSlugs: [
+      "competitor-audit",
+      "kol-cold-outreach",
+      "document-decisions",
+    ],
+    stepCount: 3,
+    nextActionCount: 2,
+    integrationCount: 2,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
+  },
+
+  {
+    slug: "contract-renewal-alert",
+    color: "#8ab57a",
+    avatar: {
+      rotation: 5,
+      skin: 3,
+      hairStyle: 1,
+      hairColor: 5,
+      expression: 2,
+      intensity: "l",
+    },
+    roles: ["ops"],
+    capability: "scheduled",
+    model: "GPT-4o mini",
+    connectors: [GOOGLE_SHEETS, GMAIL, SLACK],
+    integrations: [
+      { connector: GOOGLE_SHEETS, required: true },
+      { connector: GMAIL, required: true },
+    ],
+    relatedSlugs: [
+      "employee-onboarding",
+      "standup-summary",
+      "document-decisions",
+    ],
+    stepCount: 3,
+    nextActionCount: 2,
+    integrationCount: 2,
+    tipCount: 3,
+    promptVariantCount: 3,
+    slackPreviewCount: 2,
+  },
+
+  {
+    slug: "support-to-github",
+    color: "#b5a07a",
+    avatar: {
+      rotation: 4,
+      skin: 4,
+      hairStyle: 3,
+      hairColor: 1,
+      expression: 5,
+      intensity: "m",
+    },
+    roles: ["everyone"],
+    capability: "instant",
+    model: "Claude 4 Sonnet",
+    connectors: [INTERCOM, GITHUB, SLACK],
+    integrations: [
+      { connector: INTERCOM, required: true },
+      { connector: GITHUB, required: true },
+    ],
+    relatedSlugs: [
+      "file-bugs-from-slack",
+      "sentry-triage",
+      "slack-triage",
+    ],
+    stepCount: 3,
+    nextActionCount: 3,
+    integrationCount: 2,
     tipCount: 3,
     promptVariantCount: 3,
     slackPreviewCount: 2,

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -874,6 +874,319 @@
           "Referenzieren Sie bestehende UI-Muster beim Namen – ‚wie die VS Code Befehlspalette‘ oder ‚wie Notions Slash-Menü‘ – um v0s Generierung zu verankern.",
           "Nutzen Sie den Iterieren-Prompt direkt nach dem ersten Ergebnis. Eine Runde Verfeinerung bringt Sie meistens 90 % ans Ziel."
         ]
+      },
+      "i18n-gap-fixer": {
+        "title": "Fehlende i18n-Strings in deiner Codebasis automatisch erkennen und beheben",
+        "description": "Lass Zero dein Repository nach nicht übersetzten String-Keys durchsuchen, diese mit deinen Locale-Dateien abgleichen, die fehlenden Übersetzungen schreiben und einen PR öffnen — alles in einem Befehl.",
+        "timeSaved": "~45 Min. gespart pro Release-Zyklus",
+        "headings": {
+          "scenario": "Warum i18n-Lücken erst bei der QA auffallen",
+          "prompt": "So beauftragst du Zero, fehlende Übersetzungen zu prüfen und zu ergänzen",
+          "steps": "So scannt, vergleicht und ergänzt Zero fehlende Locale-Strings",
+          "nextActions": "PR überprüfen, auf neue Sprachen erweitern oder regelmäßige Audits einplanen",
+          "integrations": "Erforderliche Integrationen: GitHub. Optional: Notion, Slack",
+          "tips": "Best Practices für die automatisierte i18n-Pflege"
+        },
+        "scenario": "Ein Entwickler fügt ein neues Feature hinzu und schreibt drei Strings direkt in den Code. Er vergisst, die Keys zu den Locale-Dateien hinzuzufügen. Die QA entdeckt es zwei Tage später, als die Staging-Seite auf Spanisch rohe Key-Namen anzeigt. Zero kann das erkennen, bevor es die QA erreicht. Richte es auf das Repository, gib an, welche Locales geprüft werden sollen, und du erhältst einen Diff aller fehlenden Keys mit vorgeschlagenen Übersetzungen, die sofort gemergt werden können.",
+        "promptVariants": [
+          {
+            "label": "Vollständiger Audit",
+            "prompt": "@Zero scan the vm0-ai/vm0 repo for any translation keys in en.json that are missing from de.json, es.json, and ja.json. Write translations for each missing key, open a PR with the changes, and post the PR link to #engineering."
+          },
+          {
+            "label": "Einzelne Sprache",
+            "prompt": "@Zero check which keys are in en.json but missing from ja.json in turbo/apps/web/messages. Write Japanese translations for the missing keys and open a draft PR."
+          },
+          {
+            "label": "Pre-Release-Prüfung",
+            "prompt": "@Zero before we cut the release branch, audit all locale files in turbo/apps/web/messages for missing keys vs en.json and list any gaps in a Notion page under 'Release Checklist'."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero scan the repo for i18n gaps vs en.json in de, es, and ja. Write translations and open a PR."
+          },
+          {
+            "name": "Zero",
+            "text": "Found 6 missing keys across de.json, es.json, ja.json.\n\nMissing in all 3: useCases.content.daily-engineering-brief, useCases.content.competitor-pricing-monitor (4 more)\n\nWrote translations and opened PR #9430.\nhttps://github.com/vm0-ai/vm0/pull/9430"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero scannt die Locale-Dateien",
+            "description": "Zero liest die Quell-Locale-Datei (typischerweise en.json) und alle Ziel-Locale-Dateien. Es erstellt eine Key-Map für jede Datei und identifiziert jeden Key, der in der Quelle vorhanden, aber in einem oder mehreren Zielen fehlend ist."
+          },
+          {
+            "title": "Fehlende Übersetzungen geschrieben",
+            "description": "Für jeden fehlenden Key generiert Zero eine passende Übersetzung für die Zielsprache basierend auf dem englischen Wert. Es bewahrt die exakte JSON-Struktur, Array-Längen und verschachtelte Key-Hierarchie der englischen Datei."
+          },
+          {
+            "title": "PR mit den Änderungen geöffnet",
+            "description": "Zero committet die aktualisierten Locale-Dateien in einen neuen Branch, öffnet einen Pull Request gegen den Main-Branch und postet den PR-Link in Slack, falls konfiguriert. Die PR-Beschreibung listet jeden hinzugefügten Key pro Locale auf."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "PR überprüfen und mergen",
+            "description": "Prüfe die generierten Übersetzungen vor dem Mergen",
+            "examplePrompt": "@Zero show me the translations you wrote for the missing keys in ja.json — highlight any that might need a native speaker review."
+          },
+          {
+            "title": "Neue Sprache hinzufügen",
+            "description": "Abdeckung auf eine weitere Sprache erweitern",
+            "examplePrompt": "@Zero add a zh.json locale file to turbo/apps/web/messages, populate it with translations for all keys in en.json, and open a PR."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero liest Locale-Dateien, schreibt Übersetzungspatches und öffnet Pull Requests direkt gegen das Repository."
+          },
+          {
+            "description": "Zero protokolliert den Audit-Bericht auf einer Notion-Seite zur Nachverfolgung von Übersetzungslücken über die Zeit. Optional."
+          }
+        ],
+        "tips": [
+          "Führe den Audit gegen einen bestimmten Verzeichnispfad aus, um Fehlalarme durch Locale-Dateien außerhalb der Web-App zu vermeiden.",
+          "Bitte Zero, Keys zu markieren, bei denen der englische Wert Platzhalter enthält (wie {name} oder %s), damit diese Übersetzungen vor dem Mergen besonders geprüft werden.",
+          "Plane einen wöchentlichen i18n-Audit, um Locale-Dateien mit der schnellen Feature-Entwicklung synchron zu halten."
+        ]
+      },
+      "competitor-price-monitor": {
+        "title": "Preisänderungen der Konkurrenz verfolgen und wöchentliche Benachrichtigungen erhalten",
+        "description": "Gib Zero eine Liste von Preisseiten deiner Wettbewerber. Es scrapt sie nach Zeitplan, vergleicht jede mit dem Notion-Snapshot der Vorwoche, schreibt eine Auswirkungsanalyse für jede Änderung und postet jeden Montag eine Zusammenfassung in Slack, bevor deine Woche beginnt.",
+        "timeSaved": "~2 Std. gespart pro Woche",
+        "headings": {
+          "scenario": "Warum Preisinformationen zu spät eintreffen, um darauf zu reagieren",
+          "prompt": "So richtest du automatisiertes Wettbewerber-Preismonitoring mit Zero ein",
+          "steps": "So scrapt, vergleicht und meldet Zero wöchentliche Preisänderungen",
+          "nextActions": "Eine Änderung im Detail analysieren, die Watchlist aktualisieren oder die Zusammenfassung teilen",
+          "integrations": "Erforderliche Integrationen: Firecrawl und Notion. Optional: Slack",
+          "tips": "Best Practices für automatisierte Wettbewerbspreis-Analyse"
+        },
+        "scenario": "Du erfährst, dass ein Wettbewerber seinen Einstiegspreis gesenkt hat, weil ein Interessent es in einem Gespräch erwähnt. Du prüfst deren Preisseite und stellst fest, dass sich die Änderung vor drei Wochen ereignet hat. Diese Verzögerung kostet Deals. Zero scrapt deine Wettbewerberliste jeden Montag, vergleicht jede Seite mit dem Notion-Snapshot der Vorwoche, schreibt eine verständliche Auswirkungsnotiz für jede gefundene Änderung und postet eine Zusammenfassung in Slack, bevor jemand seinen Posteingang öffnet.",
+        "promptVariants": [
+          {
+            "label": "Wöchentliches Monitoring",
+            "prompt": "@Zero every Monday at 8am, scrape the pricing pages for e2b.dev, daytona.io, cursor.com, and replit.com using Firecrawl. Compare against last week's Notion snapshot, flag any changes to tiers, prices, or CTAs, write a 2-sentence impact note for each change, save the full report to Notion under 'Competitor Pricing Log', and post a digest to #competitive."
+          },
+          {
+            "label": "Sofort-Prüfung",
+            "prompt": "@Zero scrape cursor.com/pricing right now using Firecrawl, compare it to the last snapshot in Notion, and tell me what changed."
+          },
+          {
+            "label": "Historische Zusammenfassung",
+            "prompt": "@Zero pull all entries from the Competitor Pricing Log in Notion for the past 90 days and summarize how each competitor's pricing has shifted."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero run the weekly pricing monitor and post the digest to #competitive."
+          },
+          {
+            "name": "Zero",
+            "text": "Competitor Pricing Digest — Apr 14\n\nCursor: Added Ultra tier at $200/mo — targets high-willingness-to-pay power users.\nDaytona: Raised startup credit from $25K to $50K — land-and-expand before monetization.\n\nNo changes: E2B, Replit\n\nFull report saved to Notion."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero scrapt jede Preisseite über Firecrawl",
+            "description": "Zero nutzt Firecrawl, um den gerenderten Inhalt jeder Preis-URL auf der Watchlist abzurufen und extrahiert Tarifnamen, Preise, Feature-Highlights, Testbedingungen und CTAs."
+          },
+          {
+            "title": "Inhalte mit dem Notion-Snapshot abgeglichen",
+            "description": "Zero vergleicht den gescrapten Inhalt dieser Woche mit der in Notion gespeicherten Version der Vorwoche. Es markiert jede Änderung an Tarifnamen, Preisstufen, enthaltenen Features, Testzeiträumen oder Handlungsaufforderungen."
+          },
+          {
+            "title": "Bericht gespeichert und Zusammenfassung gepostet",
+            "description": "Für jede gefundene Änderung schreibt Zero eine 2-Satz-Auswirkungsnotiz, die beschreibt, was sich geändert hat und was es signalisiert. Der vollständige Bericht wird im Notion-Log gespeichert und eine kompakte Zusammenfassung wird im von dir angegebenen Slack-Kanal gepostet."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Einen Wettbewerber im Detail analysieren",
+            "description": "Die vollständige Preishistorie eines einzelnen Wettbewerbers abrufen",
+            "examplePrompt": "@Zero pull everything from the Competitor Pricing Log in Notion for Cursor and summarize how their pricing has evolved since Q1."
+          },
+          {
+            "title": "Zur Watchlist hinzufügen",
+            "description": "Einen neuen Wettbewerber in den wöchentlichen Scrape aufnehmen",
+            "examplePrompt": "@Zero add replit.com/pricing to the weekly pricing monitor and run an initial scrape now to set the Notion baseline."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero nutzt Firecrawl, um strukturierte Inhalte von Wettbewerber-Preisseiten zu rendern und zu extrahieren und dabei JavaScript-lastige Seiten zu erfassen, die Standard-Scraper nicht verarbeiten können."
+          },
+          {
+            "description": "Zero speichert wöchentliche Preis-Snapshots und Änderungsberichte in Notion für langfristige Nachverfolgung und Woche-zu-Woche-Vergleiche."
+          }
+        ],
+        "tips": [
+          "Führe zuerst einen initialen Scrape durch, bevor du den Zeitplan einrichtest. Zero braucht einen Basis-Snapshot in Notion zum Vergleichen — ohne ihn sieht jedes Feld wie eine Änderung aus.",
+          "Sei präzise, was markiert werden soll. Die Angabe von 'Tarifnamen, Preise, Testbedingungen und CTAs' hält den Diff fokussiert und reduziert Rauschen durch kleinere Textänderungen.",
+          "Füge einen Slack-Kanal zum Prompt hinzu, damit die Zusammenfassung dort landet, wo dein Team bereits jeden Montag nachschaut."
+        ]
+      },
+      "contract-renewal-alert": {
+        "title": "Benachrichtigungen erhalten, bevor Lieferantenverträge auslaufen — keine unerwarteten Verlängerungen mehr",
+        "description": "Richte Zero auf deine Vertragstabelle in Google Sheets. Es prüft nach Zeitplan anstehende Verlängerungen, berechnet die verbleibenden Tage für jeden Vertrag und sendet eine formatierte Benachrichtigung an Slack — sowie einen E-Mail-Entwurf an Gmail — für jeden Vertrag, der innerhalb deines festgelegten Zeitfensters ausläuft.",
+        "timeSaved": "~1 Std. gespart pro Verlängerungszyklus",
+        "headings": {
+          "scenario": "Warum Verträge sich verlängern, bevor jemand sie prüft",
+          "prompt": "So richtest du automatisierte Vertragsverlängerungswarnungen mit Zero ein",
+          "steps": "So liest Zero deine Verträge, berechnet Fristen und sendet Benachrichtigungen",
+          "nextActions": "Verlängerungs-E-Mail entwerfen, Tabelle aktualisieren oder an die Rechtsabteilung eskalieren",
+          "integrations": "Erforderliche Integrationen: Google Sheets und Gmail. Optional: Slack",
+          "tips": "Best Practices für automatisierte Vertragsverlängerungsverfolgung"
+        },
+        "scenario": "Ein 40.000-$-Jahresvertrag hat sich letzten Dienstag automatisch verlängert. Niemand hat es gemeldet, weil das Verlängerungsdatum in Zeile 73 einer Tabelle vergraben war, die niemand geöffnet hat. Zero liest deine Vertragstabelle jede Woche, berechnet, welche Verlängerungen in den nächsten 30 Tagen anstehen, und sendet eine Slack-Benachrichtigung mit Anbietername, Vertragswert und Frist — plus einen Entwurf für eine Verlängerungs- oder Kündigungs-E-Mail in deinen Gmail-Entwürfen, versandbereit.",
+        "promptVariants": [
+          {
+            "label": "Wöchentliche Verlängerungsprüfung",
+            "prompt": "@Zero every Monday at 9am, read the 'Vendor Contracts' sheet in Google Sheets, find any contracts expiring in the next 30 days, post a Slack alert with vendor name, contract value, and expiry date, and create a draft email in Gmail for each one asking to schedule a review call."
+          },
+          {
+            "label": "Sofort-Audit",
+            "prompt": "@Zero check the 'Vendor Contracts' sheet right now and list everything expiring in the next 60 days, sorted by days remaining."
+          },
+          {
+            "label": "Benutzerdefiniertes Zeitfenster",
+            "prompt": "@Zero read the Vendor Contracts sheet and alert me to anything expiring in the next 14 days. For each, draft a cancellation notice email in Gmail."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Zero",
+            "text": "Contract Renewal Alerts — Apr 14\n\n⚠️ Expiring in 14 days:\n• Firecrawl API — $12K/yr — expires Apr 28\n• Figma Team — $4.8K/yr — expires Apr 30\n\n📅 Expiring in 15–30 days:\n• Notion Business — $3.2K/yr — expires May 10\n\nDraft renewal emails created in Gmail for all 3."
+          },
+          {
+            "name": "Alex",
+            "text": "@Zero check Vendor Contracts for anything expiring in the next 30 days and draft renewal emails in Gmail."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero liest die Vertragstabelle",
+            "description": "Zero liest den angegebenen Google Sheets-Tab und extrahiert Anbietername, Vertragswert, Verlängerungsdatum und etwaige Notizspalten. Es parst Datumsfelder und berechnet die verbleibenden Tage bis zum Ablauf für jede Zeile."
+          },
+          {
+            "title": "Anstehende Verlängerungen identifiziert",
+            "description": "Zero filtert nach Verträgen, die innerhalb des von dir angegebenen Zeitfensters (z. B. 30 Tage) auslaufen. Es sortiert sie nach verbleibenden Tagen und gruppiert sie in dringend (unter 14 Tage) und anstehend (14–30 Tage)."
+          },
+          {
+            "title": "Benachrichtigungen gesendet und Entwürfe erstellt",
+            "description": "Zero postet eine strukturierte Slack-Nachricht mit jedem auslaufenden Vertrag samt Anbietername, Jahreswert und exaktem Ablaufdatum. Für jeden Vertrag erstellt es einen E-Mail-Entwurf in Gmail, adressiert an den Anbieterkontakt, sofern in der Tabelle vorhanden."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "E-Mail-Entwurf senden",
+            "description": "Den von Zero vorbereiteten Verlängerungs- oder Kündigungsentwurf prüfen und senden",
+            "examplePrompt": "@Zero show me the draft renewal email you created for the Firecrawl contract and update the tone to be more direct about our budget constraints."
+          },
+          {
+            "title": "Vertragstabelle aktualisieren",
+            "description": "Die Verlängerungsentscheidung zurück in Google Sheets dokumentieren",
+            "examplePrompt": "@Zero update the Vendor Contracts sheet to mark the Firecrawl contract as 'Under Review' and set the follow-up date to Apr 20."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero liest die Vertragstabelle, um Anbieternamen, Vertragswerte, Verlängerungsdaten und Kontaktinformationen zu extrahieren."
+          },
+          {
+            "description": "Zero erstellt E-Mail-Entwürfe für jeden auslaufenden Vertrag und legt sie in deinem Gmail-Entwurfsordner ab, bereit zum Überprüfen und Senden."
+          }
+        ],
+        "tips": [
+          "Verwende ein konsistentes Datumsformat in deiner Tabelle (z. B. JJJJ-MM-TT). Inkonsistente Formate führen dazu, dass Zero Verlängerungsdaten falsch parst.",
+          "Füge eine Spalte 'Kontakt-E-Mail' zur Tabelle hinzu, damit Zero jeden E-Mail-Entwurf automatisch an den richtigen Anbieterkontakt adressieren kann.",
+          "Setze das Benachrichtigungsfenster standardmäßig auf 30 Tage, führe aber zu Beginn jedes Quartals einen einmaligen 90-Tage-Audit durch, um mittelfristige Verlängerungen zu erfassen."
+        ]
+      },
+      "support-to-github": {
+        "title": "Support-Tickets an GitHub eskalieren, ohne Kontext zu verlieren",
+        "description": "Wenn ein Support-Ticket in Intercom einen reproduzierbaren Bug oder ein berechtigtes Feature-Request aufzeigt, beauftrage Zero, ein GitHub-Issue mit vollständigem Kontext zu erstellen — Gesprächszusammenfassung, Reproduktionsschritte, betroffene Nutzer und Schweregrad — und einen Link zurück in den Intercom-Thread zu posten.",
+        "timeSaved": "~15 Min. gespart pro Eskalation",
+        "headings": {
+          "scenario": "Warum bei Support-zu-Engineering-Übergaben Kontext verloren geht",
+          "prompt": "So beauftragst du Zero, ein Support-Ticket an GitHub zu eskalieren",
+          "steps": "So liest Zero das Ticket, erstellt das Issue und schließt den Kreis",
+          "nextActions": "An Engineering zuweisen, mit einem Meilenstein verknüpfen oder den Kunden benachrichtigen",
+          "integrations": "Erforderliche Integrationen: Intercom und GitHub. Optional: Slack",
+          "tips": "Best Practices für Support-zu-Engineering-Eskalationen"
+        },
+        "scenario": "Ein Nutzer meldet, dass der Slack-Connector Nachrichten über 4000 Zeichen verschluckt. Du bestätigst, dass es ein echter Bug ist. Jetzt musst du ein GitHub-Issue mit genug Kontext schreiben, damit Engineering es reproduzieren kann — Gesprächsverlauf, Nutzer-Plan, Reproduktionsschritte und Schweregrad. Dieses Zusammenschreiben dauert 15 Minuten und existiert nur in deinem Kopf. Zero liest den Intercom-Thread, extrahiert den relevanten Kontext, schreibt ein strukturiertes GitHub-Issue und postet den Link zurück in die Intercom-Konversation in unter einer Minute.",
+        "promptVariants": [
+          {
+            "label": "Als Bug eskalieren",
+            "prompt": "@Zero read Intercom conversation [ID] and create a GitHub issue in vm0-ai/vm0 labelled 'bug' with: a one-line title, reproduction steps, affected user info, and severity. Post the issue link back to the Intercom thread."
+          },
+          {
+            "label": "Als Feature-Request eskalieren",
+            "prompt": "@Zero read Intercom conversation [ID] and create a GitHub issue labelled 'enhancement' with the user's feature request, their use case, and a note on frequency. Post the issue link to the Intercom thread and tag @product."
+          },
+          {
+            "label": "Batch-Eskalation",
+            "prompt": "@Zero check all open Intercom conversations tagged 'bug-confirmed' and create a GitHub issue for each one. Post a summary list to #bug-report."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero read Intercom conversation 48291 and create a GitHub bug issue with reproduction steps. Post the link back to the thread."
+          },
+          {
+            "name": "Zero",
+            "text": "Created bug issue #9441 in vm0-ai/vm0.\n\nTitle: fix: Slack connector silently drops messages over 4000 chars\nSeverity: High — affects 12 users on Business plan\nReproduction: Send a message via @Zero with >4000 chars through a Slack connector. Message is truncated without error.\n\nPosted issue link to Intercom thread 48291."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero liest die Intercom-Konversation",
+            "description": "Zero ruft den vollständigen Konversations-Thread aus Intercom ab, einschließlich aller Kundennachrichten, Agentenantworten, Tags und interner Notizen. Es extrahiert den Nutzer-Plan, das gemeldete Verhalten und alle genannten Reproduktionsdetails."
+          },
+          {
+            "title": "GitHub-Issue mit strukturiertem Kontext geschrieben",
+            "description": "Zero schreibt ein GitHub-Issue nach dem Standard-Bug- oder Feature-Request-Template: einzeilige Überschrift, Beschreibung, Reproduktionsschritte (oder Anwendungsfall für Features), Anzahl betroffener Nutzer und Plan sowie ein Schweregrad- oder Prioritätslabel."
+          },
+          {
+            "title": "Link zurück in Intercom gepostet",
+            "description": "Nach Erstellung des Issues postet Zero die GitHub-Issue-URL als Antwort in der ursprünglichen Intercom-Konversation, damit der Support-Agent sie referenzieren kann, und postet optional eine Zusammenfassung in einem Slack-Kanal."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "An Engineering zuweisen",
+            "description": "Das Issue an das richtige Teammitglied weiterleiten",
+            "examplePrompt": "@Zero assign GitHub issue #9441 to @e7h4n and add it to the current sprint milestone."
+          },
+          {
+            "title": "Den Kunden benachrichtigen",
+            "description": "Im Intercom-Thread antworten, sobald das Issue gesichtet wurde",
+            "examplePrompt": "@Zero reply to Intercom conversation 48291 to let the user know we've filed a bug report and they'll be notified when it's resolved."
+          },
+          {
+            "title": "Batch-Erstellung aus getaggten Tickets",
+            "description": "Eine Warteschlange bestätigter Bugs auf einmal abarbeiten",
+            "examplePrompt": "@Zero find all Intercom conversations tagged 'bug-confirmed' opened this week and create a GitHub issue for each one. Post a summary to #bug-report."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero liest den vollständigen Konversations-Thread, einschließlich Kundennachrichten, interner Notizen, Nutzer-Plan und Tags, um den Eskalationskontext zu extrahieren."
+          },
+          {
+            "description": "Zero erstellt das Issue, vergibt Labels und kann es direkt aus dem Eskalations-Prompt einem Bearbeiter zuweisen oder mit einem Meilenstein verknüpfen."
+          }
+        ],
+        "tips": [
+          "Gib die Intercom-Konversations-ID in deinem Prompt an, um präzise zu zielen — Zero findet sie in der Konversations-URL.",
+          "Bitte Zero, ein Schweregrad-Label basierend auf der Anzahl betroffener Nutzer oder dem Plan des Nutzers hinzuzufügen. Das spart den Triage-Schritt für Engineering.",
+          "Nutze die Batch-Eskalation am Ende jeder Support-Schicht, um eine Warteschlange bestätigter Bugs in einem Prompt abzuarbeiten, statt einzeln."
+        ]
       }
     }
   },

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -1375,6 +1375,319 @@
           "Use Sentry's project tags or environments to narrow Zero's query to production only, not staging.",
           "Chain this with the product health briefing: run triage at 8:45, include output in the 9:00 brief so the team sees everything in one place."
         ]
+      },
+      "i18n-gap-fixer": {
+        "title": "Auto-detect and fix missing i18n strings across your codebase",
+        "description": "Ask Zero to scan your repo for untranslated string keys, cross-reference them against your locale files, write the missing translations, and open a PR — all in one command.",
+        "timeSaved": "~45 min saved per release cycle",
+        "headings": {
+          "scenario": "Why i18n gaps slip through until QA",
+          "prompt": "How to ask Zero to audit and patch missing translations",
+          "steps": "How Zero scans, matches, and writes missing locale strings",
+          "nextActions": "Review the PR, expand to new locales, or schedule recurring audits",
+          "integrations": "Required integrations: GitHub. Optional: Notion, Slack",
+          "tips": "Best practices for automated i18n maintenance"
+        },
+        "scenario": "A developer adds a new feature and hard-codes three strings. They forget to add the keys to the locale files. QA catches it two days later when the staging site shows raw key names in Spanish. Zero can catch this before it reaches QA. Point it at the repo, tell it which locales to check, and it returns a diff of every missing key with suggested translations ready to merge.",
+        "promptVariants": [
+          {
+            "label": "Full audit",
+            "prompt": "@Zero scan the vm0-ai/vm0 repo for any translation keys in en.json that are missing from de.json, es.json, and ja.json. Write translations for each missing key, open a PR with the changes, and post the PR link to #engineering."
+          },
+          {
+            "label": "Single locale",
+            "prompt": "@Zero check which keys are in en.json but missing from ja.json in turbo/apps/web/messages. Write Japanese translations for the missing keys and open a draft PR."
+          },
+          {
+            "label": "Pre-release check",
+            "prompt": "@Zero before we cut the release branch, audit all locale files in turbo/apps/web/messages for missing keys vs en.json and list any gaps in a Notion page under 'Release Checklist'."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero scan the repo for i18n gaps vs en.json in de, es, and ja. Write translations and open a PR."
+          },
+          {
+            "name": "Zero",
+            "text": "Found 6 missing keys across de.json, es.json, ja.json.\n\nMissing in all 3: useCases.content.daily-engineering-brief, useCases.content.competitor-pricing-monitor (4 more)\n\nWrote translations and opened PR #9430.\nhttps://github.com/vm0-ai/vm0/pull/9430"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero scans the locale files",
+            "description": "Zero reads the source locale file (typically en.json) and all target locale files. It builds a key map for each and identifies every key present in the source but absent in one or more targets."
+          },
+          {
+            "title": "Missing translations written",
+            "description": "For each missing key, Zero generates a translation appropriate for the target locale using the English value as source. It preserves the exact JSON structure, array lengths, and nested key hierarchy from the English file."
+          },
+          {
+            "title": "PR opened with the changes",
+            "description": "Zero commits the updated locale files to a new branch, opens a pull request against the main branch, and posts the PR link to Slack if configured. The PR description lists every key added per locale."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Review and merge the PR",
+            "description": "Check the generated translations before merging",
+            "examplePrompt": "@Zero show me the translations you wrote for the missing keys in ja.json — highlight any that might need a native speaker review."
+          },
+          {
+            "title": "Add a new locale",
+            "description": "Extend coverage to a new language",
+            "examplePrompt": "@Zero add a zh.json locale file to turbo/apps/web/messages, populate it with translations for all keys in en.json, and open a PR."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero reads locale files, writes translation patches, and opens pull requests directly against the repository."
+          },
+          {
+            "description": "Zero logs the audit report to a Notion page for tracking translation gaps over time. Optional."
+          }
+        ],
+        "tips": [
+          "Run the audit against a specific directory path to avoid false positives from locale files outside the web app.",
+          "Ask Zero to flag keys where the English value contains placeholders (like {name} or %s) so those translations get extra review before merging.",
+          "Schedule a weekly i18n audit to keep locale files in sync with fast-moving feature development."
+        ]
+      },
+      "competitor-price-monitor": {
+        "title": "Track competitor pricing changes and get weekly alerts",
+        "description": "Give Zero a list of competitor pricing pages. It scrapes them on a schedule, diffs each against the Notion snapshot from last week, writes an impact summary for every change, and posts a digest to Slack every Monday before your week begins.",
+        "timeSaved": "~2 hrs saved per week",
+        "headings": {
+          "scenario": "Why pricing intel arrives too late to act on",
+          "prompt": "How to set up automated competitor price tracking with Zero",
+          "steps": "How Zero scrapes, compares, and reports weekly pricing changes",
+          "nextActions": "Deep dive on a change, update the watchlist, or share the digest",
+          "integrations": "Required integrations: Firecrawl and Notion. Optional: Slack",
+          "tips": "Best practices for automated competitive pricing intelligence"
+        },
+        "scenario": "You find out a competitor dropped their entry price because a prospect mentioned it on a call. You check their pricing page and realise it changed three weeks ago. That kind of lag costs deals. Zero scrapes your competitor list every Monday, compares each page to the Notion snapshot from last week, writes a plain-language impact note for every change it finds, and posts a digest to Slack before anyone opens their inbox.",
+        "promptVariants": [
+          {
+            "label": "Weekly monitor",
+            "prompt": "@Zero every Monday at 8am, scrape the pricing pages for e2b.dev, daytona.io, cursor.com, and replit.com using Firecrawl. Compare against last week's Notion snapshot, flag any changes to tiers, prices, or CTAs, write a 2-sentence impact note for each change, save the full report to Notion under 'Competitor Pricing Log', and post a digest to #competitive."
+          },
+          {
+            "label": "On-demand check",
+            "prompt": "@Zero scrape cursor.com/pricing right now using Firecrawl, compare it to the last snapshot in Notion, and tell me what changed."
+          },
+          {
+            "label": "Historical summary",
+            "prompt": "@Zero pull all entries from the Competitor Pricing Log in Notion for the past 90 days and summarize how each competitor's pricing has shifted."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero run the weekly pricing monitor and post the digest to #competitive."
+          },
+          {
+            "name": "Zero",
+            "text": "Competitor Pricing Digest — Apr 14\n\nCursor: Added Ultra tier at $200/mo — targets high-willingness-to-pay power users.\nDaytona: Raised startup credit from $25K to $50K — land-and-expand before monetization.\n\nNo changes: E2B, Replit\n\nFull report saved to Notion."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero scrapes each pricing page via Firecrawl",
+            "description": "Zero uses Firecrawl to fetch the rendered content of every pricing URL on the watchlist, extracting tier names, prices, feature highlights, trial terms, and CTAs."
+          },
+          {
+            "title": "Content diffed against Notion snapshot",
+            "description": "Zero compares this week's scraped content against the version saved in Notion last week. It flags any change to plan names, pricing tiers, included features, trial periods, or calls to action."
+          },
+          {
+            "title": "Report saved and digest posted",
+            "description": "For each change found, Zero writes a 2-sentence impact note covering what changed and what it signals. The full report is saved to the Notion log and a concise digest is posted to the Slack channel you specified."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Deep dive on one competitor",
+            "description": "Get the full pricing history for a single competitor",
+            "examplePrompt": "@Zero pull everything from the Competitor Pricing Log in Notion for Cursor and summarize how their pricing has evolved since Q1."
+          },
+          {
+            "title": "Add to the watchlist",
+            "description": "Include a new competitor in the weekly scrape",
+            "examplePrompt": "@Zero add replit.com/pricing to the weekly pricing monitor and run an initial scrape now to set the Notion baseline."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero uses Firecrawl to render and extract structured content from competitor pricing pages, bypassing JavaScript-heavy pages that standard scrapers miss."
+          },
+          {
+            "description": "Zero saves weekly pricing snapshots and change reports to Notion for long-term tracking and week-over-week diffing."
+          }
+        ],
+        "tips": [
+          "Run an initial scrape first before scheduling. Zero needs a baseline snapshot in Notion to diff against — without it, every field looks like a change.",
+          "Be explicit about what to flag. Listing 'tier names, prices, trial terms, and CTAs' keeps the diff focused and reduces noise from minor copy edits.",
+          "Add a Slack channel to the prompt so the digest lands where your team already checks every Monday."
+        ]
+      },
+      "contract-renewal-alert": {
+        "title": "Get alerted before vendor contracts expire so nothing renews by surprise",
+        "description": "Point Zero at your contract spreadsheet in Google Sheets. It checks for upcoming renewals on a schedule, calculates days remaining for each contract, and sends a formatted alert to Slack — and a draft email to Gmail — for every contract expiring within your specified window.",
+        "timeSaved": "~1 hr saved per renewal cycle",
+        "headings": {
+          "scenario": "Why contracts renew before anyone reviews them",
+          "prompt": "How to set up automated contract renewal alerts with Zero",
+          "steps": "How Zero reads your contracts, calculates deadlines, and sends alerts",
+          "nextActions": "Draft the renewal email, update the sheet, or escalate to legal",
+          "integrations": "Required integrations: Google Sheets and Gmail. Optional: Slack",
+          "tips": "Best practices for automated contract renewal tracking"
+        },
+        "scenario": "A $40K annual contract auto-renewed last Tuesday. Nobody flagged it because the renewal date was buried in row 73 of a spreadsheet nobody opened. Zero reads your contracts sheet every week, calculates which renewals are coming up in the next 30 days, and sends a Slack alert with the vendor name, contract value, and deadline — plus a draft renewal or cancellation email to your Gmail drafts, ready to send.",
+        "promptVariants": [
+          {
+            "label": "Weekly renewal check",
+            "prompt": "@Zero every Monday at 9am, read the 'Vendor Contracts' sheet in Google Sheets, find any contracts expiring in the next 30 days, post a Slack alert with vendor name, contract value, and expiry date, and create a draft email in Gmail for each one asking to schedule a review call."
+          },
+          {
+            "label": "Immediate audit",
+            "prompt": "@Zero check the 'Vendor Contracts' sheet right now and list everything expiring in the next 60 days, sorted by days remaining."
+          },
+          {
+            "label": "Custom window",
+            "prompt": "@Zero read the Vendor Contracts sheet and alert me to anything expiring in the next 14 days. For each, draft a cancellation notice email in Gmail."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Zero",
+            "text": "Contract Renewal Alerts — Apr 14\n\n⚠️ Expiring in 14 days:\n• Firecrawl API — $12K/yr — expires Apr 28\n• Figma Team — $4.8K/yr — expires Apr 30\n\n📅 Expiring in 15–30 days:\n• Notion Business — $3.2K/yr — expires May 10\n\nDraft renewal emails created in Gmail for all 3."
+          },
+          {
+            "name": "Alex",
+            "text": "@Zero check Vendor Contracts for anything expiring in the next 30 days and draft renewal emails in Gmail."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero reads the contracts sheet",
+            "description": "Zero reads the specified Google Sheets tab, extracting vendor name, contract value, renewal date, and any notes column. It parses date fields and computes days until expiry for each row."
+          },
+          {
+            "title": "Upcoming renewals identified",
+            "description": "Zero filters for contracts expiring within the window you specified (e.g. 30 days). It sorts them by days remaining and groups them into urgent (under 14 days) and upcoming (14–30 days)."
+          },
+          {
+            "title": "Alerts sent and drafts created",
+            "description": "Zero posts a structured Slack message listing each expiring contract with vendor name, annual value, and exact expiry date. For each contract, it creates a draft email in Gmail addressed to the vendor contact if one is listed in the sheet."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Send the draft email",
+            "description": "Review and send the renewal or cancellation draft Zero prepared",
+            "examplePrompt": "@Zero show me the draft renewal email you created for the Firecrawl contract and update the tone to be more direct about our budget constraints."
+          },
+          {
+            "title": "Update the contract sheet",
+            "description": "Log the renewal decision back to Google Sheets",
+            "examplePrompt": "@Zero update the Vendor Contracts sheet to mark the Firecrawl contract as 'Under Review' and set the follow-up date to Apr 20."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero reads the contracts spreadsheet to extract vendor names, contract values, renewal dates, and contact information."
+          },
+          {
+            "description": "Zero creates draft emails for each expiring contract and places them in your Gmail drafts folder, ready to review and send."
+          }
+        ],
+        "tips": [
+          "Keep a consistent date format in your sheet (e.g. YYYY-MM-DD). Inconsistent formats cause Zero to misparse renewal dates.",
+          "Add a 'Contact Email' column to the sheet so Zero can address each draft email to the right vendor contact automatically.",
+          "Set the alert window to 30 days by default, but run a one-off 90-day audit at the start of each quarter to catch anything in the medium term."
+        ]
+      },
+      "support-to-github": {
+        "title": "Escalate support tickets to GitHub issues without losing context",
+        "description": "When a support ticket in Intercom reveals a reproducible bug or a legitimate feature request, ask Zero to create a GitHub issue with full context — conversation summary, steps to reproduce, affected users, and severity — and post a link back to the Intercom thread.",
+        "timeSaved": "~15 min saved per escalation",
+        "headings": {
+          "scenario": "Why support-to-engineering handoffs lose context",
+          "prompt": "How to ask Zero to escalate a support ticket to GitHub",
+          "steps": "How Zero reads the ticket, writes the issue, and closes the loop",
+          "nextActions": "Assign to engineering, link to a milestone, or notify the customer",
+          "integrations": "Required integrations: Intercom and GitHub. Optional: Slack",
+          "tips": "Best practices for support-to-engineering escalations"
+        },
+        "scenario": "A user reports that the Slack connector drops messages longer than 4000 characters. You confirm it is a real bug. Now you need to write a GitHub issue with enough context for engineering to reproduce it — conversation history, user plan, steps to reproduce, and severity. That write-up takes 15 minutes and lives in your head. Zero reads the Intercom thread, extracts the key context, writes a structured GitHub issue, and posts the link back to the Intercom conversation in under a minute.",
+        "promptVariants": [
+          {
+            "label": "Escalate to bug",
+            "prompt": "@Zero read Intercom conversation [ID] and create a GitHub issue in vm0-ai/vm0 labelled 'bug' with: a one-line title, reproduction steps, affected user info, and severity. Post the issue link back to the Intercom thread."
+          },
+          {
+            "label": "Escalate to feature request",
+            "prompt": "@Zero read Intercom conversation [ID] and create a GitHub issue labelled 'enhancement' with the user's feature request, their use case, and a note on frequency. Post the issue link to the Intercom thread and tag @product."
+          },
+          {
+            "label": "Batch escalation",
+            "prompt": "@Zero check all open Intercom conversations tagged 'bug-confirmed' and create a GitHub issue for each one. Post a summary list to #bug-report."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero read Intercom conversation 48291 and create a GitHub bug issue with reproduction steps. Post the link back to the thread."
+          },
+          {
+            "name": "Zero",
+            "text": "Created bug issue #9441 in vm0-ai/vm0.\n\nTitle: fix: Slack connector silently drops messages over 4000 chars\nSeverity: High — affects 12 users on Business plan\nReproduction: Send a message via @Zero with >4000 chars through a Slack connector. Message is truncated without error.\n\nPosted issue link to Intercom thread 48291."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero reads the Intercom conversation",
+            "description": "Zero fetches the full conversation thread from Intercom, including all customer messages, agent replies, tags, and any internal notes. It extracts user plan, reported behavior, and any reproduction details mentioned."
+          },
+          {
+            "title": "GitHub issue written with structured context",
+            "description": "Zero writes a GitHub issue following the standard bug or feature request template: one-line title, description, reproduction steps (or use case for features), affected user count and plan, and a severity or priority label."
+          },
+          {
+            "title": "Link posted back to Intercom",
+            "description": "After creating the issue, Zero posts the GitHub issue URL as a reply in the original Intercom conversation so the support agent can reference it, and optionally posts a summary to a Slack channel."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Assign to engineering",
+            "description": "Route the issue to the right team member",
+            "examplePrompt": "@Zero assign GitHub issue #9441 to @e7h4n and add it to the current sprint milestone."
+          },
+          {
+            "title": "Notify the customer",
+            "description": "Reply to the Intercom thread once the issue is triaged",
+            "examplePrompt": "@Zero reply to Intercom conversation 48291 to let the user know we've filed a bug report and they'll be notified when it's resolved."
+          },
+          {
+            "title": "Batch-create from tagged tickets",
+            "description": "Clear a queue of confirmed bugs at once",
+            "examplePrompt": "@Zero find all Intercom conversations tagged 'bug-confirmed' opened this week and create a GitHub issue for each one. Post a summary to #bug-report."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero reads the full conversation thread, including customer messages, internal notes, user plan, and tags to extract escalation context."
+          },
+          {
+            "description": "Zero creates the issue, applies labels, and can assign it or link it to a milestone directly from the escalation prompt."
+          }
+        ],
+        "tips": [
+          "Include the Intercom conversation ID in your prompt for precise targeting — Zero can find it in the conversation URL.",
+          "Ask Zero to add a severity label based on the number of affected users or the user's plan tier. This saves the triage step for engineering.",
+          "Use the batch escalation variant at the end of each support shift to clear a queue of confirmed bugs in one prompt rather than one at a time."
+        ]
       }
     }
   },

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -874,6 +874,319 @@
           "Referencia patrones de UI existentes por nombre — 'como la paleta de comandos de VS Code' o 'como el menú de barra de Notion' — para anclar la generación de v0.",
           "Usa el prompt de iterar inmediatamente después del primer resultado. Una ronda de refinamiento generalmente te lleva al 90% del resultado."
         ]
+      },
+      "i18n-gap-fixer": {
+        "title": "Detecta y corrige automáticamente cadenas i18n faltantes en tu código",
+        "description": "Pídele a Zero que escanee tu repositorio en busca de claves de traducción sin traducir, las cruce con tus archivos de idioma, escriba las traducciones faltantes y abra un PR — todo en un solo comando.",
+        "timeSaved": "~45 min ahorrados por ciclo de lanzamiento",
+        "headings": {
+          "scenario": "Por qué las brechas de i18n pasan desapercibidas hasta QA",
+          "prompt": "Cómo pedirle a Zero que audite y corrija traducciones faltantes",
+          "steps": "Cómo Zero escanea, compara y escribe cadenas de idioma faltantes",
+          "nextActions": "Revisar el PR, expandir a nuevos idiomas o programar auditorías recurrentes",
+          "integrations": "Integraciones requeridas: GitHub. Opcionales: Notion, Slack",
+          "tips": "Mejores prácticas para el mantenimiento automatizado de i18n"
+        },
+        "scenario": "Un desarrollador agrega una nueva funcionalidad y escribe tres cadenas directamente en el código. Olvida agregar las claves a los archivos de idioma. QA lo detecta dos días después cuando el sitio de staging muestra nombres de claves sin traducir en español. Zero puede detectar esto antes de que llegue a QA. Apúntalo al repositorio, dile qué idiomas verificar, y te devuelve un diff de cada clave faltante con traducciones sugeridas listas para fusionar.",
+        "promptVariants": [
+          {
+            "label": "Auditoría completa",
+            "prompt": "@Zero scan the vm0-ai/vm0 repo for any translation keys in en.json that are missing from de.json, es.json, and ja.json. Write translations for each missing key, open a PR with the changes, and post the PR link to #engineering."
+          },
+          {
+            "label": "Un solo idioma",
+            "prompt": "@Zero check which keys are in en.json but missing from ja.json in turbo/apps/web/messages. Write Japanese translations for the missing keys and open a draft PR."
+          },
+          {
+            "label": "Verificación pre-lanzamiento",
+            "prompt": "@Zero before we cut the release branch, audit all locale files in turbo/apps/web/messages for missing keys vs en.json and list any gaps in a Notion page under 'Release Checklist'."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero scan the repo for i18n gaps vs en.json in de, es, and ja. Write translations and open a PR."
+          },
+          {
+            "name": "Zero",
+            "text": "Found 6 missing keys across de.json, es.json, ja.json.\n\nMissing in all 3: useCases.content.daily-engineering-brief, useCases.content.competitor-pricing-monitor (4 more)\n\nWrote translations and opened PR #9430.\nhttps://github.com/vm0-ai/vm0/pull/9430"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero escanea los archivos de idioma",
+            "description": "Zero lee el archivo de idioma fuente (típicamente en.json) y todos los archivos de idioma objetivo. Construye un mapa de claves para cada uno e identifica cada clave presente en la fuente pero ausente en uno o más objetivos."
+          },
+          {
+            "title": "Traducciones faltantes escritas",
+            "description": "Para cada clave faltante, Zero genera una traducción apropiada para el idioma objetivo usando el valor en inglés como fuente. Preserva la estructura JSON exacta, las longitudes de arrays y la jerarquía de claves anidadas del archivo en inglés."
+          },
+          {
+            "title": "PR abierto con los cambios",
+            "description": "Zero hace commit de los archivos de idioma actualizados en una nueva rama, abre un pull request contra la rama principal y publica el enlace del PR en Slack si está configurado. La descripción del PR lista cada clave agregada por idioma."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Revisar y fusionar el PR",
+            "description": "Verifica las traducciones generadas antes de fusionar",
+            "examplePrompt": "@Zero show me the translations you wrote for the missing keys in ja.json — highlight any that might need a native speaker review."
+          },
+          {
+            "title": "Agregar un nuevo idioma",
+            "description": "Ampliar la cobertura a un nuevo idioma",
+            "examplePrompt": "@Zero add a zh.json locale file to turbo/apps/web/messages, populate it with translations for all keys in en.json, and open a PR."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero lee archivos de idioma, escribe parches de traducción y abre pull requests directamente contra el repositorio."
+          },
+          {
+            "description": "Zero registra el informe de auditoría en una página de Notion para rastrear brechas de traducción a lo largo del tiempo. Opcional."
+          }
+        ],
+        "tips": [
+          "Ejecuta la auditoría contra una ruta de directorio específica para evitar falsos positivos de archivos de idioma fuera de la aplicación web.",
+          "Pídele a Zero que marque claves donde el valor en inglés contiene marcadores de posición (como {name} o %s) para que esas traducciones reciban una revisión adicional antes de fusionar.",
+          "Programa una auditoría semanal de i18n para mantener los archivos de idioma sincronizados con el rápido desarrollo de funcionalidades."
+        ]
+      },
+      "competitor-price-monitor": {
+        "title": "Rastrea cambios de precios de la competencia y recibe alertas semanales",
+        "description": "Dale a Zero una lista de páginas de precios de tus competidores. Las extrae según un cronograma, compara cada una con la captura de Notion de la semana pasada, escribe un resumen de impacto para cada cambio y publica un resumen en Slack cada lunes antes de que empiece tu semana.",
+        "timeSaved": "~2 hrs ahorradas por semana",
+        "headings": {
+          "scenario": "Por qué la información de precios llega demasiado tarde para actuar",
+          "prompt": "Cómo configurar el seguimiento automatizado de precios de la competencia con Zero",
+          "steps": "Cómo Zero extrae, compara y reporta cambios de precios semanales",
+          "nextActions": "Profundizar en un cambio, actualizar la lista de seguimiento o compartir el resumen",
+          "integrations": "Integraciones requeridas: Firecrawl y Notion. Opcionales: Slack",
+          "tips": "Mejores prácticas para inteligencia automatizada de precios competitivos"
+        },
+        "scenario": "Te enteras de que un competidor bajó su precio de entrada porque un prospecto lo mencionó en una llamada. Revisas su página de precios y descubres que cambió hace tres semanas. Ese tipo de retraso cuesta negocios. Zero extrae tu lista de competidores cada lunes, compara cada página con la captura de Notion de la semana pasada, escribe una nota de impacto en lenguaje claro para cada cambio que encuentra y publica un resumen en Slack antes de que alguien abra su bandeja de entrada.",
+        "promptVariants": [
+          {
+            "label": "Monitoreo semanal",
+            "prompt": "@Zero every Monday at 8am, scrape the pricing pages for e2b.dev, daytona.io, cursor.com, and replit.com using Firecrawl. Compare against last week's Notion snapshot, flag any changes to tiers, prices, or CTAs, write a 2-sentence impact note for each change, save the full report to Notion under 'Competitor Pricing Log', and post a digest to #competitive."
+          },
+          {
+            "label": "Verificación inmediata",
+            "prompt": "@Zero scrape cursor.com/pricing right now using Firecrawl, compare it to the last snapshot in Notion, and tell me what changed."
+          },
+          {
+            "label": "Resumen histórico",
+            "prompt": "@Zero pull all entries from the Competitor Pricing Log in Notion for the past 90 days and summarize how each competitor's pricing has shifted."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero run the weekly pricing monitor and post the digest to #competitive."
+          },
+          {
+            "name": "Zero",
+            "text": "Competitor Pricing Digest — Apr 14\n\nCursor: Added Ultra tier at $200/mo — targets high-willingness-to-pay power users.\nDaytona: Raised startup credit from $25K to $50K — land-and-expand before monetization.\n\nNo changes: E2B, Replit\n\nFull report saved to Notion."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero extrae cada página de precios vía Firecrawl",
+            "description": "Zero usa Firecrawl para obtener el contenido renderizado de cada URL de precios en la lista de seguimiento, extrayendo nombres de planes, precios, características destacadas, términos de prueba y CTAs."
+          },
+          {
+            "title": "Contenido comparado con la captura de Notion",
+            "description": "Zero compara el contenido extraído esta semana con la versión guardada en Notion la semana pasada. Marca cualquier cambio en nombres de planes, niveles de precios, características incluidas, períodos de prueba o llamadas a la acción."
+          },
+          {
+            "title": "Informe guardado y resumen publicado",
+            "description": "Para cada cambio encontrado, Zero escribe una nota de impacto de 2 oraciones cubriendo qué cambió y qué señala. El informe completo se guarda en el registro de Notion y un resumen conciso se publica en el canal de Slack que especificaste."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Profundizar en un competidor",
+            "description": "Obtener el historial completo de precios de un solo competidor",
+            "examplePrompt": "@Zero pull everything from the Competitor Pricing Log in Notion for Cursor and summarize how their pricing has evolved since Q1."
+          },
+          {
+            "title": "Agregar a la lista de seguimiento",
+            "description": "Incluir un nuevo competidor en la extracción semanal",
+            "examplePrompt": "@Zero add replit.com/pricing to the weekly pricing monitor and run an initial scrape now to set the Notion baseline."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero usa Firecrawl para renderizar y extraer contenido estructurado de páginas de precios de la competencia, superando páginas con mucho JavaScript que los scrapers estándar no logran procesar."
+          },
+          {
+            "description": "Zero guarda capturas de precios semanales e informes de cambios en Notion para seguimiento a largo plazo y comparación semana a semana."
+          }
+        ],
+        "tips": [
+          "Ejecuta una extracción inicial antes de programar el cronograma. Zero necesita una captura base en Notion para comparar — sin ella, cada campo parece un cambio.",
+          "Sé explícito sobre qué marcar. Listar 'nombres de planes, precios, términos de prueba y CTAs' mantiene el diff enfocado y reduce el ruido de ediciones menores de texto.",
+          "Agrega un canal de Slack al prompt para que el resumen llegue donde tu equipo ya revisa cada lunes."
+        ]
+      },
+      "contract-renewal-alert": {
+        "title": "Recibe alertas antes de que expiren los contratos con proveedores para que nada se renueve por sorpresa",
+        "description": "Apunta a Zero a tu hoja de contratos en Google Sheets. Verifica renovaciones próximas según un cronograma, calcula los días restantes para cada contrato y envía una alerta formateada a Slack — y un borrador de correo a Gmail — para cada contrato que expire dentro de tu ventana especificada.",
+        "timeSaved": "~1 hr ahorrada por ciclo de renovación",
+        "headings": {
+          "scenario": "Por qué los contratos se renuevan antes de que alguien los revise",
+          "prompt": "Cómo configurar alertas automatizadas de renovación de contratos con Zero",
+          "steps": "Cómo Zero lee tus contratos, calcula plazos y envía alertas",
+          "nextActions": "Redactar el correo de renovación, actualizar la hoja o escalar a legal",
+          "integrations": "Integraciones requeridas: Google Sheets y Gmail. Opcionales: Slack",
+          "tips": "Mejores prácticas para el seguimiento automatizado de renovación de contratos"
+        },
+        "scenario": "Un contrato anual de $40K se renovó automáticamente el martes pasado. Nadie lo señaló porque la fecha de renovación estaba enterrada en la fila 73 de una hoja de cálculo que nadie abrió. Zero lee tu hoja de contratos cada semana, calcula qué renovaciones vienen en los próximos 30 días y envía una alerta en Slack con el nombre del proveedor, el valor del contrato y la fecha límite — más un borrador de correo de renovación o cancelación en tus borradores de Gmail, listo para enviar.",
+        "promptVariants": [
+          {
+            "label": "Verificación semanal de renovaciones",
+            "prompt": "@Zero every Monday at 9am, read the 'Vendor Contracts' sheet in Google Sheets, find any contracts expiring in the next 30 days, post a Slack alert with vendor name, contract value, and expiry date, and create a draft email in Gmail for each one asking to schedule a review call."
+          },
+          {
+            "label": "Auditoría inmediata",
+            "prompt": "@Zero check the 'Vendor Contracts' sheet right now and list everything expiring in the next 60 days, sorted by days remaining."
+          },
+          {
+            "label": "Ventana personalizada",
+            "prompt": "@Zero read the Vendor Contracts sheet and alert me to anything expiring in the next 14 days. For each, draft a cancellation notice email in Gmail."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Zero",
+            "text": "Contract Renewal Alerts — Apr 14\n\n⚠️ Expiring in 14 days:\n• Firecrawl API — $12K/yr — expires Apr 28\n• Figma Team — $4.8K/yr — expires Apr 30\n\n📅 Expiring in 15–30 days:\n• Notion Business — $3.2K/yr — expires May 10\n\nDraft renewal emails created in Gmail for all 3."
+          },
+          {
+            "name": "Alex",
+            "text": "@Zero check Vendor Contracts for anything expiring in the next 30 days and draft renewal emails in Gmail."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero lee la hoja de contratos",
+            "description": "Zero lee la pestaña especificada de Google Sheets, extrayendo nombre del proveedor, valor del contrato, fecha de renovación y cualquier columna de notas. Analiza los campos de fecha y calcula los días hasta el vencimiento para cada fila."
+          },
+          {
+            "title": "Renovaciones próximas identificadas",
+            "description": "Zero filtra los contratos que vencen dentro de la ventana que especificaste (por ejemplo, 30 días). Los ordena por días restantes y los agrupa en urgentes (menos de 14 días) y próximos (14–30 días)."
+          },
+          {
+            "title": "Alertas enviadas y borradores creados",
+            "description": "Zero publica un mensaje estructurado en Slack listando cada contrato por vencer con nombre del proveedor, valor anual y fecha exacta de vencimiento. Para cada contrato, crea un borrador de correo en Gmail dirigido al contacto del proveedor si hay uno registrado en la hoja."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Enviar el borrador de correo",
+            "description": "Revisar y enviar el borrador de renovación o cancelación que Zero preparó",
+            "examplePrompt": "@Zero show me the draft renewal email you created for the Firecrawl contract and update the tone to be more direct about our budget constraints."
+          },
+          {
+            "title": "Actualizar la hoja de contratos",
+            "description": "Registrar la decisión de renovación de vuelta en Google Sheets",
+            "examplePrompt": "@Zero update the Vendor Contracts sheet to mark the Firecrawl contract as 'Under Review' and set the follow-up date to Apr 20."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero lee la hoja de contratos para extraer nombres de proveedores, valores de contratos, fechas de renovación e información de contacto."
+          },
+          {
+            "description": "Zero crea borradores de correo para cada contrato por vencer y los coloca en tu carpeta de borradores de Gmail, listos para revisar y enviar."
+          }
+        ],
+        "tips": [
+          "Mantén un formato de fecha consistente en tu hoja (por ejemplo, AAAA-MM-DD). Los formatos inconsistentes causan que Zero analice mal las fechas de renovación.",
+          "Agrega una columna 'Correo de contacto' a la hoja para que Zero pueda dirigir cada borrador de correo al contacto correcto del proveedor automáticamente.",
+          "Configura la ventana de alerta en 30 días por defecto, pero ejecuta una auditoría única de 90 días al inicio de cada trimestre para captar cualquier cosa a mediano plazo."
+        ]
+      },
+      "support-to-github": {
+        "title": "Escala tickets de soporte a issues de GitHub sin perder contexto",
+        "description": "Cuando un ticket de soporte en Intercom revela un bug reproducible o una solicitud de funcionalidad legítima, pídele a Zero que cree un issue en GitHub con contexto completo — resumen de la conversación, pasos para reproducir, usuarios afectados y severidad — y publique un enlace de vuelta al hilo de Intercom.",
+        "timeSaved": "~15 min ahorrados por escalación",
+        "headings": {
+          "scenario": "Por qué las transferencias de soporte a ingeniería pierden contexto",
+          "prompt": "Cómo pedirle a Zero que escale un ticket de soporte a GitHub",
+          "steps": "Cómo Zero lee el ticket, escribe el issue y cierra el ciclo",
+          "nextActions": "Asignar a ingeniería, vincular a un hito o notificar al cliente",
+          "integrations": "Integraciones requeridas: Intercom y GitHub. Opcionales: Slack",
+          "tips": "Mejores prácticas para escalaciones de soporte a ingeniería"
+        },
+        "scenario": "Un usuario reporta que el conector de Slack descarta mensajes de más de 4000 caracteres. Confirmas que es un bug real. Ahora necesitas escribir un issue en GitHub con suficiente contexto para que ingeniería lo reproduzca — historial de conversación, plan del usuario, pasos para reproducir y severidad. Ese escrito toma 15 minutos y vive solo en tu cabeza. Zero lee el hilo de Intercom, extrae el contexto clave, escribe un issue estructurado en GitHub y publica el enlace de vuelta a la conversación de Intercom en menos de un minuto.",
+        "promptVariants": [
+          {
+            "label": "Escalar como bug",
+            "prompt": "@Zero read Intercom conversation [ID] and create a GitHub issue in vm0-ai/vm0 labelled 'bug' with: a one-line title, reproduction steps, affected user info, and severity. Post the issue link back to the Intercom thread."
+          },
+          {
+            "label": "Escalar como solicitud de funcionalidad",
+            "prompt": "@Zero read Intercom conversation [ID] and create a GitHub issue labelled 'enhancement' with the user's feature request, their use case, and a note on frequency. Post the issue link to the Intercom thread and tag @product."
+          },
+          {
+            "label": "Escalación por lotes",
+            "prompt": "@Zero check all open Intercom conversations tagged 'bug-confirmed' and create a GitHub issue for each one. Post a summary list to #bug-report."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero read Intercom conversation 48291 and create a GitHub bug issue with reproduction steps. Post the link back to the thread."
+          },
+          {
+            "name": "Zero",
+            "text": "Created bug issue #9441 in vm0-ai/vm0.\n\nTitle: fix: Slack connector silently drops messages over 4000 chars\nSeverity: High — affects 12 users on Business plan\nReproduction: Send a message via @Zero with >4000 chars through a Slack connector. Message is truncated without error.\n\nPosted issue link to Intercom thread 48291."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero lee la conversación de Intercom",
+            "description": "Zero obtiene el hilo completo de la conversación de Intercom, incluyendo todos los mensajes del cliente, respuestas del agente, etiquetas y notas internas. Extrae el plan del usuario, el comportamiento reportado y cualquier detalle de reproducción mencionado."
+          },
+          {
+            "title": "Issue de GitHub escrito con contexto estructurado",
+            "description": "Zero escribe un issue de GitHub siguiendo la plantilla estándar de bug o solicitud de funcionalidad: título de una línea, descripción, pasos de reproducción (o caso de uso para funcionalidades), cantidad de usuarios afectados y plan, y una etiqueta de severidad o prioridad."
+          },
+          {
+            "title": "Enlace publicado de vuelta en Intercom",
+            "description": "Después de crear el issue, Zero publica la URL del issue de GitHub como respuesta en la conversación original de Intercom para que el agente de soporte pueda referenciarlo, y opcionalmente publica un resumen en un canal de Slack."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Asignar a ingeniería",
+            "description": "Dirigir el issue al miembro del equipo correcto",
+            "examplePrompt": "@Zero assign GitHub issue #9441 to @e7h4n and add it to the current sprint milestone."
+          },
+          {
+            "title": "Notificar al cliente",
+            "description": "Responder al hilo de Intercom una vez que el issue fue clasificado",
+            "examplePrompt": "@Zero reply to Intercom conversation 48291 to let the user know we've filed a bug report and they'll be notified when it's resolved."
+          },
+          {
+            "title": "Creación por lotes desde tickets etiquetados",
+            "description": "Limpiar una cola de bugs confirmados de una vez",
+            "examplePrompt": "@Zero find all Intercom conversations tagged 'bug-confirmed' opened this week and create a GitHub issue for each one. Post a summary to #bug-report."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zero lee el hilo completo de la conversación, incluyendo mensajes del cliente, notas internas, plan del usuario y etiquetas para extraer el contexto de escalación."
+          },
+          {
+            "description": "Zero crea el issue, aplica etiquetas y puede asignarlo o vincularlo a un hito directamente desde el prompt de escalación."
+          }
+        ],
+        "tips": [
+          "Incluye el ID de conversación de Intercom en tu prompt para una segmentación precisa — Zero lo puede encontrar en la URL de la conversación.",
+          "Pídele a Zero que agregue una etiqueta de severidad basada en la cantidad de usuarios afectados o el plan del usuario. Esto ahorra el paso de clasificación para ingeniería.",
+          "Usa la variante de escalación por lotes al final de cada turno de soporte para limpiar una cola de bugs confirmados en un solo prompt en lugar de uno a la vez."
+        ]
       }
     }
   },

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -874,6 +874,319 @@
           "既存のUIパターンを名前で参照 — 「VS Codeのコマンドパレットのように」や「Notionのスラッシュメニューのように」 — v0の生成を導きます。",
           "最初の結果の直後にイテレーションプロンプトを使いましょう。1回の改良で通常90%の完成度に達します。"
         ]
+      },
+      "i18n-gap-fixer": {
+        "title": "コードベース全体で不足しているi18n文字列を自動検出・修正",
+        "description": "Zeroにリポジトリをスキャンして未翻訳の文字列キーを検出させ、ロケールファイルと照合し、不足している翻訳を作成してPRを開くまで、すべて1つのコマンドで実行できます。",
+        "timeSaved": "リリースサイクルあたり約45分の節約",
+        "headings": {
+          "scenario": "i18nの漏れがQAまで見過ごされる理由",
+          "prompt": "Zeroに翻訳の監査と不足分の補完を依頼する方法",
+          "steps": "Zeroがスキャン・照合・不足ロケール文字列を書き込む仕組み",
+          "nextActions": "PRをレビュー、新しいロケールに拡張、または定期監査をスケジュール",
+          "integrations": "必須連携: GitHub。オプション: Notion、Slack",
+          "tips": "i18n自動メンテナンスのベストプラクティス"
+        },
+        "scenario": "開発者が新機能を追加し、3つの文字列をハードコードします。ロケールファイルへのキー追加を忘れてしまいます。QAが2日後にステージングサイトでスペイン語の未翻訳キー名が表示されているのを発見します。ZeroはこれをQAに届く前に検出できます。リポジトリを指定し、チェック対象のロケールを指示すれば、不足しているすべてのキーのdiffと、マージ可能な翻訳候補が返されます。",
+        "promptVariants": [
+          {
+            "label": "完全監査",
+            "prompt": "@Zero scan the vm0-ai/vm0 repo for any translation keys in en.json that are missing from de.json, es.json, and ja.json. Write translations for each missing key, open a PR with the changes, and post the PR link to #engineering."
+          },
+          {
+            "label": "単一ロケール",
+            "prompt": "@Zero check which keys are in en.json but missing from ja.json in turbo/apps/web/messages. Write Japanese translations for the missing keys and open a draft PR."
+          },
+          {
+            "label": "リリース前チェック",
+            "prompt": "@Zero before we cut the release branch, audit all locale files in turbo/apps/web/messages for missing keys vs en.json and list any gaps in a Notion page under 'Release Checklist'."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Lancy",
+            "text": "@Zero scan the repo for i18n gaps vs en.json in de, es, and ja. Write translations and open a PR."
+          },
+          {
+            "name": "Zero",
+            "text": "Found 6 missing keys across de.json, es.json, ja.json.\n\nMissing in all 3: useCases.content.daily-engineering-brief, useCases.content.competitor-pricing-monitor (4 more)\n\nWrote translations and opened PR #9430.\nhttps://github.com/vm0-ai/vm0/pull/9430"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zeroがロケールファイルをスキャン",
+            "description": "Zeroはソースロケールファイル（通常en.json）とすべてのターゲットロケールファイルを読み取ります。各ファイルのキーマップを構築し、ソースには存在するが1つ以上のターゲットに存在しないキーをすべて特定します。"
+          },
+          {
+            "title": "不足している翻訳を作成",
+            "description": "不足しているキーごとに、Zeroは英語の値をソースとしてターゲットロケールに適切な翻訳を生成します。英語ファイルの正確なJSON構造、配列の長さ、ネストされたキー階層を保持します。"
+          },
+          {
+            "title": "変更を含むPRを作成",
+            "description": "Zeroは更新されたロケールファイルを新しいブランチにコミットし、メインブランチに対してプルリクエストを開き、設定されていればSlackにPRリンクを投稿します。PR説明にはロケールごとに追加されたすべてのキーが記載されます。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "PRをレビューしてマージ",
+            "description": "マージ前に生成された翻訳を確認",
+            "examplePrompt": "@Zero show me the translations you wrote for the missing keys in ja.json — highlight any that might need a native speaker review."
+          },
+          {
+            "title": "新しいロケールを追加",
+            "description": "新しい言語へのカバレッジを拡張",
+            "examplePrompt": "@Zero add a zh.json locale file to turbo/apps/web/messages, populate it with translations for all keys in en.json, and open a PR."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zeroはロケールファイルの読み取り、翻訳パッチの作成、リポジトリへのプルリクエストの直接作成を行います。"
+          },
+          {
+            "description": "Zeroは監査レポートをNotionページに記録し、翻訳の欠落を経時的に追跡します。オプションです。"
+          }
+        ],
+        "tips": [
+          "Webアプリ外のロケールファイルによる誤検出を避けるため、特定のディレクトリパスに対して監査を実行してください。",
+          "英語の値にプレースホルダー（{name}や%sなど）が含まれるキーをZeroにフラグ付けさせ、それらの翻訳はマージ前に追加レビューを行ってください。",
+          "週次のi18n監査をスケジュールして、ロケールファイルを迅速な機能開発と同期させましょう。"
+        ]
+      },
+      "competitor-price-monitor": {
+        "title": "競合の価格変更を追跡し、週次アラートを受け取る",
+        "description": "Zeroに競合の価格ページリストを渡してください。スケジュールに従ってスクレイピングし、先週のNotionスナップショットと比較し、各変更の影響サマリーを作成して、毎週月曜日に週の始まる前にSlackにダイジェストを投稿します。",
+        "timeSaved": "週あたり約2時間の節約",
+        "headings": {
+          "scenario": "価格情報が行動に間に合わないほど遅れて届く理由",
+          "prompt": "Zeroで競合の価格追跡を自動化する設定方法",
+          "steps": "Zeroが週次の価格変更をスクレイピング・比較・レポートする仕組み",
+          "nextActions": "変更の深掘り、ウォッチリストの更新、またはダイジェストの共有",
+          "integrations": "必須連携: FirecrawlとNotion。オプション: Slack",
+          "tips": "競合価格インテリジェンス自動化のベストプラクティス"
+        },
+        "scenario": "商談中に見込み客が言及したことで、競合がエントリー価格を下げていたことが判明します。競合の価格ページを確認すると、3週間前に変更されていたことがわかります。この遅れは商談の損失につながります。Zeroは毎週月曜日に競合リストをスクレイピングし、各ページを先週のNotionスナップショットと比較し、見つかった変更ごとにわかりやすい影響メモを作成して、誰もメールを開く前にSlackにダイジェストを投稿します。",
+        "promptVariants": [
+          {
+            "label": "週次モニタリング",
+            "prompt": "@Zero every Monday at 8am, scrape the pricing pages for e2b.dev, daytona.io, cursor.com, and replit.com using Firecrawl. Compare against last week's Notion snapshot, flag any changes to tiers, prices, or CTAs, write a 2-sentence impact note for each change, save the full report to Notion under 'Competitor Pricing Log', and post a digest to #competitive."
+          },
+          {
+            "label": "オンデマンドチェック",
+            "prompt": "@Zero scrape cursor.com/pricing right now using Firecrawl, compare it to the last snapshot in Notion, and tell me what changed."
+          },
+          {
+            "label": "履歴サマリー",
+            "prompt": "@Zero pull all entries from the Competitor Pricing Log in Notion for the past 90 days and summarize how each competitor's pricing has shifted."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero run the weekly pricing monitor and post the digest to #competitive."
+          },
+          {
+            "name": "Zero",
+            "text": "Competitor Pricing Digest — Apr 14\n\nCursor: Added Ultra tier at $200/mo — targets high-willingness-to-pay power users.\nDaytona: Raised startup credit from $25K to $50K — land-and-expand before monetization.\n\nNo changes: E2B, Replit\n\nFull report saved to Notion."
+          }
+        ],
+        "steps": [
+          {
+            "title": "ZeroがFirecrawlで各価格ページをスクレイピング",
+            "description": "ZeroはFirecrawlを使用してウォッチリスト上のすべての価格URLのレンダリング済みコンテンツを取得し、プラン名、価格、機能ハイライト、試用条件、CTAを抽出します。"
+          },
+          {
+            "title": "Notionスナップショットとコンテンツを比較",
+            "description": "Zeroは今週のスクレイピング内容を先週Notionに保存したバージョンと比較します。プラン名、価格帯、含まれる機能、試用期間、CTAへの変更をフラグ付けします。"
+          },
+          {
+            "title": "レポート保存とダイジェスト投稿",
+            "description": "見つかった変更ごとに、Zeroは何が変わったか、それが何を意味するかを網羅した2文の影響メモを作成します。完全なレポートはNotionログに保存され、簡潔なダイジェストが指定したSlackチャンネルに投稿されます。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "1社の競合を深掘り分析",
+            "description": "単一の競合の完全な価格履歴を取得",
+            "examplePrompt": "@Zero pull everything from the Competitor Pricing Log in Notion for Cursor and summarize how their pricing has evolved since Q1."
+          },
+          {
+            "title": "ウォッチリストに追加",
+            "description": "週次スクレイピングに新しい競合を追加",
+            "examplePrompt": "@Zero add replit.com/pricing to the weekly pricing monitor and run an initial scrape now to set the Notion baseline."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "ZeroはFirecrawlを使用して競合の価格ページから構造化コンテンツをレンダリング・抽出し、標準的なスクレイパーでは対応できないJavaScript多用ページにも対応します。"
+          },
+          {
+            "description": "Zeroは週次の価格スナップショットと変更レポートをNotionに保存し、長期的な追跡と週ごとの比較を可能にします。"
+          }
+        ],
+        "tips": [
+          "スケジュールを設定する前に初回スクレイピングを実行してください。Zeroは比較のためにNotionにベースラインスナップショットが必要です。ないと、すべてのフィールドが変更として表示されます。",
+          "フラグ付けする対象を明確に指定してください。「プラン名、価格、試用条件、CTA」とリストアップすることでdiffが焦点を絞り、軽微なコピー編集によるノイズを軽減できます。",
+          "プロンプトにSlackチャンネルを追加して、毎週月曜日にチームが既にチェックしている場所にダイジェストが届くようにしましょう。"
+        ]
+      },
+      "contract-renewal-alert": {
+        "title": "ベンダー契約の期限切れ前にアラートを受け取り、意図しない自動更新を防止",
+        "description": "ZeroをGoogle Sheetsの契約スプレッドシートに向けてください。スケジュールに従って更新予定をチェックし、各契約の残日数を計算して、指定した期間内に期限切れとなるすべての契約についてSlackにフォーマットされたアラートを送信し、Gmailに下書きメールを作成します。",
+        "timeSaved": "更新サイクルあたり約1時間の節約",
+        "headings": {
+          "scenario": "誰もレビューしないうちに契約が更新されてしまう理由",
+          "prompt": "Zeroで契約更新アラートの自動化を設定する方法",
+          "steps": "Zeroが契約を読み取り、期限を計算し、アラートを送信する仕組み",
+          "nextActions": "更新メールを下書き、シートを更新、または法務にエスカレーション",
+          "integrations": "必須連携: Google SheetsとGmail。オプション: Slack",
+          "tips": "契約更新追跡の自動化のベストプラクティス"
+        },
+        "scenario": "年間$40Kの契約が先週の火曜日に自動更新されました。更新日が誰も開かないスプレッドシートの73行目に埋もれていたため、誰もフラグを立てませんでした。Zeroは毎週契約シートを読み取り、今後30日以内に更新予定の契約を計算し、ベンダー名、契約金額、期限を含むSlackアラートを送信します。さらに、Gmailの下書きに更新または解約メールを作成して、すぐに送信できる状態にします。",
+        "promptVariants": [
+          {
+            "label": "週次更新チェック",
+            "prompt": "@Zero every Monday at 9am, read the 'Vendor Contracts' sheet in Google Sheets, find any contracts expiring in the next 30 days, post a Slack alert with vendor name, contract value, and expiry date, and create a draft email in Gmail for each one asking to schedule a review call."
+          },
+          {
+            "label": "即時監査",
+            "prompt": "@Zero check the 'Vendor Contracts' sheet right now and list everything expiring in the next 60 days, sorted by days remaining."
+          },
+          {
+            "label": "カスタム期間",
+            "prompt": "@Zero read the Vendor Contracts sheet and alert me to anything expiring in the next 14 days. For each, draft a cancellation notice email in Gmail."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Zero",
+            "text": "Contract Renewal Alerts — Apr 14\n\n⚠️ Expiring in 14 days:\n• Firecrawl API — $12K/yr — expires Apr 28\n• Figma Team — $4.8K/yr — expires Apr 30\n\n📅 Expiring in 15–30 days:\n• Notion Business — $3.2K/yr — expires May 10\n\nDraft renewal emails created in Gmail for all 3."
+          },
+          {
+            "name": "Alex",
+            "text": "@Zero check Vendor Contracts for anything expiring in the next 30 days and draft renewal emails in Gmail."
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zeroが契約シートを読み取り",
+            "description": "Zeroは指定されたGoogle Sheetsのタブを読み取り、ベンダー名、契約金額、更新日、備考列を抽出します。日付フィールドを解析し、各行の期限までの残日数を計算します。"
+          },
+          {
+            "title": "更新予定の契約を特定",
+            "description": "Zeroは指定された期間（例: 30日）内に期限切れとなる契約をフィルタリングします。残日数でソートし、緊急（14日以内）と近日中（14～30日）にグループ分けします。"
+          },
+          {
+            "title": "アラート送信と下書き作成",
+            "description": "Zeroは期限切れの各契約について、ベンダー名、年間金額、正確な期限日を記載した構造化されたSlackメッセージを投稿します。各契約について、シートにベンダー連絡先が記載されていればその宛先にGmailの下書きメールを作成します。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "下書きメールを送信",
+            "description": "Zeroが準備した更新または解約の下書きを確認して送信",
+            "examplePrompt": "@Zero show me the draft renewal email you created for the Firecrawl contract and update the tone to be more direct about our budget constraints."
+          },
+          {
+            "title": "契約シートを更新",
+            "description": "更新判断をGoogle Sheetsに記録",
+            "examplePrompt": "@Zero update the Vendor Contracts sheet to mark the Firecrawl contract as 'Under Review' and set the follow-up date to Apr 20."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zeroは契約スプレッドシートを読み取り、ベンダー名、契約金額、更新日、連絡先情報を抽出します。"
+          },
+          {
+            "description": "Zeroは期限切れの各契約について下書きメールを作成し、Gmailの下書きフォルダに配置して、レビューと送信の準備を整えます。"
+          }
+        ],
+        "tips": [
+          "シートで一貫した日付形式を使用してください（例: YYYY-MM-DD）。形式が不統一だと、Zeroが更新日を誤って解析する原因になります。",
+          "シートに「連絡先メールアドレス」列を追加すると、Zeroが各下書きメールを適切なベンダー連絡先に自動で宛てることができます。",
+          "アラート期間はデフォルトで30日に設定し、各四半期の初めに90日の一回限りの監査を実行して、中期的な契約も見逃さないようにしましょう。"
+        ]
+      },
+      "support-to-github": {
+        "title": "サポートチケットをコンテキストを失わずにGitHub issueにエスカレーション",
+        "description": "Intercomのサポートチケットで再現可能なバグや正当な機能リクエストが明らかになった場合、Zeroに完全なコンテキスト（会話サマリー、再現手順、影響を受けるユーザー、重大度）を含むGitHub issueを作成させ、Intercomスレッドにリンクを投稿させることができます。",
+        "timeSaved": "エスカレーションあたり約15分の節約",
+        "headings": {
+          "scenario": "サポートからエンジニアリングへの引き継ぎでコンテキストが失われる理由",
+          "prompt": "Zeroにサポートチケットのエスカレーションを依頼する方法",
+          "steps": "Zeroがチケットを読み取り、issueを作成し、フォローアップする仕組み",
+          "nextActions": "エンジニアリングに割り当て、マイルストーンにリンク、または顧客に通知",
+          "integrations": "必須連携: IntercomとGitHub。オプション: Slack",
+          "tips": "サポートからエンジニアリングへのエスカレーションのベストプラクティス"
+        },
+        "scenario": "ユーザーがSlackコネクターで4000文字を超えるメッセージが消失すると報告します。実際のバグであることを確認します。次に、エンジニアリングが再現できるよう十分なコンテキスト（会話履歴、ユーザープラン、再現手順、重大度）を含むGitHub issueを書く必要があります。この記述には15分かかり、あなたの頭の中にしかありません。ZeroはIntercomスレッドを読み取り、重要なコンテキストを抽出し、構造化されたGitHub issueを作成して、1分以内にIntercomの会話にリンクを投稿します。",
+        "promptVariants": [
+          {
+            "label": "バグとしてエスカレーション",
+            "prompt": "@Zero read Intercom conversation [ID] and create a GitHub issue in vm0-ai/vm0 labelled 'bug' with: a one-line title, reproduction steps, affected user info, and severity. Post the issue link back to the Intercom thread."
+          },
+          {
+            "label": "機能リクエストとしてエスカレーション",
+            "prompt": "@Zero read Intercom conversation [ID] and create a GitHub issue labelled 'enhancement' with the user's feature request, their use case, and a note on frequency. Post the issue link to the Intercom thread and tag @product."
+          },
+          {
+            "label": "一括エスカレーション",
+            "prompt": "@Zero check all open Intercom conversations tagged 'bug-confirmed' and create a GitHub issue for each one. Post a summary list to #bug-report."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Alex",
+            "text": "@Zero read Intercom conversation 48291 and create a GitHub bug issue with reproduction steps. Post the link back to the thread."
+          },
+          {
+            "name": "Zero",
+            "text": "Created bug issue #9441 in vm0-ai/vm0.\n\nTitle: fix: Slack connector silently drops messages over 4000 chars\nSeverity: High — affects 12 users on Business plan\nReproduction: Send a message via @Zero with >4000 chars through a Slack connector. Message is truncated without error.\n\nPosted issue link to Intercom thread 48291."
+          }
+        ],
+        "steps": [
+          {
+            "title": "ZeroがIntercomの会話を読み取り",
+            "description": "ZeroはIntercomから完全な会話スレッドを取得します。すべての顧客メッセージ、エージェントの返信、タグ、内部メモを含みます。ユーザープラン、報告された動作、記載された再現の詳細を抽出します。"
+          },
+          {
+            "title": "構造化されたコンテキストでGitHub issueを作成",
+            "description": "Zeroは標準的なバグまたは機能リクエストテンプレートに従ってGitHub issueを作成します: 1行のタイトル、説明、再現手順（機能の場合はユースケース）、影響を受けるユーザー数とプラン、重大度または優先度ラベル。"
+          },
+          {
+            "title": "Intercomにリンクを投稿",
+            "description": "issue作成後、ZeroはGitHub issueのURLを元のIntercom会話に返信として投稿し、サポートエージェントが参照できるようにします。オプションでSlackチャンネルにサマリーを投稿することもできます。"
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "エンジニアリングに割り当て",
+            "description": "適切なチームメンバーにissueをルーティング",
+            "examplePrompt": "@Zero assign GitHub issue #9441 to @e7h4n and add it to the current sprint milestone."
+          },
+          {
+            "title": "顧客に通知",
+            "description": "issueがトリアージされたらIntercomスレッドに返信",
+            "examplePrompt": "@Zero reply to Intercom conversation 48291 to let the user know we've filed a bug report and they'll be notified when it's resolved."
+          },
+          {
+            "title": "タグ付きチケットからの一括作成",
+            "description": "確認済みバグのキューを一度に処理",
+            "examplePrompt": "@Zero find all Intercom conversations tagged 'bug-confirmed' opened this week and create a GitHub issue for each one. Post a summary to #bug-report."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Zeroは顧客メッセージ、内部メモ、ユーザープラン、タグを含む完全な会話スレッドを読み取り、エスカレーションのコンテキストを抽出します。"
+          },
+          {
+            "description": "Zeroはissueを作成し、ラベルを適用し、エスカレーションプロンプトから直接担当者の割り当てやマイルストーンへのリンクを行えます。"
+          }
+        ],
+        "tips": [
+          "正確にターゲットするため、プロンプトにIntercomの会話IDを含めてください。Zeroは会話URLからIDを見つけることができます。",
+          "影響を受けるユーザー数やユーザーのプランに基づいて重大度ラベルを追加するようZeroに依頼してください。エンジニアリングのトリアージ工程を省略できます。",
+          "各サポートシフトの終わりに一括エスカレーションを使用して、確認済みバグのキューを1つずつではなく1つのプロンプトで一括処理しましょう。"
+        ]
       }
     }
   },


### PR DESCRIPTION
## New Use Cases — 2026-04-15

Observed from team Zero usage on April 14. 4 new entries appended to `data.ts`.

- `i18n-gap-fixer` — Auto-Fix Missing i18n Strings | engineering | GitHub + Notion + Slack
- `competitor-price-monitor` — Weekly Competitor Pricing Digest | product | Firecrawl + Notion + Slack
- `contract-renewal-alert` — Vendor Contract Renewal Alert | ops | Google Sheets + Gmail + Slack
- `support-to-github` — Escalate Support Tickets to GitHub Issues | everyone | Intercom + GitHub + Slack

## Diversity coverage
- Roles: engineering, product, ops, everyone
- Capabilities: multi-tool, scheduled, scheduled, instant
- Themes: devops / marketing / HR-ops / customer-facing

## Source observation
Lancy's Zero auto-processing Sentry errors and translating missing i18n strings; Scarlett triggering a scheduled competitor pricing digest in #marketing-and-community.

🤖 Generated by Zero use-case-monitor schedule