### PR TITLE
feat(mission-control): add voice chat panel for voice_chat tasks

### DIFF
--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -118,6 +118,7 @@
         "src/signals/zero-page/zero-chat.ts",
         "src/signals/zero-page/chat-draft.ts",
         "src/signals/voice-chat/voice-chat-session.ts",
+        "src/signals/mission-control-page/create-voice-chat-panel-signals.ts",
         "src/signals/voice-io/voice-io-tts.ts",
         "src/signals/voice-io/voice-io-stt.ts"
       ],

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -143,7 +143,7 @@ export default [
       "src/signals/zero-page/chat-draft.ts",
       "src/signals/__tests__/fetch.test.ts",
       "src/signals/voice-chat/voice-chat-session.ts",
-      "src/signals/mission-control-page/create-voice-chat-panel-signals.ts",
+      "src/signals/mission-control-page/create-voice-chat-panel-signals.ts", // TODO: migrate to zeroClient$ when voice-chat API contract is added
       "src/signals/voice-io/voice-io-tts.ts",
       "src/signals/voice-io/voice-io-stt.ts",
       "src/views/zero-page/components/org-manage/org-general-tab.tsx",

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -143,6 +143,7 @@ export default [
       "src/signals/zero-page/chat-draft.ts",
       "src/signals/__tests__/fetch.test.ts",
       "src/signals/voice-chat/voice-chat-session.ts",
+      "src/signals/mission-control-page/create-voice-chat-panel-signals.ts",
       "src/signals/voice-io/voice-io-tts.ts",
       "src/signals/voice-io/voice-io-stt.ts",
       "src/views/zero-page/components/org-manage/org-general-tab.tsx",

--- a/turbo/apps/platform/src/signals/mission-control-page/__tests__/create-voice-chat-panel-signals.test.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/__tests__/create-voice-chat-panel-signals.test.ts
@@ -122,6 +122,14 @@ describe("createVoiceChatPanelSignals", () => {
             },
             // null item — should be filtered out
             null,
+            // content is undefined (field absent) — should be filtered out
+            {
+              id: "evt-no-content",
+              seq: 4,
+              source: "user",
+              type: "speech",
+              createdAt: "2026-04-13T10:00:04Z",
+            },
           ],
         });
       }),

--- a/turbo/apps/platform/src/signals/mission-control-page/__tests__/create-voice-chat-panel-signals.test.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/__tests__/create-voice-chat-panel-signals.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { waitFor } from "@testing-library/react";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { createVoiceChatPanelSignals } from "../create-voice-chat-panel-signals.ts";
+import { createDeferredPromise, detach, Reason } from "../../utils.ts";
+
+const context = testContext();
+
+function setup() {
+  detachedSetupPage({
+    context,
+    path: "/",
+    withoutRender: true,
+  });
+}
+
+describe("createVoiceChatPanelSignals", () => {
+  it("should start with empty events list", () => {
+    setup();
+    const signals = createVoiceChatPanelSignals("sess-1");
+    const events = context.store.get(signals.events$);
+    expect(events).toHaveLength(0);
+  });
+
+  it("should accumulate valid events from polling and advance lastSeq", async () => {
+    setup();
+
+    server.use(
+      http.get("*/api/zero/voice-chat/sess-poll/context", ({ request }) => {
+        const url = new URL(request.url);
+        const after = Number(url.searchParams.get("after") ?? 0);
+        if (after === 0) {
+          return HttpResponse.json({
+            events: [
+              {
+                id: "evt-1",
+                seq: 1,
+                source: "slow-brain",
+                type: "thinking",
+                content: "Analyzing context",
+                createdAt: "2026-04-13T10:00:01Z",
+              },
+              {
+                id: "evt-2",
+                seq: 2,
+                source: "user",
+                type: "speech",
+                content: "Hello",
+                createdAt: "2026-04-13T10:00:02Z",
+              },
+            ],
+          });
+        }
+        // Subsequent polls return no new events
+        return HttpResponse.json({ events: [] });
+      }),
+    );
+
+    const signals = createVoiceChatPanelSignals("sess-poll");
+    detach(
+      context.store.set(signals.startPolling$, context.signal),
+      Reason.Daemon,
+    );
+
+    await waitFor(() => {
+      const events = context.store.get(signals.events$);
+      expect(events).toHaveLength(2);
+    });
+
+    const events = context.store.get(signals.events$);
+    expect(events[0]).toMatchObject({
+      id: "evt-1",
+      seq: 1,
+      source: "slow-brain",
+      type: "thinking",
+      content: "Analyzing context",
+    });
+    expect(events[1]).toMatchObject({
+      id: "evt-2",
+      seq: 2,
+      source: "user",
+      type: "speech",
+      content: "Hello",
+    });
+  });
+
+  it("should filter out items missing required fields from the events array", async () => {
+    setup();
+
+    server.use(
+      http.get("*/api/zero/voice-chat/sess-validate/context", () => {
+        return HttpResponse.json({
+          events: [
+            // Valid event
+            {
+              id: "evt-ok",
+              seq: 1,
+              source: "slow-brain",
+              type: "thinking",
+              content: "Valid",
+              createdAt: "2026-04-13T10:00:01Z",
+            },
+            // Missing id — should be filtered out
+            {
+              seq: 2,
+              source: "user",
+              type: "speech",
+              content: "No id",
+              createdAt: "2026-04-13T10:00:02Z",
+            },
+            // seq is a string, not number — should be filtered out
+            {
+              id: "evt-bad-seq",
+              seq: "3",
+              source: "fast-brain",
+              type: "response",
+              content: "Bad seq",
+              createdAt: "2026-04-13T10:00:03Z",
+            },
+            // null item — should be filtered out
+            null,
+          ],
+        });
+      }),
+    );
+
+    const signals = createVoiceChatPanelSignals("sess-validate");
+    detach(
+      context.store.set(signals.startPolling$, context.signal),
+      Reason.Daemon,
+    );
+
+    await waitFor(() => {
+      const events = context.store.get(signals.events$);
+      // Only the one valid event should be present
+      expect(events).toHaveLength(1);
+    });
+
+    const events = context.store.get(signals.events$);
+    expect(events[0]).toMatchObject({ id: "evt-ok", seq: 1 });
+  });
+
+  it("should return false from polling and not set events on non-ok response", async () => {
+    setup();
+
+    const pollFired = createDeferredPromise<void>(context.signal);
+    server.use(
+      http.get("*/api/zero/voice-chat/sess-error/context", () => {
+        pollFired.resolve();
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    const signals = createVoiceChatPanelSignals("sess-error");
+    detach(
+      context.store.set(signals.startPolling$, context.signal),
+      Reason.Daemon,
+    );
+
+    // Wait until the poll has fired at least once
+    await pollFired.promise;
+
+    // Events remain empty after a failed response
+    expect(context.store.get(signals.events$)).toHaveLength(0);
+  });
+});

--- a/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
@@ -72,7 +72,8 @@ export function createVoiceChatPanelSignals(
             typeof ev.id === "string" &&
             typeof ev.seq === "number" &&
             typeof ev.source === "string" &&
-            typeof ev.type === "string"
+            typeof ev.type === "string" &&
+            (typeof ev.content === "string" || ev.content === null)
           );
         });
         if (incoming.length > 0) {

--- a/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
@@ -91,6 +91,8 @@ export function createVoiceChatPanelSignals(
     );
   });
 
+  // No-op: satisfies the TaskPanelEntry.focusInput$ contract. Voice chat
+  // panels have no text input to focus.
   const focusInput$ = command(() => {});
 
   return {

--- a/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
@@ -62,7 +62,19 @@ export function createVoiceChatPanelSignals(
           return false;
         }
 
-        const incoming = (json as { events: VoiceChatEvent[] }).events;
+        const rawEvents = (json as { events: unknown[] }).events;
+        const incoming = rawEvents.filter((e): e is VoiceChatEvent => {
+          if (typeof e !== "object" || e === null) {
+            return false;
+          }
+          const ev = e as Record<string, unknown>;
+          return (
+            typeof ev.id === "string" &&
+            typeof ev.seq === "number" &&
+            typeof ev.source === "string" &&
+            typeof ev.type === "string"
+          );
+        });
         if (incoming.length > 0) {
           set(events$, (prev) => {
             return [...prev, ...incoming];

--- a/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
@@ -1,4 +1,4 @@
-import { command, computed, state, type Command, type Computed } from "ccstate";
+import { command, state, type Command, type State } from "ccstate";
 import { fetch$ } from "../fetch.ts";
 import { setLoop } from "../utils.ts";
 
@@ -21,7 +21,7 @@ export interface VoiceChatEvent {
 
 export interface VoiceChatPanelSignals {
   sessionId: string;
-  events$: Computed<VoiceChatEvent[]>;
+  events$: State<VoiceChatEvent[]>;
   startPolling$: Command<Promise<void>, [AbortSignal]>;
   focusInput$: Command<void, []>;
 }
@@ -33,17 +33,13 @@ export interface VoiceChatPanelSignals {
 export function createVoiceChatPanelSignals(
   sessionId: string,
 ): VoiceChatPanelSignals {
-  const internalEvents$ = state<VoiceChatEvent[]>([]);
-  const internalLastSeq$ = state(0);
-
-  const events$ = computed((get) => {
-    return get(internalEvents$);
-  });
+  const events$ = state<VoiceChatEvent[]>([]);
+  const lastSeq$ = state(0);
 
   const startPolling$ = command(async ({ get, set }, signal: AbortSignal) => {
     await setLoop(
       async (sig: AbortSignal) => {
-        const lastSeq = get(internalLastSeq$);
+        const lastSeq = get(lastSeq$);
         const fetchFn = get(fetch$);
         const res = await fetchFn(
           `/api/zero/voice-chat/${sessionId}/context?after=${lastSeq}`,
@@ -54,16 +50,26 @@ export function createVoiceChatPanelSignals(
           return false;
         }
 
-        const data = (await res.json()) as { events: VoiceChatEvent[] };
+        const json: unknown = await res.json();
         sig.throwIfAborted();
 
-        if (data.events.length > 0) {
-          set(internalEvents$, (prev) => {
-            return [...prev, ...data.events];
+        if (
+          typeof json !== "object" ||
+          json === null ||
+          !("events" in json) ||
+          !Array.isArray((json as { events: unknown }).events)
+        ) {
+          return false;
+        }
+
+        const incoming = (json as { events: VoiceChatEvent[] }).events;
+        if (incoming.length > 0) {
+          set(events$, (prev) => {
+            return [...prev, ...incoming];
           });
-          const lastEvent = data.events[data.events.length - 1];
-          if (lastEvent) {
-            set(internalLastSeq$, lastEvent.seq);
+          const last = incoming[incoming.length - 1];
+          if (last) {
+            set(lastSeq$, last.seq);
           }
         }
         return false;

--- a/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
@@ -1,0 +1,84 @@
+import { command, computed, state, type Command, type Computed } from "ccstate";
+import { fetch$ } from "../fetch.ts";
+import { setLoop } from "../utils.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VoiceChatEvent {
+  id: string;
+  seq: number;
+  source: string;
+  type: string;
+  content: string | null;
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// VoiceChatPanelSignals — returned by createVoiceChatPanelSignals
+// ---------------------------------------------------------------------------
+
+export interface VoiceChatPanelSignals {
+  sessionId: string;
+  events$: Computed<VoiceChatEvent[]>;
+  startPolling$: Command<Promise<void>, [AbortSignal]>;
+  focusInput$: Command<void, []>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createVoiceChatPanelSignals(
+  sessionId: string,
+): VoiceChatPanelSignals {
+  const internalEvents$ = state<VoiceChatEvent[]>([]);
+  const internalLastSeq$ = state(0);
+
+  const events$ = computed((get) => {
+    return get(internalEvents$);
+  });
+
+  const startPolling$ = command(async ({ get, set }, signal: AbortSignal) => {
+    await setLoop(
+      async (sig: AbortSignal) => {
+        const lastSeq = get(internalLastSeq$);
+        const fetchFn = get(fetch$);
+        const res = await fetchFn(
+          `/api/zero/voice-chat/${sessionId}/context?after=${lastSeq}`,
+          { signal: sig },
+        );
+
+        if (!res.ok) {
+          return false;
+        }
+
+        const data = (await res.json()) as { events: VoiceChatEvent[] };
+        sig.throwIfAborted();
+
+        if (data.events.length > 0) {
+          set(internalEvents$, (prev) => {
+            return [...prev, ...data.events];
+          });
+          const lastEvent = data.events[data.events.length - 1];
+          if (lastEvent) {
+            set(internalLastSeq$, lastEvent.seq);
+          }
+        }
+        return false;
+      },
+      3000,
+      signal,
+    );
+  });
+
+  const focusInput$ = command(() => {});
+
+  return {
+    sessionId,
+    events$,
+    startPolling$,
+    focusInput$,
+  };
+}

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
@@ -18,6 +18,10 @@ import {
   createActivitySignals,
   type ActivitySignals,
 } from "./create-activity-signals.ts";
+import {
+  createVoiceChatPanelSignals,
+  type VoiceChatPanelSignals,
+} from "./create-voice-chat-panel-signals.ts";
 import { maximizedTaskId$ } from "./mission-control-panels.ts";
 import { localStorageSignals } from "../external/local-storage.ts";
 
@@ -45,7 +49,8 @@ const OPTIMISTIC_TTL_MS = 30_000;
 
 export type TaskPanelEntry =
   | { kind: "chat"; signals: ChatThreadSignals }
-  | { kind: "activity"; signals: ActivitySignals };
+  | { kind: "activity"; signals: ActivitySignals }
+  | { kind: "voice"; signals: VoiceChatPanelSignals };
 
 // ---------------------------------------------------------------------------
 // TaskSignals — per-task signal bundle
@@ -201,7 +206,14 @@ function createPanelSignals(
         await set(signals.loadMessages$, signal);
         return;
       }
-      if (task.latestRunId) {
+      if (task.type === "voice_chat" && task.voiceChatSessionId) {
+        const panelSignal = set(resetPanelPolling$, signal);
+        const signals = createVoiceChatPanelSignals(task.voiceChatSessionId);
+        set(internalPanelEntry$, { kind: "voice", signals });
+        set(internalOpenedAt$, Date.now());
+        set(internalOpen$, true);
+        await set(signals.startPolling$, panelSignal);
+      } else if (task.latestRunId) {
         const panelSignal = set(resetPanelPolling$, signal);
         const signals = createActivitySignals(task.latestRunId);
         set(internalPanelEntry$, { kind: "activity", signals });

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -920,6 +920,83 @@ describe("mission control page", () => {
     expect(pathname()).toBe("/_/mission-control");
   });
 
+  it("should hide empty state when voice chat panel receives events", async () => {
+    // Use a unique session ID for this test
+    mockTasksAPI([
+      {
+        id: "task-vc-open",
+        type: "voice_chat",
+        title: "Live voice session",
+        summary: null,
+        agent: createAgent(),
+        latestRunId: "run-vc-open-1",
+        status: "running",
+        voiceChatSessionId: "vc-session-open",
+        createdAt: "2026-04-13T10:00:00Z",
+        updatedAt: "2026-04-13T10:00:00Z",
+      },
+    ]);
+
+    server.use(
+      http.get(
+        "*/api/zero/voice-chat/vc-session-open/context",
+        ({ request }) => {
+          const url = new URL(request.url);
+          const after = Number(url.searchParams.get("after") ?? 0);
+          if (after === 0) {
+            return HttpResponse.json({
+              events: [
+                {
+                  id: "evt-a",
+                  seq: 1,
+                  source: "slow-brain",
+                  type: "thinking",
+                  content: "Analyzing context",
+                  createdAt: "2026-04-13T10:00:01Z",
+                },
+                {
+                  id: "evt-b",
+                  seq: 2,
+                  source: "slow-brain",
+                  type: "directive",
+                  content: "Be concise",
+                  createdAt: "2026-04-13T10:00:02Z",
+                },
+              ],
+            });
+          }
+          return HttpResponse.json({ events: [] });
+        },
+      ),
+    );
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    const title = await waitFor(() => {
+      return screen.getByText("Live voice session");
+    });
+
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Close task")).toBeInTheDocument();
+    });
+
+    // Slow-brain labels rendered by SlowBrainIndicator
+    await waitFor(() => {
+      expect(screen.getByText("Thinking")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Directive")).toBeInTheDocument();
+    expect(screen.getByText("Analyzing context")).toBeInTheDocument();
+    expect(screen.getByText("Be concise")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No conversation events yet"),
+    ).not.toBeInTheDocument();
+    expect(pathname()).toBe("/_/mission-control");
+  });
+
   it("should open new chat dialog when c key is pressed", async () => {
     mockTasksAPI([]);
 

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
+import { FeatureSwitchKey } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -904,7 +905,11 @@ describe("mission control page", () => {
     );
 
     const user = userEvent.setup();
-    detachedSetupPage({ context, path: "/_/mission-control" });
+    detachedSetupPage({
+      context,
+      path: "/_/mission-control",
+      featureSwitches: { [FeatureSwitchKey.VoiceChat]: true },
+    });
 
     const title = await waitFor(() => {
       return screen.getByText("Voice chat with Zero");
@@ -970,7 +975,11 @@ describe("mission control page", () => {
     );
 
     const user = userEvent.setup();
-    detachedSetupPage({ context, path: "/_/mission-control" });
+    detachedSetupPage({
+      context,
+      path: "/_/mission-control",
+      featureSwitches: { [FeatureSwitchKey.VoiceChat]: true },
+    });
 
     const title = await waitFor(() => {
       return screen.getByText("Live voice session");

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -28,7 +28,7 @@ function createAgent() {
 function mockTasksAPI(
   tasks: {
     id: string;
-    type: "chat" | "schedule" | "slack" | "email";
+    type: "chat" | "schedule" | "slack" | "email" | "voice_chat" | "agent";
     title: string | null;
     summary: string | null;
     agent: {
@@ -43,6 +43,7 @@ function mockTasksAPI(
     scheduleId?: string;
     slackThreadSessionId?: string;
     emailThreadSessionId?: string;
+    voiceChatSessionId?: string;
     createdAt: string;
     updatedAt: string;
   }[],
@@ -878,6 +879,45 @@ describe("mission control page", () => {
       .getByText("Voice session with Zero")
       .closest("[role=button]") as HTMLElement;
     expect(card.querySelector(".tabler-icon-microphone")).not.toBeNull();
+  });
+
+  it("should open voice chat panel when clicking a voice_chat task", async () => {
+    mockTasksAPI([
+      {
+        id: "task-vc-open",
+        type: "voice_chat",
+        title: "Voice chat with Zero",
+        summary: null,
+        agent: createAgent(),
+        latestRunId: "run-vc-open-1",
+        status: "running",
+        voiceChatSessionId: "vc-session-open",
+        createdAt: "2026-04-13T10:00:00Z",
+        updatedAt: "2026-04-13T10:00:00Z",
+      },
+    ]);
+
+    server.use(
+      http.get("*/api/zero/voice-chat/vc-session-open/context", () => {
+        return HttpResponse.json({ events: [] });
+      }),
+    );
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    const title = await waitFor(() => {
+      return screen.getByText("Voice chat with Zero");
+    });
+
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Close task")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("No conversation events yet")).toBeInTheDocument();
+    expect(pathname()).toBe("/_/mission-control");
   });
 
   it("should open new chat dialog when c key is pressed", async () => {

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -921,17 +921,16 @@ describe("mission control page", () => {
   });
 
   it("should hide empty state when voice chat panel receives events", async () => {
-    // Use a unique session ID for this test
     mockTasksAPI([
       {
-        id: "task-vc-open",
+        id: "task-vc-events",
         type: "voice_chat",
         title: "Live voice session",
         summary: null,
         agent: createAgent(),
-        latestRunId: "run-vc-open-1",
+        latestRunId: "run-vc-events-1",
         status: "running",
-        voiceChatSessionId: "vc-session-open",
+        voiceChatSessionId: "vc-session-events",
         createdAt: "2026-04-13T10:00:00Z",
         updatedAt: "2026-04-13T10:00:00Z",
       },
@@ -939,7 +938,7 @@ describe("mission control page", () => {
 
     server.use(
       http.get(
-        "*/api/zero/voice-chat/vc-session-open/context",
+        "*/api/zero/voice-chat/vc-session-events/context",
         ({ request }) => {
           const url = new URL(request.url);
           const after = Number(url.searchParams.get("after") ?? 0);

--- a/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
@@ -5,6 +5,7 @@ import {
   IconArrowsMinimize,
 } from "@tabler/icons-react";
 import { processShortcut } from "@vm0/ui";
+import { FeatureSwitchKey } from "@vm0/core";
 import {
   visibleTasks$,
   closeAndFocusNextInput$,
@@ -17,6 +18,7 @@ import {
   toggleMaximizeTask$,
 } from "../../signals/mission-control-page/mission-control-panels.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { ZeroChatThreadPageInner } from "../zero-page/zero-chat-thread-page.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 import { ActivityPanelContent } from "./activity-panel-content.tsx";
@@ -169,6 +171,7 @@ function TaskPanelContent({ taskSignals }: { taskSignals: TaskSignals }) {
 }
 
 function TaskPanelEntryContent({ entry }: { entry: TaskPanelEntry }) {
+  const features = useLastResolved(featureSwitch$);
   switch (entry.kind) {
     case "chat": {
       return (
@@ -179,6 +182,9 @@ function TaskPanelEntryContent({ entry }: { entry: TaskPanelEntry }) {
       return <ActivityPanelContent signals={entry.signals} />;
     }
     case "voice": {
+      if (!features?.[FeatureSwitchKey.VoiceChat]) {
+        return null;
+      }
       return <VoiceChatPanelContent signals={entry.signals} />;
     }
   }

--- a/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
@@ -20,6 +20,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ZeroChatThreadPageInner } from "../zero-page/zero-chat-thread-page.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 import { ActivityPanelContent } from "./activity-panel-content.tsx";
+import { VoiceChatPanelContent } from "./voice-chat-panel-content.tsx";
 import { TaskTypeIcon } from "./task-card.tsx";
 
 export function TaskPanel() {
@@ -176,6 +177,9 @@ function TaskPanelEntryContent({ entry }: { entry: TaskPanelEntry }) {
     }
     case "activity": {
       return <ActivityPanelContent signals={entry.signals} />;
+    }
+    case "voice": {
+      return <VoiceChatPanelContent signals={entry.signals} />;
     }
   }
 }

--- a/turbo/apps/platform/src/views/mission-control-page/voice-chat-panel-content.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/voice-chat-panel-content.tsx
@@ -27,14 +27,18 @@ function categorizeEvent(event: VoiceChatEvent): EventCategory {
 
 function slowBrainLabel(type: string): string {
   switch (type) {
-    case "directive":
+    case "directive": {
       return "Directive";
-    case "thinking":
+    }
+    case "thinking": {
       return "Thinking";
-    case "observation":
+    }
+    case "observation": {
       return "Observation";
-    default:
+    }
+    default: {
       return type;
+    }
   }
 }
 
@@ -97,14 +101,18 @@ function SlowBrainIndicator({
 function VoiceChatEventItem({ event }: { event: VoiceChatEvent }) {
   const category = categorizeEvent(event);
   switch (category) {
-    case "user":
+    case "user": {
       return <VoiceUserBubble content={event.content ?? ""} />;
-    case "assistant":
+    }
+    case "assistant": {
       return <VoiceAssistantBubble content={event.content ?? ""} />;
-    case "slow-brain":
+    }
+    case "slow-brain": {
       return <SlowBrainIndicator type={event.type} content={event.content} />;
-    case "system":
+    }
+    case "system": {
       return null;
+    }
   }
 }
 

--- a/turbo/apps/platform/src/views/mission-control-page/voice-chat-panel-content.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/voice-chat-panel-content.tsx
@@ -1,0 +1,143 @@
+import { useGet } from "ccstate-react";
+import { IconBrain } from "@tabler/icons-react";
+import type {
+  VoiceChatPanelSignals,
+  VoiceChatEvent,
+} from "../../signals/mission-control-page/create-voice-chat-panel-signals.ts";
+import { Markdown } from "../components/markdown.tsx";
+
+// ---------------------------------------------------------------------------
+// Event classification
+// ---------------------------------------------------------------------------
+
+type EventCategory = "user" | "assistant" | "slow-brain" | "system";
+
+function categorizeEvent(event: VoiceChatEvent): EventCategory {
+  if (event.source === "user" && event.type === "speech") {
+    return "user";
+  }
+  if (event.source === "fast-brain" && event.type === "response") {
+    return "assistant";
+  }
+  if (event.source === "slow-brain") {
+    return "slow-brain";
+  }
+  return "system";
+}
+
+function slowBrainLabel(type: string): string {
+  switch (type) {
+    case "directive":
+      return "Directive";
+    case "thinking":
+      return "Thinking";
+    case "observation":
+      return "Observation";
+    default:
+      return type;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bubbles
+// ---------------------------------------------------------------------------
+
+function VoiceUserBubble({ content }: { content: string }) {
+  if (!content.trim()) {
+    return null;
+  }
+  return (
+    <div className="flex justify-end">
+      <div className="zero-chat-bubble-user rounded-xl max-w-[85%] px-4 py-3 text-sm leading-relaxed break-words overflow-hidden">
+        <Markdown source={content} />
+      </div>
+    </div>
+  );
+}
+
+function VoiceAssistantBubble({ content }: { content: string }) {
+  if (!content.trim()) {
+    return null;
+  }
+  return (
+    <div className="flex justify-start">
+      <div className="zero-chat-bubble-assistant rounded-xl max-w-[85%] px-4 py-3 text-sm leading-relaxed break-words overflow-hidden">
+        <Markdown source={content} />
+      </div>
+    </div>
+  );
+}
+
+function SlowBrainIndicator({
+  type,
+  content,
+}: {
+  type: string;
+  content: string | null;
+}) {
+  return (
+    <div className="flex items-start gap-2 px-2 py-1.5 text-xs text-muted-foreground">
+      <IconBrain size={14} className="shrink-0 mt-0.5" />
+      <div className="min-w-0">
+        <span className="font-medium">{slowBrainLabel(type)}</span>
+        {content?.trim() && (
+          <p className="mt-0.5 text-muted-foreground/80 line-clamp-3 break-words">
+            {content}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Event renderer
+// ---------------------------------------------------------------------------
+
+function VoiceChatEventItem({ event }: { event: VoiceChatEvent }) {
+  const category = categorizeEvent(event);
+  switch (category) {
+    case "user":
+      return <VoiceUserBubble content={event.content ?? ""} />;
+    case "assistant":
+      return <VoiceAssistantBubble content={event.content ?? ""} />;
+    case "slow-brain":
+      return <SlowBrainIndicator type={event.type} content={event.content} />;
+    case "system":
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function VoiceChatPanelContent({
+  signals,
+}: {
+  signals: VoiceChatPanelSignals;
+}) {
+  const events = useGet(signals.events$);
+
+  if (events.length === 0) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-3 p-4">
+        <p className="text-sm text-muted-foreground">
+          No conversation events yet
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-0 overflow-auto @container">
+      <div className="mx-auto w-full max-w-[900px] px-4 pt-4 pb-8">
+        <div className="flex flex-col gap-4">
+          {events.map((event) => {
+            return <VoiceChatEventItem key={event.id} event={event} />;
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `VoiceChatPanelContent` component to render voice conversation events (user speech, assistant responses, slow-brain indicators) in the mission control task panel
- Add `createVoiceChatPanelSignals` factory to poll voice chat session events via `/api/zero/voice-chat/:id/context`
- Wire `voice_chat` task type into `TaskPanelEntry` union and panel routing logic

## Test plan

- [ ] Open a voice_chat task in mission control and verify the voice chat panel renders
- [ ] Verify user speech bubbles, assistant response bubbles, and slow-brain indicators display correctly
- [ ] Confirm polling fetches new events incrementally (after last seq)
- [ ] Verify non-voice tasks (chat, activity) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)