### PR TITLE
perf(guest-agent): parallelize final telemetry upload with checkpoint

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -37,6 +37,7 @@ async fn run() -> i32 {
         let masker = masker::SecretMasker::from_env();
         log_info!(LOG_TAG, "▷ Cleanup");
         final_telemetry(&masker).await;
+        log_info!(LOG_TAG, "✓ Cleanup complete");
         log_info!(LOG_TAG, "Background processes stopped");
         log_info!(LOG_TAG, "✗ Sandbox failed (exit code 1)");
         return 1;
@@ -230,7 +231,14 @@ async fn execute(
         // records would never reach the server. The delta here is small (~10
         // records) so this adds ~300 ms to the critical path instead of the full
         // ~1 s we avoided by parallelizing.
-        let _ = telemetry::final_upload(masker).await;
+        //
+        // Not wrapped in `final_telemetry` because any `record_sandbox_op` it
+        // wrote would never reach the server (no third upload to pick it up);
+        // a failure log is the only operator-visible signal worth emitting.
+        if telemetry::final_upload(masker).await.is_err() {
+            log_error!(LOG_TAG, "Final telemetry catch-up upload failed");
+        }
+        log_info!(LOG_TAG, "✓ Cleanup complete");
     } else {
         if cli_exit_code == 0 && exit_code == 0 {
             log_info!(LOG_TAG, "claude-code completed successfully");
@@ -239,6 +247,7 @@ async fn execute(
         }
         log_info!(LOG_TAG, "▷ Cleanup");
         final_telemetry(masker).await;
+        log_info!(LOG_TAG, "✓ Cleanup complete");
     }
 
     exit_code

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -190,18 +190,34 @@ async fn execute(
         log_info!(LOG_TAG, "✗ Execution failed ({}s)", cli_elapsed.as_secs());
     }
 
-    // Checkpoint on success (skip when no API — local/test mode). Run the
-    // final telemetry upload in parallel with checkpoint: they share no state
-    // and target independent APIs, so serializing just inflates guest-exit
-    // latency by the telemetry upload duration (~1s). The failure / no-API
-    // branches run telemetry serially since there's no checkpoint to overlap.
+    // Checkpoint on success (skip when no API — local/test mode). The final
+    // telemetry upload runs in two phases to keep the operator-visible log
+    // output identical to the pre-parallelization sequence while still
+    // overlapping the ~1s upload with checkpoint:
+    //   1. A silent first pass inside `tokio::join!` drains the pre-checkpoint
+    //      sandbox_ops under cover of `checkpoint::create_checkpoint` — no
+    //      log banner, no error log, no `record_sandbox_op`. On failure,
+    //      position tracking doesn't advance so the catch-up re-reads the
+    //      same delta.
+    //   2. After checkpoint completes, `final_telemetry` runs serially as
+    //      the pre-parallelization "cleanup" step — it emits the `▷ Cleanup`
+    //      lifecycle banner, the `"Performing final telemetry upload..."`
+    //      log inside `final_upload`, the failure log on error, and records
+    //      the `final_telemetry_upload` sandbox op.
+    // The catch-up step also captures records checkpoint wrote after the
+    // parallel pass snapshotted the file (`session_id_read`, VAS snapshot
+    // timings, `checkpoint_total`, etc) — `telemetry_loop` breaks on
+    // shutdown without a final flush, so without this serial pass those
+    // records would never reach the server.
     if cli_exit_code == 0 && exit_code == 0 && env::has_api() {
         log_info!(LOG_TAG, "claude-code completed successfully");
 
-        log_info!(LOG_TAG, "▷ Checkpoint + Cleanup");
+        log_info!(LOG_TAG, "▷ Checkpoint");
         let cp_start = Instant::now();
-        let (cp_result, ()) =
-            tokio::join!(checkpoint::create_checkpoint(), final_telemetry(masker));
+        let (cp_result, _) = tokio::join!(
+            checkpoint::create_checkpoint(),
+            telemetry::final_upload_silent(masker),
+        );
         match cp_result {
             Ok(()) => {
                 log_info!(
@@ -223,14 +239,8 @@ async fn execute(
             }
         }
 
-        // Catch-up upload: the parallel pass above read the sandbox_ops file
-        // before checkpoint finished writing its sub-op records (`session_id_read`,
-        // VAS snapshot timings, `checkpoint_total`, etc). `telemetry_loop` breaks
-        // on shutdown without a final flush, so without this second pass those
-        // records would never reach the server. The delta here is small (~10
-        // records) so this adds ~300 ms to the critical path instead of the full
-        // ~1 s we avoided by parallelizing.
-        let _ = telemetry::final_upload(masker).await;
+        log_info!(LOG_TAG, "▷ Cleanup");
+        final_telemetry(masker).await;
     } else {
         if cli_exit_code == 0 && exit_code == 0 {
             log_info!(LOG_TAG, "claude-code completed successfully");

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -37,7 +37,6 @@ async fn run() -> i32 {
         let masker = masker::SecretMasker::from_env();
         log_info!(LOG_TAG, "▷ Cleanup");
         final_telemetry(&masker).await;
-        log_info!(LOG_TAG, "✓ Cleanup complete");
         log_info!(LOG_TAG, "Background processes stopped");
         log_info!(LOG_TAG, "✗ Sandbox failed (exit code 1)");
         return 1;
@@ -231,14 +230,7 @@ async fn execute(
         // records would never reach the server. The delta here is small (~10
         // records) so this adds ~300 ms to the critical path instead of the full
         // ~1 s we avoided by parallelizing.
-        //
-        // Not wrapped in `final_telemetry` because any `record_sandbox_op` it
-        // wrote would never reach the server (no third upload to pick it up);
-        // a failure log is the only operator-visible signal worth emitting.
-        if telemetry::final_upload(masker).await.is_err() {
-            log_error!(LOG_TAG, "Final telemetry catch-up upload failed");
-        }
-        log_info!(LOG_TAG, "✓ Cleanup complete");
+        let _ = telemetry::final_upload(masker).await;
     } else {
         if cli_exit_code == 0 && exit_code == 0 {
             log_info!(LOG_TAG, "claude-code completed successfully");
@@ -247,7 +239,6 @@ async fn execute(
         }
         log_info!(LOG_TAG, "▷ Cleanup");
         final_telemetry(masker).await;
-        log_info!(LOG_TAG, "✓ Cleanup complete");
     }
 
     exit_code

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -100,7 +100,8 @@ async fn run() -> i32 {
     exit_code
 }
 
-/// Main execution logic: working dir, CLI, checkpoint.
+/// Main execution logic: working dir, CLI, checkpoint, and final telemetry
+/// upload (parallel with checkpoint on the success path; serial otherwise).
 async fn execute(
     masker: &masker::SecretMasker,
     start: Instant,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -26,7 +26,7 @@ async fn main() {
 }
 
 /// Top-level orchestrator. Returns exit code directly (never panics/errors out).
-/// Cleanup (final telemetry + complete API) is guaranteed to run.
+/// Final telemetry upload is guaranteed to run on every code path.
 async fn run() -> i32 {
     // Record API-to-agent E2E time (as early as possible)
     guest_agent::timing::record_e2e_from_api("api_to_agent_start");
@@ -36,7 +36,7 @@ async fn run() -> i32 {
         log_error!(LOG_TAG, "Fatal: VM0_WORKING_DIR is required but not set");
         let masker = masker::SecretMasker::from_env();
         log_info!(LOG_TAG, "▷ Cleanup");
-        cleanup(&masker).await;
+        final_telemetry(&masker).await;
         log_info!(LOG_TAG, "Background processes stopped");
         log_info!(LOG_TAG, "✗ Sandbox failed (exit code 1)");
         return 1;
@@ -79,12 +79,11 @@ async fn run() -> i32 {
     log_info!(LOG_TAG, "Telemetry upload started");
     record_sandbox_op("telemetry_upload_start", t.elapsed(), true, None);
 
-    // Execute main logic (init + CLI + checkpoint)
+    // Execute main logic (init + CLI + checkpoint + final telemetry).
+    // `execute` owns the final telemetry upload — on the success path it's run
+    // in parallel with `checkpoint` so the ~1s upload doesn't serialize behind
+    // the ~4s snapshot work.
     let exit_code = execute(&masker, start, heartbeat_handle).await;
-
-    // Guaranteed cleanup: final telemetry upload
-    log_info!(LOG_TAG, "▷ Cleanup");
-    cleanup(&masker).await;
 
     // Stop all background processes (heartbeat, metrics, telemetry)
     shutdown.cancel();
@@ -190,13 +189,19 @@ async fn execute(
         log_info!(LOG_TAG, "✗ Execution failed ({}s)", cli_elapsed.as_secs());
     }
 
-    // Checkpoint on success (skip when no API — local/test mode)
+    // Checkpoint on success (skip when no API — local/test mode). Run the
+    // final telemetry upload in parallel with checkpoint: they share no state
+    // and target independent APIs, so serializing just inflates guest-exit
+    // latency by the telemetry upload duration (~1s). The failure / no-API
+    // branches run telemetry serially since there's no checkpoint to overlap.
     if cli_exit_code == 0 && exit_code == 0 && env::has_api() {
         log_info!(LOG_TAG, "claude-code completed successfully");
 
-        log_info!(LOG_TAG, "▷ Checkpoint");
+        log_info!(LOG_TAG, "▷ Checkpoint + Cleanup");
         let cp_start = Instant::now();
-        match checkpoint::create_checkpoint().await {
+        let (cp_result, ()) =
+            tokio::join!(checkpoint::create_checkpoint(), final_telemetry(masker));
+        match cp_result {
             Ok(()) => {
                 log_info!(
                     LOG_TAG,
@@ -216,19 +221,31 @@ async fn execute(
                 exit_code = 1;
             }
         }
-    } else if cli_exit_code == 0 && exit_code == 0 {
-        log_info!(LOG_TAG, "claude-code completed successfully");
-    } else if cli_exit_code != 0 {
-        log_info!(LOG_TAG, "claude-code failed with exit code {cli_exit_code}");
+
+        // Catch-up upload: the parallel pass above read the sandbox_ops file
+        // before checkpoint finished writing its sub-op records (`session_id_read`,
+        // VAS snapshot timings, `checkpoint_total`, etc). `telemetry_loop` breaks
+        // on shutdown without a final flush, so without this second pass those
+        // records would never reach the server. The delta here is small (~10
+        // records) so this adds ~300 ms to the critical path instead of the full
+        // ~1 s we avoided by parallelizing.
+        let _ = telemetry::final_upload(masker).await;
+    } else {
+        if cli_exit_code == 0 && exit_code == 0 {
+            log_info!(LOG_TAG, "claude-code completed successfully");
+        } else if cli_exit_code != 0 {
+            log_info!(LOG_TAG, "claude-code failed with exit code {cli_exit_code}");
+        }
+        log_info!(LOG_TAG, "▷ Cleanup");
+        final_telemetry(masker).await;
     }
 
     exit_code
 }
 
-/// Cleanup that always runs: final telemetry upload.
-/// Note: complete API is called by the runner after VM exits, not by guest-agent.
-async fn cleanup(masker: &masker::SecretMasker) {
-    // Final telemetry upload
+/// Final telemetry upload — records timing and logs on failure.
+/// The complete API is called by the runner after VM exits, not by guest-agent.
+async fn final_telemetry(masker: &masker::SecretMasker) {
     let telemetry_start = Instant::now();
     let telemetry_ok = telemetry::final_upload(masker).await.is_ok();
     if !telemetry_ok {

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -149,6 +149,19 @@ pub async fn final_upload(masker: &SecretMasker) -> Result<(), AgentError> {
     upload_telemetry(masker).await
 }
 
+/// Same as [`final_upload`] but without the log banner or error log.
+/// Used by the parallel-with-checkpoint first pass in `main.rs` so the
+/// operator-visible log output stays identical to the pre-parallelization
+/// sequence: only the post-`▷ Cleanup` catch-up emits the banner, and
+/// a first-pass failure is silently deferred to the catch-up (which reads
+/// the same unchanged file position and re-uploads the delta).
+pub async fn final_upload_silent(masker: &SecretMasker) -> Result<(), AgentError> {
+    if !env::has_api() {
+        return Ok(());
+    }
+    upload_telemetry(masker).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -855,3 +855,71 @@ async fn send_event_failure_writes_error_flag() {
     // Clean up
     let _ = std::fs::remove_file(flag_path);
 }
+
+// =========================================================================
+// Group 8: final_upload delta semantics
+//
+// These back the parallel-checkpoint-with-catch-up pattern in `main.rs`:
+// on the happy path, the first `final_upload` runs concurrently with
+// `checkpoint::create_checkpoint` and reads the `sandbox_ops` log before
+// checkpoint's sub-op records are written; a second `final_upload` after
+// the join picks up the delta. If `final_upload` ever stopped being
+// incremental — re-reading from offset 0 — that pattern would duplicate
+// records; if position-tracking broke in the other direction, checkpoint
+// sub-ops would be lost entirely.
+// =========================================================================
+
+#[tokio::test]
+async fn final_upload_is_incremental_between_calls() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    // Reset per-run telemetry state so this test drives sandbox_ops
+    // deterministically (other tests in this file don't record sandbox_ops,
+    // but be defensive against cross-test leakage).
+    let ops_file = guest_common::telemetry::sandbox_ops_log();
+    let pos_file = guest_agent::paths::telemetry_sandbox_ops_pos_file();
+    let _ = std::fs::remove_file(ops_file);
+    let _ = std::fs::remove_file(pos_file);
+
+    // Two mocks, registered in this order. httpmock matches by ID ascending
+    // and returns the first hit, so `first_op_mock` wins when the payload
+    // contains that substring; `catchup_mock` catches subsequent POSTs.
+    let first_op_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/telemetry")
+            .body_includes("first_op");
+        then.status(200);
+    });
+    let catchup_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.status(200);
+    });
+
+    let masker = SecretMasker::from_raw("");
+
+    // Pre-checkpoint record → parallel-pass upload captures it.
+    guest_common::telemetry::record_sandbox_op("first_op", Duration::from_millis(10), true, None);
+    guest_agent::telemetry::final_upload(&masker)
+        .await
+        .expect("first upload should succeed");
+
+    // Simulates a checkpoint sub-op written AFTER the parallel pass read
+    // the sandbox_ops file. The catch-up must pick it up.
+    guest_common::telemetry::record_sandbox_op("second_op", Duration::from_millis(20), true, None);
+    guest_agent::telemetry::final_upload(&masker)
+        .await
+        .expect("catch-up upload should succeed");
+
+    // The first upload carried `first_op` and matched `first_op_mock`.
+    // The catch-up MUST NOT have carried `first_op` (position tracking
+    // advanced past it) — otherwise `first_op_mock` would have matched
+    // twice and `catchup_mock` zero times.
+    first_op_mock.assert_calls_async(1).await;
+    catchup_mock.assert_calls_async(1).await;
+
+    first_op_mock.delete_async().await;
+    catchup_mock.delete_async().await;
+    let _ = std::fs::remove_file(ops_file);
+    let _ = std::fs::remove_file(pos_file);
+}


### PR DESCRIPTION
## Summary

Phase 2 of #9809 — cut ~700 ms off the guest-exit critical path on successful runs.

On the success path, `final_telemetry::final_upload` (~1 s) serialized behind `checkpoint::create_checkpoint` (~4.6 s). They share no state and target independent APIs, so this parallelizes them via `tokio::join!`.

A serial catch-up `final_upload` follows the parallel pass to capture checkpoint's sub-op records (`session_id_read`, VAS snapshot timings, `checkpoint_total`, etc) — the first-pass upload reads the `sandbox_ops` file before checkpoint finishes writing those records, and `telemetry_loop` breaks on shutdown without a final flush, so without the catch-up those records would never reach the server. The catch-up delta is small (~10 records, expected ~300 ms).

- Happy path wall-clock: `max(checkpoint, parallel upload) + catchup` → ~4.6 s + ~0.3 s ≈ ~4.9 s
- Old wall-clock: `checkpoint + serial upload` → ~4.6 s + ~1 s ≈ ~5.6 s
- Net savings: **~700 ms per successful run**

Failure / no-API branches keep the existing serial upload — no checkpoint to overlap with.

Also renames the former `cleanup` helper to `final_telemetry` to match its sole responsibility, and removes the now-inaccurate "complete API" mention from the `run()` doc comment (the `complete` API is called by the runner, not guest-agent).

## Test plan

- [x] `cargo clippy -p guest-agent --all-targets -- -D warnings` — clean
- [x] `cargo test -p guest-agent` — 28 passed
- [x] `cargo fmt -p guest-agent` — no diff
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)