### PR TITLE
refactor(proxy): return connector types instead of missing secret names in 424 response

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -21,16 +21,6 @@ from url_utils import build_rewrite_url
 class ConnectorNotConfiguredError(Exception):
     """Raised when the auth endpoint returns 424 — connector not linked or misconfigured."""
 
-    def __init__(
-        self,
-        message: str,
-        missing_secrets: list[str] | None = None,
-        missing_vars: list[str] | None = None,
-    ):
-        super().__init__(message)
-        self.missing_secrets = missing_secrets or []
-        self.missing_vars = missing_vars or []
-
 
 # Vercel bypass secret (still from environment as it's a secret)
 VERCEL_BYPASS = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
@@ -113,8 +103,6 @@ def _fetch_firewall_headers_sync(
         if error_info.get("code") == "CONNECTOR_NOT_CONFIGURED":
             raise ConnectorNotConfiguredError(
                 error_info.get("message", "Connector not configured"),
-                error_info.get("missingSecrets", []),
-                error_info.get("missingVars", []),
             ) from None
         raise
     return json.loads(resp.read())
@@ -381,10 +369,11 @@ async def handle_firewall_request(
             auth_query,
         )
     except ConnectorNotConfiguredError as e:
+        ref = match_info.get("ref", "")
         log_proxy_entry(
             proxy_log_path,
             "info",
-            f"Connector not linked for {firewall_base}: {e}",
+            f"Connector not configured for {firewall_base}: {e}",
             type="firewall",
             firewall_base=firewall_base,
         )
@@ -393,13 +382,11 @@ async def handle_firewall_request(
         error_body: dict = {
             "error": "connector_not_configured",
             "message": str(e),
-            "permission": match_info.get("ref", ""),
+            "permission": ref,
             "base": firewall_base,
         }
-        if e.missing_secrets:
-            error_body["missingSecrets"] = e.missing_secrets
-        if e.missing_vars:
-            error_body["missingVars"] = e.missing_vars
+        if ref:
+            error_body["connectors"] = [ref]
         flow.response = http.Response.make(
             424,
             json.dumps(error_body).encode(),

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1362,7 +1362,6 @@ class TestHandleFirewallRequest:
                 AsyncMock(
                     side_effect=auth.ConnectorNotConfiguredError(
                         "Connector not configured",
-                        ["GITHUB_TOKEN"],
                     )
                 ),
             ),
@@ -1377,13 +1376,12 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_error"] == "connector_not_configured"
         body = json.loads(flow.response.content)
         assert body["error"] == "connector_not_configured"
-        assert body["missingSecrets"] == ["GITHUB_TOKEN"]
-        assert "missingVars" not in body
+        assert body["connectors"] == ["github"]
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
 
     async def test_missing_vars_only_returns_424(self):
-        """When connector has only missing vars, return 424 with missingVars."""
+        """When connector not configured, return 424 with connector ref."""
         flow = _make_http_flow()
         api_entry = {"base": "https://hcti.io", "auth": {"headers": {}}}
         vm_info = {
@@ -1401,7 +1399,6 @@ class TestHandleFirewallRequest:
                 AsyncMock(
                     side_effect=auth.ConnectorNotConfiguredError(
                         "Connector not configured",
-                        missing_vars=["HCTI_USER_ID"],
                     )
                 ),
             ),
@@ -1414,8 +1411,7 @@ class TestHandleFirewallRequest:
         assert flow.response.status_code == 424
         body = json.loads(flow.response.content)
         assert body["error"] == "connector_not_configured"
-        assert "missingSecrets" not in body
-        assert body["missingVars"] == ["HCTI_USER_ID"]
+        assert body["connectors"] == ["htmlcsstoimage"]
 
     async def test_missing_encrypted_secrets_returns_502(self):
         """When encryptedSecrets is missing from vm_info, return 502."""
@@ -1536,7 +1532,6 @@ class TestFetchFirewallHeaders:
                 "error": {
                     "message": "Connector not configured",
                     "code": "CONNECTOR_NOT_CONFIGURED",
-                    "missingSecrets": ["GITHUB_TOKEN"],
                 }
             }
         ).encode()
@@ -1557,7 +1552,6 @@ class TestFetchFirewallHeaders:
                 auth._fetch_firewall_headers_sync(
                     "iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai"
                 )
-            assert exc_info.value.missing_secrets == ["GITHUB_TOKEN"]
             assert "Connector not configured" in str(exc_info.value)
 
     def test_non_connector_not_configured_error_reraised(self):

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -188,7 +188,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(response.status).toBe(424);
       const data = await response.json();
       expect(data.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
-      expect(data.error.missingSecrets).toEqual(["UNKNOWN_KEY"]);
     });
 
     it("should pass through headers without template syntax", async () => {
@@ -376,7 +375,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(response.status).toBe(424);
       const data = await response.json();
       expect(data.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
-      expect(data.error.missingVars).toEqual(["NONEXISTENT"]);
     });
 
     it("should work without vars field (backward compatible)", async () => {
@@ -549,7 +547,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(response.status).toBe(424);
       const data = await response.json();
       expect(data.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
-      expect(data.error.missingSecrets).toEqual(["MISSING"]);
     });
 
     it("should resolve basic with both args empty", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -366,6 +366,7 @@ function resolveTemplates(
  * Auth: Sandbox JWT
  * Body: { encryptedSecrets, authHeaders, authBase?, authQuery?, secretConnectorMap?, vars? }
  * Response: { headers, base?, query?, expiresAt?, resolvedSecrets, refreshedConnectors, refreshedSecrets }
+ *           or 424 { error } when referenced secrets/vars are missing (connector not configured)
  *           or 502 { error } when token refresh fails
  */
 export async function POST(request: Request) {
@@ -443,20 +444,22 @@ export async function POST(request: Request) {
   // Check that all referenced secrets and vars exist.
   // Missing secrets indicate the connector is enabled but not linked.
   // Missing vars indicate incomplete connector configuration.
-  const missingSecrets = [...referenced.secrets].filter((key) => {
+  const hasMissingSecrets = [...referenced.secrets].some((key) => {
     return !(key in secrets);
   });
-  const missingVars = [...referenced.vars].filter((key) => {
+  const hasMissingVars = [...referenced.vars].some((key) => {
     return !(key in (vars ?? {}));
   });
-  if (missingSecrets.length > 0 || missingVars.length > 0) {
-    const errorDetail: Record<string, unknown> = {
-      message: "Connector not configured",
-      code: "CONNECTOR_NOT_CONFIGURED",
-    };
-    if (missingSecrets.length > 0) errorDetail.missingSecrets = missingSecrets;
-    if (missingVars.length > 0) errorDetail.missingVars = missingVars;
-    return NextResponse.json({ error: errorDetail }, { status: 424 });
+  if (hasMissingSecrets || hasMissingVars) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Connector not configured",
+          code: "CONNECTOR_NOT_CONFIGURED",
+        },
+      },
+      { status: 424 },
+    );
   }
 
   // Refresh expired OAuth tokens (mutates secrets map with fresh values)


### PR DESCRIPTION
## Summary
- Replace `missingSecrets`/`missingVars` with `connectors` array in the 424 `CONNECTOR_NOT_CONFIGURED` error response
- Proxy derives connector type from firewall match `ref` instead of forwarding internal secret key names from the web endpoint
- Simplify `ConnectorNotConfiguredError` to a plain marker exception with no extra attributes

## Test plan
- [x] Web endpoint tests pass (37 tests) — 424 for missing secrets, missing vars, basic() missing secret
- [x] Python proxy tests pass (257 tests) — connector ref in 424 response, exception handling
- [x] E2e test t52 unchanged (skipped, pending zero CLI org context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)