### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -91,7 +91,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.105"
+CLAUDE_CODE_VERSION="2.1.108"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.25.4"


### PR DESCRIPTION
## Summary

Updates pinned package versions in `crates/runner/scripts/build-rootfs.sh`:

- **`CLAUDE_CODE_VERSION`**: `2.1.105` → `2.1.108`

All other pinned versions were checked and are already at their latest:
- `GO_VERSION`: `1.26.2` (latest)
- `GWS_CLI_VERSION`: `0.22.5` (latest)
- `XURL_VERSION`: `1.0.3` (latest)
- `AGENT_BROWSER_VERSION`: `0.25.4` (latest)

## Test plan

- [ ] Verify rootfs builds successfully with new Claude Code version
- [ ] Confirm `claude --version` inside the VM reports `2.1.108`

🤖 Generated with [Claude Code](https://claude.com/claude-code)