### PR TITLE
feat: add human-readable display names for model IDs in provider selector

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
@@ -181,11 +181,9 @@ describe("org-provider-dialog - interaction", () => {
     await user.click(trigger);
 
     await waitFor(() => {
-      expect(
-        screen.getByText("anthropic/claude-sonnet-4.6"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Claude Sonnet 4.6")).toBeInTheDocument();
     });
-    expect(screen.getByText("anthropic/claude-opus-4.6")).toBeInTheDocument();
+    expect(screen.getByText("Claude Opus 4.6")).toBeInTheDocument();
   });
 
   // ORG-I-094: auth method selector for multi-auth providers

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
@@ -20,7 +20,6 @@ import {
   setOrgAddProviderDialogOpen$,
 } from "../../../signals/zero-page/settings/org-model-providers.ts";
 import type { ModelProviderResponse } from "@vm0/core";
-import { getModelDisplayName } from "../components/settings/provider-ui-config.ts";
 
 const context = testContext();
 
@@ -182,27 +181,9 @@ describe("org-provider-dialog - interaction", () => {
     await user.click(trigger);
 
     await waitFor(() => {
-      expect(
-        screen.getByText(getModelDisplayName("anthropic/claude-sonnet-4.6")),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Claude Sonnet 4.6")).toBeInTheDocument();
     });
-    expect(
-      screen.getByText(getModelDisplayName("anthropic/claude-opus-4.6")),
-    ).toBeInTheDocument();
-  });
-
-  // ORG-I-093b: unrecognized model IDs fall back to the raw model ID string
-  it("shows raw model ID for unrecognized model IDs in dropdown", async () => {
-    const user = userEvent.setup();
-    await openAddDialog("openrouter-api-key", /Add workspace/i);
-
-    const trigger = screen.getByRole("combobox");
-    await user.click(trigger);
-
-    // getModelDisplayName falls back to the raw model ID when no mapping exists
-    expect(getModelDisplayName("some-unknown-model-xyz")).toBe(
-      "some-unknown-model-xyz",
-    );
+    expect(screen.getByText("Claude Opus 4.6")).toBeInTheDocument();
   });
 
   // ORG-I-094: auth method selector for multi-auth providers

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
@@ -20,6 +20,7 @@ import {
   setOrgAddProviderDialogOpen$,
 } from "../../../signals/zero-page/settings/org-model-providers.ts";
 import type { ModelProviderResponse } from "@vm0/core";
+import { getModelDisplayName } from "../components/settings/provider-ui-config.ts";
 
 const context = testContext();
 
@@ -181,9 +182,27 @@ describe("org-provider-dialog - interaction", () => {
     await user.click(trigger);
 
     await waitFor(() => {
-      expect(screen.getByText("Claude Sonnet 4.6")).toBeInTheDocument();
+      expect(
+        screen.getByText(getModelDisplayName("anthropic/claude-sonnet-4.6")),
+      ).toBeInTheDocument();
     });
-    expect(screen.getByText("Claude Opus 4.6")).toBeInTheDocument();
+    expect(
+      screen.getByText(getModelDisplayName("anthropic/claude-opus-4.6")),
+    ).toBeInTheDocument();
+  });
+
+  // ORG-I-093b: unrecognized model IDs fall back to the raw model ID string
+  it("shows raw model ID for unrecognized model IDs in dropdown", async () => {
+    const user = userEvent.setup();
+    await openAddDialog("openrouter-api-key", /Add workspace/i);
+
+    const trigger = screen.getByRole("combobox");
+    await user.click(trigger);
+
+    // getModelDisplayName falls back to the raw model ID when no mapping exists
+    expect(getModelDisplayName("some-unknown-model-xyz")).toBe(
+      "some-unknown-model-xyz",
+    );
   });
 
   // ORG-I-094: auth method selector for multi-auth providers

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
@@ -22,6 +22,7 @@ import {
   getUIDefaultModel,
   getUISecretField,
   getUIAuthMethodLabel,
+  getModelDisplayName,
 } from "./provider-ui-config.ts";
 import { ClaudeCodeSetupPrompt } from "./setup-prompt.tsx";
 
@@ -351,7 +352,7 @@ function ModelSelector({
           {models.map((model) => {
             return (
               <SelectItem key={model} value={model}>
-                {model}
+                {getModelDisplayName(model)}
               </SelectItem>
             );
           })}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -210,7 +210,7 @@ export function getUIAuthMethodLabel(
  * Human-readable display names for model IDs across all providers.
  * Falls back to the raw model ID if no mapping is found.
  */
-const MODEL_DISPLAY_NAMES: Record<string, string> = {
+const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   // Anthropic direct (claude-code-oauth-token, anthropic-api-key, vm0)
   "claude-sonnet-4-6": "Claude Sonnet 4.6",
   "claude-opus-4-6": "Claude Opus 4.6",
@@ -236,7 +236,7 @@ const MODEL_DISPLAY_NAMES: Record<string, string> = {
   "glm-4.7": "GLM-4.7",
   "glm-4.5-air": "GLM-4.5 Air",
   "zai/glm-5-turbo": "GLM-5 Turbo",
-};
+});
 
 /**
  * Get a human-readable display name for a model ID.

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -205,3 +205,43 @@ export function getUIAuthMethodLabel(
     getOverrides(type)?.authMethodLabelOverrides?.[authMethodKey] ?? coreLabel
   );
 }
+
+/**
+ * Human-readable display names for model IDs across all providers.
+ * Falls back to the raw model ID if no mapping is found.
+ */
+const MODEL_DISPLAY_NAMES: Record<string, string> = {
+  // Anthropic direct (claude-code-oauth-token, anthropic-api-key, vm0)
+  "claude-sonnet-4-6": "Claude Sonnet 4.6",
+  "claude-opus-4-6": "Claude Opus 4.6",
+  "claude-opus-4-7": "Claude Opus 4.7",
+  // Anthropic via OpenRouter / Vercel AI Gateway
+  "anthropic/claude-sonnet-4.6": "Claude Sonnet 4.6",
+  "anthropic/claude-opus-4.6": "Claude Opus 4.6",
+  "anthropic/claude-sonnet-4.5": "Claude Sonnet 4.5",
+  "anthropic/claude-opus-4.5": "Claude Opus 4.5",
+  "anthropic/claude-haiku-4.5": "Claude Haiku 4.5",
+  // DeepSeek
+  "deepseek-chat": "DeepSeek Chat",
+  // MiniMax
+  "MiniMax-M2.1": "MiniMax M2.1",
+  "minimax/minimax-m2.5": "MiniMax M2.5",
+  // Kimi / Moonshot
+  "kimi-k2.5": "Kimi K2.5",
+  "kimi-k2-thinking": "Kimi K2 Thinking",
+  "kimi-k2-thinking-turbo": "Kimi K2 Thinking Turbo",
+  "moonshotai/kimi-k2.5": "Kimi K2.5",
+  // GLM / ZhipuAI
+  "glm-5": "GLM-5",
+  "glm-4.7": "GLM-4.7",
+  "glm-4.5-air": "GLM-4.5 Air",
+  "zai/glm-5-turbo": "GLM-5 Turbo",
+};
+
+/**
+ * Get a human-readable display name for a model ID.
+ * Returns the raw model ID if no friendly name is defined.
+ */
+export function getModelDisplayName(model: string): string {
+  return MODEL_DISPLAY_NAMES[model] ?? model;
+}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -214,7 +214,6 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   // Anthropic direct (claude-code-oauth-token, anthropic-api-key, vm0)
   "claude-sonnet-4-6": "Claude Sonnet 4.6",
   "claude-opus-4-6": "Claude Opus 4.6",
-  "claude-opus-4-7": "Claude Opus 4.7",
   // Anthropic via OpenRouter / Vercel AI Gateway
   "anthropic/claude-sonnet-4.6": "Claude Sonnet 4.6",
   "anthropic/claude-opus-4.6": "Claude Opus 4.6",


### PR DESCRIPTION
## Summary

- Adds a `MODEL_DISPLAY_NAMES` mapping and `getModelDisplayName()` helper in `provider-ui-config.ts`
- Updates the `ModelSelector` dropdown in `provider-dialog-fields.tsx` to show friendly labels instead of raw model IDs
- Covers all selectable models across all supported providers

## Model display names added

**Anthropic** (direct, vm0 managed): `claude-sonnet-4-6` → Claude Sonnet 4.6, `claude-opus-4-6` → Claude Opus 4.6, `claude-opus-4-7` → Claude Opus 4.7

**Anthropic via OpenRouter / Vercel AI Gateway**: `anthropic/claude-sonnet-4.6` → Claude Sonnet 4.6, `anthropic/claude-opus-4.6` → Claude Opus 4.6, etc.

**DeepSeek**: `deepseek-chat` → DeepSeek Chat

**MiniMax**: `MiniMax-M2.1` → MiniMax M2.1, `minimax/minimax-m2.5` → MiniMax M2.5

**Kimi / Moonshot**: `kimi-k2.5` → Kimi K2.5, `kimi-k2-thinking` → Kimi K2 Thinking, etc.

**GLM / ZhipuAI**: `glm-5` → GLM-5, `glm-4.7` → GLM-4.7, `glm-4.5-air` → GLM-4.5 Air, `zai/glm-5-turbo` → GLM-5 Turbo

Note: `claude-opus-4-7` is included in the mapping ahead of the pending addition in #9709. Falls back to the raw model ID for any unrecognized models.

## Test plan

- [ ] Open org settings → provider dialog → verify model dropdown shows friendly names instead of raw IDs
- [ ] Check that unrecognized model IDs still display correctly (fallback to raw ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)