### PR TITLE
fix(zero): notify chat thread on run cancel and failure

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -24,6 +24,7 @@ import { http } from "../../../../../../src/__tests__/msw";
 import { server } from "../../../../../../src/mocks/server";
 import webpush, { WebPushError } from "web-push";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
+import { mockAblyPublish } from "../../../../../../src/__tests__/ably-mock";
 
 vi.mock("web-push", async (importActual) => {
   const actual = await importActual<{ WebPushError: typeof WebPushError }>();
@@ -55,6 +56,7 @@ describe("POST /api/internal/callbacks/chat", () => {
   let agentId: string;
 
   beforeEach(async () => {
+    mockAblyPublish.mockClear();
     context.setupMocks();
     user = await context.setupUser();
     const compose = await createTestCompose(uniqueId("chat-cb"));
@@ -384,6 +386,9 @@ describe("POST /api/internal/callbacks/chat", () => {
     });
 
     it("should persist user + error messages on failed run", async () => {
+      vi.stubEnv("ABLY_API_KEY", "test-key:test-secret");
+      reloadEnv();
+
       const { threadId, runId, secret } = await setupRunAndThread({
         status: "failed",
       });
@@ -420,6 +425,14 @@ describe("POST /api/internal/callbacks/chat", () => {
       expect(errorMsg!.content).toBe("Agent crashed");
       expect(errorMsg!.runId).toBe(runId);
       expect(errorMsg!.error).toBe("Agent crashed");
+
+      // The insert fans out chatThreadMessageCreated so the frontend's paged
+      // message view refetches and the cancelled/error row appears without
+      // a page refresh.
+      expect(mockAblyPublish).toHaveBeenCalledWith(
+        `chatThreadMessageCreated:${threadId}`,
+        null,
+      );
     });
 
     it("should not derive sessionId on failed run without agentSessionId", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -101,7 +101,7 @@ async function handleCompleted(
   // cannot produce duplicates.
   const items = await queryAssistantEvents(runId);
   if (items.length > 0) {
-    await insertAssistantEventMessages(runId, threadId, items);
+    await insertAssistantEventMessages(runId, threadId, userId, items);
   }
 
   // Use last assistant text for downstream (title, summary, notification)
@@ -155,6 +155,7 @@ async function handleFailed(
 ): Promise<void> {
   await insertChatMessage({
     chatThreadId: threadId,
+    userId,
     role: "assistant",
     content: errorMessage,
     runId,

--- a/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/route.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/route.ts
@@ -7,7 +7,6 @@ import {
   insertAssistantEventMessages,
   getChatThreadIdForRun,
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
-import { publishUserSignal } from "../../../../../src/lib/infra/realtime/client";
 import { logger } from "../../../../../src/lib/shared/logger";
 
 const log = logger("event-consumer:chat-assistant");
@@ -105,11 +104,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   const { chatThreadId: threadId, userId } = thread;
-  const written = await insertAssistantEventMessages(runId, threadId, items);
-
-  if (written > 0) {
-    await publishUserSignal([userId], `chatThreadMessageCreated:${threadId}`);
-  }
+  const written = await insertAssistantEventMessages(
+    runId,
+    threadId,
+    userId,
+    items,
+  );
 
   log.debug("Chat assistant consumer processed", {
     runId,

--- a/turbo/apps/web/app/api/user/export/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/user/export/__tests__/route.test.ts
@@ -54,11 +54,13 @@ describe("POST /api/user/export", () => {
       );
       await insertTestChatMessage({
         chatThreadId: threadId,
+        userId: user.userId,
         role: "user",
         content: "hello",
       });
       await insertTestChatMessage({
         chatThreadId: threadId,
+        userId: user.userId,
         role: "assistant",
         content: "hi there",
       });

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -8,7 +8,7 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { checkpoints } from "../../../../../src/db/schema/checkpoint";
 import { agentSessions } from "../../../../../src/db/schema/agent-session";
-import { chatMessages } from "../../../../../src/db/schema/chat-message";
+import { getChatThreadIdForRun } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
 import { eq, and } from "drizzle-orm";
 import {
   transitionRunStatus,
@@ -53,16 +53,13 @@ function scheduleTerminalSideEffects(
     await publishUserSignal([userId], `thread:${runId}`);
     await publishUserSignal([userId], `runUpdated:${runId}`);
 
-    // If this run belongs to a chat thread, notify that thread's run status changed
-    const [msg] = await globalThis.services.db
-      .select({ chatThreadId: chatMessages.chatThreadId })
-      .from(chatMessages)
-      .where(eq(chatMessages.runId, runId))
-      .limit(1);
-    if (msg?.chatThreadId) {
+    // Resolve chat thread from the authoritative zero_runs.chatThreadId mapping
+    // so this signal fires even when no chat_messages row has been written yet.
+    const chatThread = await getChatThreadIdForRun(runId);
+    if (chatThread) {
       await publishUserSignal(
         [userId],
-        `chatThreadRunUpdated:${msg.chatThreadId}`,
+        `chatThreadRunUpdated:${chatThread.chatThreadId}`,
       );
     }
 

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -110,11 +110,13 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     // 3. Insert messages directly into chat_messages table
     await insertTestChatMessage({
       chatThreadId: threadId,
+      userId: testUserId,
       role: "user",
       content: "What files changed?",
     });
     await insertTestChatMessage({
       chatThreadId: threadId,
+      userId: testUserId,
       role: "assistant",
       content: "Here are the changed files.",
       runId,
@@ -293,7 +295,7 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
       prompt: "multi-step prompt",
     });
     await addTestRunToThread(threadId, runId, testUserId);
-    await insertTestAssistantEventMessages(runId, threadId, [
+    await insertTestAssistantEventMessages(runId, threadId, testUserId, [
       { sequenceNumber: 0, content: "First partial response" },
       { sequenceNumber: 1, content: "Second partial response" },
     ]);

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
@@ -116,11 +116,13 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
 
     await insertTestChatMessage({
       chatThreadId: threadId,
+      userId: testUserId,
       role: "user",
       content: "Hello",
     });
     await insertTestChatMessage({
       chatThreadId: threadId,
+      userId: testUserId,
       role: "assistant",
       content: "Hi there",
     });
@@ -157,16 +159,19 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
 
     const msg1 = await insertTestChatMessage({
       chatThreadId: threadId,
+      userId: testUserId,
       role: "user",
       content: "First",
     });
     await insertTestChatMessage({
       chatThreadId: threadId,
+      userId: testUserId,
       role: "assistant",
       content: "Second",
     });
     await insertTestChatMessage({
       chatThreadId: threadId,
+      userId: testUserId,
       role: "user",
       content: "Third",
     });
@@ -199,16 +204,19 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     // Insert 3 messages, then request with limit=2
     await insertTestChatMessage({
       chatThreadId: threadId,
+      userId: testUserId,
       role: "user",
       content: "A",
     });
     await insertTestChatMessage({
       chatThreadId: threadId,
+      userId: testUserId,
       role: "assistant",
       content: "B",
     });
     await insertTestChatMessage({
       chatThreadId: threadId,
+      userId: testUserId,
       role: "user",
       content: "C",
     });
@@ -268,7 +276,7 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
       prompt: "test",
     });
     await addTestRunToThread(threadId, runId, testUserId, "test");
-    await insertTestAssistantEventMessages(runId, threadId, [
+    await insertTestAssistantEventMessages(runId, threadId, testUserId, [
       { sequenceNumber: 0, content: "Partial response" },
     ]);
     await transitionRunStatus(

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -230,8 +230,11 @@ const router = tsr.router(chatMessagesContract, {
 
       // Persist user message to chat_messages.
       // Only file IDs are stored — metadata is resolved at query time from S3.
+      // insertChatMessage also publishes chatThreadMessageCreated internally,
+      // so the paged-messages view picks up the new row.
       await insertChatMessage({
         chatThreadId: threadId,
+        userId: authCtx.userId,
         role: "user",
         content: body.prompt,
         runId: null,
@@ -241,15 +244,10 @@ const router = tsr.router(chatMessagesContract, {
         id: body.clientMessageId,
       });
 
-      // Notify subscribers that a new run and messages were created on this thread
       after(async () => {
         await publishUserSignal(
           [authCtx.userId],
           `chatThreadRunCreated:${threadId}`,
-        );
-        await publishUserSignal(
-          [authCtx.userId],
-          `chatThreadMessageCreated:${threadId}`,
         );
       });
 

--- a/turbo/apps/web/app/api/zero/integrations/chat/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/chat/message/route.ts
@@ -63,6 +63,7 @@ const router = tsr.router(integrationsChatMessageContract, {
 
     const message = await insertChatMessage({
       chatThreadId: threadId,
+      userId,
       role: "assistant",
       content: body.text,
       runId: null,

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { randomUUID } from "crypto";
 import { POST } from "../route";
 import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
+  insertTestChatThread,
+  addTestRunToThread,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -13,6 +15,8 @@ import {
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
+import { mockAblyPublish } from "../../../../../../../src/__tests__/ably-mock";
+import { reloadEnv } from "../../../../../../../src/env";
 
 const context = testContext();
 
@@ -103,5 +107,41 @@ describe("POST /api/zero/runs/:id/cancel", () => {
 
     const data = await response.json();
     expect(data.error.message).toContain("agent-run:write");
+  });
+
+  it("should publish chatThreadRunUpdated when the run is linked to a chat thread", async () => {
+    vi.stubEnv("ABLY_API_KEY", "test-key:test-secret");
+    reloadEnv();
+    mockAblyPublish.mockClear();
+
+    const userId = uniqueId("zcanc-chat");
+    await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
+    const threadId = await insertTestChatThread(
+      userId,
+      compose.composeId,
+      "chat thread under cancel test",
+    );
+    // Seed a running run and attach it to the thread. addTestRunToThread
+    // inserts a user message with runId=null (matching production) and sets
+    // zero_runs.chatThreadId — the authoritative mapping the cancel path now
+    // reads. The legacy reverse-lookup through chat_messages.runId would miss
+    // this row (runId is null), which is the failure mode the fix targets.
+    const { runId } = await seedTestRun(userId, compose.composeId, {
+      status: "running",
+    });
+    await addTestRunToThread(threadId, runId, userId);
+
+    const response = await POST(
+      createTestRequest(cancelUrl(runId), { method: "POST" }),
+    );
+    expect(response.status).toBe(200);
+
+    await context.mocks.flushAfter();
+
+    expect(mockAblyPublish).toHaveBeenCalledWith(
+      `chatThreadRunUpdated:${threadId}`,
+      null,
+    );
   });
 });

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -7,17 +7,14 @@ import {
 } from "../../db/schema/agent-compose";
 import { agentRuns } from "../../db/schema/agent-run";
 import { agentSessions } from "../../db/schema/agent-session";
+import { chatMessages } from "../../db/schema/chat-message";
 import { chatThreads } from "../../db/schema/chat-thread";
 import { conversations } from "../../db/schema/conversation";
 import { zeroAgents } from "../../db/schema/zero-agent";
 import { zeroRuns } from "../../db/schema/zero-run";
 import { composeJobs } from "../../db/schema/compose-job";
 import { uniqueId } from "../test-helpers";
-import {
-  insertChatMessage,
-  getMessagesByThreadId,
-  insertAssistantEventMessages,
-} from "../../lib/zero/chat-thread/chat-message-service";
+import { getMessagesByThreadId } from "../../lib/zero/chat-thread/chat-message-service";
 
 /**
  * @why-db-direct Creates compose + zero_agents WITHOUT a version — API always
@@ -385,19 +382,32 @@ export async function insertTestChatThread(
  *
  * @why-db-direct Chat messages are created by the run flow and event
  * consumers, not a standalone API endpoint. Tests need direct seeding.
+ * Bypasses insertChatMessage so seeding does not fan out Ably publishes
+ * that would pollute assertions.
  */
 export async function insertTestChatMessage(params: {
   chatThreadId: string;
+  // Accepted for API parity with insertChatMessage but unused here — seeding
+  // intentionally skips realtime publishes.
+  userId?: string;
   role: "user" | "assistant";
   content: string | null;
   runId?: string | null;
 }): Promise<{ id: string; createdAt: Date }> {
-  return insertChatMessage({
-    chatThreadId: params.chatThreadId,
-    role: params.role,
-    content: params.content,
-    runId: params.runId ?? null,
-  });
+  initServices();
+  const [row] = await globalThis.services.db
+    .insert(chatMessages)
+    .values({
+      chatThreadId: params.chatThreadId,
+      role: params.role,
+      content: params.content,
+      runId: params.runId ?? null,
+    })
+    .returning({ id: chatMessages.id, createdAt: chatMessages.createdAt });
+  if (!row) {
+    throw new Error("Failed to seed chat message");
+  }
+  return row;
 }
 
 /**
@@ -425,7 +435,8 @@ export async function addTestRunToThread(
   _userId: string,
   prompt?: string,
 ): Promise<void> {
-  await insertChatMessage({
+  initServices();
+  await globalThis.services.db.insert(chatMessages).values({
     chatThreadId: threadId,
     role: "user",
     content: prompt ?? "test prompt",
@@ -441,12 +452,36 @@ export async function addTestRunToThread(
  * Insert event-backed assistant messages for a run.
  *
  * @why-db-direct Event-backed messages are inserted by the chat-assistant
- * event consumer, not an API endpoint. Tests need direct seeding.
+ * event consumer, not an API endpoint. Tests need direct seeding. Bypasses
+ * insertAssistantEventMessages so seeding does not fan out Ably publishes
+ * that would pollute assertions.
  */
 export async function insertTestAssistantEventMessages(
   runId: string,
   threadId: string,
+  // Accepted for API parity with insertAssistantEventMessages but unused —
+  // seeding intentionally skips realtime publishes.
+  _userId: string,
   items: { sequenceNumber: number; content: string }[],
 ): Promise<number> {
-  return insertAssistantEventMessages(runId, threadId, items);
+  if (items.length === 0) return 0;
+  initServices();
+  const rows = await globalThis.services.db
+    .insert(chatMessages)
+    .values(
+      items.map((item) => {
+        return {
+          chatThreadId: threadId,
+          runId,
+          role: "assistant" as const,
+          content: item.content,
+          sequenceNumber: item.sequenceNumber,
+        };
+      }),
+    )
+    .onConflictDoNothing({
+      target: [chatMessages.runId, chatMessages.sequenceNumber],
+    })
+    .returning({ id: chatMessages.id });
+  return rows.length;
 }

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -31,7 +31,7 @@ import {
   publishUserSignal,
 } from "../realtime/client";
 import { getOrgMemberUserIds } from "../realtime/audience";
-import { chatMessages } from "../../../db/schema/chat-message";
+import { getChatThreadIdForRun } from "../../zero/chat-thread/chat-message-service";
 import type { CancelRunResult } from "../../zero/zero-run-cancel";
 
 const log = logger("service:run");
@@ -531,15 +531,14 @@ export async function dispatchCancelSideEffects(
   await publishUserSignal([result.userId], `thread:${result.runId}`);
   await publishUserSignal([result.userId], `runUpdated:${result.runId}`);
 
-  const [msg] = await globalThis.services.db
-    .select({ chatThreadId: chatMessages.chatThreadId })
-    .from(chatMessages)
-    .where(eq(chatMessages.runId, result.runId))
-    .limit(1);
-  if (msg?.chatThreadId) {
+  // Resolve chat thread from the authoritative zero_runs.chatThreadId mapping
+  // so the run-level signal fires even when no chat_messages row exists yet
+  // (e.g., user cancels before the first assistant token).
+  const chatThread = await getChatThreadIdForRun(result.runId);
+  if (chatThread) {
     await publishUserSignal(
       [result.userId],
-      `chatThreadRunUpdated:${msg.chatThreadId}`,
+      `chatThreadRunUpdated:${chatThread.chatThreadId}`,
     );
   }
 

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
@@ -6,16 +6,24 @@ import {
 import { chatThreads } from "../../../db/schema/chat-thread";
 import { agentRuns } from "../../../db/schema/agent-run";
 import { zeroRuns } from "../../../db/schema/zero-run";
+import { publishUserSignal } from "../../infra/realtime/client";
 
 /**
- * Insert a user message. Called immediately on send, before run dispatch.
+ * Insert a chat message (user row on send, or assistant row on terminal
+ * callback / direct integration) and fan out the `chatThreadMessageCreated`
+ * realtime signal to the thread owner.
  *
  * When `id` is provided, it is used as the primary key so the client can
  * reconcile an optimistic row by matching on id. Otherwise the DB default
  * (`defaultRandom()`) is used.
+ *
+ * Publishing the signal here (instead of at each call site) ensures the
+ * cancel / failure paths — which insert via the chat callback — also notify
+ * the frontend, so the cancelled message surfaces without a page refresh.
  */
 export async function insertChatMessage(params: {
   chatThreadId: string;
+  userId: string;
   role: "user" | "assistant";
   content: string | null;
   runId: string | null;
@@ -39,6 +47,12 @@ export async function insertChatMessage(params: {
   if (!row) {
     throw new Error("Failed to insert chat message");
   }
+
+  await publishUserSignal(
+    [params.userId],
+    `chatThreadMessageCreated:${params.chatThreadId}`,
+  );
+
   return row;
 }
 
@@ -58,6 +72,7 @@ export async function insertChatMessage(params: {
 export async function insertAssistantEventMessages(
   runId: string,
   threadId: string,
+  userId: string,
   items: { sequenceNumber: number; content: string; runEventId?: string }[],
 ): Promise<number> {
   if (items.length === 0) {
@@ -82,6 +97,10 @@ export async function insertAssistantEventMessages(
       target: [chatMessages.runId, chatMessages.sequenceNumber],
     })
     .returning({ id: chatMessages.id });
+
+  if (rows.length > 0) {
+    await publishUserSignal([userId], `chatThreadMessageCreated:${threadId}`);
+  }
 
   return rows.length;
 }


### PR DESCRIPTION
## Summary

- Resolve chat thread id from the authoritative `zero_runs.chatThreadId` mapping in both the cancel and terminal-complete signal paths, so `chatThreadRunUpdated` fires even when no `chat_messages` row exists yet (e.g., user cancels before the first assistant token).
- Move `chatThreadMessageCreated` publishing inside `insertChatMessage` / `insertAssistantEventMessages` so the failure/cancel paths — which insert via the chat callback — also notify the frontend. The cancelled/failed assistant message now surfaces without a page refresh.
- Update tests and the agents test-seeder to cover the new signal wiring.

## Test plan

- [x] `pnpm turbo run lint --filter=@vm0/app`
- [x] `pnpm -F @vm0/app check-types`
- [x] `pnpm format`
- [x] `pnpm knip` (via lefthook pre-commit)
- [x] `pnpm -F web exec vitest run` on all modified test files (69/69 passing)
- [ ] Manually cancel a run before first assistant token and confirm the chat thread UI updates without refresh
- [ ] Trigger an assistant failure and confirm the error message surfaces without refresh