### PR TITLE
fix(zero): apollo connector icon invisible in dark mode

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -63,7 +63,6 @@ const CONNECTOR_ICON_COLORFUL = {
   ahrefs: true,
   airtable: true,
   anthropic: true,
-  apollo: true,
   apify: true,
   asana: true,
   azure: true,


### PR DESCRIPTION
## Summary

Apollo's connector mark is monochrome (all paths use `#1F1F1E`), but it was in the `CONNECTOR_ICON_COLORFUL` allowlist — which skips the `zero-icon-mono` class, so the `[data-theme="dark"]` invert filter never applied. On any dark-mode surface (reported on mobile, but also applies to desktop dark mode) the near-black logo blended into the background.

Removing Apollo from the colorful allowlist lets `zero-icon-mono` attach to the `<img>`, so `filter: invert(1)` kicks in under dark mode and the mark renders as near-white.

Follows the pattern established in #6050.

Fixes #9906.

## Test plan

- [ ] Light mode: Apollo mark still renders as the original dark logo in the **Add connection** dialog, scope review modal, composer connectors popover, and skills UI.
- [ ] Dark mode: Apollo mark now visible (near-white) across the same surfaces, both on desktop and mobile.