### PR TITLE
fix: add display name for claude-opus-4-7

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -214,6 +214,7 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   // Anthropic direct (claude-code-oauth-token, anthropic-api-key, vm0)
   "claude-sonnet-4-6": "Claude Sonnet 4.6",
   "claude-opus-4-6": "Claude Opus 4.6",
+  "claude-opus-4-7": "Claude Opus 4.7",
   // Anthropic via OpenRouter / Vercel AI Gateway
   "anthropic/claude-sonnet-4.6": "Claude Sonnet 4.6",
   "anthropic/claude-opus-4.6": "Claude Opus 4.6",


### PR DESCRIPTION
## Summary
- `claude-opus-4-7` was registered in `model-providers.ts` but missing from `MODEL_DISPLAY_NAMES` in `provider-ui-config.ts`, so the provider settings UI rendered the raw model ID instead of "Claude Opus 4.7".

## Test plan
- [ ] Open the model provider settings dialog and confirm Claude Opus 4.7 shows its friendly display name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)