### PR TITLE
feat(cli): add per-agent authorization column to zero connector list and status

### DIFF
--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
@@ -13,6 +13,57 @@ import { server } from "../../../../mocks/server";
 import { listCommand } from "../list";
 import chalk from "chalk";
 
+const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
+const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
+
+const connectedGithub = {
+  id: "1",
+  type: "github",
+  authMethod: "oauth",
+  externalId: "12345",
+  externalUsername: "octocat",
+  externalEmail: "octocat@github.com",
+  oauthScopes: ["repo", "project", "workflow"],
+  needsReconnect: false,
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-01T00:00:00Z",
+};
+
+function stubConnectors(connectors: Array<Record<string, unknown>>) {
+  return http.get("http://localhost:3000/api/zero/connectors", () => {
+    return HttpResponse.json({
+      connectors,
+      configuredTypes: connectors.map((c) => {
+        return c.type as string;
+      }),
+    });
+  });
+}
+
+function stubAgent(id: string, displayName: string | null) {
+  return http.get(`http://localhost:3000/api/zero/agents/${id}`, () => {
+    return HttpResponse.json({
+      agentId: id,
+      ownerId: "owner-1",
+      description: null,
+      displayName,
+      sound: null,
+      avatarUrl: null,
+      permissionPolicies: null,
+      customSkills: [],
+    });
+  });
+}
+
+function stubUserConnectors(id: string, enabledTypes: string[]) {
+  return http.get(
+    `http://localhost:3000/api/zero/agents/${id}/user-connectors`,
+    () => {
+      return HttpResponse.json({ enabledTypes });
+    },
+  );
+}
+
 describe("zero connector list command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -32,87 +83,127 @@ describe("zero connector list command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
   });
 
-  describe("successful list", () => {
-    it("should show connected connector with status and account", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/zero/connectors", () => {
-          return HttpResponse.json({
-            connectors: [
-              {
-                id: "1",
-                type: "github",
-                authMethod: "oauth",
-                externalId: "12345",
-                externalUsername: "octocat",
-                externalEmail: "octocat@github.com",
-                oauthScopes: ["repo", "project", "workflow"],
-                needsReconnect: false,
-                createdAt: "2025-01-01T00:00:00Z",
-                updatedAt: "2025-01-01T00:00:00Z",
-              },
-            ],
-            configuredTypes: ["github"],
-          });
-        }),
-      );
+  describe("without agent context", () => {
+    it("renders TYPE and CONNECTED AS columns for a connected connector", async () => {
+      server.use(stubConnectors([connectedGithub]));
 
       await listCommand.parseAsync(["node", "cli"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("TYPE");
-      expect(logCalls).toContain("STATUS");
-      expect(logCalls).toContain("ACCOUNT");
+      expect(logCalls).toContain("CONNECTED AS");
+      expect(logCalls).not.toContain("ACCOUNT");
+      expect(logCalls).not.toContain("STATUS");
+      expect(logCalls).not.toContain("AUTHORIZED FOR");
       expect(logCalls).toContain("github");
-      expect(logCalls).toContain("✓");
       expect(logCalls).toContain("@octocat");
     });
 
-    it("should show not-connected status when no connectors", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/zero/connectors", () => {
-          return HttpResponse.json({ connectors: [], configuredTypes: [] });
-        }),
-      );
+    it("renders (not connected) for types with no connector", async () => {
+      server.use(stubConnectors([]));
 
       await listCommand.parseAsync(["node", "cli"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("github");
-      expect(logCalls).not.toContain("✓");
+      expect(logCalls).toContain("(not connected)");
       expect(logCalls).not.toContain("@octocat");
     });
 
-    it("should show reconnect needed status", async () => {
+    it("renders reconnect-needed state", async () => {
       server.use(
-        http.get("http://localhost:3000/api/zero/connectors", () => {
-          return HttpResponse.json({
-            connectors: [
-              {
-                id: "1",
-                type: "github",
-                authMethod: "oauth",
-                externalId: "12345",
-                externalUsername: "octocat",
-                externalEmail: "octocat@github.com",
-                oauthScopes: ["repo", "project", "workflow"],
-                needsReconnect: true,
-                createdAt: "2025-01-01T00:00:00Z",
-                updatedAt: "2025-01-01T00:00:00Z",
-              },
-            ],
-            configuredTypes: ["github"],
-          });
-        }),
+        stubConnectors([{ ...connectedGithub, needsReconnect: true }]),
       );
 
       await listCommand.parseAsync(["node", "cli"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("!");
-      expect(logCalls).toContain("(reconnect needed)");
+      expect(logCalls).toContain("@octocat (reconnect needed)");
+    });
+  });
+
+  describe("with agent context", () => {
+    it("renders AUTHORIZED FOR column with displayName when --agent is provided", async () => {
+      server.use(
+        stubConnectors([connectedGithub]),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--agent", AGENT_UUID]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("AUTHORIZED FOR maya");
+      expect(logCalls).toContain("✓");
+    });
+
+    it("renders AUTHORIZED FOR column when $ZERO_AGENT_ID is set", async () => {
+      vi.stubEnv("ZERO_AGENT_ID", AGENT_UUID);
+      server.use(
+        stubConnectors([connectedGithub]),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("AUTHORIZED FOR maya");
+      expect(logCalls).toContain("✓");
+    });
+
+    it("--agent overrides $ZERO_AGENT_ID", async () => {
+      vi.stubEnv("ZERO_AGENT_ID", ALT_AGENT_UUID);
+      server.use(
+        stubConnectors([connectedGithub]),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+        http.get(
+          `http://localhost:3000/api/zero/agents/${ALT_AGENT_UUID}`,
+          () => {
+            return HttpResponse.json(
+              { error: { message: "should not be called", code: "ERR" } },
+              { status: 500 },
+            );
+          },
+        ),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--agent", AGENT_UUID]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("AUTHORIZED FOR maya");
+    });
+
+    it("falls back to agent UUID when displayName is null", async () => {
+      server.use(
+        stubConnectors([connectedGithub]),
+        stubAgent(AGENT_UUID, null),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--agent", AGENT_UUID]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(`AUTHORIZED FOR ${AGENT_UUID}`);
+    });
+
+    it("renders - for connectors the agent is not authorized for", async () => {
+      server.use(
+        stubConnectors([connectedGithub]),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, []),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--agent", AGENT_UUID]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("AUTHORIZED FOR maya");
       expect(logCalls).not.toContain("✓");
+      expect(logCalls).toContain("-");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
@@ -13,6 +13,52 @@ import { server } from "../../../../mocks/server";
 import { statusCommand } from "../status";
 import chalk from "chalk";
 
+const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
+const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
+
+const connectedGithub = {
+  id: "1",
+  type: "github",
+  authMethod: "oauth",
+  externalId: "12345",
+  externalUsername: "octocat",
+  externalEmail: "octocat@github.com",
+  oauthScopes: ["repo", "project"],
+  needsReconnect: false,
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-01T00:00:00Z",
+};
+
+function stubConnector(body: Record<string, unknown>, status = 200) {
+  return http.get("http://localhost:3000/api/zero/connectors/:type", () => {
+    return HttpResponse.json(body, { status });
+  });
+}
+
+function stubAgent(id: string, displayName: string | null) {
+  return http.get(`http://localhost:3000/api/zero/agents/${id}`, () => {
+    return HttpResponse.json({
+      agentId: id,
+      ownerId: "owner-1",
+      description: null,
+      displayName,
+      sound: null,
+      avatarUrl: null,
+      permissionPolicies: null,
+      customSkills: [],
+    });
+  });
+}
+
+function stubUserConnectors(id: string, enabledTypes: string[]) {
+  return http.get(
+    `http://localhost:3000/api/zero/agents/${id}/user-connectors`,
+    () => {
+      return HttpResponse.json({ enabledTypes });
+    },
+  );
+}
+
 describe("zero connector status command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -32,26 +78,12 @@ describe("zero connector status command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
   });
 
-  describe("connected connector", () => {
-    it("should display connected status with details", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/zero/connectors/:type", () => {
-          return HttpResponse.json({
-            id: "1",
-            type: "github",
-            authMethod: "oauth",
-            externalId: "12345",
-            externalUsername: "octocat",
-            externalEmail: "octocat@github.com",
-            oauthScopes: ["repo", "project"],
-            needsReconnect: false,
-            createdAt: "2025-01-01T00:00:00Z",
-            updatedAt: "2025-01-01T00:00:00Z",
-          });
-        }),
-      );
+  describe("without agent context", () => {
+    it("displays connected status with details", async () => {
+      server.use(stubConnector(connectedGithub));
 
       await statusCommand.parseAsync(["node", "cli", "github"]);
 
@@ -60,24 +92,156 @@ describe("zero connector status command", () => {
       expect(logCalls).toContain("connected");
       expect(logCalls).toContain("@octocat");
       expect(logCalls).toContain("oauth");
+      expect(logCalls).not.toContain("Authorized:");
     });
-  });
 
-  describe("not connected", () => {
-    it("should display not connected status", async () => {
+    it("displays not connected status", async () => {
       server.use(
-        http.get("http://localhost:3000/api/zero/connectors/:type", () => {
-          return HttpResponse.json(
-            { error: { message: "Not found", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
+        stubConnector(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          404,
+        ),
       );
 
       await statusCommand.parseAsync(["node", "cli", "github"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("not connected");
+      expect(logCalls).not.toContain("Authorized:");
+    });
+  });
+
+  describe("with agent context", () => {
+    it("shows Authorized: ✓ when agent is authorized", async () => {
+      server.use(
+        stubConnector(connectedGithub),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--agent",
+        AGENT_UUID,
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Authorized:");
+      expect(logCalls).toContain("✓ for agent maya");
+      expect(logCalls).not.toContain("Authorize:");
+    });
+
+    it("shows Authorized: - and authorize URL when connected but not authorized", async () => {
+      server.use(
+        stubConnector(connectedGithub),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, []),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--agent",
+        AGENT_UUID,
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("- for agent maya");
+      expect(logCalls).toContain("Authorize:");
+      expect(logCalls).toContain(
+        `/connectors/github/authorize?agentId=${AGENT_UUID}`,
+      );
+    });
+
+    it("shows Authorized: - and authorize URL when connector not connected", async () => {
+      server.use(
+        stubConnector(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          404,
+        ),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, []),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--agent",
+        AGENT_UUID,
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("not connected");
+      expect(logCalls).toContain("- for agent maya");
+      expect(logCalls).toContain(
+        `/connectors/github/authorize?agentId=${AGENT_UUID}`,
+      );
+    });
+
+    it("uses $ZERO_AGENT_ID when --agent flag is not provided", async () => {
+      vi.stubEnv("ZERO_AGENT_ID", AGENT_UUID);
+      server.use(
+        stubConnector(connectedGithub),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "github"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("✓ for agent maya");
+    });
+
+    it("--agent overrides $ZERO_AGENT_ID", async () => {
+      vi.stubEnv("ZERO_AGENT_ID", ALT_AGENT_UUID);
+      server.use(
+        stubConnector(connectedGithub),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+        http.get(
+          `http://localhost:3000/api/zero/agents/${ALT_AGENT_UUID}`,
+          () => {
+            return HttpResponse.json(
+              { error: { message: "should not be called", code: "ERR" } },
+              { status: 500 },
+            );
+          },
+        ),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--agent",
+        AGENT_UUID,
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("✓ for agent maya");
+    });
+
+    it("falls back to UUID when displayName is null", async () => {
+      server.use(
+        stubConnector(connectedGithub),
+        stubAgent(AGENT_UUID, null),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--agent",
+        AGENT_UUID,
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(`✓ for agent ${AGENT_UUID}`);
     });
   });
 
@@ -100,12 +264,10 @@ describe("zero connector status command", () => {
   describe("error handling", () => {
     it("should handle authentication error", async () => {
       server.use(
-        http.get("http://localhost:3000/api/zero/connectors/:type", () => {
-          return HttpResponse.json(
-            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
-            { status: 401 },
-          );
-        }),
+        stubConnector(
+          { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+          401,
+        ),
       );
 
       await expect(async () => {

--- a/turbo/apps/cli/src/commands/zero/connector/agent-context.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/agent-context.ts
@@ -1,0 +1,25 @@
+import { getZeroAgent, getZeroAgentUserConnectors } from "../../../lib/api";
+
+interface AgentContext {
+  agentId: string;
+  displayName: string;
+  authorizedTypes: Set<string>;
+}
+
+export async function resolveAgentContext(
+  flagAgentId: string | undefined,
+): Promise<AgentContext | null> {
+  const agentId = flagAgentId ?? process.env.ZERO_AGENT_ID;
+  if (!agentId) return null;
+
+  const [agent, enabledTypes] = await Promise.all([
+    getZeroAgent(agentId),
+    getZeroAgentUserConnectors(agentId),
+  ]);
+
+  return {
+    agentId: agent.agentId,
+    displayName: agent.displayName ?? agent.agentId,
+    authorizedTypes: new Set(enabledTypes),
+  };
+}

--- a/turbo/apps/cli/src/commands/zero/connector/list.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/list.ts
@@ -4,25 +4,65 @@ import {
   CONNECTOR_TYPES,
   hasRequiredScopes,
   isFeatureEnabled,
+  type ConnectorListResponse,
   type ConnectorType,
 } from "@vm0/core";
 import { listZeroConnectors } from "../../../lib/api";
 import { getActiveOrg } from "../../../lib/api/config";
 import { withErrorHandler } from "../../../lib/command";
+import { resolveAgentContext } from "./agent-context";
+
+type Connector = ConnectorListResponse["connectors"][number];
+
+function renderIdentity(connector: Connector): string {
+  if (connector.externalUsername) return `@${connector.externalUsername}`;
+  if (connector.externalEmail) return connector.externalEmail;
+  return "-";
+}
+
+function renderConnectedAsCell(connector: Connector | undefined): string {
+  if (!connector) return chalk.dim("(not connected)");
+  const identity = renderIdentity(connector);
+  if (connector.needsReconnect) {
+    return chalk.yellow(`${identity} (reconnect needed)`);
+  }
+  const scopeMismatch =
+    connector.authMethod === "oauth" &&
+    !hasRequiredScopes(connector.type, connector.oauthScopes);
+  if (scopeMismatch) {
+    return chalk.yellow(`${identity} (permissions update available)`);
+  }
+  return identity;
+}
+
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_PATTERN, "");
+}
+
+function padEndAnsi(s: string, width: number): string {
+  const visible = stripAnsi(s).length;
+  return s + " ".repeat(Math.max(0, width - visible));
+}
 
 export const listCommand = new Command()
   .name("list")
   .alias("ls")
   .description("List all connectors and their status")
+  .option("--agent <id>", "Show per-agent authorization column")
   .action(
-    withErrorHandler(async () => {
-      const result = await listZeroConnectors();
+    withErrorHandler(async (options: { agent?: string }) => {
+      const [{ connectors }, orgId, agentCtx] = await Promise.all([
+        listZeroConnectors(),
+        getActiveOrg(),
+        resolveAgentContext(options.agent),
+      ]);
       const connectedMap = new Map(
-        result.connectors.map((c) => {
+        connectors.map((c) => {
           return [c.type, c];
         }),
       );
-      const orgId = await getActiveOrg();
 
       const allTypesRaw = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
       const allTypes: ConnectorType[] = [];
@@ -35,48 +75,49 @@ export const listCommand = new Command()
         allTypes.push(type);
       }
 
-      // Calculate column widths
       const typeWidth = Math.max(
         4,
         ...allTypes.map((t) => {
           return t.length;
         }),
       );
-      const statusText = "STATUS";
-      const statusWidth = statusText.length;
+
+      const connectedAsHeader = "CONNECTED AS";
+      const connectedCells = allTypes.map((type) => {
+        return renderConnectedAsCell(connectedMap.get(type));
+      });
+      const connectedAsWidth = Math.max(
+        connectedAsHeader.length,
+        ...connectedCells.map((c) => {
+          return stripAnsi(c).length;
+        }),
+      );
+
+      const authorizedHeader = agentCtx
+        ? `AUTHORIZED FOR ${agentCtx.displayName}`
+        : null;
 
       // Print header
-      const header = [
+      const headerParts = [
         "TYPE".padEnd(typeWidth),
-        statusText.padEnd(statusWidth),
-        "ACCOUNT",
-      ].join("  ");
-      console.log(chalk.dim(header));
+        connectedAsHeader.padEnd(connectedAsWidth),
+      ];
+      if (authorizedHeader) headerParts.push(authorizedHeader);
+      console.log(chalk.dim(headerParts.join("  ")));
 
       // Print rows
-      for (const type of allTypes) {
-        const connector = connectedMap.get(type);
-        const scopeMismatch =
-          connector !== undefined &&
-          connector.authMethod === "oauth" &&
-          !hasRequiredScopes(type, connector.oauthScopes);
-        const status = connector
-          ? connector.needsReconnect
-            ? chalk.yellow("!".padEnd(statusWidth))
-            : scopeMismatch
-              ? chalk.yellow("!".padEnd(statusWidth))
-              : chalk.green("✓".padEnd(statusWidth))
-          : chalk.dim("-".padEnd(statusWidth));
-        const account = connector?.needsReconnect
-          ? chalk.yellow("(reconnect needed)")
-          : scopeMismatch
-            ? chalk.yellow("(permissions update available)")
-            : connector?.externalUsername
-              ? `@${connector.externalUsername}`
-              : chalk.dim("-");
-
-        const row = [type.padEnd(typeWidth), status, account].join("  ");
-        console.log(row);
+      for (let i = 0; i < allTypes.length; i++) {
+        const type = allTypes[i]!;
+        const connectedCell = padEndAnsi(connectedCells[i]!, connectedAsWidth);
+        const parts = [type.padEnd(typeWidth), connectedCell];
+        if (agentCtx) {
+          parts.push(
+            agentCtx.authorizedTypes.has(type)
+              ? chalk.green("✓")
+              : chalk.dim("-"),
+          );
+        }
+        console.log(parts.join("  "));
       }
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/connector/status.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/status.ts
@@ -9,6 +9,8 @@ import {
 import { getZeroConnector } from "../../../lib/api";
 import { formatDateTime } from "../../../lib/domain/schedule-utils";
 import { withErrorHandler } from "../../../lib/command";
+import { resolveAgentContext } from "./agent-context";
+import { getPlatformOrigin } from "../doctor/platform-url";
 
 const LABEL_WIDTH = 16;
 
@@ -16,8 +18,9 @@ export const statusCommand = new Command()
   .name("status")
   .description("Show detailed status of a connector")
   .argument("<type>", "Connector type (e.g., github)")
+  .option("--agent <id>", "Show authorization state for the given agent")
   .action(
-    withErrorHandler(async (type: string) => {
+    withErrorHandler(async (type: string, options: { agent?: string }) => {
       const parseResult = connectorTypeSchema.safeParse(type);
       if (!parseResult.success) {
         const available = Object.keys(CONNECTOR_TYPES).join(", ");
@@ -26,7 +29,10 @@ export const statusCommand = new Command()
         });
       }
 
-      const connector = await getZeroConnector(parseResult.data);
+      const [connector, agentCtx] = await Promise.all([
+        getZeroConnector(parseResult.data),
+        resolveAgentContext(options.agent),
+      ]);
 
       console.log(`Connector: ${chalk.cyan(type)}`);
       console.log();
@@ -81,6 +87,22 @@ export const statusCommand = new Command()
         console.log(
           `${"Status:".padEnd(LABEL_WIDTH)}${chalk.dim("not connected")}`,
         );
+      }
+
+      if (agentCtx) {
+        const authorized = agentCtx.authorizedTypes.has(parseResult.data);
+        const glyph = authorized ? chalk.green("✓") : chalk.dim("-");
+        console.log();
+        console.log(
+          `${"Authorized:".padEnd(LABEL_WIDTH)}${glyph} for agent ${agentCtx.displayName}`,
+        );
+        if (!authorized) {
+          const origin = await getPlatformOrigin();
+          const url = `${origin}/connectors/${parseResult.data}/authorize?agentId=${agentCtx.agentId}`;
+          console.log(
+            `${"".padEnd(LABEL_WIDTH)}${chalk.dim("Authorize:")} ${url}`,
+          );
+        }
       }
     }),
   );


### PR DESCRIPTION
## Summary

- Adds an optional `--agent <id>` flag (falling back to `\$ZERO_AGENT_ID`) to both `zero connector list` and `zero connector status <type>`.
- `list` renames `STATUS`+`ACCOUNT` into a single `CONNECTED AS` column and, when agent context is present, adds an `AUTHORIZED FOR <label>` column with a two-state `✓` / `-` glyph.
- `status` adds an `Authorized:` line when agent context is present, and an indented `Authorize: <url>` hint when the agent is not authorized.

Agent label uses `displayName` when non-null, otherwise the full UUID. A new `agent-context.ts` resolves the agent and fetches `getZeroAgent()` + `getZeroAgentUserConnectors()` in parallel.

## Dependency note

Overlaps with #9747 (PR #9755) on `list.ts` / `status.ts` trailing-hint blocks. This PR deliberately leaves those blocks intact so the two PRs can land in either order; whichever lands second rebases.

## Test plan

- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm -F @vm0/cli exec vitest run` — 1070 tests pass
- [x] `pnpm knip` — clean
- [x] List without agent context: `TYPE  CONNECTED AS` only
- [x] List with `--agent`: `AUTHORIZED FOR <label>` column with ✓/-
- [x] `\$ZERO_AGENT_ID` triggers the column; `--agent` overrides env
- [x] `(not connected)` row renders
- [x] `displayName` null → label uses full UUID
- [x] Status without agent: no `Authorized:` line
- [x] Status with agent + authorized → `✓ for agent <label>`
- [x] Status with agent + unauthorized → `-` + `Authorize:` URL
- [x] Status works when connector is not connected + agent provided

Closes #9762