### PR TITLE
fix(runner): add missing doc comment on init_tracing_stderr

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -151,6 +151,7 @@ fn init_tracing_with_file(
     Ok(guard)
 }
 
+/// Initialize tracing with stderr output only (no rolling log file).
 fn init_tracing_stderr() {
     tracing_subscriber::fmt().init();
 }


### PR DESCRIPTION
## Summary
- Adds a one-line rustdoc to `init_tracing_stderr` to mirror the existing doc on sibling `init_tracing_with_file`.

## Test plan
- [x] `cargo fmt` / clippy pass locally (pre-commit hook)