### PR TITLE
fix(schedule): preserve next-run time when update omits enabled for loop

### DIFF
--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -486,6 +486,7 @@ async function buildAndDeploy(params: {
   intervalSeconds: number | undefined;
   timezone: string;
   prompt: string;
+  existingEnabled: boolean | undefined;
 }): Promise<DeployResult> {
   let cronExpression: string | undefined;
   let atTimeISO: string | undefined;
@@ -506,6 +507,9 @@ async function buildAndDeploy(params: {
     `\nDeploying schedule for agent ${chalk.cyan(params.agentName)}...`,
   );
 
+  // Preserve enabled state on update so loop schedules don't lose nextRunAt.
+  // On create, existingEnabled is undefined → omit the field so the server
+  // applies its default (disabled; enable happens later via the enable flow).
   const deployResult = await deployZeroSchedule({
     name: params.scheduleName,
     agentId: params.agentId,
@@ -514,6 +518,9 @@ async function buildAndDeploy(params: {
     intervalSeconds: params.intervalSeconds,
     timezone: params.timezone,
     prompt: params.prompt,
+    ...(params.existingEnabled !== undefined && {
+      enabled: params.existingEnabled,
+    }),
   });
 
   return deployResult;
@@ -726,6 +733,7 @@ Notes:
         intervalSeconds,
         timezone,
         prompt: promptText_,
+        existingEnabled: existingSchedule?.enabled,
       });
 
       // 8. Display deployment result

--- a/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
   createTestCompose,
   createTestOrg,
   createTestSchedule,
+  enableTestSchedule,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
 import { getTestZeroAgentId } from "../../../../../src/__tests__/db-test-assertions/agents";
@@ -237,6 +238,37 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
     expect(response.status).toBe(400);
     expect(data.error.code).toBe("SCHEDULE_PAST");
+  });
+
+  it("should preserve enabled state and nextRunAt when update omits enabled for enabled loop", async () => {
+    // Regression: an enabled loop schedule updated without the `enabled` field
+    // (e.g. CLI shortening intervalSeconds) used to get nextRunAt wiped to null
+    // while staying enabled=true — stranding it from executeDueSchedules.
+    await createTestSchedule(testComposeId, "loop-shorten", {
+      intervalSeconds: 300,
+      prompt: "Loop",
+    });
+    await enableTestSchedule(testComposeId, "loop-shorten");
+
+    const response = await POST(
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "loop-shorten",
+          intervalSeconds: 60,
+          timezone: "UTC",
+          prompt: "Loop",
+        }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.schedule.enabled).toBe(true);
+    expect(data.schedule.intervalSeconds).toBe(60);
+    expect(data.schedule.nextRunAt).not.toBeNull();
   });
 
   it("should update schedule trigger type from cron to loop", async () => {

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -408,6 +408,15 @@ export async function deploySchedule(
     )
     .limit(1);
 
+  // Partial-update semantics: when updating an existing schedule and the
+  // request omits `enabled`, inherit the current persisted value. Without
+  // this, a loop schedule's nextRunAt gets wiped to null (resolveTrigger
+  // maps falsy enabled → null), leaving enabled=true but nextRunAt=null —
+  // a stuck state executeDueSchedules can never pick up.
+  if (existing && request.enabled === undefined) {
+    request = { ...request, enabled: existing.enabled };
+  }
+
   const { triggerType, nextRunAt } = resolveTrigger(request);
   const displayName = agent.displayName ?? null;
 


### PR DESCRIPTION
## Summary

- Loop schedule updates (e.g. CLI `zero schedule setup` shortening `intervalSeconds`) used to set `nextRunAt=null` while leaving `enabled=true`, stranding the schedule from `executeDueSchedules`. No callback fires after that, so the loop stopped silently.
- Root cause: `resolveTrigger()` maps a falsy `request.enabled` to `nextRunAt=null`, and `updateExistingSchedule()` deliberately skips the `enabled` column — so an update that omits `enabled` wiped `nextRunAt` but kept `enabled=true`.
- Fix: in `deploySchedule`, when an existing row is found and the request omits `enabled`, inherit the persisted value (partial-update semantics). Also make the CLI pass `existingSchedule.enabled` explicitly.
- Added an integration test under `app/api/zero/schedules/__tests__/route.test.ts` covering the regression: create + enable a loop schedule, POST an update without `enabled`, assert `enabled === true` and `nextRunAt !== null`.

## Test plan

- [x] `pnpm -F web exec vitest run app/api/zero/schedules/__tests__/route.test.ts` — 16/16 passing (includes the new regression case)
- [x] `pnpm -F web run lint` / `pnpm -F cli run lint` — 0 errors
- [x] `pnpm -F web run check-types` / `pnpm -F cli run check-types` — pass
- [x] `pnpm format` / `pnpm knip` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)