### PR TITLE
refactor(voice-chat): migrate panel signals to typed zero client

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -143,7 +143,6 @@ export default [
       "src/signals/zero-page/chat-draft.ts",
       "src/signals/__tests__/fetch.test.ts",
       "src/signals/voice-chat/voice-chat-session.ts",
-      "src/signals/mission-control-page/create-voice-chat-panel-signals.ts", // TODO: migrate to zeroClient$ when voice-chat API contract is added
       "src/signals/voice-io/voice-io-tts.ts",
       "src/signals/voice-io/voice-io-stt.ts",
       "src/views/zero-page/components/org-manage/org-general-tab.tsx",

--- a/turbo/apps/platform/src/signals/mission-control-page/__tests__/create-voice-chat-panel-signals.test.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/__tests__/create-voice-chat-panel-signals.test.ts
@@ -87,78 +87,17 @@ describe("createVoiceChatPanelSignals", () => {
     });
   });
 
-  it("should filter out items missing required fields from the events array", async () => {
-    setup();
-
-    server.use(
-      http.get("*/api/zero/voice-chat/sess-validate/context", () => {
-        return HttpResponse.json({
-          events: [
-            // Valid event
-            {
-              id: "evt-ok",
-              seq: 1,
-              source: "slow-brain",
-              type: "thinking",
-              content: "Valid",
-              createdAt: "2026-04-13T10:00:01Z",
-            },
-            // Missing id — should be filtered out
-            {
-              seq: 2,
-              source: "user",
-              type: "speech",
-              content: "No id",
-              createdAt: "2026-04-13T10:00:02Z",
-            },
-            // seq is a string, not number — should be filtered out
-            {
-              id: "evt-bad-seq",
-              seq: "3",
-              source: "fast-brain",
-              type: "response",
-              content: "Bad seq",
-              createdAt: "2026-04-13T10:00:03Z",
-            },
-            // null item — should be filtered out
-            null,
-            // content is undefined (field absent) — should be filtered out
-            {
-              id: "evt-no-content",
-              seq: 4,
-              source: "user",
-              type: "speech",
-              createdAt: "2026-04-13T10:00:04Z",
-            },
-          ],
-        });
-      }),
-    );
-
-    const signals = createVoiceChatPanelSignals("sess-validate");
-    detach(
-      context.store.set(signals.startPolling$, context.signal),
-      Reason.Daemon,
-    );
-
-    await waitFor(() => {
-      const events = context.store.get(signals.events$);
-      // Only the one valid event should be present
-      expect(events).toHaveLength(1);
-    });
-
-    const events = context.store.get(signals.events$);
-    expect(events[0]).toMatchObject({ id: "evt-ok", seq: 1 });
-  });
-
-  it("should return false from polling and not set events on non-ok response", async () => {
+  it("should keep events$ empty when polling hits an error response", async () => {
     setup();
 
     const pollFired = createDeferredPromise<void>(context.signal);
     server.use(
       http.get("*/api/zero/voice-chat/sess-error/context", () => {
         pollFired.resolve();
-        return new HttpResponse(null, { status: 500 });
+        return HttpResponse.json(
+          { error: { message: "boom", code: "INTERNAL" } },
+          { status: 500 },
+        );
       }),
     );
 
@@ -168,10 +107,11 @@ describe("createVoiceChatPanelSignals", () => {
       Reason.Daemon,
     );
 
-    // Wait until the poll has fired at least once
+    // Wait until the poll has fired at least once. accept() throws on 500
+    // and setLoop catches the error and applies fibonacci backoff — the
+    // observable invariant is that events$ stays empty.
     await pollFired.promise;
 
-    // Events remain empty after a failed response
     expect(context.store.get(signals.events$)).toHaveLength(0);
   });
 });

--- a/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/create-voice-chat-panel-signals.ts
@@ -1,81 +1,37 @@
 import { command, state, type Command, type State } from "ccstate";
-import { fetch$ } from "../fetch.ts";
+import { zeroVoiceChatContextContract, type ContextEvent } from "@vm0/core";
+import { accept } from "../../lib/accept.ts";
+import { zeroClient$ } from "../api-client.ts";
 import { setLoop } from "../utils.ts";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface VoiceChatEvent {
-  id: string;
-  seq: number;
-  source: string;
-  type: string;
-  content: string | null;
-  createdAt: string;
-}
-
-// ---------------------------------------------------------------------------
-// VoiceChatPanelSignals — returned by createVoiceChatPanelSignals
-// ---------------------------------------------------------------------------
 
 export interface VoiceChatPanelSignals {
   sessionId: string;
-  events$: State<VoiceChatEvent[]>;
+  events$: State<ContextEvent[]>;
   startPolling$: Command<Promise<void>, [AbortSignal]>;
   focusInput$: Command<void, []>;
 }
 
-// ---------------------------------------------------------------------------
-// Factory
-// ---------------------------------------------------------------------------
-
 export function createVoiceChatPanelSignals(
   sessionId: string,
 ): VoiceChatPanelSignals {
-  const events$ = state<VoiceChatEvent[]>([]);
+  const events$ = state<ContextEvent[]>([]);
   const lastSeq$ = state(0);
 
   const startPolling$ = command(async ({ get, set }, signal: AbortSignal) => {
+    const client = get(zeroClient$)(zeroVoiceChatContextContract);
     await setLoop(
       async (sig: AbortSignal) => {
         const lastSeq = get(lastSeq$);
-        const fetchFn = get(fetch$);
-        const res = await fetchFn(
-          `/api/zero/voice-chat/${sessionId}/context?after=${lastSeq}`,
-          { signal: sig },
+        const result = await accept(
+          client.getEvents({
+            params: { id: sessionId },
+            query: { after: lastSeq },
+            fetchOptions: { signal: sig },
+          }),
+          [200],
+          { toast: false },
         );
-
-        if (!res.ok) {
-          return false;
-        }
-
-        const json: unknown = await res.json();
-        sig.throwIfAborted();
-
-        if (
-          typeof json !== "object" ||
-          json === null ||
-          !("events" in json) ||
-          !Array.isArray((json as { events: unknown }).events)
-        ) {
-          return false;
-        }
-
-        const rawEvents = (json as { events: unknown[] }).events;
-        const incoming = rawEvents.filter((e): e is VoiceChatEvent => {
-          if (typeof e !== "object" || e === null) {
-            return false;
-          }
-          const ev = e as Record<string, unknown>;
-          return (
-            typeof ev.id === "string" &&
-            typeof ev.seq === "number" &&
-            typeof ev.source === "string" &&
-            typeof ev.type === "string" &&
-            (typeof ev.content === "string" || ev.content === null)
-          );
-        });
+        const incoming = result.body.events;
         if (incoming.length > 0) {
           set(events$, (prev) => {
             return [...prev, ...incoming];

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-bubbles.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-bubbles.tsx
@@ -1,5 +1,5 @@
 import { IconBrain } from "@tabler/icons-react";
-import type { VoiceChatEvent } from "../../signals/mission-control-page/create-voice-chat-panel-signals.ts";
+import type { ContextEvent } from "@vm0/core";
 import { Markdown } from "../components/markdown.tsx";
 
 // ---------------------------------------------------------------------------
@@ -8,7 +8,7 @@ import { Markdown } from "../components/markdown.tsx";
 
 type EventCategory = "user" | "assistant" | "slow-brain" | "system";
 
-function categorizeEvent(event: VoiceChatEvent): EventCategory {
+function categorizeEvent(event: ContextEvent): EventCategory {
   if (event.source === "user" && event.type === "speech") {
     return "user";
   }
@@ -98,7 +98,7 @@ export function SlowBrainIndicator({
 // Event renderer
 // ---------------------------------------------------------------------------
 
-export function VoiceChatEventItem({ event }: { event: VoiceChatEvent }) {
+export function VoiceChatEventItem({ event }: { event: ContextEvent }) {
   const category = categorizeEvent(event);
   switch (category) {
     case "user": {


### PR DESCRIPTION
## Summary

- Migrate `create-voice-chat-panel-signals.ts` from raw `fetch$` to `zeroClient$` + `zeroVoiceChatContextContract.getEvents` (contract added in #9757).
- Delete the local `VoiceChatEvent` interface; consumers now use `ContextEvent` from `@vm0/core` — single source of truth per Epic #9759.
- Remove the `ccstate/no-direct-fetch` allow-list entry in `eslint.config.js` so the rule now enforces the migration.

Closes #9505. Part of Epic #9759 (full voice-chat migration to typed contracts).

## Behavior diff

- Before: raw `fetch$` silently continued on non-OK responses; hand-rolled runtime type narrowing filtered malformed events one-by-one.
- After: `accept(..., [200], { toast: false })` throws `ApiError` on non-OK; `setLoop` catches and applies fibonacci backoff — sustained errors no longer burn polls at full 3s rate. Schema validation happens at the client boundary via ts-rest + zod.

All observable behaviors preserved: polling interval 3s, `lastSeq$` advancement, append order, `focusInput$` no-op contract.

## Test plan

- [x] Target test file passes (3 tests): `pnpm -F @vm0/app exec vitest run src/signals/mission-control-page/__tests__/create-voice-chat-panel-signals.test.ts`
- [x] Full platform vitest run clean for this area
- [x] `pnpm turbo run lint --filter=@vm0/app` — 0 errors, 0 warnings (rule now applies to the file)
- [x] `pnpm check-types` — passes
- [x] `pnpm format` — no changes needed
- [x] `pnpm knip` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)