### PR TITLE
feat(runner): observe per-call x api connector usage in mitmproxy addon

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -20,6 +20,13 @@ from mitmproxy import ctx, http
 # Cap for non-model-provider response body buffering and decompression output.
 STREAM_BUFFER_LIMIT = 64 * 1024  # 64 KB
 
+# Decompression cap for response bodies that need full parsing for usage
+# extraction (model-provider non-SSE JSON, billable-connector JSON).  Larger
+# than STREAM_BUFFER_LIMIT (which guards capture-mode body logging) so large
+# search/timeline payloads decompress fully.  Still bounded so a malicious
+# upstream cannot exhaust memory via a decompression bomb.
+LARGE_RESPONSE_DECOMPRESS_LIMIT = 5 * 1024 * 1024  # 5 MB
+
 
 # ---------------------------------------------------------------------------
 # Body capture helpers (opt-in per run via captureNetworkBodies registry flag)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -268,7 +268,9 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     # full JSON body is available for usage extraction in response().
     sse_parser = None
     sse_decompressor = None
-    is_model_provider = flow.metadata.get("firewall_name", "").startswith("model-provider:")
+    firewall_name = flow.metadata.get("firewall_name", "")
+    is_model_provider = firewall_name.startswith("model-provider:")
+    is_billable_connector = usage.is_billable_connector(firewall_name)
     if is_model_provider:
         content_type = flow.response.headers.get("content-type", "")
         if "text/event-stream" in content_type:
@@ -277,9 +279,12 @@ def responseheaders(flow: http.HTTPFlow) -> None:
             flow.metadata["proxy_usage"] = usage_dict
             sse_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
 
-    # Model provider responses are never truncated so usage extraction
-    # always has the complete body.  Other responses use the 64 KB limit.
-    buf_limit = None if is_model_provider else body_utils.STREAM_BUFFER_LIMIT
+    # Model provider and billable connector responses are never truncated so
+    # usage extraction always has the complete body.  Other responses use the
+    # 64 KB limit.
+    buf_limit = (
+        None if (is_model_provider or is_billable_connector) else body_utils.STREAM_BUFFER_LIMIT
+    )
 
     def stream_and_buffer(chunk: bytes) -> bytes:
         if not state["truncated"]:
@@ -380,6 +385,9 @@ def response(flow: http.HTTPFlow) -> None:
             if json_usage:
                 flow.metadata["proxy_usage"] = json_usage
     usage.maybe_report_proxy_usage(flow, run_id)
+
+    # Billable connector usage observation (issue #9504, stage 0).
+    usage.log_connector_usage(flow, run_id)
 
     # Invalidate firewall header cache on 401 so next request gets fresh headers
     if flow.response and flow.response.status_code == 401 and flow.metadata.get("firewall_base"):

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -1,23 +1,34 @@
 """Proxy-side usage extraction and reporting.
 
-Extracts billing-relevant fields from model-provider responses (SSE streams
-and non-streaming JSON) and reports them to the platform webhook through a
-background thread pool.
+Two paths:
+
+- Model-provider responses (SSE streams and non-streaming JSON): extract
+  Anthropic token counts and report them to the platform webhook through
+  a background thread pool.
+- Billable connector responses (X API; see :data:`_BILLABLE_CONNECTORS`):
+  emit a multi-dimensional ``connector_usage`` entry to the per-run proxy
+  log for stage-0 observation (issue #9504).  Not yet forwarded to the
+  platform.
 """
 
 import json
 import time
 import urllib.error
+import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 
 from mitmproxy import http
 
+import body_utils
 from auth import _opener, get_api_url, make_api_request
 from body_utils import decompress_body
 from logging_utils import log_proxy_entry
 
 # ---------------------------------------------------------------------------
-# Proxy-side usage extraction (for billing verification)
+# Anthropic usage parsing primitives
+#
+# Pure parsers shared by both the SSE streaming path and the non-streaming
+# JSON fallback.
 # ---------------------------------------------------------------------------
 
 # Only extract known billing fields to avoid capturing unrelated numerics.
@@ -157,7 +168,7 @@ def extract_usage_from_json(body: bytes, headers) -> dict | None:
     Returns ``None`` when the body is not valid JSON or contains no usage.
     """
     if headers:
-        body = decompress_body(body, headers)
+        body = decompress_body(body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT)
     try:
         data = json.loads(body)
     except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
@@ -175,6 +186,16 @@ def extract_usage_from_json(body: bytes, headers) -> dict | None:
     if message_id:
         usage["message_id"] = message_id
     return usage
+
+
+# ---------------------------------------------------------------------------
+# Webhook delivery (HTTP + thread pool)
+#
+# Background thread pool processes usage reports in parallel; done() flushes
+# pending items before mitmproxy exits (SIGKILL at 15 s is the hard stop).
+# Falls back to synchronous delivery if the executor has been shut down
+# (drain/shutdown race) so reports are not silently lost.
+# ---------------------------------------------------------------------------
 
 
 def _do_report_usage(api_url: str, sandbox_token: str, run_id: str, usage: dict) -> None:
@@ -215,12 +236,6 @@ def _report_usage_with_retry(
                 )
 
 
-# ---------------------------------------------------------------------------
-# Usage reporting thread pool — replaces fire-and-forget daemon threads.
-# ThreadPoolExecutor processes reports in parallel; done() flushes pending
-# items before mitmproxy exits (SIGKILL at 15 s is the hard stop).
-# ---------------------------------------------------------------------------
-
 usage_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
 
 
@@ -241,6 +256,11 @@ def _enqueue_usage(
         # Executor shut down (done() already called during drain).
         # Fall back to synchronous delivery with retry.
         _report_usage_with_retry(api_url, sandbox_token, run_id, copied, proxy_log_path)
+
+
+# ---------------------------------------------------------------------------
+# Model-provider entry point
+# ---------------------------------------------------------------------------
 
 
 def maybe_report_proxy_usage(flow: http.HTTPFlow, run_id: str) -> None:
@@ -271,3 +291,268 @@ def maybe_report_proxy_usage(flow: http.HTTPFlow, run_id: str) -> None:
         )
         return
     _enqueue_usage(api_url, sandbox_token, run_id, proxy_usage, proxy_log_path)
+
+
+# ---------------------------------------------------------------------------
+# Billable connector usage observation (issue #9504, stage 0 of #9269).
+#
+# Records a diagnostic log entry per successful request through a billable
+# connector firewall.  Multi-dimensional fields are captured (request `ids`
+# count, response `data`/`includes`/`meta.result_count`) so a server-side
+# billing formula can be chosen later without redeploying the proxy.  No
+# usage is reported to the platform yet.
+# ---------------------------------------------------------------------------
+
+# Non-model-provider firewalls whose traffic we intend to bill.  Listing a
+# firewall here triggers full-body buffering in mitm_addon.responseheaders
+# (so log_connector_usage can parse the JSON in response()) and routes the
+# flow through log_connector_usage.  Start with X; expand once observation
+# data validates the pipeline.
+_BILLABLE_CONNECTORS = frozenset({"x"})
+
+
+def is_billable_connector(firewall_name: str) -> bool:
+    """Return True when this firewall is on the billable-connector list.
+
+    Used by ``mitm_addon.responseheaders`` to disable buffer truncation for
+    these firewalls so ``log_connector_usage`` can parse the full response
+    body in ``response()``.
+    """
+    return firewall_name in _BILLABLE_CONNECTORS
+
+
+def _parse_x_request_metadata(flow: http.HTTPFlow) -> dict:
+    """Extract billing-relevant query params from an X API request.
+
+    Returns a dict with:
+      - ``request_ids_count``: int | None — total comma-separated count
+        across all ``?ids=`` params (None when the param is absent).
+      - ``has_expansions``: bool — whether ``?expansions=`` is present.
+      - ``max_results``: int | None — value of ``?max_results=``, used
+        as an upper-bound fallback when the response body cannot be parsed.
+
+    Reads from ``flow.metadata["original_url"]`` (set by the request handler
+    via ``url_utils.get_original_url``) rather than ``pretty_url`` to stay
+    consistent with the rest of the addon.
+    """
+    parsed = urllib.parse.urlparse(flow.metadata.get("original_url", ""))
+    qs = urllib.parse.parse_qs(parsed.query)
+    ids_values = qs.get("ids", [])
+    ids_count = sum(len(v.split(",")) for v in ids_values) if ids_values else None
+    max_values = qs.get("max_results", [])
+    max_results: int | None = None
+    if max_values:
+        try:
+            max_results = int(max_values[0])
+        except ValueError:
+            max_results = None
+    return {
+        "request_ids_count": ids_count,
+        "has_expansions": "expansions" in qs,
+        "max_results": max_results,
+    }
+
+
+def _parse_x_response_metadata(flow: http.HTTPFlow) -> dict:
+    """Extract billing-relevant fields from an X API response body.
+
+    Returns a dict with at least ``body_parsed`` and ``body_truncated``
+    markers, plus optional fields when the JSON is parseable:
+
+      - ``response_data_count``: int — ``len(data)`` for a list payload,
+        ``1`` for a single object payload.
+      - ``response_includes``: dict[str, int] — counts per ``includes.<key>``.
+      - ``response_result_count``: int — ``meta.result_count`` (search /
+        paginated endpoints).
+
+    Failures (truncated buffer, malformed JSON, unexpected shape) leave
+    ``body_parsed=False`` and emit no count fields, so analysis can
+    distinguish "field absent in response" from "we couldn't parse it".
+    """
+    state = flow.metadata.get("stream_buffer_state") or {}
+    truncated = bool(state.get("truncated", False))
+    result: dict = {"body_parsed": False, "body_truncated": truncated}
+
+    buf = flow.metadata.get("stream_buffer")
+    if not buf:
+        return result
+    headers = flow.response.headers if flow.response else None
+    body = decompress_body(
+        bytes(buf), headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
+    )
+    try:
+        data = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return result
+    if not isinstance(data, dict):
+        return result
+
+    result["body_parsed"] = True
+
+    payload = data.get("data")
+    if isinstance(payload, list):
+        result["response_data_count"] = len(payload)
+    elif isinstance(payload, dict):
+        result["response_data_count"] = 1
+
+    includes = data.get("includes")
+    if isinstance(includes, dict):
+        counts = {k: len(v) for k, v in includes.items() if isinstance(v, list)}
+        if counts:
+            result["response_includes"] = counts
+
+    meta = data.get("meta")
+    if isinstance(meta, dict):
+        rc = meta.get("result_count")
+        if isinstance(rc, int):
+            result["response_result_count"] = rc
+
+    return result
+
+
+# Conservative upper bound for GET requests whose body we couldn't parse and
+# whose URL carried no count hints.  X v2 read endpoints cap max_results at
+# 100 for most collections (search, timelines, liking_users, ...); using 100
+# as the floor avoids silent undercount if X ever changes response schema
+# or returns unparseable JSON.  Higher-capacity endpoints (search/all=500,
+# followers=1000) are still over-counted relative to reality — acceptable
+# for a rare edge case that should also trigger server-side monitoring.
+_X_UNPARSEABLE_READ_FALLBACK = 100
+
+
+# Mapping from X v2 ``includes.<key>`` resource types to billing
+# permission names.  All known X v2 includes keys are listed explicitly
+# so the complete set of billing assumptions is reviewable at a glance;
+# new includes keys added by X in the future automatically fall back to
+# ``<key>.read`` via :func:`_compute_x_billable_counts` using the same
+# naming convention.
+#
+# X's 24-hour dedup is documented to apply across request paths for the
+# same resource id, so includes-returned resources share the pricing
+# tier of the direct-lookup permission.
+#
+# - ``users`` / ``tweets`` align with the existing X firewall permissions
+#   (``users.read`` / ``tweet.read``) so counts add up with direct-request
+#   counts at the same tier.  Note ``tweets`` → ``tweet.read`` is the
+#   one irregular case: the includes key is plural but the firewall
+#   permission is singular; without the explicit entry, referenced
+#   tweets would be mis-routed to a separate ``tweets.read`` key.
+# - ``media`` / ``polls`` / ``places`` / ``topics`` have no pre-existing
+#   firewall permission and get a synthetic ``<type>.read`` key that
+#   the server prices explicitly (or leaves unpriced, meaning 0).
+_INCLUDES_TO_PERMISSION = {
+    "users": "users.read",
+    "tweets": "tweet.read",
+    "media": "media.read",
+    "polls": "polls.read",
+    "places": "places.read",
+    "topics": "topics.read",
+}
+
+
+def _compute_x_billable_counts(method: str, req_meta: dict, resp_meta: dict, endpoint: str) -> dict:
+    """Derive per-permission billable resource counts for an X request.
+
+    Returns a dict mapping firewall permission name → resource count.
+    Keys are always existing X firewall permissions so the server's
+    ``credit_pricing`` table doesn't need separate entries for expansion
+    resources.
+
+    Writes (non-GET) always count as ``{endpoint: 1}`` regardless of
+    response shape — X write endpoints don't support expansions.
+
+    Reads (GET):
+
+    - **Primary**: ``max(ids_count, data_count, result_count,
+      max_results, 1)``.  When the body can't be parsed and no URL hints
+      exist, falls back to :data:`_X_UNPARSEABLE_READ_FALLBACK` (100) to
+      avoid silent undercount.
+    - **Includes**: each ``includes.<key>`` is mapped via
+      :data:`_INCLUDES_TO_PERMISSION` when that type has a dedicated
+      firewall permission (``users`` → ``users.read``, ``tweets`` →
+      ``tweet.read``).  Unknown types fall back to ``endpoint`` (the
+      primary permission) so they're priced at the parent request's
+      tier.  Counts at the same permission are summed.
+    """
+    if method != "GET":
+        return {endpoint: 1}
+
+    ids = req_meta.get("request_ids_count") or 0
+    max_r = req_meta.get("max_results") or 0
+    data = resp_meta.get("response_data_count") or 0
+    result = resp_meta.get("response_result_count") or 0
+    primary = max(ids, data, result, max_r, 1)
+
+    # Body parse failed AND no URL or response count hints available →
+    # conservative fallback.  Without this, max(...) degenerates to 1 and
+    # a search returning dozens of results would be billed as a single
+    # read.
+    if not resp_meta.get("body_parsed") and not any((ids, data, result, max_r)):
+        primary = max(primary, _X_UNPARSEABLE_READ_FALLBACK)
+
+    counts: dict = {endpoint: primary}
+
+    # Map each includes.<key> to a billing permission and accumulate.
+    # Known types use :data:`_INCLUDES_TO_PERMISSION`; unknown future
+    # types get a synthetic ``<key>.read`` key via the same convention so
+    # the server sees a consistent naming and can price (or ignore) them
+    # without a proxy redeploy.
+    includes = resp_meta.get("response_includes") or {}
+    for key, n in includes.items():
+        if n <= 0:
+            continue
+        permission = _INCLUDES_TO_PERMISSION.get(key, f"{key}.read")
+        counts[permission] = counts.get(permission, 0) + n
+
+    return counts
+
+
+def log_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
+    """Emit a billable-connector usage observation entry.
+
+    Diagnostic-only; not yet forwarded to the platform.  Stage 0 of #9269 —
+    records per-permission billable resource counts (``billable_counts``;
+    a dict keyed by firewall permission name) derived from the request
+    and response, alongside the raw signals (``request_ids_count``,
+    ``response_data_count``, ``response_includes``, ...).  The server
+    can either use ``billable_counts`` directly for per-call billing, or
+    re-derive a different formula from the raw fields if needed.
+
+    Skipped when:
+
+    - ``run_id`` is empty (no billing attribution)
+    - ``firewall_name`` is not in :data:`_BILLABLE_CONNECTORS`
+    - response status is outside 2xx (failures aren't billable)
+    - ``firewall_permission`` is empty (unknown-endpoint-allow has no
+      stable pricing key)
+    """
+    if not run_id:
+        return
+    firewall_name = flow.metadata.get("firewall_name", "")
+    if not is_billable_connector(firewall_name):
+        return
+    if not flow.response or not (200 <= flow.response.status_code < 300):
+        return
+    endpoint = flow.metadata.get("firewall_permission", "")
+    if not endpoint:
+        return
+
+    req_meta = _parse_x_request_metadata(flow)
+    resp_meta = _parse_x_response_metadata(flow)
+    billable_counts = _compute_x_billable_counts(flow.request.method, req_meta, resp_meta, endpoint)
+
+    log_proxy_entry(
+        flow.metadata.get("vm_proxy_log_path", ""),
+        "info",
+        f"Connector usage: {firewall_name}/{endpoint}",
+        type="connector_usage",
+        connector=firewall_name,
+        endpoint=endpoint,
+        rule=flow.metadata.get("firewall_rule_match", ""),
+        method=flow.request.method,
+        flow_id=flow.id,
+        status=flow.response.status_code,
+        billable_counts=billable_counts,
+        **req_meta,
+        **resp_meta,
+    )

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -326,7 +326,10 @@ def _parse_x_request_metadata(flow: http.HTTPFlow) -> dict:
 
     Returns a dict with:
       - ``request_ids_count``: int | None — total comma-separated count
-        across all ``?ids=`` params (None when the param is absent).
+        across all ``?ids=`` and ``?usernames=`` params (None when both
+        are absent).  ``usernames`` is folded in because ``GET /2/users/by``
+        uses it instead of ``ids`` for batch user lookup; both signal the
+        same "this many resources" billing dimension.
       - ``has_expansions``: bool — whether ``?expansions=`` is present.
       - ``max_results``: int | None — value of ``?max_results=``, used
         as an upper-bound fallback when the response body cannot be parsed.
@@ -337,8 +340,8 @@ def _parse_x_request_metadata(flow: http.HTTPFlow) -> dict:
     """
     parsed = urllib.parse.urlparse(flow.metadata.get("original_url", ""))
     qs = urllib.parse.parse_qs(parsed.query)
-    ids_values = qs.get("ids", [])
-    ids_count = sum(len(v.split(",")) for v in ids_values) if ids_values else None
+    id_like_values = qs.get("ids", []) + qs.get("usernames", [])
+    ids_count = sum(len(v.split(",")) for v in id_like_values) if id_like_values else None
     max_values = qs.get("max_results", [])
     max_results: int | None = None
     if max_values:
@@ -362,8 +365,12 @@ def _parse_x_response_metadata(flow: http.HTTPFlow) -> dict:
       - ``response_data_count``: int — ``len(data)`` for a list payload,
         ``1`` for a single object payload.
       - ``response_includes``: dict[str, int] — counts per ``includes.<key>``.
-      - ``response_result_count``: int — ``meta.result_count`` (search /
-        paginated endpoints).
+      - ``response_result_count``: int — total matched count.  Sourced
+        from ``meta.result_count`` (search / paginated endpoints) or
+        ``meta.total_tweet_count`` (``/2/tweets/counts/*``, where ``data``
+        carries time buckets, not tweets, and the real count lives in
+        ``meta``).  Both fields are alternative spellings of the same
+        billing dimension, so we collapse them into one log key.
 
     Failures (truncated buffer, malformed JSON, unexpected shape) leave
     ``body_parsed=False`` and emit no count fields, so analysis can
@@ -403,9 +410,15 @@ def _parse_x_response_metadata(flow: http.HTTPFlow) -> dict:
 
     meta = data.get("meta")
     if isinstance(meta, dict):
-        rc = meta.get("result_count")
-        if isinstance(rc, int):
-            result["response_result_count"] = rc
+        # ``result_count`` is the standard search/paginated field;
+        # ``total_tweet_count`` is the counts-endpoint variant where
+        # ``data`` is time buckets rather than tweets.  Prefer whichever
+        # is present (mutually exclusive in practice; if both appear,
+        # take the larger to stay on the safe side of billing).
+        candidates = [meta.get("result_count"), meta.get("total_tweet_count")]
+        rcs = [c for c in candidates if isinstance(c, int)]
+        if rcs:
+            result["response_result_count"] = max(rcs)
 
     return result
 

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -420,26 +420,12 @@ def _parse_x_response_metadata(flow: http.HTTPFlow) -> dict:
 _X_UNPARSEABLE_READ_FALLBACK = 100
 
 
-# Mapping from X v2 ``includes.<key>`` resource types to billing
-# permission names.  All known X v2 includes keys are listed explicitly
-# so the complete set of billing assumptions is reviewable at a glance;
-# new includes keys added by X in the future automatically fall back to
-# ``<key>.read`` via :func:`_compute_x_billable_counts` using the same
-# naming convention.
-#
-# X's 24-hour dedup is documented to apply across request paths for the
-# same resource id, so includes-returned resources share the pricing
-# tier of the direct-lookup permission.
-#
-# - ``users`` / ``tweets`` align with the existing X firewall permissions
-#   (``users.read`` / ``tweet.read``) so counts add up with direct-request
-#   counts at the same tier.  Note ``tweets`` → ``tweet.read`` is the
-#   one irregular case: the includes key is plural but the firewall
-#   permission is singular; without the explicit entry, referenced
-#   tweets would be mis-routed to a separate ``tweets.read`` key.
-# - ``media`` / ``polls`` / ``places`` / ``topics`` have no pre-existing
-#   firewall permission and get a synthetic ``<type>.read`` key that
-#   the server prices explicitly (or leaves unpriced, meaning 0).
+# Mapping from X v2 ``includes.<key>`` resource types to firewall
+# permission names.  Listed explicitly for reviewability; unknown future
+# keys fall back to ``<key>.read`` in :func:`_compute_x_billable_counts`.
+# The ``tweets`` → ``tweet.read`` entry is the one irregular case
+# (includes key is plural, firewall permission is singular) — without it
+# referenced tweets would land on a separate ``tweets.read`` key.
 _INCLUDES_TO_PERMISSION = {
     "users": "users.read",
     "tweets": "tweet.read",
@@ -470,9 +456,11 @@ def _compute_x_billable_counts(method: str, req_meta: dict, resp_meta: dict, end
     - **Includes**: each ``includes.<key>`` is mapped via
       :data:`_INCLUDES_TO_PERMISSION` when that type has a dedicated
       firewall permission (``users`` → ``users.read``, ``tweets`` →
-      ``tweet.read``).  Unknown types fall back to ``endpoint`` (the
-      primary permission) so they're priced at the parent request's
-      tier.  Counts at the same permission are summed.
+      ``tweet.read``).  Unknown types fall back to a synthetic
+      ``<key>.read`` permission (e.g. ``future_widget`` →
+      ``future_widget.read``) so the server can price (or ignore) new
+      expansion types without a proxy redeploy.  Counts at the same
+      permission are summed.
     """
     if method != "GET":
         return {endpoint: 1}

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -1,6 +1,7 @@
 """Tests for HTTP body capture helpers in mitm_addon."""
 
 import base64
+import json
 from unittest.mock import MagicMock
 
 from body_utils import (
@@ -641,3 +642,31 @@ class TestExtractUsageFromJson:
         result = extract_usage_from_json(body, None)
         assert result["web_search_requests"] == 2
         assert result["input_tokens"] == 10
+
+    def test_handles_large_gzipped_body(self):
+        """Body that decompresses past the legacy 64 KB cap should still parse.
+
+        Regression test for the silent 64 KB default in body_utils.decompress_body
+        which used to truncate large model-provider non-SSE responses and cause
+        usage extraction to silently fail.
+        """
+        import gzip
+
+        # Raw body > 64 KB (legacy STREAM_BUFFER_LIMIT) so the bug, if reintroduced,
+        # would truncate decompression output and break json.loads below.
+        big_text = "x" * (100 * 1024)
+        payload = json.dumps(
+            {
+                "id": "msg_1",
+                "model": "claude-sonnet-4-6",
+                "content": [{"type": "text", "text": big_text}],
+                "usage": {"input_tokens": 50, "output_tokens": 100},
+            }
+        ).encode()
+        compressed = gzip.compress(payload)
+        headers = MagicMock()
+        headers.get = lambda k, d="": "gzip" if k == "content-encoding" else d
+        result = extract_usage_from_json(compressed, headers)
+        assert result is not None
+        assert result["input_tokens"] == 50
+        assert result["output_tokens"] == 100

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1188,6 +1188,25 @@ class TestResponseUsageReporting:
         assert len(buf) == body_utils.STREAM_BUFFER_LIMIT
         assert state["truncated"]
 
+    def test_billable_connector_buffer_not_truncated(self):
+        """Billable connector responses should buffer the full body (no 64KB cap)."""
+        flow = _make_http_flow(host="api.x.com")
+        flow.response = MagicMock()
+        flow.response.headers = {"content-type": "application/json"}
+        flow.response.stream = False
+        flow.metadata["firewall_name"] = "x"
+
+        mitm_addon.responseheaders(flow)
+
+        callback = flow.response.stream
+        large_chunk = b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
+        callback(large_chunk)
+
+        buf = flow.metadata["stream_buffer"]
+        state = flow.metadata["stream_buffer_state"]
+        assert len(buf) == len(large_chunk)
+        assert not state["truncated"]
+
     def test_no_usage_report_for_non_model_provider(self, tmp_path):
         """Non-model-provider requests should not trigger usage reporting."""
         flow = _make_http_flow(host="api.github.com")
@@ -1577,6 +1596,400 @@ class TestMaybeReportProxyUsage:
 
         mock_enqueue.assert_not_called()
         assert proxy_log.exists()
+
+
+class TestLogConnectorUsage:
+    """Tests for log_connector_usage helper (issue #9504)."""
+
+    def setup_method(self):
+        _reset()
+
+    def _make_x_flow(
+        self,
+        tmp_path,
+        *,
+        path="/2/tweets",
+        query="",
+        body=b"",
+        status=200,
+        permission="tweet.read",
+        rule="GET /2/tweets",
+        content_encoding="",
+    ):
+        flow = _make_http_flow(host="api.x.com", path=path)
+        flow.metadata["original_url"] = (
+            f"https://api.x.com{path}?{query}" if query else f"https://api.x.com{path}"
+        )
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_permission"] = permission
+        flow.metadata["firewall_rule_match"] = rule
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = MagicMock()
+        flow.response.status_code = status
+        flow.response.headers = {
+            "content-type": "application/json",
+            "content-encoding": content_encoding,
+        }
+        return flow
+
+    # ---- positive cases ----
+
+    def test_logs_single_resource_get(self, tmp_path):
+        """GET /2/tweets/:id → response_data_count=1, no includes/result_count."""
+        body = json.dumps({"data": {"id": "1", "text": "hi"}}).encode()
+        flow = self._make_x_flow(tmp_path, path="/2/tweets/1", body=body, rule="GET /2/tweets/{id}")
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        mock_log.assert_called_once()
+        _, kwargs = mock_log.call_args
+        assert kwargs["type"] == "connector_usage"
+        assert kwargs["connector"] == "x"
+        assert kwargs["endpoint"] == "tweet.read"
+        assert kwargs["rule"] == "GET /2/tweets/{id}"
+        assert kwargs["status"] == 200
+        assert kwargs["response_data_count"] == 1
+        assert kwargs["body_parsed"] is True
+        assert kwargs["body_truncated"] is False
+        assert "response_includes" not in kwargs
+        assert "response_result_count" not in kwargs
+        assert kwargs["request_ids_count"] is None
+        assert kwargs["has_expansions"] is False
+        assert kwargs["max_results"] is None
+        assert kwargs["billable_counts"] == {"tweet.read": 1}
+
+    def test_logs_batch_ids(self, tmp_path):
+        """GET /2/tweets?ids=1,2,3 → request_ids_count=3 + response_data_count=3."""
+        body = json.dumps({"data": [{"id": "1"}, {"id": "2"}, {"id": "3"}]}).encode()
+        flow = self._make_x_flow(tmp_path, query="ids=1,2,3", body=body)
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["request_ids_count"] == 3
+        assert kwargs["response_data_count"] == 3
+        assert kwargs["has_expansions"] is False
+        assert kwargs["billable_counts"] == {"tweet.read": 3}
+
+    def test_logs_batch_ids_with_deletions(self, tmp_path):
+        """Batch with some missing ids → max(ids, data) wins (over-count safe)."""
+        body = json.dumps({"data": [{"id": "1"}, {"id": "3"}]}).encode()
+        flow = self._make_x_flow(tmp_path, query="ids=1,2,3", body=body)
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["request_ids_count"] == 3
+        assert kwargs["response_data_count"] == 2
+        assert kwargs["billable_counts"] == {"tweet.read": 3}  # max(3, 2)
+
+    def test_logs_expansions_includes(self, tmp_path):
+        """?expansions=author_id → response_includes carries users + media counts."""
+        body = json.dumps(
+            {
+                "data": [{"id": "1", "author_id": "99"}],
+                "includes": {
+                    "users": [{"id": "99"}],
+                    "media": [{"media_key": "m1"}, {"media_key": "m2"}],
+                },
+            }
+        ).encode()
+        flow = self._make_x_flow(
+            tmp_path,
+            query="expansions=author_id,attachments.media_keys",
+            body=body,
+        )
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["has_expansions"] is True
+        assert kwargs["response_data_count"] == 1
+        assert kwargs["response_includes"] == {"users": 1, "media": 2}
+        # Each includes type gets its own .read billing key so server can
+        # price per-type independently.
+        assert kwargs["billable_counts"] == {
+            "tweet.read": 1,
+            "users.read": 1,
+            "media.read": 2,
+        }
+
+    def test_logs_empty_search_still_bills_one(self, tmp_path):
+        """Search returning zero results still bills 1 — the search request
+        itself may cost even when data is empty, and a floor of 1 guarantees
+        we never report 0 for a successful (2xx) billable request."""
+        body = json.dumps({"data": [], "meta": {"result_count": 0}}).encode()
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/tweets/search/recent",
+            query="query=nothing",
+            body=body,
+            rule="GET /2/tweets/search/recent",
+        )
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["response_data_count"] == 0
+        assert kwargs["response_result_count"] == 0
+        assert kwargs["billable_counts"] == {"tweet.read": 1}
+
+    def test_logs_expansions_users_and_referenced_tweets(self, tmp_path):
+        """includes.users → users.read; includes.tweets accumulates into tweet.read primary."""
+        body = json.dumps(
+            {
+                "data": [{"id": "1", "author_id": "99", "referenced_tweets": [{"id": "ref1"}]}],
+                "includes": {
+                    "users": [{"id": "99"}, {"id": "author2"}],
+                    "tweets": [{"id": "ref1"}, {"id": "ref2"}],
+                },
+            }
+        ).encode()
+        flow = self._make_x_flow(
+            tmp_path,
+            query="expansions=author_id,referenced_tweets.id",
+            body=body,
+        )
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        # includes.tweets maps to tweet.read (same permission as the primary
+        # endpoint here), so the counts sum at the same key.
+        assert kwargs["billable_counts"] == {
+            "tweet.read": 3,  # 1 primary + 2 referenced tweets
+            "users.read": 2,
+        }
+
+    def test_handles_unknown_includes_key(self, tmp_path):
+        """Unknown includes.<key> types get a synthetic <key>.read billing key.
+
+        Raw field ``response_includes`` preserves the original shape so
+        future pricing rules can be added without re-processing past logs.
+        """
+        body = json.dumps(
+            {
+                "data": [{"id": "1"}],
+                "includes": {
+                    "users": [{"id": "99"}],
+                    "future_widget": [{"id": "w1"}, {"id": "w2"}, {"id": "w3"}],
+                },
+            }
+        ).encode()
+        flow = self._make_x_flow(tmp_path, query="expansions=author_id", body=body)
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        # Raw observation stays unchanged for forensic analysis.
+        assert kwargs["response_includes"] == {"users": 1, "future_widget": 3}
+        # Unknown includes types get auto-generated <key>.read keys.
+        assert kwargs["billable_counts"] == {
+            "tweet.read": 1,
+            "users.read": 1,
+            "future_widget.read": 3,
+        }
+
+    def test_logs_search_meta_result_count(self, tmp_path):
+        """search response with meta.result_count populates response_result_count."""
+        body = json.dumps(
+            {
+                "data": [{"id": str(i)} for i in range(20)],
+                "meta": {"result_count": 20, "next_token": "abc"},
+            }
+        ).encode()
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/tweets/search/recent",
+            query="query=hello&max_results=100",
+            body=body,
+            permission="tweet.read",
+            rule="GET /2/tweets/search/recent",
+        )
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["response_data_count"] == 20
+        assert kwargs["response_result_count"] == 20
+        assert kwargs["max_results"] == 100
+        # max(0, 20, 20, 100, 1) = 100 — over-count via max_results upper bound
+        assert kwargs["billable_counts"] == {"tweet.read": 100}
+
+    def test_logs_repeated_ids_param(self, tmp_path):
+        """?ids=1,2&ids=3 → request_ids_count=3 (sums all occurrences)."""
+        body = json.dumps({"data": [{"id": "1"}, {"id": "2"}, {"id": "3"}]}).encode()
+        flow = self._make_x_flow(tmp_path, query="ids=1,2&ids=3", body=body)
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["request_ids_count"] == 3
+
+    def test_handles_gzip_body(self, tmp_path):
+        """gzip-encoded response body decompresses before parsing."""
+        import gzip
+
+        raw = json.dumps({"data": [{"id": "1"}], "meta": {"result_count": 1}}).encode()
+        body = gzip.compress(raw)
+        flow = self._make_x_flow(tmp_path, body=body, content_encoding="gzip")
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["body_parsed"] is True
+        assert kwargs["response_data_count"] == 1
+        assert kwargs["response_result_count"] == 1
+        assert kwargs["billable_counts"] == {"tweet.read": 1}
+
+    def test_logs_write_operation_charges_one(self, tmp_path):
+        """POST /2/tweets → billable_counts={tweet.write:1} regardless of body shape."""
+        body = json.dumps({"data": {"id": "99", "text": "new tweet"}}).encode()
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/tweets",
+            body=body,
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+        )
+        flow.request.method = "POST"
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["method"] == "POST"
+        assert kwargs["billable_counts"] == {"tweet.write": 1}
+
+    # ---- forensic / parser-state cases ----
+
+    def test_handles_truncated_buffer(self, tmp_path):
+        """stream_buffer_state.truncated → body_parsed False, body_truncated True."""
+        flow = self._make_x_flow(tmp_path, body=b"{")
+        flow.metadata["stream_buffer_state"] = {"truncated": True}
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["body_parsed"] is False
+        assert kwargs["body_truncated"] is True
+        assert "response_data_count" not in kwargs
+
+    def test_handles_invalid_json(self, tmp_path):
+        """Malformed body → body_parsed False, no count fields, entry still logged."""
+        flow = self._make_x_flow(tmp_path, body=b"not json")
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["body_parsed"] is False
+        assert kwargs["body_truncated"] is False
+        assert "response_data_count" not in kwargs
+        assert "response_includes" not in kwargs
+        assert "response_result_count" not in kwargs
+        # No count signals + GET + body unparseable → fallback 100
+        assert kwargs["billable_counts"] == {"tweet.read": 100}
+
+    def test_billable_counts_fallback_only_when_no_hints(self, tmp_path):
+        """body_parsed False but ?ids= present → use ids_count, no fallback."""
+        flow = self._make_x_flow(tmp_path, query="ids=1,2,3", body=b"not json")
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["body_parsed"] is False
+        assert kwargs["billable_counts"] == {"tweet.read": 3}  # from ids, not fallback
+
+    def test_billable_counts_fallback_only_when_no_max_results(self, tmp_path):
+        """body_parsed False but ?max_results=50 present → use max_results, no fallback."""
+        flow = self._make_x_flow(tmp_path, query="max_results=50", body=b"not json")
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["body_parsed"] is False
+        assert kwargs["billable_counts"] == {"tweet.read": 50}
+
+    def test_handles_empty_body(self, tmp_path):
+        """Empty stream_buffer → body_parsed False, entry still logged."""
+        flow = self._make_x_flow(tmp_path, body=b"")
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["body_parsed"] is False
+
+    def test_handles_invalid_max_results(self, tmp_path):
+        """Non-integer max_results param falls back to None, doesn't raise."""
+        body = json.dumps({"data": []}).encode()
+        flow = self._make_x_flow(tmp_path, query="max_results=abc", body=body)
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        _, kwargs = mock_log.call_args
+        assert kwargs["max_results"] is None
+
+    # ---- skip cases ----
+
+    def test_skips_on_server_error(self, tmp_path):
+        flow = self._make_x_flow(tmp_path, status=500)
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        mock_log.assert_not_called()
+
+    def test_skips_on_rate_limit(self, tmp_path):
+        flow = self._make_x_flow(tmp_path, status=429)
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        mock_log.assert_not_called()
+
+    def test_skips_on_empty_permission(self, tmp_path):
+        """Unknown-endpoint-allow has no stable pricing key."""
+        flow = self._make_x_flow(tmp_path, permission="")
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        mock_log.assert_not_called()
+
+    def test_skips_on_empty_run_id(self, tmp_path):
+        flow = self._make_x_flow(tmp_path)
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "")
+        mock_log.assert_not_called()
+
+    def test_skips_for_model_provider(self, tmp_path):
+        """Model providers go through maybe_report_proxy_usage instead."""
+        flow = self._make_x_flow(tmp_path)
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        mock_log.assert_not_called()
+
+    def test_skips_for_non_billable_connector(self, tmp_path):
+        """Connectors not in _BILLABLE_CONNECTORS are not logged."""
+        flow = self._make_x_flow(tmp_path)
+        flow.metadata["firewall_name"] = "gamma"
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        mock_log.assert_not_called()
+
+    def test_skips_when_no_response(self, tmp_path):
+        flow = self._make_x_flow(tmp_path)
+        flow.response = None
+        with patch.object(usage, "log_proxy_entry") as mock_log:
+            usage.log_connector_usage(flow, "run-abc-123")
+        mock_log.assert_not_called()
+
+    # ---- integration: response() hook wiring ----
+
+    def test_response_hook_invokes_log_connector_usage(self, tmp_path):
+        """response() hook should call usage.log_connector_usage."""
+        flow = _make_http_flow(host="api.x.com", path="/2/tweets")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_permission"] = "tweet.write"
+        flow.response = MagicMock()
+        flow.response.status_code = 200
+        flow.response.headers = {"content-type": "application/json"}
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            patch.object(usage, "maybe_report_proxy_usage"),
+            patch.object(usage, "log_connector_usage") as mock_log_connector,
+        ):
+            mitm_addon.response(flow)
+
+        mock_log_connector.assert_called_once_with(flow, "run-abc-123")
 
 
 class TestErrorUsageReporting:

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1634,53 +1634,67 @@ class TestLogConnectorUsage:
         }
         return flow
 
+    def _read_entries(self, tmp_path):
+        """Read all JSONL entries from the real proxy log file."""
+        path = tmp_path / "proxy.jsonl"
+        if not path.exists():
+            return []
+        lines = [ln for ln in path.read_text().splitlines() if ln]
+        return [json.loads(ln) for ln in lines]
+
+    def _read_entry(self, tmp_path):
+        """Read the single JSONL entry written by log_connector_usage."""
+        entries = self._read_entries(tmp_path)
+        assert len(entries) == 1, f"expected 1 entry, got {len(entries)}"
+        return entries[0]
+
     # ---- positive cases ----
 
     def test_logs_single_resource_get(self, tmp_path):
         """GET /2/tweets/:id → response_data_count=1, no includes/result_count."""
         body = json.dumps({"data": {"id": "1", "text": "hi"}}).encode()
         flow = self._make_x_flow(tmp_path, path="/2/tweets/1", body=body, rule="GET /2/tweets/{id}")
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        mock_log.assert_called_once()
-        _, kwargs = mock_log.call_args
-        assert kwargs["type"] == "connector_usage"
-        assert kwargs["connector"] == "x"
-        assert kwargs["endpoint"] == "tweet.read"
-        assert kwargs["rule"] == "GET /2/tweets/{id}"
-        assert kwargs["status"] == 200
-        assert kwargs["response_data_count"] == 1
-        assert kwargs["body_parsed"] is True
-        assert kwargs["body_truncated"] is False
-        assert "response_includes" not in kwargs
-        assert "response_result_count" not in kwargs
-        assert kwargs["request_ids_count"] is None
-        assert kwargs["has_expansions"] is False
-        assert kwargs["max_results"] is None
-        assert kwargs["billable_counts"] == {"tweet.read": 1}
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["type"] == "connector_usage"
+        assert entry["connector"] == "x"
+        assert entry["endpoint"] == "tweet.read"
+        assert entry["rule"] == "GET /2/tweets/{id}"
+        assert entry["status"] == 200
+        assert entry["response_data_count"] == 1
+        assert entry["body_parsed"] is True
+        assert entry["body_truncated"] is False
+        assert "response_includes" not in entry
+        assert "response_result_count" not in entry
+        assert entry["request_ids_count"] is None
+        assert entry["has_expansions"] is False
+        assert entry["max_results"] is None
+        assert entry["billable_counts"] == {"tweet.read": 1}
+        # log_proxy_entry contract: timestamp + level + message always present.
+        assert entry["level"] == "info"
+        assert entry["message"] == "Connector usage: x/tweet.read"
+        assert "timestamp" in entry
 
     def test_logs_batch_ids(self, tmp_path):
         """GET /2/tweets?ids=1,2,3 → request_ids_count=3 + response_data_count=3."""
         body = json.dumps({"data": [{"id": "1"}, {"id": "2"}, {"id": "3"}]}).encode()
         flow = self._make_x_flow(tmp_path, query="ids=1,2,3", body=body)
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["request_ids_count"] == 3
-        assert kwargs["response_data_count"] == 3
-        assert kwargs["has_expansions"] is False
-        assert kwargs["billable_counts"] == {"tweet.read": 3}
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["request_ids_count"] == 3
+        assert entry["response_data_count"] == 3
+        assert entry["has_expansions"] is False
+        assert entry["billable_counts"] == {"tweet.read": 3}
 
     def test_logs_batch_ids_with_deletions(self, tmp_path):
         """Batch with some missing ids → max(ids, data) wins (over-count safe)."""
         body = json.dumps({"data": [{"id": "1"}, {"id": "3"}]}).encode()
         flow = self._make_x_flow(tmp_path, query="ids=1,2,3", body=body)
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["request_ids_count"] == 3
-        assert kwargs["response_data_count"] == 2
-        assert kwargs["billable_counts"] == {"tweet.read": 3}  # max(3, 2)
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["request_ids_count"] == 3
+        assert entry["response_data_count"] == 2
+        assert entry["billable_counts"] == {"tweet.read": 3}  # max(3, 2)
 
     def test_logs_expansions_includes(self, tmp_path):
         """?expansions=author_id → response_includes carries users + media counts."""
@@ -1698,15 +1712,14 @@ class TestLogConnectorUsage:
             query="expansions=author_id,attachments.media_keys",
             body=body,
         )
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["has_expansions"] is True
-        assert kwargs["response_data_count"] == 1
-        assert kwargs["response_includes"] == {"users": 1, "media": 2}
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["has_expansions"] is True
+        assert entry["response_data_count"] == 1
+        assert entry["response_includes"] == {"users": 1, "media": 2}
         # Each includes type gets its own .read billing key so server can
         # price per-type independently.
-        assert kwargs["billable_counts"] == {
+        assert entry["billable_counts"] == {
             "tweet.read": 1,
             "users.read": 1,
             "media.read": 2,
@@ -1724,12 +1737,11 @@ class TestLogConnectorUsage:
             body=body,
             rule="GET /2/tweets/search/recent",
         )
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["response_data_count"] == 0
-        assert kwargs["response_result_count"] == 0
-        assert kwargs["billable_counts"] == {"tweet.read": 1}
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["response_data_count"] == 0
+        assert entry["response_result_count"] == 0
+        assert entry["billable_counts"] == {"tweet.read": 1}
 
     def test_logs_expansions_users_and_referenced_tweets(self, tmp_path):
         """includes.users → users.read; includes.tweets accumulates into tweet.read primary."""
@@ -1747,12 +1759,11 @@ class TestLogConnectorUsage:
             query="expansions=author_id,referenced_tweets.id",
             body=body,
         )
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
         # includes.tweets maps to tweet.read (same permission as the primary
         # endpoint here), so the counts sum at the same key.
-        assert kwargs["billable_counts"] == {
+        assert entry["billable_counts"] == {
             "tweet.read": 3,  # 1 primary + 2 referenced tweets
             "users.read": 2,
         }
@@ -1773,13 +1784,12 @@ class TestLogConnectorUsage:
             }
         ).encode()
         flow = self._make_x_flow(tmp_path, query="expansions=author_id", body=body)
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
         # Raw observation stays unchanged for forensic analysis.
-        assert kwargs["response_includes"] == {"users": 1, "future_widget": 3}
+        assert entry["response_includes"] == {"users": 1, "future_widget": 3}
         # Unknown includes types get auto-generated <key>.read keys.
-        assert kwargs["billable_counts"] == {
+        assert entry["billable_counts"] == {
             "tweet.read": 1,
             "users.read": 1,
             "future_widget.read": 3,
@@ -1801,23 +1811,21 @@ class TestLogConnectorUsage:
             permission="tweet.read",
             rule="GET /2/tweets/search/recent",
         )
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["response_data_count"] == 20
-        assert kwargs["response_result_count"] == 20
-        assert kwargs["max_results"] == 100
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["response_data_count"] == 20
+        assert entry["response_result_count"] == 20
+        assert entry["max_results"] == 100
         # max(0, 20, 20, 100, 1) = 100 — over-count via max_results upper bound
-        assert kwargs["billable_counts"] == {"tweet.read": 100}
+        assert entry["billable_counts"] == {"tweet.read": 100}
 
     def test_logs_repeated_ids_param(self, tmp_path):
         """?ids=1,2&ids=3 → request_ids_count=3 (sums all occurrences)."""
         body = json.dumps({"data": [{"id": "1"}, {"id": "2"}, {"id": "3"}]}).encode()
         flow = self._make_x_flow(tmp_path, query="ids=1,2&ids=3", body=body)
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["request_ids_count"] == 3
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["request_ids_count"] == 3
 
     def test_handles_gzip_body(self, tmp_path):
         """gzip-encoded response body decompresses before parsing."""
@@ -1826,13 +1834,12 @@ class TestLogConnectorUsage:
         raw = json.dumps({"data": [{"id": "1"}], "meta": {"result_count": 1}}).encode()
         body = gzip.compress(raw)
         flow = self._make_x_flow(tmp_path, body=body, content_encoding="gzip")
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["body_parsed"] is True
-        assert kwargs["response_data_count"] == 1
-        assert kwargs["response_result_count"] == 1
-        assert kwargs["billable_counts"] == {"tweet.read": 1}
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["body_parsed"] is True
+        assert entry["response_data_count"] == 1
+        assert entry["response_result_count"] == 1
+        assert entry["billable_counts"] == {"tweet.read": 1}
 
     def test_logs_write_operation_charges_one(self, tmp_path):
         """POST /2/tweets → billable_counts={tweet.write:1} regardless of body shape."""
@@ -1846,11 +1853,10 @@ class TestLogConnectorUsage:
             rule="POST /2/tweets",
         )
         flow.request.method = "POST"
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["method"] == "POST"
-        assert kwargs["billable_counts"] == {"tweet.write": 1}
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["method"] == "POST"
+        assert entry["billable_counts"] == {"tweet.write": 1}
 
     # ---- forensic / parser-state cases ----
 
@@ -1858,111 +1864,98 @@ class TestLogConnectorUsage:
         """stream_buffer_state.truncated → body_parsed False, body_truncated True."""
         flow = self._make_x_flow(tmp_path, body=b"{")
         flow.metadata["stream_buffer_state"] = {"truncated": True}
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["body_parsed"] is False
-        assert kwargs["body_truncated"] is True
-        assert "response_data_count" not in kwargs
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["body_parsed"] is False
+        assert entry["body_truncated"] is True
+        assert "response_data_count" not in entry
 
     def test_handles_invalid_json(self, tmp_path):
         """Malformed body → body_parsed False, no count fields, entry still logged."""
         flow = self._make_x_flow(tmp_path, body=b"not json")
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["body_parsed"] is False
-        assert kwargs["body_truncated"] is False
-        assert "response_data_count" not in kwargs
-        assert "response_includes" not in kwargs
-        assert "response_result_count" not in kwargs
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["body_parsed"] is False
+        assert entry["body_truncated"] is False
+        assert "response_data_count" not in entry
+        assert "response_includes" not in entry
+        assert "response_result_count" not in entry
         # No count signals + GET + body unparseable → fallback 100
-        assert kwargs["billable_counts"] == {"tweet.read": 100}
+        assert entry["billable_counts"] == {"tweet.read": 100}
 
     def test_billable_counts_fallback_only_when_no_hints(self, tmp_path):
         """body_parsed False but ?ids= present → use ids_count, no fallback."""
         flow = self._make_x_flow(tmp_path, query="ids=1,2,3", body=b"not json")
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["body_parsed"] is False
-        assert kwargs["billable_counts"] == {"tweet.read": 3}  # from ids, not fallback
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["body_parsed"] is False
+        assert entry["billable_counts"] == {"tweet.read": 3}  # from ids, not fallback
 
     def test_billable_counts_fallback_only_when_no_max_results(self, tmp_path):
         """body_parsed False but ?max_results=50 present → use max_results, no fallback."""
         flow = self._make_x_flow(tmp_path, query="max_results=50", body=b"not json")
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["body_parsed"] is False
-        assert kwargs["billable_counts"] == {"tweet.read": 50}
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["body_parsed"] is False
+        assert entry["billable_counts"] == {"tweet.read": 50}
 
     def test_handles_empty_body(self, tmp_path):
         """Empty stream_buffer → body_parsed False, entry still logged."""
         flow = self._make_x_flow(tmp_path, body=b"")
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["body_parsed"] is False
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["body_parsed"] is False
 
     def test_handles_invalid_max_results(self, tmp_path):
         """Non-integer max_results param falls back to None, doesn't raise."""
         body = json.dumps({"data": []}).encode()
         flow = self._make_x_flow(tmp_path, query="max_results=abc", body=body)
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        _, kwargs = mock_log.call_args
-        assert kwargs["max_results"] is None
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["max_results"] is None
 
     # ---- skip cases ----
 
     def test_skips_on_server_error(self, tmp_path):
         flow = self._make_x_flow(tmp_path, status=500)
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        mock_log.assert_not_called()
+        usage.log_connector_usage(flow, "run-abc-123")
+        assert self._read_entries(tmp_path) == []
 
     def test_skips_on_rate_limit(self, tmp_path):
         flow = self._make_x_flow(tmp_path, status=429)
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        mock_log.assert_not_called()
+        usage.log_connector_usage(flow, "run-abc-123")
+        assert self._read_entries(tmp_path) == []
 
     def test_skips_on_empty_permission(self, tmp_path):
         """Unknown-endpoint-allow has no stable pricing key."""
         flow = self._make_x_flow(tmp_path, permission="")
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        mock_log.assert_not_called()
+        usage.log_connector_usage(flow, "run-abc-123")
+        assert self._read_entries(tmp_path) == []
 
     def test_skips_on_empty_run_id(self, tmp_path):
         flow = self._make_x_flow(tmp_path)
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "")
-        mock_log.assert_not_called()
+        usage.log_connector_usage(flow, "")
+        assert self._read_entries(tmp_path) == []
 
     def test_skips_for_model_provider(self, tmp_path):
         """Model providers go through maybe_report_proxy_usage instead."""
         flow = self._make_x_flow(tmp_path)
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        mock_log.assert_not_called()
+        usage.log_connector_usage(flow, "run-abc-123")
+        assert self._read_entries(tmp_path) == []
 
     def test_skips_for_non_billable_connector(self, tmp_path):
         """Connectors not in _BILLABLE_CONNECTORS are not logged."""
         flow = self._make_x_flow(tmp_path)
         flow.metadata["firewall_name"] = "gamma"
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        mock_log.assert_not_called()
+        usage.log_connector_usage(flow, "run-abc-123")
+        assert self._read_entries(tmp_path) == []
 
     def test_skips_when_no_response(self, tmp_path):
         flow = self._make_x_flow(tmp_path)
         flow.response = None
-        with patch.object(usage, "log_proxy_entry") as mock_log:
-            usage.log_connector_usage(flow, "run-abc-123")
-        mock_log.assert_not_called()
+        usage.log_connector_usage(flow, "run-abc-123")
+        assert self._read_entries(tmp_path) == []
 
     # ---- integration: response() hook wiring ----
 

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1827,6 +1827,65 @@ class TestLogConnectorUsage:
         entry = self._read_entry(tmp_path)
         assert entry["request_ids_count"] == 3
 
+    def test_logs_users_by_usernames_batch(self, tmp_path):
+        """GET /2/users/by?usernames=a,b,c → request_ids_count=3 (usernames
+        feed the same batch-count signal as ids)."""
+        body = json.dumps(
+            {"data": [{"id": "1", "username": "a"}, {"id": "2", "username": "b"}]}
+        ).encode()
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/users/by",
+            query="usernames=a,b,c",
+            body=body,
+            permission="users.read",
+            rule="GET /2/users/by",
+        )
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["request_ids_count"] == 3
+        # max(3 usernames, 2 returned) = 3 — over-count safe when one
+        # username is suspended/missing.
+        assert entry["billable_counts"] == {"users.read": 3}
+
+    def test_combines_ids_and_usernames(self, tmp_path):
+        """Defensive: if a request carries both ids and usernames, both
+        get summed.  Real X endpoints accept one or the other, but the
+        parser should not silently drop either signal."""
+        body = json.dumps({"data": []}).encode()
+        flow = self._make_x_flow(tmp_path, query="ids=1,2&usernames=a,b,c", body=body)
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["request_ids_count"] == 5
+
+    def test_logs_tweet_counts_total_tweet_count(self, tmp_path):
+        """GET /2/tweets/counts/recent: data is time buckets, real
+        billable count is meta.total_tweet_count."""
+        body = json.dumps(
+            {
+                "data": [
+                    {"start": "2026-04-14T00:00", "end": "2026-04-15T00:00", "tweet_count": 8000},
+                    {"start": "2026-04-15T00:00", "end": "2026-04-16T00:00", "tweet_count": 4567},
+                ],
+                "meta": {"total_tweet_count": 12567},
+            }
+        ).encode()
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/tweets/counts/recent",
+            query="query=hello",
+            body=body,
+            rule="GET /2/tweets/counts/recent",
+        )
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        # data carries 2 bucket objects, but the real matched-tweet count
+        # lives in meta.total_tweet_count.
+        assert entry["response_data_count"] == 2
+        assert entry["response_result_count"] == 12567
+        # max(0, 2 buckets, 12567 tweets, 0, 1) = 12567
+        assert entry["billable_counts"] == {"tweet.read": 12567}
+
     def test_handles_gzip_body(self, tmp_path):
         """gzip-encoded response body decompresses before parsing."""
         import gzip


### PR DESCRIPTION
## Summary

- Stage 0 of #9269 — proxy-side observation for X API only. Closes #9504.
- Records one structured `connector_usage` entry per successful X request to the per-run proxy log JSONL, capturing every signal needed to choose a server-side billing formula later (request `?ids=` count, expansions flag, `?max_results=`, response `data` length, `includes.*` counts, `meta.result_count`, parser state markers).
- No platform reporting, no DB schema, no contract changes — easy to revert.

## What it does

For each request whose firewall matches X (`firewall_name == "x"`), 2xx, with a non-empty `firewall_permission`, and a non-empty `run_id`, emit one log entry like:

```json
{
  "type": "connector_usage",
  "connector": "x",
  "endpoint": "tweet.read",
  "rule": "GET /2/tweets",
  "method": "GET",
  "flow_id": "...",
  "status": 200,
  "request_ids_count": 5,
  "has_expansions": true,
  "max_results": 100,
  "response_data_count": 5,
  "response_includes": {"users": 1, "media": 2},
  "response_result_count": null,
  "body_parsed": true,
  "body_truncated": false
}
```

## Why this set of fields

X API bills reads **per resource fetched** (not per request); writes per request. We don't yet know whether expansions resources are billed independently (X docs ambiguous; user reports of cost-mismatches on devcommunity suggest yes). Logging all dimensions defers the formula choice to server-side analysis against real X invoices. With the fields above and a conservative server-side rule like `max(request_ids_count, response_data_count, response_result_count, 1) + Σ includes.*`, we can guarantee never under-charging.

24-hour resource dedup is intentionally not done in proxy (cross-flow state is the wrong layer); always over-counting is the correct direction (we never under-charge).

## Implementation

| Commit | Change |
|---|---|
| `9e74cdad3` | `body_utils.py`: add `PER_CALL_DECOMPRESS_LIMIT = 5 MB` so X gzip bodies fully decompress (the default 64 KB cap would silently truncate search responses) |
| `250194924` | `usage.py`: add `is_per_call_connector`, `_parse_x_request_metadata`, `_parse_x_response_metadata`, `log_connector_usage`. `mitm_addon.py`: extend `responseheaders` to disable buffer truncation for per-call connectors; call `log_connector_usage` from `response()` after `maybe_report_proxy_usage` |
| `3ea43c19a` | 19 new tests covering single-resource / batch / expansions / search / repeated `?ids=` / gzip / truncated buffer / malformed JSON / empty body / invalid `max_results` / 6 negative gates / response()-hook integration |

Why **method A** (stdlib `json.loads` after full buffer) over alternatives: `ijson` is unusable because mitmproxy v12.2.1 ships as a PyInstaller standalone binary with frozen dependencies (`crates/runner/src/deps.rs:5`); a hand-rolled streaming JSON state machine is over-engineering for X's bounded response sizes; tail-256-byte regex would lose `includes` data, defeating the expansions-billing safeguard. Full reasoning in the issue's deep-dive comments.

## Out of scope

- Webhook upload of usage payload (Stage 1)
- `webhookUsageContract` / `credit_usage` schema extension (Stage 2)
- `credit-service.ts` per-call pricing logic (Stage 3)
- Other connectors (Nano Banana, Gamma, Veo, V0) — separate issues under #9269
- 24h resource dedup — server-side concern

## Test plan

- [x] `cd crates/runner/mitm-addon && python3 -m pytest tests/ -q` — 781 passed (19 new)
- [x] `ruff check src tests && ruff format --check src tests` — clean
- [x] `cargo check -p runner --manifest-path crates/Cargo.toml` — compiles
- [ ] After merge: deploy to staging, trigger agent X API calls, verify `type=connector_usage` entries appear in per-run proxy log JSONL with expected field values for batch, search, and write requests

## Rollback

Worst case (memory pressure or log noise): revert the one-line `usage.log_connector_usage(flow, run_id)` call in `mitm_addon.response()` — function stays dead but harmless. Full revert is a single merge-commit revert; no schema migrations to undo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)