### PR TITLE
chore(sandbox-fc): remove post-#9494 defensive umount

### DIFF
--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -11,7 +11,6 @@ use nbd_cow::NbdCowDevice;
 use sandbox::{SnapshotCreateConfig, SnapshotOutput, SnapshotProvider};
 
 use crate::api::{ApiClient, ApiError};
-use crate::command;
 use crate::config::SnapshotConfig;
 use crate::factory::{InvariantConfig, config_hash};
 use crate::network::{NetnsPool, NetnsPoolConfig};
@@ -80,18 +79,7 @@ pub async fn create_snapshot(
     //    Only remove snapshot-specific artifacts (work/, snapshot.bin, memory.bin,
     //    cow.img) — the output directory may contain other files (e.g. rootfs.ext4
     //    in unified image builds) that must not be deleted.
-    //
-    //    Defensive umount: post-#9494 the COW-device bind runs inside
-    //    `unshare --mount` and dies with the FC process, so this should
-    //    never find anything. Kept for one release to clean up any residue
-    //    from older runner versions that may exist on a metal host's image
-    //    cache.
     let work = output.work_dir();
-    let stale_bind = SandboxPaths::new(work.clone())
-        .cow_device_bind()
-        .display()
-        .to_string();
-    command::exec_ignore_errors("umount", &[stale_bind.as_str()]).await;
 
     // Remove stale snapshot artifacts individually (not rm -rf on the
     // entire output directory) — work dir tree first, then individual files.


### PR DESCRIPTION
## Summary

Removes the transitional defensive `umount` at the start of `create_snapshot` (snapshot.rs:84-94 before this PR). Post-#9494 (#9506), the COW-device bind mount lives in a private mount namespace created by `unshare --mount` and dies with the FC process, so stale binds in the main mount namespace are no longer possible.

Also drops the `use crate::command;` import that becomes unused as a result.

Closes #9525.

## Why removal is safe

Any residue that could still exist is from pre-#9494 runners that were SIGKILL'd mid-build. Such residue lives in the **main** mount namespace. After #9506, firecracker always runs inside `unshare --mount`, and its COW bind lives in the **private** namespace. Main-ns residue is therefore inert to new builds:

1. `remove_dir_all(&output.work_dir())` at snapshot.rs:98 may fail with `EBUSY` on the bind-mounted file, but the result is already discarded with `let _ = ...`.
2. `create_dir_all(&work)` succeeds because the work dir already exists.
3. FC spawns in a fresh mount namespace and creates its own bind, which shadows any pre-existing main-ns bind for the duration of the build.
4. Individual stale-file removals (`output.snapshot()`, `output.memory()`, `output.cow()`, `output.cow_bitmap()`) handle the actually-important files.

The defensive umount was therefore **cleanup hygiene**, not a functional safety net — removing it leaves a phantom entry in `findmnt` at worst. Correctness does not depend on fleet-wide verification.

## Fleet check (belt-and-braces)

Ran the removal-criteria check on dev-1:

```
$ sudo findmnt --raw -o TARGET | grep cow-device-bind
[clean]
```

Additional signals on dev-1:
- 10 active post-#9494 `vm0-runner-*` services (pr-9172, pr-9296, pr-9296-test-balloon, pr-9384, pr-9385, pr-9392, pr-9498, pr-9541, pr-9545, pr-9546) — the unshare spawn path is hit frequently.
- Fresh image dir from today (`584669248...` at Apr 15 12:47) — post-#9494 `runner build` has completed successfully in the relevant window.

Prod hosts were not checked, but per the argument above correctness does not depend on their state. The findmnt check is also a point-in-time snapshot — a SIGKILL'd build between check and merge could produce new main-ns residue, which would likewise be inert.

## Cost of removal

This does give up a small safety net: if a future change ever reintroduces a code path where FC binds COW in the main namespace (e.g. a daemon / race bypassing `unshare --mount`), residue will accumulate instead of being auto-cleaned on the next build. Worth flagging in PRs that touch `snapshot.rs` spawn logic.

## Test plan

- [x] `cargo check -p sandbox-fc` — passes
- [x] `cargo clippy -p sandbox-fc -- -D warnings` — passes (including the import removal)
- [ ] CI (crates workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)