### PR TITLE
fix(web): remove duplicate hreflang tags and broken blog images

### DIFF
--- a/turbo/apps/web/app/[locale]/__tests__/layout.test.ts
+++ b/turbo/apps/web/app/[locale]/__tests__/layout.test.ts
@@ -44,13 +44,13 @@ vi.mock("next-intl/server", () => {
 import { generateMetadata } from "../layout";
 
 describe("locale layout generateMetadata", () => {
-  it("returns metadata with alternates for valid locale", async () => {
+  it("returns metadata with openGraph for valid locale", async () => {
     const metadata = await generateMetadata({
       children: null,
       params: Promise.resolve({ locale: "en" }),
     });
 
-    expect(metadata.alternates?.canonical).toBe("https://www.vm0.ai/en");
+    expect(metadata.openGraph?.url).toBe("https://www.vm0.ai/en");
     expect(metadata.openGraph).toBeDefined();
     expect(metadata.twitter).toBeDefined();
   });
@@ -62,9 +62,7 @@ describe("locale layout generateMetadata", () => {
         params: Promise.resolve({ locale }),
       });
 
-      expect(metadata.alternates?.canonical).toBe(
-        `https://www.vm0.ai/${locale}`,
-      );
+      expect(metadata.openGraph?.url).toBe(`https://www.vm0.ai/${locale}`);
     }
   });
 

--- a/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
@@ -42,9 +42,15 @@ export async function generateMetadata({
   }
 
   const postUrl = `${getBlogBaseUrl()}/${locale}/blog/posts/${slug}`;
-  const imageUrl = post.cover.startsWith("http")
-    ? post.cover
-    : `${getBlogBaseUrl()}${post.cover}`;
+  const imageUrl = post.cover
+    ? post.cover.startsWith("http")
+      ? post.cover
+      : `${getBlogBaseUrl()}${post.cover}`
+    : undefined;
+
+  const ogImages = imageUrl
+    ? [{ url: imageUrl, width: 1200, height: 630, alt: post.title }]
+    : undefined;
 
   return {
     title: post.title,
@@ -61,20 +67,13 @@ export async function generateMetadata({
       publishedTime: post.publishedAt,
       authors: [post.author.name],
       url: postUrl,
-      images: [
-        {
-          url: imageUrl,
-          width: 1200,
-          height: 630,
-          alt: post.title,
-        },
-      ],
+      images: ogImages,
     },
     twitter: {
       card: "summary_large_image",
       title: post.title,
       description: post.excerpt,
-      images: [imageUrl],
+      images: imageUrl ? [imageUrl] : undefined,
       creator: "@vm0_ai",
       site: "@vm0_ai",
     },
@@ -121,9 +120,11 @@ export default async function BlogPostPage({ params }: PageProps) {
     .slice(0, 3);
 
   const postUrl = `${getBlogBaseUrl()}/${locale}/blog/posts/${post.slug}`;
-  const imageUrl = post.cover.startsWith("http")
-    ? post.cover
-    : `${getBlogBaseUrl()}${post.cover}`;
+  const imageUrl = post.cover
+    ? post.cover.startsWith("http")
+      ? post.cover
+      : `${getBlogBaseUrl()}${post.cover}`
+    : undefined;
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -157,7 +158,7 @@ export default async function BlogPostPage({ params }: PageProps) {
     description: post.excerpt,
     url: postUrl,
     datePublished: post.publishedAt,
-    image: imageUrl,
+    ...(imageUrl && { image: imageUrl }),
     author: {
       "@type": "Person",
       name: post.author.name,
@@ -288,14 +289,16 @@ export default async function BlogPostPage({ params }: PageProps) {
                     style={{ textDecoration: "none" }}
                   >
                     <article className="blog-card">
-                      <div className="blog-card-cover">
-                        <Image
-                          src={relatedPost.cover}
-                          alt={relatedPost.title}
-                          fill
-                          style={{ objectFit: "cover" }}
-                        />
-                      </div>
+                      {relatedPost.cover && (
+                        <div className="blog-card-cover">
+                          <Image
+                            src={relatedPost.cover}
+                            alt={relatedPost.title}
+                            fill
+                            style={{ objectFit: "cover" }}
+                          />
+                        </div>
+                      )}
                       <div className="blog-card-body">
                         <div className="blog-card-meta">
                           <span className="blog-card-category">

--- a/turbo/apps/web/app/[locale]/layout.tsx
+++ b/turbo/apps/web/app/[locale]/layout.tsx
@@ -3,7 +3,6 @@ import { NextIntlClientProvider } from "next-intl";
 import { notFound } from "next/navigation";
 import { locales, type Locale } from "../../i18n";
 import SiteHeader from "../components/SiteHeader";
-import { buildLocaleAlternates } from "../lib/seo/alternates";
 import type { Metadata } from "next";
 
 type Props = {
@@ -27,14 +26,9 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     ja: "ja_JP",
   };
 
-  // Fallback hreflang for any route that doesn't provide page-level metadata.
-  // All real pages under [locale] should override this via buildLocaleAlternates
-  // with their own path so hreflang alternates point to the correct translation.
-  const alternates = buildLocaleAlternates("", locale);
-  const ogUrl = alternates.canonical;
+  const ogUrl = `https://www.vm0.ai/${locale}`;
 
   return {
-    alternates,
     openGraph: {
       locale: localeNames[locale] || "en_US",
       alternateLocale: locales

--- a/turbo/apps/web/app/components/blog/BlogContent.tsx
+++ b/turbo/apps/web/app/components/blog/BlogContent.tsx
@@ -79,15 +79,17 @@ export default function BlogContent({
                     {featuredPost.excerpt}
                   </p>
                 </div>
-                <div className="featured-post-visual">
-                  <Image
-                    src={featuredPost.cover}
-                    alt={featuredPost.title}
-                    width={800}
-                    height={500}
-                    style={{ width: "100%", height: "auto" }}
-                  />
-                </div>
+                {featuredPost.cover && (
+                  <div className="featured-post-visual">
+                    <Image
+                      src={featuredPost.cover}
+                      alt={featuredPost.title}
+                      width={800}
+                      height={500}
+                      style={{ width: "100%", height: "auto" }}
+                    />
+                  </div>
+                )}
               </article>
             </Link>
           </div>
@@ -143,14 +145,16 @@ export default function BlogContent({
                   style={{ textDecoration: "none" }}
                 >
                   <article className="blog-card">
-                    <div className="blog-card-cover">
-                      <Image
-                        src={post.cover}
-                        alt={post.title}
-                        fill
-                        style={{ objectFit: "cover" }}
-                      />
-                    </div>
+                    {post.cover && (
+                      <div className="blog-card-cover">
+                        <Image
+                          src={post.cover}
+                          alt={post.title}
+                          fill
+                          style={{ objectFit: "cover" }}
+                        />
+                      </div>
+                    )}
                     <div className="blog-card-body">
                       <div className="blog-card-meta">
                         <span className="blog-card-category">

--- a/turbo/apps/web/app/lib/blog/__tests__/strapi.test.ts
+++ b/turbo/apps/web/app/lib/blog/__tests__/strapi.test.ts
@@ -176,7 +176,7 @@ describe("blog/strapi", () => {
         slug: "minimal-post",
         category: "General",
         author: { name: "VM0 Team" },
-        cover: "/covers/default.png",
+        cover: undefined,
       });
     });
   });

--- a/turbo/apps/web/app/lib/blog/strapi.ts
+++ b/turbo/apps/web/app/lib/blog/strapi.ts
@@ -73,7 +73,7 @@ interface StrapiArticle {
 }
 
 function transformArticle(article: StrapiArticle): BlogPost {
-  let coverUrl = "/covers/default.png";
+  let coverUrl: string | undefined;
   if (article.cover?.url) {
     const url = article.cover.url;
     coverUrl = url.startsWith("http") ? url : `${getStrapiUrl()}${url}`;

--- a/turbo/apps/web/app/lib/blog/types.ts
+++ b/turbo/apps/web/app/lib/blog/types.ts
@@ -11,5 +11,5 @@ export interface BlogPost {
   publishedAt: string;
   readTime: string;
   featured?: boolean;
-  cover: string;
+  cover?: string;
 }

--- a/turbo/apps/web/app/sitemap.ts
+++ b/turbo/apps/web/app/sitemap.ts
@@ -133,9 +133,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
       const alternates = buildAlternates(`/blog/posts/${post.slug}`, available);
 
-      const imageUrl = post.cover.startsWith("http")
-        ? post.cover
-        : `${blogBaseUrl}${post.cover}`;
+      const imageUrl = post.cover
+        ? post.cover.startsWith("http")
+          ? post.cover
+          : `${blogBaseUrl}${post.cover}`
+        : undefined;
 
       for (const locale of available) {
         urls.push({
@@ -143,7 +145,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           lastModified: new Date(post.publishedAt),
           changeFrequency: "monthly",
           priority: 0.7,
-          images: [imageUrl],
+          ...(imageUrl && { images: [imageUrl] }),
           alternates: { languages: alternates },
         });
       }


### PR DESCRIPTION
## Summary
- Remove layout-level hreflang alternates that caused duplicate `<link rel="alternate" hreflang="...">` tags when Next.js merged layout + page metadata (fixes Ahrefs "more than one page linked for the same language")
- Make blog cover images optional (`cover?: string`) to eliminate 400 errors from `/_next/image?url=%2Fcovers%2Fdefault.png` — the fallback file never existed in `public/`
- Update sitemap, OG metadata, and structured data to gracefully handle posts without cover images

## Test plan
- [ ] Verify `/en/blog` and `/ja/blog` pages render without broken images
- [ ] Verify blog post pages no longer emit duplicate hreflang tags (inspect `<head>`)
- [ ] Verify sitemap.xml doesn't reference non-existent image URLs
- [ ] Re-crawl with Ahrefs to confirm hreflang and broken image issues are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)