### PR TITLE
fix(platform): defer auto-scroll until after optimistic message is flushed

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
@@ -7,6 +8,7 @@ import {
   currentChatThreadSignals$,
   setDraftSyncDebounceMs$,
 } from "../create-chat-thread.ts";
+import { detach, Reason } from "../../utils.ts";
 
 const context = testContext();
 
@@ -37,6 +39,126 @@ function setupBaseHandlers(threadId: string) {
     }),
   );
 }
+
+describe("sendMessage$ — auto-scroll timing", () => {
+  beforeEach(() => {
+    context.store.set(setDraftSyncDebounceMs$, 0);
+  });
+
+  it("should call autoScroll$ only after the optimistic user message is already in messages$", async () => {
+    const threadId = "thread-autoscroll-timing";
+
+    server.use(
+      http.patch(`*/api/zero/chat-threads/${threadId}`, () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
+      // Keep POST handler open so sendMessage$ can proceed past the network
+      // call without completing the full run loop during this assertion-only test.
+      http.post("*/api/zero/chat/messages", () => {
+        return HttpResponse.json(
+          {
+            runId: "run-autoscroll-1",
+            threadId,
+            status: "running",
+            createdAt: "2026-04-13T00:00:00Z",
+          },
+          { status: 201 },
+        );
+      }),
+      http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+        return HttpResponse.json({
+          events: [],
+          hasMore: false,
+          framework: "claude-code",
+        });
+      }),
+      http.get("*/api/zero/logs/:runId", () => {
+        return HttpResponse.json({
+          id: "run-autoscroll-1",
+          sessionId: "session-autoscroll",
+          agentId: "zero",
+          displayName: null,
+          framework: "claude-code",
+          modelProvider: null,
+          selectedModel: null,
+          triggerSource: "web",
+          triggerAgentName: null,
+          scheduleId: null,
+          status: "completed",
+          prompt: "Hello world",
+          appendSystemPrompt: null,
+          error: null,
+          createdAt: "2026-04-13T00:00:00Z",
+          startedAt: "2026-04-13T00:00:01Z",
+          completedAt: "2026-04-13T00:00:02Z",
+          artifact: { name: null, version: null },
+        });
+      }),
+    );
+    setupBaseHandlers(threadId);
+
+    await setupPage({
+      context,
+      path: `/chats/${threadId}`,
+      withoutRender: true,
+    });
+
+    const thread = context.store.get(currentChatThreadSignals$);
+    expect(thread).not.toBeNull();
+
+    // Create a mock scroll container and register it so autoScroll$ has an
+    // element to act on. We spy on scrollTop assignment to detect when
+    // autoScroll$ fires and capture the messages$ state at that moment.
+    const scrollEl = document.createElement("div");
+    Object.defineProperty(scrollEl, "scrollHeight", { value: 500 });
+    let messagesAtScrollTime: Promise<unknown[]> | null = null;
+
+    Object.defineProperty(scrollEl, "scrollTop", {
+      get: () => {
+        return 0;
+      },
+      set: vi.fn(() => {
+        // Capture the messages$ promise the first time scroll fires.
+        if (messagesAtScrollTime === null) {
+          messagesAtScrollTime = context.store.get(
+            thread!.messages$,
+          ) as Promise<unknown[]>;
+        }
+      }),
+      configurable: true,
+    });
+
+    // Register the scroll container (simulates the ref callback in the UI).
+    context.store.set(thread!.setScrollContainer$, scrollEl);
+
+    // Fire-and-forget sendMessage$ — we only care about the scroll side-effect
+    // that happens before the long-running poll loop.
+    detach(
+      context.store.set(thread!.sendMessage$, "Hello world", context.signal),
+      Reason.Entrance,
+      "test",
+    );
+
+    // Wait until autoScroll$ fires (i.e. scrollTop is set on the container).
+    await waitFor(() => {
+      expect(messagesAtScrollTime).not.toBeNull();
+    });
+
+    // The messages$ promise captured at scroll time must resolve with the
+    // optimistic user message already present — proving the yield happened
+    // before the scroll.
+    const messages = await messagesAtScrollTime!;
+    const hasUserMessage = messages.some((m): boolean => {
+      return (
+        typeof m === "object" &&
+        m !== null &&
+        "role" in m &&
+        (m as { role: string }).role === "user"
+      );
+    });
+    expect(hasUserMessage).toBeTruthy();
+  });
+});
 
 describe("createDraftSync — scheduleDraftSync$, cancelDraftSync$, flushDraftClear$", () => {
   beforeEach(() => {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -351,11 +351,16 @@ function createSendMessage(
     set(deps.internalLocalMessages$, (prev) => {
       return [...prev, result.userMessage];
     });
-    set(deps.autoScroll$);
     set(deps.cancelDraftSync$);
     set(deps.draft.clear$);
     await set(deps.flushDraftClear$, signal);
     signal.throwIfAborted();
+
+    // Yield one microtask tick so React can flush the optimistic user message
+    // into the DOM before we scroll. Without this the scroll fires against the
+    // old layout and is effectively a no-op.
+    await delay(0, { signal });
+    set(deps.autoScroll$);
 
     const client = get(zeroClient$)(chatMessagesContract);
     const sendResult = await accept(


### PR DESCRIPTION
## Summary
- Moves the `autoScroll$` call to after a microtask yield (`delay(0)`), so React has time to flush the optimistic user message into the DOM before scrolling
- Without this fix, the scroll fires against the old layout and is effectively a no-op, causing the chat to not auto-scroll to the bottom after sending a message
- Follows up on #9462 which fixed auto-scroll on container resize — this addresses the same symptom during message send

## Test plan
- [ ] Send a message in a chat thread that requires scrolling — verify the view scrolls to the bottom automatically
- [ ] Verify scroll behavior still works on container resize
- [ ] Test with rapid consecutive messages to ensure no race conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)