### PR TITLE
feat(platform): show voice chat status badge inline with title

### DIFF
--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -57,7 +57,7 @@ type ConnectionStatus =
   | "disconnected"
   | "error";
 
-function StatusBadge({
+export function StatusBadge({
   status,
   reconnectAttempt,
 }: {
@@ -119,7 +119,8 @@ function VoiceChatStatusHeader({
   elapsedSeconds: number;
 }) {
   return (
-    <div className="shrink-0 border-b px-4 py-2 flex items-center justify-center gap-2">
+    <div className="shrink-0 border-b px-4 py-2 hidden md:flex items-center gap-2">
+      <span className="text-sm font-medium text-foreground">Voice Chat</span>
       <StatusBadge status={status} reconnectAttempt={reconnectAttempt} />
       {status === "preparing" && elapsedSeconds > 0 && (
         <span className="text-xs tabular-nums text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -44,6 +44,11 @@ import {
   autoReadEnabled$,
   toggleAutoRead$,
 } from "../../signals/voice-io/voice-io-settings.ts";
+import {
+  vcStatus$,
+  vcReconnectAttempt$,
+} from "../../signals/voice-chat/voice-chat-session.ts";
+import { StatusBadge } from "../voice-chat/voice-chat-page.tsx";
 import { OrgManageDialog } from "./components/org-manage/org-manage-dialog.tsx";
 
 function AgentAvatarInTopBar() {
@@ -85,8 +90,11 @@ function MobileTopBar() {
   const audioIOEnabled = features?.[FeatureSwitchKey.AudioIO] ?? false;
   const autoRead = useGet(autoReadEnabled$);
   const toggleAutoReadFn = useSet(toggleAutoRead$);
+  const vcStatus = useGet(vcStatus$);
+  const vcReconnectAttempt = useGet(vcReconnectAttempt$);
 
   const showInvite = isChatRoute(activeId) && isAdmin;
+  const showVoiceChatStatus = activeId === "voiceChat" && vcStatus !== "idle";
 
   const handleMenuClick = () => {
     if (mobileChatListEnabled) {
@@ -115,8 +123,8 @@ function MobileTopBar() {
       {breadcrumb && (
         <div className="flex-1 min-w-0 flex items-center gap-2 min-w-0">
           {breadcrumb.avatarAgentId && <AgentAvatarInTopBar />}
-          <div className="flex items-baseline gap-1 min-w-0 flex-1">
-            <div className="text-sm font-medium text-foreground flex items-center gap-1 shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <div className="text-sm font-medium text-foreground flex items-center gap-1 min-w-0">
               <Link
                 pathname={breadcrumb.sectionPath}
                 className="hover:opacity-70 transition-opacity no-underline text-inherit"
@@ -132,6 +140,12 @@ function MobileTopBar() {
                 </>
               )}
             </div>
+            {showVoiceChatStatus && (
+              <StatusBadge
+                status={vcStatus}
+                reconnectAttempt={vcReconnectAttempt}
+              />
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- Unify mobile and desktop voice chat layout: both show "Voice Chat" followed by the connection status badge on the same row.
- On desktop, change `VoiceChatStatusHeader` from centered badge-only to a left-aligned "Voice Chat" title + `StatusBadge`.
- On mobile, hide the page-level status header (`hidden md:flex`) and inject `StatusBadge` into the global `MobileTopBar` next to the breadcrumb title, shown when the active route is `voiceChat` and the session is not idle.

## Test plan

- [ ] Desktop: start a voice chat session, header shows "Voice Chat" + Connected/Connecting badge left-aligned
- [ ] Mobile: start a voice chat session, top bar shows "Voice Chat" followed by the status badge inline; no duplicate status row below
- [ ] Mobile: idle state shows no badge; session transitions (preparing → connecting → connected → reconnecting → disconnected) update the badge in the top bar
- [ ] Other routes (chats, works, settings, etc.) on mobile remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)