### PR TITLE
fix(runner): use continue instead of break on /proc entry read error

### DIFF
--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -213,7 +213,7 @@ async fn scan_proc_cmdlines() -> Vec<(u32, String)> {
             Ok(None) => break,
             Err(e) => {
                 tracing::warn!("scan_proc_cmdlines: read entry in /proc: {e}");
-                break;
+                continue;
             }
         };
         let name = entry.file_name();


### PR DESCRIPTION
## Summary
- `scan_proc_cmdlines` used `break` on a single `readdir` error, aborting the entire `/proc` scan. Processes listed after the failed entry were silently dropped.
- Changed `break` to `continue` so the scan skips the failed entry and continues discovering remaining processes.
- Affects all `discover_all` callers: `gc`, `doctor`, `kill`, `exec`.

Closes #9657

## Test plan
- [x] `cargo check -p runner` passes
- [x] `cargo test -p runner -- process::` — all 32 tests pass
- [ ] No regression test added: `scan_proc_cmdlines` reads `/proc` directly; triggering `readdir` errors is not feasible without filesystem mocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)