### PR TITLE
perf(zero-runs): defer dispatch with after() and remove redundant oauth pre-refresh

### DIFF
--- a/turbo/apps/web/app/api/zero/__tests__/zero-agent.test.ts
+++ b/turbo/apps/web/app/api/zero/__tests__/zero-agent.test.ts
@@ -45,6 +45,9 @@ describe("Zero Agent E2E: create → run → zero token access", () => {
     const run = (await runRes.json()) as { runId: string };
     expect(run.runId).toBeTruthy();
 
+    // Flush deferred after() callbacks (dispatch is deferred)
+    await context.mocks.flushAfter();
+
     // ── 5. Claim job as official runner via API ──
     // The run was dispatched to runner_job_queue (RUNNER_DEFAULT_GROUP=vm0/default).
     // Official runner token = vm0_official_<OFFICIAL_RUNNER_SECRET>

--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -287,6 +287,7 @@ describe("POST /api/zero/runs", () => {
       const response = await postRun({ agentId, prompt: "Hello" });
       expect(response.status).toBe(201);
       const data = await response.json();
+      await context.mocks.flushAfter();
 
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();
@@ -297,6 +298,7 @@ describe("POST /api/zero/runs", () => {
       const response = await postRun({ agentId, prompt: "Hello" });
       expect(response.status).toBe(201);
       const data = await response.json();
+      await context.mocks.flushAfter();
 
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();
@@ -307,6 +309,7 @@ describe("POST /api/zero/runs", () => {
       const response = await postRun({ agentId, prompt: "Hello" });
       expect(response.status).toBe(201);
       const data = await response.json();
+      await context.mocks.flushAfter();
 
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();
@@ -352,6 +355,7 @@ describe("POST /api/zero/runs", () => {
       const response = await postRun({ agentId, prompt: "Hello" });
       expect(response.status).toBe(201);
       const data = await response.json();
+      await context.mocks.flushAfter();
 
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();
@@ -379,6 +383,7 @@ describe("POST /api/zero/runs", () => {
       const response = await postRun({ agentId, prompt: "Hello" });
       expect(response.status).toBe(201);
       const data = await response.json();
+      await context.mocks.flushAfter();
 
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();
@@ -396,6 +401,7 @@ describe("POST /api/zero/runs", () => {
         const response = await postRun({ agentId, prompt: "Hello" });
         expect(response.status).toBe(201);
         const data = await response.json();
+        await context.mocks.flushAfter();
 
         const job = await findTestRunnerJobEntry(data.runId);
         expect(job).toBeDefined();
@@ -429,6 +435,7 @@ describe("POST /api/zero/runs", () => {
         });
         const data = await response.json();
         expect(response.status).toBe(201);
+        await context.mocks.flushAfter();
 
         const job = await findTestRunnerJobEntry(data.runId);
         expect(job).toBeDefined();
@@ -652,6 +659,7 @@ describe("POST /api/zero/runs", () => {
       const response = await postRun({ agentId, prompt: "Hello" });
       expect(response.status).toBe(201);
       const data = await response.json();
+      await context.mocks.flushAfter();
 
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();
@@ -690,6 +698,7 @@ describe("POST /api/zero/runs", () => {
       const response = await postRun({ agentId, prompt: "Hello" });
       expect(response.status).toBe(201);
       const data = await response.json();
+      await context.mocks.flushAfter();
 
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();
@@ -725,6 +734,7 @@ describe("POST /api/zero/runs", () => {
       const response = await postRun({ agentId, prompt: "Hello" });
       expect(response.status).toBe(201);
       const data = await response.json();
+      await context.mocks.flushAfter();
 
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();
@@ -755,6 +765,7 @@ describe("POST /api/zero/runs", () => {
       const response = await postRun({ agentId, prompt: "Hello" });
       expect(response.status).toBe(201);
       const data = await response.json();
+      await context.mocks.flushAfter();
 
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm";
+import { after } from "next/server";
 import {
   createHandler,
   createSafeErrorHandler,
@@ -10,7 +11,10 @@ import {
   requireAuth,
   isAuthError,
 } from "../../../../src/lib/auth/require-auth";
-import { createZeroRun } from "../../../../src/lib/zero/zero-run-service";
+import {
+  createZeroRunRecord,
+  dispatchZeroRun,
+} from "../../../../src/lib/zero/zero-run-service";
 import { handleCreateRunError } from "../../../../src/lib/zero/zero-run-errors";
 import {
   generateCallbackSecret,
@@ -121,7 +125,7 @@ const router = tsr.router(zeroRunsMainContract, {
           ]
         : [];
 
-      const result = await createZeroRun({
+      const result = await createZeroRunRecord({
         userId: authCtx.userId,
         prompt: body.prompt,
         agentId: agent.id,
@@ -132,12 +136,23 @@ const router = tsr.router(zeroRunsMainContract, {
         callbacks: agentCallbacks.length > 0 ? agentCallbacks : undefined,
       });
 
+      // Defer the heavy dispatch pipeline (token generation, secret resolution,
+      // OAuth refresh, storage manifest, runner dispatch) to after the response
+      // is flushed. Failures are recorded via markRunFailed() inside dispatchZeroRun().
+      after(() => {
+        return dispatchZeroRun(result).catch((err: unknown) => {
+          log.error("Deferred dispatch failed", {
+            runId: result.runId,
+            err,
+          });
+        });
+      });
+
       return {
         status: 201 as const,
         body: {
           runId: result.runId,
           status: result.status,
-          sandboxId: result.sandboxId,
           createdAt: result.createdAt.toISOString(),
         },
       };

--- a/turbo/apps/web/src/lib/auth/__tests__/user-cache-service.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/user-cache-service.test.ts
@@ -77,12 +77,12 @@ describe("getCachedUser", () => {
     mockClerk({ userId, email: freshEmail });
     await createTestOrg(uniqueId("org"));
 
-    // Pre-populate cache with stale entry (2 minutes ago)
-    const twoMinutesAgo = new Date(Date.now() - 120_000);
+    // Pre-populate cache with stale entry (16 minutes ago, exceeds 15-min TTL)
+    const sixteenMinutesAgo = new Date(Date.now() - 960_000);
     await insertUserCacheEntry({
       userId,
       email: "old@stale.com",
-      cachedAt: twoMinutesAgo,
+      cachedAt: sixteenMinutesAgo,
     });
 
     const result = await getCachedUser(userId);

--- a/turbo/apps/web/src/lib/auth/user-cache-service.ts
+++ b/turbo/apps/web/src/lib/auth/user-cache-service.ts
@@ -5,8 +5,8 @@ import { logger } from "../shared/logger";
 
 const log = logger("service:user-cache");
 
-/** Cache TTL aligned with Clerk JWT TTL */
-const CACHE_TTL_MS = 60_000; // 1 minute
+/** Cache TTL for user data (15 minutes) */
+const CACHE_TTL_MS = 900_000;
 
 interface CachedUser {
   userId: string;
@@ -18,7 +18,7 @@ interface CachedUser {
  * Get user data from cache or Clerk API.
  *
  * 1. Check user_cache by userId
- * 2. If fresh (< 1 min): return cached data
+ * 2. If fresh (< 15 min): return cached data
  * 3. If miss or stale: call Clerk API, upsert cache, return
  */
 export async function getCachedUser(userId: string): Promise<CachedUser> {

--- a/turbo/apps/web/src/lib/zero/context/resolve-connectors.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-connectors.ts
@@ -7,7 +7,6 @@ import { and, eq } from "drizzle-orm";
 import { logger } from "../../shared/logger";
 import { connectors } from "../../../db/schema/connector";
 import { PROVIDER_HANDLERS } from "../connector/provider-registry";
-import { refreshConnectorAccessToken } from "../connector/connector-service";
 import { getSecretValues } from "../secret/secret-service";
 
 const log = logger("zero:build-context");
@@ -76,25 +75,6 @@ export async function resolveOauthConnectorSecrets(
         return allowedTypes.includes(type);
       })
     : validConnectors;
-  // Refresh OAuth tokens in parallel.
-  // Safe: each connector writes to distinct keys in connectorSecrets (e.g. github_access_token
-  // vs slack_access_token), so concurrent mutations don't conflict.
-  await Promise.all(
-    allowedConnectors
-      .filter(({ type }) => {
-        const handler =
-          PROVIDER_HANDLERS[type as keyof typeof PROVIDER_HANDLERS];
-        return handler?.refreshToken;
-      })
-      .map(({ type }) => {
-        return refreshConnectorAccessToken(
-          type,
-          orgId,
-          userId,
-          connectorSecrets,
-        );
-      }),
-  );
 
   // Resolve environment mappings from connectors.
   const allInjectedEnvVars: Record<string, string> = {};


### PR DESCRIPTION
## Summary

Closes #9690

Reduce `POST /api/zero/runs` response time from ~5s to ~600-800ms by:

- **Deferring dispatch pipeline**: Replace synchronous `createZeroRun()` with `createZeroRunRecord()` + `after(() => dispatchZeroRun())`, mirroring the proven pattern from the chat messages route. The response only needs `runId`, `status`, and `createdAt` from Phase 1 (~800ms). The heavy Phase 2 (token generation, secret resolution, runner dispatch ~4.2s) now runs after the response is flushed.

- **Removing redundant OAuth pre-refresh**: The `Promise.all` block in `resolveOauthConnectorSecrets()` that unconditionally refreshed all OAuth tokens on every run is removed. The proxy endpoint (`/api/webhooks/agent/firewall/auth`) already handles on-demand refresh with `tokenExpiresAt` check + 60s buffer.

- **Increasing user cache TTL**: `getCachedUser()` TTL increased from 1 minute to 15 minutes. At ~10 req/day, the old TTL almost always missed, causing a Clerk API HTTP call (~100-200ms) on every request.

## Test plan

- [x] All 46 runs route tests pass with `flushAfter()` for dispatch-time assertions
- [x] All 9 user cache service tests pass with adjusted stale cache timeout
- [x] All 11 build-zero-context tests pass (OAuth removal verified)
- [x] All 20 zero-run-service tests pass
- [x] Lint, typecheck, format, knip all pass
- [ ] Post-deploy: verify `POST /api/zero/runs` P50 drops from ~4.5s to ~600-800ms in Axiom
- [ ] Post-deploy: verify runs complete (status transitions pending → running → completed)
- [ ] Post-deploy: verify OAuth connectors still work via proxy-side refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)