### PR TITLE
fix(voice-chat): observe inner content element for auto-scroll resize detection

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { testContext } from "./test-helpers.ts";
+import { createScrollSignals } from "../auto-scroll.ts";
+
+const context = testContext();
+
+// VC-SCROLL-001: ResizeObserver observes firstElementChild, not the container
+describe("createScrollSignals - ResizeObserver targets inner content", () => {
+  it("observes firstElementChild when it exists (VC-SCROLL-001)", () => {
+    const observed: Element[] = [];
+    const originalRO = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class MockResizeObserver {
+      constructor(private cb: ResizeObserverCallback) {}
+      observe(target: Element) {
+        observed.push(target);
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      const container = document.createElement("div");
+      const inner = document.createElement("div");
+      container.appendChild(inner);
+      document.body.appendChild(container);
+
+      const { setScrollContainer$ } = createScrollSignals();
+      context.store.set(setScrollContainer$, container);
+
+      expect(observed).toHaveLength(1);
+      expect(observed[0]).toBe(inner);
+    } finally {
+      globalThis.ResizeObserver = originalRO;
+    }
+  });
+
+  it("falls back to container when no child exists (VC-SCROLL-002)", () => {
+    const observed: Element[] = [];
+    const originalRO = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class MockResizeObserver {
+      constructor(private cb: ResizeObserverCallback) {}
+      observe(target: Element) {
+        observed.push(target);
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+
+      const { setScrollContainer$ } = createScrollSignals();
+      context.store.set(setScrollContainer$, container);
+
+      expect(observed).toHaveLength(1);
+      expect(observed[0]).toBe(container);
+    } finally {
+      globalThis.ResizeObserver = originalRO;
+    }
+  });
+});
+
+// VC-SCROLL-003: autoScroll$ respects disabled state
+describe("createScrollSignals - autoScroll$ gate", () => {
+  it("does not scroll when user has scrolled up (VC-SCROLL-003)", () => {
+    const container = document.createElement("div");
+    const inner = document.createElement("div");
+    container.appendChild(inner);
+    document.body.appendChild(container);
+
+    Object.defineProperty(container, "scrollHeight", {
+      get: () => {
+        return 1000;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      get: () => {
+        return 300;
+      },
+      configurable: true,
+    });
+
+    const { setScrollContainer$, autoScroll$ } = createScrollSignals();
+    context.store.set(setScrollContainer$, container);
+
+    // Simulate user scrolling down then up to disable auto-scroll
+    container.scrollTop = 500;
+    container.dispatchEvent(new Event("scroll"));
+    container.scrollTop = 200;
+    container.dispatchEvent(new Event("scroll"));
+
+    // autoScroll$ should be a no-op since the user scrolled up
+    context.store.set(autoScroll$);
+    expect(container.scrollTop).toBe(200);
+  });
+
+  it("scrolls to bottom when near bottom (VC-SCROLL-004)", () => {
+    const container = document.createElement("div");
+    const inner = document.createElement("div");
+    container.appendChild(inner);
+    document.body.appendChild(container);
+
+    Object.defineProperty(container, "scrollHeight", {
+      get: () => {
+        return 1000;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      get: () => {
+        return 300;
+      },
+      configurable: true,
+    });
+
+    const { setScrollContainer$, autoScroll$ } = createScrollSignals();
+    context.store.set(setScrollContainer$, container);
+
+    // Position near the bottom (within threshold)
+    container.scrollTop = 695;
+    container.dispatchEvent(new Event("scroll"));
+
+    context.store.set(autoScroll$);
+    expect(container.scrollTop).toBe(1000);
+  });
+});
+
+// VC-SCROLL-005: scrollToBottom$ always works regardless of disabled state
+describe("createScrollSignals - scrollToBottom$ unconditional", () => {
+  it("scrolls to bottom even when auto-scroll is disabled (VC-SCROLL-005)", () => {
+    const container = document.createElement("div");
+    const inner = document.createElement("div");
+    container.appendChild(inner);
+    document.body.appendChild(container);
+
+    Object.defineProperty(container, "scrollHeight", {
+      get: () => {
+        return 1000;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      get: () => {
+        return 300;
+      },
+      configurable: true,
+    });
+
+    const { setScrollContainer$, scrollToBottom$ } = createScrollSignals();
+    context.store.set(setScrollContainer$, container);
+
+    // Disable auto-scroll by scrolling up
+    container.scrollTop = 500;
+    container.dispatchEvent(new Event("scroll"));
+    container.scrollTop = 200;
+    container.dispatchEvent(new Event("scroll"));
+
+    // scrollToBottom$ ignores disabled state
+    context.store.set(scrollToBottom$);
+    expect(container.scrollTop).toBe(1000);
+  });
+});

--- a/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
@@ -10,7 +10,7 @@ describe("createScrollSignals - ResizeObserver targets inner content", () => {
     const observed: Element[] = [];
     const originalRO = globalThis.ResizeObserver;
     globalThis.ResizeObserver = class MockResizeObserver {
-      constructor(private cb: ResizeObserverCallback) {}
+      constructor(_cb: ResizeObserverCallback) {}
       observe(target: Element) {
         observed.push(target);
       }
@@ -38,7 +38,7 @@ describe("createScrollSignals - ResizeObserver targets inner content", () => {
     const observed: Element[] = [];
     const originalRO = globalThis.ResizeObserver;
     globalThis.ResizeObserver = class MockResizeObserver {
-      constructor(private cb: ResizeObserverCallback) {}
+      constructor(_cb: ResizeObserverCallback) {}
       observe(target: Element) {
         observed.push(target);
       }

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -68,7 +68,12 @@ export function createScrollSignals() {
           el.scrollTop = el.scrollHeight;
         }
       });
-      resizeObserver.observe(el);
+      const inner = el.firstElementChild;
+      if (inner) {
+        resizeObserver.observe(inner);
+      } else {
+        resizeObserver.observe(el);
+      }
 
       signal.addEventListener("abort", () => {
         L.debug("container unbound (abort)");


### PR DESCRIPTION
## Summary

- Fix auto-scroll not triggering in voice-chat page when new transcript entries or slow-brain indicators arrive
- Change `ResizeObserver` in `auto-scroll.ts` to observe `firstElementChild` (the inner content wrapper that actually grows) instead of the scroll container itself (whose flex-determined size never changes)
- Falls back to observing the container if no child exists, preserving existing behavior

## Root Cause

The `ResizeObserver` was observing the scroll container element, which is styled `flex-1 overflow-y-auto`. Its rendered dimensions are fixed by the flex parent layout. When new messages are added, `scrollHeight` increases but the container's actual size stays the same, so `ResizeObserver` never fires.

## Test plan

- [x] New tests verify ResizeObserver targets `firstElementChild` when present (VC-SCROLL-001)
- [x] New tests verify fallback to container when no child exists (VC-SCROLL-002)
- [x] New tests verify `autoScroll$` respects disabled state (VC-SCROLL-003, VC-SCROLL-004)
- [x] New tests verify `scrollToBottom$` works unconditionally (VC-SCROLL-005)
- [x] Existing chat scroll tests (CHAT-SCROLL-001 through 006) all pass — no regression

Closes #9604

🤖 Generated with [Claude Code](https://claude.com/claude-code)