### PR TITLE
fix(runner): only count successfully removed locks in gc_orphaned_locks

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -515,16 +515,13 @@ async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<u64>
             LockProbe::Free(_lock) => {
                 if dry_run {
                     info!("[dry-run] would remove unused lock {name}");
+                    removed += 1;
+                } else if let Err(e) = tokio::fs::remove_file(&lock_path).await {
+                    tracing::debug!("cannot remove {}: {e}", lock_path.display());
                 } else {
-                    match tokio::fs::remove_file(&lock_path).await {
-                        Ok(()) => info!("removed unused lock {name}"),
-                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                        Err(e) => {
-                            tracing::debug!("cannot remove {}: {e}", lock_path.display());
-                        }
-                    }
+                    info!("removed unused lock {name}");
+                    removed += 1;
                 }
-                removed += 1;
             }
             LockProbe::Held | LockProbe::Error(_) => {}
         }


### PR DESCRIPTION
## Summary
- `gc_orphaned_locks` incremented the `removed` counter unconditionally after `probe_lock` returned `Free`, even when the subsequent `remove_file` call failed. This caused `runner gc` to report cleaned locks that were not actually deleted.
- Restructure the `Free` arm from `match` with a separated counter to `if / else if let Err / else`, so the counter lives exclusively in the success branches (`dry-run` and `Ok`). This matches the pattern used by `gc_debootstrap` and `gc_nested_images`, and structurally prevents the bug from recurring.
- Also removes the unnecessary `NotFound` special-case: under the exclusive flock held by `probe_lock`, another GC process cannot unlink the file, making `NotFound` practically unreachable.

Closes #9585

## Test plan
- [x] `cargo test -p runner -- gc` — 54 tests pass
- [x] `cargo clippy -p runner -- -D warnings` — clean
- [ ] Verify `runner gc --dry-run` still reports correct lock counts on a live host

🤖 Generated with [Claude Code](https://claude.com/claude-code)