### PR TITLE
refactor(test): migrate credit-check to route integration test (#9423)

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -11,6 +11,10 @@ import {
   findTestRunnerJobEntry,
   insertOrgDefaultModelProvider,
   insertUserCacheEntry,
+  setOrgCredits,
+  deleteOrgRow,
+  insertOrgMembersEntry,
+  findTestRunsByUserAndPrompt,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
 import { getTestZeroAgentId } from "../../../../../src/__tests__/db-test-assertions/agents";
@@ -693,6 +697,232 @@ describe("POST /api/zero/runs", () => {
           }),
         }),
       );
+    });
+  });
+});
+
+describe("POST /api/zero/runs — credit check", () => {
+  let user: UserContext;
+  let agentId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    const compose = await createTestCompose(uniqueId("credit-agent"));
+    agentId = await getTestZeroAgentId(user.orgId, compose.name);
+    vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
+    reloadEnv();
+  });
+
+  describe("createZeroRun path", () => {
+    it("should allow VM0 run when credits > 0", async () => {
+      await setOrgCredits(user.orgId, 100);
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+        modelProvider: "vm0",
+      });
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("pending");
+      expect(data.runId).toBeDefined();
+    });
+
+    it("should reject VM0 run when credits = 0", async () => {
+      await setOrgCredits(user.orgId, 0);
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+        modelProvider: "vm0",
+      });
+
+      expect(response.status).toBe(402);
+      const data = await response.json();
+      expect(data.error.code).toBe("INSUFFICIENT_CREDITS");
+    });
+
+    it("should reject VM0 run when credits are negative", async () => {
+      await setOrgCredits(user.orgId, -500);
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+        modelProvider: "vm0",
+      });
+
+      expect(response.status).toBe(402);
+      const data = await response.json();
+      expect(data.error.code).toBe("INSUFFICIENT_CREDITS");
+    });
+
+    it("should allow non-VM0 run when credits = 0", async () => {
+      await setOrgCredits(user.orgId, 0);
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+        modelProvider: "anthropic",
+      });
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("pending");
+    });
+
+    it("should reject when org default is VM0 and credits = 0", async () => {
+      await setOrgCredits(user.orgId, 0);
+      await insertOrgDefaultModelProvider(user.orgId, "vm0");
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+      });
+
+      expect(response.status).toBe(402);
+      const data = await response.json();
+      expect(data.error.code).toBe("INSUFFICIENT_CREDITS");
+    });
+
+    it("should allow when org default is non-VM0 and credits = 0", async () => {
+      await setOrgCredits(user.orgId, 0);
+      await insertOrgDefaultModelProvider(user.orgId, "anthropic-api-key");
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+      });
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("pending");
+    });
+
+    it("should allow when no org default provider and credits = 0", async () => {
+      await setOrgCredits(user.orgId, 0);
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+      });
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("pending");
+    });
+
+    it("should reject when org_metadata row is missing", async () => {
+      await deleteOrgRow(user.orgId);
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+        modelProvider: "vm0",
+      });
+
+      expect(response.status).toBe(404);
+    });
+
+    it("should not create run record for rejected VM0 run", async () => {
+      await setOrgCredits(user.orgId, 0);
+
+      const prompt = uniqueId("rejected-vm0-no-enqueue");
+      const response = await postRun({
+        agentId,
+        prompt,
+        modelProvider: "vm0",
+      });
+
+      expect(response.status).toBe(402);
+
+      const runs = await findTestRunsByUserAndPrompt(user.userId, prompt);
+      expect(runs).toHaveLength(0);
+    });
+  });
+
+  describe("member credit cap enforcement", () => {
+    it("should reject VM0 run when creditEnabled is false", async () => {
+      await setOrgCredits(user.orgId, 10000);
+      await insertOrgDefaultModelProvider(user.orgId, "vm0");
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditCap: 100,
+        creditEnabled: false,
+      });
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+        modelProvider: "vm0",
+      });
+
+      expect(response.status).toBe(402);
+      const data = await response.json();
+      expect(data.error.code).toBe("INSUFFICIENT_CREDITS");
+    });
+
+    it("should allow non-VM0 run regardless of creditEnabled", async () => {
+      await setOrgCredits(user.orgId, 10000);
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditCap: 100,
+        creditEnabled: false,
+      });
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+        modelProvider: "anthropic",
+      });
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("pending");
+    });
+
+    it("should allow VM0 run when creditEnabled is true with cap set", async () => {
+      await setOrgCredits(user.orgId, 10000);
+      await insertOrgDefaultModelProvider(user.orgId, "vm0");
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditCap: 10000,
+        creditEnabled: true,
+      });
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+        modelProvider: "vm0",
+      });
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("pending");
+    });
+
+    it("should reject VM0 run when default provider is vm0 and creditEnabled is false", async () => {
+      await setOrgCredits(user.orgId, 10000);
+      await insertOrgDefaultModelProvider(user.orgId, "vm0");
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditCap: 100,
+        creditEnabled: false,
+      });
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+      });
+
+      expect(response.status).toBe(402);
+      const data = await response.json();
+      expect(data.error.code).toBe("INSUFFICIENT_CREDITS");
     });
   });
 });

--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -6,211 +6,25 @@ import {
 } from "../../../__tests__/test-helpers";
 import {
   createTestCompose,
-  findTestRunsByUserAndPrompt,
   findTestRunRecord,
   findTestQueueEntry,
   markRunningRunsAsCompleted,
   setOrgCredits,
-  deleteOrgRow,
   insertOrgDefaultModelProvider,
   insertOrgMembersEntry,
   insertTestZeroRun,
 } from "../../../__tests__/api-test-helpers";
 import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
 import { reloadEnv } from "../../../env";
-import { createZeroRun } from "../zero-run-service";
-import { isInsufficientCredits, isNotFound } from "../../shared/errors";
 import type { CreateRunParams } from "../../infra/run/run-service";
 import {
   drainOrgQueue,
   enqueueRun,
   dispatchQueuedZeroRun,
 } from "../zero-run-queue-service";
-import type { TriggerSource } from "@vm0/core";
 import { seedTestRun } from "../../../__tests__/db-test-seeders/runs";
 
 const context = testContext();
-
-describe("credit check (zero layer)", () => {
-  let user: UserContext;
-  let agentId: string;
-
-  beforeEach(async () => {
-    context.setupMocks();
-    user = await context.setupUser();
-    const agentName = uniqueId("agent");
-    await createTestCompose(agentName);
-    agentId = await getTestZeroAgentId(user.orgId, agentName);
-    vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
-    reloadEnv();
-  });
-
-  function baseParams(
-    overrides?: Partial<Parameters<typeof createZeroRun>[0]>,
-  ) {
-    return {
-      userId: user.userId,
-      prompt: "Credit check test",
-      agentId,
-      triggerSource: "web" as TriggerSource,
-      ...overrides,
-    };
-  }
-
-  describe("createZeroRun() path", () => {
-    it("should allow VM0 run when credits > 0", async () => {
-      await setOrgCredits(user.orgId, 100);
-
-      const result = await createZeroRun(baseParams({ modelProvider: "vm0" }));
-
-      expect(result.status).toBe("pending");
-      expect(result.runId).toBeDefined();
-    });
-
-    it("should reject VM0 run when credits = 0", async () => {
-      await setOrgCredits(user.orgId, 0);
-
-      await expect(
-        createZeroRun(baseParams({ modelProvider: "vm0" })),
-      ).rejects.toSatisfy(isInsufficientCredits);
-    });
-
-    it("should reject VM0 run when credits are negative", async () => {
-      await setOrgCredits(user.orgId, -500);
-
-      await expect(
-        createZeroRun(baseParams({ modelProvider: "vm0" })),
-      ).rejects.toSatisfy(isInsufficientCredits);
-    });
-
-    it("should allow non-VM0 run when credits = 0", async () => {
-      await setOrgCredits(user.orgId, 0);
-
-      const result = await createZeroRun(
-        baseParams({ modelProvider: "anthropic" }),
-      );
-
-      expect(result.status).toBe("pending");
-    });
-
-    it("should reject when org default is VM0 and credits = 0", async () => {
-      await setOrgCredits(user.orgId, 0);
-      await insertOrgDefaultModelProvider(user.orgId, "vm0");
-
-      await expect(createZeroRun(baseParams())).rejects.toSatisfy(
-        isInsufficientCredits,
-      );
-    });
-
-    it("should allow when org default is non-VM0 and credits = 0", async () => {
-      await setOrgCredits(user.orgId, 0);
-      await insertOrgDefaultModelProvider(user.orgId, "anthropic-api-key");
-
-      const result = await createZeroRun(baseParams());
-
-      expect(result.status).toBe("pending");
-    });
-
-    it("should allow when no org default provider and credits = 0", async () => {
-      await setOrgCredits(user.orgId, 0);
-
-      // No model provider configured — will throw noModelProvider, not credit error
-      // Since checkModelProviderConfigured runs in parallel, we just verify no credit error
-      // Actually for createZeroRun, this would fail with noModelProvider
-      // because the default compose has skipDefaultApiKey: false (has ANTHROPIC_API_KEY in compose)
-      // The default test compose has ANTHROPIC_API_KEY so model provider check is skipped
-      const result = await createZeroRun(baseParams());
-
-      expect(result.status).toBe("pending");
-    });
-
-    it("should reject when org_metadata row is missing", async () => {
-      await deleteOrgRow(user.orgId);
-
-      await expect(
-        createZeroRun(baseParams({ modelProvider: "vm0" })),
-      ).rejects.toSatisfy(isNotFound);
-    });
-
-    it("should not enqueue a rejected VM0 run", async () => {
-      await setOrgCredits(user.orgId, 0);
-
-      const prompt = "Rejected VM0 run - no enqueue";
-      await expect(
-        createZeroRun(baseParams({ modelProvider: "vm0", prompt })),
-      ).rejects.toSatisfy(isInsufficientCredits);
-
-      // Verify no run record was created (credit check rejects before createRunRecord)
-      const runs = await findTestRunsByUserAndPrompt(user.userId, prompt);
-      expect(runs).toHaveLength(0);
-    });
-  });
-
-  describe("member credit cap enforcement", () => {
-    it("should reject VM0 run when creditEnabled is false", async () => {
-      await setOrgCredits(user.orgId, 10000);
-      await insertOrgDefaultModelProvider(user.orgId, "vm0");
-
-      await insertOrgMembersEntry({
-        orgId: user.orgId,
-        userId: user.userId,
-        creditCap: 100,
-        creditEnabled: false,
-      });
-
-      await expect(
-        createZeroRun(baseParams({ modelProvider: "vm0" })),
-      ).rejects.toSatisfy(isInsufficientCredits);
-    });
-
-    it("should allow non-VM0 run regardless of creditEnabled", async () => {
-      await setOrgCredits(user.orgId, 10000);
-
-      await insertOrgMembersEntry({
-        orgId: user.orgId,
-        userId: user.userId,
-        creditCap: 100,
-        creditEnabled: false,
-      });
-
-      const result = await createZeroRun(
-        baseParams({ modelProvider: "anthropic" }),
-      );
-      expect(result.status).toBe("pending");
-    });
-
-    it("should allow VM0 run when creditEnabled is true with cap set", async () => {
-      await setOrgCredits(user.orgId, 10000);
-      await insertOrgDefaultModelProvider(user.orgId, "vm0");
-
-      await insertOrgMembersEntry({
-        orgId: user.orgId,
-        userId: user.userId,
-        creditCap: 10000,
-        creditEnabled: true,
-      });
-
-      const result = await createZeroRun(baseParams({ modelProvider: "vm0" }));
-      expect(result.status).toBe("pending");
-    });
-
-    it("should reject VM0 run when default provider is vm0 and creditEnabled is false", async () => {
-      await setOrgCredits(user.orgId, 10000);
-      await insertOrgDefaultModelProvider(user.orgId, "vm0");
-
-      await insertOrgMembersEntry({
-        orgId: user.orgId,
-        userId: user.userId,
-        creditCap: 100,
-        creditEnabled: false,
-      });
-
-      await expect(createZeroRun(baseParams())).rejects.toSatisfy(
-        isInsufficientCredits,
-      );
-    });
-  });
-});
 
 describe("credit check (infra queue path)", () => {
   let user: UserContext;


### PR DESCRIPTION
## Summary

- Migrate 13 credit check tests from `credit-check.test.ts` to `zero/runs/route.test.ts`, exercising credit checks through the POST `/api/zero/runs` route handler instead of calling `createZeroRun()` directly
- 6 queue path tests documented as exceptions — they orchestrate internal `enqueueRun`/`drainOrgQueue`/`dispatchQueuedZeroRun` flows not accessible through a single HTTP route
- Test count: 13 migrated + 6 exceptions = 19 original (zero test loss)

Closes #9423

## Test plan

- [x] All 21 route tests pass (8 existing + 13 new)
- [x] All 6 remaining credit-check.test.ts tests pass
- [x] Lint, type-check, format, knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)