### PR TITLE
fix(platform): auto-scroll to bottom on container resize

### DIFF
--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -20,7 +20,7 @@ export function createScrollSignals() {
   const autoScrollDisabled$ = state(false);
 
   const setScrollContainer$ = onRef(
-    command(({ set }, el: HTMLElement, signal: AbortSignal) => {
+    command(({ get, set }, el: HTMLElement, signal: AbortSignal) => {
       set(internalScrollContainer$, el);
 
       let lastKnownScrollTop = el.scrollTop;
@@ -37,7 +37,16 @@ export function createScrollSignals() {
       };
 
       el.addEventListener("scroll", onScroll, { passive: true });
+
+      const resizeObserver = new ResizeObserver(() => {
+        if (!get(autoScrollDisabled$)) {
+          el.scrollTop = el.scrollHeight;
+        }
+      });
+      resizeObserver.observe(el);
+
       signal.addEventListener("abort", () => {
+        resizeObserver.disconnect();
         el.removeEventListener("scroll", onScroll);
         set(internalScrollContainer$, null);
       });


### PR DESCRIPTION
## Summary
- Add `ResizeObserver` to the scroll container in `auto-scroll.ts` that automatically scrolls to the bottom when the container is resized and auto-scroll is enabled
- Clean up the observer on abort signal to prevent memory leaks
- Fixes the issue where chat content doesn't stay scrolled to bottom when the container dimensions change (e.g., window resize, layout shift)

## Test plan
- [ ] Open a chat with existing messages and verify it scrolls to bottom
- [ ] Resize the browser window and confirm the chat stays scrolled to bottom when auto-scroll is active
- [ ] Manually scroll up to disable auto-scroll, then resize — confirm it does NOT force scroll to bottom
- [ ] Verify no console errors or performance issues with the ResizeObserver

🤖 Generated with [Claude Code](https://claude.com/claude-code)