### PR TITLE
chore: install mold linker in toolchain image

### DIFF
--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -46,6 +46,25 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /usr/local/rustup/toolchains/*/share/man \
     && rustc --version && cargo --version
 
+# Install mold linker for faster linking of the runner crate.
+# Used by CI via CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C link-arg=-fuse-ld=mold".
+# The aarch64-linux-gnu-ld.mold symlink is required so aarch64-linux-gnu-gcc
+# (the linker driver in crates/.cargo/config.toml) finds mold under its
+# triple-prefixed name. mold 2.x supports cross-linking aarch64 from any host,
+# so a single binary works for both the host and the cross-compile target.
+ARG MOLD_VERSION=2.41.0
+RUN ARCH=$(dpkg --print-architecture) \
+    && case "$ARCH" in \
+        amd64) MOLD_ARCH="x86_64" ;; \
+        arm64) MOLD_ARCH="aarch64" ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" \
+       | tar xz --strip-components=2 -C /usr/local/bin "mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/mold" \
+    && ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold \
+    && ln -sf /usr/local/bin/mold /usr/local/bin/aarch64-linux-gnu-ld.mold \
+    && mold --version
+
 # Stage 3: Development environment with additional tools
 FROM toolchain-rust AS development
 


### PR DESCRIPTION
## Summary

- Bake mold 2.41.0 into the `toolchain-rust` stage (inherited by `development`) so CI doesn't have to download it per `runner-build` job.
- Multi-arch: `dpkg --print-architecture` selects between the `x86_64-linux` and `aarch64-linux` mold release tarballs.
- Symlink `mold` → `ld.mold` and `aarch64-linux-gnu-ld.mold` so `aarch64-linux-gnu-gcc -fuse-ld=mold` (used as the linker driver per `crates/.cargo/config.toml`) finds it under the expected triple-prefixed name.
- Pinned to `MOLD_VERSION=2.41.0` to match the default in `.github/actions/install-mold/action.yml` — the CI install-mold step keeps running and will overwrite mold with byte-identical content, so this PR is a no-op for current CI behavior.

This is **part 1 of a 3-PR rollout** (#9487 → #9488 → #9489):
- **This PR (#9487)**: install mold in the toolchain image.
- **Next (#9488)**: switch CI workflows to use the new image tag and delete the `install-mold` composite action.
- **Final (#9489)**: change `crates/.cargo/config.toml` to make mold the default linker for both runner and guests.

Closes #9487

## Test plan

- [ ] `docker-toolchain.yml` job builds successfully for both `linux/amd64` and `linux/arm64`.
- [ ] After merge, `docker-toolchain-publish.yml` publishes a new `vm0-toolchain-rust` image tag containing `/usr/local/bin/mold` and the two symlinks.
- [ ] Existing CI on this PR (which still uses the old image tag + install-mold action) continues to pass — confirms no-op behavior for the in-flight transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)