### PR TITLE
fix(runner): write systemd unit file atomically via tmp + rename

### DIFF
--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -239,10 +239,25 @@ async fn run_systemctl(args: &[&str]) -> RunnerResult<()> {
     Ok(())
 }
 
-/// Write a unit file directly (running as root).
+/// Write a unit file atomically: stage to a sibling `.tmp` file, then rename.
+///
+/// `rename(2)` is atomic on the same filesystem, so a concurrent
+/// `systemctl daemon-reload` (possibly triggered by unrelated unit changes
+/// on the host) sees either the old file or the new file — never a
+/// half-written one. Without this, the truncate+write window inside
+/// `std::fs::write` could let systemd parse a partial unit file and leave
+/// the unit in a broken state. Same pattern as `status::write_status`.
 fn write_unit_file(path: &Path, content: &str) -> RunnerResult<()> {
-    std::fs::write(path, content)
-        .map_err(|e| RunnerError::Internal(format!("write {}: {e}", path.display())))
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, content)
+        .map_err(|e| RunnerError::Internal(format!("write {}: {e}", tmp.display())))?;
+    std::fs::rename(&tmp, path).map_err(|e| {
+        RunnerError::Internal(format!(
+            "rename {} -> {}: {e}",
+            tmp.display(),
+            path.display()
+        ))
+    })
 }
 
 /// Check whether a systemd unit is active (running or activating).
@@ -881,6 +896,41 @@ mod tests {
         assert!(validate_env_vars(&["KEY=line1\nline2".to_string()]).is_err());
         assert!(validate_env_vars(&["KEY=foo\rbar".to_string()]).is_err());
         assert!(validate_env_vars(&["KEY=with\0nul".to_string()]).is_err());
+    }
+
+    #[test]
+    fn write_unit_file_creates_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm0-runner-test.service");
+        write_unit_file(&path, "[Unit]\nDescription=test\n").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "[Unit]\nDescription=test\n"
+        );
+    }
+
+    #[test]
+    fn write_unit_file_overwrites_existing() {
+        // Verifies the rename step replaces an existing file rather than
+        // failing — POSIX rename(2) over an existing file is the atomic
+        // swap we rely on for race-free updates.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm0-runner-test.service");
+        std::fs::write(&path, "old content").unwrap();
+        write_unit_file(&path, "new content").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new content");
+    }
+
+    #[test]
+    fn write_unit_file_does_not_leave_tmp_on_success() {
+        // The tmp file is consumed by the rename — it must not be left
+        // behind on disk. A residual `.tmp` would not be loaded by
+        // systemd (wrong suffix) but would clutter the unit directory.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm0-runner-test.service");
+        write_unit_file(&path, "content").unwrap();
+        let tmp = path.with_extension("tmp");
+        assert!(!tmp.exists(), "tmp file must be consumed by rename");
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

`write_unit_file` used `std::fs::write`, which truncates and writes the target in-place. A concurrent `systemctl daemon-reload` (possibly triggered by unrelated unit changes on the host) could read a half-written file mid-truncate and leave the unit in a broken state even though the install logic thought it succeeded.

Stage the content to a sibling `.tmp` file and `rename(2)` into place. `rename` is atomic on the same filesystem, so `daemon-reload` either sees the old file or the new file — never a partial one.

Closes #9471

## Why this approach

`crates/runner/src/status.rs:122-153` already uses the exact same pattern (`with_extension("tmp")` + `rename`) for atomic `status.json` writes. Reusing the established pattern means:
- No new dependency (this PR doesn't add anything to `Cargo.toml`)
- No new abstraction
- Reviewer doesn't need to re-evaluate "tempfile crate vs hand-rolled"

Considered and rejected:
- **`fsync(file) + fsync(parent_dir)`**: this is crash safety; the issue is about race safety. systemd itself does not require unit-file crash durability.
- **`tempfile::NamedTempFile` with random suffix**: would handle "two concurrent same-name installs racing on the same `.tmp` path", but that case is already a user/automation error and `status.rs` doesn't bother either.
- **best-effort cleanup of tmp on rename failure**: `status.rs` doesn't do it; the next install overwrites the residual `.tmp` anyway, and systemd ignores files without a `.service` suffix.

## Tests

Three new tests using `tempfile::tempdir()`:
- `write_unit_file_creates_target` — basic write
- `write_unit_file_overwrites_existing` — verifies rename-over-existing works (the atomic swap we depend on)
- `write_unit_file_does_not_leave_tmp_on_success` — guards against future regressions where the tmp is leaked

Error paths (write/rename failures) are not unit-tested — they would require fs mocking and the underlying error mapping is trivial.

All 31 service.rs tests pass.

## Test plan

- [x] `cargo test -p runner --bin runner cmd::service::` — all pass
- [x] `cargo fmt -p runner -- --check` — clean
- [x] `cargo clippy -p runner --bin runner -- -D warnings` — clean
- [ ] CI runs full crate suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)