### PR TITLE
fix(firewalls): validate category in display order, fix slack source comment

### DIFF
--- a/turbo/packages/firewalls-generator/src/codegen.ts
+++ b/turbo/packages/firewalls-generator/src/codegen.ts
@@ -223,7 +223,13 @@ export function renderCategories(
     grouped.set(cat, []);
   }
   for (const [name, category] of Object.entries(config.categories)) {
-    grouped.get(category)?.push(name);
+    const list = grouped.get(category);
+    if (!list) {
+      throw new Error(
+        `renderCategories: category "${category}" (from permission "${name}") is not in displayOrder [${config.displayOrder.join(", ")}]`,
+      );
+    }
+    list.push(name);
   }
 
   const orderVarName = `${varName.replace(/Categories$/, "")}CategoryOrder`;

--- a/turbo/packages/firewalls-generator/src/slack.ts
+++ b/turbo/packages/firewalls-generator/src/slack.ts
@@ -242,7 +242,7 @@ const SCOPE_CATEGORIES: Record<string, string> = {
   "users:read": "Read",
   "users:read.email": "Read",
 
-  // Write (22)
+  // Write (23)
   "bookmarks:write": "Write",
   "calls:write": "Write",
   "canvases:write": "Write",
@@ -251,7 +251,6 @@ const SCOPE_CATEGORIES: Record<string, string> = {
   "channels:write.topic": "Write",
   "datastore:write": "Write",
   "dnd:write": "Write",
-  "files:write": "Send",
   "groups:write": "Write",
   "groups:write.invites": "Write",
   "groups:write.topic": "Write",
@@ -272,6 +271,7 @@ const SCOPE_CATEGORIES: Record<string, string> = {
   "assistant:write": "Send",
   "chat:write": "Send",
   "conversations.connect:write": "Send",
+  "files:write": "Send",
   "im:write": "Send",
   "mpim:write": "Send",
   "mpim:write.topic": "Send",


### PR DESCRIPTION
## Summary

Follow-up to #9638. Fixes P2 review findings.

- `renderCategories()` now throws if a category value is not in `displayOrder` instead of silently dropping the permission
- Move `files:write` to Send section in `SCOPE_CATEGORIES` source and fix Write count comment (23 not 22)

## Test plan

- [x] `firewall-categories.test.ts` — 14 tests pass
- [x] `check-types` passes
- [x] Regenerated slack config unchanged (same output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)