### PR TITLE
refactor(ansible): split deploy-runner.yml into build and promote

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1227,11 +1227,21 @@ jobs:
           fi
           ansible-playbook \
             -i "${AWS_METAL_RUNNER_HOSTS}," \
-            playbooks/deploy-runner.yml \
+            playbooks/build-runner.yml \
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
-            -e "sentry_dsn=${SENTRY_DSN_RUNNER}" \
             -e "api_url=https://www.vm0.ai" \
+            -e "runner_version=${RUNNER_VERSION}" \
+            -e "r2_account_id=${R2_ACCOUNT_ID:-}" \
+            -e "r2_access_key_id=${R2_ACCESS_KEY_ID:-}" \
+            -e "r2_secret_access_key=${R2_SECRET_ACCESS_KEY:-}" \
+            -e "r2_bucket=${R2_USER_STORAGES_BUCKET_NAME:-}" \
+            -v
+          ansible-playbook \
+            -i "${AWS_METAL_RUNNER_HOSTS}," \
+            playbooks/promote-runner.yml \
+            -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
+            -e "sentry_dsn=${SENTRY_DSN_RUNNER}" \
             -e "runner_version=${RUNNER_VERSION}" \
             -e "r2_account_id=${R2_ACCOUNT_ID:-}" \
             -e "r2_access_key_id=${R2_ACCESS_KEY_ID:-}" \

--- a/ansible/playbooks/build-runner.yml
+++ b/ansible/playbooks/build-runner.yml
@@ -1,22 +1,28 @@
-# Deploy VM0 Runner (Rust)
+# Build VM0 Runner (Rust)
 #
-# This playbook deploys a new version of the Rust-based VM0 runner to production
-# metal instances. Each version gets its own bin dir and systemd service, allowing
-# the old runner to drain gracefully while the new one starts accepting jobs.
+# This playbook prepares a new version of the Rust-based VM0 runner on
+# production metal instances **without starting the service**. It copies the
+# binary, downloads dependencies, builds the default rootfs/snapshot, and
+# writes the per-version config file. The systemd service is installed by
+# the companion `promote-runner.yml` in the promote phase — this lets the
+# heavy `runner build` step run in parallel with other production builds
+# without cutting traffic over.
+#
+# Idempotent: safe to re-run for the same version (e.g. after a failed deploy).
 #
 # Usage:
-#   ansible-playbook -i "host1,host2," playbooks/deploy-runner.yml \
+#   ansible-playbook -i "host1,host2," playbooks/build-runner.yml \
 #     -e "ansible_user=ubuntu" \
 #     -e "official_runner_secret=xxx" \
 #     -e "api_url=https://www.vm0.ai" \
 #     -e "runner_version=0.3.0"
 #
 # Required Variables:
-#   - runner_version: Semantic version of the runner being deployed
-#   - official_runner_secret: Runner authentication secret
-#   - api_url: vm0 API URL
+#   - runner_version: Semantic version of the runner being built
+#   - official_runner_secret: Runner authentication secret (baked into config)
+#   - api_url: vm0 API URL (baked into config)
 
-- name: Deploy VM0 Runner
+- name: Build VM0 Runner
   hosts: all
   become: true
 
@@ -72,8 +78,10 @@
         default_snapshot_hash: "{{ default_build_output.stdout_lines | select('match', '^snapshot_hash=') | first | regex_replace('^snapshot_hash=', '') }}"
 
     # ========================================
-    # Phase 3: Configure + Install
+    # Phase 3a: Configure (no service install)
     # ========================================
+    # Writes runner.yaml to a per-version directory. Does not touch any
+    # running service — the promote phase is responsible for systemd install.
     - name: Generate runner config
       command: >
         {{ bin_dir }}/runner config
@@ -85,52 +93,3 @@
         --runner-dirname {{ runner_name }}
         --api-url {{ api_url }}
         --token vm0_official_{{ official_runner_secret }}
-
-    - name: Install and start runner service
-      command: >
-        {{ bin_dir }}/runner service install
-        --name {{ runner_name }}
-        --config {{ runner_dir }}/runner.yaml
-        {% if sentry_dsn is defined and sentry_dsn %}
-        --env SENTRY_DSN={{ sentry_dsn }}
-        {% endif %}
-
-    # ========================================
-    # Phase 4: Health check
-    # ========================================
-    - name: Verify runner health
-      command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"
-
-    # ========================================
-    # Phase 5: Drain old runners + Cleanup
-    # ========================================
-    - name: Find running runner services
-      shell: >
-        systemctl list-units 'vm0-runner-*.service' --state=running
-        --plain --no-legend | awk '{print $1}'
-        | sed 's/^vm0-runner-//;s/\.service$//'
-      register: running_runners
-      changed_when: false
-      ignore_errors: true
-
-    - name: Drain old runner services
-      command: "{{ bin_dir }}/runner service drain --name {{ item }}"
-      loop: "{{ running_runners.stdout_lines | default([]) }}"
-      when: item != runner_name
-      ignore_errors: true
-
-    - name: Garbage collect old artifacts
-      command: "{{ bin_dir }}/runner gc --keep-latest 6 --protect-version {{ runner_name }}"
-      environment:
-        # R2 credentials so `runner gc` can sweep stale image cache objects.
-        # Without these, R2-side cleanup is skipped (objects accumulate forever).
-        R2_ACCOUNT_ID: "{{ r2_account_id | default('') }}"
-        R2_ACCESS_KEY_ID: "{{ r2_access_key_id | default('') }}"
-        R2_SECRET_ACCESS_KEY: "{{ r2_secret_access_key | default('') }}"
-        R2_USER_STORAGES_BUCKET_NAME: "{{ r2_bucket | default('') }}"
-
-    # ========================================
-    # Phase 6: Final health check
-    # ========================================
-    - name: Verify runner health after cleanup
-      command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -1,0 +1,86 @@
+# Promote VM0 Runner (Rust) — Traffic Cutover Phase
+#
+# This playbook activates a runner version that was previously prepared by
+# `build-runner.yml`. It installs the systemd service (which starts the new
+# runner and begins accepting jobs), verifies health, drains the previously
+# active versions, and garbage-collects old artifacts.
+#
+# Preconditions (established by `build-runner.yml`):
+#   - /var/lib/vm0-runner/bin/v{version}/runner exists and is executable
+#   - /var/lib/vm0-runner/runners/v{version}/runner.yaml exists
+#
+# Usage:
+#   ansible-playbook -i "host1,host2," playbooks/promote-runner.yml \
+#     -e "ansible_user=ubuntu" \
+#     -e "runner_version=0.3.0"
+#
+# Required Variables:
+#   - runner_version: Semantic version of the runner being promoted
+#
+# Optional Variables:
+#   - sentry_dsn: Forwarded to the systemd unit as SENTRY_DSN
+#   - r2_account_id / r2_access_key_id / r2_secret_access_key / r2_bucket:
+#       Passed to `runner gc` so R2-side cache cleanup runs.
+
+- name: Promote VM0 Runner
+  hosts: all
+  become: true
+
+  vars:
+    runner_name: "v{{ runner_version }}"
+    data_dir: /var/lib/vm0-runner
+    bin_dir: "{{ data_dir }}/bin/{{ runner_name }}"
+    runner_dir: "{{ data_dir }}/runners/{{ runner_name }}"
+
+  tasks:
+    # ========================================
+    # Phase 3b: Install systemd service (traffic cutover point)
+    # ========================================
+    - name: Install and start runner service
+      command: >
+        {{ bin_dir }}/runner service install
+        --name {{ runner_name }}
+        --config {{ runner_dir }}/runner.yaml
+        {% if sentry_dsn is defined and sentry_dsn %}
+        --env SENTRY_DSN={{ sentry_dsn }}
+        {% endif %}
+
+    # ========================================
+    # Phase 4: Health check
+    # ========================================
+    - name: Verify runner health
+      command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"
+
+    # ========================================
+    # Phase 5: Drain old runners + Cleanup
+    # ========================================
+    - name: Find running runner services
+      shell: >
+        systemctl list-units 'vm0-runner-*.service' --state=running
+        --plain --no-legend | awk '{print $1}'
+        | sed 's/^vm0-runner-//;s/\.service$//'
+      register: running_runners
+      changed_when: false
+      ignore_errors: true
+
+    - name: Drain old runner services
+      command: "{{ bin_dir }}/runner service drain --name {{ item }}"
+      loop: "{{ running_runners.stdout_lines | default([]) }}"
+      when: item != runner_name
+      ignore_errors: true
+
+    - name: Garbage collect old artifacts
+      command: "{{ bin_dir }}/runner gc --keep-latest 6 --protect-version {{ runner_name }}"
+      environment:
+        # R2 credentials so `runner gc` can sweep stale image cache objects.
+        # Without these, R2-side cleanup is skipped (objects accumulate forever).
+        R2_ACCOUNT_ID: "{{ r2_account_id | default('') }}"
+        R2_ACCESS_KEY_ID: "{{ r2_access_key_id | default('') }}"
+        R2_SECRET_ACCESS_KEY: "{{ r2_secret_access_key | default('') }}"
+        R2_USER_STORAGES_BUCKET_NAME: "{{ r2_bucket | default('') }}"
+
+    # ========================================
+    # Phase 6: Final health check
+    # ========================================
+    - name: Verify runner health after cleanup
+      command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -94,7 +94,7 @@
       when: nbd_load.stdout | default('') | length > 0
 
     # When groups change, the current SSH session still has the old group list.
-    # Reset the connection so subsequent playbooks (deploy-runner) pick up the
+    # Reset the connection so subsequent playbooks (build-runner) pick up the
     # new membership.
     - name: Reset SSH connection to pick up new group membership
       meta: reset_connection

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -326,7 +326,7 @@ async fn get_service_pid(unit: &str) -> RunnerResult<Option<u32>> {
 /// Resolve the runner's base_dir from its service name suffix using the
 /// project-wide convention: `/var/lib/vm0-runner/runners/<suffix>/`.
 ///
-/// This matches `ansible/playbooks/deploy-runner.yml` and the `--runner-dirname`
+/// This matches `ansible/playbooks/build-runner.yml` and the `--runner-dirname`
 /// default in `runner config`. Non-standard `base_dir` overrides (dev-only)
 /// will fail to locate status.json and fall through to forceful stop.
 fn runner_base_dir(suffix: &str) -> Option<PathBuf> {

--- a/crates/runner/src/runner_dirname.rs
+++ b/crates/runner/src/runner_dirname.rs
@@ -46,7 +46,7 @@ pub fn validate_or_err(name: &str) -> RunnerResult<()> {
 /// Implicitly rejects `/` and `\` (neither is in the charset), keeping the
 /// name to a single path segment regardless of the host's separator
 /// conventions. The dot allowance exists for production semver dirnames
-/// produced by `ansible/playbooks/deploy-runner.yml` (e.g. `v0.3.0`).
+/// produced by `ansible/playbooks/build-runner.yml` (e.g. `v0.3.0`).
 pub(crate) fn validate_name(name: &str) -> bool {
     if name.is_empty() || name.starts_with('.') || name.starts_with('-') {
         return false;


### PR DESCRIPTION
## Summary

Split `ansible/playbooks/deploy-runner.yml` into two playbooks so the runner release job can be split into build-and-promote jobs (tracked in #9862):

- **`build-runner.yml`** — Phase 1 (deploy binary) + Phase 2 (`runner setup` + `runner build`) + Phase 3a (`runner config`). Writes all artifacts into per-version directories without touching any running service.
- **`promote-runner.yml`** — Phase 3b (`runner service install` — the traffic cutover point) + Phase 4 (doctor) + Phase 5 (drain old + gc) + Phase 6 (final doctor).

`release-please.yml` now invokes both playbooks back-to-back from the existing `deploy-runner-production` job. Splitting the workflow job itself is the follow-up PR for #9862 — this one is a pure refactor with no behavior change on the success path.

### Why `runner config` stays with build (not promote)

`runner config` writes `runner.yaml` under a per-version directory; it does **not** touch any running service. Keeping it with build means the hashes (`default_rootfs_hash`, `default_snapshot_hash`) are consumed as ansible facts in the same playbook that produces them — the build→promote boundary only needs `runner_version`, nothing else has to cross jobs.

### Variable interface

- `build-runner.yml` — requires `runner_version`, `official_runner_secret`, `api_url`, `r2_*` (for `runner build` cache hit)
- `promote-runner.yml` — requires `runner_version`; optional `sentry_dsn`, `r2_*` (for `runner gc` R2 sweep)

## Test plan

- [ ] CI `lint` / `test` pass
- [ ] On the next `release-please` merge, confirm both playbooks run in sequence and production deploy succeeds end-to-end on all metal hosts

Part of #9862 (ansible split). Workflow job split follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)