### PR TITLE
fix(platform): track tts playback by run id instead of message id

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -650,7 +650,7 @@ export const loadChatMessages$ = command(
           return;
         }
 
-        set(markMessageLoading$, message.id);
+        set(markMessageLoading$, message.legacyRunId!);
 
         await setLoop(
           (sig) => {
@@ -666,7 +666,7 @@ export const loadChatMessages$ = command(
         const content = await get(message.result$);
         signal.throwIfAborted();
         if (content) {
-          await set(checkAutoRead$, message.id, content, signal);
+          await set(checkAutoRead$, message.legacyRunId!, content, signal);
         }
 
         set(reloadChatThreads$);
@@ -927,7 +927,7 @@ export const sendExistingThreadMessage$ = command(
       return [...prev, assistantMessage];
     });
 
-    set(markMessageLoading$, assistantMessage.id);
+    set(markMessageLoading$, assistantMessage.legacyRunId!);
 
     const runLoop = assistantMessage.runLoop;
     if (!runLoop) {
@@ -947,7 +947,7 @@ export const sendExistingThreadMessage$ = command(
     const content = await get(assistantMessage.result$);
     signal.throwIfAborted();
     if (content) {
-      await set(checkAutoRead$, assistantMessage.id, content, signal);
+      await set(checkAutoRead$, assistantMessage.legacyRunId!, content, signal);
     }
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -383,7 +383,7 @@ function createSendMessage(
       return [...prev, assistantMessage];
     });
 
-    set(markMessageLoading$, assistantMessage.id);
+    set(markMessageLoading$, assistantMessage.legacyRunId!);
 
     const runLoop = assistantMessage.runLoop;
     if (!runLoop) {
@@ -405,7 +405,7 @@ function createSendMessage(
     const content = await get(assistantMessage.result$);
     signal.throwIfAborted();
     if (content) {
-      await set(checkAutoRead$, assistantMessage.id, content, signal);
+      await set(checkAutoRead$, assistantMessage.legacyRunId!, content, signal);
     }
   });
 }
@@ -448,7 +448,7 @@ function createLoadMessages(deps: MessageCommandsInternalScope) {
           return;
         }
 
-        set(markMessageLoading$, message.id);
+        set(markMessageLoading$, message.legacyRunId!);
 
         await setLoop(
           (sig) => {
@@ -464,7 +464,7 @@ function createLoadMessages(deps: MessageCommandsInternalScope) {
         const content = await get(message.result$);
         signal.throwIfAborted();
         if (content) {
-          await set(checkAutoRead$, message.id, content, signal);
+          await set(checkAutoRead$, message.legacyRunId!, content, signal);
         }
 
         set(reloadChatThreads$);

--- a/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
+++ b/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
@@ -78,7 +78,7 @@ function mockTtsEndpoint() {
 describe("playTts$", () => {
   const context = testContext();
 
-  it("should not trigger a second fetch when called twice with the same messageId", async () => {
+  it("should not trigger a second fetch when called twice with the same runId", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
     mockWebAudio();
     const { getFetchCount } = mockTtsEndpoint();
@@ -101,7 +101,7 @@ describe("playTts$", () => {
     expect(AudioContext).toHaveBeenCalledTimes(1);
   });
 
-  it("should allow playback for a different messageId", async () => {
+  it("should allow playback for a different runId", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
     mockWebAudio();
     const { getFetchCount } = mockTtsEndpoint();
@@ -112,7 +112,7 @@ describe("playTts$", () => {
     expect(getFetchCount()).toBe(2);
   });
 
-  it("should reset playingMessageId on fetch failure", async () => {
+  it("should reset playingRunId on fetch failure", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
     mockWebAudio();
 
@@ -131,7 +131,7 @@ describe("playTts$", () => {
     expect(playingId).toBeNull();
   });
 
-  it("should reset playingMessageId after pre-aborted signal", async () => {
+  it("should reset playingRunId after pre-aborted signal", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
     mockWebAudio();
     mockTtsEndpoint();
@@ -143,7 +143,7 @@ describe("playTts$", () => {
     expect(context.store.get(ttsPlayingRunId$)).toBeNull();
   });
 
-  it("should reset playingMessageId after signal abort during fetch", async () => {
+  it("should reset playingRunId after signal abort during fetch", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
     mockWebAudio();
 

--- a/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
+++ b/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
@@ -3,7 +3,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import { playTts$, stopTts$, ttsPlayingMessageId$ } from "../voice-io-tts.ts";
+import { playTts$, stopTts$, ttsPlayingRunId$ } from "../voice-io-tts.ts";
 import { createDeferredPromise, resetSignal } from "../../utils.ts";
 
 function mockWebAudio() {
@@ -127,7 +127,7 @@ describe("playTts$", () => {
 
     await context.store.set(playTts$, "msg-1", "Hello world", context.signal);
 
-    const playingId = context.store.get(ttsPlayingMessageId$);
+    const playingId = context.store.get(ttsPlayingRunId$);
     expect(playingId).toBeNull();
   });
 
@@ -140,7 +140,7 @@ describe("playTts$", () => {
       context.store.set(playTts$, "msg-1", "Hello world", AbortSignal.abort()),
     ).rejects.toThrow();
 
-    expect(context.store.get(ttsPlayingMessageId$)).toBeNull();
+    expect(context.store.get(ttsPlayingRunId$)).toBeNull();
   });
 
   it("should reset playingMessageId after signal abort during fetch", async () => {
@@ -167,7 +167,7 @@ describe("playTts$", () => {
     context.store.set(pageReset$, context.signal);
 
     await expect(playPromise).rejects.toThrow();
-    expect(context.store.get(ttsPlayingMessageId$)).toBeNull();
+    expect(context.store.get(ttsPlayingRunId$)).toBeNull();
   });
 
   it("should allow replaying the same message after a previous abort", async () => {
@@ -194,7 +194,7 @@ describe("playTts$", () => {
       // expected abort
     }
 
-    expect(context.store.get(ttsPlayingMessageId$)).toBeNull();
+    expect(context.store.get(ttsPlayingRunId$)).toBeNull();
 
     // Second attempt with fresh signal — must succeed
     const { getFetchCount } = mockTtsEndpoint();
@@ -209,7 +209,7 @@ describe("playTts$", () => {
 
     await context.store.set(playTts$, "msg-4", "Hello world", context.signal);
     context.store.set(stopTts$);
-    expect(context.store.get(ttsPlayingMessageId$)).toBeNull();
+    expect(context.store.get(ttsPlayingRunId$)).toBeNull();
 
     const { getFetchCount } = mockTtsEndpoint();
     await context.store.set(playTts$, "msg-4", "Hello again", context.signal);

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
@@ -10,7 +10,7 @@ const L = logger("AudioIO:TTS");
 // Internal state
 // ---------------------------------------------------------------------------
 
-const internalPlayingMessageId$ = state<string | null>(null);
+const internalPlayingRunId$ = state<string | null>(null);
 const internalCleanupFn$ = state<(() => void) | null>(null);
 
 // Auto-read tracking
@@ -21,8 +21,8 @@ const internalAutoReadTriggered$ = state<Set<string>>(new Set());
 // Public computed
 // ---------------------------------------------------------------------------
 
-export const ttsPlayingMessageId$ = computed((get) => {
-  return get(internalPlayingMessageId$);
+export const ttsPlayingRunId$ = computed((get) => {
+  return get(internalPlayingRunId$);
 });
 
 // ---------------------------------------------------------------------------
@@ -59,28 +59,23 @@ const cleanupAudio$ = command(({ get, set }) => {
     cleanupFn();
   }
 
-  set(internalPlayingMessageId$, null);
+  set(internalPlayingRunId$, null);
   set(internalCleanupFn$, null);
 });
 
 const resetPlaybackState$ = command(({ set }) => {
-  set(internalPlayingMessageId$, null);
+  set(internalPlayingRunId$, null);
   set(internalCleanupFn$, null);
 });
 
 const fetchAndPlay$ = command(
-  async (
-    { get, set },
-    messageId: string,
-    text: string,
-    signal: AbortSignal,
-  ) => {
+  async ({ get, set }, runId: string, text: string, signal: AbortSignal) => {
     set(cleanupAudio$);
-    set(internalPlayingMessageId$, messageId);
+    set(internalPlayingRunId$, runId);
 
     const plainText = stripMarkdown(text);
     if (!plainText) {
-      set(internalPlayingMessageId$, null);
+      set(internalPlayingRunId$, null);
       return;
     }
 
@@ -100,7 +95,7 @@ const fetchAndPlay$ = command(
         L.error("TTS fetch failed", error);
         await audioCtx.close();
         signal.throwIfAborted();
-        set(internalPlayingMessageId$, null);
+        set(internalPlayingRunId$, null);
         return;
       }
 
@@ -108,7 +103,7 @@ const fetchAndPlay$ = command(
         L.error("TTS API returned error");
         await audioCtx.close();
         signal.throwIfAborted();
-        set(internalPlayingMessageId$, null);
+        set(internalPlayingRunId$, null);
         return;
       }
 
@@ -116,7 +111,7 @@ const fetchAndPlay$ = command(
       if (!body) {
         await audioCtx.close();
         signal.throwIfAborted();
-        set(internalPlayingMessageId$, null);
+        set(internalPlayingRunId$, null);
         return;
       }
 
@@ -223,57 +218,45 @@ export const stopTts$ = command(({ set }) => {
 });
 
 export const playTts$ = command(
-  async (
-    { get, set },
-    messageId: string,
-    text: string,
-    signal: AbortSignal,
-  ) => {
-    if (get(internalPlayingMessageId$) === messageId) {
+  async ({ get, set }, runId: string, text: string, signal: AbortSignal) => {
+    if (get(internalPlayingRunId$) === runId) {
       return;
     }
-    await set(fetchAndPlay$, messageId, text, signal);
+    await set(fetchAndPlay$, runId, text, signal);
   },
 );
 
 /**
  * Mark a message as "seen loading" during this session.
  */
-export const markMessageLoading$ = command(
-  ({ get, set }, messageId: string) => {
-    const seen = get(internalSeenLoading$);
-    if (!seen.has(messageId)) {
-      const next = new Set(seen);
-      next.add(messageId);
-      set(internalSeenLoading$, next);
-    }
-  },
-);
+export const markMessageLoading$ = command(({ get, set }, runId: string) => {
+  const seen = get(internalSeenLoading$);
+  if (!seen.has(runId)) {
+    const next = new Set(seen);
+    next.add(runId);
+    set(internalSeenLoading$, next);
+  }
+});
 
 /**
  * Check if a completed message should be auto-read, and trigger playback.
  */
 export const checkAutoRead$ = command(
-  async (
-    { get, set },
-    messageId: string,
-    content: string,
-    signal: AbortSignal,
-  ) => {
+  async ({ get, set }, runId: string, content: string, signal: AbortSignal) => {
     if (!get(autoReadEnabled$)) {
       return;
     }
-    if (!get(internalSeenLoading$).has(messageId)) {
+    if (!get(internalSeenLoading$).has(runId)) {
       return;
     }
-    if (get(internalAutoReadTriggered$).has(messageId)) {
+    if (get(internalAutoReadTriggered$).has(runId)) {
       return;
     }
 
     const nextTriggered = new Set(get(internalAutoReadTriggered$));
-    nextTriggered.add(messageId);
+    nextTriggered.add(runId);
     set(internalAutoReadTriggered$, nextTriggered);
 
-    await set(fetchAndPlay$, messageId, content, signal);
+    await set(fetchAndPlay$, runId, content, signal);
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -30,7 +30,7 @@ import {
 import { FeatureSwitchKey, RUN_ERROR_GUIDANCE } from "@vm0/core";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
-  ttsPlayingMessageId$,
+  ttsPlayingRunId$,
   playTts$,
   stopTts$,
 } from "../../signals/voice-io/voice-io-tts.ts";
@@ -807,8 +807,8 @@ function AssistantMessageActions({
 
   const features = useLastResolved(featureSwitch$);
   const audioIOEnabled = features?.[FeatureSwitchKey.AudioIO] ?? false;
-  const playingId = useGet(ttsPlayingMessageId$);
-  const isPlayingThis = playingId === message.id;
+  const playingRunId = useGet(ttsPlayingRunId$);
+  const isPlayingThis = playingRunId === message.legacyRunId;
   const playTts = useSet(playTts$);
   const stopTts = useSet(stopTts$);
 
@@ -827,7 +827,10 @@ function AssistantMessageActions({
     if (isPlayingThis) {
       detach(stopTts(), Reason.DomCallback);
     } else {
-      detach(playTts(message.id, content, pageSignal), Reason.DomCallback);
+      detach(
+        playTts(message.legacyRunId!, content, pageSignal),
+        Reason.DomCallback,
+      );
     }
   };
 


### PR DESCRIPTION
## Summary

- Switch TTS playback tracking from `message.id` (unstable local UUID) to `legacyRunId` (stable run ID) so auto-read state survives the local→server message transition
- Rename `internalPlayingMessageId$` → `internalPlayingRunId$` and `ttsPlayingMessageId$` → `ttsPlayingRunId$`
- Update all call sites in `chat-message.ts`, `create-chat-thread.ts`, and `zero-chat-thread-page.tsx`

Closes #9486

## Test plan

- [ ] All existing TTS tests pass (210 files, 1776 tests)
- [ ] Enable auto-read → send message → Read Aloud button shows stop icon during auto-read playback
- [ ] Click stop icon during auto-read → playback stops immediately
- [ ] Manual Read Aloud (without auto-read) still works correctly
- [ ] Lint, type-check, format, and knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)