### PR TITLE
perf(guest-agent): skip storages api when memory unchanged since boot

### DIFF
--- a/crates/guest-agent/src/artifact.rs
+++ b/crates/guest-agent/src/artifact.rs
@@ -1,13 +1,13 @@
 //! VAS artifact upload — SHA-256 hashing, tar.gz creation, S3 presigned upload.
 //!
-//! Flow:
-//! 1. Walk directory, compute SHA-256 per file (skip `.git`, `.vm0`)
-//! 2. POST `/storages/prepare` with file list → get presigned URLs
-//! 3. If deduplicated, POST `/storages/commit` to update HEAD
-//! 4. Create tar.gz archive
-//! 5. Create manifest.json
-//! 6. PUT archive + manifest to S3
-//! 7. POST `/storages/commit`
+//! Flow (caller first walks the mount via [`walk_files`], then invokes
+//! [`create_snapshot`] with the pre-walked file list):
+//! 1. POST `/storages/prepare` with file list → get presigned URLs
+//! 2. If deduplicated, POST `/storages/commit` to update HEAD
+//! 3. Create tar.gz archive
+//! 4. Create manifest.json
+//! 5. PUT archive + manifest to S3
+//! 6. POST `/storages/commit`
 
 use crate::constants;
 use crate::error::AgentError;
@@ -24,10 +24,10 @@ use std::path::Path;
 const LOG_TAG: &str = "sandbox:guest-agent";
 
 #[derive(Serialize, Clone)]
-struct FileEntry {
-    path: String,
-    hash: String,
-    size: u64,
+pub(crate) struct FileEntry {
+    pub(crate) path: String,
+    pub(crate) hash: String,
+    pub(crate) size: u64,
 }
 
 #[derive(Deserialize)]
@@ -59,9 +59,28 @@ pub struct SnapshotResult {
     pub version_id: String,
 }
 
-/// Create a VAS snapshot using direct S3 upload.
+/// Walk `mount_path` in a blocking task and collect `FileEntry` records,
+/// recording the hash-compute op and emitting a "Found N files" log. Exposed
+/// so the checkpoint step can pre-walk once, decide whether to skip, and reuse
+/// the result for `create_snapshot` without a second walk.
+pub(crate) async fn walk_files(mount_path: &str) -> Result<Vec<FileEntry>, AgentError> {
+    log_info!(LOG_TAG, "Computing file hashes...");
+    let hash_start = std::time::Instant::now();
+    let mount = mount_path.to_string();
+    let files = tokio::task::spawn_blocking(move || collect_file_metadata(&mount))
+        .await
+        .map_err(|e| AgentError::Execution(format!("hash task panicked: {e}")))?;
+    record_sandbox_op("artifact_hash_compute", hash_start.elapsed(), true, None);
+    log_info!(LOG_TAG, "Found {} files", files.len());
+    Ok(files)
+}
+
+/// Create a VAS snapshot using direct S3 upload. Caller provides the
+/// pre-walked file list (see [`walk_files`]) — this lets the checkpoint step
+/// share one walk between its skip-check fingerprint and the snapshot upload.
 pub async fn create_snapshot(
     mount_path: &str,
+    files: Vec<FileEntry>,
     storage_name: &str,
     storage_type: &str,
     run_id: &str,
@@ -73,17 +92,7 @@ pub async fn create_snapshot(
         "Creating direct upload snapshot for '{storage_name}'"
     );
 
-    // Step 1: Collect file metadata (blocking I/O)
-    log_info!(LOG_TAG, "Computing file hashes...");
-    let hash_start = std::time::Instant::now();
-    let mount = mount_path.to_string();
-    let files = tokio::task::spawn_blocking(move || collect_file_metadata(&mount))
-        .await
-        .map_err(|e| AgentError::Execution(format!("hash task panicked: {e}")))?;
-    record_sandbox_op("artifact_hash_compute", hash_start.elapsed(), true, None);
-    log_info!(LOG_TAG, "Found {} files", files.len());
-
-    // Step 2: Prepare
+    // Step 1: Prepare
     log_info!(LOG_TAG, "Calling prepare endpoint...");
     let prep_start = std::time::Instant::now();
     let mut prep_payload = json!({
@@ -129,7 +138,7 @@ pub async fn create_snapshot(
     };
     record_sandbox_op("artifact_prepare_api", prep_start.elapsed(), true, None);
 
-    // Step 3: Deduplication check
+    // Step 2: Deduplication check
     if prep.existing.unwrap_or(false) {
         log_info!(
             LOG_TAG,
@@ -167,7 +176,7 @@ pub async fn create_snapshot(
         return Ok(SnapshotResult { version_id });
     }
 
-    // Step 4: Get presigned URLs
+    // Step 3: Get presigned URLs
     let uploads = prep
         .uploads
         .ok_or_else(|| AgentError::Checkpoint("No upload URLs in prepare response".into()))?;
@@ -180,7 +189,7 @@ pub async fn create_snapshot(
         .ok_or_else(|| AgentError::Checkpoint("No manifest upload info".into()))?
         .presigned_url;
 
-    // Step 5: Create archive + manifest in temp dir
+    // Step 4: Create archive + manifest in temp dir
     let temp_dir = tempfile::tempdir().map_err(AgentError::Io)?;
     let archive_path = temp_dir.path().join("archive.tar.gz");
     let manifest_path = temp_dir.path().join("manifest.json");
@@ -213,7 +222,7 @@ pub async fn create_snapshot(
     )
     .map_err(|e| AgentError::Checkpoint(format!("Failed to write manifest: {e}")))?;
 
-    // Step 6: Upload to S3
+    // Step 5: Upload to S3
     log_info!(LOG_TAG, "Uploading archive to S3...");
     let s3_start = std::time::Instant::now();
     if let Err(e) = http::put_presigned_file(&archive_url, &archive_path, "application/gzip").await
@@ -232,7 +241,7 @@ pub async fn create_snapshot(
     }
     record_sandbox_op("artifact_s3_upload", s3_start.elapsed(), true, None);
 
-    // Step 7: Commit
+    // Step 6: Commit
     log_info!(LOG_TAG, "Calling commit endpoint...");
     let commit_start = std::time::Instant::now();
     let mut commit_payload = json!({
@@ -283,10 +292,35 @@ pub async fn create_snapshot(
 }
 
 /// Walk directory and compute SHA-256 for each file, skipping `.git` and `.vm0`.
-fn collect_file_metadata(dir_path: &str) -> Vec<FileEntry> {
+pub(crate) fn collect_file_metadata(dir_path: &str) -> Vec<FileEntry> {
     let mut files = Vec::new();
     walk_dir(dir_path, "", &mut files);
     files
+}
+
+/// Deterministic 32-byte fingerprint of a pre-walked file set: SHA-256 over
+/// the path-sorted sequence of `(path, hash, size)` triples. Cheap — the
+/// per-file content hashing was already done by [`collect_file_metadata`].
+pub(crate) fn fingerprint_from_files(files: &[FileEntry]) -> [u8; 32] {
+    let mut sorted: Vec<&FileEntry> = files.iter().collect();
+    sorted.sort_by(|a, b| a.path.cmp(&b.path));
+    let mut hasher = Sha256::new();
+    for f in &sorted {
+        hasher.update(f.path.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(f.hash.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(f.size.to_le_bytes());
+        hasher.update(b"\0");
+    }
+    hasher.finalize().into()
+}
+
+/// Convenience: walk `dir_path` and compute its fingerprint. Equivalent to
+/// `fingerprint_from_files(&collect_file_metadata(dir_path))`, used at boot
+/// time where there's no snapshot upload to share the walk with.
+pub(crate) fn compute_directory_fingerprint(dir_path: &str) -> [u8; 32] {
+    fingerprint_from_files(&collect_file_metadata(dir_path))
 }
 
 fn walk_dir(current: &str, relative: &str, out: &mut Vec<FileEntry>) {
@@ -651,5 +685,89 @@ mod tests {
     fn collect_file_metadata_nonexistent_dir() {
         let files = collect_file_metadata("/nonexistent/path/that/does/not/exist");
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn fingerprint_stable_for_identical_content() {
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        std::fs::write(a.path().join("m.md"), "hello").unwrap();
+        std::fs::write(b.path().join("m.md"), "hello").unwrap();
+        let fa = compute_directory_fingerprint(a.path().to_str().unwrap());
+        let fb = compute_directory_fingerprint(b.path().to_str().unwrap());
+        assert_eq!(fa, fb);
+    }
+
+    #[test]
+    fn fingerprint_changes_on_content_edit() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("m.md"), "v1").unwrap();
+        let f1 = compute_directory_fingerprint(dir.path().to_str().unwrap());
+        std::fs::write(dir.path().join("m.md"), "v2-edited").unwrap();
+        let f2 = compute_directory_fingerprint(dir.path().to_str().unwrap());
+        assert_ne!(f1, f2);
+    }
+
+    #[test]
+    fn fingerprint_changes_on_file_added() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("m.md"), "same").unwrap();
+        let f1 = compute_directory_fingerprint(dir.path().to_str().unwrap());
+        std::fs::write(dir.path().join("extra.md"), "new").unwrap();
+        let f2 = compute_directory_fingerprint(dir.path().to_str().unwrap());
+        assert_ne!(f1, f2);
+    }
+
+    #[test]
+    fn fingerprint_changes_on_file_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.md"), "x").unwrap();
+        std::fs::write(dir.path().join("b.md"), "y").unwrap();
+        let f1 = compute_directory_fingerprint(dir.path().to_str().unwrap());
+        std::fs::remove_file(dir.path().join("b.md")).unwrap();
+        let f2 = compute_directory_fingerprint(dir.path().to_str().unwrap());
+        assert_ne!(f1, f2);
+    }
+
+    #[test]
+    fn fingerprint_ignores_git_and_vm0() {
+        let with_extras = tempfile::tempdir().unwrap();
+        let without = tempfile::tempdir().unwrap();
+        std::fs::write(with_extras.path().join("m.md"), "same").unwrap();
+        std::fs::create_dir(with_extras.path().join(".git")).unwrap();
+        std::fs::write(with_extras.path().join(".git/HEAD"), "x").unwrap();
+        std::fs::create_dir(with_extras.path().join(".vm0")).unwrap();
+        std::fs::write(with_extras.path().join(".vm0/cfg"), "y").unwrap();
+        std::fs::write(without.path().join("m.md"), "same").unwrap();
+        assert_eq!(
+            compute_directory_fingerprint(with_extras.path().to_str().unwrap()),
+            compute_directory_fingerprint(without.path().to_str().unwrap()),
+        );
+    }
+
+    #[test]
+    fn fingerprint_empty_dir_matches_nonexistent() {
+        let dir = tempfile::tempdir().unwrap();
+        let fp_empty = compute_directory_fingerprint(dir.path().to_str().unwrap());
+        let fp_missing = compute_directory_fingerprint("/nonexistent/for/fingerprint");
+        assert_eq!(fp_empty, fp_missing);
+    }
+
+    #[test]
+    fn fingerprint_order_independent() {
+        // `walk_dir` uses filesystem order, which isn't guaranteed. The
+        // fingerprint sorts by path before hashing — verify that matters by
+        // checking two sets with the same content produce the same hash even
+        // if created in different orders.
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        std::fs::write(a.path().join("z.md"), "last").unwrap();
+        std::fs::write(a.path().join("a.md"), "first").unwrap();
+        std::fs::write(b.path().join("a.md"), "first").unwrap();
+        std::fs::write(b.path().join("z.md"), "last").unwrap();
+        assert_eq!(
+            compute_directory_fingerprint(a.path().to_str().unwrap()),
+            compute_directory_fingerprint(b.path().to_str().unwrap()),
+        );
     }
 }

--- a/crates/guest-agent/src/artifact.rs
+++ b/crates/guest-agent/src/artifact.rs
@@ -55,8 +55,8 @@ struct CommitResponse {
     success: Option<bool>,
 }
 
-pub struct SnapshotResult {
-    pub version_id: String,
+pub(crate) struct SnapshotResult {
+    pub(crate) version_id: String,
 }
 
 /// Walk `mount_path` in a blocking task and collect `FileEntry` records,
@@ -78,7 +78,7 @@ pub(crate) async fn walk_files(mount_path: &str) -> Result<Vec<FileEntry>, Agent
 /// Create a VAS snapshot using direct S3 upload. Caller provides the
 /// pre-walked file list (see [`walk_files`]) — this lets the checkpoint step
 /// share one walk between its skip-check fingerprint and the snapshot upload.
-pub async fn create_snapshot(
+pub(crate) async fn create_snapshot(
     mount_path: &str,
     files: Vec<FileEntry>,
     storage_name: &str,

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -5,6 +5,7 @@ use crate::constants;
 use crate::env;
 use crate::error::AgentError;
 use crate::http;
+use crate::memory;
 use crate::paths;
 use crate::urls;
 use bytes::Bytes;
@@ -17,14 +18,23 @@ use std::path::Path;
 const LOG_TAG: &str = "sandbox:guest-agent";
 
 /// Create a checkpoint after a successful run.
-pub async fn create_checkpoint() -> Result<(), AgentError> {
+///
+/// `memory_boot_fp` is the memory-mount fingerprint captured at init time. If
+/// it's still equal to the current fingerprint, the memory content is
+/// unchanged and the storages/prepare+commit round-trips can be skipped.
+pub async fn create_checkpoint(
+    memory_boot_fp: &memory::MemoryBootFingerprint,
+) -> Result<(), AgentError> {
     let start = std::time::Instant::now();
-    let result = create_checkpoint_impl(start).await;
+    let result = create_checkpoint_impl(start, memory_boot_fp).await;
     record_sandbox_op("checkpoint_total", start.elapsed(), result.is_ok(), None);
     result
 }
 
-async fn create_checkpoint_impl(start: std::time::Instant) -> Result<(), AgentError> {
+async fn create_checkpoint_impl(
+    start: std::time::Instant,
+    memory_boot_fp: &memory::MemoryBootFingerprint,
+) -> Result<(), AgentError> {
     log_info!(LOG_TAG, "Creating checkpoint...");
 
     // Read session ID
@@ -223,8 +233,10 @@ async fn create_checkpoint_impl(start: std::time::Instant) -> Result<(), AgentEr
                 env::artifact_volume_name(),
                 env::artifact_mount_path()
             );
+            let files = artifact::walk_files(env::artifact_mount_path()).await?;
             let snapshot = artifact::create_snapshot(
                 env::artifact_mount_path(),
+                files,
                 env::artifact_volume_name(),
                 "artifact",
                 env::run_id(),
@@ -254,6 +266,38 @@ async fn create_checkpoint_impl(start: std::time::Instant) -> Result<(), AgentEr
                 );
                 return Ok(None);
             }
+            // Walk once. If the fingerprint matches the boot snapshot, the
+            // memory content is byte-identical to what the sandbox booted
+            // with — the server's HEAD already represents this exact state,
+            // so the storages /prepare + /commit round-trips (~1s combined)
+            // would be a pure no-op. Skip them and echo the parent
+            // `memory_version_id` so `agentSession.memoryName` stays
+            // associated for future resumes. Covers:
+            //   - "never used memory" (empty at boot, empty now)
+            //   - "memory preserved verbatim" (N files at boot, same N files now)
+            //   - "write-then-delete / edit-then-revert" (end state matches boot)
+            // Wipe and partial-edit cases fall through to create_snapshot
+            // with the pre-walked files (no second walk).
+            let files = artifact::walk_files(env::memory_mount_path()).await?;
+            let skip_check_start = std::time::Instant::now();
+            if let Some(boot_fp) = memory_boot_fp.as_ref()
+                && &artifact::fingerprint_from_files(&files) == boot_fp
+            {
+                log_info!(
+                    LOG_TAG,
+                    "Memory unchanged since boot, skipping storage API calls"
+                );
+                record_sandbox_op(
+                    "memory_snapshot_skipped",
+                    skip_check_start.elapsed(),
+                    true,
+                    None,
+                );
+                return Ok(Some(json!({
+                    "memoryName": env::memory_name(),
+                    "memoryVersion": env::memory_version_id(),
+                })));
+            }
             log_info!(
                 LOG_TAG,
                 "Creating VAS snapshot for memory '{}' at {}",
@@ -262,6 +306,7 @@ async fn create_checkpoint_impl(start: std::time::Instant) -> Result<(), AgentEr
             );
             let snapshot = artifact::create_snapshot(
                 env::memory_mount_path(),
+                files,
                 env::memory_name(),
                 "memory",
                 env::run_id(),

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -266,21 +266,25 @@ async fn create_checkpoint_impl(
                 );
                 return Ok(None);
             }
-            // Walk once. If the fingerprint matches the boot snapshot, the
-            // memory content is byte-identical to what the sandbox booted
-            // with — the server's HEAD already represents this exact state,
-            // so the storages /prepare + /commit round-trips (~1s combined)
-            // would be a pure no-op. Skip them and echo the parent
-            // `memory_version_id` so `agentSession.memoryName` stays
-            // associated for future resumes. Covers:
+            // Walk once. If the fingerprint matches the boot snapshot and we
+            // have a parent version to echo, the memory content is
+            // byte-identical to what the sandbox booted with — the server's
+            // HEAD already represents this exact state, so the storages
+            // /prepare + /commit round-trips (~1s combined) would be a pure
+            // no-op. Skip them and echo the parent `memory_version_id` so
+            // `agentSession.memoryName` stays associated for future resumes.
+            // Covers:
             //   - "never used memory" (empty at boot, empty now)
             //   - "memory preserved verbatim" (N files at boot, same N files now)
             //   - "write-then-delete / edit-then-revert" (end state matches boot)
-            // Wipe and partial-edit cases fall through to create_snapshot
-            // with the pre-walked files (no second walk).
+            // The `memory_version_id` non-empty guard ensures the skip
+            // payload's shape matches the normal path (a real version hash).
+            // Wipe, partial-edit, and first-run-without-parent fall through
+            // to create_snapshot with the pre-walked files (no second walk).
             let files = artifact::walk_files(env::memory_mount_path()).await?;
             let skip_check_start = std::time::Instant::now();
             if let Some(boot_fp) = memory_boot_fp.as_ref()
+                && !env::memory_version_id().is_empty()
                 && &artifact::fingerprint_from_files(&files) == boot_fp
             {
                 log_info!(

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -129,6 +129,9 @@ async fn execute(
     // Set up Claude Code auto-memory symlink (links vm0 memory to Claude Code's native path)
     let mem_start = Instant::now();
     let mem_linked = guest_agent::memory::setup_auto_memory_symlink();
+    // Snapshot memory content so the checkpoint step can skip
+    // storages/prepare+commit when nothing changed during the run.
+    let memory_boot_fp = guest_agent::memory::capture_boot_fingerprint().await;
     record_sandbox_op("memory_symlink_setup", mem_start.elapsed(), true, None);
     if mem_linked {
         log_info!(LOG_TAG, "Auto-memory symlink created");
@@ -215,7 +218,7 @@ async fn execute(
         log_info!(LOG_TAG, "▷ Checkpoint");
         let cp_start = Instant::now();
         let (cp_result, _) = tokio::join!(
-            checkpoint::create_checkpoint(),
+            checkpoint::create_checkpoint(&memory_boot_fp),
             telemetry::final_upload_silent(masker),
         );
         match cp_result {

--- a/crates/guest-agent/src/memory.rs
+++ b/crates/guest-agent/src/memory.rs
@@ -3,12 +3,51 @@
 //! Creates a symlink from Claude Code's expected auto-memory directory to the
 //! vm0 memory volume mount path, enabling native auto-memory read/write.
 
-use guest_common::log_info;
+use guest_common::{log_info, log_warn};
 use std::path::Path;
 
+use crate::artifact;
 use crate::env;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+
+/// Snapshot of the memory mount's content at boot, used by the checkpoint
+/// step to detect whether the CLI modified memory during the run. `None`
+/// means memory is not configured or the mount doesn't exist — in both cases
+/// the checkpoint step falls through to the normal path. Propagated
+/// explicitly from `main::execute` into `checkpoint::create_checkpoint` to
+/// avoid process-wide mutable state.
+pub type MemoryBootFingerprint = Option<[u8; 32]>;
+
+/// Capture the memory mount's fingerprint right now. Must be called during
+/// init, before the CLI can modify the mount. Returns `None` when memory
+/// isn't configured or the mount doesn't exist — in either case the
+/// checkpoint step's `has_memory` / `mount exists` early-returns fire, so
+/// the captured value would go unused.
+///
+/// The walk + per-file SHA-256 is offloaded to `spawn_blocking` because it
+/// can take tens to hundreds of ms for large memory directories and would
+/// otherwise block a runtime worker thread.
+pub async fn capture_boot_fingerprint() -> MemoryBootFingerprint {
+    if env::memory_driver().is_empty() || env::memory_name().is_empty() {
+        return None;
+    }
+    let mount = env::memory_mount_path();
+    if mount.is_empty() || !Path::new(mount).exists() {
+        return None;
+    }
+    let mount = mount.to_string();
+    match tokio::task::spawn_blocking(move || artifact::compute_directory_fingerprint(&mount)).await
+    {
+        Ok(fp) => Some(fp),
+        Err(e) => {
+            // spawn_blocking only returns Err on panic. Log so a silent
+            // loss of the skip optimization is observable in production.
+            log_warn!(LOG_TAG, "memory boot fingerprint capture failed: {e}");
+            None
+        }
+    }
+}
 
 /// Compute Claude Code's project directory name from a working directory path.
 ///

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -15,6 +15,11 @@ use tokio_util::sync::CancellationToken;
 /// Shared mock server — env vars are set once before any `LazyLock` in the
 /// library is accessed, so `env::api_url()`, `urls::*`, etc. all resolve to
 /// the mock server's address.
+///
+/// Memory vars are set here too (not per-test) because `env::memory_*()`
+/// values are cached via `LazyLock` — they can only be read once and cannot
+/// be changed later. `VM0_MEMORY_VERSION_ID` is set to a deterministic
+/// sentinel so the checkpoint skip test can assert the payload echoes it.
 static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
     let server = MockServer::start();
     unsafe {
@@ -24,6 +29,10 @@ static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
         std::env::set_var("VM0_WORKING_DIR", "/tmp/test-workdir");
         std::env::set_var("VM0_PROMPT", "test prompt");
         std::env::set_var("VERCEL_PROTECTION_BYPASS", "test-bypass-value");
+        std::env::set_var("VM0_MEMORY_DRIVER", "vas");
+        std::env::set_var("VM0_MEMORY_NAME", "test-memory");
+        std::env::set_var("VM0_MEMORY_MOUNT_PATH", "/tmp/vm0-test-memory-mount");
+        std::env::set_var("VM0_MEMORY_VERSION_ID", "parent-hash-abc");
     }
     server
 });
@@ -922,4 +931,190 @@ async fn final_upload_is_incremental_between_calls() {
     catchup_mock.delete_async().await;
     let _ = std::fs::remove_file(ops_file);
     let _ = std::fs::remove_file(pos_file);
+}
+
+// =========================================================================
+// Group 9: Checkpoint — memory-unchanged skip
+// =========================================================================
+
+#[tokio::test]
+async fn create_checkpoint_skips_storages_api_when_memory_unchanged_since_boot() {
+    // Captures a boot fingerprint of an empty memory mount, leaves the mount
+    // untouched, then calls create_checkpoint. The fingerprint should match
+    // on recompute, so /storages/prepare + /commit (~1s combined) must be
+    // skipped. The checkpoint payload echoes the parent `memoryVersion` to
+    // preserve `agentSession.memoryName` for future resumes.
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    // Reset memory mount and capture boot fingerprint (mirrors what
+    // `main.rs::execute` does before the CLI runs).
+    let mount = guest_agent::env::memory_mount_path();
+    let _ = std::fs::remove_dir_all(mount);
+    std::fs::create_dir_all(mount).unwrap();
+    let boot_fp = guest_agent::memory::capture_boot_fingerprint().await;
+    assert!(boot_fp.is_some(), "boot fingerprint should capture");
+
+    // Session files required by create_checkpoint.
+    let session_id_path = guest_agent::paths::session_id_file();
+    let history_path_file = guest_agent::paths::session_history_path_file();
+    let history_file = "/tmp/vm0-session-history-content-test-run-001.jsonl";
+    std::fs::write(session_id_path, "test-session-id").unwrap();
+    std::fs::write(history_path_file, history_file).unwrap();
+    std::fs::write(history_file, "{\"type\":\"user\"}\n").unwrap();
+
+    // Mocks.
+    let prepare_history_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({ "existing": true }));
+    });
+    // Match memoryName + parent-hash echo in one shot: if these fields aren't
+    // in the body, this mock won't match and the call-count check below fails.
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .body_includes("\"memoryName\":\"test-memory\"")
+            .body_includes("\"memoryVersion\":\"parent-hash-abc\"");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({ "checkpointId": "ckpt-123" }));
+    });
+    // These two must NOT be hit.
+    let storages_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/storages/prepare");
+        then.status(200);
+    });
+    let storages_commit_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/storages/commit");
+        then.status(200);
+    });
+
+    let result = guest_agent::checkpoint::create_checkpoint(&boot_fp).await;
+    assert!(result.is_ok(), "create_checkpoint failed: {result:?}");
+
+    prepare_history_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    storages_prepare_mock.assert_calls_async(0).await;
+    storages_commit_mock.assert_calls_async(0).await;
+
+    // Cleanup.
+    prepare_history_mock.delete_async().await;
+    checkpoint_mock.delete_async().await;
+    storages_prepare_mock.delete_async().await;
+    storages_commit_mock.delete_async().await;
+    let _ = std::fs::remove_file(session_id_path);
+    let _ = std::fs::remove_file(history_path_file);
+    let _ = std::fs::remove_file(history_file);
+    let _ = std::fs::remove_dir_all(mount);
+}
+
+#[tokio::test]
+async fn capture_boot_fingerprint_returns_none_when_mount_missing() {
+    // Guards the precondition used by `main::execute`: if the memory mount
+    // isn't there, capture returns None so the checkpoint skip gate stays
+    // closed and the normal path (which also early-returns on missing mount)
+    // runs.
+    let _guard = TEST_MUTEX.lock().unwrap();
+    // Force MOCK_SERVER init so `env::memory_*()` LazyLocks see the test env
+    // vars before this test reads them (otherwise, if this test runs before
+    // any other, the LazyLocks freeze to empty strings).
+    let _ = &*MOCK_SERVER;
+    let mount = guest_agent::env::memory_mount_path();
+    let _ = std::fs::remove_dir_all(mount);
+    assert!(
+        guest_agent::memory::capture_boot_fingerprint()
+            .await
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn create_checkpoint_calls_storages_api_when_memory_changed_since_boot() {
+    // Captures an empty-mount fingerprint, then writes a file before calling
+    // create_checkpoint. The fingerprint recomputed at checkpoint must differ,
+    // so the skip gate must NOT fire: /storages/prepare + /commit must be
+    // hit. Uses the dedup-hit branch (prepare returns existing:true) to keep
+    // the test small — no S3 mocks needed.
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    // Reset mount, capture boot fingerprint of empty mount.
+    let mount = guest_agent::env::memory_mount_path();
+    let _ = std::fs::remove_dir_all(mount);
+    std::fs::create_dir_all(mount).unwrap();
+    let boot_fp = guest_agent::memory::capture_boot_fingerprint().await;
+    assert!(boot_fp.is_some());
+
+    // Mutate: add a file, so the checkpoint-time fingerprint differs.
+    std::fs::write(format!("{mount}/new.md"), "written during run").unwrap();
+
+    // Session files.
+    let session_id_path = guest_agent::paths::session_id_file();
+    let history_path_file = guest_agent::paths::session_history_path_file();
+    let history_file = "/tmp/vm0-session-history-content-test-run-001.jsonl";
+    std::fs::write(session_id_path, "test-session-id").unwrap();
+    std::fs::write(history_path_file, history_file).unwrap();
+    std::fs::write(history_file, "{\"type\":\"user\"}\n").unwrap();
+
+    let prepare_history_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({ "existing": true }));
+    });
+    // Dedup-hit: prepare returns existing:true with a new versionId, so no
+    // S3 upload is needed. commit then updates HEAD.
+    let storages_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/storages/prepare");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({ "versionId": "new-hash-xyz", "existing": true }));
+    });
+    let storages_commit_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/storages/commit");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "success": true,
+                "versionId": "new-hash-xyz",
+                "storageName": "test-memory",
+                "size": 0,
+                "fileCount": 0,
+                "deduplicated": true,
+            }));
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .body_includes("\"memoryName\":\"test-memory\"")
+            .body_includes("\"memoryVersion\":\"new-hash-xyz\"");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({ "checkpointId": "ckpt-changed" }));
+    });
+
+    let result = guest_agent::checkpoint::create_checkpoint(&boot_fp).await;
+    assert!(result.is_ok(), "create_checkpoint failed: {result:?}");
+
+    prepare_history_mock.assert_calls_async(1).await;
+    storages_prepare_mock.assert_calls_async(1).await;
+    storages_commit_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
+
+    prepare_history_mock.delete_async().await;
+    storages_prepare_mock.delete_async().await;
+    storages_commit_mock.delete_async().await;
+    checkpoint_mock.delete_async().await;
+    let _ = std::fs::remove_file(session_id_path);
+    let _ = std::fs::remove_file(history_path_file);
+    let _ = std::fs::remove_file(history_file);
+    let _ = std::fs::remove_dir_all(mount);
 }


### PR DESCRIPTION
## Summary

Phase 3 of #9809. Saves ~1.12s per run whenever memory content is byte-identical between sandbox boot and checkpoint — covers both "never used memory" and the much more common "user has memory but didn't touch it this run" cases.

Closes #9831.

## How it works

- **At init** (`main::execute`, before CLI runs): walk the memory mount and compute a SHA-256 fingerprint over the path-sorted `(path, content-hash, size)` tuples. Offloaded to `spawn_blocking` so a large memory mount doesn't stall the async runtime.
- **At checkpoint** (`checkpoint::create_checkpoint`): walk memory again, recompute the fingerprint, compare. On match → skip `/storages/prepare` + `/commit` entirely and echo the parent `memory_version_id` in the checkpoint payload so `agentSession.memoryName` stays associated for future resumes.
- **Artifact path refactored** to use the same `walk_files` helper, so `create_snapshot` now accepts pre-walked files — the skip-check walk is reused on mismatch (no double walk on the miss path).

## Correctness coverage

| Scenario | Behavior |
|---|---|
| Never used memory (empty → empty) | Skip |
| Memory preserved verbatim (N files unchanged) | Skip |
| Write-then-delete / edit-then-revert (end state matches boot) | Skip (correct — no new version needed) |
| Wipe (boot non-empty, now empty) | Fingerprint differs → normal path, server records new empty version |
| Any content edit/add/remove | Fingerprint differs → normal path |
| Mount missing at boot or checkpoint | `capture_boot_fingerprint` → None → skip gate closed, normal path |

Partial-walk semantics (e.g., unreadable file) match or improve on existing `create_snapshot` behavior: the skip path preserves memory in the "persistent unreadable file" case where the old path would have silently dropped it from the upload.

## Known behavior change

`storages.updatedAt` no longer bumps on no-op runs. The only consumer is `vm0 memory list` (CLI), which now shows "time of last content change" rather than "time of last run". No GC, TTL, or retention logic depends on this field.

## Test plan

- [x] 87 unit tests (7 new for `compute_directory_fingerprint`: stability, content edit, file added/removed, ignores .git/.vm0, empty-matches-nonexistent, order-independent)
- [x] 31 integration tests (3 new):
  - `create_checkpoint_skips_storages_api_when_memory_unchanged_since_boot` — verifies skip path
  - `create_checkpoint_calls_storages_api_when_memory_changed_since_boot` — verifies skip gate lets changes through (dedup-hit flow)
  - `capture_boot_fingerprint_returns_none_when_mount_missing` — guards the precondition
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)