### PR TITLE
feat(cli): add zero connector search command

### DIFF
--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
@@ -134,6 +134,28 @@ describe("zero connector search command", () => {
       expect(types).toContain("gitlab");
     });
 
+    it("ranks tag-exact above type-substring above tag-substring", async () => {
+      // Keyword "chat" exercises three scoring tiers against the real catalog
+      // and pins the priority ordering contract so future refactors of
+      // scoreConnector cannot silently reorder them:
+      //   - slack:    tag-exact "chat"             => 70
+      //   - chatwoot: type-substring "chatwoot"    => 50
+      //   - openai:   tag-substring "chatgpt"      => 25
+      await searchCommand.parseAsync(["node", "cli", "chat", "--limit", "10"]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      const dataRows = findDataRows(lines);
+      const types = dataRows.map((row) => {
+        return row.split(/\s+/)[0];
+      });
+      const slackIdx = types.indexOf("slack");
+      const chatwootIdx = types.indexOf("chatwoot");
+      const openaiIdx = types.indexOf("openai");
+      expect(slackIdx).toBe(0);
+      expect(chatwootIdx).toBeGreaterThan(slackIdx);
+      expect(openaiIdx).toBeGreaterThan(chatwootIdx);
+    });
+
     it("prints No matches found for an unknown keyword", async () => {
       await searchCommand.parseAsync(["node", "cli", "xyz123abc"]);
 

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for zero connector search command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, scoring algorithm, formatters
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { searchCommand } from "../search";
+import chalk from "chalk";
+
+const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
+const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
+
+function stubAgent(id: string, displayName: string | null) {
+  return http.get(`http://localhost:3000/api/zero/agents/${id}`, () => {
+    return HttpResponse.json({
+      agentId: id,
+      ownerId: "owner-1",
+      description: null,
+      displayName,
+      sound: null,
+      avatarUrl: null,
+      permissionPolicies: null,
+      customSkills: [],
+    });
+  });
+}
+
+function stubUserConnectors(id: string, enabledTypes: string[]) {
+  return http.get(
+    `http://localhost:3000/api/zero/agents/${id}/user-connectors`,
+    () => {
+      return HttpResponse.json({ enabledTypes });
+    },
+  );
+}
+
+function findDataRows(lines: readonly string[]): string[] {
+  return lines.filter((line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return false;
+    if (trimmed.startsWith("TYPE")) return false;
+    if (trimmed.startsWith("No exact match")) return false;
+    if (trimmed.startsWith("Too many results")) return false;
+    if (trimmed.startsWith("No matches found")) return false;
+    return true;
+  });
+}
+
+describe("zero connector search command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe("keyword validation", () => {
+    it("rejects whitespace-only keyword", async () => {
+      await expect(async () => {
+        await searchCommand.parseAsync(["node", "cli", "   "]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Keyword cannot be empty"),
+      );
+    });
+  });
+
+  describe("without agent context", () => {
+    it("returns github first for an exact type match with no banner", async () => {
+      await searchCommand.parseAsync(["node", "cli", "github"]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      const output = lines.join("\n");
+      expect(output).not.toContain("No exact match");
+      expect(output).not.toContain("Too many results");
+      expect(output).not.toContain("AUTHORIZED FOR");
+
+      const dataRows = findDataRows(lines);
+      expect(dataRows[0]).toMatch(/^github\s/);
+    });
+
+    it("returns github for an env var exact match (GH_TOKEN)", async () => {
+      await searchCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      const output = lines.join("\n");
+      expect(output).not.toContain("No exact match");
+      const dataRows = findDataRows(lines);
+      expect(dataRows[0]).toMatch(/^github\s/);
+    });
+
+    it("returns github with No-exact-match banner for tag match GH_API_KEY", async () => {
+      await searchCommand.parseAsync(["node", "cli", "GH_API_KEY"]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      const output = lines.join("\n");
+      expect(output).toContain("No exact match. Showing closest:");
+      const dataRows = findDataRows(lines);
+      expect(dataRows[0]).toMatch(/^github\s/);
+    });
+
+    it("matches multiple connectors by shared tag vcs", async () => {
+      await searchCommand.parseAsync(["node", "cli", "vcs"]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      const output = lines.join("\n");
+      expect(output).toContain("No exact match. Showing closest:");
+      const dataRows = findDataRows(lines);
+      const types = dataRows.map((row) => {
+        return row.split(/\s+/)[0];
+      });
+      expect(types).toContain("github");
+      expect(types).toContain("gitlab");
+    });
+
+    it("prints No matches found for an unknown keyword", async () => {
+      await searchCommand.parseAsync(["node", "cli", "xyz123abc"]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      const output = lines.join("\n");
+      expect(output).toContain("No matches found.");
+      const dataRows = findDataRows(lines);
+      expect(dataRows).toHaveLength(0);
+    });
+
+    it("caps at --limit and prefixes with Too many results", async () => {
+      await searchCommand.parseAsync(["node", "cli", "api", "--limit", "3"]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      const output = lines.join("\n");
+      expect(output).toMatch(/Too many results \(top 3 of \d+\):/);
+      const dataRows = findDataRows(lines);
+      expect(dataRows).toHaveLength(3);
+    });
+
+    it("rejects a non-positive --limit", async () => {
+      await expect(async () => {
+        await searchCommand.parseAsync([
+          "node",
+          "cli",
+          "github",
+          "--limit",
+          "0",
+        ]);
+      }).rejects.toThrow();
+    });
+  });
+
+  describe("with agent context", () => {
+    it("adds AUTHORIZED FOR column when --agent is provided", async () => {
+      server.use(
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+      );
+
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--agent",
+        AGENT_UUID,
+      ]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      const output = lines.join("\n");
+      expect(output).toContain("AUTHORIZED FOR maya");
+      const githubRow = findDataRows(lines).find((line) => {
+        return line.startsWith("github");
+      });
+      expect(githubRow).toMatch(/✓/);
+    });
+
+    it("adds AUTHORIZED FOR column when ZERO_AGENT_ID is set", async () => {
+      vi.stubEnv("ZERO_AGENT_ID", AGENT_UUID);
+      server.use(
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, []),
+      );
+
+      await searchCommand.parseAsync(["node", "cli", "github"]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      const output = lines.join("\n");
+      expect(output).toContain("AUTHORIZED FOR maya");
+      const githubRow = findDataRows(lines).find((line) => {
+        return line.startsWith("github");
+      });
+      expect(githubRow).toMatch(/-/);
+    });
+
+    it("uses the full UUID as the header when displayName is null", async () => {
+      server.use(
+        stubAgent(AGENT_UUID, null),
+        stubUserConnectors(AGENT_UUID, []),
+      );
+
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--agent",
+        AGENT_UUID,
+      ]);
+
+      const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
+      expect(output).toContain(`AUTHORIZED FOR ${AGENT_UUID}`);
+    });
+
+    it("--agent overrides ZERO_AGENT_ID", async () => {
+      vi.stubEnv("ZERO_AGENT_ID", ALT_AGENT_UUID);
+      server.use(
+        stubAgent(AGENT_UUID, "from-flag"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+      );
+
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--agent",
+        AGENT_UUID,
+      ]);
+
+      const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
+      expect(output).toContain("AUTHORIZED FOR from-flag");
+      expect(output).not.toContain(ALT_AGENT_UUID);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/connector/index.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/index.ts
@@ -1,9 +1,11 @@
 import { Command } from "commander";
 import { listCommand } from "./list";
+import { searchCommand } from "./search";
 import { statusCommand } from "./status";
 
 export const zeroConnectorCommand = new Command()
   .name("connector")
   .description("Check third-party service connections (GitHub, Slack, etc.)")
   .addCommand(listCommand)
+  .addCommand(searchCommand)
   .addCommand(statusCommand);

--- a/turbo/apps/cli/src/commands/zero/connector/search.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/search.ts
@@ -1,0 +1,125 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  CONNECTOR_TYPES,
+  isFeatureEnabled,
+  searchConnectors,
+  type ConnectorType,
+} from "@vm0/core";
+import { getActiveOrg } from "../../../lib/api/config";
+import { withErrorHandler } from "../../../lib/command";
+import { resolveAgentContext } from "./agent-context";
+
+const DEFAULT_LIMIT = 5;
+const EXACT_MATCH_THRESHOLD = 80;
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_PATTERN, "");
+}
+
+function padEndAnsi(s: string, width: number): string {
+  const visible = stripAnsi(s).length;
+  return s + " ".repeat(Math.max(0, width - visible));
+}
+
+function parseLimit(raw: string): number {
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`--limit must be a positive integer, got "${raw}".`);
+  }
+  return n;
+}
+
+export const searchCommand = new Command()
+  .name("search")
+  .description("Search connectors by type, label, env var, secret, or tag")
+  .argument("<keyword>", "Search keyword (case-insensitive)")
+  .option("--agent <id>", "Show per-agent authorization column")
+  .option(
+    "--limit <n>",
+    `Maximum number of results to display (default ${DEFAULT_LIMIT})`,
+    parseLimit,
+    DEFAULT_LIMIT,
+  )
+  .action(
+    withErrorHandler(
+      async (keyword: string, options: { agent?: string; limit: number }) => {
+        const trimmed = keyword.trim();
+        if (!trimmed) {
+          throw new Error("Keyword cannot be empty.");
+        }
+
+        const [orgId, agentCtx] = await Promise.all([
+          getActiveOrg(),
+          resolveAgentContext(options.agent),
+        ]);
+
+        const isTypeAvailable = (type: ConnectorType): boolean => {
+          const config = CONNECTOR_TYPES[type];
+          const flag = config.featureFlag;
+          const hasApiToken = "api-token" in config.authMethods;
+          return !flag || isFeatureEnabled(flag, { orgId }) || hasApiToken;
+        };
+
+        const { results, total } = searchConnectors(
+          trimmed,
+          options.limit,
+          isTypeAvailable,
+        );
+
+        if (results.length === 0) {
+          console.log("No matches found.");
+          return;
+        }
+
+        const topScore = results[0]!.score;
+        if (topScore < EXACT_MATCH_THRESHOLD) {
+          console.log("No exact match. Showing closest:");
+        }
+        if (total > options.limit) {
+          console.log(`Too many results (top ${options.limit} of ${total}):`);
+        }
+
+        const typeHeader = "TYPE";
+        const labelHeader = "LABEL";
+        const typeWidth = Math.max(
+          typeHeader.length,
+          ...results.map((r) => {
+            return r.type.length;
+          }),
+        );
+        const labelWidth = Math.max(
+          labelHeader.length,
+          ...results.map((r) => {
+            return CONNECTOR_TYPES[r.type].label.length;
+          }),
+        );
+
+        const headerParts = [
+          typeHeader.padEnd(typeWidth),
+          labelHeader.padEnd(labelWidth),
+        ];
+        if (agentCtx) {
+          headerParts.push(`AUTHORIZED FOR ${agentCtx.displayName}`);
+        }
+        console.log(chalk.dim(headerParts.join("  ")));
+
+        for (const result of results) {
+          const config = CONNECTOR_TYPES[result.type];
+          const parts = [
+            result.type.padEnd(typeWidth),
+            padEndAnsi(config.label, labelWidth),
+          ];
+          if (agentCtx) {
+            parts.push(
+              agentCtx.authorizedTypes.has(result.type)
+                ? chalk.green("✓")
+                : chalk.dim("-"),
+            );
+          }
+          console.log(parts.join("  "));
+        }
+      },
+    ),
+  );

--- a/turbo/packages/core/src/contracts/connector-utils.ts
+++ b/turbo/packages/core/src/contracts/connector-utils.ts
@@ -397,117 +397,132 @@ function tokenize(input: string): Set<string> {
   return tokens;
 }
 
-function scoreConnector(
+function listSecretNames(config: ConnectorConfig): string[] {
+  const names: string[] = [];
+  for (const method of Object.values(config.authMethods)) {
+    for (const name of Object.keys(method.secrets)) {
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+type ScoreHit = { score: number; matchedField: string };
+
+function findExactMatch(
   keywordLower: string,
-  keywordTokens: Set<string>,
   type: ConnectorType,
   config: ConnectorConfig,
-): { score: number; matchedField: string } | null {
-  // 100 — type key exact (case-insensitive)
+): ScoreHit | null {
   if (type.toLowerCase() === keywordLower) {
     return { score: 100, matchedField: "type" };
   }
-
-  // 90 — env var key exact (any key in environmentMapping)
   for (const envVar of Object.keys(config.environmentMapping)) {
     if (envVar.toLowerCase() === keywordLower) {
       return { score: 90, matchedField: `env:${envVar}` };
     }
   }
-
-  // 80 — label exact (case-insensitive)
   if (config.label.toLowerCase() === keywordLower) {
     return { score: 80, matchedField: "label" };
   }
-
-  let bestScore = 0;
-  let bestField = "";
-  const record = (score: number, field: string): void => {
-    if (score > bestScore) {
-      bestScore = score;
-      bestField = field;
-    }
-  };
-
-  // 70 — tag exact
-  if (config.tags) {
-    for (const tag of config.tags) {
-      if (tag === keywordLower) {
-        record(70, `tag:${tag}`);
-      }
+  const tags = config.tags ?? [];
+  for (const tag of tags) {
+    if (tag === keywordLower) {
+      return { score: 70, matchedField: `tag:${tag}` };
     }
   }
+  return null;
+}
 
-  // 50 — type/label substring
+function findSubstringMatch(
+  keywordLower: string,
+  type: ConnectorType,
+  config: ConnectorConfig,
+): ScoreHit | null {
   if (type.toLowerCase().includes(keywordLower)) {
-    record(50, "type");
+    return { score: 50, matchedField: "type" };
   }
   if (config.label.toLowerCase().includes(keywordLower)) {
-    record(50, "label");
+    return { score: 50, matchedField: "label" };
   }
-
-  // 40 — env var key substring
   for (const envVar of Object.keys(config.environmentMapping)) {
     if (envVar.toLowerCase().includes(keywordLower)) {
-      record(40, `env:${envVar}`);
-      break;
+      return { score: 40, matchedField: `env:${envVar}` };
     }
   }
+  for (const name of listSecretNames(config)) {
+    if (name.toLowerCase().includes(keywordLower)) {
+      return { score: 30, matchedField: `secret:${name}` };
+    }
+  }
+  const tags = config.tags ?? [];
+  for (const tag of tags) {
+    if (tag.includes(keywordLower)) {
+      return { score: 25, matchedField: `tag:${tag}` };
+    }
+  }
+  return null;
+}
 
-  // 30 — secret name substring (any authMethods[*].secrets key)
-  for (const method of Object.values(config.authMethods)) {
-    let matched = false;
-    for (const secretName of Object.keys(method.secrets)) {
-      if (secretName.toLowerCase().includes(keywordLower)) {
-        record(30, `secret:${secretName}`);
-        matched = true;
-        break;
-      }
+function collectCandidateTokens(
+  type: ConnectorType,
+  config: ConnectorConfig,
+): Set<string> {
+  const tokens = new Set<string>();
+  const sources = [
+    type,
+    config.label,
+    ...Object.keys(config.environmentMapping),
+    ...listSecretNames(config),
+    ...(config.tags ?? []),
+  ];
+  for (const source of sources) {
+    for (const token of tokenize(source)) {
+      tokens.add(token);
     }
-    if (matched) break;
   }
+  return tokens;
+}
 
-  // 25 — tag substring
-  if (config.tags) {
-    for (const tag of config.tags) {
-      if (tag.includes(keywordLower)) {
-        record(25, `tag:${tag}`);
-        break;
-      }
-    }
-  }
-
-  // 10 × |intersection| — token-set intersection fallback
-  const candidateTokens = new Set<string>();
-  for (const t of tokenize(type)) candidateTokens.add(t);
-  for (const t of tokenize(config.label)) candidateTokens.add(t);
-  for (const envVar of Object.keys(config.environmentMapping)) {
-    for (const t of tokenize(envVar)) candidateTokens.add(t);
-  }
-  for (const method of Object.values(config.authMethods)) {
-    for (const secretName of Object.keys(method.secrets)) {
-      for (const t of tokenize(secretName)) candidateTokens.add(t);
-    }
-  }
-  if (config.tags) {
-    for (const tag of config.tags) {
-      for (const t of tokenize(tag)) candidateTokens.add(t);
-    }
-  }
+function findTokenIntersection(
+  keywordTokens: Set<string>,
+  type: ConnectorType,
+  config: ConnectorConfig,
+): ScoreHit | null {
+  const candidateTokens = collectCandidateTokens(type, config);
   let intersection = 0;
   let firstCommon = "";
-  for (const t of keywordTokens) {
-    if (candidateTokens.has(t)) {
+  for (const token of keywordTokens) {
+    if (candidateTokens.has(token)) {
       intersection++;
-      if (!firstCommon) firstCommon = t;
+      if (!firstCommon) firstCommon = token;
     }
   }
-  if (intersection > 0) {
-    record(10 * intersection, `token:${firstCommon}`);
-  }
+  if (intersection === 0) return null;
+  return { score: 10 * intersection, matchedField: `token:${firstCommon}` };
+}
 
-  if (bestScore < MIN_SCORE) return null;
-  return { score: bestScore, matchedField: bestField };
+function scoreConnector(
+  keywordLower: string,
+  keywordTokens: Set<string>,
+  type: ConnectorType,
+  config: ConnectorConfig,
+): ScoreHit | null {
+  const exact = findExactMatch(keywordLower, type, config);
+  if (exact) return exact;
+
+  const candidates: ScoreHit[] = [];
+  const substring = findSubstringMatch(keywordLower, type, config);
+  if (substring) candidates.push(substring);
+  const token = findTokenIntersection(keywordTokens, type, config);
+  if (token) candidates.push(token);
+
+  if (candidates.length === 0) return null;
+  const best = candidates.reduce((a, b) => {
+    return a.score >= b.score ? a : b;
+  });
+  if (best.score < MIN_SCORE) return null;
+  return best;
 }
 
 /**

--- a/turbo/packages/core/src/contracts/connector-utils.ts
+++ b/turbo/packages/core/src/contracts/connector-utils.ts
@@ -3,6 +3,7 @@ import {
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodType,
+  type ConnectorConfig,
   type ConnectorOAuthConfig,
   type ConnectorSecretConfig,
   type ConnectorType,
@@ -356,4 +357,192 @@ export function deriveApiTokenConnectedTypes(
   }
 
   return connected;
+}
+
+/**
+ * Result of a connector search hit, one per matched connector type.
+ */
+export interface ConnectorSearchResult {
+  readonly type: ConnectorType;
+  readonly score: number;
+  /** Short label describing the matched field (e.g. "type", "env:GH_TOKEN", "tag:vcs", "token:gh"). */
+  readonly matchedField: string;
+}
+
+export interface ConnectorSearchOutput {
+  /** Results sorted by score desc then type asc, already capped at `limit`. */
+  readonly results: readonly ConnectorSearchResult[];
+  /** Total candidates above the minimum threshold, before applying `limit`. */
+  readonly total: number;
+}
+
+const TOKEN_BOUNDARY = /[_\-\s]+/;
+const CASE_BOUNDARY = /(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/;
+const MIN_SCORE = 10;
+
+/**
+ * Split a string into lowercase tokens on `_`, `-`, whitespace, and
+ * camel/Pascal case boundaries. Digits stay attached to the preceding letters
+ * (e.g. `v2`). Empty tokens are dropped and duplicates deduped.
+ */
+function tokenize(input: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const chunk of input.split(TOKEN_BOUNDARY)) {
+    if (!chunk) continue;
+    for (const sub of chunk.split(CASE_BOUNDARY)) {
+      const lower = sub.toLowerCase();
+      if (lower) tokens.add(lower);
+    }
+  }
+  return tokens;
+}
+
+function scoreConnector(
+  keywordLower: string,
+  keywordTokens: Set<string>,
+  type: ConnectorType,
+  config: ConnectorConfig,
+): { score: number; matchedField: string } | null {
+  // 100 — type key exact (case-insensitive)
+  if (type.toLowerCase() === keywordLower) {
+    return { score: 100, matchedField: "type" };
+  }
+
+  // 90 — env var key exact (any key in environmentMapping)
+  for (const envVar of Object.keys(config.environmentMapping)) {
+    if (envVar.toLowerCase() === keywordLower) {
+      return { score: 90, matchedField: `env:${envVar}` };
+    }
+  }
+
+  // 80 — label exact (case-insensitive)
+  if (config.label.toLowerCase() === keywordLower) {
+    return { score: 80, matchedField: "label" };
+  }
+
+  let bestScore = 0;
+  let bestField = "";
+  const record = (score: number, field: string): void => {
+    if (score > bestScore) {
+      bestScore = score;
+      bestField = field;
+    }
+  };
+
+  // 70 — tag exact
+  if (config.tags) {
+    for (const tag of config.tags) {
+      if (tag === keywordLower) {
+        record(70, `tag:${tag}`);
+      }
+    }
+  }
+
+  // 50 — type/label substring
+  if (type.toLowerCase().includes(keywordLower)) {
+    record(50, "type");
+  }
+  if (config.label.toLowerCase().includes(keywordLower)) {
+    record(50, "label");
+  }
+
+  // 40 — env var key substring
+  for (const envVar of Object.keys(config.environmentMapping)) {
+    if (envVar.toLowerCase().includes(keywordLower)) {
+      record(40, `env:${envVar}`);
+      break;
+    }
+  }
+
+  // 30 — secret name substring (any authMethods[*].secrets key)
+  for (const method of Object.values(config.authMethods)) {
+    let matched = false;
+    for (const secretName of Object.keys(method.secrets)) {
+      if (secretName.toLowerCase().includes(keywordLower)) {
+        record(30, `secret:${secretName}`);
+        matched = true;
+        break;
+      }
+    }
+    if (matched) break;
+  }
+
+  // 25 — tag substring
+  if (config.tags) {
+    for (const tag of config.tags) {
+      if (tag.includes(keywordLower)) {
+        record(25, `tag:${tag}`);
+        break;
+      }
+    }
+  }
+
+  // 10 × |intersection| — token-set intersection fallback
+  const candidateTokens = new Set<string>();
+  for (const t of tokenize(type)) candidateTokens.add(t);
+  for (const t of tokenize(config.label)) candidateTokens.add(t);
+  for (const envVar of Object.keys(config.environmentMapping)) {
+    for (const t of tokenize(envVar)) candidateTokens.add(t);
+  }
+  for (const method of Object.values(config.authMethods)) {
+    for (const secretName of Object.keys(method.secrets)) {
+      for (const t of tokenize(secretName)) candidateTokens.add(t);
+    }
+  }
+  if (config.tags) {
+    for (const tag of config.tags) {
+      for (const t of tokenize(tag)) candidateTokens.add(t);
+    }
+  }
+  let intersection = 0;
+  let firstCommon = "";
+  for (const t of keywordTokens) {
+    if (candidateTokens.has(t)) {
+      intersection++;
+      if (!firstCommon) firstCommon = t;
+    }
+  }
+  if (intersection > 0) {
+    record(10 * intersection, `token:${firstCommon}`);
+  }
+
+  if (bestScore < MIN_SCORE) return null;
+  return { score: bestScore, matchedField: bestField };
+}
+
+/**
+ * Search the connector catalog by weighted multi-field ranking.
+ *
+ * Matches the keyword against type keys, labels, env var names, secret names,
+ * and `tags`. Score is the max over matched rules (never a sum). Results with
+ * score below the minimum threshold are dropped. Sort order: score desc, then
+ * type asc.
+ */
+export function searchConnectors(
+  keyword: string,
+  limit: number,
+  filter?: (type: ConnectorType) => boolean,
+): ConnectorSearchOutput {
+  const trimmed = keyword.trim();
+  if (!trimmed) return { results: [], total: 0 };
+
+  const keywordLower = trimmed.toLowerCase();
+  const keywordTokens = tokenize(trimmed);
+
+  const hits: ConnectorSearchResult[] = [];
+  for (const type of Object.keys(CONNECTOR_TYPES) as ConnectorType[]) {
+    if (filter && !filter(type)) continue;
+    const config = CONNECTOR_TYPES[type];
+    const hit = scoreConnector(keywordLower, keywordTokens, type, config);
+    if (!hit) continue;
+    hits.push({ type, score: hit.score, matchedField: hit.matchedField });
+  }
+
+  hits.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.type.localeCompare(b.type);
+  });
+
+  const capped = limit > 0 ? hits.slice(0, limit) : hits;
+  return { results: capped, total: hits.length };
 }

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -234,6 +234,7 @@ const CONNECTOR_TYPES_DEF = {
   },
   github: {
     label: "GitHub",
+    tags: ["gh", "gh_api_key", "git", "vcs", "scm", "repos"],
     environmentMapping: {
       GH_TOKEN: "$secrets.GITHUB_ACCESS_TOKEN",
       GITHUB_TOKEN: "$secrets.GITHUB_ACCESS_TOKEN",
@@ -261,6 +262,7 @@ const CONNECTOR_TYPES_DEF = {
   },
   notion: {
     label: "Notion",
+    tags: ["docs", "wiki", "workspace"],
     environmentMapping: {
       NOTION_TOKEN: "$secrets.NOTION_ACCESS_TOKEN",
     },
@@ -290,6 +292,7 @@ const CONNECTOR_TYPES_DEF = {
   },
   gmail: {
     label: "Gmail",
+    tags: ["email", "mail"],
     environmentMapping: {
       GMAIL_TOKEN: "$secrets.GMAIL_ACCESS_TOKEN",
     },
@@ -415,6 +418,7 @@ const CONNECTOR_TYPES_DEF = {
   },
   "google-calendar": {
     label: "Google Calendar",
+    tags: ["calendar", "scheduling", "gcal"],
     environmentMapping: {
       GOOGLE_CALENDAR_TOKEN: "$secrets.GOOGLE_CALENDAR_ACCESS_TOKEN",
     },
@@ -660,6 +664,7 @@ const CONNECTOR_TYPES_DEF = {
   },
   slack: {
     label: "Slack",
+    tags: ["chat", "messaging", "im"],
     environmentMapping: {
       SLACK_TOKEN: "$secrets.SLACK_ACCESS_TOKEN",
     },
@@ -800,6 +805,7 @@ const CONNECTOR_TYPES_DEF = {
   },
   linear: {
     label: "Linear",
+    tags: ["issues", "tickets", "project-management"],
     environmentMapping: {
       LINEAR_TOKEN: "$secrets.LINEAR_ACCESS_TOKEN",
     },
@@ -903,6 +909,7 @@ const CONNECTOR_TYPES_DEF = {
   },
   jira: {
     label: "Jira",
+    tags: ["issues", "tickets", "project-management"],
     environmentMapping: {
       JIRA_API_TOKEN: "$secrets.JIRA_API_TOKEN",
       JIRA_DOMAIN: "$vars.JIRA_DOMAIN",
@@ -2409,6 +2416,7 @@ const CONNECTOR_TYPES_DEF = {
   },
   stripe: {
     label: "Stripe",
+    tags: ["payments", "billing", "checkout"],
     environmentMapping: {
       STRIPE_TOKEN: "$secrets.STRIPE_ACCESS_TOKEN",
     },
@@ -2440,6 +2448,7 @@ const CONNECTOR_TYPES_DEF = {
   },
   openai: {
     label: "OpenAI",
+    tags: ["llm", "ai", "gpt", "chatgpt"],
     environmentMapping: {
       OPENAI_TOKEN: "$secrets.OPENAI_TOKEN",
     },
@@ -3917,6 +3926,7 @@ const CONNECTOR_TYPES_DEF = {
   },
   gitlab: {
     label: "GitLab",
+    tags: ["git", "vcs", "scm", "repos"],
     environmentMapping: {
       GITLAB_TOKEN: "$secrets.GITLAB_TOKEN",
       GITLAB_HOST: "$vars.GITLAB_HOST",

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -46,6 +46,12 @@ export interface ConnectorConfig {
   readonly oauth?: ConnectorOAuthConfig;
   /** Environment mapping declaring which env vars this connector provides. */
   readonly environmentMapping: Record<string, string>;
+  /**
+   * Optional concept words and common-guess aliases used by connector search.
+   * Lowercase only. Avoid duplicating content already in `label`,
+   * `environmentMapping` keys, or `authMethods[*].secrets` keys.
+   */
+  readonly tags?: readonly string[];
 }
 
 /**

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -391,6 +391,9 @@ export {
   getApiTokenRequiredSecretNames,
   getApiTokenFieldsByType,
   deriveApiTokenConnectedTypes,
+  searchConnectors,
+  type ConnectorSearchResult,
+  type ConnectorSearchOutput,
 } from "./connector-utils";
 export {
   connectorSessionStatusSchema,


### PR DESCRIPTION
## Summary

Closes #9773.

Adds `zero connector search <keyword>` with weighted multi-field fuzzy ranking over the connector catalog. Users can discover connectors by name, label, env var, secret, or tag, with per-agent authorization status when `--agent` (or `ZERO_AGENT_ID`) is provided.

- `@vm0/core`: new optional `tags` field on `ConnectorConfig`; populated for the top 10 connectors (github, notion, gmail, google-calendar, slack, linear, jira, openai, stripe, gitlab)
- `@vm0/core`: new `searchConnectors(keyword, limit, filter?)` helper with weighted multi-field scoring (type=100, env_exact=90, label=80, tag_exact=70, type/label_substring=50, env_substring=40, secret_substring=30, tag_substring=25, token_intersection=10×count). Symmetric tokenization applied to both keyword and field values.
- `@vm0/cli`: new `zero connector search` command. Honors feature flags, reuses `resolveAgentContext` from #9772 for the AUTHORIZED FOR column, prints banners for "No exact match" and "Too many results".

## Dependency

This PR branches off `feat/9762-zero-connector-agent-authorization` (#9772). Expect to rebase after #9772 lands. Merge #9772 first.

## Test plan

- [x] `pnpm -F @vm0/core exec vitest run` — 712 tests pass
- [x] `pnpm -F @vm0/cli exec vitest run` — 1082 tests pass (includes 12 new `zero connector search` integration tests)
- [x] `pnpm turbo run lint` — 0 errors
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)