### PR TITLE
refactor(cli): unify --artifact flag to docker-style name:version syntax

### DIFF
--- a/e2e/tests/03-runner/t50-vm0-artifact-unified-flag.bats
+++ b/e2e/tests/03-runner/t50-vm0-artifact-unified-flag.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+
+# Test unified --artifact flag with Docker-style name:version syntax (E2E happy path only)
+# This test verifies that --artifact <name> and --artifact <name:version> work correctly.
+#
+# Note: resume/continue with --artifact uses the same parsing code path and is tested
+# via CLI Command Integration Tests (see run/__tests__/resume.test.ts, continue.test.ts).
+
+load '../../helpers/setup'
+
+setup_file() {
+    # Unique agent name for this test file
+    export AGENT_NAME="e2e-t50-$(date +%s%3N)-$RANDOM"
+    export TEST_DIR="$(mktemp -d)"
+
+    # Create volume for claude-files and compose ONCE
+    create_test_volume "e2e-vol-t50"
+    export SHARED_VOLUME_NAME="$VOLUME_NAME"
+    export SHARED_VOLUME_DIR="$TEST_VOLUME_DIR"
+
+    export SHARED_CONFIG="$TEST_DIR/vm0.yaml"
+    cat > "$SHARED_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}:
+    description: "E2E test agent for unified artifact flag"
+    framework: claude-code
+    volumes:
+      - claude-files:/home/user/.claude
+    working_dir: /home/user/workspace
+volumes:
+  claude-files:
+    name: $SHARED_VOLUME_NAME
+    version: latest
+EOF
+    $VM0_CLI compose "$SHARED_CONFIG" >/dev/null
+}
+
+teardown_file() {
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+    if [ -n "$SHARED_VOLUME_DIR" ] && [ -d "$SHARED_VOLUME_DIR" ]; then
+        rm -rf "$SHARED_VOLUME_DIR"
+    fi
+}
+
+setup() {
+    export TEST_ARTIFACT_DIR="$(mktemp -d)"
+    export ARTIFACT_NAME="e2e-art-t50-$(date +%s%3N)-$RANDOM"
+}
+
+teardown() {
+    if [ -n "$TEST_ARTIFACT_DIR" ] && [ -d "$TEST_ARTIFACT_DIR" ]; then
+        rm -rf "$TEST_ARTIFACT_DIR"
+    fi
+}
+
+@test "t50-1: --artifact name mounts latest artifact" {
+    # Step 1: Create and push artifact with known content
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null
+    echo "unified-flag-content" > marker.txt
+    run $VM0_CLI artifact push
+    assert_success
+
+    # Step 2: Run agent using unified --artifact flag (name only = latest)
+    run $VM0_CLI run "$AGENT_NAME" \
+        --artifact "$ARTIFACT_NAME" \
+        --verbose \
+        "cat /home/user/workspace/marker.txt"
+
+    assert_success
+    assert_output --partial "unified-flag-content"
+}
+
+@test "t50-2: --artifact name:version mounts specific version" {
+    # Step 1: Push version 1
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null
+    echo "version-1-content" > marker.txt
+    run $VM0_CLI artifact push
+    assert_success
+    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
+    echo "# Version 1 ID: $VERSION1"
+    [ -n "$VERSION1" ]
+
+    # Step 2: Push version 2 (becomes HEAD)
+    echo "version-2-head" > marker.txt
+    run $VM0_CLI artifact push
+    assert_success
+    echo "# HEAD version pushed"
+
+    # Step 3: Run agent with --artifact name:version to pin to version 1
+    run $VM0_CLI run "$AGENT_NAME" \
+        --artifact "$ARTIFACT_NAME:$VERSION1" \
+        --verbose \
+        "cat /home/user/workspace/marker.txt"
+
+    assert_success
+
+    # Should see version-1 content (the pinned version)
+    assert_output --partial "version-1-content"
+
+    # Should NOT see HEAD content
+    refute_output --partial "version-2-head"
+
+    echo "# Verified: --artifact name:version correctly pinned to version 1"
+}

--- a/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
@@ -289,6 +289,70 @@ describe("run continue command", () => {
     });
   });
 
+  describe("--artifact flag", () => {
+    it("should send artifactName when using --artifact with name only", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await continueCommand.parseAsync([
+        "node",
+        "cli",
+        testSessionId,
+        "test prompt",
+        "--artifact",
+        "my-data",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          sessionId: testSessionId,
+          artifactName: "my-data",
+        }),
+      );
+      expect(capturedBody?.artifactVersion).toBeUndefined();
+    });
+
+    it("should send artifactName and artifactVersion when using --artifact with name:version", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await continueCommand.parseAsync([
+        "node",
+        "cli",
+        testSessionId,
+        "test prompt",
+        "--artifact",
+        "my-data:abc123",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          sessionId: testSessionId,
+          artifactName: "my-data",
+          artifactVersion: "abc123",
+        }),
+      );
+    });
+  });
+
   describe("session ID validation", () => {
     it("should reject invalid session ID format", async () => {
       await expect(async () => {

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -2202,4 +2202,129 @@ describe("run command", () => {
       },
     );
   });
+
+  describe("--artifact flag", () => {
+    it("should send artifactName when using --artifact with name only", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "test prompt",
+        "--artifact",
+        "my-data",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          artifactName: "my-data",
+        }),
+      );
+      expect(capturedBody?.artifactVersion).toBeUndefined();
+    });
+
+    it("should send artifactName and artifactVersion when using --artifact with name:version", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "test prompt",
+        "--artifact",
+        "my-data:abc123",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          artifactName: "my-data",
+          artifactVersion: "abc123",
+        }),
+      );
+    });
+
+    it("should error when both --artifact and --artifact-name are provided", async () => {
+      await expect(async () => {
+        await runCommand.parseAsync([
+          "node",
+          "cli",
+          testUuid,
+          "test prompt",
+          "--artifact",
+          "my-data",
+          "--artifact-name",
+          "other",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot use --artifact with --artifact-name or --artifact-version",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should error when both --artifact and --artifact-version are provided", async () => {
+      await expect(async () => {
+        await runCommand.parseAsync([
+          "node",
+          "cli",
+          testUuid,
+          "test prompt",
+          "--artifact",
+          "my-data",
+          "--artifact-version",
+          "v1",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot use --artifact with --artifact-name or --artifact-version",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should show deprecation warning when using --artifact-name", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/agent/runs", () => {
+          return HttpResponse.json(defaultRunResponse, { status: 201 });
+        }),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "test prompt",
+        "--artifact-name",
+        "my-data",
+      ]);
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--artifact-name is deprecated"),
+      );
+    });
+  });
 });

--- a/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
@@ -584,6 +584,70 @@ describe("run resume command", () => {
     });
   });
 
+  describe("--artifact flag", () => {
+    it("should send artifactName when using --artifact with name only", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await resumeCommand.parseAsync([
+        "node",
+        "cli",
+        testCheckpointId,
+        "test prompt",
+        "--artifact",
+        "my-data",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          checkpointId: testCheckpointId,
+          artifactName: "my-data",
+        }),
+      );
+      expect(capturedBody?.artifactVersion).toBeUndefined();
+    });
+
+    it("should send artifactName and artifactVersion when using --artifact with name:version", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await resumeCommand.parseAsync([
+        "node",
+        "cli",
+        testCheckpointId,
+        "test prompt",
+        "--artifact",
+        "my-data:abc123",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          checkpointId: testCheckpointId,
+          artifactName: "my-data",
+          artifactVersion: "abc123",
+        }),
+      );
+    });
+  });
+
   describe("next steps output", () => {
     it("should show next steps after successful completion", async () => {
       await resumeCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -4,6 +4,7 @@ import {
   collectKeyValue,
   isUUID,
   loadValues,
+  parseArtifact,
   parsePermissionPolicies,
   pollEvents,
   showNextSteps,
@@ -33,6 +34,10 @@ export const continueCommand = new Command()
     "Secrets for ${{ secrets.xxx }} (repeatable, falls back to --env-file or env vars)",
     collectKeyValue,
     {},
+  )
+  .option(
+    "--artifact <name[:version]>",
+    "Artifact storage (format: name or name:version)",
   )
   .option(
     "--append-system-prompt <text>",
@@ -65,6 +70,7 @@ export const continueCommand = new Command()
           envFile?: string;
           vars: Record<string, string>;
           secrets: Record<string, string>;
+          artifact?: string;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
           tools?: string[];
@@ -81,6 +87,7 @@ export const continueCommand = new Command()
           envFile?: string;
           vars: Record<string, string>;
           secrets: Record<string, string>;
+          artifact?: string;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
           tools?: string[];
@@ -112,12 +119,19 @@ export const continueCommand = new Command()
         const envFile = options.envFile || allOpts.envFile;
         const loadedSecrets = loadValues(secrets, requiredSecretNames, envFile);
 
-        // 4. Call unified API with sessionId
+        // 4. Parse artifact flag
+        const artifactParsed = parseArtifact(
+          options.artifact || allOpts.artifact,
+        );
+
+        // 5. Call unified API with sessionId
         const response = await createRun({
           sessionId: agentSessionId,
           prompt,
           vars: Object.keys(vars).length > 0 ? vars : undefined,
           secrets: loadedSecrets,
+          artifactName: artifactParsed?.artifactName,
+          artifactVersion: artifactParsed?.artifactVersion,
           appendSystemPrompt:
             options.appendSystemPrompt || allOpts.appendSystemPrompt,
           disallowedTools: options.disallowedTools || allOpts.disallowedTools,

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -5,6 +5,7 @@ import {
   collectVolumeVersions,
   isUUID,
   loadValues,
+  parseArtifact,
   parsePermissionPolicies,
   pollEvents,
   showNextSteps,
@@ -40,6 +41,10 @@ export const resumeCommand = new Command()
     {},
   )
   .option(
+    "--artifact <name[:version]>",
+    "Artifact storage (format: name or name:version)",
+  )
+  .option(
     "--append-system-prompt <text>",
     "Append text to the agent's system prompt",
   )
@@ -70,6 +75,7 @@ export const resumeCommand = new Command()
           envFile?: string;
           vars: Record<string, string>;
           secrets: Record<string, string>;
+          artifact?: string;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
           tools?: string[];
@@ -87,6 +93,7 @@ export const resumeCommand = new Command()
           vars: Record<string, string>;
           secrets: Record<string, string>;
           volumeVersion: Record<string, string>;
+          artifact?: string;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
           tools?: string[];
@@ -118,12 +125,19 @@ export const resumeCommand = new Command()
         const envFile = options.envFile || allOpts.envFile;
         const loadedSecrets = loadValues(secrets, requiredSecretNames, envFile);
 
-        // 4. Call unified API with checkpointId
+        // 4. Parse artifact flag
+        const artifactParsed = parseArtifact(
+          options.artifact || allOpts.artifact,
+        );
+
+        // 5. Call unified API with checkpointId
         const response = await createRun({
           checkpointId,
           prompt,
           vars: Object.keys(vars).length > 0 ? vars : undefined,
           secrets: loadedSecrets,
+          artifactName: artifactParsed?.artifactName,
+          artifactVersion: artifactParsed?.artifactVersion,
           volumeVersions:
             Object.keys(allOpts.volumeVersion).length > 0
               ? allOpts.volumeVersion

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -1,3 +1,4 @@
+import chalk from "chalk";
 import { Command, Option } from "commander";
 import {
   getComposeById,
@@ -14,6 +15,7 @@ import {
   loadValues,
   parsePermissionPolicies,
   parseIdentifier,
+  parseArtifact,
   pollEvents,
   showNextSteps,
   renderRunCreated,
@@ -50,10 +52,21 @@ export const mainRunCommand = new Command()
     collectKeyValue,
     {},
   )
-  .option("--artifact-name <name>", "Artifact storage name (required for run)")
   .option(
-    "--artifact-version <hash>",
-    "Artifact version hash (defaults to latest)",
+    "--artifact <name[:version]>",
+    "Artifact storage (format: name or name:version)",
+  )
+  .addOption(
+    new Option(
+      "--artifact-name <name>",
+      "[deprecated: use --artifact] Artifact storage name",
+    ).hideHelp(),
+  )
+  .addOption(
+    new Option(
+      "--artifact-version <hash>",
+      "[deprecated: use --artifact] Artifact version hash",
+    ).hideHelp(),
   )
   .option(
     "--volume-version <name=version>",
@@ -102,6 +115,7 @@ export const mainRunCommand = new Command()
           envFile?: string;
           vars: Record<string, string>;
           secrets: Record<string, string>;
+          artifact?: string;
           artifactName?: string;
           artifactVersion?: string;
           memory?: string;
@@ -177,7 +191,29 @@ export const mainRunCommand = new Command()
           options.envFile,
         );
 
-        // 5. Call unified API (server handles all variable expansion)
+        // 5. Resolve artifact: new --artifact flag vs deprecated --artifact-name/--artifact-version
+        let artifactName = options.artifactName;
+        let artifactVersion = options.artifactVersion;
+
+        if (options.artifact) {
+          if (options.artifactName || options.artifactVersion) {
+            throw new Error(
+              "Cannot use --artifact with --artifact-name or --artifact-version. Use --artifact <name[:version]> instead.",
+            );
+          }
+          // options.artifact is guaranteed truthy by the if-guard above
+          const parsed = parseArtifact(options.artifact)!;
+          artifactName = parsed.artifactName;
+          artifactVersion = parsed.artifactVersion;
+        } else if (options.artifactName) {
+          console.error(
+            chalk.yellow(
+              "⚠ --artifact-name is deprecated, use --artifact <name[:version]> instead",
+            ),
+          );
+        }
+
+        // 6. Call unified API (server handles all variable expansion)
         const response = await createRun({
           // Use agentComposeVersionId if resolved, otherwise use agentComposeId (resolves to HEAD)
           ...(agentComposeVersionId
@@ -186,8 +222,8 @@ export const mainRunCommand = new Command()
           prompt,
           vars,
           secrets,
-          artifactName: options.artifactName,
-          artifactVersion: options.artifactVersion,
+          artifactName,
+          artifactVersion,
           memoryName: options.memory,
           volumeVersions:
             Object.keys(options.volumeVersion).length > 0
@@ -205,7 +241,7 @@ export const mainRunCommand = new Command()
           debugNoMockClaude: options.debugNoMockClaude || undefined,
         });
 
-        // 4. Check for immediate failure (e.g., missing secrets)
+        // 7. Check for immediate failure (e.g., missing secrets)
         if (response.status === "failed") {
           throw new Error(
             "Run preparation failed",
@@ -213,10 +249,10 @@ export const mainRunCommand = new Command()
           );
         }
 
-        // 5. Display run started/queued info
+        // 8. Display run started/queued info
         renderRunCreated(response);
 
-        // 6. Poll for events and exit with appropriate code
+        // 9. Poll for events and exit with appropriate code
         const result = await pollEvents(response.runId, {
           verbose: options.verbose,
         });

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -195,6 +195,30 @@ export function parseIdentifier(identifier: string): {
 }
 
 /**
+ * Parse artifact identifier: "name" or "name:version"
+ * Returns undefined when no value is provided.
+ * Examples:
+ *   "my-artifact"          → { artifactName: "my-artifact" }
+ *   "my-artifact:abc123"   → { artifactName: "my-artifact", artifactVersion: "abc123" }
+ */
+export function parseArtifact(value: string | undefined):
+  | {
+      artifactName: string;
+      artifactVersion?: string;
+    }
+  | undefined {
+  if (!value) return undefined;
+  const colonIndex = value.indexOf(":");
+  if (colonIndex > 0 && colonIndex < value.length - 1) {
+    return {
+      artifactName: value.slice(0, colonIndex),
+      artifactVersion: value.slice(colonIndex + 1),
+    };
+  }
+  return { artifactName: value };
+}
+
+/**
  * Display run created info (queued or started)
  */
 export function renderRunCreated(response: {


### PR DESCRIPTION
## Summary

- Add `--artifact <name[:version]>` flag to `run`, `resume`, and `continue` subcommands
- Deprecate `--artifact-name` and `--artifact-version` flags (hidden from help, emit warning on use)
- Add mutual exclusivity check: using both `--artifact` and old flags produces a clear error
- No API changes — CLI parses the new syntax and splits into existing `artifactName`/`artifactVersion` fields

## Test plan

- [x] 1062 CLI tests pass (109 test files)
- [x] New integration tests for `--artifact name` and `--artifact name:version` in all 3 subcommands
- [x] Deprecation warning test for old `--artifact-name` flag
- [x] Mutual exclusivity error tests (`--artifact` + `--artifact-name`, `--artifact` + `--artifact-version`)
- [x] E2E bats test: `t50-vm0-artifact-unified-flag.bats` (latest mount + version pin)
- [x] Lint, type-check, format, knip all pass

Closes #9474

🤖 Generated with [Claude Code](https://claude.com/claude-code)