### PR TITLE
fix(zero): inject custom skill volumes on session continue

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -406,6 +406,39 @@ describe("POST /api/zero/runs", () => {
         });
         expect(skillStorage).toBeDefined();
       });
+
+      it("should inject custom skill volume on session continue", async () => {
+        const skillName = uniqueId("test-skill");
+        const compose = await createTestCompose(uniqueId("skill-agent"));
+        const skillAgentId = await getTestZeroAgentId(user.orgId, compose.name);
+        await bindCustomSkillToAgent(skillAgentId, skillName);
+        await createTestVolume(getCustomSkillStorageName(skillName));
+        await insertOrgDefaultModelProvider(user.orgId, "anthropic-api-key");
+
+        const session = await createTestSessionWithConversation(
+          user.userId,
+          skillAgentId,
+          compose.versionId,
+          "claude-code",
+        );
+
+        const response = await postRun({
+          agentId: skillAgentId,
+          sessionId: session.id,
+          prompt: "Continue session",
+        });
+        const data = await response.json();
+        expect(response.status).toBe(201);
+
+        const job = await findTestRunnerJobEntry(data.runId);
+        expect(job).toBeDefined();
+        const storages = job!.executionContext.storageManifest!.storages;
+        const expectedMountPath = `/home/user/.claude/skills/${skillName}`;
+        const skillStorage = storages.find((s) => {
+          return s.mountPath === expectedMountPath;
+        });
+        expect(skillStorage).toBeDefined();
+      });
     });
   });
 

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -304,6 +304,7 @@ export async function createTestSessionWithConversation(
   userId: string,
   agentComposeId: string,
   existingVersionId?: string,
+  cliAgentType: string = "claude",
 ): Promise<{ id: string }> {
   initServices();
   // Look up orgId from the compose
@@ -337,7 +338,7 @@ export async function createTestSessionWithConversation(
     .insert(conversations)
     .values({
       runId: run!.id,
-      cliAgentType: "claude",
+      cliAgentType: cliAgentType,
       cliAgentSessionId: uniqueId("cli-session"),
       cliAgentSessionHistory: "[]",
     })

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -281,7 +281,7 @@ describe("createZeroRun() — service-only parameters", () => {
       ]);
     });
 
-    it("should skip custom skill injection for session resume", async () => {
+    it("should inject custom skill volumes on session resume", async () => {
       const agentName = uniqueId("resume-agent");
       const compose = await createTestCompose(agentName);
       const resumeAgentId = await getTestZeroAgentId(user.orgId, agentName);
@@ -296,7 +296,7 @@ describe("createZeroRun() — service-only parameters", () => {
         compose.versionId,
       );
 
-      // Resume with sessionId — should NOT inject custom skills
+      // Resume with sessionId — should inject custom skills (agent-level binding)
       const resumed = await createZeroRunRecord({
         userId: user.userId,
         prompt: "continue",
@@ -307,7 +307,12 @@ describe("createZeroRun() — service-only parameters", () => {
 
       const resumedRun = await findTestRunRecord(resumed.runId);
       expect(resumedRun).toBeDefined();
-      expect(resumedRun!.additionalVolumes).toBeNull();
+      expect(resumedRun!.additionalVolumes).toEqual([
+        {
+          name: "custom-skill@my-skill",
+          mountPath: "/home/user/.claude/skills/my-skill",
+        },
+      ]);
     });
   });
 

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -359,15 +359,13 @@ export async function createZeroRunRecord(
   appendSystemPrompt = systemParts.join("\n\n");
 
   // 2. Construct CreateRunParams (infra knows nothing about ZERO_TOKEN)
-  //    Inject custom skill volumes for new runs (session resume inherits from checkpoint).
-  const skillVolumes = !params.sessionId
-    ? (row?.customSkills ?? []).map((name) => {
-        return {
-          name: getCustomSkillStorageName(name),
-          mountPath: `/home/user/.claude/skills/${name}`,
-        };
-      })
-    : [];
+  //    Inject custom skill volumes (agent-level, needed on every run).
+  const skillVolumes = (row?.customSkills ?? []).map((name) => {
+    return {
+      name: getCustomSkillStorageName(name),
+      mountPath: `/home/user/.claude/skills/${name}`,
+    };
+  });
 
   const runParams: CreateRunParams = {
     userId: params.userId,


### PR DESCRIPTION
## Summary

- Remove the `!params.sessionId` guard in `zero-run-service.ts` that prevented custom skill volumes from being mounted when continuing a Zero session
- Custom skills are agent-level bindings and must be injected on every run, regardless of whether it's a new session or a continuation
- Add integration test verifying skill volumes are present in the storage manifest for session-continue runs

Closes #9628

## Test plan

- [x] New test: `should inject custom skill volume on session continue` passes
- [x] All 43 existing tests in `route.test.ts` pass (no regressions)
- [x] Lint passes (0 errors)
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)