### PR TITLE
refactor(voice-chat): unify preparing and connected states into single continuous view

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-auto-scroll.ts
@@ -1,11 +1,6 @@
 import { createScrollSignals } from "../auto-scroll.ts";
 
-// --- Transcript panel ---
+// --- Voice chat scroll container ---
 
-export const { setScrollContainer$: setTranscriptScrollContainer$ } =
-  createScrollSignals();
-
-// --- Events panel ---
-
-export const { setScrollContainer$: setEventsScrollContainer$ } =
+export const { setScrollContainer$: setVoiceChatScrollContainer$ } =
   createScrollSignals();

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -242,12 +242,6 @@ export const vcEvents$ = computed((get) => {
   return get(internalEvents$);
 });
 
-export const vcSlowBrainEvents$ = computed((get) => {
-  return get(internalEvents$).filter((e) => {
-    return e.source === "slow-brain";
-  });
-});
-
 type ConversationItem =
   | { kind: "transcript"; entry: TranscriptEntry; order: number; key: string }
   | { kind: "slow-brain"; event: ContextEvent; order: number; key: string };

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -15,7 +15,6 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   vcStatus$,
-  vcSlowBrainEvents$,
   vcMuted$,
   vcError$,
   vcEnabled$,
@@ -35,10 +34,7 @@ import {
   vcConversationItems$,
   type RealtimeModel,
 } from "../../signals/voice-chat/voice-chat-session.ts";
-import {
-  setTranscriptScrollContainer$,
-  setEventsScrollContainer$,
-} from "../../signals/voice-chat/voice-chat-auto-scroll.ts";
+import { setVoiceChatScrollContainer$ } from "../../signals/voice-chat/voice-chat-auto-scroll.ts";
 import {
   meetingPrepStatus$,
   meetingPrepPrompt$,
@@ -128,39 +124,62 @@ function VoiceChatFooter({
 }) {
   return (
     <div className="border-t px-4 py-3 flex items-center justify-center gap-3">
-      {status === "disconnected" ? (
+      {status === "preparing" ? (
         <Button
-          variant="secondary"
+          variant="destructive"
+          size="sm"
           className="h-10 rounded-full px-5"
-          onClick={onRetry}
+          onClick={onEnd}
         >
-          <IconRefresh size={18} className="mr-2" />
-          Retry
+          <IconPhoneOff size={18} className="mr-2" />
+          Cancel
         </Button>
+      ) : status === "disconnected" ? (
+        <>
+          <Button
+            variant="secondary"
+            className="h-10 rounded-full px-5"
+            onClick={onRetry}
+          >
+            <IconRefresh size={18} className="mr-2" />
+            Retry
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            className="h-10 rounded-full px-5"
+            onClick={onEnd}
+          >
+            <IconPhoneOff size={18} className="mr-2" />
+            End Session
+          </Button>
+        </>
       ) : (
-        <Button
-          variant={muted ? "destructive" : "secondary"}
-          className="h-10 rounded-full px-5"
-          disabled={status !== "connected"}
-          onClick={toggleMute}
-        >
-          {muted ? (
-            <IconMicrophoneOff size={18} className="mr-2" />
-          ) : (
-            <IconMicrophone size={18} className="mr-2" />
-          )}
-          {muted ? "Unmute" : "Mute"}
-        </Button>
+        <>
+          <Button
+            variant={muted ? "destructive" : "secondary"}
+            className="h-10 rounded-full px-5"
+            disabled={status !== "connected"}
+            onClick={toggleMute}
+          >
+            {muted ? (
+              <IconMicrophoneOff size={18} className="mr-2" />
+            ) : (
+              <IconMicrophone size={18} className="mr-2" />
+            )}
+            {muted ? "Unmute" : "Mute"}
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            className="h-10 rounded-full px-5"
+            onClick={onEnd}
+          >
+            <IconPhoneOff size={18} className="mr-2" />
+            End Session
+          </Button>
+        </>
       )}
-      <Button
-        variant="destructive"
-        size="sm"
-        className="h-10 rounded-full px-5"
-        onClick={onEnd}
-      >
-        <IconPhoneOff size={18} className="mr-2" />
-        End Session
-      </Button>
     </div>
   );
 }
@@ -315,7 +334,6 @@ export function VoiceChatPage() {
   const enabled = useLastResolved(vcEnabled$);
   const agentId = useLastResolved(vcAgentId$);
   const status = useGet(vcStatus$);
-  const slowBrainEvents = useGet(vcSlowBrainEvents$);
   const muted = useGet(vcMuted$);
   const error = useGet(vcError$);
   const startSession = useSet(startVoiceChat$);
@@ -327,8 +345,7 @@ export function VoiceChatPage() {
   const prepElapsedMs = useGet(vcPrepElapsedMs$);
   const model = useGet(vcModel$);
   const setModel = useSet(setVcModel$);
-  const setTranscriptContainer = useSet(setTranscriptScrollContainer$);
-  const setEventsContainer = useSet(setEventsScrollContainer$);
+  const setScrollContainer = useSet(setVoiceChatScrollContainer$);
   const conversationItems = useGet(vcConversationItems$);
 
   const elapsedSeconds = Math.floor(prepElapsedMs / 1000);
@@ -396,67 +413,6 @@ export function VoiceChatPage() {
     );
   }
 
-  if (status === "preparing") {
-    return (
-      <div className="flex flex-col h-full">
-        <div className="flex items-center justify-between border-b px-4 py-3">
-          <div className="flex items-center gap-3">
-            <h1 className="text-lg font-semibold">
-              {prompt ? "Preparing Meeting" : "Preparing..."}
-            </h1>
-            {elapsedSeconds > 0 && (
-              <span className="text-sm tabular-nums text-muted-foreground">
-                {Math.floor(elapsedSeconds / 60)}:
-                {String(elapsedSeconds % 60).padStart(2, "0")}
-              </span>
-            )}
-            <StatusBadge status={status} />
-          </div>
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={() => {
-              endSession();
-            }}
-          >
-            <IconPhoneOff size={16} className="mr-1.5" />
-            Cancel
-          </Button>
-        </div>
-
-        {prompt && (
-          <div className="border-b px-4 py-3">
-            <p className="text-sm text-muted-foreground">Your prompt:</p>
-            <p className="text-sm mt-1">{prompt}</p>
-          </div>
-        )}
-
-        <div
-          ref={setEventsContainer}
-          className="flex-1 overflow-y-auto p-4 space-y-2"
-        >
-          <h2 className="text-sm font-medium text-muted-foreground mb-3">
-            Slow Brain Activity
-          </h2>
-          {slowBrainEvents.length === 0 && (
-            <p className="text-sm text-muted-foreground text-center py-8">
-              Waiting for slow brain to start preparation...
-            </p>
-          )}
-          {slowBrainEvents.map((event) => {
-            return (
-              <SlowBrainIndicator
-                key={event.seq}
-                type={event.type}
-                content={event.content}
-              />
-            );
-          })}
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
@@ -464,8 +420,22 @@ export function VoiceChatPage() {
         <div className="flex items-center gap-3">
           <h1 className="text-lg font-semibold">Voice Chat</h1>
           <StatusBadge status={status} reconnectAttempt={reconnectAttempt} />
+          {status === "preparing" && elapsedSeconds > 0 && (
+            <span className="text-sm tabular-nums text-muted-foreground">
+              {Math.floor(elapsedSeconds / 60)}:
+              {String(elapsedSeconds % 60).padStart(2, "0")}
+            </span>
+          )}
         </div>
       </div>
+
+      {/* Prompt banner */}
+      {prompt && (
+        <div className="border-b px-4 py-3">
+          <p className="text-sm text-muted-foreground">Your prompt:</p>
+          <p className="text-sm mt-1">{prompt}</p>
+        </div>
+      )}
 
       {/* Error banner */}
       {error && (
@@ -475,14 +445,16 @@ export function VoiceChatPage() {
       )}
 
       {/* Main content: unified conversation view */}
-      <div ref={setTranscriptContainer} className="flex-1 overflow-y-auto">
+      <div ref={setScrollContainer} className="flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-[900px] px-4 pt-4 pb-8">
           <div className="flex flex-col gap-4">
             {conversationItems.length === 0 && (
               <p className="text-sm text-muted-foreground text-center py-8">
-                {status === "connecting"
-                  ? "Connecting..."
-                  : "Speak to start the conversation."}
+                {status === "preparing"
+                  ? "Waiting for preparation to begin..."
+                  : status === "connecting"
+                    ? "Connecting..."
+                    : "Speak to start the conversation."}
               </p>
             )}
             {conversationItems.map((item) => {

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -116,7 +116,7 @@ function VoiceChatFooter({
   onEnd,
   onRetry,
 }: {
-  status: string;
+  status: ConnectionStatus;
   muted: boolean;
   toggleMute: () => void;
   onEnd: () => void;


### PR DESCRIPTION
## Summary

- Remove the separate `if (status === "preparing")` render path so all non-idle states share one continuous layout
- Delete events scroll container and rename transcript scroll container to `setVoiceChatScrollContainer$`
- Extend `VoiceChatFooter` to show Cancel (no Mute) during preparing state
- Add prompt banner and elapsed timer to the unified active layout
- Remove unused `vcSlowBrainEvents$` export

**Net result:** -39 lines, zero DOM teardown during preparing → connected transition, continuous slow-brain event visibility, preserved scroll position.

Closes #9631

## Test plan

- [x] All 1793 existing tests pass (214 test files)
- [x] Lint passes (0 errors)
- [x] Knip passes (no unused code)
- [x] Format unchanged
- [ ] Manual: verify slow-brain events remain visible when transitioning from preparing to connected
- [ ] Manual: verify prompt banner shows in both preparing and connected states
- [ ] Manual: verify footer shows Cancel during preparing, Mute + End Session during connected
- [ ] Manual: verify elapsed timer in header during preparing
- [ ] Manual: verify auto-scroll works across the transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)