### PR TITLE
fix(voice-chat): make slow-brain indicator content collapsible

### DIFF
--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-bubbles.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-bubbles.tsx
@@ -81,9 +81,13 @@ export function SlowBrainIndicator({
       <div className="min-w-0">
         <span className="font-medium">{slowBrainLabel(type)}</span>
         {content?.trim() && (
-          <p className="mt-0.5 text-muted-foreground/80 line-clamp-3 break-words">
-            {content}
-          </p>
+          <details className="group mt-0.5 cursor-pointer">
+            <summary className="list-none">
+              <p className="text-muted-foreground/80 line-clamp-3 group-open:line-clamp-none break-words">
+                {content}
+              </p>
+            </summary>
+          </details>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Replace `line-clamp-3` permanent truncation in `SlowBrainIndicator` with a native `<details>/<summary>` collapsible toggle
- Long content (e.g. directives) can now be expanded by clicking, matching the `CollapsibleText` pattern used in activity logs (`grouped-message-card.tsx`)
- Short content (under 3 lines) renders identically to before — no visual change

## Test plan

- [ ] Open a voice chat session with slow-brain activity containing long directive content
- [ ] Verify content is initially clamped to 3 lines
- [ ] Click on the content area — it should expand to show full text
- [ ] Click again — it should collapse back to 3 lines
- [ ] Verify short content (under 3 lines) shows no visual difference from before
- [ ] Verify the same behavior works in Mission Control voice chat panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)