### PR TITLE
fix(web): allow 'Why Zero' heading to wrap on mobile

### DIFF
--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -1584,7 +1584,7 @@ export default function LandingPage({
         <section className="px-5 py-10 sm:px-6 sm:py-12 md:py-16">
           <div className="mx-auto max-w-[1152px]">
             <div className="reveal flex flex-col items-center">
-              <h2 className="landing-heading whitespace-nowrap text-center text-[22px] font-medium leading-[1.2] tracking-[-0.88px] text-[hsl(var(--foreground))] sm:text-[28px] md:text-[36px]">
+              <h2 className="landing-heading text-center text-[22px] font-medium leading-[1.2] tracking-[-0.88px] text-[hsl(var(--foreground))] sm:text-[28px] md:whitespace-nowrap md:text-[36px]">
                 {t("comparison.heading")}
               </h2>
             </div>


### PR DESCRIPTION
## Summary
- The 'Why Zero' section heading ("Different from every alternative you've tried.") had `whitespace-nowrap` applied at all breakpoints, causing horizontal overflow on narrow mobile viewports.
- Scoped the nowrap to `md:` so the heading wraps naturally on mobile/tablet and stays single-line on desktop.

## Change
`turbo/apps/web/app/components/LandingPage.tsx:1587`
- before: `whitespace-nowrap ... sm:text-[28px] md:text-[36px]`
- after:  `sm:text-[28px] md:whitespace-nowrap md:text-[36px]`

## Test plan
- [ ] Load `/` at 360px width — heading wraps cleanly within viewport, no horizontal scroll.
- [ ] Load `/` at ≥768px — heading renders on a single line as before.
- [ ] Verify translated locales (de/es/ja) also render without overflow on mobile.

Recreated from #9797 (CI deployment secrets issue, code unchanged).