### PR TITLE
feat: add Kimi K2.6 Code Preview to Moonshot model provider

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -226,6 +226,7 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   "MiniMax-M2.1": "MiniMax M2.1",
   "minimax/minimax-m2.5": "MiniMax M2.5",
   // Kimi / Moonshot
+  "kimi-k2.6-code-preview": "Kimi K2.6 Code Preview",
   "kimi-k2.5": "Kimi K2.5",
   "kimi-k2-thinking": "Kimi K2 Thinking",
   "kimi-k2-thinking-turbo": "Kimi K2 Thinking Turbo",

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -144,6 +144,7 @@ export const MODEL_PROVIDER_TYPES = {
       CLAUDE_CODE_SUBAGENT_MODEL: "$model",
     } as Record<string, string>,
     models: [
+      "kimi-k2.6-code-preview",
       "kimi-k2.5",
       "kimi-k2-thinking-turbo",
       "kimi-k2-thinking",


### PR DESCRIPTION
## Summary
- Registers `kimi-k2.6-code-preview` in the `moonshot-api-key` provider's model list
- Adds a display name mapping (`Kimi K2.6 Code Preview`) in the settings UI

## Context
Moonshot AI released Kimi K2.6 Code Preview on 2026-04-13 with improved code generation and agent planning over K2.5. The model is served through the same `https://api.moonshot.ai/anthropic` endpoint already configured for the Moonshot provider, so no firewall / base-URL changes are needed.

Refs:
- https://kimi-k2.org/blog/23-kimi-k2-6-code-preview
- https://www.buildfastwithai.com/blogs/kimi-code-k26-preview-2026

## Test plan
- [ ] `pnpm --filter @vm0/core test contracts/__tests__/model-providers.test.ts`
- [ ] In the platform settings UI, select Moonshot (Kimi) provider and confirm "Kimi K2.6 Code Preview" appears in the model dropdown
- [ ] End-to-end: configure `MOONSHOT_API_KEY`, pick the new model, send a prompt, verify a successful response