### PR TITLE
test: make backpressure_drops_messages deterministic

### DIFF
--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -1523,44 +1523,82 @@ async fn token_renewal_failures_fatal() {
 // Test 22: backpressure drops messages when channel is full
 // ---------------------------------------------------------------------------
 
-#[tokio::test]
+// current_thread runtime is a determinism requirement: we rely on the
+// subscriber task's synchronous inner loop (connection.rs processes a batched
+// ProtocolMessage's Vec<AblyMessage> with no await between try_send calls)
+// being uninterruptible by the consumer task. On a multi_thread runtime,
+// the consumer on another OS thread could drain the channel between two
+// try_sends, freeing permits and causing more than CAP messages to arrive.
+#[tokio::test(flavor = "current_thread")]
 async fn backpressure_drops_messages() {
+    // Deterministically exercise the try_send backpressure path: pack N
+    // messages into ONE ProtocolMessage frame. With channel capacity = 2
+    // exactly the first 2 enqueue and the rest are dropped.
+    //
+    // The oneshot gate ensures the batch is sent only after the consumer has
+    // drained the Connected event, so the channel is empty when the batch
+    // arrives (otherwise Connected would occupy one of the two slots).
+    //
+    // Scope note: this asserts the inner try_send invariant (single-frame
+    // overflow drops cleanly). The outer multi-frame "slow consumer" property
+    // follows by composition — every WS-frame processing cycle uses this same
+    // non-blocking try_send, so the subscriber cannot stall on a slow consumer.
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
     mock_token_endpoint(&http, "testKey.testId");
 
+    const BURST: usize = 20;
+    const CAP: usize = 2;
+
     let ws_port = ws.port;
+    let (gate_tx, gate_rx) = tokio::sync::oneshot::channel::<()>();
     tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
-        // Send 10 messages rapidly (channel capacity = 2, plus 1 Connected event)
-        for i in 0..10 {
-            send_message(&mut conn, "ch", &format!("msg-{i}"), serde_json::json!(i))
-                .await
-                .unwrap();
-        }
-        // Keep connection alive
+        gate_rx.await.unwrap();
+
+        let msg = ProtocolMessage {
+            action: action::MESSAGE,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-1".into()),
+            messages: Some(
+                (0..BURST)
+                    .map(|i| AblyMessage {
+                        id: Some(format!("msg-{i}")),
+                        name: Some(format!("msg-{i}")),
+                        data: Some(serde_json::json!(i)),
+                        timestamp: Some(now_ms()),
+                        ..Default::default()
+                    })
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&msg).unwrap().into(),
+        ))
+        .await
+        .unwrap();
         tokio::time::sleep(Duration::from_secs(5)).await;
     });
 
     let mut timing = TimingConfig::default();
-    timing.event_channel_capacity = 2;
+    timing.event_channel_capacity = CAP;
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
 
     assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    gate_tx.send(()).unwrap();
 
-    // Drain some messages — we may not get all 10 due to backpressure drops,
-    // but we should get at least 1 and the stream should still work
     let mut received = 0;
     while let Ok(Some(Event::Message(_))) =
         tokio::time::timeout(Duration::from_secs(2), sub.next()).await
     {
         received += 1;
     }
-    assert!(
-        (1..10).contains(&received),
-        "expected some messages dropped, got {received}/10"
+    assert_eq!(
+        received, CAP,
+        "batch of {BURST} into a cap-{CAP} channel should deliver exactly {CAP} and drop the rest, got {received}"
     );
 }
 

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -1535,14 +1535,13 @@ async fn backpressure_drops_messages() {
     // messages into ONE ProtocolMessage frame. With channel capacity = 2
     // exactly the first 2 enqueue and the rest are dropped.
     //
-    // The oneshot gate ensures the batch is sent only after the consumer has
-    // drained the Connected event, so the channel is empty when the batch
-    // arrives (otherwise Connected would occupy one of the two slots).
-    //
-    // Scope note: this asserts the inner try_send invariant (single-frame
-    // overflow drops cleanly). The outer multi-frame "slow consumer" property
-    // follows by composition — every WS-frame processing cycle uses this same
-    // non-blocking try_send, so the subscriber cannot stall on a slow consumer.
+    // Two oneshot gates order the mock's sends:
+    //   1. `batch_gate` — mock sends the burst only after the consumer has
+    //      drained the Connected event, so the channel is empty when the
+    //      burst arrives (otherwise Connected would occupy one of the two slots).
+    //   2. `sentinel_gate` — after the burst drops, mock sends one more
+    //      message. Receiving it proves the subscriber didn't stall — the
+    //      real backpressure contract is "drop when slow, don't hang".
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
     mock_token_endpoint(&http, "testKey.testId");
@@ -1551,12 +1550,16 @@ async fn backpressure_drops_messages() {
     const CAP: usize = 2;
 
     let ws_port = ws.port;
-    let (gate_tx, gate_rx) = tokio::sync::oneshot::channel::<()>();
+    let (batch_gate_tx, batch_gate_rx) = tokio::sync::oneshot::channel::<()>();
+    let (sentinel_gate_tx, sentinel_gate_rx) = tokio::sync::oneshot::channel::<()>();
     tokio::spawn(async move {
-        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
-        gate_rx.await.unwrap();
+        let mut conn = ws
+            .accept_and_handshake("ch", "conn-1")
+            .await
+            .expect("mock handshake failed");
 
-        let msg = ProtocolMessage {
+        batch_gate_rx.await.expect("batch gate sender dropped");
+        let burst = ProtocolMessage {
             action: action::MESSAGE,
             channel: Some("ch".into()),
             channel_serial: Some("serial-1".into()),
@@ -1574,11 +1577,36 @@ async fn backpressure_drops_messages() {
             ..Default::default()
         };
         conn.send(tungstenite::Message::Binary(
-            encode_msg(&msg).unwrap().into(),
+            encode_msg(&burst).expect("encode burst failed").into(),
         ))
         .await
-        .unwrap();
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        .expect("send burst failed");
+
+        sentinel_gate_rx
+            .await
+            .expect("sentinel gate sender dropped");
+        let sentinel = ProtocolMessage {
+            action: action::MESSAGE,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-2".into()),
+            messages: Some(vec![AblyMessage {
+                id: Some("sentinel".into()),
+                name: Some("sentinel".into()),
+                data: Some(serde_json::json!("alive")),
+                timestamp: Some(now_ms()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&sentinel)
+                .expect("encode sentinel failed")
+                .into(),
+        ))
+        .await
+        .expect("send sentinel failed");
+
+        std::future::pending::<()>().await;
     });
 
     let mut timing = TimingConfig::default();
@@ -1588,7 +1616,9 @@ async fn backpressure_drops_messages() {
         .unwrap();
 
     assert!(matches!(sub.next().await.unwrap(), Event::Connected));
-    gate_tx.send(()).unwrap();
+    batch_gate_tx
+        .send(())
+        .expect("subscription closed before burst");
 
     let mut received = 0;
     while let Ok(Some(Event::Message(_))) =
@@ -1598,8 +1628,20 @@ async fn backpressure_drops_messages() {
     }
     assert_eq!(
         received, CAP,
-        "batch of {BURST} into a cap-{CAP} channel should deliver exactly {CAP} and drop the rest, got {received}"
+        "batch of {BURST} into a cap-{CAP} channel should deliver exactly {CAP} and drop the rest, got {received} — if this regressed, check connection.rs message-dispatch loop is still synchronous (no .await between try_send calls)"
     );
+
+    sentinel_gate_tx
+        .send(())
+        .expect("subscription closed before sentinel");
+    let next = tokio::time::timeout(Duration::from_secs(2), sub.next())
+        .await
+        .expect("subscriber stalled after drops — backpressure recovery broken")
+        .expect("subscription closed unexpectedly");
+    match next {
+        Event::Message(m) => assert_eq!(m.name.as_deref(), Some("sentinel")),
+        other => panic!("expected sentinel Message, got {other:?}"),
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Closes #9702
- Pack N messages into a single `ProtocolMessage` frame so the synchronous inner `try_send` loop in `connection.rs:560` fills the capacity-2 channel atomically — consumer can't interleave regardless of scheduler
- Gate the batch on a `oneshot` so it's sent only after the consumer drains `Event::Connected`, otherwise `Connected` would occupy one of the two slots and `received` would be 1 instead of 2
- Pin the test to `flavor = "current_thread"` — on `multi_thread` the consumer on another OS thread could release permits mid-loop and let all 20 messages through
- **Follow-up (40b520a)**: verify backpressure *recovery* by gating a sentinel message behind a second oneshot — receiving it proves the subscriber didn't stall. Also: `.unwrap()` → `.expect(...)` in the mock task for better panic diagnostics, regression hint in the assertion message pointing at the synchronous loop it depends on, and `sleep(5s)` → `std::future::pending()` to drop the last real-time constant.

## Why the original test was flaky

It sent 10 individual WS frames and asserted `(1..10).contains(&received)`. Under fair tokio scheduling the consumer drains each frame's message as it arrives, never fills the channel, and `received == 10` → assertion fails with a misleading message.

## Why this is deterministic now

Three layers:
1. Single WS frame → `connection.rs:560` loops `try_send` with **no await** between iterations
2. `current_thread` runtime → consumer task can't preempt the subscriber mid-loop
3. `oneshot` gate → channel is guaranteed empty when the batch lands

## What's actually asserted

- **Drop semantics**: `BURST` messages into a `CAP`-slot channel delivers exactly `CAP`, drops the rest
- **Recovery**: a subsequent sentinel message is delivered — the real backpressure contract is "drop when slow, don't hang"

## Test plan

- [x] `cargo test -p ably-subscriber --test integration backpressure_drops_messages` — 50+ consecutive runs, all pass
- [x] `cargo test -p ably-subscriber --test integration` — full suite (30 tests) green
- [x] `cargo clippy -p ably-subscriber --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p ably-subscriber -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)