### PR TITLE
refactor(test): document run-status.test.ts as service-level exception

### DIFF
--- a/turbo/apps/web/src/lib/infra/run/__tests__/run-status.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/run-status.test.ts
@@ -13,6 +13,17 @@ import { seedTestRun } from "../../../../__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
+// These tests verify the internal state-machine and database-level optimistic
+// locking guarantees of transitionRunStatus(). They are intentionally kept as
+// service-level tests because:
+// - Webhook routes add idempotency checks that bypass transitionRunStatus for
+//   terminal statuses, preventing route-level testing of rejection logic
+// - Webhook routes use fixed allowed-status lists (["pending", "running"]),
+//   so arbitrary status validation can't be tested via routes
+// - Concurrent transition testing requires direct parallel service calls
+//
+// Route-level tests for webhook completion behavior live in:
+//   app/api/webhooks/agent/complete/__tests__/route.test.ts
 describe("transitionRunStatus", () => {
   let user: UserContext;
   let composeId: string;


### PR DESCRIPTION
## Summary

Closes #9426

Reclassified `run-status.test.ts` (4 tests) as an acceptable service-level exception. These tests verify internal state-machine and database-level optimistic locking guarantees of `transitionRunStatus()` that cannot be meaningfully expressed as route integration tests:

- **Idempotency bypass**: Webhook routes check terminal status before calling `transitionRunStatus()`, so rejection logic can't be tested via routes
- **Fixed allowed-status lists**: Webhook routes always use `["pending", "running"]` — arbitrary status validation isn't testable
- **Concurrent transition test**: Requires direct parallel service calls (`Promise.all`) to test DB-level optimistic locking

Added documentation comment explaining the rationale. Zero test changes — all 4 tests preserved as-is.

## Test plan

- [x] All 4 run-status tests pass
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)