### PR TITLE
fix(blog): fill card covers edge-to-edge

### DIFF
--- a/turbo/apps/web/app/blog.css
+++ b/turbo/apps/web/app/blog.css
@@ -238,8 +238,7 @@
 .blog-card-cover img {
   width: 100%;
   height: 100%;
-  object-fit: contain;
-  padding: 20px;
+  object-fit: cover;
   transition: transform 0.3s ease;
 }
 

--- a/turbo/apps/web/app/components/blog/BlogContent.tsx
+++ b/turbo/apps/web/app/components/blog/BlogContent.tsx
@@ -148,7 +148,7 @@ export default function BlogContent({
                         src={post.cover}
                         alt={post.title}
                         fill
-                        style={{ objectFit: "contain" }}
+                        style={{ objectFit: "cover" }}
                       />
                     </div>
                     <div className="blog-card-body">


### PR DESCRIPTION
## Summary
- Blog card cover images were showing with whitespace around them (contained within a padded box) instead of filling the card.
- Switched `.blog-card-cover img` from `object-fit: contain` + `padding: 20px` to `object-fit: cover` and updated the matching inline style in `BlogContent.tsx` for consistency with the related-posts section on the post page.

## Test plan
- [ ] Verify `/en/blog` grid: cover images fill the 240px card area edge-to-edge
- [ ] Verify hover zoom still works (`transform: scale(1.05)`)
- [ ] Verify related posts on `/en/blog/posts/[slug]` still look correct (already used `cover`)