### PR TITLE
fix(runner): escape quotes and backslashes in systemd env values

### DIFF
--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -206,16 +206,19 @@ WantedBy=multi-user.target
 /// install time rather than letting `daemon-reload` fail obscurely later.
 fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
     for entry in vars {
+        // Check dangerous chars first so the KEY=VALUE error below can
+        // safely interpolate `entry` without leaking newlines/NUL into
+        // log output.
+        if entry.contains(['\n', '\r', '\0']) {
+            return Err(RunnerError::Config(
+                "invalid --env value: newline or NUL characters are not allowed".to_string(),
+            ));
+        }
         let eq_pos = entry.find('=');
         if eq_pos.is_none_or(|p| p == 0) {
             return Err(RunnerError::Config(format!(
                 "invalid --env value '{entry}': expected KEY=VALUE format"
             )));
-        }
-        if entry.contains(['\n', '\r', '\0']) {
-            return Err(RunnerError::Config(
-                "invalid --env value: newline or NUL characters are not allowed".to_string(),
-            ));
         }
     }
     Ok(())

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -806,6 +806,10 @@ mod tests {
 
     #[test]
     fn test_escape_systemd_env_value() {
+        // Empty input — degenerate but callable (helper is independent of
+        // validate); guards against future `replace` behavior changes.
+        assert_eq!(escape_systemd_env_value(""), "");
+
         // No special chars — identity.
         assert_eq!(escape_systemd_env_value("KEY=value"), "KEY=value");
 
@@ -832,7 +836,14 @@ mod tests {
 
     #[test]
     fn test_generate_unit_file_escapes_env_values() {
-        let env = vec![r#"MSG=say "hi""#.to_string(), r"PATH=C:\Users".to_string()];
+        let env = vec![
+            r#"MSG=say "hi""#.to_string(),
+            r"PATH=C:\Users".to_string(),
+            // Both `"` and `\` in a single entry — catches regressions in
+            // the helper-to-format! interaction that the helper-only test
+            // would miss (e.g. accidental extra escaping at the call site).
+            r#"K=a"\b"#.to_string(),
+        ];
         let content = generate_unit_file(
             "vm0-runner-v0.1.0",
             Path::new("/usr/bin/runner"),
@@ -842,6 +853,7 @@ mod tests {
         );
         assert!(content.contains(r#"Environment="MSG=say \"hi\"""#));
         assert!(content.contains(r#"Environment="PATH=C:\\Users""#));
+        assert!(content.contains(r#"Environment="K=a\"\\b""#));
     }
 
     #[test]
@@ -854,6 +866,10 @@ mod tests {
         // later in `escape_systemd_env_value`.
         assert!(validate_env_vars(&[r#"MSG=say "hi""#.to_string()]).is_ok());
         assert!(validate_env_vars(&[r"PATH=C:\Users".to_string()]).is_ok());
+        // Tab is intentionally NOT rejected: it is valid inside a systemd
+        // quoted `Environment=` value. Locking this in so a future "let's
+        // reject all whitespace control chars" change is an explicit choice.
+        assert!(validate_env_vars(&["KEY=with\ttab".to_string()]).is_ok());
     }
 
     #[test]

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -147,6 +147,16 @@ fn resolve_config_path(path: &Path) -> RunnerResult<PathBuf> {
     })
 }
 
+/// Escape a value for use inside systemd `Environment="..."`.
+///
+/// Inside a double-quoted `Environment=` value, systemd requires `"` to be
+/// written as `\"` and `\` as `\\`. The order matters: `\` MUST be escaped
+/// first, otherwise the `\` we insert while escaping `"` gets re-escaped,
+/// turning each original `"` into `\\"` (invalid).
+fn escape_systemd_env_value(entry: &str) -> String {
+    entry.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 /// Generate the systemd unit file content.
 fn generate_unit_file(
     unit: &str,
@@ -157,7 +167,8 @@ fn generate_unit_file(
 ) -> String {
     let mut env_lines = String::new();
     for entry in env_vars {
-        env_lines.push_str(&format!("Environment=\"{entry}\"\n"));
+        let escaped = escape_systemd_env_value(entry);
+        env_lines.push_str(&format!("Environment=\"{escaped}\"\n"));
     }
     let local_flag = if local { " --local" } else { "" };
     format!(
@@ -186,7 +197,13 @@ WantedBy=multi-user.target
     )
 }
 
-/// Validate that each env entry is in `KEY=VALUE` format.
+/// Validate that each env entry is in `KEY=VALUE` format and contains no
+/// characters that would silently corrupt the generated systemd unit file.
+///
+/// Bare newlines / carriage returns / NUL bytes inside a value break the
+/// `Environment=` directive even with proper quote/backslash escaping
+/// (a literal newline terminates the directive line). Reject these at
+/// install time rather than letting `daemon-reload` fail obscurely later.
 fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
     for entry in vars {
         let eq_pos = entry.find('=');
@@ -194,6 +211,11 @@ fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
             return Err(RunnerError::Config(format!(
                 "invalid --env value '{entry}': expected KEY=VALUE format"
             )));
+        }
+        if entry.contains(['\n', '\r', '\0']) {
+            return Err(RunnerError::Config(
+                "invalid --env value: newline or NUL characters are not allowed".to_string(),
+            ));
         }
     }
     Ok(())
@@ -780,11 +802,55 @@ mod tests {
     }
 
     #[test]
+    fn test_escape_systemd_env_value() {
+        // No special chars — identity.
+        assert_eq!(escape_systemd_env_value("KEY=value"), "KEY=value");
+
+        // Double quotes.
+        assert_eq!(
+            escape_systemd_env_value(r#"MSG=say "hi""#),
+            r#"MSG=say \"hi\""#,
+        );
+
+        // Backslashes.
+        assert_eq!(
+            escape_systemd_env_value(r"PATH=C:\Users\test"),
+            r"PATH=C:\\Users\\test",
+        );
+
+        // Mixed `\` and `"` — regressions here catch reversed-order bugs
+        // (each character alone would still pass the tests above).
+        assert_eq!(escape_systemd_env_value(r#"K=a\b"c"#), r#"K=a\\b\"c"#,);
+
+        // Trailing `\`: without escape, the generated line `"K=foo\"` would
+        // swallow the closing quote and corrupt the unit file.
+        assert_eq!(escape_systemd_env_value(r"K=foo\"), r"K=foo\\");
+    }
+
+    #[test]
+    fn test_generate_unit_file_escapes_env_values() {
+        let env = vec![r#"MSG=say "hi""#.to_string(), r"PATH=C:\Users".to_string()];
+        let content = generate_unit_file(
+            "vm0-runner-v0.1.0",
+            Path::new("/usr/bin/runner"),
+            Path::new("/etc/runner.yaml"),
+            &env,
+            false,
+        );
+        assert!(content.contains(r#"Environment="MSG=say \"hi\"""#));
+        assert!(content.contains(r#"Environment="PATH=C:\\Users""#));
+    }
+
+    #[test]
     fn test_validate_env_vars_valid() {
         assert!(validate_env_vars(&[]).is_ok());
         assert!(validate_env_vars(&["KEY=VALUE".to_string()]).is_ok());
         assert!(validate_env_vars(&["K=".to_string()]).is_ok());
         assert!(validate_env_vars(&["K=V=W".to_string()]).is_ok());
+        // `"` and `\` are valid at the validate layer — they get escaped
+        // later in `escape_systemd_env_value`.
+        assert!(validate_env_vars(&[r#"MSG=say "hi""#.to_string()]).is_ok());
+        assert!(validate_env_vars(&[r"PATH=C:\Users".to_string()]).is_ok());
     }
 
     #[test]
@@ -792,6 +858,10 @@ mod tests {
         assert!(validate_env_vars(&["NOEQUALS".to_string()]).is_err());
         assert!(validate_env_vars(&["=VALUE".to_string()]).is_err());
         assert!(validate_env_vars(&["".to_string()]).is_err());
+        // Bare newline / CR / NUL would silently corrupt the unit file.
+        assert!(validate_env_vars(&["KEY=line1\nline2".to_string()]).is_err());
+        assert!(validate_env_vars(&["KEY=foo\rbar".to_string()]).is_err());
+        assert!(validate_env_vars(&["KEY=with\0nul".to_string()]).is_err());
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `service install` previously produced malformed systemd unit files when any `--env` value contained `"` or `\`, causing `daemon-reload` to silently reject the unit.
- Add `escape_systemd_env_value` helper and wire it into `generate_unit_file`; order-of-operations (escape `\` before `"`) is explicit in the helper's doc comment.
- Reject `\n` / `\r` / `\0` in `validate_env_vars` — bare newlines break the unit file even with correct quote/backslash escaping; fail loudly at install time instead.
- `service start` (uses `systemd-run --setenv=`) was not affected and is unchanged.

Fixes #9452

## Test plan

- [x] `cargo test -p runner cmd::service::tests` — 27/27 passing (2 new tests + 2 extended)
- [x] `cargo clippy -p runner --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p runner --check` — clean
- [ ] Manual post-merge on a systemd host: `runner service install --env 'MSG=say "hi"' --env 'BACKSLASH=a\b' --env 'TRAILING=foo\'` → `systemctl show ... -p Environment` round-trips byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)