### PR TITLE
refactor: extract pure adapters for phone and imessage trigger handlers

### DIFF
--- a/turbo/apps/web/src/lib/zero/phone/handlers/__tests__/adapt-imessage-trigger.test.ts
+++ b/turbo/apps/web/src/lib/zero/phone/handlers/__tests__/adapt-imessage-trigger.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { adaptImessageTrigger } from "../adapt-imessage-trigger";
+import type { IMessageCallbackPayload } from "../../../../infra/callback/callback-payloads";
+
+const baseCallback: IMessageCallbackPayload = {
+  messageId: "msg-1",
+  fromNumber: "+15551234567",
+  userId: "user-1",
+  orgId: "org-1",
+  agentId: "agent-1",
+  agentphoneAgentId: "ap-agent-1",
+  existingSessionId: null,
+};
+
+describe("adaptImessageTrigger", () => {
+  it("maps a full context to CreateZeroRunParams", () => {
+    const result = adaptImessageTrigger({
+      agentId: "agent-1",
+      sessionId: "sess-1",
+      prompt: "hello",
+      fromNumber: "+15551234567",
+      userId: "user-1",
+      callbackContext: baseCallback,
+    });
+
+    expect(result.userId).toBe("user-1");
+    expect(result.agentId).toBe("agent-1");
+    expect(result.sessionId).toBe("sess-1");
+    expect(result.prompt).toBe("hello");
+    expect(result.triggerSource).toBe("imessage");
+    expect(result.appendSystemPrompt).toContain("iMessage");
+    expect(result.appendSystemPrompt).toContain("+15551234567");
+
+    const callback = result.callbacks?.[0];
+    if (!callback) {
+      throw new Error("expected exactly one callback");
+    }
+    expect(callback.url).toMatch(/\/api\/internal\/callbacks\/imessage$/);
+    expect(typeof callback.secret).toBe("string");
+    expect(callback.secret.length).toBeGreaterThan(0);
+    expect(callback.payload).toBe(baseCallback);
+  });
+
+  it("passes sessionId through as undefined", () => {
+    const result = adaptImessageTrigger({
+      agentId: "agent-1",
+      sessionId: undefined,
+      prompt: "hi",
+      fromNumber: "+1",
+      userId: "user-1",
+      callbackContext: baseCallback,
+    });
+    expect(result.sessionId).toBeUndefined();
+  });
+
+  it("generates a unique secret per call", () => {
+    const ctx = {
+      agentId: "agent-1",
+      sessionId: undefined,
+      prompt: "hi",
+      fromNumber: "+1",
+      userId: "user-1",
+      callbackContext: baseCallback,
+    };
+    const a = adaptImessageTrigger(ctx);
+    const b = adaptImessageTrigger(ctx);
+    const aSecret = a.callbacks?.[0]?.secret;
+    const bSecret = b.callbacks?.[0]?.secret;
+    expect(aSecret).toBeDefined();
+    expect(bSecret).toBeDefined();
+    expect(aSecret).not.toBe(bSecret);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/phone/handlers/__tests__/adapt-phone-trigger.test.ts
+++ b/turbo/apps/web/src/lib/zero/phone/handlers/__tests__/adapt-phone-trigger.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { adaptPhoneTrigger } from "../adapt-phone-trigger";
+import type { PhoneCallbackPayload } from "../../../../infra/callback/callback-payloads";
+
+const baseCallback: PhoneCallbackPayload = {
+  callId: "call-1",
+  userId: "user-1",
+  orgId: "org-1",
+  agentId: "agent-1",
+  existingSessionId: null,
+};
+
+describe("adaptPhoneTrigger", () => {
+  it("maps a full context to CreateZeroRunParams", () => {
+    const result = adaptPhoneTrigger({
+      agentId: "agent-1",
+      sessionId: "sess-1",
+      prompt: "transcript",
+      phoneContext: "# Phone Call Context\nCaller: +1",
+      userId: "user-1",
+      callbackContext: baseCallback,
+    });
+
+    expect(result.userId).toBe("user-1");
+    expect(result.agentId).toBe("agent-1");
+    expect(result.sessionId).toBe("sess-1");
+    expect(result.prompt).toBe("transcript");
+    expect(result.triggerSource).toBe("phone");
+    expect(result.appendSystemPrompt).toContain("Phone");
+
+    const callback = result.callbacks?.[0];
+    if (!callback) {
+      throw new Error("expected exactly one callback");
+    }
+    expect(callback.url).toMatch(/\/api\/internal\/callbacks\/phone$/);
+    expect(typeof callback.secret).toBe("string");
+    expect(callback.secret.length).toBeGreaterThan(0);
+    expect(callback.payload).toBe(baseCallback);
+  });
+
+  it("coerces empty appendSystemPrompt to undefined", () => {
+    const result = adaptPhoneTrigger({
+      agentId: "agent-1",
+      sessionId: undefined,
+      prompt: "hi",
+      phoneContext: "",
+      userId: "user-1",
+      callbackContext: baseCallback,
+    });
+
+    if (result.appendSystemPrompt !== undefined) {
+      expect(result.appendSystemPrompt).not.toBe("");
+    }
+  });
+
+  it("passes sessionId through as undefined", () => {
+    const result = adaptPhoneTrigger({
+      agentId: "agent-1",
+      sessionId: undefined,
+      prompt: "hi",
+      phoneContext: "ctx",
+      userId: "user-1",
+      callbackContext: baseCallback,
+    });
+    expect(result.sessionId).toBeUndefined();
+  });
+
+  it("generates a unique secret per call", () => {
+    const ctx = {
+      agentId: "agent-1",
+      sessionId: undefined,
+      prompt: "hi",
+      phoneContext: "ctx",
+      userId: "user-1",
+      callbackContext: baseCallback,
+    };
+    const a = adaptPhoneTrigger(ctx);
+    const b = adaptPhoneTrigger(ctx);
+    const aSecret = a.callbacks?.[0]?.secret;
+    const bSecret = b.callbacks?.[0]?.secret;
+    expect(aSecret).toBeDefined();
+    expect(bSecret).toBeDefined();
+    expect(aSecret).not.toBe(bSecret);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/phone/handlers/adapt-imessage-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/phone/handlers/adapt-imessage-trigger.ts
@@ -1,0 +1,33 @@
+import { buildIMessagePrompt } from "../../integration-prompt";
+import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
+import type { IMessageCallbackPayload } from "../../../infra/callback/callback-payloads";
+import type { CreateZeroRunParams } from "../../zero-run-service";
+
+interface ImessageTriggerContext {
+  agentId: string;
+  sessionId: string | undefined;
+  prompt: string;
+  fromNumber: string;
+  userId: string;
+  callbackContext: IMessageCallbackPayload;
+}
+
+export function adaptImessageTrigger(
+  ctx: ImessageTriggerContext,
+): CreateZeroRunParams {
+  return {
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    prompt: ctx.prompt,
+    appendSystemPrompt: buildIMessagePrompt(ctx.fromNumber) || undefined,
+    sessionId: ctx.sessionId,
+    triggerSource: "imessage",
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/imessage`,
+        secret: generateCallbackSecret(),
+        payload: ctx.callbackContext,
+      },
+    ],
+  };
+}

--- a/turbo/apps/web/src/lib/zero/phone/handlers/adapt-phone-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/phone/handlers/adapt-phone-trigger.ts
@@ -1,0 +1,33 @@
+import { buildPhonePrompt } from "../../integration-prompt";
+import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
+import type { PhoneCallbackPayload } from "../../../infra/callback/callback-payloads";
+import type { CreateZeroRunParams } from "../../zero-run-service";
+
+interface PhoneTriggerContext {
+  agentId: string;
+  sessionId: string | undefined;
+  prompt: string;
+  phoneContext: string;
+  userId: string;
+  callbackContext: PhoneCallbackPayload;
+}
+
+export function adaptPhoneTrigger(
+  ctx: PhoneTriggerContext,
+): CreateZeroRunParams {
+  return {
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    prompt: ctx.prompt,
+    appendSystemPrompt: buildPhonePrompt(ctx.phoneContext) || undefined,
+    sessionId: ctx.sessionId,
+    triggerSource: "phone",
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/phone`,
+        secret: generateCallbackSecret(),
+        payload: ctx.callbackContext,
+      },
+    ],
+  };
+}

--- a/turbo/apps/web/src/lib/zero/phone/handlers/run-agent-imessage.ts
+++ b/turbo/apps/web/src/lib/zero/phone/handlers/run-agent-imessage.ts
@@ -1,8 +1,7 @@
 import { createZeroRun } from "../../zero-run-service";
-import { buildIMessagePrompt } from "../../integration-prompt";
 import { logger } from "../../../shared/logger";
-import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
 import type { IMessageCallbackPayload } from "../../../infra/callback/callback-payloads";
+import { adaptImessageTrigger } from "./adapt-imessage-trigger";
 
 const log = logger("imessage:run-agent");
 
@@ -15,36 +14,9 @@ interface RunAgentParams {
   callbackContext: IMessageCallbackPayload;
 }
 
-/**
- * Execute an agent run for an iMessage conversation.
- * Creates a run, registers a callback, and returns immediately.
- */
 export async function runAgentForIMessage(
   params: RunAgentParams,
 ): Promise<void> {
-  const { agentId, sessionId, prompt, fromNumber, userId, callbackContext } =
-    params;
-
-  const appendSystemPrompt = buildIMessagePrompt(fromNumber) || undefined;
-
-  const callbackUrl = `${getApiUrl()}/api/internal/callbacks/imessage`;
-  const callbackSecret = generateCallbackSecret();
-
-  const result = await createZeroRun({
-    userId,
-    agentId,
-    prompt,
-    appendSystemPrompt,
-    sessionId,
-    triggerSource: "imessage",
-    callbacks: [
-      {
-        url: callbackUrl,
-        secret: callbackSecret,
-        payload: callbackContext,
-      },
-    ],
-  });
-
+  const result = await createZeroRun(adaptImessageTrigger(params));
   log.debug(`Run ${result.runId} dispatched for iMessage`);
 }

--- a/turbo/apps/web/src/lib/zero/phone/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/zero/phone/handlers/run-agent.ts
@@ -1,8 +1,7 @@
 import { createZeroRun } from "../../zero-run-service";
-import { buildPhonePrompt } from "../../integration-prompt";
 import { logger } from "../../../shared/logger";
-import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
 import type { PhoneCallbackPayload } from "../../../infra/callback/callback-payloads";
+import { adaptPhoneTrigger } from "./adapt-phone-trigger";
 
 const log = logger("phone:run-agent");
 
@@ -15,34 +14,7 @@ interface RunAgentParams {
   callbackContext: PhoneCallbackPayload;
 }
 
-/**
- * Execute an agent run for a phone call.
- * Creates a run, registers a callback, and returns immediately.
- */
 export async function runAgentForPhone(params: RunAgentParams): Promise<void> {
-  const { agentId, sessionId, prompt, phoneContext, userId, callbackContext } =
-    params;
-
-  const appendSystemPrompt = buildPhonePrompt(phoneContext) || undefined;
-
-  const callbackUrl = `${getApiUrl()}/api/internal/callbacks/phone`;
-  const callbackSecret = generateCallbackSecret();
-
-  const result = await createZeroRun({
-    userId,
-    agentId,
-    prompt,
-    appendSystemPrompt,
-    sessionId,
-    triggerSource: "phone",
-    callbacks: [
-      {
-        url: callbackUrl,
-        secret: callbackSecret,
-        payload: callbackContext,
-      },
-    ],
-  });
-
+  const result = await createZeroRun(adaptPhoneTrigger(params));
   log.debug(`Run ${result.runId} dispatched for phone call`);
 }


### PR DESCRIPTION
## Summary

- Add `adaptPhoneTrigger()` and `adaptImessageTrigger()` pure functions mapping trigger contexts to `CreateZeroRunParams`
- Reduce `runAgentForPhone` and `runAgentForIMessage` to thin orchestrators (create → log)
- Add unit tests for both adapters covering full mapping, `sessionId` pass-through, empty-prompt coercion, and secret uniqueness

No behavior change. `triggerSource`, callback URLs, and error propagation are preserved. Callers (`call-ended.ts`, `message-received.ts`) are untouched.

Part of Epic #9724. Reuses the pattern from merged #9761 (Telegram) and #9756 (Email).

Closes #9728

## Test plan

- [x] New `adapt-phone-trigger.test.ts` passes (4 cases)
- [x] New `adapt-imessage-trigger.test.ts` passes (3 cases)
- [x] Existing `src/lib/zero/phone` test suite remains green (11 files / 59 tests)
- [x] `pnpm turbo run lint` clean for changed files
- [x] `pnpm check-types` clean
- [x] `pnpm format` unchanged
- [x] `pnpm knip` — no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)