### PR TITLE
test(e2e): unskip t52 firewall-missing-secrets

### DIFF
--- a/e2e/tests/03-runner/t52-firewall-missing-secrets.bats
+++ b/e2e/tests/03-runner/t52-firewall-missing-secrets.bats
@@ -67,12 +67,6 @@ enable_test_connector() {
 }
 
 @test "firewall: enabled connector without secrets returns connector_not_configured" {
-    # Skip: zero run requires org context which the e2e zero CLI doesn't have.
-    # The CLI run path (vm0 run) doesn't read user_connectors, so it can't test
-    # the new allowedConnectorTypes behavior. This test will be enabled when the
-    # CLI run path also supports allowedConnectorTypes, or when e2e zero CLI
-    # auth is configured with org context.
-    skip "zero run org context not available in e2e environment"
     # Step 1: Compose an agent
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"

--- a/e2e/tests/03-runner/t52-firewall-missing-secrets.bats
+++ b/e2e/tests/03-runner/t52-firewall-missing-secrets.bats
@@ -8,6 +8,12 @@
 #
 # Uses the zero run path (not CLI run) because allowedConnectorTypes is only
 # populated from user_connectors table in the zero/platform run flow.
+#
+# Uses `linear` (not `github`): the CI test user is shared across e2e tests
+# and t42 setup_file seeds a real CI_GITHUB_TOKEN into the github connector.
+# That would let the proxy resolve auth and return 200 instead of 424. Linear
+# is not linked by any other e2e test, so it reliably exercises the missing-
+# secret branch.
 
 load '../../helpers/setup'
 
@@ -77,7 +83,7 @@ agents:
     framework: claude-code
     working_dir: /home/user/workspace
     environment:
-      GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+      LINEAR_TOKEN: \${{ secrets.LINEAR_TOKEN }}
 EOF
 
     run $VM0_CLI compose --yes --json "$TEST_DIR/vm0.yaml"
@@ -92,16 +98,16 @@ EOF
         return 1
     }
 
-    # Step 2: Enable github connector WITHOUT linking it (no secrets).
-    run enable_test_connector "$COMPOSE_ID" "github"
+    # Step 2: Enable linear connector WITHOUT linking it (no secrets).
+    run enable_test_connector "$COMPOSE_ID" "linear"
     echo "$output"
     assert_success
 
     # Step 3: Run via zero path (reads user_connectors for allowedConnectorTypes).
-    # The agent curls api.github.com — proxy matches github firewall, tries
+    # The agent curls api.linear.app — proxy matches linear firewall, tries
     # to resolve auth, discovers secret is missing, returns 424.
     run $ZERO_CLI run "$COMPOSE_ID" \
-        "curl -s -w '\n%{http_code}' https://api.github.com/repos/vm0-ai/vm0"
+        "curl -s -w '\n%{http_code}' https://api.linear.app/graphql"
 
     echo "$output"
     assert_success


### PR DESCRIPTION
## Summary

- Removes the `skip` in `t52-firewall-missing-secrets.bats`. The skip reason ("zero run org context not available in e2e environment") no longer applies.

## Why it works now

The machinery t52 needs already landed in #9878:

- `/api/cli/auth/test-token` seeds `org_metadata` (+ `org_cache`, `org_members_cache`) and mints a CLI JWT carrying `orgId`, so `getOrgMetadata()` no longer 404s when zero-run resolves the compose's org.
- `/api/cli/auth/test-enable-connector` upserts the `zeroAgents` row before inserting `user_connectors`, so the FK target exists and the zero-run service's `zeroAgents` lookup finds the agent.

t53 (test-oauth) already exercises the exact same `vm0 compose → test-enable-connector → $ZERO_CLI run <composeId>` path and is green in CI.

Closes #9892.

## Test plan

- [ ] `cli-e2e-runner` job in CI runs t52 and it passes — asserts `424` + `connector_not_configured`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)