### PR TITLE
fix(zero): resync realtime loop when tab becomes visible again

### DIFF
--- a/turbo/apps/platform/src/mocks/ably.ts
+++ b/turbo/apps/platform/src/mocks/ably.ts
@@ -36,7 +36,13 @@ export function hasSubscription(topic: string): boolean {
 }
 
 const fakeChannel = {
-  subscribe(topic: string, callback: Callback): void {
+  // Mirror real Ably: subscribe is async (server roundtrip) and the server
+  // won't deliver events to this callback until the subscription has been
+  // confirmed. Register the callback only after the returned promise
+  // resolves so tests don't accidentally race with a callback that fires
+  // before the subscribe await in consumer code has returned.
+  async subscribe(topic: string, callback: Callback): Promise<void> {
+    await Promise.resolve();
     let cbs = subscriptions.get(topic);
     if (!cbs) {
       cbs = new Set();

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { command, createStore } from "ccstate";
 import { setAblyLoop$, setupRealtime$ } from "../realtime.ts";
-import { triggerAblyEvent, resetAblySubscriptions } from "../../mocks/ably.ts";
+import {
+  triggerAblyEvent,
+  resetAblySubscriptions,
+  hasSubscription,
+} from "../../mocks/ably.ts";
 import { server } from "../../mocks/server.ts";
 import { apiRealtimeHandlers } from "../../mocks/handlers/api-realtime.ts";
 import { mockUser, clearMockedAuth } from "../../__tests__/mock-auth.ts";
@@ -63,11 +67,14 @@ describe("setAblyLoop$ with mock Ably", () => {
       controller.signal,
     );
 
-    // First call happens immediately inside setAblyLoop$ (calls === 1).
-    // The loop then waits on deferred.promise.
-    // Fire events to drive the next iterations.
+    // First call happens immediately inside setAblyLoop$ (calls === 1), then
+    // the loop subscribes and waits on deferred.promise. Match real Ably
+    // semantics: don't fire server-side events until the subscription is
+    // confirmed — otherwise events arrive before the callback is registered
+    // and get dropped on the floor.
     await vi.waitFor(() => {
       expect(calls).toBe(1);
+      expect(hasSubscription("test-topic")).toBe(true);
     });
 
     triggerAblyEvent("test-topic"); // calls === 2, returns false → loop continues

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -74,7 +74,7 @@ describe("setAblyLoop$ with mock Ably", () => {
     // and get dropped on the floor.
     await vi.waitFor(() => {
       expect(calls).toBe(1);
-      expect(hasSubscription("test-topic")).toBe(true);
+      expect(hasSubscription("test-topic")).toBeTruthy();
     });
 
     triggerAblyEvent("test-topic"); // calls === 2, returns false → loop continues

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -91,13 +91,29 @@ export const setAblyLoop$ = command(
 
     let deferred = createDeferredPromise(signal);
 
+    const pokeLoop = () => {
+      deferred.resolve(true);
+      deferred = createDeferredPromise(signal);
+    };
+
     const callback = (message: InboundMessage) => {
       L.debug("got message from topic", topic, message);
-
-      if (!deferred.settled()) {
-        deferred.resolve(true);
-      }
+      pokeLoop();
     };
+    // The browser may throttle or suspend this tab in the background, which
+    // can drop the Ably connection or leave us unaware of missed events.
+    // When the tab becomes visible again, poke the loop so it re-runs once
+    // and resyncs state with the server.
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      L.debug("tab visible, poking loop", topic);
+      pokeLoop();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange, {
+      signal,
+    });
     signal.addEventListener("abort", () => {
       channel.unsubscribe(topic, callback);
     });
@@ -109,11 +125,10 @@ export const setAblyLoop$ = command(
       await deferred.promise;
       signal.throwIfAborted();
 
-      deferred = createDeferredPromise(signal);
-
       // eslint-disable-next-line no-restricted-syntax -- polling loop requires try/catch for transient error retry with backoff
       try {
         const done = await set(loopCommand$, signal);
+        signal.throwIfAborted();
         if (done) {
           channel.unsubscribe(topic, callback);
           return;


### PR DESCRIPTION
## Summary

- **`realtime.ts`** — After a tab is backgrounded, browsers throttle or suspend websockets and we can silently miss Ably events (or lose the connection altogether). Listen for `visibilitychange` on the per-topic loop and poke it once the tab becomes visible again — the loop re-runs the polling command and resyncs with the server.
- While here, hoist the deferred re-creation into the resolve path so the callback/visibility handler no longer need a `settled()` guard. The loop awaits whichever deferred was current at the time of the poke, and a fresh deferred is ready for the next event.
- **`mocks/ably.ts`** — The above change exposed a test race: the mock's `subscribe` added the callback synchronously, so `triggerAblyEvent` fired from a test could arrive before `setAblyLoop$` had finished awaiting `subscribe`. Match real Ably semantics — subscribe is async and the callback only goes live once the returned promise resolves — which also better reflects production behavior where the server can't push events before the subscription is confirmed.
- **`realtime.test.ts`** — Consequently, wait for `hasSubscription("test-topic")` to return `true` before firing events.

## Test plan

- [x] `pnpm -F @vm0/app exec tsc --noEmit`
- [x] `pnpm -F @vm0/app exec eslint src/signals/realtime.ts src/signals/__tests__/realtime.test.ts src/mocks/ably.ts`
- [x] `pnpm -F @vm0/app exec vitest run src/signals/__tests__/realtime.test.ts`
- [ ] Manual: open a chat, background the tab for a minute, switch back — confirm new messages that arrived while backgrounded are visible without a hard refresh
- [ ] Manual on mobile Safari/Chrome: same flow from the home screen / another app

🤖 Generated with [Claude Code](https://claude.com/claude-code)