### PR TITLE
Add AI & paid-plan disclaimer to landing page footer

### DIFF
--- a/turbo/apps/web/app/components/Footer.tsx
+++ b/turbo/apps/web/app/components/Footer.tsx
@@ -32,6 +32,17 @@ export default function Footer() {
             </div>
             <p className="footer-tagline">{t("tagline")}</p>
           </div>
+          <div className="footer-disclaimer">
+            <p className="footer-disclaimer-heading">
+              {t("aiDisclaimerHeading")}
+            </p>
+            <p className="footer-disclaimer-text">
+              {t("aiDisclaimerInaccuracy")}
+            </p>
+            <p className="footer-disclaimer-text">
+              {t("aiDisclaimerPaidPlan")}
+            </p>
+          </div>
         </div>
         <div className="footer-bottom">
           <div className="footer-left">

--- a/turbo/apps/web/app/landing.css
+++ b/turbo/apps/web/app/landing.css
@@ -551,6 +551,10 @@ body {
 }
 
 .footer-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 40px;
   margin-bottom: 40px;
 }
 
@@ -558,6 +562,29 @@ body {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  flex-shrink: 0;
+}
+
+.footer-disclaimer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 440px;
+}
+
+.footer-disclaimer-heading {
+  font-size: 13px;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+  letter-spacing: 0.02em;
+  margin: 0;
+}
+
+.footer-disclaimer-text {
+  font-size: 13px;
+  color: hsl(var(--muted-foreground));
+  line-height: 1.6;
+  margin: 0;
 }
 
 .footer-logo {
@@ -1078,6 +1105,15 @@ body {
 
   .mobile-menu-overlay {
     display: block;
+  }
+
+  .footer-content {
+    flex-direction: column;
+    gap: 32px;
+  }
+
+  .footer-disclaimer {
+    max-width: 100%;
   }
 
   .footer-bottom {

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -213,7 +213,10 @@
     "termsOfUse": "Nutzungsbedingungen",
     "privacyPolicy": "Datenschutzrichtlinie",
     "consentPreferences": "Einwilligungseinstellungen",
-    "support": "Support"
+    "support": "Support",
+    "aiDisclaimerHeading": "Bitte beachten",
+    "aiDisclaimerInaccuracy": "Zero basiert auf großen Sprachmodellen. Antworten, Zusammenfassungen und andere Ausgaben können ungenau, unvollständig oder veraltet sein — bitte überprüfen Sie wichtige Informationen, bevor Sie darauf reagieren.",
+    "aiDisclaimerPaidPlan": "Die Nutzung des KI-Agenten im Slack-App-Container erfordert einen kostenpflichtigen Slack-Tarif. @Erwähnungen und Direktnachrichten an Zero sind in allen Slack-Tarifen verfügbar."
   },
   "skills": {
     "hero": {

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -213,7 +213,10 @@
     "termsOfUse": "Terms of Use",
     "privacyPolicy": "Privacy Policy",
     "consentPreferences": "Consent Preferences",
-    "support": "Support"
+    "support": "Support",
+    "aiDisclaimerHeading": "Please note",
+    "aiDisclaimerInaccuracy": "Zero is powered by large language models. Responses, summaries, and other outputs may be inaccurate, incomplete, or outdated — please verify important information before acting on it.",
+    "aiDisclaimerPaidPlan": "Using the AI agent inside the Slack app container requires a paid Slack plan. @mentions and direct messages to Zero are available on all Slack plans."
   },
   "skills": {
     "hero": {

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -213,7 +213,10 @@
     "termsOfUse": "Términos de Uso",
     "privacyPolicy": "Política de Privacidad",
     "consentPreferences": "Preferencias de Consentimiento",
-    "support": "Soporte"
+    "support": "Soporte",
+    "aiDisclaimerHeading": "Aviso importante",
+    "aiDisclaimerInaccuracy": "Zero funciona con modelos de lenguaje de gran tamaño. Las respuestas, resúmenes y otros resultados pueden ser inexactos, incompletos o estar desactualizados — verifica la información importante antes de actuar sobre ella.",
+    "aiDisclaimerPaidPlan": "El uso del agente de IA dentro del contenedor de la aplicación de Slack requiere un plan de Slack de pago. Las @menciones y los mensajes directos a Zero están disponibles en todos los planes de Slack."
   },
   "skills": {
     "hero": {

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -213,7 +213,10 @@
     "termsOfUse": "利用規約",
     "privacyPolicy": "プライバシーポリシー",
     "consentPreferences": "同意設定",
-    "support": "サポート"
+    "support": "サポート",
+    "aiDisclaimerHeading": "ご注意ください",
+    "aiDisclaimerInaccuracy": "Zeroは大規模言語モデルを利用しています。回答、要約、その他の出力は不正確、不完全、または古い情報を含む可能性があります — 重要な情報に基づいて行動する前に必ず内容をご確認ください。",
+    "aiDisclaimerPaidPlan": "Slackアプリコンテナ内のAIエージェントの利用には、有料のSlackプランが必要です。Zeroへの@メンションおよびダイレクトメッセージは、すべてのSlackプランでご利用いただけます。"
   },
   "skills": {
     "hero": {


### PR DESCRIPTION
## Summary

Addresses two items from the Slack App Directory review feedback that require user-facing disclaimers on the landing page:

1. **LLM-inaccuracy disclaimer** — Slack requires AI-powered apps to clearly disclose to users that outputs from large language models may be inaccurate, incomplete, or outdated.
2. **Paid-plan disclaimer** — The in-container AI agent experience (`assistant:write` / `client.assistant.threads.setStatus`) is gated behind Slack's paid tiers; @mention and DM interactions are available on all plans.

Both statements are now surfaced as a persistent `Please note` block on every page that renders the shared landing-page `Footer`, placed to the right of the brand block so it is visible without extra user action.

## Changes

- `turbo/apps/web/app/components/Footer.tsx` — new `.footer-disclaimer` block rendered as a right-side sibling to `.footer-brand` inside `.footer-content`, driven by three new i18n keys.
- `turbo/apps/web/app/landing.css` — convert `.footer-content` to flex (`space-between`, `flex-start`), add `.footer-disclaimer` / `.footer-disclaimer-heading` / `.footer-disclaimer-text` styles that match the existing muted-foreground / 13px tagline-and-copyright type scale, and stack vertically below 768 px.
- `turbo/apps/web/messages/{en,de,es,ja}.json` — add `aiDisclaimerHeading`, `aiDisclaimerInaccuracy`, `aiDisclaimerPaidPlan` under the existing `footer` namespace.

## Test plan

- [ ] Build succeeds (`pnpm -C turbo/apps/web build`)
- [ ] Landing page footer renders disclaimer on desktop (brand left, disclaimer right, social icons/controls in bottom row)
- [ ] Footer stacks cleanly on mobile (< 768 px) without horizontal overflow
- [ ] Disclaimer is also visible on `/terms-of-use`, `/privacy-policy`, `/support` (they all reuse `Footer`)
- [ ] Language switcher toggles the disclaimer text correctly across en/de/es/ja
- [ ] Dark mode renders the heading and body text with adequate contrast