### PR TITLE
refactor(platform): add contract-driven mockApi helper (pilot for #9707)

### DIFF
--- a/turbo/apps/platform/src/mocks/__tests__/msw-contract.test.ts
+++ b/turbo/apps/platform/src/mocks/__tests__/msw-contract.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  zeroConnectorsByTypeContract,
+  zeroConnectorsMainContract,
+} from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
+import { server } from "../server.ts";
+
+describe("mockApi contract helper", () => {
+  it("registers a handler at the contract's path + method and returns the typed body", async () => {
+    server.use(
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
+        return respond(200, {
+          connectors: [],
+          configuredTypes: [],
+          connectorProvidedSecretNames: [],
+        });
+      }),
+    );
+
+    const response = await fetch("/api/zero/connectors");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      connectors: [],
+      configuredTypes: [],
+      connectorProvidedSecretNames: [],
+    });
+  });
+
+  it("substitutes path params and supports no-body responses", async () => {
+    server.use(
+      mockApi(zeroConnectorsByTypeContract.delete, ({ params, respond }) => {
+        if (params.type === "notion") {
+          return respond(204);
+        }
+        return respond(404, {
+          error: { message: "Connector not found", code: "NOT_FOUND" },
+        });
+      }),
+    );
+
+    const ok = await fetch("/api/zero/connectors/notion", { method: "DELETE" });
+    expect(ok.status).toBe(204);
+
+    const missing = await fetch("/api/zero/connectors/slack", {
+      method: "DELETE",
+    });
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toStrictEqual({
+      error: { message: "Connector not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("enforces response body shape at compile time", () => {
+    mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
+      // @ts-expect-error — `wrongField` is not part of the 200 response schema
+      return respond(200, { wrongField: "bad" });
+    });
+
+    mockApi(zeroConnectorsByTypeContract.delete, ({ respond }) => {
+      // @ts-expect-error — 204 in this contract is declared as noBody
+      return respond(204, { anything: "forbidden" });
+    });
+
+    mockApi(zeroConnectorsByTypeContract.delete, ({ respond }) => {
+      // @ts-expect-error — 500 is not declared on this contract
+      return respond(500, { error: { message: "x", code: "x" } });
+    });
+  });
+});

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -4,13 +4,14 @@
  * Mock handlers for /api/zero/connectors endpoint (connectors via zero layer).
  */
 
-import { http, HttpResponse } from "msw";
 import {
   CONNECTOR_TYPES,
   type ConnectorResponse,
-  type ConnectorListResponse,
   type ConnectorType,
+  zeroConnectorsByTypeContract,
+  zeroConnectorsMainContract,
 } from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
 
 const ALL_CONNECTOR_TYPES = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
 
@@ -21,33 +22,29 @@ export function resetMockConnectors(): void {
 }
 
 export const apiConnectorsHandlers = [
-  // GET /api/zero/connectors - List all connectors (zero proxy)
-  http.get("*/api/zero/connectors", () => {
-    const response: ConnectorListResponse = {
+  mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
+    return respond(200, {
       connectors: mockConnectors,
       configuredTypes: ALL_CONNECTOR_TYPES,
       connectorProvidedSecretNames: [],
-    };
-    return HttpResponse.json(response);
+    });
   }),
 
-  // DELETE /api/zero/connectors/:type - Disconnect a connector (zero proxy)
-  http.delete("*/api/zero/connectors/:type", ({ params }) => {
+  mockApi(zeroConnectorsByTypeContract.delete, ({ params, respond }) => {
     const type = params.type as string;
     const existing = mockConnectors.find((c) => {
       return c.type === type;
     });
 
     if (!existing) {
-      return HttpResponse.json(
-        { error: { message: "Connector not found", code: "NOT_FOUND" } },
-        { status: 404 },
-      );
+      return respond(404, {
+        error: { message: "Connector not found", code: "NOT_FOUND" },
+      });
     }
 
     mockConnectors = mockConnectors.filter((c) => {
       return c.type !== type;
     });
-    return new HttpResponse(null, { status: 204 });
+    return respond(204);
   }),
 ];

--- a/turbo/apps/platform/src/mocks/msw-contract.ts
+++ b/turbo/apps/platform/src/mocks/msw-contract.ts
@@ -1,0 +1,62 @@
+/**
+ * Contract-driven MSW helper.
+ *
+ * Wraps an MSW handler around a ts-rest contract route so that the path,
+ * method, and response shape are all derived from the contract itself.
+ * Returning a body that doesn't match the contract's declared response
+ * schema for the given status becomes a TypeScript error at the call site.
+ *
+ * Scope note: this is the pilot helper introduced for #9707. It covers
+ * path + method + response typing. Query/body parsing and Ably event
+ * orchestration are intentionally out of scope here.
+ */
+import type {
+  AppRoute,
+  ServerInferResponseBody,
+  ServerInferResponses,
+} from "@ts-rest/core";
+import { http, HttpResponse, type HttpHandler, type PathParams } from "msw";
+
+type AnyResponse<R extends AppRoute> = ServerInferResponses<R>;
+
+type Respond<R extends AppRoute> = <
+  Status extends keyof R["responses"] & number,
+>(
+  ...args: ServerInferResponseBody<R, Status> extends undefined
+    ? [status: Status]
+    : [status: Status, body: ServerInferResponseBody<R, Status>]
+) => AnyResponse<R>;
+
+type MockHandler<R extends AppRoute> = (ctx: {
+  params: PathParams;
+  request: Request;
+  respond: Respond<R>;
+}) => AnyResponse<R> | Promise<AnyResponse<R>>;
+
+const methodMap = {
+  GET: http.get,
+  POST: http.post,
+  PUT: http.put,
+  PATCH: http.patch,
+  DELETE: http.delete,
+} as const;
+
+export function mockApi<R extends AppRoute>(
+  route: R,
+  handler: MockHandler<R>,
+): HttpHandler {
+  const register = methodMap[route.method];
+  // msw shares ts-rest's `:param` path syntax; prefix with `*` to match any origin.
+  const pattern = `*${route.path}`;
+  const respond: Respond<R> = (...args) => {
+    const [status, body] = args;
+    return { status, body } as AnyResponse<R>;
+  };
+  return register(pattern, async ({ params, request }) => {
+    const result = await handler({ params, request, respond });
+    if (result.body === null || result.body === undefined) {
+      return new HttpResponse(null, { status: result.status });
+    }
+    return HttpResponse.json(result.body, { status: result.status });
+  });
+}


### PR DESCRIPTION
## Summary

Pilot for #9707 (MSW / test refactor). Adds a small contract-driven MSW helper and migrates **one** handler file to validate feasibility before touching the other 15.

- `turbo/apps/platform/src/mocks/msw-contract.ts` — `mockApi(route, handler)` derives path + method + response typing from a `ts-rest` contract. Handlers get a typed `respond(status, body)` callback that enforces body shape against the contract's declared response schema per status code.
- `turbo/apps/platform/src/mocks/handlers/api-connectors.ts` — migrated from raw `http.get/delete` + manual JSON shapes to `mockApi`. Public exports (`apiConnectorsHandlers`, `resetMockConnectors`) unchanged, so the 18 downstream test files need no updates in this PR.
- `turbo/apps/platform/src/mocks/__tests__/msw-contract.test.ts` — verifies routing + path params + no-body responses, plus three `@ts-expect-error` cases proving that wrong body shape, body on a noBody status, and undeclared status codes all fail to compile.

## Why this pilot, not the whole refactor

#9707 covers 16 handler files, ~1,142 lines of mocks, and 213 test files using `server.use()` overrides. Before touching all of that, the helper's ergonomics and type-safety need to hold up on a handler that exercises the tricky corners:
- `GET` with typed response body (`connectorListResponseSchema`)
- `DELETE` with path params (`:type`)
- `noBody` (204) vs. typed error (404) responses

`api-connectors` hits all three and migrates in ~25 LOC diff.

## Out of scope

- Ably high-level orchestration helpers — #9707's research confirmed platform tests currently bypass Ably entirely (`IN_VITEST` hard-skips the client). Separate effort.
- Migrating the other 15 handler files.
- Migrating the 213 test files that do inline `server.use()` overrides.

## Test plan

- [x] `pnpm check-types` clean on `apps/platform`
- [x] `pnpm lint` clean on `apps/platform`
- [x] New helper tests pass (`src/mocks/__tests__/msw-contract.test.ts`, 3 tests)
- [x] All 18 connector-related test files pass (165 tests) — confirmed no regression from the handler migration
- [x] One pre-existing flake observed (`schedule-dialog.test.tsx:459`, timezone dropdown) — confirmed failing on `main` too, unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)