### PR TITLE
fix(runner): remove claim file when job read or parse fails

### DIFF
--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -214,6 +214,7 @@ impl JobProvider for LocalProvider {
             Ok(b) => b,
             Err(e) => {
                 warn!(run_id = %run_id, error = %e, "local: failed to read job file");
+                let _ = std::fs::remove_file(&claim_file);
                 return None;
             }
         };
@@ -221,6 +222,7 @@ impl JobProvider for LocalProvider {
             Ok(r) => r,
             Err(e) => {
                 warn!(run_id = %run_id, error = %e, "local: invalid job JSON");
+                let _ = std::fs::remove_file(&claim_file);
                 return None;
             }
         };
@@ -624,6 +626,44 @@ mod tests {
         assert!(
             !cancel_path.exists(),
             "cancel file should be deleted after trigger"
+        );
+    }
+
+    /// Regression: if the job file is missing when claim() reads it, the
+    /// .claim file must be removed so the job doesn't get stranded forever.
+    #[tokio::test]
+    async fn claim_cleans_up_on_missing_job_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, empty_cancel_tokens());
+
+        let run_id = RunId::new_v4();
+        let claim_path = dir.path().join(format!("{run_id}.claim"));
+
+        // No .job file — claim() should fail at the read step.
+        assert!(provider.claim(run_id).await.is_none());
+        assert!(
+            !claim_path.exists(),
+            "claim file must be removed when job read fails"
+        );
+    }
+
+    /// Regression: if the job file contains invalid JSON, claim() must
+    /// remove the .claim file instead of leaving the job permanently stuck.
+    #[tokio::test]
+    async fn claim_cleans_up_on_invalid_job_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, empty_cancel_tokens());
+
+        let run_id = RunId::new_v4();
+        let claim_path = dir.path().join(format!("{run_id}.claim"));
+        std::fs::write(dir.path().join(format!("{run_id}.job")), b"not json").unwrap();
+
+        assert!(provider.claim(run_id).await.is_none());
+        assert!(
+            !claim_path.exists(),
+            "claim file must be removed when job JSON parse fails"
         );
     }
 }


### PR DESCRIPTION
## Summary
- `LocalProvider::claim()` created a `.claim` file atomically, but if the subsequent `.job` read or JSON parse failed, the `.claim` file was left behind — `find_unclaimed_job()` would skip the `run_id` forever, stranding the job.
- Now removes the `.claim` file on both failure paths so the job can be re-discovered.

Fixes #9689

## Test plan
- [x] New regression test: `claim_cleans_up_on_missing_job_file` (no `.job` file present)
- [x] New regression test: `claim_cleans_up_on_invalid_job_json` (malformed JSON)
- [x] `cargo test -p runner provider::local` — 14/14 pass
- [x] `cargo clippy -p runner --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)