### PR TITLE
fix: surface hint when connector credential is missing from auth template

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -170,7 +170,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(data.resolvedSecrets).toEqual(["API_KEY", "API_SECRET"]);
     });
 
-    it("should resolve unknown secret to empty string", async () => {
+    it("should return 502 with hint when a referenced secret is missing", async () => {
       const encrypted = encryptTestSecrets({ KNOWN: "value" });
 
       const response = await POST(
@@ -185,10 +185,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         ),
       );
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(502);
       const data = await response.json();
-      expect(data.headers.Authorization).toBe("Bearer ");
-      expect(data.resolvedSecrets).toEqual(["UNKNOWN_KEY"]);
+      expect(data.error.code).toBe("MISSING_CONNECTOR_TOKEN");
+      expect(data.error.secrets).toEqual(["UNKNOWN_KEY"]);
+      expect(data.error.hint).toBe(
+        "Run: zero doctor check-connector --env-name UNKNOWN_KEY",
+      );
     });
 
     it("should pass through headers without template syntax", async () => {
@@ -528,7 +531,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(data.resolvedSecrets).toEqual(["OTHER", "TOKEN"]);
     });
 
-    it("should handle missing secret in basic() gracefully", async () => {
+    it("should return 502 with hint when a secret in basic() is missing", async () => {
       const encrypted = encryptTestSecrets({
         USER: "admin",
       });
@@ -545,12 +548,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         ),
       );
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(502);
       const data = await response.json();
-      // Missing secret resolves to empty string
-      const expected = `Basic ${Buffer.from("admin:").toString("base64")}`;
-      expect(data.headers.Authorization).toBe(expected);
-      expect(data.resolvedSecrets).toEqual(["MISSING", "USER"]);
+      expect(data.error.code).toBe("MISSING_CONNECTOR_TOKEN");
+      expect(data.error.secrets).toEqual(["MISSING"]);
+      expect(data.error.hint).toBe(
+        "Run: zero doctor check-connector --env-name MISSING",
+      );
     });
 
     it("should resolve basic with both args empty", async () => {
@@ -952,6 +956,9 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       const data = await response.json();
       expect(data.error.code).toBe("TOKEN_REFRESH_FAILED");
       expect(data.error.connectors).toEqual(["notion"]);
+      expect(data.error.hint).toBe(
+        "Run: zero doctor check-connector --env-name NOTION_ACCESS_TOKEN",
+      );
     });
 
     it("should return 502 when one of multiple connectors fails to refresh", async () => {
@@ -1028,6 +1035,9 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       const data = await response.json();
       expect(data.error.code).toBe("TOKEN_REFRESH_FAILED");
       expect(data.error.connectors).toEqual(["close"]);
+      expect(data.error.hint).toBe(
+        "Run: zero doctor check-connector --env-name CLOSE_ACCESS_TOKEN",
+      );
     });
 
     it("should use DB refresh token instead of stale encrypted refresh token", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -496,12 +496,18 @@ export async function POST(request: Request) {
   // If any connector token refresh failed, return an error so the addon
   // surfaces a clear message instead of silently using a stale token.
   if (failedConnectors.length > 0) {
+    const failedEnvName = Object.entries(secretConnectorMap ?? {}).find(
+      ([, ct]) => failedConnectors.includes(ct),
+    )?.[0];
     return NextResponse.json(
       {
         error: {
           message: `OAuth token expired and refresh failed for: ${failedConnectors.join(", ")}. The connector may need to be reconnected.`,
           code: "TOKEN_REFRESH_FAILED",
           connectors: failedConnectors,
+          hint: failedEnvName
+            ? `Run: zero doctor check-connector --env-name ${failedEnvName}`
+            : `Run: zero doctor check-connector --help`,
         },
       },
       { status: 502 },
@@ -517,6 +523,24 @@ export async function POST(request: Request) {
     authBase,
     authQuery,
   );
+
+  // Surface a clear error when a connector credential is absent so the agent
+  // knows to run `zero doctor check-connector` rather than seeing a silent 401
+  // from the downstream API.
+  const missingSecrets = resolvedSecrets.filter((key) => !(key in secrets));
+  if (missingSecrets.length > 0) {
+    return NextResponse.json(
+      {
+        error: {
+          message: `Connector credential missing for: ${missingSecrets.join(", ")}. The connector may not be connected.`,
+          code: "MISSING_CONNECTOR_TOKEN",
+          secrets: missingSecrets,
+          hint: `Run: zero doctor check-connector --env-name ${missingSecrets[0]}`,
+        },
+      },
+      { status: 502 },
+    );
+  }
 
   return NextResponse.json({
     headers,


### PR DESCRIPTION
## Summary
- Adds `MISSING_CONNECTOR_TOKEN` (HTTP 502) error when a `${{ secrets.X }}` template references a key not present in the decrypted secrets map, replacing the silent empty-string substitution that caused confusing 401s from downstream APIs
- Adds `hint` field to both `MISSING_CONNECTOR_TOKEN` and `TOKEN_REFRESH_FAILED` errors containing the exact `zero doctor check-connector` command for the agent to self-diagnose
- Updates two existing tests whose behavior changed and adds `hint` assertions to the two existing 502 tests

## Test plan
- [ ] `should return 502 with hint when a referenced secret is missing` — new assertion
- [ ] `should return 502 with hint when a secret in basic() is missing` — new assertion
- [ ] `should return 502 when token refresh fails` — hint field asserted
- [ ] `should return 502 when one of multiple connectors fails to refresh` — hint field asserted

Closes #9598

🤖 Generated with [Claude Code](https://claude.com/claude-code)