### PR TITLE
fix(voice-chat): interleave slow-brain events with transcript in chronological order

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -248,6 +248,55 @@ export const vcSlowBrainEvents$ = computed((get) => {
   });
 });
 
+type ConversationItem =
+  | { kind: "transcript"; entry: TranscriptEntry; order: number; key: string }
+  | { kind: "slow-brain"; event: ContextEvent; order: number; key: string };
+
+export const vcConversationItems$ = (() => {
+  const orderMap = new Map<string, number>();
+  let counter = 0;
+
+  function assignOrder(key: string): number {
+    let order = orderMap.get(key);
+    if (order === undefined) {
+      order = counter++;
+      orderMap.set(key, order);
+    }
+    return order;
+  }
+
+  return computed((get) => {
+    const transcript = get(internalTranscript$);
+    const slowBrain = get(internalEvents$).filter((e) => {
+      return e.source === "slow-brain";
+    });
+
+    if (transcript.length === 0 && slowBrain.length === 0) {
+      orderMap.clear();
+      counter = 0;
+      return [] as ConversationItem[];
+    }
+
+    const items: ConversationItem[] = [];
+
+    for (const entry of transcript) {
+      const key = entry.id;
+      items.push({ kind: "transcript", entry, order: assignOrder(key), key });
+    }
+
+    for (const event of slowBrain) {
+      const key = `sb-${event.seq}`;
+      items.push({ kind: "slow-brain", event, order: assignOrder(key), key });
+    }
+
+    items.sort((a, b) => {
+      return a.order - b.order;
+    });
+
+    return items;
+  });
+})();
+
 export const vcMuted$ = computed((get) => {
   return get(internalMuted$);
 });

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -15,7 +15,6 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   vcStatus$,
-  vcTranscript$,
   vcSlowBrainEvents$,
   vcMuted$,
   vcError$,
@@ -33,6 +32,7 @@ import {
   toggleVoiceChatMute$,
   vcModel$,
   setVcModel$,
+  vcConversationItems$,
   type RealtimeModel,
 } from "../../signals/voice-chat/voice-chat-session.ts";
 import {
@@ -315,7 +315,6 @@ export function VoiceChatPage() {
   const enabled = useLastResolved(vcEnabled$);
   const agentId = useLastResolved(vcAgentId$);
   const status = useGet(vcStatus$);
-  const transcript = useGet(vcTranscript$);
   const slowBrainEvents = useGet(vcSlowBrainEvents$);
   const muted = useGet(vcMuted$);
   const error = useGet(vcError$);
@@ -330,6 +329,7 @@ export function VoiceChatPage() {
   const setModel = useSet(setVcModel$);
   const setTranscriptContainer = useSet(setTranscriptScrollContainer$);
   const setEventsContainer = useSet(setEventsScrollContainer$);
+  const conversationItems = useGet(vcConversationItems$);
 
   const elapsedSeconds = Math.floor(prepElapsedMs / 1000);
 
@@ -478,26 +478,29 @@ export function VoiceChatPage() {
       <div ref={setTranscriptContainer} className="flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-[900px] px-4 pt-4 pb-8">
           <div className="flex flex-col gap-4">
-            {transcript.length === 0 && slowBrainEvents.length === 0 && (
+            {conversationItems.length === 0 && (
               <p className="text-sm text-muted-foreground text-center py-8">
                 {status === "connecting"
                   ? "Connecting..."
                   : "Speak to start the conversation."}
               </p>
             )}
-            {transcript.map((entry) => {
-              return entry.role === "user" ? (
-                <VoiceUserBubble key={entry.id} content={entry.text} />
-              ) : (
-                <VoiceAssistantBubble key={entry.id} content={entry.text} />
-              );
-            })}
-            {slowBrainEvents.map((event) => {
+            {conversationItems.map((item) => {
+              if (item.kind === "transcript") {
+                return item.entry.role === "user" ? (
+                  <VoiceUserBubble key={item.key} content={item.entry.text} />
+                ) : (
+                  <VoiceAssistantBubble
+                    key={item.key}
+                    content={item.entry.text}
+                  />
+                );
+              }
               return (
                 <SlowBrainIndicator
-                  key={`sb-${event.seq}`}
-                  type={event.type}
-                  content={event.content}
+                  key={item.key}
+                  type={item.event.type}
+                  content={item.event.content}
                 />
               );
             })}


### PR DESCRIPTION
## Summary

- Add `vcConversationItems$` computed signal that merges transcript entries and slow-brain events into a single chronologically ordered list using monotonic insertion-order tracking
- Replace two separate `.map()` loops in the connected state with a single render loop over the merged list
- Slow-brain indicators now appear between transcript bubbles in the order they occurred, not all at the bottom

Closes #9603

## Test plan

- [x] Existing voice-chat-page tests pass (7/7)
- [x] Existing voice-chat signal tests pass (22/22)
- [x] Lint passes (0 errors, 0 warnings)
- [x] No new type errors introduced
- [x] Knip clean (no unused exports)
- [ ] Manual: start voice chat, verify slow-brain indicators appear interleaved with transcript
- [ ] Manual: verify preparing state still shows only slow-brain events
- [ ] Manual: verify real-time streaming still works (partial assistant text updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)