### PR TITLE
fix(zero): inject custom skill volumes in zero run path

### DIFF
--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -307,6 +307,7 @@ export async function createTestAgentSession(
 export async function createTestSessionWithConversation(
   userId: string,
   agentComposeId: string,
+  existingVersionId?: string,
 ): Promise<{ id: string }> {
   initServices();
   // Look up orgId from the compose
@@ -318,8 +319,10 @@ export async function createTestSessionWithConversation(
   if (!compose) {
     throw new Error(`Compose ${agentComposeId} not found`);
   }
-  // Create compose version
-  const versionId = await createTestComposeVersion(agentComposeId, userId);
+  // Use provided version or create a new one
+  const versionId =
+    existingVersionId ??
+    (await createTestComposeVersion(agentComposeId, userId));
   // Create run record
   const [run] = await globalThis.services.db
     .insert(agentRuns)

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -115,6 +115,12 @@ export interface CreateRunParams {
   // Per-permission policies from zero agent configuration (includes unknownPolicy).
   permissionPolicies?: FirewallPolicies;
   allowedConnectorTypes?: ConnectorType[];
+  // Additional volumes to mount (e.g., custom skills).
+  additionalVolumes?: Array<{
+    name: string;
+    version?: string;
+    mountPath: string;
+  }>;
   // Pre-loaded compose data. When provided, skips the internal loadCompose() call.
   preloadedCompose?: {
     composeContent: AgentComposeYaml;

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -18,6 +18,10 @@ import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents
 import { createZeroRun, createZeroRunRecord } from "../zero-run-service";
 import { reloadEnv } from "../../../env";
 import type { TriggerSource } from "@vm0/core";
+import { initServices } from "../../../lib/init-services";
+import { agentRuns } from "../../../db/schema/agent-run";
+import { agentSessions } from "../../../db/schema/agent-session";
+import { conversations } from "../../../db/schema/conversation";
 
 // ---------------------------------------------------------------------------
 // Tests for createZeroRun parameters NOT exposed by the POST /api/zero/runs
@@ -278,6 +282,59 @@ describe("createZeroRun() — service-only parameters", () => {
           mountPath: "/home/user/.claude/skills/gamma",
         },
       ]);
+    });
+
+    it("should skip custom skill injection for session resume", async () => {
+      const agentName = uniqueId("resume-agent");
+      const compose = await createTestCompose(agentName);
+      const resumeAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      await bindCustomSkillToAgent(resumeAgentId, "my-skill");
+
+      // Build session chain: run → conversation → session using the API-created
+      // compose version (which has ANTHROPIC_API_KEY in its environment block).
+      initServices();
+      const db = globalThis.services.db;
+      const [run] = await db
+        .insert(agentRuns)
+        .values({
+          userId: user.userId,
+          orgId: user.orgId,
+          agentComposeVersionId: compose.versionId,
+          status: "completed",
+          prompt: "first run",
+        })
+        .returning({ id: agentRuns.id });
+      const [conversation] = await db
+        .insert(conversations)
+        .values({
+          runId: run!.id,
+          cliAgentType: "claude",
+          cliAgentSessionId: uniqueId("cli-session"),
+          cliAgentSessionHistory: "[]",
+        })
+        .returning({ id: conversations.id });
+      const [session] = await db
+        .insert(agentSessions)
+        .values({
+          userId: user.userId,
+          orgId: user.orgId,
+          agentComposeId: resumeAgentId,
+          conversationId: conversation!.id,
+        })
+        .returning({ id: agentSessions.id });
+
+      // Resume with sessionId — should NOT inject custom skills
+      const resumed = await createZeroRunRecord({
+        userId: user.userId,
+        prompt: "continue",
+        agentId: resumeAgentId,
+        sessionId: session!.id,
+        triggerSource: "web",
+      });
+
+      const resumedRun = await findTestRunRecord(resumed.runId);
+      expect(resumedRun).toBeDefined();
+      expect(resumedRun!.additionalVolumes).toBeNull();
     });
   });
 

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -10,6 +10,7 @@ import {
   findTestRunRecord,
   findTestZeroRun,
   findTestRunCallbacks,
+  createTestSessionWithConversation,
 } from "../../../__tests__/api-test-helpers";
 import { createTestZeroAgent } from "../../../__tests__/db-test-seeders/agents";
 import { bindCustomSkillToAgent } from "../../../__tests__/db-test-seeders/skills";
@@ -18,10 +19,6 @@ import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents
 import { createZeroRun, createZeroRunRecord } from "../zero-run-service";
 import { reloadEnv } from "../../../env";
 import type { TriggerSource } from "@vm0/core";
-import { initServices } from "../../../lib/init-services";
-import { agentRuns } from "../../../db/schema/agent-run";
-import { agentSessions } from "../../../db/schema/agent-session";
-import { conversations } from "../../../db/schema/conversation";
 
 // ---------------------------------------------------------------------------
 // Tests for createZeroRun parameters NOT exposed by the POST /api/zero/runs
@@ -290,45 +287,21 @@ describe("createZeroRun() — service-only parameters", () => {
       const resumeAgentId = await getTestZeroAgentId(user.orgId, agentName);
       await bindCustomSkillToAgent(resumeAgentId, "my-skill");
 
-      // Build session chain: run → conversation → session using the API-created
-      // compose version (which has ANTHROPIC_API_KEY in its environment block).
-      initServices();
-      const db = globalThis.services.db;
-      const [run] = await db
-        .insert(agentRuns)
-        .values({
-          userId: user.userId,
-          orgId: user.orgId,
-          agentComposeVersionId: compose.versionId,
-          status: "completed",
-          prompt: "first run",
-        })
-        .returning({ id: agentRuns.id });
-      const [conversation] = await db
-        .insert(conversations)
-        .values({
-          runId: run!.id,
-          cliAgentType: "claude",
-          cliAgentSessionId: uniqueId("cli-session"),
-          cliAgentSessionHistory: "[]",
-        })
-        .returning({ id: conversations.id });
-      const [session] = await db
-        .insert(agentSessions)
-        .values({
-          userId: user.userId,
-          orgId: user.orgId,
-          agentComposeId: resumeAgentId,
-          conversationId: conversation!.id,
-        })
-        .returning({ id: agentSessions.id });
+      // Create session using the API-created compose version (which has
+      // ANTHROPIC_API_KEY in its environment block, satisfying the model
+      // provider check during session resume).
+      const session = await createTestSessionWithConversation(
+        user.userId,
+        resumeAgentId,
+        compose.versionId,
+      );
 
       // Resume with sessionId — should NOT inject custom skills
       const resumed = await createZeroRunRecord({
         userId: user.userId,
         prompt: "continue",
         agentId: resumeAgentId,
-        sessionId: session!.id,
+        sessionId: session.id,
         triggerSource: "web",
       });
 

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -12,6 +12,7 @@ import {
   findTestRunCallbacks,
 } from "../../../__tests__/api-test-helpers";
 import { createTestZeroAgent } from "../../../__tests__/db-test-seeders/agents";
+import { bindCustomSkillToAgent } from "../../../__tests__/db-test-seeders/skills";
 import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
 import { createZeroRun, createZeroRunRecord } from "../zero-run-service";
@@ -213,6 +214,70 @@ describe("createZeroRun() — service-only parameters", () => {
       const triggerIdx = prompt.indexOf("Custom trigger context");
       expect(agentIdx).toBeLessThan(userInfoIdx);
       expect(userInfoIdx).toBeLessThan(triggerIdx);
+    });
+  });
+
+  describe("custom skill volume injection", () => {
+    it("should inject custom skills as additionalVolumes for new runs", async () => {
+      const agentName = uniqueId("skill-agent");
+      await createTestCompose(agentName);
+      const skillAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      await bindCustomSkillToAgent(skillAgentId, "my-skill");
+      await bindCustomSkillToAgent(skillAgentId, "data-tool");
+
+      const result = await createZeroRun(baseParams({ agentId: skillAgentId }));
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run).toBeDefined();
+      expect(run!.additionalVolumes).toEqual(
+        expect.arrayContaining([
+          {
+            name: "custom-skill@my-skill",
+            mountPath: "/home/user/.claude/skills/my-skill",
+          },
+          {
+            name: "custom-skill@data-tool",
+            mountPath: "/home/user/.claude/skills/data-tool",
+          },
+        ]),
+      );
+    });
+
+    it("should not inject additionalVolumes when agent has no custom skills", async () => {
+      const result = await createZeroRun(baseParams());
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run).toBeDefined();
+      expect(run!.additionalVolumes).toBeNull();
+    });
+
+    it("should inject multiple skills preserving order", async () => {
+      const agentName = uniqueId("multi-skill");
+      await createTestCompose(agentName);
+      const multiAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      await bindCustomSkillToAgent(multiAgentId, "alpha");
+      await bindCustomSkillToAgent(multiAgentId, "beta");
+      await bindCustomSkillToAgent(multiAgentId, "gamma");
+
+      const result = await createZeroRun(baseParams({ agentId: multiAgentId }));
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run).toBeDefined();
+      expect(run!.additionalVolumes).toHaveLength(3);
+      expect(run!.additionalVolumes).toEqual([
+        {
+          name: "custom-skill@alpha",
+          mountPath: "/home/user/.claude/skills/alpha",
+        },
+        {
+          name: "custom-skill@beta",
+          mountPath: "/home/user/.claude/skills/beta",
+        },
+        {
+          name: "custom-skill@gamma",
+          mountPath: "/home/user/.claude/skills/gamma",
+        },
+      ]);
     });
   });
 

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -5,6 +5,7 @@ import {
   orgTierSchema,
   isFeatureEnabled,
   FeatureSwitchKey,
+  getCustomSkillStorageName,
   type TriggerSource,
   type FirewallPolicies,
   type ConnectorType,
@@ -252,6 +253,7 @@ export async function createZeroRunRecord(
       permissionPolicies: zeroAgents.permissionPolicies,
       unknownPermissionPolicies: zeroAgents.unknownPermissionPolicies,
       orgId: zeroAgents.orgId,
+      customSkills: zeroAgents.customSkills,
     })
     .from(zeroAgents)
     .where(eq(zeroAgents.id, params.agentId))
@@ -357,6 +359,16 @@ export async function createZeroRunRecord(
   appendSystemPrompt = systemParts.join("\n\n");
 
   // 2. Construct CreateRunParams (infra knows nothing about ZERO_TOKEN)
+  //    Inject custom skill volumes for new runs (session resume inherits from checkpoint).
+  const skillVolumes = !params.sessionId
+    ? (row?.customSkills ?? []).map((name) => {
+        return {
+          name: getCustomSkillStorageName(name),
+          mountPath: `/home/user/.claude/skills/${name}`,
+        };
+      })
+    : [];
+
   const runParams: CreateRunParams = {
     userId: params.userId,
     agentComposeVersionId: resolved.agentComposeVersionId,
@@ -374,6 +386,7 @@ export async function createZeroRunRecord(
     agentName: resolved.agentName,
     orgId: resolved.orgId,
     orgTier,
+    additionalVolumes: skillVolumes.length > 0 ? skillVolumes : undefined,
   };
 
   // 3. Pre-flight checks: load compose, authorize, validate, credits, model provider


### PR DESCRIPTION
## Summary

- Fix Zero run path (`createZeroRunRecord`) to inject custom skill volumes as `additionalVolumes`, mirroring existing CLI path behavior
- Add `additionalVolumes` field to `CreateRunParams` so it flows through queue serialization
- Add `customSkills` to the existing agent metadata query in `createZeroRunRecord()`

Previously, only CLI-triggered runs (`POST /api/agent/runs`) correctly mounted custom skills. All Zero-triggered runs (web UI, schedule, Slack, Telegram, email, GitHub, agent) silently omitted them because `zero-run-service.ts` never populated `additionalVolumes`.

This also fixes:
- Queue path (Issue 6): `enqueueRun` serializes full `CreateRunParams`, so queued runs now include skills
- Checkpoint resume (Issue 5): volumes are now stored in the run record at creation time

Closes #9576

## Test plan

- [x] Integration test: custom skills injected as `additionalVolumes` for new Zero runs
- [x] Integration test: no `additionalVolumes` when agent has empty `customSkills`
- [x] Integration test: multiple skills preserve order
- [x] Regression: all 85 CLI path tests pass (`app/api/agent/runs/__tests__/route.test.ts`)
- [x] Regression: all 19 zero-run-service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)