### PR TITLE
revert: restore thinking indicator and run activity line in chat

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -93,7 +93,7 @@ export interface AssistantChatMessage {
   runLoop?: ReturnType<typeof createRunLoop>;
   summaries$?: Computed<Promise<string[]>>;
   /** All intermediate text outputs from the run's event stream (live). */
-  texts$?: Computed<Promise<AssistantTextItem[]>>;
+  texts$?: Computed<Promise<string[]>>;
   createdAt?: string;
 }
 
@@ -413,42 +413,26 @@ async function collectAllEvents(
   return allEvents;
 }
 
-export interface AssistantTextItem {
-  /**
-   * Stable key derived from the event's sequence number and block index for
-   * React reconciliation. Format: `${sequenceNumber}-${blockIndex}`.
-   */
-  key: string;
-  text: string;
-}
-
 /**
  * Extract ALL assistant text outputs from the event stream, in order.
- * Each item carries a stable key composed of the event's sequenceNumber and
- * the block's position within that event.
  */
-function extractTexts(events: AgentEvent[]): AssistantTextItem[] {
-  const items: AssistantTextItem[] = [];
+function extractTexts(events: AgentEvent[]): string[] {
+  const texts: string[] = [];
   for (const event of events) {
     if (event.eventType === "assistant") {
-      let blockIndex = 0;
       for (const block of getEventContent(event)) {
         if (block.type === "text" && block.text) {
-          items.push({
-            key: `${event.sequenceNumber}-${blockIndex}`,
-            text: block.text,
-          });
-          blockIndex++;
+          texts.push(block.text);
         }
       }
     }
   }
-  return items;
+  return texts;
 }
 
 function extractResult(events: AgentEvent[]): string {
-  const items = extractTexts(events);
-  return items[items.length - 1]?.text ?? "";
+  const texts = extractTexts(events);
+  return texts[texts.length - 1] ?? "";
 }
 
 function extractSummaries(events: AgentEvent[]): string[] {

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -11,11 +11,14 @@
 
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { openQueueDrawer$ } from "../../../signals/queue-page/queue-drawer-state.ts";
+import { pathname$ } from "../../../signals/route.ts";
+import { mockChatLifecycle } from "../../zero-page/__tests__/chat-test-helpers.ts";
 
 const context = testContext();
 
@@ -164,5 +167,57 @@ describe("queue drawer", () => {
     });
 
     expect(screen.queryByText(/Upgrade to/)).not.toBeInTheDocument();
+  });
+
+  it("clicking 'View queue' in chat should open drawer without navigating away", async () => {
+    const user = userEvent.setup();
+
+    const ctrl = mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "Do something",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: null,
+          runId: "run-queue-1",
+          status: "queued",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    ctrl.setRunStatus("queued");
+    ctrl.setQueuePosition(2);
+
+    server.use(
+      http.get("*/api/zero/runs/queue", () => {
+        return HttpResponse.json(
+          queueResponse({
+            concurrency: { tier: "free", limit: 1, active: 1, available: 0 },
+          }),
+        );
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const link = await waitFor(() => {
+      return screen.getByText("View queue");
+    });
+
+    expect(context.store.get(pathname$)).toBe("/chats/thread-test-1");
+
+    await user.click(link);
+
+    // Should stay on the chat page and open the queue drawer in-place
+    expect(context.store.get(pathname$)).toBe("/chats/thread-test-1");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /waiting in line/ }),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-activity-line-visibility.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-activity-line-visibility.test.tsx
@@ -7,7 +7,7 @@ import { mockChatLifecycle, makeToolUseEvent } from "./chat-test-helpers.ts";
 const context = testContext();
 
 describe("activity line visibility while run is still running", () => {
-  it("should show activity steps when result arrives while run is still running", async () => {
+  it("should keep showing activity line when result arrives but run is still running", async () => {
     const ctrl = mockChatLifecycle({
       threadId: "thread-activity-vis",
       chatMessages: [
@@ -33,40 +33,38 @@ describe("activity line visibility while run is still running", () => {
 
     detachedSetupPage({ context, path: "/chats/thread-activity-vis" });
 
-    // Wait for the active run to appear — Stop button visible while running
+    // Wait for the active run to appear with thinking state
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
     });
 
-    // Add tool use events so activity steps appear
+    // Add tool use events so the activity line shows summary steps
     ctrl.setEvents([
       makeToolUseEvent("Bash", { command: "ls" }, 1),
       {
         sequenceNumber: 2,
-        eventType: "assistant",
-        eventData: {
-          message: {
-            content: [
-              { type: "text", text: "Here is the first part of the answer." },
-            ],
-          },
-        },
+        eventType: "result",
+        eventData: { result: "Here is the first part of the answer." },
         createdAt: "2026-03-10T00:00:30Z",
       },
       makeToolUseEvent("Read", { path: "/tmp/data.txt" }, 3),
     ]);
 
-    // The result text is shown as it streams in via texts$
+    // The activity line (shimmer) should remain visible while the run is still running
     await waitFor(() => {
-      expect(
-        screen.getByText("Here is the first part of the answer."),
-      ).toBeInTheDocument();
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
     });
 
-    // Stop button remains visible while run is still active
-    expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    // The result body should NOT appear while the run is still active (prevents layout shift)
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Here is the first part of the answer."),
+      ).not.toBeInTheDocument();
+    });
 
-    // Complete the run — the result body should remain visible after terminal state
+    // Complete the run — the result body should appear after terminal state
     ctrl.completeRun("Here is the first part of the answer.");
 
     await waitFor(() => {
@@ -76,7 +74,7 @@ describe("activity line visibility while run is still running", () => {
     });
   });
 
-  it("should show result body when run reaches terminal status", async () => {
+  it("should hide activity line only after run reaches terminal status", async () => {
     const ctrl = mockChatLifecycle({
       threadId: "thread-activity-terminal",
       chatMessages: [
@@ -97,40 +95,42 @@ describe("activity line visibility while run is still running", () => {
 
     detachedSetupPage({ context, path: "/chats/thread-activity-terminal" });
 
-    // Stop button visible while run is active
+    // Thinking state initially
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
     });
 
-    // An assistant text event arrives while run is still "running" — shown immediately via texts$
+    // A result event arrives while run is still "running"
     ctrl.setEvents([
       {
         sequenceNumber: 1,
-        eventType: "assistant",
-        eventData: {
-          message: {
-            content: [{ type: "text", text: "Intermediate result" }],
-          },
-        },
+        eventType: "result",
+        eventData: { result: "Intermediate result" },
         createdAt: "2026-03-10T00:00:10Z",
       },
     ]);
 
-    // Result body is visible as streaming content
+    // Result body should NOT be visible while run is still active (prevents layout shift)
     await waitFor(() => {
-      expect(screen.getByText("Intermediate result")).toBeInTheDocument();
+      expect(screen.queryByText("Intermediate result")).not.toBeInTheDocument();
     });
 
-    // Now complete the run — body should remain and Stop should disappear
+    // Activity line should still be visible (run is "running")
+    expect(document.querySelector(".zero-shimmer-text")).toBeInTheDocument();
+
+    // Now complete the run — activity line should disappear and body should appear
     ctrl.completeRun("Final result");
 
     await waitFor(() => {
       expect(screen.getByText("Final result")).toBeInTheDocument();
     });
 
-    // After completion, Stop button is gone
+    // After completion, no more shimmer/activity
     await waitFor(() => {
-      expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
+      expect(
+        document.querySelector(".zero-shimmer-text"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-immediate-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-immediate-feedback.test.tsx
@@ -98,7 +98,7 @@ describe("chat immediate feedback after sending", () => {
     });
   });
 
-  it("should disable Send button immediately after submission", async () => {
+  it("should show thinking indicator and disable Send button immediately after submission", async () => {
     const user = userEvent.setup();
     const ctrl = mockChatLifecycle();
 
@@ -113,11 +113,17 @@ describe("chat immediate feedback after sending", () => {
 
     await sendMessageInUI(user, textarea, "Hello");
 
-    // With the placeholder fix, sending state should be visible even before the POST responds.
-    // Stop button replaces Send while sending.
+    // With the placeholder fix, sending state and thinking indicator
+    // should be visible even before the POST responds.
+    // With mutual exclusion ternary, Stop button replaces Send while sending.
     await waitFor(() => {
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
       expect(screen.queryByLabelText("Send")).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
     });
 
     ctrl.completeRun();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-lifecycle.test.tsx
@@ -32,9 +32,10 @@ describe("chat message lifecycle", () => {
       expect(screen.getByText("What can you do?")).toBeInTheDocument();
     });
 
-    // Stop button visible while assistant is running
+    // Assistant thinking indicator appears
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
     });
 
     ctrl.completeRun("I can help with many things!");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-queue-state.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-queue-state.test.tsx
@@ -7,12 +7,13 @@ import {
   mockChatLifecycle,
   sendMessageInUI,
   PLACEHOLDER,
+  makeToolUseEvent,
 } from "./chat-test-helpers.ts";
 
 const context = testContext();
 
 describe("chat queue state", () => {
-  it("should show Stop button when run is queued", async () => {
+  it("should show queue position when run is queued", async () => {
     const user = userEvent.setup();
     const ctrl = mockChatLifecycle();
 
@@ -31,7 +32,7 @@ describe("chat queue state", () => {
     await sendMessageInUI(user, textarea, "Hello");
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(screen.getByText(/In queue/)).toBeInTheDocument();
     });
 
     // Complete the run and wait for polling to stop
@@ -41,7 +42,7 @@ describe("chat queue state", () => {
     });
   });
 
-  it("should show Stop button when transitioning from queue to running state", async () => {
+  it("should transition from queue to running state", async () => {
     const user = userEvent.setup();
     const ctrl = mockChatLifecycle();
     ctrl.setRunStatus("queued");
@@ -58,17 +59,18 @@ describe("chat queue state", () => {
 
     await sendMessageInUI(user, textarea, "Hello");
 
-    // Stop button visible while queued
+    // Wait for queue state
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(screen.getByText(/In queue/)).toBeInTheDocument();
     });
 
-    // Transition to running
+    // Transition to running with events
     ctrl.setRunStatus("running");
+    ctrl.setEvents([makeToolUseEvent("Search")]);
 
-    // Stop button remains visible during running state
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(screen.queryByText(/In queue/)).toBeNull();
+      expect(screen.getByText("Searching for info...")).toBeInTheDocument();
     });
 
     // Complete the run and wait for polling to stop

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-resume.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-resume.test.tsx
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import { mockChatLifecycle } from "./chat-test-helpers.ts";
+import { mockChatLifecycle, makeToolUseEvent } from "./chat-test-helpers.ts";
 
 const context = testContext();
 
 describe("chat resume", () => {
-  it("should display history messages and show Stop button for active run", async () => {
-    mockChatLifecycle({
+  it("should display history messages and show thinking for active run", async () => {
+    const ctrl = mockChatLifecycle({
       threadId: "thread-resume",
       chatMessages: [
         {
@@ -45,13 +45,18 @@ describe("chat resume", () => {
       expect(screen.getByText("Follow up question")).toBeInTheDocument();
     });
 
-    // Active run should show Stop button
+    // Active run should show thinking state
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
     });
 
-    // Stop button remains while run is active
-    expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    // Add events -- activity steps should appear
+    ctrl.setEvents([makeToolUseEvent("Bash")]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Running a command...")).toBeInTheDocument();
+    });
   });
 
   it("should allow input and Stop during resume", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-sending-state.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-sending-state.test.tsx
@@ -66,7 +66,7 @@ describe("chat sending state", () => {
     });
   });
 
-  it("should show Stop button while waiting for telemetry", async () => {
+  it("should display thinking text while waiting for telemetry", async () => {
     const user = userEvent.setup();
     const ctrl = mockChatLifecycle();
 
@@ -82,7 +82,8 @@ describe("chat sending state", () => {
     await sendMessageInUI(user, textarea, "Hello");
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
     });
 
     // Complete the run and wait for polling to stop
@@ -134,7 +135,7 @@ describe("chat sending state", () => {
     });
   });
 
-  it("should keep Stop button visible when telemetry arrives", async () => {
+  it("should replace thinking with activity steps when telemetry arrives", async () => {
     const user = userEvent.setup();
     const ctrl = mockChatLifecycle();
 
@@ -149,17 +150,18 @@ describe("chat sending state", () => {
 
     await sendMessageInUI(user, textarea, "Hello");
 
-    // Wait for sending state
+    // Wait for thinking state
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
     });
 
     // Add telemetry events
     ctrl.setEvents([makeToolUseEvent("Bash")]);
 
-    // Stop button remains visible during run
+    // Wait for activity step to appear
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(screen.getByText("Running a command...")).toBeInTheDocument();
     });
 
     // Complete the run and wait for polling to stop

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-session-switch.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-session-switch.test.tsx
@@ -111,10 +111,14 @@ describe("chat session switch", () => {
       pathParams: { threadId: "thread-running" },
     });
 
-    // Stop button should appear for the active run
+    // The running thread should show the thinking/shimmer state
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
     });
+
+    // Stop button should appear for the active run
+    expect(screen.getByLabelText("Stop")).toBeInTheDocument();
   });
 
   it("should load different messages when switching between completed sessions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -152,7 +152,6 @@ export function mockChatLifecycle(options?: {
   let events: AgentEvent[] = [];
   let queuePosition = 0;
   let resultContent = "";
-  let completedContent: string | null = null;
   let threadList: ThreadListItem[] = [];
   let runPrompt: string | null = null;
   let runAssociated = false;
@@ -172,7 +171,7 @@ export function mockChatLifecycle(options?: {
             },
             {
               role: "assistant" as const,
-              content: completedContent,
+              content: null,
               runId: "a0000000-0000-4000-a000-000000000001",
               status: runStatus,
               error: runError ?? undefined,
@@ -239,17 +238,9 @@ export function mockChatLifecycle(options?: {
         artifact: { name: null, version: null },
       });
     }),
-    http.get("*/api/zero/runs/:id/telemetry/agent", ({ request }) => {
-      const url = new URL(request.url);
-      const since = url.searchParams.get("since");
-      const filteredEvents =
-        since !== null
-          ? events.filter((e) => {
-              return e.sequenceNumber > Number(since);
-            })
-          : events;
+    http.get("*/api/zero/runs/:id/telemetry/agent", () => {
       return HttpResponse.json({
-        events: filteredEvents,
+        events,
         hasMore: false,
         framework: "claude-code",
       });
@@ -293,7 +284,6 @@ export function mockChatLifecycle(options?: {
     completeRun: (content?: string) => {
       runStatus = "completed";
       resultContent = content ?? "";
-      completedContent = content ?? null;
       threadTitle = threadTitle ?? runPrompt;
       if (content) {
         events = [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -5,6 +5,7 @@ import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
 import {
   mockChatLifecycle,
+  makeToolUseEvent,
   mockSubagentThread,
   SUB_AGENT_ID,
 } from "./chat-test-helpers.ts";
@@ -84,10 +85,10 @@ describe("zero chat thread page display - attachment file preview", () => {
   });
 });
 
-// CHAT-D-038: Stop button visible while run is active
-describe("zero chat thread page display - run active state", () => {
-  it("shows Stop button while a run is active", async () => {
-    mockChatLifecycle({
+// CHAT-D-038: Run activity line renders summaries
+describe("zero chat thread page display - run activity line summaries", () => {
+  it("displays a tool-use summary in the run activity line", async () => {
+    const ctrl = mockChatLifecycle({
       chatMessages: [
         {
           role: "user",
@@ -103,18 +104,19 @@ describe("zero chat thread page display - run active state", () => {
         },
       ],
     });
+    ctrl.setEvents([makeToolUseEvent("Bash", { command: "ls" }, 1)]);
 
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(screen.getByLabelText("Current activity")).toBeInTheDocument();
     });
   });
 });
 
-// CHAT-D-039: Stop button visible when run is queued
-describe("zero chat thread page display - run queued state", () => {
-  it("shows Stop button when run is queued", async () => {
+// CHAT-D-039: Run activity line renders queue position
+describe("zero chat thread page display - run activity line queue position", () => {
+  it("displays an in-queue message with position info", async () => {
     const ctrl = mockChatLifecycle({
       chatMessages: [
         {
@@ -137,7 +139,13 @@ describe("zero chat thread page display - run queued state", () => {
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      const el = screen.getByText((_content, element) => {
+        return (
+          element?.tagName === "P" &&
+          (element.textContent?.includes("In queue") ?? false)
+        );
+      });
+      expect(el).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -199,7 +199,7 @@ describe("agent avatar link", () => {
 });
 
 describe("chat message activity line", () => {
-  it("should show result text when result arrives while run is still running", async () => {
+  it("should keep activity line visible when result arrives but run is still running", async () => {
     const lifecycle = mockChatLifecycle({
       threadId: "thread-activity-running",
       chatMessages: [
@@ -218,36 +218,34 @@ describe("chat message activity line", () => {
       ],
     });
 
-    // Provide an assistant text event while keeping the run status as "running"
+    // Provide a result event while keeping the run status as "running"
     lifecycle.setEvents([
       {
         sequenceNumber: 1,
-        eventType: "assistant",
-        eventData: {
-          message: {
-            content: [{ type: "text", text: "Here is the partial result" }],
-          },
-        },
+        eventType: "result",
+        eventData: { result: "Here is the partial result" },
         createdAt: "2026-03-10T00:00:10Z",
       },
     ]);
 
     detachedSetupPage({ context, path: "/chats/thread-activity-running" });
 
-    // Stop button is visible since the run is not terminal
+    // The activity line (spinner) should be visible since the run is not terminal.
+    // The response body is hidden during active runs to prevent layout shift.
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
     });
 
-    // The result text is shown as it streams in
+    // The result body should not be rendered while the run is still active
     await waitFor(() => {
       expect(
-        screen.getByText("Here is the partial result"),
-      ).toBeInTheDocument();
+        screen.queryByText("Here is the partial result"),
+      ).not.toBeInTheDocument();
     });
   });
 
-  it("should show result body after run reaches terminal status", async () => {
+  it("should hide activity line after run reaches terminal status", async () => {
     const lifecycle = mockChatLifecycle({
       threadId: "thread-activity-done",
       chatMessages: [
@@ -266,27 +264,35 @@ describe("chat message activity line", () => {
       ],
     });
 
-    // Start with no events — text will appear when run completes
-    lifecycle.setEvents([]);
+    // Start with a result event while still running
+    lifecycle.setEvents([
+      {
+        sequenceNumber: 1,
+        eventType: "result",
+        eventData: { result: "Final answer" },
+        createdAt: "2026-03-10T00:00:10Z",
+      },
+    ]);
 
     detachedSetupPage({ context, path: "/chats/thread-activity-done" });
 
-    // Stop button visible while running
+    // Activity line should be visible while running; body is hidden during active runs
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
     });
 
     // Now complete the run
     lifecycle.completeRun("Final answer");
 
-    // Result body should appear after reaching terminal status
+    // Activity line should disappear and body should appear after reaching terminal status
     await waitFor(() => {
-      expect(screen.getByText("Final answer")).toBeInTheDocument();
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).not.toBeInTheDocument();
     });
 
-    // Stop button is gone after completion
     await waitFor(() => {
-      expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
+      expect(screen.getByText("Final answer")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -9,6 +9,7 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   IconAlertCircle,
+  IconLoader2,
   IconPhoto,
   IconChartLine,
   IconPlayerStop,
@@ -38,6 +39,7 @@ import {
 } from "../../signals/voice-io/voice-io-settings.ts";
 import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
+import { openQueueDrawer$ } from "../../signals/queue-page/queue-drawer-state.ts";
 import { FileAttachmentChip, ImageLightbox } from "./zero-attachment-chips.tsx";
 import {
   lightboxUrl$ as attachmentLightboxUrl$,
@@ -52,7 +54,6 @@ import type {
   ZeroChatMessage,
   UserChatMessage,
   AssistantChatMessage,
-  AssistantTextItem,
 } from "../../signals/chat-page/chat-message.ts";
 import {
   currentChatThreadSignals$,
@@ -573,6 +574,132 @@ function UserMessage({ message }: { message: UserChatMessage }) {
   );
 }
 
+function deduplicateSummaries(summaries: string[]): string[] {
+  const result: string[] = [];
+  for (const s of summaries) {
+    if (result[result.length - 1] !== s) {
+      result.push(s);
+    }
+  }
+  return result;
+}
+
+/** Live run activity rendered from a message's own runLoop signals. */
+function MessageRunActivityLine({
+  message,
+  thread,
+}: {
+  message: AssistantChatMessage;
+  thread: ChatThreadSignals;
+}) {
+  const summariesLoadable = useLastLoadable(message.summaries$!);
+  const rawSummaries =
+    summariesLoadable.state === "hasData" ? summariesLoadable.data : [];
+  const detailLoadable = useLastLoadable(message.runLoop!.detail$);
+  const runStatus =
+    detailLoadable.state === "hasData" ? detailLoadable.data.status : null;
+  const queueLoadable = useLastLoadable(message.runLoop!.queuePosition$);
+  const queuePosition =
+    queueLoadable.state === "hasData" ? queueLoadable.data : 0;
+  const isQueued = runStatus === "queued";
+  const thinkingMsg = useGet(thread.thinkingMessage$);
+  const openDrawer = useSet(openQueueDrawer$);
+
+  if (isQueued) {
+    return (
+      <div className="flex items-center gap-2 min-w-0">
+        <IconLoader2
+          size={14}
+          className="animate-spin text-muted-foreground shrink-0"
+        />
+        <p className="text-muted-foreground text-xs truncate">
+          {queueLabel(queuePosition)}{" "}
+          <button
+            type="button"
+            onClick={openDrawer}
+            className="underline hover:text-foreground transition-colors"
+          >
+            View queue
+          </button>
+        </p>
+      </div>
+    );
+  }
+
+  if (rawSummaries.length === 0) {
+    return (
+      <div className="flex items-center gap-2 min-w-0">
+        <IconLoader2
+          size={14}
+          className="animate-spin text-foreground/50 shrink-0"
+        />
+        <p className="zero-shimmer-text text-xs truncate">{thinkingMsg}</p>
+      </div>
+    );
+  }
+
+  const rawItems = deduplicateSummaries(rawSummaries);
+  const items = rawItems.map((summary, position) => {
+    return {
+      key: `${position}-${summary}`,
+      summary,
+      isLast: position === rawItems.length - 1,
+    };
+  });
+
+  return (
+    <div className="relative flex flex-col gap-3">
+      {items.length > 1 && (
+        <div
+          className="absolute left-[5.5px] top-[6px] bottom-[6px] pointer-events-none"
+          aria-hidden
+        >
+          <div className="w-px h-full bg-border/60 zero-dashed-line" />
+        </div>
+      )}
+      {items.map(({ key, summary, isLast }) => {
+        return (
+          <p
+            key={key}
+            className={`flex items-center gap-2.5 min-w-0 text-xs truncate animate-in fade-in slide-in-from-bottom-1 duration-300 ${
+              isLast ? "" : "text-muted-foreground"
+            }`}
+          >
+            <span className="h-3 w-3 shrink-0 flex items-center justify-center relative z-[1] rounded-full bg-card">
+              {isLast ? (
+                <IconLoader2
+                  size={12}
+                  className="animate-spin text-foreground/50"
+                />
+              ) : (
+                <span
+                  className="text-[8px] leading-none text-foreground/30"
+                  aria-hidden
+                >
+                  ●
+                </span>
+              )}
+            </span>
+            <span
+              className={`truncate ${isLast ? "zero-shimmer-text" : ""}`}
+              aria-label={isLast ? "Current activity" : undefined}
+            >
+              {summary}
+            </span>
+          </p>
+        );
+      })}
+    </div>
+  );
+}
+
+function queueLabel(position: number): string {
+  if (position <= 1) {
+    return "In queue, waiting to start...";
+  }
+  return `In queue, ${position - 1} task${position - 1 === 1 ? "" : "s"} ahead...`;
+}
+
 function AssistantMessage({
   message,
   thread,
@@ -632,37 +759,48 @@ function ReactiveAssistantMessage({
   // Active or just-completed: render from the event stream.
   // On completion the texts$ stay stable until reloadThread$ replaces with
   // server-side grouped messages, avoiding the flash of a single result$.
-  return <ReactiveRunContent message={message} thread={thread} />;
+  const active = detail?.status !== "completed";
+  return (
+    <ReactiveRunContent message={message} thread={thread} active={active} />
+  );
 }
 
 /**
  * Renders all intermediate text outputs from the event stream.
+ * When `active` is true, an activity line is appended at the bottom.
  */
 function ReactiveRunContent({
   message,
   thread,
+  active,
 }: {
   message: AssistantChatMessage;
   thread: ChatThreadSignals;
+  active: boolean;
 }) {
-  const items: AssistantTextItem[] = useLastResolved(message.texts$!) ?? [];
-  const lastContent = items[items.length - 1]?.text ?? "";
+  const texts = useLastResolved(message.texts$!) ?? [];
+  const lastContent = texts[texts.length - 1] ?? "";
 
   return (
     <div className="group flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300">
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
         <AssistantBubbleAvatar thread={thread} />
         <div className="flex flex-col gap-3">
-          {items.map((item) => {
+          {texts.map((text) => {
             return (
               <div
-                key={item.key}
+                key={text}
                 className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words animate-in fade-in slide-in-from-bottom-1 duration-300"
               >
-                <Markdown source={item.text} />
+                <Markdown source={text} />
               </div>
             );
           })}
+          {active && (
+            <div className="zero-chat-bubble-assistant rounded-xl py-4 text-sm leading-relaxed min-w-0 overflow-hidden">
+              <MessageRunActivityLine message={message} thread={thread} />
+            </div>
+          )}
         </div>
       </div>
       <AssistantMessageActions
@@ -890,6 +1028,8 @@ function StaticAssistantMessage({
 }) {
   const content = useLastResolved(message.result$) ?? "";
 
+  const showActivityLine = isRunActive(message);
+
   if (message.error) {
     return (
       <div
@@ -911,7 +1051,7 @@ function StaticAssistantMessage({
     );
   }
 
-  if (content) {
+  if (content && !showActivityLine) {
     return (
       <div className="group flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300">
         <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
@@ -935,7 +1075,35 @@ function StaticAssistantMessage({
     );
   }
 
-  return null;
+  // Thinking / loading state
+  return (
+    <div
+      data-role="assistant"
+      className="flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300"
+    >
+      <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
+        <AssistantBubbleAvatar thread={thread} />
+        <div className="zero-chat-bubble-assistant rounded-xl py-4 text-sm leading-relaxed min-w-0 overflow-hidden">
+          {showActivityLine ? (
+            <MessageRunActivityLine message={message} thread={thread} />
+          ) : (
+            <div className="flex items-center gap-2 min-w-0">
+              <IconLoader2
+                size={14}
+                className="animate-spin text-foreground/50 shrink-0"
+              />
+              <p className="zero-shimmer-text text-xs truncate">Thinking...</p>
+            </div>
+          )}
+        </div>
+      </div>
+      <AssistantMessageActions
+        message={message}
+        content={content}
+        thread={thread}
+      />
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -945,10 +1113,13 @@ function StaticAssistantMessage({
 
 function AssistantMessageGroupItem({
   message,
+  thread,
 }: {
   message: AssistantChatMessage;
+  thread: ChatThreadSignals;
 }) {
   const content = useLastResolved(message.result$) ?? "";
+  const showActivityLine = isRunActive(message);
 
   if (message.error) {
     return (
@@ -958,7 +1129,7 @@ function AssistantMessageGroupItem({
     );
   }
 
-  if (content) {
+  if (content && !showActivityLine) {
     return (
       <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
         <Markdown source={content} />
@@ -966,7 +1137,21 @@ function AssistantMessageGroupItem({
     );
   }
 
-  return null;
+  return (
+    <div className="zero-chat-bubble-assistant rounded-xl py-4 text-sm leading-relaxed min-w-0 overflow-hidden">
+      {showActivityLine ? (
+        <MessageRunActivityLine message={message} thread={thread} />
+      ) : (
+        <div className="flex items-center gap-2 min-w-0">
+          <IconLoader2
+            size={14}
+            className="animate-spin text-foreground/50 shrink-0"
+          />
+          <p className="zero-shimmer-text text-xs truncate">Thinking...</p>
+        </div>
+      )}
+    </div>
+  );
 }
 
 function AssistantMessageGroup({
@@ -988,7 +1173,13 @@ function AssistantMessageGroup({
         <AssistantBubbleAvatar thread={thread} />
         <div className="flex flex-col gap-3">
           {messages.map((msg) => {
-            return <AssistantMessageGroupItem key={msg.id} message={msg} />;
+            return (
+              <AssistantMessageGroupItem
+                key={msg.id}
+                message={msg}
+                thread={thread}
+              />
+            );
           })}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Reverts #9564 which removed the thinking indicator and run activity line from chat
- Restores the thinking indicator and activity line UI components that were prematurely removed
- Fixes affected tests to match the restored behavior

## Test plan
- [ ] Verify thinking indicator appears during agent processing
- [ ] Verify run activity line displays correctly in chat thread
- [ ] Confirm all existing tests pass with restored components

🤖 Generated with [Claude Code](https://claude.com/claude-code)