### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -132,10 +132,10 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.110"
+CLAUDE_CODE_VERSION="2.1.111"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.25.4"
+AGENT_BROWSER_VERSION="0.25.5"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

Bump pinned tool versions in `crates/runner/scripts/build-rootfs.sh`:

| Package | Old Version | New Version |
|---------|-------------|-------------|
| `claude-code` | 2.1.110 | 2.1.111 |
| `agent-browser` | 0.25.4 | 0.25.5 |

No changes needed for:
- `go`: 1.26.2 (already latest)
- `@googleworkspace/cli`: 0.22.5 (already latest)
- `@xdevplatform/xurl`: 1.0.3 (already latest)

## Test plan
- [ ] rootfs build succeeds with updated versions
- [ ] claude binary checksum validates from GCS manifest