### PR TITLE
refactor: extract pure adapter for schedule cron trigger

### DIFF
--- a/turbo/apps/web/src/lib/zero/schedule/__tests__/adapt-schedule-trigger.test.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/__tests__/adapt-schedule-trigger.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { adaptScheduleTrigger } from "../adapt-schedule-trigger";
+
+describe("adaptScheduleTrigger", () => {
+  const base = {
+    userId: "user-1",
+    agentId: "agent-1",
+    scheduleId: "sched-1",
+    prompt: "hello",
+    appendSystemPrompt: "sys",
+    timezone: "UTC",
+    cronExpression: undefined as string | undefined,
+  };
+
+  it("maps loop trigger to loop callback URL and payload", () => {
+    const result = adaptScheduleTrigger({
+      ...base,
+      triggerType: "loop",
+    });
+
+    expect(result.userId).toBe("user-1");
+    expect(result.agentId).toBe("agent-1");
+    expect(result.scheduleId).toBe("sched-1");
+    expect(result.prompt).toBe("hello");
+    expect(result.appendSystemPrompt).toBe("sys");
+    expect(result.triggerSource).toBe("schedule");
+
+    const callback = result.callbacks?.[0];
+    if (!callback) {
+      throw new Error("expected exactly one callback");
+    }
+    expect(callback.url).toMatch(/\/api\/internal\/callbacks\/schedule\/loop$/);
+    expect(callback.payload).toEqual({ scheduleId: "sched-1" });
+    expect(typeof callback.secret).toBe("string");
+    expect(callback.secret.length).toBeGreaterThan(0);
+  });
+
+  it("maps cron trigger to cron callback URL and full payload", () => {
+    const result = adaptScheduleTrigger({
+      ...base,
+      triggerType: "cron",
+      cronExpression: "*/5 * * * *",
+      timezone: "America/New_York",
+    });
+
+    const callback = result.callbacks?.[0];
+    if (!callback) {
+      throw new Error("expected exactly one callback");
+    }
+    expect(callback.url).toMatch(/\/api\/internal\/callbacks\/schedule\/cron$/);
+    expect(callback.payload).toEqual({
+      scheduleId: "sched-1",
+      cronExpression: "*/5 * * * *",
+      timezone: "America/New_York",
+    });
+  });
+
+  it("maps once trigger to cron callback URL (shared path)", () => {
+    const result = adaptScheduleTrigger({
+      ...base,
+      triggerType: "once",
+      cronExpression: undefined,
+      timezone: "UTC",
+    });
+
+    const callback = result.callbacks?.[0];
+    if (!callback) {
+      throw new Error("expected exactly one callback");
+    }
+    expect(callback.url).toMatch(/\/api\/internal\/callbacks\/schedule\/cron$/);
+    expect(callback.payload).toEqual({
+      scheduleId: "sched-1",
+      timezone: "UTC",
+    });
+    expect(Object.keys(callback.payload as object)).not.toContain(
+      "cronExpression",
+    );
+  });
+
+  it("omits cronExpression from cron payload when undefined", () => {
+    const result = adaptScheduleTrigger({
+      ...base,
+      triggerType: "cron",
+      cronExpression: undefined,
+    });
+
+    const callback = result.callbacks?.[0];
+    if (!callback) {
+      throw new Error("expected exactly one callback");
+    }
+    expect(Object.keys(callback.payload as object)).not.toContain(
+      "cronExpression",
+    );
+  });
+
+  it("propagates scheduleId to both top-level field and callback payload", () => {
+    const result = adaptScheduleTrigger({
+      ...base,
+      triggerType: "loop",
+      scheduleId: "sched-xyz",
+    });
+    expect(result.scheduleId).toBe("sched-xyz");
+    const callback = result.callbacks?.[0];
+    if (!callback) {
+      throw new Error("expected exactly one callback");
+    }
+    expect((callback.payload as { scheduleId: string }).scheduleId).toBe(
+      "sched-xyz",
+    );
+  });
+
+  it("generates a unique secret per call", () => {
+    const ctx = { ...base, triggerType: "loop" };
+    const a = adaptScheduleTrigger(ctx);
+    const b = adaptScheduleTrigger(ctx);
+    const aSecret = a.callbacks?.[0]?.secret;
+    const bSecret = b.callbacks?.[0]?.secret;
+    expect(aSecret).toBeDefined();
+    expect(bSecret).toBeDefined();
+    expect(aSecret).not.toBe(bSecret);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/schedule/adapt-schedule-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/adapt-schedule-trigger.ts
@@ -1,0 +1,61 @@
+import { generateCallbackSecret, getApiUrl } from "../../infra/callback";
+import type {
+  ScheduleCronCallbackPayload,
+  ScheduleLoopCallbackPayload,
+} from "../../infra/callback/callback-payloads";
+import type { CreateZeroRunParams } from "../zero-run-service";
+
+interface ScheduleTriggerContext {
+  userId: string;
+  agentId: string;
+  scheduleId: string;
+  prompt: string;
+  appendSystemPrompt: string | undefined;
+  triggerType: string;
+  cronExpression: string | undefined;
+  timezone: string;
+}
+
+export function adaptScheduleTrigger(
+  ctx: ScheduleTriggerContext,
+): CreateZeroRunParams {
+  return {
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    prompt: ctx.prompt,
+    appendSystemPrompt: ctx.appendSystemPrompt,
+    scheduleId: ctx.scheduleId,
+    triggerSource: "schedule",
+    callbacks: buildScheduleCallbacks(ctx),
+  };
+}
+
+function buildScheduleCallbacks(
+  ctx: ScheduleTriggerContext,
+): CreateZeroRunParams["callbacks"] {
+  if (ctx.triggerType === "loop") {
+    const payload: ScheduleLoopCallbackPayload = { scheduleId: ctx.scheduleId };
+    return [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/schedule/loop`,
+        secret: generateCallbackSecret(),
+        payload,
+      },
+    ];
+  }
+  if (ctx.triggerType === "cron" || ctx.triggerType === "once") {
+    const payload: ScheduleCronCallbackPayload = {
+      scheduleId: ctx.scheduleId,
+      ...(ctx.cronExpression && { cronExpression: ctx.cronExpression }),
+      timezone: ctx.timezone,
+    };
+    return [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/schedule/cron`,
+        secret: generateCallbackSecret(),
+        payload,
+      },
+    ];
+  }
+  return [];
+}

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -10,12 +10,8 @@ import { notFound, badRequest, schedulePast } from "../../shared/errors";
 import { logger } from "../../shared/logger";
 import { createZeroRun } from "../zero-run-service";
 import { buildSchedulePrompt } from "../integration-prompt";
-import { generateCallbackSecret, getApiUrl } from "../../infra/callback";
 import { generateScheduleDescription } from "../ai/lightweight-model";
-import type {
-  ScheduleLoopCallbackPayload,
-  ScheduleCronCallbackPayload,
-} from "../../infra/callback/callback-payloads";
+import { adaptScheduleTrigger } from "./adapt-schedule-trigger";
 
 const log = logger("service:schedule");
 
@@ -849,41 +845,6 @@ export async function executeSchedule(
     throw new Error(`Compose ${compose.name} has no versions`);
   }
 
-  // Build callbacks for run completion
-  const callbacks: Array<{
-    url: string;
-    secret: string;
-    payload: ScheduleLoopCallbackPayload | ScheduleCronCallbackPayload;
-  }> = [];
-
-  // Loop schedule advancement callback (triggers next iteration on completion)
-  if (schedule.triggerType === "loop") {
-    const loopPayload: ScheduleLoopCallbackPayload = {
-      scheduleId: schedule.id,
-    };
-    callbacks.push({
-      url: `${getApiUrl()}/api/internal/callbacks/schedule/loop`,
-      secret: generateCallbackSecret(),
-      payload: loopPayload,
-    });
-  }
-
-  // Cron/once schedule completion callback (tracks failures, advances next run, generates summary)
-  if (schedule.triggerType === "cron" || schedule.triggerType === "once") {
-    const cronPayload: ScheduleCronCallbackPayload = {
-      scheduleId: schedule.id,
-      ...(schedule.cronExpression && {
-        cronExpression: schedule.cronExpression,
-      }),
-      timezone: schedule.timezone,
-    };
-    callbacks.push({
-      url: `${getApiUrl()}/api/internal/callbacks/schedule/cron`,
-      secret: generateCallbackSecret(),
-      payload: cronPayload,
-    });
-  }
-
   // Build schedule integration context for the agent
   // (User info is injected centrally by createZeroRunRecord)
   const integrationContext = buildSchedulePrompt({
@@ -899,15 +860,18 @@ export async function executeSchedule(
   // Note: schedule state (nextRunAt, lastRunAt, enabled) is already advanced
   // by the atomic CAS claim in executeDueSchedules(). We only need to persist
   // lastRunId after successful run creation.
-  const result = await createZeroRun({
-    userId: schedule.userId,
-    prompt: schedule.prompt,
-    appendSystemPrompt,
-    agentId: schedule.agentId,
-    scheduleId: schedule.id,
-    triggerSource: "schedule",
-    callbacks,
-  });
+  const result = await createZeroRun(
+    adaptScheduleTrigger({
+      userId: schedule.userId,
+      agentId: schedule.agentId,
+      scheduleId: schedule.id,
+      prompt: schedule.prompt,
+      appendSystemPrompt,
+      triggerType: schedule.triggerType,
+      cronExpression: schedule.cronExpression ?? undefined,
+      timezone: schedule.timezone,
+    }),
+  );
 
   // Persist lastRunId so the active-run check in executeDueSchedules works
   await globalThis.services.db


### PR DESCRIPTION
## Summary

- Add `adaptScheduleTrigger()` pure function mapping `ScheduleTriggerContext` to `CreateZeroRunParams`, with internal branching over `triggerType` (loop | cron | once) to produce the correct callback URL and payload
- Slim `executeSchedule()` in `schedule-service.ts` to call the adapter instead of building callbacks and params inline; drop unused `generateCallbackSecret`, `getApiUrl`, and `Schedule*CallbackPayload` imports
- Add unit tests covering both callback URLs, `once` sharing the cron path, `cronExpression` omission, `scheduleId` double propagation, and secret uniqueness (6 cases)

No behavior change. Error re-throw (natural propagation), callback URLs (`/schedule/loop` and `/schedule/cron`), `scheduleId` propagation, and schedule-execution row semantics are all preserved.

Part of Epic #9724. Continues the adapter pattern from #9756 (email), #9761 (telegram), #9763 (slack), #9774 (github), and #9775 (phone+imessage).

Closes #9731

## Test plan

- [x] `adapt-schedule-trigger.test.ts` — 6 cases pass
- [x] Existing `src/lib/infra/run/__tests__/scheduling.test.ts` — 11 tests still green
- [x] `pnpm turbo run lint` — 0 errors (25 pre-existing warnings unchanged)
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — unchanged
- [x] `pnpm knip` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)