### PR TITLE
feat(zero): inject system skills as additional volumes at run creation

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -440,6 +440,87 @@ describe("POST /api/zero/runs", () => {
         expect(skillStorage).toBeDefined();
       });
     });
+
+    describe("system skill volume injection", () => {
+      it("should inject system skill volumes into additionalVolumes for new run", async () => {
+        const response = await postRun({ agentId, prompt: "Hello" });
+        expect(response.status).toBe(201);
+        const data = await response.json();
+
+        const run = await findTestRunRecord(data.runId);
+        expect(run).toBeDefined();
+        expect(run!.additionalVolumes).toBeDefined();
+
+        // Verify a known SEED_SKILLS entry is present
+        const deepDiveVolume = run!.additionalVolumes!.find((v) => {
+          return v.name.includes("deep-dive");
+        });
+        expect(deepDiveVolume).toBeDefined();
+        expect(deepDiveVolume!.mountPath).toBe(
+          "/home/user/.claude/skills/deep-dive",
+        );
+        expect(deepDiveVolume!.system).toBe(true);
+
+        // Verify storage name format
+        expect(deepDiveVolume!.name).toMatch(/^agent-skills@/);
+      });
+
+      it("should inject system skill volumes on session continue", async () => {
+        const compose = await createTestCompose(uniqueId("sys-skill-agent"));
+        const sysSkillAgentId = await getTestZeroAgentId(
+          user.orgId,
+          compose.name,
+        );
+        await insertOrgDefaultModelProvider(user.orgId, "anthropic-api-key");
+
+        const session = await createTestSessionWithConversation(
+          user.userId,
+          sysSkillAgentId,
+          compose.versionId,
+          "claude-code",
+        );
+
+        const response = await postRun({
+          agentId: sysSkillAgentId,
+          sessionId: session.id,
+          prompt: "Continue session",
+        });
+        const data = await response.json();
+        expect(response.status).toBe(201);
+
+        const run = await findTestRunRecord(data.runId);
+        expect(run).toBeDefined();
+
+        const deepDiveVolume = run!.additionalVolumes!.find((v) => {
+          return v.name.includes("deep-dive");
+        });
+        expect(deepDiveVolume).toBeDefined();
+        expect(deepDiveVolume!.system).toBe(true);
+      });
+
+      it("should place custom skills after system skills in additionalVolumes", async () => {
+        const skillName = uniqueId("test-skill");
+        await bindCustomSkillToAgent(agentId, skillName);
+
+        const response = await postRun({ agentId, prompt: "Hello" });
+        expect(response.status).toBe(201);
+        const data = await response.json();
+
+        const run = await findTestRunRecord(data.runId);
+        expect(run).toBeDefined();
+
+        const volumes = run!.additionalVolumes!;
+        const systemIndex = volumes.findIndex((v) => {
+          return v.system === true;
+        });
+        const customIndex = volumes.findIndex((v) => {
+          return v.name === getCustomSkillStorageName(skillName);
+        });
+
+        expect(systemIndex).toBeGreaterThanOrEqual(0);
+        expect(customIndex).toBeGreaterThan(systemIndex);
+      });
+    });
   });
 
   describe("parameter forwarding", () => {

--- a/turbo/apps/web/src/db/schema/agent-run.ts
+++ b/turbo/apps/web/src/db/schema/agent-run.ts
@@ -37,10 +37,14 @@ export const agentRuns = pgTable(
     // Secret names for validation (values never stored - must be provided at runtime)
     secretNames: jsonb("secret_names").$type<string[]>(),
     // Additional volumes passed at run time (name, version, mountPath for checkpoint restore)
-    additionalVolumes:
-      jsonb("additional_volumes").$type<
-        Array<{ name: string; version?: string; mountPath: string }>
-      >(),
+    additionalVolumes: jsonb("additional_volumes").$type<
+      Array<{
+        name: string;
+        version?: string;
+        mountPath: string;
+        system?: boolean;
+      }>
+    >(),
     sandboxId: varchar("sandbox_id", { length: 255 }),
     result: jsonb("result"),
     error: text("error"),

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -115,11 +115,12 @@ export interface CreateRunParams {
   // Per-permission policies from zero agent configuration (includes unknownPolicy).
   permissionPolicies?: FirewallPolicies;
   allowedConnectorTypes?: ConnectorType[];
-  // Additional volumes to mount (e.g., custom skills).
+  // Additional volumes to mount (e.g., system skills, custom skills).
   additionalVolumes?: Array<{
     name: string;
     version?: string;
     mountPath: string;
+    system?: boolean;
   }>;
   // Pre-loaded compose data. When provided, skips the internal loadCompose() call.
   preloadedCompose?: {
@@ -404,6 +405,7 @@ interface InsertRunParams {
     name: string;
     version?: string;
     mountPath: string;
+    system?: boolean;
   }>;
   resumedFromCheckpointId?: string;
   sessionId?: string;

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -244,15 +244,21 @@ describe("createZeroRun() — service-only parameters", () => {
       );
     });
 
-    it("should not inject additionalVolumes when agent has no custom skills", async () => {
+    it("should inject only system skill volumes when agent has no custom skills", async () => {
       const result = await createZeroRun(baseParams());
 
       const run = await findTestRunRecord(result.runId);
       expect(run).toBeDefined();
-      expect(run!.additionalVolumes).toBeNull();
+      expect(run!.additionalVolumes).toBeDefined();
+      expect(run!.additionalVolumes!.length).toBeGreaterThan(0);
+      expect(
+        run!.additionalVolumes!.every((v) => {
+          return v.system === true;
+        }),
+      ).toBe(true);
     });
 
-    it("should inject multiple skills preserving order", async () => {
+    it("should inject multiple custom skills after system skills preserving order", async () => {
       const agentName = uniqueId("multi-skill");
       await createTestCompose(agentName);
       const multiAgentId = await getTestZeroAgentId(user.orgId, agentName);
@@ -264,8 +270,12 @@ describe("createZeroRun() — service-only parameters", () => {
 
       const run = await findTestRunRecord(result.runId);
       expect(run).toBeDefined();
-      expect(run!.additionalVolumes).toHaveLength(3);
-      expect(run!.additionalVolumes).toEqual([
+      const volumes = run!.additionalVolumes!;
+      // Custom skills appear at the end, after system skills
+      const customVolumes = volumes.filter((v) => {
+        return !v.system;
+      });
+      expect(customVolumes).toEqual([
         {
           name: "custom-skill@alpha",
           mountPath: "/home/user/.claude/skills/alpha",
@@ -307,12 +317,20 @@ describe("createZeroRun() — service-only parameters", () => {
 
       const resumedRun = await findTestRunRecord(resumed.runId);
       expect(resumedRun).toBeDefined();
-      expect(resumedRun!.additionalVolumes).toEqual([
-        {
-          name: "custom-skill@my-skill",
-          mountPath: "/home/user/.claude/skills/my-skill",
-        },
-      ]);
+      expect(resumedRun!.additionalVolumes).toEqual(
+        expect.arrayContaining([
+          {
+            name: "custom-skill@my-skill",
+            mountPath: "/home/user/.claude/skills/my-skill",
+          },
+        ]),
+      );
+      // System skills are also present
+      expect(
+        resumedRun!.additionalVolumes!.some((v) => {
+          return v.system === true;
+        }),
+      ).toBe(true);
     });
   });
 

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -6,6 +6,10 @@ import {
   isFeatureEnabled,
   FeatureSwitchKey,
   getCustomSkillStorageName,
+  getSkillStorageName,
+  getEligibleConnectorTypes,
+  resolveSkillRef,
+  parseGitHubTreeUrl,
   type TriggerSource,
   type FirewallPolicies,
   type ConnectorType,
@@ -64,6 +68,7 @@ import {
 } from "./user/user-preferences-service";
 import { getCachedUser } from "../auth/user-cache-service";
 import { buildUserInfo, type UserInfoOptions } from "./integration-prompt";
+import { SEED_SKILLS } from "./seed-skills";
 import { logger } from "../shared/logger";
 
 const log = logger("service:zero-run");
@@ -231,6 +236,33 @@ interface ZeroRunRecordResult {
 }
 
 /**
+ * Compute system skill additional volumes from SEED_SKILLS + eligible connectors.
+ * Mirrors the skill resolution logic in buildComposeContent() but produces
+ * AdditionalVolume-shaped objects instead of compose skill URLs.
+ */
+function buildSystemSkillVolumes(): Array<{
+  name: string;
+  mountPath: string;
+  system: boolean;
+}> {
+  const allSkillNames = [
+    ...new Set([...SEED_SKILLS, ...getEligibleConnectorTypes()]),
+  ];
+  return allSkillNames.flatMap((skillName) => {
+    const url = resolveSkillRef(skillName);
+    const parsed = parseGitHubTreeUrl(url);
+    if (!parsed) return [];
+    return [
+      {
+        name: getSkillStorageName(parsed.fullPath),
+        mountPath: `/home/user/.claude/skills/${parsed.skillName}`,
+        system: true,
+      },
+    ];
+  });
+}
+
+/**
  * Create a zero run record with pre-flight checks but without dispatching.
  *
  * Handles agent metadata, compose resolution, org data, pre-flight checks
@@ -359,13 +391,16 @@ export async function createZeroRunRecord(
   appendSystemPrompt = systemParts.join("\n\n");
 
   // 2. Construct CreateRunParams (infra knows nothing about ZERO_TOKEN)
-  //    Inject custom skill volumes (agent-level, needed on every run).
-  const skillVolumes = (row?.customSkills ?? []).map((name) => {
+  //    Inject system + custom skill volumes (needed on every run).
+  const systemSkillVolumes = buildSystemSkillVolumes();
+  const customSkillVolumes = (row?.customSkills ?? []).map((name) => {
     return {
       name: getCustomSkillStorageName(name),
       mountPath: `/home/user/.claude/skills/${name}`,
     };
   });
+  // System skills first, custom skills after (custom overrides system at same mount path)
+  const skillVolumes = [...systemSkillVolumes, ...customSkillVolumes];
 
   const runParams: CreateRunParams = {
     userId: params.userId,


### PR DESCRIPTION
## Summary

- Add `buildSystemSkillVolumes()` in `zero-run-service.ts` that computes system skill `AdditionalVolume[]` from `SEED_SKILLS` + `getEligibleConnectorTypes()`
- Merge system skill volumes with custom skill volumes in `createZeroRunRecord()` — system skills first, custom skills after (custom overrides at same mount path)
- Extend `additionalVolumes` inline types with `system?: boolean` flag in `CreateRunParams`, `InsertRunParams`, and the `agentRuns` schema
- Add 3 integration tests: new session injection, session continue injection, and custom-after-system ordering

Closes #9636

## Test plan

- [x] New session injects system skills with `system: true` and correct `agent-skills@` storage name format
- [x] Session continue injects system skills (no session guard)
- [x] Custom skills placed after system skills in `additionalVolumes` array
- [x] All 46 existing tests pass
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Knip passes (`pnpm knip`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)