### PR TITLE
feat: add chatHeaderNewButton switch to swap invite with new chat

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -215,7 +215,7 @@ function NewChatButton({ pageSignal }: { pageSignal: AbortSignal }) {
       data-testid="chat-header-new-button"
     >
       <IconPlus size={14} stroke={1.5} />
-      NEW
+      New
     </Button>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -15,6 +15,7 @@ import {
   IconArrowUpRight,
   IconMicrophone,
   IconPin,
+  IconPlus,
   IconUserPlus,
 } from "@tabler/icons-react";
 import {
@@ -24,6 +25,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@vm0/ui";
+import { FeatureSwitchKey } from "@vm0/core";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   currentChatAgentId$,
   currentChatAgentDisplayName$,
@@ -53,6 +56,8 @@ import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
 import {
+  createNewChatThread$,
+  creatingNewSession$,
   resetTalkSendSignal$,
   sendNewThreadMessage$,
   startNewZeroSession$,
@@ -182,6 +187,50 @@ function InviteButton({ pageSignal }: { pageSignal: AbortSignal }) {
   );
 }
 
+function NewChatButton({ pageSignal }: { pageSignal: AbortSignal }) {
+  const currentChatAgentId = useResolved(currentChatAgentId$);
+  const createNewChat = useSet(createNewChatThread$);
+  const navigateToChatFn = useSet(navigateToChat$);
+  const creatingLoadable = useLoadable(creatingNewSession$);
+  const creating = creatingLoadable.state === "loading";
+
+  const handleNewChat = () => {
+    detach(
+      createNewChat(currentChatAgentId ?? null, pageSignal).then((threadId) => {
+        if (threadId) {
+          navigateToChatFn(threadId);
+        }
+      }),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleNewChat}
+      disabled={creating}
+      className="zero-btn-morandi gap-1.5"
+      data-testid="chat-header-new-button"
+    >
+      <IconPlus size={14} stroke={1.5} />
+      NEW
+    </Button>
+  );
+}
+
+function ChatHeaderAction({ pageSignal }: { pageSignal: AbortSignal }) {
+  const features = useLastResolved(featureSwitch$);
+  const newButtonEnabled =
+    features?.[FeatureSwitchKey.ChatHeaderNewButton] ?? false;
+  return newButtonEnabled ? (
+    <NewChatButton pageSignal={pageSignal} />
+  ) : (
+    <InviteButton pageSignal={pageSignal} />
+  );
+}
+
 export function AgentChatPage() {
   const currentChatAgentId = useResolved(currentChatAgentId$);
   const currentChatAgentDisplayName = useResolved(currentChatAgentDisplayName$);
@@ -250,7 +299,7 @@ export function AgentChatPage() {
     <div className="relative flex flex-1 flex-col min-h-0">
       <header className="hidden md:block shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-2">
         <div className="flex justify-end">
-          <InviteButton pageSignal={pageSignal} />
+          <ChatHeaderAction pageSignal={pageSignal} />
         </div>
       </header>
 

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -45,4 +45,5 @@ export enum FeatureSwitchKey {
   ScheduleRunHistory = "scheduleRunHistory",
   SlackAgentSwitch = "slackAgentSwitch",
   TestOauthConnector = "testOauthConnector",
+  ChatHeaderNewButton = "chatHeaderNewButton",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -258,6 +258,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the test-oauth connector, a synthetic OAuth 2.0 provider used only for automated tests. Off in prod.",
     enabled: false,
   },
+  [FeatureSwitchKey.ChatHeaderNewButton]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Replace the Invite people button in the agent chat page header with a New button that creates a new chat thread",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.SlackAgentSwitch]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Add `ChatHeaderNewButton` feature switch (staff-only by default) that controls the top-right button in the agent chat page header.
- When off: existing **Invite people** button.
- When on: **NEW** button that creates a new chat thread for the current agent and navigates to it.

## Scope
- Only the `AgentChatPage` header action changes. `zero-chat-thread-page.tsx` and other views are untouched.

## Test plan
- [ ] Flag off (default): top-right still shows **Invite people**; clicking opens the org manage dialog on the Members tab (unchanged behavior).
- [ ] Flag on: top-right shows **NEW**; clicking creates a new chat thread and navigates to it.
- [ ] Non-admin user with flag off: Invite button remains in DOM but `aria-hidden` (unchanged).
- [ ] Existing tests `zero-chat-page.test.tsx` and `zero-chat-page-interaction.test.tsx` still pass (26 tests).
- [ ] `pnpm check-types`, `pnpm -F @vm0/app run lint`, `pnpm -F @vm0/core run lint`, `pnpm format` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)