### PR TITLE
fix(platform): wait for updatedAt change when reconnecting a connector

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -107,6 +107,64 @@ describe("connectConnector$", () => {
     expect(polling).toBeNull();
   });
 
+  it("keeps polling on reconnect until updatedAt changes", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    const mockWindow = { closed: false, close: vi.fn() };
+    vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
+
+    // Existing connector with a stable updatedAt simulates the pre-reconnect
+    // state; the poll loop should not exit until the updatedAt changes.
+    const initialUpdatedAt = "2026-01-01T00:00:00.000Z";
+    const initialResponse: ConnectorListResponse = {
+      ...makeGithubConnectorResponse(),
+      connectors: [
+        {
+          ...makeGithubConnectorResponse().connectors[0],
+          oauthScopes: ["repo"],
+          createdAt: initialUpdatedAt,
+          updatedAt: initialUpdatedAt,
+        },
+      ],
+    };
+
+    let pollCount = 0;
+    const reconnectedUpdatedAt = "2026-02-01T00:00:00.000Z";
+    server.use(
+      http.get("*/api/zero/connectors", () => {
+        pollCount++;
+        // First poll captures initialUpdatedAt; second poll still shows the
+        // stale value (OAuth callback not yet complete); third poll reflects
+        // the completed reconnect with a new updatedAt.
+        if (pollCount <= 2) {
+          return HttpResponse.json(initialResponse);
+        }
+        return HttpResponse.json({
+          ...initialResponse,
+          connectors: [
+            {
+              ...initialResponse.connectors[0],
+              oauthScopes: ["repo", "project"],
+              updatedAt: reconnectedUpdatedAt,
+            },
+          ],
+        });
+      }),
+    );
+
+    const result = await context.store.set(
+      connectConnector$,
+      "github",
+      context.signal,
+    );
+
+    expect(result).toBeTruthy();
+    // One capture poll + one stale poll + one fresh poll.
+    expect(pollCount).toBeGreaterThanOrEqual(3);
+    expect(context.store.get(pollingConnectorType$)).toBeNull();
+    expect(context.store.get(permissionDialogType$)).toBe("github");
+  });
+
   it("exits when popup is closed even if connector not found", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -336,10 +336,17 @@ export const connectConnector$ = command(
       throw new Error("Failed to open authorization window");
     }
 
-    // Poll the API until the connector appears or the popup is closed.
+    // Poll the API until the connector appears (initial connect) or its
+    // updatedAt changes (reconnect), or the popup is closed.
     // The platform and OAuth callback page live on different origins
     // (app.* vs www.*), so BroadcastChannel cannot be used.
     const startTime = Date.now();
+
+    // Snapshot taken on the first poll: `null` marks "no connector yet" and
+    // an `updatedAt` value marks "reconnect scenario — wait for it to
+    // change". The snapshot must happen *inside* the loop so we start from
+    // the freshest server state, not a cached signal value.
+    let initialUpdatedAt: string | null | undefined;
 
     await setLoop(
       async (sig) => {
@@ -349,13 +356,21 @@ export const connectConnector$ = command(
           [200],
         );
         const polled = (result.body as ConnectorListResponse).connectors;
+        const current = polled.find((c) => {
+          return c.type === type;
+        });
 
-        if (
-          polled.some((c) => {
-            return c.type === type;
-          })
-        ) {
-          return true;
+        if (initialUpdatedAt === undefined) {
+          initialUpdatedAt = current?.updatedAt ?? null;
+        } else if (current) {
+          // initialUpdatedAt === null means the connector didn't exist on
+          // the first poll; any subsequent appearance signals completion.
+          if (initialUpdatedAt === null) {
+            return true;
+          }
+          if (current.updatedAt !== initialUpdatedAt) {
+            return true;
+          }
         }
 
         if (authWindow?.closed) {


### PR DESCRIPTION
## Summary

- Fixes the Connectors page showing a stale `Permissions update available` prompt after a successful reconnect. Previously the prompt only cleared after a manual page refresh.
- The OAuth poll loop in `connectConnector$` exited as soon as any connector with the given type appeared in the API response. In the reconnect flow the connector already exists, so the first poll satisfied that condition and `reloadConnectors$` ran before the backend had written the new scopes — leaving `scopeMismatch=true` in the cache.
- Now the loop snapshots the connector's `updatedAt` on the first poll and waits for it to change (or for the connector to appear, for a fresh connect) before marking the reconnect complete.

Fixes #9812

## Test plan

- [x] Added `keeps polling on reconnect until updatedAt changes` unit test covering the reconnect path.
- [x] Existing `connectConnector$` tests still pass (9/9 in `connect-connector.test.ts`).
- [x] `pnpm -F @vm0/app run check-types` passes.
- [x] `pnpm -F @vm0/app run lint` passes.
- [ ] Manual verification: on the Connectors page, click Review on a connector with `Permissions update available`, complete the reconnect, confirm the prompt clears without a page refresh.