### PR TITLE
fix(sandbox-fc): fsync output directory after snapshot finalization

### DIFF
--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -151,6 +151,10 @@ impl SnapshotOutputPaths {
         Self { output_dir }
     }
 
+    pub fn dir(&self) -> &Path {
+        &self.output_dir
+    }
+
     pub fn snapshot(&self) -> PathBuf {
         self.output_dir.join("snapshot.bin")
     }

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -438,6 +438,18 @@ async fn run_snapshot_workflow(
             let bitmap_dst = output.cow_bitmap();
             tokio::fs::rename(&bitmap_src, &bitmap_dst).await?;
         }
+        // Persist the output directory so all four final dir entries
+        // (snapshot.bin and memory.bin written by Firecracker via the API,
+        // cow.img and cow.img.bitmap just renamed in) are durable. Without
+        // this fsync, rename(2) and Firecracker's creates return once the
+        // update is journaled but the entry may not hit disk until the FS's
+        // next commit (~5s on ext4 data=ordered). A crash in that window can
+        // leave is_complete() returning true while one or more files are
+        // missing or rolled back — worst case, cow.img present but
+        // cow.img.bitmap absent, which silently corrupts restore reads
+        // (same failure class as #9794, one layer up).
+        let dir = tokio::fs::File::open(output.dir()).await?;
+        dir.sync_all().await?;
     }
     // On error, cow_device is dropped → Drop calls destroy() (best-effort).
 


### PR DESCRIPTION
## Summary
- `create_snapshot` finalizes four files in `output_dir` (snapshot.bin, memory.bin via Firecracker API; cow.img, cow.img.bitmap via `rename`), but none of the dir entries were fsynced — so they could sit in the FS journal uncommitted (~5s on ext4 data=ordered) after the function returned success
- A crash in that window can leave `is_complete()` reporting true while one or more files are rolled back; worst case (cow.img present but cow.img.bitmap absent) silently corrupts restore reads — same class as #9794, one layer up
- Open `output_dir` once after all renames complete and call `sync_all()`; a single fsync commits the rename transactions and the Firecracker-created file entries via journal dependency
- Added a minimal `SnapshotOutputPaths::dir()` accessor to expose the path

Closes #9825

## Test plan
- [x] `cargo test -p sandbox-fc` — 143 tests pass
- [x] `cargo clippy -p sandbox-fc --all-targets` — clean
- [x] `cargo fmt -p sandbox-fc` — formatted
- [ ] CI green (lint/test/deploy/cli-e2e)

Crash-window behavior is not exercised by a unit test — no practical way to simulate FS journal commit loss without a fault-injection harness. Existing integration tests exercise `create_snapshot`'s happy path and continue to pass.

## Notes
- Complementary to #9794 (PR #9827): that fix persists the bitmap's rename inside the nbd-cow working directory; this fix persists the four final dir entries after they've been moved / written into the snapshot output directory. Both are needed because the bitmap is durable in two different parent directories across its lifecycle.
- Out of scope: durability of the *contents* of snapshot.bin / memory.bin (which Firecracker writes via its API). If Firecracker's internal fsync behavior turns out to be insufficient, that warrants a separate issue — it's not a tmp+rename problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)