### PR TITLE
perf(crates): make mold the default linker for runner and guests

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -321,11 +321,6 @@ jobs:
             -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-reseed
 
       - name: Cross-compile runner with embedded guests for ARM64
-        env:
-          # Override .cargo/config.toml to use mold (pre-installed in toolchain-rust
-          # image) for faster runner linking. Only runner uses this — guests use the
-          # default linker for image_hash consistency.
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=-fuse-ld=mold"
         run: |
           cd crates
           GUEST_AGENT_PATH="target/$TARGET_TRIPLE/release/guest-agent" \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1384,11 +1384,6 @@ jobs:
             -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-reseed
 
       - name: Cross-compile runner with embedded guests for ARM64
-        env:
-          # Override .cargo/config.toml to use mold (pre-installed in toolchain-rust
-          # image) for faster runner linking. Only runner uses this — guests use the
-          # default linker for image_hash consistency.
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=-fuse-ld=mold"
         run: |
           cd crates
           GUEST_AGENT_PATH="target/$TARGET_TRIPLE/release/guest-agent" \

--- a/crates/.cargo/config.toml
+++ b/crates/.cargo/config.toml
@@ -1,3 +1,3 @@
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-gnu-gcc"
-rustflags = ["-C", "target-feature=+crt-static"]
+rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-fuse-ld=mold"]


### PR DESCRIPTION
## Summary

Part 3 (final) of the 3-PR mold rollout — closes #9489.

- Add `-C link-arg=-fuse-ld=mold` to `crates/.cargo/config.toml` so both runner and guest builds use mold by default.
- Remove the per-job `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS` env override in `crates.yml` and `turbo.yml` — the cargo config now handles it.

## Why this is safe

mold's output is deterministic and mold has no host-specific defaults. Combined with the mold version being pinned in the toolchain image (which is also the dev container base — bumped to `20260415` in #9510), every developer and every CI run produces byte-identical guest binaries → stable `image_hash` → rootfs cache stays effective.

## Expected impact

- One-time cache invalidation: guest binary bytes change once → `image_hash` shifts once → rootfs rebuilt on first run after merge. Subsequent builds are stable.
- Faster guest link step in `runner-build` jobs.

## Test plan

- [ ] `lint` / `test` / `deploy` / `cli-e2e` jobs in `turbo.yml` all pass.
- [ ] `runner-build` jobs produce a runnable binary (verified by `deploy-runner-prepare` reaching the metal hosts).
- [ ] First post-merge `runner-build` successfully rebuilds rootfs; follow-up runs reuse R2 cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)