### PR TITLE
fix(firewalls): browserless auth should use query parameter not header

### DIFF
--- a/turbo/packages/firewalls-generator/src/browserless.ts
+++ b/turbo/packages/firewalls-generator/src/browserless.ts
@@ -4,7 +4,7 @@
  * Data source: https://docs.browserless.io/rest-apis/intro
  *
  * Browserless is a headless browser automation platform.
- * Uses Bearer token authentication.
+ * Authenticates via the `token` URL query parameter.
  * Token format: UUID v4 (e.g., 094632bb-e326-4c63-b953-82b55700b14c).
  * Three regional base URLs: production-sfo, production-lon, production-ams.
  */
@@ -22,8 +22,9 @@ function generateTypeScript(): string {
     (region) => `    {
       base: "https://production-${region}.browserless.io",
       auth: {
-        headers: {
-          Authorization: "Bearer $\{{ secrets.BROWSERLESS_TOKEN }}",
+        headers: {},
+        query: {
+          token: "$\{{ secrets.BROWSERLESS_TOKEN }}",
         },
       },
       permissions: [],


### PR DESCRIPTION
## Summary

- Browserless authenticates via `?token=` query parameter, not `Authorization: Bearer` header
- The previous config injected a Bearer header, but the agent's request URL still contained the placeholder token in `?token=`. Since Browserless checks query params first (`getTokenFromRequest` priority: query > Basic > Bearer), the fake placeholder value was used, causing 401 failures
- Switch to `auth.query: { token }` so the proxy overwrites the placeholder query parameter with the real secret

## Evidence

From [Browserless REST API docs](https://docs.browserless.io/rest-apis/intro):
> Include your token as a query parameter: `https://production-sfo.browserless.io/scrape?token=YOUR_API_TOKEN_HERE`

From [Browserless source (getTokenFromRequest)](https://github.com/browserless/browserless/blob/main/bin/scaffold/README.md):
> Gets the token from the request, whether it be a token parameter Basic/Bearer Authorization header. Token query-parameter is checked first.

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes
- [x] `pnpm -F @vm0/core exec vitest run src/contracts/__tests__/firewall-auth-base.test.ts` passes
- [x] `pnpm -F web exec vitest run app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts` passes
- [x] Python `TestAuthQueryInjection` tests pass

Closes #9595

🤖 Generated with [Claude Code](https://claude.com/claude-code)