### PR TITLE
refactor(platform): convert ably notify to ccstate command pattern

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -1,36 +1,38 @@
 import { describe, it, expect, vi } from "vitest";
-import { createStore } from "ccstate";
-import { ablyNotify$ } from "../realtime.ts";
+import { command, createStore } from "ccstate";
+import { setAblyLoop$ } from "../realtime.ts";
 
 // ---------------------------------------------------------------------------
-// ablyNotify$ — IN_VITEST fallback to setLoop
+// setAblyLoop$ — IN_VITEST fallback to setLoop
 // ---------------------------------------------------------------------------
 
-describe("ablyNotify$ — IN_VITEST fallback (setLoop)", () => {
-  it("resolves when body returns true on first call", async () => {
+describe("setAblyLoop$ — IN_VITEST fallback (setLoop)", () => {
+  it("resolves when loopCommand$ returns true on first call", async () => {
     const store = createStore();
-    const ablyNotify = store.get(ablyNotify$);
     const controller = new AbortController();
 
     const body = vi.fn().mockReturnValue(true);
-    await ablyNotify("topic", body, 0, controller.signal);
+    const loopCommand$ = command((_store, _signal: AbortSignal) => {
+      return body() as boolean;
+    });
+
+    await store.set(setAblyLoop$, "topic", loopCommand$, 0, controller.signal);
 
     expect(body).toHaveBeenCalledOnce();
   });
 
-  it("keeps calling body until it returns true", async () => {
+  it("keeps calling loopCommand$ until it returns true", async () => {
     const store = createStore();
-    const ablyNotify = store.get(ablyNotify$);
     const controller = new AbortController();
 
     let calls = 0;
-    const body = vi.fn(() => {
+    const loopCommand$ = command((_store, _signal: AbortSignal) => {
       calls++;
       return calls >= 3;
     });
 
-    await ablyNotify("topic", body, 0, controller.signal);
+    await store.set(setAblyLoop$, "topic", loopCommand$, 0, controller.signal);
 
-    expect(body.mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(calls).toBeGreaterThanOrEqual(3);
   });
 });

--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -10,7 +10,7 @@ import { createCursorPagination } from "../cursor-pagination.ts";
 import { zeroOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { createRunLoop } from "../zero-page/polling.ts";
-import { ablyNotify$ } from "../realtime.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 import { delay } from "signal-timers";
 import { accept } from "../../lib/accept.ts";
 import { navigateToChat$ } from "../zero-page/zero-nav.ts";
@@ -263,17 +263,12 @@ export const setupActivityLogLoop$ = command(
     // would be a no-op.
     await delay(0, { signal });
     set(scrollToBottomActivityDetail$);
-    const ablyNotify = get(ablyNotify$);
-    await ablyNotify(
-      `thread:${runId}`,
-      (sig) => {
-        const finished = set(run.checkFinished$, sig);
-        set(autoScrollActivityDetail$);
-        return finished;
-      },
-      3000,
-      signal,
-    );
+    const loopBody$ = command(({ set }, sig: AbortSignal) => {
+      const finished = set(run.checkFinished$, sig);
+      set(autoScrollActivityDetail$);
+      return finished;
+    });
+    await set(setAblyLoop$, `thread:${runId}`, loopBody$, 3000, signal);
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -1,7 +1,7 @@
 import { command, computed, state, type Computed } from "ccstate";
 import type { AgentEvent, LogStatus } from "../zero-page/log-types.ts";
 import { onRef, resetSignal } from "../utils.ts";
-import { ablyNotify$ } from "../realtime.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { logger } from "../log.ts";
@@ -633,7 +633,6 @@ const chatMessages$ = computed(async (get): Promise<ChatMessages | null> => {
 export const loadChatMessages$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     L.debug("Loading messages");
-    const ablyNotify = get(ablyNotify$);
     const messages = await get(chatMessages$);
     signal.throwIfAborted();
     if (!messages?.activeRunMessages.length) {
@@ -663,14 +662,16 @@ export const loadChatMessages$ = command(
 
         set(markMessageLoading$, message.legacyRunId!);
 
-        await ablyNotify(
+        const loopBody$ = command(({ set }, sig: AbortSignal) => {
+          set(reloadThinkingMessage$, (x) => {
+            return x + 1;
+          });
+          return set(runLoop.checkFinished$, sig);
+        });
+        await set(
+          setAblyLoop$,
           `thread:${message.legacyRunId}`,
-          (sig) => {
-            set(reloadThinkingMessage$, (x) => {
-              return x + 1;
-            });
-            return set(runLoop.checkFinished$, sig);
-          },
+          loopBody$,
           3000,
           signal,
         );
@@ -945,17 +946,12 @@ export const sendExistingThreadMessage$ = command(
       return;
     }
 
-    const ablyNotify = get(ablyNotify$);
-    await ablyNotify(
-      `thread:${runId}`,
-      (sig) => {
-        set(reloadChatThreads$);
-        set(reloadCurrentChatThread$);
-        return set(runLoop.checkFinished$, sig);
-      },
-      3000,
-      signal,
-    );
+    const loopBody$ = command(({ set }, sig: AbortSignal) => {
+      set(reloadChatThreads$);
+      set(reloadCurrentChatThread$);
+      return set(runLoop.checkFinished$, sig);
+    });
+    await set(setAblyLoop$, `thread:${runId}`, loopBody$, 3000, signal);
 
     // After the poll loop exits, the last `reloadCurrentChatThread$` ran at
     // the START of the final iteration — at that point the run's server-side

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1,7 +1,7 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { delay } from "signal-timers";
 import { onRef, resetSignal, throwIfNotAbort } from "../utils.ts";
-import { ablyNotify$ } from "../realtime.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 import { createScrollSignals } from "../auto-scroll.ts";
 import { logger } from "../log.ts";
 import {
@@ -384,16 +384,17 @@ function createSendMessage(
       return;
     }
 
-    const ablyNotify = get(ablyNotify$);
-    await ablyNotify(
+    const sendLoopBody$ = command(async ({ set }, sig: AbortSignal) => {
+      set(reloadChatThreads$);
+      set(deps.reloadThread$);
+      const finished = await set(runLoop.checkFinished$, sig);
+      set(deps.autoScroll$);
+      return finished;
+    });
+    await set(
+      setAblyLoop$,
       `thread:${sendResult.body.runId}`,
-      async (sig) => {
-        set(reloadChatThreads$);
-        set(deps.reloadThread$);
-        const finished = await set(runLoop.checkFinished$, sig);
-        set(deps.autoScroll$);
-        return finished;
-      },
+      sendLoopBody$,
       3000,
       signal,
     );
@@ -422,7 +423,6 @@ function createSendMessage(
 function createLoadMessages(deps: MessageCommandsInternalScope) {
   return command(async ({ get, set }, signal: AbortSignal) => {
     L.debug("Loading messages");
-    const ablyNotify = get(ablyNotify$);
     const msgs = await get(deps.chatMessages$);
     signal.throwIfAborted();
 
@@ -460,14 +460,16 @@ function createLoadMessages(deps: MessageCommandsInternalScope) {
 
         set(markMessageLoading$, message.legacyRunId!);
 
-        await ablyNotify(
+        const loadLoopBody$ = command(({ set }, sig: AbortSignal) => {
+          set(deps.reloadThinkingMessage$);
+          const finished = set(runLoop.checkFinished$, sig);
+          set(deps.autoScroll$);
+          return finished;
+        });
+        await set(
+          setAblyLoop$,
           `thread:${message.legacyRunId}`,
-          (sig) => {
-            set(deps.reloadThinkingMessage$);
-            const finished = set(runLoop.checkFinished$, sig);
-            set(deps.autoScroll$);
-            return finished;
-          },
+          loadLoopBody$,
           3000,
           signal,
         );

--- a/turbo/apps/platform/src/signals/mission-control-page/create-activity-signals.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/create-activity-signals.ts
@@ -1,6 +1,6 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { createRunLoop } from "../zero-page/polling.ts";
-import { ablyNotify$ } from "../realtime.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 import type { LogDetail, AgentEvent } from "../zero-page/log-types.ts";
 
 // ---------------------------------------------------------------------------
@@ -51,13 +51,11 @@ export function createActivitySignals(runId: string): ActivitySignals {
     set(internalStepSearch$, value);
   });
 
-  const startPolling$ = command(async ({ get, set }, signal: AbortSignal) => {
-    const ablyNotify = get(ablyNotify$);
-    await ablyNotify(
+  const startPolling$ = command(async ({ set }, signal: AbortSignal) => {
+    await set(
+      setAblyLoop$,
       `thread:${runId}`,
-      (sig) => {
-        return set(runLoop.checkFinished$, sig);
-      },
+      runLoop.checkFinished$,
       3000,
       signal,
     );

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
@@ -3,7 +3,7 @@ import { tasksContract, type TaskItem } from "@vm0/core";
 import { zeroClient$ } from "../api-client";
 import { accept } from "../../lib/accept";
 import { jsonParseOr, onRef, resetSignal, throwIfNotAbort } from "../utils.ts";
-import { ablyNotify$ } from "../realtime.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 import { clerk$ } from "../auth.ts";
 import {
   createChatThreadSignals,
@@ -349,7 +349,6 @@ const internalTaskSignals$ = state<Map<string, TaskSignals>>(new Map());
 
 export const setupTasksLoop$ = command(
   async ({ set, get }, signal: AbortSignal) => {
-    const ablyNotify = get(ablyNotify$);
     const clerk = await get(clerk$);
     signal.throwIfAborted();
     const orgId = clerk.organization?.id;
@@ -357,9 +356,8 @@ export const setupTasksLoop$ = command(
       throw new Error("setupTasksLoop$ called without active organization");
     }
 
-    await ablyNotify(
-      `tasks:${orgId}`,
-      async () => {
+    const tasksLoopBody$ = command(
+      async ({ get, set }, signal: AbortSignal) => {
         set(reloadTasks$);
         const tasks = await get(tasks$);
         signal.throwIfAborted();
@@ -442,9 +440,9 @@ export const setupTasksLoop$ = command(
 
         return false;
       },
-      10_000,
-      signal,
     );
+
+    await set(setAblyLoop$, `tasks:${orgId}`, tasksLoopBody$, 10_000, signal);
   },
 );
 

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { command, state, type Command } from "ccstate";
 import { platformRealtimeTokenContract } from "@vm0/core";
 import {
   Realtime,
@@ -6,15 +6,21 @@ import {
   type ErrorInfo,
   type TokenRequest,
   type TokenDetails,
+  type InboundMessage,
 } from "ably";
 import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { IN_VITEST } from "../env.ts";
-import { setLoop } from "./utils.ts";
-import { logger } from "./log.ts";
+import { createDeferredPromise, setLoop, throwIfAbort } from "./utils.ts";
+import { Level, logger } from "./log.ts";
+import { delay } from "signal-timers";
 
 const L = logger("Realtime");
 
+const MAX_LOOP_COUNT_IN_TEST = 1000;
+const FIB_DELAYS_MS = [
+  1000, 1000, 2000, 3000, 5000, 8000, 13_000, 21_000, 34_000, 55_000, 60_000,
+] as const;
 // ---------------------------------------------------------------------------
 // Ably client singleton
 // ---------------------------------------------------------------------------
@@ -103,103 +109,79 @@ export const setupRealtime$ = command(
     const channel = ably.channels.get(channelName);
     set(internalUserChannel$, channel);
 
-    L.info(`Realtime connected, subscribed to ${channelName}`);
+    L.debug(`Realtime connected, subscribed to ${channelName}`);
   },
 );
 
-// ---------------------------------------------------------------------------
-// ablyNotify — drop-in replacement for setLoop
-// ---------------------------------------------------------------------------
-
-type NotifyBody = (signal: AbortSignal) => Promise<boolean> | boolean;
-
-/**
- * Subscribe to `topic` on `channel` and invoke `body` on each message.
- * Resolves when `body` returns `true`, rejects on abort or subscribe failure.
- */
-async function ablyChannelNotify(
-  channel: RealtimeChannel,
-  topic: string,
-  body: NotifyBody,
-  signal: AbortSignal,
-): Promise<void> {
-  // Run body once immediately to load initial data
-  const done = await body(signal);
-  if (done) {
-    return;
-  }
-
-  // Subscribe to the specific topic on the user's channel and wait
-  // for Ably signals to re-run body.
-  return new Promise<void>((resolve, reject) => {
-    const onAbort = () => {
-      cleanup();
-      reject(signal.reason);
-    };
-
-    const messageHandler = () => {
-      const result = body(signal);
-      if (result instanceof Promise) {
-        result
-          .then((finished) => {
-            if (finished) {
-              cleanup();
-              resolve();
-            }
-          })
-          .catch((error: unknown) => {
-            cleanup();
-            reject(error);
-          });
-      } else if (result) {
-        cleanup();
-        resolve();
-      }
-    };
-
-    channel
-      .subscribe(topic, messageHandler)
-      .catch((subscribeError: unknown) => {
-        signal.removeEventListener("abort", onAbort);
-        L.warn(
-          `ablyNotify: failed to subscribe to topic "${topic}"`,
-          subscribeError,
-        );
-        reject(subscribeError);
-      });
-    signal.addEventListener("abort", onAbort, { once: true });
-
-    function cleanup() {
-      signal.removeEventListener("abort", onAbort);
-      channel.unsubscribe(topic, messageHandler);
-    }
-  });
-}
-
-/**
- * Module-level ablyNotify that reads the user channel from signal state.
- * This is the primary API used by feature code.
- *
- * Usage inside a command:
- *   const ablyNotify = get(ablyNotify$);
- *   await ablyNotify("thread:runId", body, 3000, signal);
- *
- * When Ably is connected, subscribes to the topic on the user channel.
- * Each message triggers `body`. Falls back to setLoop when Ably is
- * unavailable or in test environment.
- */
-export const ablyNotify$ = computed((get) => {
-  const channel = get(internalUserChannel$);
-
-  return function ablyNotify(
+export const setAblyLoop$ = command(
+  async (
+    { get, set },
     topic: string,
-    body: NotifyBody,
-    interval: number,
+    loopCommand$: Command<Promise<boolean> | boolean, [AbortSignal]>,
+    fallbackInterval: number,
     signal: AbortSignal,
-  ): Promise<void> {
+  ) => {
+    const channel = get(internalUserChannel$);
     if (!channel) {
-      return setLoop(body, interval, signal);
+      return setLoop(
+        (sig) => {
+          return set(loopCommand$, sig);
+        },
+        fallbackInterval,
+        signal,
+      );
     }
-    return ablyChannelNotify(channel, topic, body, signal);
-  };
-});
+
+    const done = await set(loopCommand$, signal);
+    if (done) {
+      return;
+    }
+
+    let deferred = createDeferredPromise(signal);
+
+    const callback = (message: InboundMessage) => {
+      L.debug("got message from topic", topic, message);
+
+      deferred.resolve(true);
+    };
+    signal.addEventListener("abort", () => {
+      channel.unsubscribe(topic, callback);
+    });
+    await channel.subscribe(topic, callback);
+    signal.throwIfAborted();
+
+    let loopCount = 0;
+    let fibIndex = 0;
+    while (!signal.aborted) {
+      if (IN_VITEST && loopCount++ > MAX_LOOP_COUNT_IN_TEST) {
+        channel.unsubscribe(topic, callback);
+        return;
+      }
+
+      await (IN_VITEST ? delay(0, { signal }) : deferred.promise);
+      signal.throwIfAborted();
+
+      deferred = createDeferredPromise(signal);
+
+      // eslint-disable-next-line no-restricted-syntax -- polling loop requires try/catch for transient error retry with backoff
+      try {
+        const done = await set(loopCommand$, signal);
+        fibIndex = 0;
+        if (done) {
+          channel.unsubscribe(topic, callback);
+          return;
+        }
+      } catch (error) {
+        throwIfAbort(error);
+        const backoff =
+          FIB_DELAYS_MS[Math.min(fibIndex, FIB_DELAYS_MS.length - 1)] ?? 60_000;
+        L.warn(
+          `setAblyLoop: transient error (attempt ${fibIndex + 1}), retrying in ${backoff}ms`,
+          error,
+        );
+        fibIndex++;
+        await (IN_VITEST ? delay(0, { signal }) : delay(backoff, { signal }));
+      }
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -12,7 +12,7 @@ import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { IN_VITEST } from "../env.ts";
 import { createDeferredPromise, setLoop, throwIfAbort } from "./utils.ts";
-import { Level, logger } from "./log.ts";
+import { logger } from "./log.ts";
 import { delay } from "signal-timers";
 
 const L = logger("Realtime");

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -11,16 +11,17 @@ import {
 import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { IN_VITEST } from "../env.ts";
-import { createDeferredPromise, setLoop, throwIfAbort } from "./utils.ts";
+import {
+  createDeferredPromise,
+  FIB_DELAYS_MS,
+  MAX_LOOP_COUNT_IN_TEST,
+  setLoop,
+  throwIfAbort,
+} from "./utils.ts";
 import { logger } from "./log.ts";
 import { delay } from "signal-timers";
 
 const L = logger("Realtime");
-
-const MAX_LOOP_COUNT_IN_TEST = 1000;
-const FIB_DELAYS_MS = [
-  1000, 1000, 2000, 3000, 5000, 8000, 13_000, 21_000, 34_000, 55_000, 60_000,
-] as const;
 // ---------------------------------------------------------------------------
 // Ably client singleton
 // ---------------------------------------------------------------------------
@@ -158,7 +159,16 @@ export const setAblyLoop$ = command(
         return;
       }
 
-      await (IN_VITEST ? delay(0, { signal }) : deferred.promise);
+      // In VITEST, yield to the macrotask queue via setTimeout so React can
+      // flush renders between iterations. We avoid delay(0, { signal }) because
+      // signal-timers' Promise.race leaves an abandoned promiseFromSignal that
+      // rejects as an unhandled rejection when the abort signal fires during
+      // afterEach cleanup.
+      await (IN_VITEST
+        ? new Promise<void>((resolve) => {
+            window.setTimeout(resolve, 0);
+          })
+        : deferred.promise);
       signal.throwIfAborted();
 
       deferred = createDeferredPromise(signal);
@@ -180,7 +190,11 @@ export const setAblyLoop$ = command(
           error,
         );
         fibIndex++;
-        await (IN_VITEST ? delay(0, { signal }) : delay(backoff, { signal }));
+        await (IN_VITEST
+          ? new Promise<void>((resolve) => {
+              window.setTimeout(resolve, 0);
+            })
+          : delay(backoff, { signal }));
       }
     }
   },

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -166,11 +166,11 @@ export async function bestEffort(p: Promise<unknown>): Promise<void> {
 // ---------------------------------------------------------------------------
 // Polling loop with fibonacci backoff
 // ---------------------------------------------------------------------------
-const FIB_DELAYS_MS = [
+export const FIB_DELAYS_MS = [
   1000, 1000, 2000, 3000, 5000, 8000, 13_000, 21_000, 34_000, 55_000, 60_000,
 ] as const;
 
-const MAX_LOOP_COUNT_IN_TEST = 1000;
+export const MAX_LOOP_COUNT_IN_TEST = 1000;
 /**
  * Run `loopBody` in a loop with `interval` between iterations.
  * Transient (non-abort) errors trigger fibonacci backoff retries.

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-preparation.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-preparation.ts
@@ -8,7 +8,7 @@ import { zeroClient$ } from "../api-client.ts";
 import { defaultAgentId$ } from "../agent.ts";
 import { accept, ApiError } from "../../lib/accept.ts";
 import { throwIfAbort } from "../utils.ts";
-import { ablyNotify$ } from "../realtime.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 import { clerk$ } from "../auth.ts";
 
 type PreparationStatus = "idle" | "preparing" | "ready" | "failed";
@@ -87,8 +87,7 @@ export const triggerPreparation$ = command(
     }
 
     // Poll until ready or failed.
-    // ablyNotify handles transient errors with fibonacci backoff retry via fallback.
-    const ablyNotify = get(ablyNotify$);
+    // setAblyLoop$ handles transient errors with fibonacci backoff retry.
     const clerkInstance = await get(clerk$);
     signal.throwIfAborted();
     const userId = clerkInstance.user?.id;
@@ -97,33 +96,35 @@ export const triggerPreparation$ = command(
         "voice-chat-preparation called without authenticated user",
       );
     }
-    await ablyNotify(
-      `voice:prep:${userId}`,
-      async (loopSignal: AbortSignal) => {
-        const pollRes = await accept(
-          client.trigger({ body: { agentId, mode: "meeting", prompt } }),
-          [200],
-          { toast: false },
+    const pollBody$ = command(async ({ set }, loopSignal: AbortSignal) => {
+      const pollRes = await accept(
+        client.trigger({ body: { agentId, mode: "meeting", prompt } }),
+        [200],
+        { toast: false },
+      );
+      loopSignal.throwIfAborted();
+
+      if (pollRes.body.preparation.status === "ready") {
+        set(internalPrepStatus$, "ready");
+        await set(fetchFreshPreparations$, loopSignal).catch(
+          (error: unknown) => {
+            throwIfAbort(error);
+          },
         );
-        loopSignal.throwIfAborted();
+        return true;
+      }
 
-        if (pollRes.body.preparation.status === "ready") {
-          set(internalPrepStatus$, "ready");
-          await set(fetchFreshPreparations$, loopSignal).catch(
-            (error: unknown) => {
-              throwIfAbort(error);
-            },
-          );
-          return true;
-        }
+      if (pollRes.body.preparation.status === "failed") {
+        set(internalPrepStatus$, "failed");
+        return true;
+      }
 
-        if (pollRes.body.preparation.status === "failed") {
-          set(internalPrepStatus$, "failed");
-          return true;
-        }
-
-        return false;
-      },
+      return false;
+    });
+    await set(
+      setAblyLoop$,
+      `voice:prep:${userId}`,
+      pollBody$,
       POLL_INTERVAL_MS,
       signal,
     );

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -8,7 +8,7 @@ import { featureSwitch$ } from "../external/feature-switch.ts";
 import { defaultAgentId$ } from "../agent.ts";
 import { delay } from "signal-timers";
 import { resetSignal, throwIfAbort, onDomEventFn, setLoop } from "../utils.ts";
-import { ablyNotify$ } from "../realtime.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 import { clerk$ } from "../auth.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
@@ -643,54 +643,50 @@ const startPoll$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!sid) {
     throw new Error("startPoll$ called before session ID is set");
   }
-  const ablyNotify = get(ablyNotify$);
 
-  await ablyNotify(
-    `voice:${sid}`,
-    async (signal: AbortSignal) => {
-      const sid = get(internalSessionId$);
-      if (!sid) {
-        return true;
-      }
+  const pollBody$ = command(async ({ get, set }, signal: AbortSignal) => {
+    const sid = get(internalSessionId$);
+    if (!sid) {
+      return true;
+    }
 
-      const lastSeq = get(internalLastSeq$);
-      const fetchFn = get(fetch$);
-      const res = await fetchFn(
-        `/api/zero/voice-chat/${sid}/context?after=${lastSeq}`,
-        { signal },
-      );
+    const lastSeq = get(internalLastSeq$);
+    const fetchFn = get(fetch$);
+    const res = await fetchFn(
+      `/api/zero/voice-chat/${sid}/context?after=${lastSeq}`,
+      { signal },
+    );
 
-      if (!res.ok) {
-        consecutiveFailures++;
-        if (consecutiveFailures >= POLL_FAILURE_THRESHOLD) {
-          set(internalError$, "Connection issues — retrying…");
-        }
-        return false;
-      }
-
+    if (!res.ok) {
+      consecutiveFailures++;
       if (consecutiveFailures >= POLL_FAILURE_THRESHOLD) {
-        set(internalError$, null);
-      }
-      consecutiveFailures = 0;
-
-      const data = (await res.json()) as { events: ContextEvent[] };
-      signal.throwIfAborted();
-
-      if (data.events.length > 0) {
-        set(internalEvents$, (prev) => {
-          return [...prev, ...data.events];
-        });
-        const lastEvent = data.events[data.events.length - 1];
-        if (lastEvent) {
-          set(internalLastSeq$, lastEvent.seq);
-        }
-        set(injectSlowBrainEvents$, data.events);
+        set(internalError$, "Connection issues — retrying…");
       }
       return false;
-    },
-    POLL_INTERVAL_MS,
-    signal,
-  );
+    }
+
+    if (consecutiveFailures >= POLL_FAILURE_THRESHOLD) {
+      set(internalError$, null);
+    }
+    consecutiveFailures = 0;
+
+    const data = (await res.json()) as { events: ContextEvent[] };
+    signal.throwIfAborted();
+
+    if (data.events.length > 0) {
+      set(internalEvents$, (prev) => {
+        return [...prev, ...data.events];
+      });
+      const lastEvent = data.events[data.events.length - 1];
+      if (lastEvent) {
+        set(internalLastSeq$, lastEvent.seq);
+      }
+      set(injectSlowBrainEvents$, data.events);
+    }
+    return false;
+  });
+
+  await set(setAblyLoop$, `voice:${sid}`, pollBody$, POLL_INTERVAL_MS, signal);
 });
 
 // --- WebRTC cleanup (preserves session state) ---
@@ -1023,10 +1019,8 @@ const prepareActivateConnect$ = command(
     const heartbeatPromise = set(startHeartbeat$, sessionSignal);
 
     // Poll for preparation-ready event with timeout
-    const ablyNotify = get(ablyNotify$);
-    await ablyNotify(
-      `voice:${sessionId}`,
-      async (loopSignal: AbortSignal) => {
+    const prepPollBody$ = command(
+      async ({ get, set }, loopSignal: AbortSignal) => {
         const elapsed = Date.now() - startTime;
         set(internalPrepElapsedMs$, elapsed);
 
@@ -1072,6 +1066,11 @@ const prepareActivateConnect$ = command(
         }
         return false;
       },
+    );
+    await set(
+      setAblyLoop$,
+      `voice:${sessionId}`,
+      prepPollBody$,
       POLL_INTERVAL_MS,
       sessionSignal,
     );
@@ -1127,7 +1126,7 @@ const prepareActivateConnect$ = command(
  * Falls through on failure so session creation can handle the unprepared case.
  */
 const awaitChatPreparation$ = command(
-  async ({ get }, agentId: string, signal: AbortSignal) => {
+  async ({ get, set }, agentId: string, signal: AbortSignal) => {
     const createClient = get(zeroClient$);
     const prepClient = createClient(zeroVoiceChatPrepareTriggerContract);
     const prepRes = await accept(
@@ -1142,7 +1141,6 @@ const awaitChatPreparation$ = command(
     }
 
     const prepStart = Date.now();
-    const chatAblyNotify = get(ablyNotify$);
     const clerkInstance = await get(clerk$);
     signal.throwIfAborted();
     const prepUserId = clerkInstance.user?.id;
@@ -1151,21 +1149,23 @@ const awaitChatPreparation$ = command(
         "awaitChatPreparation$ called without authenticated user",
       );
     }
-    await chatAblyNotify(
+    const chatPollBody$ = command(async (_store, loopSignal: AbortSignal) => {
+      if (Date.now() - prepStart > PREP_TIMEOUT_CHAT_MS) {
+        return true; // Timeout — proceed without cache
+      }
+      const pollRes = await accept(
+        prepClient.trigger({ body: { agentId, mode: "chat" } }),
+        [200],
+        { toast: false },
+      );
+      loopSignal.throwIfAborted();
+      const status = pollRes.body.preparation.status;
+      return status === "ready" || status === "failed";
+    });
+    await set(
+      setAblyLoop$,
       `voice:prep:${prepUserId}`,
-      async (loopSignal: AbortSignal) => {
-        if (Date.now() - prepStart > PREP_TIMEOUT_CHAT_MS) {
-          return true; // Timeout — proceed without cache
-        }
-        const pollRes = await accept(
-          prepClient.trigger({ body: { agentId, mode: "chat" } }),
-          [200],
-          { toast: false },
-        );
-        loopSignal.throwIfAborted();
-        const status = pollRes.body.preparation.status;
-        return status === "ready" || status === "failed";
-      },
+      chatPollBody$,
       POLL_INTERVAL_MS,
       signal,
     );


### PR DESCRIPTION
## Summary
- Replace `ablyNotify$` computed (which returned a closure) with `setAblyLoop$` command that accepts loop bodies as ccstate commands, making the data flow explicit and consistent with the signal architecture
- Add fibonacci backoff retry for transient errors in the realtime loop, with proper `throwIfAbort` handling to distinguish abort signals from retriable failures
- Add proper channel unsubscribe cleanup on loop completion and in test environments, plus debug logging for incoming Ably messages

## Test plan
- [ ] Existing `setAblyLoop$` vitest tests pass (renamed from `ablyNotify$` tests)
- [ ] Platform builds without type errors
- [ ] Realtime push notifications continue to trigger loop body execution in dev
- [ ] Fallback to `setLoop` polling works when Ably channel is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)