### PR TITLE
fix(billing): persist subscription period end instead of invoice accrual period

### DIFF
--- a/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -71,6 +71,25 @@ const TEST_ZERO_PRICE = JSON.stringify({
   team: [TEST_PRICE_TEAM, TEST_PRICE_TEAM_LEGACY],
 });
 
+/**
+ * Build a minimal invoice.lines payload carrying a subscription line item
+ * whose period.end matches the real subscription billing-cycle end.
+ *
+ * This mirrors the shape `handleInvoicePaid` now reads from — specifically,
+ * `invoice.lines.data[i].period.end` where the line's parent type is
+ * `"subscription_item_details"`. See issue #9777.
+ */
+function invoiceLinesWithSubscriptionPeriod(periodEnd: number) {
+  return {
+    data: [
+      {
+        period: { end: periodEnd },
+        parent: { type: "subscription_item_details" as const },
+      },
+    ],
+  };
+}
+
 const context = testContext();
 
 /** Create a Stripe webhook request */
@@ -172,7 +191,7 @@ describe("POST /api/webhooks/stripe", () => {
     it("activates subscription and sets tier", async () => {
       const cusId = uniqueId("cus-checkout");
       const subId = uniqueId("sub-checkout");
-      const invId = uniqueId("inv-checkout");
+      const itemPeriodEnd = Math.floor(Date.now() / 1000) + 30 * 86400;
 
       await updateOrgStripeFields(user.orgId, {
         stripeCustomerId: cusId,
@@ -181,13 +200,14 @@ describe("POST /api/webhooks/stripe", () => {
       stripeMocks.subscriptionsRetrieve.mockResolvedValue({
         id: subId,
         status: "active",
-        items: { data: [{ price: { id: TEST_PRICE_PRO } }] },
-        latest_invoice: invId,
-      });
-
-      stripeMocks.invoicesRetrieve.mockResolvedValue({
-        id: invId,
-        period_end: Math.floor(Date.now() / 1000) + 30 * 86400,
+        items: {
+          data: [
+            {
+              price: { id: TEST_PRICE_PRO },
+              current_period_end: itemPeriodEnd,
+            },
+          ],
+        },
       });
 
       const response = await sendWebhookEvent("checkout.session.completed", {
@@ -204,6 +224,9 @@ describe("POST /api/webhooks/stripe", () => {
       expect(billing?.subscriptionStatus).toBe("active");
       expect(billing?.currentPeriodEnd).toBeInstanceOf(Date);
       expect(billing?.cancelAtPeriodEnd).toBe(false);
+      // invoices.retrieve must NOT be called — checkout handler now reads
+      // period end directly from subscription.items (issue #9777).
+      expect(stripeMocks.invoicesRetrieve).not.toHaveBeenCalled();
     });
 
     it("is idempotent — skips if subscription already stored", async () => {
@@ -220,7 +243,6 @@ describe("POST /api/webhooks/stripe", () => {
         id: subId,
         status: "active",
         items: { data: [{ price: { id: TEST_PRICE_PRO } }] },
-        latest_invoice: null,
       });
 
       const response = await sendWebhookEvent("checkout.session.completed", {
@@ -258,7 +280,7 @@ describe("POST /api/webhooks/stripe", () => {
       const response = await sendWebhookEvent("invoice.paid", {
         id: invId,
         customer: cusId,
-        period_end: periodEnd,
+        lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
         parent: { subscription_details: { subscription: subId } },
       });
 
@@ -292,7 +314,7 @@ describe("POST /api/webhooks/stripe", () => {
       const response = await sendWebhookEvent("invoice.paid", {
         id: invId,
         customer: cusId,
-        period_end: periodEnd,
+        lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
         parent: { subscription_details: { subscription: subId } },
       });
 
@@ -325,7 +347,7 @@ describe("POST /api/webhooks/stripe", () => {
       await sendWebhookEvent("invoice.paid", {
         id: invId,
         customer: cusId,
-        period_end: periodEnd,
+        lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
         parent: { subscription_details: { subscription: subId } },
       });
 
@@ -427,7 +449,7 @@ describe("POST /api/webhooks/stripe", () => {
       const response = await sendWebhookEvent("invoice.paid", {
         id: invId,
         customer: cusId,
-        period_end: periodEnd,
+        lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
         parent: { subscription_details: { subscription: subId } },
       });
 
@@ -584,7 +606,7 @@ describe("POST /api/webhooks/stripe", () => {
       const response = await sendWebhookEvent("invoice.paid", {
         id: invId,
         customer: cusId,
-        period_end: periodEnd,
+        lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
         parent: { subscription_details: { subscription: subId } },
       });
 
@@ -596,7 +618,7 @@ describe("POST /api/webhooks/stripe", () => {
       expect(records[0]!.remaining).toBe(20000);
       expect(records[0]!.stripeInvoiceId).toBe(invId);
 
-      // expires_at should be period_end + 1 month
+      // expires_at should be subscription line period.end + 1 month
       const expectedExpiresAt = new Date(periodEnd * 1000);
       expectedExpiresAt.setMonth(expectedExpiresAt.getMonth() + 1);
       expect(records[0]!.expiresAt.getTime()).toBe(expectedExpiresAt.getTime());
@@ -634,7 +656,7 @@ describe("POST /api/webhooks/stripe", () => {
       const response = await sendWebhookEvent("invoice.paid", {
         id: invId,
         customer: cusId,
-        period_end: periodEnd,
+        lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
         parent: { subscription_details: { subscription: subId } },
       });
 
@@ -672,7 +694,7 @@ describe("POST /api/webhooks/stripe", () => {
       await sendWebhookEvent("invoice.paid", {
         id: invId,
         customer: cusId,
-        period_end: periodEnd,
+        lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
         parent: { subscription_details: { subscription: subId } },
       });
 
@@ -680,7 +702,7 @@ describe("POST /api/webhooks/stripe", () => {
       await sendWebhookEvent("invoice.paid", {
         id: invId,
         customer: cusId,
-        period_end: periodEnd,
+        lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
         parent: { subscription_details: { subscription: subId } },
       });
 
@@ -688,7 +710,7 @@ describe("POST /api/webhooks/stripe", () => {
       expect(records).toHaveLength(1);
     });
 
-    it("throws and rolls back transaction when period_end is missing", async () => {
+    it("throws and rolls back transaction when no subscription line item has period.end", async () => {
       const cusId = uniqueId("cus-no-period-end");
       const subId = uniqueId("sub-no-period-end");
       const invId = uniqueId("inv-no-period-end");
@@ -705,16 +727,17 @@ describe("POST /api/webhooks/stripe", () => {
 
       const creditsBefore = await getOrgCredits(user.orgId);
 
-      // Send invoice.paid without period_end — handler throws because
-      // period_end is required to create the expiry record
+      // Send invoice.paid with lines.data containing no subscription_item_details
+      // line — handler throws because it cannot derive the subscription
+      // period end from the invoice.
       await expect(
         sendWebhookEvent("invoice.paid", {
           id: invId,
           customer: cusId,
           parent: { subscription_details: { subscription: subId } },
-          // period_end intentionally omitted
+          lines: { data: [] },
         }),
-      ).rejects.toThrow("missing period_end");
+      ).rejects.toThrow("no subscription line item with period.end");
 
       // Credits must NOT have changed (transaction rolled back)
       const creditsAfter = await getOrgCredits(user.orgId);
@@ -723,6 +746,57 @@ describe("POST /api/webhooks/stripe", () => {
       // No expires record should have been created
       const records = await findCreditExpiresRecords(user.orgId);
       expect(records).toHaveLength(0);
+    });
+
+    it("writes subscription line period.end to currentPeriodEnd (not invoice.period_end) — regression for #9777", async () => {
+      // Regression test: before the fix, handleInvoicePaid read the
+      // top-level invoice.period_end, which on a renewal invoice collapses
+      // to the invoice creation moment — NOT the next renewal date.
+      // This resulted in currentPeriodEnd being persisted as a stale
+      // timestamp, producing an infinite "currentPeriodEnd is stale"
+      // warning loop every time getOrgBillingPeriod was called.
+      const cusId = uniqueId("cus-regression");
+      const subId = uniqueId("sub-regression");
+      const invId = uniqueId("inv-regression");
+
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+        stripeSubscriptionId: subId,
+      });
+
+      stripeMocks.subscriptionsRetrieve.mockResolvedValue({
+        id: subId,
+        items: { data: [{ price: { id: TEST_PRICE_PRO } }] },
+      });
+
+      // Simulate the exact shape of a real Stripe renewal invoice:
+      // the top-level invoice.period_end reflects the INVOICE accrual
+      // period (effectively the invoice creation moment), while the
+      // subscription line item's period.end is the actual next renewal
+      // date. The handler MUST use the latter.
+      const invoiceAccrualEnd = Math.floor(
+        new Date("2026-03-26T07:24:12Z").getTime() / 1000,
+      );
+      const subscriptionPeriodEnd = Math.floor(
+        new Date("2026-04-26T07:24:12Z").getTime() / 1000,
+      );
+
+      const response = await sendWebhookEvent("invoice.paid", {
+        id: invId,
+        customer: cusId,
+        period_end: invoiceAccrualEnd, // wrong field — must be ignored
+        lines: invoiceLinesWithSubscriptionPeriod(subscriptionPeriodEnd),
+        parent: { subscription_details: { subscription: subId } },
+      });
+
+      expect(response.status).toBe(200);
+
+      const billing = await getOrgBillingFields(user.orgId);
+      // currentPeriodEnd must be the subscription period end (Apr 26),
+      // NOT the invoice accrual end (Mar 26).
+      expect(billing?.currentPeriodEnd).toEqual(
+        new Date("2026-04-26T07:24:12Z"),
+      );
     });
 
     it("auto-recharge does NOT create expires record", async () => {

--- a/turbo/apps/web/scripts/migrations/007-backfill-current-period-end/backfill.ts
+++ b/turbo/apps/web/scripts/migrations/007-backfill-current-period-end/backfill.ts
@@ -1,0 +1,270 @@
+#!/usr/bin/env tsx
+
+/**
+ * Backfill org_metadata.current_period_end from Stripe for paying orgs.
+ *
+ * Context (see issue #9777):
+ *
+ * Before the fix, `handleInvoicePaid` persisted `invoice.period_end` into
+ * `org_metadata.current_period_end`. That field is the invoice's accrual
+ * period end — for a renewal invoice, this collapses to the invoice
+ * creation moment rather than the next renewal date. As a result, every
+ * paying org that has gone through at least one renewal under the buggy
+ * code path has a stale / past-dated `current_period_end` in the DB,
+ * which causes `getOrgBillingPeriod` to fall through to Stripe on every
+ * call (producing the "currentPeriodEnd is stale" log spam).
+ *
+ * This script reconciles every paying org's `current_period_end` against
+ * Stripe by reading `subscription.items.data[0].current_period_end` — the
+ * correct field for the subscription billing-cycle end.
+ *
+ * Usage (from turbo/apps/web):
+ *   tsx scripts/migrations/007-backfill-current-period-end/backfill.ts
+ *   tsx scripts/migrations/007-backfill-current-period-end/backfill.ts --migrate
+ *
+ * Environment:
+ *   DATABASE_URL        — Required
+ *   STRIPE_SECRET_KEY   — Required when --migrate is passed
+ */
+
+import { parseArgs } from "node:util";
+import { and, eq, isNotNull, ne } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import Stripe from "stripe";
+import { orgMetadata } from "../../../src/db/schema/org-metadata";
+
+type Db = ReturnType<typeof drizzle>;
+type ReconcileOutcome =
+  | "updated"
+  | "unchanged"
+  | "noSubscriptionItem"
+  | "pastDatedFromStripe"
+  | "failed";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PayingOrgRow {
+  orgId: string;
+  stripeSubscriptionId: string;
+  currentPeriodEnd: Date | null;
+}
+
+interface Stats {
+  total: number;
+  updated: number;
+  unchanged: number;
+  noSubscriptionItem: number;
+  pastDatedFromStripe: number;
+  failed: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const THROTTLE_MS = 100;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    return setTimeout(resolve, ms);
+  });
+}
+
+function datesEqual(a: Date | null, b: Date | null): boolean {
+  if (a === null && b === null) return true;
+  if (a === null || b === null) return false;
+  return a.getTime() === b.getTime();
+}
+
+async function reconcileOrg(
+  db: Db,
+  stripe: Stripe,
+  org: PayingOrgRow,
+  idx: string,
+  now: Date,
+): Promise<ReconcileOutcome> {
+  try {
+    const subscription = await stripe.subscriptions.retrieve(
+      org.stripeSubscriptionId,
+    );
+    const itemPeriodEnd = subscription.items.data[0]?.current_period_end;
+
+    if (!itemPeriodEnd) {
+      console.warn(
+        `${idx} ⊘ org=${org.orgId} sub=${org.stripeSubscriptionId} — subscription has no items[0].current_period_end`,
+      );
+      return "noSubscriptionItem";
+    }
+
+    const stripePeriodEnd = new Date(itemPeriodEnd * 1000);
+
+    // Defensive: don't write a past-dated value. If Stripe returns a past
+    // timestamp we log and skip rather than persist it (matching the guard
+    // added to getOrgBillingPeriod).
+    if (stripePeriodEnd < now) {
+      console.warn(
+        `${idx} ⊘ org=${org.orgId} sub=${org.stripeSubscriptionId} — Stripe period_end is in the past: ${stripePeriodEnd.toISOString()}`,
+      );
+      return "pastDatedFromStripe";
+    }
+
+    if (datesEqual(org.currentPeriodEnd, stripePeriodEnd)) {
+      console.log(
+        `${idx} = org=${org.orgId} current=${stripePeriodEnd.toISOString()} (already correct)`,
+      );
+      return "unchanged";
+    }
+
+    await db
+      .update(orgMetadata)
+      .set({ currentPeriodEnd: stripePeriodEnd, updatedAt: new Date() })
+      .where(eq(orgMetadata.orgId, org.orgId));
+
+    console.log(
+      `${idx} ✓ org=${org.orgId} before=${org.currentPeriodEnd?.toISOString() ?? "null"} after=${stripePeriodEnd.toISOString()}`,
+    );
+    return "updated";
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `${idx} ✗ org=${org.orgId} sub=${org.stripeSubscriptionId} — ${message}`,
+    );
+    return "failed";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { values: args } = parseArgs({
+    options: {
+      migrate: { type: "boolean", default: false },
+    },
+    strict: true,
+  });
+  const dryRun = !args.migrate;
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required");
+  }
+
+  const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+  if (!dryRun && !stripeSecretKey) {
+    throw new Error("STRIPE_SECRET_KEY is required for --migrate");
+  }
+
+  console.log("=== Backfill org_metadata.current_period_end ===");
+  console.log(
+    `Mode: ${dryRun ? "dry-run (pass --migrate to execute)" : "MIGRATE"}`,
+  );
+  console.log();
+
+  const stripe = stripeSecretKey ? new Stripe(stripeSecretKey) : null;
+
+  const pg = postgres(databaseUrl, { max: 1 });
+  const db = drizzle(pg);
+  const stats: Stats = {
+    total: 0,
+    updated: 0,
+    unchanged: 0,
+    noSubscriptionItem: 0,
+    pastDatedFromStripe: 0,
+    failed: 0,
+  };
+
+  try {
+    // Select every org with an active subscription — i.e. a non-null
+    // stripe_subscription_id on a non-free tier. The tier check is
+    // defensive: canceled subscriptions should already have
+    // stripe_subscription_id cleared by handleSubscriptionDeleted.
+    const rows = await db
+      .select({
+        orgId: orgMetadata.orgId,
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+        currentPeriodEnd: orgMetadata.currentPeriodEnd,
+      })
+      .from(orgMetadata)
+      .where(
+        and(
+          isNotNull(orgMetadata.stripeSubscriptionId),
+          ne(orgMetadata.tier, "free"),
+        ),
+      );
+
+    // Narrow the Drizzle result: the where clause guarantees non-null IDs
+    // but the types stay nullable until we filter explicitly.
+    const payingOrgs: PayingOrgRow[] = rows.flatMap((r) => {
+      return r.stripeSubscriptionId === null
+        ? []
+        : [
+            {
+              orgId: r.orgId,
+              stripeSubscriptionId: r.stripeSubscriptionId,
+              currentPeriodEnd: r.currentPeriodEnd,
+            },
+          ];
+    });
+
+    stats.total = payingOrgs.length;
+    console.log(
+      `Found ${stats.total} paying org(s) with active subscription\n`,
+    );
+
+    if (stats.total === 0) {
+      console.log("Nothing to do.");
+      return;
+    }
+
+    const now = new Date();
+
+    for (let i = 0; i < payingOrgs.length; i++) {
+      const org = payingOrgs[i]!;
+      const idx = `[${i + 1}/${stats.total}]`;
+
+      if (dryRun) {
+        console.log(
+          `${idx} (dry-run) org=${org.orgId} sub=${org.stripeSubscriptionId} current=${
+            org.currentPeriodEnd?.toISOString() ?? "null"
+          } — would reconcile against Stripe`,
+        );
+        stats.updated++;
+        continue;
+      }
+
+      const outcome = await reconcileOrg(db, stripe!, org, idx, now);
+      stats[outcome]++;
+      await sleep(THROTTLE_MS);
+    }
+
+    console.log("\n=== Summary ===");
+    console.log(`Total:                 ${stats.total}`);
+    console.log(`Updated:               ${stats.updated}`);
+    console.log(`Unchanged:             ${stats.unchanged}`);
+    console.log(`No subscription item:  ${stats.noSubscriptionItem}`);
+    console.log(`Past-dated from Stripe: ${stats.pastDatedFromStripe}`);
+    console.log(`Failed:                ${stats.failed}`);
+
+    if (dryRun) {
+      console.log(
+        "\nDry run — no changes were made. Pass --migrate to execute.",
+      );
+    }
+
+    if (stats.failed > 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await pg.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("Backfill failed:", err);
+  process.exit(1);
+});

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -32,7 +32,14 @@ interface InvoiceInput {
   id: string;
   customer: string | { id: string } | null;
   metadata: Record<string, string> | null;
-  period_end?: number;
+  lines: {
+    data: Array<{
+      period: { end: number };
+      parent: {
+        type: "subscription_item_details" | "invoice_item_details";
+      } | null;
+    }>;
+  };
   parent: {
     subscription_details: {
       subscription: string | { id: string };
@@ -195,17 +202,14 @@ export async function handleCheckoutCompleted(
     return;
   }
 
-  // In Stripe v2025 API, current_period_end was removed from Subscription.
-  // Use the latest_invoice.period_end if available, otherwise leave null.
-  let periodEnd: Date | undefined;
-  if (subscription.latest_invoice) {
-    const invoiceId =
-      typeof subscription.latest_invoice === "string"
-        ? subscription.latest_invoice
-        : subscription.latest_invoice.id;
-    const latestInvoice = await stripe.invoices.retrieve(invoiceId);
-    periodEnd = new Date(latestInvoice.period_end * 1000);
-  }
+  // In Stripe v2025 API, current_period_end was removed from the top-level
+  // Subscription object. The replacement is subscription.items.data[i].
+  // current_period_end — the end time of the subscription item's current
+  // billing period. (Do NOT read invoice.period_end — that field is the
+  // accrual period for the invoice, not the subscription period, and for
+  // renewal invoices collapses to the invoice creation moment.)
+  const itemPeriodEnd = subscription.items.data[0]?.current_period_end;
+  const periodEnd = itemPeriodEnd ? new Date(itemPeriodEnd * 1000) : undefined;
 
   await db
     .update(orgMetadata)
@@ -322,16 +326,22 @@ export async function handleInvoicePaid(invoice: InvoiceInput): Promise<void> {
 
     await grantOrgCredits(tx, org.orgId, credits);
 
-    // Calculate expires_at: currentPeriodEnd + 1 month
-    // invoice.period_end is required to create the expiry record correctly.
-    // If it is missing, throw so the webhook fails and Stripe retries, alerting operators.
-    const periodEndUnix = invoice.period_end;
+    // The subscription line item's period.end is the actual subscription
+    // billing-cycle end — i.e. the time the customer is paying through.
+    // (The top-level invoice.period_end is the "period over which billables
+    // accrued" and for a renewal invoice collapses to the invoice creation
+    // moment, not the next renewal date — do NOT use it here.)
+    const subscriptionLine = invoice.lines.data.find((line) => {
+      return line.parent?.type === "subscription_item_details";
+    });
+    const periodEndUnix = subscriptionLine?.period.end;
     if (!periodEndUnix) {
       throw new Error(
-        `invoice.paid missing period_end — cannot create expiry record (invoiceId=${invoice.id}, orgId=${org.orgId})`,
+        `invoice.paid has no subscription line item with period.end — cannot create expiry record (invoiceId=${invoice.id}, orgId=${org.orgId})`,
       );
     }
 
+    // Calculate expires_at: currentPeriodEnd + 1 month
     const periodEndDate = new Date(periodEndUnix * 1000);
     const expiresAt = new Date(periodEndDate);
     expiresAt.setMonth(expiresAt.getMonth() + 1);
@@ -347,7 +357,7 @@ export async function handleInvoicePaid(invoice: InvoiceInput): Promise<void> {
       .update(orgMetadata)
       .set({
         lastProcessedInvoiceId: invoice.id,
-        currentPeriodEnd: new Date(periodEndUnix * 1000),
+        currentPeriodEnd: periodEndDate,
         updatedAt: new Date(),
       })
       .where(eq(orgMetadata.orgId, org.orgId));

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-metadata-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-metadata-service.test.ts
@@ -114,7 +114,7 @@ describe("getOrgBillingPeriod", () => {
     reloadEnv();
   });
 
-  it("returns billing period from Stripe invoice when currentPeriodEnd is not cached", async () => {
+  it("returns billing period from Stripe subscription item when currentPeriodEnd is not cached", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("org");
     mockClerk({ userId });
@@ -130,29 +130,30 @@ describe("getOrgBillingPeriod", () => {
       currentPeriodEnd: null,
     });
 
+    // Use a far-future date so the "don't cache past-dated value" guard
+    // never kicks in regardless of when the test runs.
     const periodEndUnix = Math.floor(
-      new Date("2026-05-01T00:00:00Z").getTime() / 1000,
+      new Date("2099-05-01T00:00:00Z").getTime() / 1000,
     );
 
     stripeMocks.subscriptionsRetrieve.mockResolvedValueOnce({
-      latest_invoice: "inv_abc123",
-    });
-    stripeMocks.invoicesRetrieve.mockResolvedValueOnce({
-      period_end: periodEndUnix,
+      items: { data: [{ current_period_end: periodEndUnix }] },
     });
 
     const result = await getOrgBillingPeriod(orgId);
 
     if (!result) throw new Error("expected result to be non-null");
-    expect(result.end).toEqual(new Date("2026-05-01T00:00:00Z"));
+    expect(result.end).toEqual(new Date("2099-05-01T00:00:00Z"));
 
     // Start should be 1 month before end
-    const expectedStart = new Date("2026-04-01T00:00:00Z");
+    const expectedStart = new Date("2099-04-01T00:00:00Z");
     expect(result.start).toEqual(expectedStart);
 
     // Verify Stripe was called with the correct subscription ID
     expect(stripeMocks.subscriptionsRetrieve).toHaveBeenCalledWith(subId);
-    expect(stripeMocks.invoicesRetrieve).toHaveBeenCalledWith("inv_abc123");
+    // invoices.retrieve MUST NOT be called — the subscription item carries
+    // the period end directly, which eliminates an unnecessary round trip.
+    expect(stripeMocks.invoicesRetrieve).not.toHaveBeenCalled();
   });
 
   it("returns null for free tier org without subscription", async () => {
@@ -167,7 +168,7 @@ describe("getOrgBillingPeriod", () => {
     expect(stripeMocks.subscriptionsRetrieve).not.toHaveBeenCalled();
   });
 
-  it("returns null when subscription has no latest_invoice", async () => {
+  it("returns null when subscription has no items with current_period_end", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("org");
     mockClerk({ userId });
@@ -181,12 +182,45 @@ describe("getOrgBillingPeriod", () => {
     });
 
     stripeMocks.subscriptionsRetrieve.mockResolvedValueOnce({
-      latest_invoice: null,
+      items: { data: [] },
     });
 
     const result = await getOrgBillingPeriod(orgId);
 
     expect(result).toBeNull();
+  });
+
+  it("returns null and does NOT cache when refreshed periodEnd is still in the past", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    const subId = uniqueId("sub");
+    const stalePeriodEnd = new Date("2020-01-01T00:00:00Z"); // stale cached value
+
+    await updateOrgStripeFields(orgId, {
+      stripeSubscriptionId: subId,
+      stripeCustomerId: uniqueId("cus"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: stalePeriodEnd,
+    });
+
+    // Stripe returns a past-dated value (simulates data corruption or field
+    // confusion). Without the defensive guard this would persist the bad
+    // value and cause an infinite refresh loop on every subsequent call.
+    const pastPeriodEndUnix = Math.floor(
+      new Date("2020-02-01T00:00:00Z").getTime() / 1000,
+    );
+
+    stripeMocks.subscriptionsRetrieve.mockResolvedValueOnce({
+      items: { data: [{ current_period_end: pastPeriodEndUnix }] },
+    });
+
+    const result = await getOrgBillingPeriod(orgId);
+
+    expect(result).toBeNull();
+    expect(stripeMocks.subscriptionsRetrieve).toHaveBeenCalledTimes(1);
   });
 
   it("refreshes from Stripe when currentPeriodEnd is in the past", async () => {
@@ -196,7 +230,7 @@ describe("getOrgBillingPeriod", () => {
     const { id: orgId } = await createTestOrg(slug);
 
     const subId = uniqueId("sub");
-    const stalePeriodEnd = new Date("2026-03-01T00:00:00Z"); // past date
+    const stalePeriodEnd = new Date("2020-03-01T00:00:00Z"); // past date
 
     await updateOrgStripeFields(orgId, {
       stripeSubscriptionId: subId,
@@ -210,10 +244,7 @@ describe("getOrgBillingPeriod", () => {
     );
 
     stripeMocks.subscriptionsRetrieve.mockResolvedValueOnce({
-      latest_invoice: "inv_fresh123",
-    });
-    stripeMocks.invoicesRetrieve.mockResolvedValueOnce({
-      period_end: newPeriodEndUnix,
+      items: { data: [{ current_period_end: newPeriodEndUnix }] },
     });
 
     const result = await getOrgBillingPeriod(orgId);
@@ -221,7 +252,8 @@ describe("getOrgBillingPeriod", () => {
     if (!result) throw new Error("expected result to be non-null");
     expect(result.end).toEqual(new Date("2099-04-01T00:00:00Z"));
     expect(stripeMocks.subscriptionsRetrieve).toHaveBeenCalledWith(subId);
-    expect(stripeMocks.invoicesRetrieve).toHaveBeenCalledWith("inv_fresh123");
+    // invoices.retrieve MUST NOT be called anymore
+    expect(stripeMocks.invoicesRetrieve).not.toHaveBeenCalled();
   });
 
   it("uses cached value when currentPeriodEnd is in the future", async () => {
@@ -230,7 +262,7 @@ describe("getOrgBillingPeriod", () => {
     mockClerk({ userId });
     const { id: orgId } = await createTestOrg(slug);
 
-    const futurePeriodEnd = new Date("2026-05-01T00:00:00Z"); // future date
+    const futurePeriodEnd = new Date("2099-05-01T00:00:00Z"); // future date
 
     await updateOrgStripeFields(orgId, {
       stripeSubscriptionId: uniqueId("sub"),
@@ -268,10 +300,7 @@ describe("getOrgBillingPeriod", () => {
     );
 
     stripeMocks.subscriptionsRetrieve.mockResolvedValueOnce({
-      latest_invoice: "inv_cache_test",
-    });
-    stripeMocks.invoicesRetrieve.mockResolvedValueOnce({
-      period_end: periodEndUnix,
+      items: { data: [{ current_period_end: periodEndUnix }] },
     });
 
     // First call — fetches from Stripe and writes back to DB

--- a/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
+++ b/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
@@ -62,8 +62,13 @@ export async function getOrgBillingPeriod(
   const now = new Date();
   if ((!periodEnd || periodEnd < now) && orgRow?.stripeSubscriptionId) {
     // Has subscription but period is missing or expired — fetch from Stripe.
-    // In Stripe v2025 API, current_period_end was removed from Subscription.
-    // Use the latest_invoice.period_end instead.
+    // In Stripe v2025 API, current_period_end was removed from the top-level
+    // Subscription object. The replacement is subscription.items.data[i].
+    // current_period_end — the end time of the subscription item's current
+    // billing period. (Do NOT read invoice.period_end — that field is the
+    // accrual period for the invoice, not the subscription period, and for
+    // renewal invoices collapses to the invoice creation moment, which
+    // would cause this function to re-fetch Stripe on every call.)
     if (periodEnd && periodEnd < now) {
       log.warn("currentPeriodEnd is stale, refreshing from Stripe", {
         orgId,
@@ -74,13 +79,23 @@ export async function getOrgBillingPeriod(
     const subscription = await stripe.subscriptions.retrieve(
       orgRow.stripeSubscriptionId,
     );
-    if (subscription.latest_invoice) {
-      const invoiceId =
-        typeof subscription.latest_invoice === "string"
-          ? subscription.latest_invoice
-          : subscription.latest_invoice.id;
-      const latestInvoice = await stripe.invoices.retrieve(invoiceId);
-      periodEnd = new Date(latestInvoice.period_end * 1000);
+    const itemPeriodEnd = subscription.items.data[0]?.current_period_end;
+    if (itemPeriodEnd) {
+      const refreshed = new Date(itemPeriodEnd * 1000);
+
+      // Defensive: don't cache a past-dated period. If Stripe somehow gives
+      // us a stale value, or a future code change reintroduces field
+      // confusion, this guard prevents an infinite "refresh from Stripe"
+      // loop on every call.
+      if (refreshed < now) {
+        log.debug("refreshed periodEnd still in past, not caching", {
+          orgId,
+          periodEnd: refreshed,
+        });
+        return null;
+      }
+
+      periodEnd = refreshed;
 
       // Update org_metadata so future lookups skip Stripe
       await db

--- a/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
+++ b/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
@@ -83,13 +83,16 @@ export async function getOrgBillingPeriod(
     if (itemPeriodEnd) {
       const refreshed = new Date(itemPeriodEnd * 1000);
 
-      // Defensive: don't cache a past-dated period. If Stripe somehow gives
-      // us a stale value, or a future code change reintroduces field
-      // confusion, this guard prevents an infinite "refresh from Stripe"
-      // loop on every call.
+      // Don't cache a past-dated period. If Stripe returns a past-dated
+      // current_period_end for a subscription we believe is active, something
+      // is wrong (stale Stripe data, field confusion from a future code
+      // change, or an orphaned subscription). Log at warn so Axiom surfaces
+      // it and return null without caching — caching the bad value would
+      // cause an infinite "refresh from Stripe" loop on every call.
       if (refreshed < now) {
-        log.debug("refreshed periodEnd still in past, not caching", {
+        log.warn("refreshed periodEnd still in past, not caching", {
           orgId,
+          stripeSubscriptionId: orgRow.stripeSubscriptionId,
           periodEnd: refreshed,
         });
         return null;

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -109,7 +109,8 @@
     "apps/web/scripts/migrations/001-backfill-clerk-orgs/**",
     "apps/web/scripts/migrations/002-backfill-clerk-metadata/**",
     "apps/web/scripts/migrations/003-sync-clerk-slugs/**",
-    "apps/web/scripts/migrations/004-backfill-default-agent/**"
+    "apps/web/scripts/migrations/004-backfill-default-agent/**",
+    "apps/web/scripts/migrations/007-backfill-current-period-end/**"
   ],
   "ignoreDependencies": ["@commitlint/cli", "@vm0/firewalls-generator"],
   "ignoreWorkspaces": [],


### PR DESCRIPTION
## Summary

Fixes #9777.

`handleInvoicePaid` was writing `invoice.period_end` into `org_metadata.current_period_end`. That Stripe field is the invoice's accrual period — for a subscription renewal invoice, it collapses to the invoice creation moment, not the next renewal date. As a result, `currentPeriodEnd` was persisted as a stale timestamp on every renewal, producing an infinite "currentPeriodEnd is stale, refreshing from Stripe" log loop on every `getOrgBillingPeriod` call (~4k warnings over 7 days for a single org in prod).

**Code changes:**
- `billing-service.ts` `handleInvoicePaid` — read `period.end` from the invoice's subscription line item (`parent.type === "subscription_item_details"`) instead of the top-level `invoice.period_end`.
- `billing-service.ts` `handleCheckoutCompleted` — read `subscription.items.data[0].current_period_end` directly instead of fetching the latest invoice, eliminating one Stripe API call per checkout.
- `org-metadata-service.ts` `getOrgBillingPeriod` — same direct-from-subscription-item read (also eliminates a Stripe call); adds a defensive "don't cache past-dated period" guard so any future field confusion can't cascade into an infinite refresh loop.
- Updated misleading comments that pointed at the wrong field.
- New backfill script at `scripts/migrations/007-backfill-current-period-end/` reconciles every paying org's `current_period_end` against Stripe.

**Tests:**
- Updated existing `getOrgBillingPeriod` and `stripe/__tests__/route.test.ts` tests to use the new Stripe shape (`subscription.items[].current_period_end` and invoice `lines.data[].period.end`).
- Added `#9777` regression test that constructs an invoice where the top-level `period_end` and the subscription line's `period.end` point to different dates and asserts `currentPeriodEnd` is persisted as the subscription-line value.
- Added test asserting the new defensive guard: if Stripe returns a past-dated `current_period_end`, we return `null` and do NOT cache.

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/zero/org/__tests__/org-metadata-service.test.ts app/api/webhooks/stripe/__tests__/route.test.ts` — 35/35 pass
- [x] `pnpm -F web exec vitest run src/lib/zero/billing/__tests__/auto-recharge-service.test.ts` — 14/14 pass
- [x] Full web suite: `pnpm -F web exec vitest run` — 3201/3201 pass, 280/280 files
- [x] `pnpm check-types` (only pre-existing `.next/dev/types/validator.ts` TS2307s remain, unrelated to this change)
- [x] `pnpm -F web lint` — 0 errors
- [x] `pnpm knip` — clean
- [ ] After merge: run `tsx scripts/migrations/007-backfill-current-period-end/backfill.ts` in dry-run on prod, then with `--migrate`.
- [ ] After backfill: verify `currentPeriodEnd is stale` warnings drop to zero in Axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)