### PR TITLE
refactor(voice-chat): use shared createScrollSignals factory for auto-scroll

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-auto-scroll.ts
@@ -1,52 +1,15 @@
-import { command, state } from "ccstate";
-import { onRef } from "../utils.ts";
-
-const NEAR_BOTTOM_THRESHOLD = 80;
+import { createScrollSignals } from "../auto-scroll.ts";
 
 // --- Transcript panel ---
 
-const transcriptScrollContainer$ = state<HTMLElement | null>(null);
-
-export const setTranscriptScrollContainer$ = onRef(
-  command(({ set }, el: HTMLElement, signal: AbortSignal) => {
-    signal.addEventListener("abort", () => {
-      set(transcriptScrollContainer$, null);
-    });
-    set(transcriptScrollContainer$, el);
-  }),
-);
-
-export const autoScrollTranscript$ = command(({ get }) => {
-  const el = get(transcriptScrollContainer$);
-  if (!el) {
-    return;
-  }
-  const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-  if (distanceFromBottom < NEAR_BOTTOM_THRESHOLD) {
-    el.scrollTop = el.scrollHeight;
-  }
-});
+const transcriptScrollSignals = createScrollSignals();
+export const setTranscriptScrollContainer$ =
+  transcriptScrollSignals.setScrollContainer$;
+export const autoScrollTranscript$ = transcriptScrollSignals.autoScroll$;
 
 // --- Events panel ---
 
-const eventsScrollContainer$ = state<HTMLElement | null>(null);
-
-export const setEventsScrollContainer$ = onRef(
-  command(({ set }, el: HTMLElement, signal: AbortSignal) => {
-    signal.addEventListener("abort", () => {
-      set(eventsScrollContainer$, null);
-    });
-    set(eventsScrollContainer$, el);
-  }),
-);
-
-export const autoScrollEvents$ = command(({ get }) => {
-  const el = get(eventsScrollContainer$);
-  if (!el) {
-    return;
-  }
-  const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-  if (distanceFromBottom < NEAR_BOTTOM_THRESHOLD) {
-    el.scrollTop = el.scrollHeight;
-  }
-});
+const eventsScrollSignals = createScrollSignals();
+export const setEventsScrollContainer$ =
+  eventsScrollSignals.setScrollContainer$;
+export const autoScrollEvents$ = eventsScrollSignals.autoScroll$;

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-auto-scroll.ts
@@ -2,14 +2,14 @@ import { createScrollSignals } from "../auto-scroll.ts";
 
 // --- Transcript panel ---
 
-const transcriptScrollSignals = createScrollSignals();
-export const setTranscriptScrollContainer$ =
-  transcriptScrollSignals.setScrollContainer$;
-export const autoScrollTranscript$ = transcriptScrollSignals.autoScroll$;
+export const {
+  setScrollContainer$: setTranscriptScrollContainer$,
+  autoScroll$: autoScrollTranscript$,
+} = createScrollSignals();
 
 // --- Events panel ---
 
-const eventsScrollSignals = createScrollSignals();
-export const setEventsScrollContainer$ =
-  eventsScrollSignals.setScrollContainer$;
-export const autoScrollEvents$ = eventsScrollSignals.autoScroll$;
+export const {
+  setScrollContainer$: setEventsScrollContainer$,
+  autoScroll$: autoScrollEvents$,
+} = createScrollSignals();


### PR DESCRIPTION
## Summary

- Replaces the custom scroll logic in `voice-chat-auto-scroll.ts` with two instances of the shared `createScrollSignals()` factory
- Voice chat transcript and events panels now get the same smart scroll behavior as the platform chat: user-scroll-direction tracking (disables auto-scroll when user scrolls up, re-enables when back at bottom) and ResizeObserver support
- No changes needed in `use-voice-chat-auto-scroll.ts` or `voice-chat-page.tsx` — exported names are unchanged

## Changes

- `turbo/apps/platform/src/signals/voice-chat/voice-chat-auto-scroll.ts`: 52 lines → 15 lines

## Test plan

- [ ] Start a voice chat session and verify transcript auto-scrolls as new messages arrive
- [ ] Scroll up in transcript panel — auto-scroll should pause
- [ ] Scroll back to bottom — auto-scroll should resume
- [ ] Verify events panel behaves the same way
- [ ] Check preparing/meeting state events panel also scrolls correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)