### PR TITLE
feat(platform): scroll chat to bottom on send and message created

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1,5 +1,5 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
-import { delay } from "signal-timers";
+import { animationFrame, delay } from "signal-timers";
 import { onRef, resetSignal } from "../utils.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { createScrollSignals } from "../auto-scroll.ts";
@@ -599,6 +599,7 @@ function createRunTracking(
   reloadThread$: Command<void, []>,
   threadData$: Computed<Promise<ChatThread | null>>,
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>,
+  autoScroll$: Command<void, []>,
 ) {
   const allFinished$ = computed(async (get) => {
     const thread = await get(threadData$);
@@ -624,6 +625,12 @@ function createRunTracking(
 
       const onMessageCreated$ = command(async ({ set }, sig: AbortSignal) => {
         await set(fetchNextPage$, sig);
+        animationFrame(
+          () => {
+            set(autoScroll$);
+          },
+          { signal },
+        );
         return false;
       });
 
@@ -721,6 +728,7 @@ export function createChatThreadSignals(
     reloadThread$,
     threadData$,
     fetchNextPage$,
+    autoScroll$,
   );
 
   const sendMessage$ = command(
@@ -751,6 +759,12 @@ export function createChatThreadSignals(
         content: result.fullPrompt,
         createdAt: new Date().toISOString(),
       });
+      animationFrame(
+        () => {
+          set(scrollToBottom$);
+        },
+        { signal },
+      );
 
       const client = get(zeroClient$)(chatMessagesContract);
       const [, sendResult] = await Promise.all([


### PR DESCRIPTION
## Summary
- After inserting the optimistic user message in `sendMessage$`, call `scrollToBottom$` (unconditional) so the sender always snaps to their own message even if they had scrolled up.
- On the `chatThreadMessageCreated` realtime event, call `autoScroll$` (respects `autoScrollDisabled`) after `fetchNextPage$` so incoming assistant messages pull the view down only when the user hasn't scrolled up to read history.
- Both calls are deferred via `animationFrame` so the newly inserted DOM has laid out before the scroll fires.

## Test plan
- [ ] Send a message from the composer while at the bottom → view stays at the new bottom.
- [ ] Scroll up mid-history, then send a new message → view snaps back to bottom to show your message.
- [ ] Scroll up mid-history while an assistant run is streaming → incoming `chatThreadMessageCreated` events do NOT yank the view down.
- [ ] Return to the bottom during a run → subsequent `chatThreadMessageCreated` events resume auto-scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)