### PR TITLE
feat(zero): add run id to run context response

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
@@ -65,6 +65,7 @@ function makeBaseContext(
   return {
     prompt: "Default prompt text",
     appendSystemPrompt: null,
+    runId: "run-test-id",
     sessionId: null,
     secretNames: [],
     vars: null,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
@@ -181,6 +181,7 @@ describe("zeroActivityDetailPageInteraction", () => {
     const contextResponse: RunContextResponse = {
       prompt: "What is the capital of France?",
       appendSystemPrompt: null,
+      runId: "run-test-id",
       sessionId: null,
       secretNames: [],
       vars: null,

--- a/turbo/apps/platform/src/views/zero-page/components/context-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/context-content.tsx
@@ -158,6 +158,14 @@ export function ContextContent({ context }: { context: RunContextResponse }) {
         </section>
       )}
 
+      {/* Run ID */}
+      <section>
+        <SectionHeader title="Run ID" />
+        <p className="text-sm font-mono text-muted-foreground">
+          {context.runId}
+        </p>
+      </section>
+
       {/* Session */}
       {context.sessionId && (
         <section>

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
@@ -98,6 +98,7 @@ describe("GET /api/zero/runs/:id/context", () => {
 
     const data = await response.json();
     expect(data.prompt).toBe("test prompt");
+    expect(data.runId).toBe(runId);
     expect(data.sessionId).toBeNull();
     expect(data.secretNames).toEqual(["API_KEY", "DB_PASSWORD"]);
     expect(data.environment).toEqual({

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
@@ -53,6 +53,7 @@ const router = tsr.router(zeroRunContextContract, {
       body: {
         prompt: snapshot.prompt,
         appendSystemPrompt: snapshot.appendSystemPrompt,
+        runId: params.id,
         sessionId: snapshot.sessionId ?? null,
         secretNames: snapshot.secretNames,
         vars: (run.vars as Record<string, string> | undefined) ?? null,

--- a/turbo/apps/web/src/lib/shared/axiom/client.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/client.ts
@@ -192,13 +192,12 @@ export function ingestRequestLog(entry: RequestLogEntry): void {
  * Snapshot of dynamically-computed execution context fields stored in Axiom.
  * Derived from the API response shape (defined by Zod schema in @vm0/core)
  * but excludes `vars` (which comes from agent_runs at query time) and adds
- * Axiom-only fields (runId, userId) that are not exposed to clients.
+ * Axiom-only field (userId) that is not exposed to clients.
  *
  * This keeps the Axiom storage type and the API response type in sync —
  * changes to the Zod schema in zero-runs.ts are automatically reflected here.
  */
 export interface RunContextSnapshot extends Omit<RunContextResponse, "vars"> {
-  runId: string;
   userId: string;
 }
 

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -191,6 +191,7 @@ const runContextFirewallSchema = z.object({
 const runContextResponseSchema = z.object({
   prompt: z.string(),
   appendSystemPrompt: z.string().nullable(),
+  runId: z.string(),
   sessionId: z.string().nullable(),
   secretNames: z.array(z.string()),
   vars: z.record(z.string(), z.string()).nullable(),


### PR DESCRIPTION
## Summary
- Add `runId` field to the run context API response (`GET /api/zero/runs/:id/context`)
- Display Run ID in the context detail UI (between System Prompt and Session)
- Remove redundant `runId` declaration from `RunContextSnapshot` (now inherited from `RunContextResponse`)

## Test plan
- [x] Existing route tests pass with new `runId` assertion
- [x] TypeScript type check passes across all workspaces
- [x] Knip reports no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)