### PR TITLE
fix(security): scope anthropic firewall to /v1/messages path prefix

### DIFF
--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1028,6 +1028,43 @@ class TestMatchBaseUrl:
         assert params == {"sub": "internal"}
 
 
+class TestAnthropicFirewallScope:
+    """Regression tests for #9560: Anthropic firewall scoped to /v1/messages."""
+
+    BASE = "https://api.anthropic.com/v1/messages"
+
+    def test_messages_endpoint_matches(self):
+        assert match_base_url(self.BASE, self.BASE) == ("/", {})
+
+    def test_count_tokens_endpoint_matches(self):
+        result = match_base_url(f"{self.BASE}/count_tokens", self.BASE)
+        assert result == ("/count_tokens", {})
+
+    def test_batches_endpoint_matches(self):
+        result = match_base_url(f"{self.BASE}/batches/abc123", self.BASE)
+        assert result == ("/batches/abc123", {})
+
+    def test_organizations_endpoint_rejected(self):
+        assert match_base_url("https://api.anthropic.com/v1/organizations/foo", self.BASE) is None
+
+    def test_usage_endpoint_rejected(self):
+        assert match_base_url("https://api.anthropic.com/v1/usage_report", self.BASE) is None
+
+    def test_complete_endpoint_rejected(self):
+        assert match_base_url("https://api.anthropic.com/v1/complete", self.BASE) is None
+
+    def test_models_endpoint_rejected(self):
+        assert match_base_url("https://api.anthropic.com/v1/models", self.BASE) is None
+
+    def test_prefix_confusion_attack_rejected(self):
+        """Paths like /v1/messages_fake must not match /v1/messages."""
+        assert match_base_url("https://api.anthropic.com/v1/messages_fake", self.BASE) is None
+
+    def test_messages_with_query_string_matches(self):
+        result = match_base_url(f"{self.BASE}?beta=1", self.BASE)
+        assert result == ("/", {})
+
+
 # =========================================================================
 # get_firewall_headers (caching)
 # =========================================================================

--- a/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
@@ -6,6 +6,7 @@ import {
   getModels,
   getDefaultModel,
   getEnvironmentMapping,
+  MODEL_PROVIDER_FIREWALL_CONFIGS,
   type ModelProviderType,
 } from "../model-providers";
 
@@ -128,5 +129,27 @@ describe("model selection for Anthropic-native providers", () => {
   it("Anthropic-native providers have no ANTHROPIC_BASE_URL (use default)", () => {
     expect(getProviderBaseUrl("anthropic-api-key")).toBeNull();
     expect(getProviderBaseUrl("claude-code-oauth-token")).toBeNull();
+  });
+});
+
+describe("Anthropic firewall base URL scope (#9560)", () => {
+  it.each(["anthropic-api-key", "claude-code-oauth-token"] as const)(
+    "%s scopes firewall to /v1/messages path prefix",
+    (type) => {
+      const config = MODEL_PROVIDER_FIREWALL_CONFIGS[type];
+      expect(config.apis).toHaveLength(1);
+      expect(config.apis[0]!.base).toBe(
+        "https://api.anthropic.com/v1/messages",
+      );
+    },
+  );
+
+  it("third-party providers are not affected by Anthropic scoping", () => {
+    expect(
+      MODEL_PROVIDER_FIREWALL_CONFIGS["openrouter-api-key"].apis[0]!.base,
+    ).toBe("https://openrouter.ai/api");
+    expect(
+      MODEL_PROVIDER_FIREWALL_CONFIGS["moonshot-api-key"].apis[0]!.base,
+    ).toBe("https://api.moonshot.ai/anthropic");
   });
 });

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -379,10 +379,17 @@ export function getSelectableProviderTypes(): ModelProviderType[] {
  * Used to auto-generate firewall entries that protect API tokens from sandbox exposure.
  * Excluded: aws-bedrock (dynamic region URLs + SigV4), azure-foundry (dynamic resource URLs).
  *
- * Base URL is derived from environmentMapping.ANTHROPIC_BASE_URL (or https://api.anthropic.com
- * for providers without environmentMapping like anthropic-api-key and claude-code-oauth-token).
+ * Base URL is derived from environmentMapping.ANTHROPIC_BASE_URL (or
+ * https://api.anthropic.com/v1/messages for providers without environmentMapping like
+ * anthropic-api-key and claude-code-oauth-token).
+ *
+ * Scoped to /v1/messages (not the bare domain) so the vm0-managed API key is only
+ * injected on LLM inference paths — not on /v1/organizations, /v1/usage*, or other
+ * Anthropic admin endpoints. The prefix covers every endpoint Claude Code actually
+ * hits per Anthropic's LLM gateway requirements (/v1/messages and
+ * /v1/messages/count_tokens). See #9560.
  */
-const ANTHROPIC_API_BASE = "https://api.anthropic.com";
+const ANTHROPIC_API_BASE = "https://api.anthropic.com/v1/messages";
 
 function getFirewallBaseUrl(type: ModelProviderType): string {
   return getEnvironmentMapping(type)?.ANTHROPIC_BASE_URL ?? ANTHROPIC_API_BASE;


### PR DESCRIPTION
## Summary

- Change `ANTHROPIC_API_BASE` from `https://api.anthropic.com` (bare domain) to `https://api.anthropic.com/v1/messages` so the vm0-managed API key is only injected on LLM inference paths — not on `/v1/organizations`, `/v1/usage*`, or other Anthropic admin endpoints.
- Add TS and Python regression tests covering match/reject behavior for the narrowed scope.

Closes #9560

## Why

`mpFirewall()` in `turbo/packages/core/src/contracts/model-providers.ts` uses `ANTHROPIC_API_BASE` as the firewall's `base` URL. Because `match_base_url()` does prefix matching and the model-provider firewalls use `permissions: []`, the base URL is the **only** scope gate — whatever matches the base gets the API key injected.

Previously, a sandboxed agent could:
- Call `POST /v1/organizations/{id}/members` to read/modify our org membership
- Call `GET /v1/organizations/usage_report/messages` to inspect our usage
- Hit any other admin path on `api.anthropic.com`

All of those would get the vm0 API key injected.

## What endpoints does Claude Code actually use?

Per [Anthropic's LLM gateway requirements doc](https://code.claude.com/docs/en/llm-gateway):

> **Anthropic Messages**: `/v1/messages`, `/v1/messages/count_tokens`

The narrowed prefix `https://api.anthropic.com/v1/messages` covers both. OAuth token refresh hits `platform.claude.com` / `console.anthropic.com` (different domain — not affected). Third-party gateways use their own `ANTHROPIC_BASE_URL` via `environmentMapping` and are untouched by this change.

## Scope of change

Affects only providers without `environmentMapping.ANTHROPIC_BASE_URL`:
- \`anthropic-api-key\`
- \`claude-code-oauth-token\`
- \`vm0\` (resolves to \`anthropic-api-key\` at runtime)

## Test plan

- [x] \`pnpm -F @vm0/core exec vitest run\` — 695/695 pass (including 3 new assertions)
- [x] \`pytest tests/\` in \`crates/runner/mitm-addon\` — 833/833 pass (including 9 new \`TestAnthropicFirewallScope\` cases)
- [x] \`pnpm -F @vm0/core check-types\` — clean
- [x] \`pnpm turbo run lint --filter @vm0/core\` — 0 errors, 0 warnings
- [x] \`pnpm format\` — clean
- [x] \`pnpm knip\` — clean for changed files
- [x] match_base_url guard verified: \`/v1/messages_fake\` rejected (prefix-confusion protection)

## Prefix matching behavior (from new Python tests)

| Request path | Match? |
|---|---|
| \`/v1/messages\` | ✅ |
| \`/v1/messages/count_tokens\` | ✅ |
| \`/v1/messages/batches/abc123\` | ✅ |
| \`/v1/messages?beta=1\` | ✅ |
| \`/v1/organizations/foo\` | ❌ |
| \`/v1/usage_report\` | ❌ |
| \`/v1/complete\` | ❌ (legacy, Claude 3+ unsupported) |
| \`/v1/models\` | ❌ (not called by Claude Code) |
| \`/v1/messages_fake\` | ❌ (prefix-confusion rejected) |