### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -132,7 +132,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.108"
+CLAUDE_CODE_VERSION="2.1.110"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.25.4"


### PR DESCRIPTION
## Summary

Routine package version bump in `crates/runner/scripts/build-rootfs.sh`:

- **`CLAUDE_CODE_VERSION`**: `2.1.108` → `2.1.110`

All other pinned versions are already at latest:
- `GO_VERSION`: `1.26.2` ✓
- `GWS_CLI_VERSION`: `0.22.5` ✓
- `XURL_VERSION`: `1.0.3` ✓
- `AGENT_BROWSER_VERSION`: `0.25.4` ✓

All 624 runner tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)