### PR TITLE
fix(phone): use after() callback form in webhook route

### DIFF
--- a/turbo/apps/web/app/api/zero/phone/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/phone/webhook/__tests__/route.test.ts
@@ -24,23 +24,6 @@ vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 vi.mock("@axiomhq/js");
 
-// Mock next/server after() to capture callbacks for flushing
-const afterPromises: Promise<unknown>[] = [];
-vi.mock("next/server", async (importOriginal) => {
-  const original = await importOriginal<typeof import("next/server")>();
-  return {
-    ...original,
-    after: (promise: Promise<unknown>) => {
-      afterPromises.push(promise);
-    },
-  };
-});
-
-async function flushAfterCallbacks() {
-  await Promise.allSettled(afterPromises);
-  afterPromises.length = 0;
-}
-
 const context = testContext();
 
 // MSW handler for AgentPhone send-message endpoint (used when sending connect links or replies)
@@ -61,7 +44,6 @@ function createWebhookRequest(body: Record<string, unknown>): Request {
 
 describe("POST /api/zero/phone/webhook", () => {
   beforeEach(async () => {
-    afterPromises.length = 0;
     context.setupMocks();
     server.use(agentphoneSendMessage);
   });
@@ -133,9 +115,9 @@ describe("POST /api/zero/phone/webhook", () => {
 
     expect(response.status).toBe(200);
     // after() callback was registered
-    expect(afterPromises.length).toBe(1);
+    expect(globalThis.nextAfterCallbacks.length).toBe(1);
     // Handler runs without throwing (org not found — returns early gracefully)
-    await flushAfterCallbacks();
+    await context.mocks.flushAfter();
   });
 
   it("should handle agent.call_ended event type", async () => {
@@ -154,8 +136,8 @@ describe("POST /api/zero/phone/webhook", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(200);
-    expect(afterPromises.length).toBe(1);
-    await flushAfterCallbacks();
+    expect(globalThis.nextAfterCallbacks.length).toBe(1);
+    await context.mocks.flushAfter();
   });
 
   it("should dispatch run when org and linked user are found", async () => {
@@ -188,8 +170,8 @@ describe("POST /api/zero/phone/webhook", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(200);
-    expect(afterPromises.length).toBe(1);
-    await flushAfterCallbacks();
+    expect(globalThis.nextAfterCallbacks.length).toBe(1);
+    await context.mocks.flushAfter();
 
     // Verify an agent_runs record was created for the user/org — this confirms
     // handleCallEnded resolved the org, found the linked user, and dispatched a run
@@ -238,8 +220,8 @@ describe("POST /api/zero/phone/webhook", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(200);
-    expect(afterPromises.length).toBe(1);
-    await flushAfterCallbacks();
+    expect(globalThis.nextAfterCallbacks.length).toBe(1);
+    await context.mocks.flushAfter();
 
     // Verify the pending row was consumed (deleted)
     const remaining = await findPendingOutboundCall(CALL_ID);
@@ -267,7 +249,7 @@ describe("POST /api/zero/phone/webhook", () => {
     const text = await response.text();
     expect(text).toBe("OK");
     // No after() callback should have been registered for an incomplete event
-    expect(afterPromises.length).toBe(0);
+    expect(globalThis.nextAfterCallbacks.length).toBe(0);
   });
 
   it("should dispatch after() for agent.message with valid fields", async () => {
@@ -286,9 +268,9 @@ describe("POST /api/zero/phone/webhook", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(200);
-    expect(afterPromises.length).toBe(1);
+    expect(globalThis.nextAfterCallbacks.length).toBe(1);
     // Flush — org not found for unknown agentId, handler returns early gracefully
-    await flushAfterCallbacks();
+    await context.mocks.flushAfter();
   });
 
   it("should send connect link for agent.message from an unbound iMessage handle", async () => {
@@ -311,8 +293,8 @@ describe("POST /api/zero/phone/webhook", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(200);
-    expect(afterPromises.length).toBe(1);
-    await flushAfterCallbacks();
+    expect(globalThis.nextAfterCallbacks.length).toBe(1);
+    await context.mocks.flushAfter();
   });
 
   it("should dispatch run for agent.message from a bound iMessage handle", async () => {
@@ -321,7 +303,7 @@ describe("POST /api/zero/phone/webhook", () => {
     const { agentphoneAgentId } = await createPhoneOrg(user.orgId);
     await linkIMessageHandle(TEST_FROM_NUMBER, user.orgId);
     // linkIMessageHandle sends a success iMessage via after(); flush it before testing the webhook
-    await flushAfterCallbacks();
+    await context.mocks.flushAfter();
     await insertOrgDefaultModelProvider(user.orgId, "anthropic");
 
     const request = createWebhookRequest({
@@ -339,13 +321,74 @@ describe("POST /api/zero/phone/webhook", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(200);
-    expect(afterPromises.length).toBe(1);
-    await flushAfterCallbacks();
+    expect(globalThis.nextAfterCallbacks.length).toBe(1);
+    await context.mocks.flushAfter();
 
     // Verify an agent run was created for the bound user
     const run = await findMostRecentRunForUser(user.userId, user.orgId);
     expect(run).toBeDefined();
     expect(run!.userId).toBe(user.userId);
     expect(run!.orgId).toBe(user.orgId);
+  });
+
+  // Regression: createZeroRun schedules its Phase 2 dispatch via a nested
+  // after() inside handleMessageReceived/handleCallEnded. If the route
+  // registers the outer after() with an already-started promise, the nested
+  // after() is scheduled after the Next.js request context has been finalized
+  // and Phase 2 dispatch never runs — runs remain Pending forever.
+  describe("after() callback form (nested-after propagation)", () => {
+    it("registers agent.message handler via callback form", async () => {
+      const request = createWebhookRequest({
+        event: "agent.message",
+        channel: "imessage",
+        agentId: "agent_test",
+        data: {
+          messageId: "msg_test",
+          from: "+14155551234",
+          to: "+18001234567",
+          message: "Hello",
+        },
+      });
+
+      await POST(request);
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
+
+    it("registers call_ended handler via callback form", async () => {
+      const request = createWebhookRequest({
+        event: "call_ended",
+        channel: "voice",
+        agentId: "agent_test",
+        data: {
+          callId: "call_test",
+          from: "+14155551234",
+          to: "+18001234567",
+          direction: "inbound",
+        },
+      });
+
+      await POST(request);
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
+
+    it("registers agent.call_ended handler via callback form", async () => {
+      const request = createWebhookRequest({
+        event: "agent.call_ended",
+        channel: "voice",
+        agentId: "agent_test",
+        data: {
+          conversationId: "conv_test",
+          from: "+14155551234",
+          to: "+18001234567",
+          direction: "inbound",
+        },
+      });
+
+      await POST(request);
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/phone/webhook/route.ts
+++ b/turbo/apps/web/app/api/zero/phone/webhook/route.ts
@@ -160,7 +160,9 @@ export async function POST(request: Request): Promise<Response> {
       channel: messageData.channel,
     });
 
-    after(handleMessageReceived(messageData));
+    after(() => {
+      return handleMessageReceived(messageData);
+    });
     return new Response("OK", { status: 200 });
   }
 
@@ -200,8 +202,8 @@ export async function POST(request: Request): Promise<Response> {
     channel,
   });
 
-  after(
-    handleCallEnded({
+  after(() => {
+    return handleCallEnded({
       callId,
       agentId,
       fromNumber,
@@ -211,8 +213,8 @@ export async function POST(request: Request): Promise<Response> {
       durationSeconds,
       transcript,
       summary,
-    }),
-  );
+    });
+  });
 
   return new Response("OK", { status: 200 });
 }


### PR DESCRIPTION
## Summary

- Phone/iMessage webhook route (`app/api/zero/phone/webhook/route.ts`) wrapped its two handlers in `after(handler(...))` (promise form), which invoked the handler synchronously and passed a running promise to `after()`.
- After #9739 moved `createZeroRun`'s Phase 2 dispatch to its own nested `after()` call (`src/lib/zero/zero-run-service.ts:641`), that nested call now fires from inside an already-executing promise — the Next.js request-scoped `after()` context can be finalized before the nested registration lands, so Phase 2 never runs and runs triggered by inbound iMessages and voice `call_ended` events stay in `Pending` forever.
- Same bug class and fix shape as PR #9796 (Slack events route).

## Fix

Switch both handlers in `phone/webhook/route.ts` (`agent.message`, `call_ended` / `agent.call_ended`) to the callback form `after(() => handler(...))`. Next.js runs the callback in a live request context, and the nested `after()` scheduled by `createZeroRun` drains normally.

No `.catch()` added — matches PR #9796's main agent-handler pattern and the issue's explicit guidance to preserve existing error-propagation behavior.

## Test plan

- [x] Migrated the existing phone webhook test file from its local `vi.mock("next/server")` (which only recorded promises) to the shared mock in `src/__tests__/setup.ts` (which tracks both argument forms via `globalThis.nextAfterArgForms` and drains callbacks iteratively via `context.mocks.flushAfter()`). All pre-existing assertions continue to pass.
- [x] New regression suite `describe("after() callback form (nested-after propagation)")` records the argument form passed to the mocked `after()` and asserts callback form for `agent.message`, `call_ended`, and `agent.call_ended` events.
- [x] Witness: temporarily reverted the fix locally — the 3 new assertions correctly failed with `["promise"]` vs expected `["fn"]`. Restoring the fix made all 14 tests pass.
- [x] `pnpm turbo run lint --filter=web` (0 errors)
- [x] `pnpm check-types` (6/6 workspaces clean)
- [x] `pnpm knip --workspace web` (no issues)
- [x] `pnpm format` (no changes)
- [x] `pnpm -F web exec vitest run app/api/zero/phone/webhook` (14/14 pass)

Closes #9884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)