### PR TITLE
fix(platform): only show thinking indicator when awaiting reply to user

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -348,6 +348,17 @@ function ChatThreadComposer({
           setComposerFileInput$={thread.setComposerFileInput$}
           setInputRef={setInputRef}
         />
+        {sending && (
+          <div className="flex items-center justify-end gap-1.5 mt-2 pr-1">
+            <IconLoader2
+              size={12}
+              className="animate-spin text-foreground/50 shrink-0"
+            />
+            <span className="zero-shimmer-text text-xs">
+              {displayName} is working...
+            </span>
+          </div>
+        )}
       </div>
     </footer>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -397,7 +397,7 @@ function ThinkingIndicator({ thread }: { thread: ChatThreadSignals }) {
   const hasActiveRun = useLastResolved(thread.hasActiveRun$) ?? false;
   const groups = useGet(thread.groupedChatMessages$);
   const lastGroup = groups[groups.length - 1];
-  const show = hasActiveRun && lastGroup?.role === "user";
+  const show = lastGroup?.role !== "assistant" || hasActiveRun;
 
   if (!show) {
     return null;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -397,7 +397,7 @@ function ThinkingIndicator({ thread }: { thread: ChatThreadSignals }) {
   const hasActiveRun = useLastResolved(thread.hasActiveRun$) ?? false;
   const groups = useGet(thread.groupedChatMessages$);
   const lastGroup = groups[groups.length - 1];
-  const show = hasActiveRun && (!lastGroup || lastGroup.role !== "assistant");
+  const show = hasActiveRun && lastGroup?.role === "user";
 
   if (!show) {
     return null;


### PR DESCRIPTION
## Summary
- Restrict the chat thread thinking indicator to the case where a run is active **and** the last message group is from the user.
- Previously the indicator also rendered for empty threads or threads whose last group was a tool/system message, which showed a spurious "Thinking..." spinner when the assistant wasn't actually preparing a reply to the user.

Before:
```ts
const show = hasActiveRun && (!lastGroup || lastGroup.role !== "assistant");
```

After:
```ts
const show = hasActiveRun && lastGroup?.role === "user";
```

## Test plan
- [ ] Send a message in a chat thread — spinner appears until the assistant starts streaming its reply.
- [ ] Open an empty thread with no messages — spinner does **not** appear.
- [ ] Thread ending in a tool/system group with an active run — spinner does **not** appear.
- [ ] Thread ending in an assistant message — spinner does **not** appear (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)