### PR TITLE
perf(runner): offload dns and kmsg_log file i/o to blocking pool

### DIFF
--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -18,7 +18,7 @@
 use std::path::Path;
 use std::process::Stdio;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use tokio::io::AsyncBufReadExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -223,7 +223,13 @@ async fn tail_stderr(
                         map.get(&entry.source_ip).cloned()
                     };
                     if let Some(path) = log_path {
-                        write_jsonl(&path, &entry);
+                        // Move the blocking file I/O off the tokio worker thread.
+                        // Capture the timestamp *before* the spawn so it reflects
+                        // query time, not write time (which may lag under load).
+                        let timestamp = Utc::now();
+                        tokio::task::spawn_blocking(move || {
+                            write_jsonl(&path, &entry, timestamp);
+                        });
                     }
                 }
             }
@@ -269,13 +275,17 @@ fn parse_query_line(line: &str) -> Option<DnsQueryEntry> {
 }
 
 /// Append a JSON line to the network log file.
-fn write_jsonl(path: &Path, entry: &DnsQueryEntry) {
+///
+/// `timestamp` is captured by the caller (on the tokio worker) so the recorded
+/// time reflects when the DNS query was observed, not when this function —
+/// which runs on a tokio blocking thread — finally executes.
+fn write_jsonl(path: &Path, entry: &DnsQueryEntry, timestamp: DateTime<Utc>) {
     use std::io::Write;
     use std::os::unix::fs::OpenOptionsExt;
 
     // [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
     let json = serde_json::json!({
-        "timestamp": Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "timestamp": timestamp.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         "type": "dns",
         "host": entry.domain,
         "port": 53,
@@ -381,6 +391,27 @@ mod tests {
     }
 
     #[test]
+    fn write_jsonl_serializes_provided_timestamp() {
+        // Locks the contract that `write_jsonl` must use the `timestamp`
+        // parameter rather than calling `Utc::now()` internally — the whole
+        // point of the parameter is to record observation time, not the
+        // delayed write time after spawn_blocking.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dns.jsonl");
+        let entry = DnsQueryEntry {
+            source_ip: "10.200.0.2".to_string(),
+            domain: "example.com".to_string(),
+        };
+        let ts = DateTime::parse_from_rfc3339("2024-01-15T10:30:45.123Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        write_jsonl(&path, &entry, ts);
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed["timestamp"], "2024-01-15T10:30:45.123Z");
+    }
+
+    #[test]
     fn write_jsonl_creates_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dns.jsonl");
@@ -388,7 +419,7 @@ mod tests {
             source_ip: "10.200.0.2".to_string(),
             domain: "api.github.com".to_string(),
         };
-        write_jsonl(&path, &entry);
+        write_jsonl(&path, &entry, Utc::now());
         let content = std::fs::read_to_string(&path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
         assert_eq!(parsed["type"], "dns");
@@ -408,6 +439,7 @@ mod tests {
                     source_ip: "10.0.0.1".to_string(),
                     domain: domain.to_string(),
                 },
+                Utc::now(),
             );
         }
         let content = std::fs::read_to_string(&path).unwrap();

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use tokio::io::AsyncBufReadExt;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -156,7 +156,13 @@ async fn run_loop(
                         map.get(&entry.source_ip).cloned()
                     };
                     if let Some(path) = log_path {
-                        write_jsonl(&path, &entry);
+                        // Move the blocking file I/O off the tokio worker thread.
+                        // Capture the timestamp *before* the spawn so it reflects
+                        // observation time, not write time (which may lag under load).
+                        let timestamp = Utc::now();
+                        tokio::task::spawn_blocking(move || {
+                            write_jsonl(&path, &entry, timestamp);
+                        });
                     }
                 }
             }
@@ -237,13 +243,17 @@ fn extract_field<'a>(line: &'a str, key: &str) -> Option<&'a str> {
 }
 
 /// Append a JSON line to the network log file.
-fn write_jsonl(path: &Path, entry: &LogEntry) {
+///
+/// `timestamp` is captured by the caller (on the tokio worker) so the recorded
+/// time reflects when the packet was observed, not when this function — which
+/// runs on a tokio blocking thread — finally executes.
+fn write_jsonl(path: &Path, entry: &LogEntry, timestamp: DateTime<Utc>) {
     use std::io::Write;
     use std::os::unix::fs::OpenOptionsExt;
 
     // [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
     let json = serde_json::json!({
-        "timestamp": Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "timestamp": timestamp.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         "type": entry.protocol,
         "host": entry.dst_ip,
         "port": entry.dst_port,
@@ -360,6 +370,30 @@ mod tests {
     }
 
     #[test]
+    fn write_jsonl_serializes_provided_timestamp() {
+        // Locks the contract that `write_jsonl` must use the `timestamp`
+        // parameter rather than calling `Utc::now()` internally — the whole
+        // point of the parameter is to record observation time, not the
+        // delayed write time after spawn_blocking.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.jsonl");
+        let entry = LogEntry {
+            source_ip: "10.200.0.2".to_string(),
+            dst_ip: "8.8.8.8".to_string(),
+            dst_port: 53,
+            protocol: "udp".to_string(),
+            packet_size: 64,
+        };
+        let ts = DateTime::parse_from_rfc3339("2024-01-15T10:30:45.123Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        write_jsonl(&path, &entry, ts);
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed["timestamp"], "2024-01-15T10:30:45.123Z");
+    }
+
+    #[test]
     fn write_jsonl_creates_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.jsonl");
@@ -370,7 +404,7 @@ mod tests {
             protocol: "udp".to_string(),
             packet_size: 64,
         };
-        write_jsonl(&path, &entry);
+        write_jsonl(&path, &entry, Utc::now());
         let content = std::fs::read_to_string(&path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
         assert_eq!(parsed["host"], "8.8.8.8");
@@ -392,7 +426,7 @@ mod tests {
             protocol: "icmp".to_string(),
             packet_size: 84,
         };
-        write_jsonl(&path, &entry);
+        write_jsonl(&path, &entry, Utc::now());
         let content = std::fs::read_to_string(&path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
         assert_eq!(parsed["type"], "icmp");
@@ -414,6 +448,7 @@ mod tests {
                     protocol: "udp".to_string(),
                     packet_size: 64,
                 },
+                Utc::now(),
             );
         }
         let content = std::fs::read_to_string(&path).unwrap();


### PR DESCRIPTION
## Summary

- Closes #9669
- Wrap the per-query / per-packet `write_jsonl` call in `tokio::task::spawn_blocking` so file I/O no longer runs on a tokio worker thread
- Capture `Utc::now()` on the worker before the spawn so the recorded timestamp reflects observation time, not delayed write time under load
- Add two tests that pin the timestamp contract

## Context

`dns.rs:226` and `kmsg_log.rs:159` both perform synchronous `open + write + close` directly in the async stderr / stdout reader. DNS queries are unbounded (no iptables rate limit on that path), so under bursts the async runtime can be held up.

## Why spawn_blocking, not something fancier

- This is an audit finding, not an observed production issue — no evidence that per-write syscall overhead or ordering fidelity matters
- tokio's blocking pool (default 512 threads) is isolated from the async worker pool, which is what the audit actually flagged
- Kernel append-mode atomicity (writes ≤ `PIPE_BUF` = 4096 bytes; our JSONL lines are ~200 bytes) keeps individual lines intact under concurrent writes. A persistent `BufWriter<File>` cache was considered and rejected because it breaks this guarantee
- Capturing the timestamp pre-spawn means consumers can sort by `timestamp` if physical write order differs from query order

Same pattern applied to `kmsg_log.rs` for consistency, even though its path is iptables-rate-limited at 10/sec.

## Test plan

- [x] `cargo test -p runner --bin runner` — 670 passed
- [x] `cargo clippy -p runner --tests --all-targets -- -D warnings` — clean
- [x] `cargo fmt` applied
- [x] New tests `write_jsonl_serializes_provided_timestamp` in both modules pin the timestamp parameter contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)