### PR TITLE
test(zero): add regression tests for browser-initiated scroll and last-loadable guard

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
@@ -132,8 +132,8 @@ describe("createScrollSignals - autoScroll$ gate", () => {
 
 // VC-SCROLL-006: browser-initiated scrollTop decrease (no user input) does NOT
 // disable auto-scroll. The scroll anchor or layout clamping can shift scrollTop
-// down without any user gesture; those shifts must be ignored so the
-// ResizeObserver can keep snapping to the bottom.
+// without any user gesture; those shifts must be ignored so that subsequent
+// autoScroll$ calls can still snap to the bottom.
 describe("createScrollSignals - browser-initiated scroll does not disable auto-scroll", () => {
   it("auto-scroll stays enabled when scrollTop decreases without a user input event (VC-SCROLL-006)", () => {
     const container = document.createElement("div");

--- a/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
@@ -130,12 +130,12 @@ describe("createScrollSignals - autoScroll$ gate", () => {
   });
 });
 
-// VC-SCROLL-006: browser-initiated scrollTop decrease (no user input) does NOT
+// VC-SCROLL-011: browser-initiated scrollTop decrease (no user input) does NOT
 // disable auto-scroll. The scroll anchor or layout clamping can shift scrollTop
 // without any user gesture; those shifts must be ignored so that subsequent
 // autoScroll$ calls can still snap to the bottom.
 describe("createScrollSignals - browser-initiated scroll does not disable auto-scroll", () => {
-  it("auto-scroll stays enabled when scrollTop decreases without a user input event (VC-SCROLL-006)", () => {
+  it("auto-scroll stays enabled when scrollTop decreases without a user input event (VC-SCROLL-011)", () => {
     const container = document.createElement("div");
     const inner = document.createElement("div");
     container.appendChild(inner);

--- a/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
@@ -130,6 +130,48 @@ describe("createScrollSignals - autoScroll$ gate", () => {
   });
 });
 
+// VC-SCROLL-006: browser-initiated scrollTop decrease (no user input) does NOT
+// disable auto-scroll. The scroll anchor or layout clamping can shift scrollTop
+// down without any user gesture; those shifts must be ignored so the
+// ResizeObserver can keep snapping to the bottom.
+describe("createScrollSignals - browser-initiated scroll does not disable auto-scroll", () => {
+  it("auto-scroll stays enabled when scrollTop decreases without a user input event (VC-SCROLL-006)", () => {
+    const container = document.createElement("div");
+    const inner = document.createElement("div");
+    container.appendChild(inner);
+    document.body.appendChild(container);
+
+    Object.defineProperty(container, "scrollHeight", {
+      get: () => {
+        return 1000;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      get: () => {
+        return 300;
+      },
+      configurable: true,
+    });
+
+    const { setScrollContainer$, autoScroll$ } = createScrollSignals();
+    context.store.set(setScrollContainer$, container);
+
+    // Simulate scrollTop decreasing due to browser layout (no wheel/pointer/key
+    // event precedes the scroll). This mimics scroll-anchor clamping or content
+    // shrinkage — NOT a deliberate user scroll-up.
+    container.scrollTop = 500;
+    container.dispatchEvent(new Event("scroll"));
+    // No user-input event fired here — purely browser-initiated
+    container.scrollTop = 200;
+    container.dispatchEvent(new Event("scroll"));
+
+    // autoScroll$ should still execute — auto-scroll was NOT disabled
+    context.store.set(autoScroll$);
+    expect(container.scrollTop).toBe(1000);
+  });
+});
+
 // VC-SCROLL-005: scrollToBottom$ always works regardless of disabled state
 describe("createScrollSignals - scrollToBottom$ unconditional", () => {
   it("scrolls to bottom even when auto-scroll is disabled (VC-SCROLL-005)", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { detachedNavigateTo$ } from "../../../signals/route.ts";
+import { currentChatThreadSignals$ } from "../../../signals/chat-page/create-chat-thread.ts";
 
 const context = testContext();
 
@@ -237,13 +238,11 @@ describe("zero chat thread page - browser-initiated scroll does not disable auto
     scrollContainer!.scrollTop = 100;
     scrollContainer!.dispatchEvent(new Event("scroll"));
 
-    // Auto-scroll should NOT have been disabled — ResizeObserver (or a direct
-    // autoScroll$ call) should still be able to snap to the bottom.
-    // Verify by firing a synthetic resize that triggers the ResizeObserver
-    // callback path: set scrollTop back to scrollHeight directly to confirm
-    // the disabled flag is false by attempting autoScroll$ via the thread.
-    // The simplest observable check: scrollTop is not stuck at 100.
-    scrollContainer!.scrollTop = scrollContainer!.scrollHeight;
+    // Auto-scroll should NOT have been disabled. Prove it by invoking autoScroll$
+    // via the signal layer — if disabled, scrollTop would remain at 100; if
+    // enabled, autoScroll$ will snap it to scrollHeight (900).
+    const thread = context.store.get(currentChatThreadSignals$)!;
+    context.store.set(thread.autoScroll$);
     expect(scrollContainer!.scrollTop).toBe(900);
   });
 });
@@ -257,7 +256,7 @@ describe("zero chat thread page - messages remain visible during re-fetch", () =
   it("previously-loaded messages are not replaced by a skeleton when groupedChatMessages$ recomputes (CHAT-SCROLL-008)", async () => {
     // Use a deferred first response so we can verify the loading state,
     // then a fast subsequent response so messages resolve.
-    let resolveMessages = () => {};
+    let resolveMessages!: () => void;
     let firstCall = true;
     const messagesResponse = HttpResponse.json({
       messages: [
@@ -321,14 +320,9 @@ describe("zero chat thread page - messages remain visible during re-fetch", () =
     // Resolve the first (deferred) fetch with real messages
     resolveMessages();
 
-    // Messages should now appear
+    // Messages should now appear and remain visible (not replaced by skeleton
+    // or empty state) — this is the core guarantee of useLastLoadable.
     await waitFor(() => {
-      expect(screen.getByText("Last loadable message")).toBeInTheDocument();
-    });
-
-    // Verify the message remains visible (not replaced by skeleton or empty
-    // state) — this is the core guarantee of useLastLoadable.
-    await vi.waitFor(() => {
       expect(screen.getByText("Last loadable message")).toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
@@ -5,7 +5,6 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { detachedNavigateTo$ } from "../../../signals/route.ts";
-import { currentChatThreadSignals$ } from "../../../signals/chat-page/create-chat-thread.ts";
 
 const context = testContext();
 
@@ -192,9 +191,24 @@ describe("zero chat thread page - browser-initiated scroll does not disable auto
       { role: "assistant", content: "Browser scroll test reply" },
     ]);
 
+    // Capture the ResizeObserver callback installed by createScrollSignals so
+    // we can fire it manually to simulate a content-resize event. This avoids
+    // reaching into the signal store and tests through the same code path that
+    // fires in production when the inner content grows.
+    let capturedResizeCallback: ResizeObserverCallback | null = null;
+    const originalRO = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        capturedResizeCallback = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
     // Intercept the scroll container as it mounts and give it a non-zero
     // scrollHeight so we can distinguish a real scroll from a no-op.
-    const observer = new MutationObserver(() => {
+    const mutationObserver = new MutationObserver(() => {
       const el = document.querySelector<HTMLElement>("[data-scroll-container]");
       if (!el) {
         return;
@@ -212,7 +226,7 @@ describe("zero chat thread page - browser-initiated scroll does not disable auto
         configurable: true,
       });
     });
-    observer.observe(document.body, { childList: true, subtree: true });
+    mutationObserver.observe(document.body, { childList: true, subtree: true });
 
     detachedSetupPage({ context, path: "/chats/thread-browser-scroll" });
 
@@ -222,7 +236,8 @@ describe("zero chat thread page - browser-initiated scroll does not disable auto
       ).toBeInTheDocument();
     });
 
-    observer.disconnect();
+    mutationObserver.disconnect();
+    globalThis.ResizeObserver = originalRO;
 
     const scrollContainer = document.querySelector<HTMLElement>(
       "[data-scroll-container]",
@@ -238,12 +253,13 @@ describe("zero chat thread page - browser-initiated scroll does not disable auto
     scrollContainer!.scrollTop = 100;
     scrollContainer!.dispatchEvent(new Event("scroll"));
 
-    // Auto-scroll should NOT have been disabled. Prove it by invoking autoScroll$
-    // via the signal layer — if disabled, scrollTop would remain at 100; if
-    // enabled, autoScroll$ will snap it to scrollHeight (900).
-    const thread = context.store.get(currentChatThreadSignals$)!;
-    context.store.set(thread.autoScroll$);
-    expect(scrollContainer!.scrollTop).toBe(900);
+    // Auto-scroll should NOT have been disabled. Prove it by firing the
+    // ResizeObserver callback (the same path the browser uses when inner
+    // content grows during streaming). If disabled, scrollTop stays at 100;
+    // if enabled, the callback snaps it to scrollHeight.
+    expect(capturedResizeCallback).not.toBeNull();
+    capturedResizeCallback!([], {} as ResizeObserver);
+    expect(scrollContainer!.scrollTop).toBe(scrollContainer!.scrollHeight);
   });
 });
 
@@ -311,11 +327,15 @@ describe("zero chat thread page - messages remain visible during re-fetch", () =
     detachedSetupPage({ context, path: "/chats/thread-last-loadable" });
 
     // While the first messages fetch is pending, the page should show the
-    // skeleton (no messages yet — groupedChatMessages$ is in loading state)
+    // skeleton (no messages yet — groupedChatMessages$ is in loading state).
+    // Verify the scroll container is present but the message is not yet visible.
     await waitFor(() => {
       const scrollContainer = document.querySelector("[data-scroll-container]");
       expect(scrollContainer).not.toBeNull();
     });
+    // The message must NOT appear before the fetch resolves — if useLastLoadable
+    // were absent and the component showed data immediately, this would fail.
+    expect(screen.queryByText("Last loadable message")).toBeNull();
 
     // Resolve the first (deferred) fetch with real messages
     resolveMessages();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
@@ -228,38 +228,40 @@ describe("zero chat thread page - browser-initiated scroll does not disable auto
     });
     mutationObserver.observe(document.body, { childList: true, subtree: true });
 
-    detachedSetupPage({ context, path: "/chats/thread-browser-scroll" });
+    try {
+      detachedSetupPage({ context, path: "/chats/thread-browser-scroll" });
 
-    await waitFor(() => {
-      expect(
-        screen.getByText("Browser scroll test message"),
-      ).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(
+          screen.getByText("Browser scroll test message"),
+        ).toBeInTheDocument();
+      });
 
-    mutationObserver.disconnect();
-    globalThis.ResizeObserver = originalRO;
+      const scrollContainer = document.querySelector<HTMLElement>(
+        "[data-scroll-container]",
+      );
+      expect(scrollContainer).not.toBeNull();
 
-    const scrollContainer = document.querySelector<HTMLElement>(
-      "[data-scroll-container]",
-    );
-    expect(scrollContainer).not.toBeNull();
+      // Simulate a browser-initiated scrollTop decrease (no wheel/pointer/key
+      // event fires before the scroll). This mimics scroll-anchor clamping or
+      // content shrinkage — NOT a deliberate user gesture.
+      scrollContainer!.scrollTop = 400;
+      scrollContainer!.dispatchEvent(new Event("scroll"));
+      // Decrease without any user-input event:
+      scrollContainer!.scrollTop = 100;
+      scrollContainer!.dispatchEvent(new Event("scroll"));
 
-    // Simulate a browser-initiated scrollTop decrease (no wheel/pointer/key
-    // event fires before the scroll). This mimics scroll-anchor clamping or
-    // content shrinkage — NOT a deliberate user gesture.
-    scrollContainer!.scrollTop = 400;
-    scrollContainer!.dispatchEvent(new Event("scroll"));
-    // Decrease without any user-input event:
-    scrollContainer!.scrollTop = 100;
-    scrollContainer!.dispatchEvent(new Event("scroll"));
-
-    // Auto-scroll should NOT have been disabled. Prove it by firing the
-    // ResizeObserver callback (the same path the browser uses when inner
-    // content grows during streaming). If disabled, scrollTop stays at 100;
-    // if enabled, the callback snaps it to scrollHeight.
-    expect(capturedResizeCallback).not.toBeNull();
-    capturedResizeCallback!([], {} as ResizeObserver);
-    expect(scrollContainer!.scrollTop).toBe(scrollContainer!.scrollHeight);
+      // Auto-scroll should NOT have been disabled. Prove it by firing the
+      // ResizeObserver callback (the same path the browser uses when inner
+      // content grows during streaming). If disabled, scrollTop stays at 100;
+      // if enabled, the callback snaps it to scrollHeight.
+      expect(capturedResizeCallback).not.toBeNull();
+      capturedResizeCallback!([], {} as ResizeObserver);
+      expect(scrollContainer!.scrollTop).toBe(scrollContainer!.scrollHeight);
+    } finally {
+      mutationObserver.disconnect();
+      globalThis.ResizeObserver = originalRO;
+    }
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
@@ -177,5 +177,159 @@ describe("zero chat thread page - scroll fires for each new thread", () => {
     // Scroll container should still be present for the new thread
     const scrollContainer = document.querySelector("[data-scroll-container]");
     expect(scrollContainer).not.toBeNull();
+  });
+});
+
+// CHAT-SCROLL-007: browser-initiated scrollTop decrease (no user input event)
+// does NOT disable auto-scroll. This is the core regression guard for the PR
+// fix: scroll anchoring or content shrinkage can decrease scrollTop without
+// any user gesture; the scroll listener must ignore those shifts.
+describe("zero chat thread page - browser-initiated scroll does not disable auto-scroll", () => {
+  it("auto-scroll still fires after a scrollTop decrease with no preceding user input (CHAT-SCROLL-007)", async () => {
+    mockThread("thread-browser-scroll", [
+      { role: "user", content: "Browser scroll test message" },
+      { role: "assistant", content: "Browser scroll test reply" },
+    ]);
+
+    // Intercept the scroll container as it mounts and give it a non-zero
+    // scrollHeight so we can distinguish a real scroll from a no-op.
+    const observer = new MutationObserver(() => {
+      const el = document.querySelector<HTMLElement>("[data-scroll-container]");
+      if (!el) {
+        return;
+      }
+      Object.defineProperty(el, "scrollHeight", {
+        get: () => {
+          return 900;
+        },
+        configurable: true,
+      });
+      Object.defineProperty(el, "clientHeight", {
+        get: () => {
+          return 300;
+        },
+        configurable: true,
+      });
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    detachedSetupPage({ context, path: "/chats/thread-browser-scroll" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Browser scroll test message"),
+      ).toBeInTheDocument();
+    });
+
+    observer.disconnect();
+
+    const scrollContainer = document.querySelector<HTMLElement>(
+      "[data-scroll-container]",
+    );
+    expect(scrollContainer).not.toBeNull();
+
+    // Simulate a browser-initiated scrollTop decrease (no wheel/pointer/key
+    // event fires before the scroll). This mimics scroll-anchor clamping or
+    // content shrinkage — NOT a deliberate user gesture.
+    scrollContainer!.scrollTop = 400;
+    scrollContainer!.dispatchEvent(new Event("scroll"));
+    // Decrease without any user-input event:
+    scrollContainer!.scrollTop = 100;
+    scrollContainer!.dispatchEvent(new Event("scroll"));
+
+    // Auto-scroll should NOT have been disabled — ResizeObserver (or a direct
+    // autoScroll$ call) should still be able to snap to the bottom.
+    // Verify by firing a synthetic resize that triggers the ResizeObserver
+    // callback path: set scrollTop back to scrollHeight directly to confirm
+    // the disabled flag is false by attempting autoScroll$ via the thread.
+    // The simplest observable check: scrollTop is not stuck at 100.
+    scrollContainer!.scrollTop = scrollContainer!.scrollHeight;
+    expect(scrollContainer!.scrollTop).toBe(900);
+  });
+});
+
+// CHAT-SCROLL-008: useLastLoadable keeps previously-loaded messages visible
+// while groupedChatMessages$ is in a loading state. Without useLastLoadable
+// (i.e. with plain useLoadable), the component would show groups=[] during
+// the brief period the new promise is pending, causing the scroll container
+// to flash empty and the ResizeObserver to jump scroll position to the top.
+describe("zero chat thread page - messages remain visible during re-fetch", () => {
+  it("previously-loaded messages are not replaced by a skeleton when groupedChatMessages$ recomputes (CHAT-SCROLL-008)", async () => {
+    // Use a deferred first response so we can verify the loading state,
+    // then a fast subsequent response so messages resolve.
+    let resolveMessages = () => {};
+    let firstCall = true;
+    const messagesResponse = HttpResponse.json({
+      messages: [
+        {
+          id: "msg-1",
+          role: "user",
+          content: "Last loadable message",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+      hasMore: false,
+    });
+
+    server.use(
+      http.get(
+        "*/api/zero/chat-threads/thread-last-loadable/messages",
+        ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("sinceId")) {
+            return HttpResponse.json({ messages: [], hasMore: false });
+          }
+          if (firstCall) {
+            firstCall = false;
+            // First call is deferred — simulates slow initial fetch
+            return new Promise<typeof messagesResponse>((resolve) => {
+              resolveMessages = () => {
+                resolve(messagesResponse);
+              };
+            });
+          }
+          return messagesResponse;
+        },
+      ),
+      http.get("*/api/zero/chat-threads/thread-last-loadable", () => {
+        return HttpResponse.json({
+          id: "thread-last-loadable",
+          title: null,
+          agentId: "c0000000-0000-4000-a000-000000000001",
+          chatMessages: [],
+          latestSessionId: null,
+          activeRunIds: [],
+          unsavedRuns: [],
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-last-loadable" });
+
+    // While the first messages fetch is pending, the page should show the
+    // skeleton (no messages yet — groupedChatMessages$ is in loading state)
+    await waitFor(() => {
+      const scrollContainer = document.querySelector("[data-scroll-container]");
+      expect(scrollContainer).not.toBeNull();
+    });
+
+    // Resolve the first (deferred) fetch with real messages
+    resolveMessages();
+
+    // Messages should now appear
+    await waitFor(() => {
+      expect(screen.getByText("Last loadable message")).toBeInTheDocument();
+    });
+
+    // Verify the message remains visible (not replaced by skeleton or empty
+    // state) — this is the core guarantee of useLastLoadable.
+    await vi.waitFor(() => {
+      expect(screen.getByText("Last loadable message")).toBeInTheDocument();
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
@@ -195,11 +195,18 @@ describe("zero chat thread page - browser-initiated scroll does not disable auto
     // we can fire it manually to simulate a content-resize event. This avoids
     // reaching into the signal store and tests through the same code path that
     // fires in production when the inner content grows.
+    //
+    // Only capture the first observer constructed — createScrollSignals builds
+    // exactly one ResizeObserver per container bind, and we want that specific
+    // callback. Using a first-capture guard prevents any additional observers
+    // created by unrelated code in the render path from overwriting it.
     let capturedResizeCallback: ResizeObserverCallback | null = null;
     const originalRO = globalThis.ResizeObserver;
     globalThis.ResizeObserver = class MockResizeObserver {
       constructor(cb: ResizeObserverCallback) {
-        capturedResizeCallback = cb;
+        if (capturedResizeCallback === null) {
+          capturedResizeCallback = cb;
+        }
       }
       observe() {}
       unobserve() {}
@@ -266,23 +273,32 @@ describe("zero chat thread page - browser-initiated scroll does not disable auto
 });
 
 // CHAT-SCROLL-008: useLastLoadable keeps previously-loaded messages visible
-// while groupedChatMessages$ is in a loading state. Without useLastLoadable
-// (i.e. with plain useLoadable), the component would show groups=[] during
-// the brief period the new promise is pending, causing the scroll container
-// to flash empty and the ResizeObserver to jump scroll position to the top.
+// while groupedChatMessages$ is in a loading state. The regression scenario is
+// loaded → reloading → loaded: when the user navigates to a second thread,
+// groupedChatMessages$ for the new thread returns a new Promise (initial fetch
+// is pending). Without useLastLoadable (i.e. plain useLoadable), the component
+// immediately receives state="loading" for the new atom, drops groups to [],
+// and renders ChatSkeleton — wiping the previous thread's messages from the DOM
+// before the new ones arrive. useLastLoadable keeps the previous data visible
+// until the new promise settles.
 describe("zero chat thread page - messages remain visible during re-fetch", () => {
-  it("previously-loaded messages are not replaced by a skeleton when groupedChatMessages$ recomputes (CHAT-SCROLL-008)", async () => {
-    // Use a deferred first response so we can verify the loading state,
-    // then a fast subsequent response so messages resolve.
-    let resolveMessages!: () => void;
-    let firstCall = true;
-    const messagesResponse = HttpResponse.json({
+  it("previously-loaded messages stay visible while the next thread's groupedChatMessages$ is pending (CHAT-SCROLL-008)", async () => {
+    // Thread A resolves immediately.
+    mockThread("thread-ll-a", [
+      { role: "user", content: "Thread A message" },
+      { role: "assistant", content: "Thread A reply" },
+    ]);
+
+    // Thread B has a deferred messages response so we can observe the
+    // intermediate state while groupedChatMessages$ is in loading state.
+    let resolveThreadBMessages!: () => void;
+    const threadBMessagesResponse = HttpResponse.json({
       messages: [
         {
-          id: "msg-1",
+          id: "msg-b-1",
           role: "user",
-          content: "Last loadable message",
-          createdAt: "2026-03-10T00:00:00Z",
+          content: "Thread B message",
+          createdAt: "2026-03-10T00:00:01Z",
         },
       ],
       hasMore: false,
@@ -290,27 +306,23 @@ describe("zero chat thread page - messages remain visible during re-fetch", () =
 
     server.use(
       http.get(
-        "*/api/zero/chat-threads/thread-last-loadable/messages",
+        "*/api/zero/chat-threads/thread-ll-b/messages",
         ({ request }) => {
           const url = new URL(request.url);
           if (url.searchParams.get("sinceId")) {
             return HttpResponse.json({ messages: [], hasMore: false });
           }
-          if (firstCall) {
-            firstCall = false;
-            // First call is deferred — simulates slow initial fetch
-            return new Promise<typeof messagesResponse>((resolve) => {
-              resolveMessages = () => {
-                resolve(messagesResponse);
-              };
-            });
-          }
-          return messagesResponse;
+          // Initial fetch is deferred — keeps groupedChatMessages$ in loading state.
+          return new Promise<typeof threadBMessagesResponse>((resolve) => {
+            resolveThreadBMessages = () => {
+              resolve(threadBMessagesResponse);
+            };
+          });
         },
       ),
-      http.get("*/api/zero/chat-threads/thread-last-loadable", () => {
+      http.get("*/api/zero/chat-threads/thread-ll-b", () => {
         return HttpResponse.json({
-          id: "thread-last-loadable",
+          id: "thread-ll-b",
           title: null,
           agentId: "c0000000-0000-4000-a000-000000000001",
           chatMessages: [],
@@ -321,31 +333,36 @@ describe("zero chat thread page - messages remain visible during re-fetch", () =
           updatedAt: "2026-03-10T00:00:00Z",
         });
       }),
-      http.get("*/api/zero/chat-threads", () => {
-        return HttpResponse.json({ threads: [] });
-      }),
     );
 
-    detachedSetupPage({ context, path: "/chats/thread-last-loadable" });
+    detachedSetupPage({ context, path: "/chats/thread-ll-a" });
 
-    // While the first messages fetch is pending, the page should show the
-    // skeleton (no messages yet — groupedChatMessages$ is in loading state).
-    // Verify the scroll container is present but the message is not yet visible.
+    // Wait for thread A's messages to load and render.
     await waitFor(() => {
-      const scrollContainer = document.querySelector("[data-scroll-container]");
-      expect(scrollContainer).not.toBeNull();
+      expect(screen.getByText("Thread A message")).toBeInTheDocument();
     });
-    // The message must NOT appear before the fetch resolves — if useLastLoadable
-    // were absent and the component showed data immediately, this would fail.
-    expect(screen.queryByText("Last loadable message")).toBeNull();
 
-    // Resolve the first (deferred) fetch with real messages
-    resolveMessages();
+    // Navigate to thread B — groupedChatMessages$ for the new thread instance
+    // starts in a loading state (the deferred fetch above is still pending).
+    context.store.set(detachedNavigateTo$, "/chats/:threadId", {
+      pathParams: { threadId: "thread-ll-b" },
+    });
 
-    // Messages should now appear and remain visible (not replaced by skeleton
-    // or empty state) — this is the core guarantee of useLastLoadable.
+    // While thread B's initial messages fetch is pending, thread A's messages
+    // must remain in the DOM. With plain useLoadable the component would
+    // immediately switch to state="loading", drop groups=[], and show
+    // ChatSkeleton instead — this assertion would fail. useLastLoadable keeps
+    // the previous resolved data visible until the new promise settles.
     await waitFor(() => {
-      expect(screen.getByText("Last loadable message")).toBeInTheDocument();
+      expect(screen.getByText("Thread A message")).toBeInTheDocument();
+    });
+
+    // Resolve thread B's fetch — messages should now appear and thread A's
+    // messages should be replaced by thread B's.
+    resolveThreadBMessages();
+
+    await waitFor(() => {
+      expect(screen.getByText("Thread B message")).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Follow-up to #9930. The fix itself is already merged; this PR only adds the regression tests that were on the branch but did not make it into the squash-merge.
- `VC-SCROLL-006` in `auto-scroll.test.ts`: verifies that a `scrollTop` decrease without a preceding user input event does not disable auto-scroll — the core behavioral guarantee of the fix.
- `CHAT-SCROLL-007` / `CHAT-SCROLL-008` in `chat-scroll-behavior.test.tsx`: integration-level regression tests for browser-initiated scroll via full page render, and for messages staying visible while `groupedChatMessages$` recomputes (`useLastLoadable` guard).

## Test plan
- [ ] `pnpm -F @vm0/platform exec vitest src/signals/__tests__/auto-scroll.test.ts`
- [ ] `pnpm -F @vm0/platform exec vitest src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)