### PR TITLE
test(infra): add system volume resolution priority and skip tests

### DIFF
--- a/turbo/apps/web/src/lib/infra/storage/__tests__/additional-volumes.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/additional-volumes.test.ts
@@ -348,6 +348,66 @@ describe("Additional Volumes", () => {
       expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
     });
 
+    it("should prefer SYSTEM_ORG over runtime org when both have the volume", async () => {
+      const storageName = uniqueId("sys-priority");
+      const { versionId: systemVersionId } = await createTestVolumeForOrg(
+        SYSTEM_ORG_ID,
+        storageName,
+      );
+      // Also create in runtime org — should NOT be used
+      await createTestVolume(storageName);
+
+      const additional: AdditionalVolume[] = [
+        { name: storageName, mountPath: "/mnt/priority", system: true },
+      ];
+
+      const manifest = await prepareStorageManifest(
+        undefined,
+        {},
+        user.orgId,
+        user.orgId,
+        user.userId,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        additional,
+      );
+
+      expect(manifest.storages).toHaveLength(1);
+      expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
+      expect(manifest.storages[0]!.vasVersionId).toBe(systemVersionId);
+    });
+
+    it("should silently skip system volume not found in either org", async () => {
+      const additional: AdditionalVolume[] = [
+        {
+          name: "nonexistent-system-vol",
+          mountPath: "/mnt/missing-sys",
+          system: true,
+        },
+      ];
+
+      const manifest = await prepareStorageManifest(
+        undefined,
+        {},
+        user.orgId,
+        user.orgId,
+        user.userId,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        additional,
+      );
+
+      expect(manifest.storages).toHaveLength(0);
+    });
+
     it("should resolve non-system volume from runtime org only", async () => {
       const storageName = uniqueId("nonsys-vol");
       const { versionId } = await createTestVolume(storageName);


### PR DESCRIPTION
## Summary

- Add test verifying SYSTEM_ORG takes priority over runtime org when both have the same volume (`system: true`)
- Add test verifying system volumes silently skip when not found in either SYSTEM_ORG or runtime org

These cover two edge cases in the two-org resolution path for additional volumes (added in #9637) that weren't previously tested.

## Test plan

- [x] All 13 additional-volumes tests pass (including 2 new)
- [x] All 20 zero-run-service tests pass
- [x] All 46 route integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)