### PR TITLE
fix(runner): forward secretconnectormap in claim response

### DIFF
--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -530,5 +530,52 @@ describe("POST /api/runners/jobs/:id/claim", () => {
       expect(data.settings).toBeUndefined();
       expect(data.tools).toBeUndefined();
     });
+
+    // Regression for #9868 — claim route used to hand-pick fields from
+    // storedContext and silently dropped secretConnectorMap, breaking the
+    // mitmproxy OAuth refresh path. Pin both secretConnectorMap and
+    // encryptedSecrets so any future refactor of the response body can't
+    // drop them without tripping a test.
+    it("should forward secretConnectorMap and encryptedSecrets to the runner", async () => {
+      const { versionId } = await createTestCompose(
+        "test-secret-connector-map",
+      );
+
+      const encryptedSecrets = encryptSecretsMap(
+        { GMAIL_ACCESS_TOKEN: "ya29.real-token" },
+        globalThis.services.env.SECRETS_ENCRYPTION_KEY,
+      );
+      const secretConnectorMap = {
+        GMAIL_ACCESS_TOKEN: "gmail",
+        GMAIL_TOKEN: "gmail",
+      };
+
+      const { runId } = await createTestRunnerJob(
+        user.userId,
+        versionId,
+        "vm0/default",
+        { encryptedSecrets, secretConnectorMap },
+      );
+
+      const token = await createTestCliToken(user.userId);
+      const request = createTestRequest(
+        `http://localhost:3000/api/runners/jobs/${runId}/claim`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.secretConnectorMap).toEqual(secretConnectorMap);
+      expect(data.encryptedSecrets).toBe(encryptedSecrets);
+    });
   });
 });

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -542,7 +542,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
       );
 
       const encryptedSecrets = encryptSecretsMap(
-        { GMAIL_ACCESS_TOKEN: "ya29.real-token" },
+        { GMAIL_ACCESS_TOKEN: "fake-access-token" },
         globalThis.services.env.SECRETS_ENCRYPTION_KEY,
       );
       const secretConnectorMap = {

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -198,6 +198,7 @@ const router = tsr.router(runnersJobClaimContract, {
         resumeSession: storedContext.resumeSession,
         secretValues, // Decrypted secret values for log masking
         encryptedSecrets: storedContext.encryptedSecrets, // Encrypted blob for auth resolution
+        secretConnectorMap: storedContext.secretConnectorMap, // Secret name → connector type for runtime OAuth refresh
         cliAgentType: storedContext.cliAgentType,
         firewalls: storedContext.firewalls,
         networkPolicies: storedContext.networkPolicies,

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -179,11 +179,14 @@ const router = tsr.router(runnersJobClaimContract, {
         })
       : null;
 
-    // Return execution context (context already prepared at job creation)
+    // Return execution context (context already prepared at job creation).
+    // Spread storedContext so any future field added to storedExecutionContextSchema
+    // auto-forwards — avoids the silent-drop class of bug (see #9868).
     // Note: apiUrl is not returned - runner uses its configured server.url
     return {
       status: 200 as const,
       body: {
+        ...storedContext,
         runId: run.id,
         prompt: run.prompt,
         appendSystemPrompt: run.appendSystemPrompt,
@@ -191,27 +194,7 @@ const router = tsr.router(runnersJobClaimContract, {
         vars: (run.vars as Record<string, string>) ?? null,
         checkpointId: run.resumedFromCheckpointId ?? null,
         sandboxToken,
-        // From stored context (prepared at job creation):
-        workingDir: storedContext.workingDir,
-        storageManifest: storedContext.storageManifest,
-        environment: storedContext.environment,
-        resumeSession: storedContext.resumeSession,
         secretValues, // Decrypted secret values for log masking
-        encryptedSecrets: storedContext.encryptedSecrets, // Encrypted blob for auth resolution
-        secretConnectorMap: storedContext.secretConnectorMap, // Secret name → connector type for runtime OAuth refresh
-        cliAgentType: storedContext.cliAgentType,
-        firewalls: storedContext.firewalls,
-        networkPolicies: storedContext.networkPolicies,
-        disallowedTools: storedContext.disallowedTools,
-        tools: storedContext.tools,
-        settings: storedContext.settings,
-        experimentalProfile: storedContext.experimentalProfile,
-        debugNoMockClaude: storedContext.debugNoMockClaude,
-        captureNetworkBodies: storedContext.captureNetworkBodies,
-        apiStartTime: storedContext.apiStartTime,
-        userTimezone: storedContext.userTimezone,
-        memoryName: storedContext.memoryName,
-        featureFlags: storedContext.featureFlags,
       },
     };
   },


### PR DESCRIPTION
## Summary

The runner claim route at `turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts` hand-picks fields from `storedContext` into the response body but omitted `secretConnectorMap`. That drop cascaded through the runner proxy registry into mitmproxy, so the auth webhook always received an undefined map and `refreshExpiredTokens` never fired.

The full plumbing — zod schemas on both sides, Rust struct, proxy registry (camelCase), mitm-addon POST body, and the refresh branch in the firewall auth endpoint — was already in place. Only this one wire was missing, and has been since `secretConnectorMap` was introduced in #4764 (`git log -S secretConnectorMap -- turbo/apps/web/app/api/runners/` returned zero results prior to this commit).

Closes #9868.

## Test plan

- [ ] Trigger a run with a refreshable OAuth connector (e.g. gmail) and inspect `proxy-registry.json` — `secretConnectorMap` should be populated.
- [ ] During a run where the access token is near expiry, confirm the firewall-auth webhook log emits "Refreshing expired gmail token" instead of silently returning stale secrets.
- [ ] Verify unrelated runs (no refresh-capable connectors) remain unaffected.

## Related

- #4764 — original introduction of `secretConnectorMap` (missed this wire)
- #9694 — removed the build-time pre-refresh that was masking this bug
- #9865 — restored the pre-refresh as interim mitigation; now runtime refresh actually fires too

🤖 Generated with [Claude Code](https://claude.com/claude-code)