### PR TITLE
fix(web): scale slack icon on use-cases pages to match intended size

### DIFF
--- a/turbo/apps/web/app/[locale]/use-cases/UseCasesGalleryClient.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/UseCasesGalleryClient.tsx
@@ -43,7 +43,7 @@ function ConnectorIcon({ connector }: { connector: ConnectorRef }) {
   if (!connector.icon) return null;
   return (
     <div
-      className="flex items-center justify-center rounded-[6px] bg-white p-1"
+      className="flex items-center justify-center overflow-hidden rounded-[6px] bg-white p-1"
       style={{ width: 32, height: 32 }}
       title={connector.label}
     >
@@ -52,7 +52,7 @@ function ConnectorIcon({ connector }: { connector: ConnectorRef }) {
         alt={connector.label}
         width={20}
         height={20}
-        className={`object-contain${connector.dark ? " landing-icon-invert" : ""}`}
+        className={`object-contain${connector.dark ? " landing-icon-invert" : ""}${connector.looseViewBox ? " scale-[2.2]" : ""}`}
       />
     </div>
   );

--- a/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
@@ -237,13 +237,15 @@ export default function UseCaseDetailClient({ useCase }: { useCase: UseCase }) {
                 return (
                   <div key={i} className="uc-integration">
                     {integration.connector.icon ? (
-                      <Image
-                        src={integration.connector.icon}
-                        alt={integration.connector.label}
-                        width={32}
-                        height={32}
-                        className={`uc-integration-icon${integration.connector.dark ? " landing-icon-invert" : ""}${integration.connector.looseViewBox ? " scale-[2.2]" : ""}`}
-                      />
+                      <div className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden">
+                        <Image
+                          src={integration.connector.icon}
+                          alt={integration.connector.label}
+                          width={32}
+                          height={32}
+                          className={`uc-integration-icon${integration.connector.dark ? " landing-icon-invert" : ""}${integration.connector.looseViewBox ? " scale-[2.2]" : ""}`}
+                        />
+                      </div>
                     ) : (
                       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[hsl(var(--gray-100))] text-sm font-medium text-[hsl(var(--muted-foreground))]">
                         {integration.connector.label[0]}

--- a/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
@@ -19,13 +19,16 @@ interface PromptVariant {
 function ConnectorBadge({ connector }: { connector: ConnectorRef }) {
   if (!connector.icon) return null;
   return (
-    <span className="uc-connector-badge" title={connector.label}>
+    <span
+      className="uc-connector-badge overflow-hidden"
+      title={connector.label}
+    >
       <Image
         src={connector.icon}
         alt={connector.label}
         width={20}
         height={20}
-        className={`uc-connector-icon${connector.dark ? " landing-icon-invert" : ""}`}
+        className={`uc-connector-icon${connector.dark ? " landing-icon-invert" : ""}${connector.looseViewBox ? " scale-[2.2]" : ""}`}
       />
     </span>
   );
@@ -239,7 +242,7 @@ export default function UseCaseDetailClient({ useCase }: { useCase: UseCase }) {
                         alt={integration.connector.label}
                         width={32}
                         height={32}
-                        className={`uc-integration-icon${integration.connector.dark ? " landing-icon-invert" : ""}`}
+                        className={`uc-integration-icon${integration.connector.dark ? " landing-icon-invert" : ""}${integration.connector.looseViewBox ? " scale-[2.2]" : ""}`}
                       />
                     ) : (
                       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[hsl(var(--gray-100))] text-sm font-medium text-[hsl(var(--muted-foreground))]">

--- a/turbo/apps/web/app/[locale]/use-cases/data.ts
+++ b/turbo/apps/web/app/[locale]/use-cases/data.ts
@@ -12,6 +12,10 @@ export interface ConnectorRef {
   darkIcon?: string;
   /** true when the icon SVG is dark-coloured and needs inversion in dark mode */
   dark?: boolean;
+  /** true when the icon SVG's artwork only fills a fraction of its viewBox
+   *  (e.g. the official Slack Mark's 270×270 viewBox with artwork centred in
+   *  ~45%). The renderer scales the <img> up to compensate. */
+  looseViewBox?: boolean;
 }
 
 export interface IntegrationData {
@@ -55,6 +59,7 @@ const SLACK: ConnectorRef = {
   id: "slack",
   label: "Slack",
   icon: "/assets/mockup/slack.svg",
+  looseViewBox: true,
 };
 
 const SENTRY: ConnectorRef = {


### PR DESCRIPTION
## Summary

Slack's icon on `/en/use-cases` and `/en/use-cases/:slug` renders visibly tiny next to the other connector logos after the official Slack Mark swap in #9780 — the official SVG uses a 270×270 viewBox whose artwork only fills ~45% of the canvas, so at 20×20 / 32×32 fixed img slots the visible mark drops to ~9–14px.

- Add `looseViewBox?: boolean` to `ConnectorRef` (`data.ts`) and mark `SLACK` with it.
- In the three render sites (`UseCasesGalleryClient.ConnectorIcon`, `UseCaseDetailClient.ConnectorBadge`, integrations row), add `overflow-hidden` on the outer slot and apply `scale-[2.2]` to the `<Image>` when `looseViewBox` is set.

Scales the Slack mark back to the intended visible size without touching other connectors or the shared SVG.

## Test plan

- [ ] `/en/use-cases` — confirm Slack mark in the connector strip matches the size of neighbouring logos (Sentry, GitHub, etc.)
- [ ] `/en/use-cases/<any-slug-with-slack>` — confirm the hero connector badges and the Integrations section render Slack at parity with other icons
- [ ] Verify no clipping on the rounded `bg-white` chip around the gallery icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)