### PR TITLE
chore(docker): preinstall python3 and ansible in toolchain-rust image

### DIFF
--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -65,6 +65,12 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -sf /usr/local/bin/mold /usr/local/bin/aarch64-linux-gnu-ld.mold \
     && mold --version
 
+# Install Python3 and Ansible for runner deployments via SSH.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-pip \
+    && pip3 install --no-cache-dir ansible-core \
+    && rm -rf /var/lib/apt/lists/*
+
 # Stage 3: Development environment with additional tools
 FROM toolchain-rust AS development
 
@@ -180,11 +186,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && sed -i "s/UI.initSetting('resize', 'off')/UI.initSetting('resize', 'remote')/" /usr/share/novnc/app/ui.js \
     && sed -i "s/UI.initSetting('reconnect', false)/UI.initSetting('reconnect', true)/" /usr/share/novnc/app/ui.js
-
-# Install pip for Python testing
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/*
 
 # Install cargo-llvm-cov for Rust test coverage
 RUN cargo install cargo-llvm-cov --locked \


### PR DESCRIPTION
## Summary
- Move `python3-pip` + `ansible-core` install from runtime (`deploy-runner-production` job) into the `toolchain-rust` Docker image
- Remove duplicate `python3-pip` layer from `development` stage (now inherited from `toolchain-rust`)
- Saves ~10min on every runner release deployment ([example run](https://github.com/vm0-ai/vm0/actions/runs/24507146391/job/71629202083): "Install Python3 and Ansible" step 11:20:41 → 11:30:42)

## Follow-up
After the new toolchain image is published, remove the `Install Python3 and Ansible` step from `release-please.yml` `deploy-runner-production` job.

## Test plan
- [ ] Docker toolchain build CI passes
- [ ] Publish new toolchain image
- [ ] Verify `deploy-runner-production` works with the pre-installed ansible

🤖 Generated with [Claude Code](https://claude.com/claude-code)