### PR TITLE
feat: add granular realtime signals for run and chat thread updates

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -364,6 +364,10 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
 
       expect(mockAblyPublish).toHaveBeenCalledWith(`thread:${run.runId}`, null);
       expect(mockAblyPublish).toHaveBeenCalledWith(`tasks:${user.orgId}`, null);
+      expect(mockAblyPublish).toHaveBeenCalledWith(
+        `runUpdated:${run.runId}`,
+        null,
+      );
     });
   });
 });

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -79,6 +79,7 @@ const router = tsr.router(runsCancelContract, {
 
         // Notify run owner that run was cancelled
         await publishUserSignal([userId], `thread:${runId}`);
+        await publishUserSignal([userId], `runUpdated:${runId}`);
         // Notify org members that task list may have changed
         const orgMembers = await getOrgMemberUserIds(result.orgId);
         await publishUserSignal(orgMembers, `tasks:${result.orgId}`);

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../../src/__tests__/test-helpers";
 import { reloadEnv } from "../../../../../src/env";
 import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
+import { mockAblyPublish } from "../../../../../src/__tests__/ably-mock";
 
 const context = testContext();
 
@@ -20,6 +21,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
   let testComposeId: string;
 
   beforeEach(async () => {
+    mockAblyPublish.mockClear();
     context.setupMocks();
     user = await context.setupUser();
 
@@ -267,6 +269,33 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       expect(cleanedResult.reason).toBe(
         "Run timed out while pending (never started)",
       );
+    });
+  });
+
+  describe("Signal Publishing", () => {
+    it("should publish runUpdated signal for each cleaned-up expired run", async () => {
+      vi.stubEnv("ABLY_API_KEY", "test-key:test-secret");
+      reloadEnv();
+
+      const runCreationTime = Date.now();
+      const { runId } = await seedTestRun(user.userId, testComposeId);
+
+      // Mock Date.now to return time 6 minutes in the future (past pending timeout of 5 minutes)
+      context.mocks.dateNow.mockReturnValue(runCreationTime + 6 * 60 * 1000);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cron/cleanup-sandboxes",
+        {
+          headers: {
+            Authorization: `Bearer ${cronSecret}`,
+          },
+        },
+      );
+
+      const response = await GET(request);
+      expect(response.status).toBe(200);
+
+      expect(mockAblyPublish).toHaveBeenCalledWith(`runUpdated:${runId}`, null);
     });
   });
 });

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -20,6 +20,7 @@ import {
   dispatchQueuedZeroRun,
 } from "../../../../src/lib/zero/zero-run-queue-service";
 import { processOrgCredits } from "../../../../src/lib/zero/credit/credit-service";
+import { publishUserSignal } from "../../../../src/lib/infra/realtime/client";
 import { logger } from "../../../../src/lib/shared/logger";
 import { env } from "../../../../src/env";
 
@@ -151,6 +152,7 @@ const router = tsr.router(cronCleanupSandboxesContract, {
     const staleRuns = await globalThis.services.db
       .select({
         id: agentRuns.id,
+        userId: agentRuns.userId,
         orgId: agentRuns.orgId,
         status: agentRuns.status,
         sandboxId: agentRuns.sandboxId,
@@ -246,6 +248,8 @@ const router = tsr.router(cronCleanupSandboxesContract, {
           );
 
           await processOrgCredits(run.orgId);
+
+          await publishUserSignal([run.userId], `runUpdated:${run.id}`);
 
           const isDebug =
             run.composeName?.startsWith(DEBUG_COMPOSE_PREFIX) ?? false;

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -103,7 +103,8 @@ async function handleCompleted(
   // cannot produce duplicates.
   const items = await queryAssistantEvents(runId);
   if (items.length > 0) {
-    const chatThreadId = (await getChatThreadIdForRun(runId)) ?? threadId;
+    const resolved = await getChatThreadIdForRun(runId);
+    const chatThreadId = resolved?.chatThreadId ?? threadId;
     await insertAssistantEventMessages(runId, chatThreadId, items);
   }
 

--- a/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/__tests__/route.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "../route";
+import {
+  createTestCompose,
+  insertTestChatThread,
+  addTestRunToThread,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import { createSignedCallbackRequest } from "../../../../../../src/__tests__/api-test-helpers/callbacks";
+import { reloadEnv } from "../../../../../../src/env";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
+import { mockAblyPublish } from "../../../../../../src/__tests__/ably-mock";
+
+// SECRETS_ENCRYPTION_KEY as stubbed in setup.ts
+const SECRETS_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const CONSUMER_URL =
+  "http://localhost:3000/api/internal/event-consumers/chat-assistant";
+
+function buildAssistantEvent(
+  sequenceNumber: number,
+  text: string,
+): Record<string, unknown> {
+  return {
+    type: "assistant",
+    sequenceNumber,
+    message: {
+      id: `msg_${sequenceNumber}`,
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
+function buildToolUseEvent(sequenceNumber: number): Record<string, unknown> {
+  return {
+    type: "assistant",
+    sequenceNumber,
+    message: {
+      id: `msg_${sequenceNumber}`,
+      content: [{ type: "tool_use", id: "tool_123", name: "bash", input: {} }],
+    },
+  };
+}
+
+const context = testContext();
+
+describe("POST /api/internal/event-consumers/chat-assistant", () => {
+  let user: UserContext;
+  let agentComposeId: string;
+
+  beforeEach(async () => {
+    mockAblyPublish.mockClear();
+    context.setupMocks();
+    user = await context.setupUser();
+    const compose = await createTestCompose(uniqueId("chat-assistant"));
+    agentComposeId = compose.composeId;
+    vi.stubEnv("ABLY_API_KEY", "test-key:test-secret");
+    reloadEnv();
+  });
+
+  function createEventConsumerRequest(body: unknown) {
+    return createSignedCallbackRequest(
+      CONSUMER_URL,
+      body,
+      SECRETS_ENCRYPTION_KEY,
+    );
+  }
+
+  it("should return 401 for requests with invalid signature", async () => {
+    const request = createSignedCallbackRequest(
+      CONSUMER_URL,
+      { runId: "some-run", events: [], context: {} },
+      "wrong-key",
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 0 processed when no events contain text", async () => {
+    const { runId } = await seedTestRun(user.userId, agentComposeId);
+    const threadId = await insertTestChatThread(
+      user.userId,
+      agentComposeId,
+      "test thread",
+    );
+    await addTestRunToThread(threadId, runId, user.userId);
+
+    const request = createEventConsumerRequest({
+      runId,
+      events: [buildToolUseEvent(1)],
+      context: { userId: user.userId, orgId: user.orgId },
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.processed).toBe(0);
+
+    expect(mockAblyPublish).not.toHaveBeenCalled();
+  });
+
+  it("should return 0 processed when run is not tied to a chat thread", async () => {
+    const { runId } = await seedTestRun(user.userId, agentComposeId);
+
+    const request = createEventConsumerRequest({
+      runId,
+      events: [buildAssistantEvent(1, "Hello!")],
+      context: { userId: user.userId, orgId: user.orgId },
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.processed).toBe(0);
+
+    expect(mockAblyPublish).not.toHaveBeenCalled();
+  });
+
+  it("should publish chatThreadMessageCreated signal when text events are written", async () => {
+    const { runId } = await seedTestRun(user.userId, agentComposeId);
+    const threadId = await insertTestChatThread(
+      user.userId,
+      agentComposeId,
+      "test thread",
+    );
+    await addTestRunToThread(threadId, runId, user.userId);
+
+    const request = createEventConsumerRequest({
+      runId,
+      events: [buildAssistantEvent(1, "Hello from the assistant!")],
+      context: { userId: user.userId, orgId: user.orgId },
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.processed).toBe(1);
+
+    expect(mockAblyPublish).toHaveBeenCalledWith(
+      `chatThreadMessageCreated:${threadId}`,
+      null,
+    );
+  });
+});

--- a/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/route.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/route.ts
@@ -8,8 +8,6 @@ import {
   getChatThreadIdForRun,
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
 import { publishUserSignal } from "../../../../../src/lib/infra/realtime/client";
-import { agentRuns } from "../../../../../src/db/schema/agent-run";
-import { eq } from "drizzle-orm";
 import { logger } from "../../../../../src/lib/shared/logger";
 
 const log = logger("event-consumer:chat-assistant");
@@ -100,26 +98,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ processed: 0 });
   }
 
-  const threadId = await getChatThreadIdForRun(runId);
-  if (!threadId) {
+  const thread = await getChatThreadIdForRun(runId);
+  if (!thread) {
     // Run is not tied to a chat thread (e.g., non-chat trigger) — skip.
     return NextResponse.json({ processed: 0 });
   }
 
+  const { chatThreadId: threadId, userId } = thread;
   const written = await insertAssistantEventMessages(runId, threadId, items);
 
   if (written > 0) {
-    const [run] = await globalThis.services.db
-      .select({ userId: agentRuns.userId })
-      .from(agentRuns)
-      .where(eq(agentRuns.id, runId))
-      .limit(1);
-    if (run) {
-      await publishUserSignal(
-        [run.userId],
-        `chatThreadMessageCreated:${threadId}`,
-      );
-    }
+    await publishUserSignal([userId], `chatThreadMessageCreated:${threadId}`);
   }
 
   log.debug("Chat assistant consumer processed", {

--- a/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/route.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/route.ts
@@ -7,6 +7,9 @@ import {
   insertAssistantEventMessages,
   getChatThreadIdForRun,
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
+import { publishUserSignal } from "../../../../../src/lib/infra/realtime/client";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import { eq } from "drizzle-orm";
 import { logger } from "../../../../../src/lib/shared/logger";
 
 const log = logger("event-consumer:chat-assistant");
@@ -104,6 +107,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   const written = await insertAssistantEventMessages(runId, threadId, items);
+
+  if (written > 0) {
+    const [run] = await globalThis.services.db
+      .select({ userId: agentRuns.userId })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId))
+      .limit(1);
+    if (run) {
+      await publishUserSignal(
+        [run.userId],
+        `chatThreadMessageCreated:${threadId}`,
+      );
+    }
+  }
 
   log.debug("Chat assistant consumer processed", {
     runId,

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -1053,6 +1053,10 @@ describe("POST /api/webhooks/agent/complete", () => {
 
       expect(mockAblyPublish).toHaveBeenCalledWith(`thread:${testRunId}`, null);
       expect(mockAblyPublish).toHaveBeenCalledWith(`tasks:${user.orgId}`, null);
+      expect(mockAblyPublish).toHaveBeenCalledWith(
+        `runUpdated:${testRunId}`,
+        null,
+      );
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -51,6 +51,7 @@ function scheduleTerminalSideEffects(
 
     // Notify run owner that run state changed
     await publishUserSignal([userId], `thread:${runId}`);
+    await publishUserSignal([userId], `runUpdated:${runId}`);
     // Notify org members that task list may have changed
     const orgMembers = await getOrgMemberUserIds(orgId);
     await publishUserSignal(orgMembers, `tasks:${orgId}`);

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -22,6 +22,7 @@ import { reloadEnv } from "../../../../../../src/env";
 import { server } from "../../../../../../src/mocks/server";
 import { http } from "../../../../../../src/__tests__/msw";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
+import { mockAblyPublish } from "../../../../../../src/__tests__/ably-mock";
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 
@@ -31,6 +32,7 @@ const URL = "http://localhost:3000/api/zero/chat/messages";
 
 describe("POST /api/zero/chat/messages", () => {
   beforeEach(() => {
+    mockAblyPublish.mockClear();
     context.setupMocks();
   });
 
@@ -418,6 +420,37 @@ describe("POST /api/zero/chat/messages", () => {
       await context.mocks.flushAfter();
 
       expect(openRouterHandler.mocked).toHaveBeenCalledTimes(1);
+    });
+
+    describe("Signal Publishing", () => {
+      it("should publish chatThreadRunCreated and chatThreadMessageCreated signals after sending a message", async () => {
+        vi.stubEnv("ABLY_API_KEY", "test-key:test-secret");
+        reloadEnv();
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "hello signal test",
+            }),
+          }),
+        );
+        expect(response.status).toBe(201);
+        const data = await response.json();
+
+        await context.mocks.flushAfter();
+
+        expect(mockAblyPublish).toHaveBeenCalledWith(
+          `chatThreadRunCreated:${data.threadId}`,
+          null,
+        );
+        expect(mockAblyPublish).toHaveBeenCalledWith(
+          `chatThreadMessageCreated:${data.threadId}`,
+          null,
+        );
+      });
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -36,6 +36,7 @@ import {
   generateCallbackSecret,
 } from "../../../../../src/lib/infra/callback";
 import type { ChatCallbackPayload } from "../../../../../src/lib/infra/callback/callback-payloads";
+import { publishUserSignal } from "../../../../../src/lib/infra/realtime/client";
 import { logger } from "../../../../../src/lib/shared/logger";
 
 const log = logger("zero:chat-messages");
@@ -198,6 +199,18 @@ const router = tsr.router(chatMessagesContract, {
         role: "assistant",
         content: null,
         runId: result.runId,
+      });
+
+      // Notify subscribers that a new run and messages were created on this thread
+      after(async () => {
+        await publishUserSignal(
+          [authCtx.userId],
+          `chatThreadRunCreated:${threadId}`,
+        );
+        await publishUserSignal(
+          [authCtx.userId],
+          `chatThreadMessageCreated:${threadId}`,
+        );
       });
 
       // Defer the heavy dispatch pipeline (token generation, secret resolution,

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
@@ -1,5 +1,6 @@
 import { eq, asc, desc, and, isNotNull, isNull } from "drizzle-orm";
 import { chatMessages } from "../../../db/schema/chat-message";
+import { chatThreads } from "../../../db/schema/chat-thread";
 import { agentRuns } from "../../../db/schema/agent-run";
 
 /**
@@ -72,21 +73,25 @@ export async function insertAssistantEventMessages(
 }
 
 /**
- * Resolve the chat_thread_id for a run from its placeholder assistant row.
- * Returns null when the run is not tied to a chat thread (e.g., non-chat
- * triggers like cron/schedule), so event consumers can silently skip it.
+ * Resolve the chat_thread_id and owner user_id for a run from its placeholder
+ * assistant row. Returns null when the run is not tied to a chat thread (e.g.,
+ * non-chat triggers like cron/schedule), so event consumers can silently skip it.
  */
 export async function getChatThreadIdForRun(
   runId: string,
-): Promise<string | null> {
+): Promise<{ chatThreadId: string; userId: string } | null> {
   const [row] = await globalThis.services.db
-    .select({ chatThreadId: chatMessages.chatThreadId })
+    .select({
+      chatThreadId: chatMessages.chatThreadId,
+      userId: chatThreads.userId,
+    })
     .from(chatMessages)
+    .innerJoin(chatThreads, eq(chatMessages.chatThreadId, chatThreads.id))
     .where(
       and(eq(chatMessages.runId, runId), eq(chatMessages.role, "assistant")),
     )
     .limit(1);
-  return row?.chatThreadId ?? null;
+  return row ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `runUpdated:{runId}` signals to cancel, complete, and cleanup-sandboxes routes so the frontend can detect run state changes without polling
- Add `chatThreadRunCreated:{threadId}` and `chatThreadMessageCreated:{threadId}` signals to the chat messages route and chat-assistant event consumer for real-time chat thread updates
- These fine-grained signals complement the existing coarse `thread:{runId}` signal, enabling more targeted frontend subscriptions

## Test plan
- [ ] Verify cancel run triggers `runUpdated` signal to the run owner
- [ ] Verify agent complete webhook triggers `runUpdated` signal
- [ ] Verify stale run cleanup triggers `runUpdated` signal
- [ ] Verify sending a chat message triggers both `chatThreadRunCreated` and `chatThreadMessageCreated` signals
- [ ] Verify chat-assistant event consumer triggers `chatThreadMessageCreated` when messages are written
- [ ] Confirm existing `thread:` and `tasks:` signals are still emitted (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)