### PR TITLE
refactor(platform): drive chat messages from async computed, remove paged flat list

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -74,7 +74,8 @@ export const setupChatPage$ = command(
       );
     }
 
-    await set(thread.fetchNextPage$, signal);
+    await get(thread.groupedChatMessages$);
+    signal.throwIfAborted();
     set(thread.scrollToBottom$);
 
     await set(thread.loadPagedMessages$, signal);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -66,9 +66,8 @@ export interface ChatThreadSignals {
   // ── Draft sync ────────────────────────────────────────────────────────────
   scheduleDraftSync$: Command<Promise<void>, [AbortSignal]>;
   // ── Paged messages (sole rendering path) ─────────────────────────────────
-  pagedChatMessages$: Computed<PagedChatMessage[]>;
-  latestChatMessageId$: Computed<string | undefined>;
-  groupedChatMessages$: Computed<GroupedChatMessageGroup[]>;
+  latestChatMessageId$: Computed<Promise<string | undefined>>;
+  groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>;
   allFinished$: Computed<Promise<boolean>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
   loadPagedMessages$: Command<Promise<void>, [AbortSignal]>;
@@ -441,33 +440,74 @@ function mergeIntoGroups(
 }
 
 function createPagedMessages(threadId: string) {
-  const internalGroups$ = state<GroupedChatMessageGroup[]>([]);
+  // Initial page — threadId is captured in closure so this computed runs
+  // exactly once per thread signal instance. View subscription is what
+  // triggers the fetch.
+  const initialMessages$ = computed(
+    async (get): Promise<PagedChatMessage[]> => {
+      const client = get(zeroClient$)(chatThreadMessagesContract);
+      const result = await accept(
+        client.list({
+          params: { threadId },
+          query: { limit: 50 },
+        }),
+        [200],
+      );
+      L.debug("initialMessages$", {
+        threadId,
+        count: result.body.messages.length,
+      });
+      return result.body.messages;
+    },
+  );
 
-  const groupedChatMessages$ = computed((get) => {
-    return get(internalGroups$);
-  });
+  // Everything beyond the initial page: subsequent fetchNextPage results
+  // and optimistic inserts. Dedup on write (keyed by id).
+  const deltaMessages$ = state<PagedChatMessage[]>([]);
 
-  const pagedChatMessages$ = computed((get) => {
-    const groups = get(internalGroups$);
-    const all: PagedChatMessage[] = [];
-    for (const group of groups) {
-      all.push(...group.messages);
+  const appendDeltaMessages$ = command(({ set }, msgs: PagedChatMessage[]) => {
+    if (msgs.length === 0) {
+      return;
     }
-    return all;
+    set(deltaMessages$, (prev) => {
+      const byId = new Map<string, PagedChatMessage>();
+      for (const m of prev) {
+        byId.set(m.id, m);
+      }
+      let changed = false;
+      for (const m of msgs) {
+        const existing = byId.get(m.id);
+        if (existing !== m) {
+          byId.set(m.id, m);
+          changed = true;
+        }
+      }
+      return changed ? Array.from(byId.values()) : prev;
+    });
   });
 
-  const latestChatMessageId$ = computed((get) => {
-    const groups = get(internalGroups$);
-    const lastGroup = groups[groups.length - 1];
-    if (!lastGroup) {
-      return undefined;
-    }
-    const msgs = lastGroup.messages;
-    return msgs[msgs.length - 1].id;
-  });
+  const groupedChatMessages$ = computed(
+    async (get): Promise<GroupedChatMessageGroup[]> => {
+      const initial = await get(initialMessages$);
+      const deltas = get(deltaMessages$);
+      return mergeIntoGroups([], [...initial, ...deltas]);
+    },
+  );
+
+  const latestChatMessageId$ = computed(
+    async (get): Promise<string | undefined> => {
+      const groups = await get(groupedChatMessages$);
+      const lastGroup = groups[groups.length - 1];
+      if (!lastGroup) {
+        return undefined;
+      }
+      const msgs = lastGroup.messages;
+      return msgs[msgs.length - 1]?.id;
+    },
+  );
 
   const fetchNextPage$ = command(async ({ get, set }, signal: AbortSignal) => {
-    const sinceId = get(latestChatMessageId$);
+    const sinceId = await get(latestChatMessageId$);
     signal.throwIfAborted();
 
     const client = get(zeroClient$)(chatThreadMessagesContract);
@@ -495,24 +535,18 @@ function createPagedMessages(threadId: string) {
     });
 
     if (result.body.messages.length === 0) {
-      return true; // no new messages
+      return true;
     }
 
-    set(internalGroups$, (prev) => {
-      return mergeIntoGroups(prev, result.body.messages);
-    });
-
+    set(appendDeltaMessages$, result.body.messages);
     return false;
   });
 
   const insertOptimisticMessage$ = command(({ set }, msg: PagedChatMessage) => {
-    set(internalGroups$, (prev) => {
-      return mergeIntoGroups(prev, [msg]);
-    });
+    set(appendDeltaMessages$, [msg]);
   });
 
   return {
-    pagedChatMessages$,
     latestChatMessageId$,
     groupedChatMessages$,
     fetchNextPage$,
@@ -583,11 +617,7 @@ function createRunTracking(
       }
 
       const threadId = thread.id;
-      L.debug("loadPagedMessages$ start", { threadId });
-      await set(fetchNextPage$, signal);
-      signal.throwIfAborted();
-
-      L.debug("loadPagedMessages$ thread loaded", {
+      L.debug("loadPagedMessages$ start", {
         threadId,
         activeRunIds: thread.activeRunIds,
       });
@@ -676,7 +706,6 @@ export function createChatThreadSignals(
     copyMessage$,
   } = createThreadUIState();
   const {
-    pagedChatMessages$,
     latestChatMessageId$,
     groupedChatMessages$,
     fetchNextPage$,
@@ -777,7 +806,6 @@ export function createChatThreadSignals(
     setInputRef$,
     focusInput$,
     scheduleDraftSync$,
-    pagedChatMessages$,
     latestChatMessageId$,
     groupedChatMessages$,
     allFinished$,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3,6 +3,7 @@ import {
   useSet,
   useLastLoadable,
   useLastResolved,
+  useLoadable,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -217,18 +218,20 @@ export function ZeroChatThreadPageInner({
   thread: ChatThreadSignals;
   autoFocus?: boolean;
 }) {
-  const groups = useGet(thread.groupedChatMessages$);
-
-  // Use threadData$ for loading/error detection (async computed has proper
-  // loading/error state whereas the sync paged computed does not).
+  const groupsLoadable = useLoadable(thread.groupedChatMessages$);
   const threadDataLoadable = useLastLoadable(thread.threadData$);
   const sessionError =
     threadDataLoadable.state === "hasError"
       ? threadDataLoadable.error instanceof Error
         ? threadDataLoadable.error.message
         : "Failed to load chat"
-      : null;
-  const messagesLoading = threadDataLoadable.state === "loading";
+      : groupsLoadable.state === "hasError"
+        ? groupsLoadable.error instanceof Error
+          ? groupsLoadable.error.message
+          : "Failed to load messages"
+        : null;
+  const messagesLoading = groupsLoadable.state === "loading";
+  const groups = groupsLoadable.state === "hasData" ? groupsLoadable.data : [];
   const setScrollContainer = useSet(thread.setScrollContainer$);
 
   return (
@@ -293,7 +296,7 @@ function ChatThreadComposer({
   thread: ChatThreadSignals;
   autoFocus?: boolean;
 }) {
-  const groups = useGet(thread.groupedChatMessages$);
+  const groups = useLastResolved(thread.groupedChatMessages$) ?? [];
   const hasMessages = groups.length > 0;
   const displayName = useLastResolved(thread.agentDisplayName$) ?? "Zero";
   const allFinished = useLastResolved(thread.allFinished$) ?? false;
@@ -409,7 +412,7 @@ function ChatSkeleton() {
 // ---------------------------------------------------------------------------
 
 function ThinkingIndicator({ thread }: { thread: ChatThreadSignals }) {
-  const groups = useGet(thread.groupedChatMessages$);
+  const groups = useLastResolved(thread.groupedChatMessages$) ?? [];
   const lastGroup = groups[groups.length - 1];
   const show = lastGroup && lastGroup.role !== "assistant";
 


### PR DESCRIPTION
## Summary
- Replace the mutable `internalGroups$` state in `createPagedMessages` with a pair: an **async computed `initialMessages$`** (fetches the first page exactly once per thread via the `threadId` closure) and a `deltaMessages$` state that accumulates later pages + optimistic inserts with id-based dedup on write.
- `groupedChatMessages$` and `latestChatMessageId$` are now **async computeds** derived from the two sources. The view subscribes via `useLoadable(thread.groupedChatMessages\$)` which naturally drives the `<ChatSkeleton />` loading state — no more \`messagesLoaded\` flag needed.
- Drop the redundant `fetchNextPage$` call in `setupChatPage$` and the one inside `loadPagedMessages$`. The initial fetch is triggered by the view subscription + a setup-time `await get(thread.groupedChatMessages$)` before `scrollToBottom$`.
- Remove `pagedChatMessages$` from `ChatThreadSignals` — no external consumers and `groupedChatMessages$` is now the sole source.
- Migrate view usages: `useLoadable` in `ZeroChatThreadPageInner` to gate skeleton / empty state / render; `useLastResolved` in `ChatThreadComposer` and `ThinkingIndicator` where only the resolved value is needed.

## Test plan
- [ ] Open a fresh thread → `<ChatSkeleton />` shows until the first page resolves, no "Send a message..." or thinking-indicator flash.
- [ ] Open a thread with existing messages → messages render and scroll to bottom on first render.
- [ ] Send a message → optimistic user row appears immediately (delta message); assistant reply streams in; indicator transitions correctly.
- [ ] Navigate between threads → each thread gets its own `initialMessages$` fetch (runs once per threadId).
- [ ] Cancel / complete a run → Ably push triggers `fetchNextPage$` which appends to `deltaMessages$`; no duplicate rows for messages also present in the initial page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)