### PR TITLE
feat: add zero chat message send command with chat-message:write capability

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -15,6 +15,7 @@ describe("zero CLI program", () => {
     const expectedCommands = [
       "org",
       "agent",
+      "chat",
       "connector",
       "doctor",
       "logs",
@@ -53,7 +54,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 17 commands", () => {
-    expect(commandNames).toHaveLength(17);
+  it("should have exactly 18 commands", () => {
+    expect(commandNames).toHaveLength(18);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
@@ -61,7 +61,7 @@ describe("zero chat message send command", () => {
       expect(logCalls).toContain("thread-456");
     });
 
-    it("should send a message to a user with --agent", async () => {
+    it("should send a message with --agent (new thread)", async () => {
       let capturedBody: Record<string, unknown> | undefined;
 
       server.use(
@@ -81,8 +81,6 @@ describe("zero chat message send command", () => {
       await sendCommand.parseAsync([
         "node",
         "cli",
-        "--user",
-        "user_abc123",
         "--agent",
         "550e8400-e29b-41d4-a716-446655440001",
         "--text",
@@ -90,7 +88,6 @@ describe("zero chat message send command", () => {
       ]);
 
       expect(capturedBody).toMatchObject({
-        user: "user_abc123",
         agent: "550e8400-e29b-41d4-a716-446655440001",
         text: "Hello from agent!",
       });
@@ -99,52 +96,74 @@ describe("zero chat message send command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Message sent");
     });
+
+    it("should send a message with --title when creating a new thread", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(CHAT_MESSAGE_URL, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            {
+              messageId: "msg-title",
+              threadId: "thread-titled",
+              createdAt: "2026-01-01T00:00:00.000Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await sendCommand.parseAsync([
+        "node",
+        "cli",
+        "--agent",
+        "550e8400-e29b-41d4-a716-446655440001",
+        "--text",
+        "Hello!",
+        "--title",
+        "greeting",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        agent: "550e8400-e29b-41d4-a716-446655440001",
+        text: "Hello!",
+        title: "greeting",
+      });
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Message sent");
+      expect(logCalls).toContain("thread-titled");
+    });
   });
 
   describe("validation errors", () => {
-    it("should error when both --thread and --user are provided", async () => {
+    it("should error when both --thread and --agent are provided", async () => {
       await expect(async () => {
         await sendCommand.parseAsync([
           "node",
           "cli",
           "--thread",
           "550e8400-e29b-41d4-a716-446655440000",
-          "--user",
-          "user_abc123",
+          "--agent",
+          "550e8400-e29b-41d4-a716-446655440001",
           "--text",
           "hello",
         ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("--thread and --user are mutually exclusive"),
+        expect.stringContaining("--thread and --agent are mutually exclusive"),
       );
     });
 
-    it("should error when neither --thread nor --user is provided", async () => {
+    it("should error when neither --thread nor --agent is provided", async () => {
       await expect(async () => {
         await sendCommand.parseAsync(["node", "cli", "--text", "hello"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Either --thread or --user must be provided"),
-      );
-    });
-
-    it("should error when --user is provided without --agent", async () => {
-      await expect(async () => {
-        await sendCommand.parseAsync([
-          "node",
-          "cli",
-          "--user",
-          "user_abc123",
-          "--text",
-          "hello",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("--agent is required when --user is provided"),
+        expect.stringContaining("Either --thread or --agent must be provided"),
       );
     });
 

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for zero chat message send command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { sendCommand } from "../message/send";
+import chalk from "chalk";
+
+const CHAT_MESSAGE_URL =
+  "http://localhost:3000/api/zero/integrations/chat/message";
+
+describe("zero chat message send command", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful send", () => {
+    it("should send a message to an existing thread", async () => {
+      server.use(
+        http.post(CHAT_MESSAGE_URL, () => {
+          return HttpResponse.json(
+            {
+              messageId: "msg-123",
+              threadId: "thread-456",
+              createdAt: "2026-01-01T00:00:00.000Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await sendCommand.parseAsync([
+        "node",
+        "cli",
+        "--thread",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--text",
+        "hello world",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Message sent");
+      expect(logCalls).toContain("msg-123");
+      expect(logCalls).toContain("thread-456");
+    });
+
+    it("should send a message to a user with --agent", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(CHAT_MESSAGE_URL, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            {
+              messageId: "msg-789",
+              threadId: "thread-new",
+              createdAt: "2026-01-01T00:00:00.000Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await sendCommand.parseAsync([
+        "node",
+        "cli",
+        "--user",
+        "user_abc123",
+        "--agent",
+        "550e8400-e29b-41d4-a716-446655440001",
+        "--text",
+        "Hello from agent!",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        user: "user_abc123",
+        agent: "550e8400-e29b-41d4-a716-446655440001",
+        text: "Hello from agent!",
+      });
+      expect(capturedBody).not.toHaveProperty("thread");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Message sent");
+    });
+  });
+
+  describe("validation errors", () => {
+    it("should error when both --thread and --user are provided", async () => {
+      await expect(async () => {
+        await sendCommand.parseAsync([
+          "node",
+          "cli",
+          "--thread",
+          "550e8400-e29b-41d4-a716-446655440000",
+          "--user",
+          "user_abc123",
+          "--text",
+          "hello",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--thread and --user are mutually exclusive"),
+      );
+    });
+
+    it("should error when neither --thread nor --user is provided", async () => {
+      await expect(async () => {
+        await sendCommand.parseAsync(["node", "cli", "--text", "hello"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Either --thread or --user must be provided"),
+      );
+    });
+
+    it("should error when --user is provided without --agent", async () => {
+      await expect(async () => {
+        await sendCommand.parseAsync([
+          "node",
+          "cli",
+          "--user",
+          "user_abc123",
+          "--text",
+          "hello",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--agent is required when --user is provided"),
+      );
+    });
+
+    it("should error when --text is not provided", async () => {
+      await expect(async () => {
+        await sendCommand.parseAsync([
+          "node",
+          "cli",
+          "--thread",
+          "550e8400-e29b-41d4-a716-446655440000",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--text is required"),
+      );
+    });
+  });
+
+  describe("API errors", () => {
+    it("should handle 401 unauthorized", async () => {
+      server.use(
+        http.post(CHAT_MESSAGE_URL, () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await sendCommand.parseAsync([
+          "node",
+          "cli",
+          "--thread",
+          "550e8400-e29b-41d4-a716-446655440000",
+          "--text",
+          "hello",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+    });
+
+    it("should handle 403 missing capability", async () => {
+      server.use(
+        http.post(CHAT_MESSAGE_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Missing required capability: chat-message:write",
+                code: "FORBIDDEN",
+              },
+            },
+            { status: 403 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await sendCommand.parseAsync([
+          "node",
+          "cli",
+          "--thread",
+          "550e8400-e29b-41d4-a716-446655440000",
+          "--text",
+          "hello",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Missing required capability"),
+      );
+    });
+
+    it("should handle 404 thread not found", async () => {
+      server.use(
+        http.post(CHAT_MESSAGE_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Chat thread not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await sendCommand.parseAsync([
+          "node",
+          "cli",
+          "--thread",
+          "550e8400-e29b-41d4-a716-446655440000",
+          "--text",
+          "hello",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Chat thread not found"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/chat/index.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/index.ts
@@ -10,5 +10,5 @@ export const zeroChatCommand = new Command()
     `
 Examples:
   Send to thread:   zero chat message send -t <thread-id> --text "Hello!"
-  Send to user:     zero chat message send -u <user-id> -a <agent-id> --text "Hello!"`,
+  Send to agent:    zero chat message send -a <agent-id> --text "Hello!"`,
   );

--- a/turbo/apps/cli/src/commands/zero/chat/index.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/index.ts
@@ -1,0 +1,14 @@
+import { Command } from "commander";
+import { zeroChatMessageCommand } from "./message";
+
+export const zeroChatCommand = new Command()
+  .name("chat")
+  .description("Send messages to web chat threads")
+  .addCommand(zeroChatMessageCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Send to thread:   zero chat message send -t <thread-id> --text "Hello!"
+  Send to user:     zero chat message send -u <user-id> -a <agent-id> --text "Hello!"`,
+  );

--- a/turbo/apps/cli/src/commands/zero/chat/message/index.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/message/index.ts
@@ -1,0 +1,13 @@
+import { Command } from "commander";
+import { sendCommand } from "./send";
+
+export const zeroChatMessageCommand = new Command()
+  .name("message")
+  .description("Manage chat messages")
+  .addCommand(sendCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero chat message send -t <thread-id> --text "Hello!"`,
+  );

--- a/turbo/apps/cli/src/commands/zero/chat/message/send.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/message/send.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from "fs";
+import { Command } from "commander";
+import chalk from "chalk";
+import { sendChatMessage } from "../../../../lib/api";
+import { withErrorHandler } from "../../../../lib/command";
+
+export const sendCommand = new Command()
+  .name("send")
+  .description("Send a message to a web chat thread")
+  .option("-t, --thread <id>", "Existing chat thread ID")
+  .option("-u, --user <userId>", "Target user ID (creates a new thread)")
+  .option("-a, --agent <agentId>", "Agent ID (required with --user)")
+  .option("--text <message>", "Message text")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Send to existing thread:  zero chat message send -t <thread-id> --text "Hello!"
+  Send to user (new thread): zero chat message send -u <user-id> -a <agent-id> --text "Hello!"
+
+Notes:
+  - Either --thread or --user is required; they are mutually exclusive
+  - --agent is required when using --user
+  - --text is required (or pipe via stdin)`,
+  )
+  .action(
+    withErrorHandler(
+      async (options: {
+        thread?: string;
+        user?: string;
+        agent?: string;
+        text?: string;
+      }) => {
+        let text = options.text;
+        const { thread, user, agent } = options;
+
+        // Validate mutual exclusion: exactly one of --thread or --user
+        if (!thread && !user) {
+          throw new Error("Either --thread or --user must be provided", {
+            cause: new Error(
+              'Usage: zero chat message send -t THREAD_ID --text "your message"\n       zero chat message send -u USER_ID -a AGENT_ID --text "your message"',
+            ),
+          });
+        }
+        if (thread && user) {
+          throw new Error("--thread and --user are mutually exclusive", {
+            cause: new Error(
+              "Provide either --thread to send to an existing thread or --user to create a new thread, not both",
+            ),
+          });
+        }
+
+        // Validate --agent is required with --user
+        if (user && !agent) {
+          throw new Error("--agent is required when --user is provided", {
+            cause: new Error(
+              'Usage: zero chat message send -u USER_ID -a AGENT_ID --text "your message"',
+            ),
+          });
+        }
+
+        // Read from stdin if text not provided and stdin is explicitly piped
+        if (!text && process.stdin.isTTY === false) {
+          text = readFileSync("/dev/stdin", "utf8").trim();
+        }
+
+        if (!text) {
+          throw new Error("--text is required", {
+            cause: new Error(
+              'Usage: zero chat message send -t THREAD_ID --text "your message"',
+            ),
+          });
+        }
+
+        const result = await sendChatMessage({
+          thread: thread || undefined,
+          user: user || undefined,
+          agent: agent || undefined,
+          text,
+        });
+
+        console.log(
+          chalk.green(
+            `✓ Message sent (id: ${result.messageId}, thread: ${result.threadId})`,
+          ),
+        );
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/chat/message/send.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/message/send.ts
@@ -8,53 +8,43 @@ export const sendCommand = new Command()
   .name("send")
   .description("Send a message to a web chat thread")
   .option("-t, --thread <id>", "Existing chat thread ID")
-  .option("-u, --user <userId>", "Target user ID (creates a new thread)")
-  .option("-a, --agent <agentId>", "Agent ID (required with --user)")
+  .option("-a, --agent <agentId>", "Agent ID (creates a new thread)")
   .option("--text <message>", "Message text")
+  .option("--title <title>", "Thread title (only with --agent)")
   .addHelpText(
     "after",
     `
 Examples:
-  Send to existing thread:  zero chat message send -t <thread-id> --text "Hello!"
-  Send to user (new thread): zero chat message send -u <user-id> -a <agent-id> --text "Hello!"
+  Send to existing thread:   zero chat message send -t <thread-id> --text "Hello!"
+  Send to agent (new thread): zero chat message send -a <agent-id> --text "Hello!"
 
 Notes:
-  - Either --thread or --user is required; they are mutually exclusive
-  - --agent is required when using --user
+  - Either --thread or --agent is required; they are mutually exclusive
   - --text is required (or pipe via stdin)`,
   )
   .action(
     withErrorHandler(
       async (options: {
         thread?: string;
-        user?: string;
         agent?: string;
         text?: string;
+        title?: string;
       }) => {
         let text = options.text;
-        const { thread, user, agent } = options;
+        const { thread, agent, title } = options;
 
-        // Validate mutual exclusion: exactly one of --thread or --user
-        if (!thread && !user) {
-          throw new Error("Either --thread or --user must be provided", {
+        // Validate mutual exclusion: exactly one of --thread or --agent
+        if (!thread && !agent) {
+          throw new Error("Either --thread or --agent must be provided", {
             cause: new Error(
-              'Usage: zero chat message send -t THREAD_ID --text "your message"\n       zero chat message send -u USER_ID -a AGENT_ID --text "your message"',
+              'Usage: zero chat message send -t THREAD_ID --text "your message"\n       zero chat message send -a AGENT_ID --text "your message"',
             ),
           });
         }
-        if (thread && user) {
-          throw new Error("--thread and --user are mutually exclusive", {
+        if (thread && agent) {
+          throw new Error("--thread and --agent are mutually exclusive", {
             cause: new Error(
-              "Provide either --thread to send to an existing thread or --user to create a new thread, not both",
-            ),
-          });
-        }
-
-        // Validate --agent is required with --user
-        if (user && !agent) {
-          throw new Error("--agent is required when --user is provided", {
-            cause: new Error(
-              'Usage: zero chat message send -u USER_ID -a AGENT_ID --text "your message"',
+              "Provide either --thread to send to an existing thread or --agent to create a new thread, not both",
             ),
           });
         }
@@ -74,9 +64,9 @@ Notes:
 
         const result = await sendChatMessage({
           thread: thread || undefined,
-          user: user || undefined,
           agent: agent || undefined,
           text,
+          title: title || undefined,
         });
 
         console.log(

--- a/turbo/apps/cli/src/lib/api/domains/integrations-chat.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-chat.ts
@@ -1,0 +1,22 @@
+import { initClient } from "@ts-rest/core";
+import {
+  integrationsChatMessageContract,
+  type SendChatMessageBody,
+  type SendChatMessageResponse,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+export async function sendChatMessage(
+  body: SendChatMessageBody,
+): Promise<SendChatMessageResponse> {
+  const config = await getClientConfig();
+  const client = initClient(integrationsChatMessageContract, config);
+
+  const result = await client.sendMessage({ body, headers: {} });
+
+  if (result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to send chat message");
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -133,6 +133,9 @@ export {
   completeSlackFileUpload,
 } from "./domains/integrations-slack";
 
+// Domain modules - Integrations Chat
+export { sendChatMessage } from "./domains/integrations-chat";
+
 // Domain modules - Zero Schedules
 export {
   deployZeroSchedule,

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -11,6 +11,7 @@ import { zeroPreferenceCommand } from "./commands/zero/preference";
 import { zeroRunCommand } from "./commands/zero/run";
 import { zeroScheduleCommand } from "./commands/zero/schedule";
 import { zeroSecretCommand } from "./commands/zero/secret";
+import { zeroChatCommand } from "./commands/zero/chat";
 import { zeroSlackCommand } from "./commands/zero/slack";
 import { zeroVariableCommand } from "./commands/zero/variable";
 import { zeroWhoamiCommand } from "./commands/zero/whoami";
@@ -38,6 +39,7 @@ const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   schedule: "schedule:read",
   doctor: null,
   logs: "agent-run:read",
+  chat: "chat-message:write",
   slack: "slack:write",
   whoami: null,
   "developer-support": null,
@@ -55,6 +57,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroRunCommand,
   zeroScheduleCommand,
   zeroSecretCommand,
+  zeroChatCommand,
   zeroSlackCommand,
   zeroVariableCommand,
   zeroLogsCommand,

--- a/turbo/apps/web/app/api/zero/integrations/chat/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/chat/message/route.ts
@@ -41,13 +41,17 @@ const router = tsr.router(integrationsChatMessageContract, {
         throw badRequest("Can only create chat threads for yourself");
       }
 
+      if (!body.agent) {
+        throw badRequest("Agent is required when creating a new thread");
+      }
+
       // Verify agent exists and belongs to caller's org
       const [agent] = await globalThis.services.db
         .select({ id: agentComposes.id })
         .from(agentComposes)
         .where(
           and(
-            eq(agentComposes.id, body.agent!),
+            eq(agentComposes.id, body.agent),
             orgId ? eq(agentComposes.orgId, orgId) : undefined,
           ),
         )
@@ -57,7 +61,7 @@ const router = tsr.router(integrationsChatMessageContract, {
         throw notFound("Agent not found");
       }
 
-      const newThread = await createChatThread(body.user, body.agent!);
+      const newThread = await createChatThread(body.user, body.agent);
       threadId = newThread.id;
     }
 

--- a/turbo/apps/web/app/api/zero/integrations/chat/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/chat/message/route.ts
@@ -36,11 +36,7 @@ const router = tsr.router(integrationsChatMessageContract, {
       const thread = await getChatThread(body.thread, userId);
       threadId = thread.id;
     } else {
-      // Mode B: Create new thread for user
-      if (body.user !== userId) {
-        throw badRequest("Can only create chat threads for yourself");
-      }
-
+      // Mode B: Create new thread for the authenticated user
       if (!body.agent) {
         throw badRequest("Agent is required when creating a new thread");
       }
@@ -61,7 +57,7 @@ const router = tsr.router(integrationsChatMessageContract, {
         throw notFound("Agent not found");
       }
 
-      const newThread = await createChatThread(body.user, body.agent);
+      const newThread = await createChatThread(userId, body.agent, body.title);
       threadId = newThread.id;
     }
 

--- a/turbo/apps/web/app/api/zero/integrations/chat/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/chat/message/route.ts
@@ -1,0 +1,86 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../../src/lib/ts-rest-handler";
+import { integrationsChatMessageContract } from "@vm0/core";
+import { initServices } from "../../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../../src/lib/auth/require-auth";
+import {
+  getChatThread,
+  createChatThread,
+} from "../../../../../../src/lib/zero/chat-thread/chat-thread-service";
+import { insertChatMessage } from "../../../../../../src/lib/zero/chat-thread/chat-message-service";
+import { agentComposes } from "../../../../../../src/db/schema/agent-compose";
+import { eq, and } from "drizzle-orm";
+import { badRequest, notFound } from "../../../../../../src/lib/shared/errors";
+
+const router = tsr.router(integrationsChatMessageContract, {
+  sendMessage: async ({ body, headers }) => {
+    initServices();
+
+    const authResult = await requireAuth(headers.authorization, {
+      requiredCapability: "chat-message:write",
+    });
+    if (isAuthError(authResult)) return authResult;
+
+    const { userId, orgId } = authResult;
+
+    let threadId: string;
+
+    if (body.thread) {
+      // Mode A: Send to existing thread (ownership check built into getChatThread)
+      const thread = await getChatThread(body.thread, userId);
+      threadId = thread.id;
+    } else {
+      // Mode B: Create new thread for user
+      if (body.user !== userId) {
+        throw badRequest("Can only create chat threads for yourself");
+      }
+
+      // Verify agent exists and belongs to caller's org
+      const [agent] = await globalThis.services.db
+        .select({ id: agentComposes.id })
+        .from(agentComposes)
+        .where(
+          and(
+            eq(agentComposes.id, body.agent!),
+            orgId ? eq(agentComposes.orgId, orgId) : undefined,
+          ),
+        )
+        .limit(1);
+
+      if (!agent) {
+        throw notFound("Agent not found");
+      }
+
+      const newThread = await createChatThread(body.user, body.agent!);
+      threadId = newThread.id;
+    }
+
+    const message = await insertChatMessage({
+      chatThreadId: threadId,
+      role: "assistant",
+      content: body.text,
+      runId: null,
+    });
+
+    return {
+      status: 201 as const,
+      body: {
+        messageId: message.id,
+        threadId,
+        createdAt: message.createdAt.toISOString(),
+      },
+    };
+  },
+});
+
+const handler = createHandler(integrationsChatMessageContract, router, {
+  errorHandler: createSafeErrorHandler("integrations-chat-message"),
+});
+
+export { handler as POST };

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -267,6 +267,7 @@ describe("sandbox-token", () => {
         "schedule:read",
         "schedule:write",
         "slack:write",
+        "chat-message:write",
         "connector:read",
       ]);
       expect(auth?.capabilities).not.toContain("agent-run:write");
@@ -289,6 +290,7 @@ describe("sandbox-token", () => {
         "schedule:read",
         "schedule:write",
         "slack:write",
+        "chat-message:write",
         "connector:read",
         "computer-use:write",
         "voice-chat:write",

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -23,8 +23,8 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 12 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(12);
+  it("should have exactly 13 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(13);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -36,6 +36,7 @@ export const ZERO_CAPABILITIES = [
   "schedule:write",
   "schedule:delete",
   "slack:write",
+  "chat-message:write",
   "connector:read",
   "computer-use:write",
   "voice-chat:write",
@@ -69,6 +70,10 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     },
     "schedule:delete": { group: "Schedules", label: "Delete schedules" },
     "slack:write": { group: "Integrations", label: "Send Slack messages" },
+    "chat-message:write": {
+      group: "Integrations",
+      label: "Send chat messages",
+    },
     "connector:read": { group: "Connectors", label: "View connected services" },
     "computer-use:write": {
       group: "Computer Use",

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -697,6 +697,10 @@ export {
   integrationsSlackUploadCompleteContract,
   type SlackUploadCompleteBody,
   type SlackUploadCompleteResponse,
+  integrationsChatMessageContract,
+  type IntegrationsChatMessageContract,
+  type SendChatMessageBody,
+  type SendChatMessageResponse,
 } from "./integrations";
 export {
   zeroBillingStatusContract,

--- a/turbo/packages/core/src/contracts/integrations.ts
+++ b/turbo/packages/core/src/contracts/integrations.ts
@@ -127,6 +127,65 @@ export type SlackUploadCompleteResponse = z.infer<
   typeof slackUploadCompleteResponseSchema
 >;
 
+/**
+ * Integration Chat message contract
+ * POST /api/zero/integrations/chat/message
+ *
+ * Sends a message to a web chat thread.
+ * Requires `chat-message:write` capability (via ZERO_TOKEN).
+ */
+const sendChatMessageBodySchema = z
+  .object({
+    thread: z.string().uuid("Invalid thread ID").optional(),
+    user: z.string().min(1, "User ID is required").optional(),
+    agent: z.string().uuid("Invalid agent ID").optional(),
+    text: z.string().min(1, "Message text is required"),
+  })
+  .refine(
+    (data) => {
+      return Boolean(data.thread) !== Boolean(data.user);
+    },
+    { message: "Exactly one of 'thread' or 'user' must be provided" },
+  )
+  .refine(
+    (data) => {
+      return !data.user || data.agent;
+    },
+    { message: "'agent' is required when 'user' is provided" },
+  );
+
+export type SendChatMessageBody = z.infer<typeof sendChatMessageBodySchema>;
+
+const sendChatMessageResponseSchema = z.object({
+  messageId: z.string(),
+  threadId: z.string(),
+  createdAt: z.string(),
+});
+
+export type SendChatMessageResponse = z.infer<
+  typeof sendChatMessageResponseSchema
+>;
+
+export const integrationsChatMessageContract = c.router({
+  sendMessage: {
+    method: "POST",
+    path: "/api/zero/integrations/chat/message",
+    headers: authHeadersSchema,
+    body: sendChatMessageBodySchema,
+    responses: {
+      201: sendChatMessageResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Send a message to a web chat thread",
+  },
+});
+
+export type IntegrationsChatMessageContract =
+  typeof integrationsChatMessageContract;
+
 export const integrationsSlackUploadCompleteContract = c.router({
   complete: {
     method: "POST",

--- a/turbo/packages/core/src/contracts/integrations.ts
+++ b/turbo/packages/core/src/contracts/integrations.ts
@@ -137,21 +137,15 @@ export type SlackUploadCompleteResponse = z.infer<
 const sendChatMessageBodySchema = z
   .object({
     thread: z.string().uuid("Invalid thread ID").optional(),
-    user: z.string().min(1, "User ID is required").optional(),
     agent: z.string().uuid("Invalid agent ID").optional(),
     text: z.string().min(1, "Message text is required"),
+    title: z.string().min(1, "Title must not be empty").optional(),
   })
   .refine(
     (data) => {
-      return Boolean(data.thread) !== Boolean(data.user);
+      return Boolean(data.thread) !== Boolean(data.agent);
     },
-    { message: "Exactly one of 'thread' or 'user' must be provided" },
-  )
-  .refine(
-    (data) => {
-      return !data.user || data.agent;
-    },
-    { message: "'agent' is required when 'user' is provided" },
+    { message: "Exactly one of 'thread' or 'agent' must be provided" },
   );
 
 export type SendChatMessageBody = z.infer<typeof sendChatMessageBodySchema>;


### PR DESCRIPTION
## Summary
- Add new `zero chat message send` CLI command for sending assistant-role messages to web chat threads
- Add `chat-message:write` capability to the zero capability system (auto-included in zero tokens)
- Add `POST /api/zero/integrations/chat/message` API endpoint with ownership validation
- Two modes: `--thread <id>` (existing thread) and `--user <userId> --agent <agentId>` (new thread)

Closes #9579

## Changes

| Package | Files | Description |
|---------|-------|-------------|
| `@vm0/core` | `composes.ts`, `integrations.ts`, `index.ts` | New capability + ts-rest contract |
| `apps/web` | `route.ts` | API route handler with auth + ownership checks |
| `apps/cli` | `send.ts`, `index.ts`, `integrations-chat.ts`, `zero.ts` | CLI command + API domain + registration |
| `apps/cli` | `send.test.ts` | 9 integration tests (MSW-based) |

## Test plan
- [x] 9 CLI integration tests pass (successful send, validation errors, API errors)
- [x] Lint clean (`oxlint` + `eslint`)
- [x] Knip clean (no unused exports)
- [x] Format clean (prettier)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)