### PR TITLE
fix(platform+web): stabilize chat thinking indicator and publish cancel signals

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -69,7 +69,7 @@ export interface ChatThreadSignals {
   pagedChatMessages$: Computed<PagedChatMessage[]>;
   latestChatMessageId$: Computed<string | undefined>;
   groupedChatMessages$: Computed<GroupedChatMessageGroup[]>;
-  hasActiveRun$: Computed<Promise<boolean>>;
+  allFinished$: Computed<Promise<boolean>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
   loadPagedMessages$: Command<Promise<void>, [AbortSignal]>;
 }
@@ -566,12 +566,12 @@ function createRunTracking(
   threadData$: Computed<Promise<ChatThread | null>>,
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>,
 ) {
-  const hasActiveRun$ = computed(async (get) => {
+  const allFinished$ = computed(async (get) => {
     const thread = await get(threadData$);
     if (!thread) {
       return false;
     }
-    return thread.activeRunIds.length > 0;
+    return thread.activeRunIds.length === 0;
   });
 
   const loadPagedMessages$ = command(
@@ -651,7 +651,7 @@ function createRunTracking(
     signal.throwIfAborted();
   });
 
-  return { hasActiveRun$, loadPagedMessages$, cancelRun$ };
+  return { allFinished$, loadPagedMessages$, cancelRun$ };
 }
 
 // ---------------------------------------------------------------------------
@@ -688,7 +688,7 @@ export function createChatThreadSignals(
 
   const prepareUserMessage$ = createPrepareUserMessage(draft);
 
-  const { hasActiveRun$, loadPagedMessages$, cancelRun$ } = createRunTracking(
+  const { allFinished$, loadPagedMessages$, cancelRun$ } = createRunTracking(
     reloadThread$,
     threadData$,
     fetchNextPage$,
@@ -780,7 +780,7 @@ export function createChatThreadSignals(
     pagedChatMessages$,
     latestChatMessageId$,
     groupedChatMessages$,
-    hasActiveRun$,
+    allFinished$,
     fetchNextPage$,
     loadPagedMessages$,
   };

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -296,9 +296,9 @@ function ChatThreadComposer({
   const groups = useGet(thread.groupedChatMessages$);
   const hasMessages = groups.length > 0;
   const displayName = useLastResolved(thread.agentDisplayName$) ?? "Zero";
-  const hasActiveRun = useLastResolved(thread.hasActiveRun$) ?? false;
+  const allFinished = useLastResolved(thread.allFinished$) ?? false;
   const [sendLoadable, send] = useLoadableSet(thread.sendMessage$);
-  const sending = hasActiveRun || sendLoadable.state === "loading";
+  const sending = !allFinished || sendLoadable.state === "loading";
   const input = useGet(thread.draft.input$);
   const setInput = useSet(thread.draft.setInput$);
   const cancelRun = useSet(thread.cancelRun$);
@@ -323,7 +323,7 @@ function ChatThreadComposer({
   return (
     <footer
       data-chat-composer
-      className="relative shrink-0 px-4 sm:px-6 pt-3 pb-8 bg-[hsl(var(--background))]"
+      className="relative shrink-0 px-4 sm:px-6 pt-3 pb-2 bg-[hsl(var(--background))]"
     >
       <div className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-t from-[hsl(var(--background))] to-transparent" />
       <div className="mx-auto max-w-[900px]">
@@ -348,17 +348,21 @@ function ChatThreadComposer({
           setComposerFileInput$={thread.setComposerFileInput$}
           setInputRef={setInputRef}
         />
-        {sending && (
-          <div className="flex items-center justify-end gap-1.5 mt-2 pr-1">
-            <IconLoader2
-              size={12}
-              className="animate-spin text-foreground/50 shrink-0"
-            />
-            <span className="zero-shimmer-text text-xs">
-              {displayName} is working...
-            </span>
-          </div>
-        )}
+        <div
+          aria-hidden={allFinished}
+          className={cn(
+            "flex items-center justify-end gap-1.5 mt-2 pr-1 transition-opacity",
+            allFinished && "opacity-0",
+          )}
+        >
+          <IconLoader2
+            size={12}
+            className="animate-spin text-foreground/50 shrink-0"
+          />
+          <span className="zero-shimmer-text text-xs">
+            {displayName} is working...
+          </span>
+        </div>
       </div>
     </footer>
   );
@@ -405,10 +409,9 @@ function ChatSkeleton() {
 // ---------------------------------------------------------------------------
 
 function ThinkingIndicator({ thread }: { thread: ChatThreadSignals }) {
-  const hasActiveRun = useLastResolved(thread.hasActiveRun$) ?? false;
   const groups = useGet(thread.groupedChatMessages$);
   const lastGroup = groups[groups.length - 1];
-  const show = lastGroup?.role !== "assistant" || hasActiveRun;
+  const show = lastGroup && lastGroup.role !== "assistant";
 
   if (!show) {
     return null;
@@ -430,6 +433,13 @@ function ThinkingIndicator({ thread }: { thread: ChatThreadSignals }) {
             <p className="zero-shimmer-text text-xs truncate">Thinking...</p>
           </div>
         </div>
+      </div>
+      <div
+        aria-hidden
+        className="@[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px]"
+      >
+        <div className="hidden @[900px]:block" />
+        <div className="flex items-center py-2 gap-1 -ml-1" />
       </div>
     </div>
   );
@@ -733,14 +743,7 @@ function PagedGroupActions({
   const playTts = useSet(playTts$);
   const stopTts = useSet(stopTts$);
 
-  // Hide actions for user groups or while a run is still active.
-  const hasActiveRun = group.messages.some((m) => {
-    return (
-      m.status === "queued" || m.status === "pending" || m.status === "running"
-    );
-  });
-
-  if (group.role === "user" || hasActiveRun) {
+  if (group.role === "user") {
     return null;
   }
 

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -26,7 +26,12 @@ import {
   type FirewallPolicies,
   type ConnectorType,
 } from "@vm0/core";
-import { publishCancelNotification } from "../realtime/client";
+import {
+  publishCancelNotification,
+  publishUserSignal,
+} from "../realtime/client";
+import { getOrgMemberUserIds } from "../realtime/audience";
+import { chatMessages } from "../../../db/schema/chat-message";
 import type { CancelRunResult } from "../../zero/zero-run-cancel";
 
 const log = logger("service:run");
@@ -522,6 +527,24 @@ export async function dispatchCancelSideEffects(
         }
       : undefined,
   );
+
+  await publishUserSignal([result.userId], `thread:${result.runId}`);
+  await publishUserSignal([result.userId], `runUpdated:${result.runId}`);
+
+  const [msg] = await globalThis.services.db
+    .select({ chatThreadId: chatMessages.chatThreadId })
+    .from(chatMessages)
+    .where(eq(chatMessages.runId, result.runId))
+    .limit(1);
+  if (msg?.chatThreadId) {
+    await publishUserSignal(
+      [result.userId],
+      `chatThreadRunUpdated:${msg.chatThreadId}`,
+    );
+  }
+
+  const orgMembers = await getOrgMemberUserIds(result.orgId);
+  await publishUserSignal(orgMembers, `tasks:${result.orgId}`);
 
   return shouldDrain;
 }

--- a/turbo/apps/web/src/lib/zero/zero-run-cancel.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-cancel.ts
@@ -10,6 +10,7 @@ import { notFound, badRequest } from "../shared/errors";
 export interface CancelRunResult {
   runId: string;
   previousStatus: string;
+  userId: string;
   orgId: string;
   sandboxId: string | null;
   runnerGroup: string | null;
@@ -69,6 +70,7 @@ export async function cancelRun(
   return {
     runId,
     previousStatus: run.status,
+    userId: run.userId,
     orgId: run.orgId,
     sandboxId: run.sandboxId,
     runnerGroup: run.runnerGroup,


### PR DESCRIPTION
## Summary

Two related fixes around the chat thread run lifecycle:

**Backend (`apps/web`)**
- `dispatchCancelSideEffects` now publishes the same Ably signals as the completion webhook: `thread:{runId}`, `runUpdated:{runId}`, `chatThreadRunUpdated:{chatThreadId}` (when the run is part of a chat thread), and `tasks:{orgId}`. Previously it only notified the runner channel, so cancelling a run left the frontend stuck showing "thinking" until a manual refresh.
- Added `userId` to `CancelRunResult` so the cancel service can publish user-scoped signals.

**Frontend (`apps/platform`)**
- Renamed `thread.hasActiveRun$` to `thread.allFinished$` (inverted) and derived a persistent "{agent} is working..." banner under the composer from it.
- Banner is always mounted, using `opacity-0` + `aria-hidden` when idle, so the input no longer jumps up/down when the indicator toggles. Footer `pb-8` → `pb-2` to keep the total vertical footprint unchanged.
- Each assistant group always renders the actions toolbar (view logs / copy / TTS), regardless of run status. Without this, newly streamed messages showed no toolbar until the page was refreshed.
- Added a matching placeholder actions row under the `ThinkingIndicator` so the layout height is consistent between the "Thinking..." state and the subsequent assistant group.
- `ThinkingIndicator` no longer renders when the thread has zero groups (prevents it from appearing over the chat skeleton on initial load).

## Test plan
- [ ] Send a message → "Zero is working..." banner appears immediately, stays visible until the run finishes, no flicker on the send→run handoff.
- [ ] Cancel an in-flight run → banner disappears and thinking indicator clears without a manual page refresh.
- [ ] During a streamed assistant reply, verify the view-logs / copy buttons are present (no refresh required).
- [ ] Open a fresh thread → chat skeleton shows, no "Send a message..." text or thinking indicator flashes before messages load.
- [ ] Open an empty thread after initial load → "Send a message..." empty state appears as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)