### PR TITLE
fix(connectors): add workflow scope to GitHub OAuth connector

### DIFF
--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
@@ -96,7 +96,7 @@ describe("zero connector list command", () => {
                 externalId: "12345",
                 externalUsername: "octocat",
                 externalEmail: "octocat@github.com",
-                oauthScopes: ["repo", "project"],
+                oauthScopes: ["repo", "project", "workflow"],
                 needsReconnect: true,
                 createdAt: "2025-01-01T00:00:00Z",
                 updatedAt: "2025-01-01T00:00:00Z",

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
@@ -47,7 +47,7 @@ describe("zero connector list command", () => {
                 externalId: "12345",
                 externalUsername: "octocat",
                 externalEmail: "octocat@github.com",
-                oauthScopes: ["repo", "project"],
+                oauthScopes: ["repo", "project", "workflow"],
                 needsReconnect: false,
                 createdAt: "2025-01-01T00:00:00Z",
                 updatedAt: "2025-01-01T00:00:00Z",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
@@ -53,7 +53,7 @@ describe("connectors page - connector status indicators", () => {
       {
         type: "github",
         needsReconnect: true,
-        oauthScopes: ["repo", "project"],
+        oauthScopes: ["repo", "project", "workflow"],
       },
     ]);
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
@@ -121,7 +121,7 @@ describe("connectors page - connector status indicators", () => {
       {
         type: "github",
         externalUsername: "octocat",
-        oauthScopes: ["repo", "project"],
+        oauthScopes: ["repo", "project", "workflow"],
       },
     ]);
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
@@ -100,7 +100,7 @@ describe("connectors page - connector status indicators", () => {
   });
 
   it("connector shows scope mismatch state (CONN-D-005)", async () => {
-    // GitHub requires ["repo", "project"] scopes; empty array triggers mismatch
+    // GitHub requires ["repo", "project", "workflow"] scopes; empty array triggers mismatch
     mockConnectors([
       { type: "github", oauthScopes: [], needsReconnect: false },
     ]);

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -35,12 +35,20 @@ describe("hasRequiredScopes", () => {
   });
 
   it("returns true when all required scopes are present", () => {
-    expect(hasRequiredScopes("github", ["repo", "project"])).toBe(true);
+    expect(hasRequiredScopes("github", ["repo", "project", "workflow"])).toBe(
+      true,
+    );
   });
 
   it("returns true when stored scopes are a superset of required", () => {
     expect(
-      hasRequiredScopes("github", ["repo", "project", "read:org", "user"]),
+      hasRequiredScopes("github", [
+        "repo",
+        "project",
+        "workflow",
+        "read:org",
+        "user",
+      ]),
     ).toBe(true);
   });
 });

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -32,6 +32,8 @@ describe("hasRequiredScopes", () => {
     expect(hasRequiredScopes("github", [])).toBe(false);
     expect(hasRequiredScopes("github", ["read:org"])).toBe(false);
     expect(hasRequiredScopes("github", ["repo"])).toBe(false);
+    // tokens without "workflow" scope (e.g. pre-existing tokens) must reconnect
+    expect(hasRequiredScopes("github", ["repo", "project"])).toBe(false);
   });
 
   it("returns true when all required scopes are present", () => {

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -227,7 +227,7 @@ const CONNECTOR_TYPES_DEF = {
     oauth: {
       authorizationUrl: "https://github.com/login/oauth/authorize",
       tokenUrl: "https://github.com/login/oauth/access_token",
-      scopes: ["repo", "project"],
+      scopes: ["repo", "project", "workflow"],
     },
   },
   notion: {


### PR DESCRIPTION
## Summary
- Adds `workflow` scope to the GitHub OAuth connector's requested scopes
- Previously only `repo` and `project` were requested, which prevented pushing to `.github/workflows/` files
- After re-authorizing the GitHub connector, agents will be able to update workflow files

## Note
Existing OAuth tokens will not automatically gain this scope. Users need to re-authorize the GitHub connector after this change is deployed.