### PR TITLE
fix(vsock-proto): avoid unbounded allocation from untrusted env_count

### DIFF
--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -931,7 +931,10 @@ mod tests {
         // attempting to allocate a vector sized by env_count.
         let mut p = encode_exec(1000, "", &[], false);
         p.extend_from_slice(&u32::MAX.to_be_bytes());
-        assert!(decode_exec(&p).is_err());
+        assert!(matches!(
+            decode_exec(&p),
+            Err(ProtocolError::InvalidPayload(_))
+        ));
     }
 
     #[test]

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -350,7 +350,10 @@ fn decode_exec_inner(payload: &[u8]) -> Result<(DecodedExec<'_>, usize), Protoco
     let env_count = read_u32_at(payload, env_start)
         .ok_or(ProtocolError::InvalidPayload("exec env count truncated"))?
         as usize;
-    let mut env = Vec::with_capacity(env_count);
+    // Do not pre-allocate based on env_count: it is untrusted wire data and a
+    // malformed message can claim u32::MAX pairs. The per-iteration bounds
+    // checks below return an error as soon as the payload runs out.
+    let mut env = Vec::new();
     let mut offset = env_start + 4;
     for _ in 0..env_count {
         let key_len = read_u32_at(payload, offset)
@@ -919,6 +922,16 @@ mod tests {
     #[test]
     fn decode_exec_too_short() {
         assert!(decode_exec(&[0; 4]).is_err());
+    }
+
+    #[test]
+    fn decode_exec_rejects_oversized_env_count() {
+        // Valid exec header (empty cmd, no env) plus an env_count field claiming
+        // u32::MAX pairs but no actual pair bytes. Must return Err without
+        // attempting to allocate a vector sized by env_count.
+        let mut p = encode_exec(1000, "", &[], false);
+        p.extend_from_slice(&u32::MAX.to_be_bytes());
+        assert!(decode_exec(&p).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `decode_exec_inner` called `Vec::with_capacity(env_count)` with a `u32` read directly from the wire. A malformed `MSG_EXEC`/`MSG_SPAWN_WATCH` claiming `u32::MAX` pairs would request ~64 GiB and abort the guest vsock process before a `ProtocolError` could propagate.
- Drop the pre-allocation — the per-iteration bounds checks in the decode loop already return `InvalidPayload` as soon as the payload runs out, and exec setup is not a hot path so the amortized grow cost is negligible.
- Add a regression test (`decode_exec_rejects_oversized_env_count`) that constructs a tiny payload with `env_count = u32::MAX` and asserts the decoder returns `Err` without panicking.

Closes #9700

## Test plan
- [x] `cargo test -p vsock-proto --lib` — all 33 tests pass, including the new one
- [x] `cargo clippy -p vsock-proto --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p vsock-proto -- --check` — clean
- [x] Existing `full_message_exec_roundtrip` / `exec_payload_roundtrip_with_env` still pass, confirming legitimate env decoding is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)