### PR TITLE
fix(nbd-cow): fsync parent directory after bitmap rename

### DIFF
--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -663,6 +663,19 @@ mod tests {
     }
 
     #[test]
+    fn bitmap_save_rejects_path_without_parent() {
+        let base = create_base_image(&vec![0x00; 4096]);
+        let cow_file = NamedTempFile::new().unwrap();
+        let cow = make_cow(&base, &cow_file, 4096, 1024 * 1024);
+
+        // `/` has no parent. The function must reject it before touching the FS
+        // so callers can't accidentally skip the parent-dir fsync durability
+        // guarantee by passing a degenerate path.
+        let err = cow.save_bitmap(Path::new("/")).unwrap_err();
+        assert!(matches!(err, NbdCowError::Io(_)), "got {err:?}");
+    }
+
+    #[test]
     fn bitmap_empty_round_trip() {
         let base = create_base_image(&vec![0x00; 4096]);
         let cow_file = NamedTempFile::new().unwrap();

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -332,10 +332,29 @@ impl CowLayer {
         for word in raw {
             data.extend_from_slice(&(*word as u64).to_le_bytes());
         }
-        // Write to a temp file, fsync, then rename for crash-safe atomicity.
-        // Without fsync, a power failure after rename could leave a corrupt bitmap
-        // (data still in page cache), which would cause dirty-block information
-        // loss on the next restore.
+        // Crash-safe bitmap swap: write tmp → fsync(tmp) → rename → fsync(dir).
+        // Two fsyncs, each covering a different guarantee:
+        //   - fsync(tmp): makes the bitmap bytes durable on the inode.
+        //   - fsync(dir): makes the rename's dir-entry update durable. Without
+        //     this, rename(2) returns after journaling the entry but the update
+        //     may not hit disk until the FS's next commit (~5s on ext4
+        //     data=ordered). A crash in that window can leave the bitmap path
+        //     pointing at the old file (or absent), while the COW data file —
+        //     already fsynced by CowLayer::sync — is durable. The resulting
+        //     bitmap/COW divergence silently corrupts reads on the next restore:
+        //     dirty bits disagree with actual COW content, reads fall through
+        //     to stale base-image bytes.
+        //
+        // Open the parent dir fd up front so a malformed path (no parent) fails
+        // before any FS mutation, and hold it across the rename so the final
+        // fsync targets a stable inode.
+        let parent = path.parent().ok_or_else(|| {
+            NbdCowError::Io(std::io::Error::other(format!(
+                "bitmap path has no parent directory: {}",
+                path.display()
+            )))
+        })?;
+        let dir_fd = File::open(parent)?;
         let tmp_path = PathBuf::from(format!("{}.tmp", path.display()));
         if let Err(e) = File::create(&tmp_path).and_then(|f| {
             f.write_all_at(&data, 0)?;
@@ -348,6 +367,7 @@ impl CowLayer {
             let _ = std::fs::remove_file(&tmp_path);
             return Err(e.into());
         }
+        dir_fd.sync_all()?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- `save_bitmap` used tmp+fsync+rename but never fsynced the parent directory, so the rename's dir-entry update could sit in the FS journal uncommitted (~5s on ext4 data=ordered)
- A crash in that window leaves the bitmap path stale while the COW data file — already durable via `CowLayer::sync` — diverges, silently corrupting reads on the next restore (dirty bits disagree with COW content)
- Open the parent directory up front (fails fast on a malformed path before any FS mutation) and `sync_all()` it after the successful rename; the single trailing fsync commits both the tmp's dir entry and the rename on any journaling FS

Closes #9794

## Test plan
- [x] `cargo test -p nbd-cow` — 45 existing unit + 2 non-ignored integration tests pass; `bitmap_save_load_round_trip` still green
- [x] `cargo clippy -p nbd-cow --all-targets` — clean
- [x] `cargo fmt -p nbd-cow` — formatted
- [ ] CI green (lint/test/deploy/cli-e2e)

Crash-window behavior is not exercised by a unit test — no practical way to simulate FS journal commit loss without a fault-injection harness. The round-trip test exercises the modified codepath end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)