### PR TITLE
fix(runner): make build-rootfs.sh cleanup safe against umount failure

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -112,6 +112,10 @@ ROOTFS_FILE="rootfs.ext4"
 CA_CERT_FILE="mitmproxy-ca-cert.pem"
 CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt"
 
+# `$$` here is the *inner* (post-re-exec) bash PID — sudo forks, so the
+# inner PID differs from any outer bash that may have invoked the script
+# without the `--_unshared_` sentinel. Do not read `$$` above the re-exec
+# gate and expect the same value here.
 TMP_ROOTFS="${ROOTFS_FILE}.tmp.$$"
 
 # Paths derived from arguments

--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -575,8 +575,13 @@ mv "$TMP_ROOTFS_PATH" "$ROOTFS_PATH"
 # (runner reading/replacing the file) don't need sudo. SUDO_USER is set
 # by the outer sudo at re-exec time; if it is missing or "root" the
 # chown is a no-op.
+#
+# Don't fail the build on chown error: the artifact is valid on disk and
+# mode 644 makes it world-readable, so a mis-ownership is cosmetic — the
+# runner can still consume it. Warn instead so operators can investigate.
 if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
-  chown "$SUDO_USER" "$ROOTFS_PATH"
+  chown "$SUDO_USER" "$ROOTFS_PATH" \
+    || echo "warning: chown $SUDO_USER $ROOTFS_PATH failed; file remains root-owned" >&2
 fi
 
 # Report size

--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -162,6 +162,12 @@ cleanup_chroot() {
   # the root cause if it still fails.
   local target attempt
   for target in "$ROOTFS_DIR/dev" "$ROOTFS_DIR/sys" "$ROOTFS_DIR/proc"; do
+    # Skip if never mounted (e.g. early failure before debootstrap_build
+    # installed the binds). Avoids retrying umount on plain dirs and
+    # polluting CI logs with "not mounted" errors from the final attempt.
+    if ! mountpoint -q "$target" 2>/dev/null; then
+      continue
+    fi
     for attempt in 1 2 3; do
       if [[ $attempt -eq 3 ]]; then
         # Surface stderr on the final attempt so CI logs capture the
@@ -523,7 +529,7 @@ create_ext4() {
 }
 
 # ---------------------------------------------------------------------------
-# Main
+# Main (runs inside the private mount namespace set up by the re-exec above)
 # ---------------------------------------------------------------------------
 
 check_dependencies

--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -10,6 +10,17 @@
 # cp to ext4 mount). mkfs.ext4 -d populates the ext4 image directly from
 # the rootfs directory.
 #
+# The build runs inside a private mount namespace (via `unshare --mount
+# --propagation private`). Bind mounts of host /proc, /sys, /dev created
+# for chroot operations are confined to this namespace — the host never
+# sees them, and the kernel auto-unmounts everything when the script exits
+# (including on SIGKILL, where the EXIT trap would not fire).
+#
+# `rm -rf --one-file-system` in the cleanup trap is a hard safety net: even
+# if umount fails inside our namespace, rm refuses to cross the bind-mount
+# boundary, eliminating any risk of unlinking host /dev entries through the
+# shared devtmpfs superblock.
+#
 # Usage:
 #   bash build-rootfs.sh \
 #     --output-dir /path/to/output \
@@ -25,6 +36,22 @@
 #     [--mirror http://archive.ubuntu.com/ubuntu]
 
 set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Re-exec inside a private mount namespace
+# ---------------------------------------------------------------------------
+#
+# Uses a positional sentinel (not an env var) so we don't depend on sudoers
+# allowing env preservation.
+if [[ "${1:-}" != "--_unshared_" ]]; then
+  if ! command -v unshare &>/dev/null; then
+    echo "error: unshare not found (install util-linux)" >&2
+    exit 1
+  fi
+  exec sudo unshare --mount --propagation private \
+    -- bash "$0" "--_unshared_" "$@"
+fi
+shift
 
 # ---------------------------------------------------------------------------
 # Argument parsing
@@ -125,22 +152,51 @@ check_dependencies() {
 # ---------------------------------------------------------------------------
 
 cleanup_chroot() {
-  if [[ -n "$ROOTFS_DIR" ]]; then
-    # -R unmounts recursively — bind-mounting /dev brings in sub-mounts
-    # like /dev/shm, /dev/mqueue, /dev/hugepages that must be removed first.
-    sudo umount -R "$ROOTFS_DIR/dev" 2>/dev/null || true
-    sudo umount "$ROOTFS_DIR/sys" 2>/dev/null || true
-    sudo umount "$ROOTFS_DIR/proc" 2>/dev/null || true
+  if [[ -z "$ROOTFS_DIR" ]]; then
+    return
   fi
+  # -R unmounts recursively — bind-mounting /dev brings in sub-mounts
+  # like /dev/shm, /dev/mqueue, /dev/hugepages that must be removed first.
+  # Retry handles transient EBUSY from chroot subprocesses that haven't
+  # fully exited yet. The last attempt lets stderr through so CI logs show
+  # the root cause if it still fails.
+  local target attempt
+  for target in "$ROOTFS_DIR/dev" "$ROOTFS_DIR/sys" "$ROOTFS_DIR/proc"; do
+    for attempt in 1 2 3; do
+      if [[ $attempt -eq 3 ]]; then
+        # Surface stderr on the final attempt so CI logs capture the
+        # busy reason. set -e will abort if this fails — that is the
+        # desired behavior for the pre-mkfs call (polluted ext4 is
+        # worse than a failed build); the EXIT trap wraps in `|| true`
+        # to keep the rest of cleanup running.
+        sudo umount -R "$target"
+        break
+      fi
+      if sudo umount -R "$target" 2>/dev/null; then
+        break
+      fi
+      sleep 0.5
+    done
+  done
 }
 
 cleanup() {
   echo "cleaning up..."
-  cleanup_chroot
-  sudo rm -f "$TMP_ROOTFS_PATH" 2>/dev/null || true
+  # Best-effort umount on the failure path. Errors surface to stderr but
+  # `|| true` keeps the rest of cleanup running under set -e.
+  cleanup_chroot || true
   if [[ -n "$ROOTFS_DIR" ]]; then
-    sudo rm -rf "$ROOTFS_DIR" 2>/dev/null || true
+    # `--one-file-system`: if cleanup_chroot failed, $ROOTFS_DIR/{dev,sys,proc}
+    # still bind-mount host devtmpfs/procfs/sysfs. Because bind mounts share
+    # the source superblock (private propagation only confines mount events,
+    # not inode data), a plain `rm -rf` could unlink host /dev/null etc.
+    # This flag makes rm refuse to cross the bind-mount boundary, trading a
+    # leaked tmp dir for guaranteed host safety. The leak itself is bounded:
+    # the private mount namespace dies with this script and the kernel
+    # reclaims both the mounts and (via systemd-tmpfiles) the /tmp entry.
+    sudo rm -rf --one-file-system "$ROOTFS_DIR" || true
   fi
+  rm -f "$TMP_ROOTFS_PATH" || true
 }
 
 trap cleanup EXIT

--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -21,6 +21,9 @@
 # boundary, eliminating any risk of unlinking host /dev entries through the
 # shared devtmpfs superblock.
 #
+# The output rootfs file is chowned back to $SUDO_USER at the end so the
+# runner can operate on it without sudo (matches pre-unshare ownership).
+#
 # Usage:
 #   bash build-rootfs.sh \
 #     --output-dir /path/to/output \
@@ -42,14 +45,18 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 #
 # Uses a positional sentinel (not an env var) so we don't depend on sudoers
-# allowing env preservation.
-if [[ "${1:-}" != "--_unshared_" ]]; then
-  if ! command -v unshare &>/dev/null; then
-    echo "error: unshare not found (install util-linux)" >&2
-    exit 1
-  fi
+# allowing env preservation. The sentinel is prefixed with `__vm0_` to make
+# an accidental arg collision vanishingly unlikely.
+readonly UNSHARE_SENTINEL="--__vm0_unshared__"
+if [[ "${1:-}" != "$UNSHARE_SENTINEL" ]]; then
+  for cmd in sudo unshare; do
+    if ! command -v "$cmd" &>/dev/null; then
+      echo "error: $cmd not found (sudo is required to enter a mount namespace; unshare from util-linux)" >&2
+      exit 1
+    fi
+  done
   exec sudo unshare --mount --propagation private \
-    -- bash "$0" "--_unshared_" "$@"
+    -- bash "$0" "$UNSHARE_SENTINEL" "$@"
 fi
 shift
 
@@ -114,8 +121,8 @@ CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt"
 
 # `$$` here is the *inner* (post-re-exec) bash PID — sudo forks, so the
 # inner PID differs from any outer bash that may have invoked the script
-# without the `--_unshared_` sentinel. Do not read `$$` above the re-exec
-# gate and expect the same value here.
+# without the UNSHARE_SENTINEL. Do not read `$$` above the re-exec gate
+# and expect the same value here.
 TMP_ROOTFS="${ROOTFS_FILE}.tmp.$$"
 
 # Paths derived from arguments
@@ -137,7 +144,7 @@ AGENT_BROWSER_VERSION="0.25.4"
 check_dependencies() {
   local missing=()
 
-  for cmd in debootstrap sudo chroot mktemp stat mkfs.ext4; do
+  for cmd in debootstrap sudo chroot mktemp stat mkfs.ext4 umount mountpoint unshare; do
     if ! command -v "$cmd" &> /dev/null; then
       missing+=("$cmd")
     fi
@@ -155,6 +162,9 @@ check_dependencies() {
 # Cleanup
 # ---------------------------------------------------------------------------
 
+readonly UMOUNT_ATTEMPTS=3
+readonly UMOUNT_BACKOFF_SECONDS=0.5
+
 cleanup_chroot() {
   if [[ -z "$ROOTFS_DIR" ]]; then
     return
@@ -162,32 +172,38 @@ cleanup_chroot() {
   # -R unmounts recursively — bind-mounting /dev brings in sub-mounts
   # like /dev/shm, /dev/mqueue, /dev/hugepages that must be removed first.
   # Retry handles transient EBUSY from chroot subprocesses that haven't
-  # fully exited yet. The last attempt lets stderr through so CI logs show
-  # the root cause if it still fails.
-  local target attempt
+  # fully exited yet. We buffer every attempt's stderr and dump all of
+  # them on final failure so diagnostic output covers the full sequence
+  # (attempt 1 EPERM vs attempt 3 EBUSY etc.) rather than just the last.
+  local target attempt err_log attempt_err
+  local any_failure=0
   for target in "$ROOTFS_DIR/dev" "$ROOTFS_DIR/sys" "$ROOTFS_DIR/proc"; do
     # Skip if never mounted (e.g. early failure before debootstrap_build
     # installed the binds). Avoids retrying umount on plain dirs and
-    # polluting CI logs with "not mounted" errors from the final attempt.
+    # polluting CI logs with "not mounted" errors.
     if ! mountpoint -q "$target" 2>/dev/null; then
       continue
     fi
-    for attempt in 1 2 3; do
-      if [[ $attempt -eq 3 ]]; then
-        # Surface stderr on the final attempt so CI logs capture the
-        # busy reason. set -e will abort if this fails — that is the
-        # desired behavior for the pre-mkfs call (polluted ext4 is
-        # worse than a failed build); the EXIT trap wraps in `|| true`
-        # to keep the rest of cleanup running.
-        sudo umount -R "$target"
+    err_log=""
+    for (( attempt=1; attempt <= UMOUNT_ATTEMPTS; attempt++ )); do
+      if attempt_err=$(sudo umount -R "$target" 2>&1); then
         break
       fi
-      if sudo umount -R "$target" 2>/dev/null; then
-        break
-      fi
-      sleep 0.5
+      err_log+="attempt ${attempt}: ${attempt_err}"$'\n'
+      (( attempt < UMOUNT_ATTEMPTS )) && sleep "$UMOUNT_BACKOFF_SECONDS"
     done
+    # All attempts exhausted for this target — surface the buffered error
+    # sequence and remember the failure, but keep going so the remaining
+    # targets also get a chance to unmount.
+    if (( attempt > UMOUNT_ATTEMPTS )); then
+      printf '%s' "$err_log" >&2
+      any_failure=1
+    fi
   done
+  # Non-zero return aborts via set -e in the pre-mkfs call (polluted ext4
+  # is worse than a failed build); the EXIT trap wraps in `|| true` so
+  # this does not interrupt the remainder of cleanup.
+  return "$any_failure"
 }
 
 cleanup() {
@@ -210,6 +226,10 @@ cleanup() {
 }
 
 trap cleanup EXIT
+# Surface the failing command + line number on set -e-driven aborts. Fires
+# only for commands that would propagate to set -e (i.e. not in `|| true`,
+# `if`, etc.), so it doesn't spam on deliberately-handled failures.
+trap 'echo "error: command failed at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 
 # ---------------------------------------------------------------------------
 # Bootstrap Ubuntu 24.04 rootfs
@@ -549,6 +569,15 @@ create_ext4
 
 # Move into final place
 mv "$TMP_ROOTFS_PATH" "$ROOTFS_PATH"
+
+# The unshare re-exec escalates to root, so the rootfs file was created
+# as root. Restore ownership to the invoking user so downstream callers
+# (runner reading/replacing the file) don't need sudo. SUDO_USER is set
+# by the outer sudo at re-exec time; if it is missing or "root" the
+# chown is a no-op.
+if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
+  chown "$SUDO_USER" "$ROOTFS_PATH"
+fi
 
 # Report size
 SIZE=$(stat -c%s "$ROOTFS_PATH")


### PR DESCRIPTION
## Summary

Closes #9468.

Hardens `crates/runner/scripts/build-rootfs.sh` cleanup so a failed `umount` of the bind-mounted host /proc, /sys, /dev can never result in data loss on the host or a silently-corrupted rootfs image.

## Background

`build-rootfs.sh` bind-mounts host `/proc`, `/sys`, `/dev` into a tmp rootfs dir for chroot operations and tears them down in `cleanup_chroot` (both explicitly pre-mkfs and via `trap cleanup EXIT`). Before this PR:

1. Each `umount` swallowed errors with `2>/dev/null || true`.
2. The subsequent `sudo rm -rf "$ROOTFS_DIR" 2>/dev/null || true` would, if an umount had silently failed, **traverse through the still-active bind mount and unlink host entries** (devtmpfs files can be unlinked through a bind mount — procfs/sysfs mostly refuse at the kernel layer but don't fully).
3. The explicit pre-`create_ext4` call suffered the same silent-swallow, so `mkfs.ext4 -d` could package bind-mount-visible host content into the rootfs image without anyone noticing.

Issue #9468 proposed a retry loop + lazy umount. That reduces the probability of the foot-gun firing but doesn't eliminate it. Discussion on that issue (see issue comments) concluded a structural refactor was preferable.

## Changes

Three complementary safety layers:

**1. Private mount namespace (structural).** Re-exec the script under `sudo unshare --mount --propagation private`. All bind mounts live in the disposable namespace:
- Host never sees them (private propagation prevents propagation back).
- Namespace dies with the script (SIGKILL-safe — no trap needed for mount cleanup).

**2. Robust, diagnostic `cleanup_chroot`.** Retry umount 3× with 0.5s backoff for transient EBUSY, but **buffer every attempt's stderr** and dump the full sequence on final failure so an EPERM on attempt 1 isn't masked by a subsequent EBUSY. Continues through /sys and /proc even if /dev exhausts retries. When called pre-`mkfs.ext4`, failure aborts the build (via `set -e`) instead of letting mkfs package bind-mount contents.

**3. `rm -rf --one-file-system` as hard safety net.** Even in a private mount namespace, bind mounts still share the source superblock — `rm -rf` can still unlink host inodes through the shared devtmpfs. `--one-file-system` makes rm refuse to cross the bind-mount boundary, trading a leaked tmp dir for guaranteed host safety. The leak is bounded: namespace death reclaims the mounts, and `/tmp` systemd-tmpfiles reclaims the directory.

## Additional polish

- `UNSHARE_SENTINEL`, `UMOUNT_ATTEMPTS`, `UMOUNT_BACKOFF_SECONDS` are named `readonly` constants instead of hard-coded literals.
- `check_dependencies` lists the full util-linux surface (`umount`, `mountpoint`, `unshare`) so required dependencies are self-documenting.
- Pre-exec dependency check covers both `sudo` and `unshare`.
- Added an `ERR` trap that prints the failing line + command on `set -e` aborts for easier CI diagnosis (stays silent in `|| true` / `if` / `&&` contexts).
- Output rootfs file is `chown`ed back to `$SUDO_USER` at the end (best-effort; warns but doesn't fail the build if chown fails) so the runner keeps its pre-unshare ability to read/replace the file without sudo.

## Deployment notes for reviewers

- **sudoers**: The re-exec at the top of the script runs `sudo unshare ...`. Confirm the runner user's sudoers rule on metal runners and the toolchain CI container is either `ALL` or explicitly allows `/usr/bin/unshare` in addition to the existing bind-mount / debootstrap / chroot entries. If it's a narrow whitelist, an ansible update is needed before this merges.
- **Output ownership**: The rootfs file is now produced by a root-owned process (inside `sudo unshare`) and then `chown`ed back to `$SUDO_USER`. Downstream callers read / rename / `sudo` the file as before, so the restored ownership preserves the pre-PR contract.
- **Cache invalidation**: `build-rootfs.sh` content is hashed into the rootfs build-input hash, so this PR invalidates the R2 rootfs cache once. All fixes are bundled so this is a one-time cost.

## Follow-up considerations (not addressed here)

- **apt postinst daemons may extend mount-namespace lifetime.** `install_packages` installs postgresql-16 / redis-server / etc. Some postinst scripts can fork daemons that inherit our private mount namespace. Because a namespace is released only when its last process exits, a lingering helper daemon keeps the bind mounts alive in the kernel *after* our script exits. The host never sees them (private propagation) so there is no safety impact, but on long-lived metal runners this could accumulate a small kernel footprint. No instances observed in production — Debian's `policy-rc.d` + chroot detection usually blocks service start — but worth a periodic `lsns -t mnt` sweep if odd behavior shows up.
- **`shopt -s inherit_errexit` not set.** `$(dpkg --print-architecture)` failures don't propagate `set -e` to the outer shell. Pre-existing; not a correctness bug, only affects error-message precision.

## Test plan

- [ ] CI: `lint`, `test`, `deploy-runner` jobs go green — these exercise the full runner build (including `build-rootfs.sh`) end-to-end on ARM64.
- [ ] `cli-e2e-runner` passes — runs a full rootfs build + Firecracker boot cycle.
- [ ] Manually verify `ps -o pid,mnt --forest` on metal runner after a PR build shows no lingering mount namespaces (defense-in-depth; namespace should die with the script regardless).
- [ ] Verify output rootfs file ownership matches the runner user after a CI build (`ls -l $OUTPUT_DIR/rootfs.ext4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)