### PR TITLE
fix: prevent credit usage numbers from wrapping

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -487,16 +487,16 @@ function MembersTable({
                   )}
                 </div>
               </div>
-              <span className="text-[13px] tabular-nums text-foreground">
+              <span className="text-[13px] tabular-nums text-foreground whitespace-nowrap">
                 {member.creditsCharged.toLocaleString()}
               </span>
-              <span className="text-[13px] tabular-nums text-muted-foreground/50">
+              <span className="text-[13px] tabular-nums text-muted-foreground/50 whitespace-nowrap">
                 {remaining !== null ? remaining.toLocaleString() : "–"}
               </span>
               {isAdmin ? (
                 <InlineCapInput member={member} />
               ) : (
-                <span className="text-[13px] tabular-nums text-muted-foreground">
+                <span className="text-[13px] tabular-nums text-muted-foreground whitespace-nowrap">
                   {member.creditCap !== null
                     ? member.creditCap.toLocaleString()
                     : "—"}


### PR DESCRIPTION
Closes #9515

Add `whitespace-nowrap` to the Used, Remaining, and Limit cap number cells in the team credit usage list, preventing values like "118.7 K" from splitting across two lines.