### PR TITLE
feat: add auth.query support to firewall schema for query-parameter authentication

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -68,6 +68,7 @@ def _fetch_firewall_headers_sync(
     secret_connector_map: dict | None = None,
     vars_map: dict | None = None,
     auth_base: str | None = None,
+    auth_query: dict | None = None,
 ) -> dict:
     """Synchronous helper — runs in a thread to avoid blocking the event loop.
 
@@ -78,6 +79,8 @@ def _fetch_firewall_headers_sync(
     body: dict = {"encryptedSecrets": encrypted_secrets, "authHeaders": auth_headers}
     if auth_base:
         body["authBase"] = auth_base
+    if auth_query:
+        body["authQuery"] = auth_query
     if secret_connector_map:
         body["secretConnectorMap"] = secret_connector_map
     if vars_map:
@@ -95,6 +98,7 @@ async def fetch_firewall_headers(
     secret_connector_map: dict | None = None,
     vars_map: dict | None = None,
     auth_base: str | None = None,
+    auth_query: dict | None = None,
 ) -> dict:
     """Resolve auth headers via server-side decryption.
 
@@ -113,6 +117,7 @@ async def fetch_firewall_headers(
         secret_connector_map,
         vars_map,
         auth_base,
+        auth_query,
     )
 
 
@@ -205,6 +210,7 @@ def _build_cache_hit(cached: dict) -> dict | None:
             "resolved_secrets": cached.get("resolvedSecrets", []),
             "cache_hit": True,
             **({"base": cached["base"]} if "base" in cached else {}),
+            **({"query": cached["query"]} if "query" in cached else {}),
         }
     return None
 
@@ -218,6 +224,7 @@ async def get_firewall_headers(
     secret_connector_map: dict | None = None,
     vars_map: dict | None = None,
     auth_base: str | None = None,
+    auth_query: dict | None = None,
 ) -> dict:
     """Get firewall auth headers with TTL-based caching.
 
@@ -255,6 +262,7 @@ async def get_firewall_headers(
             secret_connector_map,
             vars_map,
             auth_base,
+            auth_query,
         )
         headers = result["headers"]
         resolved_secrets = result.get("resolvedSecrets", [])
@@ -265,6 +273,8 @@ async def get_firewall_headers(
         }
         if result.get("base"):
             cache_entry["base"] = result["base"]
+        if result.get("query"):
+            cache_entry["query"] = result["query"]
         _firewall_header_cache[cache_key] = cache_entry
         ret: dict = {
             "headers": headers,
@@ -275,6 +285,8 @@ async def get_firewall_headers(
         }
         if result.get("base"):
             ret["base"] = result["base"]
+        if result.get("query"):
+            ret["query"] = result["query"]
         return ret
 
 
@@ -290,6 +302,7 @@ async def handle_firewall_request(
     encrypted_secrets = vm_info.get("encryptedSecrets")
     auth_headers = api_entry.get("auth", {}).get("headers", {})
     auth_base = api_entry.get("auth", {}).get("base")
+    auth_query = api_entry.get("auth", {}).get("query") or None
     secret_connector_map = vm_info.get("secretConnectorMap")
     vars_map = vm_info.get("vars")
 
@@ -336,6 +349,7 @@ async def handle_firewall_request(
             secret_connector_map,
             vars_map,
             auth_base,
+            auth_query,
         )
     except Exception as e:
         log_proxy_entry(
@@ -368,9 +382,22 @@ async def handle_firewall_request(
     # The addon forwards the request itself because mitmproxy's eager
     # connection already connected to the placeholder IP — we can't redirect
     # it. Setting flow.response bypasses the upstream connection entirely.
+    resolved_query = token_meta.get("query")
+
     resolved_base = token_meta.get("base")
     if resolved_base:
         new_url = build_rewrite_url(resolved_base, match_info, flow.request.pretty_url)
+
+        # Merge resolved auth.query params into the forwarded URL
+        if resolved_query:
+            parsed = urllib.parse.urlparse(new_url)
+            qs_parts: list[str] = []
+            if parsed.query:
+                qs_parts.append(parsed.query)
+            qs_parts.append(urllib.parse.urlencode(resolved_query))
+            new_url = urllib.parse.urlunparse(
+                (parsed.scheme, parsed.netloc, parsed.path, "", "&".join(qs_parts), "")
+            )
 
         # Merge original request headers with resolved auth headers
         req_headers = dict(flow.request.headers)
@@ -417,6 +444,10 @@ async def handle_firewall_request(
         # Standard header injection path
         for header_name, header_value in headers.items():
             flow.request.headers[header_name] = header_value
+        # Standard query param injection path
+        if resolved_query:
+            for key, value in resolved_query.items():
+                flow.request.query[key] = value
 
     flow.metadata["firewall_action"] = "ALLOW"
     flow.metadata["auth_resolved_secrets"] = token_meta.get("resolved_secrets", [])

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -302,7 +302,7 @@ async def handle_firewall_request(
     encrypted_secrets = vm_info.get("encryptedSecrets")
     auth_headers = api_entry.get("auth", {}).get("headers", {})
     auth_base = api_entry.get("auth", {}).get("base")
-    auth_query = api_entry.get("auth", {}).get("query") or None
+    auth_query = api_entry.get("auth", {}).get("query")
     secret_connector_map = vm_info.get("secretConnectorMap")
     vars_map = vm_info.get("vars")
 
@@ -388,15 +388,17 @@ async def handle_firewall_request(
     if resolved_base:
         new_url = build_rewrite_url(resolved_base, match_info, flow.request.pretty_url)
 
-        # Merge resolved auth.query params into the forwarded URL
+        # Merge resolved auth.query params into the forwarded URL.
+        # Uses parse_qs + merge so auth.query overwrites duplicate keys
+        # (consistent with the standard path's flow.request.query[k] = v).
         if resolved_query:
             parsed = urllib.parse.urlparse(new_url)
-            qs_parts: list[str] = []
-            if parsed.query:
-                qs_parts.append(parsed.query)
-            qs_parts.append(urllib.parse.urlencode(resolved_query))
+            existing_qs = urllib.parse.parse_qs(parsed.query, keep_blank_values=True)
+            for key, value in resolved_query.items():
+                existing_qs[key] = [value]
+            new_qs = urllib.parse.urlencode(existing_qs, doseq=True)
             new_url = urllib.parse.urlunparse(
-                (parsed.scheme, parsed.netloc, parsed.path, "", "&".join(qs_parts), "")
+                (parsed.scheme, parsed.netloc, parsed.path, "", new_qs, "")
             )
 
         # Merge original request headers with resolved auth headers

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -30,6 +30,7 @@ def _make_http_flow(client_ip="10.200.0.1", host="api.github.com", port=443, pat
     flow.request.method = "GET"
     flow.request.content = b""
     flow.request.headers = {}
+    flow.request.query = {}
     flow.metadata = {"vm_run_id": "test-run"}
     flow.response = None
     return flow
@@ -1052,7 +1053,9 @@ class TestGetFirewallHeaders:
 
         assert headers["headers"] == mock_headers
         assert headers["cache_hit"] is False
-        mock_fetch.assert_called_once_with(encrypted, auth_templates, "tok-xyz", None, None, None)
+        mock_fetch.assert_called_once_with(
+            encrypted, auth_templates, "tok-xyz", None, None, None, None
+        )
 
         # Verify the cache was populated
         cache_key = ("run-1", "https://api.github.com")
@@ -1980,6 +1983,162 @@ class TestAuthBaseUrlRewriteEdgeCases:
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.request.url == original_url
         assert "auth_url_rewrite" not in flow.metadata
+
+
+# =========================================================================
+# auth.query injection
+# =========================================================================
+
+
+class TestAuthQueryInjection:
+    """Tests for query parameter injection via auth.query."""
+
+    async def test_query_params_injected_on_standard_path(self):
+        """Resolved auth.query params are injected into flow.request.query."""
+        flow = _make_http_flow()
+        api_entry = {
+            "base": "https://serpapi.com",
+            "auth": {"headers": {}, "query": {"api_key": "${{ secrets.SERPAPI_TOKEN }}"}},
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok",
+            "encryptedSecrets": "iv:tag:data",
+        }
+        match_info = {
+            "name": "serpapi",
+            "ref": "serpapi",
+            "permission": "search",
+            "rule": "GET /search",
+            "params": {},
+        }
+        token_meta = {
+            "headers": {},
+            "resolved_secrets": ["SERPAPI_TOKEN"],
+            "cache_hit": False,
+            "query": {"api_key": "resolved-key-123"},
+        }
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth.ctx, "log", MagicMock(), create=True),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+        assert "auth_url_rewrite" not in flow.metadata
+        assert flow.request.query["api_key"] == "resolved-key-123"
+
+    async def test_query_params_with_headers_simultaneously(self):
+        """auth.query and auth.headers can coexist on the standard path."""
+        flow = _make_http_flow()
+        api_entry = {
+            "base": "https://example.com",
+            "auth": {
+                "headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"},
+                "query": {"key": "${{ secrets.QUERY_KEY }}"},
+            },
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok",
+            "encryptedSecrets": "iv:tag:data",
+        }
+        match_info = {
+            "name": "ex",
+            "ref": "ex",
+            "permission": "read",
+            "rule": "GET /data",
+            "params": {},
+        }
+        token_meta = {
+            "headers": {"Authorization": "Bearer real-token"},
+            "resolved_secrets": ["TOKEN", "QUERY_KEY"],
+            "cache_hit": False,
+            "query": {"key": "resolved-query-value"},
+        }
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth.ctx, "log", MagicMock(), create=True),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+        assert flow.request.headers["Authorization"] == "Bearer real-token"
+        assert flow.request.query["key"] == "resolved-query-value"
+
+    async def test_query_params_merged_into_rewrite_url(self):
+        """auth.query params are appended to the forwarded URL in the URL rewrite path."""
+        flow = _make_http_flow(host="firewall-placeholder.vm3.ai", path="/hook")
+        api_entry = {
+            "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
+            "auth": {
+                "headers": {},
+                "base": "${{ secrets.WEBHOOK }}",
+                "query": {"api_key": "${{ secrets.KEY }}"},
+            },
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok",
+            "encryptedSecrets": "iv:tag:data",
+        }
+        match_info = {
+            "name": "test",
+            "ref": "test",
+            "permission": "send",
+            "rule": "POST /",
+            "params": {},
+            "rel_path": "/",
+        }
+        token_meta = {
+            "headers": {},
+            "base": "https://real-api.com/webhook/secret",
+            "resolved_secrets": ["WEBHOOK", "KEY"],
+            "cache_hit": False,
+            "query": {"api_key": "resolved-key-456"},
+        }
+        mock_forward = AsyncMock(return_value=(200, b"ok", {}))
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            patch.object(auth.ctx, "log", MagicMock(), create=True),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+        assert flow.metadata["auth_url_rewrite"] is True
+        # Verify the forwarded URL contains the auth.query params
+        call_args = mock_forward.call_args
+        forwarded_url = call_args[0][0]
+        assert "api_key=resolved-key-456" in forwarded_url
+        assert forwarded_url.startswith("https://real-api.com/webhook/secret")
+
+    async def test_no_query_injection_when_absent(self):
+        """No query modification when auth.query is not present."""
+        flow = _make_http_flow()
+        api_entry = {
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"}},
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok",
+            "encryptedSecrets": "iv:tag:data",
+        }
+        match_info = {
+            "name": "gh",
+            "ref": "gh",
+            "permission": "read",
+            "rule": "GET /repos/{owner}/{repo}",
+            "params": {},
+        }
+        token_meta = {
+            "headers": {"Authorization": "Bearer real"},
+            "resolved_secrets": ["TOKEN"],
+            "cache_hit": False,
+        }
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth.ctx, "log", MagicMock(), create=True),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+        assert flow.request.headers["Authorization"] == "Bearer real"
+        # No query params should have been added
+        assert len(flow.request.query) == 0
 
 
 # =========================================================================

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -2026,6 +2026,43 @@ class TestAuthQueryInjection:
         assert "auth_url_rewrite" not in flow.metadata
         assert flow.request.query["api_key"] == "resolved-key-123"
 
+    async def test_query_param_overwrites_existing_key(self):
+        """auth.query overwrites a query param already present in the original request."""
+        flow = _make_http_flow(path="/search?api_key=agent-value&q=test")
+        flow.request.pretty_url = "https://serpapi.com/search?api_key=agent-value&q=test"
+        flow.request.query = {"api_key": "agent-value", "q": "test"}
+        api_entry = {
+            "base": "https://serpapi.com",
+            "auth": {"headers": {}, "query": {"api_key": "${{ secrets.SERPAPI_TOKEN }}"}},
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok",
+            "encryptedSecrets": "iv:tag:data",
+        }
+        match_info = {
+            "name": "serpapi",
+            "ref": "serpapi",
+            "permission": "search",
+            "rule": "GET /search",
+            "params": {},
+        }
+        token_meta = {
+            "headers": {},
+            "resolved_secrets": ["SERPAPI_TOKEN"],
+            "cache_hit": False,
+            "query": {"api_key": "real-secret-key"},
+        }
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth.ctx, "log", MagicMock(), create=True),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+        # auth.query overwrites the agent's api_key
+        assert flow.request.query["api_key"] == "real-secret-key"
+        # Other query params are preserved
+        assert flow.request.query["q"] == "test"
+
     async def test_query_params_with_headers_simultaneously(self):
         """auth.query and auth.headers can coexist on the standard path."""
         flow = _make_http_flow()

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -781,6 +781,7 @@ mod tests {
                         "Bearer ${{ secrets.GMAIL_TOKEN }}".to_string(),
                     )]),
                     base: None,
+                    query: None,
                 },
                 permissions: Some(vec![FirewallPermission {
                     name: "mail-read".to_string(),
@@ -919,6 +920,7 @@ mod tests {
                 auth: FirewallAuth {
                     headers: std::collections::HashMap::new(),
                     base: Some("${{ secrets.DISCORD_WEBHOOK_URL }}".to_string()),
+                    query: None,
                 },
                 permissions: None,
             }],
@@ -948,6 +950,74 @@ mod tests {
         assert_eq!(api["auth"]["base"], "${{ secrets.DISCORD_WEBHOOK_URL }}");
         // headers should be empty object
         assert_eq!(api["auth"]["headers"], serde_json::json!({}));
+    }
+
+    #[tokio::test]
+    async fn registry_firewall_auth_query_serialized() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let lock_path = dir.path().join("proxy-registry.lock");
+        let empty = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 0,
+        };
+        write_registry(&registry_path, &empty).await.unwrap();
+
+        let handle = ProxyRegistryHandle {
+            registry_path: registry_path.clone(),
+            lock_path,
+        };
+
+        let firewall_entries = vec![Firewall {
+            name: "serpapi".to_string(),
+            ref_key: "serpapi".to_string(),
+            apis: vec![FirewallApi {
+                id: String::new(),
+                base: "https://serpapi.com".to_string(),
+                auth: FirewallAuth {
+                    headers: std::collections::HashMap::new(),
+                    base: None,
+                    query: Some(
+                        [(
+                            "api_key".to_string(),
+                            "${{ secrets.SERPAPI_TOKEN }}".to_string(),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                },
+                permissions: None,
+            }],
+        }];
+
+        let registration = VmRegistration {
+            run_id: "run-query-auth",
+            sandbox_token: "tok",
+            network_log_path: std::path::Path::new("/tmp/network-run-query.jsonl"),
+            proxy_log_path: std::path::Path::new("/tmp/proxy-run-query.jsonl"),
+            firewalls: Some(&firewall_entries),
+            network_policies: None,
+            encrypted_secrets: Some("enc_data"),
+            secret_connector_map: None,
+            vars: None,
+            capture_network_bodies: false,
+        };
+        handle
+            .register_vm("10.200.0.8", &registration)
+            .await
+            .unwrap();
+
+        // Verify auth.query is preserved in the registry JSON.
+        let raw = tokio::fs::read_to_string(&registry_path).await.unwrap();
+        let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let api = &value["vms"]["10.200.0.8"]["firewalls"][0]["apis"][0];
+        assert_eq!(
+            api["auth"]["query"],
+            serde_json::json!({"api_key": "${{ secrets.SERPAPI_TOKEN }}"})
+        );
+        // headers should be empty object, base should be absent
+        assert_eq!(api["auth"]["headers"], serde_json::json!({}));
+        assert_eq!(api["auth"]["base"], serde_json::Value::Null);
     }
 
     #[tokio::test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -133,6 +133,10 @@ pub struct FirewallAuth {
     /// When set, the proxy rewrites the request URL instead of injecting headers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base: Option<String>,
+    /// Optional query parameters with secret/var templates for query-param auth.
+    /// When set, the proxy injects resolved query params into the request URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query: Option<std::collections::HashMap<String, String>>,
 }
 
 /// Per-firewall grant configuration: which permissions are authorized and
@@ -398,6 +402,7 @@ mod tests {
                         .into_iter()
                         .collect(),
                     base: None,
+                    query: None,
                 },
                 permissions: Some(vec![FirewallPermission {
                     name: "metadata:read".into(),
@@ -424,6 +429,7 @@ mod tests {
         let auth = FirewallAuth {
             headers: HashMap::new(),
             base: None,
+            query: None,
         };
         let json = serde_json::to_value(&auth).unwrap();
         assert!(json.get("base").is_none());

--- a/e2e/tests/03-runner/t51-firewall-auth-query.bats
+++ b/e2e/tests/03-runner/t51-firewall-auth-query.bats
@@ -23,8 +23,9 @@ setup_file() {
     export AGENT_NAME="e2e-auth-query-${UNIQUE_ID}"
     export ARTIFACT_NAME="e2e-auth-query-artifact-${UNIQUE_ID}"
 
-    # Set up serpapi connector — api-token auth, single secret
-    set_user_secret "SERPAPI_TOKEN" "fake-serpapi-token-for-e2e"
+    # Set up serpapi connector — api-token auth, single secret.
+    # Uses $ZERO_CLI (same pattern as t43-firewall-dynamic-base-url).
+    $ZERO_CLI secret set SERPAPI_TOKEN --body "fake-serpapi-token-for-e2e"
 
     # Create artifact
     mkdir -p "$TEST_DIR/$ARTIFACT_NAME"

--- a/e2e/tests/03-runner/t51-firewall-auth-query.bats
+++ b/e2e/tests/03-runner/t51-firewall-auth-query.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+
+# Test firewall auth.query — query-parameter authentication injection.
+#
+# Verifies the full flow for connectors that authenticate via URL query params
+# (e.g., SerpApi uses ?api_key=XXX instead of an Authorization header):
+# 1. Set up connector via user secret
+# 2. Compose agent with environment referencing connector secret
+# 3. System auto-detects serpapi as connected, adds firewall with auth.query
+# 4. Placeholder env var injected in sandbox
+# 5. Proxy matches requests and injects api_key query parameter
+
+load '../../helpers/setup'
+
+setup_file() {
+    if [[ -z "$VM0_API_URL" ]]; then
+        echo "VM0_API_URL not set" >&2
+        return 1
+    fi
+
+    export TEST_DIR="$(mktemp -d)"
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    export AGENT_NAME="e2e-auth-query-${UNIQUE_ID}"
+    export ARTIFACT_NAME="e2e-auth-query-artifact-${UNIQUE_ID}"
+
+    # Set up serpapi connector — api-token auth, single secret
+    set_user_secret "SERPAPI_TOKEN" "fake-serpapi-token-for-e2e"
+
+    # Create artifact
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null 2>&1
+    echo "test" > test.txt
+    $VM0_CLI artifact push >/dev/null 2>&1
+    cd - >/dev/null
+}
+
+teardown_file() {
+    $ZERO_CLI secret delete -y SERPAPI_TOKEN 2>/dev/null || true
+
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+@test "firewall: auth.query — serpapi placeholder injection" {
+    cat > "$TEST_DIR/vm0-placeholder.yaml" <<EOF
+version: "1.0"
+
+agents:
+  ${AGENT_NAME}-placeholder:
+    description: "SerpApi auth.query placeholder test"
+    framework: claude-code
+    working_dir: /home/user/workspace
+    environment:
+      SERPAPI_TOKEN: \${{ secrets.SERPAPI_TOKEN }}
+EOF
+
+    run $VM0_CLI compose --yes "$TEST_DIR/vm0-placeholder.yaml"
+    echo "$output"
+    assert_success
+
+    run $VM0_CLI run "${AGENT_NAME}-placeholder" \
+        --artifact "$ARTIFACT_NAME" \
+        "echo \"TOKEN=\$SERPAPI_TOKEN\""
+
+    echo "$output"
+    assert_success
+    assert_output --partial "Run completed successfully"
+
+    # Token should be the placeholder (not the real fake token)
+    assert_output --partial "TOKEN=CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCof"
+}
+
+@test "firewall: auth.query — serpapi proxy query param injection" {
+    cat > "$TEST_DIR/vm0-proxy.yaml" <<EOF
+version: "1.0"
+
+agents:
+  ${AGENT_NAME}-proxy:
+    description: "SerpApi auth.query proxy test"
+    framework: claude-code
+    working_dir: /home/user/workspace
+    environment:
+      SERPAPI_TOKEN: \${{ secrets.SERPAPI_TOKEN }}
+EOF
+
+    run $VM0_CLI compose --yes "$TEST_DIR/vm0-proxy.yaml"
+    echo "$output"
+    assert_success
+
+    # Make a request to SerpApi through the proxy.
+    # The proxy should inject api_key as a query parameter (auth.query).
+    #
+    # Key insight: SerpApi returns 200 when no api_key is present (anonymous),
+    # but returns 401 when api_key IS present but invalid. So 401 is the
+    # definitive proof that the proxy injected our fake api_key query param.
+    # 403 = firewall blocked (proxy didn't match).
+    run $VM0_CLI run "${AGENT_NAME}-proxy" \
+        --artifact "$ARTIFACT_NAME" \
+        "STATUS=\$(curl -s -o /dev/null -w '%{http_code}' 'https://serpapi.com/search?q=test&engine=google') && echo \"SERPAPI_STATUS=\$STATUS\""
+
+    echo "$output"
+    assert_success
+    assert_output --partial "Run completed successfully"
+
+    # 401 proves api_key was injected (SerpApi rejects our fake token).
+    # 429 also proves injection (rate-limited, but request reached SerpApi with api_key).
+    # Without api_key, SerpApi returns 200 (anonymous access).
+    # 403 would mean the proxy blocked the request entirely.
+    refute_output --partial "SERPAPI_STATUS=200"
+    refute_output --partial "SERPAPI_STATUS=403"
+    assert_output --regexp "SERPAPI_STATUS=(401|429)"
+
+    # Check network logs confirm firewall match
+    RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
+    [ -n "$RUN_ID" ] || {
+        echo "# Failed to extract Run ID"
+        return 1
+    }
+
+    # ALLOW: proxy matched serpapi firewall and injected query param
+    wait_for_log "$RUN_ID" --network -- "[serpapi]"
+}

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -211,6 +211,105 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  describe("Query parameter resolution", () => {
+    it("should resolve authQuery templates with decrypted secrets", async () => {
+      const encrypted = encryptTestSecrets({
+        SERPAPI_TOKEN: "test-api-key-123",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {},
+            authQuery: {
+              api_key: "${{ secrets.SERPAPI_TOKEN }}",
+            },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.query).toEqual({ api_key: "test-api-key-123" });
+      expect(data.headers).toEqual({});
+      expect(data.resolvedSecrets).toEqual(["SERPAPI_TOKEN"]);
+    });
+
+    it("should resolve authQuery with vars", async () => {
+      const encrypted = encryptTestSecrets({ KEY: "unused" });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {},
+            authQuery: {
+              workspace: "${{ vars.WORKSPACE_ID }}",
+            },
+            vars: { WORKSPACE_ID: "ws-42" },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.query).toEqual({ workspace: "ws-42" });
+      expect(data.resolvedSecrets).toEqual([]);
+    });
+
+    it("should resolve both headers and query simultaneously", async () => {
+      const encrypted = encryptTestSecrets({
+        API_TOKEN: "bearer-token",
+        QUERY_KEY: "query-secret",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.API_TOKEN }}",
+            },
+            authQuery: {
+              key: "${{ secrets.QUERY_KEY }}",
+            },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers).toEqual({ Authorization: "Bearer bearer-token" });
+      expect(data.query).toEqual({ key: "query-secret" });
+      expect(data.resolvedSecrets).toEqual(["API_TOKEN", "QUERY_KEY"]);
+    });
+
+    it("should omit query field when authQuery is not provided", async () => {
+      const encrypted = encryptTestSecrets({ TOKEN: "value" });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.TOKEN }}",
+            },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers).toEqual({ Authorization: "Bearer value" });
+      expect(data.query).toBeUndefined();
+    });
+  });
+
   describe("Vars resolution", () => {
     it("should resolve ${{ vars.X }} templates", async () => {
       const encrypted = encryptTestSecrets({ TOKEN: "secret-value" });

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -395,8 +395,9 @@ function resolveTemplates(
  * on demand and an expiresAt timestamp is returned for addon-side TTL caching.
  *
  * Auth: Sandbox JWT
- * Body: { encryptedSecrets, authHeaders, secretConnectorMap?, vars? }
- * Response: { headers, expiresAt? } or 502 { error } when token refresh fails
+ * Body: { encryptedSecrets, authHeaders, authBase?, authQuery?, secretConnectorMap?, vars? }
+ * Response: { headers, base?, query?, expiresAt?, resolvedSecrets, refreshedConnectors, refreshedSecrets }
+ *           or 502 { error } when token refresh fails
  */
 export async function POST(request: Request) {
   initServices();

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -19,6 +19,7 @@ const bodySchema = z.object({
   encryptedSecrets: z.string().min(1),
   authHeaders: z.record(z.string(), z.string()),
   authBase: z.string().optional(),
+  authQuery: z.record(z.string(), z.string()).optional(),
   secretConnectorMap: z.record(z.string(), z.string()).optional(),
   vars: z.record(z.string(), z.string()).optional(),
 });
@@ -231,10 +232,11 @@ async function refreshExpiredTokens(
   };
 }
 
-/** Collect all secret keys referenced in auth header templates (simple + basic). */
+/** Collect all secret keys referenced in auth header/base/query templates (simple + basic). */
 function collectReferencedSecrets(
   authHeaders: Record<string, string>,
   authBase?: string,
+  authQuery?: Record<string, string>,
 ): Set<string> {
   const keys = new Set<string>();
   for (const template of Object.values(authHeaders)) {
@@ -249,6 +251,13 @@ function collectReferencedSecrets(
   if (authBase) {
     for (const match of authBase.matchAll(TEMPLATE_RE)) {
       if (match[1] === "secrets" && match[2]) keys.add(match[2]);
+    }
+  }
+  if (authQuery) {
+    for (const template of Object.values(authQuery)) {
+      for (const match of template.matchAll(TEMPLATE_RE)) {
+        if (match[1] === "secrets" && match[2]) keys.add(match[2]);
+      }
     }
   }
   return keys;
@@ -287,7 +296,7 @@ function resolveBasicArg(
 
 /**
  * Resolve ${{ secrets.XXX }}, ${{ vars.XXX }}, and ${{ basic(...) }} templates
- * in auth header values and optional auth base URL.
+ * in auth header values, optional auth base URL, and optional auth query params.
  */
 function resolveTemplates(
   authHeaders: Record<string, string>,
@@ -295,10 +304,12 @@ function resolveTemplates(
   vars: Record<string, string>,
   runId: string,
   authBase?: string,
+  authQuery?: Record<string, string>,
 ): {
   headers: Record<string, string>;
   resolvedSecrets: string[];
   base?: string;
+  query?: Record<string, string>;
 } {
   const resolvedKeys = new Set<string>();
 
@@ -357,10 +368,20 @@ function resolveTemplates(
   // Resolve auth base URL template
   const resolvedBase = authBase ? resolveSimple(authBase) : undefined;
 
+  // Resolve auth query param templates
+  const resolvedQuery = authQuery
+    ? Object.fromEntries(
+        Object.entries(authQuery).map(([k, v]) => {
+          return [k, resolveSimple(v)];
+        }),
+      )
+    : undefined;
+
   return {
     headers,
     resolvedSecrets: [...resolvedKeys].sort(),
     base: resolvedBase,
+    query: resolvedQuery,
   };
 }
 
@@ -420,8 +441,14 @@ export async function POST(request: Request) {
       { status: 400 },
     );
   }
-  const { encryptedSecrets, authHeaders, authBase, secretConnectorMap, vars } =
-    parsed.data;
+  const {
+    encryptedSecrets,
+    authHeaders,
+    authBase,
+    authQuery,
+    secretConnectorMap,
+    vars,
+  } = parsed.data;
 
   // Decrypt secrets
   let secrets: Record<string, string> | null;
@@ -441,7 +468,11 @@ export async function POST(request: Request) {
   }
 
   // Collect which secret keys are referenced in auth templates
-  const referencedKeys = collectReferencedSecrets(authHeaders, authBase);
+  const referencedKeys = collectReferencedSecrets(
+    authHeaders,
+    authBase,
+    authQuery,
+  );
 
   // Refresh expired OAuth tokens (mutates secrets map with fresh values)
   let expiresAt: number | null = null;
@@ -477,17 +508,19 @@ export async function POST(request: Request) {
   }
 
   // Resolve templates with (possibly refreshed) secret values
-  const { headers, resolvedSecrets, base } = resolveTemplates(
+  const { headers, resolvedSecrets, base, query } = resolveTemplates(
     authHeaders,
     secrets,
     vars ?? {},
     auth.runId,
     authBase,
+    authQuery,
   );
 
   return NextResponse.json({
     headers,
     base,
+    query,
     expiresAt,
     resolvedSecrets,
     refreshedConnectors,

--- a/turbo/packages/core/src/contracts/__tests__/firewall-auth-base.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-auth-base.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { extractSecretNamesFromApis } from "../firewalls";
 
-describe("extractSecretNamesFromApis with auth.base", () => {
+describe("extractSecretNamesFromApis with auth.base and auth.query", () => {
   it("extracts secrets from auth.headers only", () => {
     const apis = [
       {
@@ -70,5 +70,54 @@ describe("extractSecretNamesFromApis with auth.base", () => {
       },
     ];
     expect(extractSecretNamesFromApis(apis)).toEqual([]);
+  });
+
+  it("extracts secrets from auth.query", () => {
+    const apis = [
+      {
+        base: "https://serpapi.com",
+        auth: {
+          headers: {},
+          query: {
+            api_key: "${{ secrets.SERPAPI_TOKEN }}",
+          },
+        },
+      },
+    ];
+    expect(extractSecretNamesFromApis(apis)).toEqual(["SERPAPI_TOKEN"]);
+  });
+
+  it("extracts secrets from both auth.headers and auth.query", () => {
+    const apis = [
+      {
+        base: "https://example.com",
+        auth: {
+          headers: {
+            Authorization: "Bearer ${{ secrets.API_TOKEN }}",
+          },
+          query: {
+            key: "${{ secrets.QUERY_KEY }}",
+          },
+        },
+      },
+    ];
+    const result = extractSecretNamesFromApis(apis);
+    expect(result).toContain("API_TOKEN");
+    expect(result).toContain("QUERY_KEY");
+    expect(result).toHaveLength(2);
+  });
+
+  it("skips auth.query when not present", () => {
+    const apis = [
+      {
+        base: "https://api.github.com",
+        auth: {
+          headers: {
+            Authorization: "Bearer ${{ secrets.TOKEN }}",
+          },
+        },
+      },
+    ];
+    expect(extractSecretNamesFromApis(apis)).toEqual(["TOKEN"]);
   });
 });

--- a/turbo/packages/core/src/contracts/firewalls.ts
+++ b/turbo/packages/core/src/contracts/firewalls.ts
@@ -28,6 +28,7 @@ export const firewallApiSchema = z.object({
   auth: z.object({
     headers: z.record(z.string(), z.string()),
     base: z.string().optional(),
+    query: z.record(z.string(), z.string()).optional(),
   }),
   permissions: z.array(firewallPermissionSchema).optional(),
 });
@@ -215,6 +216,15 @@ export function extractSecretNamesFromApis(
     if (entry.auth.base) {
       for (const match of entry.auth.base.matchAll(AUTH_SECRET_PATTERN)) {
         names.add(match[1]!);
+      }
+    }
+    // Scan auth.query for secret references (query-param auth connectors).
+    // Only simple ${{ secrets.X }} — basic() makes no sense in query params.
+    if (entry.auth.query) {
+      for (const value of Object.values(entry.auth.query)) {
+        for (const match of value.matchAll(AUTH_SECRET_PATTERN)) {
+          names.add(match[1]!);
+        }
       }
     }
   }

--- a/turbo/packages/firewalls-generator/src/serpapi.ts
+++ b/turbo/packages/firewalls-generator/src/serpapi.ts
@@ -3,7 +3,7 @@
  *
  * Data source: https://serpapi.com/search-api
  *
- * SerpApi supports Bearer token authentication via Authorization header.
+ * SerpApi authenticates via the `api_key` URL query parameter.
  * API key format is not publicly documented; using generic placeholder.
  */
 
@@ -33,8 +33,9 @@ function generateTypeScript(): string {
     "    {",
     '      base: "https://serpapi.com",',
     "      auth: {",
-    "        headers: {",
-    '          Authorization: "Bearer ${{ secrets.SERPAPI_TOKEN }}",',
+    "        headers: {},",
+    "        query: {",
+    '          api_key: "${{ secrets.SERPAPI_TOKEN }}",',
     "        },",
     "      },",
     "      permissions: [],",


### PR DESCRIPTION
## Summary

- Add `auth.query: Record<string, string>` as a third auth mechanism in the firewall schema, alongside `auth.headers` and `auth.base`
- Fix SerpApi generator: was incorrectly using Bearer header, now uses `auth.query` with `api_key` parameter
- All three auth mechanisms can be freely combined

## Motivation

Some APIs authenticate via URL query parameters (e.g., SerpApi uses `?api_key=XXX`). Previously the only workaround was `auth.base` URL rewriting, which is semantically wrong and forces the addon into the self-forwarding codepath.

## Changes across 5 layers

| Layer | File | Change |
|---|---|---|
| TS Schema | `firewalls.ts` | `auth.query` field + `extractSecretNamesFromApis` scans query templates |
| Rust | `types.rs` | `FirewallAuth.query: Option<HashMap>` with serde passthrough |
| Platform API | `route.ts` | `authQuery` in body schema, template resolution, response |
| Proxy addon | `auth.py` | Thread `auth_query`, inject into `flow.request.query` (standard) or merge into forwarded URL (rewrite) |
| Generator | `serpapi.ts` | Bearer header → `auth.query` with `api_key` |

## Test plan

- [x] TS: `extractSecretNamesFromApis` extracts secrets from `auth.query` (3 cases)
- [x] Rust: `FirewallAuth.query` round-trips through registry JSON
- [x] Platform API: `authQuery` template resolution with secrets/vars (4 cases)
- [x] Proxy addon: query injection on standard path, with headers, on URL rewrite path, absent case (4 cases)
- [x] E2E: `t51-firewall-auth-query.bats` — placeholder injection + proxy query param injection via SerpApi
- [x] Type check, lint, knip all pass

Closes #9567, closes #9568

🤖 Generated with [Claude Code](https://claude.com/claude-code)