### PR TITLE
fix: restore og:image and twitter:card on homepage

### DIFF
--- a/turbo/apps/web/app/[locale]/layout.tsx
+++ b/turbo/apps/web/app/[locale]/layout.tsx
@@ -58,6 +58,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
       ],
     },
     twitter: {
+      card: "summary_large_image",
       images: ["/og-image.png"],
     },
   };

--- a/turbo/apps/web/app/[locale]/page.tsx
+++ b/turbo/apps/web/app/[locale]/page.tsx
@@ -26,11 +26,21 @@ export async function generateMetadata({
       description:
         "Meet Zero, your AI teammate that runs in secure microVMs. Automate workflows in Slack, GitHub, and the web — with isolated execution, audit trails, and full transparency.",
       url,
+      images: [
+        {
+          url: "/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: "VM0 - Your Trustworthy AI Teammate",
+        },
+      ],
     },
     twitter: {
+      card: "summary_large_image",
       title: "VM0 - Your Trustworthy AI Teammate",
       description:
         "Meet Zero, your AI teammate that runs in secure microVMs. Automate workflows in Slack, GitHub, and the web.",
+      images: ["/og-image.png"],
     },
   };
 }


### PR DESCRIPTION
## Problem

The vm0.ai homepage link preview on X/Twitter is broken — no image shows up.

**Root cause**: In Next.js App Router, defining any property of a nested metadata object (`openGraph`, `twitter`) in a child page/layout **completely replaces** the parent's version of that object — it does not do a deep merge. The homepage `[locale]/page.tsx` defined `openGraph` without `images` and `twitter` without `card` or `images`, silently dropping those from the parent `layout.tsx`.

This resulted in no `og:image` tag and `twitter:card: "summary"` being rendered instead of `summary_large_image`.

## Fix

- `[locale]/page.tsx`: add `images` to `openGraph`, add `card: "summary_large_image"` + `images` to `twitter`
- `[locale]/layout.tsx`: add `card: "summary_large_image"` to the `twitter` fallback

## Test

After deploy, verify with:
```
curl -sS "https://www.vm0.ai/en" | grep -E "og:image|twitter:card"
```

Expected:
```
<meta property="og:image" content="https://www.vm0.ai/og-image.png"/>
<meta name="twitter:card" content="summary_large_image"/>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)