### PR TITLE
fix: add robots.txt to platform app to block all crawlers

### DIFF
--- a/turbo/apps/platform/public/robots.txt
+++ b/turbo/apps/platform/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary

- Adds `turbo/apps/platform/public/robots.txt` with `Disallow: /` to block all search engine crawlers from `app.vm0.ai`
- `app.vm0.ai` is a fully authenticated SPA — none of its routes should ever be indexed
- The absence of this file caused ~196 onboarding/app pages to be crawled after the onboarding prompt rollout, dropping the SEO health score to 41 (Fair) with 690 errors

## Root Cause

When a site has no `robots.txt`, crawlers default to allowing everything. The onboarding prompt rollout introduced new crawlable `app.vm0.ai` paths that were picked up in the Apr 13–15 crawl cycle, triggering issues: no canonical, no H1, no meta description, no outgoing links, hreflang conflicts — all on authenticated app pages with 0 organic load.

## Change

```
turbo/apps/platform/public/robots.txt
```
```
User-agent: *
Disallow: /
```

## Test plan

- [ ] Deploy to staging and verify `https://app.vm0.ai/robots.txt` returns the correct content
- [ ] Confirm no existing functionality is impacted (robots.txt only affects crawlers, not users)
- [ ] After next crawl cycle, verify health score recovers and the ~196 affected pages are removed from the index

Closes #9547

🤖 Generated with [Claude Code](https://claude.com/claude-code)