### PR TITLE
refactor(zero): remove skills from compose pipeline and server-side-compose

### DIFF
--- a/turbo/apps/web/src/lib/infra/compose/server-side-compose.ts
+++ b/turbo/apps/web/src/lib/infra/compose/server-side-compose.ts
@@ -1,6 +1,5 @@
-import { eq, and, inArray } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import {
-  resolveSkillRef,
   AGENT_NAME_REGEX,
   isSupportedFramework,
   type SupportedFramework,
@@ -12,7 +11,6 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
-import { skills } from "../../../db/schema/skill";
 import { logger } from "../../shared/logger";
 
 const log = logger("compose:server-side");
@@ -135,14 +133,11 @@ async function upsertComposeRecord(params: {
 /**
  * Attempt server-side compose for platform mode.
  *
- * Bypasses the E2B sandbox by resolving skills from the database cache,
- * injecting connector env vars via buildComposeContent, expanding firewall
- * configs, uploading instructions, and creating the compose record — all
- * server-side.
+ * Validates agent config, uploads instructions, and creates the compose
+ * record — all server-side.
  *
  * @returns Compose result if successful, or `null` if the server-side path
- *          is not possible (e.g., uncached skills) and the caller should
- *          fall back to the sandbox.
+ *          is not possible and the caller should fall back to the sandbox.
  */
 export async function serverSideCompose(params: {
   userId: string;
@@ -155,37 +150,17 @@ export async function serverSideCompose(params: {
   versionId: string;
 } | null> {
   const { userId, orgId, content, instructions } = params;
-  const db = globalThis.services.db;
 
   // 1. Validate and extract agent config
   const { agentName, normalizedName, framework, agent } =
     extractAgentConfig(content);
 
-  // 2. Resolve skill references and check cache
-  const agentSkills = (agent.skills ?? []) as string[];
-  const resolvedSkillUrls = agentSkills.map(resolveSkillRef);
-
-  let cachedSkills: { url: string }[] = [];
-  if (resolvedSkillUrls.length > 0) {
-    cachedSkills = await db
-      .select({ url: skills.url })
-      .from(skills)
-      .where(inArray(skills.url, resolvedSkillUrls));
-
-    if (cachedSkills.length !== resolvedSkillUrls.length) {
-      log.info(
-        `Missing ${resolvedSkillUrls.length - cachedSkills.length} cached skills, falling back to sandbox`,
-      );
-      return null;
-    }
-  }
-
-  // 3. Use environment as-is (connector env vars already injected by buildComposeContent)
+  // 2. Use environment as-is (connector env vars already injected by buildComposeContent)
   const environment: Record<string, string> = {
     ...((agent.environment ?? {}) as Record<string, string>),
   };
 
-  // 4. Build resolved content with normalized agent name
+  // 3. Build resolved content with normalized agent name
   const agentsCopy = content.agents as Record<string, Record<string, unknown>>;
   const agentDef = { ...agentsCopy[agentName]! };
   const resolvedContent = {
@@ -199,7 +174,7 @@ export async function serverSideCompose(params: {
     },
   } as AgentComposeYaml;
 
-  // 6. Upload instructions if provided
+  // 4. Upload instructions if provided
   if (instructions !== undefined) {
     await uploadInstructionsServerSide({
       orgId,
@@ -209,7 +184,7 @@ export async function serverSideCompose(params: {
     });
   }
 
-  // 7. Create compose record
+  // 5. Create compose record
   const versionId = computeComposeVersionId(resolvedContent);
   const composeId = await upsertComposeRecord({
     userId,

--- a/turbo/apps/web/src/lib/zero/__tests__/build-compose-content.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-compose-content.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildComposeContent } from "../build-compose-content";
-import { SEED_SKILLS } from "../seed-skills";
-import { resolveSkillRef, getInstructionsFilename } from "@vm0/core";
+import { getInstructionsFilename } from "@vm0/core";
 
 describe("buildComposeContent", () => {
   it("should return valid compose structure without volumes", () => {
@@ -19,75 +18,14 @@ describe("buildComposeContent", () => {
       }),
     );
 
-    // Custom skill volumes are no longer part of compose — they are injected
-    // as additionalVolumes at run creation time
+    // Skills and volumes are not part of compose — they are injected
+    // as additionalVolumes at run creation time via buildSystemSkillVolumes()
     const agent = (result.agents as Record<string, Record<string, unknown>>)[
       "my-agent"
     ]!;
+    expect(agent.skills).toBeUndefined();
     expect(agent.volumes).toBeUndefined();
     expect(result.volumes).toBeUndefined();
-  });
-
-  it("should include all seed skills", () => {
-    const result = buildComposeContent("agent");
-    const agent = (result.agents as Record<string, Record<string, unknown>>)[
-      "agent"
-    ]!;
-    const skills = agent.skills as string[];
-
-    for (const seedSkill of SEED_SKILLS) {
-      const url = resolveSkillRef(seedSkill);
-      expect(skills).toContain(url);
-    }
-  });
-
-  it("should include GA connector types as skills", () => {
-    const result = buildComposeContent("agent");
-    const agent = (result.agents as Record<string, Record<string, unknown>>)[
-      "agent"
-    ]!;
-    const skills = agent.skills as string[];
-
-    // github and jira are GA connectors (no feature flag)
-    expect(skills).toContain(resolveSkillRef("github"));
-    expect(skills).toContain(resolveSkillRef("jira"));
-  });
-
-  it("should include feature-flagged connectors that have api-token", () => {
-    const result = buildComposeContent("agent");
-    const agent = (result.agents as Record<string, Record<string, unknown>>)[
-      "agent"
-    ]!;
-    const skills = agent.skills as string[];
-
-    // mercury: feature-flagged + has api-token → should be included
-    expect(skills).toContain(resolveSkillRef("mercury"));
-    // ahrefs: feature-flagged + has api-token → should be included
-    expect(skills).toContain(resolveSkillRef("ahrefs"));
-  });
-
-  it("should exclude feature-flagged OAuth-only connectors from skills", () => {
-    const result = buildComposeContent("agent");
-    const agent = (result.agents as Record<string, Record<string, unknown>>)[
-      "agent"
-    ]!;
-    const skills = agent.skills as string[];
-
-    // reddit: feature-flagged + OAuth-only → should be excluded
-    expect(skills).not.toContain(resolveSkillRef("reddit"));
-    // canva: feature-flagged + OAuth-only → should be excluded
-    expect(skills).not.toContain(resolveSkillRef("canva"));
-  });
-
-  it("should not produce duplicate skills", () => {
-    const result = buildComposeContent("agent");
-    const agent = (result.agents as Record<string, Record<string, unknown>>)[
-      "agent"
-    ]!;
-    const skills = agent.skills as string[];
-    const unique = new Set(skills);
-
-    expect(skills).toHaveLength(unique.size);
   });
 
   it("should inject connector env var templates for GA connectors", () => {

--- a/turbo/apps/web/src/lib/zero/build-compose-content.ts
+++ b/turbo/apps/web/src/lib/zero/build-compose-content.ts
@@ -1,32 +1,24 @@
 import {
-  resolveSkillRef,
   getInstructionsFilename,
   getConnectorEnvironmentMapping,
   getEligibleConnectorTypes,
   connectorTypeSchema,
 } from "@vm0/core";
-import { SEED_SKILLS } from "./seed-skills";
 
 /**
  * Build compose content for a zero agent.
  *
- * Always includes all SEED_SKILLS plus eligible connector type skill names.
- * Eligible = GA (no feature flag) or has api-token auth (feature flag only
- * gates OAuth, not api-token).
+ * Produces a compose object with framework, instructions, and environment.
  * Connector env var templates are baked into the compose so that
  * expandEnvironmentFromCompose can resolve firewall placeholders at runtime.
+ *
+ * Skills are NOT included in compose — they are injected at runtime via
+ * buildSystemSkillVolumes() → AdditionalVolumes.
  */
 export function buildComposeContent(
   agentName: string,
 ): Record<string, unknown> {
   const eligibleConnectorTypes = getEligibleConnectorTypes();
-
-  const allSkillNames = [
-    ...new Set([...SEED_SKILLS, ...eligibleConnectorTypes]),
-  ];
-  const skills = allSkillNames.map((name) => {
-    return resolveSkillRef(name);
-  });
 
   const environment: Record<string, string> = {
     ZERO_AGENT_ID: "${{ vars.ZERO_AGENT_ID }}",
@@ -54,10 +46,6 @@ export function buildComposeContent(
     instructions: getInstructionsFilename("claude-code"),
     environment,
   };
-
-  if (skills.length > 0) {
-    agentDef.skills = skills;
-  }
 
   return {
     version: "1",


### PR DESCRIPTION
## Summary

- Remove the `skills` field from zero agent compose YAML output in `buildComposeContent()`
- Eliminate the skill cache check from `serverSideCompose()` (queried `skills` table, returned 422 on miss)
- Skills are exclusively injected at runtime via `buildSystemSkillVolumes()` → `AdditionalVolumes`

Part of #9667 (epic: remove skill concept from infra layer — Phase 1)

Closes #9671

## Changes

| File | Change |
|------|--------|
| `build-compose-content.ts` | Remove `SEED_SKILLS`, `resolveSkillRef` imports; remove skills computation and assignment |
| `server-side-compose.ts` | Remove `skills` schema import, `inArray`, `resolveSkillRef`; remove skill cache check block |
| `build-compose-content.test.ts` | Remove 5 skills-related tests; add `skills: undefined` assertion |

## Test plan

- [x] `build-compose-content.test.ts` — 6 tests pass (5 removed, 1 updated with no-skills assertion)
- [x] `agents/route.test.ts` — 70 integration tests pass (full agent CRUD pipeline)
- [x] Lint, format, knip all pass
- [x] Type-check passes (pre-existing `@vm0/core` generated file errors unchanged)
- [x] Verified `buildSystemSkillVolumes()` independently computes skills for runtime injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)