### PR TITLE
docs: redesign README around Zero's product positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,105 @@
 <h2 align="center">
   <a href="https://vm0.ai"><img src="https://github.com/vm0-ai/vm0/blob/main/turbo/apps/web/public/assets/Logo_VM0_combo_black_bg.svg" alt="VM0 Logo" width="500"></a>
-  <br>
-  <br>
-  Natural language Agent, 24/7 in cloud sandbox
-  <br
-  <br>
+  <br><br>
+  Zero, your trustworthy AI teammate for real work.
+  <br><br>
   <p>
     <a href="https://deepwiki.com/vm0-ai/vm0"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
-    <a href="https://npmjs.com/@vm0/cli"><img src="https://img.shields.io/npm/v/@vm0/cli" alt="NPM Version" /></a>
     <a href="https://vm0.productlane.com"><img src="https://img.shields.io/badge/Productlane-Roadmap-blue" /></a>
-    <a href="https://github.com/vm0-ai/vm0/actions/workflows/turbo.yml?query=event%3Apush+branch%3Amain"><img src="https://github.com/vm0-ai/vm0/actions/workflows/turbo.yml/badge.svg?event=push"
-    alt="CI" /></a>
-    <a href="https://codecov.io/gh/vm0-ai/vm0" > 
-      <img src="https://codecov.io/gh/vm0-ai/vm0/branch/main/graph/badge.svg?token=UZSMUBBOUC"/> 
-    </a>
+    <a href="https://github.com/vm0-ai/vm0/actions/workflows/turbo.yml?query=event%3Apush+branch%3Amain"><img src="https://github.com/vm0-ai/vm0/actions/workflows/turbo.yml/badge.svg?event=push" alt="CI" /></a>
+    <a href="https://codecov.io/gh/vm0-ai/vm0"><img src="https://codecov.io/gh/vm0-ai/vm0/branch/main/graph/badge.svg?token=UZSMUBBOUC"/></a>
+    <a href="https://discord.gg/WMpAmHFfp6"><img src="https://img.shields.io/discord/1234567890?label=Discord&logo=discord" alt="Discord" /></a>
   </p>
-  <a href="https://trendshift.io/repositories/19748" target="_blank"><img src="https://trendshift.io/api/badge/repositories/19748" alt="vm0-ai%2Fvm0 | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+  <a href="https://trendshift.io/repositories/19748" target="_blank"><img src="https://trendshift.io/api/badge/repositories/19748" alt="vm0-ai%2Fvm0 | Trendshift" width="250" height="55"/></a>
 </h2>
 
-[Website](https://www.vm0.ai) / [Discord](https://discord.gg/WMpAmHFfp6)
+<p align="center">
+  <b>Zero connects to 100+ tools and does the work — reports, triage, outreach, research. In Slack or on the web.</b>
+</p>
 
-`VM0` runs natural language-described workflows automatically on schedule in remote sandbox environments.
+<p align="center">
+  <a href="https://vm0.ai/sign-up"><b>Get started →</b></a> ·
+  <a href="https://vm0.ai/en/use-cases"><b>Use cases</b></a> ·
+  <a href="https://vm0.ai/en/blog"><b>Blog</b></a> ·
+  <a href="https://discord.gg/WMpAmHFfp6"><b>Discord</b></a>
+</p>
 
-⭐ Star us on GitHub, it motivates us a lot! ⭐
+⭐ **Star us on GitHub — it motivates us a lot!** ⭐
 
 ---
 
-## 🔥 What you GET
+## What Zero owns for your team
 
-- **Just Claude Code**, zero abstraction, nothing new to learn
-- **Cloud sandbox**, run Claude Code in isolated claude sandbox 24/7
-- **Skill Native**, Compatible with 35,738+ skills in [skills.sh](https://skills.sh), and 70+ high quality SaaS integration skill like GitHub, Slack, Notion, Firecrawl, and [more](https://github.com/vm0-ai/vm0-skills), 
-- **Persistence**, continue chat, resume, fork, and version your workflow sessions
-- **Observability**, logs, metrics, and network visibility for every run
+Zero isn't another chatbot or rigid automation. It's a teammate you @mention in Slack and hand real roles to.
 
-## 🚀 Quick Start
+### 🪄 For Founders & CEOs — the overflow only a founder carries
+- **Daily business brief** — Calendar, Linear, Slack, and X pulled into one morning digest, delivered before standup.
+- **Investor & board updates** — Monthly email drafted from live metrics and this month's shipping. You edit tone, not numbers.
+- **Inbox triage** — Ranks your mail, drafts replies in your voice, surfaces what only you can answer.
+- **Decision log** — Every "we decided X" buried in Slack becomes a searchable Notion record.
 
-From zero to workflow agent in 5 minutes
+### 📣 For Sales & Marketing — an SDR that researches, writes, and sends
+- **KOL & prospect research** — Crawls X and the open web into a Notion tracker with bios, follower counts, engagement signals.
+- **Personalized outreach** — Cold emails written from each prospect's own content. Reads like a thoughtful human, not a batch send.
+- **Lead follow-ups** — Scores Gmail leads, drafts tailored follow-ups. Reps only touch hot conversations.
+- **Marketing pulse** — Campaign results, content engagement, and site analytics rolled up to Slack every Monday.
 
-```bash
-npm install -g @vm0/cli && vm0 init
-```
+### ⚙️ For Engineering — a dev teammate that covers your backlog
+- **Sentry error triage** — Failures ranked by impact, stack traces expanded, root-cause read, not a log dump.
+- **Tech debt scanner** — Weekly repo scan surfaces risky files as Linear tickets with reproduction steps.
+- **Bug filing from Slack** — Bug reports in threads turn into scoped Linear/GitHub issues with owners.
+- **Release notes & standups** — Linear activity and merged PRs become changelog-ready notes.
 
-## 📚 Architecture
+### 🛟 For Operations & Support — the ops hire you can bring on day one
+- **Weekly status report** — A week of calendar, email, and Linear stitched into a share-ready summary.
+- **Employee onboarding** — Day-one checklist: accounts, docs, Slack channels, calendar invites. Hands-free.
+- **Meeting digests** — Standups and all-hands become tracked action items with owners.
+- **Cross-team reminders** — Pending approvals, missing inputs, report deadlines chased on schedule.
+
+👉 **[Explore 30+ ready-to-use recipes →](https://vm0.ai/en/use-cases)**
+
+---
+
+## Why Zero is different
+
+| | |
+|---|---|
+| 🧠 **Remembers your context** | Past decisions, project context, preferences carry across sessions. No re-explaining. |
+| ⏰ **Scheduled intelligence** | Runs recurring tasks — daily error scans, morning briefs, tech debt reports — without being prompted. |
+| 🤝 **Specialized sub-agents** | Create agents for specific jobs — research, triage, outreach — and let them work in parallel. |
+| 🔧 **Tool orchestration** | Picks and chains the right tools from 100+ integrations. You describe the goal; Zero figures out the steps. |
+| 🆔 **Knows who you are** | "My PRs," "assign to me." Zero resolves your identity across GitHub, Slack, and Linear automatically. |
+
+---
+
+## Works with 100+ tools you already use
+
+Slack · GitHub · Gmail · Google Calendar · Google Sheets · Notion · Linear · Sentry · Axiom · HubSpot · Intercom · Figma · Vercel · Dropbox · DocuSign · Deel · Airtable · Ahrefs · Plausible · Resend · X · Reddit · v0 · Anthropic Managed Agents · …and [100+ more](https://github.com/vm0-ai/vm0-skills).
+
+---
+
+## Your data stays yours
+
+- **Granular permissions** — Set read/write permissions per tool, per agent. Zero only touches what you explicitly allow.
+- **Isolated execution** — Every task runs in its own Firecracker microVM. Credentials never leave the sandbox.
+- **Fully auditable** — Logs, metrics, and network visibility for every run.
+- **Open source** — This repo. Inspect, fork, or self-host.
+
+Read our [Security overview](https://vm0.ai/en/security).
+
+---
+
+## Get started
 
 <p align="center">
-  <a href="./docs/architecture.md">
-    <img src="./docs/arch.svg" alt="VM0 Architecture Diagram" width="800">
-  </a>
+  <a href="https://vm0.ai/sign-up"><b>Sign up at vm0.ai →</b></a>
 </p>
 
-- **[Architecture Documentation](./docs/architecture.md)** - Comprehensive technical reference covering sandbox technologies (Firecracker microVMs), infrastructure components and network architecture
+From first message to working AI teammate in under 5 minutes. No credit card required.
 
-For user-facing guides and tutorials, see the [architecture documentation](./docs/architecture.md).
+---
 
-## 📊 Coverage
+## Coverage
 
 <p align="center">
   <a href="https://codecov.io/gh/vm0-ai/vm0">
@@ -62,7 +107,9 @@ For user-facing guides and tutorials, see the [architecture documentation](./doc
   </a>
 </p>
 
-## 🤝 Contribute
+---
+
+## Contribute
 
 <p><a href="https://github.com/vm0-ai/vm0/blob/main/CONTRIBUTING.md">
   <img src="https://contrib.rocks/image?repo=vm0-ai/vm0" />
@@ -70,6 +117,8 @@ For user-facing guides and tutorials, see the [architecture documentation](./doc
 
 ![Alt](https://repobeats.axiom.co/api/embed/ef46db5e11f5146fcc8af07077a79d789efdfbe5.svg "Repobeats analytics image")
 
-## 📃 License
+---
+
+## License
 
 See [LICENSE](./LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -10,15 +10,17 @@
     <a href="https://codecov.io/gh/vm0-ai/vm0"><img src="https://codecov.io/gh/vm0-ai/vm0/branch/main/graph/badge.svg?token=UZSMUBBOUC"/></a>
     <a href="https://discord.gg/WMpAmHFfp6"><img src="https://img.shields.io/discord/1234567890?label=Discord&logo=discord" alt="Discord" /></a>
   </p>
-  <a href="https://trendshift.io/repositories/19748" target="_blank"><img src="https://trendshift.io/api/badge/repositories/19748" alt="vm0-ai%2Fvm0 | Trendshift" width="250" height="55"/></a>
 </h2>
+
+<p align="center">
+  <a href="https://trendshift.io/repositories/19748" target="_blank"><img src="https://trendshift.io/api/badge/repositories/19748" alt="vm0-ai%2Fvm0 | Trendshift" width="250" height="55"/></a>
+</p>
 
 <p align="center">
   <b>Zero connects to 100+ tools and does the work — reports, triage, outreach, research. In Slack or on the web.</b>
 </p>
 
 <p align="center">
-  <a href="https://vm0.ai/sign-up"><b>Get started →</b></a> ·
   <a href="https://vm0.ai/en/use-cases"><b>Use cases</b></a> ·
   <a href="https://vm0.ai/en/blog"><b>Blog</b></a> ·
   <a href="https://discord.gg/WMpAmHFfp6"><b>Discord</b></a>
@@ -86,16 +88,6 @@ Slack · GitHub · Gmail · Google Calendar · Google Sheets · Notion · Linear
 - **Open source** — This repo. Inspect, fork, or self-host.
 
 Read our [Security overview](https://vm0.ai/en/security).
-
----
-
-## Get started
-
-<p align="center">
-  <a href="https://vm0.ai/sign-up"><b>Sign up at vm0.ai →</b></a>
-</p>
-
-From first message to working AI teammate in under 5 minutes. No credit card required.
 
 ---
 


### PR DESCRIPTION
## Summary

Realigns the repo's README with vm0.ai's current product narrative ("Zero, your trustworthy AI teammate for real work") instead of the earlier "natural language agent in cloud sandbox" framing.

- Replaces hero tagline; drops the `@vm0/cli` npm badge (CLI is no longer a supported entry point).
- Adds role-based use-case sections (Founders, Sales & Marketing, Engineering, Ops) mirroring vm0.ai/en.
- Adds a "Why Zero is different" capability table (memory, scheduled intelligence, sub-agents, tool orchestration, identity).
- Flattens the 100+ connector list; links to `vm0-ai/vm0-skills` (now at 100+ skills).
- Keeps "Your data stays yours" / security, Codecov, contributors, Repobeats, License.
- Removes the outdated `docs/architecture.md` section, the old `Quick Start` CLI block, the `skills.sh` reference, competitor comparison, and blog roundup.
- `Get started` is a single CTA → vm0.ai/sign-up.

## Test plan

- [ ] GitHub renders the new README on the branch preview
- [ ] All external links resolve (vm0.ai, use-cases, security, Discord, trendshift, Codecov, DeepWiki, vm0-skills)
- [ ] Badges still load (CI, Codecov, DeepWiki, Productlane, Trendshift)