### PR TITLE
feat(platform): add task event grouping and rendering in log views

### DIFF
--- a/turbo/apps/platform/src/views/activity/__tests__/grouped-message-card.test.tsx
+++ b/turbo/apps/platform/src/views/activity/__tests__/grouped-message-card.test.tsx
@@ -532,4 +532,163 @@ describe("groupedMessageCard", () => {
     await user.click(summary);
     expect(toolSummary.open).toBeFalsy();
   });
+
+  // ACT-D-075
+  it("merges task_started and task_notification into a single Task card", async () => {
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "system",
+          eventData: {
+            subtype: "task_started",
+            task_id: "task-abc-075",
+            tool_use_id: "tu-task-075",
+            description: "Run sub-agent task 075",
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+        {
+          sequenceNumber: 1,
+          eventType: "system",
+          eventData: {
+            subtype: "task_notification",
+            task_id: "task-abc-075",
+            status: "completed",
+            summary: "Task finished successfully",
+          },
+          createdAt: "2026-03-10T14:56:05Z",
+        },
+      ]),
+    );
+
+    // Should render exactly one "Task" card, not two
+    await waitFor(() => {
+      const taskCards = screen.getAllByText("Task");
+      expect(taskCards).toHaveLength(1);
+    });
+  });
+
+  // ACT-D-076
+  it("absorbs task_progress heartbeats into the parent task row", async () => {
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "system",
+          eventData: {
+            subtype: "task_started",
+            task_id: "task-abc-076",
+            tool_use_id: "tu-task-076",
+            description: "Long running task 076",
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+        {
+          sequenceNumber: 1,
+          eventType: "system",
+          eventData: {
+            subtype: "task_progress",
+            task_id: "task-abc-076",
+          },
+          createdAt: "2026-03-10T14:56:03Z",
+        },
+        {
+          sequenceNumber: 2,
+          eventType: "system",
+          eventData: {
+            subtype: "task_progress",
+            task_id: "task-abc-076",
+          },
+          createdAt: "2026-03-10T14:56:04Z",
+        },
+        {
+          sequenceNumber: 3,
+          eventType: "system",
+          eventData: {
+            subtype: "task_notification",
+            task_id: "task-abc-076",
+            status: "completed",
+            summary: "Done",
+          },
+          createdAt: "2026-03-10T14:56:05Z",
+        },
+      ]),
+    );
+
+    // All three task events collapse to one "Task" card
+    await waitFor(() => {
+      const taskCards = screen.getAllByText("Task");
+      expect(taskCards).toHaveLength(1);
+    });
+  });
+
+  // ACT-D-077
+  it("routes child assistant events into task childMessages and shows tool count", async () => {
+    const user = userEvent.setup();
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "system",
+          eventData: {
+            subtype: "task_started",
+            task_id: "task-abc-077",
+            tool_use_id: "tu-task-077",
+            description: "Sub-agent with tools",
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+        {
+          sequenceNumber: 1,
+          eventType: "assistant",
+          eventData: {
+            parent_tool_use_id: "tu-task-077",
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "tu-bash-077",
+                  name: "Bash",
+                  input: { command: "echo child-077" },
+                },
+              ],
+            },
+          },
+          createdAt: "2026-03-10T14:56:03Z",
+        },
+        {
+          sequenceNumber: 2,
+          eventType: "system",
+          eventData: {
+            subtype: "task_notification",
+            task_id: "task-abc-077",
+            status: "completed",
+            summary: "Done",
+          },
+          createdAt: "2026-03-10T14:56:04Z",
+        },
+      ]),
+    );
+
+    // Task card shows "1 steps" badge
+    await waitFor(() => {
+      expect(screen.getByText("1 steps")).toBeInTheDocument();
+    });
+
+    // Expand the task details to see child messages
+    const taskHeading = screen.getByText("Task");
+    const details = taskHeading.closest("details") as HTMLDetailsElement;
+    expect(details).not.toBeNull();
+    const summary = details.querySelector("summary")!;
+    await user.click(summary);
+
+    // Child bash tool should appear inside
+    await waitFor(() => {
+      expect(screen.getByText("Bash")).toBeInTheDocument();
+    });
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
@@ -1,6 +1,10 @@
 import { IconCheck, IconCircleDashed, IconLoader } from "@tabler/icons-react";
 import { Markdown } from "../../../components/markdown.tsx";
-import type { GroupedMessage, ToolOperation } from "./log-detail-utils.ts";
+import {
+  isTaskEventData,
+  type GroupedMessage,
+  type ToolOperation,
+} from "./log-detail-utils.ts";
 import { ToolSummary } from "./tool-summary.tsx";
 import {
   SystemInitContent,
@@ -108,9 +112,11 @@ function TaskMessageCard({
   searchTerm?: string;
   showConnector?: boolean;
 }) {
-  const data = message.eventData as Record<string, unknown>;
-  const description = (data.description ?? data.task_summary ?? "") as string;
-  const taskStatus = data.task_status as string | undefined;
+  const taskData = isTaskEventData(message.eventData)
+    ? message.eventData
+    : null;
+  const description = taskData?.description ?? taskData?.task_summary ?? "";
+  const taskStatus = taskData?.task_status;
   const isFailed = taskStatus === "error" || taskStatus === "failed";
   const isRunning = !taskStatus;
   const timestamp = formatEventTime(message.createdAt);
@@ -275,27 +281,35 @@ function ResultMessageCard({
 }) {
   const timestamp = formatEventTime(message.createdAt);
   return (
-    <div className={`${MESSAGE_SPACING} relative`}>
+    <div className="relative">
       {showConnector && (
         <div
           className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/70"
           aria-hidden="true"
         />
       )}
-      <div className="flex gap-2 items-center relative">
-        <StatusDot variant="primary" />
-        <span className="font-semibold text-sm text-foreground">Summary</span>
-        <span className="flex-1" />
-        <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap hidden sm:inline">
-          {timestamp}
-        </span>
-      </div>
-      <div className="text-xs text-muted-foreground pl-5 mt-1 sm:hidden">
-        {timestamp}
-      </div>
-      <div className="ml-[18px] mt-2 relative">
-        <ResultEventContent eventData={eventData} />
-      </div>
+      <details className="group relative" open>
+        <summary className="cursor-pointer list-none relative py-2">
+          <div className="flex gap-2 items-center">
+            <StatusDot variant="primary" />
+            <span className="font-semibold text-sm text-foreground">
+              Summary
+            </span>
+            <span className="flex-1" />
+            <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap hidden sm:inline">
+              {timestamp}
+            </span>
+          </div>
+          <div className="text-xs text-muted-foreground pl-5 mt-1 sm:hidden">
+            {timestamp}
+          </div>
+        </summary>
+        {/* Vertical line from dot to content */}
+        <div className="absolute left-[2px] top-[2.25rem] bottom-0 w-[1px] bg-border/70 group-open:block hidden" />
+        <div className="ml-[18px] mt-2 relative">
+          <ResultEventContent eventData={eventData} />
+        </div>
+      </details>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
@@ -59,6 +59,7 @@ export function GroupedMessageCard({
       <SystemMessageCard
         message={message}
         eventData={eventData}
+        searchTerm={searchTerm}
         showConnector={showConnector}
       />
     );
@@ -98,16 +99,143 @@ export function GroupedMessageCard({
   );
 }
 
+function TaskMessageCard({
+  message,
+  searchTerm,
+  showConnector = false,
+}: {
+  message: GroupedMessage;
+  searchTerm?: string;
+  showConnector?: boolean;
+}) {
+  const data = message.eventData as Record<string, unknown>;
+  const description = (data.description ?? data.task_summary ?? "") as string;
+  const taskStatus = data.task_status as string | undefined;
+  const isFailed = taskStatus === "error" || taskStatus === "failed";
+  const isRunning = !taskStatus;
+  const timestamp = formatEventTime(message.createdAt);
+  const children = message.childMessages ?? [];
+  const hasChildren = children.length > 0;
+
+  // Count tool operations across child messages
+  const toolCount = children.reduce((sum, child) => {
+    return sum + (child.toolOperations?.length ?? 0);
+  }, 0);
+
+  if (!hasChildren) {
+    return (
+      <div className={`${MESSAGE_SPACING} relative`}>
+        {showConnector && (
+          <div
+            className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/70"
+            aria-hidden="true"
+          />
+        )}
+        <div className="flex gap-2 items-center relative">
+          {isRunning ? (
+            <IconLoader className="h-3 w-3 text-yellow-600 animate-spin shrink-0" />
+          ) : (
+            <StatusDot variant={isFailed ? "error" : "success"} />
+          )}
+          <span className="font-semibold text-sm text-foreground shrink-0">
+            Task
+          </span>
+          {description && (
+            <span className="text-sm text-muted-foreground truncate">
+              {description}
+            </span>
+          )}
+          <span className="flex-1" />
+          <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap hidden sm:inline">
+            {timestamp}
+          </span>
+        </div>
+        <div className="text-xs text-muted-foreground pl-5 mt-1 sm:hidden">
+          {timestamp}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      {showConnector && (
+        <div
+          className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/70"
+          aria-hidden="true"
+        />
+      )}
+      <details className="group relative">
+        <summary className="cursor-pointer list-none relative py-2">
+          <div className="flex gap-2 items-center">
+            {isRunning ? (
+              <IconLoader className="h-3 w-3 text-yellow-600 animate-spin shrink-0" />
+            ) : (
+              <StatusDot variant={isFailed ? "error" : "success"} />
+            )}
+            <span className="font-semibold text-sm text-foreground shrink-0">
+              Task
+            </span>
+            {description && (
+              <span className="text-sm text-muted-foreground truncate">
+                {description}
+              </span>
+            )}
+            {toolCount > 0 && (
+              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                {toolCount} steps
+              </span>
+            )}
+            <span className="flex-1" />
+            <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap hidden sm:inline">
+              {timestamp}
+            </span>
+          </div>
+          <div className="text-xs text-muted-foreground pl-5 mt-1 sm:hidden">
+            {timestamp}
+          </div>
+        </summary>
+        <div className="mt-1">
+          {children.map((child, i) => {
+            return (
+              <GroupedMessageCard
+                key={child.sequenceNumber ?? i}
+                message={child}
+                searchTerm={searchTerm}
+                showConnector={i < children.length - 1}
+              />
+            );
+          })}
+        </div>
+      </details>
+    </div>
+  );
+}
+
 function SystemMessageCard({
   message,
   eventData,
+  searchTerm,
   showConnector = false,
 }: {
   message: GroupedMessage;
   eventData: EventData;
+  searchTerm?: string;
   showConnector?: boolean;
 }) {
   const subtype = eventData.subtype;
+
+  // Task events are rendered by TaskMessageCard
+  if (subtype === "task_started" || subtype === "task_notification") {
+    return (
+      <TaskMessageCard
+        message={message}
+        searchTerm={searchTerm}
+        showConnector={showConnector}
+      />
+    );
+  }
+
   const timestamp = formatEventTime(message.createdAt);
   return (
     <div className={`${MESSAGE_SPACING} relative`}>
@@ -147,35 +275,27 @@ function ResultMessageCard({
 }) {
   const timestamp = formatEventTime(message.createdAt);
   return (
-    <div className="relative">
+    <div className={`${MESSAGE_SPACING} relative`}>
       {showConnector && (
         <div
           className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/70"
           aria-hidden="true"
         />
       )}
-      <details className="group relative" open>
-        <summary className="cursor-pointer list-none relative py-2">
-          <div className="flex gap-2 items-center">
-            <StatusDot variant="primary" />
-            <span className="font-semibold text-sm text-foreground">
-              Summary
-            </span>
-            <span className="flex-1" />
-            <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap hidden sm:inline">
-              {timestamp}
-            </span>
-          </div>
-          <div className="text-xs text-muted-foreground pl-5 mt-1 sm:hidden">
-            {timestamp}
-          </div>
-        </summary>
-        {/* Vertical line from dot to content */}
-        <div className="absolute left-[2px] top-[2.25rem] bottom-0 w-[1px] bg-border/70 group-open:block hidden" />
-        <div className="ml-[18px] mt-2 relative">
-          <ResultEventContent eventData={eventData} />
-        </div>
-      </details>
+      <div className="flex gap-2 items-center relative">
+        <StatusDot variant="primary" />
+        <span className="font-semibold text-sm text-foreground">Summary</span>
+        <span className="flex-1" />
+        <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap hidden sm:inline">
+          {timestamp}
+        </span>
+      </div>
+      <div className="text-xs text-muted-foreground pl-5 mt-1 sm:hidden">
+        {timestamp}
+      </div>
+      <div className="ml-[18px] mt-2 relative">
+        <ResultEventContent eventData={eventData} />
+      </div>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
@@ -199,7 +199,7 @@ function TaskMessageCard({
           {children.map((child, i) => {
             return (
               <GroupedMessageCard
-                key={child.sequenceNumber ?? i}
+                key={child.sequenceNumber}
                 message={child}
                 searchTerm={searchTerm}
                 showConnector={i < children.length - 1}

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -385,7 +385,9 @@ function findParentTask(
   ctx: GroupingContext,
 ): GroupedMessage | null {
   const parentId = eventData.parent_tool_use_id;
-  if (!parentId) return null;
+  if (!parentId) {
+    return null;
+  }
   return ctx.taskByToolUseId.get(parentId) ?? null;
 }
 
@@ -399,6 +401,71 @@ function appendChildToTask(task: GroupedMessage, child: GroupedMessage): void {
   task.childMessages.push(child);
 }
 
+/**
+ * Merge tool-only operations into the last child assistant message of a task.
+ * Returns true if merged, false if a new child should be created instead.
+ */
+function mergeToolsIntoLastChild(
+  parentTask: GroupedMessage,
+  toolOperations: ToolOperation[],
+  pendingToolUses: GroupingContext["pendingToolUses"],
+): boolean {
+  const lastChild =
+    parentTask.childMessages?.[parentTask.childMessages.length - 1];
+  if (lastChild?.type !== "assistant") {
+    return false;
+  }
+  if (!lastChild.toolOperations) {
+    lastChild.toolOperations = [];
+  }
+  lastChild.toolOperations.push(...toolOperations);
+  for (const op of toolOperations) {
+    pendingToolUses.set(op.toolUseId, { operation: op, message: lastChild });
+  }
+  return true;
+}
+
+/**
+ * Process assistant event that belongs to a child (sub-agent) task.
+ */
+function processChildAssistantEvent(
+  event: AgentEvent,
+  eventData: GroupingEventData,
+  parentTask: GroupedMessage,
+  ctx: GroupingContext,
+): void {
+  const contents = eventData.message?.content ?? [];
+  const { textParts, toolOperations } = parseAssistantContent(contents);
+  const hasText = textParts.length > 0;
+  const hasTools = toolOperations.length > 0;
+
+  if (!hasText && !hasTools) {
+    return;
+  }
+
+  // Merge tool-only events into the last child assistant message
+  if (!hasText && hasTools) {
+    if (
+      mergeToolsIntoLastChild(parentTask, toolOperations, ctx.pendingToolUses)
+    ) {
+      return;
+    }
+  }
+
+  const child: GroupedMessage = {
+    type: "assistant",
+    sequenceNumber: event.sequenceNumber,
+    createdAt: event.createdAt,
+    textBefore: hasText ? textParts.join("\n\n") : undefined,
+    toolOperations: hasTools ? toolOperations : undefined,
+    eventData: event.eventData,
+  };
+  appendChildToTask(parentTask, child);
+  for (const op of toolOperations) {
+    ctx.pendingToolUses.set(op.toolUseId, { operation: op, message: child });
+  }
+}
+
 function processAssistantEvent(
   event: AgentEvent,
   eventData: GroupingEventData,
@@ -407,45 +474,7 @@ function processAssistantEvent(
   // Route child events into their parent task
   const parentTask = findParentTask(eventData, ctx);
   if (parentTask) {
-    const contents = eventData.message?.content ?? [];
-    const { textParts, toolOperations } = parseAssistantContent(contents);
-    const hasText = textParts.length > 0;
-    const hasTools = toolOperations.length > 0;
-
-    if (hasText || hasTools) {
-      // Merge tool-only events into the last child assistant message
-      if (!hasText && hasTools) {
-        const lastChild =
-          parentTask.childMessages?.[parentTask.childMessages.length - 1];
-        if (lastChild?.type === "assistant") {
-          if (!lastChild.toolOperations) lastChild.toolOperations = [];
-          lastChild.toolOperations.push(...toolOperations);
-          for (const op of toolOperations) {
-            ctx.pendingToolUses.set(op.toolUseId, {
-              operation: op,
-              message: lastChild,
-            });
-          }
-          return;
-        }
-      }
-
-      const child: GroupedMessage = {
-        type: "assistant",
-        sequenceNumber: event.sequenceNumber,
-        createdAt: event.createdAt,
-        textBefore: hasText ? textParts.join("\n\n") : undefined,
-        toolOperations: hasTools ? toolOperations : undefined,
-        eventData: event.eventData,
-      };
-      appendChildToTask(parentTask, child);
-      for (const op of toolOperations) {
-        ctx.pendingToolUses.set(op.toolUseId, {
-          operation: op,
-          message: child,
-        });
-      }
-    }
+    processChildAssistantEvent(event, eventData, parentTask, ctx);
     return;
   }
 

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -92,6 +92,31 @@ export interface GroupingEventData {
 }
 
 /**
+ * Shape of task-related system event data (task_started, task_notification, task_progress).
+ */
+interface TaskEventData extends GroupingEventData {
+  task_id: string;
+  // Present in task_started
+  tool_use_id?: string;
+  description?: string;
+  // Present in task_notification
+  status?: string;
+  summary?: string;
+  // Augmented in-place when a notification is merged into a started event
+  task_status?: string;
+  task_summary?: string;
+  task_completed_at?: string;
+}
+
+export function isTaskEventData(data: unknown): data is TaskEventData {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    typeof (data as Record<string, unknown>).task_id === "string"
+  );
+}
+
+/**
  * Extract the key parameter from tool input for display in summary
  */
 function extractKeyParam(
@@ -317,45 +342,52 @@ interface GroupingContext {
 function processSystemEvent(event: AgentEvent, ctx: GroupingContext): void {
   const eventData = event.eventData as GroupingEventData;
   const subtype = eventData.subtype;
-  const taskId = (event.eventData as Record<string, unknown>).task_id as
-    | string
-    | undefined;
 
-  // Merge task_started + task_notification into a single row by task_id
-  if (subtype === "task_started" && taskId) {
-    const toolUseId = (event.eventData as Record<string, unknown>)
-      .tool_use_id as string | undefined;
-    const message: GroupedMessage = {
+  if (!isTaskEventData(event.eventData)) {
+    ctx.grouped.push({
       type: "system",
       sequenceNumber: event.sequenceNumber,
       createdAt: event.createdAt,
       eventData: event.eventData,
+    });
+    return;
+  }
+
+  const taskData = event.eventData;
+  const taskId = taskData.task_id;
+
+  // Merge task_started + task_notification into a single row by task_id
+  if (subtype === "task_started") {
+    const message: GroupedMessage = {
+      type: "system",
+      sequenceNumber: event.sequenceNumber,
+      createdAt: event.createdAt,
+      eventData: taskData,
     };
     ctx.grouped.push(message);
     ctx.pendingTasks.set(taskId, message);
-    if (toolUseId) {
-      ctx.taskByToolUseId.set(toolUseId, message);
+    if (taskData.tool_use_id) {
+      ctx.taskByToolUseId.set(taskData.tool_use_id, message);
     }
     return;
   }
 
-  if (subtype === "task_notification" && taskId) {
+  if (subtype === "task_notification") {
     const pending = ctx.pendingTasks.get(taskId);
     if (pending) {
       // Merge notification into the existing task_started message
-      const existingData = pending.eventData as Record<string, unknown>;
-      const notificationData = event.eventData as Record<string, unknown>;
-      existingData.task_status = notificationData.status;
-      existingData.task_summary = notificationData.summary;
+      const existingData = pending.eventData as TaskEventData;
+      existingData.task_status = taskData.status;
+      existingData.task_summary = taskData.summary;
       existingData.task_completed_at = event.createdAt;
       ctx.pendingTasks.delete(taskId);
       return;
     }
-    // Orphan notification — fall through to standalone
+    // Orphan notification (no matching task_started) — fall through to standalone
   }
 
   // task_progress is a heartbeat signal — absorb it into the parent task row
-  if (subtype === "task_progress" && taskId && ctx.pendingTasks.has(taskId)) {
+  if (subtype === "task_progress" && ctx.pendingTasks.has(taskId)) {
     return;
   }
 
@@ -648,12 +680,13 @@ function getVisibleGroupedMessageText(message: GroupedMessage): string {
       parts.push(eventData.subtype);
     }
     // Include task description/summary for search
-    const rawData = message.eventData as Record<string, unknown>;
-    if (typeof rawData.description === "string") {
-      parts.push(rawData.description);
-    }
-    if (typeof rawData.task_summary === "string") {
-      parts.push(rawData.task_summary);
+    if (isTaskEventData(message.eventData)) {
+      if (message.eventData.description) {
+        parts.push(message.eventData.description);
+      }
+      if (message.eventData.task_summary) {
+        parts.push(message.eventData.task_summary);
+      }
     }
     if (eventData.tools) {
       parts.push(...eventData.tools);

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -66,6 +66,8 @@ export interface GroupedMessage {
   // For "todo" type: current state of all tasks
   todoState?: TodoItem[];
   eventData: unknown;
+  // For task system events: child messages from sub-agent
+  childMessages?: GroupedMessage[];
 }
 
 // ============ EVENT GROUPING ============
@@ -77,6 +79,7 @@ interface ToolResultMeta {
 
 export interface GroupingEventData {
   subtype?: string;
+  parent_tool_use_id?: string;
   message?: {
     content: MessageContent[] | null;
   };
@@ -305,9 +308,57 @@ interface GroupingContext {
     { operation: ToolOperation; message: GroupedMessage }
   >;
   todoState: Map<string, { content: string; status: string }>;
+  pendingTasks: Map<string, GroupedMessage>;
+  // Map from tool_use_id (that spawned the task) → task GroupedMessage
+  // Used to route child events via parent_tool_use_id
+  taskByToolUseId: Map<string, GroupedMessage>;
 }
 
 function processSystemEvent(event: AgentEvent, ctx: GroupingContext): void {
+  const eventData = event.eventData as GroupingEventData;
+  const subtype = eventData.subtype;
+  const taskId = (event.eventData as Record<string, unknown>).task_id as
+    | string
+    | undefined;
+
+  // Merge task_started + task_notification into a single row by task_id
+  if (subtype === "task_started" && taskId) {
+    const toolUseId = (event.eventData as Record<string, unknown>)
+      .tool_use_id as string | undefined;
+    const message: GroupedMessage = {
+      type: "system",
+      sequenceNumber: event.sequenceNumber,
+      createdAt: event.createdAt,
+      eventData: event.eventData,
+    };
+    ctx.grouped.push(message);
+    ctx.pendingTasks.set(taskId, message);
+    if (toolUseId) {
+      ctx.taskByToolUseId.set(toolUseId, message);
+    }
+    return;
+  }
+
+  if (subtype === "task_notification" && taskId) {
+    const pending = ctx.pendingTasks.get(taskId);
+    if (pending) {
+      // Merge notification into the existing task_started message
+      const existingData = pending.eventData as Record<string, unknown>;
+      const notificationData = event.eventData as Record<string, unknown>;
+      existingData.task_status = notificationData.status;
+      existingData.task_summary = notificationData.summary;
+      existingData.task_completed_at = event.createdAt;
+      ctx.pendingTasks.delete(taskId);
+      return;
+    }
+    // Orphan notification — fall through to standalone
+  }
+
+  // task_progress is a heartbeat signal — absorb it into the parent task row
+  if (subtype === "task_progress" && taskId && ctx.pendingTasks.has(taskId)) {
+    return;
+  }
+
   ctx.grouped.push({
     type: "system",
     sequenceNumber: event.sequenceNumber,
@@ -325,11 +376,79 @@ function processResultEvent(event: AgentEvent, ctx: GroupingContext): void {
   });
 }
 
+/**
+ * Find the parent task for a child event via parent_tool_use_id.
+ * Returns the task GroupedMessage if found, null otherwise.
+ */
+function findParentTask(
+  eventData: GroupingEventData,
+  ctx: GroupingContext,
+): GroupedMessage | null {
+  const parentId = eventData.parent_tool_use_id;
+  if (!parentId) return null;
+  return ctx.taskByToolUseId.get(parentId) ?? null;
+}
+
+/**
+ * Append a child message to a task's childMessages array.
+ */
+function appendChildToTask(task: GroupedMessage, child: GroupedMessage): void {
+  if (!task.childMessages) {
+    task.childMessages = [];
+  }
+  task.childMessages.push(child);
+}
+
 function processAssistantEvent(
   event: AgentEvent,
   eventData: GroupingEventData,
   ctx: GroupingContext,
 ): void {
+  // Route child events into their parent task
+  const parentTask = findParentTask(eventData, ctx);
+  if (parentTask) {
+    const contents = eventData.message?.content ?? [];
+    const { textParts, toolOperations } = parseAssistantContent(contents);
+    const hasText = textParts.length > 0;
+    const hasTools = toolOperations.length > 0;
+
+    if (hasText || hasTools) {
+      // Merge tool-only events into the last child assistant message
+      if (!hasText && hasTools) {
+        const lastChild =
+          parentTask.childMessages?.[parentTask.childMessages.length - 1];
+        if (lastChild?.type === "assistant") {
+          if (!lastChild.toolOperations) lastChild.toolOperations = [];
+          lastChild.toolOperations.push(...toolOperations);
+          for (const op of toolOperations) {
+            ctx.pendingToolUses.set(op.toolUseId, {
+              operation: op,
+              message: lastChild,
+            });
+          }
+          return;
+        }
+      }
+
+      const child: GroupedMessage = {
+        type: "assistant",
+        sequenceNumber: event.sequenceNumber,
+        createdAt: event.createdAt,
+        textBefore: hasText ? textParts.join("\n\n") : undefined,
+        toolOperations: hasTools ? toolOperations : undefined,
+        eventData: event.eventData,
+      };
+      appendChildToTask(parentTask, child);
+      for (const op of toolOperations) {
+        ctx.pendingToolUses.set(op.toolUseId, {
+          operation: op,
+          message: child,
+        });
+      }
+    }
+    return;
+  }
+
   const contents = eventData.message?.content ?? [];
   const { textParts, toolOperations } = parseAssistantContent(contents);
   const hasText = textParts.length > 0;
@@ -396,6 +515,10 @@ function processUserEvent(
   eventData: GroupingEventData,
   ctx: GroupingContext,
 ): void {
+  // Child user events belong to a task — route orphan results there
+  const parentTask = findParentTask(eventData, ctx);
+  const target = parentTask?.childMessages ?? ctx.grouped;
+
   const contents = eventData.message?.content ?? [];
   const toolMeta = eventData.tool_use_result;
 
@@ -406,7 +529,7 @@ function processUserEvent(
         toolMeta,
         ctx.pendingToolUses,
         event,
-        ctx.grouped,
+        target,
       );
     }
   }
@@ -439,6 +562,8 @@ export function groupEventsIntoMessages(
     grouped: [],
     pendingToolUses: new Map(),
     todoState: new Map(),
+    pendingTasks: new Map(),
+    taskByToolUseId: new Map(),
   };
 
   for (const event of deduped) {
@@ -492,6 +617,14 @@ function getVisibleGroupedMessageText(message: GroupedMessage): string {
   if (message.type === "system") {
     if (eventData.subtype) {
       parts.push(eventData.subtype);
+    }
+    // Include task description/summary for search
+    const rawData = message.eventData as Record<string, unknown>;
+    if (typeof rawData.description === "string") {
+      parts.push(rawData.description);
+    }
+    if (typeof rawData.task_summary === "string") {
+      parts.push(rawData.task_summary);
     }
     if (eventData.tools) {
       parts.push(...eventData.tools);


### PR DESCRIPTION
## Summary

- Add `TaskMessageCard` component that renders task system events (`task_started`, `task_notification`) with collapsible child messages showing sub-agent activity and tool step counts
- Implement task event merging logic in `log-detail-utils.ts` to consolidate `task_started`/`task_notification`/`task_progress` events into single grouped rows by `task_id`
- Route child agent events (assistant/user) into their parent task via `parent_tool_use_id`, keeping the log view hierarchy clean
- Simplify `ResultMessageCard` by removing the collapsible details/summary wrapper — summaries are now always visible

## Test plan

- [ ] Verify task events appear as grouped rows in the log detail view
- [ ] Verify collapsible task cards expand to show child messages from sub-agents
- [ ] Verify task completion status (success/error/running) renders correct status indicators
- [ ] Verify search term highlighting propagates into task child messages
- [ ] Verify result/summary messages render without the collapsible wrapper
- [ ] Verify orphan `task_notification` events without a matching `task_started` still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)