### PR TITLE
fix(zero-runs): restore oauth pre-refresh before dispatching run

### DIFF
--- a/turbo/apps/web/src/lib/zero/context/resolve-connectors.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-connectors.ts
@@ -7,6 +7,7 @@ import { and, eq } from "drizzle-orm";
 import { logger } from "../../shared/logger";
 import { connectors } from "../../../db/schema/connector";
 import { PROVIDER_HANDLERS } from "../connector/provider-registry";
+import { refreshConnectorAccessToken } from "../connector/connector-service";
 import { getSecretValues } from "../secret/secret-service";
 
 const log = logger("zero:build-context");
@@ -75,6 +76,25 @@ export async function resolveOauthConnectorSecrets(
         return allowedTypes.includes(type);
       })
     : validConnectors;
+  // Refresh OAuth tokens in parallel.
+  // Safe: each connector writes to distinct keys in connectorSecrets (e.g. github_access_token
+  // vs slack_access_token), so concurrent mutations don't conflict.
+  await Promise.all(
+    allowedConnectors
+      .filter(({ type }) => {
+        const handler =
+          PROVIDER_HANDLERS[type as keyof typeof PROVIDER_HANDLERS];
+        return handler?.refreshToken;
+      })
+      .map(({ type }) => {
+        return refreshConnectorAccessToken(
+          type,
+          orgId,
+          userId,
+          connectorSecrets,
+        );
+      }),
+  );
 
   // Resolve environment mappings from connectors.
   const allInjectedEnvVars: Record<string, string> = {};


### PR DESCRIPTION
## Summary

Partial revert of #9694. The `after()`-based deferred dispatch is **kept**; only the OAuth pre-refresh that was removed from `resolveOauthConnectorSecrets` is restored.

Without the pre-refresh, runs that start with an expired access token hit the connector mid-flight and fail before the firewall auth endpoint gets a chance to refresh. Re-adding the parallel refresh on the dispatch path covers the common case where the cached token is already stale at run start.

## Test plan

- [ ] Trigger a zero run where a connector's access token has expired; verify the run proceeds instead of failing on first connector call.
- [ ] Confirm unrelated runs (no refresh-capable connectors) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)