### PR TITLE
fix(firewalls): assign x api rules to single primary scope instead of all scopes

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -525,7 +525,7 @@ jobs:
       - uses: ./.github/actions/toolchain-init
       - name: Test Other Packages
         working-directory: turbo
-        run: pnpm vitest run --project=@vm0/core --project=@vm0/ui --coverage.enabled --coverage.reporter=json
+        run: pnpm vitest run --project=@vm0/core --project=@vm0/ui --project=@vm0/firewalls-generator --coverage.enabled --coverage.reporter=json
       - name: Upload coverage to Codecov
         if: success() || failure()
         uses: codecov/codecov-action@v6

--- a/turbo/packages/firewalls-generator/package.json
+++ b/turbo/packages/firewalls-generator/package.json
@@ -144,6 +144,7 @@
     "@vm0/typescript-config": "workspace:*",
     "tsx": "^4.19.4",
     "typescript": "5.9.3",
+    "vitest": "^4.1.4",
     "yaml": "^2.8.3"
   }
 }

--- a/turbo/packages/firewalls-generator/src/__tests__/x-scope-priority.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/x-scope-priority.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { pickPrimaryScope, scopePriority } from "../x";
+
+describe("scopePriority", () => {
+  it("returns priority for known scopes", () => {
+    expect(scopePriority("tweet.write", "test")).toBe(100);
+    expect(scopePriority("like.read", "test")).toBe(50);
+    expect(scopePriority("tweet.read", "test")).toBe(5);
+    expect(scopePriority("users.read", "test")).toBe(5);
+  });
+
+  it("throws on unknown scope", () => {
+    expect(() => scopePriority("unknown.scope", "GET /2/foo")).toThrow(
+      'Unknown scope "unknown.scope" on GET /2/foo',
+    );
+  });
+});
+
+describe("pickPrimaryScope", () => {
+  it("returns the only scope for single-scope endpoints", () => {
+    expect(pickPrimaryScope(["tweet.read"], "GET /2/tweets/{id}")).toBe(
+      "tweet.read",
+    );
+  });
+
+  it("picks write scope over read scopes", () => {
+    expect(
+      pickPrimaryScope(
+        ["tweet.read", "tweet.write", "users.read"],
+        "POST /2/tweets",
+      ),
+    ).toBe("tweet.write");
+  });
+
+  it("picks like.write for like endpoints", () => {
+    expect(
+      pickPrimaryScope(
+        ["like.write", "tweet.read", "users.read"],
+        "POST /2/users/{id}/likes",
+      ),
+    ).toBe("like.write");
+  });
+
+  it("picks specific read over base read scopes", () => {
+    expect(
+      pickPrimaryScope(
+        ["dm.read", "tweet.read", "users.read"],
+        "GET /2/dm_events",
+      ),
+    ).toBe("dm.read");
+  });
+
+  it("breaks tweet.read vs users.read tie by path: /2/tweets → tweet.read", () => {
+    expect(
+      pickPrimaryScope(["tweet.read", "users.read"], "GET /2/tweets/{id}"),
+    ).toBe("tweet.read");
+  });
+
+  it("breaks tweet.read vs users.read tie by path: /2/tweets/search/recent → tweet.read", () => {
+    expect(
+      pickPrimaryScope(
+        ["tweet.read", "users.read"],
+        "GET /2/tweets/search/recent",
+      ),
+    ).toBe("tweet.read");
+  });
+
+  it("breaks tweet.read vs users.read tie by path: /2/users → users.read", () => {
+    expect(
+      pickPrimaryScope(["tweet.read", "users.read"], "GET /2/users/me"),
+    ).toBe("users.read");
+  });
+
+  it("breaks tie for /2/communities path → users.read", () => {
+    expect(
+      pickPrimaryScope(
+        ["tweet.read", "users.read"],
+        "GET /2/communities/search",
+      ),
+    ).toBe("users.read");
+  });
+
+  it("throws on unknown scope", () => {
+    expect(() =>
+      pickPrimaryScope(["tweet.read", "future.scope"], "GET /2/foo"),
+    ).toThrow('Unknown scope "future.scope"');
+  });
+
+  it("throws on unresolvable priority tie", () => {
+    expect(() =>
+      pickPrimaryScope(["tweet.read", "users.read"], "GET /2/unknown/path"),
+    ).toThrow("Priority tie");
+  });
+});

--- a/turbo/packages/firewalls-generator/src/x.ts
+++ b/turbo/packages/firewalls-generator/src/x.ts
@@ -48,6 +48,106 @@ function extractScopeDescriptions(spec: OpenApiSpec): Record<string, string> {
   return oauth?.flows?.authorizationCode?.scopes ?? {};
 }
 
+// ── Scope priority for primary-group selection ──────────────────────────
+//
+// When an endpoint requires multiple OAuth scopes (conjunctive — all must
+// be granted), we assign the rule to a single "primary" permission group:
+// the scope with the highest priority.
+//
+// Rationale: X API uses `tweet.read` and `users.read` as broad base scopes
+// required by almost every endpoint. The *specific* scope (e.g. `like.write`,
+// `dm.read`) describes the actual action and should own the rule for both
+// firewall authorization and billing attribution.
+//
+// If the highest priority is tied, codegen fails — add the new scope to
+// the table with a distinct priority. If a scope is missing entirely,
+// codegen also fails — add it before regenerating.
+
+const SCOPE_PRIORITY: Record<string, number> = {
+  // write scopes — highest (the action the endpoint performs)
+  "tweet.write": 100,
+  "tweet.moderate.write": 100,
+  "like.write": 100,
+  "dm.write": 100,
+  "follows.write": 100,
+  "list.write": 100,
+  "bookmark.write": 100,
+  "mute.write": 100,
+  "block.write": 100,
+  "media.write": 100,
+
+  // specific read scopes — the domain-level read capability
+  "like.read": 50,
+  "dm.read": 50,
+  "follows.read": 50,
+  "list.read": 50,
+  "bookmark.read": 50,
+  "block.read": 50,
+  "mute.read": 50,
+  "space.read": 50,
+  "timeline.read": 50,
+
+  // broad read scopes — required by many endpoints as base scopes.
+  // Same priority: tie is broken by path-based heuristic below.
+  "users.read": 5,
+  "tweet.read": 5,
+};
+
+// Path prefix → scope mapping for breaking ties between same-priority scopes.
+// When two scopes have equal priority, the scope whose prefix matches the
+// API path wins.  Entries are checked in order; first match wins.
+const PATH_TIEBREAKER: Array<[prefix: string, scope: string]> = [
+  ["/2/tweets", "tweet.read"],
+  ["/2/users", "users.read"],
+  ["/2/communities", "users.read"],
+  ["/2/news", "users.read"],
+];
+
+/**
+ * Pick the single primary scope for an endpoint with multiple OAuth scopes.
+ * Fails loudly on unknown scopes or unresolvable priority ties.
+ */
+function pickPrimaryScope(scopes: string[], rule: string): string {
+  if (scopes.length === 1) return scopes[0]!;
+
+  // Validate: every scope must be in the priority table
+  for (const scope of scopes) {
+    if (!(scope in SCOPE_PRIORITY)) {
+      throw new Error(
+        `Unknown scope "${scope}" on ${rule}. ` +
+          `Add it to SCOPE_PRIORITY in x.ts before regenerating.`,
+      );
+    }
+  }
+
+  // Sort by priority descending
+  const sorted = [...scopes].sort(
+    (a, b) => SCOPE_PRIORITY[b]! - SCOPE_PRIORITY[a]!,
+  );
+
+  // No tie → return highest
+  if (SCOPE_PRIORITY[sorted[0]!]! !== SCOPE_PRIORITY[sorted[1]!]!) {
+    return sorted[0]!;
+  }
+
+  // Tie: collect all scopes at the top priority
+  const topPriority = SCOPE_PRIORITY[sorted[0]!]!;
+  const tied = sorted.filter((s) => SCOPE_PRIORITY[s]! === topPriority);
+
+  // Try path-based tiebreaker: extract path from rule ("METHOD /path")
+  const path = rule.split(" ")[1] ?? "";
+  for (const [prefix, scope] of PATH_TIEBREAKER) {
+    if (path.startsWith(prefix) && tied.includes(scope)) {
+      return scope;
+    }
+  }
+
+  throw new Error(
+    `Priority tie between ${tied.map((s) => `"${s}"`).join(", ")} on ${rule}. ` +
+      `Add a PATH_TIEBREAKER entry or adjust SCOPE_PRIORITY in x.ts.`,
+  );
+}
+
 // ── Grouping ─────────────────────────────────────────────────────────────
 
 /** Group name for endpoints that only support app-only (BearerToken) auth. */
@@ -92,15 +192,14 @@ function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
       const rule = `${methodLower.toUpperCase()} ${apiPath}`;
 
       if (oauthScopes.size > 0) {
-        // Group by each OAuth scope
-        for (const scope of oauthScopes) {
-          let ruleSet = groups.get(scope);
-          if (!ruleSet) {
-            ruleSet = new Set();
-            groups.set(scope, ruleSet);
-          }
-          ruleSet.add(rule);
+        // Assign rule to a single primary scope (highest priority)
+        const primary = pickPrimaryScope([...oauthScopes], rule);
+        let ruleSet = groups.get(primary);
+        if (!ruleSet) {
+          ruleSet = new Set();
+          groups.set(primary, ruleSet);
         }
+        ruleSet.add(rule);
       } else {
         // BearerToken-only endpoint (app-only auth, no user scopes)
         let ruleSet = groups.get(APP_ONLY_GROUP);

--- a/turbo/packages/firewalls-generator/src/x.ts
+++ b/turbo/packages/firewalls-generator/src/x.ts
@@ -103,36 +103,41 @@ const PATH_TIEBREAKER: Array<[prefix: string, scope: string]> = [
   ["/2/news", "users.read"],
 ];
 
+/** Look up scope priority; throws on unknown scope for fail-fast. */
+export function scopePriority(scope: string, rule: string): number {
+  const p = SCOPE_PRIORITY[scope];
+  if (p === undefined) {
+    throw new Error(
+      `Unknown scope "${scope}" on ${rule}. ` +
+        `Add it to SCOPE_PRIORITY in x.ts before regenerating.`,
+    );
+  }
+  return p;
+}
+
 /**
  * Pick the single primary scope for an endpoint with multiple OAuth scopes.
  * Fails loudly on unknown scopes or unresolvable priority ties.
  */
-function pickPrimaryScope(scopes: string[], rule: string): string {
-  if (scopes.length === 1) return scopes[0]!;
+export function pickPrimaryScope(scopes: string[], rule: string): string {
+  if (scopes.length === 1) return scopes[0] ?? "";
 
-  // Validate: every scope must be in the priority table
-  for (const scope of scopes) {
-    if (!(scope in SCOPE_PRIORITY)) {
-      throw new Error(
-        `Unknown scope "${scope}" on ${rule}. ` +
-          `Add it to SCOPE_PRIORITY in x.ts before regenerating.`,
-      );
-    }
-  }
-
-  // Sort by priority descending
+  // Validate all scopes and sort by priority descending
   const sorted = [...scopes].sort(
-    (a, b) => SCOPE_PRIORITY[b]! - SCOPE_PRIORITY[a]!,
+    (a, b) => scopePriority(b, rule) - scopePriority(a, rule),
   );
 
+  const first = sorted[0] ?? "";
+  const second = sorted[1] ?? "";
+
   // No tie → return highest
-  if (SCOPE_PRIORITY[sorted[0]!]! !== SCOPE_PRIORITY[sorted[1]!]!) {
-    return sorted[0]!;
+  if (scopePriority(first, rule) !== scopePriority(second, rule)) {
+    return first;
   }
 
   // Tie: collect all scopes at the top priority
-  const topPriority = SCOPE_PRIORITY[sorted[0]!]!;
-  const tied = sorted.filter((s) => SCOPE_PRIORITY[s]! === topPriority);
+  const topPriority = scopePriority(first, rule);
+  const tied = sorted.filter((s) => scopePriority(s, rule) === topPriority);
 
   // Try path-based tiebreaker: extract path from rule ("METHOD /path")
   const path = rule.split(" ")[1] ?? "";

--- a/turbo/packages/firewalls-generator/vitest.config.ts
+++ b/turbo/packages/firewalls-generator/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   apps/cli:
     dependencies:
@@ -135,7 +135,7 @@ importers:
         version: 6.24.1
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -298,7 +298,7 @@ importers:
         version: 8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   apps/web:
     dependencies:
@@ -512,7 +512,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/core:
     dependencies:
@@ -543,7 +543,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/eslint-config:
     devDependencies:
@@ -595,6 +595,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -701,7 +704,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -8067,7 +8070,6 @@ packages:
       '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -12431,7 +12433,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -12478,7 +12480,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -16540,7 +16542,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -16569,7 +16571,20 @@ snapshots:
       '@vitest/ui': 4.1.4(vitest@4.1.4)
       happy-dom: 20.8.9
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vscode-languageserver-textdocument@1.0.12: {}
 


### PR DESCRIPTION
## Summary

- Fix X firewall codegen to assign each endpoint rule to a single primary OAuth scope instead of all required scopes
- Add `SCOPE_PRIORITY` table (write=100 > specific read=50 > base read=5) with path-based tiebreaker for `tweet.read` vs `users.read`
- Unknown scopes or unresolvable priority ties fail codegen loudly

## Problem

The X codegen added each endpoint rule to **every** OAuth scope it requires. For example, `POST /2/tweets` (scopes: `tweet.read` + `tweet.write` + `users.read`) appeared in all three permission groups.

**Firewall security**: write operations like `POST /2/tweets` were permitted by the `tweet.read` permission group alone.

**Billing attribution** (#9621): the proxy matcher returned the first matching group (`tweet.read`), mis-attributing write operations and user lookups.

## Before / After

| Endpoint | Before | After |
|----------|--------|-------|
| `POST /2/tweets` | tweet.read, tweet.write, users.read | `tweet.write` |
| `GET /2/users/me` | tweet.read, users.read | `users.read` |
| `POST /2/users/{id}/likes` | like.write, tweet.read, users.read | `like.write` |
| `GET /2/tweets/{id}` | tweet.read, users.read | `tweet.read` |
| `GET /2/tweets/search/recent` | tweet.read, users.read | `tweet.read` |

Generated file shrinks from ~15KB to 11.3KB (162 rules, each appearing once instead of duplicated across groups).

## Test plan

- [x] `pnpm -F @vm0/firewalls-generator generate:x` succeeds (21 groups, 162 rules)
- [x] `pnpm -F @vm0/core exec vitest run` — 703 tests pass
- [x] `pnpm check-types` passes
- [x] `pnpm knip` — no issues
- [x] Manual review: all 21 permission groups verified for correct endpoint assignment

Closes #9624

🤖 Generated with [Claude Code](https://claude.com/claude-code)