### PR TITLE
fix(scripts): parse rootfs/snapshot hashes in dev-runner deploy

### DIFF
--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -98,16 +98,17 @@ cmd_deploy() {
     log "Building $PROFILE..."
     BUILD_LOG=$(mktemp)
     ssh_cmd "$RUNNER_BIN build --profile $PROFILE" | tee "$BUILD_LOG"
-    IMAGE_HASH=$(grep '^image_hash=' "$BUILD_LOG" | cut -d= -f2)
+    ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG" | cut -d= -f2)
+    SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG" | cut -d= -f2)
     rm -f "$BUILD_LOG"
 
-    if [[ -z "$IMAGE_HASH" ]]; then
-      log "Error: failed to extract image hash for $PROFILE"
+    if [[ -z "$ROOTFS_HASH" || -z "$SNAPSHOT_HASH" ]]; then
+      log "Error: failed to extract rootfs/snapshot hash for $PROFILE"
       exit 1
     fi
-    log "$PROFILE: image=$IMAGE_HASH"
+    log "$PROFILE: rootfs=$ROOTFS_HASH snapshot=$SNAPSHOT_HASH"
 
-    CONFIG_ARGS+=" --profile $PROFILE --image-hash $IMAGE_HASH"
+    CONFIG_ARGS+=" --profile $PROFILE --rootfs-hash $ROOTFS_HASH --snapshot-hash $SNAPSHOT_HASH"
   done
 
   # Generate config


### PR DESCRIPTION
## Summary
- `scripts/dev-runner.sh` was grepping for `^image_hash=` and passing `--image-hash` to `runner config`, but the runner was refactored (a549299c1) to emit `rootfs_hash=` + `snapshot_hash=` and now accepts `--rootfs-hash` + `--snapshot-hash` instead.
- Every `pnpm runner` deploy exited 1 at the "Building vm0/default..." step because `IMAGE_HASH` was always empty.
- Parse both hashes from the build log and forward them with the new flags.

## Test plan
- [ ] `pnpm runner` completes and starts the `vm0-runner-local-*` service
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)