### PR TITLE
fix(platform): suppress permission dialog after connector connect during onboarding

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
+import { permissionDialogType$ } from "../../../signals/zero-page/settings/connectors.ts";
+import type { ConnectorListResponse } from "@vm0/core";
+
+vi.mock("signal-timers", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("signal-timers")>();
+  return {
+    ...mod,
+    delay: () => {
+      return Promise.resolve();
+    },
+  };
+});
+
+const context = testContext();
+
+function makeGithubConnectedResponse(): ConnectorListResponse {
+  return {
+    connectors: [
+      {
+        id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        type: "github",
+        authMethod: "oauth",
+        externalId: "12345",
+        externalUsername: "testuser",
+        externalEmail: "test@example.com",
+        oauthScopes: ["repo", "read:user"],
+        needsReconnect: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ],
+    configuredTypes: ["github"],
+    connectorProvidedSecretNames: [],
+  };
+}
+
+function mockAdminOnboarding() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: true,
+        hasOrg: true,
+        hasDefaultAgent: false,
+        defaultAgentId: null,
+        defaultAgentMetadata: null,
+      });
+    }),
+    http.post("*/api/zero/onboarding/setup", () => {
+      return HttpResponse.json({
+        agentId: "d0000000-0000-4000-a000-000000000001",
+      });
+    }),
+  );
+}
+
+describe("onboarding connector permission dialog suppression", () => {
+  it("should not set permissionDialogType$ after OAuth connect during onboarding", async () => {
+    const user = userEvent.setup();
+    mockAdminOnboarding();
+
+    const mockWindow = { closed: false, close: vi.fn() };
+    vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
+
+    detachedSetupPage({ context, path: "/onboarding" });
+
+    // Step 1: Workspace name
+    await waitFor(() => {
+      expect(screen.getByText(/Name your workspace/)).toBeInTheDocument();
+    });
+    const input = screen.getByPlaceholderText("e.g. Acme Corp");
+    await fill(input, "Test Workspace");
+    await user.click(screen.getByText("Next"));
+
+    // Step 2: Choose your tools — select GitHub
+    await waitFor(() => {
+      expect(screen.getByText("Choose your tools")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("connector-card-github"));
+    await user.click(screen.getByText("Next"));
+
+    // Step 3: Connect your apps
+    await waitFor(() => {
+      expect(screen.getByText("Connect your apps")).toBeInTheDocument();
+    });
+
+    // Mock the connectors API to return GitHub as connected (simulates
+    // successful OAuth — the polling inside connectConnector$ will pick it up).
+    server.use(
+      http.get("*/api/zero/connectors", () => {
+        return HttpResponse.json(makeGithubConnectedResponse());
+      }),
+    );
+
+    // Click "Connect" on GitHub — this triggers connectConnector$ which
+    // normally sets permissionDialogType$, but the onboarding wrapper
+    // clears it immediately after.
+    await user.click(screen.getByText("Connect"));
+
+    // Wait for connector to show as connected
+    await waitFor(() => {
+      expect(screen.getByText("Connected")).toBeInTheDocument();
+    });
+
+    // The key assertion: permissionDialogType$ should be null because the
+    // onboarding component clears it after connectConnector$ completes.
+    // Without the fix, this would be "github".
+    await waitFor(() => {
+      expect(context.store.get(permissionDialogType$)).toBeNull();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -45,6 +45,7 @@ import {
   pollingConnectorType$,
   selectedConnectorType$,
   setSelectedConnectorType$,
+  setPermissionDialogType$,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -220,6 +221,7 @@ function ConnectStepContent() {
   const pollingType = useGet(pollingConnectorType$);
   const connect = useSet(connectConnector$);
   const setSelectedConnector = useSet(setSelectedConnectorType$);
+  const clearPermissionDialog = useSet(setPermissionDialogType$);
   const pageSignal = useGet(pageSignal$);
 
   const allConnectors =
@@ -258,7 +260,15 @@ function ConnectStepContent() {
     if (connector?.availableAuthMethods.includes("api-token")) {
       setSelectedConnector(type);
     } else {
-      detach(connect(type, pageSignal), Reason.DomCallback);
+      // During onboarding the backend authorizes connectors for the default
+      // agent at step 4, so suppress the multi-agent permission dialog that
+      // connectConnector$ normally triggers.
+      detach(
+        connect(type, pageSignal).then(() => {
+          return clearPermissionDialog(null);
+        }),
+        Reason.DomCallback,
+      );
     }
   };
 
@@ -954,6 +964,7 @@ export function ZeroOnboarding() {
   const effectiveStep = useLastResolved(onboardingEffectiveStep$);
   const selectedConnectorType = useGet(selectedConnectorType$);
   const setSelected = useSet(setSelectedConnectorType$);
+  const clearPermissionDialog = useSet(setPermissionDialogType$);
 
   if (!effectiveStep) {
     return null;
@@ -971,7 +982,9 @@ export function ZeroOnboarding() {
             return setSelected(null);
           }}
           onSuccess={() => {
-            /* connector list refreshes automatically */
+            // During onboarding the backend authorizes connectors for the
+            // default agent at step 4, so suppress the permission dialog.
+            clearPermissionDialog(null);
           }}
         />
       )}


### PR DESCRIPTION
## Summary

- **Problem:** `connectConnector$` and `submitApiToken$` unconditionally set `permissionDialogType$` on success. During onboarding, this state leaks and triggers an unexpected multi-agent permission dialog when the user navigates to the connectors page after onboarding completes.
- **Fix:** Clear `permissionDialogType$` after both the direct OAuth path and the ConnectModal path in the onboarding component. The backend already authorizes connectors for the default agent at step 4 (`/api/zero/onboarding/setup` and `/api/zero/onboarding/complete`), making the dialog redundant during onboarding.
- Adds integration test verifying `permissionDialogType$` is null after connecting a connector during onboarding step 3.

## Test plan

- [x] New integration test: `onboarding-connect-permission.test.tsx` — verifies permission dialog state is cleared after OAuth connect during onboarding
- [x] All existing onboarding tests pass (11 tests across 4 files)
- [x] All existing connect-connector tests pass (8 tests)
- [ ] Manual: complete admin onboarding with a connector → verify no permission dialog appears on the connectors page

🤖 Generated with [Claude Code](https://claude.com/claude-code)