### PR TITLE
fix(zero): prevent chat scroll jump to top on new message arrival

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -90,9 +90,10 @@ export default [
       "ccstate/prefer-user-event": [
         "error",
         {
-          // scroll events cannot be simulated by userEvent; allow dispatchEvent
-          // with new Event("scroll") for tests that verify auto-scroll behaviour.
-          allowedEventTypes: ["scroll"],
+          // scroll and wheel events cannot be simulated by userEvent; allow
+          // dispatchEvent with these event types for tests that verify
+          // auto-scroll behaviour (including the user-input gate check).
+          allowedEventTypes: ["scroll", "wheel"],
         },
       ],
       "ccstate/no-test-delay": "error",

--- a/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
@@ -85,9 +85,12 @@ describe("createScrollSignals - autoScroll$ gate", () => {
     const { setScrollContainer$, autoScroll$ } = createScrollSignals();
     context.store.set(setScrollContainer$, container);
 
-    // Simulate user scrolling down then up to disable auto-scroll
+    // Simulate user scrolling down then up to disable auto-scroll.
+    // Fire a wheel event first so the scroll listener recognizes the
+    // subsequent decrease in scrollTop as a genuine user interaction.
     container.scrollTop = 500;
     container.dispatchEvent(new Event("scroll"));
+    container.dispatchEvent(new Event("wheel"));
     container.scrollTop = 200;
     container.dispatchEvent(new Event("scroll"));
 
@@ -151,9 +154,10 @@ describe("createScrollSignals - scrollToBottom$ unconditional", () => {
     const { setScrollContainer$, scrollToBottom$ } = createScrollSignals();
     context.store.set(setScrollContainer$, container);
 
-    // Disable auto-scroll by scrolling up
+    // Disable auto-scroll by scrolling up (with wheel event to mimic real user input)
     container.scrollTop = 500;
     container.dispatchEvent(new Event("scroll"));
+    container.dispatchEvent(new Event("wheel"));
     container.scrollTop = 200;
     container.dispatchEvent(new Event("scroll"));
 

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -4,6 +4,19 @@ import { logger } from "./log.ts";
 
 const L = logger("AutoScroll");
 const AT_BOTTOM_THRESHOLD = 10;
+const USER_INPUT_WINDOW_MS = 200;
+
+function isUserScrollKey(key: string): boolean {
+  return (
+    key === "PageUp" ||
+    key === "PageDown" ||
+    key === "ArrowUp" ||
+    key === "ArrowDown" ||
+    key === "Home" ||
+    key === "End" ||
+    key === " "
+  );
+}
 
 function scrollInfo(el: HTMLElement) {
   const top = Math.round(el.scrollTop);
@@ -35,6 +48,17 @@ export function createScrollSignals() {
       L.debug("container bound");
 
       let lastKnownScrollTop = el.scrollTop;
+      let lastUserInputAt = 0;
+
+      const markUserInput = () => {
+        lastUserInputAt = performance.now();
+      };
+
+      const onKeyDown = (e: KeyboardEvent) => {
+        if (isUserScrollKey(e.key)) {
+          markUserInput();
+        }
+      };
 
       const onScroll = () => {
         const distanceFromBottom =
@@ -46,11 +70,27 @@ export function createScrollSignals() {
             L.debug("re-enabled (at bottom)", scrollInfo(el));
           }
         } else if (el.scrollTop < lastKnownScrollTop) {
-          const wasDisabled = get(autoScrollDisabled$);
-          set(autoScrollDisabled$, true);
-          if (!wasDisabled) {
+          // Only treat a scrollTop decrease as "user scrolled up" when it
+          // coincides with a recent user input. The browser can also decrease
+          // scrollTop on its own — when content below the viewport shrinks it
+          // clamps to the new max, and scroll anchoring can nudge position on
+          // layout changes. Those programmatic shifts should not disable
+          // auto-scroll; we want ResizeObserver to snap back to the bottom.
+          const userRecent =
+            performance.now() - lastUserInputAt < USER_INPUT_WINDOW_MS;
+          if (userRecent) {
+            const wasDisabled = get(autoScrollDisabled$);
+            set(autoScrollDisabled$, true);
+            if (!wasDisabled) {
+              L.debug(
+                "DISABLED (scrolled up)",
+                scrollInfo(el),
+                `lastKnown=${Math.round(lastKnownScrollTop)}`,
+              );
+            }
+          } else {
             L.debug(
-              "DISABLED (scrolled up)",
+              "scrollTop decreased without user input (ignored)",
               scrollInfo(el),
               `lastKnown=${Math.round(lastKnownScrollTop)}`,
             );
@@ -60,6 +100,10 @@ export function createScrollSignals() {
       };
 
       el.addEventListener("scroll", onScroll, { passive: true });
+      el.addEventListener("wheel", markUserInput, { passive: true });
+      el.addEventListener("touchmove", markUserInput, { passive: true });
+      el.addEventListener("pointerdown", markUserInput, { passive: true });
+      el.addEventListener("keydown", onKeyDown, { passive: true });
 
       const resizeObserver = new ResizeObserver(() => {
         const disabled = get(autoScrollDisabled$);
@@ -79,6 +123,10 @@ export function createScrollSignals() {
         L.debug("container unbound (abort)");
         resizeObserver.disconnect();
         el.removeEventListener("scroll", onScroll);
+        el.removeEventListener("wheel", markUserInput);
+        el.removeEventListener("touchmove", markUserInput);
+        el.removeEventListener("pointerdown", markUserInput);
+        el.removeEventListener("keydown", onKeyDown);
         set(internalScrollContainer$, null);
       });
     }),

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3,7 +3,6 @@ import {
   useSet,
   useLastLoadable,
   useLastResolved,
-  useLoadable,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -218,7 +217,7 @@ export function ZeroChatThreadPageInner({
   thread: ChatThreadSignals;
   autoFocus?: boolean;
 }) {
-  const groupsLoadable = useLoadable(thread.groupedChatMessages$);
+  const groupsLoadable = useLastLoadable(thread.groupedChatMessages$);
   const threadDataLoadable = useLastLoadable(thread.threadData$);
   const sessionError =
     threadDataLoadable.state === "hasError"


### PR DESCRIPTION
## Summary

Two related fixes for chat auto-scroll being incorrectly disabled when new realtime messages arrive:

1. **`zero-chat-thread-page.tsx`** — Switched `useLoadable` → `useLastLoadable` for `groupedChatMessages$`. Previously, every delta update put the async computed briefly into `loading`, flipping `groups` to `[]` and unmounting the message rows. That collapsed `scrollHeight` and the browser clamped `scrollTop` to 0; the scroll listener then read that clamp as "user scrolled up" and disabled auto-scroll.

2. **`auto-scroll.ts`** — Gate the "scrolled up" branch on a recent user input (`wheel` / `touchmove` / `pointerdown` / scroll-key `keydown`). Even without the list flicker, the `ThinkingIndicator` unmounts the moment the assistant message arrives (last group role flips from `user` → `assistant`), which briefly shrinks the container; the browser clamps `scrollTop` to the new max and the listener used to misread that as a manual scroll-up too. With the user-input gate, pure browser-driven scroll adjustments (clamping, scroll anchoring) are ignored and `ResizeObserver` can snap back to the bottom once content settles.

## Test plan
- [x] `pnpm -F @vm0/app exec tsc --noEmit`
- [x] `pnpm -F @vm0/app exec eslint src/signals/auto-scroll.ts src/views/zero-page/zero-chat-thread-page.tsx`
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx`
- [ ] Manual: open a chat at the bottom, send a message, confirm the view stays pinned to the bottom as the assistant reply streams in
- [ ] Manual: actually scroll up with wheel/touch — auto-scroll should disable as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)