### PR TITLE
feat(cli): guide connector authorization in agent create and status output

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -62,6 +62,15 @@ describe("zero agent create command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("comp_xyz789");
       expect(logCalls).toContain("created");
+      expect(logCalls).toContain(
+        "Next steps to authorize connectors for this agent:",
+      );
+      expect(logCalls).toContain(
+        "zero connector search <keyword> --agent comp_xyz789",
+      );
+      expect(logCalls).toContain(
+        "zero connector status <type> --agent comp_xyz789",
+      );
     });
 
     it("should create agent with custom skills and include them in request body", async () => {

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -73,6 +73,19 @@ Examples:
         if (agent.displayName) {
           console.log(`  Display Name: ${agent.displayName}`);
         }
+
+        console.log();
+        console.log("Next steps to authorize connectors for this agent:");
+        console.log("  - Search connectors this agent needs:");
+        console.log(
+          `      zero connector search <keyword> --agent ${agent.agentId}`,
+        );
+        console.log(
+          "  - Check authorization status (prints an authorize URL if not authorized):",
+        );
+        console.log(
+          `      zero connector status <type> --agent ${agent.agentId}`,
+        );
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
@@ -112,7 +112,7 @@ describe("zero connector status command", () => {
   });
 
   describe("with agent context", () => {
-    it("shows Authorized: ✓ when agent is authorized", async () => {
+    it("shows authorized prose when agent is authorized", async () => {
       server.use(
         stubConnector(connectedGithub),
         stubAgent(AGENT_UUID, "maya"),
@@ -128,12 +128,16 @@ describe("zero connector status command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Authorized:");
-      expect(logCalls).toContain("✓ for agent maya");
-      expect(logCalls).not.toContain("Authorize:");
+      expect(logCalls).toContain(
+        `The github connector is authorized for agent maya (${AGENT_UUID}).`,
+      );
+      expect(logCalls).not.toContain("is not authorized");
+      expect(logCalls).not.toContain("is not connected");
+      expect(logCalls).not.toContain("[Authorize github]");
+      expect(logCalls).not.toContain("[Connect github]");
     });
 
-    it("shows Authorized: - and authorize URL when connected but not authorized", async () => {
+    it("shows authorize link when connected but agent is not authorized", async () => {
       server.use(
         stubConnector(connectedGithub),
         stubAgent(AGENT_UUID, "maya"),
@@ -149,14 +153,18 @@ describe("zero connector status command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("- for agent maya");
-      expect(logCalls).toContain("Authorize:");
+      expect(logCalls).toContain(
+        `The github connector is not authorized for agent maya (${AGENT_UUID}).`,
+      );
+      expect(logCalls).toContain("[Authorize github](");
       expect(logCalls).toContain(
         `/connectors/github/authorize?agentId=${AGENT_UUID}`,
       );
+      expect(logCalls).not.toContain("is not connected");
+      expect(logCalls).not.toContain("[Connect github]");
     });
 
-    it("shows Authorized: - and authorize URL when connector not connected", async () => {
+    it("shows connect link when connector is not connected", async () => {
       server.use(
         stubConnector(
           { error: { message: "Not found", code: "NOT_FOUND" } },
@@ -175,11 +183,14 @@ describe("zero connector status command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("not connected");
-      expect(logCalls).toContain("- for agent maya");
       expect(logCalls).toContain(
-        `/connectors/github/authorize?agentId=${AGENT_UUID}`,
+        `The github connector is not connected. Once connected, it will be authorized for agent maya (${AGENT_UUID}).`,
       );
+      expect(logCalls).toContain("[Connect github](");
+      expect(logCalls).toContain(
+        `/connectors/github/connect?agentId=${AGENT_UUID}`,
+      );
+      expect(logCalls).not.toContain("[Authorize github]");
     });
 
     it("uses $ZERO_AGENT_ID when --agent flag is not provided", async () => {
@@ -193,7 +204,9 @@ describe("zero connector status command", () => {
       await statusCommand.parseAsync(["node", "cli", "github"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("✓ for agent maya");
+      expect(logCalls).toContain(
+        `The github connector is authorized for agent maya (${AGENT_UUID}).`,
+      );
     });
 
     it("--agent overrides $ZERO_AGENT_ID", async () => {
@@ -222,10 +235,12 @@ describe("zero connector status command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("✓ for agent maya");
+      expect(logCalls).toContain(
+        `The github connector is authorized for agent maya (${AGENT_UUID}).`,
+      );
     });
 
-    it("falls back to UUID when displayName is null", async () => {
+    it("falls back to UUID-only label when displayName is null", async () => {
       server.use(
         stubConnector(connectedGithub),
         stubAgent(AGENT_UUID, null),
@@ -241,7 +256,10 @@ describe("zero connector status command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(`✓ for agent ${AGENT_UUID}`);
+      expect(logCalls).toContain(
+        `The github connector is authorized for agent ${AGENT_UUID}.`,
+      );
+      expect(logCalls).not.toContain(`${AGENT_UUID} (${AGENT_UUID})`);
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/connector/status.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/status.ts
@@ -91,16 +91,32 @@ export const statusCommand = new Command()
 
       if (agentCtx) {
         const authorized = agentCtx.authorizedTypes.has(parseResult.data);
-        const glyph = authorized ? chalk.green("✓") : chalk.dim("-");
+        const isConnected = connector !== null;
+        const agentLabel =
+          agentCtx.displayName === agentCtx.agentId
+            ? agentCtx.agentId
+            : `${agentCtx.displayName} (${agentCtx.agentId})`;
+
         console.log();
-        console.log(
-          `${"Authorized:".padEnd(LABEL_WIDTH)}${glyph} for agent ${agentCtx.displayName}`,
-        );
-        if (!authorized) {
+        if (authorized) {
+          console.log(
+            `The ${parseResult.data} connector is authorized for agent ${agentLabel}.`,
+          );
+        } else if (!isConnected) {
+          const origin = await getPlatformOrigin();
+          const url = `${origin}/connectors/${parseResult.data}/connect?agentId=${agentCtx.agentId}`;
+          console.log(
+            `The ${parseResult.data} connector is not connected. Once connected, it will be authorized for agent ${agentLabel}.`,
+          );
+          console.log(`Connect it at: [Connect ${parseResult.data}](${url})`);
+        } else {
           const origin = await getPlatformOrigin();
           const url = `${origin}/connectors/${parseResult.data}/authorize?agentId=${agentCtx.agentId}`;
           console.log(
-            `${"".padEnd(LABEL_WIDTH)}${chalk.dim("Authorize:")} ${url}`,
+            `The ${parseResult.data} connector is not authorized for agent ${agentLabel}.`,
+          );
+          console.log(
+            `Authorize it at: [Authorize ${parseResult.data}](${url})`,
           );
         }
       }


### PR DESCRIPTION
## Summary

- Append a "Next steps" hint to `zero agent create` stdout pointing the parent agent to `zero connector search <keyword> --agent <id>` and `zero connector status <type> --agent <id>` with the new agent's ID interpolated.
- Rewrite the agent-authorization block in `zero connector status` as three explicit prose states (authorized / not connected / not authorized) with Markdown action links, matching the style of `zero doctor check-connector`. When the connector is not yet connected, the output now emits a `connect?agentId=...` URL (which auto-authorizes the agent after the connect flow completes) instead of an `authorize` URL that would dead-end.
- Update `status.test.ts` and `create.test.ts` to assert the new output shapes.

Closes #9859. Supersedes #9201.

## Test plan

- [x] `pnpm -F @vm0/cli exec vitest run src/commands/zero/agent/__tests__/create.test.ts src/commands/zero/connector/__tests__/status.test.ts` — 14/14 passing.
- [x] `pnpm turbo run lint --filter=@vm0/cli` — 0 errors.
- [x] `pnpm format` — applied.
- [x] `pnpm knip --workspace apps/cli` — clean.
- [ ] Manual: run `zero agent create --display-name "Test"` and verify the new hint appears.
- [ ] Manual: run `zero connector status github --agent <id>` in the three states and verify each prose/link variant renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)