### PR TITLE
feat(platform): add keyboard shortcuts help dialog to mission control

### DIFF
--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
@@ -98,6 +98,18 @@ export const setNewChatDialogOpen$ = command(({ set }, open: boolean) => {
 });
 
 // ---------------------------------------------------------------------------
+// Keyboard shortcuts help dialog state
+// ---------------------------------------------------------------------------
+
+const internalShortcutHelpOpen$ = state(false);
+export const shortcutHelpOpen$ = computed((get) => {
+  return get(internalShortcutHelpOpen$);
+});
+export const setShortcutHelpOpen$ = command(({ set }, open: boolean) => {
+  set(internalShortcutHelpOpen$, open);
+});
+
+// ---------------------------------------------------------------------------
 // Keyboard shortcuts
 // ---------------------------------------------------------------------------
 
@@ -116,6 +128,9 @@ export const setupMissionControlKeyboard$ = command(
         },
         c: () => {
           set(setNewChatDialogOpen$, true);
+        },
+        "shift+?": () => {
+          set(setShortcutHelpOpen$, true);
         },
         y: () => {
           const container = get(internalTaskListRef$);

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -900,6 +900,7 @@ describe("mission control page", () => {
   });
 
   it("should open keyboard shortcuts help dialog when shift+? is pressed", async () => {
+    const user = userEvent.setup();
     mockTasksAPI([]);
 
     detachedSetupPage({ context, path: "/_/mission-control" });
@@ -908,20 +909,15 @@ describe("mission control page", () => {
       expect(screen.getByText("No active tasks")).toBeInTheDocument();
     });
 
-    // shift+? shortcut is registered by setupMissionControlKeyboard$
-    // userEvent does not have "?" in its keyMap, so dispatch the event directly
-    document.dispatchEvent(
-      new KeyboardEvent("keydown", {
-        key: "?",
-        shiftKey: true,
-        bubbles: true,
-        cancelable: true,
-      }),
-    );
+    // "?" is not in userEvent's default keyMap; hold Shift explicitly so the
+    // keydown event carries shiftKey:true and key:"?" — matching the shift+? binding
+    await user.keyboard("{Shift>}?{/Shift}");
 
     await waitFor(() => {
-      // ShortcutHelpDialog title
-      expect(screen.getByText("Keyboard Shortcuts")).toBeInTheDocument();
+      // ShortcutHelpDialog is rendered as a dialog with accessible name
+      expect(
+        screen.getByRole("dialog", { name: /keyboard shortcuts/i }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -899,6 +899,32 @@ describe("mission control page", () => {
     });
   });
 
+  it("should open keyboard shortcuts help dialog when shift+? is pressed", async () => {
+    mockTasksAPI([]);
+
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    await waitFor(() => {
+      expect(screen.getByText("No active tasks")).toBeInTheDocument();
+    });
+
+    // shift+? shortcut is registered by setupMissionControlKeyboard$
+    // userEvent does not have "?" in its keyMap, so dispatch the event directly
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "?",
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    await waitFor(() => {
+      // ShortcutHelpDialog title
+      expect(screen.getByText("Keyboard Shortcuts")).toBeInTheDocument();
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Unread tracking tests
   // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
@@ -19,12 +19,15 @@ import {
   setTaskListRef$,
   newChatDialogOpen$,
   setNewChatDialogOpen$,
+  shortcutHelpOpen$,
+  setShortcutHelpOpen$,
   createAndShowChatTask$,
 } from "../../signals/mission-control-page/mission-control.ts";
 import { subagents$, defaultAgentName$ } from "../../signals/agent.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { AgentListDialog } from "../zero-page/zero-sidebar-dialogs.tsx";
+import { ShortcutHelpDialog } from "./shortcut-help-dialog.tsx";
 import { TaskList } from "./task-list.tsx";
 import { TaskPanel } from "./task-panel.tsx";
 import { CollapsedTaskListBar } from "./collapsed-task-list-bar.tsx";
@@ -38,6 +41,8 @@ export function MissionControlPage() {
   const setListRef = useSet(setTaskListRef$);
   const newChatOpen = useGet(newChatDialogOpen$);
   const setNewChatOpen = useSet(setNewChatDialogOpen$);
+  const shortcutHelp = useGet(shortcutHelpOpen$);
+  const setShortcutHelp = useSet(setShortcutHelpOpen$);
   const subagents = useLastResolved(subagents$) ?? [];
   const displayName = useLastResolved(defaultAgentName$) ?? "Zero";
   const createAndShowChatTask = useSet(createAndShowChatTask$);
@@ -126,6 +131,7 @@ export function MissionControlPage() {
         subagents={subagents}
         onNewChat={onNewChat}
       />
+      <ShortcutHelpDialog open={shortcutHelp} onOpenChange={setShortcutHelp} />
     </Group>
   );
 }

--- a/turbo/apps/platform/src/views/mission-control-page/shortcut-help-dialog.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/shortcut-help-dialog.tsx
@@ -39,7 +39,7 @@ export function ShortcutHelpDialog({
             title="Task Card"
             shortcuts={[
               { key: "enter", label: "Open task" },
-              { key: " ", label: "Toggle panel" },
+              { key: "space", label: "Toggle panel" },
             ]}
           />
           <ShortcutSection

--- a/turbo/apps/platform/src/views/mission-control-page/shortcut-help-dialog.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/shortcut-help-dialog.tsx
@@ -1,0 +1,88 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  getShortcutLabel,
+} from "@vm0/ui";
+
+export function ShortcutHelpDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Keyboard Shortcuts</DialogTitle>
+          <DialogDescription>
+            Available shortcuts in Mission Control
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <ShortcutSection
+            title="Global"
+            shortcuts={[
+              { key: "j", label: "Next task" },
+              { key: "k", label: "Previous task" },
+              { key: "mod+b", label: "Toggle task list" },
+              { key: "c", label: "New chat" },
+              { key: "y", label: "Archive task" },
+              { key: "shift+?", label: "Show shortcuts" },
+            ]}
+          />
+          <ShortcutSection
+            title="Task Card"
+            shortcuts={[
+              { key: "enter", label: "Open task" },
+              { key: " ", label: "Toggle panel" },
+            ]}
+          />
+          <ShortcutSection
+            title="Task Panel"
+            shortcuts={[
+              { key: "mod+shift+enter", label: "Maximize / restore" },
+              { key: "escape", label: "Back to task card" },
+              { key: "ctrl+d", label: "Close panel" },
+            ]}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ShortcutSection({
+  title,
+  shortcuts,
+}: {
+  title: string;
+  shortcuts: { key: string; label: string }[];
+}) {
+  return (
+    <div>
+      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+        {title}
+      </h3>
+      <div className="space-y-1">
+        {shortcuts.map((shortcut) => {
+          return (
+            <div
+              key={shortcut.key}
+              className="flex items-center justify-between py-1"
+            >
+              <span className="text-sm">{shortcut.label}</span>
+              <kbd className="ml-4 shrink-0 rounded border border-border bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground">
+                {getShortcutLabel(shortcut.key)}
+              </kbd>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/turbo/packages/ui/src/lib/keyboard-shortcuts.ts
+++ b/turbo/packages/ui/src/lib/keyboard-shortcuts.ts
@@ -145,6 +145,14 @@ export function processShortcut(
 // Display labels
 // ---------------------------------------------------------------------------
 
+const KEY_DISPLAY_NAMES: Record<string, string> = {
+  space: "Space",
+};
+
+function formatKey(key: string): string {
+  return KEY_DISPLAY_NAMES[key] ?? key.charAt(0).toUpperCase() + key.slice(1);
+}
+
 export function getShortcutLabel(shortcut: string): string {
   const parsed = parseShortcut(shortcut);
 
@@ -159,7 +167,7 @@ export function getShortcutLabel(shortcut: string): string {
     if (parsed.alt) {
       parts.push("⌥");
     }
-    parts.push(parsed.key.charAt(0).toUpperCase() + parsed.key.slice(1));
+    parts.push(formatKey(parsed.key));
     return parts.join("");
   }
 
@@ -173,6 +181,6 @@ export function getShortcutLabel(shortcut: string): string {
   if (parsed.alt) {
     parts.push("Alt");
   }
-  parts.push(parsed.key.charAt(0).toUpperCase() + parsed.key.slice(1));
+  parts.push(formatKey(parsed.key));
   return parts.join("+");
 }


### PR DESCRIPTION
## Summary
- Add a keyboard shortcuts help dialog to Mission Control, triggered by pressing `Shift+?`
- New `ShortcutHelpDialog` component displays all available shortcuts organized by section (Global, Task Card, Task Panel)
- Add `shortcutHelpOpen$` signal state and `setShortcutHelpOpen$` command to manage dialog visibility

## Test plan
- [ ] Press `Shift+?` on Mission Control page and verify the shortcuts dialog appears
- [ ] Verify all listed shortcuts match actual functionality
- [ ] Verify dialog closes when clicking outside or pressing Escape

🤖 Generated with [Claude Code](https://claude.com/claude-code)