### PR TITLE
feat(runner): parse x ndjson streams incrementally and bound buffer

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -268,9 +268,33 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     # full JSON body is available for usage extraction in response().
     sse_parser = None
     sse_decompressor = None
+    ndjson_parser = None
+    ndjson_decompressor = None
     firewall_name = flow.metadata.get("firewall_name", "")
     is_model_provider = firewall_name.startswith("model-provider:")
     is_billable_connector = usage.is_billable_connector(firewall_name)
+
+    # Classify X NDJSON streams early so we can register an incremental parser
+    # and avoid buffering the (potentially multi-GB) stream body.  Only a
+    # cheap path-only check happens here — full request metadata is parsed
+    # later in response() by log_connector_usage.
+    #
+    # Gated on 2xx status so error responses (4xx/5xx on stream endpoints
+    # return JSON, not NDJSON) fall through to the existing unbounded-buffer
+    # path and preserve the full error body for forensic inspection in
+    # network logs.  log_connector_usage already skips non-2xx responses
+    # so no billing record is affected either way.
+    #
+    # Reads ``original_url`` with no fallback — kept consistent with
+    # :func:`usage._parse_x_request_metadata` so the log entry's
+    # ``is_stream`` field cannot diverge from the parser registration
+    # decision.  For any billable connector flow, ``request()`` has
+    # already populated ``original_url`` before ``responseheaders`` fires.
+    is_x_stream = False
+    if is_billable_connector and 200 <= flow.response.status_code < 300:
+        stream_path = urllib.parse.urlparse(flow.metadata.get("original_url", "")).path
+        is_x_stream = usage.is_x_stream_path(stream_path)
+
     if is_model_provider:
         content_type = flow.response.headers.get("content-type", "")
         if "text/event-stream" in content_type:
@@ -278,13 +302,25 @@ def responseheaders(flow: http.HTTPFlow) -> None:
             sse_parser = parser_fn
             flow.metadata["proxy_usage"] = usage_dict
             sse_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
+    elif is_x_stream:
+        parser_fn, ndjson_state = usage.create_x_ndjson_extractor()
+        ndjson_parser = parser_fn
+        # Deliberately NOT "proxy_usage" — that key would route through
+        # maybe_report_proxy_usage and trigger the model-provider webhook.
+        # x_ndjson_state is only consumed by log_connector_usage.
+        flow.metadata["x_ndjson_state"] = ndjson_state
+        ndjson_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
 
-    # Model provider and billable connector responses are never truncated so
-    # usage extraction always has the complete body.  Other responses use the
-    # 64 KB limit.
-    buf_limit = (
-        None if (is_model_provider or is_billable_connector) else body_utils.STREAM_BUFFER_LIMIT
-    )
+    # Buffer cap policy:
+    # - Model providers: unbounded — need full body for non-SSE JSON usage extraction.
+    # - X non-stream billable connectors: unbounded — full body feeds json.loads.
+    # - X stream endpoints: STREAM_BUFFER_LIMIT (64 KB) — parser handles bytes
+    #   incrementally; the buffer is kept only for forensic network logging.
+    # - Everything else: STREAM_BUFFER_LIMIT (default 64 KB).
+    if is_model_provider or (is_billable_connector and not is_x_stream):
+        buf_limit = None
+    else:
+        buf_limit = body_utils.STREAM_BUFFER_LIMIT
 
     def stream_and_buffer(chunk: bytes) -> bytes:
         if not state["truncated"]:
@@ -300,6 +336,9 @@ def responseheaders(flow: http.HTTPFlow) -> None:
         if sse_parser is not None:
             plaintext = sse_decompressor(chunk) if sse_decompressor else chunk
             sse_parser(plaintext)
+        elif ndjson_parser is not None:
+            plaintext = ndjson_decompressor(chunk) if ndjson_decompressor else chunk
+            ndjson_parser(plaintext)
         return chunk
 
     flow.response.stream = stream_and_buffer
@@ -463,6 +502,14 @@ def error(flow: http.HTTPFlow) -> None:
     # The SSE parser may have partially populated proxy_usage before the
     # connection error occurred.  Partial data is better than none.
     usage.maybe_report_proxy_usage(flow, run_id)
+
+    # Billable connector usage for X NDJSON streams that crash mid-flight
+    # (issue #9534): the incremental parser populated x_ndjson_state during
+    # chunks; log what was observed so partial streams aren't silently
+    # dropped from billing.  log_connector_usage no-ops when there's no
+    # response or the status is non-2xx, so normal model-provider errors
+    # are unaffected.
+    usage.log_connector_usage(flow, run_id)
 
     log_proxy_entry(
         proxy_log_path,

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -16,6 +16,7 @@ import time
 import urllib.error
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
+from typing import TypedDict
 
 from mitmproxy import http
 
@@ -79,6 +80,9 @@ def create_sse_usage_extractor():
     incrementally and *usage* is a dict that accumulates extracted fields.
     """
     usage: dict = {}
+    # Mutate in-place (``line_buf[:] = ...``, ``extend(...)``) throughout
+    # ``parse_chunk`` — captured by the closure.  Rebinding via
+    # ``line_buf = ...`` would create a new local and lose cross-call state.
     line_buf = bytearray()
     event_type = {"current": None}
     # Events we need to parse — all others are skipped to avoid buffering
@@ -360,6 +364,24 @@ def is_x_stream_path(path: str) -> bool:
 MAX_NDJSON_LINE_BYTES = 5 * 1024 * 1024  # 5 MB
 
 
+class NdjsonState(TypedDict):
+    """Accumulated parser state for an X NDJSON stream.
+
+    Populated by :func:`create_x_ndjson_extractor`'s ``parse_chunk`` and
+    read by :func:`_parse_x_response_metadata` when emitting the billing
+    log entry.
+    """
+
+    data_count: int
+    """Number of lines whose top-level ``data`` is a dict (one tweet per line)."""
+    includes: dict[str, int]
+    """Running sum of ``len(includes.<key>)`` across all lines, per key."""
+    lines_parsed: int
+    """JSON-parseable non-blank lines."""
+    lines_failed: int
+    """Lines that failed JSON decoding."""
+
+
 def create_x_ndjson_extractor():
     """Create an incremental NDJSON parser for X v2 streaming responses.
 
@@ -387,12 +409,15 @@ def create_x_ndjson_extractor():
     upstream).  A truncated trailing line at connection close (no final
     ``\\n``) stays in the buffer uncounted — worst-case under-count is 1.
     """
-    state: dict = {
+    state: NdjsonState = {
         "data_count": 0,
         "includes": {},
         "lines_parsed": 0,
         "lines_failed": 0,
     }
+    # Mutate in-place (``line_buf[:] = ...``, ``extend(...)``) throughout
+    # ``parse_chunk`` — captured by the closure.  Rebinding via
+    # ``line_buf = ...`` would create a new local and lose cross-call state.
     line_buf = bytearray()
 
     def parse_chunk(chunk: bytes) -> None:

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -314,11 +314,117 @@ _BILLABLE_CONNECTORS = frozenset({"x"})
 def is_billable_connector(firewall_name: str) -> bool:
     """Return True when this firewall is on the billable-connector list.
 
-    Used by ``mitm_addon.responseheaders`` to disable buffer truncation for
-    these firewalls so ``log_connector_usage`` can parse the full response
-    body in ``response()``.
+    Used by ``mitm_addon.responseheaders`` to choose the response-body
+    handling strategy:
+
+    - **Non-stream endpoints**: disable buffer truncation so
+      ``log_connector_usage`` can ``json.loads`` the full body in
+      ``response()``.
+    - **Stream endpoints** (see :data:`_X_STREAM_ENDPOINTS`): register an
+      incremental NDJSON parser via :func:`create_x_ndjson_extractor` so
+      we never buffer the (potentially multi-GB) stream body.
     """
     return firewall_name in _BILLABLE_CONNECTORS
+
+
+# X v2 NDJSON streaming endpoint paths (exact match — ``/2/tweets/search/stream/rules``
+# is a regular request/response endpoint for rules management, NOT a stream).
+# Streams deliver one JSON object per line, possibly for hours; responseheaders
+# registers an incremental NDJSON parser as the stream callback so we never
+# buffer the response body.
+_X_STREAM_ENDPOINTS = frozenset(
+    {
+        "/2/tweets/search/stream",
+        "/2/tweets/sample/stream",
+        "/2/tweets/sample10/stream",
+        "/2/tweets/compliance/stream",
+        "/2/users/compliance/stream",
+    }
+)
+
+
+def is_x_stream_path(path: str) -> bool:
+    """Return True when *path* is one of the X v2 NDJSON streaming endpoints.
+
+    Exact match only — ``/2/tweets/search/stream/rules`` (rules management)
+    must NOT match because it's a regular JSON request/response, not a stream.
+    """
+    return path in _X_STREAM_ENDPOINTS
+
+
+# Single NDJSON line cap — matches ``LARGE_RESPONSE_DECOMPRESS_LIMIT`` in
+# ``body_utils.py``.  A real X tweet line (``data`` + ``includes`` +
+# ``matching_rules`` with full expansion) should never approach this size;
+# exceeding it indicates malformed or hostile upstream data, so the parser
+# drops ``line_buf`` to protect memory.
+MAX_NDJSON_LINE_BYTES = 5 * 1024 * 1024  # 5 MB
+
+
+def create_x_ndjson_extractor():
+    """Create an incremental NDJSON parser for X v2 streaming responses.
+
+    X v2 streaming endpoints deliver one JSON object per line separated by
+    ``\\n`` (or ``\\r\\n``), with blank lines as keep-alives.  Each tweet
+    line typically has the shape::
+
+        {"data": {...tweet...}, "includes": {...}, "matching_rules": [...]}
+
+    Returns ``(parse_chunk, state)`` where *parse_chunk* processes raw
+    response bytes incrementally (so we never buffer the full body) and
+    *state* is a dict that accumulates:
+
+    - ``data_count``: int — number of lines whose top-level ``data`` is a
+      dict (one tweet per line).  Lines whose ``data`` is an array or
+      absent contribute 0 to this counter but still bump ``lines_parsed``.
+    - ``includes``: dict[str, int] — running sum across all lines of
+      ``len(includes.<key>)`` for each expansion resource key.
+    - ``lines_parsed``: int — JSON-parseable non-blank lines.
+    - ``lines_failed``: int — lines that failed JSON decoding.
+
+    The parser keeps a ``line_buf`` holding the in-flight partial line
+    across chunk boundaries.  If a single line ever exceeds
+    :data:`MAX_NDJSON_LINE_BYTES` the buffer is reset (malformed / hostile
+    upstream).  A truncated trailing line at connection close (no final
+    ``\\n``) stays in the buffer uncounted — worst-case under-count is 1.
+    """
+    state: dict = {
+        "data_count": 0,
+        "includes": {},
+        "lines_parsed": 0,
+        "lines_failed": 0,
+    }
+    line_buf = bytearray()
+
+    def parse_chunk(chunk: bytes) -> None:
+        line_buf.extend(chunk)
+        while b"\n" in line_buf:
+            raw, _, rest = line_buf.partition(b"\n")
+            line_buf[:] = rest
+            line = raw.rstrip(b"\r")
+            if not line:
+                continue  # keep-alive blank line
+            try:
+                obj = json.loads(line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                state["lines_failed"] += 1
+                continue
+            state["lines_parsed"] += 1
+            if not isinstance(obj, dict):
+                continue
+            if isinstance(obj.get("data"), dict):
+                state["data_count"] += 1
+            inc = obj.get("includes")
+            if isinstance(inc, dict):
+                for k, v in inc.items():
+                    if isinstance(v, list):
+                        state["includes"][k] = state["includes"].get(k, 0) + len(v)
+        # Defense: if a single line exceeds MAX_NDJSON_LINE_BYTES (malformed
+        # or hostile upstream) reset line_buf so we don't hold unbounded
+        # memory.  Subsequent lines parse normally.
+        if len(line_buf) > MAX_NDJSON_LINE_BYTES:
+            line_buf[:] = b""
+
+    return parse_chunk, state
 
 
 def _parse_x_request_metadata(flow: http.HTTPFlow) -> dict:
@@ -333,6 +439,8 @@ def _parse_x_request_metadata(flow: http.HTTPFlow) -> dict:
       - ``has_expansions``: bool — whether ``?expansions=`` is present.
       - ``max_results``: int | None — value of ``?max_results=``, used
         as an upper-bound fallback when the response body cannot be parsed.
+      - ``is_stream``: bool — True when the request path is one of the X v2
+        NDJSON streaming endpoints (see :data:`_X_STREAM_ENDPOINTS`).
 
     Reads from ``flow.metadata["original_url"]`` (set by the request handler
     via ``url_utils.get_original_url``) rather than ``pretty_url`` to stay
@@ -353,6 +461,7 @@ def _parse_x_request_metadata(flow: http.HTTPFlow) -> dict:
         "request_ids_count": ids_count,
         "has_expansions": "expansions" in qs,
         "max_results": max_results,
+        "is_stream": is_x_stream_path(parsed.path),
     }
 
 
@@ -372,6 +481,15 @@ def _parse_x_response_metadata(flow: http.HTTPFlow) -> dict:
         ``meta``).  Both fields are alternative spellings of the same
         billing dimension, so we collapse them into one log key.
 
+    For X NDJSON streaming endpoints, ``responseheaders`` registers an
+    incremental parser that populates ``flow.metadata["x_ndjson_state"]``
+    as response bytes arrive.  When that state is present we return its
+    accumulated counters directly (``body_format: "ndjson"``) and skip
+    the full-body ``json.loads`` path, since stream buffers are capped
+    at ``STREAM_BUFFER_LIMIT`` and don't contain the full response.
+    For streams ``body_truncated`` is always ``False`` — the incremental
+    parser saw every byte even if the forensic ``stream_buffer`` filled up.
+
     Failures (truncated buffer, malformed JSON, unexpected shape) leave
     ``body_parsed=False`` and emit no count fields, so analysis can
     distinguish "field absent in response" from "we couldn't parse it".
@@ -379,6 +497,27 @@ def _parse_x_response_metadata(flow: http.HTTPFlow) -> dict:
     state = flow.metadata.get("stream_buffer_state") or {}
     truncated = bool(state.get("truncated", False))
     result: dict = {"body_parsed": False, "body_truncated": truncated}
+
+    # Streaming branch: NDJSON parser accumulated counts in flow.metadata
+    # during response chunks.  Use those directly — the stream_buffer is
+    # intentionally tiny (64 KB) for streams and does NOT hold the body.
+    #
+    # Override body_truncated to False: the stream_buffer-derived truncated
+    # flag reflects the forensic buffer cap, but the NDJSON parser processed
+    # every chunk regardless of that cap, so billing counts are complete.
+    # Reporting body_truncated=True here would misleadingly suggest the
+    # counts are unreliable when they are not.
+    ndjson_state = flow.metadata.get("x_ndjson_state")
+    if ndjson_state is not None:
+        result["body_parsed"] = True
+        result["body_truncated"] = False
+        result["body_format"] = "ndjson"
+        result["response_data_count"] = ndjson_state["data_count"]
+        if ndjson_state["includes"]:
+            result["response_includes"] = dict(ndjson_state["includes"])
+        result["ndjson_lines_parsed"] = ndjson_state["lines_parsed"]
+        result["ndjson_lines_failed"] = ndjson_state["lines_failed"]
+        return result
 
     buf = flow.metadata.get("stream_buffer")
     if not buf:

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -15,6 +15,7 @@ import json
 import time
 import urllib.error
 import urllib.parse
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import TypedDict
 
@@ -66,7 +67,7 @@ def _extract_billing_usage(raw_usage, target: dict) -> None:
                 target["web_search_requests"] = wsr
 
 
-def create_sse_usage_extractor():
+def create_sse_usage_extractor() -> tuple[Callable[[bytes], None], dict]:
     """Create an incremental SSE parser that extracts usage from Anthropic API streams.
 
     All model providers in this system use the Anthropic Messages API streaming
@@ -382,7 +383,7 @@ class NdjsonState(TypedDict):
     """Lines that failed JSON decoding."""
 
 
-def create_x_ndjson_extractor():
+def create_x_ndjson_extractor() -> tuple[Callable[[bytes], None], NdjsonState]:
     """Create an incremental NDJSON parser for X v2 streaming responses.
 
     X v2 streaming endpoints deliver one JSON object per line separated by

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -510,6 +510,145 @@ class TestResponseHeadersHandler:
 
         mitm_addon.responseheaders(flow)  # Should not raise
 
+    # ---- X NDJSON streaming parser registration (issue #9534) ----
+
+    def test_x_stream_endpoint_registers_ndjson_parser(self):
+        """X filtered-stream endpoint wires incremental NDJSON parser.
+
+        Note: X streams return ``content-type: application/json`` with chunked
+        transfer encoding — same as non-stream endpoints.  Stream detection is
+        URL-based, not content-type-based.
+        """
+        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+        flow.response = MagicMock()
+        flow.response.status_code = 200
+        flow.response.headers = {"content-type": "application/json"}
+        flow.response.stream = False
+
+        mitm_addon.responseheaders(flow)
+
+        assert "x_ndjson_state" in flow.metadata
+        callback = flow.response.stream
+        callback(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
+        callback(b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"}]}}\n')
+        state = flow.metadata["x_ndjson_state"]
+        assert state["data_count"] == 2
+        assert state["includes"] == {"users": 2}
+
+    def test_x_stream_buffer_capped_at_stream_limit(self):
+        """Stream endpoint must NOT buffer multi-MB bodies — uses 64 KB cap."""
+        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+        flow.response = MagicMock()
+        flow.response.status_code = 200
+        flow.response.headers = {"content-type": "application/json"}
+        flow.response.stream = False
+
+        mitm_addon.responseheaders(flow)
+
+        callback = flow.response.stream
+        # First parseable line, then ~200 KB of junk.  Parser sees the first
+        # line; buffer truncates at STREAM_BUFFER_LIMIT.
+        callback(b'{"data":{"id":"1"}}\n' + b"x" * (200 * 1024))
+        assert len(flow.metadata["stream_buffer"]) <= body_utils.STREAM_BUFFER_LIMIT
+        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert flow.metadata["x_ndjson_state"]["data_count"] == 1
+
+    def test_x_non_stream_endpoint_keeps_unbounded_buffer(self):
+        """Non-stream X requests still need full body for json.loads."""
+        flow = _make_http_flow(host="api.x.com", path="/2/users/by")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["original_url"] = "https://api.x.com/2/users/by?ids=1,2,3"
+        flow.response = MagicMock()
+        flow.response.status_code = 200
+        flow.response.headers = {"content-type": "application/json"}
+        flow.response.stream = False
+
+        mitm_addon.responseheaders(flow)
+
+        callback = flow.response.stream
+        callback(b"x" * (200 * 1024))
+        assert len(flow.metadata["stream_buffer"]) == 200 * 1024
+        assert flow.metadata["stream_buffer_state"]["truncated"] is False
+        assert "x_ndjson_state" not in flow.metadata
+
+    def test_x_stream_rules_is_not_registered_as_stream(self):
+        """/2/tweets/search/stream/rules is rules mgmt, not a stream — no NDJSON parser."""
+        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream/rules")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream/rules"
+        flow.response = MagicMock()
+        flow.response.status_code = 200
+        flow.response.headers = {"content-type": "application/json"}
+        flow.response.stream = False
+
+        mitm_addon.responseheaders(flow)
+
+        # No NDJSON state registered; regular unbounded X buffer path
+        assert "x_ndjson_state" not in flow.metadata
+
+    def test_x_stream_error_response_keeps_unbounded_buffer(self):
+        """4xx/5xx on stream endpoints must preserve full error body (no NDJSON parser).
+
+        Error responses on stream endpoints return a single JSON error object,
+        not NDJSON.  The NDJSON parser gate on 2xx prevents the stream buffer
+        from being capped at 64 KB so forensic logging sees the full body.
+        """
+        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+        flow.response = MagicMock()
+        flow.response.status_code = 401  # unauthorized — returns JSON error, not NDJSON
+        flow.response.headers = {"content-type": "application/json"}
+        flow.response.stream = False
+
+        mitm_addon.responseheaders(flow)
+
+        # No NDJSON parser — error body would fail NDJSON parsing anyway.
+        assert "x_ndjson_state" not in flow.metadata
+        callback = flow.response.stream
+        # Unbounded X buffer retains the full error body for forensic logging.
+        error_body = b'{"title":"Unauthorized","detail":"' + b"x" * (200 * 1024) + b'"}'
+        callback(error_body)
+        assert len(flow.metadata["stream_buffer"]) == len(error_body)
+        assert flow.metadata["stream_buffer_state"]["truncated"] is False
+
+    def test_x_stream_gzip_compressed_body(self):
+        """Gzip-encoded NDJSON stream: decompressor + parser wire up correctly."""
+        import gzip
+
+        ndjson_body = (
+            b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n'
+            b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"}]}}\n'
+            b'{"data":{"id":"3"},"includes":{"users":[{"id":"u3"}]}}\n'
+        )
+        compressed = gzip.compress(ndjson_body)
+
+        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+        flow.response = MagicMock()
+        flow.response.status_code = 200
+        flow.response.headers = {
+            "content-type": "application/json",
+            "content-encoding": "gzip",
+        }
+        flow.response.stream = False
+
+        mitm_addon.responseheaders(flow)
+
+        callback = flow.response.stream
+        # Feed compressed bytes in two chunks to exercise incremental decompression.
+        mid = len(compressed) // 2
+        callback(compressed[:mid])
+        callback(compressed[mid:])
+        state = flow.metadata["x_ndjson_state"]
+        assert state["data_count"] == 3
+        assert state["includes"] == {"users": 3}
+
 
 class TestResponseHandler:
     def setup_method(self):
@@ -915,6 +1054,107 @@ class TestSseUsageExtractor:
         assert usage["input_tokens"] == 100  # unchanged (not in delta)
 
 
+class TestNdjsonExtractor:
+    """Tests for create_x_ndjson_extractor incremental parser (issue #9534)."""
+
+    def test_single_line(self):
+        parse, state = usage.create_x_ndjson_extractor()
+        parse(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
+        assert state["data_count"] == 1
+        assert state["includes"] == {"users": 1}
+        assert state["lines_parsed"] == 1
+        assert state["lines_failed"] == 0
+
+    def test_multiple_lines_aggregate_counts(self):
+        parse, state = usage.create_x_ndjson_extractor()
+        parse(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
+        parse(b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"},{"id":"u3"}]}}\n')
+        assert state["data_count"] == 2
+        assert state["includes"] == {"users": 3}
+        assert state["lines_parsed"] == 2
+
+    def test_chunked_line_split_mid_json(self):
+        parse, state = usage.create_x_ndjson_extractor()
+        parse(b'{"data":{"id":"1"},"include')
+        parse(b's":{"users":[{"id":"u1"}]}}\n')
+        assert state["data_count"] == 1
+        assert state["includes"] == {"users": 1}
+        assert state["lines_parsed"] == 1
+
+    def test_keep_alive_blank_lines(self):
+        parse, state = usage.create_x_ndjson_extractor()
+        parse(b"\n\n")
+        parse(b'{"data":{"id":"1"}}\n')
+        parse(b"\n")
+        parse(b'{"data":{"id":"2"}}\n')
+        assert state["data_count"] == 2
+        assert state["lines_parsed"] == 2
+
+    def test_crlf_line_endings(self):
+        parse, state = usage.create_x_ndjson_extractor()
+        parse(b'{"data":{"id":"1"}}\r\n{"data":{"id":"2"}}\r\n')
+        assert state["data_count"] == 2
+        assert state["lines_parsed"] == 2
+
+    def test_malformed_line_increments_failures(self):
+        parse, state = usage.create_x_ndjson_extractor()
+        parse(b'{"data":{"id":"1"}}\n')
+        parse(b"not json at all\n")
+        parse(b'{"data":{"id":"2"}}\n')
+        assert state["data_count"] == 2
+        assert state["lines_parsed"] == 2
+        assert state["lines_failed"] == 1
+
+    def test_truncated_trailing_line_not_counted(self):
+        """Connection drops mid-line — partial trailing line stays in buf, not counted."""
+        parse, state = usage.create_x_ndjson_extractor()
+        parse(b'{"data":{"id":"1"}}\n{"data":{"id":"2"}')  # no trailing \n
+        assert state["data_count"] == 1
+        assert state["lines_parsed"] == 1
+
+    def test_empty_chunks_safe(self):
+        parse, state = usage.create_x_ndjson_extractor()
+        parse(b"")
+        parse(b'{"data":{"id":"1"}}\n')
+        parse(b"")
+        assert state["data_count"] == 1
+
+    def test_oversized_line_dropped(self):
+        """Line > MAX_NDJSON_LINE_BYTES is dropped; subsequent lines parse normally."""
+        parse, state = usage.create_x_ndjson_extractor()
+        big = b"x" * (usage.MAX_NDJSON_LINE_BYTES + 1024)
+        parse(big)
+        # line_buf should have been reset
+        parse(b'{"data":{"id":"after"}}\n')
+        assert state["data_count"] == 1
+        assert state["lines_parsed"] == 1
+
+    def test_includes_multiple_keys(self):
+        parse, state = usage.create_x_ndjson_extractor()
+        parse(
+            b'{"data":{"id":"1"},"includes":'
+            b'{"users":[{"id":"u1"}],'
+            b'"tweets":[{"id":"t1"},{"id":"t2"}],'
+            b'"media":[{"id":"m1"}]}}\n'
+        )
+        assert state["includes"] == {"users": 1, "tweets": 2, "media": 1}
+
+    def test_data_array_not_counted(self):
+        """Line where top-level ``data`` is an array (not a dict) contributes 0 to data_count."""
+        parse, state = usage.create_x_ndjson_extractor()
+        parse(b'{"data":[1,2,3]}\n')
+        assert state["data_count"] == 0
+        assert state["lines_parsed"] == 1
+
+    def test_non_dict_top_level_skipped(self):
+        parse, state = usage.create_x_ndjson_extractor()
+        parse(b'"some string"\n')
+        parse(b"42\n")
+        parse(b'{"data":{"id":"1"}}\n')
+        assert state["lines_parsed"] == 3
+        assert state["data_count"] == 1
+
+
 class TestDoReportUsage:
     """Tests for _do_report_usage HTTP request construction."""
 
@@ -1192,6 +1432,7 @@ class TestResponseUsageReporting:
         """Billable connector responses should buffer the full body (no 64KB cap)."""
         flow = _make_http_flow(host="api.x.com")
         flow.response = MagicMock()
+        flow.response.status_code = 200
         flow.response.headers = {"content-type": "application/json"}
         flow.response.stream = False
         flow.metadata["firewall_name"] = "x"
@@ -1493,6 +1734,93 @@ class TestErrorHandler:
         assert "connection reset by peer" in content
         assert "slack.com" in content
 
+    def test_error_logs_connector_usage_for_x_stream(self, tmp_path):
+        """Mid-flight stream crash: partial counts still reported (issue #9534)."""
+        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        log_path = str(tmp_path / "network.jsonl")
+        proxy_log = tmp_path / "proxy.jsonl"
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log)
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
+        flow.metadata["x_ndjson_state"] = {
+            "data_count": 23,
+            "includes": {"users": 5},
+            "lines_parsed": 23,
+            "lines_failed": 0,
+        }
+        flow.metadata["stream_buffer"] = bytearray()
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = MagicMock()
+        flow.response.status_code = 200
+        # X streams return application/json with chunked transfer, not x-ndjson.
+        flow.response.headers = {"content-type": "application/json"}
+        flow.error = MagicMock()
+        flow.error.msg = "connection reset by peer"
+
+        mitm_addon.error(flow)
+
+        # proxy.jsonl should contain both the connection_error and the connector_usage entries
+        entries = [json.loads(ln) for ln in proxy_log.read_text().splitlines() if ln]
+        usage_entries = [e for e in entries if e.get("type") == "connector_usage"]
+        assert len(usage_entries) == 1
+        assert usage_entries[0]["response_data_count"] == 23
+        assert usage_entries[0]["body_format"] == "ndjson"
+        assert usage_entries[0]["is_stream"] is True
+
+    def test_full_pipeline_stream_error_midflight(self, tmp_path):
+        """End-to-end: responseheaders → partial chunks → error() logs observed counts.
+
+        Simulates a real scenario: stream opens successfully, a few tweets
+        arrive, then the connection resets.  No pre-populated state — the
+        incremental parser must have accumulated counts from the chunks.
+        """
+        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        log_path = str(tmp_path / "network.jsonl")
+        proxy_log = tmp_path / "proxy.jsonl"
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log)
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
+        flow.response = MagicMock()
+        flow.response.status_code = 200
+        flow.response.headers = {"content-type": "application/json"}
+        flow.response.stream = False
+
+        # 1. Register parser
+        mitm_addon.responseheaders(flow)
+        callback = flow.response.stream
+        assert "x_ndjson_state" in flow.metadata
+
+        # 2. Receive two complete tweets, then a partial third (cut off)
+        callback(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
+        callback(b'{"data":{"id":"2"}}\n')
+        callback(b'{"data":{"id":"3"}')  # no trailing \n — connection dies here
+
+        # 3. Connection aborts
+        flow.error = MagicMock()
+        flow.error.msg = "connection reset by peer"
+        mitm_addon.error(flow)
+
+        # 4. Log must reflect the 2 complete tweets (partial 3rd is dropped)
+        entries = [json.loads(ln) for ln in proxy_log.read_text().splitlines() if ln]
+        usage_entries = [e for e in entries if e.get("type") == "connector_usage"]
+        assert len(usage_entries) == 1
+        e = usage_entries[0]
+        assert e["body_format"] == "ndjson"
+        assert e["response_data_count"] == 2  # not 3 — partial trailing dropped
+        assert e["response_includes"] == {"users": 1}
+        assert e["is_stream"] is True
+        assert e["body_truncated"] is False  # billing is complete despite disconnect
+
 
 class TestMaybeReportProxyUsage:
     """Tests for maybe_report_proxy_usage helper."""
@@ -1596,6 +1924,28 @@ class TestMaybeReportProxyUsage:
 
         mock_enqueue.assert_not_called()
         assert proxy_log.exists()
+
+
+class TestIsXStreamPath:
+    """Tests for is_x_stream_path predicate (issue #9534)."""
+
+    def test_all_five_stream_endpoints_match(self):
+        assert usage.is_x_stream_path("/2/tweets/search/stream") is True
+        assert usage.is_x_stream_path("/2/tweets/sample/stream") is True
+        assert usage.is_x_stream_path("/2/tweets/sample10/stream") is True
+        assert usage.is_x_stream_path("/2/tweets/compliance/stream") is True
+        assert usage.is_x_stream_path("/2/users/compliance/stream") is True
+
+    def test_stream_rules_is_not_stream(self):
+        # Rules management is a regular JSON request/response endpoint.
+        assert usage.is_x_stream_path("/2/tweets/search/stream/rules") is False
+
+    def test_non_stream_paths_do_not_match(self):
+        assert usage.is_x_stream_path("/2/tweets/search/recent") is False
+        assert usage.is_x_stream_path("/2/users/by") is False
+        assert usage.is_x_stream_path("/2/tweets/1") is False
+        assert usage.is_x_stream_path("") is False
+        assert usage.is_x_stream_path("/") is False
 
 
 class TestLogConnectorUsage:
@@ -1917,6 +2267,172 @@ class TestLogConnectorUsage:
         assert entry["method"] == "POST"
         assert entry["billable_counts"] == {"tweet.write": 1}
 
+    # ---- is_stream request signal (issue #9534) ----
+
+    def test_is_stream_false_for_non_stream_endpoint(self, tmp_path):
+        """Regular request/response endpoints mark is_stream=False."""
+        body = json.dumps({"data": {"id": "1"}}).encode()
+        flow = self._make_x_flow(tmp_path, path="/2/tweets/1", body=body)
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["is_stream"] is False
+
+    def test_is_stream_true_for_filtered_stream_endpoint(self, tmp_path):
+        """/2/tweets/search/stream marks is_stream=True in log entry."""
+        body = json.dumps({"data": {"id": "1"}}).encode()  # single dict; real path uses NDJSON
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/tweets/search/stream",
+            body=body,
+            rule="GET /2/tweets/search/stream",
+        )
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["is_stream"] is True
+
+    def test_is_stream_true_with_query_params(self, tmp_path):
+        """Stream URL with realistic query params still marks is_stream=True.
+
+        X filtered streams are always called with expansions, tweet.fields, etc.
+        The URL parser must strip the query before matching against
+        _X_STREAM_ENDPOINTS — regression guard against future refactors that
+        accidentally use startswith/substring matching instead of exact path.
+        """
+        body = json.dumps({"data": {"id": "1"}}).encode()
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/tweets/search/stream",
+            query="expansions=author_id,referenced_tweets.id"
+            "&tweet.fields=created_at,public_metrics"
+            "&backfill_minutes=5",
+            body=body,
+            rule="GET /2/tweets/search/stream",
+        )
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["is_stream"] is True
+        assert entry["has_expansions"] is True
+
+    def test_is_stream_false_for_stream_rules(self, tmp_path):
+        """POST /2/tweets/search/stream/rules is NOT a stream (rules mgmt)."""
+        body = json.dumps({"data": [{"id": "r1", "value": "rule"}]}).encode()
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/tweets/search/stream/rules",
+            body=body,
+            status=201,
+            permission="tweet.read",
+            rule="POST /2/tweets/search/stream/rules",
+        )
+        flow.request.method = "POST"
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["is_stream"] is False
+
+    # ---- streaming: x_ndjson_state feeds billing directly (issue #9534) ----
+
+    def test_logs_x_stream_with_ndjson_state(self, tmp_path):
+        """Stream with pre-populated x_ndjson_state logs aggregated counts."""
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/tweets/search/stream",
+            body=b"",  # stream_buffer is empty — NDJSON parser handled the body
+            rule="GET /2/tweets/search/stream",
+        )
+        flow.metadata["x_ndjson_state"] = {
+            "data_count": 50,
+            "includes": {"users": 47, "tweets": 12},
+            "lines_parsed": 50,
+            "lines_failed": 1,
+        }
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["body_parsed"] is True
+        assert entry["body_format"] == "ndjson"
+        assert entry["response_data_count"] == 50
+        assert entry["response_includes"] == {"users": 47, "tweets": 12}
+        assert entry["ndjson_lines_parsed"] == 50
+        assert entry["ndjson_lines_failed"] == 1
+        assert entry["is_stream"] is True
+        # billable_counts: primary max(0,50,0,0,1)=50; users.read=47; tweets→tweet.read
+        # (tweet.read primary 50 + 12 from includes = 62)
+        assert entry["billable_counts"]["tweet.read"] == 62
+        assert entry["billable_counts"]["users.read"] == 47
+
+    def test_logs_x_stream_empty_no_fallback(self, tmp_path):
+        """Stream that delivered 0 tweets bills 1 (min), NOT _X_UNPARSEABLE_READ_FALLBACK."""
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/tweets/search/stream",
+            body=b"",
+            rule="GET /2/tweets/search/stream",
+        )
+        flow.metadata["x_ndjson_state"] = {
+            "data_count": 0,
+            "includes": {},
+            "lines_parsed": 0,
+            "lines_failed": 0,
+        }
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["body_parsed"] is True
+        assert entry["body_format"] == "ndjson"
+        assert entry["response_data_count"] == 0
+        # No fallback — body_parsed=True so _X_UNPARSEABLE_READ_FALLBACK is not triggered.
+        # primary = max(0,0,0,0,1) = 1
+        assert entry["billable_counts"] == {"tweet.read": 1}
+
+    def test_logs_x_stream_ignores_buffer_when_ndjson_state_present(self, tmp_path):
+        """When x_ndjson_state is present, stream_buffer contents are ignored."""
+        # Put junk in the buffer that would fail json.loads — NDJSON path should
+        # win and return the accumulated state without trying to parse the buffer.
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/tweets/search/stream",
+            body=b"this-is-not-json-at-all",
+            rule="GET /2/tweets/search/stream",
+        )
+        flow.metadata["x_ndjson_state"] = {
+            "data_count": 7,
+            "includes": {},
+            "lines_parsed": 7,
+            "lines_failed": 0,
+        }
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["body_parsed"] is True
+        assert entry["body_format"] == "ndjson"
+        assert entry["response_data_count"] == 7
+
+    def test_logs_x_stream_body_truncated_false_even_when_buffer_truncated(self, tmp_path):
+        """Stream with truncated forensic buffer still reports body_truncated=False.
+
+        The 64 KB stream_buffer cap is for forensic logging only; the NDJSON
+        parser processed every chunk incrementally, so billing counts are
+        complete.  Reporting body_truncated=True here would misleadingly
+        suggest counts are unreliable.
+        """
+        flow = self._make_x_flow(
+            tmp_path,
+            path="/2/tweets/search/stream",
+            body=b"whatever-forensic-bytes",
+            rule="GET /2/tweets/search/stream",
+        )
+        # Simulate a long-lived stream where the forensic buffer filled up
+        # while the parser kept accumulating state.
+        flow.metadata["stream_buffer_state"] = {"truncated": True}
+        flow.metadata["x_ndjson_state"] = {
+            "data_count": 50000,
+            "includes": {"users": 12000},
+            "lines_parsed": 50000,
+            "lines_failed": 0,
+        }
+        usage.log_connector_usage(flow, "run-abc-123")
+        entry = self._read_entry(tmp_path)
+        assert entry["body_parsed"] is True
+        assert entry["body_truncated"] is False  # NOT True — billing is complete
+        assert entry["response_data_count"] == 50000
+
     # ---- forensic / parser-state cases ----
 
     def test_handles_truncated_buffer(self, tmp_path):
@@ -2042,6 +2558,62 @@ class TestLogConnectorUsage:
             mitm_addon.response(flow)
 
         mock_log_connector.assert_called_once_with(flow, "run-abc-123")
+
+    # ---- full pipeline: responseheaders → stream chunks → response (issue #9534) ----
+
+    def test_full_streaming_pipeline_filtered_stream(self, tmp_path):
+        """End-to-end: responseheaders registers parser, chunks accumulate, response() logs."""
+        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
+        flow.response = MagicMock()
+        flow.response.status_code = 200
+        # X streams return application/json with chunked transfer, not x-ndjson.
+        flow.response.headers = {"content-type": "application/json"}
+        flow.response.stream = False
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        # 1. responseheaders — registers NDJSON parser
+        mitm_addon.responseheaders(flow)
+        callback = flow.response.stream
+        assert "x_ndjson_state" in flow.metadata
+
+        # 2. Stream chunks (including keep-alives and a mid-line split)
+        chunks = [
+            b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n',
+            b"\n",  # keep-alive
+            b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"}]}}\n',
+            b'{"data":{"id":"3"}',  # split mid-line
+            b',"includes":{"users":[{"id":"u3"}]}}\n',
+        ]
+        for chunk in chunks:
+            callback(chunk)
+
+        # 3. Simulated disconnect — response() fires and logs
+        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+            mitm_addon.response(flow)
+
+        # 4. Verify the log entry
+        entries = [
+            json.loads(ln) for ln in (tmp_path / "proxy.jsonl").read_text().splitlines() if ln
+        ]
+        usage_entries = [e for e in entries if e.get("type") == "connector_usage"]
+        assert len(usage_entries) == 1
+        e = usage_entries[0]
+        assert e["body_format"] == "ndjson"
+        assert e["response_data_count"] == 3
+        assert e["response_includes"] == {"users": 3}
+        assert e["is_stream"] is True
+        # billable_counts: primary max(0,3,0,0,1)=3; users from includes=3
+        assert e["billable_counts"]["tweet.read"] == 3
+        assert e["billable_counts"]["users.read"] == 3
 
 
 class TestErrorUsageReporting:

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1,6 +1,7 @@
 """Tests for HTTP/TLS/TCP handlers."""
 
 import asyncio
+import gzip
 import json
 import time
 from pathlib import Path
@@ -618,8 +619,6 @@ class TestResponseHeadersHandler:
 
     def test_x_stream_gzip_compressed_body(self):
         """Gzip-encoded NDJSON stream: decompressor + parser wire up correctly."""
-        import gzip
-
         ndjson_body = (
             b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n'
             b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"}]}}\n'
@@ -1238,8 +1237,6 @@ class TestResponseHeadersSseParser:
 
     def test_decompresses_gzip_sse_before_parsing(self):
         """Compressed SSE streams must be decompressed before usage extraction."""
-        import gzip
-
         flow = _make_http_flow(host="api.anthropic.com")
         flow.response = MagicMock()
         flow.response.headers = {
@@ -2238,8 +2235,6 @@ class TestLogConnectorUsage:
 
     def test_handles_gzip_body(self, tmp_path):
         """gzip-encoded response body decompresses before parsing."""
-        import gzip
-
         raw = json.dumps({"data": [{"id": "1"}], "meta": {"result_count": 1}}).encode()
         body = gzip.compress(raw)
         flow = self._make_x_flow(tmp_path, body=body, content_encoding="gzip")


### PR DESCRIPTION
## Summary

Replace the buffer-everything-then-parse approach for X v2 streaming endpoints (filtered/sample/sample10/compliance streams) with an incremental NDJSON parser registered as a `flow.response.stream` callback — same pattern as the existing SSE extractor.

**Impact**: the stream buffer for X billable streams is now capped at `STREAM_BUFFER_LIMIT` (64 KB) instead of unbounded, eliminating the multi-GB OOM risk on long-lived streams.

**Billing correctness**: a filtered stream that delivers 50,000 tweets is now logged as 50,000 instead of the `_X_UNPARSEABLE_READ_FALLBACK` value of 100.

Closes #9534

## Design highlights

- **Reuse proven pattern**: `create_x_ndjson_extractor()` mirrors `create_sse_usage_extractor()` shape `(parse_chunk, state)`; wired into `responseheaders()` the same way SSE is
- **`x_ndjson_state` metadata key (not `proxy_usage`)**: intentional to avoid triggering `maybe_report_proxy_usage`'s webhook path
- **2xx gate**: parser only registers for successful responses; 4xx/5xx fall through to existing unbounded buffer so error bodies stay available for forensic inspection
- **`error()` hook also logs**: streams that crash mid-flight still report observed counts
- **`MAX_NDJSON_LINE_BYTES = 5 MB`**: matches `LARGE_RESPONSE_DECOMPRESS_LIMIT`, defends against malformed/hostile upstream
- **`body_truncated: False` for streams**: the parser saw every byte even if the forensic buffer filled up — reporting True would mislead server-side billing

## Key code

- `usage.py`: new `_X_STREAM_ENDPOINTS` frozenset + `is_x_stream_path()` + `create_x_ndjson_extractor()` + NDJSON branch in `_parse_x_response_metadata`; `_parse_x_request_metadata` adds `is_stream` field
- `mitm_addon.py`: `responseheaders()` registers NDJSON parser for 2xx X stream responses; `error()` calls `log_connector_usage`
- `tests/test_handlers.py`: 31 new tests covering parser isolation, chunk boundaries, gzip compression, status gate, full pipeline, mid-stream crash

## Out of scope (deferred)

- Periodic flush for streams that never close
- Per-tweet pricing tables (server-side `credit_pricing`)
- 24h UTC dedup logic (server-side)
- Other connectors beyond X

## Test plan

- [x] `pytest` — 824/824 passing (31 new tests + existing regression)
- [x] `ruff check` — all checks passed
- [x] `ruff format --check` — all files formatted
- [ ] CI green (build + lint + test)
- [ ] Manual verification in staging once merged (stream connector runs a filtered stream and sees correct per-tweet billing in proxy logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)