### PR TITLE
fix(slack): use after() callback form so nested dispatch runs

### DIFF
--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -1160,4 +1160,141 @@ describe("POST /api/zero/slack/events", () => {
       expect(await countSlackOrgConnections(workspaceId)).toBe(0);
     });
   });
+
+  // Regression: createZeroRun schedules its Phase 2 dispatch via a nested
+  // after() inside handleOrgMention/handleOrgDirectMessage. If the route
+  // registers the outer after() with an already-started promise, the nested
+  // after() is scheduled after the Next.js request context has been finalized
+  // and Phase 2 dispatch never runs — runs remain Pending forever.
+  describe("after() callback form (nested-after propagation)", () => {
+    it("registers app_mention handler via callback form", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_mention",
+          user: "U-random",
+          text: "Hello",
+          ts: uniqueId("ts"),
+          channel: "C-test",
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      await POST(request);
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
+
+    it("registers direct_message handler via callback form", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "message",
+          channel_type: "im",
+          user: "U-random",
+          text: "Hello",
+          ts: uniqueId("ts"),
+          channel: "D-test",
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      await POST(request);
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
+
+    it("registers app_home_opened (home) handler via callback form", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_home_opened",
+          user: "U-random",
+          tab: "home",
+          channel: "D-test",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      await POST(request);
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
+
+    it("registers app_home_opened (messages) handler via callback form", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_home_opened",
+          user: "U-random",
+          tab: "messages",
+          channel: "D-test",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      await POST(request);
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
+
+    it("registers app_uninstalled cleanup via callback form", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: { type: "app_uninstalled" },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      await POST(request);
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
+
+    it("registers tokens_revoked cleanup via callback form", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "tokens_revoked",
+          tokens: { bot: ["xoxb-revoked"] },
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      await POST(request);
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
+  });
 });

--- a/turbo/apps/web/app/api/zero/slack/events/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/route.ts
@@ -89,8 +89,8 @@ function handleEventCallback(payload: SlackEventCallback) {
 
   if (event.type === "app_mention") {
     initServices();
-    after(
-      handleOrgMention({
+    after(() => {
+      return handleOrgMention({
         workspaceId: payload.team_id,
         channelId: event.channel,
         channelType: event.channel_type,
@@ -101,8 +101,8 @@ function handleEventCallback(payload: SlackEventCallback) {
         files: event.files,
       }).catch((error) => {
         log.error("Error handling org app_mention", { error });
-      }),
-    );
+      });
+    });
   }
 
   if (
@@ -112,8 +112,8 @@ function handleEventCallback(payload: SlackEventCallback) {
     !event.bot_id
   ) {
     initServices();
-    after(
-      handleOrgDirectMessage({
+    after(() => {
+      return handleOrgDirectMessage({
         workspaceId: payload.team_id,
         channelId: event.channel,
         userId: event.user,
@@ -123,42 +123,42 @@ function handleEventCallback(payload: SlackEventCallback) {
         threadTs: event.thread_ts,
       }).catch((error) => {
         log.error("Error handling org direct_message", { error });
-      }),
-    );
+      });
+    });
   }
 
   if (event.type === "app_home_opened" && event.tab === "home") {
     initServices();
-    after(
-      handleOrgAppHomeOpened({
+    after(() => {
+      return handleOrgAppHomeOpened({
         workspaceId: payload.team_id,
         userId: event.user,
       }).catch((error) => {
         log.error("Error handling org app_home_opened", { error });
-      }),
-    );
+      });
+    });
   }
 
   if (event.type === "app_home_opened" && event.tab === "messages") {
     initServices();
-    after(
-      handleOrgMessagesTabOpened({
+    after(() => {
+      return handleOrgMessagesTabOpened({
         workspaceId: payload.team_id,
         userId: event.user,
         channelId: event.channel,
       }).catch((error) => {
         log.error("Error handling org messages_tab_opened", { error });
-      }),
-    );
+      });
+    });
   }
 
   if (event.type === "app_uninstalled") {
     initServices();
-    after(
-      cleanupWorkspaceInstallation(payload.team_id).catch((error) => {
+    after(() => {
+      return cleanupWorkspaceInstallation(payload.team_id).catch((error) => {
         log.error("Error handling app_uninstalled", { error });
-      }),
-    );
+      });
+    });
   }
 
   if (
@@ -167,11 +167,11 @@ function handleEventCallback(payload: SlackEventCallback) {
     event.tokens.bot.length > 0
   ) {
     initServices();
-    after(
-      cleanupWorkspaceInstallation(payload.team_id).catch((error) => {
+    after(() => {
+      return cleanupWorkspaceInstallation(payload.team_id).catch((error) => {
         log.error("Error handling tokens_revoked", { error });
-      }),
-    );
+      });
+    });
   }
 }
 

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -66,6 +66,7 @@ const resetEnv = vi.hoisted(() => {
     );
     // Initialize Next.js after() callback queue (shared with test-helpers.ts flushAfter)
     globalThis.nextAfterCallbacks = [];
+    globalThis.nextAfterArgForms = [];
   };
   fn(); // Initial call before imports
   return fn;
@@ -89,8 +90,10 @@ vi.mock("next/server", async (importOriginal) => {
     ...original,
     after: (fnOrPromise: (() => Promise<unknown>) | Promise<unknown>) => {
       if (typeof fnOrPromise === "function") {
+        globalThis.nextAfterArgForms.push("fn");
         globalThis.nextAfterCallbacks.push(fnOrPromise);
       } else {
+        globalThis.nextAfterArgForms.push("promise");
         // Wrap promise in a function for consistent handling in flushAfter()
         globalThis.nextAfterCallbacks.push(() => {
           return fnOrPromise;
@@ -293,6 +296,7 @@ beforeEach(() => {
   resetEnv();
   reloadEnv();
   globalThis.nextAfterCallbacks = [];
+  globalThis.nextAfterArgForms = [];
 });
 
 afterEach(() => {

--- a/turbo/apps/web/src/types/global.d.ts
+++ b/turbo/apps/web/src/types/global.d.ts
@@ -24,4 +24,10 @@ declare global {
   var services: Services;
   // Captured Next.js after() callbacks for test assertions (see setup.ts)
   var nextAfterCallbacks: Array<() => Promise<unknown>>;
+  // Per-call record of the after() argument form: "fn" when called with a
+  // callback, "promise" when called with an already-started promise. Callback
+  // form is required for nested after() to propagate the Next.js request
+  // context — promise form defers a chain that may register nested after()
+  // calls after the context has been finalized.
+  var nextAfterArgForms: Array<"fn" | "promise">;
 }


### PR DESCRIPTION
## Summary

- Slack's `/api/zero/slack/events` route wrapped its handlers in `after(handlerPromise.catch(...))`, which invokes the handler synchronously and passes a running promise to `after()`.
- After #9739 moved `createZeroRun`'s Phase 2 dispatch to its own nested `after()` call, that nested call now fires from inside an already-executing promise — the Next.js request-scoped `after()` context can be finalized before the nested registration lands, so Phase 2 never runs and Slack runs stay in `Pending`.
- Web (`/api/zero/runs`) and Telegram aren't affected because they either `await createZeroRun` directly or use the callback form `after(() => handler())`.

## Fix

Switch every handler in `slack/events/route.ts` (mention, DM, home/messages tabs, uninstall, tokens-revoked) to the callback form `after(() => handler())`. Next.js runs the callback in a live request context, and the nested `after()` scheduled by `createZeroRun` drains normally.

## Test plan

- [x] New regression suite in `slack/events/__tests__/route.test.ts` records the argument form passed to the mocked `after()` via `globalThis.nextAfterArgForms` and asserts callback form for each event type.
- [x] Temporarily reverted the fix locally — the two new assertions correctly failed with `["promise"]` vs expected `["fn"]`.
- [x] `pnpm turbo run lint --filter=web`
- [x] `pnpm knip --workspace web`
- [x] `pnpm -F web exec vitest run app/api/zero/slack/events` (39/39 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)