### PR TITLE
test: add Vitest coverage for voice-chat bubbles, panel content, and agent chat page

### DIFF
--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/voice-chat-panel-content.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/voice-chat-panel-content.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for VoiceChatPanelContent component.
+ *
+ * Rendered in the Mission Control task panel when an active voice_chat task
+ * is present. The component polls /api/zero/voice-chat/:sessionId/context
+ * and renders events via VoiceChatEventItem.
+ *
+ * Covers:
+ * - MC-VCP-001: Empty state — shows placeholder text when no events exist
+ * - MC-VCP-002: Events state — shows event bubbles when events arrive via poll
+ *
+ * See: turbo/apps/platform/src/views/mission-control-page/voice-chat-panel-content.tsx
+ * Related commits: #9592 (replace two-panel layout with unified conversation view)
+ */
+
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { FeatureSwitchKey } from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+const SESSION_ID = "vc-panel-session-001";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ContextEvent {
+  id: string;
+  seq: number;
+  source: string;
+  type: string;
+  content: string | null;
+  createdAt: string;
+}
+
+/**
+ * Set up mission-control with a voice_chat task and open the panel by clicking
+ * the task card. Returns the userEvent instance for further interactions.
+ *
+ * The context mock handler returns events only on the first poll (after=0) and
+ * empty on subsequent polls, preventing setLoop from exceeding the test
+ * iteration limit.
+ */
+async function setupAndOpenVoiceChatPanel(events: ContextEvent[]) {
+  server.use(
+    http.get("*/api/zero/tasks", () => {
+      return HttpResponse.json({
+        tasks: [
+          {
+            id: "task-vcp-001",
+            type: "voice_chat",
+            title: "Voice session",
+            summary: null,
+            agent: {
+              id: "c0000000-0000-4000-a000-000000000001",
+              name: "zero",
+              displayName: null,
+              avatarUrl: null,
+            },
+            latestRunId: null,
+            status: null,
+            voiceChatSessionId: SESSION_ID,
+            createdAt: "2026-04-17T00:00:00Z",
+            updatedAt: "2026-04-17T00:00:00Z",
+          },
+        ],
+      });
+    }),
+    http.get(`*/api/zero/voice-chat/${SESSION_ID}/context`, ({ request }) => {
+      const url = new URL(request.url);
+      const after = Number(url.searchParams.get("after") ?? 0);
+      // Return events only on the first poll; subsequent polls return empty
+      // so setLoop terminates gracefully within the test iteration limit.
+      if (after === 0) {
+        return HttpResponse.json({ events });
+      }
+      return HttpResponse.json({ events: [] });
+    }),
+  );
+
+  const user = userEvent.setup();
+  detachedSetupPage({
+    context,
+    path: "/_/mission-control",
+    featureSwitches: { [FeatureSwitchKey.VoiceChat]: true },
+  });
+
+  // Click the task card to open the voice chat panel
+  const taskCard = await waitFor(() => {
+    return screen.getByText("Voice session");
+  });
+  await user.click(taskCard);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText("Close task")).toBeInTheDocument();
+  });
+
+  return user;
+}
+
+// ---------------------------------------------------------------------------
+// MC-VCP-001: Empty state
+// ---------------------------------------------------------------------------
+
+describe("voice-chat-panel-content - empty state (MC-VCP-001)", () => {
+  it("shows 'No conversation events yet' when no events exist", async () => {
+    await setupAndOpenVoiceChatPanel([]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No conversation events yet"),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MC-VCP-002: Events rendered
+// ---------------------------------------------------------------------------
+
+describe("voice-chat-panel-content - events rendered (MC-VCP-002)", () => {
+  it("renders event content when the context poll returns events", async () => {
+    await setupAndOpenVoiceChatPanel([
+      {
+        id: "evt-panel-001",
+        seq: 1,
+        source: "user",
+        type: "speech",
+        content: "Schedule a meeting for tomorrow",
+        createdAt: "2026-04-17T00:00:01Z",
+      },
+      {
+        id: "evt-panel-002",
+        seq: 2,
+        source: "fast-brain",
+        type: "response",
+        content: "Sure, I will schedule it.",
+        createdAt: "2026-04-17T00:00:02Z",
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Schedule a meeting for tomorrow"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Sure, I will schedule it.")).toBeInTheDocument();
+
+    // The empty state message should NOT be visible
+    expect(
+      screen.queryByText("No conversation events yet"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/voice-chat/__tests__/voice-chat-bubbles.test.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/__tests__/voice-chat-bubbles.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Tests for VoiceChatEventItem, VoiceUserBubble, VoiceAssistantBubble,
+ * and SlowBrainIndicator components.
+ *
+ * Rendered via the mission-control page with an active voice_chat task.
+ * Clicking the task card opens the VoiceChatPanelContent which renders
+ * events via VoiceChatEventItem.
+ *
+ * Covers:
+ * - VC-B-001: User speech event renders a user bubble
+ * - VC-B-002: Fast-brain response renders an assistant bubble
+ * - VC-B-003: Slow-brain event renders the SlowBrainIndicator label
+ * - VC-B-004: SlowBrainIndicator content is collapsible via <details> element
+ * - VC-B-005: Empty slow-brain content does not render a <details> element
+ *
+ * See: turbo/apps/platform/src/views/voice-chat/voice-chat-bubbles.tsx
+ * Related commits: #9652 (make slow-brain indicator content collapsible)
+ *                  #9592 (replace two-panel layout with unified conversation view)
+ */
+
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { FeatureSwitchKey } from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+function createAgent() {
+  return {
+    id: "agent-1",
+    name: "test-agent",
+    displayName: "Test Agent",
+    avatarUrl: null,
+  };
+}
+
+function mockTasksAndContext(
+  sessionId: string,
+  taskId: string,
+  runId: string,
+  events: {
+    id: string;
+    seq: number;
+    source: string;
+    type: string;
+    content: string | null;
+    createdAt: string;
+  }[],
+) {
+  server.use(
+    http.get("*/api/zero/tasks", () => {
+      return HttpResponse.json({
+        tasks: [
+          {
+            id: taskId,
+            type: "voice_chat",
+            title: "Voice session",
+            summary: null,
+            agent: createAgent(),
+            latestRunId: runId,
+            status: "running",
+            voiceChatSessionId: sessionId,
+            createdAt: "2026-04-17T00:00:00Z",
+            updatedAt: "2026-04-17T00:00:00Z",
+          },
+        ],
+      });
+    }),
+    http.get(`*/api/zero/voice-chat/${sessionId}/context`, ({ request }) => {
+      const url = new URL(request.url);
+      const after = Number(url.searchParams.get("after") ?? 0);
+      // Return events only on the first poll (after=0); subsequent polls return
+      // empty so setLoop does not accumulate events or exceed the test iteration limit.
+      if (after === 0) {
+        return HttpResponse.json({ events });
+      }
+      return HttpResponse.json({ events: [] });
+    }),
+  );
+}
+
+async function openVoiceChatPanel(sessionId: string) {
+  const user = userEvent.setup();
+  detachedSetupPage({
+    context,
+    path: "/_/mission-control",
+    featureSwitches: { [FeatureSwitchKey.VoiceChat]: true },
+  });
+
+  const title = await waitFor(() => {
+    return screen.getByText("Voice session");
+  });
+  await user.click(title);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText("Close task")).toBeInTheDocument();
+  });
+
+  return user;
+}
+
+describe("voice-chat-bubbles", () => {
+  // ---------------------------------------------------------------------------
+  // VC-B-001: User speech bubble
+  // ---------------------------------------------------------------------------
+
+  it("renders user bubble content for speech events from user source (VC-B-001)", async () => {
+    mockTasksAndContext("vc-b-001", "task-vc-b-001", "run-vc-b-001", [
+      {
+        id: "evt-001",
+        seq: 1,
+        source: "user",
+        type: "speech",
+        content: "Hello from user",
+        createdAt: "2026-04-17T00:00:01Z",
+      },
+    ]);
+
+    await openVoiceChatPanel("vc-b-001");
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello from user")).toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // VC-B-002: Assistant response bubble
+  // ---------------------------------------------------------------------------
+
+  it("renders assistant bubble content for response events from fast-brain source (VC-B-002)", async () => {
+    mockTasksAndContext("vc-b-002", "task-vc-b-002", "run-vc-b-002", [
+      {
+        id: "evt-002",
+        seq: 2,
+        source: "fast-brain",
+        type: "response",
+        content: "Hello from assistant",
+        createdAt: "2026-04-17T00:00:02Z",
+      },
+    ]);
+
+    await openVoiceChatPanel("vc-b-002");
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello from assistant")).toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // VC-B-003: Slow-brain label renders
+  // ---------------------------------------------------------------------------
+
+  it("renders the slow-brain type label for slow-brain events (VC-B-003)", async () => {
+    mockTasksAndContext("vc-b-003", "task-vc-b-003", "run-vc-b-003", [
+      {
+        id: "evt-003",
+        seq: 3,
+        source: "slow-brain",
+        type: "thinking",
+        content: "Analyzing the request...",
+        createdAt: "2026-04-17T00:00:03Z",
+      },
+    ]);
+
+    await openVoiceChatPanel("vc-b-003");
+
+    await waitFor(() => {
+      expect(screen.getByText("Thinking")).toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // VC-B-004: Slow-brain content is collapsible (<details>)
+  // ---------------------------------------------------------------------------
+
+  it("renders a details element for slow-brain events with non-empty content (VC-B-004)", async () => {
+    mockTasksAndContext("vc-b-004", "task-vc-b-004", "run-vc-b-004", [
+      {
+        id: "evt-004",
+        seq: 4,
+        source: "slow-brain",
+        type: "directive",
+        content: "Performing deep analysis of the documents",
+        createdAt: "2026-04-17T00:00:04Z",
+      },
+    ]);
+
+    await openVoiceChatPanel("vc-b-004");
+
+    await waitFor(() => {
+      expect(screen.getByText("Directive")).toBeInTheDocument();
+    });
+
+    // Content must be inside a collapsible <details> element (added in #9652)
+    const detailsEl = document.querySelector("details");
+    expect(detailsEl).not.toBeNull();
+    expect(detailsEl?.textContent).toContain(
+      "Performing deep analysis of the documents",
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // VC-B-005: Slow-brain with null content shows no details element
+  // ---------------------------------------------------------------------------
+
+  it("does not render a details element when slow-brain content is null (VC-B-005)", async () => {
+    mockTasksAndContext("vc-b-005", "task-vc-b-005", "run-vc-b-005", [
+      {
+        id: "evt-005",
+        seq: 5,
+        source: "slow-brain",
+        type: "observation",
+        content: null,
+        createdAt: "2026-04-17T00:00:05Z",
+      },
+    ]);
+
+    await openVoiceChatPanel("vc-b-005");
+
+    await waitFor(() => {
+      expect(screen.getByText("Observation")).toBeInTheDocument();
+    });
+
+    expect(document.querySelector("details")).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-page.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Tests for AgentChatPage component.
+ *
+ * Covers:
+ * - Voice chat mic button: hidden when voiceChat feature switch is off
+ * - Voice chat mic button: visible when voiceChat feature switch is on
+ * - Tagline renders on page load
+ * - Invite button visibility depends on org admin status
+ *
+ * See: turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+ * Related commits: #9685 (add voice chat mic button to chat homepage)
+ */
+
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.ts";
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const CHAT_PATH = `/agents/${AGENT_ID}/chat`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockChatHomepageApis() {
+  server.use(
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    http.get("*/api/zero/user-preferences", () => {
+      return HttpResponse.json({ pinnedAgentIds: [] });
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AG-C-001: Voice chat mic button — feature switch off
+// ---------------------------------------------------------------------------
+
+describe("agent-chat-page - voice chat mic button hidden (AG-C-001)", () => {
+  it("does not render the voice chat mic button when voiceChat feature is disabled", async () => {
+    mockChatHomepageApis();
+
+    detachedSetupPage({ context, path: CHAT_PATH });
+
+    // Wait for the chat composer to appear (page fully loaded)
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(/automate workflows/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByLabelText("Start voice chat"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AG-C-002: Voice chat mic button — feature switch on
+// ---------------------------------------------------------------------------
+
+describe("agent-chat-page - voice chat mic button visible (AG-C-002)", () => {
+  it("renders the voice chat mic button when voiceChat feature is enabled", async () => {
+    setMockFeatureSwitches({ voiceChat: true });
+    mockChatHomepageApis();
+
+    detachedSetupPage({ context, path: CHAT_PATH });
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Start voice chat"),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AG-C-003: Tagline renders
+// ---------------------------------------------------------------------------
+
+describe("agent-chat-page - tagline renders (AG-C-003)", () => {
+  it("renders a tagline when the page loads", async () => {
+    mockChatHomepageApis();
+
+    detachedSetupPage({ context, path: CHAT_PATH });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-tagline")).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AG-C-004: Invite button visible to admin
+// ---------------------------------------------------------------------------
+
+describe("agent-chat-page - invite button admin (AG-C-004)", () => {
+  it("renders the invite button for org admins", async () => {
+    mockChatHomepageApis();
+
+    server.use(
+      http.get("*/api/zero/org/members", () => {
+        return HttpResponse.json({ members: [] });
+      }),
+    );
+
+    detachedSetupPage({ context, path: CHAT_PATH });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("invite-button")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **AG-C-001..004**: `AgentChatPage` — mic button feature-switch gating, tagline render, and invite button admin visibility
- **VC-B-001..005**: `VoiceChatEventItem` / `VoiceUserBubble` / `VoiceAssistantBubble` / `SlowBrainIndicator` — event categorisation into user/assistant/slow-brain bubbles, collapsible `<details>` for slow-brain content (#9652), and null-content guard
- **MC-VCP-001..002**: `VoiceChatPanelContent` — empty state placeholder and events-rendered state

All three files cover view code changed in the past 24 hours with no prior test coverage.

## Key pattern

Context mock handlers filter by the `after` query param — events returned only on the first poll (`after=0`), empty thereafter. This prevents `setLoop` from exceeding the 100-iteration VITEST limit and avoids the `clearAllDetached` cascade that corrupts subsequent tests.

## Test plan

- [x] `voice-chat-bubbles.test.tsx` — 5 tests passing (VC-B-001..005)
- [x] `voice-chat-panel-content.test.tsx` — 2 tests passing (MC-VCP-001..002)
- [x] `agent-chat-page.test.tsx` — 4 tests passing (AG-C-001..004)
- [x] `mission-control-page.test.tsx` — existing 25 tests still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)