### PR TITLE
fix(phone): add cleanup cron job for orphaned pending_outbound_calls rows

### DIFF
--- a/turbo/apps/web/app/api/cron/phone-cleanup/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/phone-cleanup/__tests__/route.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET } from "../route";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
+import { insertPendingOutboundCall } from "../../../../../src/__tests__/db-test-seeders/phone";
+import { findPendingOutboundCall } from "../../../../../src/__tests__/db-test-assertions/phone";
+import { reloadEnv } from "../../../../../src/env";
+
+vi.hoisted(() => {
+  vi.stubEnv("CRON_SECRET", "test-cron-secret");
+});
+
+const context = testContext();
+
+function cronRequest(secret?: string) {
+  return new Request("http://localhost:3000/api/cron/phone-cleanup", {
+    method: "GET",
+    headers: secret ? { authorization: `Bearer ${secret}` } : {},
+  });
+}
+
+describe("GET /api/cron/phone-cleanup", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    vi.stubEnv("CRON_SECRET", "test-cron-secret");
+    reloadEnv();
+  });
+
+  it("should return 401 with invalid cron secret", async () => {
+    const response = await GET(cronRequest("wrong-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect((body as { error: { code: string } }).error.code).toBe(
+      "UNAUTHORIZED",
+    );
+  });
+
+  it("should return 401 with no authorization header", async () => {
+    const response = await GET(cronRequest());
+    expect(response.status).toBe(401);
+  });
+
+  it("should return zero cleaned when no stale rows exist", async () => {
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect((body as { success: boolean; cleaned: number }).success).toBe(true);
+    expect((body as { success: boolean; cleaned: number }).cleaned).toBe(0);
+  });
+
+  it("should delete pending outbound call rows older than 24h", async () => {
+    const user = await context.setupUser();
+    const callId = uniqueId("call-stale");
+    const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000); // 25h ago
+
+    await insertPendingOutboundCall({
+      callId,
+      orgId: user.orgId,
+      userId: user.userId,
+      agentId: "00000000-0000-0000-0000-000000000001",
+      createdAt: staleTime,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect((body as { cleaned: number }).cleaned).toBe(1);
+    expect(await findPendingOutboundCall(callId)).toBeUndefined();
+  });
+
+  it("should not delete recent pending outbound call rows (<24h)", async () => {
+    const user = await context.setupUser();
+    const callId = uniqueId("call-fresh");
+
+    await insertPendingOutboundCall({
+      callId,
+      orgId: user.orgId,
+      userId: user.userId,
+      agentId: "00000000-0000-0000-0000-000000000002",
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect((body as { cleaned: number }).cleaned).toBe(0);
+    expect(await findPendingOutboundCall(callId)).toBeDefined();
+  });
+});

--- a/turbo/apps/web/app/api/cron/phone-cleanup/route.ts
+++ b/turbo/apps/web/app/api/cron/phone-cleanup/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { lt } from "drizzle-orm";
+import { initServices } from "../../../../src/lib/init-services";
+import { logger } from "../../../../src/lib/shared/logger";
+import { env } from "../../../../src/env";
+import { pendingOutboundCalls } from "../../../../src/db/schema/pending-outbound-call";
+
+const log = logger("cron:phone-cleanup");
+
+// Pending outbound call rows older than this threshold are considered orphaned
+// (i.e. the call_ended webhook was never delivered) and should be removed.
+const PENDING_CALL_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export async function GET(request: Request): Promise<Response> {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = env().CRON_SECRET;
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { error: { message: "Invalid cron secret", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const cutoff = new Date(Date.now() - PENDING_CALL_TTL_MS);
+
+  const deleted = await globalThis.services.db
+    .delete(pendingOutboundCalls)
+    .where(lt(pendingOutboundCalls.createdAt, cutoff))
+    .returning({ callId: pendingOutboundCalls.callId });
+
+  if (deleted.length > 0) {
+    log.info("Cleaned up orphaned pending outbound calls", {
+      count: deleted.length,
+    });
+  }
+
+  return NextResponse.json({ success: true, cleaned: deleted.length });
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/phone.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/phone.ts
@@ -122,6 +122,7 @@ export async function insertPendingOutboundCall(opts: {
   userId: string;
   agentId: string;
   sessionId?: string;
+  createdAt?: Date;
 }): Promise<void> {
   initServices();
   await globalThis.services.db.insert(pendingOutboundCalls).values({
@@ -130,5 +131,6 @@ export async function insertPendingOutboundCall(opts: {
     userId: opts.userId,
     agentId: opts.agentId,
     sessionId: opts.sessionId ?? null,
+    createdAt: opts.createdAt,
   });
 }

--- a/turbo/apps/web/vercel.json
+++ b/turbo/apps/web/vercel.json
@@ -42,6 +42,10 @@
     {
       "path": "/api/cron/compare-proxy-usage",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/cron/phone-cleanup",
+      "schedule": "0 2 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `GET /api/cron/phone-cleanup` that deletes `pending_outbound_calls` rows older than 24h
- Registers the cron at `0 2 * * *` (daily at 02:00 UTC) in `vercel.json`
- Adds `createdAt` override to `insertPendingOutboundCall` test seeder so tests can simulate stale rows without direct DB access
- Includes 5 integration tests covering auth, empty state, stale deletion, and fresh-row preservation

## Context

PR #9465 introduced the `pending_outbound_calls` table and its schema JSDoc noted that rows are "deleted after processing (or after TTL expiry)". The TTL expiry mechanism was missing — orphaned rows from undelivered `call_ended` webhooks would accumulate indefinitely. This PR adds that cleanup job.

## Test plan

- [ ] `pnpm -F web exec vitest run app/api/cron/phone-cleanup` — all 5 tests pass
- [ ] `pnpm turbo run lint` — no errors
- [ ] `pnpm check-types` — no type errors
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)