### PR TITLE
fix(platform): swallow service worker registration rejection

### DIFF
--- a/turbo/apps/platform/src/lib/push-notifications.ts
+++ b/turbo/apps/platform/src/lib/push-notifications.ts
@@ -22,8 +22,19 @@ export const registerServiceWorker$ = command(
       return;
     }
 
-    const registration = await navigator.serviceWorker.register("/sw.js");
+    // Registration can reject for reasons outside our control: private
+    // browsing, enterprise/browser policy, user-disabled SW, etc. Push
+    // notifications are a non-critical enhancement, so swallow the
+    // rejection to avoid aborting bootstrap or spamming Sentry.
+    const registration = await navigator.serviceWorker
+      .register("/sw.js")
+      .catch(() => {
+        return null;
+      });
     signal.throwIfAborted();
+    if (!registration) {
+      return;
+    }
     set(swRegistration$, registration);
   },
 );


### PR DESCRIPTION
## Summary
- `navigator.serviceWorker.register("/sw.js")` can reject for reasons outside our control — private browsing, enterprise/browser policy, user-disabled SW — producing a bare `Rejected` error in Sentry (PLATFORM-29).
- Push notifications are a non-critical PWA enhancement, so this rejection should not abort bootstrap or pollute Sentry.
- Wrap the registration in `.catch(() => null)` and no-op when the registration couldn't be created.

Fixes #9717

## Test plan
- [ ] Verify Sentry PLATFORM-29 stops receiving `Rejected` reports after deploy
- [ ] Confirm push notifications still work in Chrome (happy path)
- [ ] Confirm bootstrap does not fail in Safari private mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)