### PR TITLE
refactor: update compose and cook commands to use unified --artifact flag

### DIFF
--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -349,7 +349,7 @@ async function finalizeCompose(
     console.log("  Run your agent:");
     console.log(
       chalk.cyan(
-        `    vm0 run ${displayName}:${shortVersionId} --artifact-name <artifact> "your prompt"`,
+        `    vm0 run ${displayName}:${shortVersionId} --artifact <artifact> "your prompt"`,
       ),
     );
   }

--- a/turbo/apps/cli/src/commands/cook/cook.ts
+++ b/turbo/apps/cli/src/commands/cook/cook.ts
@@ -219,15 +219,13 @@ async function runAgent(
 ): Promise<void> {
   console.log();
   console.log(chalk.bold("Running agent:"));
-  printCommand(
-    `vm0 run ${agentName} --artifact-name ${ARTIFACT_DIR} "${prompt}"`,
-  );
+  printCommand(`vm0 run ${agentName} --artifact ${ARTIFACT_DIR} "${prompt}"`);
   console.log();
 
   const runArgs = [
     "run",
     agentName,
-    "--artifact-name",
+    "--artifact",
     ARTIFACT_DIR,
     ...(options.envFile ? ["--env-file", options.envFile] : []),
     ...(options.verbose ? ["--verbose"] : []),
@@ -308,7 +306,7 @@ export const cookAction = new Command()
           console.log();
           console.log("To run your agent:");
           printCommand(
-            `vm0 run ${agentName} --artifact-name ${ARTIFACT_DIR} "your prompt"`,
+            `vm0 run ${agentName} --artifact ${ARTIFACT_DIR} "your prompt"`,
           );
         }
       },


### PR DESCRIPTION
## Summary

- Replace deprecated `--artifact-name` with `--artifact` in `compose/index.ts` help text
- Replace deprecated `--artifact-name` with `--artifact` in `cook/cook.ts` display text and programmatic args
- These were the last remaining references to the old flag outside of the deprecated alias in `run.ts`

Closes #9516

## Test plan

- [x] `grep -r "artifact-name" compose/` returns no results
- [x] `grep -r "artifact-name" cook/` returns no results
- [x] Compose tests pass (93 tests)
- [x] Cook tests pass (37 tests)
- [x] Run tests pass (158 tests)
- [x] Lint passes
- [x] CLI type check passes
- [x] Format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)