### PR TITLE
refactor(runner): split image hash into rootfs_hash and snapshot_hash

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -301,7 +301,8 @@ jobs:
     outputs:
       host: ${{ needs.detect.outputs.metal-host }}
       job-ref: ${{ needs.detect.outputs.metal-job-ref }}
-      default-image-hash: ${{ steps.build.outputs.default-image-hash }}
+      default-rootfs-hash: ${{ steps.build.outputs.default-rootfs-hash }}
+      default-snapshot-hash: ${{ steps.build.outputs.default-snapshot-hash }}
     steps:
       - uses: actions/checkout@v6
 
@@ -312,7 +313,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # IMPORTANT: these compile settings (--release, default linker, no
-      # custom RUSTFLAGS) must match release-please.yml so image_hash is
+      # custom RUSTFLAGS) must match release-please.yml so rootfs_hash is
       # identical across pipelines and R2 cache hits on deploy. See #9192.
       - name: Cross-compile guest binaries for ARM64
         run: |
@@ -412,14 +413,16 @@ jobs:
             R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY}' \
             R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME}' \
             ${BIN_DIR}/runner build --profile vm0/default" | tee "$BUILD_LOG_DEFAULT"
-          DEFAULT_IMAGE_HASH=$(grep '^image_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
+          DEFAULT_ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
+          DEFAULT_SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
           rm -f "$BUILD_LOG_DEFAULT"
 
-          if [ -z "$DEFAULT_IMAGE_HASH" ]; then
-            echo "ERROR: Failed to extract default image hash"
+          if [ -z "$DEFAULT_ROOTFS_HASH" ] || [ -z "$DEFAULT_SNAPSHOT_HASH" ]; then
+            echo "ERROR: Failed to extract rootfs_hash or snapshot_hash"
             exit 1
           fi
-          echo "default-image-hash=${DEFAULT_IMAGE_HASH}" >> "$GITHUB_OUTPUT"
+          echo "default-rootfs-hash=${DEFAULT_ROOTFS_HASH}" >> "$GITHUB_OUTPUT"
+          echo "default-snapshot-hash=${DEFAULT_SNAPSHOT_HASH}" >> "$GITHUB_OUTPUT"
 
   runner-benchmark:
     runs-on: ubuntu-latest
@@ -441,7 +444,8 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          DEFAULT_IMAGE_HASH: ${{ needs.runner-build.outputs.default-image-hash }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
@@ -453,7 +457,8 @@ jobs:
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
             --profile vm0/default \
-            --image-hash ${DEFAULT_IMAGE_HASH} \
+            --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+            --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
             --name ${JOB_REF}-bench \
             --group vm0/development-${JOB_REF} \
             --runner-dirname ${JOB_REF}-bench \
@@ -496,7 +501,8 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          DEFAULT_IMAGE_HASH: ${{ needs.runner-build.outputs.default-image-hash }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
@@ -506,7 +512,8 @@ jobs:
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
             --profile vm0/default \
-            --image-hash ${DEFAULT_IMAGE_HASH} \
+            --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+            --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
             --name ${JOB_REF}-exec \
             --group vm0/exec-${JOB_REF} \
             --runner-dirname ${JOB_REF}-exec \
@@ -757,7 +764,8 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          DEFAULT_IMAGE_HASH: ${{ needs.runner-build.outputs.default-image-hash }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
@@ -767,7 +775,8 @@ jobs:
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
             --profile vm0/default \
-            --image-hash ${DEFAULT_IMAGE_HASH} \
+            --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+            --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
             --name ${JOB_REF}-cancel \
             --group vm0/cancel-${JOB_REF} \
             --runner-dirname ${JOB_REF}-cancel \
@@ -868,7 +877,8 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          DEFAULT_IMAGE_HASH: ${{ needs.runner-build.outputs.default-image-hash }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
@@ -878,7 +888,8 @@ jobs:
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
             --profile vm0/default \
-            --image-hash ${DEFAULT_IMAGE_HASH} \
+            --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+            --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
             --name ${JOB_REF}-balloon \
             --group vm0/balloon-${JOB_REF} \
             --runner-dirname ${JOB_REF}-balloon \
@@ -1076,7 +1087,8 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          DEFAULT_IMAGE_HASH: ${{ needs.runner-build.outputs.default-image-hash }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
@@ -1088,7 +1100,8 @@ jobs:
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
               --profile vm0/default \
-              --image-hash ${DEFAULT_IMAGE_HASH} \
+              --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+              --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
               --name ${JOB_REF}-${SUFFIX} \
               --group ${GROUP} \
               --runner-dirname ${JOB_REF}-${SUFFIX} \
@@ -1192,7 +1205,8 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          DEFAULT_IMAGE_HASH: ${{ needs.runner-build.outputs.default-image-hash }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
@@ -1202,7 +1216,8 @@ jobs:
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
             --profile vm0/default \
-            --image-hash ${DEFAULT_IMAGE_HASH} \
+            --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+            --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
             --name ${JOB_REF}-keepalive \
             --group vm0/keepalive-${JOB_REF} \
             --runner-dirname ${JOB_REF}-keepalive \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -881,7 +881,7 @@ jobs:
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       # IMPORTANT: these compile settings (--release, default linker, no
-      # custom RUSTFLAGS) must match crates.yml / turbo.yml so image_hash is
+      # custom RUSTFLAGS) must match crates.yml / turbo.yml so rootfs_hash is
       # identical across pipelines and R2 cache hits on deploy. See #9192.
       - name: Cross-compile guest binaries for ARM64
         run: |

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1363,7 +1363,8 @@ jobs:
       runner-dir: ${{ steps.host.outputs.runner-dir }}
       runner-matrix: ${{ steps.runner-matrix.outputs.matrix }}
       chunk-count: ${{ steps.runner-matrix.outputs.chunk-count }}
-      image-hash-map: ${{ steps.deploy.outputs.image-hash-map }}
+      rootfs-hash-map: ${{ steps.deploy.outputs.rootfs-hash-map }}
+      snapshot-hash-map: ${{ steps.deploy.outputs.snapshot-hash-map }}
     steps:
       - uses: actions/checkout@v6
 
@@ -1375,7 +1376,7 @@ jobs:
           save-if: false
 
       # IMPORTANT: these compile settings (--release, default linker, no
-      # custom RUSTFLAGS) must match release-please.yml so image_hash is
+      # custom RUSTFLAGS) must match release-please.yml so rootfs_hash is
       # identical across pipelines and R2 cache hits on deploy. See #9192.
       - name: Cross-compile guest binaries for ARM64
         run: |
@@ -1557,20 +1558,24 @@ jobs:
             exit 1
           fi
 
-          # Extract per-host build hashes — they may differ across hosts
-          # because the image hash includes the host kernel version and CPU model.
-          HASH_MAP=$(jq -n '{}')
+          # Extract per-host build hashes — rootfs hash is shared (R2 cached),
+          # snapshot hash may differ across hosts.
+          ROOTFS_MAP=$(jq -n '{}')
+          SNAPSHOT_MAP=$(jq -n '{}')
           for HOST in "${HOSTS[@]}"; do
-            HASH=$(grep '^image_hash=' "${LOG_DIR}/${HOST}.log" | cut -d= -f2)
-            if [ -z "$HASH" ]; then
-              echo "::error::Failed to extract image hash from ${HOST} log"
+            ROOTFS_HASH=$(grep '^rootfs_hash=' "${LOG_DIR}/${HOST}.log" | cut -d= -f2)
+            SNAPSHOT_HASH=$(grep '^snapshot_hash=' "${LOG_DIR}/${HOST}.log" | cut -d= -f2)
+            if [ -z "$ROOTFS_HASH" ] || [ -z "$SNAPSHOT_HASH" ]; then
+              echo "::error::Failed to extract rootfs/snapshot hash from ${HOST} log"
               rm -rf "$LOG_DIR"
               exit 1
             fi
-            HASH_MAP=$(echo "$HASH_MAP" | jq -c --arg h "$HOST" --arg v "$HASH" '. + {($h): $v}')
+            ROOTFS_MAP=$(echo "$ROOTFS_MAP" | jq -c --arg h "$HOST" --arg v "$ROOTFS_HASH" '. + {($h): $v}')
+            SNAPSHOT_MAP=$(echo "$SNAPSHOT_MAP" | jq -c --arg h "$HOST" --arg v "$SNAPSHOT_HASH" '. + {($h): $v}')
           done
           rm -rf "$LOG_DIR"
-          echo "image-hash-map=${HASH_MAP}" >> "$GITHUB_OUTPUT"
+          echo "rootfs-hash-map=${ROOTFS_MAP}" >> "$GITHUB_OUTPUT"
+          echo "snapshot-hash-map=${SNAPSHOT_MAP}" >> "$GITHUB_OUTPUT"
 
   # Deploy runner start: generate config with real preview URL and start service
   # Waits for both deploy-runner-prepare (binaries + image) and deploy-web (preview URL)
@@ -1612,7 +1617,8 @@ jobs:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
-          IMAGE_HASH_MAP: ${{ needs.deploy-runner-prepare.outputs.image-hash-map }}
+          ROOTFS_HASH_MAP: ${{ needs.deploy-runner-prepare.outputs.rootfs-hash-map }}
+          SNAPSHOT_HASH_MAP: ${{ needs.deploy-runner-prepare.outputs.snapshot-hash-map }}
           PREVIEW_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
@@ -1623,11 +1629,13 @@ jobs:
             local REMOTE="${METAL_USER}@${HOST}"
             echo "=== Starting runner ${RUNNER_NAME} on ${HOST} ==="
 
-            # Look up per-host image hash (differs across kernel versions)
-            local IMAGE_HASH
-            IMAGE_HASH=$(echo "$IMAGE_HASH_MAP" | jq -r --arg h "$HOST" '.[$h]')
-            if [ -z "$IMAGE_HASH" ] || [ "$IMAGE_HASH" = "null" ]; then
-              echo "::error::No image hash found for ${HOST} in hash map"
+            # Look up per-host hashes
+            local ROOTFS_HASH SNAPSHOT_HASH
+            ROOTFS_HASH=$(echo "$ROOTFS_HASH_MAP" | jq -r --arg h "$HOST" '.[$h]')
+            SNAPSHOT_HASH=$(echo "$SNAPSHOT_HASH_MAP" | jq -r --arg h "$HOST" '.[$h]')
+            if [ -z "$ROOTFS_HASH" ] || [ "$ROOTFS_HASH" = "null" ] \
+                || [ -z "$SNAPSHOT_HASH" ] || [ "$SNAPSHOT_HASH" = "null" ]; then
+              echo "::error::No rootfs/snapshot hash found for ${HOST} in hash map"
               return 1
             fi
 
@@ -1642,7 +1650,8 @@ jobs:
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
               --profile vm0/default \
-              --image-hash ${IMAGE_HASH} \
+              --rootfs-hash ${ROOTFS_HASH} \
+              --snapshot-hash ${SNAPSHOT_HASH} \
               --name ${RUNNER_NAME} \
               --group vm0/development-${JOB_REF} \
               --runner-dirname ${JOB_REF} \

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -66,9 +66,10 @@
         R2_USER_STORAGES_BUCKET_NAME: "{{ r2_bucket | default('') }}"
       register: default_build_output
 
-    - name: Parse default build hash
+    - name: Parse default build hashes
       set_fact:
-        default_image_hash: "{{ default_build_output.stdout_lines | select('match', '^image_hash=') | first | regex_replace('^image_hash=', '') }}"
+        default_rootfs_hash: "{{ default_build_output.stdout_lines | select('match', '^rootfs_hash=') | first | regex_replace('^rootfs_hash=', '') }}"
+        default_snapshot_hash: "{{ default_build_output.stdout_lines | select('match', '^snapshot_hash=') | first | regex_replace('^snapshot_hash=', '') }}"
 
     # ========================================
     # Phase 3: Configure + Install
@@ -77,7 +78,8 @@
       command: >
         {{ bin_dir }}/runner config
         --profile vm0/default
-        --image-hash {{ default_image_hash }}
+        --rootfs-hash {{ default_rootfs_hash }}
+        --snapshot-hash {{ default_snapshot_hash }}
         --name {{ runner_name }}
         --group {{ runner_group }}
         --runner-dirname {{ runner_name }}

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -63,10 +63,9 @@ pub async fn run_benchmark(
         .clone();
     // Block until memory.bin is in page cache so benchmark numbers are stable.
     {
-        let path = home
-            .images_dir()
-            .join(&default_profile.image_hash)
-            .join("memory.bin");
+        let path = crate::paths::RootfsPaths::new(&home, &default_profile.rootfs_hash)
+            .snapshot(&default_profile.snapshot_hash)
+            .memory_bin();
         let _ = tokio::task::spawn_blocking(move || prefetch::prefetch_memory(&path)).await;
     }
 

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -8,7 +8,7 @@ use crate::ca;
 use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
-use crate::paths::{HomePaths, ImagePaths, touch_mtime};
+use crate::paths::{HomePaths, RootfsPaths, touch_mtime};
 use crate::profile;
 use crate::r2_cache::R2ImageCache;
 
@@ -16,13 +16,13 @@ const BUILD_SCRIPT: &str = include_str!("../../scripts/build-rootfs.sh");
 const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
 const INJECT_CA_SCRIPT: &str = include_str!("../../scripts/inject-ca.sh");
 
-/// Bump this to invalidate all cached images without changing any input files.
-/// Affects both the local cache directory and the R2 object key (since the
-/// version seeds the hash that names both).
+/// Bump to invalidate all cached rootfs images (R2 + local).
 ///
-/// Bumping leaves the previous-hash R2 objects orphaned; they're swept by
-/// `runner gc` after the configured TTL (see `r2_cache::gc_older_than`).
-const IMAGE_CACHE_VERSION: u32 = 3;
+/// Bumping orphans previous R2 objects; swept by `runner gc` after TTL.
+const ROOTFS_CACHE_VERSION: u32 = 1;
+
+/// Bump to invalidate all cached snapshots (local only; R2 stores rootfs only).
+const SNAPSHOT_CACHE_VERSION: u32 = 1;
 
 #[cfg(bundled_guests)]
 mod embedded {
@@ -166,11 +166,20 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         ),
     ];
 
-    // Compute rootfs-only image hash (snapshot is always created locally).
-    let hash = compute_image_hash(&bins, def.disk_mb).await?;
-    tracing::info!("image hash: {hash}");
-    // Machine-readable output — do not change format without updating consumers
-    println!("image_hash={hash}");
+    // Compute two separate hashes: rootfs (R2-cacheable) and snapshot (local only).
+    let rootfs_hash = compute_rootfs_hash(&bins, def.disk_mb).await?;
+    let snapshot_hash = compute_snapshot_hash(
+        &rootfs_hash,
+        def.vcpu,
+        def.memory_mb,
+        FIRECRACKER_VERSION,
+        KERNEL_VERSION,
+        &provider.config_hash(),
+    );
+    tracing::info!("rootfs_hash: {rootfs_hash}, snapshot_hash: {snapshot_hash}");
+    // Machine-readable output — consumed by CI workflows and ansible playbook.
+    println!("rootfs_hash={rootfs_hash}");
+    println!("snapshot_hash={snapshot_hash}");
 
     if dry_run {
         return Ok(());
@@ -181,12 +190,18 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
     // Ensure CA exists — rootfs build embeds the CA cert into the image.
     ca::ensure(&paths).await?;
 
-    let image = ImagePaths::new(&paths, &hash);
-    let output_dir = image.dir();
+    let rootfs_paths = RootfsPaths::new(&paths, &rootfs_hash);
+    let snapshot_paths = rootfs_paths.snapshot(&snapshot_hash);
+    let rootfs_dir = rootfs_paths.dir();
+    let snapshot_dir = snapshot_paths.dir();
 
-    if is_image_complete(&image).await? {
-        tracing::info!("[OK] image already built: {}", output_dir.display());
-        touch_mtime(output_dir);
+    // Fast path: both rootfs and snapshot already present.
+    if is_rootfs_present(&rootfs_paths).await?
+        && provider.is_complete(snapshot_dir).await.unwrap_or(false)
+    {
+        tracing::info!("[OK] image already built: rootfs={rootfs_hash}, snapshot={snapshot_hash}");
+        touch_mtime(rootfs_dir);
+        touch_mtime(snapshot_dir);
         return Ok(());
     }
 
@@ -200,13 +215,17 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         tracing::info!("R2 cache disabled (R2_* env vars not set) — skipping download and upload");
     }
 
-    // Acquire exclusive lock to prevent concurrent builds with the same hash.
-    let _lock = lock::acquire(paths.image_lock(&hash)).await?;
+    // Acquire exclusive locks to prevent concurrent builds and block GC.
+    let _rootfs_lock = lock::acquire(paths.rootfs_lock(&rootfs_hash)).await?;
+    let _snapshot_lock = lock::acquire(paths.snapshot_lock(&snapshot_hash)).await?;
 
     // Re-check after acquiring lock — another process may have completed the build.
-    if is_image_complete(&image).await? {
-        tracing::info!("[OK] image already built: {}", output_dir.display());
-        touch_mtime(output_dir);
+    if is_rootfs_present(&rootfs_paths).await?
+        && provider.is_complete(snapshot_dir).await.unwrap_or(false)
+    {
+        tracing::info!("[OK] image already built: rootfs={rootfs_hash}, snapshot={snapshot_hash}");
+        touch_mtime(rootfs_dir);
+        touch_mtime(snapshot_dir);
         return Ok(());
     }
 
@@ -227,162 +246,153 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
 
     // --- Phase 1: Obtain rootfs ---
     //
-    // R2 caches only rootfs.ext4 (not snapshot files). Snapshots are always
-    // created locally because they contain host-specific state (page cache,
-    // kernel metadata). This design allows hosts with different hardware to
-    // share the rootfs cache while each creating its own snapshot.
-    //
-    // `force_reupload`: set when R2 download succeeded structurally but the
-    // rootfs is missing — the bad R2 object is atomically overwritten on the
-    // next upload.
+    // R2 caches only rootfs.ext4. Snapshots are always created locally
+    // because they contain host-specific state (page cache, kernel metadata).
+    // Multiple snapshot variants can share one rootfs.
 
     let mut force_reupload = false;
     let mut rootfs_from_r2 = false;
 
-    // No upfront `remove_dir_all(output_dir)` here: a previous interrupted
-    // build may have left stale bind mounts in `output_dir/work/` (snapshot.rs
-    // bind-mounts the NBD COW device there), which would cause EBUSY on a
-    // blanket removal. Downstream steps each handle their own cleanup:
-    //   - try_download's finalize_staging rename replaces output_dir atomically
-    //   - build-rootfs.sh writes rootfs via mkfs.ext4 -> rename (overwrites)
-    //   - snapshot.rs::create_snapshot umounts stale binds, then removes only
-    //     its own artifacts (snapshot.bin, memory.bin, cow.img, work/)
+    let need_rootfs = !is_rootfs_present(&rootfs_paths).await?;
 
-    // Try R2 download (rootfs only). try_download manages its own staging
-    // directory and atomic rename, so output_dir stays absent on failure.
-    if let Some(cache) = &r2 {
-        match cache.try_download(&hash, output_dir).await {
-            Ok(true) => {
-                if tokio::fs::try_exists(image.rootfs()).await.unwrap_or(false) {
-                    // Remove any non-rootfs files from the download (e.g. stale
-                    // snapshot artifacts from an old archive format).
-                    remove_all_except_rootfs(&image).await;
-                    tracing::info!("[OK] rootfs downloaded from R2: {}", output_dir.display());
-                    rootfs_from_r2 = true;
-                } else {
-                    tracing::warn!(
-                        "R2 download for {hash} succeeded but rootfs missing — \
-                         will rebuild locally and force-overwrite the bad object"
-                    );
-                    force_reupload = true;
-                    // Clean up the bad download so local build starts fresh.
-                    if let Err(e) = tokio::fs::remove_dir_all(&output_dir).await {
+    if need_rootfs {
+        // Try R2 download (rootfs only). try_download manages its own staging
+        // directory and atomic rename, so rootfs_dir stays absent on failure.
+        if let Some(cache) = &r2 {
+            match cache.try_download(&rootfs_hash, rootfs_dir).await {
+                Ok(true) => {
+                    if tokio::fs::try_exists(rootfs_paths.rootfs())
+                        .await
+                        .unwrap_or(false)
+                    {
+                        // Remove any non-rootfs files from the download (e.g. stale
+                        // snapshot artifacts from an old archive format).
+                        remove_all_except_rootfs(&rootfs_paths).await;
+                        tracing::info!("[OK] rootfs downloaded from R2: {}", rootfs_dir.display());
+                        rootfs_from_r2 = true;
+                    } else {
                         tracing::warn!(
-                            "failed to clean bad R2 download at {}: {e}",
-                            output_dir.display()
+                            "R2 download for {rootfs_hash} succeeded but rootfs missing — \
+                             will rebuild locally and force-overwrite the bad object"
                         );
+                        force_reupload = true;
+                        if let Err(e) = tokio::fs::remove_dir_all(rootfs_dir).await {
+                            tracing::warn!(
+                                "failed to clean bad R2 download at {}: {e}",
+                                rootfs_dir.display()
+                            );
+                        }
                     }
                 }
+                Ok(false) => {
+                    tracing::info!("R2 cache miss for {rootfs_hash} — building locally")
+                }
+                Err(e) => {
+                    tracing::warn!("R2 download failed: {e} — falling back to local build")
+                }
             }
-            Ok(false) => tracing::info!("R2 cache miss for {hash} — building locally"),
-            Err(e) => tracing::warn!("R2 download failed: {e} — falling back to local build"),
         }
-    }
 
-    if !rootfs_from_r2 {
-        // Create output_dir for local build (R2 path creates it via rename).
-        tokio::fs::create_dir_all(&output_dir)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("create {}: {e}", output_dir.display())))?;
-
-        // Local rootfs build — the slow path (debootstrap + apt install).
-        let output_dir_str = output_dir.to_string_lossy();
-        let guest_agent_str = guest_agent.to_string_lossy();
-        let guest_download_str = guest_download.to_string_lossy();
-        let guest_init_str = guest_init.to_string_lossy();
-        let guest_mock_claude_str = guest_mock_claude.to_string_lossy();
-        let guest_reseed_str = guest_reseed.to_string_lossy();
-        let ca_dir_str = ca_dir.to_string_lossy();
-        let debootstrap_dir = paths.debootstrap_dir();
-        tokio::fs::create_dir_all(&debootstrap_dir)
-            .await
-            .map_err(|e| {
-                RunnerError::Internal(format!("create {}: {e}", debootstrap_dir.display()))
+        if !rootfs_from_r2 {
+            // Create rootfs_dir for local build (R2 path creates it via rename).
+            tokio::fs::create_dir_all(rootfs_dir).await.map_err(|e| {
+                RunnerError::Internal(format!("create {}: {e}", rootfs_dir.display()))
             })?;
-        let debootstrap_dir_str = debootstrap_dir.to_string_lossy();
-        let disk_mb_str = def.disk_mb.to_string();
 
-        let status = tokio::process::Command::new("bash")
-            .arg(work_dir.path().join("build-rootfs.sh"))
-            .args([
-                "--output-dir",
-                &output_dir_str,
-                "--ca-dir",
-                &ca_dir_str,
-                "--debootstrap-dir",
-                &debootstrap_dir_str,
-                "--hash",
-                &hash,
-                "--disk-mb",
-                &disk_mb_str,
-                "--guest-agent",
-                &guest_agent_str,
-                "--guest-download",
-                &guest_download_str,
-                "--guest-init",
-                &guest_init_str,
-                "--guest-mock-claude",
-                &guest_mock_claude_str,
-                "--guest-reseed",
-                &guest_reseed_str,
-                // Dummy nameserver — all UDP 53 is iptables-REDIRECT'd to dnsmasq.
-                // Must be routable (not loopback/gateway) so packets leave the VM.
-                "--dns-nameserver",
-                "8.8.8.8",
-            ])
-            .stdin(std::process::Stdio::null())
-            .status()
-            .await
-            .map_err(|e| RunnerError::Internal(format!("spawn build script: {e}")))?;
+            // Local rootfs build — the slow path (debootstrap + apt install).
+            let rootfs_dir_str = rootfs_dir.to_string_lossy();
+            let guest_agent_str = guest_agent.to_string_lossy();
+            let guest_download_str = guest_download.to_string_lossy();
+            let guest_init_str = guest_init.to_string_lossy();
+            let guest_mock_claude_str = guest_mock_claude.to_string_lossy();
+            let guest_reseed_str = guest_reseed.to_string_lossy();
+            let ca_dir_str = ca_dir.to_string_lossy();
+            let debootstrap_dir = paths.debootstrap_dir();
+            tokio::fs::create_dir_all(&debootstrap_dir)
+                .await
+                .map_err(|e| {
+                    RunnerError::Internal(format!("create {}: {e}", debootstrap_dir.display()))
+                })?;
+            let debootstrap_dir_str = debootstrap_dir.to_string_lossy();
+            let disk_mb_str = def.disk_mb.to_string();
 
-        if !status.success() {
-            return Err(RunnerError::Internal(format!(
-                "build-rootfs.sh failed with {status}"
-            )));
-        }
+            let status = tokio::process::Command::new("bash")
+                .arg(work_dir.path().join("build-rootfs.sh"))
+                .args([
+                    "--output-dir",
+                    &rootfs_dir_str,
+                    "--ca-dir",
+                    &ca_dir_str,
+                    "--debootstrap-dir",
+                    &debootstrap_dir_str,
+                    "--hash",
+                    &rootfs_hash,
+                    "--disk-mb",
+                    &disk_mb_str,
+                    "--guest-agent",
+                    &guest_agent_str,
+                    "--guest-download",
+                    &guest_download_str,
+                    "--guest-init",
+                    &guest_init_str,
+                    "--guest-mock-claude",
+                    &guest_mock_claude_str,
+                    "--guest-reseed",
+                    &guest_reseed_str,
+                    "--dns-nameserver",
+                    "8.8.8.8",
+                ])
+                .stdin(std::process::Stdio::null())
+                .status()
+                .await
+                .map_err(|e| RunnerError::Internal(format!("spawn build script: {e}")))?;
 
-        // Verify rootfs contents (verify script is NOT part of the input hash)
-        let rootfs_str = image.rootfs().to_string_lossy().into_owned();
-        let status = tokio::process::Command::new("bash")
-            .arg(work_dir.path().join("verify-rootfs.sh"))
-            .args(["--rootfs", &rootfs_str])
-            .stdin(std::process::Stdio::null())
-            .status()
-            .await
-            .map_err(|e| RunnerError::Internal(format!("spawn verify script: {e}")))?;
+            if !status.success() {
+                return Err(RunnerError::Internal(format!(
+                    "build-rootfs.sh failed with {status}"
+                )));
+            }
 
-        if !status.success() {
-            return Err(RunnerError::Internal(format!(
-                "verify-rootfs.sh failed with {status}"
-            )));
-        }
+            let rootfs_str = rootfs_paths.rootfs().to_string_lossy().into_owned();
+            let status = tokio::process::Command::new("bash")
+                .arg(work_dir.path().join("verify-rootfs.sh"))
+                .args(["--rootfs", &rootfs_str])
+                .stdin(std::process::Stdio::null())
+                .status()
+                .await
+                .map_err(|e| RunnerError::Internal(format!("spawn verify script: {e}")))?;
 
-        let rootfs_sz = file_sizes(&image.rootfs()).await;
-        tracing::info!(
-            rootfs_logical = %rootfs_sz.0,
-            rootfs_disk = %rootfs_sz.1,
-            "rootfs creation complete"
-        );
+            if !status.success() {
+                return Err(RunnerError::Internal(format!(
+                    "verify-rootfs.sh failed with {status}"
+                )));
+            }
 
-        // Upload rootfs to R2 BEFORE CA injection — the cached rootfs should
-        // be generic (build host's CA) so other hosts can download and inject
-        // their own CA. Non-fatal: image is already on local disk.
-        if let Some(cache) = &r2 {
-            let files = vec![image.rootfs()];
-            match cache.upload(&hash, &files, force_reupload).await {
-                Ok(()) => tracing::info!("uploaded rootfs to R2: {hash}"),
-                Err(e) => tracing::warn!("R2 upload failed: {e} — rootfs is on local disk"),
+            let rootfs_sz = file_sizes(&rootfs_paths.rootfs()).await;
+            tracing::info!(
+                rootfs_logical = %rootfs_sz.0,
+                rootfs_disk = %rootfs_sz.1,
+                "rootfs creation complete"
+            );
+
+            // Upload rootfs to R2 BEFORE CA injection — the cached rootfs should
+            // be generic (build host's CA) so other hosts can download and inject
+            // their own CA.
+            if let Some(cache) = &r2 {
+                let files = vec![rootfs_paths.rootfs()];
+                match cache.upload(&rootfs_hash, &files, force_reupload).await {
+                    Ok(()) => tracing::info!("uploaded rootfs to R2: {rootfs_hash}"),
+                    Err(e) => tracing::warn!("R2 upload failed: {e} — rootfs is on local disk"),
+                }
             }
         }
+    } else {
+        tracing::info!("[OK] rootfs already present: {}", rootfs_dir.display());
     }
 
     // --- Phase 1.5: Replace CA cert (R2-downloaded rootfs only) ---
-    //
-    // The R2-cached rootfs contains the build host's CA. Replace it with the
-    // local host's CA before creating the snapshot, so TLS interception works.
-    // Local builds already have the correct CA from build-rootfs.sh.
     if rootfs_from_r2 {
-        let rootfs_str = image.rootfs().to_string_lossy().into_owned();
+        let rootfs_str = rootfs_paths.rootfs().to_string_lossy().into_owned();
         let ca_dir_str = ca_dir.to_string_lossy().into_owned();
         let status = tokio::process::Command::new("bash")
             .arg(work_dir.path().join("inject-ca.sh"))
@@ -400,15 +410,21 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         tracing::info!("CA cert replaced in R2-downloaded rootfs");
     }
 
-    // --- Phase 2: Build snapshot (always local) ---
+    // --- Phase 2: Build snapshot ---
+    //
+    // Snapshot dir is nested under the rootfs dir:
+    // <images>/<rootfs_hash>/snapshots/<snapshot_hash>/
+    tokio::fs::create_dir_all(snapshot_dir)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", snapshot_dir.display())))?;
 
-    let rootfs_path = image.rootfs();
+    let rootfs_path = rootfs_paths.rootfs();
     let create_config = sandbox::SnapshotCreateConfig {
-        id: hash.clone(),
+        id: snapshot_hash.clone(),
         binary_path: paths.firecracker_bin(FIRECRACKER_VERSION),
         kernel_path: paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION),
         rootfs_path,
-        output_dir: output_dir.to_path_buf(),
+        output_dir: snapshot_dir.to_path_buf(),
         vcpu_count: def.vcpu,
         memory_mb: def.memory_mb,
     };
@@ -430,21 +446,22 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         "snapshot creation complete"
     );
 
-    tracing::info!("image creation complete: {hash}");
+    tracing::info!("image creation complete: rootfs={rootfs_hash}, snapshot={snapshot_hash}");
     Ok(())
 }
 
-/// Remove all files in the image directory except rootfs.ext4.
+/// Remove all files in the rootfs directory except rootfs.ext4 and the snapshots/ subtree.
 ///
 /// After an R2 download the archive may contain stale artifacts from an
 /// older cache format. Cleaning them ensures `create_snapshot` writes
-/// into a directory that only contains the rootfs.
-async fn remove_all_except_rootfs(image: &ImagePaths) {
+/// into a clean snapshot subdirectory.
+async fn remove_all_except_rootfs(rootfs: &RootfsPaths) {
     let rootfs_name = std::ffi::OsStr::new("rootfs.ext4");
-    let mut entries = match tokio::fs::read_dir(image.dir()).await {
+    let snapshots_name = std::ffi::OsStr::new("snapshots");
+    let mut entries = match tokio::fs::read_dir(rootfs.dir()).await {
         Ok(e) => e,
         Err(e) => {
-            tracing::warn!("failed to read dir {}: {e}", image.dir().display());
+            tracing::warn!("failed to read dir {}: {e}", rootfs.dir().display());
             return;
         }
     };
@@ -453,11 +470,12 @@ async fn remove_all_except_rootfs(image: &ImagePaths) {
             Ok(Some(entry)) => entry,
             Ok(None) => break,
             Err(e) => {
-                tracing::warn!("read entry in {}: {e}", image.dir().display());
+                tracing::warn!("read entry in {}: {e}", rootfs.dir().display());
                 break;
             }
         };
-        if entry.file_name() != rootfs_name {
+        let name = entry.file_name();
+        if name != rootfs_name && name != snapshots_name {
             let path = entry.path();
             let result = if path.is_dir() {
                 tokio::fs::remove_dir_all(&path).await
@@ -471,42 +489,31 @@ async fn remove_all_except_rootfs(image: &ImagePaths) {
     }
 }
 
-/// Check whether all expected image outputs exist in the directory.
-async fn is_image_complete(image: &ImagePaths) -> RunnerResult<bool> {
-    for path in image.expected_files() {
-        let exists = tokio::fs::try_exists(&path)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("check {}: {e}", path.display())))?;
-        if !exists {
-            return Ok(false);
-        }
-    }
-    Ok(true)
+/// Check whether rootfs.ext4 exists.
+async fn is_rootfs_present(rootfs: &RootfsPaths) -> RunnerResult<bool> {
+    tokio::fs::try_exists(rootfs.rootfs())
+        .await
+        .map_err(|e| RunnerError::Internal(format!("check {}: {e}", rootfs.rootfs().display())))
 }
 
 /// Compute a rootfs-only hash for R2 image caching.
 ///
 /// Inputs:
-///   - `IMAGE_CACHE_VERSION` — bump to force invalidation
+///   - `ROOTFS_CACHE_VERSION` — bump to force invalidation
 ///   - `BUILD_SCRIPT` — rootfs build script content
 ///   - `disk_mb` — disk size from profile
 ///   - guest binaries — sorted by destination path
 ///
-/// Host-specific fields (kernel, CPU, BIOS) and snapshot-specific fields
-/// (vcpu, memory, firecracker/kernel version) are intentionally excluded:
-/// the R2 cache stores only the rootfs, and snapshots are always created
-/// locally. Excluding host fields allows different hardware to share the
-/// same rootfs cache.
+/// Snapshot-specific fields (vcpu, memory, firecracker/kernel version,
+/// provider config) are excluded — they go into `compute_snapshot_hash`.
 ///
-/// **Changing this function invalidates all cached images.**
-async fn compute_image_hash(guest_bins: &[(&Path, &str)], disk_mb: u32) -> RunnerResult<String> {
+/// **Changing this function invalidates all cached rootfs images.**
+async fn compute_rootfs_hash(guest_bins: &[(&Path, &str)], disk_mb: u32) -> RunnerResult<String> {
     let mut hasher = Sha256::new();
 
-    // Cache version seed — bump IMAGE_CACHE_VERSION to force invalidation.
-    hasher.update(b"version:");
-    hasher.update(IMAGE_CACHE_VERSION.to_le_bytes());
+    hasher.update(b"rootfs_version:");
+    hasher.update(ROOTFS_CACHE_VERSION.to_le_bytes());
 
-    // Rootfs inputs
     hasher.update(b"script:");
     hasher.update(BUILD_SCRIPT.as_bytes());
     hasher.update(b"disk_mb:");
@@ -522,6 +529,42 @@ async fn compute_image_hash(guest_bins: &[(&Path, &str)], disk_mb: u32) -> Runne
     }
 
     Ok(hex::encode(hasher.finalize()))
+}
+
+/// Compute a snapshot hash from all inputs that affect snapshot content.
+///
+/// This hash is local-only (R2 stores only rootfs). It covers:
+///   - `SNAPSHOT_CACHE_VERSION` — manual bump counter
+///   - `rootfs_hash` — the rootfs this snapshot is built from
+///   - `vcpu`, `memory_mb` — VM resource config
+///   - `fc_version`, `kernel_version` — Firecracker and guest kernel versions
+///   - `provider_config_hash` — sandbox-fc internal config (boot args, prewarm, etc.)
+fn compute_snapshot_hash(
+    rootfs_hash: &str,
+    vcpu: u32,
+    memory_mb: u32,
+    fc_version: &str,
+    kernel_version: &str,
+    provider_config_hash: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+
+    hasher.update(b"snapshot_version:");
+    hasher.update(SNAPSHOT_CACHE_VERSION.to_le_bytes());
+    hasher.update(b"rootfs:");
+    hasher.update(rootfs_hash.as_bytes());
+    hasher.update(b"vcpu:");
+    hasher.update(vcpu.to_le_bytes());
+    hasher.update(b"memory_mb:");
+    hasher.update(memory_mb.to_le_bytes());
+    hasher.update(b"fc_version:");
+    hasher.update(fc_version.as_bytes());
+    hasher.update(b"kernel_version:");
+    hasher.update(kernel_version.as_bytes());
+    hasher.update(b"provider_config:");
+    hasher.update(provider_config_hash.as_bytes());
+
+    hex::encode(hasher.finalize())
 }
 
 /// Return `(logical, disk)` as human-readable strings (e.g. "65.2 MiB").
@@ -580,34 +623,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compute_image_hash_deterministic() {
+    async fn compute_rootfs_hash_deterministic() {
         let dir = tempfile::tempdir().unwrap();
         let bin = dir.path().join("agent");
         tokio::fs::write(&bin, b"binary-content").await.unwrap();
         let bins: &[(&Path, &str)] = &[(&bin, "/usr/local/bin/guest-agent")];
 
-        let h1 = compute_image_hash(bins, 16384).await.unwrap();
-        let h2 = compute_image_hash(bins, 16384).await.unwrap();
+        let h1 = compute_rootfs_hash(bins, 16384).await.unwrap();
+        let h2 = compute_rootfs_hash(bins, 16384).await.unwrap();
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64); // SHA-256 hex
     }
 
-    /// Verify that each parameterized input changes the hash.
     #[tokio::test]
-    async fn compute_image_hash_sensitive_to_all_inputs() {
+    async fn compute_rootfs_hash_sensitive_to_all_inputs() {
         let dir = tempfile::tempdir().unwrap();
         let bin_a = dir.path().join("agent-a");
         let bin_b = dir.path().join("agent-b");
         tokio::fs::write(&bin_a, b"content-a").await.unwrap();
         tokio::fs::write(&bin_b, b"content-b").await.unwrap();
 
-        let base = compute_image_hash(&[(&bin_a, "/usr/local/bin/guest-agent")], 16384)
+        let base = compute_rootfs_hash(&[(&bin_a, "/usr/local/bin/guest-agent")], 16384)
             .await
             .unwrap();
 
-        // Different binary content
         let different_content =
-            compute_image_hash(&[(&bin_b, "/usr/local/bin/guest-agent")], 16384)
+            compute_rootfs_hash(&[(&bin_b, "/usr/local/bin/guest-agent")], 16384)
                 .await
                 .unwrap();
         assert_ne!(
@@ -615,45 +656,73 @@ mod tests {
             "hash must change with binary content"
         );
 
-        // Different disk_mb
-        let different_disk = compute_image_hash(&[(&bin_a, "/usr/local/bin/guest-agent")], 32768)
+        let different_disk = compute_rootfs_hash(&[(&bin_a, "/usr/local/bin/guest-agent")], 32768)
             .await
             .unwrap();
         assert_ne!(base, different_disk, "hash must change with disk_mb");
 
-        // Different dest path
         let different_dest =
-            compute_image_hash(&[(&bin_a, "/usr/local/bin/guest-download")], 16384)
+            compute_rootfs_hash(&[(&bin_a, "/usr/local/bin/guest-download")], 16384)
                 .await
                 .unwrap();
         assert_ne!(base, different_dest, "hash must change with dest path");
     }
 
+    #[test]
+    fn compute_snapshot_hash_deterministic() {
+        let h1 = compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.14.1", "6.1.155", "config_xxx");
+        let h2 = compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.14.1", "6.1.155", "config_xxx");
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64);
+    }
+
+    #[test]
+    fn compute_snapshot_hash_sensitive_to_each_field() {
+        let base = compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.14.1", "6.1.155", "cfg");
+
+        assert_ne!(
+            base,
+            compute_snapshot_hash("rootfs_bbb", 2, 4096, "v1.14.1", "6.1.155", "cfg"),
+            "must change with rootfs_hash"
+        );
+        assert_ne!(
+            base,
+            compute_snapshot_hash("rootfs_aaa", 4, 4096, "v1.14.1", "6.1.155", "cfg"),
+            "must change with vcpu"
+        );
+        assert_ne!(
+            base,
+            compute_snapshot_hash("rootfs_aaa", 2, 8192, "v1.14.1", "6.1.155", "cfg"),
+            "must change with memory_mb"
+        );
+        assert_ne!(
+            base,
+            compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.15.0", "6.1.155", "cfg"),
+            "must change with fc_version"
+        );
+        assert_ne!(
+            base,
+            compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.14.1", "6.2.0", "cfg"),
+            "must change with kernel_version"
+        );
+        assert_ne!(
+            base,
+            compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.14.1", "6.1.155", "cfg2"),
+            "must change with provider_config_hash"
+        );
+    }
+
     #[tokio::test]
-    async fn is_image_complete_requires_all_four_files() {
+    async fn is_rootfs_present_checks_rootfs_file() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
-        let image = ImagePaths::new(&home, "test-hash");
-        tokio::fs::create_dir_all(image.dir()).await.unwrap();
+        let rootfs = RootfsPaths::new(&home, "test-hash");
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
 
-        // Empty directory → incomplete
-        assert!(!is_image_complete(&image).await.unwrap());
+        assert!(!is_rootfs_present(&rootfs).await.unwrap());
 
-        // Only rootfs → incomplete
-        tokio::fs::write(image.rootfs(), b"").await.unwrap();
-        assert!(!is_image_complete(&image).await.unwrap());
-
-        // rootfs + snapshot.bin → incomplete
-        tokio::fs::write(image.snapshot_bin(), b"").await.unwrap();
-        assert!(!is_image_complete(&image).await.unwrap());
-
-        // rootfs + snapshot.bin + memory.bin → incomplete
-        tokio::fs::write(image.memory_bin(), b"").await.unwrap();
-        assert!(!is_image_complete(&image).await.unwrap());
-
-        // All four files → complete
-        tokio::fs::write(image.cow_img(), b"").await.unwrap();
-        assert!(is_image_complete(&image).await.unwrap());
+        tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
+        assert!(is_rootfs_present(&rootfs).await.unwrap());
     }
 
     /// Guard the `[sync:ca-constants]` contract between build-rootfs.sh,
@@ -706,12 +775,45 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn is_image_complete_nonexistent_dir() {
+    async fn is_rootfs_present_nonexistent_dir() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
-        let image = ImagePaths::new(&home, "does-not-exist");
+        let rootfs = RootfsPaths::new(&home, "does-not-exist");
 
-        assert!(!is_image_complete(&image).await.unwrap());
+        assert!(!is_rootfs_present(&rootfs).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn remove_all_except_rootfs_preserves_rootfs_and_snapshots() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+        let rootfs = RootfsPaths::new(&home, "test-hash");
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        tokio::fs::write(rootfs.rootfs(), b"rootfs").await.unwrap();
+
+        // Create a snapshots/ subdir with content
+        let snap_dir = rootfs.dir().join("snapshots").join("snap1");
+        tokio::fs::create_dir_all(&snap_dir).await.unwrap();
+        tokio::fs::write(snap_dir.join("snapshot.bin"), b"snap")
+            .await
+            .unwrap();
+
+        // Create a stale file that should be removed
+        tokio::fs::write(rootfs.dir().join("stale.txt"), b"old")
+            .await
+            .unwrap();
+
+        remove_all_except_rootfs(&rootfs).await;
+
+        assert!(rootfs.rootfs().exists(), "rootfs.ext4 must survive");
+        assert!(
+            snap_dir.join("snapshot.bin").exists(),
+            "snapshots/ must survive"
+        );
+        assert!(
+            !rootfs.dir().join("stale.txt").exists(),
+            "stale file must be removed"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -13,13 +13,16 @@ use crate::profile;
 
 #[derive(Args)]
 pub struct ConfigArgs {
-    /// Profile entries: --profile vm0/default --image-hash abc123
-    /// Can be repeated for multiple profiles. Each --profile starts a new entry.
+    /// Profile entries: --profile vm0/default --rootfs-hash abc --snapshot-hash def
+    /// Can be repeated for multiple profiles.
     #[arg(long, required = true)]
     profile: Vec<String>,
-    /// Image hash for the preceding --profile (one per profile, in order)
+    /// Rootfs hash for the preceding --profile (one per profile, in order)
     #[arg(long, required = true)]
-    image_hash: Vec<String>,
+    rootfs_hash: Vec<String>,
+    /// Snapshot hash for the preceding --profile (one per profile, in order)
+    #[arg(long, required = true)]
+    snapshot_hash: Vec<String>,
 
     /// Runner logical name
     #[arg(long)]
@@ -50,16 +53,18 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
     // Pure-CPU validation first — fail fast before any filesystem I/O.
     crate::group::validate_or_err(&args.group)?;
     crate::runner_dirname::validate_or_err(&args.runner_dirname)?;
-    if args.profile.len() != args.image_hash.len() {
+    if args.profile.len() != args.rootfs_hash.len()
+        || args.profile.len() != args.snapshot_hash.len()
+    {
         return Err(RunnerError::Config(
-            "--profile and --image-hash must be specified the same number of times".into(),
+            "--profile, --rootfs-hash, and --snapshot-hash must be specified the same number of times".into(),
         ));
     }
     for profile_name in &args.profile {
         profile::validate_or_err(profile_name)?;
     }
-    for image_hash in &args.image_hash {
-        crate::image_hash::validate_or_err(image_hash)?;
+    for h in args.rootfs_hash.iter().chain(args.snapshot_hash.iter()) {
+        crate::image_hash::validate_or_err(h)?;
     }
 
     let paths = HomePaths::new()?;
@@ -68,27 +73,32 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
     let mut profiles = BTreeMap::new();
     for (i, profile_name) in args.profile.iter().enumerate() {
         let def = profile::get(profile_name)?;
-        // Length equality is validated above, so this index is safe.
-        let image_hash = args
-            .image_hash
+        // Length equality is validated above, so these indices are safe.
+        let rootfs_hash = args
+            .rootfs_hash
             .get(i)
-            .ok_or_else(|| RunnerError::Internal(format!("missing image_hash at index {i}")))?;
+            .ok_or_else(|| RunnerError::Internal(format!("missing rootfs_hash at index {i}")))?;
+        let snapshot_hash = args
+            .snapshot_hash
+            .get(i)
+            .ok_or_else(|| RunnerError::Internal(format!("missing snapshot_hash at index {i}")))?;
 
-        // Verify image directory exists on disk.
-        let image_dir = paths.images_dir().join(image_hash);
-        if !tokio::fs::try_exists(&image_dir)
+        // Verify rootfs directory exists on disk.
+        let rootfs_dir = paths.images_dir().join(rootfs_hash);
+        if !tokio::fs::try_exists(&rootfs_dir)
             .await
-            .map_err(|e| RunnerError::Internal(format!("check image dir: {e}")))?
+            .map_err(|e| RunnerError::Internal(format!("check rootfs dir: {e}")))?
         {
             return Err(RunnerError::Config(format!(
-                "image not found for hash {image_hash}; run `build --profile {profile_name}` first"
+                "rootfs not found for hash {rootfs_hash}; run `build --profile {profile_name}` first"
             )));
         }
 
         profiles.insert(
             profile_name.clone(),
             ProfileConfig {
-                image_hash: image_hash.clone(),
+                rootfs_hash: rootfs_hash.clone(),
+                snapshot_hash: snapshot_hash.clone(),
                 vcpu: def.vcpu,
                 memory_mb: def.memory_mb,
                 disk_mb: def.disk_mb,
@@ -133,7 +143,8 @@ mod tests {
     fn args_with_dirname(dirname: &str) -> ConfigArgs {
         ConfigArgs {
             profile: vec!["vm0/default".into()],
-            image_hash: vec!["dummy".into()],
+            rootfs_hash: vec!["dummy".into()],
+            snapshot_hash: vec!["dummy".into()],
             name: "test".into(),
             group: "vm0/test".into(),
             runner_dirname: dirname.into(),

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -158,113 +158,38 @@ struct GcCandidate {
     _lock: Flock<std::fs::File>,
 }
 
-/// GC a single flat artifact directory.
+/// Try to delete an orphaned rootfs directory (no surviving snapshots).
 ///
-/// Each subdirectory is named by its content hash. We try an exclusive nonblocking
-/// flock on the corresponding lock file — if it succeeds the resource is unused.
-/// The exclusive lock is held until deletion to prevent TOCTOU races.
-///
-/// Only used by tests now — image GC migrated to `gc_nested_images`.
-#[cfg(test)]
-async fn gc_dir(
-    label: &str,
-    dir: &Path,
-    lock_path_fn: impl Fn(&str) -> PathBuf,
-    keep_latest: Option<usize>,
-    dry_run: bool,
-) -> RunnerResult<u64> {
-    let mut entries = match tokio::fs::read_dir(dir).await {
-        Ok(rd) => rd,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
-        Err(e) => {
-            return Err(RunnerError::Internal(format!(
-                "read {}: {e}",
-                dir.display()
-            )));
-        }
-    };
-
-    let mut candidates: Vec<GcCandidate> = Vec::new();
-
-    while let Some(entry) = next_entry_warn(&mut entries, label, dir).await {
-        let path = entry.path();
-        let Some(hash) = path.file_name().and_then(|n| n.to_str()).map(String::from) else {
-            continue;
-        };
-
-        let lock_path = lock_path_fn(&hash);
-        match probe_lock(&lock_path) {
-            LockProbe::Free(lock) => {
-                let (size, mtime) = dir_stats(&path).await;
-                candidates.push(GcCandidate {
-                    path,
-                    hash,
-                    size,
-                    mtime,
-                    _lock: lock,
-                });
-            }
-            LockProbe::Held => {
-                info!("{label}/{hash}: in use, skipping");
-            }
-            LockProbe::Error(e) => {
-                info!("{label}/{hash}: lock probe failed ({e}), skipping");
-            }
-        }
-    }
-
-    // Protect recently-created artifacts from deletion. This closes the race
-    // window between `runner build` releasing its lock and `runner start`
-    // acquiring a shared lock.
-    let now = SystemTime::now();
-    let mut protected = Vec::new();
-    candidates.retain(|c| {
-        let age = now.duration_since(c.mtime).unwrap_or_default();
-        if age < GC_MIN_AGE {
-            protected.push((c.hash.clone(), age));
-            false
-        } else {
-            true
-        }
-    });
-    for (hash, age) in &protected {
+/// Caller must hold the exclusive rootfs lock. Returns bytes freed (0 if
+/// skipped due to age, dry-run, or deletion error).
+async fn try_delete_orphan_rootfs(rootfs_path: &Path, rootfs_hash: &str, dry_run: bool) -> u64 {
+    let (rootfs_size, rootfs_mtime) = dir_stats(rootfs_path).await;
+    let age = SystemTime::now()
+        .duration_since(rootfs_mtime)
+        .unwrap_or_default();
+    if age < GC_MIN_AGE {
         info!(
-            "{label}/{hash}: too recent ({}s old), skipping",
+            "images/{rootfs_hash}: orphaned but too recent ({}s), keeping",
             age.as_secs()
         );
+        return 0;
     }
-
-    // Sort by mtime descending (newest first) so keep_latest keeps the most recent.
-    candidates.sort_by(|a, b| b.mtime.cmp(&a.mtime));
-
-    let keep_count = keep_latest.unwrap_or(0);
-    for c in candidates.iter().take(keep_count) {
+    if dry_run {
         info!(
-            "{label}/{}: keeping (latest unused, {})",
-            c.hash,
-            human_bytes(c.size)
+            "[dry-run] would delete orphaned rootfs images/{rootfs_hash} ({})",
+            human_bytes(rootfs_size)
         );
+        return 0;
     }
-
-    let mut freed = 0u64;
-    for c in candidates.iter().skip(keep_count) {
-        if dry_run {
-            info!(
-                "[dry-run] would delete {label}/{} ({})",
-                c.hash,
-                human_bytes(c.size)
-            );
-        } else {
-            if let Err(e) = tokio::fs::remove_dir_all(&c.path).await {
-                warn!("failed to remove {label}/{}: {e} (skipping)", c.hash);
-                continue;
-            }
-            info!("deleted {label}/{} ({})", c.hash, human_bytes(c.size));
-        }
-        freed += c.size;
+    if let Err(e) = tokio::fs::remove_dir_all(rootfs_path).await {
+        warn!("failed to remove orphaned rootfs images/{rootfs_hash}: {e}");
+        return 0;
     }
-
-    Ok(freed)
+    info!(
+        "deleted orphaned rootfs images/{rootfs_hash} ({})",
+        human_bytes(rootfs_size)
+    );
+    rootfs_size
 }
 
 /// GC for the nested image layout: `<images>/<rootfs>/snapshots/<snapshot>/`.
@@ -329,33 +254,9 @@ async fn gc_nested_images(
             Ok(rd) => rd,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 // No snapshots/ subdirectory — orphaned rootfs.
-                // Can only delete if we hold the rootfs lock.
                 if can_delete_rootfs {
-                    let (rootfs_size, rootfs_mtime) = dir_stats(&rootfs_path).await;
-                    let age = SystemTime::now()
-                        .duration_since(rootfs_mtime)
-                        .unwrap_or_default();
-                    if age >= GC_MIN_AGE {
-                        if dry_run {
-                            info!(
-                                "[dry-run] would delete orphaned rootfs images/{rootfs_hash} ({})",
-                                human_bytes(rootfs_size)
-                            );
-                        } else if let Err(e) = tokio::fs::remove_dir_all(&rootfs_path).await {
-                            warn!("failed to remove orphaned rootfs images/{rootfs_hash}: {e}");
-                        } else {
-                            info!(
-                                "deleted orphaned rootfs images/{rootfs_hash} ({})",
-                                human_bytes(rootfs_size)
-                            );
-                            total_freed += rootfs_size;
-                        }
-                    } else {
-                        info!(
-                            "images/{rootfs_hash}: no snapshots, too recent ({}s), keeping",
-                            age.as_secs()
-                        );
-                    }
+                    total_freed +=
+                        try_delete_orphan_rootfs(&rootfs_path, &rootfs_hash, dry_run).await;
                 }
                 continue;
             }
@@ -461,31 +362,7 @@ async fn gc_nested_images(
             Err(_) => false,
         };
         if !has_snapshots && can_delete_rootfs {
-            let (rootfs_size, rootfs_mtime) = dir_stats(&rootfs_path).await;
-            let age = SystemTime::now()
-                .duration_since(rootfs_mtime)
-                .unwrap_or_default();
-            if age >= GC_MIN_AGE {
-                if dry_run {
-                    info!(
-                        "[dry-run] would delete orphaned rootfs images/{rootfs_hash} ({})",
-                        human_bytes(rootfs_size)
-                    );
-                } else if let Err(e) = tokio::fs::remove_dir_all(&rootfs_path).await {
-                    warn!("failed to remove orphaned rootfs images/{rootfs_hash}: {e}");
-                } else {
-                    info!(
-                        "deleted orphaned rootfs images/{rootfs_hash} ({})",
-                        human_bytes(rootfs_size)
-                    );
-                    total_freed += rootfs_size;
-                }
-            } else {
-                info!(
-                    "images/{rootfs_hash}: orphaned but too recent ({}s), keeping",
-                    age.as_secs()
-                );
-            }
+            total_freed += try_delete_orphan_rootfs(&rootfs_path, &rootfs_hash, dry_run).await;
         }
     }
 
@@ -1234,191 +1111,6 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn gc_empty_dir() {
-        let dir = tempfile::tempdir().unwrap();
-        let locks_dir = dir.path().join("locks");
-        std::fs::create_dir_all(&locks_dir).unwrap();
-
-        let artifacts_dir = dir.path().join("rootfs");
-        std::fs::create_dir_all(&artifacts_dir).unwrap();
-
-        let freed = gc_dir(
-            "rootfs",
-            &artifacts_dir,
-            |hash| locks_dir.join(format!("rootfs-{hash}.lock")),
-            None,
-            false,
-        )
-        .await
-        .unwrap();
-        assert_eq!(freed, 0);
-    }
-
-    #[tokio::test]
-    async fn gc_deletes_unused_dir() {
-        use std::fs::FileTimes;
-        use std::time::Duration;
-
-        let dir = tempfile::tempdir().unwrap();
-        let locks_dir = dir.path().join("locks");
-        std::fs::create_dir_all(&locks_dir).unwrap();
-
-        let artifacts_dir = dir.path().join("rootfs");
-        let hash_dir = artifacts_dir.join("abc123");
-        std::fs::create_dir_all(&hash_dir).unwrap();
-        std::fs::write(hash_dir.join("rootfs.ext4"), b"data").unwrap();
-        // Set mtime past GC_MIN_AGE so the artifact is eligible for deletion.
-        let old_time = SystemTime::now() - Duration::from_secs(3600);
-        std::fs::File::open(&hash_dir)
-            .unwrap()
-            .set_times(FileTimes::new().set_modified(old_time))
-            .unwrap();
-
-        let freed = gc_dir(
-            "rootfs",
-            &artifacts_dir,
-            |hash| locks_dir.join(format!("rootfs-{hash}.lock")),
-            None,
-            false,
-        )
-        .await
-        .unwrap();
-
-        assert!(!hash_dir.exists(), "dir should be deleted");
-        assert!(freed > 0 || cfg!(target_os = "macos")); // blocks may be 0 on some FS
-    }
-
-    #[tokio::test]
-    async fn gc_skips_locked_dir() {
-        let dir = tempfile::tempdir().unwrap();
-        let locks_dir = dir.path().join("locks");
-        std::fs::create_dir_all(&locks_dir).unwrap();
-
-        let artifacts_dir = dir.path().join("rootfs");
-        let hash_dir = artifacts_dir.join("abc123");
-        std::fs::create_dir_all(&hash_dir).unwrap();
-        std::fs::write(hash_dir.join("rootfs.ext4"), b"data").unwrap();
-
-        // Hold a shared lock (simulating runner start).
-        let lock_path = locks_dir.join("rootfs-abc123.lock");
-        let file = std::fs::File::options()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(&lock_path)
-            .unwrap();
-        let _shared = Flock::lock(file, FlockArg::LockShared).unwrap();
-
-        let freed = gc_dir(
-            "rootfs",
-            &artifacts_dir,
-            |hash| locks_dir.join(format!("rootfs-{hash}.lock")),
-            None,
-            false,
-        )
-        .await
-        .unwrap();
-
-        assert!(hash_dir.exists(), "dir should NOT be deleted");
-        assert_eq!(freed, 0);
-    }
-
-    #[tokio::test]
-    async fn gc_dry_run_does_not_delete() {
-        use std::fs::FileTimes;
-        use std::time::Duration;
-
-        let dir = tempfile::tempdir().unwrap();
-        let locks_dir = dir.path().join("locks");
-        std::fs::create_dir_all(&locks_dir).unwrap();
-
-        let artifacts_dir = dir.path().join("rootfs");
-        let hash_dir = artifacts_dir.join("abc123");
-        std::fs::create_dir_all(&hash_dir).unwrap();
-        std::fs::write(hash_dir.join("rootfs.ext4"), b"data").unwrap();
-        // Set mtime past GC_MIN_AGE so the artifact is eligible for deletion.
-        let old_time = SystemTime::now() - Duration::from_secs(3600);
-        std::fs::File::open(&hash_dir)
-            .unwrap()
-            .set_times(FileTimes::new().set_modified(old_time))
-            .unwrap();
-
-        let freed = gc_dir(
-            "rootfs",
-            &artifacts_dir,
-            |hash| locks_dir.join(format!("rootfs-{hash}.lock")),
-            None,
-            true,
-        )
-        .await
-        .unwrap();
-
-        assert!(hash_dir.exists(), "dry-run should not delete");
-        assert!(freed > 0 || cfg!(target_os = "macos"));
-    }
-
-    #[tokio::test]
-    async fn gc_keep_latest_preserves_newest() {
-        use std::fs::FileTimes;
-        use std::time::Duration;
-
-        let dir = tempfile::tempdir().unwrap();
-        let locks_dir = dir.path().join("locks");
-        std::fs::create_dir_all(&locks_dir).unwrap();
-
-        let artifacts_dir = dir.path().join("snapshots");
-
-        // Create two dirs and set explicit directory mtimes for determinism.
-        // dir_stats uses the root directory mtime as the "last used" signal.
-        let old_dir = artifacts_dir.join("old_hash");
-        std::fs::create_dir_all(&old_dir).unwrap();
-        std::fs::write(old_dir.join("snapshot.bin"), b"old").unwrap();
-        let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
-        std::fs::File::open(&old_dir)
-            .unwrap()
-            .set_times(FileTimes::new().set_modified(old_time))
-            .unwrap();
-
-        let new_dir = artifacts_dir.join("new_hash");
-        std::fs::create_dir_all(&new_dir).unwrap();
-        std::fs::write(new_dir.join("snapshot.bin"), b"new").unwrap();
-        let new_time = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000);
-        std::fs::File::open(&new_dir)
-            .unwrap()
-            .set_times(FileTimes::new().set_modified(new_time))
-            .unwrap();
-
-        gc_dir(
-            "snapshots",
-            &artifacts_dir,
-            |hash| locks_dir.join(format!("snapshot-{hash}.lock")),
-            Some(1),
-            false,
-        )
-        .await
-        .unwrap();
-
-        assert!(new_dir.exists(), "newest should be kept");
-        assert!(!old_dir.exists(), "oldest should be deleted");
-    }
-
-    #[tokio::test]
-    async fn gc_nonexistent_dir_is_ok() {
-        let dir = tempfile::tempdir().unwrap();
-        let freed = gc_dir(
-            "rootfs",
-            &dir.path().join("nonexistent"),
-            |hash| dir.path().join(format!("{hash}.lock")),
-            None,
-            false,
-        )
-        .await
-        .unwrap();
-        assert_eq!(freed, 0);
-    }
-
     fn test_home(root: &Path) -> HomePaths {
         HomePaths::with_root(root.to_path_buf())
     }
@@ -1839,6 +1531,39 @@ mod tests {
         assert!(freed > 0);
     }
 
+    /// A locked snapshot must survive even with keep_latest=0 and old mtime.
+    #[tokio::test]
+    async fn gc_nested_images_skips_locked_snapshot() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let images_dir = home.images_dir();
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let rootfs_dir = images_dir.join("rootfs_lock_test");
+        let snap = rootfs_dir.join("snapshots").join("snap_locked");
+        std::fs::create_dir_all(&snap).unwrap();
+        std::fs::write(snap.join("snapshot.bin"), b"data").unwrap();
+        std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+
+        // Make old enough to be GC-eligible.
+        let old_time = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        std::fs::File::open(&snap)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        // Hold a shared lock on the snapshot (simulating runner start).
+        let snap_lock_file = lock::open_lock_file(&home.snapshot_lock("snap_locked")).unwrap();
+        let _snap_held = Flock::lock(snap_lock_file, FlockArg::LockShared).unwrap();
+
+        let freed = gc_nested_images(&home, Some(0), false).await.unwrap();
+        assert!(snap.exists(), "locked snapshot must survive");
+        assert_eq!(freed, 0);
+    }
+
     #[test]
     fn gc_protect_version_flag_is_accepted() {
         let r = GcCli::try_parse_from(["gc", "--protect-version", "v0.78.3"]);
@@ -1900,67 +1625,6 @@ mod tests {
         assert_eq!(removed, 2);
         assert!(!system_log.exists());
         assert!(!metrics_log.exists());
-    }
-
-    #[tokio::test]
-    async fn gc_min_age_preserves_recent_artifact() {
-        let dir = tempfile::tempdir().unwrap();
-        let locks_dir = dir.path().join("locks");
-        std::fs::create_dir_all(&locks_dir).unwrap();
-
-        let artifacts_dir = dir.path().join("rootfs");
-        let recent_dir = artifacts_dir.join("recent_hash");
-        std::fs::create_dir_all(&recent_dir).unwrap();
-        std::fs::write(recent_dir.join("rootfs.ext4"), b"data").unwrap();
-        // mtime defaults to now — well within GC_MIN_AGE (10 min)
-
-        let freed = gc_dir(
-            "rootfs",
-            &artifacts_dir,
-            |hash| locks_dir.join(format!("rootfs-{hash}.lock")),
-            Some(0), // keep_latest=0 would normally delete everything
-            false,
-        )
-        .await
-        .unwrap();
-
-        assert!(recent_dir.exists(), "recent artifact should be protected");
-        assert_eq!(freed, 0);
-    }
-
-    #[tokio::test]
-    async fn gc_min_age_allows_old_artifact_deletion() {
-        use std::fs::FileTimes;
-        use std::time::Duration;
-
-        let dir = tempfile::tempdir().unwrap();
-        let locks_dir = dir.path().join("locks");
-        std::fs::create_dir_all(&locks_dir).unwrap();
-
-        let artifacts_dir = dir.path().join("rootfs");
-        let old_dir = artifacts_dir.join("old_hash");
-        std::fs::create_dir_all(&old_dir).unwrap();
-        std::fs::write(old_dir.join("rootfs.ext4"), b"data").unwrap();
-
-        // Set mtime to 1 hour ago — well past GC_MIN_AGE
-        let old_time = SystemTime::now() - Duration::from_secs(3600);
-        std::fs::File::open(&old_dir)
-            .unwrap()
-            .set_times(FileTimes::new().set_modified(old_time))
-            .unwrap();
-
-        let freed = gc_dir(
-            "rootfs",
-            &artifacts_dir,
-            |hash| locks_dir.join(format!("rootfs-{hash}.lock")),
-            Some(0),
-            false,
-        )
-        .await
-        .unwrap();
-
-        assert!(!old_dir.exists(), "old artifact should be deleted");
-        assert!(freed > 0 || cfg!(target_os = "macos"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -51,14 +51,7 @@ pub struct GcArgs {
 pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
     let home = HomePaths::new()?;
 
-    let images_freed = gc_dir(
-        "images",
-        &home.images_dir(),
-        |hash| home.image_lock(hash),
-        args.keep_latest,
-        args.dry_run,
-    )
-    .await?;
+    let images_freed = gc_nested_images(&home, args.keep_latest, args.dry_run).await?;
 
     // Workspace GC must run BEFORE orphaned lock cleanup: it reads base_dir
     // paths from lock files to discover workspaces from dead runners. If
@@ -165,11 +158,14 @@ struct GcCandidate {
     _lock: Flock<std::fs::File>,
 }
 
-/// GC a single artifact directory (e.g. images/).
+/// GC a single flat artifact directory.
 ///
 /// Each subdirectory is named by its content hash. We try an exclusive nonblocking
 /// flock on the corresponding lock file — if it succeeds the resource is unused.
 /// The exclusive lock is held until deletion to prevent TOCTOU races.
+///
+/// Only used by tests now — image GC migrated to `gc_nested_images`.
+#[cfg(test)]
 async fn gc_dir(
     label: &str,
     dir: &Path,
@@ -269,6 +265,231 @@ async fn gc_dir(
     }
 
     Ok(freed)
+}
+
+/// GC for the nested image layout: `<images>/<rootfs>/snapshots/<snapshot>/`.
+///
+/// Per-rootfs: mtime-sort snapshots, keep the latest `keep_latest`, delete the rest.
+/// After per-rootfs cleanup: if a rootfs dir has no surviving snapshots and its
+/// mtime is older than `GC_MIN_AGE`, delete the entire rootfs dir (orphan cleanup).
+async fn gc_nested_images(
+    home: &HomePaths,
+    keep_latest: Option<usize>,
+    dry_run: bool,
+) -> RunnerResult<u64> {
+    let images_dir = home.images_dir();
+    let mut rootfs_entries = match tokio::fs::read_dir(&images_dir).await {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "read {}: {e}",
+                images_dir.display()
+            )));
+        }
+    };
+
+    let mut total_freed = 0u64;
+
+    while let Some(rootfs_entry) = next_entry_warn(&mut rootfs_entries, "images", &images_dir).await
+    {
+        let rootfs_path = rootfs_entry.path();
+        let Some(rootfs_hash) = rootfs_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(String::from)
+        else {
+            continue;
+        };
+
+        // Skip non-directories (e.g. stale temp files).
+        if !rootfs_path.is_dir() {
+            continue;
+        }
+
+        // Probe rootfs lock. If held (by start/build), we can still GC
+        // individual snapshots (guarded by their own locks), but must NOT
+        // delete the rootfs directory itself.
+        let rootfs_lock_path = home.rootfs_lock(&rootfs_hash);
+        let _rootfs_lock = match probe_lock(&rootfs_lock_path) {
+            LockProbe::Free(lock) => Some(lock),
+            LockProbe::Held => {
+                info!("images/{rootfs_hash}: rootfs in use, will only GC unlocked snapshots");
+                None
+            }
+            LockProbe::Error(e) => {
+                info!("images/{rootfs_hash}: lock probe failed ({e}), skipping");
+                continue;
+            }
+        };
+        let can_delete_rootfs = _rootfs_lock.is_some();
+
+        let snapshots_dir = rootfs_path.join("snapshots");
+        let mut snapshot_entries = match tokio::fs::read_dir(&snapshots_dir).await {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // No snapshots/ subdirectory — orphaned rootfs.
+                // Can only delete if we hold the rootfs lock.
+                if can_delete_rootfs {
+                    let (rootfs_size, rootfs_mtime) = dir_stats(&rootfs_path).await;
+                    let age = SystemTime::now()
+                        .duration_since(rootfs_mtime)
+                        .unwrap_or_default();
+                    if age >= GC_MIN_AGE {
+                        if dry_run {
+                            info!(
+                                "[dry-run] would delete orphaned rootfs images/{rootfs_hash} ({})",
+                                human_bytes(rootfs_size)
+                            );
+                        } else if let Err(e) = tokio::fs::remove_dir_all(&rootfs_path).await {
+                            warn!("failed to remove orphaned rootfs images/{rootfs_hash}: {e}");
+                        } else {
+                            info!(
+                                "deleted orphaned rootfs images/{rootfs_hash} ({})",
+                                human_bytes(rootfs_size)
+                            );
+                            total_freed += rootfs_size;
+                        }
+                    } else {
+                        info!(
+                            "images/{rootfs_hash}: no snapshots, too recent ({}s), keeping",
+                            age.as_secs()
+                        );
+                    }
+                }
+                continue;
+            }
+            Err(e) => {
+                warn!("images/{rootfs_hash}/snapshots: read failed ({e}), skipping");
+                continue;
+            }
+        };
+
+        // Collect snapshot candidates.
+        let mut candidates: Vec<GcCandidate> = Vec::new();
+        while let Some(snap_entry) =
+            next_entry_warn(&mut snapshot_entries, "snapshots", &snapshots_dir).await
+        {
+            let snap_path = snap_entry.path();
+            let Some(snap_hash) = snap_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(String::from)
+            else {
+                continue;
+            };
+            if !snap_path.is_dir() {
+                continue;
+            }
+
+            let lock_path = home.snapshot_lock(&snap_hash);
+            match probe_lock(&lock_path) {
+                LockProbe::Free(lock) => {
+                    let (size, mtime) = dir_stats(&snap_path).await;
+                    candidates.push(GcCandidate {
+                        path: snap_path,
+                        hash: snap_hash,
+                        size,
+                        mtime,
+                        _lock: lock,
+                    });
+                }
+                LockProbe::Held => {
+                    info!("images/{rootfs_hash}/snapshots/{snap_hash}: in use, skipping");
+                }
+                LockProbe::Error(e) => {
+                    info!(
+                        "images/{rootfs_hash}/snapshots/{snap_hash}: lock probe failed ({e}), skipping"
+                    );
+                }
+            }
+        }
+
+        // Protect recently-created snapshots.
+        let now = SystemTime::now();
+        candidates.retain(|c| {
+            let age = now.duration_since(c.mtime).unwrap_or_default();
+            if age < GC_MIN_AGE {
+                info!(
+                    "images/{rootfs_hash}/snapshots/{}: too recent ({}s), keeping",
+                    c.hash,
+                    age.as_secs()
+                );
+                false
+            } else {
+                true
+            }
+        });
+
+        // Sort by mtime descending (newest first), keep latest N.
+        candidates.sort_by(|a, b| b.mtime.cmp(&a.mtime));
+        let keep_count = keep_latest.unwrap_or(0);
+        for c in candidates.iter().take(keep_count) {
+            info!(
+                "images/{rootfs_hash}/snapshots/{}: keeping (latest unused, {})",
+                c.hash,
+                human_bytes(c.size)
+            );
+        }
+
+        for c in candidates.iter().skip(keep_count) {
+            if dry_run {
+                info!(
+                    "[dry-run] would delete images/{rootfs_hash}/snapshots/{} ({})",
+                    c.hash,
+                    human_bytes(c.size)
+                );
+            } else if let Err(e) = tokio::fs::remove_dir_all(&c.path).await {
+                warn!(
+                    "failed to remove images/{rootfs_hash}/snapshots/{}: {e}",
+                    c.hash
+                );
+            } else {
+                info!(
+                    "deleted images/{rootfs_hash}/snapshots/{} ({})",
+                    c.hash,
+                    human_bytes(c.size)
+                );
+                total_freed += c.size;
+            }
+        }
+
+        // Check if rootfs is now orphaned (no remaining snapshots).
+        // Only delete rootfs if we hold the exclusive rootfs lock.
+        let has_snapshots = match tokio::fs::read_dir(&snapshots_dir).await {
+            Ok(mut rd) => rd.next_entry().await.ok().flatten().is_some(),
+            Err(_) => false,
+        };
+        if !has_snapshots && can_delete_rootfs {
+            let (rootfs_size, rootfs_mtime) = dir_stats(&rootfs_path).await;
+            let age = SystemTime::now()
+                .duration_since(rootfs_mtime)
+                .unwrap_or_default();
+            if age >= GC_MIN_AGE {
+                if dry_run {
+                    info!(
+                        "[dry-run] would delete orphaned rootfs images/{rootfs_hash} ({})",
+                        human_bytes(rootfs_size)
+                    );
+                } else if let Err(e) = tokio::fs::remove_dir_all(&rootfs_path).await {
+                    warn!("failed to remove orphaned rootfs images/{rootfs_hash}: {e}");
+                } else {
+                    info!(
+                        "deleted orphaned rootfs images/{rootfs_hash} ({})",
+                        human_bytes(rootfs_size)
+                    );
+                    total_freed += rootfs_size;
+                }
+            } else {
+                info!(
+                    "images/{rootfs_hash}: orphaned but too recent ({}s), keeping",
+                    age.as_secs()
+                );
+            }
+        }
+    }
+
+    Ok(total_freed)
 }
 
 enum LockProbe {
@@ -1402,6 +1623,220 @@ mod tests {
             "skipped version should survive"
         );
         assert!(!bin_dir.join("v2.0.0").exists());
+    }
+
+    #[tokio::test]
+    async fn gc_nested_images_empty_dir_returns_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let freed = gc_nested_images(&home, Some(1), false).await.unwrap();
+        assert_eq!(freed, 0);
+    }
+
+    #[tokio::test]
+    async fn gc_nested_images_keeps_latest_per_rootfs() {
+        use std::fs::FileTimes;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let images_dir = home.images_dir();
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        // Create rootfs with two snapshots
+        let rootfs_dir = images_dir.join("rootfs_aaa");
+        let snap_old = rootfs_dir.join("snapshots").join("snap_old");
+        let snap_new = rootfs_dir.join("snapshots").join("snap_new");
+        for d in [&snap_old, &snap_new] {
+            std::fs::create_dir_all(d).unwrap();
+            std::fs::write(d.join("snapshot.bin"), b"data").unwrap();
+        }
+        std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+
+        // Set distinct mtimes — old snapshot is clearly old
+        let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        std::fs::File::open(&snap_old)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+        let new_time = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000);
+        std::fs::File::open(&snap_new)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(new_time))
+            .unwrap();
+
+        let freed = gc_nested_images(&home, Some(1), false).await.unwrap();
+
+        assert!(snap_new.exists(), "newest snapshot should survive");
+        assert!(!snap_old.exists(), "oldest snapshot should be deleted");
+        assert!(
+            rootfs_dir.join("rootfs.ext4").exists(),
+            "rootfs should survive"
+        );
+        assert!(freed > 0);
+    }
+
+    #[tokio::test]
+    async fn gc_nested_images_orphaned_rootfs_old_enough() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let images_dir = home.images_dir();
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        // Rootfs with no snapshots/ directory at all
+        let rootfs_dir = images_dir.join("orphan_rootfs");
+        std::fs::create_dir_all(&rootfs_dir).unwrap();
+        std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+
+        // Make it old enough for GC
+        let old_time = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        std::fs::File::open(&rootfs_dir)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        let freed = gc_nested_images(&home, None, false).await.unwrap();
+        assert!(!rootfs_dir.exists(), "orphaned rootfs should be deleted");
+        assert!(freed > 0);
+    }
+
+    #[tokio::test]
+    async fn gc_nested_images_dry_run_deletes_nothing() {
+        use std::fs::FileTimes;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let images_dir = home.images_dir();
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let rootfs_dir = images_dir.join("rootfs_bbb");
+        let snap = rootfs_dir.join("snapshots").join("snap_x");
+        std::fs::create_dir_all(&snap).unwrap();
+        std::fs::write(snap.join("snapshot.bin"), b"data").unwrap();
+        std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+
+        let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        std::fs::File::open(&snap)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        // keep_latest=0 + dry_run: would delete but doesn't actually
+        let freed = gc_nested_images(&home, Some(0), true).await.unwrap();
+        assert!(snap.exists(), "dry-run must not delete");
+        assert_eq!(freed, 0, "dry-run must not count freed space");
+    }
+
+    /// Empty `snapshots/` directory (not missing, just empty) → orphan rootfs deleted.
+    /// Different code path from "no snapshots/ dir at all" (which hits the NotFound branch).
+    #[tokio::test]
+    async fn gc_nested_images_empty_snapshots_dir_orphans_rootfs() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let images_dir = home.images_dir();
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let rootfs_dir = images_dir.join("rootfs_empty_snaps");
+        let snapshots_dir = rootfs_dir.join("snapshots");
+        std::fs::create_dir_all(&snapshots_dir).unwrap();
+        std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+
+        // Make rootfs old enough for GC.
+        let old_time = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        std::fs::File::open(&rootfs_dir)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        let freed = gc_nested_images(&home, None, false).await.unwrap();
+        assert!(
+            !rootfs_dir.exists(),
+            "orphaned rootfs (empty snapshots/) should be deleted"
+        );
+        assert!(freed > 0);
+    }
+
+    /// Snapshots younger than GC_MIN_AGE are unconditionally kept, even with keep_latest=0.
+    #[tokio::test]
+    async fn gc_nested_images_recent_snapshot_protected() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let images_dir = home.images_dir();
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let rootfs_dir = images_dir.join("rootfs_recent");
+        let snap = rootfs_dir.join("snapshots").join("snap_fresh");
+        std::fs::create_dir_all(&snap).unwrap();
+        std::fs::write(snap.join("snapshot.bin"), b"data").unwrap();
+        std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+
+        // mtime is NOW (default) — well within GC_MIN_AGE.
+        // keep_latest=0 would delete everything, but GC_MIN_AGE protects.
+        let freed = gc_nested_images(&home, Some(0), false).await.unwrap();
+        assert!(
+            snap.exists(),
+            "recent snapshot must survive despite keep_latest=0"
+        );
+        assert!(
+            rootfs_dir.exists(),
+            "rootfs must survive (has protected snapshot)"
+        );
+        assert_eq!(freed, 0);
+    }
+
+    /// When the rootfs lock is held, GC can still delete unlocked snapshots
+    /// but must NOT delete the rootfs directory itself.
+    #[tokio::test]
+    async fn gc_nested_images_locked_rootfs_still_cleans_unlocked_snapshots() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let images_dir = home.images_dir();
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let rootfs_dir = images_dir.join("can_delete_rootfs");
+        let snap_used = rootfs_dir.join("snapshots").join("snap_used");
+        let snap_old = rootfs_dir.join("snapshots").join("snap_old");
+        for d in [&snap_used, &snap_old] {
+            std::fs::create_dir_all(d).unwrap();
+            std::fs::write(d.join("snapshot.bin"), b"data").unwrap();
+        }
+        std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+
+        // Make snap_old old enough to be GC-eligible.
+        let old_time = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        std::fs::File::open(&snap_old)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        // Simulate `runner start` holding shared locks on rootfs + snap_used.
+        let rootfs_lock_file =
+            lock::open_lock_file(&home.rootfs_lock("can_delete_rootfs")).unwrap();
+        let _rootfs_held = Flock::lock(rootfs_lock_file, FlockArg::LockShared).unwrap();
+        let snap_lock_file = lock::open_lock_file(&home.snapshot_lock("snap_used")).unwrap();
+        let _snap_held = Flock::lock(snap_lock_file, FlockArg::LockShared).unwrap();
+
+        let freed = gc_nested_images(&home, Some(0), false).await.unwrap();
+        assert!(
+            !snap_old.exists(),
+            "unlocked old snapshot should be deleted"
+        );
+        assert!(snap_used.exists(), "locked snapshot must survive");
+        assert!(rootfs_dir.exists(), "rootfs must survive (lock held)");
+        assert!(freed > 0);
     }
 
     #[test]

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -134,12 +134,18 @@ pub async fn run_start(
     let runner_id = load_or_generate_runner_id(&runner_config.base_dir).await?;
     info!(runner_id = %runner_id, runner_name = %runner_config.name, "runner identity");
 
-    // Shared lock on image per profile — allows `runner gc` to detect in-use resources.
+    // Shared locks on rootfs + snapshot per profile — allows `runner gc` to detect in-use resources.
     let mut _resource_locks = Vec::new();
     for profile in runner_config.profiles.values() {
-        let lock = lock::acquire_shared(home.image_lock(&profile.image_hash)).await?;
-        touch_mtime(&home.images_dir().join(&profile.image_hash));
-        _resource_locks.push(lock);
+        let rootfs_lock = lock::acquire_shared(home.rootfs_lock(&profile.rootfs_hash)).await?;
+        let rootfs_paths = crate::paths::RootfsPaths::new(&home, &profile.rootfs_hash);
+        touch_mtime(rootfs_paths.dir());
+        _resource_locks.push(rootfs_lock);
+        let snapshot_lock =
+            lock::acquire_shared(home.snapshot_lock(&profile.snapshot_hash)).await?;
+        let snapshot_paths = rootfs_paths.snapshot(&profile.snapshot_hash);
+        touch_mtime(snapshot_paths.dir());
+        _resource_locks.push(snapshot_lock);
     }
 
     let log_paths = LogPaths::new(home.logs_dir());
@@ -154,10 +160,9 @@ pub async fn run_start(
 
     // Start background prefetch of snapshot memory for all profiles.
     for profile in runner_config.profiles.values() {
-        let path = home
-            .images_dir()
-            .join(&profile.image_hash)
-            .join("memory.bin");
+        let path = crate::paths::RootfsPaths::new(&home, &profile.rootfs_hash)
+            .snapshot(&profile.snapshot_hash)
+            .memory_bin();
         tokio::task::spawn_blocking(move || prefetch::prefetch_memory(&path));
     }
 
@@ -1512,7 +1517,8 @@ mod tests {
         m.insert(
             "vm0/default".to_string(),
             config::ProfileConfig {
-                image_hash: "hash".into(),
+                rootfs_hash: "hash".into(),
+                snapshot_hash: "snap".into(),
                 vcpu: 2,
                 memory_mb: 4096,
                 disk_mb: 10240,
@@ -2354,7 +2360,8 @@ mod tests {
         m.insert(
             "vm0/default".to_string(),
             config::ProfileConfig {
-                image_hash: "hash".into(),
+                rootfs_hash: "hash".into(),
+                snapshot_hash: "snap".into(),
                 vcpu: 2,
                 memory_mb: 4096,
                 disk_mb: 10240,
@@ -2363,7 +2370,8 @@ mod tests {
         m.insert(
             "vm0/large".to_string(),
             config::ProfileConfig {
-                image_hash: "hash2".into(),
+                rootfs_hash: "hash2".into(),
+                snapshot_hash: "snap2".into(),
                 vcpu: 4,
                 memory_mb: 8192,
                 disk_mb: 20480,

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::idle_pool::DEFAULT_IDLE_TIMEOUT_SECS;
-use crate::paths::{HomePaths, ImagePaths};
+use crate::paths::{HomePaths, RootfsPaths};
 use crate::profile;
 
 /// 0 means auto-detect from host CPU and memory at startup.
@@ -37,7 +37,10 @@ pub struct FirecrackerConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProfileConfig {
-    pub image_hash: String,
+    /// Content-addressed rootfs hash (R2-cacheable, shared across snapshot variants).
+    pub rootfs_hash: String,
+    /// Content-addressed snapshot hash (local-only, covers FC/kernel/vcpu/memory/provider config).
+    pub snapshot_hash: String,
     pub vcpu: u32,
     pub memory_mb: u32,
     pub disk_mb: u32,
@@ -134,7 +137,8 @@ async fn validate(config: &RunnerConfig, home: &HomePaths) -> RunnerResult<()> {
         profile::validate_or_err(name)?;
     }
     for profile in config.profiles.values() {
-        crate::image_hash::validate_or_err(&profile.image_hash)?;
+        crate::image_hash::validate_or_err(&profile.rootfs_hash)?;
+        crate::image_hash::validate_or_err(&profile.snapshot_hash)?;
     }
 
     check_path_exists(&config.ca_dir, "ca_dir").await?;
@@ -165,10 +169,15 @@ async fn validate(config: &RunnerConfig, home: &HomePaths) -> RunnerResult<()> {
                 profile.disk_mb
             )));
         }
-        // Validate all image files exist on disk.
-        let image_paths = ImagePaths::new(home, &profile.image_hash);
-        for path in image_paths.expected_files() {
-            check_path_exists(&path, &format!("profile {name} image")).await?;
+        // Validate rootfs files exist on disk.
+        let rootfs_paths = RootfsPaths::new(home, &profile.rootfs_hash);
+        for path in rootfs_paths.expected_files() {
+            check_path_exists(&path, &format!("profile {name} rootfs")).await?;
+        }
+        // Validate snapshot files exist on disk.
+        let snapshot_paths = rootfs_paths.snapshot(&profile.snapshot_hash);
+        for path in snapshot_paths.expected_files() {
+            check_path_exists(&path, &format!("profile {name} snapshot")).await?;
         }
     }
 
@@ -224,16 +233,17 @@ impl RunnerConfig {
         profile: &ProfileConfig,
         home: &HomePaths,
     ) -> sandbox::FactoryConfig {
-        let image_paths = ImagePaths::new(home, &profile.image_hash);
+        let rootfs_paths = RootfsPaths::new(home, &profile.rootfs_hash);
+        let snapshot_paths = rootfs_paths.snapshot(&profile.snapshot_hash);
         sandbox::FactoryConfig {
             profile: profile_name.to_string(),
             binary_path: firecracker.binary.clone(),
             kernel_path: firecracker.kernel.clone(),
-            rootfs_path: image_paths.rootfs(),
+            rootfs_path: rootfs_paths.rootfs(),
             base_dir: base_dir.to_path_buf(),
             snapshot: Some(sandbox::SnapshotRef {
-                output_dir: image_paths.dir().to_path_buf(),
-                hash: profile.image_hash.clone(),
+                output_dir: snapshot_paths.dir().to_path_buf(),
+                hash: profile.snapshot_hash.clone(),
             }),
         }
     }
@@ -243,19 +253,30 @@ impl RunnerConfig {
 mod tests {
     use super::*;
 
-    /// 64 lowercase hex chars — matches `Sha256::digest(...).hex_encode()`
-    /// shape so the new `image_hash` validator accepts it.
-    const TEST_HASH: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    /// 64 lowercase hex chars — matches `Sha256::digest(...).hex_encode()`.
+    const TEST_ROOTFS_HASH: &str =
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const TEST_SNAPSHOT_HASH: &str =
+        "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
 
     /// Create a HomePaths rooted in a temp dir and populate fake image files
-    /// for the given image hashes so config validation passes.
-    async fn test_home_with_artifacts(dir: &std::path::Path, image_hashes: &[&str]) -> HomePaths {
+    /// for the given (rootfs_hash, snapshot_hash) pairs so config validation passes.
+    async fn test_home_with_artifacts(dir: &std::path::Path, hashes: &[(&str, &str)]) -> HomePaths {
         let home = HomePaths::with_root(dir.join("vm0-runner"));
-        for &hash in image_hashes {
-            let image = ImagePaths::new(&home, hash);
-            tokio::fs::create_dir_all(image.dir()).await.unwrap();
-            for path in image.expected_files() {
-                tokio::fs::write(&path, b"").await.unwrap();
+        for &(rootfs_hash, snapshot_hash) in hashes {
+            let rootfs = RootfsPaths::new(&home, rootfs_hash);
+            tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+            tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
+            if !snapshot_hash.is_empty() {
+                let snapshot = rootfs.snapshot(snapshot_hash);
+                tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
+                for path in [
+                    snapshot.snapshot_bin(),
+                    snapshot.memory_bin(),
+                    snapshot.cow_img(),
+                ] {
+                    tokio::fs::write(&path, b"").await.unwrap();
+                }
             }
         }
         home
@@ -266,7 +287,8 @@ mod tests {
         profiles.insert(
             "vm0/default".into(),
             ProfileConfig {
-                image_hash: TEST_HASH.into(),
+                rootfs_hash: TEST_ROOTFS_HASH.into(),
+                snapshot_hash: TEST_SNAPSHOT_HASH.into(),
                 vcpu: 2,
                 memory_mb: 4096,
                 disk_mb: 16384,
@@ -295,7 +317,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
     disk_mb: 16384
@@ -310,10 +333,12 @@ server:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
-        let home = test_home_with_artifacts(dir.path(), &[TEST_HASH]).await;
+        let home =
+            test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
 
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
@@ -323,7 +348,7 @@ server:
         assert_eq!(config.profiles.len(), 1);
         let default = &config.profiles["vm0/default"];
         assert_eq!(default.vcpu, 2);
-        assert_eq!(default.image_hash, TEST_HASH);
+        assert_eq!(default.rootfs_hash, TEST_ROOTFS_HASH);
         assert_eq!(config.sandbox.max_concurrent, 8);
         assert!((config.sandbox.concurrency_factor - 2.0).abs() < f64::EPSILON);
         let server = config.server.unwrap();
@@ -339,7 +364,8 @@ server:
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[TEST_HASH]).await;
+        let home =
+            test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
 
         let yaml = format!(
             r#"
@@ -352,7 +378,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
     disk_mb: 16384
@@ -361,7 +388,8 @@ profiles:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");
@@ -383,7 +411,7 @@ profiles:
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[] as &[&str]).await;
+        let home = test_home_with_artifacts(dir.path(), &[] as &[(&str, &str)]).await;
 
         let yaml = format!(
             r#"
@@ -420,7 +448,7 @@ profiles: {{}}
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[] as &[&str]).await;
+        let home = test_home_with_artifacts(dir.path(), &[] as &[(&str, &str)]).await;
 
         let yaml = format!(
             r#"
@@ -433,7 +461,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   bad-name:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
     disk_mb: 16384
@@ -442,7 +471,8 @@ profiles:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");
@@ -456,14 +486,14 @@ profiles:
     }
 
     #[tokio::test]
-    async fn load_rejects_invalid_image_hash() {
+    async fn load_rejects_invalid_rootfs_hash() {
         let dir = tempfile::tempdir().unwrap();
         let fc = dir.path().join("firecracker");
         let kernel = dir.path().join("vmlinux");
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[] as &[&str]).await;
+        let home = test_home_with_artifacts(dir.path(), &[] as &[(&str, &str)]).await;
 
         // `../etc` would escape `images_dir()` if joined unchecked. The
         // validator must reject this at config-load time, before any
@@ -479,7 +509,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: ../etc
+    rootfs_hash: ../etc
+    snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
     disk_mb: 16384
@@ -488,6 +519,48 @@ profiles:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
+            snap_hash = TEST_SNAPSHOT_HASH,
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        assert!(err.to_string().contains("invalid image hash"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn load_rejects_invalid_snapshot_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        for f in [&fc, &kernel] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+        let home = test_home_with_artifacts(dir.path(), &[] as &[(&str, &str)]).await;
+
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+profiles:
+  vm0/default:
+    rootfs_hash: {hash}
+    snapshot_hash: ../etc
+    vcpu: 2
+    memory_mb: 4096
+    disk_mb: 16384
+"#,
+            base_dir = dir.path().display(),
+            ca_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+            hash = TEST_ROOTFS_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");
@@ -505,7 +578,7 @@ profiles:
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[] as &[&str]).await;
+        let home = test_home_with_artifacts(dir.path(), &[] as &[(&str, &str)]).await;
 
         let yaml = format!(
             r#"
@@ -518,7 +591,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 0
     memory_mb: 4096
     disk_mb: 16384
@@ -527,7 +601,8 @@ profiles:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");
@@ -545,7 +620,7 @@ profiles:
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[] as &[&str]).await;
+        let home = test_home_with_artifacts(dir.path(), &[] as &[(&str, &str)]).await;
 
         let yaml = format!(
             r#"
@@ -558,7 +633,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
     disk_mb: 0
@@ -567,7 +643,8 @@ profiles:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");
@@ -585,7 +662,8 @@ profiles:
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[TEST_HASH]).await;
+        let home =
+            test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
 
         let yaml = format!(
             r#"
@@ -598,7 +676,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 1024
     memory_mb: 4096
     disk_mb: 16384
@@ -607,7 +686,8 @@ profiles:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");
@@ -626,7 +706,7 @@ profiles:
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[] as &[&str]).await;
+        let home = test_home_with_artifacts(dir.path(), &[] as &[(&str, &str)]).await;
 
         let yaml = format!(
             r#"
@@ -639,7 +719,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 2048
     memory_mb: 4096
     disk_mb: 16384
@@ -648,7 +729,8 @@ profiles:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");
@@ -666,7 +748,7 @@ profiles:
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[] as &[&str]).await;
+        let home = test_home_with_artifacts(dir.path(), &[] as &[(&str, &str)]).await;
 
         let yaml = format!(
             r#"
@@ -679,7 +761,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 2000000
     disk_mb: 16384
@@ -688,7 +771,8 @@ profiles:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");
@@ -706,7 +790,7 @@ profiles:
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[] as &[&str]).await;
+        let home = test_home_with_artifacts(dir.path(), &[] as &[(&str, &str)]).await;
 
         let yaml = format!(
             r#"
@@ -719,7 +803,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
     disk_mb: 2000000
@@ -728,7 +813,8 @@ profiles:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");
@@ -747,11 +833,11 @@ profiles:
             tokio::fs::write(f, b"").await.unwrap();
         }
 
-        // Create image directory with only rootfs.ext4 (missing snapshot files).
+        // Create rootfs.ext4 but NO snapshot files — validation should fail.
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
-        let image = ImagePaths::new(&home, TEST_HASH);
-        tokio::fs::create_dir_all(image.dir()).await.unwrap();
-        tokio::fs::write(image.rootfs(), b"").await.unwrap();
+        let rootfs = RootfsPaths::new(&home, TEST_ROOTFS_HASH);
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
 
         let yaml = format!(
             r#"
@@ -764,7 +850,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
     disk_mb: 16384
@@ -773,7 +860,8 @@ profiles:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");
@@ -795,7 +883,8 @@ profiles:
             tokio::fs::write(f, b"").await.unwrap();
         }
 
-        let home = test_home_with_artifacts(dir.path(), &[TEST_HASH]).await;
+        let home =
+            test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
 
         for bad_value in ["0.0", "-1.0", ".nan", ".inf", "-.inf"] {
             let yaml = format!(
@@ -809,7 +898,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
     disk_mb: 16384
@@ -820,7 +910,8 @@ sandbox:
                 ca_dir = dir.path().display(),
                 fc = fc.display(),
                 kernel = kernel.display(),
-                hash = TEST_HASH,
+                hash = TEST_ROOTFS_HASH,
+                snap_hash = TEST_SNAPSHOT_HASH,
             );
 
             let config_path = dir.path().join("runner.yaml");
@@ -842,7 +933,8 @@ sandbox:
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[TEST_HASH]).await;
+        let home =
+            test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
 
         let runner_dir = dir.path().join("my-runner");
         let config = RunnerConfig {
@@ -880,7 +972,8 @@ sandbox:
         for name in ["firecracker", "vmlinux"] {
             tokio::fs::write(sub.join(name), b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[TEST_HASH]).await;
+        let home =
+            test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
 
         let yaml = format!(
             r#"
@@ -893,12 +986,14 @@ firecracker:
   kernel: artifacts/vmlinux
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
     disk_mb: 16384
 "#,
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");
@@ -937,14 +1032,13 @@ profiles:
 
         assert_eq!(fc.binary_path, dir.path().join("firecracker"));
         assert_eq!(fc.kernel_path, dir.path().join("vmlinux"));
-        assert_eq!(
-            fc.rootfs_path,
-            home.images_dir().join(TEST_HASH).join("rootfs.ext4")
-        );
+        let rootfs_paths = RootfsPaths::new(&home, TEST_ROOTFS_HASH);
+        assert_eq!(fc.rootfs_path, rootfs_paths.rootfs());
         assert_eq!(fc.profile, "vm0/default");
         let snap = fc.snapshot.unwrap();
-        assert_eq!(snap.hash, TEST_HASH);
-        assert_eq!(snap.output_dir, home.images_dir().join(TEST_HASH));
+        assert_eq!(snap.hash, TEST_SNAPSHOT_HASH);
+        let snapshot_paths = RootfsPaths::new(&home, TEST_ROOTFS_HASH).snapshot(TEST_SNAPSHOT_HASH);
+        assert_eq!(snap.output_dir, snapshot_paths.dir().to_path_buf());
     }
 
     #[tokio::test]
@@ -955,7 +1049,8 @@ profiles:
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[TEST_HASH]).await;
+        let home =
+            test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
 
         let runner_dir = dir.path().join("my-runner");
         let config = RunnerConfig {
@@ -992,7 +1087,8 @@ profiles:
         for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
-        let home = test_home_with_artifacts(dir.path(), &[TEST_HASH]).await;
+        let home =
+            test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
 
         // YAML without any idle pool fields
         let yaml = format!(
@@ -1006,7 +1102,8 @@ firecracker:
   kernel: {kernel}
 profiles:
   vm0/default:
-    image_hash: {hash}
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
     disk_mb: 16384
@@ -1015,7 +1112,8 @@ profiles:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            hash = TEST_HASH,
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
         );
 
         let config_path = dir.path().join("runner.yaml");

--- a/crates/runner/src/image_hash.rs
+++ b/crates/runner/src/image_hash.rs
@@ -1,19 +1,19 @@
-//! Validation for image content-addressed hashes.
+//! Validation for content-addressed hashes (rootfs and snapshot).
 //!
-//! `image_hash` is produced by [`crate::cmd::build`]'s `compute_image_hash`
-//! as `hex::encode(Sha256::digest(...))`, so the canonical format is
-//! exactly 64 lowercase hex characters. The value is later joined
+//! Both `rootfs_hash` and `snapshot_hash` are produced as
+//! `hex::encode(Sha256::digest(...))`, so the canonical format is
+//! exactly 64 lowercase hex characters. The values are joined
 //! against [`crate::paths::HomePaths::images_dir`] to form on-disk
 //! paths, so any input containing `..`, `/`, or other path
 //! metacharacters could escape the intended directory. This module is
-//! the single source of truth for what counts as a safe `image_hash`.
+//! the single source of truth for what counts as a safe hash value.
 
 use crate::error::{RunnerError, RunnerResult};
 
 /// Validate `hash` and return a [`RunnerError::Config`] with a uniform
-/// message if it fails. Use this at every callsite that takes an
-/// `image_hash` from the user (CLI flags, YAML config) so the error
-/// wording stays consistent.
+/// message if it fails. Use this at every callsite that takes a hash
+/// from the user (CLI flags, YAML config) so the error wording stays
+/// consistent.
 pub fn validate_or_err(hash: &str) -> RunnerResult<()> {
     if !validate_name(hash) {
         return Err(RunnerError::Config(format!(

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -127,20 +127,26 @@ impl HomePaths {
         self.locks_dir().join(format!("base-dir-{hash}.lock"))
     }
 
-    pub fn image_lock(&self, hash: &str) -> PathBuf {
-        self.locks_dir().join(format!("image-{hash}.lock"))
+    pub fn rootfs_lock(&self, hash: &str) -> PathBuf {
+        self.locks_dir().join(format!("rootfs-{hash}.lock"))
+    }
+
+    pub fn snapshot_lock(&self, hash: &str) -> PathBuf {
+        self.locks_dir().join(format!("snapshot-{hash}.lock"))
     }
 }
 
-/// Paths for a unified image build output (rootfs + snapshot, keyed by image hash).
-pub struct ImagePaths {
+/// Paths for a rootfs build output, keyed by rootfs hash.
+///
+/// Layout: `<images_dir>/<rootfs_hash>/rootfs.ext4`
+pub struct RootfsPaths {
     dir: PathBuf,
 }
 
-impl ImagePaths {
-    pub fn new(home: &HomePaths, hash: &str) -> Self {
+impl RootfsPaths {
+    pub fn new(home: &HomePaths, rootfs_hash: &str) -> Self {
         Self {
-            dir: home.images_dir().join(hash),
+            dir: home.images_dir().join(rootfs_hash),
         }
     }
 
@@ -150,6 +156,39 @@ impl ImagePaths {
 
     pub fn rootfs(&self) -> PathBuf {
         self.dir.join("rootfs.ext4")
+    }
+
+    /// All files that must exist for the rootfs to be considered complete.
+    pub fn expected_files(&self) -> [PathBuf; 1] {
+        [self.rootfs()]
+    }
+
+    /// Derive snapshot paths nested under this rootfs.
+    pub fn snapshot(&self, snapshot_hash: &str) -> SnapshotPaths {
+        SnapshotPaths {
+            dir: self.dir.join("snapshots").join(snapshot_hash),
+        }
+    }
+
+    /// Parent directory for all snapshots under this rootfs.
+    #[cfg(test)]
+    pub fn snapshots_dir(&self) -> PathBuf {
+        self.dir.join("snapshots")
+    }
+}
+
+/// Paths for a snapshot build output, nested under a [`RootfsPaths`].
+///
+/// Layout: `<images_dir>/<rootfs_hash>/snapshots/<snapshot_hash>/{snapshot.bin,memory.bin,cow.img}`
+///
+/// Constructed via [`RootfsPaths::snapshot`].
+pub struct SnapshotPaths {
+    dir: PathBuf,
+}
+
+impl SnapshotPaths {
+    pub fn dir(&self) -> &Path {
+        &self.dir
     }
 
     pub fn snapshot_bin(&self) -> PathBuf {
@@ -164,14 +203,9 @@ impl ImagePaths {
         self.dir.join("cow.img")
     }
 
-    /// All files that must exist for the image to be considered complete.
-    pub fn expected_files(&self) -> [PathBuf; 4] {
-        [
-            self.rootfs(),
-            self.snapshot_bin(),
-            self.memory_bin(),
-            self.cow_img(),
-        ]
+    /// All files that must exist for the snapshot to be considered complete.
+    pub fn expected_files(&self) -> [PathBuf; 3] {
+        [self.snapshot_bin(), self.memory_bin(), self.cow_img()]
     }
 }
 
@@ -261,9 +295,9 @@ mod tests {
     #[test]
     fn lock_paths() {
         let home = HomePaths::with_root(PathBuf::from("/test"));
-        let image_lock = home.image_lock("abc123");
-        assert!(image_lock.starts_with("/test/locks/"));
-        assert!(image_lock.to_string_lossy().contains("image-abc123"));
+        let rootfs_lock = home.rootfs_lock("abc123");
+        assert!(rootfs_lock.starts_with("/test/locks/"));
+        assert!(rootfs_lock.to_string_lossy().contains("rootfs-abc123"));
     }
 
     #[test]
@@ -294,24 +328,51 @@ mod tests {
     }
 
     #[test]
-    fn image_paths_structure() {
+    fn rootfs_paths_layout() {
         let home = HomePaths::with_root(PathBuf::from("/test"));
-        let ip = ImagePaths::new(&home, "abc123");
-        assert_eq!(ip.dir(), Path::new("/test/images/abc123"));
+        let rp = RootfsPaths::new(&home, "aaa");
+        assert_eq!(rp.dir(), Path::new("/test/images/aaa"));
+        assert_eq!(rp.rootfs(), PathBuf::from("/test/images/aaa/rootfs.ext4"));
         assert_eq!(
-            ip.rootfs(),
-            PathBuf::from("/test/images/abc123/rootfs.ext4")
+            rp.snapshots_dir(),
+            PathBuf::from("/test/images/aaa/snapshots")
+        );
+    }
+
+    #[test]
+    fn snapshot_paths_layout() {
+        let home = HomePaths::with_root(PathBuf::from("/test"));
+        let sp = RootfsPaths::new(&home, "aaa").snapshot("bbb");
+        assert_eq!(sp.dir(), Path::new("/test/images/aaa/snapshots/bbb"));
+        assert_eq!(
+            sp.snapshot_bin(),
+            PathBuf::from("/test/images/aaa/snapshots/bbb/snapshot.bin")
         );
         assert_eq!(
-            ip.snapshot_bin(),
-            PathBuf::from("/test/images/abc123/snapshot.bin")
+            sp.memory_bin(),
+            PathBuf::from("/test/images/aaa/snapshots/bbb/memory.bin")
         );
         assert_eq!(
-            ip.memory_bin(),
-            PathBuf::from("/test/images/abc123/memory.bin")
+            sp.cow_img(),
+            PathBuf::from("/test/images/aaa/snapshots/bbb/cow.img")
         );
-        assert_eq!(ip.cow_img(), PathBuf::from("/test/images/abc123/cow.img"));
-        assert_eq!(ip.expected_files().len(), 4);
+        assert_eq!(sp.expected_files().len(), 3);
+    }
+
+    #[test]
+    fn rootfs_expected_files() {
+        let home = HomePaths::with_root(PathBuf::from("/test"));
+        let rp = RootfsPaths::new(&home, "aaa");
+        let files = rp.expected_files();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0], rp.rootfs());
+    }
+
+    #[test]
+    fn snapshot_lock_path() {
+        let home = HomePaths::with_root(PathBuf::from("/test"));
+        let lock = home.snapshot_lock("bbb");
+        assert_eq!(lock, PathBuf::from("/test/locks/snapshot-bbb.lock"));
     }
 
     #[test]

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -127,8 +127,12 @@ impl HomePaths {
         self.locks_dir().join(format!("base-dir-{hash}.lock"))
     }
 
+    /// Lock file for a rootfs hash.
+    ///
+    /// Keeps the `image-` prefix for backward compatibility: during rolling
+    /// deploys, old runner binaries still hold locks under this name.
     pub fn rootfs_lock(&self, hash: &str) -> PathBuf {
-        self.locks_dir().join(format!("rootfs-{hash}.lock"))
+        self.locks_dir().join(format!("image-{hash}.lock"))
     }
 
     pub fn snapshot_lock(&self, hash: &str) -> PathBuf {
@@ -297,7 +301,7 @@ mod tests {
         let home = HomePaths::with_root(PathBuf::from("/test"));
         let rootfs_lock = home.rootfs_lock("abc123");
         assert!(rootfs_lock.starts_with("/test/locks/"));
-        assert!(rootfs_lock.to_string_lossy().contains("rootfs-abc123"));
+        assert!(rootfs_lock.to_string_lossy().contains("image-abc123"));
     }
 
     #[test]

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -1,14 +1,14 @@
 //! R2 cache for `runner build` rootfs artifacts.
 //!
-//! Single-key bundle per image hash: `runner-images/{hash}.tar.zst` in the
-//! existing `R2_USER_STORAGES_BUCKET_NAME` bucket. Only rootfs.ext4 is
+//! Single-key bundle per rootfs hash: `runner-images/{rootfs_hash}.tar.zst` in
+//! the existing `R2_USER_STORAGES_BUCKET_NAME` bucket. Only rootfs.ext4 is
 //! cached in R2; snapshot files are always created locally because they
 //! contain host-specific state (page cache, kernel metadata).
 //!
 //! ## Lifecycle
 //!
 //! 1. `runner build` computes a rootfs-only hash and checks local cache.
-//! 2. On miss, after acquiring `image_lock(hash)`, it tries `try_download`.
+//! 2. On miss, after acquiring `rootfs_lock(hash)`, it tries `try_download`.
 //! 3. On download hit, the caller injects the local CA into the rootfs and
 //!    creates a snapshot locally.
 //! 4. On download miss, it does the local rootfs build, then `upload`s the
@@ -41,9 +41,8 @@
 //! ## R2-side cleanup
 //!
 //! Completed objects (`runner-images/{hash}.tar.zst`) are **never deleted on
-//! upload**. Each `IMAGE_CACHE_VERSION` bump, build-script change, guest
-//! binary rebuild, or firecracker/kernel upgrade produces a new hash and
-//! orphans the previous object.
+//! upload**. Each `ROOTFS_CACHE_VERSION` bump, build-script change, or guest
+//! binary rebuild produces a new rootfs hash and orphans the previous object.
 //!
 //! Cleanup happens via `gc_older_than`, called from `runner gc` (which the
 //! deploy playbook runs after every release). Default TTL is 7 days. Each

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -259,6 +259,24 @@ mod tests {
         );
     }
 
+    /// Guard against using a composite `<rootfs>/<snapshot>` as sock_id.
+    /// That would exceed 107 bytes (sun_path limit) and fail at bind time.
+    #[test]
+    fn composite_sock_id_would_overflow_sun_path() {
+        let rootfs = "a".repeat(64);
+        let snapshot = "b".repeat(64);
+        let composite = format!("{rootfs}/{snapshot}");
+        let runtime = RuntimePaths::new();
+        let sock = SockPaths::new(runtime.sock_dir(&composite));
+        let vsock = sock.vsock();
+        assert!(
+            vsock.as_os_str().len() > 107,
+            "composite sock_id MUST overflow sun_path — if this fails, the guard is stale: {} bytes ({})",
+            vsock.as_os_str().len(),
+            vsock.display()
+        );
+    }
+
     #[test]
     fn cow_bitmap_consistent_with_cow() {
         let output = SnapshotOutputPaths::new(PathBuf::from("/data/images/abc123"));

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -77,8 +77,7 @@ pub async fn create_snapshot(
     //    as bind-mount targets during restore, so they must be deterministic.
     //
     //    Only remove snapshot-specific artifacts (work/, snapshot.bin, memory.bin,
-    //    cow.img) — the output directory may contain other files (e.g. rootfs.ext4
-    //    in unified image builds) that must not be deleted.
+    //    cow.img) — not the entire output directory.
     let work = output.work_dir();
 
     // Remove stale snapshot artifacts individually (not rm -rf on the


### PR DESCRIPTION
## Summary

- Split single `image_hash` into `rootfs_hash` (R2-cacheable) + `snapshot_hash` (local-only) to fix a latent correctness gap where snapshot-affecting inputs (FC/kernel version, vcpu, memory_mb, provider config) were not part of the cache key
- Nested storage layout: `<images>/<rootfs_hash>/snapshots/<snapshot_hash>/`
- Two-level GC with independent rootfs/snapshot locking — can clean unused snapshots even when the rootfs is in use by another profile
- CI workflows and ansible playbook updated to parse and pass both hashes

## Test plan

- [x] `compute_snapshot_hash` deterministic and sensitive to each input field
- [x] `is_rootfs_present` gate logic
- [x] `remove_all_except_rootfs` preserves `snapshots/` subtree
- [x] Config: invalid `snapshot_hash` rejected, both hashes required
- [x] GC: keeps latest N per rootfs, orphan rootfs cleanup, GC_MIN_AGE protection, locked rootfs still allows snapshot cleanup
- [x] sun_path: 64-char snapshot_hash fits, composite would overflow (negative test)
- [x] 671 runner + 143 sandbox-fc tests pass

Closes #9544

🤖 Generated with [Claude Code](https://claude.com/claude-code)