### PR TITLE
fix(cli): bundle @sentry/node to eliminate intermittent ci module resolution failures

### DIFF
--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -26,10 +26,10 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@ngrok/ngrok": "^1.6.0",
-    "@sentry/node": "^10.38.0"
+    "@ngrok/ngrok": "^1.6.0"
   },
   "devDependencies": {
+    "@sentry/node": "^10.38.0",
     "@ts-rest/core": "3.53.0-rc.1",
     "@types/node": "^24.3.0",
     "@types/prompts": "^2.4.9",

--- a/turbo/apps/cli/tsup.config.ts
+++ b/turbo/apps/cli/tsup.config.ts
@@ -27,8 +27,14 @@ export default defineConfig({
       "const require = __createRequire(import.meta.url);",
     ].join("\n"),
   },
-  // Only keep native/loader-hook packages external; everything else is bundled
-  external: ["@sentry/node", "@ngrok/ngrok"],
+  // @ngrok/ngrok contains platform-specific native binaries (.node) that
+  // cannot be bundled by esbuild — must remain external.
+  // All other dependencies live in devDependencies and are bundled by tsup.
+  // @sentry/node was previously external due to ImportInTheMiddle ESM loader
+  // hook issues, but that was fixed upstream in sentry-javascript v8.8.0
+  // (see getsentry/sentry-javascript#12009). It is now in devDependencies
+  // and bundled like everything else.
+  external: ["@ngrok/ngrok"],
   // Resolve packages from the CLI's node_modules when bundling workspace deps
   // (e.g. @vm0/core imports zod, which lives in apps/cli/node_modules)
   esbuildOptions(options) {

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -72,10 +72,10 @@ importers:
       '@ngrok/ngrok':
         specifier: ^1.6.0
         version: 1.7.0
+    devDependencies:
       '@sentry/node':
         specifier: ^10.38.0
         version: 10.46.0
-    devDependencies:
       '@ts-rest/core':
         specifier: 3.53.0-rc.1
         version: 3.53.0-rc.1(@types/node@24.3.0)


### PR DESCRIPTION
## Summary
- Move `@sentry/node` from `dependencies` to `devDependencies` so tsup bundles it into the CLI instead of keeping it as an external runtime dependency
- The ImportInTheMiddle ESM loader hook issue that originally motivated externalizing it was fixed upstream in [sentry-javascript v8.8.0](https://github.com/getsentry/sentry-javascript/issues/12009) (June 2024). We are on v10.46.0
- When external, the deployed CLI resolved `@sentry/node` at runtime through `npm link` symlinks → `pnpm deploy` node_modules, which intermittently failed in CI parallel E2E tests with `Cannot find package @sentry/node`

## Test plan
- [x] `pnpm build` succeeds, no external `@sentry/node` import in output
- [x] `node dist/index.js --help` and `node dist/zero.js --help` both work
- [x] CLI works even after deleting `node_modules/@sentry` from deploy output (confirms it's fully bundled)
- [ ] CI E2E tests pass (the cook test that was intermittently failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)