### PR TITLE
fix(proxy): add structured logging for model provider usage report lifecycle

### DIFF
--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -228,16 +228,38 @@ def _report_usage_with_retry(
     for attempt in range(max_retries + 1):
         try:
             _do_report_usage(api_url, sandbox_token, run_id, usage)
+            log_proxy_entry(
+                proxy_log_path,
+                "info",
+                "Usage report succeeded",
+                type="usage",
+                api_url=api_url,
+                **usage,
+            )
             return
         except Exception as exc:
             if attempt < max_retries:
+                log_proxy_entry(
+                    proxy_log_path,
+                    "warn",
+                    f"Usage report attempt {attempt + 1} failed, retrying: {exc}",
+                    type="usage",
+                    api_url=api_url,
+                    error=str(exc),
+                    attempt=attempt + 1,
+                    **usage,
+                )
                 time.sleep(0.5)
             else:
                 log_proxy_entry(
                     proxy_log_path,
-                    "warn",
-                    f"Usage report failed after {attempt + 1} attempts: {exc}",
+                    "error",
+                    f"Usage report failed after {attempt + 1} attempts, giving up: {exc}",
                     type="usage",
+                    api_url=api_url,
+                    error=str(exc),
+                    attempts=attempt + 1,
+                    **usage,
                 )
 
 
@@ -253,6 +275,14 @@ def _enqueue_usage(
     falls back to synchronous delivery so the report is not silently lost.
     """
     copied = dict(usage)
+    log_proxy_entry(
+        proxy_log_path,
+        "info",
+        "Usage report enqueued",
+        type="usage",
+        api_url=api_url,
+        **copied,
+    )
     try:
         usage_executor.submit(
             _report_usage_with_retry, api_url, sandbox_token, run_id, copied, proxy_log_path
@@ -260,6 +290,13 @@ def _enqueue_usage(
     except RuntimeError:
         # Executor shut down (done() already called during drain).
         # Fall back to synchronous delivery with retry.
+        log_proxy_entry(
+            proxy_log_path,
+            "warn",
+            "Usage executor shut down, falling back to synchronous delivery",
+            type="usage",
+            api_url=api_url,
+        )
         _report_usage_with_retry(api_url, sandbox_token, run_id, copied, proxy_log_path)
 
 

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -234,7 +234,7 @@ def _report_usage_with_retry(
                 "Usage report succeeded",
                 type="usage",
                 api_url=api_url,
-                **usage,
+                usage=usage,
             )
             return
         except Exception as exc:
@@ -247,7 +247,7 @@ def _report_usage_with_retry(
                     api_url=api_url,
                     error=str(exc),
                     attempt=attempt + 1,
-                    **usage,
+                    usage=usage,
                 )
                 time.sleep(0.5)
             else:
@@ -258,8 +258,8 @@ def _report_usage_with_retry(
                     type="usage",
                     api_url=api_url,
                     error=str(exc),
-                    attempts=attempt + 1,
-                    **usage,
+                    attempt=attempt + 1,
+                    usage=usage,
                 )
 
 
@@ -281,7 +281,7 @@ def _enqueue_usage(
         "Usage report enqueued",
         type="usage",
         api_url=api_url,
-        **copied,
+        usage=copied,
     )
     try:
         usage_executor.submit(

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -234,7 +234,7 @@ def _report_usage_with_retry(
                 "Usage report succeeded",
                 type="usage",
                 api_url=api_url,
-                usage=usage,
+                **usage,
             )
             return
         except Exception as exc:
@@ -247,7 +247,7 @@ def _report_usage_with_retry(
                     api_url=api_url,
                     error=str(exc),
                     attempt=attempt + 1,
-                    usage=usage,
+                    **usage,
                 )
                 time.sleep(0.5)
             else:
@@ -259,7 +259,7 @@ def _report_usage_with_retry(
                     api_url=api_url,
                     error=str(exc),
                     attempt=attempt + 1,
-                    usage=usage,
+                    **usage,
                 )
 
 
@@ -281,7 +281,7 @@ def _enqueue_usage(
         "Usage report enqueued",
         type="usage",
         api_url=api_url,
-        usage=copied,
+        **copied,
     )
     try:
         usage_executor.submit(


### PR DESCRIPTION
## Summary

- Add structured proxy log entries at every stage of model provider usage report delivery
- **Enqueued** (info): logged when usage report is submitted to the thread pool
- **Succeeded** (info): logged after webhook returns 2xx
- **Retrying** (warn): logged on intermediate failure before retry
- **Giving up** (error): logged when all retries exhausted
- **Executor shutdown fallback** (warn): logged when thread pool is already shut down during drain
- All log entries include `api_url` and full usage payload (`model`, `input_tokens`, `output_tokens`, `message_id`, etc.) as structured fields

## Test plan

- [x] 840 existing mitm-addon tests pass
- [ ] Deploy to dev runner and verify proxy log entries appear for model provider requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)