### PR TITLE
fix(sandbox-fc): fail snapshot when destroy_keep_cow retries exhaust

### DIFF
--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -423,7 +423,7 @@ impl CowLayer {
 /// Compute the bitmap sidecar path for a given COW file path.
 ///
 /// Convention: `{cow_path}.bitmap` (e.g., `cow.img.bitmap`).
-pub(crate) fn bitmap_path_for(cow_path: &Path) -> PathBuf {
+pub fn bitmap_path_for(cow_path: &Path) -> PathBuf {
     let mut name = cow_path.as_os_str().to_os_string();
     name.push(".bitmap");
     PathBuf::from(name)

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -404,7 +404,6 @@ async fn run_snapshot_workflow(
     // released. The COW-device bind mount lived inside the FC process's
     // private mount namespace and was auto-cleaned when the process exited.
     if result.is_ok() {
-        let cow_file = cow_device.cow_file().to_owned();
         let mut last_err = None;
         for attempt in 0..DESTROY_RETRIES {
             match cow_device.destroy_keep_cow().await {
@@ -413,31 +412,38 @@ async fn run_snapshot_workflow(
                     break;
                 }
                 Err(e) => {
+                    last_err = Some(e);
                     if attempt + 1 < DESTROY_RETRIES {
-                        last_err = Some(e);
                         tokio::time::sleep(DESTROY_RETRY_DELAY).await;
-                    } else {
-                        tracing::warn!(
-                            error = %e,
-                            "destroy_keep_cow failed after {DESTROY_RETRIES} attempts"
-                        );
-                        last_err = Some(e);
                     }
                 }
             }
         }
-        if last_err.is_some() {
-            // Last resort: abandon the device. It persists in the kernel
-            // until `runner gc` cleans it up. Does NOT delete the COW file.
+        if let Some(e) = last_err {
+            // Last resort: abandon the device so Drop is a no-op. It persists
+            // in the kernel until `runner gc` cleans it up; the COW file is
+            // left in the work dir and will be cleaned up by the next
+            // `create_snapshot` run.
+            //
+            // Fail the snapshot instead of finalizing it: without a successful
+            // `destroy_keep_cow` we cannot rely on `save_bitmap` having
+            // persisted the dirty bitmap, and renaming the COW file into the
+            // output dir without a matching bitmap would produce a snapshot
+            // that `is_complete()` reports as valid but silently corrupts
+            // restore reads (dirty blocks shadowed by base image). See #9843.
             cow_device.abandon();
+            return Err(SnapshotError::Process(format!(
+                "destroy_keep_cow exhausted retries; device abandoned, snapshot aborted (last error: {e})"
+            )));
         }
-        tokio::fs::rename(&cow_file, &output.cow()).await?;
-        // Also move the bitmap sidecar if it exists (for snapshot restore).
+        // destroy_keep_cow succeeded, so save_bitmap succeeded — the bitmap
+        // sidecar is on disk. Rename is unconditional: if the sidecar is
+        // missing we want to fail loudly, not silently produce a
+        // bitmap-less snapshot.
+        let cow_file = cow_device.cow_file();
         let bitmap_src = std::path::PathBuf::from(format!("{}.bitmap", cow_file.display()));
-        if tokio::fs::try_exists(&bitmap_src).await.unwrap_or(false) {
-            let bitmap_dst = output.cow_bitmap();
-            tokio::fs::rename(&bitmap_src, &bitmap_dst).await?;
-        }
+        tokio::fs::rename(&bitmap_src, &output.cow_bitmap()).await?;
+        tokio::fs::rename(cow_file, &output.cow()).await?;
         // Persist the output directory so all four final dir entries
         // (snapshot.bin and memory.bin written by Firecracker via the API,
         // cow.img and cow.img.bitmap just renamed in) are durable. Without

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -33,6 +33,8 @@ pub enum SnapshotError {
     Setup(String),
     #[error("firecracker process failed: {0}")]
     Process(String),
+    #[error("teardown failed: {0}")]
+    Teardown(String),
     #[error("api error: {0}")]
     Api(#[from] ApiError),
     #[error("vsock connection failed: {0}")]
@@ -432,7 +434,7 @@ async fn run_snapshot_workflow(
             // that `is_complete()` reports as valid but silently corrupts
             // restore reads (dirty blocks shadowed by base image). See #9843.
             cow_device.abandon();
-            return Err(SnapshotError::Process(format!(
+            return Err(SnapshotError::Teardown(format!(
                 "destroy_keep_cow exhausted retries; device abandoned, snapshot aborted (last error: {e})"
             )));
         }
@@ -441,7 +443,7 @@ async fn run_snapshot_workflow(
         // missing we want to fail loudly, not silently produce a
         // bitmap-less snapshot.
         let cow_file = cow_device.cow_file();
-        let bitmap_src = std::path::PathBuf::from(format!("{}.bitmap", cow_file.display()));
+        let bitmap_src = nbd_cow::cow::bitmap_path_for(cow_file);
         tokio::fs::rename(&bitmap_src, &output.cow_bitmap()).await?;
         tokio::fs::rename(cow_file, &output.cow()).await?;
         // Persist the output directory so all four final dir entries
@@ -590,6 +592,7 @@ impl SnapshotProvider for FirecrackerSnapshotProvider {
         let sc = create_snapshot(config).await.map_err(|e| match e {
             SnapshotError::Setup(msg) => sandbox::SnapshotError::Setup(msg),
             SnapshotError::Process(msg) => sandbox::SnapshotError::Process(msg),
+            SnapshotError::Teardown(msg) => sandbox::SnapshotError::Teardown(msg),
             SnapshotError::Api(api_err) => sandbox::SnapshotError::Api(api_err.to_string()),
             SnapshotError::Vsock(msg) => sandbox::SnapshotError::Vsock(msg),
             SnapshotError::Io(io_err) => sandbox::SnapshotError::Io(io_err),

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -39,6 +39,8 @@ pub enum SnapshotError {
     Setup(String),
     #[error("process failed: {0}")]
     Process(String),
+    #[error("teardown failed: {0}")]
+    Teardown(String),
     #[error("backend api error: {0}")]
     Api(String),
     #[error("vsock connection failed: {0}")]


### PR DESCRIPTION
## Summary

Closes #9843.

When `destroy_keep_cow` fails all `DESTROY_RETRIES` (5) attempts inside `run_snapshot_workflow`, the previous code called `abandon()` (which skips `save_bitmap`) and still renamed `cow.img` into the output directory. Result: `is_complete()` returns true but `cow.img.bitmap` is absent — on next `runner build`, `CowLayer::new` initializes an all-zero dirty bitmap, treats dirty COW blocks as clean, and silently serves stale base-image bytes. Same silent-corruption class as #9794, reached through a different path (bitmap never written, not written-but-non-durable).

## Changes

- **Retry exhaustion becomes a hard failure.** After `DESTROY_RETRIES` failed attempts, `abandon()` the device and `return Err(SnapshotError::Process(...))`. The kernel-side NBD device persists and is cleaned up by `runner gc` (unchanged `abandon()` contract). The work-dir `cow.img` is reclaimed by the next `create_snapshot` via the stale-cleanup at the top of `create_snapshot`.
- **Finalize step tightened.** Once `destroy_keep_cow` succeeds, the bitmap sidecar is known to exist on disk (invariant: `shutdown_inner(true)` calls `save_bitmap` before returning Ok). Rename it unconditionally instead of `if try_exists`, and rename **bitmap first, cow second** — this way the only possible mid-finalize crash state is "bitmap in output_dir, cow in work_dir", which `is_complete()` correctly reports as incomplete so the next build rebuilds. The previous order left the opposite intermediate (cow in, bitmap missing), indistinguishable from the #9843 corruption at `is_complete()` time.
- Retry loop cleanup: removed the redundant `tracing::warn!` in the terminal-retry branch (the error is now propagated through `Err`, no need to log twice).

## Not included

- **No new test.** Triggering the failure path requires NBD netlink / `save_bitmap` fault injection; `NbdCowDevice` isn't trait-abstracted, `run_snapshot_workflow` depends on real Firecracker + netns + NBD, and the project's "integration tests only" rule (`docs/testing.md`) discourages unit-testing internals. Matches the ROI assessment in #9843 itself.
- **No changes to `is_complete()`.** The new rename ordering exploits its existing contract (checks `snapshot.bin`, `memory.bin`, `cow.img`; doesn't check `cow.img.bitmap`). Adding a bitmap check would bake the invariant into a different module and add a compatibility concern for any existing snapshots without bitmaps.
- **`factory.rs` retry pattern at line 470 is not touched.** It calls `destroy()` (delete cow + bitmap), not `destroy_keep_cow()` (preserve for snapshot), so it isn't in the #9843 failure class.

## Test plan

- [x] `cargo fmt --check -p sandbox-fc`
- [x] `cargo clippy -p sandbox-fc --all-targets -- -D warnings`
- [ ] CI: lint, test, cli-e2e.
- [ ] Exercised implicitly by every successful `runner build` (normal path: retry succeeds first attempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)