### PR TITLE
fix(web): fix strapi use case content and remove duplicate hreflang

### DIFF
--- a/turbo/apps/web/app/[locale]/__tests__/layout.test.ts
+++ b/turbo/apps/web/app/[locale]/__tests__/layout.test.ts
@@ -44,13 +44,13 @@ vi.mock("next-intl/server", () => {
 import { generateMetadata } from "../layout";
 
 describe("locale layout generateMetadata", () => {
-  it("returns metadata with alternates for valid locale", async () => {
+  it("returns metadata with openGraph for valid locale", async () => {
     const metadata = await generateMetadata({
       children: null,
       params: Promise.resolve({ locale: "en" }),
     });
 
-    expect(metadata.alternates?.canonical).toBe("https://www.vm0.ai/en");
+    expect(metadata.openGraph?.url).toBe("https://www.vm0.ai/en");
     expect(metadata.openGraph).toBeDefined();
     expect(metadata.twitter).toBeDefined();
   });
@@ -62,9 +62,7 @@ describe("locale layout generateMetadata", () => {
         params: Promise.resolve({ locale }),
       });
 
-      expect(metadata.alternates?.canonical).toBe(
-        `https://www.vm0.ai/${locale}`,
-      );
+      expect(metadata.openGraph?.url).toBe(`https://www.vm0.ai/${locale}`);
     }
   });
 

--- a/turbo/apps/web/app/[locale]/layout.tsx
+++ b/turbo/apps/web/app/[locale]/layout.tsx
@@ -3,7 +3,6 @@ import { NextIntlClientProvider } from "next-intl";
 import { notFound } from "next/navigation";
 import { locales, type Locale } from "../../i18n";
 import SiteHeader from "../components/SiteHeader";
-import { buildLocaleAlternates } from "../lib/seo/alternates";
 import type { Metadata } from "next";
 
 type Props = {
@@ -27,14 +26,9 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     ja: "ja_JP",
   };
 
-  // Fallback hreflang for any route that doesn't provide page-level metadata.
-  // All real pages under [locale] should override this via buildLocaleAlternates
-  // with their own path so hreflang alternates point to the correct translation.
-  const alternates = buildLocaleAlternates("", locale);
-  const ogUrl = alternates.canonical;
+  const ogUrl = `https://www.vm0.ai/${locale}`;
 
   return {
-    alternates,
     openGraph: {
       locale: localeNames[locale] || "en_US",
       alternateLocale: locales

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -3085,6 +3085,88 @@
           "Add a time window for long-running projects: 'focus on the last 14 days' prevents Zero from surfacing stale context as if it's current.",
           "Pair with Document Decisions to auto-log the brief to Notion — useful for recurring reviews where you want a historical snapshot per week."
         ]
+      },
+      "multilingual-cms-publishing": {
+        "title": "Mehrsprachige Strapi-Inhalte mit einem einzigen Zero-Prompt veröffentlichen",
+        "description": "Sagen Sie Zero, was geschrieben werden soll. Zero erstellt Ihren Inhalt auf Englisch, Chinesisch und Japanisch — an jede Sprache angepasst, nicht nur übersetzt — und überträgt alle drei als Entwürfe in einem Schritt nach Strapi.",
+        "timeSaved": "~60 Min. gespart",
+        "headings": {
+          "scenario": "Warum mehrsprachige CMS-Veröffentlichung Ihren Nachmittag frisst",
+          "prompt": "So bitten Sie Zero, mehrsprachige Inhalte zu erstellen und zu veröffentlichen",
+          "steps": "Wie Zero Inhalte schreibt, lokalisiert und mit Strapi synchronisiert",
+          "nextActions": "Wiederkehrende Beiträge planen, einen Content-Kalender stapelweise abarbeiten oder bestehende Inhalte lokalisieren",
+          "integrations": "Erforderliche Integrationen: Strapi und Notion",
+          "tips": "Best Practices für KI-gestützte mehrsprachige Content-Veröffentlichung"
+        },
+        "scenario": "Ihr Produkt hat gerade ein neues Feature geliefert. Es braucht einen Artikel in drei Sprachen — Englisch für die globale Website, Chinesisch für den asiatischen Markt, Japanisch für den Japan-Blog. Normalerweise bedeutet das: die englische Version schreiben, ein Übersetzungstool öffnen, für jede Sprache in Strapi kopieren, Formatierung korrigieren, prüfen ob keine Felder fehlen. Mindestens 45 Minuten, nur für einen Beitrag. Sie geben Zero die Stichpunkte und Ihre Zielsprachen. Fertig.",
+        "promptVariants": [
+          {
+            "label": "Detailliert",
+            "prompt": "@Zero erstelle eine Produktankündigung für unser neues Permission-Isolation-Feature. Kernpunkte: Agenten können nur auf vom Eigentümer autorisierte Tools zugreifen, kein gemeinsamer Token-Leak zwischen Agenten, Enterprise-Grade-Isolation. Veröffentliche als Entwürfe in Strapi auf Englisch, vereinfachtem Chinesisch und Japanisch."
+          },
+          {
+            "label": "Schnell",
+            "prompt": "@Zero schreibe eine kurze Ankündigung für Permission Isolation und veröffentliche sie in Strapi auf Englisch, Chinesisch und Japanisch."
+          },
+          {
+            "label": "Geplant",
+            "prompt": "@Zero jedes Mal wenn wir ein Release in Produktion liefern, ziehe die Release Notes von GitHub und veröffentliche eine lokalisierte Ankündigung in Strapi auf Englisch, Chinesisch und Japanisch."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero erstelle eine Produktankündigung für Permission Isolation — Agenten greifen nur auf autorisierte Tools zu, kein Cross-Agent-Token-Leak. Veröffentliche als Entwürfe in Strapi auf Englisch, Chinesisch und Japanisch."
+          },
+          {
+            "name": "Zero",
+            "text": "Fertig. Eintrag #42 in Strapi mit 3 Sprachen erstellt:\n• en — \"Introducing Permission Isolation\"\n• zh-Hans — \"权限隔离正式上线\"\n• ja — \"権限の分離機能リリース\"\n\nAlle als Entwurf gespeichert. Prüfen: cms.vm0.ai/admin/content-manager/use-cases/42"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero schreibt die englische Vorlage",
+            "description": "Zero nimmt Ihre Stichpunkte und erstellt eine strukturierte Ankündigung: Titel, Meta-Beschreibung und Fließtext. Es folgt Ihrem Markenton und formatiert den Inhalt passend zu Ihrem Strapi-Collection-Schema."
+          },
+          {
+            "title": "Zero lokalisiert pro Markt",
+            "description": "Zero übersetzt nicht einfach. Es passt jede Version an den kulturellen Kontext des Zielmarkts an — formelle Struktur für Japanisch, direkt und informativ für Chinesisch, gesprächig für Englisch — damit jeder Beitrag wie nativer Inhalt wirkt, nicht wie eine Übersetzung."
+          },
+          {
+            "title": "Zero synchronisiert alle Sprachen mit Strapi",
+            "description": "Zero ruft die Strapi REST API auf, erstellt den Haupteintrag und postet dann jede Lokalisierung der Reihe nach. Alle drei landen als Entwürfe mit korrekten Sprach-Tags und Feld-Zuordnungen. Sie erhalten eine Bestätigung und einen direkten Link zur Überprüfung im Strapi-Admin."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Release Notes automatisieren",
+            "description": "Mit GitHub verbinden und bei jedem Deploy automatisch veröffentlichen",
+            "examplePrompt": "@Zero immer wenn ein GitHub-Release in unserem Repo getaggt wird, schreibe eine lokalisierte Ankündigung und veröffentliche sie in Strapi auf Englisch, Chinesisch und Japanisch."
+          },
+          {
+            "title": "Bestehende Inhalte lokalisieren",
+            "description": "Einen Rückstand nur-englischer Beiträge übersetzen",
+            "examplePrompt": "@Zero finde alle Strapi-Artikel mit dem Tag 'en-only' und erstelle chinesische und japanische Lokalisierungen. Veröffentliche als Entwürfe."
+          },
+          {
+            "title": "Content-Kalender stapelweise abarbeiten",
+            "description": "Eine ganze Woche an Beiträgen aus einem Notion-Dokument planen und veröffentlichen",
+            "examplePrompt": "@Zero lies den Content-Kalender in Notion und veröffentliche jeden geplanten Beitrag in Strapi in allen drei Sprachen. Markiere jeden als Entwurf."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "API-Token-Verbindung zu Ihrer Strapi-Instanz. Zero benötigt Content-Manager-Berechtigungen zum Erstellen und Aktualisieren von Einträgen über Sprachen hinweg."
+          },
+          {
+            "description": "Optional. Nutzen Sie Notion als Content-Planungszentrale — Brief, Content-Kalender oder Quellmaterial, das Zero vor dem Schreiben liest."
+          }
+        ],
+        "tips": [
+          "Geben Sie Zero den Strapi-Collection-Namen und die Sprach-Codes direkt an. 'Veröffentliche in der Announcements-Collection in en, zh-Hans und ja' liefert sauberere Ergebnisse als vage Anweisungen.",
+          "Vor dem Veröffentlichen prüfen. Zero erstellt standardmäßig Entwürfe — nutzen Sie den Strapi-Admin-Link, den Zero zurückgibt, um jede Sprache vor dem Go-Live zu überprüfen.",
+          "Geben Sie Zero Markenkontext. Fügen Sie Ihre Brand-Voice-Richtlinien oder einen Beispielbeitrag aus der Zielsprache ein — die Ausgabe wird spürbar markengerechter."
+        ]
       }
     }
   },

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -1784,7 +1784,7 @@
         ],
         "integrations": [
           {
-            "description": "OAuth connection to your Strapi instance. Zero needs content-manager permissions to create and update entries across locales."
+            "description": "API token connection to your Strapi instance. Zero needs content-manager permissions to create and update entries across locales."
           },
           {
             "description": "Optional. Use Notion as your content planning hub — brief, content calendar, or source material that Zero reads before drafting."

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -3085,6 +3085,88 @@
           "Add a time window for long-running projects: 'focus on the last 14 days' prevents Zero from surfacing stale context as if it's current.",
           "Pair with Document Decisions to auto-log the brief to Notion — useful for recurring reviews where you want a historical snapshot per week."
         ]
+      },
+      "multilingual-cms-publishing": {
+        "title": "Publica contenido multilingüe en Strapi desde un solo prompt de Zero",
+        "description": "Dile a Zero qué escribir. Zero redacta tu contenido en inglés, chino y japonés — adaptado por idioma, no solo traducido — y sube los tres a Strapi como borradores de una sola vez.",
+        "timeSaved": "~60 min ahorrados",
+        "headings": {
+          "scenario": "Por qué publicar en CMS multilingüe consume toda tu tarde",
+          "prompt": "Cómo pedirle a Zero que cree y publique contenido multilingüe",
+          "steps": "Cómo Zero escribe, localiza y sincroniza contenido con Strapi",
+          "nextActions": "Programar publicaciones recurrentes, procesar un calendario de contenido o localizar contenido existente",
+          "integrations": "Integraciones requeridas: Strapi y Notion",
+          "tips": "Mejores prácticas para publicación multilingüe asistida por IA"
+        },
+        "scenario": "Tu producto acaba de lanzar una nueva función. Necesita un artículo en tres idiomas — inglés para el sitio global, chino para el mercado asiático, japonés para el blog de Japón. Normalmente eso significa: escribir la versión en inglés, abrir una herramienta de traducción, copiar y pegar en Strapi para cada idioma, corregir el formato, verificar que no falten campos. Cuarenta y cinco minutos como mínimo, solo para una publicación. Le das a Zero los puntos clave y tus idiomas objetivo. Listo.",
+        "promptVariants": [
+          {
+            "label": "Detallado",
+            "prompt": "@Zero crea un anuncio de producto para nuestra nueva función de Aislamiento de Permisos. Puntos clave: los agentes solo pueden acceder a herramientas autorizadas por su propietario, sin filtración de tokens entre agentes, aislamiento de nivel empresarial. Publica en Strapi en inglés, chino simplificado y japonés como borradores."
+          },
+          {
+            "label": "Rápido",
+            "prompt": "@Zero escribe un anuncio corto para Aislamiento de Permisos y publícalo en Strapi en inglés, chino y japonés."
+          },
+          {
+            "label": "Programado",
+            "prompt": "@Zero cada vez que enviemos un release a producción, obtén las notas de lanzamiento de GitHub y publica un anuncio localizado en Strapi en inglés, chino y japonés."
+          }
+        ],
+        "slackPreview": [
+          {
+            "name": "Scarlett",
+            "text": "@Zero crea un anuncio de producto para Aislamiento de Permisos — los agentes solo acceden a herramientas autorizadas, sin filtración de tokens entre agentes. Publica en Strapi en inglés, chino y japonés como borradores."
+          },
+          {
+            "name": "Zero",
+            "text": "Listo. Entrada #42 creada en Strapi con 3 idiomas:\n• en — \"Introducing Permission Isolation\"\n• zh-Hans — \"权限隔离正式上线\"\n• ja — \"権限の分離機能リリース\"\n\nTodos como borrador. Revisar: cms.vm0.ai/admin/content-manager/use-cases/42"
+          }
+        ],
+        "steps": [
+          {
+            "title": "Zero escribe la versión maestra en inglés",
+            "description": "Zero toma tus puntos clave y redacta un anuncio estructurado: título, meta descripción y cuerpo del texto. Sigue el tono de tu marca y formatea el contenido para coincidir con el esquema de tu colección en Strapi."
+          },
+          {
+            "title": "Zero localiza por mercado",
+            "description": "Zero no solo traduce. Adapta cada versión al registro cultural del mercado objetivo — estructura formal para japonés, directo e informativo para chino, conversacional para inglés — para que cada publicación se lea como contenido nativo, no como una traducción."
+          },
+          {
+            "title": "Zero sincroniza todos los idiomas con Strapi",
+            "description": "Zero llama a la API REST de Strapi, crea la entrada maestra y luego publica cada localización en secuencia. Las tres quedan como borradores con etiquetas de idioma correctas y mapeo de campos. Recibes una confirmación y un enlace directo para revisar en el admin de Strapi."
+          }
+        ],
+        "nextActions": [
+          {
+            "title": "Automatiza tus notas de lanzamiento",
+            "description": "Conecta con GitHub y publica automáticamente en cada deploy",
+            "examplePrompt": "@Zero cada vez que se etiquete un release de GitHub en nuestro repo, escribe un anuncio localizado y publícalo en Strapi en inglés, chino y japonés."
+          },
+          {
+            "title": "Localiza contenido existente",
+            "description": "Traduce un backlog de publicaciones solo en inglés",
+            "examplePrompt": "@Zero encuentra todos los artículos de Strapi etiquetados como 'en-only' y crea localizaciones en chino y japonés para cada uno. Publica como borradores."
+          },
+          {
+            "title": "Procesa un calendario de contenido",
+            "description": "Planifica y publica una semana completa de publicaciones desde un documento de Notion",
+            "examplePrompt": "@Zero lee el calendario de contenido en Notion y publica cada publicación planificada en Strapi en los tres idiomas. Marca cada una como borrador."
+          }
+        ],
+        "integrations": [
+          {
+            "description": "Conexión por token API a tu instancia de Strapi. Zero necesita permisos de content-manager para crear y actualizar entradas en todos los idiomas."
+          },
+          {
+            "description": "Opcional. Usa Notion como tu centro de planificación de contenido — brief, calendario de contenido o material fuente que Zero lee antes de redactar."
+          }
+        ],
+        "tips": [
+          "Dale a Zero el nombre de la colección de Strapi y los códigos de idioma desde el principio. 'Publica en la colección de anuncios en en, zh-Hans y ja' produce resultados más limpios que instrucciones vagas.",
+          "Revisa antes de publicar. Zero crea borradores por defecto — usa el enlace del admin de Strapi que Zero devuelve para verificar cada idioma antes de publicar.",
+          "Dale contexto de marca a Zero. Pega tus guías de voz de marca o una publicación de ejemplo del idioma objetivo — la salida será notablemente más acorde a la marca."
+        ]
       }
     }
   },

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -1702,7 +1702,7 @@
         ],
         "integrations": [
           {
-            "description": "StrapiインスタンスへのOAuth接続。Zeroがロケールをまたいでエントリを作成・更新するには content-manager 権限が必要です。"
+            "description": "StrapiインスタンスへのAPIトークン接続。Zeroがロケールをまたいでエントリを作成・更新するには content-manager 権限が必要です。"
           },
           {
             "description": "任意。Notionをコンテンツ計画の拠点として活用 — ブリーフ、コンテンツカレンダー、またはZeroが草稿前に参照するソース素材として使えます。"

--- a/turbo/apps/web/public/assets/connectors/strapi.svg
+++ b/turbo/apps/web/public/assets/connectors/strapi.svg
@@ -1,6 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
-  <rect x="4" y="4" width="56" height="56" rx="12" fill="#8E75FF"/>
-  <rect x="14" y="14" width="36" height="11" rx="3" fill="white"/>
-  <rect x="14" y="28" width="24" height="11" rx="3" fill="white"/>
-  <rect x="14" y="42" width="13" height="11" rx="3" fill="white" opacity="0.75"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" fill="none"><path fill="#4945FF" d="M42.6 0H21.4v21.3h14.9c1 0 1.8.8 1.8 1.8v14.8H59.4V3.6A3.6 3.6 0 0 0 55.8 0h-13.2Z"/><path fill="#4945FF" fill-opacity=".4" d="M21.4 0v21.3H4.6l-.1-.1V21c0-.2.1-.3.2-.4L21 .3c.1-.1.2-.2.4-.2l.1-.1h-.1Z"/><path fill="#4945FF" fill-opacity=".4" d="M38.1 42.7H21.4V25.9c0-1.3 1-2.3 2.3-2.3h14.4v19.1Z"/><path fill="#4945FF" fill-opacity=".4" d="M21.4 42.7v16.7h.1l.1-.1L38 43.1c.1-.1.2-.2.2-.4V42.6l-.1.1H21.4Z"/></svg>


### PR DESCRIPTION
## Summary
- Replace placeholder Strapi SVG with official brand icon from platform app
- Fix Strapi integration description: OAuth → API token (en, ja) — Strapi uses API token auth, not OAuth
- Add missing Strapi use case translations for de and es
- Remove layout-level hreflang alternates that caused duplicate hreflang tags on every child page, fixing Ahrefs warnings: "more than one page for same language", "missing self-hreflang", and "hreflang to redirect or broken page"

## Test plan
- [ ] Verify Strapi icon renders correctly on `/use-cases` gallery
- [ ] Verify Strapi use case page loads in all 4 locales (en, ja, de, es)
- [ ] Verify no duplicate hreflang tags on `/en/blog` and other pages
- [ ] Verify layout test passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)