### PR TITLE
feat: add claude-opus-4-7 to vm0 managed model provider

### DIFF
--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -47,10 +47,10 @@ const MODEL_PRICING: (typeof creditPricing.$inferInsert)[] = [
   {
     model: "claude-opus-4-7",
     modelProvider: "vm0",
-    inputTokenPrice: usd(15),
-    outputTokenPrice: usd(75),
-    cacheReadTokenPrice: usd(1.5),
-    cacheCreationTokenPrice: usd(18.75),
+    inputTokenPrice: usd(5),
+    outputTokenPrice: usd(25),
+    cacheReadTokenPrice: usd(0.5),
+    cacheCreationTokenPrice: usd(6.25),
   },
 ];
 

--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -44,6 +44,14 @@ const MODEL_PRICING: (typeof creditPricing.$inferInsert)[] = [
     cacheReadTokenPrice: usd(1.5),
     cacheCreationTokenPrice: usd(18.75),
   },
+  {
+    model: "claude-opus-4-7",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(15),
+    outputTokenPrice: usd(75),
+    cacheReadTokenPrice: usd(1.5),
+    cacheCreationTokenPrice: usd(18.75),
+  },
 ];
 
 /**

--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -146,11 +146,15 @@ describe("VM0 managed model provider", () => {
     });
 
     it("should have all VM0 provider models mapped", () => {
-      const vm0Models = ["claude-sonnet-4-6", "claude-opus-4-6"];
+      const vm0Models = [
+        "claude-sonnet-4-6",
+        "claude-opus-4-6",
+        "claude-opus-4-7",
+      ];
       for (const model of vm0Models) {
         expect(VM0_MODEL_TO_PROVIDER[model]).toBeDefined();
       }
-      expect(Object.keys(VM0_MODEL_TO_PROVIDER)).toHaveLength(2);
+      expect(Object.keys(VM0_MODEL_TO_PROVIDER)).toHaveLength(3);
     });
   });
 });

--- a/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
@@ -102,6 +102,7 @@ describe("model selection for Anthropic-native providers", () => {
       const models = getModels(type);
       expect(models).toContain("claude-sonnet-4-6");
       expect(models).toContain("claude-opus-4-6");
+      expect(models).toContain("claude-opus-4-7");
     },
   );
 

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -77,7 +77,11 @@ export const MODEL_PROVIDER_TYPES = {
       CLAUDE_CODE_OAUTH_TOKEN: "$secret",
       ANTHROPIC_MODEL: "$model",
     } as Record<string, string>,
-    models: ["claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7"] as string[],
+    models: [
+      "claude-sonnet-4-6",
+      "claude-opus-4-6",
+      "claude-opus-4-7",
+    ] as string[],
     defaultModel: "claude-sonnet-4-6",
   },
   "anthropic-api-key": {
@@ -91,7 +95,11 @@ export const MODEL_PROVIDER_TYPES = {
       ANTHROPIC_API_KEY: "$secret",
       ANTHROPIC_MODEL: "$model",
     } as Record<string, string>,
-    models: ["claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7"] as string[],
+    models: [
+      "claude-sonnet-4-6",
+      "claude-opus-4-6",
+      "claude-opus-4-7",
+    ] as string[],
     defaultModel: "claude-sonnet-4-6",
   },
   "openrouter-api-key": {

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -45,6 +45,10 @@ export const VM0_MODEL_TO_PROVIDER: Record<
     concreteType: "anthropic-api-key",
     vendor: "anthropic",
   },
+  "claude-opus-4-7": {
+    concreteType: "anthropic-api-key",
+    vendor: "anthropic",
+  },
 };
 
 /**
@@ -73,7 +77,7 @@ export const MODEL_PROVIDER_TYPES = {
       CLAUDE_CODE_OAUTH_TOKEN: "$secret",
       ANTHROPIC_MODEL: "$model",
     } as Record<string, string>,
-    models: ["claude-sonnet-4-6", "claude-opus-4-6"] as string[],
+    models: ["claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7"] as string[],
     defaultModel: "claude-sonnet-4-6",
   },
   "anthropic-api-key": {
@@ -87,7 +91,7 @@ export const MODEL_PROVIDER_TYPES = {
       ANTHROPIC_API_KEY: "$secret",
       ANTHROPIC_MODEL: "$model",
     } as Record<string, string>,
-    models: ["claude-sonnet-4-6", "claude-opus-4-6"] as string[],
+    models: ["claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7"] as string[],
     defaultModel: "claude-sonnet-4-6",
   },
   "openrouter-api-key": {


### PR DESCRIPTION
## Summary

- Adds `claude-opus-4-7` to `VM0_MODEL_TO_PROVIDER` so it resolves through the `anthropic-api-key` concrete provider
- Exposes `claude-opus-4-7` as a selectable model in both `claude-code-oauth-token` and `anthropic-api-key` provider configs
- Adds dev-seed pricing for `claude-opus-4-7` (same rate as opus-4-6: \$15 input / \$75 output per 1M tokens)
- Updates model provider test to assert `claude-opus-4-7` is present in both provider model lists

## Test plan

- [ ] `pnpm test` in `packages/core` passes (model-providers tests updated)
- [ ] Dev seed runs without errors with new pricing entry
- [ ] Model selector UI shows `claude-opus-4-7` as an option for vm0, anthropic-api-key, and claude-code-oauth-token providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)