### PR TITLE
fix: rely on keytool rpath for libjli.so in chroot invocations

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -402,12 +402,10 @@ inject_files() {
 
   # Import proxy CA into Java's separate trust store (cacerts keystore).
   # Java does not read the system CA bundle — it has its own PKCS12 keystore.
-  # In chroot, keytool can't find libjli.so via the default search path,
-  # so we locate it and add its directory to LD_LIBRARY_PATH.
-  local jli_dir
-  jli_dir=$(sudo chroot "$ROOTFS_DIR" find /usr/lib/jvm -name libjli.so -printf '%h' -quit)
-  sudo chroot "$ROOTFS_DIR" env LD_LIBRARY_PATH="$jli_dir" \
-    keytool -importcert -trustcacerts \
+  # keytool finds libjli.so via its baked-in RPATH [$ORIGIN:$ORIGIN/../lib];
+  # $ORIGIN resolves because debootstrap_build bind-mounts /proc into the
+  # chroot (glibc reads /proc/self/exe for $ORIGIN).
+  sudo chroot "$ROOTFS_DIR" keytool -importcert -trustcacerts \
     -keystore /etc/ssl/certs/java/cacerts \
     -storepass changeit -noprompt \
     -alias vm0-proxy-ca \

--- a/crates/runner/scripts/inject-ca.sh
+++ b/crates/runner/scripts/inject-ca.sh
@@ -21,6 +21,9 @@ cleanup() {
     # keytool) may briefly hold references after returning.  Final attempt
     # lets stderr through so CI logs show the root cause if it still fails.
     if [[ -n "$MOUNT_DIR" ]]; then
+        # Umount /proc bind first (avoid EBUSY on outer umount).  No-op if
+        # the bind was never established; swallowed either way.
+        sudo umount "${MOUNT_DIR}/proc" 2>/dev/null || true
         for attempt in 1 2 3; do
             if [[ $attempt -eq 3 ]]; then
                 sudo umount "$MOUNT_DIR" || true
@@ -69,6 +72,14 @@ MOUNT_DIR="$(mktemp -d)"
 LOOP_DEV="$(sudo losetup --find --show "$ROOTFS")"
 sudo mount "$LOOP_DEV" "$MOUNT_DIR"
 
+# Bind-mount /proc so keytool's RPATH [$ORIGIN:$ORIGIN/../lib] resolves —
+# glibc derives $ORIGIN from readlink(/proc/self/exe).  DO NOT remove:
+# without /proc, libjli.so lookup fails with an opaque linker error.
+# Exposes host /proc inside the chroot; acceptable here because only our
+# trusted keytool/update-ca-certificates run against this rootfs.  If you
+# add more chroot commands below, reconsider (consider `unshare --pid`).
+sudo mount --bind /proc "${MOUNT_DIR}/proc"
+
 # Replace CA certificate
 sudo cp "$ca_cert" "${MOUNT_DIR}/${CA_ROOTFS_DEST}"
 sudo chmod 644 "${MOUNT_DIR}/${CA_ROOTFS_DEST}"
@@ -80,17 +91,13 @@ sudo chroot "$MOUNT_DIR" update-ca-certificates
 # keystore where the alias doesn't exist), here the alias vm0-proxy-ca
 # already exists from the original build. keytool -importcert rejects
 # duplicate aliases, so we must delete first then re-import.
-# keytool requires libjli.so on the library path; locate it dynamically.
 # `|| true` handles the (unexpected) case where the alias is absent; stderr
 # is NOT suppressed so real keystore errors surface in CI logs.
-jli_dir=$(sudo chroot "$MOUNT_DIR" find /usr/lib/jvm -name libjli.so -printf '%h' -quit)
-sudo chroot "$MOUNT_DIR" env LD_LIBRARY_PATH="$jli_dir" \
-    keytool -delete \
+sudo chroot "$MOUNT_DIR" keytool -delete \
     -keystore /etc/ssl/certs/java/cacerts \
     -storepass changeit \
     -alias vm0-proxy-ca || true
-sudo chroot "$MOUNT_DIR" env LD_LIBRARY_PATH="$jli_dir" \
-    keytool -importcert -trustcacerts \
+sudo chroot "$MOUNT_DIR" keytool -importcert -trustcacerts \
     -keystore /etc/ssl/certs/java/cacerts \
     -storepass changeit -noprompt \
     -alias vm0-proxy-ca \


### PR DESCRIPTION
## Summary

Closes #9483 by **removing** the fragile `find + LD_LIBRARY_PATH` dance altogether, not by adding an empty-check around it.

## Why the hack existed

`keytool` ELF ships with `RPATH=[$ORIGIN:$ORIGIN/../lib]` (verified via `readelf -d` on `openjdk-17-jre-headless` / noble aarch64). Normally the dynamic linker resolves `$ORIGIN` from `readlink("/proc/self/exe")` (glibc `elf/dl-origin.c`), and that alone finds `libjli.so` — no `LD_LIBRARY_PATH` needed.

- `build-rootfs.sh` bind-mounts `/proc /sys /dev` into its chroot (lines 178–180), so RPATH would have worked on its own; the `LD_LIBRARY_PATH` there was redundant (copy-paste).
- `inject-ca.sh` only mounted the loopback device. No `/proc` → `$ORIGIN` resolution fails → `libjli.so: cannot open shared object file`. That's the real reason the `LD_LIBRARY_PATH` rescue existed.

Empirically confirmed in the dev container: running the extracted keytool binary with `/proc` masked by a tmpfs overlay reproduces the exact error; restoring `/proc` makes it succeed.

## Changes

- `inject-ca.sh`: bind-mount `/proc` after the loop mount; umount `/proc` first in the cleanup trap (avoid EBUSY on the outer umount). Drop `find libjli.so` + `env LD_LIBRARY_PATH=…` wrappers on both `keytool` invocations.
- `build-rootfs.sh`: drop the same wrapper on the `keytool` invocation. No mount changes (chroot already has `/proc`).

## Why this is better than the issue-proposed empty-check

The issue proposed guarding against an empty `jli_dir` with an explicit error message. That improves diagnostics but leaves the underlying smell (searching the filesystem to compensate for a missing `/proc`) intact and still requires per-openjdk-layout-change maintenance. This PR removes the error path entirely — if Java's package layout changes, `keytool` fails with a normal dynamic-linker error, surfaced cleanly by `set -euo pipefail`.

## Test plan

- [ ] CI `runner-build` runs both scripts end-to-end (build-rootfs.sh during rootfs construction, inject-ca.sh when pulling cached rootfs from R2) — primary integration gate
- [ ] `bash -n` passed locally on both scripts
- [ ] Behavior verified via controlled `/proc`-masking experiment on extracted openjdk ELF

Closes #9483

🤖 Generated with [Claude Code](https://claude.com/claude-code)