### PR TITLE
feat(cli): show connection status in zero connector search output

### DIFF
--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
@@ -16,6 +16,31 @@ import chalk from "chalk";
 const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
 const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
 
+const connectedGithub = {
+  id: "1",
+  type: "github",
+  authMethod: "oauth",
+  externalId: "12345",
+  externalUsername: "octocat",
+  externalEmail: "octocat@github.com",
+  oauthScopes: ["repo", "project", "workflow"],
+  needsReconnect: false,
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-01T00:00:00Z",
+};
+
+function stubConnectors(connectors: Array<Record<string, unknown>>) {
+  return http.get("http://localhost:3000/api/zero/connectors", () => {
+    return HttpResponse.json({
+      connectors,
+      configuredTypes: connectors.map((c) => {
+        return c.type as string;
+      }),
+      connectorProvidedSecretNames: [],
+    });
+  });
+}
+
 function stubAgent(id: string, displayName: string | null) {
   return http.get(`http://localhost:3000/api/zero/agents/${id}`, () => {
     return HttpResponse.json({
@@ -95,6 +120,8 @@ describe("zero connector search command", () => {
       expect(output).not.toContain("No exact match");
       expect(output).not.toContain("Too many results");
       expect(output).not.toContain("AUTHORIZED FOR");
+      expect(output).not.toContain("LABEL");
+      expect(output).toContain("CONNECTED AS");
 
       const dataRows = findDataRows(lines);
       expect(dataRows[0]).toMatch(/^github\s/);
@@ -267,6 +294,73 @@ describe("zero connector search command", () => {
       const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
       expect(output).toContain("AUTHORIZED FOR from-flag");
       expect(output).not.toContain(ALT_AGENT_UUID);
+    });
+  });
+
+  describe("CONNECTED AS column", () => {
+    it("renders @username for a connected type", async () => {
+      server.use(stubConnectors([connectedGithub]));
+
+      await searchCommand.parseAsync(["node", "cli", "github"]);
+
+      const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
+      expect(output).toContain("CONNECTED AS");
+      expect(output).not.toContain("LABEL");
+      expect(output).toContain("@octocat");
+    });
+
+    it("renders (not connected) for a type with no connector", async () => {
+      server.use(stubConnectors([]));
+
+      await searchCommand.parseAsync(["node", "cli", "github"]);
+
+      const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
+      expect(output).toContain("(not connected)");
+    });
+
+    it("renders reconnect-needed state", async () => {
+      server.use(
+        stubConnectors([{ ...connectedGithub, needsReconnect: true }]),
+      );
+
+      await searchCommand.parseAsync(["node", "cli", "github"]);
+
+      const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
+      expect(output).toContain("@octocat (reconnect needed)");
+    });
+
+    it("renders permissions-update-available when oauth scopes are insufficient", async () => {
+      server.use(
+        stubConnectors([{ ...connectedGithub, oauthScopes: ["repo"] }]),
+      );
+
+      await searchCommand.parseAsync(["node", "cli", "github"]);
+
+      const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
+      expect(output).toContain("(permissions update available)");
+    });
+  });
+
+  describe("error handling", () => {
+    it("surfaces auth errors from listZeroConnectors", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json(
+            {
+              error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await searchCommand.parseAsync(["node", "cli", "github"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
     });
   });
 });

--- a/turbo/apps/cli/src/commands/zero/connector/connected-as.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/connected-as.ts
@@ -1,0 +1,38 @@
+import chalk from "chalk";
+import { hasRequiredScopes, type ConnectorListResponse } from "@vm0/core";
+
+type Connector = ConnectorListResponse["connectors"][number];
+
+function renderIdentity(connector: Connector): string {
+  if (connector.externalUsername) return `@${connector.externalUsername}`;
+  if (connector.externalEmail) return connector.externalEmail;
+  return "-";
+}
+
+export function renderConnectedAsCell(
+  connector: Connector | undefined,
+): string {
+  if (!connector) return chalk.dim("(not connected)");
+  const identity = renderIdentity(connector);
+  if (connector.needsReconnect) {
+    return chalk.yellow(`${identity} (reconnect needed)`);
+  }
+  const scopeMismatch =
+    connector.authMethod === "oauth" &&
+    !hasRequiredScopes(connector.type, connector.oauthScopes);
+  if (scopeMismatch) {
+    return chalk.yellow(`${identity} (permissions update available)`);
+  }
+  return identity;
+}
+
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_PATTERN, "");
+}
+
+export function padEndAnsi(s: string, width: number): string {
+  const visible = stripAnsi(s).length;
+  return s + " ".repeat(Math.max(0, width - visible));
+}

--- a/turbo/apps/cli/src/commands/zero/connector/list.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/list.ts
@@ -2,49 +2,14 @@ import { Command } from "commander";
 import chalk from "chalk";
 import {
   CONNECTOR_TYPES,
-  hasRequiredScopes,
   isFeatureEnabled,
-  type ConnectorListResponse,
   type ConnectorType,
 } from "@vm0/core";
 import { listZeroConnectors } from "../../../lib/api";
 import { getActiveOrg } from "../../../lib/api/config";
 import { withErrorHandler } from "../../../lib/command";
 import { resolveAgentContext } from "./agent-context";
-
-type Connector = ConnectorListResponse["connectors"][number];
-
-function renderIdentity(connector: Connector): string {
-  if (connector.externalUsername) return `@${connector.externalUsername}`;
-  if (connector.externalEmail) return connector.externalEmail;
-  return "-";
-}
-
-function renderConnectedAsCell(connector: Connector | undefined): string {
-  if (!connector) return chalk.dim("(not connected)");
-  const identity = renderIdentity(connector);
-  if (connector.needsReconnect) {
-    return chalk.yellow(`${identity} (reconnect needed)`);
-  }
-  const scopeMismatch =
-    connector.authMethod === "oauth" &&
-    !hasRequiredScopes(connector.type, connector.oauthScopes);
-  if (scopeMismatch) {
-    return chalk.yellow(`${identity} (permissions update available)`);
-  }
-  return identity;
-}
-
-const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
-
-function stripAnsi(s: string): string {
-  return s.replace(ANSI_PATTERN, "");
-}
-
-function padEndAnsi(s: string, width: number): string {
-  const visible = stripAnsi(s).length;
-  return s + " ".repeat(Math.max(0, width - visible));
-}
+import { padEndAnsi, renderConnectedAsCell, stripAnsi } from "./connected-as";
 
 export const listCommand = new Command()
   .name("list")

--- a/turbo/apps/cli/src/commands/zero/connector/search.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/search.ts
@@ -6,22 +6,14 @@ import {
   searchConnectors,
   type ConnectorType,
 } from "@vm0/core";
+import { listZeroConnectors } from "../../../lib/api";
 import { getActiveOrg } from "../../../lib/api/config";
 import { withErrorHandler } from "../../../lib/command";
 import { resolveAgentContext } from "./agent-context";
+import { padEndAnsi, renderConnectedAsCell, stripAnsi } from "./connected-as";
 
 const DEFAULT_LIMIT = 5;
 const EXACT_MATCH_THRESHOLD = 80;
-const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
-
-function stripAnsi(s: string): string {
-  return s.replace(ANSI_PATTERN, "");
-}
-
-function padEndAnsi(s: string, width: number): string {
-  const visible = stripAnsi(s).length;
-  return s + " ".repeat(Math.max(0, width - visible));
-}
 
 function parseLimit(raw: string): number {
   const n = Number.parseInt(raw, 10);
@@ -50,10 +42,16 @@ export const searchCommand = new Command()
           throw new Error("Keyword cannot be empty.");
         }
 
-        const [orgId, agentCtx] = await Promise.all([
+        const [{ connectors }, orgId, agentCtx] = await Promise.all([
+          listZeroConnectors(),
           getActiveOrg(),
           resolveAgentContext(options.agent),
         ]);
+        const connectedMap = new Map(
+          connectors.map((c) => {
+            return [c.type, c];
+          }),
+        );
 
         const isTypeAvailable = (type: ConnectorType): boolean => {
           const config = CONNECTOR_TYPES[type];
@@ -82,34 +80,39 @@ export const searchCommand = new Command()
         }
 
         const typeHeader = "TYPE";
-        const labelHeader = "LABEL";
+        const connectedAsHeader = "CONNECTED AS";
+
+        const connectedCells = results.map((r) => {
+          return renderConnectedAsCell(connectedMap.get(r.type));
+        });
+
         const typeWidth = Math.max(
           typeHeader.length,
           ...results.map((r) => {
             return r.type.length;
           }),
         );
-        const labelWidth = Math.max(
-          labelHeader.length,
-          ...results.map((r) => {
-            return CONNECTOR_TYPES[r.type].label.length;
+        const connectedAsWidth = Math.max(
+          connectedAsHeader.length,
+          ...connectedCells.map((c) => {
+            return stripAnsi(c).length;
           }),
         );
 
         const headerParts = [
           typeHeader.padEnd(typeWidth),
-          labelHeader.padEnd(labelWidth),
+          connectedAsHeader.padEnd(connectedAsWidth),
         ];
         if (agentCtx) {
           headerParts.push(`AUTHORIZED FOR ${agentCtx.displayName}`);
         }
         console.log(chalk.dim(headerParts.join("  ")));
 
-        for (const result of results) {
-          const config = CONNECTOR_TYPES[result.type];
+        for (let i = 0; i < results.length; i++) {
+          const result = results[i]!;
           const parts = [
             result.type.padEnd(typeWidth),
-            padEndAnsi(config.label, labelWidth),
+            padEndAnsi(connectedCells[i]!, connectedAsWidth),
           ];
           if (agentCtx) {
             parts.push(


### PR DESCRIPTION
## Summary

- `zero connector search` now renders the same `CONNECTED AS` cell as `zero connector list` (account / reconnect-needed / permissions-update-available), so agents can decide whether to connect / reconnect / update permissions without running `list` or `status` as a separate step.
- Dropped the redundant `LABEL` column — human-readable identity already lives in `CONNECTED AS`.
- Extracted `renderConnectedAsCell` and the two ANSI width helpers into a new `connected-as.ts` module used by both `list.ts` and `search.ts` (no more duplication).

## Test plan

- [x] `pnpm -F @vm0/cli exec vitest run src/commands/zero/connector/__tests__/list.test.ts src/commands/zero/connector/__tests__/search.test.ts` — 28/28 pass
- [x] `pnpm -F @vm0/cli exec vitest run` — 1073/1073 pass
- [x] `pnpm turbo run lint` — green
- [x] `pnpm check-types` — green
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no new findings

Closes #9800

🤖 Generated with [Claude Code](https://claude.com/claude-code)