### PR TITLE
fix: truncate task description on mobile when steps badge present

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
@@ -526,10 +526,10 @@ function CollapsedToolGroup({
           <summary className="cursor-pointer list-none w-full text-left">
             <div className="flex items-center gap-2">
               <StatusDot variant="success" />
-              <span className="font-semibold text-sm text-foreground shrink-0">
+              <span className="font-semibold text-sm text-foreground truncate min-w-0">
                 {group.toolName}
               </span>
-              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground shrink-0">
                 {label}
               </span>
               {timestamp && (

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
@@ -183,12 +183,12 @@ function TaskMessageCard({
               Task
             </span>
             {description && (
-              <span className="text-sm text-muted-foreground truncate">
+              <span className="text-sm text-muted-foreground truncate min-w-0">
                 {description}
               </span>
             )}
             {toolCount > 0 && (
-              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground shrink-0">
                 {toolCount} steps
               </span>
             )}


### PR DESCRIPTION
Closes #9679

**Problem**: On mobile, task rows with a steps badge wraps/overflows because the description `<span>` has `truncate` but no `min-w-0`. In a flex container, without `min-w-0`, a flex item won't shrink below its natural content width, so `truncate` never kicks in.

**Changes** in `grouped-message-card.tsx`:
- Description span: add `min-w-0` so it can shrink and ellipsis properly
- Steps badge span: add `shrink-0` so it stays visible and doesn't get squeezed