### PR TITLE
feat(cli): add --volume flag for dynamic volume mounting

### DIFF
--- a/e2e/tests/03-runner/t49-vm0-dynamic-volume.bats
+++ b/e2e/tests/03-runner/t49-vm0-dynamic-volume.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+
+# Test VM0 dynamic volume mounting via --volume flag (E2E happy path only)
+# This test verifies that --volume flag can mount volumes that are not defined
+# in the agent's compose configuration.
+#
+# Note: resume/continue with --volume uses the same code path and is tested
+# via CLI Command Integration Tests (see run/__tests__/dynamic-volume.test.ts).
+
+load '../../helpers/setup'
+
+setup_file() {
+    # Unique agent name for this test file
+    export AGENT_NAME="e2e-t49-$(date +%s%3N)-$RANDOM"
+    export TEST_DIR="$(mktemp -d)"
+    export TEST_CONFIG="$TEST_DIR/vm0.yaml"
+
+    # Create claude-files volume (required for agent to run)
+    export CLAUDE_VOLUME_NAME="e2e-vol-t49-claude-$(date +%s%3N)-$RANDOM"
+    mkdir -p "$TEST_DIR/$CLAUDE_VOLUME_NAME"
+    cd "$TEST_DIR/$CLAUDE_VOLUME_NAME"
+    cat > CLAUDE.md << 'VOLEOF'
+This is a test file for the volume.
+VOLEOF
+    $VM0_CLI volume init --name "$CLAUDE_VOLUME_NAME" >/dev/null
+    $VM0_CLI volume push >/dev/null
+    cd - >/dev/null
+
+    # Create dynamic volume A with known content
+    export DYNAMIC_VOL_A="e2e-vol-t49-dyn-a-$(date +%s%3N)-$RANDOM"
+    mkdir -p "$TEST_DIR/$DYNAMIC_VOL_A"
+    cd "$TEST_DIR/$DYNAMIC_VOL_A"
+    echo "dynamic-content-a" > data.txt
+    $VM0_CLI volume init --name "$DYNAMIC_VOL_A" >/dev/null
+    $VM0_CLI volume push >/dev/null
+    cd - >/dev/null
+
+    # Create dynamic volume B with different content
+    export DYNAMIC_VOL_B="e2e-vol-t49-dyn-b-$(date +%s%3N)-$RANDOM"
+    mkdir -p "$TEST_DIR/$DYNAMIC_VOL_B"
+    cd "$TEST_DIR/$DYNAMIC_VOL_B"
+    echo "dynamic-content-b" > data.txt
+    $VM0_CLI volume init --name "$DYNAMIC_VOL_B" >/dev/null
+    $VM0_CLI volume push >/dev/null
+    cd - >/dev/null
+
+    # Create inline config — agent has NO volumes except claude-files
+    cat > "$TEST_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}:
+    description: "Test agent for dynamic volume mounting"
+    framework: claude-code
+    volumes:
+      - claude-files:/home/user/.config/claude
+    working_dir: /home/user/workspace
+volumes:
+  claude-files:
+    name: $CLAUDE_VOLUME_NAME
+    version: latest
+EOF
+
+    # Compose agent once for all tests
+    $VM0_CLI compose "$TEST_CONFIG" >/dev/null
+}
+
+setup() {
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    export ARTIFACT_NAME="e2e-art-dynvol-${UNIQUE_ID}"
+}
+
+teardown_file() {
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+@test "t49-1: build agent configuration" {
+    run $VM0_CLI compose "$TEST_CONFIG"
+    assert_success
+    assert_output --partial "$AGENT_NAME"
+}
+
+@test "t49-2: --volume mounts dynamic volume at runtime (latest)" {
+    # Create artifact
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null
+    echo "test" > marker.txt
+    run $VM0_CLI artifact push
+    assert_success
+
+    # Run agent with --volume pointing to a volume NOT in compose config
+    run $VM0_CLI run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        --volume "$DYNAMIC_VOL_A:/home/user/data" \
+        --verbose \
+        "cat /home/user/data/data.txt"
+
+    assert_success
+    assert_output --partial "dynamic-content-a"
+}
+
+@test "t49-3: --volume with specific version" {
+    # Push version 1 with v1-specific content
+    cd "$TEST_DIR/$DYNAMIC_VOL_A"
+    echo "v1-content" > data.txt
+    run $VM0_CLI volume push
+    assert_success
+    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
+    [ -n "$VERSION1" ]
+
+    # Push version 2 (HEAD) with different content
+    echo "v2-head-content" > data.txt
+    run $VM0_CLI volume push
+    assert_success
+
+    # Create artifact
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null
+    echo "test" > marker.txt
+    run $VM0_CLI artifact push
+    assert_success
+
+    # Run with specific version — should see v1 content, not HEAD
+    run $VM0_CLI run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        --volume "$DYNAMIC_VOL_A:$VERSION1:/home/user/data" \
+        --verbose \
+        "cat /home/user/data/data.txt"
+
+    assert_success
+    assert_output --partial "v1-content"
+    refute_output --partial "v2-head-content"
+}
+
+@test "t49-4: multiple --volume flags mount multiple volumes" {
+    # Create artifact
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null
+    echo "test" > marker.txt
+    run $VM0_CLI artifact push
+    assert_success
+
+    # Run with two dynamic volumes at different mount paths
+    run $VM0_CLI run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        --volume "$DYNAMIC_VOL_A:/home/user/data-a" \
+        --volume "$DYNAMIC_VOL_B:/home/user/data-b" \
+        --verbose \
+        "cat /home/user/data-a/data.txt && cat /home/user/data-b/data.txt"
+
+    assert_success
+    assert_output --partial "dynamic-content-a"
+    assert_output --partial "dynamic-content-b"
+}

--- a/e2e/tests/03-runner/t49-vm0-dynamic-volume.bats
+++ b/e2e/tests/03-runner/t49-vm0-dynamic-volume.bats
@@ -136,6 +136,12 @@ teardown_file() {
 }
 
 @test "t49-4: multiple --volume flags mount multiple volumes" {
+    # Push fresh content to vol-a (t49-3 changed its HEAD)
+    cd "$TEST_DIR/$DYNAMIC_VOL_A"
+    echo "multi-test-a" > data.txt
+    run $VM0_CLI volume push
+    assert_success
+
     # Create artifact
     mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
     cd "$TEST_DIR/$ARTIFACT_NAME"
@@ -153,6 +159,6 @@ teardown_file() {
         "cat /home/user/data-a/data.txt && cat /home/user/data-b/data.txt"
 
     assert_success
-    assert_output --partial "dynamic-content-a"
+    assert_output --partial "multi-test-a"
     assert_output --partial "dynamic-content-b"
 }

--- a/turbo/apps/cli/src/commands/run/__tests__/dynamic-volume.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/dynamic-volume.test.ts
@@ -1,0 +1,498 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { createMockChildProcess } from "../../../mocks/spawn-helpers";
+import { runCommand } from "../index";
+import { parseVolume, collectVolumes } from "../shared";
+import chalk from "chalk";
+
+// Mock child_process.spawn since it's an external system call boundary
+vi.mock("child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("child_process")>();
+  return {
+    ...original,
+    spawn: vi.fn(),
+  };
+});
+
+import { spawn } from "child_process";
+const mockSpawn = vi.mocked(spawn);
+
+/**
+ * CLI Command Integration Tests for --volume option
+ *
+ * Tests the --volume parameter parsing and API transmission for:
+ * - run command
+ * - continue command
+ * - resume command
+ *
+ * The actual dynamic volume mount behavior is tested via E2E tests
+ * (see e2e/tests/03-runner/t49-vm0-dynamic-volume.bats).
+ */
+describe("--volume option", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  const testUuid = "550e8400-e29b-41d4-a716-446655440000";
+  const testSessionId = "660e8400-e29b-41d4-a716-446655440001";
+  const testCheckpointId = "770e8400-e29b-41d4-a716-446655440002";
+
+  // Default compose response
+  const defaultComposeResponse = {
+    id: testUuid,
+    name: "test-agent",
+    headVersionId: "version-123",
+    content: {
+      version: "1",
+      agents: { "test-agent": { provider: "claude" } },
+    },
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  };
+
+  // Default run response
+  const defaultRunResponse = {
+    runId: "run-123",
+    status: "running",
+    sandboxId: "sbx-456",
+    output: "Success",
+    executionTimeMs: 1000,
+    createdAt: "2025-01-01T00:00:00Z",
+  };
+
+  // Default events response with completed status
+  const defaultEventsResponse = {
+    events: [
+      {
+        sequenceNumber: 0,
+        eventType: "result",
+        eventData: {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          duration_ms: 1000,
+          num_turns: 1,
+          result: "Done",
+          session_id: "test",
+          total_cost_usd: 0,
+          usage: {},
+        },
+        createdAt: "2025-01-01T00:00:00Z",
+      },
+    ],
+    hasMore: false,
+    nextSequence: 0,
+    run: { status: "completed" },
+    framework: "claude-code",
+  };
+
+  // Default session response
+  const defaultSessionResponse = {
+    id: testSessionId,
+    secretNames: [],
+  };
+
+  // Default checkpoint response
+  const defaultCheckpointResponse = {
+    id: testCheckpointId,
+    agentComposeSnapshot: {
+      secretNames: [],
+    },
+  };
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    // Default handlers
+    server.use(
+      http.get("http://localhost:3000/api/agent/composes/:id", () => {
+        return HttpResponse.json(defaultComposeResponse);
+      }),
+      http.post("http://localhost:3000/api/agent/runs", () => {
+        return HttpResponse.json(defaultRunResponse, { status: 201 });
+      }),
+      http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+        return HttpResponse.json(defaultEventsResponse);
+      }),
+      http.get("http://localhost:3000/api/agent/sessions/:id", () => {
+        return HttpResponse.json(defaultSessionResponse);
+      }),
+      http.get("http://localhost:3000/api/agent/checkpoints/:id", () => {
+        return HttpResponse.json(defaultCheckpointResponse);
+      }),
+      // Default npm registry handler - return same version to skip upgrade
+      http.get("https://registry.npmjs.org/*/latest", () => {
+        return HttpResponse.json({ version: "0.0.0-test" });
+      }),
+    );
+
+    // Default spawn mock - succeeds immediately
+    mockSpawn.mockImplementation(() => {
+      return createMockChildProcess(0) as never;
+    });
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("parseVolume", () => {
+    it("should parse name:/path format", () => {
+      const result = parseVolume("my-data:/mnt/data");
+      expect(result).toEqual({ name: "my-data", mountPath: "/mnt/data" });
+    });
+
+    it("should parse name:version:/path format", () => {
+      const result = parseVolume("my-data:abc123:/mnt/data");
+      expect(result).toEqual({
+        name: "my-data",
+        version: "abc123",
+        mountPath: "/mnt/data",
+      });
+    });
+
+    it("should reject input with no mount path", () => {
+      expect(() => {
+        return parseVolume("my-data");
+      }).toThrow(
+        "Invalid volume format: my-data (expected name:/path or name:version:/path)",
+      );
+    });
+
+    it("should reject empty name", () => {
+      expect(() => {
+        return parseVolume(":/mnt/data");
+      }).toThrow("Invalid volume format: :/mnt/data (name cannot be empty)");
+    });
+
+    it("should reject mount path not starting with /", () => {
+      expect(() => {
+        return parseVolume("my-data:abc123:not-a-path");
+      }).toThrow("Invalid volume mount path: not-a-path (must start with /)");
+    });
+
+    it("should reject empty version in 3-part format", () => {
+      expect(() => {
+        return parseVolume("my-data::/mnt/data");
+      }).toThrow(
+        "Invalid volume format: my-data::/mnt/data (version cannot be empty)",
+      );
+    });
+
+    it("should reject too many parts", () => {
+      expect(() => {
+        return parseVolume("a:b:c:d");
+      }).toThrow(
+        "Invalid volume format: a:b:c:d (expected name:/path or name:version:/path)",
+      );
+    });
+  });
+
+  describe("collectVolumes", () => {
+    it("should accumulate volumes into array", () => {
+      let result = collectVolumes("vol-a:/mnt/a", []);
+      result = collectVolumes("vol-b:/mnt/b", result);
+      expect(result).toEqual([
+        { name: "vol-a", mountPath: "/mnt/a" },
+        { name: "vol-b", mountPath: "/mnt/b" },
+      ]);
+    });
+
+    it("should start with empty array", () => {
+      const result = collectVolumes("vol:/mnt/vol", []);
+      expect(result).toEqual([{ name: "vol", mountPath: "/mnt/vol" }]);
+    });
+  });
+
+  describe("run command with --volume", () => {
+    it("should pass single volume to API as additionalVolumes", async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "test prompt",
+        "--artifact-name",
+        "test-artifact",
+        "--volume",
+        "my-data:/mnt/data",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          additionalVolumes: [{ name: "my-data", mountPath: "/mnt/data" }],
+        }),
+      );
+    });
+
+    it("should pass multiple volumes to API", async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "test prompt",
+        "--artifact-name",
+        "test-artifact",
+        "--volume",
+        "vol-a:/mnt/a",
+        "--volume",
+        "vol-b:v2:/mnt/b",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          additionalVolumes: [
+            { name: "vol-a", mountPath: "/mnt/a" },
+            { name: "vol-b", version: "v2", mountPath: "/mnt/b" },
+          ],
+        }),
+      );
+    });
+
+    it("should omit additionalVolumes when not provided", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "test prompt",
+        "--artifact-name",
+        "test-artifact",
+      ]);
+
+      expect(capturedBody?.additionalVolumes).toBeUndefined();
+    });
+
+    it("should work independently with --volume-version", async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "test prompt",
+        "--artifact-name",
+        "test-artifact",
+        "--volume",
+        "dynamic-vol:/mnt/dynamic",
+        "--volume-version",
+        "compose-vol=v2",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          additionalVolumes: [
+            { name: "dynamic-vol", mountPath: "/mnt/dynamic" },
+          ],
+          volumeVersions: { "compose-vol": "v2" },
+        }),
+      );
+    });
+  });
+
+  describe("continue command with --volume", () => {
+    it("should pass volumes to API as additionalVolumes", async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        "continue",
+        testSessionId,
+        "test prompt",
+        "--volume",
+        "extra:/mnt/extra",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          sessionId: testSessionId,
+          additionalVolumes: [{ name: "extra", mountPath: "/mnt/extra" }],
+        }),
+      );
+    });
+
+    it("should omit additionalVolumes when not provided", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        "continue",
+        testSessionId,
+        "test prompt",
+      ]);
+
+      expect(capturedBody?.additionalVolumes).toBeUndefined();
+    });
+  });
+
+  describe("resume command with --volume", () => {
+    it("should pass volumes to API as additionalVolumes", async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        "resume",
+        testCheckpointId,
+        "test prompt",
+        "--volume",
+        "extra:v1:/mnt/extra",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          checkpointId: testCheckpointId,
+          additionalVolumes: [
+            { name: "extra", version: "v1", mountPath: "/mnt/extra" },
+          ],
+        }),
+      );
+    });
+
+    it("should pass multiple volumes to API", async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        "resume",
+        testCheckpointId,
+        "test prompt",
+        "--volume",
+        "vol-a:/mnt/a",
+        "--volume",
+        "vol-b:/mnt/b",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          checkpointId: testCheckpointId,
+          additionalVolumes: [
+            { name: "vol-a", mountPath: "/mnt/a" },
+            { name: "vol-b", mountPath: "/mnt/b" },
+          ],
+        }),
+      );
+    });
+
+    it("should work independently with --volume-version", async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        "resume",
+        testCheckpointId,
+        "test prompt",
+        "--volume",
+        "dynamic:/mnt/dynamic",
+        "--volume-version",
+        "compose-vol=v3",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          checkpointId: testCheckpointId,
+          additionalVolumes: [{ name: "dynamic", mountPath: "/mnt/dynamic" }],
+          volumeVersions: { "compose-vol": "v3" },
+        }),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -2,6 +2,7 @@ import { Command, Option } from "commander";
 import { getSession, createRun } from "../../lib/api";
 import {
   collectKeyValue,
+  collectVolumes,
   isUUID,
   loadValues,
   parseArtifact,
@@ -38,6 +39,12 @@ export const continueCommand = new Command()
   .option(
     "--artifact <name[:version]>",
     "Artifact storage (format: name or name:version)",
+  )
+  .option(
+    "--volume <volume>",
+    "Mount a volume (repeatable, format: name:/path or name:version:/path)",
+    collectVolumes,
+    [],
   )
   .option(
     "--append-system-prompt <text>",
@@ -88,6 +95,7 @@ export const continueCommand = new Command()
           vars: Record<string, string>;
           secrets: Record<string, string>;
           artifact?: string;
+          volume: Array<{ name: string; version?: string; mountPath: string }>;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
           tools?: string[];
@@ -132,6 +140,8 @@ export const continueCommand = new Command()
           secrets: loadedSecrets,
           artifactName: artifactParsed?.artifactName,
           artifactVersion: artifactParsed?.artifactVersion,
+          additionalVolumes:
+            allOpts.volume.length > 0 ? allOpts.volume : undefined,
           appendSystemPrompt:
             options.appendSystemPrompt || allOpts.appendSystemPrompt,
           disallowedTools: options.disallowedTools || allOpts.disallowedTools,

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -3,6 +3,7 @@ import { getCheckpoint, createRun } from "../../lib/api";
 import {
   collectKeyValue,
   collectVolumeVersions,
+  collectVolumes,
   isUUID,
   loadValues,
   parseArtifact,
@@ -43,6 +44,12 @@ export const resumeCommand = new Command()
   .option(
     "--artifact <name[:version]>",
     "Artifact storage (format: name or name:version)",
+  )
+  .option(
+    "--volume <volume>",
+    "Mount a volume (repeatable, format: name:/path or name:version:/path)",
+    collectVolumes,
+    [],
   )
   .option(
     "--append-system-prompt <text>",
@@ -94,6 +101,7 @@ export const resumeCommand = new Command()
           secrets: Record<string, string>;
           volumeVersion: Record<string, string>;
           artifact?: string;
+          volume: Array<{ name: string; version?: string; mountPath: string }>;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
           tools?: string[];
@@ -142,6 +150,8 @@ export const resumeCommand = new Command()
             Object.keys(allOpts.volumeVersion).length > 0
               ? allOpts.volumeVersion
               : undefined,
+          additionalVolumes:
+            allOpts.volume.length > 0 ? allOpts.volume : undefined,
           appendSystemPrompt:
             options.appendSystemPrompt || allOpts.appendSystemPrompt,
           disallowedTools: options.disallowedTools || allOpts.disallowedTools,

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -138,20 +138,25 @@ export const resumeCommand = new Command()
           options.artifact || allOpts.artifact,
         );
 
-        // 5. Call unified API with checkpointId
+        // 5. Prepare optional fields
+        const resolvedVars = Object.keys(vars).length > 0 ? vars : undefined;
+        const volumeVersions =
+          Object.keys(allOpts.volumeVersion).length > 0
+            ? allOpts.volumeVersion
+            : undefined;
+        const additionalVolumes =
+          allOpts.volume.length > 0 ? allOpts.volume : undefined;
+
+        // 6. Call unified API with checkpointId
         const response = await createRun({
           checkpointId,
           prompt,
-          vars: Object.keys(vars).length > 0 ? vars : undefined,
+          vars: resolvedVars,
           secrets: loadedSecrets,
           artifactName: artifactParsed?.artifactName,
           artifactVersion: artifactParsed?.artifactVersion,
-          volumeVersions:
-            Object.keys(allOpts.volumeVersion).length > 0
-              ? allOpts.volumeVersion
-              : undefined,
-          additionalVolumes:
-            allOpts.volume.length > 0 ? allOpts.volume : undefined,
+          volumeVersions,
+          additionalVolumes,
           appendSystemPrompt:
             options.appendSystemPrompt || allOpts.appendSystemPrompt,
           disallowedTools: options.disallowedTools || allOpts.disallowedTools,
@@ -161,7 +166,7 @@ export const resumeCommand = new Command()
             options.permissionPolicies || allOpts.permissionPolicies,
           ),
           debugNoMockClaude:
-            options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,
+            options.debugNoMockClaude || allOpts.debugNoMockClaude,
         });
 
         // 4. Check for immediate failure (e.g., missing secrets)

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -182,7 +182,7 @@ export const mainRunCommand = new Command()
             agentComposeVersionId = versionInfo.versionId;
           } catch (error) {
             throw new Error(`Version not found: ${version}`, {
-              cause: error instanceof Error ? error : undefined,
+              cause: error,
             });
           }
         }
@@ -221,7 +221,15 @@ export const mainRunCommand = new Command()
           );
         }
 
-        // 6. Call unified API (server handles all variable expansion)
+        // 6. Prepare optional fields
+        const volumeVersions =
+          Object.keys(options.volumeVersion).length > 0
+            ? options.volumeVersion
+            : undefined;
+        const additionalVolumes =
+          options.volume.length > 0 ? options.volume : undefined;
+
+        // 7. Call unified API (server handles all variable expansion)
         const response = await createRun({
           // Use agentComposeVersionId if resolved, otherwise use agentComposeId (resolves to HEAD)
           ...(agentComposeVersionId
@@ -233,12 +241,8 @@ export const mainRunCommand = new Command()
           artifactName,
           artifactVersion,
           memoryName: options.memory,
-          volumeVersions:
-            Object.keys(options.volumeVersion).length > 0
-              ? options.volumeVersion
-              : undefined,
-          additionalVolumes:
-            options.volume.length > 0 ? options.volume : undefined,
+          volumeVersions,
+          additionalVolumes,
           conversationId: options.conversation,
           appendSystemPrompt: options.appendSystemPrompt,
           disallowedTools: options.disallowedTools,

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -9,6 +9,7 @@ import {
 import {
   collectKeyValue,
   collectVolumeVersions,
+  collectVolumes,
   isUUID,
   extractVarNames,
   extractSecretNames,
@@ -74,6 +75,12 @@ export const mainRunCommand = new Command()
     collectVolumeVersions,
     {},
   )
+  .option(
+    "--volume <volume>",
+    "Mount a volume (repeatable, format: name:/path or name:version:/path)",
+    collectVolumes,
+    [],
+  )
   .option("--memory <name>", "Memory storage name")
   .option(
     "--conversation <id>",
@@ -120,6 +127,7 @@ export const mainRunCommand = new Command()
           artifactVersion?: string;
           memory?: string;
           volumeVersion: Record<string, string>;
+          volume: Array<{ name: string; version?: string; mountPath: string }>;
           conversation?: string;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
@@ -229,6 +237,8 @@ export const mainRunCommand = new Command()
             Object.keys(options.volumeVersion).length > 0
               ? options.volumeVersion
               : undefined,
+          additionalVolumes:
+            options.volume.length > 0 ? options.volume : undefined,
           conversationId: options.conversation,
           appendSystemPrompt: options.appendSystemPrompt,
           disallowedTools: options.disallowedTools,

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -48,6 +48,66 @@ export function collectVolumeVersions(
 }
 
 /**
+ * Parse Docker-style volume declaration.
+ * Format: "name:/mount/path" (latest) or "name:version:/mount/path" (specific version)
+ *
+ * Parsing rule: split on ':', last segment starts with '/' = mount path,
+ * first = storage name, middle (if present) = version.
+ */
+export function parseVolume(value: string): {
+  name: string;
+  version?: string;
+  mountPath: string;
+} {
+  const parts = value.split(":");
+
+  if (parts.length < 2 || parts.length > 3) {
+    throw new Error(
+      `Invalid volume format: ${value} (expected name:/path or name:version:/path)`,
+    );
+  }
+
+  // After the length check above, parts has exactly 2 or 3 elements
+  const name = parts[0] as string;
+  const mountPath =
+    parts.length === 3 ? (parts[2] as string) : (parts[1] as string);
+
+  if (!name) {
+    throw new Error(`Invalid volume format: ${value} (name cannot be empty)`);
+  }
+
+  if (!mountPath.startsWith("/")) {
+    throw new Error(
+      `Invalid volume mount path: ${mountPath} (must start with /)`,
+    );
+  }
+
+  if (parts.length === 2) {
+    return { name, mountPath };
+  }
+
+  const version = parts[1] as string;
+  if (!version) {
+    throw new Error(
+      `Invalid volume format: ${value} (version cannot be empty)`,
+    );
+  }
+
+  return { name, version, mountPath };
+}
+
+/**
+ * Collector for repeatable --volume flags.
+ * Accumulates into an array of parsed volume objects.
+ */
+export function collectVolumes(
+  value: string,
+  previous: Array<{ name: string; version?: string; mountPath: string }>,
+): Array<{ name: string; version?: string; mountPath: string }> {
+  return [...previous, parseVolume(value)];
+}
+
+/**
  * Parse and validate --permission-policies JSON string.
  * Returns undefined when no value is provided.
  */

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -31,6 +31,12 @@ export async function createRun(body: {
   vars?: Record<string, string>;
   secrets?: Record<string, string>;
   volumeVersions?: Record<string, string>;
+  // Additional volumes passed directly at run time (bypass compose)
+  additionalVolumes?: Array<{
+    name: string;
+    version?: string;
+    mountPath: string;
+  }>;
   // Debug flag (internal use only)
   debugNoMockClaude?: boolean;
   // Capture HTTP request headers, request bodies, and response bodies in network logs


### PR DESCRIPTION
## Summary

- Add `--volume name:/path` and `--volume name:version:/path` Docker-style CLI flag to `vm0 run`, `vm0 run resume`, and `vm0 run continue`
- Parse volume declarations via `parseVolume()` / `collectVolumes()` in shared.ts
- Send parsed volumes as `additionalVolumes` to the API (field added in #9475)

## Changes

| File | Change |
|------|--------|
| `turbo/apps/cli/src/commands/run/shared.ts` | Add `parseVolume()` and `collectVolumes()` parser functions |
| `turbo/apps/cli/src/commands/run/run.ts` | Add `--volume` flag, pass `additionalVolumes` to API |
| `turbo/apps/cli/src/commands/run/resume.ts` | Add `--volume` flag, pass `additionalVolumes` to API |
| `turbo/apps/cli/src/commands/run/continue.ts` | Add `--volume` flag, pass `additionalVolumes` to API |
| `turbo/apps/cli/src/lib/api/domains/runs.ts` | Add `additionalVolumes` to `createRun()` body type |
| `turbo/apps/cli/src/commands/run/__tests__/dynamic-volume.test.ts` | Integration tests (18 tests) |
| `e2e/tests/03-runner/t49-vm0-dynamic-volume.bats` | E2E tests (4 tests) |

## Test plan

- [x] `parseVolume()` correctly handles `name:/path` and `name:version:/path` formats
- [x] Invalid formats produce clear error messages (no name, no mount path, bad path, empty version)
- [x] `collectVolumes()` accumulates multiple volumes into array
- [x] `--volume` flag sends `additionalVolumes` to API for run/resume/continue commands
- [x] `--volume` and `--volume-version` work independently together
- [x] Omitting `--volume` does not send `additionalVolumes` to API
- [x] All 149 existing run command tests pass (no regressions)
- [x] Lint, typecheck, format, knip all pass
- [ ] E2E tests verify dynamic mount (latest), specific version, and multiple volumes

Closes #9476

🤖 Generated with [Claude Code](https://claude.com/claude-code)