### PR TITLE
perf(ci): parallelize toolchain publish across native arm64 runner

### DIFF
--- a/.github/workflows/docker-toolchain-publish.yml
+++ b/.github/workflows/docker-toolchain-publish.yml
@@ -20,14 +20,107 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  toolchain:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push toolchain image (digest only)
+        id: build-toolchain
+        uses: docker/build-push-action@v7
+        with:
+          context: ./docker/toolchain
+          file: ./docker/toolchain/Dockerfile
+          target: toolchain
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/vm0-ai/vm0-toolchain,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build and push toolchain-rust image (digest only)
+        id: build-toolchain-rust
+        uses: docker/build-push-action@v7
+        with:
+          context: ./docker/toolchain
+          file: ./docker/toolchain/Dockerfile
+          target: toolchain-rust
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/vm0-ai/vm0-toolchain-rust,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build and push development image (digest only)
+        id: build-dev
+        uses: docker/build-push-action@v7
+        with:
+          context: ./docker/toolchain
+          file: ./docker/toolchain/Dockerfile
+          target: development
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/vm0-ai/vm0-dev,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Export digests
+        run: |
+          mkdir -p /tmp/digests/toolchain /tmp/digests/toolchain-rust /tmp/digests/dev
+          tc_digest="${{ steps.build-toolchain.outputs.digest }}"
+          tr_digest="${{ steps.build-toolchain-rust.outputs.digest }}"
+          dev_digest="${{ steps.build-dev.outputs.digest }}"
+          touch "/tmp/digests/toolchain/${tc_digest#sha256:}"
+          touch "/tmp/digests/toolchain-rust/${tr_digest#sha256:}"
+          touch "/tmp/digests/dev/${dev_digest#sha256:}"
+
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -45,56 +138,34 @@ jobs:
           echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "date=$(date +'%Y%m%d')" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push toolchain image
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/toolchain
-          file: ./docker/toolchain/Dockerfile
-          target: toolchain
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/vm0-ai/vm0-toolchain:latest
-            ${{ env.REGISTRY }}/vm0-ai/vm0-toolchain:${{ steps.meta.outputs.sha_short }}
-            ${{ env.REGISTRY }}/vm0-ai/vm0-toolchain:${{ steps.meta.outputs.date }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          labels: |
-            org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.revision=${{ github.sha }}
+      - name: Create multi-arch manifests
+        env:
+          SHA_SHORT: ${{ steps.meta.outputs.sha_short }}
+          DATE: ${{ steps.meta.outputs.date }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
 
-      - name: Build and push toolchain-rust image
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/toolchain
-          file: ./docker/toolchain/Dockerfile
-          target: toolchain-rust
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/vm0-ai/vm0-toolchain-rust:latest
-            ${{ env.REGISTRY }}/vm0-ai/vm0-toolchain-rust:${{ steps.meta.outputs.sha_short }}
-            ${{ env.REGISTRY }}/vm0-ai/vm0-toolchain-rust:${{ steps.meta.outputs.date }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          labels: |
-            org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.revision=${{ github.sha }}
+          for image in toolchain toolchain-rust dev; do
+            case "$image" in
+              dev) repo=vm0-dev ;;
+              *)   repo=vm0-$image ;;
+            esac
 
-      - name: Build and push development image
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/toolchain
-          file: ./docker/toolchain/Dockerfile
-          target: development
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/vm0-ai/vm0-dev:latest
-            ${{ env.REGISTRY }}/vm0-ai/vm0-dev:${{ steps.meta.outputs.sha_short }}
-            ${{ env.REGISTRY }}/vm0-ai/vm0-dev:${{ steps.meta.outputs.date }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          labels: |
-            org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            refs=()
+            for digest_file in /tmp/digests/digests-*/"$image"/*; do
+              digest=$(basename "$digest_file")
+              refs+=("${REGISTRY}/vm0-ai/${repo}@sha256:${digest}")
+            done
+
+            if [ "${#refs[@]}" -eq 0 ]; then
+              echo "Error: no digests found for $image" >&2
+              exit 1
+            fi
+
+            docker buildx imagetools create \
+              --tag "${REGISTRY}/vm0-ai/${repo}:latest" \
+              --tag "${REGISTRY}/vm0-ai/${repo}:${SHA_SHORT}" \
+              --tag "${REGISTRY}/vm0-ai/${repo}:${DATE}" \
+              "${refs[@]}"
+          done

--- a/.github/workflows/docker-toolchain-publish.yml
+++ b/.github/workflows/docker-toolchain-publish.yml
@@ -115,7 +115,7 @@ jobs:
 
   merge:
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/docker-toolchain-publish.yml
+++ b/.github/workflows/docker-toolchain-publish.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             arch: amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
@@ -93,10 +93,15 @@ jobs:
 
       - name: Export digests
         run: |
+          set -euo pipefail
           mkdir -p /tmp/digests/toolchain /tmp/digests/toolchain-rust /tmp/digests/dev
           tc_digest="${{ steps.build-toolchain.outputs.digest }}"
           tr_digest="${{ steps.build-toolchain-rust.outputs.digest }}"
           dev_digest="${{ steps.build-dev.outputs.digest }}"
+          for name in tc_digest tr_digest dev_digest; do
+            value="${!name}"
+            [ -n "${value#sha256:}" ] || { echo "empty $name from build step" >&2; exit 1; }
+          done
           touch "/tmp/digests/toolchain/${tc_digest#sha256:}"
           touch "/tmp/digests/toolchain-rust/${tr_digest#sha256:}"
           touch "/tmp/digests/dev/${dev_digest#sha256:}"

--- a/.github/workflows/docker-toolchain-publish.yml
+++ b/.github/workflows/docker-toolchain-publish.yml
@@ -98,10 +98,9 @@ jobs:
           tc_digest="${{ steps.build-toolchain.outputs.digest }}"
           tr_digest="${{ steps.build-toolchain-rust.outputs.digest }}"
           dev_digest="${{ steps.build-dev.outputs.digest }}"
-          for name in tc_digest tr_digest dev_digest; do
-            value="${!name}"
-            [ -n "${value#sha256:}" ] || { echo "empty $name from build step" >&2; exit 1; }
-          done
+          [ -n "${tc_digest#sha256:}" ]  || { echo "empty digest from toolchain build" >&2; exit 1; }
+          [ -n "${tr_digest#sha256:}" ]  || { echo "empty digest from toolchain-rust build" >&2; exit 1; }
+          [ -n "${dev_digest#sha256:}" ] || { echo "empty digest from development build" >&2; exit 1; }
           touch "/tmp/digests/toolchain/${tc_digest#sha256:}"
           touch "/tmp/digests/toolchain-rust/${tr_digest#sha256:}"
           touch "/tmp/digests/dev/${dev_digest#sha256:}"
@@ -116,11 +115,8 @@ jobs:
 
   merge:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -137,19 +133,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        run: |
-          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-          echo "date=$(date +'%Y%m%d')" >> "$GITHUB_OUTPUT"
-
       - name: Create multi-arch manifests
-        env:
-          SHA_SHORT: ${{ steps.meta.outputs.sha_short }}
-          DATE: ${{ steps.meta.outputs.date }}
         run: |
           set -euo pipefail
           shopt -s nullglob
+
+          SHA_SHORT="${GITHUB_SHA:0:7}"
+          DATE="$(date +'%Y%m%d')"
 
           for image in toolchain toolchain-rust dev; do
             case "$image" in

--- a/.github/workflows/docker-toolchain.yml
+++ b/.github/workflows/docker-toolchain.yml
@@ -25,28 +25,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build toolchain image
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/toolchain
-          file: ./docker/toolchain/Dockerfile
-          target: toolchain
-          push: false
-          tags: vm0-toolchain:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build toolchain-rust image
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/toolchain
-          file: ./docker/toolchain/Dockerfile
-          target: toolchain-rust
-          push: false
-          tags: vm0-toolchain-rust:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
+      # `target: development` builds through `toolchain` and `toolchain-rust`
+      # transitively, so this single step validates the entire Dockerfile.
       - name: Build development image
         uses: docker/build-push-action@v7
         with:


### PR DESCRIPTION
## Summary

- Replace QEMU-emulated arm64 builds with native `ubuntu-24.04-arm` runner via matrix strategy. amd64 and arm64 build in parallel; per-platform images push by digest, then a final `merge` job assembles multi-arch manifests with `docker buildx imagetools create`.
- Simplify the PR validation workflow to a single `target: development` build (transitively builds `toolchain` and `toolchain-rust`, so the prior step-per-target was redundant).

Expected publish runtime: 47 min → ~5 min (the dev image's 39-min arm64 QEMU phase is the entire bottleneck and gets eliminated).

Closes #9713

## Test plan

- [ ] CI on this PR runs the simplified `docker-toolchain.yml` (only triggers if `docker/toolchain/**` or its workflow file changes — won't fire for this PR; verified manually by re-reading the workflow)
- [ ] After merge, watch the first run of `docker-toolchain-publish.yml` on main:
  - Both matrix legs (amd64 / arm64) succeed and emit digests
  - `merge` job succeeds and the resulting `:latest`, `:<sha>`, `:<date>` tags carry both architectures
  - `docker manifest inspect ghcr.io/vm0-ai/vm0-dev:latest` lists both `linux/amd64` and `linux/arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)