### PR TITLE
fix: self-heal oauth connectors with null token expiry

### DIFF
--- a/turbo/apps/web/app/api/connectors/[type]/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/__tests__/route.test.ts
@@ -1548,8 +1548,10 @@ describe("GET /api/connectors/:type/callback - OAuth Callback", () => {
       expect(tokenExpiresAt?.getTime()).toBe(expectedExpiry.getTime());
     });
 
-    it("should leave tokenExpiresAt null when provider does not return expires_in", async () => {
+    it("should fallback to 1h tokenExpiresAt when provider does not return expires_in", async () => {
       const user = await context.setupUser();
+      const frozenNow = 1700000000000;
+      vi.spyOn(Date, "now").mockReturnValue(frozenNow);
 
       const { handlers: mswHandlers } = createNotionOAuthMock({
         accessToken: "notion-access-token",
@@ -1574,12 +1576,14 @@ describe("GET /api/connectors/:type/callback - OAuth Callback", () => {
       expect(location).toContain("/connector/success");
       expect(location).toContain("type=notion");
 
-      // Verify tokenExpiresAt is null (non-expiring token)
+      // Verify tokenExpiresAt falls back to now + 3600s so the firewall auth
+      // endpoint can still judge freshness and trigger refresh on expiry.
+      // See #9836.
       const tokenExpiresAt = await findTestConnectorTokenExpiresAt(
         user.orgId,
         "notion",
       );
-      expect(tokenExpiresAt).toBeNull();
+      expect(tokenExpiresAt?.getTime()).toBe(frozenNow + 3600 * 1000);
     });
   });
 

--- a/turbo/apps/web/app/api/connectors/[type]/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/__tests__/route.test.ts
@@ -1413,6 +1413,35 @@ describe("GET /api/connectors/:type/callback - OAuth Callback", () => {
       const location = response.headers.get("location");
       expect(location).toContain("/connector/error");
     });
+
+    it("should keep tokenExpiresAt null for non-refreshable connector missing expires_in", async () => {
+      // Slack user tokens are long-lived and the handler defines no
+      // refreshToken method, so the #9836 fallback must NOT apply — we keep
+      // null to signal "don't try to refresh" to the firewall auth path.
+      const user = await context.setupUser();
+
+      const { handlers: mswHandlers } = createSlackOAuthMock({
+        accessToken: "xoxp-no-expiry-token",
+      });
+      server.use(...mswHandlers);
+
+      const request = createCallbackRequest({
+        code: "valid-code",
+        state: "test-state",
+        savedState: "test-state",
+        connectorType: "slack",
+      });
+      const response = await GET(request, {
+        params: Promise.resolve({ type: "slack" }),
+      });
+
+      expect(response.status).toBe(307);
+      const tokenExpiresAt = await findTestConnectorTokenExpiresAt(
+        user.orgId,
+        "slack",
+      );
+      expect(tokenExpiresAt).toBeNull();
+    });
   });
 
   describe("Notion OAuth Flow", () => {

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -763,15 +763,25 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(data.expiresAt).toBe(expectedExpiry);
     });
 
-    it("should return null expiresAt for non-expiring token", async () => {
-      // tokenExpiresAt = null means non-expiring
+    it("should refresh and backfill tokenExpiresAt when stored expiry is null", async () => {
+      // Regression for #9836: historical rows with tokenExpiresAt = null must
+      // self-heal on next firewall call, not be treated as non-expiring.
       await setupNotionConnector({
         tokenExpiresAt: null,
-        accessToken: "permanent-notion-token",
+        accessToken: "stale-notion-token",
       });
 
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, () => {
+          return HttpResponse.json({
+            access_token: "backfilled-notion-token",
+            expires_in: 3600,
+          });
+        }),
+      );
+
       const encrypted = encryptTestSecrets({
-        NOTION_ACCESS_TOKEN: "permanent-notion-token",
+        NOTION_ACCESS_TOKEN: "stale-notion-token",
         NOTION_REFRESH_TOKEN: "notion-refresh-token",
       });
 
@@ -790,10 +800,16 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
       expect(response.status).toBe(200);
       const data = await response.json();
-      expect(data.headers.Authorization).toBe("Bearer permanent-notion-token");
-      expect(data.refreshedConnectors).toEqual([]);
-      expect(data.refreshedSecrets).toEqual([]);
-      expect(data.expiresAt).toBeNull();
+      expect(data.headers.Authorization).toBe("Bearer backfilled-notion-token");
+      expect(data.refreshedConnectors).toEqual(["notion"]);
+      expect(data.refreshedSecrets).toEqual(["NOTION_ACCESS_TOKEN"]);
+      expect(data.expiresAt).toBeTypeOf("number");
+      // Verify the null was backfilled in DB
+      const tokenExpiresAt = await findTestConnectorTokenExpiresAt(
+        user.orgId,
+        "notion",
+      );
+      expect(tokenExpiresAt).not.toBeNull();
     });
 
     it("should return null expiresAt without secretConnectorMap", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -30,6 +30,13 @@ const log = logger("webhook:firewall-auth");
 const TEMPLATE_RE = /\$\{\{\s*(secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 
 /**
+ * Refresh tokens whose expiry falls within this buffer to avoid serving a
+ * token that expires mid-request. Chosen to absorb network latency + clock
+ * skew between our server and the OAuth provider.
+ */
+const REFRESH_BUFFER_SECS = 60;
+
+/**
  * Load refresh tokens from DB into the secrets map.
  * The encrypted secrets snapshot only contains mapped env vars (access tokens);
  * refresh tokens are kept server-side and must be fetched from DB (#7365).
@@ -110,7 +117,6 @@ async function refreshExpiredTokens(
   );
 
   const now = Math.floor(Date.now() / 1000);
-  const REFRESH_BUFFER_SECS = 60;
 
   // Refresh tokens that are expired or expiring within the buffer window (parallel).
   // null/undefined expiry means we don't know when the token expires — treat as

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -112,14 +112,15 @@ async function refreshExpiredTokens(
   const now = Math.floor(Date.now() / 1000);
   const REFRESH_BUFFER_SECS = 60;
 
-  // Refresh tokens that are expired or expiring within the buffer window (parallel)
+  // Refresh tokens that are expired or expiring within the buffer window (parallel).
+  // null/undefined expiry means we don't know when the token expires — treat as
+  // "needs refresh" so we backfill tokenExpiresAt. All connectors reaching this
+  // filter are refreshable OAuth (pre-filtered in resolve-connectors.ts), so
+  // their access tokens DO expire by definition. See #9836.
   const toRefresh = connectorTypes.filter((ct) => {
     const tokenExpiry = expiryMap.get(ct);
-    return (
-      tokenExpiry !== undefined &&
-      tokenExpiry !== null &&
-      tokenExpiry <= now + REFRESH_BUFFER_SECS
-    );
+    if (tokenExpiry === undefined || tokenExpiry === null) return true;
+    return tokenExpiry <= now + REFRESH_BUFFER_SECS;
   });
 
   // Build reverse map: connectorType → [envVarNames that reference its token]

--- a/turbo/apps/web/src/db/schema/connector.ts
+++ b/turbo/apps/web/src/db/schema/connector.ts
@@ -27,7 +27,7 @@ export const connectors = pgTable(
     externalUsername: varchar("external_username", { length: 255 }),
     externalEmail: varchar("external_email", { length: 255 }),
     oauthScopes: text("oauth_scopes"), // JSON array of scopes
-    tokenExpiresAt: timestamp("token_expires_at"), // null = non-expiring token
+    tokenExpiresAt: timestamp("token_expires_at"), // null = unknown; refreshable OAuth connectors auto-refresh on next use to backfill
     userId: text("user_id").notNull(),
     orgId: text("org_id").notNull(),
 

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -19,6 +19,14 @@ import { PROVIDER_HANDLERS } from "./provider-registry";
 const log = logger("service:connector");
 
 /**
+ * Fallback access-token lifetime (seconds) when a provider omits `expires_in`.
+ * 1 hour matches every OAuth provider we integrate (Google, Notion, etc.), and
+ * guarantees `tokenExpiresAt` is never null so the firewall auth endpoint can
+ * always judge freshness and trigger a refresh. See #9836.
+ */
+const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 3600;
+
+/**
  * Validate and parse connector type from database value
  */
 function parseConnectorType(type: string): ConnectorType {
@@ -286,10 +294,20 @@ export async function upsertOAuthConnector(
 ): Promise<{ connector: ConnectorResponse; created: boolean }> {
   const secretName = getSecretNameForConnector(type);
   const db = globalThis.services.db;
+  // Some providers issue non-expiring access tokens (e.g., classic GitHub
+  // OAuth apps, legacy Notion) — those handlers omit `refreshToken`, so we
+  // keep `tokenExpiresAt` null and the firewall refresh path naturally
+  // skips them. For refreshable providers, fall back to 1 h when the
+  // exchange response lacks `expires_in` so firewall auth can always judge
+  // freshness and never hit the null-skip bug from #9836.
+  const isRefreshable =
+    type !== "computer" && !!PROVIDER_HANDLERS[type]?.refreshToken;
+  const fallbackSecs = isRefreshable
+    ? DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS
+    : null;
+  const expiresInSecs = options?.expiresIn ?? fallbackSecs;
   const tokenExpiresAt =
-    options?.expiresIn != null
-      ? new Date(Date.now() + options.expiresIn * 1000)
-      : null;
+    expiresInSecs != null ? new Date(Date.now() + expiresInSecs * 1000) : null;
 
   // Upsert access token secret
   await upsertSecretByOrg(
@@ -592,8 +610,10 @@ export async function refreshConnectorAccessToken(
     }
 
     // Update tokenExpiresAt so subsequent expiry checks are accurate.
-    // Fallback to 1 hour — all providers without expires_in (e.g. Notion) have ~1h tokens.
-    const expiresAt = new Date(Date.now() + (result.expiresIn ?? 3600) * 1000);
+    const expiresAt = new Date(
+      Date.now() +
+        (result.expiresIn ?? DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS) * 1000,
+    );
     await globalThis.services.db
       .update(connectors)
       .set({ tokenExpiresAt: expiresAt, updatedAt: new Date() })

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -301,7 +301,7 @@ export async function upsertOAuthConnector(
   // exchange response lacks `expires_in` so firewall auth can always judge
   // freshness and never hit the null-skip bug from #9836.
   const isRefreshable =
-    type !== "computer" && !!PROVIDER_HANDLERS[type]?.refreshToken;
+    type !== "computer" && !!PROVIDER_HANDLERS[type].refreshToken;
   const fallbackSecs = isRefreshable
     ? DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS
     : null;


### PR DESCRIPTION
## Summary

Fixes #9836 — refreshable OAuth connectors (Gmail, Notion, Google Sheets/Docs/Drive, Linear, DocuSign, Figma, etc.) could get stuck in a permanent 401 loop when their `tokenExpiresAt` DB column was `null`.

Root cause (two bugs compounding):
1. `refreshExpiredTokens` in the firewall auth webhook filtered out connectors whose expiry was `null`, treating `null` as "non-expiring" even though every connector reaching that filter is refreshable OAuth by definition.
2. `upsertOAuthConnector` stored `tokenExpiresAt = null` whenever a provider omitted `expires_in`, even for providers whose handler defines `refreshToken` (and therefore issues expiring tokens).

Combined with the mitm addon's cache logic (`auth.py:224` — `expiresAt: null` → permanent cache until 401 invalidation), null rows got stuck in an infinite refresh-skip / 401 loop.

## Changes

- **`firewall/auth/route.ts:116-123`** — null/undefined expiry now triggers a refresh for connectors in `secretConnectorMap` (which is already pre-filtered to refreshable OAuth), so legacy null rows self-heal and backfill on next firewall call.
- **`connector-service.ts: upsertOAuthConnector`** — refreshable providers now fall back to 1 h when the exchange response omits `expires_in`. Non-refreshable handlers (classic GitHub OAuth, legacy Notion, etc.) keep `null` since their tokens are genuinely long-lived and never enter the refresh path.
- Extracted the 3600 magic number into `DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS`, shared between initial exchange and refresh paths.
- Updated schema comment: `null` = "unknown" for refreshable connectors, not "non-expiring".
- Tests: rewrote the obsolete `"return null expiresAt for non-expiring token"` case into a regression test verifying null expiry triggers refresh + backfill; updated the Notion callback test to assert 1 h fallback.

## Test plan
- [x] `pnpm -F web exec vitest run app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts 'app/api/connectors/'` — 160/160 pass
- [x] `pnpm -F web check-types` — clean
- [x] `pnpm -F web lint` — no new errors (25 pre-existing warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)