### PR TITLE
fix(web): add missing SEO meta tags to homepage

### DIFF
--- a/turbo/apps/web/app/[locale]/page.tsx
+++ b/turbo/apps/web/app/[locale]/page.tsx
@@ -22,15 +22,28 @@ export async function generateMetadata({
       "Zero, your trustworthy AI teammate for real work. Connects to 100+ tools and does the work — reports, triage, outreach, research — in Slack or on the web.",
     alternates: buildLocaleAlternates("", locale as Locale),
     openGraph: {
+      type: "website",
       title: "VM0 - Your Trustworthy AI Teammate",
       description:
         "Zero, your trustworthy AI teammate for real work. Connects to 100+ tools and does the work — reports, triage, outreach, research — in Slack or on the web.",
       url,
+      images: [
+        {
+          url: "/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: "VM0 - Your Trustworthy AI Teammate",
+        },
+      ],
     },
     twitter: {
+      card: "summary_large_image",
       title: "VM0 - Your Trustworthy AI Teammate",
       description:
         "Zero connects to 100+ tools and does the work. Reports, triage, outreach, research. In Slack or on the web.",
+      images: ["/og-image.png"],
+      site: "@vm0_ai",
+      creator: "@vm0_ai",
     },
   };
 }

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -229,7 +229,7 @@ export default async function RootLayout({
                 "@context": "https://schema.org",
                 "@type": "SoftwareApplication",
                 name: "VM0",
-                applicationCategory: "DeveloperApplication",
+                applicationCategory: "BusinessApplication",
                 operatingSystem: "Web, Linux, macOS, Windows",
                 offers: {
                   "@type": "Offer",

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -5,16 +5,6 @@ const withNextIntl = createNextIntlPlugin("./i18n.ts");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  async redirects() {
-    return [
-      {
-        source: "/:path*",
-        has: [{ type: "host", value: "vm0.ai" }],
-        destination: "https://www.vm0.ai/:path*",
-        permanent: true,
-      },
-    ];
-  },
   async headers() {
     return [
       {

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -5,6 +5,16 @@ const withNextIntl = createNextIntlPlugin("./i18n.ts");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "vm0.ai" }],
+        destination: "https://www.vm0.ai/:path*",
+        permanent: true,
+      },
+    ];
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- Add explicit `og:type`, `og:image` (with dimensions), `twitter:card: summary_large_image`, `twitter:image`, `twitter:site`, and `twitter:creator` to the homepage `generateMetadata` — these were configured in the root layout but not rendering due to Next.js multi-level metadata merging behavior
- Fix `SoftwareApplication` JSON-LD `applicationCategory` from non-standard `"DeveloperApplication"` to `"BusinessApplication"` per schema.org spec
- Add permanent (301) redirect from `vm0.ai` to `www.vm0.ai` via `next.config.js` redirects to replace the default 307 temporary redirect

## Context
SEO audit found that the homepage was missing critical Open Graph and Twitter Card meta tags in the rendered HTML, despite them being configured in the root `layout.tsx`. The issue is that the homepage `page.tsx` provided its own partial `openGraph`/`twitter` objects, and Next.js metadata resolution doesn't deep-merge nested objects reliably across three layout levels (root → locale → page).

Other pages (pricing, security, use-cases, blog) already had complete metadata and were unaffected.

## Test plan
- [ ] Deploy to preview and verify `og:image`, `og:type`, `twitter:card` appear in rendered HTML via `curl -s <url> | grep og:`
- [ ] Test social share preview on Twitter/Slack/LinkedIn
- [ ] Verify `vm0.ai` redirects with 301 instead of 307
- [ ] Validate JSON-LD with Google Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)