### PR TITLE
chore(slack): drop user scopes Slack rejects outside RTS/MCP

### DIFF
--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -674,10 +674,13 @@ const CONNECTOR_TYPES_DEF = {
     oauth: {
       authorizationUrl: "https://slack.com/oauth/v2/authorize",
       tokenUrl: "https://slack.com/api/oauth.v2.access",
+      // Note: Slack does not approve `search:read` or user `*:history`
+      // scopes outside of RTS / MCP applications. The personal connector
+      // intentionally omits them. Bot-side history access is provided
+      // separately by the org install flow's SLACK_BOT_SCOPES.
       scopes: [
         // Channels
         "channels:read",
-        "channels:history",
         // Messaging
         "chat:write",
         // Users
@@ -687,16 +690,12 @@ const CONNECTOR_TYPES_DEF = {
         "files:read",
         "files:write",
         // Direct messages (high priority)
-        "im:history",
         "im:write",
         // Reactions (high priority)
         "reactions:read",
         "reactions:write",
-        // Search (high priority)
-        "search:read",
         // Private channels (high priority)
         "groups:read",
-        "groups:history",
         // Reminders (medium priority)
         "reminders:read",
         "reminders:write",
@@ -705,8 +704,6 @@ const CONNECTOR_TYPES_DEF = {
         "pins:write",
         // User groups (medium priority)
         "usergroups:read",
-        // Multi-person DMs (medium priority)
-        "mpim:history",
         // Do Not Disturb (low priority)
         "dnd:read",
         // Bookmarks (low priority)


### PR DESCRIPTION
## Context

Slack App Directory reviewer (2026-04-16) flagged the personal Slack connector's install URL for:

1. Requesting user-token scopes not declared in the app settings
2. Requesting `search:read` and user `*:history` scopes, which Slack explicitly does not approve outside RTS/MCP applications

## Change

Remove the five scopes Slack will never approve from `connectors.ts` slack block:

- `search:read`
- `channels:history` (user)
- `groups:history` (user)
- `im:history` (user)
- `mpim:history` (user)

The remaining 19 user scopes stay; they are declared in the Slack App Settings → User Token Scopes (pending upload as part of this submission cycle).

## Bot behavior: unaffected

Bot token scopes live in `SLACK_BOT_SCOPES` (`slack-org/scopes.ts`), a separate list. `conversations.history` / `conversations.replies` in `slack/context.ts` use the bot client; bot-side `channels:history` / `groups:history` / `im:history` / `mpim:history` are preserved.

## Personal connector runtime: unaffected

Grepped for runtime callers of the removed scopes' APIs:

- `search.messages` — only in `specs-map.json` (firewall spec), no business code calls it
- `conversations.history` via user token — no callsite uses user token for this; all `conversations.history` calls route through the bot client
- `reactions.list` (removed user `reactions:read`? — kept) — unchanged

Existing connected users keep their already-issued user tokens; only new authorizations get the reduced scope set.

## Test plan

- [ ] CI green (`slack.test.ts` only asserts `user_scope=` is present, not specific values)
- [ ] After merge: update Slack App Settings → User Token Scopes to mirror the remaining 19 scopes
- [ ] Resubmit to Slack App Directory with reply explaining the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)