### PR TITLE
fix(telegram): use after() callback form in webhook route

### DIFF
--- a/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
@@ -85,8 +85,8 @@ export async function POST(
   const chatId = String(message.chat.id);
 
   // Route to appropriate handler
-  after(
-    (async () => {
+  after(() => {
+    return (async () => {
       const messageText = message.text ?? message.caption;
       const command = parseBotCommand(messageText, installation.botUsername);
 
@@ -149,8 +149,8 @@ export async function POST(
       await storeTelegramMessage(installationId, chatId, message);
     })().catch((error) => {
       log.error("Error handling telegram webhook", { error, installationId });
-    }),
-  );
+    });
+  });
 
   // Return 200 immediately
   return new Response("OK", { status: 200 });

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { HttpResponse } from "msw";
 import {
   testContext,
@@ -19,23 +19,6 @@ import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 import { POST } from "../[installationId]/route";
 import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
-
-// Mock Next.js after() to execute synchronously
-const afterPromises: Promise<unknown>[] = [];
-vi.mock("next/server", async (importOriginal) => {
-  const original = await importOriginal<typeof import("next/server")>();
-  return {
-    ...original,
-    after: (promise: Promise<unknown>) => {
-      afterPromises.push(promise);
-    },
-  };
-});
-
-async function flushAfterCallbacks() {
-  await Promise.all(afterPromises);
-  afterPromises.length = 0;
-}
 
 const context = testContext();
 
@@ -107,7 +90,6 @@ describe("Telegram bot commands", () => {
   let userId: string;
 
   beforeEach(async () => {
-    afterPromises.length = 0;
     context.setupMocks();
     const user = await context.setupUser();
     userId = user.userId;
@@ -145,7 +127,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("/help");
@@ -169,7 +151,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       // No message sent — command was for a different bot
       expect(sendMsg.mocked).not.toHaveBeenCalled();
@@ -193,7 +175,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("/help");
@@ -217,7 +199,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("/help");
@@ -244,7 +226,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       const text = sendMsg.calls[0]?.text ?? "";
@@ -275,7 +257,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("already connected");
@@ -299,7 +281,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("/telegram/connect?bot=");
@@ -325,7 +307,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("disconnected");
@@ -356,7 +338,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("not connected");
@@ -382,7 +364,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       const text = sendMsg.calls[0]?.text ?? "";
@@ -410,7 +392,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("admin");
@@ -446,7 +428,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       // Verify confirmation message
       expect(sendMsg.mocked).toHaveBeenCalled();
@@ -479,7 +461,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("Connect your account");
@@ -503,7 +485,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       // No message sent in group chat
       expect(sendMsg.mocked).not.toHaveBeenCalled();
@@ -543,7 +525,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       // Queued notification edits the thinking message (not a new sendMessage)
       const queuedMsg = editMsg.calls.find((c) => {
@@ -573,7 +555,7 @@ describe("Telegram bot commands", () => {
         params: Promise.resolve({ installationId }),
       });
       expect(response.status).toBe(200);
-      await flushAfterCallbacks();
+      await context.mocks.flushAfter();
 
       // Queued notification edits the thinking message (not a new sendMessage)
       const queuedMsg = editMsg.calls.find((c) => {

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
@@ -23,7 +23,11 @@ import { POST } from "../[installationId]/route";
 async function flushAfterCallbacks() {
   const callbacks = [...globalThis.nextAfterCallbacks];
   globalThis.nextAfterCallbacks = [];
-  await Promise.all(callbacks.map((cb) => cb()));
+  await Promise.all(
+    callbacks.map((cb) => {
+      return cb();
+    }),
+  );
 }
 
 const context = testContext();

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { HttpResponse } from "msw";
 import {
   testContext,
@@ -15,21 +15,15 @@ import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 import { POST } from "../[installationId]/route";
 
-// Mock Next.js after() to execute synchronously
-const afterPromises: Promise<unknown>[] = [];
-vi.mock("next/server", async (importOriginal) => {
-  const original = await importOriginal<typeof import("next/server")>();
-  return {
-    ...original,
-    after: (promise: Promise<unknown>) => {
-      afterPromises.push(promise);
-    },
-  };
-});
-
+// Uses the shared `next/server` mock from src/__tests__/setup.ts, which records
+// both the argument form (globalThis.nextAfterArgForms) and the callback queue
+// (globalThis.nextAfterCallbacks). Tests draining the queue use the helper
+// below; regression tests that only care about the argument form assert on
+// globalThis.nextAfterArgForms directly.
 async function flushAfterCallbacks() {
-  await Promise.all(afterPromises);
-  afterPromises.length = 0;
+  const callbacks = [...globalThis.nextAfterCallbacks];
+  globalThis.nextAfterCallbacks = [];
+  await Promise.all(callbacks.map((cb) => cb()));
 }
 
 const context = testContext();
@@ -55,7 +49,6 @@ describe("POST /api/telegram/webhook/[installationId]", () => {
   let installationId: string;
 
   beforeEach(async () => {
-    afterPromises.length = 0;
     installationId = await createTelegramInstallation();
   });
 
@@ -155,7 +148,7 @@ describe("POST /api/telegram/webhook/[installationId]", () => {
     expect(response.status).toBe(200);
 
     // after() was called (handler was dispatched)
-    expect(afterPromises.length).toBe(1);
+    expect(globalThis.nextAfterCallbacks.length).toBe(1);
 
     // Handler errors are caught gracefully (no unhandled rejections)
     await flushAfterCallbacks();
@@ -177,7 +170,7 @@ describe("POST /api/telegram/webhook/[installationId]", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(afterPromises.length).toBe(1);
+    expect(globalThis.nextAfterCallbacks.length).toBe(1);
     await flushAfterCallbacks();
   });
 
@@ -263,6 +256,91 @@ describe("POST /api/telegram/webhook/[installationId]", () => {
       const afterData = await afterResponse.json();
       expect(afterData.linked).toBe(true);
       expect(afterData.telegramUserId).toBe(String(telegramUserId));
+    });
+  });
+
+  // Regression: createZeroRun schedules its Phase 2 dispatch via a nested
+  // after() inside handleTelegramDirectMessage / handleTelegramMention. If the
+  // route registers the outer after() with an already-started promise, the
+  // nested after() is scheduled after the Next.js request context has been
+  // finalized and Phase 2 dispatch never runs — runs remain Pending forever.
+  describe("after() callback form (nested-after propagation)", () => {
+    it("registers DM handler via callback form", async () => {
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 123, type: "private" },
+          from: { id: 456, username: "testuser" },
+          text: "hello",
+        },
+      });
+
+      await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
+
+    it("registers @mention handler via callback form", async () => {
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 123, type: "group" },
+          from: { id: 456, username: "testuser" },
+          text: "@test_bot hi",
+          entities: [{ type: "mention", offset: 0, length: 9 }],
+        },
+      });
+
+      await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
+
+    it("registers reply-to-bot handler via callback form", async () => {
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 123, type: "group" },
+          from: { id: 456, username: "testuser" },
+          text: "thanks",
+          reply_to_message: {
+            message_id: 99,
+            chat: { id: 123, type: "group" },
+            from: { id: 1, is_bot: true, username: "test_bot" },
+          },
+        },
+      });
+
+      await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+    });
+
+    it("registers /start command handler via callback form", async () => {
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 123, type: "private" },
+          from: { id: 456, username: "testuser" },
+          text: "/start sometoken",
+        },
+      });
+
+      await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+
+      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Telegram's `/api/telegram/webhook/[installationId]` route wrapped its IIFE in `after((async () => {...})().catch(...))`, which invokes the IIFE synchronously and passes a running promise to `after()`.
- After #9739 moved `createZeroRun`'s Phase 2 dispatch to its own nested `after()` call (`turbo/apps/web/src/lib/zero/zero-run-service.ts:641`), that nested call now fires from inside an already-executing promise — the Next.js request-scoped `after()` context can be finalized before the nested registration lands, so Phase 2 never runs and Telegram DMs, @mentions, and replies to the bot create `zero_runs` rows that stay in `Pending` forever.
- This mirrors the Slack-events bug fixed by #9796. Parent epic: #9880. Closes #9883.

## Fix

Switch the single outer `after()` in `app/api/telegram/webhook/[installationId]/route.ts` to the callback form `after(() => ...)`. IIFE body, routing branches, and handlers are unchanged; only the outer wrapping moves from promise form to thunk form. Next.js runs the callback inside a live request context, and the nested `after()` scheduled by `createZeroRun` drains normally.

## Test plan

- [x] New regression `describe("after() callback form (nested-after propagation)")` block in `app/api/telegram/webhook/__tests__/route.test.ts` — records the argument form via `globalThis.nextAfterArgForms` and asserts callback form for DM, @mention, reply-to-bot, and `/start` command paths.
- [x] Migrated the test file off its local `vi.mock("next/server")` onto the shared mock in `src/__tests__/setup.ts` (matches #9796's pattern and makes the witness assertion possible).
- [x] **Witness confirmed**: temporarily reverted the route fix locally — all 4 new assertions failed with `expected ["promise"] to equal ["fn"]`. Restored the fix and they pass.
- [x] `pnpm -F web exec vitest run app/api/telegram/webhook/__tests__/route.test.ts` — 13/13 pass
- [x] `pnpm turbo run lint --filter=web`
- [x] `pnpm check-types`
- [x] `pnpm knip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)