### PR TITLE
refactor: extract voice chat trigger adapters as pure functions

### DIFF
--- a/turbo/apps/web/src/lib/zero/voice-chat/__tests__/adapt-voice-chat-prepare-trigger.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/__tests__/adapt-voice-chat-prepare-trigger.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { adaptVoiceChatPrepareTrigger } from "../adapt-voice-chat-prepare-trigger";
+
+const baseCtx = {
+  userId: "user-1",
+  agentId: "agent-1",
+  prompt: "prepare a voice chat briefing",
+  appendSystemPrompt: "# Voice Chat Preparation\nDo the thing.",
+  preparationId: "prep-1",
+};
+
+describe("adaptVoiceChatPrepareTrigger", () => {
+  it("propagates identity fields verbatim", () => {
+    const result = adaptVoiceChatPrepareTrigger(baseCtx);
+
+    expect(result.userId).toBe("user-1");
+    expect(result.agentId).toBe("agent-1");
+    expect(result.prompt).toBe("prepare a voice chat briefing");
+    expect(result.appendSystemPrompt).toBe(
+      "# Voice Chat Preparation\nDo the thing.",
+    );
+  });
+
+  it("sets triggerSource to 'voice-chat'", () => {
+    const result = adaptVoiceChatPrepareTrigger(baseCtx);
+    expect(result.triggerSource).toBe("voice-chat");
+  });
+
+  it("builds the prepare callback URL and payload", () => {
+    const result = adaptVoiceChatPrepareTrigger(baseCtx);
+
+    const callback = result.callbacks?.[0];
+    if (!callback) {
+      throw new Error("expected exactly one callback");
+    }
+    expect(callback.url).toMatch(
+      /\/api\/internal\/callbacks\/voice-chat-prepare$/,
+    );
+    expect(callback.payload).toEqual({ preparationId: "prep-1" });
+  });
+
+  it("emits exactly one callback", () => {
+    const result = adaptVoiceChatPrepareTrigger(baseCtx);
+    expect(result.callbacks).toHaveLength(1);
+  });
+
+  it("generates a unique secret per invocation", () => {
+    const a = adaptVoiceChatPrepareTrigger(baseCtx);
+    const b = adaptVoiceChatPrepareTrigger(baseCtx);
+    const aSecret = a.callbacks?.[0]?.secret;
+    const bSecret = b.callbacks?.[0]?.secret;
+    expect(aSecret).toBeDefined();
+    expect(bSecret).toBeDefined();
+    expect(aSecret).not.toBe(bSecret);
+  });
+
+  it("produces a fresh payload object per invocation", () => {
+    const a = adaptVoiceChatPrepareTrigger(baseCtx);
+    const b = adaptVoiceChatPrepareTrigger(baseCtx);
+    expect(a.callbacks?.[0]?.payload).not.toBe(b.callbacks?.[0]?.payload);
+  });
+
+  it("returns a non-empty string secret", () => {
+    const result = adaptVoiceChatPrepareTrigger(baseCtx);
+    const secret = result.callbacks?.[0]?.secret;
+    expect(typeof secret).toBe("string");
+    expect(secret && secret.length).toBeGreaterThan(0);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/voice-chat/__tests__/adapt-voice-chat-session-trigger.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/__tests__/adapt-voice-chat-session-trigger.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { adaptVoiceChatSessionTrigger } from "../adapt-voice-chat-session-trigger";
+
+const baseCtx = {
+  userId: "user-1",
+  agentId: "agent-1",
+  prompt: "observe the voice-chat conversation",
+  appendSystemPrompt: "# Voice Chat Session\nStart observing.",
+  sessionId: "sess-1",
+};
+
+describe("adaptVoiceChatSessionTrigger", () => {
+  it("propagates identity fields verbatim", () => {
+    const result = adaptVoiceChatSessionTrigger(baseCtx);
+
+    expect(result.userId).toBe("user-1");
+    expect(result.agentId).toBe("agent-1");
+    expect(result.prompt).toBe("observe the voice-chat conversation");
+    expect(result.appendSystemPrompt).toBe(
+      "# Voice Chat Session\nStart observing.",
+    );
+  });
+
+  it("sets triggerSource to 'voice-chat'", () => {
+    const result = adaptVoiceChatSessionTrigger(baseCtx);
+    expect(result.triggerSource).toBe("voice-chat");
+  });
+
+  it("builds the session callback URL and payload", () => {
+    const result = adaptVoiceChatSessionTrigger(baseCtx);
+
+    const callback = result.callbacks?.[0];
+    if (!callback) {
+      throw new Error("expected exactly one callback");
+    }
+    expect(callback.url).toMatch(/\/api\/internal\/callbacks\/voice-chat$/);
+    expect(callback.payload).toEqual({ sessionId: "sess-1" });
+  });
+
+  it("emits exactly one callback", () => {
+    const result = adaptVoiceChatSessionTrigger(baseCtx);
+    expect(result.callbacks).toHaveLength(1);
+  });
+
+  it("generates a unique secret per invocation", () => {
+    const a = adaptVoiceChatSessionTrigger(baseCtx);
+    const b = adaptVoiceChatSessionTrigger(baseCtx);
+    const aSecret = a.callbacks?.[0]?.secret;
+    const bSecret = b.callbacks?.[0]?.secret;
+    expect(aSecret).toBeDefined();
+    expect(bSecret).toBeDefined();
+    expect(aSecret).not.toBe(bSecret);
+  });
+
+  it("produces a fresh payload object per invocation", () => {
+    const a = adaptVoiceChatSessionTrigger(baseCtx);
+    const b = adaptVoiceChatSessionTrigger(baseCtx);
+    expect(a.callbacks?.[0]?.payload).not.toBe(b.callbacks?.[0]?.payload);
+  });
+
+  it("returns a non-empty string secret", () => {
+    const result = adaptVoiceChatSessionTrigger(baseCtx);
+    const secret = result.callbacks?.[0]?.secret;
+    expect(typeof secret).toBe("string");
+    expect(secret && secret.length).toBeGreaterThan(0);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/voice-chat/adapt-voice-chat-prepare-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/adapt-voice-chat-prepare-trigger.ts
@@ -1,0 +1,33 @@
+import { generateCallbackSecret, getApiUrl } from "../../infra/callback";
+import type { VoiceChatPrepareCallbackPayload } from "../../infra/callback/callback-payloads";
+import type { CreateZeroRunParams } from "../zero-run-service";
+
+interface VoiceChatPrepareTriggerContext {
+  userId: string;
+  agentId: string;
+  prompt: string;
+  appendSystemPrompt: string;
+  preparationId: string;
+}
+
+export function adaptVoiceChatPrepareTrigger(
+  ctx: VoiceChatPrepareTriggerContext,
+): CreateZeroRunParams {
+  const callbackPayload: VoiceChatPrepareCallbackPayload = {
+    preparationId: ctx.preparationId,
+  };
+  return {
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    prompt: ctx.prompt,
+    appendSystemPrompt: ctx.appendSystemPrompt,
+    triggerSource: "voice-chat",
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/voice-chat-prepare`,
+        secret: generateCallbackSecret(),
+        payload: callbackPayload,
+      },
+    ],
+  };
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat/adapt-voice-chat-session-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/adapt-voice-chat-session-trigger.ts
@@ -1,0 +1,33 @@
+import { generateCallbackSecret, getApiUrl } from "../../infra/callback";
+import type { VoiceChatCallbackPayload } from "../../infra/callback/callback-payloads";
+import type { CreateZeroRunParams } from "../zero-run-service";
+
+interface VoiceChatSessionTriggerContext {
+  userId: string;
+  agentId: string;
+  prompt: string;
+  appendSystemPrompt: string;
+  sessionId: string;
+}
+
+export function adaptVoiceChatSessionTrigger(
+  ctx: VoiceChatSessionTriggerContext,
+): CreateZeroRunParams {
+  const callbackPayload: VoiceChatCallbackPayload = {
+    sessionId: ctx.sessionId,
+  };
+  return {
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    prompt: ctx.prompt,
+    appendSystemPrompt: ctx.appendSystemPrompt,
+    triggerSource: "voice-chat",
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/voice-chat`,
+        secret: generateCallbackSecret(),
+        payload: callbackPayload,
+      },
+    ],
+  };
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
@@ -5,8 +5,7 @@ import {
   buildVoiceChatPrepareOnlyPrompt,
   buildVoiceChatMeetingPreparePrompt,
 } from "../integration-prompt";
-import { generateCallbackSecret, getApiUrl } from "../../infra/callback";
-import type { VoiceChatPrepareCallbackPayload } from "../../infra/callback/callback-payloads";
+import { adaptVoiceChatPrepareTrigger } from "./adapt-voice-chat-prepare-trigger";
 import { logger } from "../../shared/logger";
 
 const log = logger("zero:voice-chat:preparation");
@@ -179,22 +178,15 @@ export async function dispatchPreparationRun(
     ? "You are Zero preparing for a voice meeting. Research the meeting topic and prepare a comprehensive briefing."
     : "You are Zero preparing for a voice chat. Review the agent configuration and user context, then output an initial directive.";
 
-  const callbackPayload: VoiceChatPrepareCallbackPayload = { preparationId };
-
-  const result = await createZeroRun({
-    userId,
-    agentId,
-    prompt,
-    appendSystemPrompt,
-    triggerSource: "voice-chat",
-    callbacks: [
-      {
-        url: `${getApiUrl()}/api/internal/callbacks/voice-chat-prepare`,
-        secret: generateCallbackSecret(),
-        payload: callbackPayload,
-      },
-    ],
-  });
+  const result = await createZeroRun(
+    adaptVoiceChatPrepareTrigger({
+      userId,
+      agentId,
+      prompt,
+      appendSystemPrompt,
+      preparationId,
+    }),
+  );
 
   await db
     .update(voiceChatPreparations)

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -12,8 +12,7 @@ import {
 } from "../integration-prompt";
 import { conflict, notFound, badRequest, forbidden } from "../../shared/errors";
 import { logger } from "../../shared/logger";
-import { generateCallbackSecret, getApiUrl } from "../../infra/callback";
-import type { VoiceChatCallbackPayload } from "../../infra/callback/callback-payloads";
+import { adaptVoiceChatSessionTrigger } from "./adapt-voice-chat-session-trigger";
 
 const log = logger("zero:voice-chat:session");
 
@@ -169,24 +168,15 @@ export async function dispatchSlowBrain(
     });
   }
 
-  const callbackPayload: VoiceChatCallbackPayload = {
-    sessionId: session.id,
-  };
-
-  const result = await createZeroRun({
-    userId,
-    agentId,
-    prompt,
-    appendSystemPrompt,
-    triggerSource: "voice-chat",
-    callbacks: [
-      {
-        url: `${getApiUrl()}/api/internal/callbacks/voice-chat`,
-        secret: generateCallbackSecret(),
-        payload: callbackPayload,
-      },
-    ],
-  });
+  const result = await createZeroRun(
+    adaptVoiceChatSessionTrigger({
+      userId,
+      agentId,
+      prompt,
+      appendSystemPrompt,
+      sessionId: session.id,
+    }),
+  );
 
   // Update session with runId
   await db
@@ -247,24 +237,15 @@ export async function dispatchObservationSlowBrain(session: {
   const appendSystemPrompt = buildVoiceChatObservationOnlyPrompt(session.id);
   const prompt = `You are Zero's slow-brain for voice-chat session ${session.id}. Preparation is complete. Start observing the conversation.`;
 
-  const callbackPayload: VoiceChatCallbackPayload = {
-    sessionId: session.id,
-  };
-
-  const result = await createZeroRun({
-    userId: session.userId,
-    agentId: session.agentId,
-    prompt,
-    appendSystemPrompt,
-    triggerSource: "voice-chat",
-    callbacks: [
-      {
-        url: `${getApiUrl()}/api/internal/callbacks/voice-chat`,
-        secret: generateCallbackSecret(),
-        payload: callbackPayload,
-      },
-    ],
-  });
+  const result = await createZeroRun(
+    adaptVoiceChatSessionTrigger({
+      userId: session.userId,
+      agentId: session.agentId,
+      prompt,
+      appendSystemPrompt,
+      sessionId: session.id,
+    }),
+  );
 
   await db
     .update(voiceChatSessions)


### PR DESCRIPTION
## Summary

Closes #9732. Part of Epic #9724.

Extracts `adaptVoiceChatPrepareTrigger` and `adaptVoiceChatSessionTrigger` as pure synchronous transforms from trigger context to `CreateZeroRunParams`. The three voice-chat dispatch functions (`dispatchPreparationRun`, `dispatchSlowBrain`, `dispatchObservationSlowBrain`) now delegate param construction to these adapters while keeping every side-effect (runId updates, session-start events, meeting-prompt events) unchanged.

One session-trigger adapter is shared by both `dispatchSlowBrain` and `dispatchObservationSlowBrain` because they use the identical callback URL (`/api/internal/callbacks/voice-chat`) and payload shape (`{ sessionId }`) — only `prompt` and `appendSystemPrompt` differ, and those come from the caller.

### `after()` runtime safety

Epic #9724 flagged voice-chat as a potential WebRTC/SSE runtime-context risk for the deferred `after()` dispatch inside `createZeroRun()`. Static call-graph analysis shows all three dispatches run inside standard Next.js POST route handlers:

- `dispatchPreparationRun` ← `POST /api/zero/voice-chat/prepare/route.ts`
- `dispatchSlowBrain` ← `POST /api/zero/voice-chat/route.ts`
- `dispatchObservationSlowBrain` ← `POST /api/zero/voice-chat/route.ts`

The WebRTC connection is client-to-OpenAI-Realtime with a separate ephemeral-token route (`openai-token.ts`); the dispatches themselves are plain HTTP POSTs returning `NextResponse.json`. No SSE, no persistent connection, no non-request-scope call site. `after()` is safe — no escape hatch needed.

### Tests

Two adapter test files with 7 cases each (14 total), matching the pattern from #9775 `phone/__tests__/adapt-phone-trigger.test.ts`: identity propagation, `triggerSource`, callback URL + payload, single-callback assertion, unique secret per invocation, fresh payload object, non-empty secret. Uses the "invoke twice, compare secrets" determinism pattern (no DI parameter).

Existing voice-chat route integration tests (`route.test.ts` × 2, 31 cases) remain green.

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/zero/voice-chat/__tests__/adapt-voice-chat-*-trigger.test.ts` → 14/14 passing
- [x] `pnpm -F web exec vitest run app/api/zero/voice-chat/**/__tests__/route.test.ts` → 31/31 passing
- [x] `pnpm check-types` → clean
- [x] `pnpm turbo run lint` → 0 errors
- [x] `pnpm format` → unchanged
- [x] `pnpm knip` → no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)