### PR TITLE
Drop assistant:write scope from Slack bot

### DIFF
--- a/turbo/apps/web/app/api/zero/slack/oauth/install/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/oauth/install/__tests__/route.test.ts
@@ -37,8 +37,8 @@ describe("/api/zero/slack/oauth/install", () => {
     const scopes = redirectUrl.searchParams.get("scope")!.split(",");
 
     expect(scopes).toContain("app_mentions:read");
-    expect(scopes).toContain("assistant:write");
     expect(scopes).toContain("chat:write");
+    expect(scopes).not.toContain("assistant:write");
     expect(scopes).toContain("channels:history");
     expect(scopes).toContain("im:history");
     expect(scopes).toContain("commands");

--- a/turbo/apps/web/src/lib/zero/slack-org/scopes.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/scopes.ts
@@ -7,7 +7,6 @@
  */
 export const SLACK_BOT_SCOPES: readonly string[] = [
   "app_mentions:read",
-  "assistant:write",
   "chat:write",
   "channels:read",
   "channels:history",

--- a/turbo/apps/web/src/lib/zero/slack/client.ts
+++ b/turbo/apps/web/src/lib/zero/slack/client.ts
@@ -250,7 +250,7 @@ export async function exchangeOAuthCodeForUser(
  * Shows a typing-style status below the thread (e.g. "is thinking...").
  * Pass an empty string to clear the status.
  *
- * Requires the `assistant:write` scope and "Agents & AI Apps" enabled.
+ * Per the 2026-03-05 Slack scope update, this API only requires `chat:write`.
  *
  * @param client - Slack WebClient
  * @param channel - Channel ID


### PR DESCRIPTION
## Summary
- Remove `assistant:write` from `SLACK_BOT_SCOPES` — the app only calls `assistant.threads.setStatus`, which per the [2026-03-05 scope update](https://docs.slack.dev/changelog/2026/03/05/set-status-scope-update) now requires only `chat:write` (already requested).
- Update the `setThreadStatus` comment in `slack/client.ts` to reflect the new scope requirement.
- Update the install route test to assert `assistant:write` is no longer in the requested scope list.

## Why
Slack App Review feedback (2026-04-16):
> You've added `assistant:write` without all the events needed for it to function. If you're only using this for `assistant.threads.setStatus`, this now relies on `chat:write`.

We only use `setStatus` (see `mention.ts`, `direct-message.ts`) and do not implement the full Agents/AI Apps UX (no `assistant_thread_started`, `setSuggestedPrompts`, `setTitle`, etc.), so option B — drop the scope — is the cleanest fix.

## Post-merge action
Update the Slack App manifest in the Slack admin console: **OAuth & Permissions → Bot Token Scopes** → remove `assistant:write`. Existing workspaces will trigger the "Update Permissions" reinstall flow automatically via `hasAllBotScopes`.

## Test plan
- [ ] `pnpm test` under `turbo/apps/web` — install route scope test passes
- [ ] Manual: reinstall into a test workspace, confirm @mention / DM still shows "is thinking..." status indicator
- [ ] Manual: confirm Slack admin console manifest now lists 14 scopes (was 15)