### PR TITLE
fix(ci): pass --build-env alongside --env in prebuilt vercel deploy

### DIFF
--- a/.github/actions/vercel-deploy/action.yml
+++ b/.github/actions/vercel-deploy/action.yml
@@ -136,6 +136,10 @@ runs:
           fi
 
           # Add runtime environment variables
+          # NOTE: `--build-env` is required alongside `--env` even in prebuilt mode;
+          # without it `vercel deploy --prebuilt` does not register these vars in the
+          # deployment's runtime env, leaving `process.env.CRON_SECRET` (and every
+          # other secret) undefined. This mirrors the standard-mode branch below.
           if [ -n "$INPUT_ENV_VARS" ]; then
             echo "Adding runtime environment variables..."
             while IFS= read -r line; do
@@ -144,7 +148,7 @@ runs:
                 KEY="${line%%=*}"
                 VALUE="${line#*=}"
                 echo "Adding runtime env: $KEY"
-                DEPLOY_ARGS+=(--env "$KEY=$VALUE")
+                DEPLOY_ARGS+=(--build-env "$KEY=$VALUE" --env "$KEY=$VALUE")
               fi
             done <<< "$INPUT_ENV_VARS"
           fi


### PR DESCRIPTION
## Summary

`vercel deploy --prebuilt --prod --env KEY=VAL` does **not** register runtime env vars on the resulting deployment. Deployments produced through the prebuilt path end up with only Vercel system envs (~86 keys) and **zero user envs** — so `process.env.CRON_SECRET`, `DATABASE_URL`, every OAuth secret, etc. are all `undefined` at runtime.

Fix is one line: in the prebuilt branch of `.github/actions/vercel-deploy/action.yml`, pass every env var as **both** `--build-env KEY=VAL` and `--env KEY=VAL`, matching the behaviour of the standard-mode branch immediately below. `--build-env` is what actually triggers Vercel to encrypt and attach the vars to the deployment's runtime env registry.

## Timeline of the incident (all times UTC 2026-04-17)

- **09:36** — last good production deploy `dpl_BBR2aLZCuvzbiiNEgkL7GbdcgL6e` (standard mode). `205` env vars on the deployment, `CRON_SECRET` present.
- **09:55 / 10:10** — workflow_dispatch on `feat/release-please-phased-deploy` (dry-run of phased-deploy split). Both produced prebuilt deploys; the 10:10 one promoted.
- **09:58:32** — first `Invalid cron secret provided` in Axiom (`vm0-web-logs-prod`).
- **10:22** — #9847 merged (adds `vercel-promote` action + `skip-domain` input).
- **10:47** — #9854 merged (splits release-please web/app deploys into build + promote, flips `prebuilt: "true"` in the production release path).
- **11:02 / 12:34** — subsequent release PR merges deploy via the new prebuilt flow. Every resulting production deployment has `86` env vars, `CRON_SECRET` missing.
- **Now** — every minute `Invalid cron secret` fires; all 11 Vercel crons are 401ing. `executeDueSchedules` never runs, so `executeSchedule` CAS claim never fires, and schedules like Qiqi's 5-min `gmail-poll` (issue #9874) are stuck.

## Why this wasn't caught

- The app build step (`export KEY=VALUE` + `vercel build`) is unaffected — static analysis / type-checks pass.
- The staged deploy test exercised "builds without error", not "deployment has expected env registered".
- `--env` in prebuilt mode silently drops the vars; there's no Vercel CLI error or warning.

## How to verify after merge

1. Let the next release PR merge (or manually re-run the latest release workflow).
2. `curl -s -H "Authorization: Bearer $VERCEL_TOKEN" "https://api.vercel.com/v13/deployments/<new-uid>?teamId=team_WRqI0kCoX5KcRInRWgZ1nBF0" | jq '.env | length'` should report ≥ 200, not 86.
3. `grep` the new deployment's env list for `CRON_SECRET` — must be present.
4. `/api/cron/execute-schedules` stops returning 401 (check `vm0-web-logs-prod` for `Invalid cron secret provided`).
5. Bump `next_run_at` on the 5 overdue schedules so they re-enter the claim loop.

## Considered alternatives

- **Project-level `vercel env add`** — proper long-term fix (project currently has `0` project-level envs, which is a fragile setup), but not minimal and not scoped to this incident. Follow-up issue.
- **Revert #9854** — also works; kept as a fallback if this fix doesn't restore env registration in practice. In that case the phased-deploy pattern needs a rework before re-landing.

## Test plan

- [ ] Merge + wait for the next release PR to deploy via this action
- [ ] Confirm new production deployment has `CRON_SECRET` in its env list (Vercel API)
- [ ] Confirm Axiom stops logging `Invalid cron secret provided`
- [ ] Confirm `executeDueSchedules` starts running again (check `zero_schedules.last_run_at` for the 5 overdue rows)
- [ ] Manually bump `next_run_at` on the 5 overdue schedules (`gmail-poll`, `pr-review-merge`, `hn-daily-digest-schedule`, `daily-standup`, `default`)
- [ ] Close #9874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
