### PR TITLE
fix(runner): verify ca landed in system bundle after inject-ca

### DIFF
--- a/crates/runner/scripts/inject-ca.sh
+++ b/crates/runner/scripts/inject-ca.sh
@@ -76,6 +76,18 @@ sudo chmod 644 "${MOUNT_DIR}/${CA_ROOTFS_DEST}"
 # Rebuild system CA bundle (updates /etc/ssl/certs/ca-certificates.crt)
 sudo chroot "$MOUNT_DIR" update-ca-certificates
 
+# Verify update-ca-certificates actually included our CA in the bundle.
+# `update-ca-certificates` can exit 0 while silently emitting a bundle
+# that does not contain our cert (e.g. if the source file was not
+# recognised as PEM). Without this check the failure would surface
+# later as an opaque snapshot-creation or VM-boot TLS error. Uses the
+# same 2nd-line fingerprint technique as verify-rootfs.sh.
+ca_line=$(sudo sed -n '2p' "${MOUNT_DIR}/${CA_ROOTFS_DEST}")
+if [[ -z "$ca_line" ]] || ! sudo grep -qF "$ca_line" "${MOUNT_DIR}/etc/ssl/certs/ca-certificates.crt"; then
+    echo "error: proxy CA not found in system bundle after update-ca-certificates" >&2
+    exit 1
+fi
+
 # Update Java keystore. Unlike build-rootfs.sh (which imports into a fresh
 # keystore where the alias doesn't exist), here the alias vm0-proxy-ca
 # already exists from the original build. keytool -importcert rejects

--- a/crates/runner/scripts/inject-ca.sh
+++ b/crates/runner/scripts/inject-ca.sh
@@ -82,8 +82,24 @@ sudo chroot "$MOUNT_DIR" update-ca-certificates
 # recognised as PEM). Without this check the failure would surface
 # later as an opaque snapshot-creation or VM-boot TLS error. Uses the
 # same 2nd-line fingerprint technique as verify-rootfs.sh.
-ca_line=$(sudo sed -n '2p' "${MOUNT_DIR}/${CA_ROOTFS_DEST}")
-if [[ -z "$ca_line" ]] || ! sudo grep -qF "$ca_line" "${MOUNT_DIR}/etc/ssl/certs/ca-certificates.crt"; then
+#
+# Reads don't need sudo: the bundle is 644 and our CA file is 644
+# (we chmod'd it above); the rootfs root is 755 (same assumption
+# verify-rootfs.sh makes).
+ca_line=$(sed -n '2p' "${MOUNT_DIR}/${CA_ROOTFS_DEST}")
+# Reject an empty line 2 or a PEM header/footer on line 2 (latter
+# happens when the source cert has a leading blank line). Matching
+# either against the bundle with `grep -F` would false-positive
+# because every cert in the bundle has BEGIN/END framing lines.
+if [[ -z "$ca_line" ]] \
+    || [[ "$ca_line" == -----BEGIN* ]] \
+    || [[ "$ca_line" == -----END* ]]; then
+    echo "error: proxy CA file malformed (line 2 is empty or a PEM framing line)" >&2
+    exit 1
+fi
+# `-- "$ca_line"` stops option parsing so a line starting with `-`
+# can never be mistaken for a grep flag.
+if ! grep -qF -- "$ca_line" "${MOUNT_DIR}/etc/ssl/certs/ca-certificates.crt"; then
     echo "error: proxy CA not found in system bundle after update-ca-certificates" >&2
     exit 1
 fi

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -173,11 +173,19 @@ bundle_path="${MOUNT_DIR}/etc/ssl/certs/ca-certificates.crt"
 if [[ ! -f "$bundle_path" ]]; then
   errors+=("system CA bundle not found at /etc/ssl/certs/ca-certificates.crt")
 elif [[ -f "$ca_path" ]]; then
-  # Read second line of CA cert as a unique identifier
+  # Read second line of CA cert as a unique identifier. Reject an
+  # empty line 2 or a PEM header/footer on line 2 (latter happens
+  # when the source cert has a leading blank line) — matching either
+  # against the bundle with `grep -F` would false-positive because
+  # every cert in the bundle has BEGIN/END framing lines. `-- "$pat"`
+  # also stops option parsing so a pattern starting with `-` can
+  # never be mistaken for a grep flag.
   ca_line=$(sed -n '2p' "$ca_path")
-  if [[ -z "$ca_line" ]]; then
-    errors+=("proxy CA cert appears empty or malformed")
-  elif grep -qF "$ca_line" "$bundle_path"; then
+  if [[ -z "$ca_line" ]] \
+      || [[ "$ca_line" == -----BEGIN* ]] \
+      || [[ "$ca_line" == -----END* ]]; then
+    errors+=("proxy CA cert appears empty or malformed (line 2 missing or PEM framing)")
+  elif grep -qF -- "$ca_line" "$bundle_path"; then
     echo "  proxy CA bundle: updated"
   else
     errors+=("proxy CA not found in system CA bundle (update-ca-certificates may have failed)")

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -687,6 +687,24 @@ mod tests {
         );
     }
 
+    /// Guard: inject-ca.sh must verify the CA actually made it into the
+    /// system bundle after `update-ca-certificates`. `update-ca-certificates`
+    /// can exit 0 while silently omitting our cert (e.g. malformed PEM),
+    /// which would later surface as an opaque snapshot/VM-boot TLS error.
+    /// See #9482.
+    #[test]
+    fn inject_ca_verifies_bundle_after_update() {
+        assert!(
+            INJECT_CA_SCRIPT.contains("update-ca-certificates"),
+            "inject-ca.sh must call update-ca-certificates"
+        );
+        assert!(
+            INJECT_CA_SCRIPT.contains("proxy CA not found in system bundle"),
+            "inject-ca.sh must verify proxy CA landed in system bundle after \
+             update-ca-certificates (silent failure guard; see #9482)"
+        );
+    }
+
     #[tokio::test]
     async fn is_image_complete_nonexistent_dir() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- Add a post-`update-ca-certificates` check in `inject-ca.sh` that grep's the proxy CA's 2nd-line fingerprint against the generated `/etc/ssl/certs/ca-certificates.crt` bundle — failing loudly if the CA did not actually make it in.
- Add a compile-time guard test (`inject_ca_verifies_bundle_after_update`) in `cmd/build.rs` so future refactors of the script cannot silently drop the check.

## Why

`update-ca-certificates` can exit 0 while silently omitting our CA (e.g. malformed PEM, unexpected filename). Without an explicit check, this surfaces later as an opaque `create_snapshot` or VM-boot TLS error on R2-downloaded rootfs, and debugging lands in the wrong place (network/proxy) rather than at the CA injection stage.

The 2nd-line fingerprint technique is the same one `verify-rootfs.sh` already uses (lines 177-184), so the semantics stay consistent across the local-build verify path and the R2-download inject path.

## Scope note (why not `verify-rootfs.sh`?)

#9482 suggested running `verify-rootfs.sh` after `inject-ca.sh`, but that would:
1. Re-mount the ~1 GB rootfs and re-check 15+ items (python, ruby, php, javac, gcc, clang, psql, redis, guest binaries…) that `inject-ca.sh` does not touch — pure waste.
2. Still not cover the one other concern listed in the issue (`keytool` alias) — `verify-rootfs.sh` doesn't inspect the Java keystore.

Narrowing to the single realistic silent-failure mode (bundle regen) is cheaper and more targeted. The other scenarios (`keytool` success without alias; chroot sub-command printing errors and returning 0) are prevented by `set -euo pipefail` + explicit exit-code checks already in place; the only real gap was the `update-ca-certificates` step.

Closes #9482.

## Test plan

- [x] New `inject_ca_verifies_bundle_after_update` test passes locally
- [x] Existing `ca_constants_in_sync_across_scripts` test still passes
- [x] `cargo clippy -p runner` clean
- [x] `bash -n inject-ca.sh` passes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)