### PR TITLE
test(zero): add integration test for custom skill volume injection in zero run path

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -15,6 +15,7 @@ import {
   deleteOrgRow,
   insertOrgMembersEntry,
   findTestRunsByUserAndPrompt,
+  createTestVolume,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
 import { getTestZeroAgentId } from "../../../../../src/__tests__/db-test-assertions/agents";
@@ -36,8 +37,9 @@ import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 import { updateUserPreferences } from "../../../../../src/lib/zero/user/user-preferences-service";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Test setup: direct service call for data setup in runs route tests
 import { updateUserFeatureSwitches } from "../../../../../src/lib/zero/user/feature-switches-service";
-import { FeatureSwitchKey } from "@vm0/core";
+import { FeatureSwitchKey, getCustomSkillStorageName } from "@vm0/core";
 import * as core from "@vm0/core";
+import { bindCustomSkillToAgent } from "../../../../../src/__tests__/db-test-seeders/skills";
 
 const context = testContext();
 
@@ -383,6 +385,27 @@ describe("POST /api/zero/runs", () => {
       expect(job!.executionContext.disallowedTools).toEqual(
         expect.arrayContaining(["CronCreate", "CronList", "CronDelete"]),
       );
+    });
+
+    describe("custom skill volume injection", () => {
+      it("should inject custom skill volume into storage manifest for new run", async () => {
+        const skillName = uniqueId("test-skill");
+        await bindCustomSkillToAgent(agentId, skillName);
+        await createTestVolume(getCustomSkillStorageName(skillName));
+
+        const response = await postRun({ agentId, prompt: "Hello" });
+        expect(response.status).toBe(201);
+        const data = await response.json();
+
+        const job = await findTestRunnerJobEntry(data.runId);
+        expect(job).toBeDefined();
+        const storages = job!.executionContext.storageManifest!.storages;
+        const expectedMountPath = `/home/user/.claude/skills/${skillName}`;
+        const skillStorage = storages.find((s) => {
+          return s.mountPath === expectedMountPath;
+        });
+        expect(skillStorage).toBeDefined();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Add route-level integration test verifying the end-to-end flow: custom skill binding → Zero run → storage manifest contains skill volume with correct mount path
- Covers the fix from PR #9582 which resolved the bug where Zero run path did not inject custom skill volumes

Closes #9576

## Test plan
- [x] New test passes: `pnpm -F web exec vitest run app/api/zero/runs/__tests__/route.test.ts`
- [x] All 42 existing tests in the file continue to pass
- [x] Lint, typecheck, format, and knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)