### PR TITLE
test: auto-cover views changed 2026-04-18

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -404,3 +404,59 @@ describe("chat-d-063: download link renders for file attachment", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// CHAT-D-064: Video attachment chip uses the video branch (not image/file icon)
+// Covers the video branch added to AttachmentChip in #9662.
+// ---------------------------------------------------------------------------
+
+describe("chat-d-064: video attachment chip shows neither image thumbnail nor file-type icon", () => {
+  it("renders composer chip without image preview or file-type icon for an mp4 upload", async () => {
+    const user = userEvent.setup();
+    const videoUrl = "https://example.com/demo.mp4";
+
+    server.use(
+      http.post("*/api/zero/uploads", () => {
+        return HttpResponse.json({
+          id: "upload-video-1",
+          filename: "demo.mp4",
+          contentType: "video/mp4",
+          size: 2048,
+          url: videoUrl,
+        });
+      }),
+    );
+    mockChatAPI();
+
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+    });
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    await user.upload(
+      fileInput!,
+      new File(["v"], "demo.mp4", { type: "video/mp4" }),
+    );
+
+    // Wait for the chip's Remove button, which appears only after the
+    // attachment has been added to the draft.
+    await waitFor(() => {
+      expect(screen.getByLabelText("Remove demo.mp4")).toBeInTheDocument();
+    });
+
+    const chipDiv = document.querySelector<HTMLElement>('[title="demo.mp4"]');
+    expect(chipDiv).toBeInTheDocument();
+
+    // Image branch would render an <img> with src=videoUrl; video branch must not.
+    expect(
+      document.querySelector(`img[src="${videoUrl}"]`),
+    ).not.toBeInTheDocument();
+    // File branch would render an aria-hidden file-type icon <img>; video must not.
+    expect(
+      chipDiv?.querySelector('img[aria-hidden="true"]'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -84,6 +84,42 @@ describe("zero chat thread page display - attachment file preview", () => {
   });
 });
 
+// CHAT-D-065: Video attachments render an inline <video controls> player.
+// Covers isVideoFilename + video branch added to PagedUserMessage in #9662.
+describe("zero chat thread page display - attachment video preview", () => {
+  it("renders a video element with controls for mp4 attachments", async () => {
+    const videoUrl = "https://example.com/clip.mp4";
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: `[Attached file: clip.mp4](${videoUrl})\nDownload with: curl ${videoUrl}\n`,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const video = await waitFor(() => {
+      const el = document.querySelector<HTMLVideoElement>(
+        `video[src="${videoUrl}"]`,
+      );
+      expect(el).toBeInTheDocument();
+      return el;
+    });
+
+    expect(video?.hasAttribute("controls")).toBeTruthy();
+    // Must not fall through to the image or download branches.
+    expect(
+      document.querySelector(`img[src="${videoUrl}"]`),
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector('a[download="clip.mp4"]'),
+    ).not.toBeInTheDocument();
+  });
+});
+
 // CHAT-D-043: Message status indicators render in ChatMessageRow
 describe("zero chat thread page display - message status indicators", () => {
   it("displays a Stop button status indicator when a run is active", async () => {


### PR DESCRIPTION
## Summary

Auto-generated coverage for view changes merged in the last 24 hours that lacked accompanying tests.

The video-attachment feature from #9662 added:
- A `video/*` branch in `AttachmentChip` (composer preview) that renders `IconVideo` instead of an image thumbnail or file-type icon.
- A `<video controls>` branch in `PagedUserMessage` (sent message) that renders mp4/webm/mov attachments inline instead of falling through to the image or download chip.

Neither branch was exercised by a test. This PR adds:

- `CHAT-D-064` in `zero-attachment-chips.test.tsx` — verifies that uploading `demo.mp4` produces a chip that takes neither the image nor the file-type-icon path.
- `CHAT-D-065` in `zero-chat-thread-page-display.test.tsx` — verifies that an inline `[Attached file: clip.mp4]` reference renders a `<video controls src=...>` element, and does NOT render an `<img>` thumbnail or `<a download>` anchor.

## Test plan

- [x] `pnpm exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx` — 16/16 passing
- [x] `pnpm exec oxlint` / `pnpm exec eslint --max-warnings 0` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)