### PR TITLE
fix(cli): update init next steps to use auth login and --secrets flag

### DIFF
--- a/turbo/apps/cli/src/commands/init/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/init/__tests__/index.test.ts
@@ -187,13 +187,13 @@ describe("init command", () => {
 
       expect(mockConsoleLog).toHaveBeenCalledWith("Next steps:");
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("zero org model-provider setup"),
+        expect.stringContaining("vm0 auth login"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("AGENTS.md"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("vm0 run"),
+        expect.stringContaining("vm0 run --secrets CLAUDE_CODE_OAUTH_TOKEN"),
       );
     });
 

--- a/turbo/apps/cli/src/commands/init/index.ts
+++ b/turbo/apps/cli/src/commands/init/index.ts
@@ -119,14 +119,12 @@ export const initCommand = new Command()
       // Print next steps
       console.log();
       console.log("Next steps:");
-      console.log(
-        `  1. Set up model provider (one-time): ${chalk.cyan("zero org model-provider setup")}`,
-      );
+      console.log(`  1. Log in to VM0: ${chalk.cyan("vm0 auth login")}`);
       console.log(
         `  2. Edit ${chalk.cyan("AGENTS.md")} to customize your agent's workflow`,
       );
       console.log(
-        `  3. Run your agent: ${chalk.cyan('vm0 run "let\'s start working"')}`,
+        `  3. Run your agent: ${chalk.cyan('vm0 run --secrets CLAUDE_CODE_OAUTH_TOKEN=<token> "let\'s start working"')}`,
       );
     }),
   );


### PR DESCRIPTION
## Summary
- Replace outdated `zero org model-provider setup` step with `vm0 auth login`
- Update run command example to include `--secrets CLAUDE_CODE_OAUTH_TOKEN=<token>` flag
- Update test assertions to match new next steps output

## Test plan
- [x] `pnpm turbo run lint --filter=@vm0/cli` — 0 warnings, 0 errors
- [x] `pnpm format` — no formatting changes needed
- [x] `pnpm -F @vm0/cli exec vitest run` — 112 files, 1060 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)