### PR TITLE
fix(zero): left-align agent reply email container

### DIFF
--- a/turbo/apps/web/src/lib/zero/email/templates/agent-reply.tsx
+++ b/turbo/apps/web/src/lib/zero/email/templates/agent-reply.tsx
@@ -27,7 +27,7 @@ export function AgentReplyEmail({
     <Html>
       <Head />
       <Body style={bodyStyle}>
-        <Container style={containerStyle}>
+        <Container align="left" style={containerStyle}>
           <Markdown
             markdownContainerStyles={markdownContainerStyle}
             markdownCustomStyles={markdownCustomStyles}
@@ -57,9 +57,8 @@ const bodyStyle = {
 };
 
 const containerStyle = {
-  margin: "0 auto",
+  margin: "0",
   padding: "0 24px",
-  maxWidth: "600px",
 };
 
 const markdownContainerStyle = {


### PR DESCRIPTION
## Summary
- Remove centered layout (`margin: "0 auto"`) and `maxWidth: "600px"` constraint from agent reply email container
- Add `align="left"` prop to `<Container>` and set `margin: "0"` so email content aligns to the left edge

## Test plan
- [ ] Verify agent reply emails render left-aligned in email clients
- [ ] Confirm no visual regressions in email template rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)