### PR TITLE
feat(web): add connector discovery guidance to agent system prompt

### DIFF
--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -71,6 +71,7 @@ function buildAgentToolsPrompt(): string {
     "- Slack messaging, file uploads, and file downloads: `zero slack --help`. Your replies are automatically sent to the originating thread — only use these commands for different channels/threads. Never use SLACK_TOKEN directly — it's a user OAuth token.",
     "- Download a Slack file attachment to local disk: `zero slack download-file -h` for usage and how to read different file types. Use this whenever a Slack message context includes a `[Slack file]` block.",
     "- Download a web-uploaded file to local disk: `zero web download-file -h` for usage and how to read different file types. Use this whenever a web chat message includes a `[Web file]` block.",
+    "- Third-party services (GitHub, Slack, Notion, 100+ more) are accessed via connectors that expose env vars like `GH_TOKEN`. Find: `zero connector search <keyword>`. List connected: `zero connector list`. Inspect: `zero connector status <type>`.",
     "- Diagnose connector health (token presence, firewall rules, permission policies): `zero doctor check-connector --help`.",
     "- Troubleshoot permission denials: `zero doctor permission-deny --help` to identify which permission covers a blocked request.",
     "- Request permission changes: `zero doctor permission-change --help` to enable or disable a permission.",


### PR DESCRIPTION
## Summary

- Add a new bullet to `buildAgentToolsPrompt()` in `turbo/apps/web/src/lib/zero/agent-prompt.ts` that introduces the **connector** concept and points agents at the three discovery commands (`zero connector search`, `zero connector list`, `zero connector status`).
- The new bullet is inserted **immediately before** the existing `Diagnose connector health` line; no other bullet is modified.

## Motivation

Previously the word "connector" appeared exactly once in the agent prompt (`zero doctor check-connector`). Agents had no conceptual explanation of what a connector is, no idea the platform has 100+ available, and no pointer to the discovery commands. Making discovery a first-class prompt line lets agents self-serve before guessing env var names or asking the user.

Closes #9804

## Test plan

- [x] Local diff vs. `origin/main` is exactly one added line in one file, zero deletions — verified with `git diff origin/main`.
- [x] `pnpm -F web lint` — passes (no new errors; pre-existing warnings unchanged).
- [x] `pnpm format` — no changes needed.
- [x] Pre-commit `knip` and `commitlint` hooks — green.
- [ ] CI `lint`, `check-types`, `test`, `cli-e2e`, and `deploy` jobs pass on this PR (authoritative check).