### PR TITLE
fix: show pin button on touch devices in agent dialogs

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -303,7 +303,7 @@ export function ManagePinnedAgentsDialog({
                         <TooltipTrigger asChild>
                           <button
                             type="button"
-                            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18"
+                            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18"
                             onClick={() => {
                               return togglePin(agent.id);
                             }}
@@ -591,7 +591,7 @@ export function AgentListDialog({
                           <TooltipTrigger asChild>
                             <button
                               type="button"
-                              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
+                              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
                               onClick={() => {
                                 return togglePin(agent.id);
                               }}


### PR DESCRIPTION
## Summary
Fixes #9901. On mobile/touch devices, the pin affordance in the "Talk to" agent picker and the "Manage pinned agents" dialog was only revealed on hover, making it impossible for touch-only users to pin agents.

Added a `[@media(hover:none)]:opacity-100` Tailwind arbitrary variant next to the existing `group-hover:opacity-100` / `group-focus-within:opacity-100` rules so the pin button is always visible on devices where hover is unavailable, while keeping the hover-to-reveal behavior on pointer devices.

## Changes
- `turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx`: two pin buttons (Talk-to picker + Manage-pinned dialog) now render at full opacity under `@media (hover: none)`.

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx` — 20/20 pass
- [x] `pnpm -F @vm0/app exec tsc --noEmit` — clean
- [x] `pnpm -F @vm0/app exec eslint src/views/zero-page/zero-sidebar-dialogs.tsx` — clean
- [x] `pnpm -F @vm0/app exec prettier --write` — no diff
- [ ] Manual verify on iOS Safari: open Talk to picker, confirm pin icon is visible next to every "Others" agent and tappable; open Manage pinned dialog, confirm pin icon visible for every available agent.
- [ ] Desktop regression: pin icon still hidden until row hover/focus.