### PR TITLE
refactor(infra): generalize skill-upload to volume-upload and relocate system skill hash

### DIFF
--- a/turbo/apps/web/app/api/zero/skills/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/skills/[name]/route.ts
@@ -24,9 +24,9 @@ import {
 } from "../../../../../src/db/schema/storage";
 import { eq, and, sql } from "drizzle-orm";
 import {
-  uploadSkillServerSide,
-  deleteSkillServerSide,
-} from "../../../../../src/lib/infra/storage/skill-upload";
+  uploadVolumeServerSide,
+  deleteVolumeServerSide,
+} from "../../../../../src/lib/infra/storage/volume-upload";
 import {
   downloadManifest,
   downloadS3Buffer,
@@ -205,9 +205,9 @@ const router = tsr.router(zeroSkillsDetailContract, {
     }
 
     // Upload new files (creates new version, no compose rebuild needed)
-    await uploadSkillServerSide({
+    await uploadVolumeServerSide({
       orgId: org.orgId,
-      skillName: params.name,
+      storageName: getCustomSkillStorageName(params.name),
       files: body.files,
     });
 
@@ -309,9 +309,9 @@ const router = tsr.router(zeroSkillsDetailContract, {
       );
 
     // Delete S3 storage
-    await deleteSkillServerSide({
+    await deleteVolumeServerSide({
       orgId: org.orgId,
-      skillName: params.name,
+      storageName: getCustomSkillStorageName(params.name),
     });
 
     log.info(

--- a/turbo/apps/web/app/api/zero/skills/route.ts
+++ b/turbo/apps/web/app/api/zero/skills/route.ts
@@ -3,7 +3,10 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../src/lib/ts-rest-handler";
-import { zeroSkillsCollectionContract } from "@vm0/core";
+import {
+  zeroSkillsCollectionContract,
+  getCustomSkillStorageName,
+} from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -12,7 +15,7 @@ import {
 import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
 import { zeroSkills } from "../../../../src/db/schema/zero-skill";
 import { eq, and } from "drizzle-orm";
-import { uploadSkillServerSide } from "../../../../src/lib/infra/storage/skill-upload";
+import { uploadVolumeServerSide } from "../../../../src/lib/infra/storage/volume-upload";
 import { SEED_SKILLS } from "../../../../src/lib/zero/seed-skills";
 import { requireAdminPermission } from "../../../../src/lib/zero/require-agent-permission";
 import { logger } from "../../../../src/lib/shared/logger";
@@ -111,9 +114,9 @@ const router = tsr.router(zeroSkillsCollectionContract, {
     });
 
     // Upload skill files to S3
-    await uploadSkillServerSide({
+    await uploadVolumeServerSide({
       orgId: org.orgId,
-      skillName: body.name,
+      storageName: getCustomSkillStorageName(body.name),
       files: body.files,
     });
 

--- a/turbo/apps/web/src/lib/infra/storage/content-hash.ts
+++ b/turbo/apps/web/src/lib/infra/storage/content-hash.ts
@@ -83,32 +83,3 @@ export function computeContentHashFromHashes(
   const combined = `storage:${storageId}\n${entries.join("\n")}`;
   return createHash("sha256").update(combined).digest("hex");
 }
-
-/**
- * Compute content-addressable hash for a system skill.
- *
- * Uses a fixed prefix (skill URL) instead of storageId so the same
- * skill content always produces the same hash across environments.
- *
- * @param skillUrl Canonical GitHub tree URL for the skill
- * @param files Array of file entries with path and pre-computed hash
- * @returns 64-character lowercase hexadecimal SHA-256 hash
- */
-export function computeSystemSkillHash(
-  skillUrl: string,
-  files: FileEntryWithHash[],
-): string {
-  if (files.length === 0) {
-    return createHash("sha256")
-      .update(`system-skill:${skillUrl}\n`)
-      .digest("hex");
-  }
-
-  const entries = files
-    .map((file) => {
-      return `${file.path}:${file.hash}`;
-    })
-    .sort();
-  const combined = `system-skill:${skillUrl}\n${entries.join("\n")}`;
-  return createHash("sha256").update(combined).digest("hex");
-}

--- a/turbo/apps/web/src/lib/infra/storage/upload-storage.ts
+++ b/turbo/apps/web/src/lib/infra/storage/upload-storage.ts
@@ -19,7 +19,7 @@ interface LogMethods {
  * Handles the full flow: tar.gz creation, storage upsert,
  * dedup check, S3 upload, and version+HEAD transaction.
  *
- * Used by both instruction-upload and skill-upload.
+ * Used by both instruction-upload and volume-upload.
  */
 export async function uploadStorageServerSide(params: {
   orgId: string;

--- a/turbo/apps/web/src/lib/infra/storage/volume-upload.ts
+++ b/turbo/apps/web/src/lib/infra/storage/volume-upload.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { mkdtemp } from "node:fs/promises";
 import { eq, and } from "drizzle-orm";
 import * as tar from "tar";
-import { getCustomSkillStorageName, VOLUME_ORG_USER_ID } from "@vm0/core";
+import { VOLUME_ORG_USER_ID } from "@vm0/core";
 import { storages, storageVersions } from "../../../db/schema/storage";
 import {
   putS3Object,
@@ -18,22 +18,21 @@ import { computeContentHashFromHashes, hashFileContent } from "./content-hash";
 import { env } from "../../../env";
 import { logger } from "../../shared/logger";
 
-const log = logger("storage:skill-upload");
+const log = logger("storage:volume-upload");
 
 /**
- * Upload a custom skill with multiple files to S3 from the server side.
+ * Upload a volume with multiple files to S3 from the server side.
  *
  * Creates a multi-file tar.gz archive from the provided files array,
  * computes content-addressable version hashes, and uploads to S3
  * with deduplication support.
  */
-export async function uploadSkillServerSide(params: {
+export async function uploadVolumeServerSide(params: {
   orgId: string;
-  skillName: string;
+  storageName: string;
   files: Array<{ path: string; content: string }>;
 }): Promise<{ storageName: string; versionId: string }> {
-  const { orgId, skillName, files } = params;
-  const storageName = getCustomSkillStorageName(skillName);
+  const { orgId, storageName, files } = params;
 
   // Compute per-file hashes and sizes
   const fileEntries = files.map((f) => {
@@ -51,7 +50,7 @@ export async function uploadSkillServerSide(params: {
   }, 0);
 
   // Create multi-file tar.gz archive via temp directory
-  const tmpDir = await mkdtemp(join(tmpdir(), "vm0-skill-"));
+  const tmpDir = await mkdtemp(join(tmpdir(), "vm0-volume-"));
 
   try {
     // Write files preserving directory structure
@@ -207,7 +206,7 @@ export async function uploadSkillServerSide(params: {
     });
 
     log.debug(
-      `Uploaded skill ${skillName}: ${versionId} (${files.length} files)`,
+      `Uploaded volume ${storageName}: ${versionId} (${files.length} files)`,
     );
     return { storageName, versionId };
   } finally {
@@ -216,18 +215,17 @@ export async function uploadSkillServerSide(params: {
 }
 
 /**
- * Delete a custom skill's storage from S3 and database.
+ * Delete a volume's storage from S3 and database.
  *
  * Removes storage versions, the storage record, and S3 objects.
  * Idempotent -- returns silently if the storage doesn't exist.
  */
-export async function deleteSkillServerSide(params: {
+export async function deleteVolumeServerSide(params: {
   orgId: string;
-  skillName: string;
+  storageName: string;
 }): Promise<void> {
-  const { orgId, skillName } = params;
+  const { orgId, storageName } = params;
 
-  const storageName = getCustomSkillStorageName(skillName);
   const db = globalThis.services.db;
 
   // 1. Look up storage by name + orgId
@@ -273,5 +271,5 @@ export async function deleteSkillServerSide(params: {
 
   await db.delete(storages).where(eq(storages.id, storage.id));
 
-  log.debug(`Deleted skill storage: ${storageName}`);
+  log.debug(`Deleted volume storage: ${storageName}`);
 }

--- a/turbo/apps/web/src/lib/zero/skills/content-hash.ts
+++ b/turbo/apps/web/src/lib/zero/skills/content-hash.ts
@@ -1,0 +1,36 @@
+/**
+ * Content hash for system skills.
+ * Moved from infra layer — this function is only used by sync-skills.
+ */
+
+import { createHash } from "crypto";
+import type { FileEntryWithHash } from "../../infra/storage/content-hash";
+
+/**
+ * Compute content-addressable hash for a system skill.
+ *
+ * Uses a fixed prefix (skill URL) instead of storageId so the same
+ * skill content always produces the same hash across environments.
+ *
+ * @param skillUrl Canonical GitHub tree URL for the skill
+ * @param files Array of file entries with path and pre-computed hash
+ * @returns 64-character lowercase hexadecimal SHA-256 hash
+ */
+export function computeSystemSkillHash(
+  skillUrl: string,
+  files: FileEntryWithHash[],
+): string {
+  if (files.length === 0) {
+    return createHash("sha256")
+      .update(`system-skill:${skillUrl}\n`)
+      .digest("hex");
+  }
+
+  const entries = files
+    .map((file) => {
+      return `${file.path}:${file.hash}`;
+    })
+    .sort();
+  const combined = `system-skill:${skillUrl}\n${entries.join("\n")}`;
+  return createHash("sha256").update(combined).digest("hex");
+}

--- a/turbo/apps/web/src/lib/zero/skills/sync-skills.ts
+++ b/turbo/apps/web/src/lib/zero/skills/sync-skills.ts
@@ -25,10 +25,8 @@ import {
 } from "@vm0/core";
 import { fetchHeadCommitSha } from "./git-refs";
 import { downloadAndExtractSkills, type ExtractedSkill } from "./tarball";
-import {
-  computeSystemSkillHash,
-  type FileEntryWithHash,
-} from "../../infra/storage/content-hash";
+import { computeSystemSkillHash } from "./content-hash";
+import type { FileEntryWithHash } from "../../infra/storage/content-hash";
 import {
   putS3Object,
   listS3Objects,

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -103,7 +103,7 @@
     "apps/platform/src/test/mocks/clerk-react-experimental.ts",
     "apps/cli/src/lib/utils/paginate.ts",
     "apps/web/src/lib/auth/sandbox-token.ts",
-    "apps/web/src/lib/infra/storage/skill-upload.ts",
+    "apps/web/src/lib/infra/storage/volume-upload.ts",
     "scripts/rebuild-snapshots.ts",
     "scripts/rebuild-snapshots-from-db.ts",
     "apps/web/scripts/migrations/001-backfill-clerk-orgs/**",


### PR DESCRIPTION
## Summary

- Rename `skill-upload.ts` → `volume-upload.ts` with generic `storageName` param instead of `skillName`
- Move `computeSystemSkillHash()` from infra layer to zero layer (`zero/skills/content-hash.ts`)
- Update all callers (3 API routes) to compute storage name themselves via `getCustomSkillStorageName()`
- Update `knip.json` entry and `upload-storage.ts` docstring reference

Part of Epic #9667 — remove skill concept from infra layer (Phase 1).

Closes #9672

## Test plan

- [x] No behavioral changes — pure rename/move refactoring
- [x] `grep` confirms no skill-specific references remain in infra upload files
- [x] Format, lint, and knip pass
- [x] Pre-existing `@vm0/core` type errors (generated firewall files) unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)