### PR TITLE
refactor(contracts): consolidate voice-chat ts-rest contracts

### DIFF
--- a/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/append.test.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/append.test.ts
@@ -32,6 +32,7 @@ describe("zero voice-chat context append command", () => {
     it("should append an event with --content", async () => {
       let capturedBody: Record<string, unknown> | undefined;
       const createdEvent = {
+        id: "evt-1",
         seq: 1,
         source: "slow-brain",
         type: "directive",
@@ -42,7 +43,7 @@ describe("zero voice-chat context append command", () => {
       server.use(
         http.post(CONTEXT_URL, async ({ request }) => {
           capturedBody = (await request.json()) as Record<string, unknown>;
-          return HttpResponse.json(createdEvent, { status: 200 });
+          return HttpResponse.json({ event: createdEvent }, { status: 200 });
         }),
       );
 
@@ -77,10 +78,14 @@ describe("zero voice-chat context append command", () => {
           capturedBody = (await request.json()) as Record<string, unknown>;
           return HttpResponse.json(
             {
-              seq: 1,
-              source: "slow-brain",
-              type: "heartbeat",
-              createdAt: "2026-01-01T00:00:00Z",
+              event: {
+                id: "evt-1",
+                seq: 1,
+                source: "slow-brain",
+                type: "heartbeat",
+                content: null,
+                createdAt: "2026-01-01T00:00:00Z",
+              },
             },
             { status: 200 },
           );

--- a/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/get.test.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/get.test.ts
@@ -33,6 +33,7 @@ describe("zero voice-chat context get command", () => {
       const events = {
         events: [
           {
+            id: "evt-1",
             seq: 1,
             source: "user",
             type: "message",

--- a/turbo/apps/cli/src/lib/api/domains/zero-voice-chat-context.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-voice-chat-context.ts
@@ -1,7 +1,6 @@
 import { initClient } from "@ts-rest/core";
 import {
-  zeroVoiceChatContextGetContract,
-  zeroVoiceChatContextAppendContract,
+  zeroVoiceChatContextContract,
   type ContextEventsResponse,
   type ContextEvent,
   type AppendContextEventBody,
@@ -13,7 +12,7 @@ export async function getVoiceChatContextEvents(
   after?: number,
 ): Promise<ContextEventsResponse> {
   const config = await getClientConfig();
-  const client = initClient(zeroVoiceChatContextGetContract, config);
+  const client = initClient(zeroVoiceChatContextContract, config);
 
   const result = await client.getEvents({
     params: { id: sessionId },
@@ -33,7 +32,7 @@ export async function appendVoiceChatContextEvent(
   body: AppendContextEventBody,
 ): Promise<ContextEvent> {
   const config = await getClientConfig();
-  const client = initClient(zeroVoiceChatContextAppendContract, config);
+  const client = initClient(zeroVoiceChatContextContract, config);
 
   const result = await client.appendEvent({
     params: { id: sessionId },
@@ -42,7 +41,7 @@ export async function appendVoiceChatContextEvent(
   });
 
   if (result.status === 200) {
-    return result.body;
+    return result.body.event;
   }
 
   handleError(result, "Failed to append voice-chat context event");

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -808,14 +808,22 @@ export {
   type PushSubscriptionsContract,
 } from "./push-subscriptions";
 export {
-  zeroVoiceChatContextGetContract,
-  zeroVoiceChatContextAppendContract,
-  type ZeroVoiceChatContextGetContract,
-  type ZeroVoiceChatContextAppendContract,
+  zeroVoiceChatContextContract,
+  type ZeroVoiceChatContextContract,
   type ContextEvent,
   type ContextEventsResponse,
   type AppendContextEventBody,
 } from "./zero-voice-chat-context";
+export {
+  zeroVoiceChatSessionsContract,
+  type ZeroVoiceChatSessionsContract,
+  type VoiceChatMode,
+  type VoiceChatSession,
+  type VoiceChatSessionCreated,
+  type CreateVoiceChatSessionBody,
+  type VoiceChatTokenBody,
+  type VoiceChatTokenResponse,
+} from "./zero-voice-chat-sessions";
 export {
   zeroVoiceChatPrepareTriggerContract,
   zeroVoiceChatPrepareCompleteContract,

--- a/turbo/packages/core/src/contracts/zero-voice-chat-context.ts
+++ b/turbo/packages/core/src/contracts/zero-voice-chat-context.ts
@@ -5,10 +5,11 @@ import { apiErrorSchema } from "./errors";
 const c = initContract();
 
 const contextEventSchema = z.object({
+  id: z.string(),
   seq: z.number(),
   source: z.string(),
   type: z.string(),
-  content: z.string().optional(),
+  content: z.string().nullable(),
   createdAt: z.string(),
 });
 
@@ -22,7 +23,7 @@ const appendContextEventBodySchema = z.object({
   content: z.string().optional(),
 });
 
-export const zeroVoiceChatContextGetContract = c.router({
+export const zeroVoiceChatContextContract = c.router({
   getEvents: {
     method: "GET",
     path: "/api/zero/voice-chat/:id/context",
@@ -36,9 +37,7 @@ export const zeroVoiceChatContextGetContract = c.router({
     },
     summary: "Get shared context events for a voice-chat session",
   },
-});
 
-export const zeroVoiceChatContextAppendContract = c.router({
   appendEvent: {
     method: "POST",
     path: "/api/zero/voice-chat/:id/context",
@@ -46,7 +45,7 @@ export const zeroVoiceChatContextAppendContract = c.router({
     pathParams: z.object({ id: z.string().min(1) }),
     body: appendContextEventBodySchema,
     responses: {
-      200: contextEventSchema,
+      200: z.object({ event: contextEventSchema }),
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
@@ -54,10 +53,7 @@ export const zeroVoiceChatContextAppendContract = c.router({
   },
 });
 
-export type ZeroVoiceChatContextGetContract =
-  typeof zeroVoiceChatContextGetContract;
-export type ZeroVoiceChatContextAppendContract =
-  typeof zeroVoiceChatContextAppendContract;
+export type ZeroVoiceChatContextContract = typeof zeroVoiceChatContextContract;
 export type ContextEvent = z.infer<typeof contextEventSchema>;
 export type ContextEventsResponse = z.infer<typeof contextEventsResponseSchema>;
 export type AppendContextEventBody = z.infer<

--- a/turbo/packages/core/src/contracts/zero-voice-chat-sessions.ts
+++ b/turbo/packages/core/src/contracts/zero-voice-chat-sessions.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const voiceChatModeSchema = z.enum(["chat", "meeting"]);
+
+const voiceChatSessionBaseSchema = z.object({
+  id: z.string(),
+  mode: voiceChatModeSchema,
+  status: z.string(),
+});
+
+const voiceChatSessionCreatedSchema = voiceChatSessionBaseSchema.extend({
+  runId: z.string(),
+  createdAt: z.string(),
+  prepared: z.boolean(),
+});
+
+const createVoiceChatSessionBodySchema = z.object({
+  agentId: z.string().min(1),
+  mode: voiceChatModeSchema.optional(),
+  prompt: z.string().min(1).optional(),
+});
+
+const voiceChatTokenBodySchema = z.object({
+  model: z.string().optional(),
+});
+
+const voiceChatTokenResponseSchema = z.object({
+  client_secret: z.object({
+    value: z.string(),
+    expires_at: z.number(),
+  }),
+});
+
+const okResponseSchema = z.object({ ok: z.literal(true) });
+
+export const zeroVoiceChatSessionsContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/zero/voice-chat",
+    headers: authHeadersSchema,
+    body: createVoiceChatSessionBodySchema,
+    responses: {
+      200: z.object({ session: voiceChatSessionCreatedSchema }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "Create a new voice-chat session",
+  },
+
+  token: {
+    method: "POST",
+    path: "/api/zero/voice-chat/token",
+    headers: authHeadersSchema,
+    body: voiceChatTokenBodySchema,
+    responses: {
+      200: voiceChatTokenResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Mint an ephemeral OpenAI realtime token for voice-chat",
+  },
+
+  heartbeat: {
+    method: "POST",
+    path: "/api/zero/voice-chat/:id/heartbeat",
+    headers: authHeadersSchema,
+    pathParams: z.object({ id: z.string().min(1) }),
+    body: z.object({}),
+    responses: {
+      200: okResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Keep a voice-chat session alive",
+  },
+
+  activate: {
+    method: "POST",
+    path: "/api/zero/voice-chat/:id/activate",
+    headers: authHeadersSchema,
+    pathParams: z.object({ id: z.string().min(1) }),
+    body: z.object({}),
+    responses: {
+      200: z.object({ session: voiceChatSessionBaseSchema }),
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Activate a preparing voice-chat session",
+  },
+
+  end: {
+    method: "POST",
+    path: "/api/zero/voice-chat/:id/end",
+    headers: authHeadersSchema,
+    pathParams: z.object({ id: z.string().min(1) }),
+    body: z.object({}),
+    responses: {
+      200: okResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "End a voice-chat session",
+  },
+});
+
+export type ZeroVoiceChatSessionsContract =
+  typeof zeroVoiceChatSessionsContract;
+export type VoiceChatMode = z.infer<typeof voiceChatModeSchema>;
+export type VoiceChatSession = z.infer<typeof voiceChatSessionBaseSchema>;
+export type VoiceChatSessionCreated = z.infer<
+  typeof voiceChatSessionCreatedSchema
+>;
+export type CreateVoiceChatSessionBody = z.infer<
+  typeof createVoiceChatSessionBodySchema
+>;
+export type VoiceChatTokenBody = z.infer<typeof voiceChatTokenBodySchema>;
+export type VoiceChatTokenResponse = z.infer<
+  typeof voiceChatTokenResponseSchema
+>;


### PR DESCRIPTION
## Summary

Pure-additive ts-rest contract consolidation for `/api/zero/voice-chat/*`. Closes #9757 and unblocks the consumer-migration work in epic #9759.

- **Fix `contextEventSchema`** to match the actual route payload:
  - Add `id: z.string()` (used as React key in `voice-chat-panel-content.tsx`).
  - Change `content: z.string().optional()` → `z.string().nullable()` (column is nullable and routes serialise `null`).
- **Consolidate** the two split context contracts into a single aggregated router `zeroVoiceChatContextContract` with operations `getEvents` / `appendEvent`, matching the `tasksContract` style.
- **Correct** `appendEvent.responses.200` from bare `contextEventSchema` to `z.object({ event: contextEventSchema })`, matching the real route (`NextResponse.json({ event })`). The CLI wrapper unwraps `result.body.event` internally so the public signature of `appendVoiceChatContextEvent` is unchanged.
- **Add `zeroVoiceChatSessionsContract`** covering the five previously-uncontracted endpoints: `create`, `token`, `heartbeat`, `activate`, `end`. Schemas derived from the actual route handlers under `apps/web/app/api/zero/voice-chat/**/route.ts`.
- **Update CLI consumer** `apps/cli/src/lib/api/domains/zero-voice-chat-context.ts` — rename-only for imports, plus the one-line `result.body.event` unwrap.
- **Update MSW fixtures** in `append.test.ts` and `get.test.ts` for the required `id` field and the wrapped append response. No test-logic changes.
- **Remove** the old split exports `zeroVoiceChatContextGetContract` / `zeroVoiceChatContextAppendContract` (+ their types) from `contracts/index.ts`.

No platform signal migration; that stays in #9505 and the voice-chat-session migration issue.

## Test plan

- [x] `pnpm -F @vm0/cli exec vitest run src/commands/zero/voice-chat` — 8/8 pass locally
- [x] `pnpm -F @vm0/core exec vitest run` — 712/712 pass
- [x] `pnpm -F @vm0/cli exec vitest run` — 1060/1060 pass
- [x] `pnpm turbo run lint` green
- [x] `pnpm check-types` green
- [x] `pnpm format` clean
- [x] `pnpm knip` clean
- [ ] CI (reviewers to confirm green on all required jobs)

## Notes for reviewer

- Focus on schema correctness against the real route payloads (see `apps/web/app/api/zero/voice-chat/**/route.ts`). Every contract response shape in this PR is derived directly from the route handler returning that shape.
- The append-response envelope (`{ event }`) was previously mismatched between contract and route — this PR aligns them; the CLI's `JSON.stringify(data)` output is byte-identical because the wrapper unwraps.
- Only runtime consumer of the old split contracts was the CLI domain wrapper; no platform-side edits were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)