### PR TITLE
refactor: extract pure adapter for telegram trigger handler

### DIFF
--- a/turbo/apps/web/src/lib/zero/telegram/handlers/__tests__/adapt-telegram-trigger.test.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/__tests__/adapt-telegram-trigger.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { adaptTelegramTrigger } from "../adapt-telegram-trigger";
+import type { TelegramCallbackPayload } from "../../../../infra/callback/callback-payloads";
+
+const baseCallback: TelegramCallbackPayload = {
+  installationId: "inst-1",
+  chatId: "chat-1",
+  messageId: "msg-1",
+  rootMessageId: null,
+  userLinkId: "link-1",
+  agentId: "compose-1",
+  existingSessionId: null,
+  isDM: false,
+  thinkingMessageId: null,
+};
+
+describe("adaptTelegramTrigger", () => {
+  it("maps a full context to CreateZeroRunParams", () => {
+    const result = adaptTelegramTrigger({
+      agentId: "agent-1",
+      sessionId: "sess-1",
+      prompt: "hello",
+      threadContext: "previous message\nanother",
+      userId: "user-1",
+      callbackContext: baseCallback,
+    });
+
+    expect(result.userId).toBe("user-1");
+    expect(result.agentId).toBe("agent-1");
+    expect(result.sessionId).toBe("sess-1");
+    expect(result.prompt).toBe("hello");
+    expect(result.triggerSource).toBe("telegram");
+    expect(result.appendSystemPrompt).toContain("Telegram");
+
+    const callback = result.callbacks?.[0];
+    if (!callback) {
+      throw new Error("expected exactly one callback");
+    }
+    expect(callback.url).toMatch(/\/api\/internal\/callbacks\/telegram$/);
+    expect(typeof callback.secret).toBe("string");
+    expect(callback.secret.length).toBeGreaterThan(0);
+    expect(callback.payload).toBe(baseCallback);
+  });
+
+  it("coerces empty appendSystemPrompt to undefined", () => {
+    const result = adaptTelegramTrigger({
+      agentId: "agent-1",
+      sessionId: undefined,
+      prompt: "hi",
+      threadContext: "",
+      userId: "user-1",
+      callbackContext: baseCallback,
+    });
+
+    // The `|| undefined` coercion rule: appendSystemPrompt is never "".
+    if (result.appendSystemPrompt !== undefined) {
+      expect(result.appendSystemPrompt).not.toBe("");
+    }
+  });
+
+  it("passes sessionId through as undefined", () => {
+    const result = adaptTelegramTrigger({
+      agentId: "agent-1",
+      sessionId: undefined,
+      prompt: "hi",
+      threadContext: "ctx",
+      userId: "user-1",
+      callbackContext: baseCallback,
+    });
+    expect(result.sessionId).toBeUndefined();
+  });
+
+  it("generates a unique secret per call", () => {
+    const ctx = {
+      agentId: "agent-1",
+      sessionId: undefined,
+      prompt: "hi",
+      threadContext: "ctx",
+      userId: "user-1",
+      callbackContext: baseCallback,
+    };
+    const a = adaptTelegramTrigger(ctx);
+    const b = adaptTelegramTrigger(ctx);
+    const aSecret = a.callbacks?.[0]?.secret;
+    const bSecret = b.callbacks?.[0]?.secret;
+    expect(aSecret).toBeDefined();
+    expect(bSecret).toBeDefined();
+    expect(aSecret).not.toBe(bSecret);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/adapt-telegram-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/adapt-telegram-trigger.ts
@@ -1,0 +1,33 @@
+import { buildTelegramPrompt } from "../../integration-prompt";
+import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
+import type { TelegramCallbackPayload } from "../../../infra/callback/callback-payloads";
+import type { CreateZeroRunParams } from "../../zero-run-service";
+
+interface TelegramTriggerContext {
+  agentId: string;
+  sessionId: string | undefined;
+  prompt: string;
+  threadContext: string;
+  userId: string;
+  callbackContext: TelegramCallbackPayload;
+}
+
+export function adaptTelegramTrigger(
+  ctx: TelegramTriggerContext,
+): CreateZeroRunParams {
+  return {
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    prompt: ctx.prompt,
+    appendSystemPrompt: buildTelegramPrompt(ctx.threadContext) || undefined,
+    sessionId: ctx.sessionId,
+    triggerSource: "telegram",
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/telegram`,
+        secret: generateCallbackSecret(),
+        payload: ctx.callbackContext,
+      },
+    ],
+  };
+}

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/run-agent.ts
@@ -1,11 +1,10 @@
 import { isRunDispatchError } from "../../../infra/run";
 import { createZeroRun } from "../../zero-run-service";
-import { buildTelegramPrompt } from "../../integration-prompt";
 import { isApiError } from "../../../shared/errors";
 import { RUN_ERROR_GUIDANCE } from "@vm0/core";
 import { logger } from "../../../shared/logger";
-import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
 import type { TelegramCallbackPayload } from "../../../infra/callback/callback-payloads";
+import { adaptTelegramTrigger } from "./adapt-telegram-trigger";
 
 const log = logger("telegram:run-agent");
 
@@ -27,74 +26,51 @@ interface RunAgentResult {
 }
 
 /**
- * Execute an agent run for Telegram
+ * Execute an agent run for Telegram.
  *
- * Creates a run, registers a callback, and returns immediately.
- * The callback will be invoked when the run completes.
+ * Thin orchestrator: adapt Telegram-specific params into CreateZeroRunParams,
+ * call createZeroRun (which defers dispatch internally), translate errors
+ * into Telegram-user-facing strings.
  */
 export async function runAgentForTelegram(
   params: RunAgentParams,
 ): Promise<RunAgentResult> {
-  const {
-    composeId,
-    agentId,
-    agentName,
-    sessionId,
-    prompt,
-    threadContext,
-    userId,
-    callbackContext,
-  } = params;
-
-  const appendSystemPrompt = buildTelegramPrompt(threadContext) || undefined;
-
-  const callbackUrl = `${getApiUrl()}/api/internal/callbacks/telegram`;
-  const callbackSecret = generateCallbackSecret();
-
   try {
-    const result = await createZeroRun({
-      userId,
-      agentId,
-      prompt,
-      appendSystemPrompt,
-      sessionId,
-      triggerSource: "telegram",
-      callbacks: [
-        {
-          url: callbackUrl,
-          secret: callbackSecret,
-          payload: callbackContext,
-        },
-      ],
-    });
-
-    const status = result.status === "queued" ? "queued" : "accepted";
-    log.debug(`Run ${result.runId} ${status} for Telegram agent ${agentName}`);
-
-    return {
-      status,
-      runId: result.runId,
-    };
+    const result = await createZeroRun(adaptTelegramTrigger(params));
+    const status: "accepted" | "queued" =
+      result.status === "queued" ? "queued" : "accepted";
+    log.debug(
+      `Run ${result.runId} ${status} for Telegram agent ${params.agentName}`,
+    );
+    return { status, runId: result.runId };
   } catch (error) {
-    if (isApiError(error)) {
-      const guidance = RUN_ERROR_GUIDANCE[error.code];
-      const response = guidance
-        ? `${guidance.title}: ${guidance.guidance}`
-        : error.message;
-      log.warn(`Pre-run check failed: ${error.code}`, {
-        composeId,
-        agentName,
-        userId,
-      });
-      return { status: "failed", response, runId: undefined };
-    }
-    const runId = isRunDispatchError(error) ? error.runId : undefined;
-    log.error("Failed to create run", { composeId, agentName, userId, error });
-    return {
-      status: "failed",
-      response:
-        "Something went wrong while starting the agent. Please try again later.",
-      runId,
-    };
+    return translateTelegramRunError(error, params);
   }
+}
+
+function translateTelegramRunError(
+  error: unknown,
+  params: RunAgentParams,
+): RunAgentResult {
+  const { composeId, agentName, userId } = params;
+  if (isApiError(error)) {
+    const guidance = RUN_ERROR_GUIDANCE[error.code];
+    const response = guidance
+      ? `${guidance.title}: ${guidance.guidance}`
+      : error.message;
+    log.warn(`Pre-run check failed: ${error.code}`, {
+      composeId,
+      agentName,
+      userId,
+    });
+    return { status: "failed", response, runId: undefined };
+  }
+  const runId = isRunDispatchError(error) ? error.runId : undefined;
+  log.error("Failed to create run", { composeId, agentName, userId, error });
+  return {
+    status: "failed",
+    response:
+      "Something went wrong while starting the agent. Please try again later.",
+    runId,
+  };
 }

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -78,7 +78,7 @@ const log = logger("service:zero-run");
  * All zero trigger paths (web, schedule, telegram, slack, email, github)
  * use this interface to create agent runs with consistent defaults.
  */
-interface ZeroRunParams {
+export interface CreateZeroRunParams {
   userId: string;
   prompt: string;
   agentId: string;
@@ -232,7 +232,7 @@ interface ZeroRunRecordResult {
   record?: CreateRunRecordResult;
   runParams?: CreateRunParams;
   orgId?: string;
-  zeroParams?: ZeroRunParams;
+  zeroParams?: CreateZeroRunParams;
   /** Pre-fetched in Phase 1 — reused in dispatchZeroRun to avoid duplicate DB query */
   featureSwitchOverrides?: Partial<Record<FeatureSwitchKey, boolean>>;
   /** Pre-fetched user timezone in Phase 1 — passed to buildZeroExecutionContext */
@@ -276,7 +276,7 @@ function buildSystemSkillVolumes(): Array<{
  * Internal to zero-run-service — callers should use createZeroRun().
  */
 async function createZeroRunRecord(
-  params: ZeroRunParams,
+  params: CreateZeroRunParams,
 ): Promise<ZeroRunRecordResult> {
   const db = globalThis.services.db;
 
@@ -629,7 +629,7 @@ export interface CreateZeroRunResult {
  * persisted on the run row via markRunFailed() inside dispatchZeroRun.
  */
 export async function createZeroRun(
-  params: ZeroRunParams,
+  params: CreateZeroRunParams,
 ): Promise<CreateZeroRunResult> {
   const result = await createZeroRunRecord(params);
 
@@ -660,7 +660,7 @@ export async function createZeroRun(
  */
 async function persistZeroRunMetadata(
   runId: string,
-  params: ZeroRunParams,
+  params: CreateZeroRunParams,
 ): Promise<void> {
   await globalThis.services.db.insert(zeroRuns).values({
     id: runId,


### PR DESCRIPTION
## Summary

Extract `adaptTelegramTrigger()` as a pure function that maps `TelegramTriggerContext` to `CreateZeroRunParams`. Reduce `runAgentForTelegram` to a thin orchestrator (adapt → `createZeroRun` → translate error).

Rename `ZeroRunParams` → `CreateZeroRunParams` and export it, pairing with the already-exported `CreateZeroRunResult`. This matches the parallel approach in sibling PRs for Slack (#9726) and Email (#9729) so all three extractions share the same public type.

No behavior change. User-facing Telegram error strings are unchanged.

Part of Epic #9724.

## Changes

- **New** `apps/web/src/lib/zero/telegram/handlers/adapt-telegram-trigger.ts` — pure adapter, no DB/HTTP, 33 lines.
- **Rewritten** `apps/web/src/lib/zero/telegram/handlers/run-agent.ts` — thin orchestrator (76 lines incl. imports + co-located `translateTelegramRunError`). Down from 100 lines.
- **Renamed** `ZeroRunParams` → `CreateZeroRunParams` and exported in `apps/web/src/lib/zero/zero-run-service.ts`.
- **New** `apps/web/src/lib/zero/telegram/handlers/__tests__/adapt-telegram-trigger.test.ts` — unit tests for the adapter (mapping, sessionId passthrough, secret uniqueness).

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/zero/telegram/handlers/__tests__/adapt-telegram-trigger` — 4/4 passed
- [x] `pnpm -F web exec vitest run src/lib/zero/telegram` — 82/82 passed
- [x] `pnpm -F web exec vitest run app/api/telegram` — 33/33 passed (integration tests for webhook flow unchanged)
- [x] `pnpm -F web exec vitest run src/lib/zero/__tests__/zero-run-service` — 21/21 passed (rename did not break internal usage)
- [x] `pnpm -F web check-types` — clean
- [x] `pnpm -F web lint` — 0 errors
- [x] `pnpm knip` — no unused code
- [x] `pnpm format` — clean

## Definition of Done (per #9727)

- [x] `adaptTelegramTrigger()` is a pure function in its own file
- [x] `runAgentForTelegram` is a thin orchestrator (≤ 50 lines — public handler is ~15 lines; whole file 76 lines)
- [x] User-facing Telegram error responses unchanged (translator body is identical to pre-refactor)
- [x] New adapter unit test passes
- [x] Existing Telegram integration tests pass
- [x] Lint, type-check, format, knip pass

Closes #9727

🤖 Generated with [Claude Code](https://claude.com/claude-code)