### PR TITLE
fix: show agent display name on connector authorize/connect pages

### DIFF
--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -3,6 +3,7 @@ import { zeroUserConnectorsContract, type ConnectorType } from "@vm0/core";
 import { accept } from "../../lib/accept.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { zeroClient$ } from "../api-client.ts";
+import { agents$ } from "../agent.ts";
 
 /**
  * Connector type extracted from `/connectors/:type/authorize` route params.
@@ -18,6 +19,15 @@ export const directedAuthorizeType$ = computed((get): string | null => {
  */
 export const directedAuthorizeAgentId$ = computed((get): string | null => {
   return get(searchParams$).get("agentId");
+});
+
+/** Agent display name resolved from agentId query param. */
+export const directedAuthorizeAgentName$ = computed(async (get) => {
+  const agentId = get(directedAuthorizeAgentId$);
+  if (!agentId) return null;
+  const agents = await get(agents$);
+  const agent = agents.find((a) => a.id === agentId);
+  return agent?.displayName ?? null;
 });
 
 /** Fetch enabled connector types for the agent from the API. */

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -24,9 +24,13 @@ export const directedAuthorizeAgentId$ = computed((get): string | null => {
 /** Agent display name resolved from agentId query param. */
 export const directedAuthorizeAgentName$ = computed(async (get) => {
   const agentId = get(directedAuthorizeAgentId$);
-  if (!agentId) return null;
+  if (!agentId) {
+    return null;
+  }
   const agents = await get(agents$);
-  const agent = agents.find((a) => a.id === agentId);
+  const agent = agents.find((a) => {
+    return a.id === agentId;
+  });
   return agent?.displayName ?? null;
 });
 

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { pathParams$, searchParams$ } from "../route.ts";
+import { agents$ } from "../agent.ts";
 
 /**
  * Connector type extracted from `/connectors/:type/connect` route params.
@@ -16,6 +17,15 @@ export const directedConnectType$ = computed((get): string | null => {
  */
 export const directedConnectAgentId$ = computed((get): string | null => {
   return get(searchParams$).get("agentId");
+});
+
+/** Agent display name resolved from agentId query param on connect page. */
+export const directedConnectAgentName$ = computed(async (get) => {
+  const agentId = get(directedConnectAgentId$);
+  if (!agentId) return null;
+  const agents = await get(agents$);
+  const agent = agents.find((a) => a.id === agentId);
+  return agent?.displayName ?? null;
 });
 
 const internalTokenDialogOpen$ = state(false);

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
@@ -22,9 +22,13 @@ export const directedConnectAgentId$ = computed((get): string | null => {
 /** Agent display name resolved from agentId query param on connect page. */
 export const directedConnectAgentName$ = computed(async (get) => {
   const agentId = get(directedConnectAgentId$);
-  if (!agentId) return null;
+  if (!agentId) {
+    return null;
+  }
   const agents = await get(agents$);
-  const agent = agents.find((a) => a.id === agentId);
+  const agent = agents.find((a) => {
+    return a.id === agentId;
+  });
   return agent?.displayName ?? null;
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -19,6 +19,24 @@ const context = testContext();
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
 
+function mockAgentWithName(agentId: string, displayName: string) {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: agentId,
+          displayName,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
+    }),
+  );
+}
+
 function mockConnectorsConnected(type: string) {
   server.use(
     http.get("*/api/zero/connectors", () => {
@@ -166,6 +184,23 @@ describe("directed authorize page", () => {
       ).toBeInTheDocument();
     });
     expect(screen.getByText("Authorize Zero")).toBeInTheDocument();
+  });
+
+  it("shows agent display name instead of 'Zero' when agent has a name", async () => {
+    mockAgentWithName(AGENT_ID, "My Assistant");
+    mockConnectorsConnected("gmail");
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("My Assistant needs Gmail to proceed"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("Authorize My Assistant")).toBeInTheDocument();
   });
 
   it("has a logo link that navigates to /connectors", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -46,6 +46,24 @@ function mockConnectors(
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
 
+function mockAgentWithName(agentId: string, displayName: string) {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: agentId,
+          displayName,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
+    }),
+  );
+}
+
 function mockUserConnectors(agentId: string, enabledTypes: string[] = []) {
   server.use(
     http.get(`*/api/zero/agents/${agentId}/user-connectors`, () => {
@@ -104,6 +122,21 @@ describe("directed connect page", () => {
       ).not.toBeInTheDocument();
     });
     expect(screen.queryByText("Connect")).not.toBeInTheDocument();
+  });
+
+  it("shows agent display name instead of 'Zero' when agent has a name", async () => {
+    mockAgentWithName(AGENT_ID, "My Assistant");
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/gmail/connect?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("My Assistant needs Gmail to proceed"),
+      ).toBeInTheDocument();
+    });
   });
 
   it("opens api-token dialog for a connector without oauth", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -12,6 +12,7 @@ import { detach, Reason } from "../../signals/utils.ts";
 import {
   directedAuthorizeType$,
   directedAuthorizeAgentId$,
+  directedAuthorizeAgentName$,
   agentEnabledTypes$,
   justAuthorizedTypes$,
   authorizeConnector$,
@@ -118,6 +119,7 @@ function Vm0Logo() {
 function DirectedAuthorizeCard() {
   const type = useGet(directedAuthorizeType$);
   const agentId = useGet(directedAuthorizeAgentId$);
+  const agentNameLoadable = useLastLoadable(directedAuthorizeAgentName$);
   const pollingType = useGet(pollingConnectorType$);
   const connect = useSet(connectConnector$);
   const authorize = useSet(authorizeConnector$);
@@ -133,6 +135,10 @@ function DirectedAuthorizeCard() {
 
   const connectorType = type as ConnectorType;
   const config = CONNECTOR_TYPES[connectorType];
+  const agentName =
+    agentNameLoadable.state === "hasData" && agentNameLoadable.data
+      ? agentNameLoadable.data
+      : "Zero";
   const isConnecting = pollingType === connectorType;
   const isLoading =
     (!justConnected.has(connectorType) && allLoadable.state === "loading") ||
@@ -184,7 +190,7 @@ function DirectedAuthorizeCard() {
                 <h1 className="text-lg font-medium text-foreground">
                   {isAuthorized
                     ? `${config.label} authorized`
-                    : `Zero needs ${config.label} to proceed`}
+                    : `${agentName} needs ${config.label} to proceed`}
                 </h1>
                 <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
                   <ConnectorIcon type={connectorType} size={20} />
@@ -212,7 +218,7 @@ function DirectedAuthorizeCard() {
                   {isConnecting && (
                     <IconLoader2 size={14} className="animate-spin" />
                   )}
-                  {isConnecting ? "Connecting..." : "Authorize Zero"}
+                  {isConnecting ? "Connecting..." : `Authorize ${agentName}`}
                 </button>
               )}
             </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -273,19 +273,16 @@ function DirectedConnectCard() {
   const isConnecting = pollingType === connectorType;
   const isLoading =
     !justConnected.has(connectorType) && allLoadable.state === "loading";
+  const allData = allLoadable.state === "hasData" ? allLoadable.data : [];
   const isConnected =
     justConnected.has(connectorType) ||
-    (allLoadable.state === "hasData" &&
-      allLoadable.data.some((c) => {
-        return c.type === connectorType && c.connected;
-      }));
+    allData.some((c) => {
+      return c.type === connectorType && c.connected;
+    });
 
-  const item =
-    allLoadable.state === "hasData"
-      ? allLoadable.data.find((c) => {
-          return c.type === connectorType;
-        })
-      : null;
+  const item = allData.find((c) => {
+    return c.type === connectorType;
+  });
 
   const hasOAuth = item
     ? item.availableAuthMethods.includes("oauth")

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -25,6 +25,7 @@ import { detach, Reason } from "../../signals/utils.ts";
 import {
   directedConnectType$,
   directedConnectAgentId$,
+  directedConnectAgentName$,
   tokenDialogOpen$,
   setTokenDialogOpen$,
 } from "../../signals/connectors-page/directed-connect-type.ts";
@@ -249,6 +250,7 @@ function ApiTokenDialog({
 function DirectedConnectCard() {
   const type = useGet(directedConnectType$);
   const agentId = useGet(directedConnectAgentId$);
+  const agentNameLoadable = useLastLoadable(directedConnectAgentName$);
   const pollingType = useGet(pollingConnectorType$);
   const connect = useSet(connectConnector$);
   const authorize = useSet(authorizeConnector$);
@@ -264,6 +266,10 @@ function DirectedConnectCard() {
 
   const connectorType = type as ConnectorType;
   const config = CONNECTOR_TYPES[connectorType];
+  const agentName =
+    agentNameLoadable.state === "hasData" && agentNameLoadable.data
+      ? agentNameLoadable.data
+      : "Zero";
   const isConnecting = pollingType === connectorType;
   const isLoading =
     !justConnected.has(connectorType) && allLoadable.state === "loading";
@@ -322,7 +328,7 @@ function DirectedConnectCard() {
                   <h1 className="text-lg font-medium text-foreground">
                     {isConnected
                       ? `${config.label} connected`
-                      : `Zero needs ${config.label} to proceed`}
+                      : `${agentName} needs ${config.label} to proceed`}
                   </h1>
                   <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
                     <ConnectorIcon type={connectorType} size={20} />


### PR DESCRIPTION
## Summary
- Resolve agent `displayName` from `agentId` query param on both authorize and connect pages
- Replace hardcoded "Zero" with the actual agent name (e.g. "My Assistant needs GitHub to proceed", "Authorize My Assistant")
- Falls back to "Zero" when agent name is unavailable

## Test plan
- [x] Added test: authorize page shows agent display name when available
- [x] Added test: connect page shows agent display name when available
- [x] Existing 19 tests still pass (9 authorize + 12 connect = 21 total)
- [x] Type check passes
- [x] Knip clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)