### PR TITLE
refactor(infra): replace agent-skills prefix check with explicit system flag

### DIFF
--- a/e2e/tests/03-runner/t17-vm0-simplified-compose.bats
+++ b/e2e/tests/03-runner/t17-vm0-simplified-compose.bats
@@ -268,43 +268,6 @@ EOF
     assert_output --partial "UNIQUE_MARKER_FOR_E2E_TEST"
 }
 
-@test "vm0 run with skills mounts skill directory" {
-    echo "# Creating config with skills..."
-    # Skills work with any image - they're just file mounts
-    cat > "$TEST_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  $AGENT_NAME:
-    framework: claude-code
-    skills:
-      - https://github.com/vm0-ai/vm0-skills/tree/main/github
-EOF
-
-    echo "# Running vm0 compose..."
-    run $VM0_CLI compose --yes "$TEST_DIR/vm0.yaml"
-    assert_success
-
-    echo "# Initializing artifact storage..."
-    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
-    cd "$TEST_DIR/$ARTIFACT_NAME"
-    $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null
-    run $VM0_CLI artifact push
-    assert_success
-
-    echo "# Running agent to verify skill is mounted..."
-    # The skill is mounted at /home/user/.claude/skills/github/
-    # Provide mock GH_TOKEN since github skill requires it
-    run $VM0_CLI run "$AGENT_NAME" \
-        --artifact "$ARTIFACT_NAME" \
-        --secrets "GH_TOKEN=mock-token-for-test" \
-        "ls /home/user/.claude/skills/github/"
-    assert_success
-
-    echo "# Verifying skill directory contains SKILL.md..."
-    assert_output --partial "SKILL.md"
-}
-
 @test "vm0 run has gh cli installed by default" {
     echo "# Creating config without apps field..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF

--- a/turbo/apps/web/src/lib/infra/agent-compose/types.ts
+++ b/turbo/apps/web/src/lib/infra/agent-compose/types.ts
@@ -11,6 +11,8 @@ export interface VolumeConfig {
   version: string; // Required: version hash or "latest"
   /** When true, skip mounting without error if volume doesn't exist */
   optional?: boolean;
+  /** When true, resolve SYSTEM_ORG first, agent org as fallback */
+  system?: boolean;
 }
 
 /**
@@ -27,12 +29,6 @@ interface AgentDefinition {
    * Auto-uploaded as volume and mounted at /home/user/.claude/CLAUDE.md
    */
   instructions?: string;
-  /**
-   * Array of GitHub tree URLs for agent skills.
-   * Each skill is auto-downloaded and mounted at /home/user/.claude/skills/{skillName}/
-   * Format: https://github.com/{owner}/{repo}/tree/{branch}/{path}
-   */
-  skills?: string[];
   /**
    * Route this agent to a self-hosted runner instead of E2B.
    * When specified, runs will be queued for the specified runner group.

--- a/turbo/apps/web/src/lib/infra/storage/__tests__/system-volume-resolution.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/system-volume-resolution.test.ts
@@ -15,32 +15,10 @@ import type { AgentVolumeConfig } from "../types";
 
 const context = testContext();
 
-/** Build a skill GitHub URL with a unique suffix */
-function uniqueSkillUrl(): {
-  url: string;
-  storageName: string;
-} {
-  const suffix = uniqueId("skill");
-  const url = `https://github.com/test-org/test-repo/tree/main/${suffix}`;
-  const storageName = `agent-skills@test-org/test-repo/tree/main/${suffix}`;
-  return { url, storageName };
-}
-
-/** Agent config that produces a single skill volume */
-function skillAgentConfig(skillUrl: string): AgentVolumeConfig {
-  return {
-    agents: {
-      "test-agent": {
-        skills: [skillUrl],
-      },
-    },
-  };
-}
-
-/** Agent config that produces a regular (non-skill) volume */
-function regularVolumeConfig(
+function systemVolumeConfig(
   volumeName: string,
   storageName: string,
+  opts: { system: boolean; optional?: boolean },
 ): AgentVolumeConfig {
   return {
     agents: {
@@ -52,12 +30,14 @@ function regularVolumeConfig(
       [volumeName]: {
         name: storageName,
         version: "latest",
+        system: opts.system,
+        optional: opts.optional,
       },
     },
   };
 }
 
-describe("System Skill Resolution", () => {
+describe("System Volume Resolution (VolumeConfig.system)", () => {
   let user: UserContext;
 
   beforeEach(async () => {
@@ -65,17 +45,16 @@ describe("System Skill Resolution", () => {
     user = await context.setupUser();
   });
 
-  it("should resolve skill from system org when available", async () => {
-    const { url, storageName } = uniqueSkillUrl();
-
-    // Create skill storage under SYSTEM_ORG_ID
+  it("resolves system volume from SYSTEM_ORG when available", async () => {
+    const volumeName = uniqueId("vol");
+    const storageName = uniqueId("sys-vol");
     const { versionId } = await createTestVolumeForOrg(
       SYSTEM_ORG_ID,
       storageName,
     );
 
     const manifest = await prepareStorageManifest(
-      skillAgentConfig(url),
+      systemVolumeConfig(volumeName, storageName, { system: true }),
       {},
       user.orgId,
       user.orgId,
@@ -87,14 +66,13 @@ describe("System Skill Resolution", () => {
     expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
   });
 
-  it("should fall back to agent org when skill not in system org", async () => {
-    const { url, storageName } = uniqueSkillUrl();
-
-    // Create skill storage under agent's org (NOT system org)
+  it("falls back to agent org when system volume not in SYSTEM_ORG", async () => {
+    const volumeName = uniqueId("vol");
+    const storageName = uniqueId("sys-fallback");
     const { versionId } = await createTestVolume(storageName);
 
     const manifest = await prepareStorageManifest(
-      skillAgentConfig(url),
+      systemVolumeConfig(volumeName, storageName, { system: true }),
       {},
       user.orgId,
       user.orgId,
@@ -106,15 +84,17 @@ describe("System Skill Resolution", () => {
     expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
   });
 
-  it("should resolve regular volumes from agent org only", async () => {
+  it("prefers SYSTEM_ORG over agent org when both have the volume", async () => {
     const volumeName = uniqueId("vol");
-    const storageName = uniqueId("storage");
-
-    // Create regular volume under agent's org
+    const storageName = uniqueId("sys-priority");
+    const { versionId: systemVersionId } = await createTestVolumeForOrg(
+      SYSTEM_ORG_ID,
+      storageName,
+    );
     await createTestVolume(storageName);
 
     const manifest = await prepareStorageManifest(
-      regularVolumeConfig(volumeName, storageName),
+      systemVolumeConfig(volumeName, storageName, { system: true }),
       {},
       user.orgId,
       user.orgId,
@@ -122,14 +102,18 @@ describe("System Skill Resolution", () => {
     );
 
     expect(manifest.storages).toHaveLength(1);
-    expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
+    expect(manifest.storages[0]!.vasVersionId).toBe(systemVersionId);
   });
 
-  it("should skip skill volume when not found in any org", async () => {
-    const { url } = uniqueSkillUrl();
+  it("skips optional system volume silently when missing in both orgs", async () => {
+    const volumeName = uniqueId("vol");
+    const storageName = uniqueId("missing-sys");
 
     const manifest = await prepareStorageManifest(
-      skillAgentConfig(url),
+      systemVolumeConfig(volumeName, storageName, {
+        system: true,
+        optional: true,
+      }),
       {},
       user.orgId,
       user.orgId,
@@ -139,23 +123,13 @@ describe("System Skill Resolution", () => {
     expect(manifest.storages).toHaveLength(0);
   });
 
-  it("should resolve available skills and skip missing ones", async () => {
-    const found = uniqueSkillUrl();
-    const missing = uniqueSkillUrl();
-
-    // Only create storage for the first skill
-    await createTestVolumeForOrg(SYSTEM_ORG_ID, found.storageName);
-
-    const config: AgentVolumeConfig = {
-      agents: {
-        "test-agent": {
-          skills: [found.url, missing.url],
-        },
-      },
-    };
+  it("resolves non-system compose volume from agent org only", async () => {
+    const volumeName = uniqueId("vol");
+    const storageName = uniqueId("nonsys-vol");
+    const { versionId } = await createTestVolume(storageName);
 
     const manifest = await prepareStorageManifest(
-      config,
+      systemVolumeConfig(volumeName, storageName, { system: false }),
       {},
       user.orgId,
       user.orgId,
@@ -163,6 +137,7 @@ describe("System Skill Resolution", () => {
     );
 
     expect(manifest.storages).toHaveLength(1);
-    expect(manifest.storages[0]!.vasStorageName).toBe(found.storageName);
+    expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
+    expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
   });
 });

--- a/turbo/apps/web/src/lib/infra/storage/storage-resolver.ts
+++ b/turbo/apps/web/src/lib/infra/storage/storage-resolver.ts
@@ -10,8 +10,6 @@ import type {
 import {
   expandVariablesInString,
   getInstructionsStorageName,
-  getSkillStorageName,
-  parseGitHubTreeUrl,
   getValidatedFramework,
 } from "@vm0/core";
 
@@ -28,21 +26,6 @@ import {
 function getInstructionsMountPath(framework?: string): string {
   getValidatedFramework(framework);
   return "/home/user/.claude";
-}
-
-/**
- * Get the base path for skills based on framework
- *
- * Each framework expects skills at a specific location:
- * - claude-code: ~/.claude/skills/
- *
- * @param framework - The framework name (e.g., "claude-code")
- * @returns The base path for skills
- * @throws Error if framework is defined but not supported
- */
-function getSkillsBasePath(framework?: string): string {
-  getValidatedFramework(framework);
-  return "/home/user/.claude/skills";
 }
 
 /**
@@ -136,6 +119,7 @@ function resolveVasVolume(
       vasStorageName: storageName,
       vasVersion: version,
       optional: volumeConfig.optional,
+      system: volumeConfig.system,
     },
     error: null,
   };
@@ -236,16 +220,15 @@ function processVolumeDeclarations(
 }
 
 /**
- * Resolve instruction and skill volumes for an agent.
+ * Resolve instruction volumes for an agent.
  */
-function resolveInstructionsAndSkills(
+function resolveInstructions(
   config: AgentVolumeConfig,
-  agent: { instructions?: unknown; skills?: string[]; framework?: unknown },
+  agent: { instructions?: unknown; framework?: unknown },
 ): ResolvedVolume[] {
   const volumes: ResolvedVolume[] = [];
   const framework = agent.framework as string | undefined;
 
-  // Process instructions if specified
   if (agent.instructions) {
     const agentName = config.agents ? Object.keys(config.agents)[0] : undefined;
     if (agentName) {
@@ -258,25 +241,6 @@ function resolveInstructionsAndSkills(
         vasStorageName: storageName,
         vasVersion: "latest",
       });
-    }
-  }
-
-  // Process skills if specified
-  if (agent.skills && agent.skills.length > 0) {
-    const skillsBasePath = getSkillsBasePath(framework);
-    for (const skillUrl of agent.skills) {
-      const parsed = parseGitHubTreeUrl(skillUrl);
-      if (parsed) {
-        const storageName = getSkillStorageName(parsed.fullPath);
-        volumes.push({
-          name: storageName,
-          driver: "vas",
-          mountPath: `${skillsBasePath}/${parsed.skillName}`,
-          vasStorageName: storageName,
-          vasVersion: "latest",
-          optional: true,
-        });
-      }
     }
   }
 
@@ -324,9 +288,9 @@ export function resolveVolumes(
     errors.push(...declaredErrors);
   }
 
-  // Process instructions and skills
+  // Process instructions
   if (agent) {
-    volumes.push(...resolveInstructionsAndSkills(config, agent));
+    volumes.push(...resolveInstructions(config, agent));
   }
 
   // Process artifact (skip when resuming from checkpoint or when not provided)

--- a/turbo/apps/web/src/lib/infra/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/infra/storage/storage-service.ts
@@ -534,8 +534,8 @@ export async function prepareStorageManifest(
 
 /** Partitioned volumes for batch vs individual resolution */
 interface PartitionedVolumes {
-  latestSkillVolumes: ResolvedVolume[];
-  latestNonSkillVolumes: ResolvedVolume[];
+  latestSystemComposeVolumes: ResolvedVolume[];
+  latestNonSystemComposeVolumes: ResolvedVolume[];
   nonLatestVolumes: ResolvedVolume[];
   latestSystemAdditional: AdditionalVolume[];
   latestNonSystemAdditional: AdditionalVolume[];
@@ -550,8 +550,8 @@ function partitionVolumes(
   additionalVolumes: AdditionalVolume[],
   volumeVersionOverrides: Record<string, string> | undefined,
 ): PartitionedVolumes {
-  const latestSkillVolumes: ResolvedVolume[] = [];
-  const latestNonSkillVolumes: ResolvedVolume[] = [];
+  const latestSystemComposeVolumes: ResolvedVolume[] = [];
+  const latestNonSystemComposeVolumes: ResolvedVolume[] = [];
   const nonLatestVolumes: ResolvedVolume[] = [];
 
   for (const volume of volumes) {
@@ -566,10 +566,10 @@ function partitionVolumes(
 
     if (volume.vasVersion !== "latest") {
       nonLatestVolumes.push(volume);
-    } else if (volume.vasStorageName.startsWith("agent-skills@")) {
-      latestSkillVolumes.push(volume);
+    } else if (volume.system === true) {
+      latestSystemComposeVolumes.push(volume);
     } else {
-      latestNonSkillVolumes.push(volume);
+      latestNonSystemComposeVolumes.push(volume);
     }
   }
 
@@ -589,8 +589,8 @@ function partitionVolumes(
   }
 
   return {
-    latestSkillVolumes,
-    latestNonSkillVolumes,
+    latestSystemComposeVolumes,
+    latestNonSystemComposeVolumes,
     nonLatestVolumes,
     latestSystemAdditional,
     latestNonSystemAdditional,
@@ -625,9 +625,9 @@ async function executeBatchResolution(
   artifactSource: ResolvedArtifact | null,
   memoryName: string | undefined,
 ): Promise<Map<string, { versionId: string; s3Key: string }>> {
-  // Phase 1: System org batch (skills + system additional volumes)
+  // Phase 1: System org batch (system compose volumes + system additional volumes)
   const systemLookups: StorageLookup[] = [
-    ...partitioned.latestSkillVolumes.map((v) => {
+    ...partitioned.latestSystemComposeVolumes.map((v) => {
       return systemVolumeLookup(v.vasStorageName);
     }),
     ...partitioned.latestSystemAdditional.map((v) => {
@@ -638,11 +638,18 @@ async function executeBatchResolution(
   const systemResults = await batchResolveLatestVersions(systemLookups);
 
   // Identify misses for fallback
-  const skillMisses = partitioned.latestSkillVolumes.filter((v) => {
-    return !systemResults.has(
-      lookupKey(SYSTEM_ORG_ID, VOLUME_ORG_USER_ID, v.vasStorageName, "volume"),
-    );
-  });
+  const systemComposeMisses = partitioned.latestSystemComposeVolumes.filter(
+    (v) => {
+      return !systemResults.has(
+        lookupKey(
+          SYSTEM_ORG_ID,
+          VOLUME_ORG_USER_ID,
+          v.vasStorageName,
+          "volume",
+        ),
+      );
+    },
+  );
   const systemAdditionalMisses = partitioned.latestSystemAdditional.filter(
     (v) => {
       return !systemResults.has(
@@ -651,12 +658,12 @@ async function executeBatchResolution(
     },
   );
 
-  // Phase 2: Remaining lookups (non-skill volumes, misses, additional, artifact, memory)
+  // Phase 2: Remaining lookups (non-system compose volumes, misses, additional, artifact, memory)
   const remainingLookups: StorageLookup[] = [
-    ...partitioned.latestNonSkillVolumes.map((v) => {
+    ...partitioned.latestNonSystemComposeVolumes.map((v) => {
       return orgVolumeLookup(agentClerkOrgId, v.vasStorageName);
     }),
-    ...skillMisses.map((v) => {
+    ...systemComposeMisses.map((v) => {
       return orgVolumeLookup(agentClerkOrgId, v.vasStorageName);
     }),
     ...systemAdditionalMisses.map((v) => {
@@ -702,10 +709,9 @@ async function resolveNonLatestVolumes(
   return Promise.all(
     volumes.map(async (volume) => {
       try {
-        const isSkill = volume.vasStorageName.startsWith("agent-skills@");
         let resolved: { versionId: string; s3Key: string } | undefined;
 
-        if (isSkill) {
+        if (volume.system === true) {
           try {
             resolved = await resolveVersion(
               SYSTEM_ORG_ID,
@@ -806,8 +812,8 @@ async function buildManifestFromResults(
 ): Promise<StorageManifest> {
   const composeEntryPromises: Promise<ManifestStorage>[] = [];
 
-  // Skill volumes: try system org, then agent org
-  for (const volume of partitioned.latestSkillVolumes) {
+  // System-flagged compose volumes: try system org, then agent org
+  for (const volume of partitioned.latestSystemComposeVolumes) {
     const resolved = lookupWithFallback(
       allResults,
       lookupKey(
@@ -845,8 +851,8 @@ async function buildManifestFromResults(
     }
   }
 
-  // Non-skill volumes: agent org only
-  for (const volume of partitioned.latestNonSkillVolumes) {
+  // Non-system compose volumes: agent org only
+  for (const volume of partitioned.latestNonSystemComposeVolumes) {
     const key = lookupKey(
       agentClerkOrgId,
       VOLUME_ORG_USER_ID,

--- a/turbo/apps/web/src/lib/infra/storage/types.ts
+++ b/turbo/apps/web/src/lib/infra/storage/types.ts
@@ -26,6 +26,8 @@ export interface ResolvedVolume {
   vasVersion: string; // Version hash or "latest"
   /** When true, skip mounting without error if volume doesn't exist */
   optional?: boolean;
+  /** When true, resolve SYSTEM_ORG first, agent org as fallback */
+  system?: boolean;
 }
 
 /**
@@ -71,7 +73,6 @@ export interface AgentVolumeConfig {
       framework?: string; // Framework name (e.g., "claude-code") for mount path resolution
       volumes?: string[];
       instructions?: string; // Path to instructions file (stored as agent-instructions@{name} volume)
-      skills?: string[]; // GitHub tree URLs (stored as agent-skills@{path} volumes)
     }
   >;
   volumes?: Record<string, VolumeConfig>;


### PR DESCRIPTION
## Summary

- Replace the implicit `agent-skills@` storage-name prefix check with an explicit `system?: boolean` flag on `VolumeConfig` and `ResolvedVolume`. SYSTEM_ORG-first resolution is now opt-in.
- Drop the legacy `skills` field from `AgentDefinition` and strip skill-specific branching out of the storage resolver and service (the zero-agent path already injects skills as `AdditionalVolume` with `system: true`, so no runtime regression).
- Rewrite the integration test as `system-volume-resolution.test.ts` covering: SYSTEM_ORG hit, agent-org fallback, SYSTEM_ORG priority, optional silent skip, and a non-system control case.

Closes #9751. Part of epic #9668 (Phase 2 — CLI path).

> Note: per coordination with dc-vm0-b, this PR should merge **last**, after #9752 / #9753 / #9754.

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/infra/storage` — 22 tests pass (3 test files)
- [x] `pnpm -F web exec vitest run src/lib/infra` — 93 tests pass (10 test files)
- [x] `pnpm -F web exec eslint` on changed files — clean
- [x] `pnpm -F web exec prettier --check` on changed files — clean
- [x] `pnpm knip` (via pre-commit hook) — no issues
- [ ] CI: lint + test + cli-e2e green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)