### PR TITLE
feat(ci): add vercel-promote action and skip-domain input for staged deploys

### DIFF
--- a/.github/actions/vercel-deploy/action.yml
+++ b/.github/actions/vercel-deploy/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: "Build locally and deploy prebuilt artifacts (skips remote build on Vercel)"
     required: false
     default: "false"
+  skip-domain:
+    description: "Produce a Staged production deployment that is prod-eligible but not yet serving traffic (requires prebuilt=true and environment=production). Promote later via vercel-promote."
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -76,11 +80,19 @@ runs:
       env:
         INPUT_ENV_VARS: ${{ inputs.environment-variables }}
         INPUT_PREBUILT: ${{ inputs.prebuilt }}
+        INPUT_SKIP_DOMAIN: ${{ inputs.skip-domain }}
         INPUT_ENVIRONMENT: ${{ inputs.environment }}
         INPUT_VERCEL_TOKEN: ${{ inputs.vercel-token }}
         INPUT_META_BRANCH: ${{ inputs.meta-branch }}
         INPUT_META_PR: ${{ inputs.meta-pr }}
       run: |
+        if [ "$INPUT_SKIP_DOMAIN" == "true" ]; then
+          if [ "$INPUT_PREBUILT" != "true" ] || [ "$INPUT_ENVIRONMENT" != "production" ]; then
+            echo "::error::skip-domain=true requires prebuilt=true and environment=production (got prebuilt=$INPUT_PREBUILT, environment=$INPUT_ENVIRONMENT)"
+            exit 1
+          fi
+        fi
+
         if [ "$INPUT_PREBUILT" == "true" ]; then
           # === Prebuilt mode: build locally, deploy artifacts only ===
 
@@ -112,6 +124,10 @@ runs:
 
           if [ "$INPUT_ENVIRONMENT" == "production" ]; then
             DEPLOY_ARGS+=(--prod)
+          fi
+
+          if [ "$INPUT_SKIP_DOMAIN" == "true" ]; then
+            DEPLOY_ARGS+=(--skip-domain)
           fi
 
           # Add runtime environment variables

--- a/.github/actions/vercel-promote/action.yml
+++ b/.github/actions/vercel-promote/action.yml
@@ -1,0 +1,59 @@
+name: "Vercel Promote"
+description: "Promote a Staged production deployment to serve live traffic (no rebuild)"
+
+inputs:
+  vercel-token:
+    description: "Vercel authentication token"
+    required: true
+  vercel-org-id:
+    description: "Vercel organization ID"
+    required: true
+  vercel-project-id:
+    description: "Vercel project ID"
+    required: true
+  deployment-url:
+    description: "Staged Vercel deployment URL to promote (produced by vercel-deploy with skip-domain=true)"
+    required: true
+  timeout:
+    description: "Max duration to wait for the promotion to complete (e.g. 60s, 2m). Vercel CLI default is 3m."
+    required: false
+    default: "60s"
+
+outputs:
+  url:
+    description: "The promoted deployment URL (same as input deployment-url on success)"
+    value: ${{ steps.promote.outputs.url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Vercel
+      uses: ./.github/actions/vercel-setup
+      with:
+        vercel-token: ${{ inputs.vercel-token }}
+        vercel-org-id: ${{ inputs.vercel-org-id }}
+        vercel-project-id: ${{ inputs.vercel-project-id }}
+
+    - name: Promote deployment
+      id: promote
+      shell: bash
+      env:
+        VERCEL_TOKEN: ${{ inputs.vercel-token }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        DEPLOYMENT_URL: ${{ inputs.deployment-url }}
+        TIMEOUT: ${{ inputs.timeout }}
+      run: |
+        if [ -z "$DEPLOYMENT_URL" ]; then
+          echo "::error::deployment-url input is empty; cannot promote"
+          exit 1
+        fi
+
+        echo "Promoting deployment: ${DEPLOYMENT_URL} (timeout=${TIMEOUT})"
+
+        vercel promote "${DEPLOYMENT_URL}" \
+          --token="${VERCEL_TOKEN}" \
+          --scope="${VERCEL_ORG_ID}" \
+          --timeout="${TIMEOUT}"
+
+        echo "url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
+        echo "Promote complete: ${DEPLOYMENT_URL}"


### PR DESCRIPTION
## Summary
- Adds `skip-domain` input to `vercel-deploy` composite action. When combined with `prebuilt=true` and `environment=production`, appends `--skip-domain` so the deployment lands as a Vercel **Staged** production deployment — prod-eligible but not yet serving live traffic.
- Adds a new `vercel-promote` composite action that wraps `vercel promote <url>` with a configurable timeout (default `60s`). Promotion is rebuild-free per Vercel's documented semantics.

## Why
Preparation only. This is PR 1 of 2 for splitting the release-please pipeline into three phases: **build (staged) → migrate → promote**. The goal of that split is to keep the `migrate start → traffic switched` window under 30 s.

This PR does **not** wire either new surface into any workflow. No existing caller touches `skip-domain` or `vercel-promote`, so production release behaviour is unchanged.

## Preconditions enforced
- `skip-domain=true` requires `prebuilt=true` AND `environment=production`. Any other combination fails fast with `::error::`.
- `vercel-promote` requires a non-empty `deployment-url` input.

## Test plan
- [ ] CI lint / YAML parse passes on this branch.
- [ ] Follow-up PR 2 wires `build-*-production` and `promote-*-production` jobs and does the end-to-end dry-run on a feature branch before cutting over main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)