### PR TITLE
fix(platform): wrap tts cleanup fn in updater to prevent immediate execution

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
+++ b/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
@@ -215,4 +215,21 @@ describe("playTts$", () => {
     await context.store.set(playTts$, "msg-4", "Hello again", context.signal);
     expect(getFetchCount()).toBe(1);
   });
+
+  it("should invoke cleanup function (reader.cancel + audioCtx.close) when stopTts$ is called", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+    const { mockAudioContext } = mockWebAudio();
+    mockTtsEndpoint();
+
+    await context.store.set(playTts$, "msg-5", "Hello world", context.signal);
+
+    // AudioContext.close should not have been called during normal playback
+    expect(mockAudioContext.close).not.toHaveBeenCalled();
+
+    // stopTts$ triggers the stored cleanup function
+    context.store.set(stopTts$);
+
+    // The cleanup function should have called audioCtx.close()
+    expect(mockAudioContext.close).toHaveBeenCalledTimes(1);
+  });
 });

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
@@ -128,13 +128,16 @@ const fetchAndPlay$ = command(
       let lastSource: AudioBufferSourceNode | null = null;
       let carry: Uint8Array | null = null;
 
-      set(internalCleanupFn$, () => {
+      const cleanupFn = () => {
         reader.cancel().catch((error: unknown) => {
           L.debug("reader cancel error", error);
         });
         audioCtx.close().catch((error: unknown) => {
           L.debug("audioCtx close error", error);
         });
+      };
+      set(internalCleanupFn$, () => {
+        return cleanupFn;
       });
 
       for (;;) {


### PR DESCRIPTION
## Summary

- Fix TTS Read Aloud button producing no sound due to cleanup function being immediately executed instead of stored
- `ccstate` treats function arguments to `set(atom, fn)` as updater functions — the cleanup closure was invoked immediately, closing the AudioContext before audio could play
- Wrap cleanup function in updater form `set(internalCleanupFn$, () => { return cleanupFn; })` so it's stored as the atom value

Closes #9437

## Test plan

- [x] All 7 existing TTS tests pass
- [x] Lint passes (0 errors, 0 warnings)
- [x] Format clean
- [x] Knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)