### PR TITLE
refactor(api): stop auto-injecting custom skills on /api/agent/runs

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1132,9 +1132,6 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     // Note: "Missing required secrets" validation is tested in the Validation
     // describe block above.
 
-    // This test relies on the test agent having no customSkills bound.
-    // If customSkills are added in beforeEach, skill volumes will be prepended
-    // and the strict .toEqual() below will fail — update accordingly.
     it("should store additionalVolumes in run record", async () => {
       const additionalVolumes = [
         { name: "my-data", version: "latest", mountPath: "/data" },
@@ -1161,58 +1158,17 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(record!.additionalVolumes).toBeNull();
     });
 
-    it("should inject custom skills as additionalVolumes for new runs", async () => {
-      // Bind custom skills to the agent (zero_agents row created by createTestCompose)
+    it("should not inject zeroAgents.customSkills into CLI run volumes", async () => {
       await bindCustomSkillToAgent(testComposeId, "my-skill");
-      await bindCustomSkillToAgent(testComposeId, "data-tool");
 
       const { runId } = await createTestRun(
         testComposeId,
-        "Run with custom skills",
+        "CLI run is skill-agnostic",
       );
 
       const record = await findTestRunRecord(runId);
       expect(record).toBeDefined();
-      expect(record!.additionalVolumes).toEqual(
-        expect.arrayContaining([
-          {
-            name: "custom-skill@my-skill",
-            mountPath: "/home/user/.claude/skills/my-skill",
-          },
-          {
-            name: "custom-skill@data-tool",
-            mountPath: "/home/user/.claude/skills/data-tool",
-          },
-        ]),
-      );
-    });
-
-    it("should merge custom skills with explicit additionalVolumes", async () => {
-      // Bind a custom skill to the agent
-      await bindCustomSkillToAgent(testComposeId, "my-skill");
-
-      // Provide explicit additionalVolumes in the request body
-      const explicitVolumes = [
-        { name: "my-data", version: "latest", mountPath: "/data" },
-      ];
-
-      const { runId } = await createTestRun(
-        testComposeId,
-        "Run with skills and volumes",
-        { additionalVolumes: explicitVolumes },
-      );
-
-      const record = await findTestRunRecord(runId);
-      expect(record).toBeDefined();
-
-      // Skill volumes should come first, then explicit volumes
-      expect(record!.additionalVolumes).toEqual([
-        {
-          name: "custom-skill@my-skill",
-          mountPath: "/home/user/.claude/skills/my-skill",
-        },
-        { name: "my-data", version: "latest", mountPath: "/data" },
-      ]);
+      expect(record!.additionalVolumes).toBeNull();
     });
   });
 

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -8,7 +8,6 @@ import {
   ALL_RUN_STATUSES,
   type RunStatus,
   orgTierSchema,
-  getCustomSkillStorageName,
 } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -16,7 +15,6 @@ import {
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
-import { zeroAgents } from "../../../../src/db/schema/zero-agent";
 import type { AdditionalVolume } from "../../../../src/lib/infra/storage/types";
 import { and, eq, inArray, desc, gte, lte, sql } from "drizzle-orm";
 import {
@@ -53,41 +51,19 @@ import { env } from "../../../../src/env";
 const log = logger("api:runs");
 
 /**
- * Resolve additional volumes for a run, including custom skill volumes.
+ * Merge body/resolved additionalVolumes, normalizing empty arrays to undefined.
  *
- * For new runs: injects the agent's custom skills as additional volumes,
- * merged with any explicit volumes from the request body or resolved context.
- *
- * For checkpoint/session resume: skills are already captured in the resolved
- * additionalVolumes from the original run — no re-injection needed.
+ * Body volumes take precedence over resolved context. The CLI run path is
+ * skill-agnostic: zeroAgents.customSkills are not injected here (they belong
+ * exclusively to /api/zero/runs).
  */
-async function resolveRunAdditionalVolumes(params: {
-  composeId: string | undefined;
-  isResume: boolean;
+function resolveRunAdditionalVolumes(params: {
   bodyAdditionalVolumes: AdditionalVolume[] | undefined;
   resolvedAdditionalVolumes: AdditionalVolume[] | undefined;
-}): Promise<AdditionalVolume[] | undefined> {
-  let skillVolumes: AdditionalVolume[] = [];
-  if (!params.isResume && params.composeId) {
-    const [agentRecord] = await globalThis.services.db
-      .select({ customSkills: zeroAgents.customSkills })
-      .from(zeroAgents)
-      .where(eq(zeroAgents.id, params.composeId))
-      .limit(1);
-
-    skillVolumes = (agentRecord?.customSkills ?? []).map((name) => {
-      return {
-        name: getCustomSkillStorageName(name),
-        mountPath: `/home/user/.claude/skills/${name}`,
-      };
-    });
-  }
-
-  const merged = [
-    ...skillVolumes,
-    ...(params.bodyAdditionalVolumes ?? params.resolvedAdditionalVolumes ?? []),
-  ];
-  return merged.length > 0 ? merged : undefined;
+}): AdditionalVolume[] | undefined {
+  const merged =
+    params.bodyAdditionalVolumes ?? params.resolvedAdditionalVolumes;
+  return merged && merged.length > 0 ? merged : undefined;
 }
 
 /**
@@ -354,10 +330,8 @@ const router = tsr.router(runsMainContract, {
         );
       }
 
-      // 6. Resolve additional volumes (custom skills + explicit volumes)
-      const finalAdditionalVolumes = await resolveRunAdditionalVolumes({
-        composeId: composeMeta.composeId,
-        isResume: !!(body.checkpointId || body.sessionId),
+      // 6. Resolve additional volumes (body takes precedence over resolved context)
+      const finalAdditionalVolumes = resolveRunAdditionalVolumes({
         bodyAdditionalVolumes: body.additionalVolumes,
         resolvedAdditionalVolumes: resolved.additionalVolumes,
       });


### PR DESCRIPTION
## Summary

- Remove `zeroAgents.customSkills` auto-injection from `POST /api/agent/runs`. The CLI run path is now skill-agnostic.
- Collapse `resolveRunAdditionalVolumes()` into a pure sync helper that just merges body/resolved `additionalVolumes` and normalizes empty arrays to `undefined` — no DB lookup.
- Delete two positive tests that asserted skill injection; add one negative test that locks the new contract; drop the now-stale guard comment on the "store additionalVolumes" test.

## Behavioral change

**CLI runs against a zero agent no longer auto-mount customSkills.** Users must pass them explicitly via `--volume custom-skill@{name}:/home/user/.claude/skills/{name}`. Skill injection remains exclusive to `/api/zero/runs` (unchanged). Required by epic #9668 acceptance.

## Scope

- `turbo/apps/web/app/api/agent/runs/route.ts` — drop DB lookup, drop `getCustomSkillStorageName` and `zeroAgents` imports, keep a minimal pure helper (avoids bumping `create` handler complexity past the eslint limit).
- `turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts` — remove 2 positive tests, add 1 negative test, remove stale comment.

Does NOT touch `/api/zero/runs` or `zero-run-service.ts` (out of scope per epic).

Part of #9668.
Closes #9752.

## Test plan

- [x] `grep customSkills|getCustomSkillStorageName|zeroAgents turbo/apps/web/app/api/agent/runs/route.ts` → only hit is an intentional docstring negative assertion.
- [x] `pnpm -F web exec vitest run app/api/agent/runs/__tests__/route.test.ts` → 84/84 passing (includes new negative test).
- [x] `pnpm -F web exec vitest run app/api/zero/runs src/lib/zero/__tests__/zero-run-service.test.ts` → 93/93 passing (zero path untouched).
- [x] `pnpm turbo run lint` → green.
- [x] `pnpm check-types` → green.
- [x] `pnpm format` → no diff.
- [x] `pnpm knip` → no new issues.

## Rollback

`git revert`. Restores the DB lookup and prepend behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)