### PR TITLE
fix: split r2 image cache to rootfs only with local snapshot creation

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -79,6 +79,9 @@ done
 # ---------------------------------------------------------------------------
 
 ROOTFS_FILE="rootfs.ext4"
+# [sync:ca-constants] Keep in sync with: crates/runner/scripts/inject-ca.sh
+# and verify-rootfs.sh. Enforced by the `ca_constants_in_sync_across_scripts`
+# test in cmd/build.rs at compile time.
 CA_CERT_FILE="mitmproxy-ca-cert.pem"
 CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt"
 

--- a/crates/runner/scripts/inject-ca.sh
+++ b/crates/runner/scripts/inject-ca.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# inject-ca.sh — Replace CA certificate in an existing rootfs.ext4 image.
+#
+# Mounts the rootfs via loopback, replaces the proxy CA certificate,
+# rebuilds the system CA bundle, and updates the Java keystore.
+# Used after downloading a rootfs from R2 cache — the cached rootfs
+# contains the build host's CA which must be replaced with the local
+# host's CA before creating a snapshot.
+#
+# Usage: inject-ca.sh --rootfs <path> --ca-dir <path>
+
+set -euo pipefail
+
+ROOTFS=""
+CA_DIR=""
+MOUNT_DIR=""
+
+cleanup() {
+    if [[ -n "$MOUNT_DIR" ]]; then
+        sudo umount "$MOUNT_DIR" 2>/dev/null || true
+        rmdir "$MOUNT_DIR" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --rootfs)  ROOTFS="$2"; shift 2 ;;
+        --ca-dir)  CA_DIR="$2"; shift 2 ;;
+        *)         echo "error: unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+[[ -f "$ROOTFS" ]] || { echo "error: rootfs not found: $ROOTFS" >&2; exit 1; }
+[[ -d "$CA_DIR" ]] || { echo "error: ca-dir not found: $CA_DIR" >&2; exit 1; }
+
+# Constants — keep in sync with build-rootfs.sh
+# [sync:ca-constants] Keep in sync with: crates/runner/scripts/build-rootfs.sh
+CA_CERT_FILE="mitmproxy-ca-cert.pem"
+CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt"
+
+ca_cert="${CA_DIR}/${CA_CERT_FILE}"
+[[ -f "$ca_cert" ]] || { echo "error: CA cert not found: $ca_cert" >&2; exit 1; }
+
+# Mount rootfs read-write via loopback
+MOUNT_DIR="$(mktemp -d)"
+sudo mount -o loop "$ROOTFS" "$MOUNT_DIR"
+
+# Replace CA certificate
+sudo cp "$ca_cert" "${MOUNT_DIR}/${CA_ROOTFS_DEST}"
+sudo chmod 644 "${MOUNT_DIR}/${CA_ROOTFS_DEST}"
+
+# Rebuild system CA bundle (updates /etc/ssl/certs/ca-certificates.crt)
+sudo chroot "$MOUNT_DIR" update-ca-certificates
+
+# Update Java keystore. Unlike build-rootfs.sh (which imports into a fresh
+# keystore where the alias doesn't exist), here the alias vm0-proxy-ca
+# already exists from the original build. keytool -importcert rejects
+# duplicate aliases, so we must delete first then re-import.
+# keytool requires libjli.so on the library path; locate it dynamically.
+jli_dir=$(sudo chroot "$MOUNT_DIR" find /usr/lib/jvm -name libjli.so -printf '%h' -quit)
+sudo chroot "$MOUNT_DIR" env LD_LIBRARY_PATH="$jli_dir" \
+    keytool -delete \
+    -keystore /etc/ssl/certs/java/cacerts \
+    -storepass changeit \
+    -alias vm0-proxy-ca 2>/dev/null || true
+sudo chroot "$MOUNT_DIR" env LD_LIBRARY_PATH="$jli_dir" \
+    keytool -importcert -trustcacerts \
+    -keystore /etc/ssl/certs/java/cacerts \
+    -storepass changeit -noprompt \
+    -alias vm0-proxy-ca \
+    -file "/${CA_ROOTFS_DEST}"
+
+echo "[OK] CA cert replaced in rootfs"

--- a/crates/runner/scripts/inject-ca.sh
+++ b/crates/runner/scripts/inject-ca.sh
@@ -58,12 +58,14 @@ sudo chroot "$MOUNT_DIR" update-ca-certificates
 # already exists from the original build. keytool -importcert rejects
 # duplicate aliases, so we must delete first then re-import.
 # keytool requires libjli.so on the library path; locate it dynamically.
+# `|| true` handles the (unexpected) case where the alias is absent; stderr
+# is NOT suppressed so real keystore errors surface in CI logs.
 jli_dir=$(sudo chroot "$MOUNT_DIR" find /usr/lib/jvm -name libjli.so -printf '%h' -quit)
 sudo chroot "$MOUNT_DIR" env LD_LIBRARY_PATH="$jli_dir" \
     keytool -delete \
     -keystore /etc/ssl/certs/java/cacerts \
     -storepass changeit \
-    -alias vm0-proxy-ca 2>/dev/null || true
+    -alias vm0-proxy-ca || true
 sudo chroot "$MOUNT_DIR" env LD_LIBRARY_PATH="$jli_dir" \
     keytool -importcert -trustcacerts \
     -keystore /etc/ssl/certs/java/cacerts \

--- a/crates/runner/scripts/inject-ca.sh
+++ b/crates/runner/scripts/inject-ca.sh
@@ -14,11 +14,32 @@ set -euo pipefail
 ROOTFS=""
 CA_DIR=""
 MOUNT_DIR=""
+LOOP_DEV=""
 
 cleanup() {
+    # Retry umount a few times — chroot subprocesses (update-ca-certificates,
+    # keytool) may briefly hold references after returning.  Final attempt
+    # lets stderr through so CI logs show the root cause if it still fails.
     if [[ -n "$MOUNT_DIR" ]]; then
-        sudo umount "$MOUNT_DIR" 2>/dev/null || true
+        for attempt in 1 2 3; do
+            if [[ $attempt -eq 3 ]]; then
+                sudo umount "$MOUNT_DIR" || true
+                break
+            fi
+            if sudo umount "$MOUNT_DIR" 2>/dev/null; then
+                break
+            fi
+            sleep 0.5
+        done
         rmdir "$MOUNT_DIR" 2>/dev/null || true
+    fi
+    # Explicit loop device detach as a backstop. With LO_FLAGS_AUTOCLEAR
+    # (set by `losetup --find --show` via mount defaults), a successful
+    # umount already releases the device; this covers the umount-failed
+    # and SIGKILL-before-umount edge cases. Swallows errors because
+    # losetup -d on an already-detached device returns ENXIO.
+    if [[ -n "$LOOP_DEV" ]]; then
+        sudo losetup -d "$LOOP_DEV" 2>/dev/null || true
     fi
 }
 trap cleanup EXIT
@@ -42,9 +63,11 @@ CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt"
 ca_cert="${CA_DIR}/${CA_CERT_FILE}"
 [[ -f "$ca_cert" ]] || { echo "error: CA cert not found: $ca_cert" >&2; exit 1; }
 
-# Mount rootfs read-write via loopback
+# Mount rootfs read-write via loopback.  Explicit losetup gives us the
+# device name for the cleanup fallback (mount -o loop doesn't expose it).
 MOUNT_DIR="$(mktemp -d)"
-sudo mount -o loop "$ROOTFS" "$MOUNT_DIR"
+LOOP_DEV="$(sudo losetup --find --show "$ROOTFS")"
+sudo mount "$LOOP_DEV" "$MOUNT_DIR"
 
 # Replace CA certificate
 sudo cp "$ca_cert" "${MOUNT_DIR}/${CA_ROOTFS_DEST}"

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -32,6 +32,9 @@ fi
 # Constants
 # ---------------------------------------------------------------------------
 
+# [sync:ca-constants] Keep in sync with: crates/runner/scripts/build-rootfs.sh
+# and inject-ca.sh. Enforced by the `ca_constants_in_sync_across_scripts`
+# test in cmd/build.rs at compile time.
 CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt"
 
 # ---------------------------------------------------------------------------

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -444,7 +444,10 @@ async fn remove_all_except_rootfs(image: &ImagePaths) {
     let rootfs_name = std::ffi::OsStr::new("rootfs.ext4");
     let mut entries = match tokio::fs::read_dir(image.dir()).await {
         Ok(e) => e,
-        Err(_) => return,
+        Err(e) => {
+            tracing::warn!("failed to read dir {}: {e}", image.dir().display());
+            return;
+        }
     };
     loop {
         let entry = match entries.next_entry().await {
@@ -654,26 +657,35 @@ mod tests {
         assert!(is_image_complete(&image).await.unwrap());
     }
 
-    /// Guard the `[sync:ca-constants]` contract between build-rootfs.sh and
-    /// inject-ca.sh. Drift between the two scripts' CA cert paths would
-    /// cause silent CA injection failures on R2-downloaded rootfs.
+    /// Guard the `[sync:ca-constants]` contract between build-rootfs.sh,
+    /// inject-ca.sh, and verify-rootfs.sh. Drift would cause silent CA
+    /// injection/verification failures on R2-downloaded rootfs.
     #[test]
     fn ca_constants_in_sync_across_scripts() {
         let ca_cert_line = r#"CA_CERT_FILE="mitmproxy-ca-cert.pem""#;
         let ca_dest_line = r#"CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt""#;
+
+        // Scripts that use both constants.
         for (script, name) in [
             (BUILD_SCRIPT, "build-rootfs.sh"),
             (INJECT_CA_SCRIPT, "inject-ca.sh"),
         ] {
             assert!(
                 script.contains(ca_cert_line),
-                "{name} missing CA_CERT_FILE constant — sync with other script"
+                "{name} missing CA_CERT_FILE constant — sync with other scripts"
             );
             assert!(
                 script.contains(ca_dest_line),
-                "{name} missing CA_ROOTFS_DEST constant — sync with other script"
+                "{name} missing CA_ROOTFS_DEST constant — sync with other scripts"
             );
         }
+
+        // verify-rootfs.sh only uses CA_ROOTFS_DEST (it reads the cert from
+        // inside the rootfs, not from the host CA_DIR).
+        assert!(
+            VERIFY_SCRIPT.contains(ca_dest_line),
+            "verify-rootfs.sh missing CA_ROOTFS_DEST constant — sync with other scripts"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -267,7 +267,12 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
                     );
                     force_reupload = true;
                     // Clean up the bad download so local build starts fresh.
-                    let _ = tokio::fs::remove_dir_all(&output_dir).await;
+                    if let Err(e) = tokio::fs::remove_dir_all(&output_dir).await {
+                        tracing::warn!(
+                            "failed to clean bad R2 download at {}: {e}",
+                            output_dir.display()
+                        );
+                    }
                 }
             }
             Ok(false) => tracing::info!("R2 cache miss for {hash} — building locally"),
@@ -452,10 +457,13 @@ async fn remove_all_except_rootfs(image: &ImagePaths) {
         };
         if entry.file_name() != rootfs_name {
             let path = entry.path();
-            if path.is_dir() {
-                let _ = tokio::fs::remove_dir_all(&path).await;
+            let result = if path.is_dir() {
+                tokio::fs::remove_dir_all(&path).await
             } else {
-                let _ = tokio::fs::remove_file(&path).await;
+                tokio::fs::remove_file(&path).await
+            };
+            if let Err(e) = result {
+                tracing::warn!("failed to remove stale entry {}: {e}", path.display());
             }
         }
     }
@@ -644,6 +652,28 @@ mod tests {
         // All four files → complete
         tokio::fs::write(image.cow_img(), b"").await.unwrap();
         assert!(is_image_complete(&image).await.unwrap());
+    }
+
+    /// Guard the `[sync:ca-constants]` contract between build-rootfs.sh and
+    /// inject-ca.sh. Drift between the two scripts' CA cert paths would
+    /// cause silent CA injection failures on R2-downloaded rootfs.
+    #[test]
+    fn ca_constants_in_sync_across_scripts() {
+        let ca_cert_line = r#"CA_CERT_FILE="mitmproxy-ca-cert.pem""#;
+        let ca_dest_line = r#"CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt""#;
+        for (script, name) in [
+            (BUILD_SCRIPT, "build-rootfs.sh"),
+            (INJECT_CA_SCRIPT, "inject-ca.sh"),
+        ] {
+            assert!(
+                script.contains(ca_cert_line),
+                "{name} missing CA_CERT_FILE constant — sync with other script"
+            );
+            assert!(
+                script.contains(ca_dest_line),
+                "{name} missing CA_ROOTFS_DEST constant — sync with other script"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -239,15 +239,14 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
     let mut force_reupload = false;
     let mut rootfs_from_r2 = false;
 
-    // Clean up any incomplete image from a previous interrupted build (e.g.
-    // rootfs exists but snapshot is missing). A complete image was already
-    // caught above. try_download handles the case where output_dir already
-    // exists (finalize_staging replaces it), so this is safe for both paths.
-    if tokio::fs::try_exists(&output_dir).await.unwrap_or(false) {
-        tokio::fs::remove_dir_all(&output_dir)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("clean {}: {e}", output_dir.display())))?;
-    }
+    // No upfront `remove_dir_all(output_dir)` here: a previous interrupted
+    // build may have left stale bind mounts in `output_dir/work/` (snapshot.rs
+    // bind-mounts the NBD COW device there), which would cause EBUSY on a
+    // blanket removal. Downstream steps each handle their own cleanup:
+    //   - try_download's finalize_staging rename replaces output_dir atomically
+    //   - build-rootfs.sh writes rootfs via mkfs.ext4 -> rename (overwrites)
+    //   - snapshot.rs::create_snapshot umounts stale binds, then removes only
+    //     its own artifacts (snapshot.bin, memory.bin, cow.img, work/)
 
     // Try R2 download (rootfs only). try_download manages its own staging
     // directory and atomic rename, so output_dir stays absent on failure.

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -14,6 +14,7 @@ use crate::r2_cache::R2ImageCache;
 
 const BUILD_SCRIPT: &str = include_str!("../../scripts/build-rootfs.sh");
 const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
+const INJECT_CA_SCRIPT: &str = include_str!("../../scripts/inject-ca.sh");
 
 /// Bump this to invalidate all cached images without changing any input files.
 /// Affects both the local cache directory and the R2 object key (since the
@@ -21,7 +22,7 @@ const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
 ///
 /// Bumping leaves the previous-hash R2 objects orphaned; they're swept by
 /// `runner gc` after the configured TTL (see `r2_cache::gc_older_than`).
-const IMAGE_CACHE_VERSION: u32 = 2;
+const IMAGE_CACHE_VERSION: u32 = 3;
 
 #[cfg(bundled_guests)]
 mod embedded {
@@ -134,7 +135,7 @@ async fn resolve_guest(
     )))
 }
 
-/// Build a unified image (rootfs + snapshot) and return the image hash.
+/// Build an image (rootfs from R2 cache or local build, snapshot always local).
 pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> RunnerResult<()> {
     let def = profile::get(&args.profile)?;
     let dry_run = args.dry_run;
@@ -165,8 +166,8 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         ),
     ];
 
-    // Compute unified image hash from all rootfs + snapshot inputs.
-    let hash = compute_image_hash(&bins, def.disk_mb, provider, def.vcpu, def.memory_mb).await?;
+    // Compute rootfs-only image hash (snapshot is always created locally).
+    let hash = compute_image_hash(&bins, def.disk_mb).await?;
     tracing::info!("image hash: {hash}");
     // Machine-readable output — do not change format without updating consumers
     println!("image_hash={hash}");
@@ -209,54 +210,7 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         return Ok(());
     }
 
-    // Try R2 download before falling back to local build. try_download manages
-    // its own staging directory and atomic rename, so output_dir stays absent
-    // on failure (no false-positive cache hits from partial unpack).
-    //
-    // `force_reupload`: set when we observed a structurally-valid download
-    // (Ok(true)) whose extracted content failed `is_image_complete`. Without
-    // it the next `upload` call would dedup-skip on `exists() = true` and
-    // leave the bad object in place, locking the entire fleet out of this
-    // hash. We pass it through as `force` to `upload` rather than calling
-    // `delete` first — force-upload is a single atomic PUT that doesn't
-    // depend on `s3:DeleteObject` permission being healthy (a persistently
-    // failing delete would otherwise leave the corruption stuck forever).
-    let mut force_reupload = false;
-    if let Some(cache) = &r2 {
-        match cache.try_download(&hash, output_dir).await {
-            Ok(true) => {
-                if is_image_complete(&image).await? {
-                    tracing::info!("[OK] image downloaded from R2: {}", output_dir.display());
-                    touch_mtime(output_dir);
-                    return Ok(());
-                }
-                tracing::warn!(
-                    "R2 download for {hash} succeeded but image incomplete — \
-                     will rebuild locally and force-overwrite the bad object"
-                );
-                force_reupload = true;
-            }
-            Ok(false) => tracing::info!("R2 cache miss for {hash} — building locally"),
-            // Err is ambiguous (transient network vs. content corruption);
-            // we don't force-overwrite here — false overwrite on a network
-            // blip would amplify load (every host re-uploads the same hash).
-            Err(e) => tracing::warn!("R2 download failed: {e} — falling back to local build"),
-        }
-    }
-
-    // --- Phase 1: Build rootfs ---
-
-    // Clean up any partial build from a previous failed attempt so we start fresh.
-    if tokio::fs::try_exists(&output_dir).await.unwrap_or(false) {
-        tokio::fs::remove_dir_all(&output_dir)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("clean {}: {e}", output_dir.display())))?;
-    }
-    tokio::fs::create_dir_all(&output_dir)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", output_dir.display())))?;
-
-    // Write scripts to a temp directory
+    // Write scripts to a temp directory (needed for both R2 and local paths).
     let work_dir =
         tempfile::tempdir().map_err(|e| RunnerError::Internal(format!("create temp dir: {e}")))?;
     tokio::fs::write(work_dir.path().join("build-rootfs.sh"), BUILD_SCRIPT)
@@ -265,91 +219,186 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
     tokio::fs::write(work_dir.path().join("verify-rootfs.sh"), VERIFY_SCRIPT)
         .await
         .map_err(|e| RunnerError::Internal(format!("write verify script: {e}")))?;
+    tokio::fs::write(work_dir.path().join("inject-ca.sh"), INJECT_CA_SCRIPT)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("write inject-ca script: {e}")))?;
 
-    let script_path = work_dir.path().join("build-rootfs.sh");
-    let output_dir_str = output_dir.to_string_lossy();
-    let guest_agent_str = guest_agent.to_string_lossy();
-    let guest_download_str = guest_download.to_string_lossy();
-    let guest_init_str = guest_init.to_string_lossy();
-    let guest_mock_claude_str = guest_mock_claude.to_string_lossy();
-    let guest_reseed_str = guest_reseed.to_string_lossy();
     let ca_dir = paths.ca_dir();
-    let ca_dir_str = ca_dir.to_string_lossy();
-    let debootstrap_dir = paths.debootstrap_dir();
-    tokio::fs::create_dir_all(&debootstrap_dir)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", debootstrap_dir.display())))?;
-    let debootstrap_dir_str = debootstrap_dir.to_string_lossy();
-    let disk_mb_str = def.disk_mb.to_string();
 
-    let status = tokio::process::Command::new("bash")
-        .arg(&script_path)
-        .args([
-            "--output-dir",
-            &output_dir_str,
-            "--ca-dir",
-            &ca_dir_str,
-            "--debootstrap-dir",
-            &debootstrap_dir_str,
-            "--hash",
-            &hash,
-            "--disk-mb",
-            &disk_mb_str,
-            "--guest-agent",
-            &guest_agent_str,
-            "--guest-download",
-            &guest_download_str,
-            "--guest-init",
-            &guest_init_str,
-            "--guest-mock-claude",
-            &guest_mock_claude_str,
-            "--guest-reseed",
-            &guest_reseed_str,
-            // Dummy nameserver — all UDP 53 is iptables-REDIRECT'd to dnsmasq.
-            // Must be routable (not loopback/gateway) so packets leave the VM.
-            "--dns-nameserver",
-            "8.8.8.8",
-        ])
-        .stdin(std::process::Stdio::null())
-        .status()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("spawn build script: {e}")))?;
+    // --- Phase 1: Obtain rootfs ---
+    //
+    // R2 caches only rootfs.ext4 (not snapshot files). Snapshots are always
+    // created locally because they contain host-specific state (page cache,
+    // kernel metadata). This design allows hosts with different hardware to
+    // share the rootfs cache while each creating its own snapshot.
+    //
+    // `force_reupload`: set when R2 download succeeded structurally but the
+    // rootfs is missing — the bad R2 object is atomically overwritten on the
+    // next upload.
 
-    if !status.success() {
-        return Err(RunnerError::Internal(format!(
-            "build-rootfs.sh failed with {status}"
-        )));
+    let mut force_reupload = false;
+    let mut rootfs_from_r2 = false;
+
+    // Clean up any incomplete image from a previous interrupted build (e.g.
+    // rootfs exists but snapshot is missing). A complete image was already
+    // caught above. try_download handles the case where output_dir already
+    // exists (finalize_staging replaces it), so this is safe for both paths.
+    if tokio::fs::try_exists(&output_dir).await.unwrap_or(false) {
+        tokio::fs::remove_dir_all(&output_dir)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("clean {}: {e}", output_dir.display())))?;
     }
 
-    // Verify rootfs contents (verify script is NOT part of the input hash)
+    // Try R2 download (rootfs only). try_download manages its own staging
+    // directory and atomic rename, so output_dir stays absent on failure.
+    if let Some(cache) = &r2 {
+        match cache.try_download(&hash, output_dir).await {
+            Ok(true) => {
+                if tokio::fs::try_exists(image.rootfs()).await.unwrap_or(false) {
+                    // Remove any non-rootfs files from the download (e.g. stale
+                    // snapshot artifacts from an old archive format).
+                    remove_all_except_rootfs(&image).await;
+                    tracing::info!("[OK] rootfs downloaded from R2: {}", output_dir.display());
+                    rootfs_from_r2 = true;
+                } else {
+                    tracing::warn!(
+                        "R2 download for {hash} succeeded but rootfs missing — \
+                         will rebuild locally and force-overwrite the bad object"
+                    );
+                    force_reupload = true;
+                    // Clean up the bad download so local build starts fresh.
+                    let _ = tokio::fs::remove_dir_all(&output_dir).await;
+                }
+            }
+            Ok(false) => tracing::info!("R2 cache miss for {hash} — building locally"),
+            Err(e) => tracing::warn!("R2 download failed: {e} — falling back to local build"),
+        }
+    }
+
+    if !rootfs_from_r2 {
+        // Create output_dir for local build (R2 path creates it via rename).
+        tokio::fs::create_dir_all(&output_dir)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("create {}: {e}", output_dir.display())))?;
+
+        // Local rootfs build — the slow path (debootstrap + apt install).
+        let output_dir_str = output_dir.to_string_lossy();
+        let guest_agent_str = guest_agent.to_string_lossy();
+        let guest_download_str = guest_download.to_string_lossy();
+        let guest_init_str = guest_init.to_string_lossy();
+        let guest_mock_claude_str = guest_mock_claude.to_string_lossy();
+        let guest_reseed_str = guest_reseed.to_string_lossy();
+        let ca_dir_str = ca_dir.to_string_lossy();
+        let debootstrap_dir = paths.debootstrap_dir();
+        tokio::fs::create_dir_all(&debootstrap_dir)
+            .await
+            .map_err(|e| {
+                RunnerError::Internal(format!("create {}: {e}", debootstrap_dir.display()))
+            })?;
+        let debootstrap_dir_str = debootstrap_dir.to_string_lossy();
+        let disk_mb_str = def.disk_mb.to_string();
+
+        let status = tokio::process::Command::new("bash")
+            .arg(work_dir.path().join("build-rootfs.sh"))
+            .args([
+                "--output-dir",
+                &output_dir_str,
+                "--ca-dir",
+                &ca_dir_str,
+                "--debootstrap-dir",
+                &debootstrap_dir_str,
+                "--hash",
+                &hash,
+                "--disk-mb",
+                &disk_mb_str,
+                "--guest-agent",
+                &guest_agent_str,
+                "--guest-download",
+                &guest_download_str,
+                "--guest-init",
+                &guest_init_str,
+                "--guest-mock-claude",
+                &guest_mock_claude_str,
+                "--guest-reseed",
+                &guest_reseed_str,
+                // Dummy nameserver — all UDP 53 is iptables-REDIRECT'd to dnsmasq.
+                // Must be routable (not loopback/gateway) so packets leave the VM.
+                "--dns-nameserver",
+                "8.8.8.8",
+            ])
+            .stdin(std::process::Stdio::null())
+            .status()
+            .await
+            .map_err(|e| RunnerError::Internal(format!("spawn build script: {e}")))?;
+
+        if !status.success() {
+            return Err(RunnerError::Internal(format!(
+                "build-rootfs.sh failed with {status}"
+            )));
+        }
+
+        // Verify rootfs contents (verify script is NOT part of the input hash)
+        let rootfs_str = image.rootfs().to_string_lossy().into_owned();
+        let status = tokio::process::Command::new("bash")
+            .arg(work_dir.path().join("verify-rootfs.sh"))
+            .args(["--rootfs", &rootfs_str])
+            .stdin(std::process::Stdio::null())
+            .status()
+            .await
+            .map_err(|e| RunnerError::Internal(format!("spawn verify script: {e}")))?;
+
+        if !status.success() {
+            return Err(RunnerError::Internal(format!(
+                "verify-rootfs.sh failed with {status}"
+            )));
+        }
+
+        let rootfs_sz = file_sizes(&image.rootfs()).await;
+        tracing::info!(
+            rootfs_logical = %rootfs_sz.0,
+            rootfs_disk = %rootfs_sz.1,
+            "rootfs creation complete"
+        );
+
+        // Upload rootfs to R2 BEFORE CA injection — the cached rootfs should
+        // be generic (build host's CA) so other hosts can download and inject
+        // their own CA. Non-fatal: image is already on local disk.
+        if let Some(cache) = &r2 {
+            let files = vec![image.rootfs()];
+            match cache.upload(&hash, &files, force_reupload).await {
+                Ok(()) => tracing::info!("uploaded rootfs to R2: {hash}"),
+                Err(e) => tracing::warn!("R2 upload failed: {e} — rootfs is on local disk"),
+            }
+        }
+    }
+
+    // --- Phase 1.5: Replace CA cert (R2-downloaded rootfs only) ---
+    //
+    // The R2-cached rootfs contains the build host's CA. Replace it with the
+    // local host's CA before creating the snapshot, so TLS interception works.
+    // Local builds already have the correct CA from build-rootfs.sh.
+    if rootfs_from_r2 {
+        let rootfs_str = image.rootfs().to_string_lossy().into_owned();
+        let ca_dir_str = ca_dir.to_string_lossy().into_owned();
+        let status = tokio::process::Command::new("bash")
+            .arg(work_dir.path().join("inject-ca.sh"))
+            .args(["--rootfs", &rootfs_str, "--ca-dir", &ca_dir_str])
+            .stdin(std::process::Stdio::null())
+            .status()
+            .await
+            .map_err(|e| RunnerError::Internal(format!("spawn inject-ca script: {e}")))?;
+
+        if !status.success() {
+            return Err(RunnerError::Internal(format!(
+                "inject-ca.sh failed with {status}"
+            )));
+        }
+        tracing::info!("CA cert replaced in R2-downloaded rootfs");
+    }
+
+    // --- Phase 2: Build snapshot (always local) ---
+
     let rootfs_path = image.rootfs();
-    let verify_path = work_dir.path().join("verify-rootfs.sh");
-    let rootfs_str = rootfs_path.to_string_lossy();
-
-    let status = tokio::process::Command::new("bash")
-        .arg(&verify_path)
-        .args(["--rootfs", &rootfs_str])
-        .stdin(std::process::Stdio::null())
-        .status()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("spawn verify script: {e}")))?;
-
-    if !status.success() {
-        return Err(RunnerError::Internal(format!(
-            "verify-rootfs.sh failed with {status}"
-        )));
-    }
-
-    let rootfs_sz = file_sizes(&rootfs_path).await;
-    tracing::info!(
-        rootfs = %rootfs_path.display(),
-        rootfs_logical = %rootfs_sz.0,
-        rootfs_disk = %rootfs_sz.1,
-        "rootfs creation complete"
-    );
-
-    // --- Phase 2: Build snapshot ---
-
     let create_config = sandbox::SnapshotCreateConfig {
         id: hash.clone(),
         binary_path: paths.firecracker_bin(FIRECRACKER_VERSION),
@@ -368,33 +417,48 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         file_sizes(&output.cow_path),
     );
     tracing::info!(
-        snapshot = %output.snapshot_path.display(),
         snapshot_logical = %snapshot_sz.0,
         snapshot_disk = %snapshot_sz.1,
-        memory = %output.memory_path.display(),
         memory_logical = %memory_sz.0,
         memory_disk = %memory_sz.1,
-        cow = %output.cow_path.display(),
         cow_logical = %cow_sz.0,
         cow_disk = %cow_sz.1,
         "snapshot creation complete"
     );
 
-    // Synchronous R2 upload after Phase 2. Failure is non-fatal — the image is
-    // already on local disk; subsequent hosts just won't get a cache hit.
-    // `exists()` dedup inside `upload()` avoids same-deploy N-host duplicate
-    // uploads; `force_reupload` bypasses dedup so a previously-detected
-    // corrupt object gets atomically overwritten.
-    if let Some(cache) = &r2 {
-        let files = image.expected_files().to_vec();
-        match cache.upload(&hash, &files, force_reupload).await {
-            Ok(()) => tracing::info!("uploaded image to R2: {hash}"),
-            Err(e) => tracing::warn!("R2 upload failed: {e} — image is on local disk"),
-        }
-    }
-
     tracing::info!("image creation complete: {hash}");
     Ok(())
+}
+
+/// Remove all files in the image directory except rootfs.ext4.
+///
+/// After an R2 download the archive may contain stale artifacts from an
+/// older cache format. Cleaning them ensures `create_snapshot` writes
+/// into a directory that only contains the rootfs.
+async fn remove_all_except_rootfs(image: &ImagePaths) {
+    let rootfs_name = std::ffi::OsStr::new("rootfs.ext4");
+    let mut entries = match tokio::fs::read_dir(image.dir()).await {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(e) => {
+                tracing::warn!("read entry in {}: {e}", image.dir().display());
+                break;
+            }
+        };
+        if entry.file_name() != rootfs_name {
+            let path = entry.path();
+            if path.is_dir() {
+                let _ = tokio::fs::remove_dir_all(&path).await;
+            } else {
+                let _ = tokio::fs::remove_file(&path).await;
+            }
+        }
+    }
 }
 
 /// Check whether all expected image outputs exist in the directory.
@@ -410,105 +474,22 @@ async fn is_image_complete(image: &ImagePaths) -> RunnerResult<bool> {
     Ok(true)
 }
 
-/// Read a sysfs file, trimming whitespace. Returns empty string on failure.
-fn read_sysfs_trimmed(path: &str) -> String {
-    match std::fs::read_to_string(path) {
-        Ok(s) => s.trim().to_owned(),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(e) => {
-            tracing::warn!("failed to read {path}: {e}");
-            String::new()
-        }
-    }
-}
-
-/// Read CPU microcode/revision version.
-///
-/// On x86_64: `/sys/devices/system/cpu/cpu0/microcode/version`
-/// On ARM64: `/sys/devices/system/cpu/cpu0/regs/identification/revidr_el1`
-fn read_cpu_microcode() -> Option<String> {
-    let paths = [
-        "/sys/devices/system/cpu/cpu0/microcode/version",
-        "/sys/devices/system/cpu/cpu0/regs/identification/revidr_el1",
-    ];
-    for path in paths {
-        match std::fs::read_to_string(path) {
-            Ok(v) => {
-                let v = v.trim();
-                if !v.is_empty() {
-                    return Some(v.to_owned());
-                }
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => tracing::warn!("failed to read {path}: {e}"),
-        }
-    }
-    None
-}
-
-/// Read a stable CPU model identifier from `/proc/cpuinfo`.
-///
-/// On ARM64 this extracts `CPU implementer`, `CPU part`, and `CPU variant`
-/// (e.g. "0x41:0xd40:0x1" for Neoverse V1 / Graviton 3).
-/// On x86_64 this extracts the `model name` line.
-fn read_cpu_model() -> Option<String> {
-    let cpuinfo = match std::fs::read_to_string("/proc/cpuinfo") {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!("failed to read /proc/cpuinfo: {e}");
-            return None;
-        }
-    };
-
-    // ARM64: combine implementer + part + variant
-    let get = |key: &str| -> Option<&str> {
-        cpuinfo.lines().find_map(|line| {
-            let (k, v) = line.split_once(':')?;
-            if k.trim() == key {
-                Some(v.trim())
-            } else {
-                None
-            }
-        })
-    };
-
-    if let (Some(implementer), Some(part)) = (get("CPU implementer"), get("CPU part")) {
-        let variant = get("CPU variant").unwrap_or("0x0");
-        return Some(format!("{implementer}:{part}:{variant}"));
-    }
-
-    // x86_64: use model name
-    if let Some(model) = get("model name") {
-        return Some(model.to_owned());
-    }
-
-    tracing::warn!("could not determine CPU model from /proc/cpuinfo");
-    None
-}
-
-/// Compute a unified hash from all rootfs + snapshot inputs.
+/// Compute a rootfs-only hash for R2 image caching.
 ///
 /// Inputs:
 ///   - `IMAGE_CACHE_VERSION` — bump to force invalidation
 ///   - `BUILD_SCRIPT` — rootfs build script content
 ///   - `disk_mb` — disk size from profile
 ///   - guest binaries — sorted by destination path
-///   - `provider.config_hash()` — boot args, guest network config
-///   - `FIRECRACKER_VERSION` / `KERNEL_VERSION` — binary versions
-///   - `vcpu` / `memory_mb` — VM resource settings
-///   - host kernel version (`uname -r`)
-///   - CPU model (implementer:part:variant on ARM, model name on x86)
-///   - CPU microcode/revision version
-///   - BIOS version and release
+///
+/// Host-specific fields (kernel, CPU, BIOS) and snapshot-specific fields
+/// (vcpu, memory, firecracker/kernel version) are intentionally excluded:
+/// the R2 cache stores only the rootfs, and snapshots are always created
+/// locally. Excluding host fields allows different hardware to share the
+/// same rootfs cache.
 ///
 /// **Changing this function invalidates all cached images.**
-async fn compute_image_hash(
-    guest_bins: &[(&Path, &str)],
-    disk_mb: u32,
-    provider: &dyn SnapshotProvider,
-    vcpu: u32,
-    memory_mb: u32,
-) -> RunnerResult<String> {
+async fn compute_image_hash(guest_bins: &[(&Path, &str)], disk_mb: u32) -> RunnerResult<String> {
     let mut hasher = Sha256::new();
 
     // Cache version seed — bump IMAGE_CACHE_VERSION to force invalidation.
@@ -529,44 +510,6 @@ async fn compute_image_hash(
         hasher.update(tag.as_bytes());
         hasher.update(&content);
     }
-
-    // Snapshot inputs
-    hasher.update(b"fc_config:");
-    hasher.update(provider.config_hash().as_bytes());
-    hasher.update(b"firecracker:");
-    hasher.update(FIRECRACKER_VERSION.as_bytes());
-    hasher.update(b"kernel:");
-    hasher.update(KERNEL_VERSION.as_bytes());
-    hasher.update(b"vcpu:");
-    hasher.update(vcpu.to_le_bytes());
-    hasher.update(b"memory_mb:");
-    hasher.update(memory_mb.to_le_bytes());
-
-    // Host kernel version — snapshots are not portable across kernel versions
-    // because KVM exposes different registers (e.g. ARM64 firmware pseudo-regs).
-    let uname =
-        nix::sys::utsname::uname().map_err(|e| RunnerError::Internal(format!("uname: {e}")))?;
-    hasher.update(b"host_kernel:");
-    hasher.update(uname.release().as_encoded_bytes());
-
-    // CPU model — different CPU models expose different registers and features,
-    // making snapshots non-portable (e.g. Graviton 2 vs 3).
-    hasher.update(b"cpu_model:");
-    let cpu_id = read_cpu_model().unwrap_or_default();
-    hasher.update(cpu_id.as_bytes());
-
-    // CPU microcode/revision — microcode updates can change available MSRs (x86)
-    // or CPU behavior (ARM). Gracefully defaults to empty if not available.
-    hasher.update(b"cpu_microcode:");
-    hasher.update(read_cpu_microcode().unwrap_or_default().as_bytes());
-
-    // BIOS/firmware version and revision — firmware updates can change ACPI tables,
-    // CPU feature advertisement, and memory map, affecting KVM register state in
-    // snapshots. Both fields can change independently.
-    hasher.update(b"bios_version:");
-    hasher.update(read_sysfs_trimmed("/sys/devices/virtual/dmi/id/bios_version").as_bytes());
-    hasher.update(b"bios_release:");
-    hasher.update(read_sysfs_trimmed("/sys/devices/virtual/dmi/id/bios_release").as_bytes());
 
     Ok(hex::encode(hasher.finalize()))
 }
@@ -632,23 +575,14 @@ mod tests {
         let bin = dir.path().join("agent");
         tokio::fs::write(&bin, b"binary-content").await.unwrap();
         let bins: &[(&Path, &str)] = &[(&bin, "/usr/local/bin/guest-agent")];
-        let provider = sandbox_mock::MockSnapshotProvider;
 
-        let h1 = compute_image_hash(bins, 16384, &provider, 2, 2048)
-            .await
-            .unwrap();
-        let h2 = compute_image_hash(bins, 16384, &provider, 2, 2048)
-            .await
-            .unwrap();
+        let h1 = compute_image_hash(bins, 16384).await.unwrap();
+        let h2 = compute_image_hash(bins, 16384).await.unwrap();
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64); // SHA-256 hex
     }
 
     /// Verify that each parameterized input changes the hash.
-    ///
-    /// Note: host-specific inputs (kernel version, CPU model, microcode, BIOS)
-    /// are read from the runtime environment and cannot be varied in tests.
-    /// Their inclusion is validated by `compute_image_hash_deterministic`.
     #[tokio::test]
     async fn compute_image_hash_sensitive_to_all_inputs() {
         let dir = tempfile::tempdir().unwrap();
@@ -656,92 +590,33 @@ mod tests {
         let bin_b = dir.path().join("agent-b");
         tokio::fs::write(&bin_a, b"content-a").await.unwrap();
         tokio::fs::write(&bin_b, b"content-b").await.unwrap();
-        let provider = sandbox_mock::MockSnapshotProvider;
 
-        let base = compute_image_hash(
-            &[(&bin_a, "/usr/local/bin/guest-agent")],
-            16384,
-            &provider,
-            2,
-            2048,
-        )
-        .await
-        .unwrap();
+        let base = compute_image_hash(&[(&bin_a, "/usr/local/bin/guest-agent")], 16384)
+            .await
+            .unwrap();
 
         // Different binary content
-        let different_content = compute_image_hash(
-            &[(&bin_b, "/usr/local/bin/guest-agent")],
-            16384,
-            &provider,
-            2,
-            2048,
-        )
-        .await
-        .unwrap();
+        let different_content =
+            compute_image_hash(&[(&bin_b, "/usr/local/bin/guest-agent")], 16384)
+                .await
+                .unwrap();
         assert_ne!(
             base, different_content,
             "hash must change with binary content"
         );
 
         // Different disk_mb
-        let different_disk = compute_image_hash(
-            &[(&bin_a, "/usr/local/bin/guest-agent")],
-            32768,
-            &provider,
-            2,
-            2048,
-        )
-        .await
-        .unwrap();
+        let different_disk = compute_image_hash(&[(&bin_a, "/usr/local/bin/guest-agent")], 32768)
+            .await
+            .unwrap();
         assert_ne!(base, different_disk, "hash must change with disk_mb");
 
         // Different dest path
-        let different_dest = compute_image_hash(
-            &[(&bin_a, "/usr/local/bin/guest-download")],
-            16384,
-            &provider,
-            2,
-            2048,
-        )
-        .await
-        .unwrap();
+        let different_dest =
+            compute_image_hash(&[(&bin_a, "/usr/local/bin/guest-download")], 16384)
+                .await
+                .unwrap();
         assert_ne!(base, different_dest, "hash must change with dest path");
-
-        // Different vcpu
-        let different_vcpu = compute_image_hash(
-            &[(&bin_a, "/usr/local/bin/guest-agent")],
-            16384,
-            &provider,
-            4,
-            2048,
-        )
-        .await
-        .unwrap();
-        assert_ne!(base, different_vcpu, "hash must change with vcpu");
-
-        // Different memory_mb
-        let different_memory = compute_image_hash(
-            &[(&bin_a, "/usr/local/bin/guest-agent")],
-            16384,
-            &provider,
-            2,
-            4096,
-        )
-        .await
-        .unwrap();
-        assert_ne!(base, different_memory, "hash must change with memory_mb");
-
-        // Different provider
-        let different_provider = compute_image_hash(
-            &[(&bin_a, "/usr/local/bin/guest-agent")],
-            16384,
-            &sandbox_fc::FirecrackerSnapshotProvider,
-            2,
-            2048,
-        )
-        .await
-        .unwrap();
-        assert_ne!(base, different_provider, "hash must change with provider");
     }
 
     #[tokio::test]

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -777,7 +777,13 @@ async fn finalize_staging(staging: &Path, final_dir: &Path) -> Result<(), R2Erro
             "{} already exists (likely stale from a partial run: {e}); replacing",
             final_dir.display()
         );
-        let _ = tokio::fs::remove_dir_all(final_dir).await;
+        if let Err(e) = tokio::fs::remove_dir_all(final_dir).await {
+            // Log but keep trying the rename — it may still succeed if the
+            // directory is empty/orphaned in a recoverable way.  EBUSY here
+            // typically indicates a stale bind mount from a crashed snapshot
+            // creation; the retry rename will then fail with the real cause.
+            tracing::warn!("remove_dir_all {}: {e}", final_dir.display());
+        }
         tokio::fs::rename(staging, final_dir).await?;
     }
     Ok(())

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -1,25 +1,26 @@
-//! R2 cache for unified `runner build` image artifacts.
+//! R2 cache for `runner build` rootfs artifacts.
 //!
 //! Single-key bundle per image hash: `runner-images/{hash}.tar.zst` in the
-//! existing `R2_USER_STORAGES_BUCKET_NAME` bucket. The 4 files from
-//! `ImagePaths::expected_files()` are packed dense (no sparse-tar handling);
-//! `cow.img` sparseness is restored on unpack via best-effort
-//! `fallocate(FALLOC_FL_PUNCH_HOLE)`.
+//! existing `R2_USER_STORAGES_BUCKET_NAME` bucket. Only rootfs.ext4 is
+//! cached in R2; snapshot files are always created locally because they
+//! contain host-specific state (page cache, kernel metadata).
 //!
 //! ## Lifecycle
 //!
-//! 1. `runner build` computes hash and checks local cache (existing logic).
+//! 1. `runner build` computes a rootfs-only hash and checks local cache.
 //! 2. On miss, after acquiring `image_lock(hash)`, it tries `try_download`.
-//! 3. On download miss, it does the local rootfs+snapshot build (existing logic).
-//! 4. After `is_image_complete()` succeeds, it calls `upload`.
+//! 3. On download hit, the caller injects the local CA into the rootfs and
+//!    creates a snapshot locally.
+//! 4. On download miss, it does the local rootfs build, then `upload`s the
+//!    rootfs, then creates a snapshot locally.
 //!
 //! Atomicity guarantees:
 //! - Multipart upload is atomic from consumer POV (object only appears after
 //!   `CompleteMultipartUpload`); abandoned segments are auto-cleaned by R2's
 //!   default 7-day lifecycle.
 //! - Download unpacks into a `{hash}.tmp/` staging directory then `rename`s
-//!   to `{hash}/` — partial unpack from a crash never produces a false-positive
-//!   `is_image_complete()` hit.
+//!   to `{hash}/` — partial unpack from a crash never produces a directory
+//!   that looks like a successful download.
 //!
 //! Configuration semantics: `from_env` returns `Ok(None)` only when **all four**
 //! `R2_*` env vars are unset or empty (dev/test path). Setting 1-3 of 4 is a
@@ -81,17 +82,17 @@
 //!
 //! ## Corrupt-object eviction
 //!
-//! A structurally-valid archive whose extracted content fails
-//! `is_image_complete` (e.g. uploaded by an old/buggy producer, or
-//! attacker-controlled IAM key writing a bogus tar to a predicted hash
-//! key) would otherwise dead-lock the fleet's cache for that hash: every
-//! host downloads → unpacks → fails completeness → rebuilds locally →
-//! `upload`'s `exists()` dedup-skips → the bad object stays, forever.
+//! A structurally-valid archive whose extracted content lacks rootfs.ext4
+//! (e.g. uploaded by an old/buggy producer, or attacker-controlled IAM
+//! key writing a bogus tar to a predicted hash key) would otherwise
+//! dead-lock the fleet's cache for that hash: every host downloads →
+//! unpacks → finds no rootfs → rebuilds locally → `upload`'s `exists()`
+//! dedup-skips → the bad object stays, forever.
 //!
 //! `cmd::build::run_build` defends by passing `force = true` to `upload`
-//! whenever it observes "download Ok(true) but is_image_complete=false".
-//! That bypasses the dedup check and atomically overwrites the bad object
-//! in a single PUT — robust against `s3:DeleteObject` permission being
+//! whenever it observes "download Ok(true) but rootfs missing". That
+//! bypasses the dedup check and atomically overwrites the bad object in
+//! a single PUT — robust against `s3:DeleteObject` permission being
 //! revoked or transiently failing (which a `delete + retry-upload`
 //! sequence would not be).
 //!
@@ -102,9 +103,9 @@
 //!
 //! 1. **Path traversal (`..` components) is silently dropped**. Verified by
 //!    `unpack_rejects_path_traversal`. The malicious entry is skipped; the
-//!    staging dir ends up missing one or more expected files;
-//!    `is_image_complete()` (in `cmd::build`) rejects the partial result; the
-//!    caller falls back to local build. Safe.
+//!    staging dir ends up missing rootfs.ext4; the caller's post-download
+//!    check (rootfs presence) rejects the result and falls back to local
+//!    build. Safe.
 //!
 //! 2. **Symlink and hardlink entries are rejected**. `unpack_from_reader`
 //!    iterates entries and rejects any whose type is not `Regular`,
@@ -112,13 +113,15 @@
 //!    devices, FIFOs, and extended-header pseudo-entries all cause an
 //!    immediate error, preventing an attacker with R2 write access from
 //!    crafting a tar where expected filenames are symlinks to host paths.
-//!    (`GNUSparse` is allowed because `cow.img` is a sparse file and
-//!    `tar::Builder` uses this entry type for it.)
+//!    (`GNUSparse` is retained for forward compatibility with any future
+//!    sparse file in the archive; rootfs.ext4 itself is packed as a
+//!    regular file.)
 //!
-//! **Maintenance note**: `is_image_complete()` is the structural check that
-//! catches case (1). If you add a new file to the image, you MUST extend
-//! `is_image_complete()` accordingly — otherwise an attacker-controlled tar
-//! that omits the new file would still pass the completeness check.
+//! **Maintenance note**: the caller (`cmd::build::run_build`) checks
+//! rootfs presence after download and sets `force_reupload = true` if it
+//! is missing. If you add a new file to the R2 archive, you MUST extend
+//! that check accordingly — otherwise an attacker-controlled tar that
+//! omits the new file would go undetected.
 
 use std::path::{Path, PathBuf};
 
@@ -256,8 +259,8 @@ impl R2ImageCache {
 
     /// Try to download `runner-images/{hash}.tar.zst`, streaming directly
     /// through zstd decode + tar unpack into a sibling staging directory,
-    /// then best-effort sparse-restore `cow.img`, then atomic rename to
-    /// `final_dir`. No temp file — bounded memory regardless of image size.
+    /// then atomic rename to `final_dir`. No temp file — bounded memory
+    /// regardless of image size.
     ///
     /// Network hangs are bounded by the AWS SDK's own per-operation timeouts;
     /// outer call sites (CI/systemd) bound total wall time.
@@ -313,11 +316,11 @@ impl R2ImageCache {
     ///
     /// **`force = true`**: skip the dedup check and always upload, atomically
     /// replacing whatever is currently at the key. Used by `cmd::build` after
-    /// detecting a corrupt prior upload (download succeeded but
-    /// `is_image_complete` failed). Going through `delete + dedup-upload`
-    /// would deadlock the fleet's cache if `DeleteObject` permission is
-    /// missing or transiently failing — `force` is a single-round-trip atomic
-    /// overwrite that doesn't depend on `s3:DeleteObject`.
+    /// detecting a corrupt prior upload (download succeeded but rootfs.ext4
+    /// is missing). Going through `delete + dedup-upload` would deadlock the
+    /// fleet's cache if `DeleteObject` permission is missing or transiently
+    /// failing — `force` is a single-round-trip atomic overwrite that doesn't
+    /// depend on `s3:DeleteObject`.
     ///
     /// Network hangs are bounded by the AWS SDK's own per-operation timeouts;
     /// outer call sites (CI/systemd) bound total wall time.
@@ -702,8 +705,9 @@ fn zstd_workers() -> u32 {
 /// GNU sparse file (symlinks, hardlinks, devices, etc.). An attacker with
 /// R2 write access
 /// could otherwise craft a tar where expected filenames are symlinks to
-/// host paths, bypassing `is_image_complete` and exposing host files to
-/// Firecracker. See module-level "Tar entry security" docs.
+/// host paths, bypassing the caller's post-download rootfs check and
+/// exposing host files to Firecracker. See module-level "Tar entry
+/// security" docs.
 fn unpack_from_reader<R: std::io::Read>(reader: R, dest: &Path) -> Result<(), R2Error> {
     let zr = zstd::stream::read::Decoder::new(reader)?;
     let mut archive = tar::Archive::new(zr);
@@ -743,8 +747,14 @@ where
     .map_err(|e| R2Error::Io(io_other(e)))?
 }
 
-/// Finish the unpack: best-effort sparse-restore `cow.img`, then atomic rename
-/// `staging` to `final_dir`. Same-parent rename is atomic on ext4/xfs.
+/// Finish the unpack: best-effort sparse-restore any `cow.img` if present,
+/// then atomic rename `staging` to `final_dir`. Same-parent rename is
+/// atomic on ext4/xfs.
+///
+/// The cow.img handling is retained as defensive infrastructure — the
+/// current R2 archive only contains rootfs.ext4, but `punch_hole` is a
+/// no-op when cow.img is absent and kept in case sparse files are added
+/// back to the archive in the future.
 async fn finalize_staging(staging: &Path, final_dir: &Path) -> Result<(), R2Error> {
     let cow = staging.join("cow.img");
     if let Ok(meta) = tokio::fs::metadata(&cow).await {
@@ -761,8 +771,8 @@ async fn finalize_staging(staging: &Path, final_dir: &Path) -> Result<(), R2Erro
 
     if let Err(e) = tokio::fs::rename(staging, final_dir).await {
         // Expected recovery path: a previous `runner build` for this hash
-        // crashed after creating final_dir but before is_image_complete
-        // would pass. Wipe the stale directory and retry the rename.
+        // crashed after creating final_dir but before the build finished.
+        // Wipe the stale directory and retry the rename.
         tracing::info!(
             "{} already exists (likely stale from a partial run: {e}); replacing",
             final_dir.display()
@@ -1575,8 +1585,8 @@ mod tests {
 
     /// Empty file list: pack succeeds and produces a valid (empty) tar.zst.
     /// Round-trip unpack gives an empty `final_dir`. This is degenerate but
-    /// must not panic — it's the canary for `is_image_complete()` invariants
-    /// changing in the future.
+    /// must not panic — it's the canary for the caller's post-download
+    /// completeness check (currently: rootfs.ext4 presence) to catch.
     #[tokio::test]
     async fn pack_unpack_empty_files_list() {
         let archive = tempfile::NamedTempFile::new().unwrap();
@@ -1654,9 +1664,10 @@ mod tests {
     }
 
     /// `force = true` MUST NOT call `head_object` — the corrupt-eviction
-    /// contract: after detecting a bad object via `is_image_complete=false`,
-    /// the caller relies on `upload(_, _, true)` to force-overwrite without
-    /// re-checking existence (which would still say "exists, skip").
+    /// contract: after detecting a bad object (download succeeded but
+    /// rootfs.ext4 missing), the caller relies on `upload(_, _, true)` to
+    /// force-overwrite without re-checking existence (which would still
+    /// say "exists, skip").
     #[tokio::test]
     async fn upload_force_true_bypasses_exists_check() {
         use aws_sdk_s3::Client;

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -747,28 +747,9 @@ where
     .map_err(|e| R2Error::Io(io_other(e)))?
 }
 
-/// Finish the unpack: best-effort sparse-restore any `cow.img` if present,
-/// then atomic rename `staging` to `final_dir`. Same-parent rename is
-/// atomic on ext4/xfs.
-///
-/// The cow.img handling is retained as defensive infrastructure — the
-/// current R2 archive only contains rootfs.ext4, but `punch_hole` is a
-/// no-op when cow.img is absent and kept in case sparse files are added
-/// back to the archive in the future.
+/// Finish the unpack: atomic rename `staging` to `final_dir`. Same-parent
+/// rename is atomic on ext4/xfs.
 async fn finalize_staging(staging: &Path, final_dir: &Path) -> Result<(), R2Error> {
-    let cow = staging.join("cow.img");
-    if let Ok(meta) = tokio::fs::metadata(&cow).await {
-        let len = meta.len();
-        if len > 0 {
-            let result = tokio::task::spawn_blocking(move || punch_hole(&cow, len))
-                .await
-                .map_err(|e| R2Error::Io(io_other(e)))?;
-            if let Err(e) = result {
-                tracing::warn!("punch_hole on cow.img failed: {e}");
-            }
-        }
-    }
-
     if let Err(e) = tokio::fs::rename(staging, final_dir).await {
         // Expected recovery path: a previous `runner build` for this hash
         // crashed after creating final_dir but before the build finished.
@@ -824,38 +805,6 @@ async fn read_full<R: tokio::io::AsyncRead + Unpin>(
             .ok_or_else(|| R2Error::Io(io_other("read offset overflow")))?;
     }
     Ok(total)
-}
-
-/// Best-effort `FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE` over the whole file.
-/// Logs and swallows EOPNOTSUPP (tmpfs); returns Err for other failures.
-fn punch_hole(path: &Path, len: u64) -> Result<(), R2Error> {
-    let f = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(path)?;
-    let len_i64 = i64::try_from(len).map_err(|_| {
-        R2Error::Io(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("file size too large for fallocate: {len}"),
-        ))
-    })?;
-    match nix::fcntl::fallocate(
-        &f,
-        nix::fcntl::FallocateFlags::FALLOC_FL_PUNCH_HOLE
-            | nix::fcntl::FallocateFlags::FALLOC_FL_KEEP_SIZE,
-        0,
-        len_i64,
-    ) {
-        Ok(()) => Ok(()),
-        Err(nix::Error::EOPNOTSUPP) => {
-            tracing::warn!(
-                "filesystem doesn't support FALLOC_FL_PUNCH_HOLE; cow.img will remain dense \
-                 ({len} bytes on disk)"
-            );
-            Ok(())
-        }
-        Err(e) => Err(R2Error::Io(std::io::Error::other(e.to_string()))),
-    }
 }
 
 #[cfg(test)]
@@ -1124,45 +1073,13 @@ mod tests {
 
     // ---- pack / unpack round-trip --------------------------------------
 
-    /// Write the four canonical image files into `dir` with the same byte
-    /// content for both packing and verification. cow.img is sparse (16 MiB
-    /// logical, only first 1 MiB written).
+    /// Write the rootfs file (the only file cached in R2) into `dir`.
     async fn write_mock_image_files(dir: &Path) -> Vec<PathBuf> {
         let rootfs = dir.join("rootfs.ext4");
-        let snapshot = dir.join("snapshot.bin");
-        let memory = dir.join("memory.bin");
-        let cow = dir.join("cow.img");
-
-        // Distinct content per file so cross-contamination shows up as a diff.
         tokio::fs::write(&rootfs, b"rootfs-content".repeat(1024))
             .await
             .unwrap();
-        tokio::fs::write(&snapshot, b"snapshot-bin").await.unwrap();
-        tokio::fs::write(&memory, vec![0u8; 4 * 1024 * 1024])
-            .await
-            .unwrap();
-
-        // Sparse cow.img: 16 MiB logical, 1 MiB at the front.
-        let cow_file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&cow)
-            .unwrap();
-        cow_file.set_len(16 * 1024 * 1024).unwrap();
-        drop(cow_file);
-        tokio::fs::write(&cow, vec![0xAB; 1024 * 1024])
-            .await
-            .unwrap();
-        // Re-truncate to logical size after writing data — write() truncates.
-        std::fs::OpenOptions::new()
-            .write(true)
-            .open(&cow)
-            .unwrap()
-            .set_len(16 * 1024 * 1024)
-            .unwrap();
-
-        vec![rootfs, snapshot, memory, cow]
+        vec![rootfs]
     }
 
     /// Helper: full atomic unpack from an on-disk archive (test-only path).
@@ -1180,7 +1097,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pack_then_unpack_round_trips_4_files() {
+    async fn pack_then_unpack_round_trips_rootfs() {
         let src_dir = tempfile::tempdir().unwrap();
         let dst_root = tempfile::tempdir().unwrap();
         let final_dir = dst_root.path().join("hash-abc");
@@ -1202,19 +1119,12 @@ mod tests {
             .await
             .unwrap();
 
-        // All 4 file names exist and round-trip the prefix bytes.
-        for name in ["rootfs.ext4", "snapshot.bin", "memory.bin", "cow.img"] {
-            let dst = final_dir.join(name);
-            let src = src_dir.path().join(name);
-            assert!(dst.exists(), "{name} should exist after unpack");
-            let dst_meta = std::fs::metadata(&dst).unwrap();
-            let src_meta = std::fs::metadata(&src).unwrap();
-            assert_eq!(
-                dst_meta.len(),
-                src_meta.len(),
-                "{name} logical size mismatch"
-            );
-        }
+        let dst = final_dir.join("rootfs.ext4");
+        let src = src_dir.path().join("rootfs.ext4");
+        assert!(dst.exists(), "rootfs.ext4 should exist after unpack");
+        let dst_meta = std::fs::metadata(&dst).unwrap();
+        let src_meta = std::fs::metadata(&src).unwrap();
+        assert_eq!(dst_meta.len(), src_meta.len(), "rootfs size mismatch");
 
         // Staging directory should no longer exist after the rename.
         assert!(!staging_dir(&final_dir).exists());
@@ -1464,34 +1374,9 @@ mod tests {
         assert_unpack_rejects_typeflag(b'1', b"/etc/passwd").await;
     }
 
-    /// `finalize_staging` skips `punch_hole` when `cow.img` is empty (size=0).
-    /// Different branch from `finalize_works_without_cow_img` — there the
-    /// file is absent; here it exists with zero length. Both must succeed
-    /// without invoking the fallocate syscall (which is undefined for len=0).
+    /// `finalize_staging` performs the atomic rename for a rootfs-only archive.
     #[tokio::test]
-    async fn finalize_skips_punch_hole_on_zero_byte_cow() {
-        let dst_root = tempfile::tempdir().unwrap();
-        let final_dir = dst_root.path().join("hash");
-        let staging = staging_dir(&final_dir);
-        tokio::fs::create_dir_all(&staging).await.unwrap();
-        tokio::fs::write(staging.join("cow.img"), b"")
-            .await
-            .unwrap();
-        tokio::fs::write(staging.join("rootfs.ext4"), b"data")
-            .await
-            .unwrap();
-
-        finalize_staging(&staging, &final_dir).await.unwrap();
-
-        let cow_meta = std::fs::metadata(final_dir.join("cow.img")).unwrap();
-        assert_eq!(cow_meta.len(), 0, "0-byte cow.img preserved as-is");
-        assert!(!staging.exists(), "staging consumed by rename");
-    }
-
-    /// `finalize_staging` skips `punch_hole` cleanly when `cow.img` is absent.
-    /// Defends against future producers that ship without cow.img.
-    #[tokio::test]
-    async fn finalize_works_without_cow_img() {
+    async fn finalize_renames_rootfs_only_staging() {
         let dst_root = tempfile::tempdir().unwrap();
         let final_dir = dst_root.path().join("hash");
         let staging = staging_dir(&final_dir);
@@ -1499,13 +1384,11 @@ mod tests {
         tokio::fs::write(staging.join("rootfs.ext4"), b"data")
             .await
             .unwrap();
-        // Intentionally: no cow.img.
 
         finalize_staging(&staging, &final_dir).await.unwrap();
 
         assert!(final_dir.exists());
         assert!(final_dir.join("rootfs.ext4").exists());
-        assert!(!final_dir.join("cow.img").exists());
         assert!(!staging.exists(), "staging consumed by rename");
     }
 


### PR DESCRIPTION
## Summary
- R2 now caches only rootfs.ext4 (not snapshot files); snapshots are always created locally
- After downloading rootfs from R2, the local host's CA cert is injected via new `inject-ca.sh` (loop mount + chroot `update-ca-certificates` + Java keytool)
- `compute_image_hash` drops host-specific fields (kernel, CPU, BIOS) and snapshot-specific fields (firecracker/kernel version, vcpu, memory_mb) — hosts with different hardware can now share the rootfs cache
- `IMAGE_CACHE_VERSION` bumped from 2 to 3 to invalidate old 4-file cache entries
- R2 download path sanitizes `output_dir` to keep only rootfs.ext4, then runs CA injection before snapshot creation

## Why

Fixes #9448. Cross-host R2 cache reuse was broken because:
1. Rootfs embedded the build host's CA cert
2. Snapshot memory contained guest kernel's page cache with cached ext4 metadata for cert files
3. Simple rootfs CA replacement would be masked by stale page cache

The fix: cache only the expensive rootfs build (debootstrap + apt), always create snapshots from a fresh boot with the correct local CA.

## Test plan

- [ ] `runner-build` job runs the new build flow end-to-end
- [ ] `runner-benchmark` validates snapshot + CA work correctly (TLS through proxy)
- [ ] `runner-exec` runs comprehensive HTTPS tests for all runtimes
- [ ] `runner-snapshot-verify` (PR #9444) confirms CA certs not in page cache
- [ ] Local dev: `runner build`, delete snapshot files, rebuild → should trigger R2 rootfs cache hit + local CA inject + local snapshot

Closes #9448

🤖 Generated with [Claude Code](https://claude.com/claude-code)