### PR TITLE
fix: include activity logs for all session runs in diagnostic bundle

### DIFF
--- a/turbo/apps/web/app/api/zero/report-error/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/report-error/__tests__/route.test.ts
@@ -237,7 +237,7 @@ describe("POST /api/zero/report-error", () => {
     expect(entryNames).toContain("environment.json");
     expect(entryNames).toContain("connectors.json");
     expect(entryNames).toContain("agent-config.json");
-    expect(entryNames).toContain("activity-log.json");
+    expect(entryNames.some((n) => n.startsWith("activity-log-"))).toBe(true);
   });
 
   it("should include system-log.txt when Axiom returns system log data", async () => {

--- a/turbo/apps/web/app/api/zero/report-error/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/report-error/__tests__/route.test.ts
@@ -237,7 +237,11 @@ describe("POST /api/zero/report-error", () => {
     expect(entryNames).toContain("environment.json");
     expect(entryNames).toContain("connectors.json");
     expect(entryNames).toContain("agent-config.json");
-    expect(entryNames.some((n) => n.startsWith("activity-log-"))).toBe(true);
+    expect(
+      entryNames.some((n) => {
+        return n.startsWith("activity-log-");
+      }),
+    ).toBe(true);
   });
 
   it("should include system-log.txt when Axiom returns system log data", async () => {

--- a/turbo/apps/web/src/lib/infra/run/activity-log-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/activity-log-service.ts
@@ -13,7 +13,7 @@ interface AxiomAgentEvent {
   eventData: Record<string, unknown>;
 }
 
-interface RunMeta {
+export interface RunMeta {
   id: string;
   status: string;
   error: string | null;

--- a/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
+++ b/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
@@ -151,8 +151,12 @@ export async function submitDiagnosticBundle(
     promptCount: promptEvents.length,
   });
 
-  // Assemble activity log (same format as activity detail download)
-  const activityLog = await assembleActivityLog(runId, run, agentConfig);
+  // Assemble activity logs for all session runs
+  const activityLogs = await Promise.all(
+    sessionRuns.map((r) => {
+      return assembleActivityLog(r.id, r, agentConfig);
+    }),
+  );
 
   // Safe connector subset (no tokens)
   const safeConnectors = connectors.map((c) => {
@@ -218,10 +222,12 @@ export async function submitDiagnosticBundle(
       path: "agent-config.json",
       content: JSON.stringify(agentConfig, null, 2),
     },
-    {
-      path: "activity-log.json",
-      content: JSON.stringify(activityLog),
-    },
+    ...activityLogs.map((al, i) => {
+      return {
+        path: `activity-log-${i}.json`,
+        content: JSON.stringify(al),
+      };
+    }),
   ];
 
   if (systemLogText) {
@@ -335,18 +341,42 @@ async function collectAgentConfig(
   };
 }
 
+interface SessionRunRecord {
+  id: string;
+  status: string;
+  error: string | null;
+  prompt: string;
+  appendSystemPrompt: string | null;
+  createdAt: Date;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  runnerGroup: string | null;
+  continuedFromSessionId: string | null;
+  result: unknown;
+}
+
+const sessionRunSelect = {
+  id: agentRuns.id,
+  status: agentRuns.status,
+  error: agentRuns.error,
+  prompt: agentRuns.prompt,
+  appendSystemPrompt: agentRuns.appendSystemPrompt,
+  createdAt: agentRuns.createdAt,
+  startedAt: agentRuns.startedAt,
+  completedAt: agentRuns.completedAt,
+  runnerGroup: agentRuns.runnerGroup,
+  continuedFromSessionId: agentRuns.continuedFromSessionId,
+  result: agentRuns.result,
+};
+
 async function collectSessionRuns(
   db: typeof globalThis.services.db,
   runId: string,
   sessionId: string | null,
-): Promise<{ id: string; prompt: string; createdAt: Date }[]> {
+): Promise<SessionRunRecord[]> {
   if (sessionId) {
     return db
-      .select({
-        id: agentRuns.id,
-        prompt: agentRuns.prompt,
-        createdAt: agentRuns.createdAt,
-      })
+      .select(sessionRunSelect)
       .from(agentRuns)
       .where(
         or(
@@ -358,11 +388,7 @@ async function collectSessionRuns(
   }
 
   return db
-    .select({
-      id: agentRuns.id,
-      prompt: agentRuns.prompt,
-      createdAt: agentRuns.createdAt,
-    })
+    .select(sessionRunSelect)
     .from(agentRuns)
     .where(eq(agentRuns.id, runId))
     .limit(1);

--- a/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
+++ b/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
@@ -7,7 +7,10 @@ import {
 } from "../../../db/schema/agent-compose";
 import { zeroAgents } from "../../../db/schema/zero-agent";
 import { queryAxiom, getDatasetName, DATASETS } from "../../shared/axiom";
-import { assembleActivityLog } from "../../infra/run/activity-log-service";
+import {
+  assembleActivityLog,
+  type RunMeta,
+} from "../../infra/run/activity-log-service";
 import { listConnectors } from "../connector/connector-service";
 import { uploadS3Buffer, generatePresignedUrl } from "../../infra/s3/s3-client";
 import { createPlainSupportThread } from "./plain-service";
@@ -33,19 +36,8 @@ interface ChatHistoryEvent {
   _time: string;
 }
 
-interface DiagnosticRunRecord {
-  id: string;
-  status: string;
-  error: string | null;
-  prompt: string;
-  appendSystemPrompt: string | null;
-  createdAt: Date;
-  startedAt: Date | null;
-  completedAt: Date | null;
+interface DiagnosticRunRecord extends RunMeta {
   agentComposeVersionId: string | null;
-  runnerGroup: string | null;
-  continuedFromSessionId: string | null;
-  result: unknown;
 }
 
 interface DiagnosticBundleParams {
@@ -341,20 +333,6 @@ async function collectAgentConfig(
   };
 }
 
-interface SessionRunRecord {
-  id: string;
-  status: string;
-  error: string | null;
-  prompt: string;
-  appendSystemPrompt: string | null;
-  createdAt: Date;
-  startedAt: Date | null;
-  completedAt: Date | null;
-  runnerGroup: string | null;
-  continuedFromSessionId: string | null;
-  result: unknown;
-}
-
 const sessionRunSelect = {
   id: agentRuns.id,
   status: agentRuns.status,
@@ -373,7 +351,7 @@ async function collectSessionRuns(
   db: typeof globalThis.services.db,
   runId: string,
   sessionId: string | null,
-): Promise<SessionRunRecord[]> {
+): Promise<RunMeta[]> {
   if (sessionId) {
     return db
       .select(sessionRunSelect)


### PR DESCRIPTION
## Summary
- Previously `activity-log.json` only contained data for the single run that triggered the report, while other files (`chat-history.jsonl`, `system-log.txt`, `network-log.jsonl`) already covered the full session
- Now generates `activity-log-{index}.json` for each run in the session, making the diagnostic bundle consistent
- Expanded `collectSessionRuns` to return full run metadata so each run can be passed to `assembleActivityLog`

## Test plan
- [x] All 35 existing tests pass (developer-support + report-error)
- [x] Type check passes
- [x] Pre-commit hooks (prettier, knip, commitlint) pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)