### PR TITLE
feat: add server-side additional volumes support in storage manifest

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -355,6 +355,7 @@ const router = tsr.router(runsMainContract, {
           artifactVersion: resolved.artifactVersion ?? body.artifactVersion,
           memoryName: resolved.memoryName ?? body.memoryName,
           volumeVersions: resolved.volumeVersions ?? body.volumeVersions,
+          additionalVolumes: body.additionalVolumes,
           environment: resolved.environment,
           userTimezone: resolved.userTimezone,
           firewalls: resolved.firewalls,

--- a/turbo/apps/web/src/lib/infra/run/context/build-context.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/build-context.ts
@@ -19,6 +19,11 @@ interface BuildInfraContextParams {
   artifactVersion?: string;
   memoryName?: string;
   volumeVersions?: Record<string, string>;
+  additionalVolumes?: Array<{
+    name: string;
+    version?: string;
+    mountPath: string;
+  }>;
   environment?: Record<string, string>;
   userTimezone?: string;
   firewalls?: Firewalls;
@@ -74,6 +79,7 @@ export function buildInfraExecutionContext(
     artifactVersion: params.artifactVersion,
     memoryName: params.memoryName,
     volumeVersions: params.volumeVersions,
+    additionalVolumes: params.additionalVolumes,
     environment,
     userTimezone: params.userTimezone,
     firewalls: params.firewalls,

--- a/turbo/apps/web/src/lib/infra/run/context/build-context.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/build-context.ts
@@ -1,6 +1,7 @@
 import { expandEnvironmentFromCompose } from "../environment/expand-environment";
 import type { ExecutionContext, ResumeSession } from "../types";
 import type { ArtifactSnapshot } from "../../checkpoint/types";
+import type { AdditionalVolume } from "../../storage/types";
 import type { Firewalls, NetworkPolicies } from "@vm0/core";
 
 interface BuildInfraContextParams {
@@ -19,11 +20,7 @@ interface BuildInfraContextParams {
   artifactVersion?: string;
   memoryName?: string;
   volumeVersions?: Record<string, string>;
-  additionalVolumes?: Array<{
-    name: string;
-    version?: string;
-    mountPath: string;
-  }>;
+  additionalVolumes?: AdditionalVolume[];
   environment?: Record<string, string>;
   userTimezone?: string;
   firewalls?: Firewalls;

--- a/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
@@ -142,6 +142,7 @@ export async function prepareForExecution(
     context.resumeArtifact,
     workingDir,
     context.memoryName,
+    context.additionalVolumes,
   );
   const storageEnd = Date.now();
 

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -71,6 +71,13 @@ export interface ExecutionContext {
   // Volume version overrides (volume name -> version)
   volumeVersions?: Record<string, string>;
 
+  // Additional volumes passed at run time (bypass compose)
+  additionalVolumes?: Array<{
+    name: string;
+    version?: string;
+    mountPath: string;
+  }>;
+
   // Environment variables expanded server-side from compose's environment field
   // Uses vars and secrets to resolve ${{ vars.xxx }} and ${{ secrets.xxx }} references
   environment?: Record<string, string>;

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -1,4 +1,5 @@
 import type { ArtifactSnapshot } from "../checkpoint/types";
+import type { AdditionalVolume } from "../storage/types";
 import type { Firewalls, NetworkPolicies } from "@vm0/core";
 
 /**
@@ -72,11 +73,7 @@ export interface ExecutionContext {
   volumeVersions?: Record<string, string>;
 
   // Additional volumes passed at run time (bypass compose)
-  additionalVolumes?: Array<{
-    name: string;
-    version?: string;
-    mountPath: string;
-  }>;
+  additionalVolumes?: AdditionalVolume[];
 
   // Environment variables expanded server-side from compose's environment field
   // Uses vars and secrets to resolve ${{ vars.xxx }} and ${{ secrets.xxx }} references

--- a/turbo/apps/web/src/lib/infra/storage/__tests__/additional-volumes.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/additional-volumes.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach } from "vitest";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Internal infrastructure: no API route
+import { prepareStorageManifest } from "../storage-service";
+import {
+  createTestVolume,
+  createTestVolumeForOrg,
+} from "../../../../__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../__tests__/test-helpers";
+import type { AdditionalVolume, AgentVolumeConfig } from "../types";
+
+const context = testContext();
+
+/** Agent config that produces a single regular volume at the given mount path */
+function composeVolumeConfig(
+  volumeName: string,
+  storageName: string,
+  mountPath: string,
+): AgentVolumeConfig {
+  return {
+    agents: {
+      "test-agent": {
+        volumes: [`${volumeName}:${mountPath}`],
+      },
+    },
+    volumes: {
+      [volumeName]: {
+        name: storageName,
+        version: "latest",
+      },
+    },
+  };
+}
+
+describe("Additional Volumes", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("should include additional volume when no compose volumes exist", async () => {
+    const storageName = uniqueId("addvol");
+    const { versionId } = await createTestVolume(storageName);
+
+    const additional: AdditionalVolume[] = [
+      { name: storageName, mountPath: "/mnt/extra" },
+    ];
+
+    const manifest = await prepareStorageManifest(
+      undefined,
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      additional,
+    );
+
+    expect(manifest.storages).toHaveLength(1);
+    expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
+    expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
+    expect(manifest.storages[0]!.mountPath).toBe("/mnt/extra");
+  });
+
+  it("should override compose volume at same mount path", async () => {
+    const composeStorageName = uniqueId("compose-vol");
+    const additionalStorageName = uniqueId("additional-vol");
+    const volumeKey = uniqueId("vol");
+
+    await createTestVolume(composeStorageName);
+    const { versionId: additionalVersionId } = await createTestVolume(
+      additionalStorageName,
+    );
+
+    const additional: AdditionalVolume[] = [
+      { name: additionalStorageName, mountPath: "/data" },
+    ];
+
+    const manifest = await prepareStorageManifest(
+      composeVolumeConfig(volumeKey, composeStorageName, "/data"),
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      additional,
+    );
+
+    expect(manifest.storages).toHaveLength(1);
+    expect(manifest.storages[0]!.vasStorageName).toBe(additionalStorageName);
+    expect(manifest.storages[0]!.vasVersionId).toBe(additionalVersionId);
+    expect(manifest.storages[0]!.mountPath).toBe("/data");
+  });
+
+  it("should silently skip non-existent additional volume", async () => {
+    const additional: AdditionalVolume[] = [
+      { name: "nonexistent-volume", mountPath: "/mnt/missing" },
+    ];
+
+    const manifest = await prepareStorageManifest(
+      undefined,
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      additional,
+    );
+
+    expect(manifest.storages).toHaveLength(0);
+  });
+
+  it("should default to latest version when not specified", async () => {
+    const storageName = uniqueId("addvol-latest");
+    const { versionId } = await createTestVolume(storageName);
+
+    const additional: AdditionalVolume[] = [
+      { name: storageName, mountPath: "/mnt/latest" },
+    ];
+
+    const manifest = await prepareStorageManifest(
+      undefined,
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      additional,
+    );
+
+    expect(manifest.storages).toHaveLength(1);
+    expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
+  });
+
+  it("should resolve specific version for additional volume", async () => {
+    const storageName = uniqueId("addvol-version");
+    const { versionId } = await createTestVolume(storageName);
+
+    const additional: AdditionalVolume[] = [
+      { name: storageName, version: versionId, mountPath: "/mnt/versioned" },
+    ];
+
+    const manifest = await prepareStorageManifest(
+      undefined,
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      additional,
+    );
+
+    expect(manifest.storages).toHaveLength(1);
+    expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
+    expect(manifest.storages[0]!.mountPath).toBe("/mnt/versioned");
+  });
+
+  it("should include all additional volumes in manifest", async () => {
+    const storageName1 = uniqueId("multi-vol-1");
+    const storageName2 = uniqueId("multi-vol-2");
+    await createTestVolume(storageName1);
+    await createTestVolume(storageName2);
+
+    const additional: AdditionalVolume[] = [
+      { name: storageName1, mountPath: "/mnt/one" },
+      { name: storageName2, mountPath: "/mnt/two" },
+    ];
+
+    const manifest = await prepareStorageManifest(
+      undefined,
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      additional,
+    );
+
+    expect(manifest.storages).toHaveLength(2);
+    const names = manifest.storages.map((s) => {
+      return s.vasStorageName;
+    });
+    expect(names).toContain(storageName1);
+    expect(names).toContain(storageName2);
+  });
+
+  it("should resolve additional volumes from runtime org not agent org", async () => {
+    const storageName = uniqueId("runtime-vol");
+    // Create volume under user's org (acts as runtime org)
+    const { versionId } = await createTestVolume(storageName);
+
+    // Use a different agent org (non-existent) — should still work
+    // because additional volumes use runtimeClerkOrgId
+    const fakeAgentOrgId = "org_fake_agent_org_id";
+
+    const additional: AdditionalVolume[] = [
+      { name: storageName, mountPath: "/mnt/runtime" },
+    ];
+
+    const manifest = await prepareStorageManifest(
+      undefined,
+      {},
+      fakeAgentOrgId,
+      user.orgId,
+      user.userId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      additional,
+    );
+
+    expect(manifest.storages).toHaveLength(1);
+    expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
+    expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
+  });
+
+  it("should keep compose volumes at different mount paths", async () => {
+    const composeStorageName = uniqueId("compose-keep");
+    const additionalStorageName = uniqueId("additional-keep");
+    const volumeKey = uniqueId("vol");
+
+    await createTestVolume(composeStorageName);
+    await createTestVolume(additionalStorageName);
+
+    const additional: AdditionalVolume[] = [
+      { name: additionalStorageName, mountPath: "/mnt/extra" },
+    ];
+
+    const manifest = await prepareStorageManifest(
+      composeVolumeConfig(volumeKey, composeStorageName, "/data"),
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      additional,
+    );
+
+    expect(manifest.storages).toHaveLength(2);
+    const mountPaths = manifest.storages.map((s) => {
+      return s.mountPath;
+    });
+    expect(mountPaths).toContain("/data");
+    expect(mountPaths).toContain("/mnt/extra");
+  });
+});

--- a/turbo/apps/web/src/lib/infra/storage/__tests__/additional-volumes.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/additional-volumes.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Internal infrastructure: no API route
 import { prepareStorageManifest } from "../storage-service";
-import {
-  createTestVolume,
-  createTestVolumeForOrg,
-} from "../../../../__tests__/api-test-helpers";
+import { createTestVolume } from "../../../../__tests__/api-test-helpers";
 import {
   testContext,
   uniqueId,

--- a/turbo/apps/web/src/lib/infra/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/infra/storage/storage-service.ts
@@ -5,7 +5,9 @@ import { logger } from "../../shared/logger";
 import { badRequest } from "../../shared/errors";
 import {
   DEFAULT_MEMORY_MOUNT_PATH,
+  type AdditionalVolume,
   type AgentVolumeConfig,
+  type ResolvedArtifact,
   type StorageManifest,
   type ManifestStorage,
   type ManifestArtifact,
@@ -263,6 +265,64 @@ async function resolveVersion(
 }
 
 /**
+ * Process a single additional volume: resolve version from runtime org and generate presigned URL.
+ * Always optional — returns null if the volume is not found.
+ */
+async function resolveAdditionalVolume(
+  vol: AdditionalVolume,
+  runtimeClerkOrgId: string,
+  bucketName: string,
+): Promise<ManifestStorage | null> {
+  const version = vol.version || "latest";
+  try {
+    const { versionId, s3Key } = await resolveVersion(
+      runtimeClerkOrgId,
+      vol.name,
+      "volume",
+      version,
+      VOLUME_ORG_USER_ID,
+    );
+    const archiveKey = `${s3Key}/archive.tar.gz`;
+    const archiveUrl = await generatePresignedUrl(bucketName, archiveKey);
+    return {
+      name: vol.name,
+      mountPath: vol.mountPath,
+      vasStorageName: vol.name,
+      vasVersionId: versionId,
+      archiveUrl,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("not found")) {
+      log.warn(`Additional volume "${vol.name}" not found, skipping`);
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Determine the artifact source: use resumeArtifact if provided, otherwise fall back to resolved artifact.
+ */
+function resolveArtifactSource(
+  resolvedArtifact: ResolvedArtifact | null,
+  resumeArtifact: { artifactName: string; artifactVersion: string } | undefined,
+  resumeArtifactMountPath: string | undefined,
+): ResolvedArtifact | null {
+  if (!resumeArtifact) return resolvedArtifact;
+  if (!resumeArtifactMountPath) {
+    throw badRequest(
+      "resumeArtifactMountPath is required when resumeArtifact is provided (working_dir must be configured)",
+    );
+  }
+  return {
+    driver: "vas" as const,
+    vasStorageName: resumeArtifact.artifactName,
+    vasVersion: resumeArtifact.artifactVersion,
+    mountPath: resumeArtifactMountPath,
+  };
+}
+
+/**
  * Prepare storage manifest with presigned URLs for direct download to sandbox
  * This method generates presigned URLs instead of downloading files to local temp
  *
@@ -291,6 +351,7 @@ export async function prepareStorageManifest(
   resumeArtifact?: { artifactName: string; artifactVersion: string },
   resumeArtifactMountPath?: string,
   memoryName?: string,
+  additionalVolumes?: AdditionalVolume[],
 ): Promise<StorageManifest> {
   log.debug("Preparing storage manifest with presigned URLs...");
 
@@ -303,8 +364,13 @@ export async function prepareStorageManifest(
   // Skip artifact in resolveVolumes if we're using resumeArtifact (we'll handle it separately)
   const skipArtifact = !!resumeArtifact;
 
-  // If no agent config and no resume artifact and no memory, return empty manifest
-  if (!agentConfig && !resumeArtifact && !memoryName) {
+  // If no agent config and no resume artifact and no memory and no additional volumes, return empty manifest
+  if (
+    !agentConfig &&
+    !resumeArtifact &&
+    !memoryName &&
+    (!additionalVolumes || additionalVolumes.length === 0)
+  ) {
     return { storages: [], artifact: null, memory: null };
   }
 
@@ -416,22 +482,17 @@ export async function prepareStorageManifest(
     },
   );
 
+  // Process additional volumes (always optional, use Runtime Org)
+  const additionalPromises = (additionalVolumes ?? []).map((vol) => {
+    return resolveAdditionalVolume(vol, runtimeClerkOrgId, bucketName);
+  });
+
   // Handle artifact: either from resumeArtifact or from volumeResult
-  // Note: resumeArtifactMountPath is required when resumeArtifact is provided (no fallback)
-  let artifactSource = volumeResult.artifact;
-  if (resumeArtifact) {
-    if (!resumeArtifactMountPath) {
-      throw badRequest(
-        "resumeArtifactMountPath is required when resumeArtifact is provided (working_dir must be configured)",
-      );
-    }
-    artifactSource = {
-      driver: "vas" as const,
-      vasStorageName: resumeArtifact.artifactName,
-      vasVersion: resumeArtifact.artifactVersion,
-      mountPath: resumeArtifactMountPath,
-    };
-  }
+  const artifactSource = resolveArtifactSource(
+    volumeResult.artifact,
+    resumeArtifact,
+    resumeArtifactMountPath,
+  );
 
   const artifactPromise = artifactSource
     ? (async () => {
@@ -495,19 +556,42 @@ export async function prepareStorageManifest(
     : Promise.resolve(null);
 
   // Wait for all URL generation to complete in parallel
-  const [storageResults, artifact, memory] = await Promise.all([
-    Promise.all(volumePromises),
-    artifactPromise,
-    memoryPromise,
-  ]);
+  const [storageResults, additionalResults, artifact, memory] =
+    await Promise.all([
+      Promise.all(volumePromises),
+      Promise.all(additionalPromises),
+      artifactPromise,
+      memoryPromise,
+    ]);
 
-  // Filter out null results (skipped optional volumes)
-  const filteredStorages = storageResults.filter((s): s is ManifestStorage => {
-    return s !== null;
-  });
+  // Filter nulls from additional volumes
+  const resolvedAdditional = additionalResults.filter(
+    (s): s is ManifestStorage => {
+      return s !== null;
+    },
+  );
+
+  // Build set of additional volume mount paths for override
+  const additionalMountPaths = new Set(
+    resolvedAdditional.map((s) => {
+      return s.mountPath;
+    }),
+  );
+
+  // Filter compose volumes: remove any whose mount path conflicts with additional volumes
+  const filteredCompose = storageResults
+    .filter((s): s is ManifestStorage => {
+      return s !== null;
+    })
+    .filter((s) => {
+      return !additionalMountPaths.has(s.mountPath);
+    });
+
+  // Merge: compose (filtered) + additional
+  const filteredStorages = [...filteredCompose, ...resolvedAdditional];
 
   log.debug(
-    `Storage manifest prepared: ${filteredStorages.length} storages, ${artifact ? "1 artifact" : "no artifact"}, ${memory ? "1 memory" : "no memory"}`,
+    `Storage manifest prepared: ${filteredStorages.length} storages (${filteredCompose.length} compose + ${resolvedAdditional.length} additional), ${artifact ? "1 artifact" : "no artifact"}, ${memory ? "1 memory" : "no memory"}`,
   );
 
   return {

--- a/turbo/apps/web/src/lib/infra/storage/types.ts
+++ b/turbo/apps/web/src/lib/infra/storage/types.ts
@@ -78,6 +78,16 @@ export interface AgentVolumeConfig {
 }
 
 /**
+ * Volume passed directly at run time, bypassing compose.
+ * Always optional (skip without error if not found).
+ */
+export interface AdditionalVolume {
+  name: string; // Storage name
+  version?: string; // Version hash or "latest" (defaults to "latest")
+  mountPath: string; // Absolute path in sandbox
+}
+
+/**
  * Storage entry in manifest
  */
 export interface ManifestStorage {

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -44,6 +44,17 @@ const unifiedRunRequestSchema = z.object({
   volumeVersions: z.record(z.string(), z.string()).optional(),
   memoryName: z.string().optional(),
 
+  // Additional volumes passed directly at run time (bypass compose)
+  additionalVolumes: z
+    .array(
+      z.object({
+        name: z.string(),
+        version: z.string().optional(),
+        mountPath: z.string(),
+      }),
+    )
+    .optional(),
+
   // Debug flag to force real Claude in mock environments (internal use only)
   debugNoMockClaude: z.boolean().optional(),
 


### PR DESCRIPTION
## Summary

- Add `AdditionalVolume` type and `additionalVolumes` optional field to the API schema, `ExecutionContext`, and `BuildInfraContextParams`
- Implement merge logic in `prepareStorageManifest()`: additional volumes are resolved from `runtimeClerkOrgId` (caller's org), always optional (skip on not-found), and override compose volumes at the same mount path
- Wire the new field through the full pipeline: API route → build-context → execution-preparer → storage-service

## Test plan

- [x] Additional volume with no compose volumes → appears in manifest
- [x] Additional volume at same mount path as compose volume → additional wins
- [x] Non-existent additional volume → silently skipped
- [x] Version defaults to "latest" when not specified
- [x] Specific version → correct version resolved
- [x] Multiple additional volumes → all appear
- [x] Additional volumes resolved from runtime org (not agent org)
- [x] Compose volumes at different mount paths preserved alongside additional volumes
- [x] All existing storage tests pass (17/17)
- [x] Lint, type-check, format, knip all pass

Closes #9475

🤖 Generated with [Claude Code](https://claude.com/claude-code)