### PR TITLE
chore(test-oauth): address p1/p2 follow-ups from pr 9878 review

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
@@ -1,17 +1,14 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { eq, desc } from "drizzle-orm";
 import { connectorTypeSchema } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { upsertOAuthConnector } from "../../../../../src/lib/zero/connector/connector-service";
 import { PROVIDER_HANDLERS } from "../../../../../src/lib/zero/connector/provider-registry";
 import {
   resolveTestUserId,
+  resolveTestUserOrg,
   DEFAULT_TEST_EMAIL,
 } from "../../../../../src/lib/auth/test-user";
-import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
-import { getOrgMetadata } from "../../../../../src/lib/zero/org/org-metadata-service";
-import { isNotFound } from "../../../../../src/lib/shared/errors";
 import { isTestEndpointAllowed } from "../../../../../src/lib/auth/test-endpoint-guard";
 
 const bodySchema = z.object({
@@ -71,25 +68,7 @@ export async function POST(request: Request) {
   const url = new URL(request.url);
   const email = url.searchParams.get("email") ?? DEFAULT_TEST_EMAIL;
   const userId = await resolveTestUserId(email);
-
-  // Look up test user's org from org_members_cache (populated by test-token endpoint)
-  const [cached] = await globalThis.services.db
-    .select({ orgId: orgMembersCache.orgId })
-    .from(orgMembersCache)
-    .where(eq(orgMembersCache.userId, userId))
-    .orderBy(desc(orgMembersCache.cachedAt))
-    .limit(1);
-
-  let org: { orgId: string; tier: string } | null = null;
-  if (cached) {
-    try {
-      org = await getOrgMetadata(cached.orgId);
-    } catch (error) {
-      if (!isNotFound(error)) throw error;
-      // org_members_cache entry exists but org_metadata row doesn't yet — use defaults
-      org = { orgId: cached.orgId, tier: "free" };
-    }
-  }
+  const org = await resolveTestUserOrg(userId);
   if (!org) {
     return NextResponse.json(
       { error: "Test user has no org — run test-token first" },

--- a/turbo/apps/web/app/api/cli/auth/test-enable-connector/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-enable-connector/__tests__/route.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "../route";
+import { DEFAULT_TEST_EMAIL } from "../../../../../../src/lib/auth/test-user";
+import {
+  createTestRequest,
+  insertOrgCacheEntry,
+  ensureOrgRow,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { testContext } from "../../../../../../src/__tests__/test-helpers";
+import { reloadEnv } from "../../../../../../src/env";
+import { seedTestCompose } from "../../../../../../src/__tests__/db-test-seeders/agents";
+import { insertOrgMembersCacheEntry } from "../../../../../../src/__tests__/db-test-seeders/org-members-cache";
+import { setOrgCredits } from "../../../../../../src/__tests__/db-test-seeders/org";
+import { findUserConnectorTypes } from "../../../../../../src/__tests__/db-test-assertions/connectors";
+
+// Mock Clerk Backend API — resolveTestUserId is the only Clerk touch this
+// route makes directly, but src/__tests__/clerk-mock.ts (imported via
+// testContext) calls `vi.mocked(auth)`, so the `auth` stub must remain
+// even though this test doesn't exercise it.
+const mockGetUserList = vi.fn();
+vi.mock("@clerk/nextjs/server", () => {
+  return {
+    clerkClient: vi.fn(async () => {
+      return {
+        users: { getUserList: mockGetUserList },
+      };
+    }),
+    auth: vi.fn(async () => {
+      return { userId: null, orgId: null, orgRole: null };
+    }),
+  };
+});
+
+const context = testContext();
+
+const TEST_USER_ID = "user_enable_connector";
+const TEST_ORG_ID = "org_enable_connector";
+// Push cache entries far enough out that org_members_cache / org_cache TTLs
+// never expire mid-test and fall back to Clerk (which is mocked).
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+describe("/api/cli/auth/test-enable-connector", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    vi.stubEnv("VERCEL_ENV", "");
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("CLERK_SECRET_KEY", "test-secret-key");
+    reloadEnv();
+
+    mockGetUserList.mockResolvedValue({ data: [{ id: TEST_USER_ID }] });
+
+    await insertOrgCacheEntry({ orgId: TEST_ORG_ID, slug: "enable-conn-org" });
+    await ensureOrgRow(TEST_ORG_ID);
+
+    // Seed the lookup caches test-token normally populates so the route's
+    // resolveTestUserOrg() resolves to this test's org.
+    await insertOrgMembersCacheEntry({
+      orgId: TEST_ORG_ID,
+      userId: TEST_USER_ID,
+      role: "admin",
+      cachedAt: new Date(Date.now() + ONE_YEAR_MS),
+    });
+    // `setOrgCredits` upserts into org_metadata — we only care that the
+    // row exists so `getOrgMetadata()` inside the route doesn't 404.
+    await setOrgCredits(TEST_ORG_ID, 100_000);
+  });
+
+  it("returns 404 in production", async () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    reloadEnv();
+    const response = await POST(
+      createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-enable-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            composeId: "00000000-0000-0000-0000-000000000000",
+            connectorTypes: ["github"],
+          }),
+        },
+      ),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects unknown connector types", async () => {
+    const { composeId } = await seedTestCompose({
+      userId: TEST_USER_ID,
+      orgId: TEST_ORG_ID,
+      name: `compose-unknown-${Date.now()}`,
+    });
+    const response = await POST(
+      createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-enable-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            composeId,
+            connectorTypes: ["not-a-real-connector"],
+          }),
+        },
+      ),
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("Unknown connector types");
+  });
+
+  it("rejects requests for a compose that does not exist", async () => {
+    const response = await POST(
+      createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-enable-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            composeId: "00000000-0000-0000-0000-000000000000",
+            connectorTypes: ["github"],
+          }),
+        },
+      ),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("writes user_connectors rows for each requested connector", async () => {
+    const { composeId } = await seedTestCompose({
+      userId: TEST_USER_ID,
+      orgId: TEST_ORG_ID,
+      name: `compose-ok-${Date.now()}`,
+    });
+
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/cli/auth/test-enable-connector?email=${encodeURIComponent(
+          DEFAULT_TEST_EMAIL,
+        )}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            composeId,
+            connectorTypes: ["github", "slack"],
+          }),
+        },
+      ),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+    expect(body.composeId).toBe(composeId);
+    expect(body.connectorTypes).toEqual(["github", "slack"]);
+
+    const types = await findUserConnectorTypes(TEST_USER_ID, composeId);
+    expect(types.sort()).toEqual(["github", "slack"].sort());
+  });
+});

--- a/turbo/apps/web/app/api/cli/auth/test-enable-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-enable-connector/route.ts
@@ -1,18 +1,16 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { eq, desc } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { connectorTypeSchema } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
   resolveTestUserId,
+  resolveTestUserOrg,
   DEFAULT_TEST_EMAIL,
 } from "../../../../../src/lib/auth/test-user";
-import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
 import { zeroAgents } from "../../../../../src/db/schema/zero-agent";
 import { userConnectors } from "../../../../../src/db/schema/user-connector";
-import { getOrgMetadata } from "../../../../../src/lib/zero/org/org-metadata-service";
-import { isNotFound } from "../../../../../src/lib/shared/errors";
 import { isTestEndpointAllowed } from "../../../../../src/lib/auth/test-endpoint-guard";
 
 const bodySchema = z.object({
@@ -66,32 +64,15 @@ export async function POST(request: Request) {
   const url = new URL(request.url);
   const email = url.searchParams.get("email") ?? DEFAULT_TEST_EMAIL;
   const userId = await resolveTestUserId(email);
-
-  const db = globalThis.services.db;
-
-  // Look up test user's org
-  const [cached] = await db
-    .select({ orgId: orgMembersCache.orgId })
-    .from(orgMembersCache)
-    .where(eq(orgMembersCache.userId, userId))
-    .orderBy(desc(orgMembersCache.cachedAt))
-    .limit(1);
-
-  let org: { orgId: string; tier: string } | null = null;
-  if (cached) {
-    try {
-      org = await getOrgMetadata(cached.orgId);
-    } catch (error) {
-      if (!isNotFound(error)) throw error;
-      org = { orgId: cached.orgId, tier: "free" };
-    }
-  }
+  const org = await resolveTestUserOrg(userId);
   if (!org) {
     return NextResponse.json(
       { error: "Test user has no org — run test-token first" },
       { status: 400 },
     );
   }
+
+  const db = globalThis.services.db;
 
   // Ensure zeroAgents record exists (user_connectors has FK to it)
   const [compose] = await db

--- a/turbo/apps/web/app/api/test/oauth-provider/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/test/oauth-provider/__tests__/route.test.ts
@@ -4,7 +4,7 @@ import { POST as tokenPost } from "../token/route";
 import { GET as userinfoGet } from "../userinfo/route";
 import { GET as echoGet } from "../echo/route";
 import { reloadEnv } from "../../../../../src/env";
-import { mintAccessToken } from "../_lib/token-helpers";
+import { mintAccessToken, mintExpiredAccessToken } from "../_lib/token-helpers";
 
 const APP_URL = "http://localhost:3000";
 
@@ -259,15 +259,33 @@ describe("/api/test/oauth-provider", () => {
       expect(body.error).toBe("invalid_grant");
     });
 
-    it("unknown refresh token succeeds with default scenario", async () => {
-      // A fresh refresh token the server hasn't seen is treated as success —
-      // matches real OAuth 2 providers that don't track every refresh token.
+    it("rejects testoauth_rt_* with unknown scenario tag", async () => {
+      // Prefix says "this is one of ours" but the scenario segment isn't one
+      // of the four valid values → reject as malformed. Guards against
+      // silently falling through to success when a test typos the scenario.
       const response = await tokenPost(
         makeTokenRequest({
           grant_type: "refresh_token",
           client_id: "test-oauth-client",
           client_secret: "test-oauth-secret",
-          refresh_token: "testoauth_rt_unknown",
+          refresh_token: "testoauth_rt_unknown_abc",
+        }),
+      );
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.error).toBe("invalid_grant");
+    });
+
+    it("accepts refresh tokens without our prefix as success", async () => {
+      // Real OAuth 2 providers don't require refresh tokens to carry
+      // structure; preserve that tolerance so tests seeding arbitrary
+      // tokens (e.g. from external fixtures) still succeed.
+      const response = await tokenPost(
+        makeTokenRequest({
+          grant_type: "refresh_token",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+          refresh_token: "arbitrary-opaque-token",
         }),
       );
       expect(response.status).toBe(200);
@@ -318,8 +336,7 @@ describe("/api/test/oauth-provider", () => {
     });
 
     it("returns 401 for expired access token", async () => {
-      const token = mintAccessToken(0);
-      // Move Date.now forward so the token has demonstrably expired.
+      const token = mintExpiredAccessToken();
       const response = await userinfoGet(
         new Request(`${APP_URL}/api/test/oauth-provider/userinfo`, {
           headers: { authorization: `Bearer ${token}` },
@@ -352,7 +369,7 @@ describe("/api/test/oauth-provider", () => {
     });
 
     it("returns 401 for expired access token", async () => {
-      const token = mintAccessToken(0);
+      const token = mintExpiredAccessToken();
       const response = await echoGet(
         new Request(`${APP_URL}/api/test/oauth-provider/echo`, {
           headers: { authorization: `Bearer ${token}` },

--- a/turbo/apps/web/app/api/test/oauth-provider/_lib/token-helpers.ts
+++ b/turbo/apps/web/app/api/test/oauth-provider/_lib/token-helpers.ts
@@ -39,6 +39,16 @@ export function mintAccessToken(expiresInSecs: number): string {
   return `${ACCESS_PREFIX}${expiresAtMs}_${randomId()}`;
 }
 
+/**
+ * Mint a token whose embedded expiry is unambiguously in the past.
+ * Avoids the `mintAccessToken(0)` + "hope the next Date.now() is later"
+ * race in tests.
+ */
+export function mintExpiredAccessToken(): string {
+  const pastMs = Date.now() - 1000;
+  return `${ACCESS_PREFIX}${pastMs}_${randomId()}`;
+}
+
 export function mintRefreshToken(scenario: TestOAuthScenario): string {
   return `${REFRESH_PREFIX}${scenario}_${randomId()}`;
 }
@@ -49,6 +59,10 @@ export function mintAuthCode(scenario: TestOAuthScenario): string {
 
 export function isTestOAuthAccessToken(value: string): boolean {
   return value.startsWith(ACCESS_PREFIX);
+}
+
+export function isTestOAuthRefreshToken(value: string): boolean {
+  return value.startsWith(REFRESH_PREFIX);
 }
 
 /**

--- a/turbo/apps/web/app/api/test/oauth-provider/authorize/route.ts
+++ b/turbo/apps/web/app/api/test/oauth-provider/authorize/route.ts
@@ -20,7 +20,7 @@ const scenarioSchema = z.enum(TEST_OAUTH_SCENARIOS);
  * The scenario is encoded into the code itself — the token endpoint decodes
  * it — because on Vercel there's no shared in-memory state across instances.
  */
-export function GET(request: Request): Response {
+export async function GET(request: Request): Promise<Response> {
   if (!isTestEndpointAllowed(request)) {
     return new NextResponse("Not found", { status: 404 });
   }

--- a/turbo/apps/web/app/api/test/oauth-provider/echo/route.ts
+++ b/turbo/apps/web/app/api/test/oauth-provider/echo/route.ts
@@ -14,7 +14,7 @@ import {
  * access token. Validates the injected token's baked-in expiry and returns
  * 401 if stale — so a broken refresh pipeline surfaces as a non-200 in E2E.
  */
-export function GET(request: Request): Response {
+export async function GET(request: Request): Promise<Response> {
   if (!isTestEndpointAllowed(request)) {
     return new NextResponse("Not found", { status: 404 });
   }

--- a/turbo/apps/web/app/api/test/oauth-provider/token/route.ts
+++ b/turbo/apps/web/app/api/test/oauth-provider/token/route.ts
@@ -5,6 +5,7 @@ import {
   TEST_OAUTH_CLIENT_SECRET,
 } from "../../../../../src/lib/zero/connector/providers/test-oauth";
 import {
+  isTestOAuthRefreshToken,
   mintAccessToken,
   mintRefreshToken,
   parseScenarioFromCode,
@@ -80,18 +81,32 @@ function handleRefreshToken(refreshToken: string | null): Response {
       { status: 400 },
     );
   }
-  // Unknown refresh tokens (not minted by us) are treated as success — this
-  // matches real OAuth 2 providers that don't require their refresh tokens
-  // to carry structure. Tests that want to drive refresh failure do so by
-  // first minting a refresh token via authorize(?scenario=invalid-refresh).
-  const scenario = parseScenarioFromRefreshToken(refreshToken) ?? "success";
-  if (scenario === "invalid-refresh" || scenario === "revoked") {
+  // Refresh token handling tiers:
+  //  1. testoauth_rt_* but scenario segment is unknown → reject as malformed.
+  //     Without this a typo ("revokes" instead of "revoked") would silently
+  //     fall through to "success" and mask the test scenario the author meant.
+  //  2. testoauth_rt_<scenario>_* with one of the rejection scenarios → 400.
+  //  3. No prefix at all (not one of ours) → accept-as-success. Real OAuth
+  //     providers don't force callers to carry structure; we preserve that
+  //     tolerance so tests seeding arbitrary refresh tokens still succeed.
+  const scenario = parseScenarioFromRefreshToken(refreshToken);
+  if (!scenario && isTestOAuthRefreshToken(refreshToken)) {
+    return NextResponse.json(
+      {
+        error: "invalid_grant",
+        error_description: "malformed or unknown refresh token scenario",
+      },
+      { status: 400 },
+    );
+  }
+  const resolved: TestOAuthScenario = scenario ?? "success";
+  if (resolved === "invalid-refresh" || resolved === "revoked") {
     return NextResponse.json(
       { error: "invalid_grant", error_description: "refresh token rejected" },
       { status: 400 },
     );
   }
-  return NextResponse.json(mintTokensForScenario(scenario));
+  return NextResponse.json(mintTokensForScenario(resolved));
 }
 
 /**

--- a/turbo/apps/web/app/api/test/oauth-provider/userinfo/route.ts
+++ b/turbo/apps/web/app/api/test/oauth-provider/userinfo/route.ts
@@ -14,7 +14,7 @@ import {
  * Validates the token's embedded expiry — tokens past their baked-in
  * timestamp return 401, mirroring real providers.
  */
-export function GET(request: Request): Response {
+export async function GET(request: Request): Promise<Response> {
   if (!isTestEndpointAllowed(request)) {
     return new NextResponse("Not found", { status: 404 });
   }

--- a/turbo/apps/web/src/__tests__/db-test-assertions/connectors.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/connectors.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { initServices } from "../../lib/init-services";
 import { secrets } from "../../db/schema/secret";
 import { connectors } from "../../db/schema/connector";
+import { userConnectors } from "../../db/schema/user-connector";
 import { decryptSecretValue } from "../../lib/shared/crypto/secrets-encryption";
 
 // ---------------------------------------------------------------------------
@@ -57,4 +58,27 @@ export async function findTestConnectorTokenExpiresAt(
 
   if (!row) return undefined;
   return row.tokenExpiresAt;
+}
+
+/**
+ * List the connector types granted to a (user, agent) pair. Returns the
+ * literal `connector_type` strings in insertion order.
+ */
+export async function findUserConnectorTypes(
+  userId: string,
+  agentId: string,
+): Promise<string[]> {
+  initServices();
+  const rows = await globalThis.services.db
+    .select({ connectorType: userConnectors.connectorType })
+    .from(userConnectors)
+    .where(
+      and(
+        eq(userConnectors.userId, userId),
+        eq(userConnectors.agentId, agentId),
+      ),
+    );
+  return rows.map((r) => {
+    return r.connectorType;
+  });
 }

--- a/turbo/apps/web/src/lib/auth/test-user.ts
+++ b/turbo/apps/web/src/lib/auth/test-user.ts
@@ -1,4 +1,10 @@
 import { clerkClient } from "@clerk/nextjs/server";
+import { desc, eq } from "drizzle-orm";
+import { orgMembersCache } from "../../db/schema/org-members-cache";
+import {
+  getOrgMetadata,
+  type OrgMetadata,
+} from "../zero/org/org-metadata-service";
 
 export const DEFAULT_TEST_EMAIL = "dev+clerk_test+serial@vm0-e2e.ai";
 
@@ -20,4 +26,26 @@ export async function resolveTestUserId(
     throw new Error(`Test user not found for email: ${email}`);
   }
   return userId;
+}
+
+/**
+ * Look up the test user's org + metadata via org_members_cache → org_metadata.
+ *
+ * Returns `null` when the user has no cached membership at all (e.g.
+ * `test-token` was never called to seed caches). `test-token` also upserts
+ * `org_metadata` for the resolved org, so the metadata lookup should
+ * always succeed once that endpoint has run — hence we let NotFound from
+ * `getOrgMetadata` bubble up rather than masking it with a fallback.
+ */
+export async function resolveTestUserOrg(
+  userId: string,
+): Promise<OrgMetadata | null> {
+  const [cached] = await globalThis.services.db
+    .select({ orgId: orgMembersCache.orgId })
+    .from(orgMembersCache)
+    .where(eq(orgMembersCache.userId, userId))
+    .orderBy(desc(orgMembersCache.cachedAt))
+    .limit(1);
+  if (!cached) return null;
+  return getOrgMetadata(cached.orgId);
 }

--- a/turbo/apps/web/src/lib/zero/connector/providers/test-oauth.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/test-oauth.ts
@@ -34,20 +34,28 @@ interface UserInfo {
   email: string | null;
 }
 
-function resolveUrl(path: string | undefined): string {
+function resolveUrl(field: string, path: string | undefined): string {
   if (!path) {
-    throw new Error("Test OAuth URL missing from CONNECTOR_TYPES_DEF");
+    throw new Error(
+      `Test OAuth URL missing: CONNECTOR_TYPES_DEF["test-oauth"].oauth.${field} is not set`,
+    );
   }
   const base = env().NEXT_PUBLIC_APP_URL.replace(/\/$/, "");
   return `${base}${path}`;
 }
 
 function getAuthorizationUrl(): string {
-  return resolveUrl(getConnectorOAuthConfig("test-oauth")?.authorizationUrl);
+  return resolveUrl(
+    "authorizationUrl",
+    getConnectorOAuthConfig("test-oauth")?.authorizationUrl,
+  );
 }
 
 function getTokenUrl(): string {
-  return resolveUrl(getConnectorOAuthConfig("test-oauth")?.tokenUrl);
+  return resolveUrl(
+    "tokenUrl",
+    getConnectorOAuthConfig("test-oauth")?.tokenUrl,
+  );
 }
 
 export function buildTestOAuthAuthorizationUrl(
@@ -170,7 +178,7 @@ export async function fetchTestOAuthUserInfo(
         : {}),
     },
   });
-  const response = userinfoRouteHandler(request);
+  const response = await userinfoRouteHandler(request);
 
   if (!response.ok) {
     throw new Error(`Test OAuth userinfo failed: ${response.status}`);


### PR DESCRIPTION
## Summary

Post-merge cleanups for #9878. Everything here is internal refactor / test hygiene — the only behavior delta is a tighter validation rule in the fake OAuth token route.

### P1
- **Real `await`**: echo / userinfo / authorize handlers now `async`, so the in-process `await userinfoRouteHandler(request)` in `test-oauth.ts` is a genuine awaitable (no more \`ts80007\` hint).
- **Deduplicate test-user org lookup**: new \`resolveTestUserOrg(userId)\` in \`src/lib/auth/test-user.ts\`. Both \`test-connector\` and \`test-enable-connector\` now use it; each route sheds ~20 lines.
- **Drop dead NotFound fallback**: \`test-token\` seeds \`org_metadata\` since PR #9878, so the \`catch { org = { tier: "free" } }\` path in the two test-only routes was dead code (Bad Smell #13). Removed.
- **Fake refresh token validation**: \`handleRefreshToken\` now 400s when a token carries our \`testoauth_rt_\` prefix but an unknown scenario tag, instead of silently fall-through to success. Tokens without our prefix still succeed (preserving OAuth-provider tolerance).

### P2
- \`resolveUrl\` error names the missing field (\`authorizationUrl\` / \`tokenUrl\`) instead of a generic "missing" message.
- New \`mintExpiredAccessToken()\` replaces the \`mintAccessToken(0)\` + "hope Date.now ticks forward" race in the route tests.
- New route-level integration test for \`test-enable-connector\` (prod guard, unknown-connector rejection, missing-compose rejection, happy-path \`user_connectors\` insertion).
- New \`findUserConnectorTypes\` assertion helper in \`db-test-assertions/connectors.ts\`.

### Not done (deferred)
- \`cache env()\` in test-oauth.ts (micro-optimisation).
- DRY up t53 bats compose-id extraction (two uses, not worth abstraction).
- Post-merge 401-rate monitoring for other OAuth connectors (non-code).

## Test plan

- [x] \`cd turbo && pnpm -F web check-types\`
- [x] \`cd turbo && pnpm -F web exec vitest run app/api/test/oauth-provider app/api/cli/auth/test-enable-connector\` — 29 tests pass
- [x] \`cd turbo && pnpm -F web exec eslint app/api/cli/auth/test-enable-connector/__tests__/route.test.ts\` — clean

Refs #9878.

🤖 Generated with [Claude Code](https://claude.com/claude-code)