### PR TITLE
fix(security): scope all model provider firewalls to /v1/messages

### DIFF
--- a/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
@@ -132,24 +132,22 @@ describe("model selection for Anthropic-native providers", () => {
   });
 });
 
-describe("Anthropic firewall base URL scope (#9560)", () => {
-  it.each(["anthropic-api-key", "claude-code-oauth-token"] as const)(
+describe("firewall base URL scoped to /v1/messages (#9560)", () => {
+  it.each([
+    ["anthropic-api-key", "https://api.anthropic.com/v1/messages"],
+    ["claude-code-oauth-token", "https://api.anthropic.com/v1/messages"],
+    ["openrouter-api-key", "https://openrouter.ai/api/v1/messages"],
+    ["moonshot-api-key", "https://api.moonshot.ai/anthropic/v1/messages"],
+    ["minimax-api-key", "https://api.minimax.io/anthropic/v1/messages"],
+    ["deepseek-api-key", "https://api.deepseek.com/anthropic/v1/messages"],
+    ["zai-api-key", "https://api.z.ai/api/anthropic/v1/messages"],
+    ["vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1/messages"],
+  ] as const)(
     "%s scopes firewall to /v1/messages path prefix",
-    (type) => {
+    (type, expectedBase) => {
       const config = MODEL_PROVIDER_FIREWALL_CONFIGS[type];
       expect(config.apis).toHaveLength(1);
-      expect(config.apis[0]!.base).toBe(
-        "https://api.anthropic.com/v1/messages",
-      );
+      expect(config.apis[0]!.base).toBe(expectedBase);
     },
   );
-
-  it("third-party providers are not affected by Anthropic scoping", () => {
-    expect(
-      MODEL_PROVIDER_FIREWALL_CONFIGS["openrouter-api-key"].apis[0]!.base,
-    ).toBe("https://openrouter.ai/api");
-    expect(
-      MODEL_PROVIDER_FIREWALL_CONFIGS["moonshot-api-key"].apis[0]!.base,
-    ).toBe("https://api.moonshot.ai/anthropic");
-  });
 });

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -379,20 +379,19 @@ export function getSelectableProviderTypes(): ModelProviderType[] {
  * Used to auto-generate firewall entries that protect API tokens from sandbox exposure.
  * Excluded: aws-bedrock (dynamic region URLs + SigV4), azure-foundry (dynamic resource URLs).
  *
- * Base URL is derived from environmentMapping.ANTHROPIC_BASE_URL (or
- * https://api.anthropic.com/v1/messages for providers without environmentMapping like
- * anthropic-api-key and claude-code-oauth-token).
- *
- * Scoped to /v1/messages (not the bare domain) so the vm0-managed API key is only
- * injected on LLM inference paths — not on /v1/organizations, /v1/usage*, or other
- * Anthropic admin endpoints. The prefix covers every endpoint Claude Code actually
- * hits per Anthropic's LLM gateway requirements (/v1/messages and
- * /v1/messages/count_tokens). See #9560.
+ * getFirewallBaseUrl() appends /v1/messages to every provider's base URL so the
+ * vm0-managed API key is only injected on LLM inference paths — not on vendor admin
+ * endpoints (/v1/organizations, /v1/credits, etc.). The prefix covers every endpoint
+ * Claude Code actually hits per Anthropic's LLM gateway requirements (/v1/messages
+ * and /v1/messages/count_tokens). See #9560.
  */
-const ANTHROPIC_API_BASE = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_API_BASE = "https://api.anthropic.com";
 
 function getFirewallBaseUrl(type: ModelProviderType): string {
-  return getEnvironmentMapping(type)?.ANTHROPIC_BASE_URL ?? ANTHROPIC_API_BASE;
+  const base = (
+    getEnvironmentMapping(type)?.ANTHROPIC_BASE_URL ?? ANTHROPIC_API_BASE
+  ).replace(/\/+$/, "");
+  return `${base}/v1/messages`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Move `/v1/messages` path scoping from `ANTHROPIC_API_BASE` constant into `getFirewallBaseUrl()` so it applies to **all** model providers, not just Anthropic-native ones.
- Third-party gateways (OpenRouter, Moonshot, MiniMax, DeepSeek, ZAI, Vercel) now also have their firewall base narrowed to the inference path.

Follow-up to #9566 (which only scoped Anthropic-native providers).

## Why

PR #9566 changed `ANTHROPIC_API_BASE` to include `/v1/messages`, but `getFirewallBaseUrl()` returns `environmentMapping.ANTHROPIC_BASE_URL` directly for third-party providers — so those still had bare-domain base URLs. A sandboxed agent could still access vendor admin endpoints (e.g. `/v1/credits` on OpenRouter) with the injected API key.

## What changed

```ts
// Before (only Anthropic-native providers scoped)
const ANTHROPIC_API_BASE = "https://api.anthropic.com/v1/messages";
function getFirewallBaseUrl(type) {
  return getEnvironmentMapping(type)?.ANTHROPIC_BASE_URL ?? ANTHROPIC_API_BASE;
}

// After (all providers scoped)
const ANTHROPIC_API_BASE = "https://api.anthropic.com";
function getFirewallBaseUrl(type) {
  const base = (getEnvironmentMapping(type)?.ANTHROPIC_BASE_URL ?? ANTHROPIC_API_BASE)
    .replace(/\/+$/, "");
  return `${base}/v1/messages`;
}
```

Resulting base URLs:

| Provider | Base URL |
|---|---|
| `anthropic-api-key` | `https://api.anthropic.com/v1/messages` |
| `claude-code-oauth-token` | `https://api.anthropic.com/v1/messages` |
| `openrouter-api-key` | `https://openrouter.ai/api/v1/messages` |
| `moonshot-api-key` | `https://api.moonshot.ai/anthropic/v1/messages` |
| `minimax-api-key` | `https://api.minimax.io/anthropic/v1/messages` |
| `deepseek-api-key` | `https://api.deepseek.com/anthropic/v1/messages` |
| `zai-api-key` | `https://api.z.ai/api/anthropic/v1/messages` |
| `vercel-ai-gateway` | `https://ai-gateway.vercel.sh/v1/messages` |

## Test plan

- [x] TS test now asserts correct base URL for all 8 firewall-supported providers (not just 2)
- [x] Python `TestAnthropicFirewallScope` tests unchanged and still pass (9/9)
- [x] `check-types` clean
- [x] `lint` clean
- [x] `knip` clean