### PR TITLE
fix(web): align blog cards and scale cover illustrations

### DIFF
--- a/turbo/apps/web/app/blog.css
+++ b/turbo/apps/web/app/blog.css
@@ -194,6 +194,11 @@
   gap: 32px;
 }
 
+.blog-grid > a {
+  display: block;
+  height: 100%;
+}
+
 /* Blog Card - with cover image */
 .blog-card {
   background: var(--card-bg);
@@ -205,6 +210,7 @@
   position: relative;
   z-index: 1;
   border: 1px solid var(--border-light);
+  height: 100%;
 }
 
 .blog-card:hover {
@@ -219,15 +225,21 @@
 /* Blog Card Cover Image */
 .blog-card-cover {
   width: 100%;
-  height: 200px;
+  height: 240px;
   position: relative;
   overflow: hidden;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+[data-theme="light"] .blog-card-cover {
+  background: rgba(0, 0, 0, 0.02);
 }
 
 .blog-card-cover img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
+  padding: 20px;
   transition: transform 0.3s ease;
 }
 

--- a/turbo/apps/web/app/components/blog/BlogContent.tsx
+++ b/turbo/apps/web/app/components/blog/BlogContent.tsx
@@ -148,7 +148,7 @@ export default function BlogContent({
                         src={post.cover}
                         alt={post.title}
                         fill
-                        style={{ objectFit: "cover" }}
+                        style={{ objectFit: "contain" }}
                       />
                     </div>
                     <div className="blog-card-body">


### PR DESCRIPTION
## Summary
- Align cards in the same row to the tallest sibling so mismatched text lengths no longer cause uneven card heights.
- Increase the cover container from 200px to 240px for a more balanced silhouette.
- Switch the cover image to `object-fit: contain` with padding plus a subtle neutral backdrop, so the illustration reads at a comfortable size instead of being cropped and oversized.

## Before / After
Before: Left card collapses to content height while the right card stretches; circular illustrations fill the short 200px cover edge-to-edge.
After: Cards share the row height; illustrations sit centered with breathing room inside a slightly taller, backdrop-tinted cover.

## Test plan
- [ ] Visit `/en/blog` on preview and confirm the two-column grid keeps both cards the same height when excerpts differ in length.
- [ ] Verify cover illustrations render centered with padding and without cropping.
- [ ] Spot-check DE / JA / ES locales to confirm longer translations still align.
- [ ] Check responsive behavior at <900px (single column) — cover should still display cleanly.
- [ ] Verify light and dark themes: the cover backdrop should look intentional in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)