### PR TITLE
refactor(platform): migrate api-org.ts to mockApi helper (#9707 Phase 1)

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-org.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org.ts
@@ -5,11 +5,11 @@
  * Default behavior: user always has an org (for tests that need auth to work).
  */
 
-import { http, HttpResponse } from "msw";
-import type { Org } from "../../signals/org.ts";
+import { zeroOrgContract, type OrgResponse } from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
 
 // Mock org data — default to admin role for development
-const mockOrg: Org = {
+const mockOrg: OrgResponse = {
   id: "org_1",
   slug: "user-12345678",
   name: "User 12345678",
@@ -17,8 +17,7 @@ const mockOrg: Org = {
 };
 
 export const apiOrgHandlers = [
-  // GET /api/zero/org - Get current user's default org (zero proxy)
-  http.get("*/api/zero/org", () => {
-    return HttpResponse.json(mockOrg);
+  mockApi(zeroOrgContract.get, ({ respond }) => {
+    return respond(200, mockOrg);
   }),
 ];

--- a/turbo/apps/platform/src/signals/org.ts
+++ b/turbo/apps/platform/src/signals/org.ts
@@ -1,15 +1,10 @@
 import { command, computed, state } from "ccstate";
-import { zeroOrgContract, type OrgResponse } from "@vm0/core";
+import { zeroOrgContract } from "@vm0/core";
 import { user$ } from "./auth.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 
 const reloadOrg$ = state(0);
-
-/**
- * Re-export for backward compatibility with mocks and consumers.
- */
-export type Org = OrgResponse;
 
 /**
  * Current user's default org.


### PR DESCRIPTION
## Summary

- Replaces the raw `http.get("*/api/zero/org", ...)` call in `api-org.ts` with the typed `mockApi(zeroOrgContract.get, ...)` helper, so any drift between the mock response shape and the real ts-rest contract is caught at compile time (`pnpm check-types`)
- Removes the now-unused `Org` re-export type from `signals/org.ts` (it was only consumed by `api-org.ts`; knip flagged it as unused after the migration)

Closes #9950. Part of #9707.

Reference pilot: PR #9928 (api-connectors.ts migration)
Foundation helper: PR #9937 (mockApi typed body/query/params)

## Test plan

- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm -F @vm0/app lint` — clean (0 warnings, 0 errors)
- [x] `pnpm format` — no changes needed
- [x] Knip — no unused exports or dependencies
- [x] Org handler tests (`src/signals/__tests__/api-client.test.ts`, `src/mocks/__tests__/`, `src/views/org/__tests__/`, `src/views/zero-page/__tests__/org-*`) — all passing (102 tests across 9 files)
- [ ] Full vitest suite — pre-existing flakes in `schedule-dialog.test.tsx` are unrelated to this change (noted in acceptance criteria)

🤖 Generated with [Claude Code](https://claude.com/claude-code)