### PR TITLE
refactor(runner): split mitm_addon.py into usage.py and body_utils.py

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -1,0 +1,263 @@
+"""Body processing helpers shared between usage extraction and body capture.
+
+Exports:
+
+- ``_STREAM_BUFFER_LIMIT`` — 64 KB cap used by the streaming buffer in
+  ``mitm_addon.responseheaders`` and by the decompression safety cap.
+- Streaming / one-shot decompression for gzip, deflate, br, zstd.
+- UTF-8-safe truncation, text/binary content detection and encoding.
+- Header redaction for sensitive names (auth, token, cookie, …).
+- ``_add_capture_fields`` — composes capture-mode log entry fields.
+"""
+
+import base64
+import zlib
+
+import brotli  # type: ignore[import-untyped]
+import zstandard
+from mitmproxy import ctx, http
+
+# Cap for non-model-provider response body buffering and decompression output.
+_STREAM_BUFFER_LIMIT = 64 * 1024  # 64 KB
+
+
+# ---------------------------------------------------------------------------
+# Body capture helpers (opt-in per run via captureNetworkBodies registry flag)
+# ---------------------------------------------------------------------------
+
+
+_TEXT_CONTENT_TYPES = (
+    "text/",
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/x-www-form-urlencoded",
+    "application/graphql",
+)
+
+# Header names containing any of these keywords (case-insensitive) are redacted.
+_SENSITIVE_HEADER_KEYWORDS = (
+    "auth",
+    "token",
+    "secret",
+    "api-key",
+    "apikey",
+    "credential",
+    "password",
+    "cookie",
+)
+
+
+def _create_stream_decompressor(headers: http.Headers):
+    """Create an incremental decompressor for streaming chunks.
+
+    Returns a callable that decompresses each chunk, maintaining state
+    across calls.  Returns None if the response is not compressed.
+    """
+    encoding = headers.get("content-encoding", "").strip().lower()
+    if not encoding or encoding == "identity":
+        return None
+    if encoding in ("gzip", "deflate"):
+        wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
+        obj = zlib.decompressobj(wbits)
+
+        def decompress_zlib(chunk: bytes) -> bytes:
+            try:
+                return obj.decompress(chunk)
+            except zlib.error:
+                return b""
+
+        return decompress_zlib
+    if encoding == "br":
+        dec = brotli.Decompressor()
+
+        def decompress_br(chunk: bytes) -> bytes:
+            try:
+                return dec.process(chunk)
+            except brotli.error:
+                return b""
+
+        return decompress_br
+    if encoding == "zstd":
+        obj = zstandard.ZstdDecompressor().decompressobj()
+
+        def decompress_zstd(chunk: bytes) -> bytes:
+            try:
+                return obj.decompress(chunk)
+            except zstandard.ZstdError:
+                return b""
+
+        return decompress_zstd
+    return None
+
+
+def _decompress_body(
+    data: bytes, headers: http.Headers, max_output: int = _STREAM_BUFFER_LIMIT
+) -> bytes:
+    """Decompress response body based on Content-Encoding header.
+
+    The stream callback receives raw wire bytes.  When the server uses
+    gzip/deflate/br/zstd encoding, we must decompress before capturing.
+    Uses incremental decompression so truncated compressed data still
+    yields whatever decompressed bytes are available.
+
+    Output is capped at *max_output* bytes to guard against decompression
+    bombs (small compressed payload expanding to huge output).
+
+    Returns the original data unchanged if not compressed or on error.
+    """
+    encoding = headers.get("content-encoding", "").strip().lower()
+    if not encoding or encoding == "identity":
+        return data
+    try:
+        if encoding in ("gzip", "deflate"):
+            # wbits: gzip=16+MAX_WBITS, deflate=MAX_WBITS
+            wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
+            obj = zlib.decompressobj(wbits)
+            result = obj.decompress(data, max_length=max_output)
+            return result if result else data
+        if encoding == "br":
+            dec = brotli.Decompressor()
+            result = dec.process(data)
+            return result[:max_output] if result else data
+        if encoding == "zstd":
+            obj = zstandard.ZstdDecompressor().decompressobj()
+            result = obj.decompress(data)
+            return result[:max_output] if result else data
+    except (zlib.error, brotli.error, zstandard.ZstdError) as exc:
+        try:
+            ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
+        except AttributeError:
+            pass  # ctx.log unavailable outside mitmproxy runtime
+    return data
+
+
+def _is_text_content(content_type: str) -> bool:
+    """Check if content-type indicates text-like content worth capturing."""
+    if not content_type:
+        return True  # assume text when unspecified
+    ct = content_type.lower().split(";")[0].strip()
+    return any(ct.startswith(prefix) for prefix in _TEXT_CONTENT_TYPES)
+
+
+def _truncate_bytes_utf8_safe(data: bytes, max_size: int) -> bytes:
+    """Truncate bytes at a UTF-8 character boundary.
+
+    After slicing at *max_size*, checks whether the last character is
+    complete.  If not, removes the incomplete trailing bytes (at most 4).
+    """
+    if len(data) <= max_size:
+        return data
+    t = data[:max_size]
+    # Find the start of the last character by scanning backwards
+    # past continuation bytes (10xxxxxx = 0x80..0xBF).
+    i = len(t)
+    while i > 0 and (t[i - 1] & 0xC0) == 0x80:
+        i -= 1
+    if i == 0:
+        return t  # all continuation bytes — shouldn't happen in valid UTF-8
+    lead = t[i - 1]
+    # Determine the expected sequence length from the lead byte.
+    if lead < 0x80:
+        expected = 1
+    elif lead < 0xE0:
+        expected = 2
+    elif lead < 0xF0:
+        expected = 3
+    else:
+        expected = 4
+    # If the sequence starting at (i-1) has fewer bytes than expected,
+    # it was cut — remove the incomplete sequence.
+    actual = len(t) - (i - 1)
+    if actual < expected:
+        return t[: i - 1]
+    return t
+
+
+def _encode_body(content: bytes, content_type: str) -> tuple:
+    """Encode body content. Returns (encoded_string, encoding_type) or (None, None) for binary."""
+    if not _is_text_content(content_type):
+        return None, None  # skip binary bodies
+    try:
+        return content.decode("utf-8"), "utf-8"
+    except UnicodeDecodeError:
+        return base64.b64encode(content).decode("ascii"), "base64"
+
+
+def _is_sensitive_header(name: str) -> bool:
+    """Check if a header name likely carries sensitive data."""
+    lower = name.lower()
+    return any(kw in lower for kw in _SENSITIVE_HEADER_KEYWORDS)
+
+
+def _redact_headers(headers) -> dict:
+    """Build a dict of headers with sensitive values replaced by ***."""
+    result = {}
+    for name, value in headers.items(multi=True):
+        if name in result:
+            continue  # keep first occurrence only (headers.items gives all)
+        result[name] = "***" if _is_sensitive_header(name) else value
+    return result
+
+
+def _add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
+    """Add request/response headers and bodies to a log entry.
+
+    # [NETWORK_LOG_FIELDS] — capture-only fields, not part of the core schema.
+    # Fields: request_headers, request_body, request_body_encoding,
+    #         request_body_truncated, response_headers, response_body,
+    #         response_body_encoding, response_body_truncated
+    """
+    # Request headers (always available)
+    log_entry["request_headers"] = _redact_headers(flow.request.headers)
+
+    # Request body
+    if flow.request.content:
+        req_ct = flow.request.headers.get("content-type", "")
+        body = flow.request.content
+        truncated = len(body) > _STREAM_BUFFER_LIMIT
+        if truncated:
+            body = _truncate_bytes_utf8_safe(body, _STREAM_BUFFER_LIMIT)
+        encoded, encoding = _encode_body(body, req_ct)
+        if encoded is not None:
+            log_entry["request_body"] = encoded
+            log_entry["request_body_encoding"] = encoding
+            if truncated:
+                log_entry["request_body_truncated"] = True
+        else:
+            log_entry["request_body_encoding"] = "binary"
+
+    # Response headers
+    if flow.response:
+        log_entry["response_headers"] = _redact_headers(flow.response.headers)
+
+    # Response body — read from stream_buffer (available for all responses).
+    # The buffer contains raw wire bytes (possibly gzip/br/zstd compressed).
+    if flow.response:
+        stream_buf = flow.metadata.get("stream_buffer")
+        if stream_buf is not None:
+            body = _decompress_body(bytes(stream_buf), flow.response.headers)
+        else:
+            try:
+                body = flow.response.content
+            except (zlib.error, ValueError):
+                # ZlibError (decompression failure) or ValueError from mitmproxy
+                log_entry["response_body_encoding"] = "binary"
+                return
+        if not body:
+            return
+        stream_state = flow.metadata.get("stream_buffer_state")
+        res_ct = flow.response.headers.get("content-type", "")
+        # stream_buffer may already be truncated at _STREAM_BUFFER_LIMIT.
+        # Also check decompressed size in case it expanded beyond the limit.
+        truncated = (stream_state and stream_state["truncated"]) or len(body) > _STREAM_BUFFER_LIMIT
+        if truncated:
+            body = _truncate_bytes_utf8_safe(body, _STREAM_BUFFER_LIMIT)
+        encoded, encoding = _encode_body(body, res_ct)
+        if encoded is not None:
+            log_entry["response_body"] = encoded
+            log_entry["response_body_encoding"] = encoding
+            if truncated:
+                log_entry["response_body_truncated"] = True
+        else:
+            log_entry["response_body_encoding"] = "binary"

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -2,12 +2,12 @@
 
 Exports:
 
-- ``_STREAM_BUFFER_LIMIT`` — 64 KB cap used by the streaming buffer in
+- ``STREAM_BUFFER_LIMIT`` — 64 KB cap used by the streaming buffer in
   ``mitm_addon.responseheaders`` and by the decompression safety cap.
 - Streaming / one-shot decompression for gzip, deflate, br, zstd.
 - UTF-8-safe truncation, text/binary content detection and encoding.
 - Header redaction for sensitive names (auth, token, cookie, …).
-- ``_add_capture_fields`` — composes capture-mode log entry fields.
+- ``add_capture_fields`` — composes capture-mode log entry fields.
 """
 
 import base64
@@ -18,7 +18,7 @@ import zstandard
 from mitmproxy import ctx, http
 
 # Cap for non-model-provider response body buffering and decompression output.
-_STREAM_BUFFER_LIMIT = 64 * 1024  # 64 KB
+STREAM_BUFFER_LIMIT = 64 * 1024  # 64 KB
 
 
 # ---------------------------------------------------------------------------
@@ -48,7 +48,7 @@ _SENSITIVE_HEADER_KEYWORDS = (
 )
 
 
-def _create_stream_decompressor(headers: http.Headers):
+def create_stream_decompressor(headers: http.Headers):
     """Create an incremental decompressor for streaming chunks.
 
     Returns a callable that decompresses each chunk, maintaining state
@@ -91,8 +91,8 @@ def _create_stream_decompressor(headers: http.Headers):
     return None
 
 
-def _decompress_body(
-    data: bytes, headers: http.Headers, max_output: int = _STREAM_BUFFER_LIMIT
+def decompress_body(
+    data: bytes, headers: http.Headers, max_output: int = STREAM_BUFFER_LIMIT
 ) -> bytes:
     """Decompress response body based on Content-Encoding header.
 
@@ -200,7 +200,7 @@ def _redact_headers(headers) -> dict:
     return result
 
 
-def _add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
+def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     """Add request/response headers and bodies to a log entry.
 
     # [NETWORK_LOG_FIELDS] — capture-only fields, not part of the core schema.
@@ -215,9 +215,9 @@ def _add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     if flow.request.content:
         req_ct = flow.request.headers.get("content-type", "")
         body = flow.request.content
-        truncated = len(body) > _STREAM_BUFFER_LIMIT
+        truncated = len(body) > STREAM_BUFFER_LIMIT
         if truncated:
-            body = _truncate_bytes_utf8_safe(body, _STREAM_BUFFER_LIMIT)
+            body = _truncate_bytes_utf8_safe(body, STREAM_BUFFER_LIMIT)
         encoded, encoding = _encode_body(body, req_ct)
         if encoded is not None:
             log_entry["request_body"] = encoded
@@ -236,7 +236,7 @@ def _add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     if flow.response:
         stream_buf = flow.metadata.get("stream_buffer")
         if stream_buf is not None:
-            body = _decompress_body(bytes(stream_buf), flow.response.headers)
+            body = decompress_body(bytes(stream_buf), flow.response.headers)
         else:
             try:
                 body = flow.response.content
@@ -248,11 +248,11 @@ def _add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             return
         stream_state = flow.metadata.get("stream_buffer_state")
         res_ct = flow.response.headers.get("content-type", "")
-        # stream_buffer may already be truncated at _STREAM_BUFFER_LIMIT.
+        # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.
         # Also check decompressed size in case it expanded beyond the limit.
-        truncated = (stream_state and stream_state["truncated"]) or len(body) > _STREAM_BUFFER_LIMIT
+        truncated = (stream_state and stream_state["truncated"]) or len(body) > STREAM_BUFFER_LIMIT
         if truncated:
-            body = _truncate_bytes_utf8_safe(body, _STREAM_BUFFER_LIMIT)
+            body = _truncate_bytes_utf8_safe(body, STREAM_BUFFER_LIMIT)
         encoded, encoding = _encode_body(body, res_ct)
         if encoded is not None:
             log_entry["response_body"] = encoded

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -23,7 +23,7 @@ from mitmproxy.addonmanager import Loader
 # so that:
 #   1. Cross-module calls read as ``usage.X(...)`` / ``body_utils.X(...)``,
 #      making the module boundary visible at call sites.
-#   2. Tests can patch ``usage._name`` / ``body_utils._name`` in one place and
+#   2. Tests can patch ``usage.name`` / ``body_utils.name`` in one place and
 #      it affects both direct callers in those modules and handler callers
 #      here — no mock-placement pitfalls.
 import body_utils
@@ -252,7 +252,7 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     Enable response streaming with body buffering.
 
     Uses a callback to stream response data to the client immediately
-    while accumulating a copy in memory (up to ``_STREAM_BUFFER_LIMIT``).
+    while accumulating a copy in memory (up to ``STREAM_BUFFER_LIMIT``).
     Once the limit is exceeded, buffering stops but streaming continues
     uninterrupted.  The buffered body is available in the ``response()``
     hook via ``flow.metadata["stream_buffer"]``.
@@ -272,14 +272,14 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     if is_model_provider:
         content_type = flow.response.headers.get("content-type", "")
         if "text/event-stream" in content_type:
-            parser_fn, usage_dict = usage._create_sse_usage_extractor()
+            parser_fn, usage_dict = usage.create_sse_usage_extractor()
             sse_parser = parser_fn
             flow.metadata["proxy_usage"] = usage_dict
-            sse_decompressor = body_utils._create_stream_decompressor(flow.response.headers)
+            sse_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
 
     # Model provider responses are never truncated so usage extraction
     # always has the complete body.  Other responses use the 64 KB limit.
-    buf_limit = None if is_model_provider else body_utils._STREAM_BUFFER_LIMIT
+    buf_limit = None if is_model_provider else body_utils.STREAM_BUFFER_LIMIT
 
     def stream_and_buffer(chunk: bytes) -> bytes:
         if not state["truncated"]:
@@ -363,7 +363,7 @@ def response(flow: http.HTTPFlow) -> None:
 
         # Add request headers, request body, and response body when capture is enabled
         if flow.metadata.get("capture_body"):
-            body_utils._add_capture_fields(flow, log_entry)
+            body_utils.add_capture_fields(flow, log_entry)
 
         log_network_entry(network_log_path, log_entry)
 
@@ -373,13 +373,13 @@ def response(flow: http.HTTPFlow) -> None:
     if not flow.metadata.get("proxy_usage") and stream_buf and run_id:
         firewall_name = flow.metadata.get("firewall_name", "")
         if firewall_name.startswith("model-provider:"):
-            json_usage = usage._extract_usage_from_json(
+            json_usage = usage.extract_usage_from_json(
                 bytes(stream_buf),
                 flow.response.headers if flow.response else None,
             )
             if json_usage:
                 flow.metadata["proxy_usage"] = json_usage
-    usage._maybe_report_proxy_usage(flow, run_id)
+    usage.maybe_report_proxy_usage(flow, run_id)
 
     # Invalidate firewall header cache on 401 so next request gets fresh headers
     if flow.response and flow.response.status_code == 401 and flow.metadata.get("firewall_base"):
@@ -454,7 +454,7 @@ def error(flow: http.HTTPFlow) -> None:
     # Report proxy-extracted usage for model provider responses.
     # The SSE parser may have partially populated proxy_usage before the
     # connection error occurred.  Partial data is better than none.
-    usage._maybe_report_proxy_usage(flow, run_id)
+    usage.maybe_report_proxy_usage(flow, run_id)
 
     log_proxy_entry(
         proxy_log_path,
@@ -477,7 +477,7 @@ def done():
     ``shutdown(wait=True)`` blocks until all submitted futures complete;
     SIGKILL is the hard stop if any report takes too long.
     """
-    usage._usage_executor.shutdown(wait=True)
+    usage.usage_executor.shutdown(wait=True)
 
 
 # ============================================================================

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -9,27 +9,29 @@ This addon runs on the runner HOST (not inside VMs) and:
 4. Logs network activity per-run to JSONL files
 """
 
-import base64
 import json
 import os
 import time
-import urllib.error
 import urllib.parse
-import zlib
-from concurrent.futures import ThreadPoolExecutor
 
-import brotli  # type: ignore[import-untyped]
-import zstandard
 from mitmproxy import ctx, http, tcp, tls
 from mitmproxy.addonmanager import Loader
 
-# --- Sub-module imports (only symbols used in this file's own code) ---
+# --- Sub-module imports ---
+#
+# Usage/body_utils are imported by module (not selective `from X import ...`)
+# so that:
+#   1. Cross-module calls read as ``usage.X(...)`` / ``body_utils.X(...)``,
+#      making the module boundary visible at call sites.
+#   2. Tests can patch ``usage._name`` / ``body_utils._name`` in one place and
+#      it affects both direct callers in those modules and handler callers
+#      here — no mock-placement pitfalls.
+import body_utils
+import usage
 from auth import (
     _firewall_header_cache,
-    _opener,
     evict_stale_cache_keys,
     handle_firewall_request,
-    make_api_request,
 )
 from logging_utils import add_firewall_metadata, log_network_entry, log_proxy_entry
 from matching import FirewallAllow, FirewallBlock, match_firewall_request
@@ -240,264 +242,9 @@ async def request(flow: http.HTTPFlow) -> None:
     flow.metadata["firewall_action"] = "ALLOW"
 
 
-_STREAM_BUFFER_LIMIT = 64 * 1024  # 64 KB
-
-
-# ---------------------------------------------------------------------------
-# Proxy-side usage extraction (for billing verification)
-# ---------------------------------------------------------------------------
-
-# Only extract known billing fields to avoid capturing unrelated numerics.
-_BILLING_FIELDS = frozenset(
-    (
-        "input_tokens",
-        "output_tokens",
-        "cache_read_input_tokens",
-        "cache_creation_input_tokens",
-    )
-)
-
-
-def _extract_billing_usage(raw_usage, target: dict) -> None:
-    """Extract known billing fields from an Anthropic usage object into *target*.
-
-    Handles both flat fields (input_tokens, etc.) and the nested
-    ``server_tool_use.web_search_requests`` field.
-
-    Only positive values overwrite existing entries — ``message_delta`` may
-    send ``0`` for fields already set correctly by ``message_start``.
-    """
-    if not raw_usage or not isinstance(raw_usage, dict):
-        return
-    for k, v in raw_usage.items():
-        if k in _BILLING_FIELDS and isinstance(v, (int, float)):
-            if v > 0 or k not in target:
-                target[k] = v
-    stu = raw_usage.get("server_tool_use")
-    if isinstance(stu, dict):
-        wsr = stu.get("web_search_requests")
-        if isinstance(wsr, (int, float)):
-            if wsr > 0 or "web_search_requests" not in target:
-                target["web_search_requests"] = wsr
-
-
-def _create_sse_usage_extractor():
-    """Create an incremental SSE parser that extracts usage from Anthropic API streams.
-
-    All model providers in this system use the Anthropic Messages API streaming
-    format.  Usage data appears in two SSE events:
-
-    - ``message_start`` — ``message.usage`` contains input token counts and
-      ``message.model`` identifies the model.
-    - ``message_delta`` — ``usage`` contains the final ``output_tokens`` count.
-
-    Returns ``(parse_chunk, usage)`` where *parse_chunk* processes raw bytes
-    incrementally and *usage* is a dict that accumulates extracted fields.
-    """
-    usage: dict = {}
-    line_buf = bytearray()
-    event_type = {"current": None}
-    # Events we need to parse — all others are skipped to avoid buffering
-    # large content_block_delta payloads.
-    _usage_events = frozenset(("message_start", "message_delta"))
-    # When True, discard incoming bytes until the next empty line (event
-    # boundary) to avoid buffering irrelevant data lines.
-    skipping = {"active": False}
-
-    def parse_chunk(chunk: bytes) -> None:
-        # In skip mode, scan for event boundary (empty line) without
-        # buffering the (potentially large) chunk.
-        if skipping["active"]:
-            # Look for \n\n or \r\n\r\n in existing buf + new chunk.
-            combined = line_buf + chunk
-            for sep in (b"\r\n\r\n", b"\n\n"):
-                idx = combined.find(sep)
-                if idx != -1:
-                    # Found event boundary — line_buf gets the remainder.
-                    # Do NOT extend again below; data is already in line_buf.
-                    after = idx + len(sep)
-                    line_buf[:] = combined[after:]
-                    skipping["active"] = False
-                    event_type["current"] = None
-                    break
-            else:
-                # No boundary found — discard everything except the
-                # last few bytes (could be a partial \r\n\r\n).
-                line_buf[:] = combined[-3:] if len(combined) > 3 else combined
-                return
-            # Boundary found — fall through to process line_buf contents.
-            # line_buf already has the data, so skip the extend.
-        else:
-            line_buf.extend(chunk)
-        while b"\n" in line_buf:
-            raw_line, _, remaining = line_buf.partition(b"\n")
-            line_buf[:] = remaining
-            line = raw_line.rstrip(b"\r").decode("utf-8", errors="replace")
-
-            # Blank line = event boundary.
-            if line == "":
-                event_type["current"] = None
-                skipping["active"] = False
-                continue
-
-            if skipping["active"]:
-                continue
-
-            if line.startswith("event: "):
-                evt_name = line[7:]
-                event_type["current"] = evt_name
-                if evt_name not in _usage_events:
-                    # Skip data lines of this event within line_buf.
-                    # Cross-chunk large data lines are handled by the
-                    # skip mode at the top of parse_chunk.
-                    skipping["active"] = True
-                    continue
-            elif line.startswith("data: "):
-                evt = event_type["current"]
-                if evt == "message_start":
-                    try:
-                        data = json.loads(line[6:])
-                        msg = data.get("message") or {}
-                        model = msg.get("model")
-                        if model:
-                            usage["model"] = model
-                        message_id = msg.get("id")
-                        if message_id:
-                            usage["message_id"] = message_id
-                        _extract_billing_usage(msg.get("usage"), usage)
-                    except (json.JSONDecodeError, AttributeError, TypeError):
-                        pass  # SSE data lines may be partial/malformed; best-effort extraction
-                elif evt == "message_delta":
-                    try:
-                        data = json.loads(line[6:])
-                        _extract_billing_usage(data.get("usage"), usage)
-                    except (json.JSONDecodeError, AttributeError, TypeError):
-                        pass  # SSE data lines may be partial/malformed; best-effort extraction
-
-    return parse_chunk, usage
-
-
-def _extract_usage_from_json(body: bytes, headers) -> dict | None:
-    """Extract usage from a non-streaming Anthropic API JSON response.
-
-    Falls back to decompressing the body if *headers* indicate compression.
-    Returns ``None`` when the body is not valid JSON or contains no usage.
-    """
-    if headers:
-        body = _decompress_body(body, headers)
-    try:
-        data = json.loads(body)
-    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
-        return None
-    if not isinstance(data, dict):
-        return None
-    usage: dict = {}
-    model = data.get("model")
-    if model:
-        usage["model"] = model
-    _extract_billing_usage(data.get("usage"), usage)
-    if not usage:
-        return None
-    message_id = data.get("id")
-    if message_id:
-        usage["message_id"] = message_id
-    return usage
-
-
-def _do_report_usage(api_url: str, sandbox_token: str, run_id: str, usage: dict) -> None:
-    """POST extracted usage to the platform webhook.  Raises on failure."""
-    url = f"{api_url}/api/webhooks/agent/usage"
-    payload = json.dumps({"runId": run_id, "usage": usage}).encode()
-    req = make_api_request(url, payload, sandbox_token)
-    try:
-        resp = _opener.open(req, timeout=10)
-        resp.close()
-    except urllib.error.HTTPError as exc:
-        exc.close()  # HTTPError holds an open socket
-        raise
-
-
-def _report_usage_with_retry(
-    api_url: str,
-    sandbox_token: str,
-    run_id: str,
-    usage: dict,
-    proxy_log_path: str = "",
-    max_retries: int = 1,
-) -> None:
-    """Report usage with retry.  Swallows all exceptions after final attempt."""
-    for attempt in range(max_retries + 1):
-        try:
-            _do_report_usage(api_url, sandbox_token, run_id, usage)
-            return
-        except Exception as exc:
-            if attempt < max_retries:
-                time.sleep(0.5)
-            else:
-                log_proxy_entry(
-                    proxy_log_path,
-                    "warn",
-                    f"Usage report failed after {attempt + 1} attempts: {exc}",
-                    type="usage",
-                )
-
-
-# ---------------------------------------------------------------------------
-# Usage reporting thread pool — replaces fire-and-forget daemon threads.
-# ThreadPoolExecutor processes reports in parallel; done() flushes pending
-# items before mitmproxy exits (SIGKILL at 15 s is the hard stop).
-# ---------------------------------------------------------------------------
-
-_usage_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
-
-
-def _enqueue_usage(
-    api_url: str, sandbox_token: str, run_id: str, usage: dict, proxy_log_path: str = ""
-) -> None:
-    """Submit usage report to the thread pool.  Copies the dict to avoid mutation.
-
-    If the executor has already been shut down (drain/shutdown race),
-    falls back to synchronous delivery so the report is not silently lost.
-    """
-    copied = dict(usage)
-    try:
-        _usage_executor.submit(
-            _report_usage_with_retry, api_url, sandbox_token, run_id, copied, proxy_log_path
-        )
-    except RuntimeError:
-        # Executor shut down (done() already called during drain).
-        # Fall back to synchronous delivery with retry.
-        _report_usage_with_retry(api_url, sandbox_token, run_id, copied, proxy_log_path)
-
-
-def _maybe_report_proxy_usage(flow: http.HTTPFlow, run_id: str) -> None:
-    """Enqueue proxy-extracted usage for model provider responses if available."""
-    firewall_name = flow.metadata.get("firewall_name", "")
-    if not (firewall_name.startswith("model-provider:") and run_id):
-        return
-    proxy_usage = flow.metadata.get("proxy_usage")
-    if not proxy_usage:
-        return
-    # Fall back to flow.id when the upstream response did not carry an `id`
-    # field (non-Anthropic-shaped providers, malformed responses).  Without a
-    # stable per-flow key the server side cannot deduplicate retries, which
-    # would double-charge.  flow.id is unique per flow and stable across
-    # retries of the usage webhook (the usage dict is copied once in
-    # _enqueue_usage and reused).
-    if not proxy_usage.get("message_id"):
-        proxy_usage["message_id"] = flow.id
-    sandbox_token = flow.metadata.get("vm_sandbox_token", "")
-    api_url = get_api_url()
-    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
-    if not sandbox_token or not api_url:
-        log_proxy_entry(
-            proxy_log_path,
-            "warn",
-            "Cannot report usage: missing sandbox_token or api_url",
-            type="usage",
-        )
-        return
-    _enqueue_usage(api_url, sandbox_token, run_id, proxy_usage, proxy_log_path)
+# ============================================================================
+# HTTP Response Handlers
+# ============================================================================
 
 
 def responseheaders(flow: http.HTTPFlow) -> None:
@@ -525,14 +272,14 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     if is_model_provider:
         content_type = flow.response.headers.get("content-type", "")
         if "text/event-stream" in content_type:
-            parser_fn, usage_dict = _create_sse_usage_extractor()
+            parser_fn, usage_dict = usage._create_sse_usage_extractor()
             sse_parser = parser_fn
             flow.metadata["proxy_usage"] = usage_dict
-            sse_decompressor = _create_stream_decompressor(flow.response.headers)
+            sse_decompressor = body_utils._create_stream_decompressor(flow.response.headers)
 
     # Model provider responses are never truncated so usage extraction
     # always has the complete body.  Other responses use the 64 KB limit.
-    buf_limit = None if is_model_provider else _STREAM_BUFFER_LIMIT
+    buf_limit = None if is_model_provider else body_utils._STREAM_BUFFER_LIMIT
 
     def stream_and_buffer(chunk: bytes) -> bytes:
         if not state["truncated"]:
@@ -553,248 +300,6 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     flow.response.stream = stream_and_buffer
     flow.metadata["stream_buffer"] = buf
     flow.metadata["stream_buffer_state"] = state
-
-
-# ---------------------------------------------------------------------------
-# Body capture helpers (opt-in per run via captureNetworkBodies registry flag)
-# ---------------------------------------------------------------------------
-
-
-_TEXT_CONTENT_TYPES = (
-    "text/",
-    "application/json",
-    "application/xml",
-    "application/javascript",
-    "application/x-www-form-urlencoded",
-    "application/graphql",
-)
-
-# Header names containing any of these keywords (case-insensitive) are redacted.
-_SENSITIVE_HEADER_KEYWORDS = (
-    "auth",
-    "token",
-    "secret",
-    "api-key",
-    "apikey",
-    "credential",
-    "password",
-    "cookie",
-)
-
-
-def _create_stream_decompressor(headers: http.Headers):
-    """Create an incremental decompressor for streaming chunks.
-
-    Returns a callable that decompresses each chunk, maintaining state
-    across calls.  Returns None if the response is not compressed.
-    """
-    encoding = headers.get("content-encoding", "").strip().lower()
-    if not encoding or encoding == "identity":
-        return None
-    if encoding in ("gzip", "deflate"):
-        wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
-        obj = zlib.decompressobj(wbits)
-
-        def decompress_zlib(chunk: bytes) -> bytes:
-            try:
-                return obj.decompress(chunk)
-            except zlib.error:
-                return b""
-
-        return decompress_zlib
-    if encoding == "br":
-        dec = brotli.Decompressor()
-
-        def decompress_br(chunk: bytes) -> bytes:
-            try:
-                return dec.process(chunk)
-            except brotli.error:
-                return b""
-
-        return decompress_br
-    if encoding == "zstd":
-        obj = zstandard.ZstdDecompressor().decompressobj()
-
-        def decompress_zstd(chunk: bytes) -> bytes:
-            try:
-                return obj.decompress(chunk)
-            except zstandard.ZstdError:
-                return b""
-
-        return decompress_zstd
-    return None
-
-
-def _decompress_body(
-    data: bytes, headers: http.Headers, max_output: int = _STREAM_BUFFER_LIMIT
-) -> bytes:
-    """Decompress response body based on Content-Encoding header.
-
-    The stream callback receives raw wire bytes.  When the server uses
-    gzip/deflate/br/zstd encoding, we must decompress before capturing.
-    Uses incremental decompression so truncated compressed data still
-    yields whatever decompressed bytes are available.
-
-    Output is capped at *max_output* bytes to guard against decompression
-    bombs (small compressed payload expanding to huge output).
-
-    Returns the original data unchanged if not compressed or on error.
-    """
-    encoding = headers.get("content-encoding", "").strip().lower()
-    if not encoding or encoding == "identity":
-        return data
-    try:
-        if encoding in ("gzip", "deflate"):
-            # wbits: gzip=16+MAX_WBITS, deflate=MAX_WBITS
-            wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
-            obj = zlib.decompressobj(wbits)
-            result = obj.decompress(data, max_length=max_output)
-            return result if result else data
-        if encoding == "br":
-            dec = brotli.Decompressor()
-            result = dec.process(data)
-            return result[:max_output] if result else data
-        if encoding == "zstd":
-            obj = zstandard.ZstdDecompressor().decompressobj()
-            result = obj.decompress(data)
-            return result[:max_output] if result else data
-    except (zlib.error, brotli.error, zstandard.ZstdError) as exc:
-        try:
-            ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
-        except AttributeError:
-            pass  # ctx.log unavailable outside mitmproxy runtime
-    return data
-
-
-def _is_text_content(content_type: str) -> bool:
-    """Check if content-type indicates text-like content worth capturing."""
-    if not content_type:
-        return True  # assume text when unspecified
-    ct = content_type.lower().split(";")[0].strip()
-    return any(ct.startswith(prefix) for prefix in _TEXT_CONTENT_TYPES)
-
-
-def _truncate_bytes_utf8_safe(data: bytes, max_size: int) -> bytes:
-    """Truncate bytes at a UTF-8 character boundary.
-
-    After slicing at *max_size*, checks whether the last character is
-    complete.  If not, removes the incomplete trailing bytes (at most 4).
-    """
-    if len(data) <= max_size:
-        return data
-    t = data[:max_size]
-    # Find the start of the last character by scanning backwards
-    # past continuation bytes (10xxxxxx = 0x80..0xBF).
-    i = len(t)
-    while i > 0 and (t[i - 1] & 0xC0) == 0x80:
-        i -= 1
-    if i == 0:
-        return t  # all continuation bytes — shouldn't happen in valid UTF-8
-    lead = t[i - 1]
-    # Determine the expected sequence length from the lead byte.
-    if lead < 0x80:
-        expected = 1
-    elif lead < 0xE0:
-        expected = 2
-    elif lead < 0xF0:
-        expected = 3
-    else:
-        expected = 4
-    # If the sequence starting at (i-1) has fewer bytes than expected,
-    # it was cut — remove the incomplete sequence.
-    actual = len(t) - (i - 1)
-    if actual < expected:
-        return t[: i - 1]
-    return t
-
-
-def _encode_body(content: bytes, content_type: str) -> tuple:
-    """Encode body content. Returns (encoded_string, encoding_type) or (None, None) for binary."""
-    if not _is_text_content(content_type):
-        return None, None  # skip binary bodies
-    try:
-        return content.decode("utf-8"), "utf-8"
-    except UnicodeDecodeError:
-        return base64.b64encode(content).decode("ascii"), "base64"
-
-
-def _is_sensitive_header(name: str) -> bool:
-    """Check if a header name likely carries sensitive data."""
-    lower = name.lower()
-    return any(kw in lower for kw in _SENSITIVE_HEADER_KEYWORDS)
-
-
-def _redact_headers(headers) -> dict:
-    """Build a dict of headers with sensitive values replaced by ***."""
-    result = {}
-    for name, value in headers.items(multi=True):
-        if name in result:
-            continue  # keep first occurrence only (headers.items gives all)
-        result[name] = "***" if _is_sensitive_header(name) else value
-    return result
-
-
-def _add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
-    """Add request/response headers and bodies to a log entry.
-
-    # [NETWORK_LOG_FIELDS] — capture-only fields, not part of the core schema.
-    # Fields: request_headers, request_body, request_body_encoding,
-    #         request_body_truncated, response_headers, response_body,
-    #         response_body_encoding, response_body_truncated
-    """
-    # Request headers (always available)
-    log_entry["request_headers"] = _redact_headers(flow.request.headers)
-
-    # Request body
-    if flow.request.content:
-        req_ct = flow.request.headers.get("content-type", "")
-        body = flow.request.content
-        truncated = len(body) > _STREAM_BUFFER_LIMIT
-        if truncated:
-            body = _truncate_bytes_utf8_safe(body, _STREAM_BUFFER_LIMIT)
-        encoded, encoding = _encode_body(body, req_ct)
-        if encoded is not None:
-            log_entry["request_body"] = encoded
-            log_entry["request_body_encoding"] = encoding
-            if truncated:
-                log_entry["request_body_truncated"] = True
-        else:
-            log_entry["request_body_encoding"] = "binary"
-
-    # Response headers
-    if flow.response:
-        log_entry["response_headers"] = _redact_headers(flow.response.headers)
-
-    # Response body — read from stream_buffer (available for all responses).
-    # The buffer contains raw wire bytes (possibly gzip/br/zstd compressed).
-    if flow.response:
-        stream_buf = flow.metadata.get("stream_buffer")
-        if stream_buf is not None:
-            body = _decompress_body(bytes(stream_buf), flow.response.headers)
-        else:
-            try:
-                body = flow.response.content
-            except (zlib.error, ValueError):
-                # ZlibError (decompression failure) or ValueError from mitmproxy
-                log_entry["response_body_encoding"] = "binary"
-                return
-        if not body:
-            return
-        stream_state = flow.metadata.get("stream_buffer_state")
-        res_ct = flow.response.headers.get("content-type", "")
-        # stream_buffer may already be truncated at _STREAM_BUFFER_LIMIT.
-        # Also check decompressed size in case it expanded beyond the limit.
-        truncated = (stream_state and stream_state["truncated"]) or len(body) > _STREAM_BUFFER_LIMIT
-        if truncated:
-            body = _truncate_bytes_utf8_safe(body, _STREAM_BUFFER_LIMIT)
-        encoded, encoding = _encode_body(body, res_ct)
-        if encoded is not None:
-            log_entry["response_body"] = encoded
-            log_entry["response_body_encoding"] = encoding
-            if truncated:
-                log_entry["response_body_truncated"] = True
-        else:
-            log_entry["response_body_encoding"] = "binary"
 
 
 def response(flow: http.HTTPFlow) -> None:
@@ -858,7 +363,7 @@ def response(flow: http.HTTPFlow) -> None:
 
         # Add request headers, request body, and response body when capture is enabled
         if flow.metadata.get("capture_body"):
-            _add_capture_fields(flow, log_entry)
+            body_utils._add_capture_fields(flow, log_entry)
 
         log_network_entry(network_log_path, log_entry)
 
@@ -868,13 +373,13 @@ def response(flow: http.HTTPFlow) -> None:
     if not flow.metadata.get("proxy_usage") and stream_buf and run_id:
         firewall_name = flow.metadata.get("firewall_name", "")
         if firewall_name.startswith("model-provider:"):
-            json_usage = _extract_usage_from_json(
+            json_usage = usage._extract_usage_from_json(
                 bytes(stream_buf),
                 flow.response.headers if flow.response else None,
             )
             if json_usage:
                 flow.metadata["proxy_usage"] = json_usage
-    _maybe_report_proxy_usage(flow, run_id)
+    usage._maybe_report_proxy_usage(flow, run_id)
 
     # Invalidate firewall header cache on 401 so next request gets fresh headers
     if flow.response and flow.response.status_code == 401 and flow.metadata.get("firewall_base"):
@@ -949,7 +454,7 @@ def error(flow: http.HTTPFlow) -> None:
     # Report proxy-extracted usage for model provider responses.
     # The SSE parser may have partially populated proxy_usage before the
     # connection error occurred.  Partial data is better than none.
-    _maybe_report_proxy_usage(flow, run_id)
+    usage._maybe_report_proxy_usage(flow, run_id)
 
     log_proxy_entry(
         proxy_log_path,
@@ -972,7 +477,7 @@ def done():
     ``shutdown(wait=True)`` blocks until all submitted futures complete;
     SIGKILL is the hard stop if any report takes too long.
     """
-    _usage_executor.shutdown(wait=True)
+    usage._usage_executor.shutdown(wait=True)
 
 
 # ============================================================================

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -13,7 +13,7 @@ from concurrent.futures import ThreadPoolExecutor
 from mitmproxy import http
 
 from auth import _opener, get_api_url, make_api_request
-from body_utils import _decompress_body
+from body_utils import decompress_body
 from logging_utils import log_proxy_entry
 
 # ---------------------------------------------------------------------------
@@ -54,7 +54,7 @@ def _extract_billing_usage(raw_usage, target: dict) -> None:
                 target["web_search_requests"] = wsr
 
 
-def _create_sse_usage_extractor():
+def create_sse_usage_extractor():
     """Create an incremental SSE parser that extracts usage from Anthropic API streams.
 
     All model providers in this system use the Anthropic Messages API streaming
@@ -150,14 +150,14 @@ def _create_sse_usage_extractor():
     return parse_chunk, usage
 
 
-def _extract_usage_from_json(body: bytes, headers) -> dict | None:
+def extract_usage_from_json(body: bytes, headers) -> dict | None:
     """Extract usage from a non-streaming Anthropic API JSON response.
 
     Falls back to decompressing the body if *headers* indicate compression.
     Returns ``None`` when the body is not valid JSON or contains no usage.
     """
     if headers:
-        body = _decompress_body(body, headers)
+        body = decompress_body(body, headers)
     try:
         data = json.loads(body)
     except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
@@ -221,7 +221,7 @@ def _report_usage_with_retry(
 # items before mitmproxy exits (SIGKILL at 15 s is the hard stop).
 # ---------------------------------------------------------------------------
 
-_usage_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
+usage_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
 
 
 def _enqueue_usage(
@@ -234,7 +234,7 @@ def _enqueue_usage(
     """
     copied = dict(usage)
     try:
-        _usage_executor.submit(
+        usage_executor.submit(
             _report_usage_with_retry, api_url, sandbox_token, run_id, copied, proxy_log_path
         )
     except RuntimeError:
@@ -243,7 +243,7 @@ def _enqueue_usage(
         _report_usage_with_retry(api_url, sandbox_token, run_id, copied, proxy_log_path)
 
 
-def _maybe_report_proxy_usage(flow: http.HTTPFlow, run_id: str) -> None:
+def maybe_report_proxy_usage(flow: http.HTTPFlow, run_id: str) -> None:
     """Enqueue proxy-extracted usage for model provider responses if available."""
     firewall_name = flow.metadata.get("firewall_name", "")
     if not (firewall_name.startswith("model-provider:") and run_id):

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -1,0 +1,273 @@
+"""Proxy-side usage extraction and reporting.
+
+Extracts billing-relevant fields from model-provider responses (SSE streams
+and non-streaming JSON) and reports them to the platform webhook through a
+background thread pool.
+"""
+
+import json
+import time
+import urllib.error
+from concurrent.futures import ThreadPoolExecutor
+
+from mitmproxy import http
+
+from auth import _opener, get_api_url, make_api_request
+from body_utils import _decompress_body
+from logging_utils import log_proxy_entry
+
+# ---------------------------------------------------------------------------
+# Proxy-side usage extraction (for billing verification)
+# ---------------------------------------------------------------------------
+
+# Only extract known billing fields to avoid capturing unrelated numerics.
+_BILLING_FIELDS = frozenset(
+    (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+    )
+)
+
+
+def _extract_billing_usage(raw_usage, target: dict) -> None:
+    """Extract known billing fields from an Anthropic usage object into *target*.
+
+    Handles both flat fields (input_tokens, etc.) and the nested
+    ``server_tool_use.web_search_requests`` field.
+
+    Only positive values overwrite existing entries — ``message_delta`` may
+    send ``0`` for fields already set correctly by ``message_start``.
+    """
+    if not raw_usage or not isinstance(raw_usage, dict):
+        return
+    for k, v in raw_usage.items():
+        if k in _BILLING_FIELDS and isinstance(v, (int, float)):
+            if v > 0 or k not in target:
+                target[k] = v
+    stu = raw_usage.get("server_tool_use")
+    if isinstance(stu, dict):
+        wsr = stu.get("web_search_requests")
+        if isinstance(wsr, (int, float)):
+            if wsr > 0 or "web_search_requests" not in target:
+                target["web_search_requests"] = wsr
+
+
+def _create_sse_usage_extractor():
+    """Create an incremental SSE parser that extracts usage from Anthropic API streams.
+
+    All model providers in this system use the Anthropic Messages API streaming
+    format.  Usage data appears in two SSE events:
+
+    - ``message_start`` — ``message.usage`` contains input token counts and
+      ``message.model`` identifies the model.
+    - ``message_delta`` — ``usage`` contains the final ``output_tokens`` count.
+
+    Returns ``(parse_chunk, usage)`` where *parse_chunk* processes raw bytes
+    incrementally and *usage* is a dict that accumulates extracted fields.
+    """
+    usage: dict = {}
+    line_buf = bytearray()
+    event_type = {"current": None}
+    # Events we need to parse — all others are skipped to avoid buffering
+    # large content_block_delta payloads.
+    _usage_events = frozenset(("message_start", "message_delta"))
+    # When True, discard incoming bytes until the next empty line (event
+    # boundary) to avoid buffering irrelevant data lines.
+    skipping = {"active": False}
+
+    def parse_chunk(chunk: bytes) -> None:
+        # In skip mode, scan for event boundary (empty line) without
+        # buffering the (potentially large) chunk.
+        if skipping["active"]:
+            # Look for \n\n or \r\n\r\n in existing buf + new chunk.
+            combined = line_buf + chunk
+            for sep in (b"\r\n\r\n", b"\n\n"):
+                idx = combined.find(sep)
+                if idx != -1:
+                    # Found event boundary — line_buf gets the remainder.
+                    # Do NOT extend again below; data is already in line_buf.
+                    after = idx + len(sep)
+                    line_buf[:] = combined[after:]
+                    skipping["active"] = False
+                    event_type["current"] = None
+                    break
+            else:
+                # No boundary found — discard everything except the
+                # last few bytes (could be a partial \r\n\r\n).
+                line_buf[:] = combined[-3:] if len(combined) > 3 else combined
+                return
+            # Boundary found — fall through to process line_buf contents.
+            # line_buf already has the data, so skip the extend.
+        else:
+            line_buf.extend(chunk)
+        while b"\n" in line_buf:
+            raw_line, _, remaining = line_buf.partition(b"\n")
+            line_buf[:] = remaining
+            line = raw_line.rstrip(b"\r").decode("utf-8", errors="replace")
+
+            # Blank line = event boundary.
+            if line == "":
+                event_type["current"] = None
+                skipping["active"] = False
+                continue
+
+            if skipping["active"]:
+                continue
+
+            if line.startswith("event: "):
+                evt_name = line[7:]
+                event_type["current"] = evt_name
+                if evt_name not in _usage_events:
+                    # Skip data lines of this event within line_buf.
+                    # Cross-chunk large data lines are handled by the
+                    # skip mode at the top of parse_chunk.
+                    skipping["active"] = True
+                    continue
+            elif line.startswith("data: "):
+                evt = event_type["current"]
+                if evt == "message_start":
+                    try:
+                        data = json.loads(line[6:])
+                        msg = data.get("message") or {}
+                        model = msg.get("model")
+                        if model:
+                            usage["model"] = model
+                        message_id = msg.get("id")
+                        if message_id:
+                            usage["message_id"] = message_id
+                        _extract_billing_usage(msg.get("usage"), usage)
+                    except (json.JSONDecodeError, AttributeError, TypeError):
+                        pass  # SSE data lines may be partial/malformed; best-effort extraction
+                elif evt == "message_delta":
+                    try:
+                        data = json.loads(line[6:])
+                        _extract_billing_usage(data.get("usage"), usage)
+                    except (json.JSONDecodeError, AttributeError, TypeError):
+                        pass  # SSE data lines may be partial/malformed; best-effort extraction
+
+    return parse_chunk, usage
+
+
+def _extract_usage_from_json(body: bytes, headers) -> dict | None:
+    """Extract usage from a non-streaming Anthropic API JSON response.
+
+    Falls back to decompressing the body if *headers* indicate compression.
+    Returns ``None`` when the body is not valid JSON or contains no usage.
+    """
+    if headers:
+        body = _decompress_body(body, headers)
+    try:
+        data = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    usage: dict = {}
+    model = data.get("model")
+    if model:
+        usage["model"] = model
+    _extract_billing_usage(data.get("usage"), usage)
+    if not usage:
+        return None
+    message_id = data.get("id")
+    if message_id:
+        usage["message_id"] = message_id
+    return usage
+
+
+def _do_report_usage(api_url: str, sandbox_token: str, run_id: str, usage: dict) -> None:
+    """POST extracted usage to the platform webhook.  Raises on failure."""
+    url = f"{api_url}/api/webhooks/agent/usage"
+    payload = json.dumps({"runId": run_id, "usage": usage}).encode()
+    req = make_api_request(url, payload, sandbox_token)
+    try:
+        resp = _opener.open(req, timeout=10)
+        resp.close()
+    except urllib.error.HTTPError as exc:
+        exc.close()  # HTTPError holds an open socket
+        raise
+
+
+def _report_usage_with_retry(
+    api_url: str,
+    sandbox_token: str,
+    run_id: str,
+    usage: dict,
+    proxy_log_path: str = "",
+    max_retries: int = 1,
+) -> None:
+    """Report usage with retry.  Swallows all exceptions after final attempt."""
+    for attempt in range(max_retries + 1):
+        try:
+            _do_report_usage(api_url, sandbox_token, run_id, usage)
+            return
+        except Exception as exc:
+            if attempt < max_retries:
+                time.sleep(0.5)
+            else:
+                log_proxy_entry(
+                    proxy_log_path,
+                    "warn",
+                    f"Usage report failed after {attempt + 1} attempts: {exc}",
+                    type="usage",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Usage reporting thread pool — replaces fire-and-forget daemon threads.
+# ThreadPoolExecutor processes reports in parallel; done() flushes pending
+# items before mitmproxy exits (SIGKILL at 15 s is the hard stop).
+# ---------------------------------------------------------------------------
+
+_usage_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
+
+
+def _enqueue_usage(
+    api_url: str, sandbox_token: str, run_id: str, usage: dict, proxy_log_path: str = ""
+) -> None:
+    """Submit usage report to the thread pool.  Copies the dict to avoid mutation.
+
+    If the executor has already been shut down (drain/shutdown race),
+    falls back to synchronous delivery so the report is not silently lost.
+    """
+    copied = dict(usage)
+    try:
+        _usage_executor.submit(
+            _report_usage_with_retry, api_url, sandbox_token, run_id, copied, proxy_log_path
+        )
+    except RuntimeError:
+        # Executor shut down (done() already called during drain).
+        # Fall back to synchronous delivery with retry.
+        _report_usage_with_retry(api_url, sandbox_token, run_id, copied, proxy_log_path)
+
+
+def _maybe_report_proxy_usage(flow: http.HTTPFlow, run_id: str) -> None:
+    """Enqueue proxy-extracted usage for model provider responses if available."""
+    firewall_name = flow.metadata.get("firewall_name", "")
+    if not (firewall_name.startswith("model-provider:") and run_id):
+        return
+    proxy_usage = flow.metadata.get("proxy_usage")
+    if not proxy_usage:
+        return
+    # Fall back to flow.id when the upstream response did not carry an `id`
+    # field (non-Anthropic-shaped providers, malformed responses).  Without a
+    # stable per-flow key the server side cannot deduplicate retries, which
+    # would double-charge.  flow.id is unique per flow and stable across
+    # retries of the usage webhook (the usage dict is copied once in
+    # _enqueue_usage and reused).
+    if not proxy_usage.get("message_id"):
+        proxy_usage["message_id"] = flow.id
+    sandbox_token = flow.metadata.get("vm_sandbox_token", "")
+    api_url = get_api_url()
+    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+    if not sandbox_token or not api_url:
+        log_proxy_entry(
+            proxy_log_path,
+            "warn",
+            "Cannot report usage: missing sandbox_token or api_url",
+            type="usage",
+        )
+        return
+    _enqueue_usage(api_url, sandbox_token, run_id, proxy_usage, proxy_log_path)

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -4,15 +4,15 @@ import base64
 from unittest.mock import MagicMock
 
 from body_utils import (
-    _STREAM_BUFFER_LIMIT,
-    _add_capture_fields,
+    STREAM_BUFFER_LIMIT,
     _encode_body,
     _is_sensitive_header,
     _is_text_content,
     _redact_headers,
     _truncate_bytes_utf8_safe,
+    add_capture_fields,
 )
-from usage import _extract_usage_from_json
+from usage import extract_usage_from_json
 
 
 class TestIsTextContent:
@@ -202,7 +202,7 @@ class TestAddCaptureFields:
     def test_captures_request_body(self):
         flow = self._make_flow(request_body=b'{"prompt": "hello"}')
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["request_body"] == '{"prompt": "hello"}'
         assert entry["request_body_encoding"] == "utf-8"
         assert "request_body_truncated" not in entry
@@ -210,14 +210,14 @@ class TestAddCaptureFields:
     def test_captures_response_body(self):
         flow = self._make_flow(response_body=b'{"result": "ok"}')
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "ok"}'
         assert entry["response_body_encoding"] == "utf-8"
 
     def test_captures_request_headers(self):
         flow = self._make_flow()
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "request_headers" in entry
         assert entry["request_headers"]["Content-Type"] == "application/json"
         assert entry["request_headers"]["Host"] == "api.example.com"
@@ -225,7 +225,7 @@ class TestAddCaptureFields:
     def test_captures_response_headers(self):
         flow = self._make_flow()
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "response_headers" in entry
         assert entry["response_headers"]["Content-Type"] == "application/json"
         assert entry["response_headers"]["X-Request-Id"] == "req-123"
@@ -238,7 +238,7 @@ class TestAddCaptureFields:
             else iter([])
         )
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_headers"]["Set-Cookie"] == "***"
         assert entry["response_headers"]["Content-Type"] == "text/html"
 
@@ -246,31 +246,31 @@ class TestAddCaptureFields:
         flow = self._make_flow()
         flow.response = None
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "response_headers" not in entry
 
     def test_truncates_large_request_body(self):
-        body = b"x" * (_STREAM_BUFFER_LIMIT + 1000)
+        body = b"x" * (STREAM_BUFFER_LIMIT + 1000)
         flow = self._make_flow(request_body=body, request_ct="text/plain")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["request_body_truncated"] is True
-        assert len(entry["request_body"]) == _STREAM_BUFFER_LIMIT
+        assert len(entry["request_body"]) == STREAM_BUFFER_LIMIT
 
     def test_truncates_large_response_body(self):
-        body = b"y" * (_STREAM_BUFFER_LIMIT + 1000)
+        body = b"y" * (STREAM_BUFFER_LIMIT + 1000)
         flow = self._make_flow(response_body=body, response_ct="text/plain")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body_truncated"] is True
-        assert len(entry["response_body"]) == _STREAM_BUFFER_LIMIT
+        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
 
     def test_no_body_fields_when_empty(self):
         flow = self._make_flow(request_body=None, response_body=None)
         # response.content is None
         flow.response.content = None
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "request_body" not in entry
         assert "request_body_encoding" not in entry  # no body = no encoding
         assert "response_body" not in entry
@@ -287,7 +287,7 @@ class TestAddCaptureFields:
             lambda self: (_ for _ in ()).throw(zlib.error("decompression failed"))
         )
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "request_body" in entry  # request body still captured
         assert "response_headers" in entry  # headers captured before body access
         assert "response_body" not in entry  # response body skipped
@@ -296,7 +296,7 @@ class TestAddCaptureFields:
     def test_binary_request_body_marks_encoding(self):
         flow = self._make_flow(request_body=b"\x89PNG\r\n", request_ct="image/png")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "request_body" not in entry
         assert entry["request_body_encoding"] == "binary"
         assert "request_headers" in entry  # headers still captured
@@ -306,25 +306,25 @@ class TestAddCaptureFields:
             response_body=b"\x00\x01\x02", response_ct="application/octet-stream"
         )
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "response_body" not in entry
         assert entry["response_body_encoding"] == "binary"
 
     def test_request_body_exactly_at_limit_not_truncated(self):
-        body = b"x" * _STREAM_BUFFER_LIMIT
+        body = b"x" * STREAM_BUFFER_LIMIT
         flow = self._make_flow(request_body=body, request_ct="text/plain")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "request_body_truncated" not in entry
-        assert len(entry["request_body"]) == _STREAM_BUFFER_LIMIT
+        assert len(entry["request_body"]) == STREAM_BUFFER_LIMIT
 
     def test_response_body_exactly_at_limit_not_truncated(self):
-        body = b"y" * _STREAM_BUFFER_LIMIT
+        body = b"y" * STREAM_BUFFER_LIMIT
         flow = self._make_flow(response_body=body, response_ct="text/plain")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "response_body_truncated" not in entry
-        assert len(entry["response_body"]) == _STREAM_BUFFER_LIMIT
+        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
 
     def test_duplicate_headers_keeps_first(self):
         headers = MagicMock()
@@ -339,15 +339,15 @@ class TestAddCaptureFields:
         assert len(result) == 2
 
     def test_truncation_preserves_utf8_boundary(self):
-        # Body is _STREAM_BUFFER_LIMIT + a 3-byte char "€" (\xe2\x82\xac)
-        body = b"x" * _STREAM_BUFFER_LIMIT + "\u20ac".encode("utf-8")
+        # Body is STREAM_BUFFER_LIMIT + a 3-byte char "€" (\xe2\x82\xac)
+        body = b"x" * STREAM_BUFFER_LIMIT + "\u20ac".encode("utf-8")
         flow = self._make_flow(request_body=body, request_ct="text/plain")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["request_body_truncated"] is True
         # Should be valid UTF-8 (truncated at char boundary, not mid-char)
         assert entry["request_body_encoding"] == "utf-8"
-        assert len(entry["request_body"]) == _STREAM_BUFFER_LIMIT  # all ASCII before the €
+        assert len(entry["request_body"]) == STREAM_BUFFER_LIMIT  # all ASCII before the €
 
     def test_text_request_with_binary_response(self):
         flow = self._make_flow(
@@ -357,7 +357,7 @@ class TestAddCaptureFields:
             response_ct="image/png",
         )
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["request_body"] == '{"q": "test"}'
         assert "response_body" not in entry
         assert entry["response_body_encoding"] == "binary"
@@ -370,7 +370,7 @@ class TestAddCaptureFields:
             response_ct="application/gzip",
         )
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "request_body" not in entry
         assert entry["request_body_encoding"] == "binary"
         assert "response_body" not in entry
@@ -384,7 +384,7 @@ class TestAddCaptureFields:
             response_body=b'{"a": "result"}',
         )
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["request_body"] == '{"q": "test"}'
         assert entry["response_body"] == '{"a": "result"}'
         assert entry["request_headers"]["Host"] == "api.example.com"
@@ -396,7 +396,7 @@ class TestAddCaptureFields:
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.metadata["stream_buffer_state"] = {"truncated": False}
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"streamed": true}'
         assert entry["response_body_encoding"] == "utf-8"
         assert "response_body_truncated" not in entry
@@ -407,19 +407,19 @@ class TestAddCaptureFields:
         flow.metadata["stream_buffer"] = bytearray()
         flow.metadata["stream_buffer_state"] = {"truncated": False}
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "response_body" not in entry
         assert "response_body_encoding" not in entry
         assert "response_headers" in entry  # headers still captured
 
     def test_stream_buffer_truncated_marks_truncation(self):
         """When stream_buffer was truncated, response_body_truncated should be set."""
-        body = b"x" * _STREAM_BUFFER_LIMIT
+        body = b"x" * STREAM_BUFFER_LIMIT
         flow = self._make_flow()
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.metadata["stream_buffer_state"] = {"truncated": True}
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body_truncated"] is True
 
     def test_stream_buffer_gzip_decompressed(self):
@@ -435,13 +435,13 @@ class TestAddCaptureFields:
         flow.metadata["stream_buffer"] = bytearray(compressed)
         flow.metadata["stream_buffer_state"] = {"truncated": False}
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "ok"}'
         assert entry["response_body_encoding"] == "utf-8"
 
 
 class TestDecompression:
-    """Integration tests for decompression through _add_capture_fields."""
+    """Integration tests for decompression through add_capture_fields."""
 
     def _make_flow_with_compressed_buffer(self, data, encoding, content_type="application/json"):
         flow = MagicMock()
@@ -468,13 +468,13 @@ class TestDecompression:
     def test_no_encoding_captures_plain_text(self):
         flow = self._make_flow_with_compressed_buffer(b'{"ok": true}', "")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"ok": true}'
 
     def test_identity_encoding_captures_body(self):
         flow = self._make_flow_with_compressed_buffer(b'{"ok": true}', "identity")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"ok": true}'
 
     def test_gzip_decompressed(self):
@@ -483,7 +483,7 @@ class TestDecompression:
         original = b'{"result": "hello world"}'
         flow = self._make_flow_with_compressed_buffer(gzip.compress(original), "gzip")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
         assert entry["response_body_encoding"] == "utf-8"
 
@@ -493,7 +493,7 @@ class TestDecompression:
         original = b'{"result": "hello world"}'
         flow = self._make_flow_with_compressed_buffer(zlib.compress(original), "deflate")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
 
     def test_brotli_decompressed(self):
@@ -502,7 +502,7 @@ class TestDecompression:
         original = b'{"result": "hello world"}'
         flow = self._make_flow_with_compressed_buffer(brotli.compress(original), "br")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
 
     def test_zstd_decompressed(self):
@@ -512,7 +512,7 @@ class TestDecompression:
         compressed = zstandard.ZstdCompressor().compress(original)
         flow = self._make_flow_with_compressed_buffer(compressed, "zstd")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
 
     def test_invalid_gzip_marks_binary(self):
@@ -521,7 +521,7 @@ class TestDecompression:
             b"not gzip at all", "gzip", content_type="text/plain"
         )
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         # Original compressed bytes are not valid UTF-8 text, but this happens
         # to be valid UTF-8 so it gets captured as-is
         assert "response_body" in entry
@@ -530,7 +530,7 @@ class TestDecompression:
     def test_unknown_encoding_passes_through(self):
         flow = self._make_flow_with_compressed_buffer(b'{"ok": true}', "x-custom")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"ok": true}'
 
     def test_truncated_gzip_partial_decompress(self):
@@ -543,7 +543,7 @@ class TestDecompression:
         flow = self._make_flow_with_compressed_buffer(truncated, "gzip", "text/plain")
         flow.metadata["stream_buffer_state"]["truncated"] = True
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert "response_body" in entry
         assert entry["response_body_truncated"] is True
 
@@ -555,12 +555,12 @@ class TestDecompression:
         original = b"\x00" * (1024 * 1024)
         compressed = gzip.compress(original)
         # Compressed data fits in buffer limit
-        assert len(compressed) < _STREAM_BUFFER_LIMIT
+        assert len(compressed) < STREAM_BUFFER_LIMIT
         flow = self._make_flow_with_compressed_buffer(compressed, "gzip", "text/plain")
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         # Body should be capped, not 1MB
-        assert len(entry.get("response_body", "")) <= _STREAM_BUFFER_LIMIT
+        assert len(entry.get("response_body", "")) <= STREAM_BUFFER_LIMIT
 
     def test_truncated_brotli_falls_back(self):
         """Truncated brotli data should fall back gracefully."""
@@ -572,7 +572,7 @@ class TestDecompression:
         flow = self._make_flow_with_compressed_buffer(truncated, "br", "text/plain")
         flow.metadata["stream_buffer_state"]["truncated"] = True
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         # Should not crash; body is either partial decompressed or original
         assert entry.get("response_body_truncated") is True or "response_body" not in entry
 
@@ -586,16 +586,16 @@ class TestDecompression:
         flow = self._make_flow_with_compressed_buffer(truncated, "zstd", "text/plain")
         flow.metadata["stream_buffer_state"]["truncated"] = True
         entry = {}
-        _add_capture_fields(flow, entry)
+        add_capture_fields(flow, entry)
         assert entry.get("response_body_truncated") is True or "response_body" not in entry
 
 
 class TestExtractUsageFromJson:
-    """Tests for _extract_usage_from_json helper."""
+    """Tests for extract_usage_from_json helper."""
 
     def test_extracts_model_and_tokens(self):
         body = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":100,"output_tokens":500}}'
-        result = _extract_usage_from_json(body, None)
+        result = extract_usage_from_json(body, None)
         assert result == {
             "model": "claude-sonnet-4-6",
             "input_tokens": 100,
@@ -608,7 +608,7 @@ class TestExtractUsageFromJson:
             b'{"input_tokens":10,"output_tokens":5,'
             b'"cache_read_input_tokens":50,"cache_creation_input_tokens":0}}'
         )
-        result = _extract_usage_from_json(body, None)
+        result = extract_usage_from_json(body, None)
         assert result["cache_read_input_tokens"] == 50
         assert result["cache_creation_input_tokens"] == 0
 
@@ -619,18 +619,18 @@ class TestExtractUsageFromJson:
         compressed = gzip.compress(original)
         headers = MagicMock()
         headers.get = lambda k, d="": "gzip" if k == "content-encoding" else d
-        result = _extract_usage_from_json(compressed, headers)
+        result = extract_usage_from_json(compressed, headers)
         assert result["model"] == "test"
         assert result["input_tokens"] == 42
 
     def test_invalid_json_returns_none(self):
-        assert _extract_usage_from_json(b"not json", None) is None
+        assert extract_usage_from_json(b"not json", None) is None
 
     def test_no_usage_field_returns_none(self):
-        assert _extract_usage_from_json(b'{"id":"msg_1"}', None) is None
+        assert extract_usage_from_json(b'{"id":"msg_1"}', None) is None
 
     def test_non_dict_returns_none(self):
-        assert _extract_usage_from_json(b"[1,2,3]", None) is None
+        assert extract_usage_from_json(b"[1,2,3]", None) is None
 
     def test_extracts_web_search_requests(self):
         body = (
@@ -638,6 +638,6 @@ class TestExtractUsageFromJson:
             b'{"input_tokens":10,"output_tokens":5,'
             b'"server_tool_use":{"web_search_requests":2}}}'
         )
-        result = _extract_usage_from_json(body, None)
+        result = extract_usage_from_json(body, None)
         assert result["web_search_requests"] == 2
         assert result["input_tokens"] == 10

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -3,16 +3,16 @@
 import base64
 from unittest.mock import MagicMock
 
-from mitm_addon import (
+from body_utils import (
     _STREAM_BUFFER_LIMIT,
     _add_capture_fields,
     _encode_body,
-    _extract_usage_from_json,
     _is_sensitive_header,
     _is_text_content,
     _redact_headers,
     _truncate_bytes_utf8_safe,
 )
+from usage import _extract_usage_from_json
 
 
 class TestIsTextContent:

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -12,7 +12,7 @@ import auth
 import body_utils
 import mitm_addon
 import usage
-from usage import _create_sse_usage_extractor
+from usage import create_sse_usage_extractor
 
 
 def _make_http_flow(client_ip="10.200.0.1", host="example.com", port=443, path="/"):
@@ -421,16 +421,16 @@ class TestResponseHeadersHandler:
 
         callback = flow.response.stream
         # Fill buffer to just under limit
-        chunk = b"x" * body_utils._STREAM_BUFFER_LIMIT
+        chunk = b"x" * body_utils.STREAM_BUFFER_LIMIT
         result = callback(chunk)
         assert result == chunk
-        assert len(flow.metadata["stream_buffer"]) == body_utils._STREAM_BUFFER_LIMIT
+        assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is False
 
         # Next chunk should trigger truncation
         result2 = callback(b"overflow")
         assert result2 == b"overflow"  # still forwarded to client
-        assert len(flow.metadata["stream_buffer"]) == body_utils._STREAM_BUFFER_LIMIT
+        assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
     def test_stream_callback_large_single_chunk(self):
@@ -443,10 +443,10 @@ class TestResponseHeadersHandler:
         mitm_addon.responseheaders(flow)
 
         callback = flow.response.stream
-        big_chunk = b"A" * (body_utils._STREAM_BUFFER_LIMIT + 1000)
+        big_chunk = b"A" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
         result = callback(big_chunk)
         assert result == big_chunk  # full chunk forwarded to client
-        assert len(flow.metadata["stream_buffer"]) == body_utils._STREAM_BUFFER_LIMIT
+        assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
     def test_stream_callback_partial_fill_then_overflow(self):
@@ -459,14 +459,14 @@ class TestResponseHeadersHandler:
         mitm_addon.responseheaders(flow)
 
         callback = flow.response.stream
-        half = body_utils._STREAM_BUFFER_LIMIT // 2
+        half = body_utils.STREAM_BUFFER_LIMIT // 2
         callback(b"A" * half)
         assert flow.metadata["stream_buffer_state"]["truncated"] is False
 
         # This chunk overflows — should capture up to the limit
-        callback(b"B" * body_utils._STREAM_BUFFER_LIMIT)
-        remaining = body_utils._STREAM_BUFFER_LIMIT - half
-        assert len(flow.metadata["stream_buffer"]) == body_utils._STREAM_BUFFER_LIMIT
+        callback(b"B" * body_utils.STREAM_BUFFER_LIMIT)
+        remaining = body_utils.STREAM_BUFFER_LIMIT - half
+        assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer"][:half] == bytearray(b"A" * half)
         assert flow.metadata["stream_buffer"][half:] == bytearray(b"B" * remaining)
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
@@ -665,7 +665,7 @@ class TestSseUsageExtractor:
     """Tests for the incremental SSE usage parser."""
 
     def test_extracts_usage_from_message_start(self):
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         chunk = (
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-6",'
@@ -681,7 +681,7 @@ class TestSseUsageExtractor:
         assert usage["output_tokens"] == 1
 
     def test_extracts_output_tokens_from_message_delta(self):
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         # First send message_start
         parse(
             b"event: message_start\n"
@@ -700,7 +700,7 @@ class TestSseUsageExtractor:
 
     def test_handles_chunked_lines(self):
         """SSE data split across multiple chunks mid-line should still parse."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         # Split the data line in the middle
         parse(b"event: message_start\n")
         parse(b'data: {"type":"message_start","message":{"model":"claude-opus-4-6"')
@@ -709,7 +709,7 @@ class TestSseUsageExtractor:
         assert usage["input_tokens"] == 200
 
     def test_skips_content_events(self):
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         parse(
             b"event: content_block_delta\n"
             b'data: {"type":"content_block_delta",'
@@ -718,19 +718,19 @@ class TestSseUsageExtractor:
         assert usage == {}
 
     def test_resilient_to_malformed_json(self):
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         parse(b"event: message_start\ndata: {invalid json}\n\n")
         assert usage == {}  # no crash, no data
 
     def test_empty_chunks(self):
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         parse(b"")
         parse(b"")
         assert usage == {}
 
     def test_crlf_line_endings(self):
         """Servers may use \\r\\n line endings — parser should handle them."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         chunk = (
             b"event: message_start\r\n"
             b'data: {"type":"message_start","message":'
@@ -744,7 +744,7 @@ class TestSseUsageExtractor:
 
     def test_skips_content_block_data_without_buffering(self):
         """Large content_block_delta data should not accumulate in line_buf."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         # First, send message_start to get input tokens
         parse(
             b"event: message_start\n"
@@ -764,7 +764,7 @@ class TestSseUsageExtractor:
 
     def test_skip_recovery_same_chunk(self):
         """When skip mode finds boundary and next event in one chunk, both should parse."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         # Enter skip mode with content_block_delta
         parse(b"event: content_block_delta\n")
         # Single chunk: end of skipped event + message_delta
@@ -777,7 +777,7 @@ class TestSseUsageExtractor:
 
     def test_skip_with_leftover_in_line_buf(self):
         """Entering skip mode leaves unprocessed line_buf data; next chunk should handle it."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         # One chunk has event line + start of data (no newline yet) + another event
         # The while loop processes "event: content_block_start", sets skip, returns.
         # line_buf still has the partial "data: ..." from this chunk.
@@ -793,7 +793,7 @@ class TestSseUsageExtractor:
 
     def test_consecutive_skip_events(self):
         """Multiple non-usage events in a row should all be skipped."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         parse(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":'
@@ -815,7 +815,7 @@ class TestSseUsageExtractor:
 
     def test_empty_usage_dict_not_reported(self):
         """Empty proxy_usage (SSE ran but no usage found) should not trigger report."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         # Only content events, no message_start or message_delta
         parse(b"event: ping\ndata: {}\n\n")
         assert usage == {}
@@ -824,7 +824,7 @@ class TestSseUsageExtractor:
 
     def test_event_without_data_line(self):
         """event: line followed by blank line (no data:) should not crash."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         parse(b"event: message_start\n\n")
         # No data extracted, event_type reset
         assert usage == {}
@@ -834,7 +834,7 @@ class TestSseUsageExtractor:
 
     def test_non_numeric_usage_values_ignored(self):
         """Non-numeric usage values (e.g. string) should be silently skipped."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         parse(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"model":"m",'
@@ -845,7 +845,7 @@ class TestSseUsageExtractor:
 
     def test_unknown_usage_fields_excluded(self):
         """Only known billing fields should be extracted, not arbitrary numerics."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         parse(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"model":"m",'
@@ -856,7 +856,7 @@ class TestSseUsageExtractor:
 
     def test_extracts_web_search_requests(self):
         """web_search_requests from server_tool_use should be extracted."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         parse(
             b"event: message_delta\n"
             b'data: {"type":"message_delta",'
@@ -872,7 +872,7 @@ class TestSseUsageExtractor:
         The Anthropic API includes all usage fields in message_delta, but cache
         fields may be 0 even when message_start reported non-zero values.
         """
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         parse(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
@@ -897,7 +897,7 @@ class TestSseUsageExtractor:
 
     def test_message_delta_positive_values_do_overwrite(self):
         """message_delta with positive values should update the usage dict."""
-        parse, usage = _create_sse_usage_extractor()
+        parse, usage = create_sse_usage_extractor()
         parse(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"model":"m",'
@@ -1069,9 +1069,9 @@ class TestResponseUsageReporting:
 
     def teardown_method(self):
         try:
-            usage._usage_executor.submit(lambda: None)
+            usage.usage_executor.submit(lambda: None)
         except RuntimeError:
-            usage._usage_executor = usage.ThreadPoolExecutor(
+            usage.usage_executor = usage.ThreadPoolExecutor(
                 max_workers=4, thread_name_prefix="usage"
             )
 
@@ -1098,7 +1098,7 @@ class TestResponseUsageReporting:
 
         with (
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(usage, "_maybe_report_proxy_usage") as mock_report,
+            patch.object(usage, "maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.response(flow)
 
@@ -1138,7 +1138,7 @@ class TestResponseUsageReporting:
 
         with (
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(usage, "_maybe_report_proxy_usage") as mock_report,
+            patch.object(usage, "maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.response(flow)
 
@@ -1160,8 +1160,8 @@ class TestResponseUsageReporting:
         mitm_addon.responseheaders(flow)
 
         callback = flow.response.stream
-        # Feed data exceeding _STREAM_BUFFER_LIMIT (64KB)
-        large_chunk = b"x" * (body_utils._STREAM_BUFFER_LIMIT + 1000)
+        # Feed data exceeding STREAM_BUFFER_LIMIT (64KB)
+        large_chunk = b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
         callback(large_chunk)
 
         buf = flow.metadata["stream_buffer"]
@@ -1180,12 +1180,12 @@ class TestResponseUsageReporting:
         mitm_addon.responseheaders(flow)
 
         callback = flow.response.stream
-        large_chunk = b"x" * (body_utils._STREAM_BUFFER_LIMIT + 1000)
+        large_chunk = b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
         callback(large_chunk)
 
         buf = flow.metadata["stream_buffer"]
         state = flow.metadata["stream_buffer_state"]
-        assert len(buf) == body_utils._STREAM_BUFFER_LIMIT
+        assert len(buf) == body_utils.STREAM_BUFFER_LIMIT
         assert state["truncated"]
 
     def test_no_usage_report_for_non_model_provider(self, tmp_path):
@@ -1205,11 +1205,11 @@ class TestResponseUsageReporting:
 
         with (
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(usage, "_maybe_report_proxy_usage") as mock_report,
+            patch.object(usage, "maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.response(flow)
 
-        # _maybe_report_proxy_usage is always called; it checks firewall_name internally
+        # maybe_report_proxy_usage is always called; it checks firewall_name internally
         mock_report.assert_called_once()
 
     def test_full_path_response_to_opener(self, tmp_path):
@@ -1244,10 +1244,10 @@ class TestResponseUsageReporting:
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
             # Flush the executor to ensure the background POST completes
-            usage._usage_executor.shutdown(wait=True)
+            usage.usage_executor.shutdown(wait=True)
 
         # Restore executor
-        usage._usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
+        usage.usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
 
         # Verify the webhook POST reached _opener with correct payload
         mock_opener.open.assert_called_once()
@@ -1286,9 +1286,9 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
-            usage._usage_executor.shutdown(wait=True)
+            usage.usage_executor.shutdown(wait=True)
 
-        usage._usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
+        usage.usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
 
         mock_opener.open.assert_called_once()
         req = mock_opener.open.call_args[0][0]
@@ -1329,9 +1329,9 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage._usage_executor.shutdown(wait=True)
+            usage.usage_executor.shutdown(wait=True)
 
-        usage._usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
+        usage.usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
 
         mock_opener.open.assert_called_once()
         req = mock_opener.open.call_args[0][0]
@@ -1367,9 +1367,9 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage._usage_executor.shutdown(wait=True)
+            usage.usage_executor.shutdown(wait=True)
 
-        usage._usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
+        usage.usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
 
         mock_opener.open.assert_called_once()
         req = mock_opener.open.call_args[0][0]
@@ -1476,7 +1476,7 @@ class TestErrorHandler:
 
 
 class TestMaybeReportProxyUsage:
-    """Tests for _maybe_report_proxy_usage helper."""
+    """Tests for maybe_report_proxy_usage helper."""
 
     def setup_method(self):
         _reset()
@@ -1495,7 +1495,7 @@ class TestMaybeReportProxyUsage:
             patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(usage, "_enqueue_usage") as mock_enqueue,
         ):
-            usage._maybe_report_proxy_usage(flow, "run-abc-123")
+            usage.maybe_report_proxy_usage(flow, "run-abc-123")
 
         mock_enqueue.assert_called_once()
         args = mock_enqueue.call_args[0]
@@ -1511,7 +1511,7 @@ class TestMaybeReportProxyUsage:
         flow.metadata["proxy_usage"] = {"input_tokens": 50}
 
         with patch.object(usage, "_enqueue_usage") as mock_enqueue:
-            usage._maybe_report_proxy_usage(flow, "run-abc-123")
+            usage.maybe_report_proxy_usage(flow, "run-abc-123")
 
         mock_enqueue.assert_not_called()
 
@@ -1526,7 +1526,7 @@ class TestMaybeReportProxyUsage:
             patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(usage, "_enqueue_usage") as mock_enqueue,
         ):
-            usage._maybe_report_proxy_usage(flow, "run-abc-123")
+            usage.maybe_report_proxy_usage(flow, "run-abc-123")
 
         mock_enqueue.assert_not_called()
 
@@ -1537,7 +1537,7 @@ class TestMaybeReportProxyUsage:
         flow.metadata["proxy_usage"] = {"input_tokens": 50}
 
         with patch.object(usage, "_enqueue_usage") as mock_enqueue:
-            usage._maybe_report_proxy_usage(flow, "")
+            usage.maybe_report_proxy_usage(flow, "")
 
         mock_enqueue.assert_not_called()
 
@@ -1554,7 +1554,7 @@ class TestMaybeReportProxyUsage:
             patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(usage, "_enqueue_usage") as mock_enqueue,
         ):
-            usage._maybe_report_proxy_usage(flow, "run-abc-123")
+            usage.maybe_report_proxy_usage(flow, "run-abc-123")
 
         mock_enqueue.assert_not_called()
         assert proxy_log.exists()
@@ -1573,20 +1573,20 @@ class TestMaybeReportProxyUsage:
             patch.object(usage, "get_api_url", return_value=""),
             patch.object(usage, "_enqueue_usage") as mock_enqueue,
         ):
-            usage._maybe_report_proxy_usage(flow, "run-abc-123")
+            usage.maybe_report_proxy_usage(flow, "run-abc-123")
 
         mock_enqueue.assert_not_called()
         assert proxy_log.exists()
 
 
 class TestErrorUsageReporting:
-    """Tests that error() hook calls _maybe_report_proxy_usage."""
+    """Tests that error() hook calls maybe_report_proxy_usage."""
 
     def setup_method(self):
         _reset()
 
     def test_error_calls_maybe_report(self, tmp_path):
-        """error() should invoke _maybe_report_proxy_usage."""
+        """error() should invoke maybe_report_proxy_usage."""
         flow = _make_http_flow(host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
@@ -1599,7 +1599,7 @@ class TestErrorUsageReporting:
 
         with (
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(usage, "_maybe_report_proxy_usage") as mock_report,
+            patch.object(usage, "maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.error(flow)
 
@@ -1656,9 +1656,9 @@ class TestEnqueueUsage:
     def teardown_method(self):
         """Ensure executor is always restored even if a test fails mid-way."""
         try:
-            usage._usage_executor.submit(lambda: None)
+            usage.usage_executor.submit(lambda: None)
         except RuntimeError:
-            usage._usage_executor = usage.ThreadPoolExecutor(
+            usage.usage_executor = usage.ThreadPoolExecutor(
                 max_workers=4, thread_name_prefix="usage"
             )
 
@@ -1673,7 +1673,7 @@ class TestEnqueueUsage:
         with patch.object(usage, "_report_usage_with_retry", capture_usage):
             usage._enqueue_usage("url", "tok", "run-1", original)
             original["input_tokens"] = 999
-            usage._usage_executor.shutdown(wait=True)
+            usage.usage_executor.shutdown(wait=True)
 
         assert len(captured) == 1
         assert captured[0]["input_tokens"] == 100
@@ -1681,7 +1681,7 @@ class TestEnqueueUsage:
     def test_enqueue_submits_to_executor(self):
         """_enqueue_usage should submit work to the thread pool."""
         mock_executor = MagicMock()
-        with patch.object(usage, "_usage_executor", mock_executor):
+        with patch.object(usage, "usage_executor", mock_executor):
             usage._enqueue_usage("url", "tok", "run-1", {"k": 1})
         mock_executor.submit.assert_called_once()
         args = mock_executor.submit.call_args[0]
@@ -1692,7 +1692,7 @@ class TestEnqueueUsage:
 
     def test_enqueue_falls_back_to_sync_after_shutdown(self):
         """After executor shutdown, _enqueue_usage should deliver synchronously with retry."""
-        usage._usage_executor.shutdown(wait=True)
+        usage.usage_executor.shutdown(wait=True)
 
         with patch.object(usage, "_report_usage_with_retry") as mock_retry:
             usage._enqueue_usage("url", "tok", "run-1", {"input_tokens": 42})
@@ -1706,7 +1706,7 @@ class TestDoneHook:
     def test_done_shuts_down_executor(self):
         """done() should call shutdown(wait=True) on the executor."""
         mock_executor = MagicMock()
-        with patch.object(usage, "_usage_executor", mock_executor):
+        with patch.object(usage, "usage_executor", mock_executor):
             mitm_addon.done()
         mock_executor.shutdown.assert_called_once_with(wait=True)
 

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -9,7 +9,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import auth
+import body_utils
 import mitm_addon
+import usage
+from usage import _create_sse_usage_extractor
 
 
 def _make_http_flow(client_ip="10.200.0.1", host="example.com", port=443, path="/"):
@@ -418,16 +421,16 @@ class TestResponseHeadersHandler:
 
         callback = flow.response.stream
         # Fill buffer to just under limit
-        chunk = b"x" * mitm_addon._STREAM_BUFFER_LIMIT
+        chunk = b"x" * body_utils._STREAM_BUFFER_LIMIT
         result = callback(chunk)
         assert result == chunk
-        assert len(flow.metadata["stream_buffer"]) == mitm_addon._STREAM_BUFFER_LIMIT
+        assert len(flow.metadata["stream_buffer"]) == body_utils._STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is False
 
         # Next chunk should trigger truncation
         result2 = callback(b"overflow")
         assert result2 == b"overflow"  # still forwarded to client
-        assert len(flow.metadata["stream_buffer"]) == mitm_addon._STREAM_BUFFER_LIMIT
+        assert len(flow.metadata["stream_buffer"]) == body_utils._STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
     def test_stream_callback_large_single_chunk(self):
@@ -440,10 +443,10 @@ class TestResponseHeadersHandler:
         mitm_addon.responseheaders(flow)
 
         callback = flow.response.stream
-        big_chunk = b"A" * (mitm_addon._STREAM_BUFFER_LIMIT + 1000)
+        big_chunk = b"A" * (body_utils._STREAM_BUFFER_LIMIT + 1000)
         result = callback(big_chunk)
         assert result == big_chunk  # full chunk forwarded to client
-        assert len(flow.metadata["stream_buffer"]) == mitm_addon._STREAM_BUFFER_LIMIT
+        assert len(flow.metadata["stream_buffer"]) == body_utils._STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
     def test_stream_callback_partial_fill_then_overflow(self):
@@ -456,14 +459,14 @@ class TestResponseHeadersHandler:
         mitm_addon.responseheaders(flow)
 
         callback = flow.response.stream
-        half = mitm_addon._STREAM_BUFFER_LIMIT // 2
+        half = body_utils._STREAM_BUFFER_LIMIT // 2
         callback(b"A" * half)
         assert flow.metadata["stream_buffer_state"]["truncated"] is False
 
         # This chunk overflows — should capture up to the limit
-        callback(b"B" * mitm_addon._STREAM_BUFFER_LIMIT)
-        remaining = mitm_addon._STREAM_BUFFER_LIMIT - half
-        assert len(flow.metadata["stream_buffer"]) == mitm_addon._STREAM_BUFFER_LIMIT
+        callback(b"B" * body_utils._STREAM_BUFFER_LIMIT)
+        remaining = body_utils._STREAM_BUFFER_LIMIT - half
+        assert len(flow.metadata["stream_buffer"]) == body_utils._STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer"][:half] == bytearray(b"A" * half)
         assert flow.metadata["stream_buffer"][half:] == bytearray(b"B" * remaining)
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
@@ -662,7 +665,7 @@ class TestSseUsageExtractor:
     """Tests for the incremental SSE usage parser."""
 
     def test_extracts_usage_from_message_start(self):
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         chunk = (
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-6",'
@@ -678,7 +681,7 @@ class TestSseUsageExtractor:
         assert usage["output_tokens"] == 1
 
     def test_extracts_output_tokens_from_message_delta(self):
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         # First send message_start
         parse(
             b"event: message_start\n"
@@ -697,7 +700,7 @@ class TestSseUsageExtractor:
 
     def test_handles_chunked_lines(self):
         """SSE data split across multiple chunks mid-line should still parse."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         # Split the data line in the middle
         parse(b"event: message_start\n")
         parse(b'data: {"type":"message_start","message":{"model":"claude-opus-4-6"')
@@ -706,7 +709,7 @@ class TestSseUsageExtractor:
         assert usage["input_tokens"] == 200
 
     def test_skips_content_events(self):
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         parse(
             b"event: content_block_delta\n"
             b'data: {"type":"content_block_delta",'
@@ -715,19 +718,19 @@ class TestSseUsageExtractor:
         assert usage == {}
 
     def test_resilient_to_malformed_json(self):
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         parse(b"event: message_start\ndata: {invalid json}\n\n")
         assert usage == {}  # no crash, no data
 
     def test_empty_chunks(self):
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         parse(b"")
         parse(b"")
         assert usage == {}
 
     def test_crlf_line_endings(self):
         """Servers may use \\r\\n line endings — parser should handle them."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         chunk = (
             b"event: message_start\r\n"
             b'data: {"type":"message_start","message":'
@@ -741,7 +744,7 @@ class TestSseUsageExtractor:
 
     def test_skips_content_block_data_without_buffering(self):
         """Large content_block_delta data should not accumulate in line_buf."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         # First, send message_start to get input tokens
         parse(
             b"event: message_start\n"
@@ -761,7 +764,7 @@ class TestSseUsageExtractor:
 
     def test_skip_recovery_same_chunk(self):
         """When skip mode finds boundary and next event in one chunk, both should parse."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         # Enter skip mode with content_block_delta
         parse(b"event: content_block_delta\n")
         # Single chunk: end of skipped event + message_delta
@@ -774,7 +777,7 @@ class TestSseUsageExtractor:
 
     def test_skip_with_leftover_in_line_buf(self):
         """Entering skip mode leaves unprocessed line_buf data; next chunk should handle it."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         # One chunk has event line + start of data (no newline yet) + another event
         # The while loop processes "event: content_block_start", sets skip, returns.
         # line_buf still has the partial "data: ..." from this chunk.
@@ -790,7 +793,7 @@ class TestSseUsageExtractor:
 
     def test_consecutive_skip_events(self):
         """Multiple non-usage events in a row should all be skipped."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         parse(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":'
@@ -812,7 +815,7 @@ class TestSseUsageExtractor:
 
     def test_empty_usage_dict_not_reported(self):
         """Empty proxy_usage (SSE ran but no usage found) should not trigger report."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         # Only content events, no message_start or message_delta
         parse(b"event: ping\ndata: {}\n\n")
         assert usage == {}
@@ -821,7 +824,7 @@ class TestSseUsageExtractor:
 
     def test_event_without_data_line(self):
         """event: line followed by blank line (no data:) should not crash."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         parse(b"event: message_start\n\n")
         # No data extracted, event_type reset
         assert usage == {}
@@ -831,7 +834,7 @@ class TestSseUsageExtractor:
 
     def test_non_numeric_usage_values_ignored(self):
         """Non-numeric usage values (e.g. string) should be silently skipped."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         parse(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"model":"m",'
@@ -842,7 +845,7 @@ class TestSseUsageExtractor:
 
     def test_unknown_usage_fields_excluded(self):
         """Only known billing fields should be extracted, not arbitrary numerics."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         parse(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"model":"m",'
@@ -853,7 +856,7 @@ class TestSseUsageExtractor:
 
     def test_extracts_web_search_requests(self):
         """web_search_requests from server_tool_use should be extracted."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         parse(
             b"event: message_delta\n"
             b'data: {"type":"message_delta",'
@@ -869,7 +872,7 @@ class TestSseUsageExtractor:
         The Anthropic API includes all usage fields in message_delta, but cache
         fields may be 0 even when message_start reported non-zero values.
         """
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         parse(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
@@ -894,7 +897,7 @@ class TestSseUsageExtractor:
 
     def test_message_delta_positive_values_do_overwrite(self):
         """message_delta with positive values should update the usage dict."""
-        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse, usage = _create_sse_usage_extractor()
         parse(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"model":"m",'
@@ -916,10 +919,10 @@ class TestDoReportUsage:
     """Tests for _do_report_usage HTTP request construction."""
 
     def test_posts_correct_payload(self):
-        usage = {"model": "claude-sonnet-4-6", "input_tokens": 100}
-        with patch.object(mitm_addon, "_opener") as mock_opener:
+        usage_data = {"model": "claude-sonnet-4-6", "input_tokens": 100}
+        with patch.object(usage, "_opener") as mock_opener:
             mock_opener.open.return_value = MagicMock()
-            mitm_addon._do_report_usage("https://api.vm0.ai", "tok-123", "run-1", usage)
+            usage._do_report_usage("https://api.vm0.ai", "tok-123", "run-1", usage_data)
         mock_opener.open.assert_called_once()
         req = mock_opener.open.call_args[0][0]
         assert req.full_url == "https://api.vm0.ai/api/webhooks/agent/usage"
@@ -933,12 +936,12 @@ class TestDoReportUsage:
     def test_raises_on_network_error(self):
         """Network failures should propagate (retry handled by caller)."""
         with patch.object(
-            mitm_addon,
+            usage,
             "_opener",
             **{"open.side_effect": ConnectionError("refused")},
         ):
             with pytest.raises(ConnectionError):
-                mitm_addon._do_report_usage("https://api.vm0.ai", "tok", "run-1", {})
+                usage._do_report_usage("https://api.vm0.ai", "tok", "run-1", {})
 
     def test_closes_http_error_response(self):
         """HTTPError (non-2xx) should be closed to avoid socket leak."""
@@ -949,21 +952,21 @@ class TestDoReportUsage:
         )
         http_err.close = MagicMock()
         with patch.object(
-            mitm_addon,
+            usage,
             "_opener",
             **{"open.side_effect": http_err},
         ):
             with pytest.raises(urllib.error.HTTPError):
-                mitm_addon._do_report_usage("https://api.vm0.ai", "tok", "run-1", {})
+                usage._do_report_usage("https://api.vm0.ai", "tok", "run-1", {})
         http_err.close.assert_called_once()
 
     def test_adds_vercel_bypass_header(self):
         with (
-            patch.object(mitm_addon, "_opener") as mock_opener,
+            patch.object(usage, "_opener") as mock_opener,
             patch.object(auth, "VERCEL_BYPASS", "bypass-secret"),
         ):
             mock_opener.open.return_value = MagicMock()
-            mitm_addon._do_report_usage("https://api.vm0.ai", "tok", "run-1", {})
+            usage._do_report_usage("https://api.vm0.ai", "tok", "run-1", {})
         req = mock_opener.open.call_args[0][0]
         assert req.get_header("X-vercel-protection-bypass") == "bypass-secret"
 
@@ -1066,9 +1069,9 @@ class TestResponseUsageReporting:
 
     def teardown_method(self):
         try:
-            mitm_addon._usage_executor.submit(lambda: None)
+            usage._usage_executor.submit(lambda: None)
         except RuntimeError:
-            mitm_addon._usage_executor = mitm_addon.ThreadPoolExecutor(
+            usage._usage_executor = usage.ThreadPoolExecutor(
                 max_workers=4, thread_name_prefix="usage"
             )
 
@@ -1095,7 +1098,7 @@ class TestResponseUsageReporting:
 
         with (
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "_maybe_report_proxy_usage") as mock_report,
+            patch.object(usage, "_maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.response(flow)
 
@@ -1135,15 +1138,15 @@ class TestResponseUsageReporting:
 
         with (
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "_maybe_report_proxy_usage") as mock_report,
+            patch.object(usage, "_maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.response(flow)
 
         # JSON fallback should populate proxy_usage in metadata
-        usage = flow.metadata["proxy_usage"]
-        assert usage["model"] == "claude-sonnet-4-6"
-        assert usage["input_tokens"] == 50
-        assert usage["output_tokens"] == 200
+        extracted = flow.metadata["proxy_usage"]
+        assert extracted["model"] == "claude-sonnet-4-6"
+        assert extracted["input_tokens"] == 50
+        assert extracted["output_tokens"] == 200
         mock_report.assert_called_once_with(flow, "run-abc-123")
 
     def test_model_provider_buffer_not_truncated(self):
@@ -1158,7 +1161,7 @@ class TestResponseUsageReporting:
 
         callback = flow.response.stream
         # Feed data exceeding _STREAM_BUFFER_LIMIT (64KB)
-        large_chunk = b"x" * (mitm_addon._STREAM_BUFFER_LIMIT + 1000)
+        large_chunk = b"x" * (body_utils._STREAM_BUFFER_LIMIT + 1000)
         callback(large_chunk)
 
         buf = flow.metadata["stream_buffer"]
@@ -1177,12 +1180,12 @@ class TestResponseUsageReporting:
         mitm_addon.responseheaders(flow)
 
         callback = flow.response.stream
-        large_chunk = b"x" * (mitm_addon._STREAM_BUFFER_LIMIT + 1000)
+        large_chunk = b"x" * (body_utils._STREAM_BUFFER_LIMIT + 1000)
         callback(large_chunk)
 
         buf = flow.metadata["stream_buffer"]
         state = flow.metadata["stream_buffer_state"]
-        assert len(buf) == mitm_addon._STREAM_BUFFER_LIMIT
+        assert len(buf) == body_utils._STREAM_BUFFER_LIMIT
         assert state["truncated"]
 
     def test_no_usage_report_for_non_model_provider(self, tmp_path):
@@ -1202,7 +1205,7 @@ class TestResponseUsageReporting:
 
         with (
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "_maybe_report_proxy_usage") as mock_report,
+            patch.object(usage, "_maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.response(flow)
 
@@ -1234,19 +1237,17 @@ class TestResponseUsageReporting:
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "_opener") as mock_opener,
+            patch.object(usage, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
             # Flush the executor to ensure the background POST completes
-            mitm_addon._usage_executor.shutdown(wait=True)
+            usage._usage_executor.shutdown(wait=True)
 
         # Restore executor
-        mitm_addon._usage_executor = mitm_addon.ThreadPoolExecutor(
-            max_workers=4, thread_name_prefix="usage"
-        )
+        usage._usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
 
         # Verify the webhook POST reached _opener with correct payload
         mock_opener.open.assert_called_once()
@@ -1279,17 +1280,15 @@ class TestResponseUsageReporting:
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "_opener") as mock_opener,
+            patch.object(usage, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
-            mitm_addon._usage_executor.shutdown(wait=True)
+            usage._usage_executor.shutdown(wait=True)
 
-        mitm_addon._usage_executor = mitm_addon.ThreadPoolExecutor(
-            max_workers=4, thread_name_prefix="usage"
-        )
+        usage._usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
 
         mock_opener.open.assert_called_once()
         req = mock_opener.open.call_args[0][0]
@@ -1324,17 +1323,15 @@ class TestResponseUsageReporting:
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "_opener") as mock_opener,
+            patch.object(usage, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            mitm_addon._usage_executor.shutdown(wait=True)
+            usage._usage_executor.shutdown(wait=True)
 
-        mitm_addon._usage_executor = mitm_addon.ThreadPoolExecutor(
-            max_workers=4, thread_name_prefix="usage"
-        )
+        usage._usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
 
         mock_opener.open.assert_called_once()
         req = mock_opener.open.call_args[0][0]
@@ -1364,17 +1361,15 @@ class TestResponseUsageReporting:
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "_opener") as mock_opener,
+            patch.object(usage, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            mitm_addon._usage_executor.shutdown(wait=True)
+            usage._usage_executor.shutdown(wait=True)
 
-        mitm_addon._usage_executor = mitm_addon.ThreadPoolExecutor(
-            max_workers=4, thread_name_prefix="usage"
-        )
+        usage._usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
 
         mock_opener.open.assert_called_once()
         req = mock_opener.open.call_args[0][0]
@@ -1497,10 +1492,10 @@ class TestMaybeReportProxyUsage:
         }
 
         with (
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon, "_enqueue_usage") as mock_enqueue,
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage, "_enqueue_usage") as mock_enqueue,
         ):
-            mitm_addon._maybe_report_proxy_usage(flow, "run-abc-123")
+            usage._maybe_report_proxy_usage(flow, "run-abc-123")
 
         mock_enqueue.assert_called_once()
         args = mock_enqueue.call_args[0]
@@ -1515,8 +1510,8 @@ class TestMaybeReportProxyUsage:
         flow.metadata["firewall_name"] = "github"
         flow.metadata["proxy_usage"] = {"input_tokens": 50}
 
-        with patch.object(mitm_addon, "_enqueue_usage") as mock_enqueue:
-            mitm_addon._maybe_report_proxy_usage(flow, "run-abc-123")
+        with patch.object(usage, "_enqueue_usage") as mock_enqueue:
+            usage._maybe_report_proxy_usage(flow, "run-abc-123")
 
         mock_enqueue.assert_not_called()
 
@@ -1528,10 +1523,10 @@ class TestMaybeReportProxyUsage:
         # No proxy_usage in metadata
 
         with (
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon, "_enqueue_usage") as mock_enqueue,
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage, "_enqueue_usage") as mock_enqueue,
         ):
-            mitm_addon._maybe_report_proxy_usage(flow, "run-abc-123")
+            usage._maybe_report_proxy_usage(flow, "run-abc-123")
 
         mock_enqueue.assert_not_called()
 
@@ -1541,8 +1536,8 @@ class TestMaybeReportProxyUsage:
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["proxy_usage"] = {"input_tokens": 50}
 
-        with patch.object(mitm_addon, "_enqueue_usage") as mock_enqueue:
-            mitm_addon._maybe_report_proxy_usage(flow, "")
+        with patch.object(usage, "_enqueue_usage") as mock_enqueue:
+            usage._maybe_report_proxy_usage(flow, "")
 
         mock_enqueue.assert_not_called()
 
@@ -1556,10 +1551,10 @@ class TestMaybeReportProxyUsage:
         flow.metadata["vm_proxy_log_path"] = str(proxy_log)
 
         with (
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon, "_enqueue_usage") as mock_enqueue,
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage, "_enqueue_usage") as mock_enqueue,
         ):
-            mitm_addon._maybe_report_proxy_usage(flow, "run-abc-123")
+            usage._maybe_report_proxy_usage(flow, "run-abc-123")
 
         mock_enqueue.assert_not_called()
         assert proxy_log.exists()
@@ -1575,10 +1570,10 @@ class TestMaybeReportProxyUsage:
         flow.metadata["vm_proxy_log_path"] = str(proxy_log)
 
         with (
-            patch.object(mitm_addon, "get_api_url", return_value=""),
-            patch.object(mitm_addon, "_enqueue_usage") as mock_enqueue,
+            patch.object(usage, "get_api_url", return_value=""),
+            patch.object(usage, "_enqueue_usage") as mock_enqueue,
         ):
-            mitm_addon._maybe_report_proxy_usage(flow, "run-abc-123")
+            usage._maybe_report_proxy_usage(flow, "run-abc-123")
 
         mock_enqueue.assert_not_called()
         assert proxy_log.exists()
@@ -1604,7 +1599,7 @@ class TestErrorUsageReporting:
 
         with (
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "_maybe_report_proxy_usage") as mock_report,
+            patch.object(usage, "_maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.error(flow)
 
@@ -1615,28 +1610,28 @@ class TestReportUsageWithRetry:
     """Tests for _report_usage_with_retry retry logic."""
 
     def test_succeeds_on_first_attempt(self):
-        with patch.object(mitm_addon, "_do_report_usage") as mock_do:
-            mitm_addon._report_usage_with_retry("url", "tok", "run-1", {})
+        with patch.object(usage, "_do_report_usage") as mock_do:
+            usage._report_usage_with_retry("url", "tok", "run-1", {})
         mock_do.assert_called_once()
 
     def test_retries_on_failure(self):
         with patch.object(
-            mitm_addon,
+            usage,
             "_do_report_usage",
             side_effect=[ConnectionError("fail"), None],
         ) as mock_do:
-            mitm_addon._report_usage_with_retry("url", "tok", "run-1", {})
+            usage._report_usage_with_retry("url", "tok", "run-1", {})
         assert mock_do.call_count == 2
 
     def test_gives_up_after_max_retries(self, tmp_path):
         proxy_log = tmp_path / "proxy-run-1.jsonl"
         with patch.object(
-            mitm_addon,
+            usage,
             "_do_report_usage",
             side_effect=ConnectionError("fail"),
         ):
             # Should not raise
-            mitm_addon._report_usage_with_retry(
+            usage._report_usage_with_retry(
                 "url", "tok", "run-1", {}, proxy_log_path=str(proxy_log), max_retries=2
             )
         assert proxy_log.exists()
@@ -1645,13 +1640,13 @@ class TestReportUsageWithRetry:
     def test_sleeps_between_retries(self):
         with (
             patch.object(
-                mitm_addon,
+                usage,
                 "_do_report_usage",
                 side_effect=[ConnectionError("fail"), None],
             ),
-            patch.object(mitm_addon.time, "sleep") as mock_sleep,
+            patch.object(usage.time, "sleep") as mock_sleep,
         ):
-            mitm_addon._report_usage_with_retry("url", "tok", "run-1", {})
+            usage._report_usage_with_retry("url", "tok", "run-1", {})
         mock_sleep.assert_called_once_with(0.5)
 
 
@@ -1661,9 +1656,9 @@ class TestEnqueueUsage:
     def teardown_method(self):
         """Ensure executor is always restored even if a test fails mid-way."""
         try:
-            mitm_addon._usage_executor.submit(lambda: None)
+            usage._usage_executor.submit(lambda: None)
         except RuntimeError:
-            mitm_addon._usage_executor = mitm_addon.ThreadPoolExecutor(
+            usage._usage_executor = usage.ThreadPoolExecutor(
                 max_workers=4, thread_name_prefix="usage"
             )
 
@@ -1672,13 +1667,13 @@ class TestEnqueueUsage:
         original = {"input_tokens": 100}
         captured = []
 
-        def capture_usage(_url, _tok, _rid, usage, _proxy_log_path=""):
-            captured.append(usage)
+        def capture_usage(_url, _tok, _rid, u, _proxy_log_path=""):
+            captured.append(u)
 
-        with patch.object(mitm_addon, "_report_usage_with_retry", capture_usage):
-            mitm_addon._enqueue_usage("url", "tok", "run-1", original)
+        with patch.object(usage, "_report_usage_with_retry", capture_usage):
+            usage._enqueue_usage("url", "tok", "run-1", original)
             original["input_tokens"] = 999
-            mitm_addon._usage_executor.shutdown(wait=True)
+            usage._usage_executor.shutdown(wait=True)
 
         assert len(captured) == 1
         assert captured[0]["input_tokens"] == 100
@@ -1686,21 +1681,21 @@ class TestEnqueueUsage:
     def test_enqueue_submits_to_executor(self):
         """_enqueue_usage should submit work to the thread pool."""
         mock_executor = MagicMock()
-        with patch.object(mitm_addon, "_usage_executor", mock_executor):
-            mitm_addon._enqueue_usage("url", "tok", "run-1", {"k": 1})
+        with patch.object(usage, "_usage_executor", mock_executor):
+            usage._enqueue_usage("url", "tok", "run-1", {"k": 1})
         mock_executor.submit.assert_called_once()
         args = mock_executor.submit.call_args[0]
-        assert args[0] == mitm_addon._report_usage_with_retry
+        assert args[0] == usage._report_usage_with_retry
         assert args[1] == "url"
         assert args[2] == "tok"
         assert args[3] == "run-1"
 
     def test_enqueue_falls_back_to_sync_after_shutdown(self):
         """After executor shutdown, _enqueue_usage should deliver synchronously with retry."""
-        mitm_addon._usage_executor.shutdown(wait=True)
+        usage._usage_executor.shutdown(wait=True)
 
-        with patch.object(mitm_addon, "_report_usage_with_retry") as mock_retry:
-            mitm_addon._enqueue_usage("url", "tok", "run-1", {"input_tokens": 42})
+        with patch.object(usage, "_report_usage_with_retry") as mock_retry:
+            usage._enqueue_usage("url", "tok", "run-1", {"input_tokens": 42})
 
         mock_retry.assert_called_once_with("url", "tok", "run-1", {"input_tokens": 42}, "")
 
@@ -1711,7 +1706,7 @@ class TestDoneHook:
     def test_done_shuts_down_executor(self):
         """done() should call shutdown(wait=True) on the executor."""
         mock_executor = MagicMock()
-        with patch.object(mitm_addon, "_usage_executor", mock_executor):
+        with patch.object(usage, "_usage_executor", mock_executor):
             mitm_addon.done()
         mock_executor.shutdown.assert_called_once_with(wait=True)
 

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -563,9 +563,11 @@ mod tests {
         for expected in [
             "mitm_addon.py",
             "auth.py",
+            "body_utils.py",
             "matching.py",
             "url_utils.py",
             "logging_utils.py",
+            "usage.py",
         ] {
             assert!(
                 files.contains(&expected),


### PR DESCRIPTION
## Summary

- Extract proxy-side usage extraction/reporting into `usage.py` (272 lines)
- Extract body processing helpers (decompression, encoding, capture) into `body_utils.py` (258 lines)
- Reduces `mitm_addon.py` from **1052 → 554 lines**

Pure code motion — no behavior changes. Sets up `usage.py` as the home for future per-call connector billing extractors (X API #9286, Veo, Gamma).

Closes #9460

## Design note

`mitm_addon.py` uses `import usage` / `import body_utils` (not selective `from X import ...`) and calls via `usage.X()` / `body_utils.X()`. This makes the module boundary visible at call sites and lets tests patch `usage._name` in one place regardless of caller — avoiding the Python mock-placement pitfall where patching the importer's binding fails to intercept calls from within the source module.

## Test plan

- [x] `pnpm`-side: N/A (Python + Rust only)
- [x] Python: `pytest tests/` — 762 passed
- [x] Python: `ruff check` / `ruff format --check` clean
- [x] Rust: `cargo test -p runner` — 616 passed (includes updated `addon_scripts_are_embedded`)
- [x] Rust: `cargo clippy -p runner` clean
- [x] Executor lifecycle: verified `done()` sees runtime `_usage_executor` replacement via module attribute lookup
- [x] Worker join: `shutdown(wait=True)` correctly joins all 4 workers (subprocess exit 0)
- [x] No new resource leaks (threads, sockets, buffers, caches all preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)