### PR TITLE
chore(ci): remove unnecessary toolchain-init from deploy-runner-production

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -853,7 +853,6 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/toolchain-init
 
       - name: Install Python3 and Ansible
         run: |


### PR DESCRIPTION
## Summary
- Remove `toolchain-init` action from `deploy-runner-production` job in release-please workflow
- This job only cross-compiles Rust binaries and deploys via SSH — it doesn't need `pnpm install` or git safe.directory config
- Saves the `pnpm install --frozen-lockfile` time on every runner release

🤖 Generated with [Claude Code](https://claude.com/claude-code)