### PR TITLE
fix(imessage): clean up seeder signature and remove defensive catch

### DIFF
--- a/turbo/apps/web/app/api/zero/phone/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/phone/webhook/__tests__/route.test.ts
@@ -319,7 +319,7 @@ describe("POST /api/zero/phone/webhook", () => {
     const TEST_FROM_NUMBER = `+1555${uniqueId("").replace(/-/g, "").slice(0, 7)}`;
     const user = await context.setupUser();
     const { agentphoneAgentId } = await createPhoneOrg(user.orgId);
-    await linkIMessageHandle(TEST_FROM_NUMBER, user.userId, user.orgId);
+    await linkIMessageHandle(TEST_FROM_NUMBER, user.orgId);
     // linkIMessageHandle sends a success iMessage via after(); flush it before testing the webhook
     await flushAfterCallbacks();
     await insertOrgDefaultModelProvider(user.orgId, "anthropic");

--- a/turbo/apps/web/src/__tests__/db-test-seeders/phone.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/phone.ts
@@ -146,7 +146,6 @@ export async function insertPendingOutboundCall(opts: {
  */
 export async function linkIMessageHandle(
   imessageHandle: string,
-  _userId: string,
   orgId: string,
 ): Promise<void> {
   const timestamp = Math.floor(Date.now() / 1000);

--- a/turbo/apps/web/src/lib/zero/phone/imessage-service.ts
+++ b/turbo/apps/web/src/lib/zero/phone/imessage-service.ts
@@ -42,9 +42,7 @@ export async function sendIMessage(opts: {
   });
 
   if (!response.ok) {
-    const text = await response.text().catch(() => {
-      return "unknown";
-    });
+    const text = await response.text();
     log.error("AgentPhone sendMessage failed", {
       status: response.status,
       body: text,


### PR DESCRIPTION
## Summary

Follow-up P1 fixes from PR #9463 review that merged before the fixes could be pushed:

- Remove unused second parameter (`_userId`) from `linkIMessageHandle` seeder in `phone.ts`. The user identity is determined by the active Clerk mock, not the passed-in value — the parameter was silently ignored and misled callers into thinking it affected behavior.
- Update the call site in the webhook route test to use the new two-arg signature.
- Remove redundant `.catch()` on `response.text()` in `imessage-service.ts`. The outer `sendIMessage()` already throws on failure; the catch was suppressing a low-level error unnecessarily (violates fail-fast principle).

## Test plan
- [x] All 33 iMessage integration tests pass (link, callback, webhook, connect action)
- [x] Format, lint, type-check, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)