### PR TITLE
refactor(platform): migrate api-integrations-slack-connect.ts to mockApi helper

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-slack-connect.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-slack-connect.ts
@@ -5,7 +5,8 @@
  * Default behavior: user is not yet connected.
  */
 
-import { http, HttpResponse } from "msw";
+import { zeroSlackConnectContract } from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
 
 interface MockSlackConnectData {
   isConnected: boolean;
@@ -32,22 +33,23 @@ export function resetMockSlackConnect(): void {
 
 export const apiIntegrationsSlackConnectHandlers = [
   // GET /api/zero/integrations/slack/connect — check connection status
-  http.get("*/api/zero/integrations/slack/connect", () => {
-    return HttpResponse.json({
+  mockApi(zeroSlackConnectContract.getStatus, ({ respond }) => {
+    return respond(200, {
       isConnected: mockData.isConnected,
       isAdmin: false,
     });
   }),
 
   // POST /api/zero/integrations/slack/connect — connect account
-  http.post("*/api/zero/integrations/slack/connect", () => {
+  // body ({ workspaceId, slackUserId, channelId?, threadTs? }) is contract-typed
+  // but not used for routing — the mock simulates errors via mockData.postError.
+  mockApi(zeroSlackConnectContract.connect, ({ respond }) => {
     if (mockData.postError) {
-      return HttpResponse.json(
-        { error: { message: mockData.postError, code: "BAD_REQUEST" } },
-        { status: 400 },
-      );
+      return respond(400, {
+        error: { message: mockData.postError, code: "BAD_REQUEST" },
+      });
     }
-    return HttpResponse.json({
+    return respond(200, {
       success: true,
       connectionId: "conn-mock-001",
       role: "member",


### PR DESCRIPTION
## Summary

- Replaces raw `http.get`/`http.post` MSW calls in `api-integrations-slack-connect.ts` with the contract-driven `mockApi` helper
- GET and POST `/api/zero/integrations/slack/connect` response shapes are now compile-time verified against `zeroSlackConnectContract`
- POST body fields (`workspaceId`, `slackUserId`, `channelId?`, `threadTs?`) are contract-typed at the `mockApi` layer; documented that the mock routes on `mockData.postError` instead of body fields
- All exported symbols (`apiIntegrationsSlackConnectHandlers`, `setMockSlackConnectData`, `resetMockSlackConnect`) unchanged — no test file changes needed

Part of #9707 refactor. Closes #9947.

## Test plan

- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm -F @vm0/app lint` — clean (0 warnings, 0 errors)
- [x] All 17 tests in `zero-slack-connect-page.test.tsx` and `zero-slack-connect.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)