### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -132,10 +132,10 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.111"
+CLAUDE_CODE_VERSION="2.1.112"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.25.5"
+AGENT_BROWSER_VERSION="0.26.0"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

Update pinned package versions in `crates/runner/scripts/build-rootfs.sh`.

| Package | Old | New |
| --- | --- | --- |
| claude-code | 2.1.111 | 2.1.112 |
| agent-browser | 0.25.5 | 0.26.0 |

The following pins were checked and are already at their latest versions: Go (1.26.2), @googleworkspace/cli (0.22.5), @xdevplatform/xurl (1.0.3).

## Test plan

- [ ] CI builds the rootfs image successfully
- [ ] New claude-code and agent-browser binaries start cleanly inside the guest

🤖 Generated with [Claude Code](https://claude.com/claude-code)