### PR TITLE
refactor: hide after() inside createZeroRun and collapse optimized routes

### DIFF
--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -20,14 +20,23 @@ import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { POST } from "../route";
 import { reloadEnv } from "../../../../../src/env";
 
-// Mock Next.js after() to capture callbacks for controlled execution
+// Mock Next.js after() to capture callbacks for controlled execution.
+// Supports both function and promise arguments to match Next.js behavior.
 const afterPromises: Promise<unknown>[] = [];
 vi.mock("next/server", async (importOriginal) => {
   const original = await importOriginal<typeof import("next/server")>();
   return {
     ...original,
-    after: (promise: Promise<unknown>) => {
-      afterPromises.push(promise);
+    after: (fnOrPromise: (() => Promise<unknown>) | Promise<unknown>) => {
+      if (typeof fnOrPromise === "function") {
+        afterPromises.push(
+          Promise.resolve().then(() => {
+            return fnOrPromise();
+          }),
+        );
+      } else {
+        afterPromises.push(fnOrPromise);
+      }
     },
   };
 });
@@ -37,10 +46,12 @@ const context = testContext();
 const TEST_WEBHOOK_SECRET = "test-github-webhook-secret";
 const TEST_APP_SLUG = "vm0-bot";
 
-/** Wait for all after() callbacks to complete */
+/** Wait for all after() callbacks to complete, including nested ones. */
 async function flushAfterCallbacks() {
-  await Promise.all(afterPromises);
-  afterPromises.length = 0;
+  while (afterPromises.length > 0) {
+    const pending = afterPromises.splice(0, afterPromises.length);
+    await Promise.all(pending);
+  }
 }
 
 /** Sign a payload with HMAC-SHA256 matching GitHub's format */

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -11,10 +11,7 @@ import {
   requireAuth,
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
-import {
-  createZeroRunRecord,
-  dispatchZeroRun,
-} from "../../../../../src/lib/zero/zero-run-service";
+import { createZeroRun } from "../../../../../src/lib/zero/zero-run-service";
 import {
   buildWebChatPrompt,
   buildWebAttachFilesPrompt,
@@ -217,9 +214,9 @@ const router = tsr.router(chatMessagesContract, {
       // Build prompt: user text + file descriptions appended
       const fullPrompt = buildFullPrompt(body.prompt, body.attachFiles);
 
-      // Create the run record (pre-flight checks + advisory-locked INSERT).
-      // Does NOT dispatch — tokens, secrets, and runner dispatch are deferred.
-      const result = await createZeroRunRecord({
+      // Create the run. Phase 2 dispatch is deferred inside createZeroRun
+      // via after() so the response flushes before tokens/secrets/runner work.
+      const result = await createZeroRun({
         userId: authCtx.userId,
         prompt: fullPrompt,
         agentId: body.agentId,
@@ -258,18 +255,6 @@ const router = tsr.router(chatMessagesContract, {
           [authCtx.userId],
           `chatThreadMessageCreated:${threadId}`,
         );
-      });
-
-      // Defer the heavy dispatch pipeline (token generation, secret resolution,
-      // OAuth refresh, storage manifest, runner dispatch) to after the response
-      // is flushed. Failures are recorded via markRunFailed() inside dispatchZeroRun().
-      after(() => {
-        return dispatchZeroRun(result).catch((err: unknown) => {
-          log.error("Deferred dispatch failed", {
-            runId: result.runId,
-            err,
-          });
-        });
       });
 
       return {

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -1,5 +1,4 @@
 import { eq } from "drizzle-orm";
-import { after } from "next/server";
 import {
   createHandler,
   createSafeErrorHandler,
@@ -11,10 +10,7 @@ import {
   requireAuth,
   isAuthError,
 } from "../../../../src/lib/auth/require-auth";
-import {
-  createZeroRunRecord,
-  dispatchZeroRun,
-} from "../../../../src/lib/zero/zero-run-service";
+import { createZeroRun } from "../../../../src/lib/zero/zero-run-service";
 import { handleCreateRunError } from "../../../../src/lib/zero/zero-run-errors";
 import {
   generateCallbackSecret,
@@ -125,7 +121,7 @@ const router = tsr.router(zeroRunsMainContract, {
           ]
         : [];
 
-      const result = await createZeroRunRecord({
+      const result = await createZeroRun({
         userId: authCtx.userId,
         prompt: body.prompt,
         agentId: agent.id,
@@ -134,18 +130,6 @@ const router = tsr.router(zeroRunsMainContract, {
         triggerSource: isAgentTriggered ? "agent" : "web",
         triggerAgentId,
         callbacks: agentCallbacks.length > 0 ? agentCallbacks : undefined,
-      });
-
-      // Defer the heavy dispatch pipeline (token generation, secret resolution,
-      // OAuth refresh, storage manifest, runner dispatch) to after the response
-      // is flushed. Failures are recorded via markRunFailed() inside dispatchZeroRun().
-      after(() => {
-        return dispatchZeroRun(result).catch((err: unknown) => {
-          log.error("Deferred dispatch failed", {
-            runId: result.runId,
-            err,
-          });
-        });
       });
 
       return {

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -399,13 +399,17 @@ export function testContext(): TestContext {
       dateNow: dateNowMock,
       date: dateMocks,
       async flushAfter() {
-        const callbacks = [...globalThis.nextAfterCallbacks];
-        globalThis.nextAfterCallbacks = [];
-        await Promise.all(
-          callbacks.map((fn) => {
-            return fn();
-          }),
-        );
+        // Drain iteratively so callbacks that schedule more after() calls
+        // (e.g. createZeroRun's deferred dispatch) are also executed.
+        while (globalThis.nextAfterCallbacks.length > 0) {
+          const callbacks = [...globalThis.nextAfterCallbacks];
+          globalThis.nextAfterCallbacks = [];
+          await Promise.all(
+            callbacks.map((fn) => {
+              return fn();
+            }),
+          );
+        }
       },
     };
     mockHelpers = helpers;

--- a/turbo/apps/web/src/lib/infra/run/index.ts
+++ b/turbo/apps/web/src/lib/infra/run/index.ts
@@ -12,6 +12,5 @@ export {
   isRunDispatchError,
   type RunDispatchError,
   type CreateRunParams,
-  type CreateRunResult,
   type CreateRunRecordResult,
 } from "./run-service";

--- a/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
@@ -69,6 +69,7 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
 
       const result = await createZeroRun(baseParams({ agentId: noKeyAgentId }));
 
+      await context.mocks.flushAfter();
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       // Model provider token is replaced with placeholder (firewall gateway protects it)
@@ -94,6 +95,7 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
 
       const result = await createZeroRun(baseParams({ agentId: modelAgentId }));
 
+      await context.mocks.flushAfter();
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       expect(job!.executionContext.environment).toMatchObject({
@@ -142,6 +144,7 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
         baseParams({ agentId: secretAgentId }),
       );
 
+      await context.mocks.flushAfter();
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       // User value should win
@@ -177,6 +180,7 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
         baseParams({ agentId: secretAgentId }),
       );
 
+      await context.mocks.flushAfter();
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       expect(job!.executionContext.environment).toMatchObject({
@@ -209,6 +213,7 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
 
       const result = await createZeroRun(baseParams({ agentId: varAgentId }));
 
+      await context.mocks.flushAfter();
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       expect(job!.executionContext.environment).toMatchObject({
@@ -237,6 +242,7 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
 
       const result = await createZeroRun(baseParams({ agentId: varAgentId }));
 
+      await context.mocks.flushAfter();
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       expect(job!.executionContext.environment).toMatchObject({
@@ -266,6 +272,7 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
 
       const result = await createZeroRun(baseParams({ agentId: varAgentId }));
 
+      await context.mocks.flushAfter();
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       // createZeroRun doesn't accept CLI vars directly, so user value wins
@@ -293,6 +300,7 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
 
       const result = await createZeroRun(baseParams({ agentId: connAgentId }));
 
+      await context.mocks.flushAfter();
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       // Real secret value must not leak — the template stays unresolved
@@ -324,6 +332,7 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
 
       const result = await createZeroRun(baseParams({ agentId: connAgentId }));
 
+      await context.mocks.flushAfter();
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       // AXIOM_TOKEN should be resolved (firewall gateway replaces with placeholder)
@@ -349,6 +358,7 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
 
       const result = await createZeroRun(baseParams({ agentId: connAgentId }));
 
+      await context.mocks.flushAfter();
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       // Custom secrets should always pass through regardless of connector permissions

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -8,6 +8,7 @@ import {
   createTestCompose,
   createTestSchedule,
   findTestRunRecord,
+  findTestRunnerJobEntry,
   findTestZeroRun,
   findTestRunCallbacks,
   createTestSessionWithConversation,
@@ -16,7 +17,7 @@ import { createTestZeroAgent } from "../../../__tests__/db-test-seeders/agents";
 import { bindCustomSkillToAgent } from "../../../__tests__/db-test-seeders/skills";
 import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
-import { createZeroRun, createZeroRunRecord } from "../zero-run-service";
+import { createZeroRun } from "../zero-run-service";
 import { reloadEnv } from "../../../env";
 import type { TriggerSource } from "@vm0/core";
 
@@ -146,6 +147,7 @@ describe("createZeroRun() — service-only parameters", () => {
         }),
       );
 
+      await context.mocks.flushAfter();
       const callbacks = await findTestRunCallbacks(result.runId);
       expect(callbacks).toHaveLength(1);
       expect(callbacks[0]!.url).toBe("https://example.com/callback");
@@ -307,7 +309,7 @@ describe("createZeroRun() — service-only parameters", () => {
       );
 
       // Resume with sessionId — should inject custom skills (agent-level binding)
-      const resumed = await createZeroRunRecord({
+      const resumed = await createZeroRun({
         userId: user.userId,
         prompt: "continue",
         agentId: resumeAgentId,
@@ -334,9 +336,10 @@ describe("createZeroRun() — service-only parameters", () => {
     });
   });
 
-  describe("createZeroRunRecord early metadata persistence", () => {
+  describe("early metadata persistence", () => {
     it("should persist zero_runs row before dispatch so activity queries see correct triggerSource", async () => {
-      const result = await createZeroRunRecord({
+      // No flushAfter() — triggerSource must be visible from Phase 1.
+      const result = await createZeroRun({
         userId: user.userId,
         prompt: "test prompt",
         agentId,
@@ -351,7 +354,7 @@ describe("createZeroRun() — service-only parameters", () => {
     it("should persist triggerSource for all sources before dispatch", async () => {
       const sources: TriggerSource[] = ["web", "slack", "schedule", "agent"];
       for (const triggerSource of sources) {
-        const result = await createZeroRunRecord({
+        const result = await createZeroRun({
           userId: user.userId,
           prompt: "test",
           agentId,
@@ -362,6 +365,26 @@ describe("createZeroRun() — service-only parameters", () => {
         expect(zeroRun).toBeDefined();
         expect(zeroRun!.triggerSource).toBe(triggerSource);
       }
+    });
+  });
+
+  describe("deferred dispatch", () => {
+    it("returns after Phase 1; Phase 2 runs only once the after() queue flushes", async () => {
+      const result = await createZeroRun(baseParams());
+
+      // Phase 1 is synchronous: run record exists immediately.
+      const runBeforeFlush = await findTestRunRecord(result.runId);
+      expect(runBeforeFlush).toBeDefined();
+
+      // Phase 2 is queued via after(): no runner job yet.
+      const jobBeforeFlush = await findTestRunnerJobEntry(result.runId);
+      expect(jobBeforeFlush).toBeUndefined();
+
+      await context.mocks.flushAfter();
+
+      // After flushing, dispatch has run and the runner job is visible.
+      const jobAfterFlush = await findTestRunnerJobEntry(result.runId);
+      expect(jobAfterFlush).toBeDefined();
     });
   });
 });

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/run-agent.ts
@@ -27,7 +27,7 @@ interface RunAgentParams {
 }
 
 interface RunAgentResult {
-  status: "dispatched" | "queued" | "failed";
+  status: "accepted" | "queued" | "failed";
   response?: string;
   runId: string | undefined;
   errorCode?: string;
@@ -91,7 +91,7 @@ export async function runAgentForSlackOrg(
       ],
     });
 
-    const status = result.status === "queued" ? "queued" : "dispatched";
+    const status = result.status === "queued" ? "queued" : "accepted";
     log.debug(`Run ${result.runId} ${status} for Slack org agent ${agentName}`);
 
     return { status, runId: result.runId };

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/run-agent.ts
@@ -21,7 +21,7 @@ interface RunAgentParams {
 }
 
 interface RunAgentResult {
-  status: "dispatched" | "queued" | "failed";
+  status: "accepted" | "queued" | "failed";
   response?: string;
   runId: string | undefined;
 }
@@ -68,7 +68,7 @@ export async function runAgentForTelegram(
       ],
     });
 
-    const status = result.status === "queued" ? "queued" : "dispatched";
+    const status = result.status === "queued" ? "queued" : "accepted";
     log.debug(`Run ${result.runId} ${status} for Telegram agent ${agentName}`);
 
     return {

--- a/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
@@ -1,6 +1,6 @@
 import { eq, and, gt, lt, desc, isNull } from "drizzle-orm";
 import { voiceChatPreparations } from "../../../db/schema/voice-chat";
-import { createZeroRun } from "../zero-run-service";
+import { createZeroRun, type CreateZeroRunResult } from "../zero-run-service";
 import {
   buildVoiceChatPrepareOnlyPrompt,
   buildVoiceChatMeetingPreparePrompt,
@@ -166,7 +166,7 @@ export async function dispatchPreparationRun(
   userId: string,
   agentId: string,
   options?: { mode?: "chat" | "meeting"; prompt?: string },
-) {
+): Promise<CreateZeroRunResult> {
   const db = globalThis.services.db;
   const meetingPrompt =
     options?.mode === "meeting" ? options.prompt : undefined;

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -3,7 +3,7 @@ import {
   voiceChatSessions,
   voiceChatEvents,
 } from "../../../db/schema/voice-chat";
-import { createZeroRun } from "../zero-run-service";
+import { createZeroRun, type CreateZeroRunResult } from "../zero-run-service";
 import { cancelRun } from "../zero-run-cancel";
 import {
   buildVoiceChatQuickPrepPrompt,
@@ -146,7 +146,7 @@ export async function dispatchSlowBrain(
   userId: string,
   agentId: string,
   options?: { mode?: "chat" | "meeting"; prompt?: string },
-) {
+): Promise<CreateZeroRunResult> {
   const db = globalThis.services.db;
   const meetingPrompt =
     options?.mode === "meeting" ? options.prompt : undefined;
@@ -242,7 +242,7 @@ export async function dispatchObservationSlowBrain(session: {
   id: string;
   userId: string;
   agentId: string;
-}) {
+}): Promise<CreateZeroRunResult> {
   const db = globalThis.services.db;
   const appendSystemPrompt = buildVoiceChatObservationOnlyPrompt(session.id);
   const prompt = `You are Zero's slow-brain for voice-chat session ${session.id}. Preparation is complete. Start observing the conversation.`;

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -606,8 +606,12 @@ async function dispatchZeroRun(
  * Only fields populated by Phase 1 (pre-flight + INSERT) are exposed; Phase 2
  * (tokens, context, dispatch) runs deferred inside after() so its outputs
  * (sandboxId, final dispatched status) are not available at return time.
+ *
+ * `status` reflects Phase 1 state only — it is always `"pending"` (record
+ * inserted, dispatch scheduled via after()) or `"queued"` (concurrency limit,
+ * will be dispatched by the queue worker). It is NEVER a post-dispatch status.
  */
-interface CreateZeroRunResult {
+export interface CreateZeroRunResult {
   runId: string;
   status: RunStatus;
   createdAt: Date;

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -1,4 +1,5 @@
 import { eq, and, sql } from "drizzle-orm";
+import { after } from "next/server";
 import {
   resolveFirewallPolicies,
   toFirewallPolicies,
@@ -22,7 +23,6 @@ import {
   loadCompose,
   markRunFailed,
   registerCallbacks,
-  type CreateRunResult,
   type CreateRunParams,
   type CreateRunRecordResult,
 } from "../infra/run";
@@ -273,9 +273,9 @@ function buildSystemSkillVolumes(): Array<{
  * (credits, model provider), and advisory-locked run record creation.
  * Does NOT generate tokens, build execution context, or dispatch to runner.
  *
- * Use dispatchZeroRun() to complete the dispatch pipeline after this returns.
+ * Internal to zero-run-service — callers should use createZeroRun().
  */
-export async function createZeroRunRecord(
+async function createZeroRunRecord(
   params: ZeroRunParams,
 ): Promise<ZeroRunRecordResult> {
   const db = globalThis.services.db;
@@ -530,9 +530,9 @@ export async function createZeroRunRecord(
  * runner dispatch, and zero-layer metadata persistence.
  * On failure: marks run as failed and drains the org queue.
  *
- * Safe to call from after() — errors are handled internally.
+ * Internal to zero-run-service — scheduled via after() inside createZeroRun().
  */
-export async function dispatchZeroRun(
+async function dispatchZeroRun(
   result: ZeroRunRecordResult,
 ): Promise<{ status: RunStatus; sandboxId?: string } | undefined> {
   const { record, runParams, orgId, zeroParams } = result;
@@ -601,36 +601,50 @@ export async function dispatchZeroRun(
 }
 
 /**
+ * Public result of createZeroRun().
+ *
+ * Only fields populated by Phase 1 (pre-flight + INSERT) are exposed; Phase 2
+ * (tokens, context, dispatch) runs deferred inside after() so its outputs
+ * (sandboxId, final dispatched status) are not available at return time.
+ */
+interface CreateZeroRunResult {
+  runId: string;
+  status: RunStatus;
+  createdAt: Date;
+}
+
+/**
  * Create an agent run with zero-layer defaults.
  *
- * Composition of createZeroRunRecord() + dispatchZeroRun(). Performs the
- * full synchronous pipeline: pre-flight checks, record creation, token
- * generation, context building, and runner dispatch.
+ * Phase 1 (pre-flight checks + advisory-locked INSERT) runs synchronously and
+ * is awaited by the caller. Phase 2 (token generation, context building,
+ * runner dispatch) is deferred via Next.js after() so the caller's response
+ * flushes before the heavy dispatch pipeline runs.
  *
- * All trigger paths except chat messages use this function directly.
- * The chat messages route uses createZeroRunRecord() + after(dispatchZeroRun)
- * to defer the dispatch pipeline and return a response faster.
+ * Dispatch failures are caught inside the after() callback, logged, and
+ * persisted on the run row via markRunFailed() inside dispatchZeroRun.
  */
 export async function createZeroRun(
   params: ZeroRunParams,
-): Promise<CreateRunResult> {
+): Promise<CreateZeroRunResult> {
   const result = await createZeroRunRecord(params);
 
-  // Enqueued runs (concurrency limit) — no dispatch needed
-  if (!result.record) {
-    return {
-      runId: result.runId,
-      status: result.status,
-      createdAt: result.createdAt,
-    };
+  // Dispatch only when a record was actually inserted; enqueued runs
+  // (concurrency limit) are drained by the queue worker later.
+  if (result.record) {
+    after(() => {
+      return dispatchZeroRun(result).catch((err: unknown) => {
+        log.error("Deferred dispatch failed", {
+          runId: result.runId,
+          err,
+        });
+      });
+    });
   }
-
-  const dispatchResult = await dispatchZeroRun(result);
 
   return {
     runId: result.runId,
-    status: dispatchResult?.status ?? "pending",
-    sandboxId: dispatchResult?.sandboxId,
+    status: result.status,
     createdAt: result.createdAt,
   };
 }


### PR DESCRIPTION
## Summary

- Hide the `after()`-deferred Phase 2 dispatch inside `createZeroRun()`, so all 10 sync callers (Schedule/Slack/Telegram/Phone/iMessage/Email × 2/GitHub/Voice Chat × 2) get the ~1–1.5s webhook/cron response speedup automatically, with zero call-site changes.
- Un-export `createZeroRunRecord` and `dispatchZeroRun` — both are now purely service-internal.
- Collapse `/api/zero/runs` and `/api/zero/chat/messages` routes: the explicit two-step `createZeroRunRecord → after(dispatchZeroRun)` pattern is gone; they just `await createZeroRun(...)`.

## Why

Today, two routes duplicate the same `createZeroRunRecord → after(dispatchZeroRun)` pattern while the other 10 callers run the full pipeline synchronously. Surfacing `after()` as an internal property of `createZeroRun` deletes that duplication and opts every caller into the optimization — their HTTP/webhook responses flush before the heavy token-generation + context-building + runner-dispatch work runs.

Phase 1 (pre-flight + INSERT) remains `await`ed so callers still see `runId`, `status`, and `createdAt` synchronously. Phase 2 runs via Next.js `after()` with failures caught, logged, and persisted to the run row via `markRunFailed()`.

## Test plan

- [x] `src/lib/zero/__tests__/zero-run-service.test.ts` — existing early-metadata tests (renamed) now use `createZeroRun` directly; new `deferred dispatch` witness test asserts Phase 2 only runs after `flushAfter()`.
- [x] `src/lib/zero/__tests__/build-zero-context.test.ts` — all 10 runner-job assertions now await `flushAfter()` before inspecting.
- [x] Updated `flushAfter()` helpers (global test-helpers + github route test's local mock) drain nested `after()` calls iteratively, so a single flush catches Phase 2 scheduled from inside an outer `after()`.
- [x] Full `pnpm -F web exec vitest run` — only 4 pre-existing `compare-proxy-usage` flakes (fail on `main` too; unrelated to this refactor).
- [x] `pnpm turbo run lint`, `pnpm check-types`, `pnpm knip` — all clean.

Closes #9725

🤖 Generated with [Claude Code](https://claude.com/claude-code)