### PR TITLE
fix(web): harden locale layout metadata against invalid locale params

### DIFF
--- a/turbo/apps/web/app/[locale]/__tests__/layout.test.ts
+++ b/turbo/apps/web/app/[locale]/__tests__/layout.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+
+// External: next/navigation
+vi.mock("next/navigation", () => {
+  return {
+    notFound: vi.fn(),
+  };
+});
+
+// External: next-intl
+vi.mock("next-intl", () => {
+  return {
+    NextIntlClientProvider: ({ children }: { children: unknown }) => {
+      return children;
+    },
+  };
+});
+
+// External: next-intl/navigation
+vi.mock("next-intl/navigation", () => {
+  return {
+    createNavigation: vi.fn(() => {
+      return {
+        Link: () => {
+          return null;
+        },
+        redirect: vi.fn(),
+        usePathname: vi.fn(),
+        useRouter: vi.fn(),
+      };
+    }),
+  };
+});
+
+// External: next-intl/server (used by i18n.ts)
+vi.mock("next-intl/server", () => {
+  return {
+    getRequestConfig: vi.fn((fn: unknown) => {
+      return fn;
+    }),
+  };
+});
+
+import { generateMetadata } from "../layout";
+
+describe("locale layout generateMetadata", () => {
+  it("returns metadata with alternates for valid locale", async () => {
+    const metadata = await generateMetadata({
+      children: null,
+      params: Promise.resolve({ locale: "en" }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe("https://www.vm0.ai/en");
+    expect(metadata.openGraph).toBeDefined();
+    expect(metadata.twitter).toBeDefined();
+  });
+
+  it("returns metadata for each supported locale", async () => {
+    for (const locale of ["en", "de", "ja", "es"]) {
+      const metadata = await generateMetadata({
+        children: null,
+        params: Promise.resolve({ locale }),
+      });
+
+      expect(metadata.alternates?.canonical).toBe(
+        `https://www.vm0.ai/${locale}`,
+      );
+    }
+  });
+
+  it("returns empty metadata for invalid locale with dot", async () => {
+    const metadata = await generateMetadata({
+      children: null,
+      params: Promise.resolve({ locale: "apple-touch-icon.png" }),
+    });
+
+    expect(metadata).toEqual({});
+  });
+
+  it("returns empty metadata for invalid locale without dot", async () => {
+    const metadata = await generateMetadata({
+      children: null,
+      params: Promise.resolve({ locale: "swagger" }),
+    });
+
+    expect(metadata).toEqual({});
+  });
+
+  it("returns empty metadata for openapi.json locale", async () => {
+    const metadata = await generateMetadata({
+      children: null,
+      params: Promise.resolve({ locale: "openapi.json" }),
+    });
+
+    expect(metadata).toEqual({});
+  });
+});

--- a/turbo/apps/web/app/[locale]/layout.tsx
+++ b/turbo/apps/web/app/[locale]/layout.tsx
@@ -13,6 +13,11 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
+
+  if (!locales.includes(params.locale as Locale)) {
+    return {};
+  }
+
   const locale = params.locale as Locale;
 
   const localeNames: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Add locale validation to `generateMetadata` in `app/[locale]/layout.tsx` so invalid locale values (e.g. `apple-touch-icon.png`, `openapi.json`) return empty metadata instead of generating incorrect canonical URLs
- Add test coverage for the locale layout metadata guard with 5 test cases covering valid locales, dotted paths, and non-locale strings

## Context

When bots request paths like `/apple-touch-icon.png`, the middleware matcher excludes them (due to `.*\..*` pattern), so `clerkMiddleware()` never runs. Next.js falls through to the `[locale]` dynamic segment. The layout component already had a `notFound()` guard (since the initial i18n commit), but `generateMetadata` was missing validation and used an unsafe `as Locale` cast, generating incorrect canonical URLs for invalid locales.

## Test plan

- [x] All 5 new layout tests pass (`generateMetadata` with valid/invalid locales)
- [x] Lint passes (0 errors)
- [x] Knip passes (no unused exports)
- [x] Existing proxy.locale-guard tests still pass
- [ ] CI pipeline passes

Closes #9419

🤖 Generated with [Claude Code](https://claude.com/claude-code)