### PR TITLE
feat(platform): add active panel tracking and global keyboard shortcuts

### DIFF
--- a/e2e/playwright/tests/webchat.spec.ts
+++ b/e2e/playwright/tests/webchat.spec.ts
@@ -15,7 +15,7 @@ test("send a chat message and receive a response", async ({ page }) => {
   // Send a message — mock claude executes this as bash
   const marker = `e2e-${Date.now()}`;
   await textarea.fill(`echo ${marker}`);
-  await page.getByRole("button", { name: "Send" }).click();
+  await page.getByRole("button", { name: "Send", exact: true }).click();
 
   // Verify user message appears
   await expect(

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-panels.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-panels.ts
@@ -8,6 +8,7 @@ import type { PanelImperativeHandle } from "react-resizable-panels";
 const internalTaskListCollapsed$ = state(false);
 const internalMaximizedTaskId$ = state<string | null>(null);
 const internalTaskListPanelRef$ = state<PanelImperativeHandle | null>(null);
+const internalActivePanelId$ = state<string | null>(null);
 
 // ---------------------------------------------------------------------------
 // Computed (read-only)
@@ -19,6 +20,10 @@ export const taskListCollapsed$ = computed((get) => {
 
 export const maximizedTaskId$ = computed((get) => {
   return get(internalMaximizedTaskId$);
+});
+
+export const activePanelId$ = computed((get) => {
+  return get(internalActivePanelId$);
 });
 
 // ---------------------------------------------------------------------------
@@ -49,6 +54,14 @@ export const toggleTaskList$ = command(({ get }) => {
   } else {
     panelRef.collapse();
   }
+});
+
+// ---------------------------------------------------------------------------
+// Commands — active panel
+// ---------------------------------------------------------------------------
+
+export const setActivePanelId$ = command(({ set }, id: string | null) => {
+  set(internalActivePanelId$, id);
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
@@ -22,7 +22,10 @@ import {
   createVoiceChatPanelSignals,
   type VoiceChatPanelSignals,
 } from "./create-voice-chat-panel-signals.ts";
-import { maximizedTaskId$ } from "./mission-control-panels.ts";
+import {
+  maximizedTaskId$,
+  setActivePanelId$,
+} from "./mission-control-panels.ts";
 import { localStorageSignals } from "../external/local-storage.ts";
 
 // ---------------------------------------------------------------------------
@@ -203,6 +206,7 @@ function createPanelSignals(
         set(internalPanelEntry$, { kind: "chat", signals });
         set(internalOpenedAt$, Date.now());
         set(internalOpen$, true);
+        set(setActivePanelId$, taskId);
         await set(signals.loadMessages$, signal);
         return;
       }
@@ -212,6 +216,7 @@ function createPanelSignals(
         set(internalPanelEntry$, { kind: "voice", signals });
         set(internalOpenedAt$, Date.now());
         set(internalOpen$, true);
+        set(setActivePanelId$, taskId);
         await set(signals.startPolling$, panelSignal);
       } else if (task.latestRunId) {
         const panelSignal = set(resetPanelPolling$, signal);
@@ -219,6 +224,7 @@ function createPanelSignals(
         set(internalPanelEntry$, { kind: "activity", signals });
         set(internalOpenedAt$, Date.now());
         set(internalOpen$, true);
+        set(setActivePanelId$, taskId);
         await set(signals.startPolling$, panelSignal);
       }
     },
@@ -559,6 +565,17 @@ export const addOptimisticTask$ = command(
     return ts;
   },
 );
+
+// ---------------------------------------------------------------------------
+// Lookup by task ID (sync — used by global keyboard shortcuts)
+// ---------------------------------------------------------------------------
+
+export const focusTaskCard$ = command(({ get, set }, taskId: string) => {
+  const ts = get(internalTaskSignals$).get(taskId);
+  if (ts) {
+    set(ts.focusCard$);
+  }
+});
 
 // ---------------------------------------------------------------------------
 // Cross-task commands

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
@@ -1,12 +1,19 @@
 import { command, computed, state } from "ccstate";
-import { toggleTaskList$ } from "./mission-control-panels.ts";
+import { matchShortcut } from "@vm0/ui";
+import {
+  activePanelId$,
+  toggleMaximizeTask$,
+  toggleTaskList$,
+} from "./mission-control-panels.ts";
 import {
   addOptimisticTask$,
   archiveAndFocusNext$,
+  closeAndFocusNextInput$,
+  focusTaskCard$,
   setupTasksLoop$,
 } from "./mission-control-tasks.ts";
 import { setupGlobalShortcut } from "../../lib/setup-global-shortcut.ts";
-import { onRef, throwIfNotAbort } from "../utils.ts";
+import { onDomEventFn, onRef, throwIfNotAbort } from "../utils.ts";
 import { agents$ } from "../agent.ts";
 import { zeroOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
 import { createNewChatThread$ } from "../chat-page/chat-message.ts";
@@ -150,6 +157,48 @@ export const setupMissionControlKeyboard$ = command(
         },
       },
       signal,
+    );
+
+    // Panel shortcuts — work from any context (including editable targets),
+    // targeting the active panel. Skipped if already handled by the panel's
+    // own onKeyDown (detected via e.defaultPrevented).
+    document.addEventListener(
+      "keydown",
+      onDomEventFn(async (e: KeyboardEvent) => {
+        if (e.defaultPrevented) {
+          return;
+        }
+        const activeId = get(activePanelId$);
+        if (!activeId) {
+          return;
+        }
+
+        if (matchShortcut("mod+shift+enter", e)) {
+          e.preventDefault();
+          set(toggleMaximizeTask$, activeId);
+          return;
+        }
+
+        if (matchShortcut("escape", e)) {
+          e.preventDefault();
+          set(focusTaskCard$, activeId);
+          return;
+        }
+
+        // ctrl+d — close active panel (panel-local handler covers the
+        // textarea-empty case; this covers everywhere else)
+        if (
+          e.key === "d" &&
+          e.ctrlKey &&
+          !e.metaKey &&
+          !e.shiftKey &&
+          !e.altKey
+        ) {
+          e.preventDefault();
+          await set(closeAndFocusNextInput$, activeId, signal);
+        }
+      }),
+      { signal },
     );
   },
 );

--- a/turbo/apps/platform/src/views/mission-control-page/shortcut-help-dialog.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/shortcut-help-dialog.tsx
@@ -4,7 +4,7 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  getShortcutLabel,
+  getShortcutParts,
 } from "@vm0/ui";
 
 export function ShortcutHelpDialog({
@@ -27,12 +27,12 @@ export function ShortcutHelpDialog({
           <ShortcutSection
             title="Global"
             shortcuts={[
+              { key: "shift+?", label: "Show shortcuts" },
               { key: "j", label: "Next task" },
               { key: "k", label: "Previous task" },
               { key: "mod+b", label: "Toggle task list" },
               { key: "c", label: "New chat" },
               { key: "y", label: "Archive task" },
-              { key: "shift+?", label: "Show shortcuts" },
             ]}
           />
           <ShortcutSection
@@ -65,7 +65,7 @@ function ShortcutSection({
 }) {
   return (
     <div>
-      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+      <h3 className="text-xs font-medium text-muted-foreground tracking-wide mb-2">
         {title}
       </h3>
       <div className="space-y-1">
@@ -76,9 +76,18 @@ function ShortcutSection({
               className="flex items-center justify-between py-1"
             >
               <span className="text-sm">{shortcut.label}</span>
-              <kbd className="ml-4 shrink-0 rounded border border-border bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground">
-                {getShortcutLabel(shortcut.key)}
-              </kbd>
+              <div className="ml-4 shrink-0 flex items-center gap-1">
+                {getShortcutParts(shortcut.key).map((part) => {
+                  return (
+                    <kbd
+                      key={part}
+                      className="inline-flex items-center justify-center rounded border border-border bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground min-w-[1.5rem]"
+                    >
+                      {part}
+                    </kbd>
+                  );
+                })}
+              </div>
             </div>
           );
         })}

--- a/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
@@ -14,7 +14,9 @@ import {
 } from "../../signals/mission-control-page/mission-control-tasks.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
+  activePanelId$,
   maximizedTaskId$,
+  setActivePanelId$,
   toggleMaximizeTask$,
 } from "../../signals/mission-control-page/mission-control-panels.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -56,16 +58,23 @@ function TaskPanelCard({ taskSignals }: { taskSignals: TaskSignals }) {
   const scrollCardIntoView = useSet(taskSignals.scrollCardIntoView$);
   const setInputFocused = useSet(taskSignals.setInputFocused$);
   const closeAndFocusNext = useSet(closeAndFocusNextInput$);
+  const setActivePanel = useSet(setActivePanelId$);
   const pageSignal = useGet(pageSignal$);
   const maximizedId = useGet(maximizedTaskId$);
+  const activeId = useGet(activePanelId$);
 
   const taskId = taskSignals.taskId;
   const isMaximized = maximizedId === taskId;
+  const isActive = activeId === taskId;
 
   return (
     <div
       className="flex flex-col h-full min-h-0"
+      onPointerDown={() => {
+        setActivePanel(taskId);
+      }}
       onFocus={(e) => {
+        setActivePanel(taskId);
         if (e.target instanceof HTMLTextAreaElement) {
           scrollCardIntoView();
           setInputFocused(true);
@@ -103,8 +112,10 @@ function TaskPanelCard({ taskSignals }: { taskSignals: TaskSignals }) {
         );
       }}
     >
-      <div className="shrink-0 flex items-center justify-between gap-2 px-4 py-2 border-b bg-muted/30">
-        <TaskPanelTitle taskSignals={taskSignals} />
+      <div
+        className={`shrink-0 flex items-center justify-between gap-2 px-4 py-2 border-b transition-colors ${isActive ? "border-b-primary/50 bg-muted/50" : "bg-muted/30"}`}
+      >
+        <TaskPanelTitle taskSignals={taskSignals} active={isActive} />
         <div className="flex items-center gap-0.5 shrink-0">
           <button
             type="button"
@@ -139,12 +150,20 @@ function TaskPanelCard({ taskSignals }: { taskSignals: TaskSignals }) {
   );
 }
 
-function TaskPanelTitle({ taskSignals }: { taskSignals: TaskSignals }) {
+function TaskPanelTitle({
+  taskSignals,
+  active,
+}: {
+  taskSignals: TaskSignals;
+  active: boolean;
+}) {
   const task = useGet(taskSignals.task$);
   const agentName = task.agent.displayName ?? task.agent.name;
 
   return (
-    <div className="flex items-center gap-1.5 min-w-0 text-xs text-muted-foreground font-medium">
+    <div
+      className={`flex items-center gap-1.5 min-w-0 text-xs font-medium transition-colors ${active ? "text-foreground" : "text-muted-foreground"}`}
+    >
       <TaskTypeIcon task={task} />
       <AvatarFromUrl
         avatarUrl={task.agent.avatarUrl}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -812,7 +812,7 @@ function AssistantMessageActions({
   const playTts = useSet(playTts$);
   const stopTts = useSet(stopTts$);
 
-  if (!message.legacyRunId) {
+  if (!message.legacyRunId || isRunActive(message)) {
     return null;
   }
 

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -24,6 +24,7 @@ export {
   matchShortcut,
   processShortcut,
   getShortcutLabel,
+  getShortcutParts,
   isEditableTarget,
   type KeyboardEventLike,
 } from "./lib/keyboard-shortcuts";

--- a/turbo/packages/ui/src/lib/keyboard-shortcuts.ts
+++ b/turbo/packages/ui/src/lib/keyboard-shortcuts.ts
@@ -184,3 +184,37 @@ export function getShortcutLabel(shortcut: string): string {
   parts.push(formatKey(parsed.key));
   return parts.join("+");
 }
+
+/**
+ * Returns individual key parts for rendering each as a separate element.
+ * All text is lowercase. Handles `ctrl` as a distinct modifier (not `mod`).
+ */
+export function getShortcutParts(shortcut: string): string[] {
+  const segments = shortcut.toLowerCase().split("+");
+  const result: string[] = [];
+  let key = "";
+
+  for (const segment of segments) {
+    switch (segment) {
+      case "mod":
+        result.push(isMac ? "⌘" : "ctrl");
+        break;
+      case "ctrl":
+        result.push(isMac ? "⌃" : "ctrl");
+        break;
+      case "shift":
+        result.push(isMac ? "⇧" : "shift");
+        break;
+      case "alt":
+        result.push(isMac ? "⌥" : "alt");
+        break;
+      default:
+        key = segment;
+    }
+  }
+
+  if (key) {
+    result.push(key);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

- Add active panel state tracking to mission control, with visual highlighting of the focused task panel (title bar color change on focus/click)
- Register global keyboard shortcuts that operate on the active panel: `Mod+Shift+Enter` (toggle maximize), `Escape` (focus task card), `Ctrl+D` (close panel)
- Improve shortcut help dialog to render each key as a separate `<kbd>` element using new `getShortcutParts` utility
- Hide assistant message actions while a run is still active in zero chat thread

## Test plan

- [ ] Open multiple task panels and verify clicking/focusing one highlights its title bar
- [ ] Press `Mod+Shift+Enter` to toggle maximize on the active panel
- [ ] Press `Escape` to focus the task card from within a panel
- [ ] Press `Ctrl+D` to close the active panel
- [ ] Open the shortcut help dialog (`?`) and verify keys render as separate badges
- [ ] Verify assistant message actions are hidden during active runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)