### PR TITLE
refactor(zero-runs): extract pure adapter for github issue-event handler

### DIFF
--- a/turbo/apps/web/src/lib/zero/github/handlers/__tests__/adapt-github-trigger.test.ts
+++ b/turbo/apps/web/src/lib/zero/github/handlers/__tests__/adapt-github-trigger.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { adaptGithubTrigger } from "../adapt-github-trigger";
+
+function buildContext(
+  overrides: Partial<Parameters<typeof adaptGithubTrigger>[0]> = {},
+): Parameters<typeof adaptGithubTrigger>[0] {
+  return {
+    userId: "user-123",
+    agentId: "agent-abc",
+    sessionId: "session-xyz",
+    prompt: "Please investigate this issue",
+    appendSystemPrompt: "# GitHub Issue Context\n\n...",
+    callbackPayload: {
+      installationId: "install-row-1",
+      repo: "vm0-ai/vm0",
+      issueNumber: 9730,
+      agentId: "compose-id-1",
+      existingSessionId: "session-xyz",
+      triggerCommentId: "123456",
+      triggerCommentBody: "@bot help",
+      triggerReactionId: "987654",
+    },
+    ...overrides,
+  };
+}
+
+describe("adaptGithubTrigger", () => {
+  it("returns CreateZeroRunParams with triggerSource 'github'", () => {
+    expect(adaptGithubTrigger(buildContext()).triggerSource).toBe("github");
+  });
+
+  it("propagates identity, prompt, session and appendSystemPrompt fields", () => {
+    const ctx = buildContext();
+    const result = adaptGithubTrigger(ctx);
+    expect(result.userId).toBe(ctx.userId);
+    expect(result.agentId).toBe(ctx.agentId);
+    expect(result.sessionId).toBe(ctx.sessionId);
+    expect(result.prompt).toBe(ctx.prompt);
+    expect(result.appendSystemPrompt).toBe(ctx.appendSystemPrompt);
+  });
+
+  it("passes through undefined sessionId for a new session", () => {
+    const result = adaptGithubTrigger(buildContext({ sessionId: undefined }));
+    expect(result.sessionId).toBeUndefined();
+  });
+
+  it("passes through undefined appendSystemPrompt", () => {
+    const result = adaptGithubTrigger(
+      buildContext({ appendSystemPrompt: undefined }),
+    );
+    expect(result.appendSystemPrompt).toBeUndefined();
+  });
+
+  it("builds a single callback with the github issues callback URL", () => {
+    const result = adaptGithubTrigger(buildContext());
+    expect(result.callbacks).toHaveLength(1);
+    expect(result.callbacks?.[0]?.url).toMatch(
+      /\/api\/internal\/callbacks\/github\/issues$/,
+    );
+  });
+
+  it("generates a 64-character hex callback secret", () => {
+    const result = adaptGithubTrigger(buildContext());
+    expect(result.callbacks?.[0]?.secret).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("forwards callbackPayload verbatim", () => {
+    const ctx = buildContext();
+    const result = adaptGithubTrigger(ctx);
+    expect(result.callbacks?.[0]?.payload).toEqual(ctx.callbackPayload);
+  });
+
+  it("generates a fresh secret per invocation (pure except for secret/env)", () => {
+    const ctx = buildContext();
+    const r1 = adaptGithubTrigger(ctx);
+    const r2 = adaptGithubTrigger(ctx);
+    expect(r1.userId).toBe(r2.userId);
+    expect(r1.prompt).toBe(r2.prompt);
+    expect(r1.callbacks?.[0]?.secret).not.toBe(r2.callbacks?.[0]?.secret);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/github/handlers/adapt-github-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/github/handlers/adapt-github-trigger.ts
@@ -1,0 +1,32 @@
+import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
+import type { GitHubIssuesCallbackPayload } from "../../../infra/callback/callback-payloads";
+import type { CreateZeroRunParams } from "../../zero-run-service";
+
+interface GithubTriggerContext {
+  userId: string;
+  agentId: string;
+  sessionId: string | undefined;
+  prompt: string;
+  appendSystemPrompt: string | undefined;
+  callbackPayload: GitHubIssuesCallbackPayload;
+}
+
+export function adaptGithubTrigger(
+  ctx: GithubTriggerContext,
+): CreateZeroRunParams {
+  return {
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    sessionId: ctx.sessionId,
+    prompt: ctx.prompt,
+    appendSystemPrompt: ctx.appendSystemPrompt,
+    triggerSource: "github",
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/github/issues`,
+        secret: generateCallbackSecret(),
+        payload: ctx.callbackPayload,
+      },
+    ],
+  };
+}

--- a/turbo/apps/web/src/lib/zero/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/zero/github/handlers/issue-event.ts
@@ -8,8 +8,8 @@ import { validateAgentSession } from "../../zero-run-validation";
 import { createZeroRun } from "../../zero-run-service";
 import { buildGitHubPrompt } from "../../integration-prompt";
 import { resolveAgentId } from "../../zero-compose-service";
-import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
 import type { GitHubIssuesCallbackPayload } from "../../../infra/callback/callback-payloads";
+import { adaptGithubTrigger } from "./adapt-github-trigger";
 import { getInstallationAccessToken } from "../github-app";
 import {
   type IssueComment,
@@ -483,10 +483,8 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     !!commentId,
   );
 
-  // 6. Create agent run with callback
-  const callbackUrl = `${getApiUrl()}/api/internal/callbacks/github/issues`;
-  const callbackSecret = generateCallbackSecret();
-  const callbackContext: GitHubIssuesCallbackPayload = {
+  // 6. Create agent run via pure adapter
+  const callbackPayload: GitHubIssuesCallbackPayload = {
     installationId: installation.id,
     repo,
     issueNumber,
@@ -498,21 +496,16 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
   };
 
   try {
-    const result = await createZeroRun({
-      userId: vm0UserId,
-      prompt: resolvedPrompt,
-      appendSystemPrompt,
-      agentId,
-      sessionId: existingSessionId,
-      triggerSource: "github",
-      callbacks: [
-        {
-          url: callbackUrl,
-          secret: callbackSecret,
-          payload: callbackContext,
-        },
-      ],
-    });
+    const result = await createZeroRun(
+      adaptGithubTrigger({
+        userId: vm0UserId,
+        agentId,
+        sessionId: existingSessionId,
+        prompt: resolvedPrompt,
+        appendSystemPrompt,
+        callbackPayload,
+      }),
+    );
 
     log.info("Agent run dispatched for GitHub issue", {
       runId: result.runId,


### PR DESCRIPTION
## Summary

- Adds `adaptGithubTrigger()` — pure adapter mapping a `GithubTriggerContext` into `CreateZeroRunParams`.
- Slims `dispatchAgentRun` in `github/handlers/issue-event.ts`: callback URL, secret and payload assembly now flow through the adapter.
- Preserves GitHub-specific dispatch-error handling (remove `eyes` reaction + post error comment) unchanged.
- No runtime behavior change.

Part of #9724. Closes #9730.

## Test plan

- [x] New adapter unit tests (8 cases) pass: `pnpm -F web exec vitest run src/lib/zero/github/handlers/__tests__/adapt-github-trigger.test.ts`
- [x] Type check: `pnpm check-types`
- [x] Lint: `pnpm turbo run lint --filter=web`
- [x] Format: `pnpm format`
- [x] Knip: `pnpm knip`
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)