### PR TITLE
refactor: extract pure adapters for Email inbound-reply and inbound-trigger

### DIFF
--- a/turbo/apps/web/src/lib/zero/email/handlers/__tests__/adapt-email-reply.test.ts
+++ b/turbo/apps/web/src/lib/zero/email/handlers/__tests__/adapt-email-reply.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { adaptEmailReplyTrigger } from "../adapt-email-reply";
+import { buildIntegrationPrompt } from "../../../integration-prompt";
+
+function buildContext(
+  overrides: Partial<Parameters<typeof adaptEmailReplyTrigger>[0]> = {},
+): Parameters<typeof adaptEmailReplyTrigger>[0] {
+  return {
+    userId: "user-123",
+    agentId: "agent-abc",
+    sessionId: "session-xyz",
+    prompt: "Hello agent",
+    callbackPayload: {
+      emailThreadSessionId: "thread-1",
+      inboundEmailId: "email-1",
+      inboundMessageId: "<msg@example.com>",
+      inboundReferences: "<a@x> <b@x>",
+      replyRecipientTo: ["user@example.com"],
+      replyRecipientCc: ["cc@example.com"],
+    },
+    ...overrides,
+  };
+}
+
+describe("adaptEmailReplyTrigger", () => {
+  it("returns CreateZeroRunParams with triggerSource 'email'", () => {
+    const result = adaptEmailReplyTrigger(buildContext());
+    expect(result.triggerSource).toBe("email");
+  });
+
+  it("propagates identity and prompt fields", () => {
+    const ctx = buildContext();
+    const result = adaptEmailReplyTrigger(ctx);
+    expect(result.userId).toBe(ctx.userId);
+    expect(result.agentId).toBe(ctx.agentId);
+    expect(result.sessionId).toBe(ctx.sessionId);
+    expect(result.prompt).toBe(ctx.prompt);
+  });
+
+  it("sets appendSystemPrompt to Email integration prompt", () => {
+    const result = adaptEmailReplyTrigger(buildContext());
+    expect(result.appendSystemPrompt).toBe(buildIntegrationPrompt("Email"));
+  });
+
+  it("builds a single reply callback with correct URL", () => {
+    const result = adaptEmailReplyTrigger(buildContext());
+    expect(result.callbacks).toHaveLength(1);
+    expect(result.callbacks?.[0]?.url).toMatch(
+      /\/api\/zero\/email\/callbacks\/reply$/,
+    );
+  });
+
+  it("generates a 64-character hex callback secret", () => {
+    const result = adaptEmailReplyTrigger(buildContext());
+    expect(result.callbacks?.[0]?.secret).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("forwards callbackPayload verbatim", () => {
+    const ctx = buildContext();
+    const result = adaptEmailReplyTrigger(ctx);
+    expect(result.callbacks?.[0]?.payload).toEqual(ctx.callbackPayload);
+  });
+
+  it("generates a fresh secret per invocation (pure except for secret/env)", () => {
+    const ctx = buildContext();
+    const r1 = adaptEmailReplyTrigger(ctx);
+    const r2 = adaptEmailReplyTrigger(ctx);
+    // Identity fields stable
+    expect(r1.userId).toBe(r2.userId);
+    expect(r1.prompt).toBe(r2.prompt);
+    // Secrets differ per invocation (cryptographically random)
+    expect(r1.callbacks?.[0]?.secret).not.toBe(r2.callbacks?.[0]?.secret);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/email/handlers/__tests__/adapt-email-trigger.test.ts
+++ b/turbo/apps/web/src/lib/zero/email/handlers/__tests__/adapt-email-trigger.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { adaptEmailTriggerTrigger } from "../adapt-email-trigger";
+import { buildIntegrationPrompt } from "../../../integration-prompt";
+
+function buildContext(
+  overrides: Partial<Parameters<typeof adaptEmailTriggerTrigger>[0]> = {},
+): Parameters<typeof adaptEmailTriggerTrigger>[0] {
+  return {
+    userId: "user-123",
+    agentId: "agent-abc",
+    prompt: "Subject line\n\nBody content",
+    callbackPayload: {
+      senderEmail: "sender@example.com",
+      agentId: "agent-abc",
+      userId: "user-123",
+      inboundEmailId: "email-1",
+      replyToken: "session-uuid.abcdef0123456789",
+      inboundMessageId: "<msg@example.com>",
+      inboundReferences: undefined,
+      subject: "Subject line",
+      runtimeOrgId: "org-1",
+      replyRecipientTo: ["sender@example.com"],
+      replyRecipientCc: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("adaptEmailTriggerTrigger", () => {
+  it("returns CreateZeroRunParams with triggerSource 'email'", () => {
+    const result = adaptEmailTriggerTrigger(buildContext());
+    expect(result.triggerSource).toBe("email");
+  });
+
+  it("propagates identity and prompt fields", () => {
+    const ctx = buildContext();
+    const result = adaptEmailTriggerTrigger(ctx);
+    expect(result.userId).toBe(ctx.userId);
+    expect(result.agentId).toBe(ctx.agentId);
+    expect(result.prompt).toBe(ctx.prompt);
+  });
+
+  it("does not set sessionId (trigger flow starts a fresh session)", () => {
+    const result = adaptEmailTriggerTrigger(buildContext());
+    expect(result.sessionId).toBeUndefined();
+  });
+
+  it("sets appendSystemPrompt to Email integration prompt", () => {
+    const result = adaptEmailTriggerTrigger(buildContext());
+    expect(result.appendSystemPrompt).toBe(buildIntegrationPrompt("Email"));
+  });
+
+  it("builds a single trigger callback with correct URL", () => {
+    const result = adaptEmailTriggerTrigger(buildContext());
+    expect(result.callbacks).toHaveLength(1);
+    expect(result.callbacks?.[0]?.url).toMatch(
+      /\/api\/zero\/email\/callbacks\/trigger$/,
+    );
+  });
+
+  it("generates a 64-character hex callback secret", () => {
+    const result = adaptEmailTriggerTrigger(buildContext());
+    expect(result.callbacks?.[0]?.secret).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("forwards callbackPayload verbatim", () => {
+    const ctx = buildContext();
+    const result = adaptEmailTriggerTrigger(ctx);
+    expect(result.callbacks?.[0]?.payload).toEqual(ctx.callbackPayload);
+  });
+
+  it("generates a fresh secret per invocation (pure except for secret/env)", () => {
+    const ctx = buildContext();
+    const r1 = adaptEmailTriggerTrigger(ctx);
+    const r2 = adaptEmailTriggerTrigger(ctx);
+    expect(r1.userId).toBe(r2.userId);
+    expect(r1.prompt).toBe(r2.prompt);
+    expect(r1.callbacks?.[0]?.secret).not.toBe(r2.callbacks?.[0]?.secret);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/email/handlers/adapt-email-reply.ts
+++ b/turbo/apps/web/src/lib/zero/email/handlers/adapt-email-reply.ts
@@ -1,0 +1,38 @@
+import { buildIntegrationPrompt } from "../../integration-prompt";
+import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
+import type { CreateZeroRunParams } from "../../zero-run-service";
+
+interface EmailReplyTriggerContext {
+  userId: string;
+  agentId: string;
+  sessionId: string;
+  prompt: string;
+  callbackPayload: {
+    emailThreadSessionId: string;
+    inboundEmailId: string;
+    inboundMessageId: string | undefined;
+    inboundReferences: string | undefined;
+    replyRecipientTo: string[];
+    replyRecipientCc: string[];
+  };
+}
+
+export function adaptEmailReplyTrigger(
+  ctx: EmailReplyTriggerContext,
+): CreateZeroRunParams {
+  return {
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    sessionId: ctx.sessionId,
+    prompt: ctx.prompt,
+    appendSystemPrompt: buildIntegrationPrompt("Email"),
+    triggerSource: "email",
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/zero/email/callbacks/reply`,
+        secret: generateCallbackSecret(),
+        payload: ctx.callbackPayload,
+      },
+    ],
+  };
+}

--- a/turbo/apps/web/src/lib/zero/email/handlers/adapt-email-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/email/handlers/adapt-email-trigger.ts
@@ -1,0 +1,41 @@
+import { buildIntegrationPrompt } from "../../integration-prompt";
+import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
+import type { CreateZeroRunParams } from "../../zero-run-service";
+
+interface EmailTriggerTriggerContext {
+  userId: string;
+  agentId: string;
+  prompt: string;
+  callbackPayload: {
+    senderEmail: string;
+    agentId: string;
+    userId: string;
+    inboundEmailId: string;
+    replyToken: string;
+    inboundMessageId: string | undefined;
+    inboundReferences: string | undefined;
+    subject: string;
+    runtimeOrgId: string;
+    replyRecipientTo: string[];
+    replyRecipientCc: string[];
+  };
+}
+
+export function adaptEmailTriggerTrigger(
+  ctx: EmailTriggerTriggerContext,
+): CreateZeroRunParams {
+  return {
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    prompt: ctx.prompt,
+    appendSystemPrompt: buildIntegrationPrompt("Email"),
+    triggerSource: "email",
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/zero/email/callbacks/trigger`,
+        secret: generateCallbackSecret(),
+        payload: ctx.callbackPayload,
+      },
+    ],
+  };
+}

--- a/turbo/apps/web/src/lib/zero/email/handlers/inbound-reply.ts
+++ b/turbo/apps/web/src/lib/zero/email/handlers/inbound-reply.ts
@@ -10,8 +10,7 @@ import {
   type HandlerResult,
 } from "./shared";
 import { createZeroRun } from "../../zero-run-service";
-import { buildIntegrationPrompt } from "../../integration-prompt";
-import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
+import { adaptEmailReplyTrigger } from "./adapt-email-reply";
 import { getUserIdByEmail } from "../../../auth/get-user-id-by-email";
 import { logger } from "../../../shared/logger";
 
@@ -161,12 +160,14 @@ export async function handleInboundEmailReply(
     replyContent = `${replyContent}\n\n${attachmentText}`;
   }
 
-  // 10. Build callbacks for email reply notification
-  const callbacks = [
-    {
-      url: `${getApiUrl()}/api/zero/email/callbacks/reply`,
-      secret: generateCallbackSecret(),
-      payload: {
+  // 10. Dispatch agent run via pure adapter
+  const result = await createZeroRun(
+    adaptEmailReplyTrigger({
+      userId: session.userId,
+      agentId: session.agentId,
+      sessionId: session.agentSessionId,
+      prompt: replyContent,
+      callbackPayload: {
         emailThreadSessionId: session.id,
         inboundEmailId: emailId,
         inboundMessageId,
@@ -174,20 +175,8 @@ export async function handleInboundEmailReply(
         replyRecipientTo: replyRecipients.to,
         replyRecipientCc: replyRecipients.cc,
       },
-    },
-  ];
-
-  // 11. Create run with integration context as system prompt
-  const appendSystemPrompt = buildIntegrationPrompt("Email");
-  const result = await createZeroRun({
-    userId: session.userId,
-    prompt: replyContent,
-    appendSystemPrompt,
-    agentId: session.agentId,
-    sessionId: session.agentSessionId,
-    triggerSource: "email",
-    callbacks,
-  });
+    }),
+  );
 
   log.info("Dispatched agent run from email reply", {
     runId: result.runId,

--- a/turbo/apps/web/src/lib/zero/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/email/handlers/inbound-trigger.ts
@@ -11,8 +11,7 @@ import {
   type HandlerResult,
 } from "./shared";
 import { createZeroRun } from "../../zero-run-service";
-import { buildIntegrationPrompt } from "../../integration-prompt";
-import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
+import { adaptEmailTriggerTrigger } from "./adapt-email-trigger";
 import { getUserIdByEmail } from "../../../auth/get-user-id-by-email";
 import { getOrgIdBySlug } from "../../../auth/org-cache";
 import { getMemberRole } from "../../../auth/org-membership-cache";
@@ -202,12 +201,13 @@ export async function handleInboundEmailTrigger(
   const sessionPlaceholderId = crypto.randomUUID();
   const replyToken = generateReplyToken(sessionPlaceholderId);
 
-  // 11. Build callback
-  const callbacks = [
-    {
-      url: `${getApiUrl()}/api/zero/email/callbacks/trigger`,
-      secret: generateCallbackSecret(),
-      payload: {
+  // 11. Dispatch agent run via pure adapter
+  const result = await createZeroRun(
+    adaptEmailTriggerTrigger({
+      userId,
+      agentId,
+      prompt,
+      callbackPayload: {
         senderEmail,
         agentId,
         userId,
@@ -220,19 +220,8 @@ export async function handleInboundEmailTrigger(
         replyRecipientTo: replyRecipients.to,
         replyRecipientCc: replyRecipients.cc,
       },
-    },
-  ];
-
-  // 12. Create run with integration context as system prompt
-  const appendSystemPrompt = buildIntegrationPrompt("Email");
-  const result = await createZeroRun({
-    userId,
-    prompt,
-    appendSystemPrompt,
-    agentId,
-    triggerSource: "email",
-    callbacks,
-  });
+    }),
+  );
 
   log.info("Dispatched agent run from email trigger", {
     runId: result.runId,

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -78,7 +78,7 @@ const log = logger("service:zero-run");
  * All zero trigger paths (web, schedule, telegram, slack, email, github)
  * use this interface to create agent runs with consistent defaults.
  */
-interface ZeroRunParams {
+export interface CreateZeroRunParams {
   userId: string;
   prompt: string;
   agentId: string;
@@ -232,7 +232,7 @@ interface ZeroRunRecordResult {
   record?: CreateRunRecordResult;
   runParams?: CreateRunParams;
   orgId?: string;
-  zeroParams?: ZeroRunParams;
+  zeroParams?: CreateZeroRunParams;
   /** Pre-fetched in Phase 1 — reused in dispatchZeroRun to avoid duplicate DB query */
   featureSwitchOverrides?: Partial<Record<FeatureSwitchKey, boolean>>;
   /** Pre-fetched user timezone in Phase 1 — passed to buildZeroExecutionContext */
@@ -276,7 +276,7 @@ function buildSystemSkillVolumes(): Array<{
  * Internal to zero-run-service — callers should use createZeroRun().
  */
 async function createZeroRunRecord(
-  params: ZeroRunParams,
+  params: CreateZeroRunParams,
 ): Promise<ZeroRunRecordResult> {
   const db = globalThis.services.db;
 
@@ -629,7 +629,7 @@ export interface CreateZeroRunResult {
  * persisted on the run row via markRunFailed() inside dispatchZeroRun.
  */
 export async function createZeroRun(
-  params: ZeroRunParams,
+  params: CreateZeroRunParams,
 ): Promise<CreateZeroRunResult> {
   const result = await createZeroRunRecord(params);
 
@@ -660,7 +660,7 @@ export async function createZeroRun(
  */
 async function persistZeroRunMetadata(
   runId: string,
-  params: ZeroRunParams,
+  params: CreateZeroRunParams,
 ): Promise<void> {
   await globalThis.services.db.insert(zeroRuns).values({
     id: runId,


### PR DESCRIPTION
## Summary

- Extract dispatch-param construction from the two Email handlers into pure adapter functions `adaptEmailReplyTrigger` and `adaptEmailTriggerTrigger`, collocated in `src/lib/zero/email/handlers/`.
- Handlers keep **all** business logic (DMARC verification, reply-token HMAC, org/member/agent resolution, attachment processing, recipient computation). Only the inline callback + `createZeroRun` block becomes a single adapter call.
- Export `CreateZeroRunParams` from `zero-run-service.ts` (previously internal as `ZeroRunParams`) — mirrors the already-exported `CreateZeroRunResult` and gives every integration adapter a shared param type.

Part of Epic #9724.

## Why

Per the epic, each trigger handler reimplements the same scaffolding (build `appendSystemPrompt`, build callback URL/secret/payload, call the run service). The only trigger-specific parts for Email are the callback URL (`/reply` vs `/trigger`) and the callback payload shape. Extracting both into small pure functions makes the handlers easier to read and the dispatch contract trivially unit-testable. This PR ships the Email slice; sibling PRs (#9726 Slack, #9727 Telegram, #9728 Phone/iMessage, #9730 GitHub, #9731 Schedule, #9732 Voice Chat) will each migrate their handler onto the same pattern.

## Design Choices

1. **Export `CreateZeroRunParams`** rather than defining the shape locally in each adapter — the foundation note from PR #9739 established "import, don't redefine" for `CreateZeroRunResult`; the same principle applies to the params side. Rename from internal `ZeroRunParams` keeps the `Create*` naming family consistent.
2. **Two adapter files** (`adapt-email-reply.ts`, `adapt-email-trigger.ts`) mirror the handler filenames (`inbound-reply.ts`, `inbound-trigger.ts`). Exported function names follow the epic convention (`adaptEmailReplyTrigger` / `adaptEmailTriggerTrigger`).
3. **Nested `callbackPayload`** in the adapter context — the adapter owns routing (URL + secret); the caller owns payload shape.
4. **No shared callback-builder helper** — two call sites with 3 lines each; YAGNI.
5. **Unit tests only** for adapters. Email inbound integration tests don't exist today (they'd require mocking Resend/DMARC/S3) and are out of scope for a structural refactor.

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/zero/email/` — 5 test files, 69 tests pass (including the 2 new adapter tests with 15 assertions total).
- [x] `pnpm -F web exec vitest run src/lib/zero/__tests__/` — 9 test files, 104 tests pass (zero-run-service rename didn't regress anything).
- [x] `pnpm turbo run lint` — 0 errors.
- [x] `pnpm check-types` — passes.
- [x] `pnpm format` — clean.
- [x] `pnpm knip` — no issues.
- [x] `grep -n "createZeroRun(" turbo/apps/web/src/lib/zero/email/handlers/*.ts` — each handler has exactly one call, taking adapter output. No stray inline callbacks.

Closes #9729

🤖 Generated with [Claude Code](https://claude.com/claude-code)