### PR TITLE
refactor(zero): scope connector skill injection to user-authorized connectors

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -527,6 +527,57 @@ describe("POST /api/zero/runs", () => {
         expect(systemIndex).toBeGreaterThanOrEqual(0);
         expect(customIndex).toBeGreaterThan(systemIndex);
       });
+
+      it("scopes connector skill volumes to user_connectors rows", async () => {
+        await createTestUserConnector(
+          user.orgId,
+          user.userId,
+          agentId,
+          "slack",
+        );
+
+        const response = await postRun({ agentId, prompt: "Hello" });
+        expect(response.status).toBe(201);
+        const data = await response.json();
+
+        const run = await findTestRunRecord(data.runId);
+        expect(run).toBeDefined();
+        const systemMounts = run!.additionalVolumes!.filter((v) => {
+          return v.system === true;
+        });
+        const mountPaths = new Set(
+          systemMounts.map((v) => {
+            return v.mountPath;
+          }),
+        );
+
+        expect(mountPaths.has("/home/user/.claude/skills/slack")).toBe(true);
+        expect(mountPaths.has("/home/user/.claude/skills/github")).toBe(false);
+      });
+
+      it("does not mount any connector skill when user has no user_connectors rows", async () => {
+        const response = await postRun({ agentId, prompt: "Hello" });
+        expect(response.status).toBe(201);
+        const data = await response.json();
+
+        const run = await findTestRunRecord(data.runId);
+        expect(run).toBeDefined();
+        const systemMounts = run!.additionalVolumes!.filter((v) => {
+          return v.system === true;
+        });
+        const mountPaths = new Set(
+          systemMounts.map((v) => {
+            return v.mountPath;
+          }),
+        );
+
+        expect(mountPaths.has("/home/user/.claude/skills/slack")).toBe(false);
+        expect(mountPaths.has("/home/user/.claude/skills/github")).toBe(false);
+        // SEED_SKILLS still mount
+        expect(mountPaths.has("/home/user/.claude/skills/deep-dive")).toBe(
+          true,
+        );
+      });
     });
   });
 

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../../__tests__/api-test-helpers";
 import { createTestZeroAgent } from "../../../__tests__/db-test-seeders/agents";
 import { bindCustomSkillToAgent } from "../../../__tests__/db-test-seeders/skills";
+import { createTestUserConnector } from "../../../__tests__/db-test-seeders/connectors";
 import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
 import { createZeroRun } from "../zero-run-service";
@@ -365,6 +366,59 @@ describe("createZeroRun() — service-only parameters", () => {
         expect(zeroRun).toBeDefined();
         expect(zeroRun!.triggerSource).toBe(triggerSource);
       }
+    });
+  });
+
+  describe("connector skill volume scoping", () => {
+    function getSystemSkillNames(
+      volumes: Array<{ mountPath: string; system?: boolean }>,
+    ) {
+      return new Set(
+        volumes
+          .filter((v) => {
+            return v.system === true;
+          })
+          .map((v) => {
+            return v.mountPath.split("/").pop()!;
+          }),
+      );
+    }
+
+    it("mounts only SEED_SKILLS when no user_connectors rows exist", async () => {
+      const result = await createZeroRun(baseParams());
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run).toBeDefined();
+      const skillNames = getSystemSkillNames(run!.additionalVolumes!);
+      expect(skillNames.has("deep-dive")).toBe(true);
+      expect(skillNames.has("slack")).toBe(false);
+      expect(skillNames.has("github")).toBe(false);
+    });
+
+    it("mounts an authorized connector's skill alongside SEED_SKILLS", async () => {
+      await createTestUserConnector(user.orgId, user.userId, agentId, "slack");
+
+      const result = await createZeroRun(baseParams());
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run).toBeDefined();
+      const skillNames = getSystemSkillNames(run!.additionalVolumes!);
+      expect(skillNames.has("deep-dive")).toBe(true);
+      expect(skillNames.has("slack")).toBe(true);
+      expect(skillNames.has("github")).toBe(false);
+    });
+
+    it("mounts multiple authorized connector skills", async () => {
+      await createTestUserConnector(user.orgId, user.userId, agentId, "slack");
+      await createTestUserConnector(user.orgId, user.userId, agentId, "github");
+
+      const result = await createZeroRun(baseParams());
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run).toBeDefined();
+      const skillNames = getSystemSkillNames(run!.additionalVolumes!);
+      expect(skillNames.has("slack")).toBe(true);
+      expect(skillNames.has("github")).toBe(true);
     });
   });
 

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -8,7 +8,6 @@ import {
   FeatureSwitchKey,
   getCustomSkillStorageName,
   getSkillStorageName,
-  getEligibleConnectorTypes,
   resolveSkillRef,
   parseGitHubTreeUrl,
   type TriggerSource,
@@ -240,18 +239,17 @@ interface ZeroRunRecordResult {
 }
 
 /**
- * Compute system skill additional volumes from SEED_SKILLS + eligible connectors.
- * Mirrors the skill resolution logic in buildComposeContent() but produces
- * AdditionalVolume-shaped objects instead of compose skill URLs.
+ * Compute system skill additional volumes from SEED_SKILLS plus the per-user
+ * authorized connector types. SEED_SKILLS are always injected; connector
+ * skills are injected only for connectors the user has authorized for the
+ * agent (via the user_connectors table).
  */
-function buildSystemSkillVolumes(): Array<{
+function buildSystemSkillVolumes(connectorTypes: readonly string[]): Array<{
   name: string;
   mountPath: string;
   system: boolean;
 }> {
-  const allSkillNames = [
-    ...new Set([...SEED_SKILLS, ...getEligibleConnectorTypes()]),
-  ];
+  const allSkillNames = [...new Set([...SEED_SKILLS, ...connectorTypes])];
   return allSkillNames.flatMap((skillName) => {
     const url = resolveSkillRef(skillName);
     const parsed = parseGitHubTreeUrl(url);
@@ -414,7 +412,9 @@ async function createZeroRunRecord(
 
   // Construct CreateRunParams (infra knows nothing about ZERO_TOKEN)
   // Inject system + custom skill volumes (needed on every run).
-  const systemSkillVolumes = buildSystemSkillVolumes();
+  const systemSkillVolumes = buildSystemSkillVolumes(
+    allowedConnectorTypes ?? [],
+  );
   const customSkillVolumes = (row?.customSkills ?? []).map((name) => {
     return {
       name: getCustomSkillStorageName(name),


### PR DESCRIPTION
## Summary

- Per-run system skill volumes now derive connector skills from the `user_connectors` table (per user + agent) instead of the static `getEligibleConnectorTypes()` catalog.
- `SEED_SKILLS` (32 hardcoded workflow skills) is unchanged — always injected; only the connector portion is now user-scoped.
- Aligns skill mounting with firewall seeding (`resolveFirewallPolicies`) and OAuth env injection (`buildZeroExecutionContext`), which already read from the same `allowedConnectorTypes` source. The `getEligibleConnectorTypes` import is removed from `zero-run-service.ts` (still used by `build-compose-content.ts`, `dev-seed.ts`, etc.).

## Test plan

- [x] Service-level integration tests added (`zero-run-service.test.ts`):
  - 0 `user_connectors` rows → only `SEED_SKILLS` mount; no `slack`/`github`
  - 1 row (`slack`) → SEED + `slack`, no `github`
  - Multiple rows → all authorized connectors mount
- [x] Route-level integration tests added (`route.test.ts`):
  - With `user_connectors` row → connector skill present, others absent
  - No rows → no connector skills, `deep-dive` (a SEED skill) still present
- [x] All existing tests in `apps/web` pass: `pnpm -F web exec vitest run` (24+48 tests in the two affected files)
- [x] `pnpm format` clean
- [x] `pnpm turbo run lint --filter=web` clean (warnings pre-existing, not from this PR)
- [x] `pnpm knip --workspace web` clean

## Notes

- Closes #9834
- The issue body referenced `SEED_SKILLS.length` as 33; the actual constant has 32 entries. Non-blocking; flagged only for accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)