### PR TITLE
feat(infra): add system org resolution for additional volumes

### DIFF
--- a/turbo/apps/web/src/lib/infra/storage/__tests__/additional-volumes.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/additional-volumes.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, beforeEach } from "vitest";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Internal infrastructure: no API route
 import { prepareStorageManifest } from "../storage-service";
-import { createTestVolume } from "../../../../__tests__/api-test-helpers";
+import {
+  createTestVolume,
+  createTestVolumeForOrg,
+} from "../../../../__tests__/api-test-helpers";
 import {
   testContext,
   uniqueId,
   type UserContext,
 } from "../../../../__tests__/test-helpers";
 import type { AdditionalVolume, AgentVolumeConfig } from "../types";
+import { SYSTEM_ORG_ID } from "@vm0/core";
 
 const context = testContext();
 
@@ -282,5 +286,94 @@ describe("Additional Volumes", () => {
     });
     expect(mountPaths).toContain("/data");
     expect(mountPaths).toContain("/mnt/extra");
+  });
+
+  describe("system flag resolution", () => {
+    it("should resolve system volume from SYSTEM_ORG when available", async () => {
+      const storageName = uniqueId("sys-vol");
+      const { versionId } = await createTestVolumeForOrg(
+        SYSTEM_ORG_ID,
+        storageName,
+      );
+
+      const additional: AdditionalVolume[] = [
+        { name: storageName, mountPath: "/mnt/system", system: true },
+      ];
+
+      const manifest = await prepareStorageManifest(
+        undefined,
+        {},
+        user.orgId,
+        user.orgId,
+        user.userId,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        additional,
+      );
+
+      expect(manifest.storages).toHaveLength(1);
+      expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
+      expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
+    });
+
+    it("should fall back to runtime org when system volume not in SYSTEM_ORG", async () => {
+      const storageName = uniqueId("sys-fallback");
+      const { versionId } = await createTestVolume(storageName);
+
+      const additional: AdditionalVolume[] = [
+        { name: storageName, mountPath: "/mnt/fallback", system: true },
+      ];
+
+      const manifest = await prepareStorageManifest(
+        undefined,
+        {},
+        user.orgId,
+        user.orgId,
+        user.userId,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        additional,
+      );
+
+      expect(manifest.storages).toHaveLength(1);
+      expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
+      expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
+    });
+
+    it("should resolve non-system volume from runtime org only", async () => {
+      const storageName = uniqueId("nonsys-vol");
+      const { versionId } = await createTestVolume(storageName);
+
+      const additional: AdditionalVolume[] = [
+        { name: storageName, mountPath: "/mnt/regular" },
+      ];
+
+      const manifest = await prepareStorageManifest(
+        undefined,
+        {},
+        user.orgId,
+        user.orgId,
+        user.userId,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        additional,
+      );
+
+      expect(manifest.storages).toHaveLength(1);
+      expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
+      expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
+    });
   });
 });

--- a/turbo/apps/web/src/lib/infra/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/infra/storage/storage-service.ts
@@ -275,13 +275,36 @@ async function resolveAdditionalVolume(
 ): Promise<ManifestStorage | null> {
   const version = vol.version || "latest";
   try {
-    const { versionId, s3Key } = await resolveVersion(
-      runtimeClerkOrgId,
-      vol.name,
-      "volume",
-      version,
-      VOLUME_ORG_USER_ID,
-    );
+    let resolved: { versionId: string; s3Key: string } | undefined;
+
+    if (vol.system) {
+      try {
+        resolved = await resolveVersion(
+          SYSTEM_ORG_ID,
+          vol.name,
+          "volume",
+          version,
+          VOLUME_ORG_USER_ID,
+        );
+      } catch (error) {
+        if (!(error instanceof Error && error.message.includes("not found"))) {
+          throw error;
+        }
+        // System org miss — fall through to runtime org
+      }
+    }
+
+    if (!resolved) {
+      resolved = await resolveVersion(
+        runtimeClerkOrgId,
+        vol.name,
+        "volume",
+        version,
+        VOLUME_ORG_USER_ID,
+      );
+    }
+
+    const { versionId, s3Key } = resolved;
     const archiveKey = `${s3Key}/archive.tar.gz`;
     const archiveUrl = await generatePresignedUrl(bucketName, archiveKey);
     return {

--- a/turbo/apps/web/src/lib/infra/storage/types.ts
+++ b/turbo/apps/web/src/lib/infra/storage/types.ts
@@ -85,6 +85,7 @@ export interface AdditionalVolume {
   name: string; // Storage name
   version?: string; // Version hash or "latest" (defaults to "latest")
   mountPath: string; // Absolute path in sandbox
+  system?: boolean; // When true, resolve against SYSTEM_ORG first, fallback to runtime org
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `system?: boolean` flag to `AdditionalVolume` interface to support two-org resolution
- Modify `resolveAdditionalVolume()` to try SYSTEM_ORG first when `system: true`, falling back to runtime org
- Add 3 integration tests covering system-org hit, fallback to runtime org, and non-system regression

Closes #9635

## Test plan

- [x] New integration tests pass: system-org volume resolution, fallback, and non-system regression
- [x] All existing tests pass (no regression in single-org additional volume resolution)
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Format passes (`pnpm format`)
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)