### PR TITLE
refactor(test): migrate users.ts helpers from service calls to route calls

### DIFF
--- a/turbo/apps/web/app/api/zero/user-preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/user-preferences/__tests__/route.test.ts
@@ -493,7 +493,7 @@ describe("consumeCaptureNetworkBodies", () => {
   it("should decrement and return true when remaining > 0", async () => {
     const user = await context.setupUser();
 
-    await updateTestUserPreferencesAll(user.orgId, user.userId, {
+    await updateTestUserPreferencesAll({
       captureNetworkBodiesRemaining: 3,
     });
 
@@ -503,14 +503,14 @@ describe("consumeCaptureNetworkBodies", () => {
     );
     expect(consumed).toBe(true);
 
-    const prefs = await getTestUserPreferencesAll(user.orgId, user.userId);
+    const prefs = await getTestUserPreferencesAll();
     expect(prefs.captureNetworkBodiesRemaining).toBe(2);
   });
 
   it("should decrement to zero and stop", async () => {
     const user = await context.setupUser();
 
-    await updateTestUserPreferencesAll(user.orgId, user.userId, {
+    await updateTestUserPreferencesAll({
       captureNetworkBodiesRemaining: 1,
     });
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
@@ -1,10 +1,10 @@
-import {
-  consumeCaptureNetworkBodies,
-  getUserPreferences,
-  updateUserPreferences,
-} from "../../lib/zero/user/user-preferences-service";
+import { consumeCaptureNetworkBodies } from "../../lib/zero/user/user-preferences-service";
 import { getVm0ApiKey } from "../../lib/zero/vm0-key/vm0-key-service";
 import { POST as registerPushSubscriptionRoute } from "../../../app/api/zero/push-subscriptions/route";
+import {
+  GET as getUserPreferencesRoute,
+  POST as updateUserPreferencesRoute,
+} from "../../../app/api/zero/user-preferences/route";
 import { randomUUID } from "crypto";
 import { createTestRequest } from "./core";
 
@@ -85,39 +85,54 @@ export async function consumeTestCaptureNetworkBodies(
 }
 
 /**
- * Get the full user preferences object for testing.
- * Wraps getUserPreferences from user-preferences-service.
+ * Get the full user preferences object for testing via the
+ * GET /api/zero/user-preferences route. The caller must be
+ * authenticated via mockClerk() before calling this function.
  */
-export async function getTestUserPreferencesAll(
-  orgId: string,
-  userId: string,
-): Promise<{
+export async function getTestUserPreferencesAll(): Promise<{
   timezone: string | null;
   pinnedAgentIds: string[];
   sendMode: string;
   captureNetworkBodiesRemaining: number;
 }> {
-  return getUserPreferences(orgId, userId);
+  const response = await getUserPreferencesRoute(
+    createTestRequest("http://localhost:3000/api/zero/user-preferences"),
+  );
+  if (response.status !== 200) {
+    throw new Error(
+      `Failed to get user preferences: status ${response.status}`,
+    );
+  }
+  return response.json();
 }
 
 /**
- * Update user preferences for test setup.
- * Wraps updateUserPreferences from user-preferences-service.
+ * Update user preferences for test setup via the
+ * POST /api/zero/user-preferences route. The caller must be
+ * authenticated via mockClerk() before calling this function.
  */
-export async function updateTestUserPreferencesAll(
-  orgId: string,
-  userId: string,
-  prefs: {
-    timezone?: string;
-    pinnedAgentIds?: string[];
-    sendMode?: "enter" | "cmd-enter";
-    captureNetworkBodiesRemaining?: number;
-  },
-): Promise<{
+export async function updateTestUserPreferencesAll(prefs: {
+  timezone?: string;
+  pinnedAgentIds?: string[];
+  sendMode?: "enter" | "cmd-enter";
+  captureNetworkBodiesRemaining?: number;
+}): Promise<{
   timezone: string | null;
   pinnedAgentIds: string[];
   sendMode: string;
   captureNetworkBodiesRemaining: number;
 }> {
-  return updateUserPreferences(orgId, userId, prefs);
+  const response = await updateUserPreferencesRoute(
+    createTestRequest("http://localhost:3000/api/zero/user-preferences", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(prefs),
+    }),
+  );
+  if (response.status !== 200) {
+    throw new Error(
+      `Failed to update user preferences: status ${response.status}`,
+    );
+  }
+  return response.json();
 }


### PR DESCRIPTION
## Summary

- Migrate `getTestUserPreferencesAll()` and `updateTestUserPreferencesAll()` from direct service function calls to GET/POST route handler calls
- Remove `orgId`/`userId` params (auth now comes from mockClerk context), matching the existing `createTestPushSubscription()` pattern
- Update 3 call sites in `user-preferences/__tests__/route.test.ts`

Closes #9399

## Test plan

- [x] All 26 user-preferences route tests pass
- [x] Lint passes (0 errors)
- [x] Type-check passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)