### PR TITLE
perf(runner): defer best-effort telemetry past provider.complete

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2419,6 +2419,7 @@ dependencies = [
  "guest-mock-claude",
  "guest-reseed",
  "hex",
+ "httpmock",
  "nbd-cow",
  "nix",
  "reqeast",

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -51,6 +51,7 @@ guest-download = { workspace = true }
 guest-init = { workspace = true }
 guest-mock-claude = { workspace = true }
 guest-reseed = { workspace = true }
+httpmock = { workspace = true }
 sandbox-mock = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -23,6 +23,7 @@ use crate::http::HttpClient;
 use crate::idle_pool::{IdleEntry, IdlePool, IdlePoolConfig, ParkResult};
 use crate::kmsg_log;
 use crate::lock;
+use crate::network_logs;
 use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
 use crate::provider::{ApiProvider, JobProvider, LocalProvider};
@@ -1074,6 +1075,11 @@ fn spawn_job(
     let mode = ctx.mode;
     let factory_for_cleanup = Arc::clone(&factory);
 
+    // Preserve the sandbox token so the post-complete network-log upload (below)
+    // can authenticate after `context` has been moved into the executor task.
+    let sandbox_token = context.sandbox_token.clone();
+    let exec_config_for_upload = Arc::clone(&exec_config);
+
     jobs.spawn(async move {
         // Inner spawn isolates panics: if execute_job panics, the outer task
         // still reports completion and releases budget.
@@ -1095,8 +1101,8 @@ fn spawn_job(
             }
         });
 
-        let (exit_code, err, sandbox, source_ip, guest_session_id) = match inner.await {
-            Ok(outcome) => {
+        let (exit_code, err, sandbox, source_ip, guest_session_id, telemetry) = match inner.await {
+            Ok((outcome, telemetry)) => {
                 let err = if job_cancel.is_cancelled() {
                     Some("cancelled by user".to_string())
                 } else {
@@ -1108,6 +1114,7 @@ fn spawn_job(
                     outcome.sandbox,
                     outcome.source_ip,
                     outcome.guest_session_id,
+                    Some(telemetry),
                 )
             }
             Err(e) => {
@@ -1117,6 +1124,7 @@ fn spawn_job(
                     Some(format!("internal error: {e}")),
                     None,
                     String::new(),
+                    None,
                     None,
                 )
             }
@@ -1228,6 +1236,22 @@ fn spawn_job(
         if !parked {
             budget.release(vcpu, memory_mb);
         }
+
+        // Best-effort telemetry, deferred past `provider.complete` so the
+        // user-visible run-complete signal isn't blocked on these uploads.
+        // They're still awaited (not spawned) so the surrounding `jobs`
+        // JoinSet drains them on graceful shutdown — no data loss on SIGTERM.
+        if let Some(telemetry) = telemetry {
+            telemetry.flush().await;
+        }
+        let network_log_path = exec_config_for_upload.log_paths.network_log(run_id);
+        network_logs::upload_network_logs(
+            &exec_config_for_upload.http,
+            run_id,
+            &sandbox_token,
+            &network_log_path,
+        )
+        .await;
 
         Some(run_id)
     });

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1076,10 +1076,11 @@ fn spawn_job(
     let mode = ctx.mode;
     let factory_for_cleanup = Arc::clone(&factory);
 
-    // Captured for the post-complete deferred work below (telemetry flush +
-    // network-log upload). `context` gets moved into the inner executor task
-    // and `exec_config` with it, so we snapshot the token and bump the Arc
-    // before spawning.
+    // Captured for the post-complete deferred work below: the panic-arm
+    // empty `JobTelemetry` construction, the final `telemetry.flush()`, and
+    // the mitm `upload_network_logs()` POST. `context` gets moved into the
+    // inner executor task and `exec_config` with it, so we snapshot the
+    // token and bump the Arc before spawning.
     let sandbox_token = context.sandbox_token.clone();
     let exec_config_for_deferred = Arc::clone(&exec_config);
 
@@ -2244,18 +2245,28 @@ mod tests {
 
     /// Regression guard: the post-complete deferred network-log upload (moved
     /// out of `post_job_cleanup` by #9828) must still reach the telemetry
-    /// endpoint, including during graceful drain shutdown. The outer `jobs`
-    /// JoinSet must drain the `tokio::join!` in `spawn_job` — a fire-and-forget
-    /// `tokio::spawn` would silently lose this upload when the runtime drops.
+    /// endpoint, AND the drain shutdown must actually block on it — catching a
+    /// `tokio::spawn` fire-and-forget refactor that would silently lose the
+    /// upload on runtime drop.
+    ///
+    /// The mock responds with a 400 ms delay. Since the job completes almost
+    /// immediately under `MockSandboxRuntime`, `shutdown()` is invoked while
+    /// the deferred `tokio::join!(flush, upload)` is still in-flight, so a
+    /// well-behaved drain returns AFTER the mock delay elapses. A detached
+    /// upload would let shutdown return immediately — the elapsed-time
+    /// assertion below is what catches that.
     #[tokio::test]
     async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
         use httpmock::prelude::*;
+
+        const MOCK_DELAY: Duration = Duration::from_millis(400);
 
         let server = MockServer::start_async().await;
         let telemetry_mock = server
             .mock_async(|when, then| {
                 when.method(POST).path("/api/webhooks/agent/telemetry");
-                then.status(200)
+                then.delay(MOCK_DELAY)
+                    .status(200)
                     .header("content-type", "application/json")
                     .body(r#"{"success":true,"id":"ok"}"#);
             })
@@ -2285,17 +2296,28 @@ mod tests {
             .await;
         assert!(completion.is_some(), "job should complete");
 
-        // Drain shutdown — `jobs.join_next()` must wait for each `spawn_job`
-        // closure's deferred `tokio::join!(flush, upload)` before returning.
+        // Drain shutdown — must block on each `spawn_job` closure's deferred
+        // `tokio::join!(flush, upload)` via the outer `jobs` JoinSet.
+        let shutdown_start = tokio::time::Instant::now();
         shutdown(&env, run_handle).await;
+        let shutdown_elapsed = shutdown_start.elapsed();
 
-        // At least one POST: the mitm network-log upload. Also possible: a
-        // separate POST for sandbox-op telemetry (vm_create etc). Either way,
-        // the endpoint must have been hit — proving the deferred work isn't
-        // silently dropped on runtime shutdown.
+        // At least one POST: the mitm network-log upload (and likely a second
+        // for sandbox-op telemetry like `vm_create`). The endpoint must have
+        // been hit — a fire-and-forget refactor that dropped the await on
+        // runtime shutdown would fail this.
         assert!(
             telemetry_mock.calls_async().await >= 1,
             "telemetry endpoint should receive deferred post-complete upload"
+        );
+
+        // Stronger invariant: drain must actually WAIT for the deferred work.
+        // With a 400 ms mock delay, a well-behaved drain takes ≥ the delay;
+        // a detached (fire-and-forget) upload would let shutdown return in
+        // tens of ms, dropping the in-flight request on runtime teardown.
+        assert!(
+            shutdown_elapsed >= MOCK_DELAY - Duration::from_millis(50),
+            "drain must block on deferred upload (≥{MOCK_DELAY:?}); took only {shutdown_elapsed:?}",
         );
     }
 

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1076,10 +1076,12 @@ fn spawn_job(
     let mode = ctx.mode;
     let factory_for_cleanup = Arc::clone(&factory);
 
-    // Preserve the sandbox token so the post-complete network-log upload (below)
-    // can authenticate after `context` has been moved into the executor task.
+    // Captured for the post-complete deferred work below (telemetry flush +
+    // network-log upload). `context` gets moved into the inner executor task
+    // and `exec_config` with it, so we snapshot the token and bump the Arc
+    // before spawning.
     let sandbox_token = context.sandbox_token.clone();
-    let exec_config_for_upload = Arc::clone(&exec_config);
+    let exec_config_for_deferred = Arc::clone(&exec_config);
 
     jobs.spawn(async move {
         // Inner spawn isolates panics: if execute_job panics, the outer task
@@ -1124,7 +1126,7 @@ fn spawn_job(
                 // empty collector so the post-complete flush path stays
                 // unconditional. `flush` early-returns on empty pending_ops.
                 let empty_telemetry = JobTelemetry::new(
-                    exec_config_for_upload.http.clone(),
+                    exec_config_for_deferred.http.clone(),
                     run_id,
                     sandbox_token.clone(),
                 );
@@ -1253,11 +1255,11 @@ fn spawn_job(
         // Flush and upload run concurrently — they share no state and both
         // target the telemetry endpoint, so parallelism shortens the drain
         // window (~383 ms + ~1.6 s → ~1.6 s).
-        let network_log_path = exec_config_for_upload.log_paths.network_log(run_id);
+        let network_log_path = exec_config_for_deferred.log_paths.network_log(run_id);
         tokio::join!(
             telemetry.flush(),
             network_logs::upload_network_logs(
-                &exec_config_for_upload.http,
+                &exec_config_for_deferred.http,
                 run_id,
                 &sandbox_token,
                 &network_log_path,
@@ -2032,6 +2034,27 @@ mod tests {
             max_concurrent,
             make_provider,
             Box::new(MockSandboxRuntime::new()),
+            "http://localhost:0",
+        )
+    }
+
+    /// Variant that points the runner's HTTP client at an explicit URL. Used by
+    /// tests that spin up an `httpmock::MockServer` to observe webhook traffic.
+    fn mock_run_config_with_api_url(
+        profiles: BTreeMap<String, config::ProfileConfig>,
+        budget_vcpu: u32,
+        budget_memory_mb: u32,
+        max_concurrent: usize,
+        api_url: &str,
+    ) -> (RunConfig, MockRunEnv) {
+        build_mock_run_config_with_runtime(
+            profiles,
+            budget_vcpu,
+            budget_memory_mb,
+            max_concurrent,
+            MockJobProvider::new,
+            Box::new(MockSandboxRuntime::new()),
+            api_url,
         )
     }
 
@@ -2042,6 +2065,7 @@ mod tests {
         max_concurrent: usize,
         make_provider: impl FnOnce(CancellationToken) -> (Arc<MockJobProvider>, MockProviderHandle),
         runtime: Box<dyn sandbox::SandboxRuntime>,
+        api_url: &str,
     ) -> (RunConfig, MockRunEnv) {
         let temp_dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
@@ -2095,9 +2119,9 @@ mod tests {
             cancel_tokens: Arc::clone(&cancel_tokens),
             cancel: cancel.clone(),
             exec_config: Arc::new(executor::ExecutorConfig {
-                api_url: "http://localhost:0".into(),
+                api_url: api_url.to_string(),
                 registry,
-                http: crate::http::HttpClient::new("http://localhost:0".into()).unwrap(),
+                http: crate::http::HttpClient::new(api_url.to_string()).unwrap(),
                 log_paths: crate::paths::LogPaths::new(log_dir),
                 ip_log_map: kmsg_log::new_ip_log_map(),
             }),
@@ -2216,6 +2240,63 @@ mod tests {
         assert!(c.error.is_none());
 
         shutdown(&env, run_handle).await;
+    }
+
+    /// Regression guard: the post-complete deferred network-log upload (moved
+    /// out of `post_job_cleanup` by #9828) must still reach the telemetry
+    /// endpoint, including during graceful drain shutdown. The outer `jobs`
+    /// JoinSet must drain the `tokio::join!` in `spawn_job` — a fire-and-forget
+    /// `tokio::spawn` would silently lose this upload when the runtime drops.
+    #[tokio::test]
+    async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
+        use httpmock::prelude::*;
+
+        let server = MockServer::start_async().await;
+        let telemetry_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/api/webhooks/agent/telemetry");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"success":true,"id":"ok"}"#);
+            })
+            .await;
+
+        let (config, env) =
+            mock_run_config_with_api_url(test_profiles(), 8, 32768, 4, &server.base_url());
+
+        // Seed a network log file so `upload_network_logs` has a payload to POST
+        // (otherwise it early-returns on NotFound and the assertion below would
+        // measure nothing).
+        let run_id = RunId::new_v4();
+        let network_log_path = config.exec_config.log_paths.network_log(run_id);
+        std::fs::create_dir_all(network_log_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &network_log_path,
+            r#"{"timestamp":"2026-01-01T00:00:00","action":"ALLOW","host":"example.com","method":"GET","url":"https://example.com/","status":200}"#,
+        )
+        .unwrap();
+
+        let run_handle = tokio::spawn(run(config));
+        push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(completion.is_some(), "job should complete");
+
+        // Drain shutdown — `jobs.join_next()` must wait for each `spawn_job`
+        // closure's deferred `tokio::join!(flush, upload)` before returning.
+        shutdown(&env, run_handle).await;
+
+        // At least one POST: the mitm network-log upload. Also possible: a
+        // separate POST for sandbox-op telemetry (vm_create etc). Either way,
+        // the endpoint must have been hit — proving the deferred work isn't
+        // silently dropped on runtime shutdown.
+        assert!(
+            telemetry_mock.calls_async().await >= 1,
+            "telemetry endpoint should receive deferred post-complete upload"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -3796,6 +3877,7 @@ mod tests {
             max_concurrent,
             MockJobProvider::new,
             Box::new(MockSandboxRuntime::with_overrides(overrides)),
+            "http://localhost:0",
         )
     }
 

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -31,6 +31,7 @@ use crate::proxy;
 use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::status::{RunnerMode, StatusTracker};
+use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, HeartbeatState};
 
 /// Initial backoff before retrying mitmproxy after a crash.
@@ -1114,18 +1115,26 @@ fn spawn_job(
                     outcome.sandbox,
                     outcome.source_ip,
                     outcome.guest_session_id,
-                    Some(telemetry),
+                    telemetry,
                 )
             }
             Err(e) => {
                 error!(run_id = %run_id, error = %e, "executor task panicked");
+                // Panic lost the in-flight telemetry buffer; substitute an
+                // empty collector so the post-complete flush path stays
+                // unconditional. `flush` early-returns on empty pending_ops.
+                let empty_telemetry = JobTelemetry::new(
+                    exec_config_for_upload.http.clone(),
+                    run_id,
+                    sandbox_token.clone(),
+                );
                 (
                     1,
                     Some(format!("internal error: {e}")),
                     None,
                     String::new(),
                     None,
-                    None,
+                    empty_telemetry,
                 )
             }
         };
@@ -1241,17 +1250,19 @@ fn spawn_job(
         // user-visible run-complete signal isn't blocked on these uploads.
         // They're still awaited (not spawned) so the surrounding `jobs`
         // JoinSet drains them on graceful shutdown — no data loss on SIGTERM.
-        if let Some(telemetry) = telemetry {
-            telemetry.flush().await;
-        }
+        // Flush and upload run concurrently — they share no state and both
+        // target the telemetry endpoint, so parallelism shortens the drain
+        // window (~383 ms + ~1.6 s → ~1.6 s).
         let network_log_path = exec_config_for_upload.log_paths.network_log(run_id);
-        network_logs::upload_network_logs(
-            &exec_config_for_upload.http,
-            run_id,
-            &sandbox_token,
-            &network_log_path,
-        )
-        .await;
+        tokio::join!(
+            telemetry.flush(),
+            network_logs::upload_network_logs(
+                &exec_config_for_upload.http,
+                run_id,
+                &sandbox_token,
+                &network_log_path,
+            ),
+        );
 
         Some(run_id)
     });

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -58,10 +58,11 @@ pub struct ExecuteOutcome {
 /// Execute a single job inside a **new** Firecracker VM.
 ///
 /// Returns [`ExecuteOutcome`] with the sandbox still alive (not stopped/destroyed)
-/// plus the pending [`JobTelemetry`] buffer. The caller decides whether to
-/// park the sandbox or destroy it, and **must** flush the telemetry **after**
-/// firing `provider.complete` so the user-visible run-complete signal isn't
-/// blocked on best-effort telemetry uploads (~383 ms saved per job).
+/// plus the pending [`JobTelemetry`] buffer. The caller (`spawn_job` in
+/// `cmd/start.rs`) decides whether to park the sandbox or destroy it, and
+/// **must** flush the telemetry **after** firing `provider.complete` so the
+/// user-visible run-complete signal isn't blocked on best-effort telemetry
+/// uploads (~383 ms saved per job).
 pub async fn execute_job(
     factory: &dyn SandboxFactory,
     context: ExecutionContext,
@@ -108,8 +109,9 @@ pub async fn execute_job(
 ///
 /// Skips create + start. Re-registers proxy, fixes clock, then runs the agent.
 /// Returns [`ExecuteOutcome`] with the sandbox still alive plus the pending
-/// [`JobTelemetry`] buffer — the caller must flush telemetry after firing
-/// `provider.complete` (see [`execute_job`] for rationale).
+/// [`JobTelemetry`] buffer — the caller (`spawn_job` in `cmd/start.rs`) must
+/// flush telemetry after firing `provider.complete` (see [`execute_job`] for
+/// rationale).
 pub async fn execute_job_reuse(
     idle_entry: IdleEntry,
     context: ExecutionContext,
@@ -342,9 +344,9 @@ async fn unregister_proxy(config: &ExecutorConfig, context: &ExecutionContext, s
 ///
 /// Called after `run_in_sandbox` completes, whether the sandbox will be
 /// parked (keep-alive) or destroyed. The mitmproxy network-log upload is
-/// deliberately **not** done here — the caller runs it after
-/// `provider.complete` so the user-visible run-complete signal isn't blocked
-/// on the best-effort upload (~1.6 s saved per job).
+/// deliberately **not** done here — `spawn_job` (in `cmd/start.rs`) runs
+/// it after `provider.complete` so the user-visible run-complete signal
+/// isn't blocked on the best-effort upload (~1.6 s saved per job).
 async fn post_job_cleanup(
     sandbox: &dyn Sandbox,
     config: &ExecutorConfig,

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -20,7 +20,6 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::idle_pool::IdleEntry;
 use crate::kmsg_log;
-use crate::network_logs;
 use crate::paths::{LogPaths, guest};
 use crate::proxy::{self, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
@@ -58,8 +57,11 @@ pub struct ExecuteOutcome {
 
 /// Execute a single job inside a **new** Firecracker VM.
 ///
-/// Returns [`ExecuteOutcome`] with the sandbox still alive (not stopped/destroyed).
-/// The caller decides whether to park it in the idle pool or destroy it.
+/// Returns [`ExecuteOutcome`] with the sandbox still alive (not stopped/destroyed)
+/// plus the pending [`JobTelemetry`] buffer. The caller decides whether to
+/// park the sandbox or destroy it, and **must** flush the telemetry **after**
+/// firing `provider.complete` so the user-visible run-complete signal isn't
+/// blocked on best-effort telemetry uploads (~383 ms saved per job).
 pub async fn execute_job(
     factory: &dyn SandboxFactory,
     context: ExecutionContext,
@@ -67,7 +69,7 @@ pub async fn execute_job(
     config: &ExecutorConfig,
     params: &JobParams,
     cancel: CancellationToken,
-) -> ExecuteOutcome {
+) -> (ExecuteOutcome, JobTelemetry) {
     let run_id = context.run_id;
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
@@ -99,21 +101,21 @@ pub async fn execute_job(
     };
 
     info!(run_id = %run_id, exit_code = outcome.exit_code, "job finished");
-    telemetry.flush().await;
-
-    outcome
+    (outcome, telemetry)
 }
 
 /// Execute a single job inside a **reused** (kept-alive) VM.
 ///
 /// Skips create + start. Re-registers proxy, fixes clock, then runs the agent.
-/// Returns [`ExecuteOutcome`] with the sandbox still alive.
+/// Returns [`ExecuteOutcome`] with the sandbox still alive plus the pending
+/// [`JobTelemetry`] buffer — the caller must flush telemetry after firing
+/// `provider.complete` (see [`execute_job`] for rationale).
 pub async fn execute_job_reuse(
     idle_entry: IdleEntry,
     context: ExecutionContext,
     config: &ExecutorConfig,
     cancel: CancellationToken,
-) -> ExecuteOutcome {
+) -> (ExecuteOutcome, JobTelemetry) {
     let run_id = context.run_id;
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
@@ -139,9 +141,7 @@ pub async fn execute_job_reuse(
     .await;
 
     info!(run_id = %run_id, exit_code = outcome.exit_code, reused = true, "job finished");
-    telemetry.flush().await;
-
-    outcome
+    (outcome, telemetry)
 }
 
 fn record_api_latency(context: &ExecutionContext, telemetry: &mut JobTelemetry) {
@@ -338,10 +338,13 @@ async fn unregister_proxy(config: &ExecutorConfig, context: &ExecutionContext, s
     config.ip_log_map.lock().await.remove(source_ip);
 }
 
-/// Post-job cleanup: copy logs, unregister proxy, upload network logs.
+/// Post-job cleanup: copy logs, unregister proxy.
 ///
 /// Called after `run_in_sandbox` completes, whether the sandbox will be
-/// parked (keep-alive) or destroyed.
+/// parked (keep-alive) or destroyed. The mitmproxy network-log upload is
+/// deliberately **not** done here — the caller runs it after
+/// `provider.complete` so the user-visible run-complete signal isn't blocked
+/// on the best-effort upload (~1.6 s saved per job).
 async fn post_job_cleanup(
     sandbox: &dyn Sandbox,
     config: &ExecutorConfig,
@@ -349,17 +352,7 @@ async fn post_job_cleanup(
     source_ip: &str,
 ) {
     copy_guest_logs(sandbox, context, &config.log_paths).await;
-
     unregister_proxy(config, context, source_ip).await;
-
-    let network_log_path = config.log_paths.network_log(context.run_id);
-    network_logs::upload_network_logs(
-        &config.http,
-        context.run_id,
-        &context.sandbox_token,
-        &network_log_path,
-    )
-    .await;
 }
 
 async fn run_in_sandbox(
@@ -2416,7 +2409,7 @@ mod tests {
         factory.startup().await.unwrap();
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job(
+        let (outcome, _telemetry) = execute_job(
             &factory,
             minimal_context(),
             SandboxId::new_v4(),
@@ -2439,7 +2432,7 @@ mod tests {
         factory.push_create_result(Err(SandboxError::CreationFailed("boom".into())));
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job(
+        let (outcome, _telemetry) = execute_job(
             &factory,
             minimal_context(),
             SandboxId::new_v4(),
@@ -2466,7 +2459,7 @@ mod tests {
 
         // First: create a sandbox via normal execute_job
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job(
+        let (outcome, _telemetry) = execute_job(
             &factory,
             minimal_context(),
             SandboxId::new_v4(),
@@ -2497,7 +2490,8 @@ mod tests {
 
         // Reuse the sandbox for a second turn
         let cancel = tokio_util::sync::CancellationToken::new();
-        let reuse_outcome = execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
+        let (reuse_outcome, _telemetry) =
+            execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
         assert_eq!(reuse_outcome.exit_code, 0);
         assert!(reuse_outcome.error.is_none());
         assert!(reuse_outcome.sandbox.is_some());
@@ -2519,7 +2513,7 @@ mod tests {
         assert_eq!(ctx.session_id(), Some("test-session-abc"));
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job(
+        let (outcome, _telemetry) = execute_job(
             &factory,
             ctx,
             SandboxId::new_v4(),
@@ -2559,7 +2553,8 @@ mod tests {
         });
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let reuse_outcome = execute_job_reuse(idle_entry, ctx2, &config, cancel).await;
+        let (reuse_outcome, _telemetry) =
+            execute_job_reuse(idle_entry, ctx2, &config, cancel).await;
         assert_eq!(reuse_outcome.exit_code, 0);
         assert!(reuse_outcome.sandbox.is_some());
     }
@@ -2575,7 +2570,7 @@ mod tests {
 
         // Execute first job
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job(
+        let (outcome, _telemetry) = execute_job(
             &factory,
             minimal_context(),
             SandboxId::new_v4(),
@@ -2620,7 +2615,7 @@ mod tests {
 
         // Execute reuse
         let cancel = tokio_util::sync::CancellationToken::new();
-        let reuse_outcome =
+        let (reuse_outcome, _telemetry) =
             execute_job_reuse(reuse_entry, minimal_context(), &config, cancel).await;
         assert_eq!(reuse_outcome.exit_code, 0);
         assert!(reuse_outcome.sandbox.is_some());
@@ -2688,7 +2683,8 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
+        let (outcome, _telemetry) =
+            execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
 
         assert_eq!(outcome.exit_code, 1);
         assert!(outcome.error.unwrap().contains("vsock broken"));
@@ -2730,7 +2726,8 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
+        let (outcome, _telemetry) =
+            execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
 
         assert_eq!(outcome.exit_code, 1);
         assert!(outcome.error.unwrap().contains("reseed timeout"));
@@ -2774,7 +2771,7 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job_reuse(idle_entry, ctx, &config, cancel).await;
+        let (outcome, _telemetry) = execute_job_reuse(idle_entry, ctx, &config, cancel).await;
 
         assert_eq!(outcome.exit_code, 1);
         assert!(outcome.error.unwrap().contains("disk full"));
@@ -2792,7 +2789,7 @@ mod tests {
         factory.startup().await.unwrap();
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job(
+        let (outcome, _telemetry) = execute_job(
             &factory,
             minimal_context(),
             SandboxId::new_v4(),

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -17,6 +17,7 @@ const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(5);
 /// periodically (auto on 30 s threshold) and at job end.
 ///
 /// Owns its state — passed as `&mut` through the call chain, no `Mutex` needed.
+#[must_use = "JobTelemetry buffers pending ops until `flush()` is awaited; dropping it loses them"]
 pub struct JobTelemetry {
     http: HttpClient,
     run_id: RunId,


### PR DESCRIPTION
## Summary

Cuts ~2 s off the user-visible run-complete latency (Phase 1 of #9809) by deferring two best-effort telemetry uploads past `provider.complete`:

- `upload_network_logs` (mitmproxy log POST, ~1.6 s, 508 entries serial)
- `JobTelemetry::flush` (sandbox_operations batch, ~383 ms)

## Approach

**Reorder, don't detach.** Both uploads move out of `execute_job`/`execute_job_reuse` and `post_job_cleanup`, into the job spawn closure in `start.rs`, running *after* `provider.complete` → `status.remove_run` → `budget.release`. They stay `.await`ed (not `tokio::spawn`'d).

Why not `tokio::spawn`:
- Runtime drop on SIGTERM kills detached tasks → **firewall audit trail lost on every runner deploy** (network logs carry ALLOW/DENY + firewall_permission).
- No backpressure against a slow telemetry endpoint.

Reorder keeps the awaits inside the existing `jobs: JoinSet<...>` closure, which the draining shutdown already waits on (`start.rs:807-832`). Zero new concurrency model, zero data loss on graceful shutdown.

## Token validity after complete

Verified: `getSandboxAuthForRun` checks JWT signature/expiry/runId only; the telemetry endpoint queries `agentRuns` without filtering on run status. So telemetry posts after `complete` still authenticate.

## Scope

Phase 1 only (issue items #1 + #4). Phase 2 (guest-agent `tokio::join!` checkpoint + final_telemetry_upload) and Phase 3 (empty-memory webhook short-circuit) will be separate PRs.

## Test plan

- [ ] 679 runner unit tests pass locally
- [ ] `cargo clippy -p runner --all-targets -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] CI green
- [ ] Deploy to dev, verify complete webhook fires ~2 s earlier and `upload_network_logs` entries still show up in Axiom
- [ ] Verify runner SIGTERM mid-job drains telemetry before exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)