### PR TITLE
feat(platform): show google oauth verification notice before connecting

### DIFF
--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
-import { MinimalSidebarLayout } from "../../views/zero-page/zero-directed-connect-page.tsx";
+import { MinimalSidebarLayout } from "../../views/zero-page/zero-directed-shared.tsx";
 import { PermissionAllowPage } from "../../views/permission-allow/permission-allow-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";

--- a/turbo/apps/platform/src/signals/report-error/report-error-page-setup.ts
+++ b/turbo/apps/platform/src/signals/report-error/report-error-page-setup.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
-import { MinimalSidebarLayout } from "../../views/zero-page/zero-directed-connect-page.tsx";
+import { MinimalSidebarLayout } from "../../views/zero-page/zero-directed-shared.tsx";
 import { ReportErrorPage } from "../../views/report-error/report-error-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-interaction.test.tsx
@@ -35,6 +35,44 @@ test("connect button opens api-token form (CONN-I-011)", async () => {
   expect(screen.getByText("Save")).toBeInTheDocument();
 });
 
+test("connect button on Google connector opens dialog with OAuth notice (CONN-I-020)", async () => {
+  const user = userEvent.setup();
+  detachedSetupPage({ context, path: "/connectors" });
+
+  await waitFor(() => {
+    expect(screen.getByLabelText("Connect Gmail")).toBeInTheDocument();
+  });
+
+  await user.click(screen.getByLabelText("Connect Gmail"));
+
+  await waitFor(() => {
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+  expect(
+    screen.getByText(/Google will show a security warning/),
+  ).toBeInTheDocument();
+  expect(screen.getByText("Advanced")).toBeInTheDocument();
+  expect(screen.getByText(/Go to vm0\.ai \(unsafe\)/)).toBeInTheDocument();
+});
+
+test("connect button on api-token-only connector opens dialog without OAuth notice (CONN-I-021)", async () => {
+  const user = userEvent.setup();
+  detachedSetupPage({ context, path: "/connectors" });
+
+  await waitFor(() => {
+    expect(screen.getByLabelText("Connect Axiom")).toBeInTheDocument();
+  });
+
+  await user.click(screen.getByLabelText("Connect Axiom"));
+
+  await waitFor(() => {
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+  expect(
+    screen.queryByText(/Google will show a security warning/),
+  ).not.toBeInTheDocument();
+});
+
 test("review button opens scope diff with added permissions (CONN-I-013)", async () => {
   const user = userEvent.setup();
   mockConnectors([{ type: "github", oauthScopes: [] }]);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -220,4 +220,84 @@ describe("directed authorize page", () => {
     const logoLink = screen.getByLabelText("VM0");
     expect(logoLink.closest("a")).toHaveAttribute("href", "/connectors");
   });
+
+  it("shows Google OAuth notice when Google connector is not yet connected (AUTH-D-060)", async () => {
+    // No mockConnectorsConnected → connector not in the connected list
+    detachedSetupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Gmail to proceed"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/Google will show a security warning/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Advanced")).toBeInTheDocument();
+    expect(screen.getByText(/Go to vm0\.ai \(unsafe\)/)).toBeInTheDocument();
+  });
+
+  it("does not show Google OAuth notice when Google connector is already connected (AUTH-D-061)", async () => {
+    mockConnectorsConnected("gmail");
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Gmail to proceed"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/Google will show a security warning/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show Google OAuth notice when connector is already authorized (AUTH-D-062)", async () => {
+    mockConnectorsConnected("gmail");
+    server.use(
+      http.get("*/api/zero/agents/:id/user-connectors", () => {
+        return HttpResponse.json({ enabledTypes: ["gmail"] });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Gmail authorized")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/Google will show a security warning/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show Google OAuth notice for non-Google OAuth connectors (AUTH-D-063)", async () => {
+    mockConnectorsConnected("github");
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/github/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs GitHub to proceed"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/Google will show a security warning/),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -388,6 +388,64 @@ describe("directed connect page", () => {
     });
   });
 
+  it("shows Google OAuth notice for a Google connector when not connected (CONN-D-060)", async () => {
+    detachedSetupPage({ context, path: "/connectors/gmail/connect" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Gmail to proceed"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/Google will show a security warning/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Advanced")).toBeInTheDocument();
+    expect(screen.getByText(/Go to vm0\.ai \(unsafe\)/)).toBeInTheDocument();
+  });
+
+  it("shows Google OAuth notice for other Google connectors (CONN-D-061)", async () => {
+    detachedSetupPage({ context, path: "/connectors/google-sheets/connect" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Google Sheets to proceed"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/Google will show a security warning/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show Google OAuth notice for non-Google OAuth connectors (CONN-D-062)", async () => {
+    detachedSetupPage({ context, path: "/connectors/github/connect" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs GitHub to proceed"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/Google will show a security warning/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show Google OAuth notice when Google connector is already connected (CONN-D-063)", async () => {
+    mockConnectors([{ type: "gmail" }]);
+
+    detachedSetupPage({ context, path: "/connectors/gmail/connect" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Gmail connected")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/Google will show a security warning/),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not call authorize after API token connect when agentId is absent", async () => {
     const user = userEvent.setup();
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -30,8 +30,7 @@ import {
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { detach, Reason } from "../../../../signals/utils.ts";
-import { AvatarSvgPreview } from "../../avatar-svg-preview.tsx";
-import { getAvatarPresets } from "../../zero-avatars.ts";
+import { GoogleOAuthNotice } from "../../zero-directed-shared.tsx";
 
 // ---------------------------------------------------------------------------
 // Inline markdown renderer for help text
@@ -202,30 +201,7 @@ function ConnectModalContent({
 
   return (
     <div className="flex flex-col gap-4">
-      {hasOAuth && isGoogleOAuth && (
-        <div className="flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-4">
-          <AvatarSvgPreview
-            config={getAvatarPresets()[0]}
-            size={36}
-            className="h-9 w-9 rounded-full"
-            alt="Zero"
-          />
-          <div className="text-xs leading-relaxed text-muted-foreground space-y-1.5">
-            <p>
-              Google will show a security warning because we&rsquo;re still
-              completing their app verification. This is a standard review
-              process for new integrations and does not affect your security.
-            </p>
-            <p>
-              To continue, select{" "}
-              <strong className="text-foreground">Advanced</strong> then{" "}
-              <strong className="text-foreground">Go to vm0.ai (unsafe)</strong>
-              . We only request the minimum permissions needed, and your
-              credentials are encrypted at rest.
-            </p>
-          </div>
-        </div>
-      )}
+      {isGoogleOAuth && <GoogleOAuthNotice />}
 
       {hasOAuth && (
         <Button

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -8,7 +8,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorType,
+  isGoogleOAuthConnector,
+} from "@vm0/core";
 import {
   allConnectorTypes$,
   pollingConnectorType$,
@@ -26,6 +30,8 @@ import {
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { detach, Reason } from "../../../../signals/utils.ts";
+import { AvatarSvgPreview } from "../../avatar-svg-preview.tsx";
+import { getAvatarPresets } from "../../zero-avatars.ts";
 
 // ---------------------------------------------------------------------------
 // Inline markdown renderer for help text
@@ -192,8 +198,35 @@ function ConnectModalContent({
     );
   }
 
+  const isGoogleOAuth = hasOAuth && isGoogleOAuthConnector(item.type);
+
   return (
     <div className="flex flex-col gap-4">
+      {hasOAuth && isGoogleOAuth && (
+        <div className="flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-4">
+          <AvatarSvgPreview
+            config={getAvatarPresets()[0]}
+            size={36}
+            className="h-9 w-9 rounded-full"
+            alt="Zero"
+          />
+          <div className="text-xs leading-relaxed text-muted-foreground space-y-1.5">
+            <p>
+              Google will show a security warning because we&rsquo;re still
+              completing their app verification. This is a standard review
+              process for new integrations and does not affect your security.
+            </p>
+            <p>
+              To continue, select{" "}
+              <strong className="text-foreground">Advanced</strong> then{" "}
+              <strong className="text-foreground">Go to vm0.ai (unsafe)</strong>
+              . We only request the minimum permissions needed, and your
+              credentials are encrypted at rest.
+            </p>
+          </div>
+        </div>
+      )}
+
       {hasOAuth && (
         <Button
           variant="outline"

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -49,9 +49,6 @@ import {
   TooltipTrigger,
 } from "@vm0/ui";
 
-/** @deprecated Use isGoogleOAuthConnector from @vm0/core instead. Kept for tooltip usage. */
-const isGoogleConnector = isGoogleOAuthConnector;
-
 function GlobalConnectorCard({
   connector,
   isPolling,
@@ -234,7 +231,7 @@ function AvailableConnectorCard({
           data-testid="connector-help-text"
           className="text-xs text-muted-foreground line-clamp-2"
         >
-          {isGoogleConnector(connector.type) ? (
+          {isGoogleOAuthConnector(connector.type) ? (
             <>
               <TooltipProvider delayDuration={200}>
                 <Tooltip>
@@ -317,7 +314,7 @@ export function ZeroConnectorsPage() {
       (ct &&
         ct.availableAuthMethods.length === 1 &&
         ct.availableAuthMethods[0] === "api-token") ||
-      isGoogleConnector(type)
+      isGoogleOAuthConnector(type)
     ) {
       setSelected(type);
     } else {

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -8,7 +8,11 @@ import {
   IconLoader2,
   IconDotsVertical,
 } from "@tabler/icons-react";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorType,
+  isGoogleOAuthConnector,
+} from "@vm0/core";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
@@ -45,15 +49,8 @@ import {
   TooltipTrigger,
 } from "@vm0/ui";
 
-function isGoogleConnector(type: string) {
-  return (
-    type === "gmail" ||
-    type === "google-sheets" ||
-    type === "google-docs" ||
-    type === "google-drive" ||
-    type === "google-calendar"
-  );
-}
+/** @deprecated Use isGoogleOAuthConnector from @vm0/core instead. Kept for tooltip usage. */
+const isGoogleConnector = isGoogleOAuthConnector;
 
 function GlobalConnectorCard({
   connector,
@@ -317,9 +314,10 @@ export function ZeroConnectorsPage() {
       return c.type === type;
     });
     if (
-      ct &&
-      ct.availableAuthMethods.length === 1 &&
-      ct.availableAuthMethods[0] === "api-token"
+      (ct &&
+        ct.availableAuthMethods.length === 1 &&
+        ct.availableAuthMethods[0] === "api-token") ||
+      isGoogleConnector(type)
     ) {
       setSelected(type);
     } else {

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -1,6 +1,12 @@
 import type { ReactNode } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorType,
+  isGoogleOAuthConnector,
+} from "@vm0/core";
+import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
+import { getAvatarPresets } from "./zero-avatars.ts";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
@@ -198,6 +204,36 @@ function DirectedAuthorizeCard() {
                 <p className="w-60 text-sm text-muted-foreground">
                   {config.helpText}
                 </p>
+                {!isAuthorized &&
+                  !isConnected &&
+                  isGoogleOAuthConnector(connectorType) && (
+                    <div className="w-full mt-2 flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-4 text-left">
+                      <AvatarSvgPreview
+                        config={getAvatarPresets()[0]}
+                        size={36}
+                        className="h-9 w-9 rounded-full"
+                        alt="Zero"
+                      />
+                      <div className="text-xs leading-relaxed text-muted-foreground space-y-1.5">
+                        <p>
+                          Google will show a security warning because
+                          we&rsquo;re still completing their app verification.
+                          This is a standard review process for new integrations
+                          and does not affect your security.
+                        </p>
+                        <p>
+                          To continue, select{" "}
+                          <strong className="text-foreground">Advanced</strong>{" "}
+                          then{" "}
+                          <strong className="text-foreground">
+                            Go to vm0.ai (unsafe)
+                          </strong>
+                          . We only request the minimum permissions needed, and
+                          your credentials are encrypted at rest.
+                        </p>
+                      </div>
+                    </div>
+                  )}
               </>
             )}
           </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -29,6 +29,42 @@ import {
 } from "./zero-directed-shared.tsx";
 
 // ---------------------------------------------------------------------------
+// Action button / authorized badge
+// ---------------------------------------------------------------------------
+
+function AuthorizeAction({
+  isAuthorized,
+  isConnecting,
+  agentName,
+  onAuthorize,
+}: {
+  isAuthorized: boolean;
+  isConnecting: boolean;
+  agentName: string;
+  onAuthorize: () => void;
+}) {
+  if (isAuthorized) {
+    return (
+      <div className="inline-flex h-9 w-[140px] items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
+        <IconCheck size={16} />
+        Authorized
+      </div>
+    );
+  }
+  return (
+    <button
+      type="button"
+      disabled={isConnecting}
+      onClick={onAuthorize}
+      className="inline-flex h-9 items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] px-4 text-sm font-medium text-white transition-colors hover:bg-[#d35400] disabled:opacity-60"
+    >
+      {isConnecting && <IconLoader2 size={14} className="animate-spin" />}
+      {isConnecting ? "Connecting..." : `Authorize ${agentName}`}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main card
 // ---------------------------------------------------------------------------
 
@@ -120,24 +156,12 @@ function DirectedAuthorizeCard() {
           </div>
           {!isLoading && (
             <div className="flex items-center justify-center">
-              {isAuthorized ? (
-                <div className="inline-flex h-9 w-[140px] items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
-                  <IconCheck size={16} />
-                  Authorized
-                </div>
-              ) : (
-                <button
-                  type="button"
-                  disabled={isConnecting}
-                  onClick={handleAuthorize}
-                  className="inline-flex h-9 items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] px-4 text-sm font-medium text-white transition-colors hover:bg-[#d35400] disabled:opacity-60"
-                >
-                  {isConnecting && (
-                    <IconLoader2 size={14} className="animate-spin" />
-                  )}
-                  {isConnecting ? "Connecting..." : `Authorize ${agentName}`}
-                </button>
-              )}
+              <AuthorizeAction
+                isAuthorized={isAuthorized}
+                isConnecting={isConnecting}
+                agentName={agentName}
+                onAuthorize={handleAuthorize}
+              />
             </div>
           )}
         </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -1,12 +1,9 @@
-import type { ReactNode } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   CONNECTOR_TYPES,
   type ConnectorType,
   isGoogleOAuthConnector,
 } from "@vm0/core";
-import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
-import { getAvatarPresets } from "./zero-avatars.ts";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
@@ -24,99 +21,12 @@ import {
   authorizeConnector$,
 } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
-import {
-  orgManageDialogOpen$,
-  setOrgManageDialogOpen$,
-} from "../../signals/zero-page/settings/org-manage-dialog.ts";
-import { OrgManageDialog } from "./components/org-manage/org-manage-dialog.tsx";
-import { ZeroOrgSwitcher } from "./zero-org-switcher.tsx";
-import { AccountDropdown } from "./zero-sidebar.tsx";
-import { VM0ClerkProvider } from "../clerk/clerk-provider.tsx";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import { Link } from "../router/link.tsx";
-
-// ---------------------------------------------------------------------------
-// Layout (shared with directed connect page)
-// ---------------------------------------------------------------------------
-
-function MinimalSidebarLayout({ children }: { children: ReactNode }) {
-  const onAccountAction = useSet(handleZeroAccountAction$);
-  const dialogOpen = useGet(orgManageDialogOpen$);
-  const setDialogOpen = useSet(setOrgManageDialogOpen$);
-  const pageSignal = useGet(pageSignal$);
-
-  return (
-    <div className="zero-app flex h-dvh w-full bg-background">
-      <OrgManageDialog
-        open={dialogOpen}
-        onOpenChange={(open) => {
-          detach(setDialogOpen(open, pageSignal), Reason.DomCallback);
-        }}
-      />
-      <VM0ClerkProvider>
-        <aside className="zero-nav hidden md:flex h-full w-[255px] shrink-0 flex-col bg-sidebar">
-          <div className="shrink-0 px-2 pt-1.5">
-            <ZeroOrgSwitcher />
-          </div>
-          <div className="flex-1" />
-          <div className="p-2">
-            <AccountDropdown onAccountAction={onAccountAction} />
-          </div>
-        </aside>
-      </VM0ClerkProvider>
-      <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg">
-        {children}
-      </div>
-    </div>
-  );
-}
-
-function Vm0Logo() {
-  return (
-    <svg
-      width="82"
-      height="20"
-      viewBox="0 0 100 30"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-label="VM0"
-    >
-      <path
-        d="M13.3915 0.0627979C13.2455 -0.0209506 13.0657 -0.020839 12.9198 0.0630906L1.0053 6.91543C0.692394 7.09539 0.690093 7.54442 1.00114 7.72755L12.9156 14.7423C13.0636 14.8295 13.2475 14.8296 13.3957 14.7426L25.3445 7.72785C25.6562 7.54485 25.6539 7.09497 25.3404 6.91514L13.3915 0.0627979Z"
-        fill="#ED4E01"
-      />
-      <path
-        d="M0.710495 8.33374L12.6479 15.2595C12.7944 15.3445 12.8846 15.5015 12.8846 15.6715L12.8843 29.5237C12.8843 29.8899 12.4897 30.1187 12.1741 29.9356L0.236691 23.0096C0.0902206 22.9246 -3.46036e-06 22.7676 0 22.5977L0.00028208 8.74568C0.000289537 8.37949 0.394855 8.15064 0.710495 8.33374Z"
-        fill="#ED4E01"
-      />
-      <path
-        d="M24.947 21.6772C24.947 21.9507 24.8017 22.2036 24.5655 22.3415L16.2103 27.219C15.6975 27.5184 15.0533 27.1485 15.0533 26.5547L15.0531 16.7842C15.0531 16.5107 15.1983 16.2578 15.4345 16.1199L23.7897 11.2425C24.3025 10.9431 24.9468 11.313 24.9468 11.9068L24.947 21.6772ZM13.6541 16.3426V29.5279C13.6541 29.8852 14.0308 30.1106 14.3391 29.9444L14.3538 29.9362L25.5769 23.3654C26.25 22.9808 26.3462 22.6924 26.3459 22.1188L26.3459 8.93378C26.3459 8.57084 25.9572 8.344 25.6462 8.52548L14.4231 15.0001C14.0385 15.2885 13.6539 15.577 13.6541 16.3426Z"
-        fill="#ED4E01"
-      />
-      <path
-        d="M25.9616 10.58L15.2113 28.4616L14.2308 27.8817L24.981 10.0001L25.9616 10.58Z"
-        fill="#ED4E01"
-      />
-      <path
-        d="M42.1865 25L34.3459 5H37.4651L43.7887 21.4575L50.1264 5H53.2315L45.3908 25H42.1865Z"
-        fill="currentColor"
-      />
-      <path
-        d="M66.9877 25L59.4023 10.3417V25H56.4957V5H59.6716L67.413 20.0628L75.1686 5H78.3304V25H75.438V10.3417L67.8526 25H66.9877Z"
-        fill="currentColor"
-      />
-      <path
-        d="M99.3459 22.1409C99.3459 22.5314 99.2703 22.9033 99.1191 23.2566C98.9678 23.6007 98.7599 23.9028 98.4952 24.1632C98.2305 24.4235 97.9186 24.6281 97.5594 24.7768C97.2097 24.9256 96.8363 25 96.4393 25H86.2735C85.8765 25 85.4984 24.9256 85.1392 24.7768C84.7894 24.6281 84.4822 24.4235 84.2176 24.1632C83.9529 23.9028 83.745 23.6007 83.5937 23.2566C83.4425 22.9033 83.3669 22.5314 83.3669 22.1409V7.85914C83.3669 7.46862 83.4425 7.10135 83.5937 6.75732C83.745 6.404 83.9529 6.10181 84.2176 5.85077C84.4822 5.59042 84.7894 5.38587 85.1392 5.2371C85.4984 5.07903 85.8765 5 86.2735 5H96.4393C96.8363 5 97.2097 5.07903 97.5594 5.2371C97.9186 5.38587 98.2305 5.59042 98.4952 5.85077C98.7599 6.10181 98.9678 6.404 99.1191 6.75732C99.2703 7.10135 99.3459 7.46862 99.3459 7.85914V22.1409ZM86.2735 7.85914V22.1409H96.4393V7.85914H86.2735Z"
-        fill="currentColor"
-      />
-      <path
-        d="M94.8994 6.79107L97.1494 8.06891L87.8973 23.8325L85.6473 22.5547L94.8994 6.79107Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-}
+import {
+  MinimalSidebarLayout,
+  Vm0LogoLink,
+  GoogleOAuthNotice,
+} from "./zero-directed-shared.tsx";
 
 // ---------------------------------------------------------------------------
 // Main card
@@ -164,10 +74,8 @@ function DirectedAuthorizeCard() {
 
   const handleAuthorize = () => {
     if (isConnected) {
-      // Connector already connected — just authorize for this agent
       detach(authorize(connectorType, agentId, signal), Reason.DomCallback);
     } else {
-      // Need to connect first, then authorize
       detach(
         (async () => {
           await connect(connectorType, signal);
@@ -181,9 +89,7 @@ function DirectedAuthorizeCard() {
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
-        <Link pathname="/connectors" className="no-underline text-foreground">
-          <Vm0Logo />
-        </Link>
+        <Vm0LogoLink />
         <div className="flex w-full flex-col gap-4">
           <div className="flex flex-col items-center gap-2.5">
             {isLoading ? (
@@ -207,32 +113,7 @@ function DirectedAuthorizeCard() {
                 {!isAuthorized &&
                   !isConnected &&
                   isGoogleOAuthConnector(connectorType) && (
-                    <div className="w-full mt-2 flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-4 text-left">
-                      <AvatarSvgPreview
-                        config={getAvatarPresets()[0]}
-                        size={36}
-                        className="h-9 w-9 rounded-full"
-                        alt="Zero"
-                      />
-                      <div className="text-xs leading-relaxed text-muted-foreground space-y-1.5">
-                        <p>
-                          Google will show a security warning because
-                          we&rsquo;re still completing their app verification.
-                          This is a standard review process for new integrations
-                          and does not affect your security.
-                        </p>
-                        <p>
-                          To continue, select{" "}
-                          <strong className="text-foreground">Advanced</strong>{" "}
-                          then{" "}
-                          <strong className="text-foreground">
-                            Go to vm0.ai (unsafe)
-                          </strong>
-                          . We only request the minimum permissions needed, and
-                          your credentials are encrypted at rest.
-                        </p>
-                      </div>
-                    </div>
+                    <GoogleOAuthNotice />
                   )}
               </>
             )}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -1,12 +1,9 @@
-import type { ReactNode } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   CONNECTOR_TYPES,
   type ConnectorType,
   isGoogleOAuthConnector,
 } from "@vm0/core";
-import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
-import { getAvatarPresets } from "./zero-avatars.ts";
 import { Input } from "@vm0/ui/components/ui/input";
 import {
   Dialog,
@@ -37,95 +34,12 @@ import {
 } from "../../signals/connectors-page/directed-connect-type.ts";
 import { authorizeConnector$ } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
-import {
-  orgManageDialogOpen$,
-  setOrgManageDialogOpen$,
-} from "../../signals/zero-page/settings/org-manage-dialog.ts";
-import { OrgManageDialog } from "./components/org-manage/org-manage-dialog.tsx";
-import { ZeroOrgSwitcher } from "./zero-org-switcher.tsx";
-import { AccountDropdown } from "./zero-sidebar.tsx";
-import { VM0ClerkProvider } from "../clerk/clerk-provider.tsx";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import { Link } from "../router/link.tsx";
-
-export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
-  const onAccountAction = useSet(handleZeroAccountAction$);
-  const dialogOpen = useGet(orgManageDialogOpen$);
-  const setDialogOpen = useSet(setOrgManageDialogOpen$);
-  const pageSignal = useGet(pageSignal$);
-
-  return (
-    <div className="zero-app flex h-dvh w-full bg-background">
-      <OrgManageDialog
-        open={dialogOpen}
-        onOpenChange={(open) => {
-          detach(setDialogOpen(open, pageSignal), Reason.DomCallback);
-        }}
-      />
-      <VM0ClerkProvider>
-        <aside className="zero-nav hidden md:flex h-full w-[255px] shrink-0 flex-col bg-sidebar">
-          <div className="shrink-0 px-2 pt-1.5">
-            <ZeroOrgSwitcher />
-          </div>
-          <div className="flex-1" />
-          <div className="p-2">
-            <AccountDropdown onAccountAction={onAccountAction} />
-          </div>
-        </aside>
-      </VM0ClerkProvider>
-      <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg">
-        {children}
-      </div>
-    </div>
-  );
-}
-
-function Vm0Logo() {
-  return (
-    <svg
-      width="82"
-      height="20"
-      viewBox="0 0 100 30"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-label="VM0"
-    >
-      <path
-        d="M13.3915 0.0627979C13.2455 -0.0209506 13.0657 -0.020839 12.9198 0.0630906L1.0053 6.91543C0.692394 7.09539 0.690093 7.54442 1.00114 7.72755L12.9156 14.7423C13.0636 14.8295 13.2475 14.8296 13.3957 14.7426L25.3445 7.72785C25.6562 7.54485 25.6539 7.09497 25.3404 6.91514L13.3915 0.0627979Z"
-        fill="#ED4E01"
-      />
-      <path
-        d="M0.710495 8.33374L12.6479 15.2595C12.7944 15.3445 12.8846 15.5015 12.8846 15.6715L12.8843 29.5237C12.8843 29.8899 12.4897 30.1187 12.1741 29.9356L0.236691 23.0096C0.0902206 22.9246 -3.46036e-06 22.7676 0 22.5977L0.00028208 8.74568C0.000289537 8.37949 0.394855 8.15064 0.710495 8.33374Z"
-        fill="#ED4E01"
-      />
-      <path
-        d="M24.947 21.6772C24.947 21.9507 24.8017 22.2036 24.5655 22.3415L16.2103 27.219C15.6975 27.5184 15.0533 27.1485 15.0533 26.5547L15.0531 16.7842C15.0531 16.5107 15.1983 16.2578 15.4345 16.1199L23.7897 11.2425C24.3025 10.9431 24.9468 11.313 24.9468 11.9068L24.947 21.6772ZM13.6541 16.3426V29.5279C13.6541 29.8852 14.0308 30.1106 14.3391 29.9444L14.3538 29.9362L25.5769 23.3654C26.25 22.9808 26.3462 22.6924 26.3459 22.1188L26.3459 8.93378C26.3459 8.57084 25.9572 8.344 25.6462 8.52548L14.4231 15.0001C14.0385 15.2885 13.6539 15.577 13.6541 16.3426Z"
-        fill="#ED4E01"
-      />
-      <path
-        d="M25.9616 10.58L15.2113 28.4616L14.2308 27.8817L24.981 10.0001L25.9616 10.58Z"
-        fill="#ED4E01"
-      />
-      <path
-        d="M42.1865 25L34.3459 5H37.4651L43.7887 21.4575L50.1264 5H53.2315L45.3908 25H42.1865Z"
-        fill="currentColor"
-      />
-      <path
-        d="M66.9877 25L59.4023 10.3417V25H56.4957V5H59.6716L67.413 20.0628L75.1686 5H78.3304V25H75.438V10.3417L67.8526 25H66.9877Z"
-        fill="currentColor"
-      />
-      <path
-        d="M99.3459 22.1409C99.3459 22.5314 99.2703 22.9033 99.1191 23.2566C98.9678 23.6007 98.7599 23.9028 98.4952 24.1632C98.2305 24.4235 97.9186 24.6281 97.5594 24.7768C97.2097 24.9256 96.8363 25 96.4393 25H86.2735C85.8765 25 85.4984 24.9256 85.1392 24.7768C84.7894 24.6281 84.4822 24.4235 84.2176 24.1632C83.9529 23.9028 83.745 23.6007 83.5937 23.2566C83.4425 22.9033 83.3669 22.5314 83.3669 22.1409V7.85914C83.3669 7.46862 83.4425 7.10135 83.5937 6.75732C83.745 6.404 83.9529 6.10181 84.2176 5.85077C84.4822 5.59042 84.7894 5.38587 85.1392 5.2371C85.4984 5.07903 85.8765 5 86.2735 5H96.4393C96.8363 5 97.2097 5.07903 97.5594 5.2371C97.9186 5.38587 98.2305 5.59042 98.4952 5.85077C98.7599 6.10181 98.9678 6.404 99.1191 6.75732C99.2703 7.10135 99.3459 7.46862 99.3459 7.85914V22.1409ZM86.2735 7.85914V22.1409H96.4393V7.85914H86.2735Z"
-        fill="currentColor"
-      />
-      <path
-        d="M94.8994 6.79107L97.1494 8.06891L87.8973 23.8325L85.6473 22.5547L94.8994 6.79107Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-}
+import {
+  MinimalSidebarLayout,
+  Vm0LogoLink,
+  GoogleOAuthNotice,
+} from "./zero-directed-shared.tsx";
 
 function renderMarkdown(text: string): string {
   return text
@@ -316,9 +230,7 @@ function DirectedConnectCard() {
     <>
       <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
         <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
-          <Link pathname="/connectors" className="no-underline text-foreground">
-            <Vm0Logo />
-          </Link>
+          <Vm0LogoLink />
           <div className="flex w-full flex-col gap-4">
             <div className="flex flex-col items-center gap-2.5">
               {isLoading ? (
@@ -340,32 +252,7 @@ function DirectedConnectCard() {
                     {config.helpText}
                   </p>
                   {!isConnected && isGoogleOAuthConnector(connectorType) && (
-                    <div className="w-full mt-2 flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-4 text-left">
-                      <AvatarSvgPreview
-                        config={getAvatarPresets()[0]}
-                        size={36}
-                        className="h-9 w-9 rounded-full"
-                        alt="Zero"
-                      />
-                      <div className="text-xs leading-relaxed text-muted-foreground space-y-1.5">
-                        <p>
-                          Google will show a security warning because
-                          we&rsquo;re still completing their app verification.
-                          This is a standard review process for new integrations
-                          and does not affect your security.
-                        </p>
-                        <p>
-                          To continue, select{" "}
-                          <strong className="text-foreground">Advanced</strong>{" "}
-                          then{" "}
-                          <strong className="text-foreground">
-                            Go to vm0.ai (unsafe)
-                          </strong>
-                          . We only request the minimum permissions needed, and
-                          your credentials are encrypted at rest.
-                        </p>
-                      </div>
-                    </div>
+                    <GoogleOAuthNotice />
                   )}
                 </>
               )}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -1,6 +1,12 @@
 import type { ReactNode } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorType,
+  isGoogleOAuthConnector,
+} from "@vm0/core";
+import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
+import { getAvatarPresets } from "./zero-avatars.ts";
 import { Input } from "@vm0/ui/components/ui/input";
 import {
   Dialog,
@@ -333,6 +339,34 @@ function DirectedConnectCard() {
                   <p className="w-60 text-sm text-muted-foreground">
                     {config.helpText}
                   </p>
+                  {!isConnected && isGoogleOAuthConnector(connectorType) && (
+                    <div className="w-full mt-2 flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-4 text-left">
+                      <AvatarSvgPreview
+                        config={getAvatarPresets()[0]}
+                        size={36}
+                        className="h-9 w-9 rounded-full"
+                        alt="Zero"
+                      />
+                      <div className="text-xs leading-relaxed text-muted-foreground space-y-1.5">
+                        <p>
+                          Google will show a security warning because
+                          we&rsquo;re still completing their app verification.
+                          This is a standard review process for new integrations
+                          and does not affect your security.
+                        </p>
+                        <p>
+                          To continue, select{" "}
+                          <strong className="text-foreground">Advanced</strong>{" "}
+                          then{" "}
+                          <strong className="text-foreground">
+                            Go to vm0.ai (unsafe)
+                          </strong>
+                          . We only request the minimum permissions needed, and
+                          your credentials are encrypted at rest.
+                        </p>
+                      </div>
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -1,0 +1,123 @@
+import type { ReactNode } from "react";
+import { useGet, useSet } from "ccstate-react";
+import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
+import { getAvatarPresets } from "./zero-avatars.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
+import {
+  orgManageDialogOpen$,
+  setOrgManageDialogOpen$,
+} from "../../signals/zero-page/settings/org-manage-dialog.ts";
+import { OrgManageDialog } from "./components/org-manage/org-manage-dialog.tsx";
+import { ZeroOrgSwitcher } from "./zero-org-switcher.tsx";
+import { AccountDropdown } from "./zero-sidebar.tsx";
+import { VM0ClerkProvider } from "../clerk/clerk-provider.tsx";
+import { Link } from "../router/link.tsx";
+
+export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
+  const onAccountAction = useSet(handleZeroAccountAction$);
+  const dialogOpen = useGet(orgManageDialogOpen$);
+  const setDialogOpen = useSet(setOrgManageDialogOpen$);
+  const pageSignal = useGet(pageSignal$);
+
+  return (
+    <div className="zero-app flex h-dvh w-full bg-background">
+      <OrgManageDialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          detach(setDialogOpen(open, pageSignal), Reason.DomCallback);
+        }}
+      />
+      <VM0ClerkProvider>
+        <aside className="zero-nav hidden md:flex h-full w-[255px] shrink-0 flex-col bg-sidebar">
+          <div className="shrink-0 px-2 pt-1.5">
+            <ZeroOrgSwitcher />
+          </div>
+          <div className="flex-1" />
+          <div className="p-2">
+            <AccountDropdown onAccountAction={onAccountAction} />
+          </div>
+        </aside>
+      </VM0ClerkProvider>
+      <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function Vm0LogoLink() {
+  return (
+    <Link pathname="/connectors" className="no-underline text-foreground">
+      <svg
+        width="82"
+        height="20"
+        viewBox="0 0 100 30"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-label="VM0"
+      >
+        <path
+          d="M13.3915 0.0627979C13.2455 -0.0209506 13.0657 -0.020839 12.9198 0.0630906L1.0053 6.91543C0.692394 7.09539 0.690093 7.54442 1.00114 7.72755L12.9156 14.7423C13.0636 14.8295 13.2475 14.8296 13.3957 14.7426L25.3445 7.72785C25.6562 7.54485 25.6539 7.09497 25.3404 6.91514L13.3915 0.0627979Z"
+          fill="#ED4E01"
+        />
+        <path
+          d="M0.710495 8.33374L12.6479 15.2595C12.7944 15.3445 12.8846 15.5015 12.8846 15.6715L12.8843 29.5237C12.8843 29.8899 12.4897 30.1187 12.1741 29.9356L0.236691 23.0096C0.0902206 22.9246 -3.46036e-06 22.7676 0 22.5977L0.00028208 8.74568C0.000289537 8.37949 0.394855 8.15064 0.710495 8.33374Z"
+          fill="#ED4E01"
+        />
+        <path
+          d="M24.947 21.6772C24.947 21.9507 24.8017 22.2036 24.5655 22.3415L16.2103 27.219C15.6975 27.5184 15.0533 27.1485 15.0533 26.5547L15.0531 16.7842C15.0531 16.5107 15.1983 16.2578 15.4345 16.1199L23.7897 11.2425C24.3025 10.9431 24.9468 11.313 24.9468 11.9068L24.947 21.6772ZM13.6541 16.3426V29.5279C13.6541 29.8852 14.0308 30.1106 14.3391 29.9444L14.3538 29.9362L25.5769 23.3654C26.25 22.9808 26.3462 22.6924 26.3459 22.1188L26.3459 8.93378C26.3459 8.57084 25.9572 8.344 25.6462 8.52548L14.4231 15.0001C14.0385 15.2885 13.6539 15.577 13.6541 16.3426Z"
+          fill="#ED4E01"
+        />
+        <path
+          d="M25.9616 10.58L15.2113 28.4616L14.2308 27.8817L24.981 10.0001L25.9616 10.58Z"
+          fill="#ED4E01"
+        />
+        <path
+          d="M42.1865 25L34.3459 5H37.4651L43.7887 21.4575L50.1264 5H53.2315L45.3908 25H42.1865Z"
+          fill="currentColor"
+        />
+        <path
+          d="M66.9877 25L59.4023 10.3417V25H56.4957V5H59.6716L67.413 20.0628L75.1686 5H78.3304V25H75.438V10.3417L67.8526 25H66.9877Z"
+          fill="currentColor"
+        />
+        <path
+          d="M99.3459 22.1409C99.3459 22.5314 99.2703 22.9033 99.1191 23.2566C98.9678 23.6007 98.7599 23.9028 98.4952 24.1632C98.2305 24.4235 97.9186 24.6281 97.5594 24.7768C97.2097 24.9256 96.8363 25 96.4393 25H86.2735C85.8765 25 85.4984 24.9256 85.1392 24.7768C84.7894 24.6281 84.4822 24.4235 84.2176 24.1632C83.9529 23.9028 83.745 23.6007 83.5937 23.2566C83.4425 22.9033 83.3669 22.5314 83.3669 22.1409V7.85914C83.3669 7.46862 83.4425 7.10135 83.5937 6.75732C83.745 6.404 83.9529 6.10181 84.2176 5.85077C84.4822 5.59042 84.7894 5.38587 85.1392 5.2371C85.4984 5.07903 85.8765 5 86.2735 5H96.4393C96.8363 5 97.2097 5.07903 97.5594 5.2371C97.9186 5.38587 98.2305 5.59042 98.4952 5.85077C98.7599 6.10181 98.9678 6.404 99.1191 6.75732C99.2703 7.10135 99.3459 7.46862 99.3459 7.85914V22.1409ZM86.2735 7.85914V22.1409H96.4393V7.85914H86.2735Z"
+          fill="currentColor"
+        />
+        <path
+          d="M94.8994 6.79107L97.1494 8.06891L87.8973 23.8325L85.6473 22.5547L94.8994 6.79107Z"
+          fill="currentColor"
+        />
+      </svg>
+    </Link>
+  );
+}
+
+export function GoogleOAuthNotice() {
+  return (
+    <div className="w-full mt-2 flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-4 text-left">
+      <AvatarSvgPreview
+        config={getAvatarPresets()[0]}
+        size={36}
+        className="h-9 w-9 rounded-full"
+        alt="Zero"
+      />
+      <div className="text-xs leading-relaxed text-muted-foreground space-y-1.5">
+        <p>
+          Google will show a security warning because we&rsquo;re still
+          completing their app verification. This is a standard review process
+          for new integrations and does not affect your security.
+        </p>
+        <p>
+          To continue, select{" "}
+          <strong className="text-foreground">Advanced</strong> then{" "}
+          <strong className="text-foreground">Go to vm0.ai (unsafe)</strong>. We
+          only request the minimum permissions needed, and your credentials are
+          encrypted at rest.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -13,7 +13,11 @@ import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
 import zeroAnimatedSrc from "./assets/zero-animated.webp";
 import slackPreviewImg from "./assets/Slack.png";
 import { Button, Input } from "@vm0/ui";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorType,
+  isGoogleOAuthConnector,
+} from "@vm0/core";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   zeroWorkspaceName$,
@@ -257,7 +261,10 @@ function ConnectStepContent() {
     if (connector?.connected) {
       return;
     }
-    if (connector?.availableAuthMethods.includes("api-token")) {
+    if (
+      connector?.availableAuthMethods.includes("api-token") ||
+      isGoogleOAuthConnector(type)
+    ) {
       setSelectedConnector(type);
     } else {
       // During onboarding the backend authorizes connectors for the default

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -318,12 +318,13 @@ describe("isGoogleOAuthConnector", () => {
 
       if (result) {
         // If classified as Google, the OAuth URL must point to accounts.google.com
+        const authorizationUrl = oauthConfig?.authorizationUrl;
         expect(
-          oauthConfig?.authorizationUrl,
+          authorizationUrl,
           `${type}: Google connector must have an authorizationUrl`,
         ).toBeDefined();
         expect(
-          new URL(oauthConfig!.authorizationUrl).hostname,
+          new URL(authorizationUrl as string).hostname,
           `${type}: Google connector authorizationUrl must use accounts.google.com`,
         ).toBe("accounts.google.com");
       } else if (oauthConfig?.authorizationUrl) {

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -8,6 +8,7 @@ import {
   getConnectorProvidedSecretNames,
   getConnectorAuthMethods,
   getConnectorOAuthConfig,
+  isGoogleOAuthConnector,
 } from "../connector-utils";
 
 describe("hasRequiredScopes", () => {
@@ -268,5 +269,92 @@ describe("getConnectorTypeForSecretName", () => {
 
   it("returns null for unknown secret name", () => {
     expect(getConnectorTypeForSecretName("UNKNOWN_SECRET")).toBeNull();
+  });
+});
+
+describe("isGoogleOAuthConnector", () => {
+  const GOOGLE_CONNECTORS = [
+    "gmail",
+    "google-sheets",
+    "google-docs",
+    "google-drive",
+    "google-calendar",
+    "google-meet",
+  ] as const;
+
+  it("returns true for all known Google OAuth connectors", () => {
+    for (const type of GOOGLE_CONNECTORS) {
+      expect(
+        isGoogleOAuthConnector(type),
+        `${type} should be identified as a Google OAuth connector`,
+      ).toBe(true);
+    }
+  });
+
+  it("returns false for non-Google OAuth connectors", () => {
+    const nonGoogleOAuth = ["github", "notion", "slack", "linear"] as const;
+    for (const type of nonGoogleOAuth) {
+      expect(
+        isGoogleOAuthConnector(type),
+        `${type} should not be identified as a Google OAuth connector`,
+      ).toBe(false);
+    }
+  });
+
+  it("returns false for api-token-only connectors", () => {
+    const apiTokenOnly = ["axiom", "atlassian", "ahrefs"] as const;
+    for (const type of apiTokenOnly) {
+      expect(
+        isGoogleOAuthConnector(type),
+        `${type} has no OAuth config and should return false`,
+      ).toBe(false);
+    }
+  });
+
+  it("returns true only for connectors whose OAuth authorizationUrl hostname is accounts.google.com", () => {
+    for (const type of connectorTypeSchema.options) {
+      const result = isGoogleOAuthConnector(type);
+      const oauthConfig = getConnectorOAuthConfig(type);
+
+      if (result) {
+        // If classified as Google, the OAuth URL must point to accounts.google.com
+        expect(
+          oauthConfig?.authorizationUrl,
+          `${type}: Google connector must have an authorizationUrl`,
+        ).toBeDefined();
+        expect(
+          new URL(oauthConfig!.authorizationUrl).hostname,
+          `${type}: Google connector authorizationUrl must use accounts.google.com`,
+        ).toBe("accounts.google.com");
+      } else if (oauthConfig?.authorizationUrl) {
+        // If not classified as Google but has an OAuth URL, it must NOT be accounts.google.com
+        let hostname: string | null = null;
+        try {
+          hostname = new URL(oauthConfig.authorizationUrl).hostname;
+        } catch {
+          // invalid URL — isGoogleOAuthConnector correctly returns false
+        }
+        if (hostname) {
+          expect(
+            hostname,
+            `${type}: non-Google connector must not use accounts.google.com`,
+          ).not.toBe("accounts.google.com");
+        }
+      }
+    }
+  });
+
+  it("covers exactly the same set as the legacy hardcoded type list", () => {
+    // Ensures isGoogleOAuthConnector detects at least the 6 connectors
+    // previously handled by the hardcoded isGoogleConnector function.
+    const detected = connectorTypeSchema.options.filter(isGoogleOAuthConnector);
+    for (const type of GOOGLE_CONNECTORS) {
+      expect(
+        detected,
+        `${type} must be detected by isGoogleOAuthConnector`,
+      ).toContain(type);
+    }
+    // No non-Google connector should slip through
+    expect(detected.length).toBe(GOOGLE_CONNECTORS.length);
   });
 });

--- a/turbo/packages/core/src/contracts/connector-utils.ts
+++ b/turbo/packages/core/src/contracts/connector-utils.ts
@@ -164,7 +164,14 @@ export function getConnectorOAuthConfig(
  */
 export function isGoogleOAuthConnector(type: ConnectorType): boolean {
   const oauthConfig = getConnectorOAuthConfig(type);
-  return !!oauthConfig?.authorizationUrl?.includes("accounts.google.com");
+  if (!oauthConfig?.authorizationUrl) return false;
+  try {
+    return (
+      new URL(oauthConfig.authorizationUrl).hostname === "accounts.google.com"
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/turbo/packages/core/src/contracts/connector-utils.ts
+++ b/turbo/packages/core/src/contracts/connector-utils.ts
@@ -160,6 +160,14 @@ export function getConnectorOAuthConfig(
 }
 
 /**
+ * Check if a connector type uses Google OAuth (accounts.google.com).
+ */
+export function isGoogleOAuthConnector(type: ConnectorType): boolean {
+  const oauthConfig = getConnectorOAuthConfig(type);
+  return !!oauthConfig?.authorizationUrl?.includes("accounts.google.com");
+}
+
+/**
  * Check if stored OAuth scopes cover all required scopes for a connector type.
  * Returns true if no OAuth config exists (non-OAuth connector) or all required scopes are present.
  * Returns false if storedScopes is null (legacy connector) or missing any required scope.

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -382,6 +382,7 @@ export {
   getConnectorManagedSecretNames,
   getConnectorTypeForSecretName,
   getConnectorOAuthConfig,
+  isGoogleOAuthConnector,
   hasRequiredScopes,
   getScopeDiff,
   type ScopeDiff,


### PR DESCRIPTION
## Summary
- Google connectors now show an informational notice (with Zero avatar) explaining the unverified app warning before initiating OAuth
- Users see step-by-step instructions to click **Advanced** → **Go to vm0.ai (unsafe)**
- Covers all connector OAuth entry points: connectors page dialog, onboarding flow, directed connect page, and directed authorize page
- Adds `isGoogleOAuthConnector()` utility to `@vm0/core` that detects Google connectors by OAuth authorization URL

## Test plan
- [ ] Go to `/connectors`, click any Google connector (Gmail, Google Sheets, etc.) — should show dialog with Zero avatar and verification notice before OAuth
- [ ] Go through onboarding flow, connect a Google connector — should show the same dialog
- [ ] Visit `/connectors/gmail/connect` — should show inline notice with Zero avatar
- [ ] Visit `/connectors/gmail/authorize?agentId=...` — should show inline notice with Zero avatar
- [ ] Click a non-Google connector (e.g. GitHub) — should behave as before (no dialog for OAuth-only connectors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)