### PR TITLE
fix(platform): silence expected 401 auth errors in sentry

### DIFF
--- a/turbo/apps/platform/src/lib/sentry.ts
+++ b/turbo/apps/platform/src/lib/sentry.ts
@@ -49,6 +49,11 @@ export function initSentry(): void {
       "ResizeObserver loop",
       // Clerk SDK - session cleared by Mobile Safari ITP (third-party noise)
       "Unable to authenticate the request",
+      // 401 responses thrown by accept() — fetch$/zeroClient$ already route
+      // these to clerk.redirectToSignIn(), so the ApiError rejection is an
+      // expected side effect of the in-flight redirect, not a real failure.
+      "Not authenticated",
+      "Authentication required",
       // Expected API errors surfaced as toasts — not actionable in Sentry
       "Credits depleted",
       "Insufficient credits",


### PR DESCRIPTION
## Summary

- Add `"Not authenticated"` and `"Authentication required"` to the Sentry `ignoreErrors` list in `apps/platform/src/lib/sentry.ts`
- These 401 messages are thrown by `accept()` after `fetch$` / `zeroClient$` have already kicked off `clerk.redirectToSignIn()` — the ApiError rejection is an expected side effect of the in-flight redirect, not a real failure

## Why

Sentry issues PLATFORM-27 (`Authentication required`, unhandled) and PLATFORM-28 (`Not authenticated`) surface the same root cause: the 401 response is returned to the caller (per the fire-and-forget redirect contract in `auth-retry.ts`), `accept()` wraps it into an `ApiError`, and for read-path computed signals it bubbles to the React error boundary before the redirect completes.

Rather than restructuring the accept/signal error flow, this is a minimal fix that stops the noise at the Sentry layer — matching the existing pattern already used for `"Unable to authenticate the request"` (Clerk ITP noise) and `"Credits depleted"`.

Closes #9716

## Test plan

- [ ] Verify Sentry dashboard stops receiving new events matching `Not authenticated` / `Authentication required` after deploy
- [ ] Manually invalidate session in a staging environment and confirm redirect-to-sign-in still fires (no behavior change to auth flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)