### PR TITLE
fix(firewalls): linear placeholder should use oauth token format

### DIFF
--- a/turbo/packages/firewalls-generator/src/linear.ts
+++ b/turbo/packages/firewalls-generator/src/linear.ts
@@ -4,14 +4,17 @@
  * Data source: https://developers.linear.app/docs/graphql/working-with-the-graphql-api
  *
  * Linear is a project management tool for software teams.
+ * OAuth access tokens use Bearer prefix in Authorization header.
+ * Token format: 64-character hex string.
  */
 
 import { writeOutput } from "./codegen";
 
 const DOCS_URL =
   "https://developers.linear.app/docs/graphql/working-with-the-graphql-api";
-// Format: lin_api_ + 40 alphanumeric (gitleaks: linear-api-key)
-const PLACEHOLDER_VALUE = "lin_api_CoffeeSafeLocalCoffeeSafeLocalCoffeeSafe";
+// OAuth access token: 64-char hex string
+const PLACEHOLDER_VALUE =
+  "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe10ca1c0ff";
 
 function generateTypeScript(): string {
   const lines: string[] = [


### PR DESCRIPTION
## Summary
- Linear OAuth access tokens are 64-char hex strings, not `lin_api_` prefixed personal API keys
- Updated placeholder from `lin_api_CoffeeSafe...` to `c0ffee5afe10ca1...` (standard hex fill pattern)
- Bearer auth header is correct for OAuth tokens — no change needed there
- Updated JSDoc to document OAuth token format

Closes #9600

## Test plan
- [x] `pnpm -F @vm0/firewalls-generator generate:linear` succeeds
- [x] Generated output has correct placeholder format
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)