### PR TITLE
feat(platform): open mobile sidebar via left-edge swipe in PWA mode

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -48,6 +48,7 @@ import { setupSkeletonPage$, setupErrorPage$ } from "./skeleton-page-setup.ts";
 import { startSkeletonCycling$ } from "./app-skeleton.ts";
 import { setupMissionControlPage$ } from "./mission-control-page/mission-control-page.ts";
 import { setupRealtime$ } from "./realtime.ts";
+import { setupPwaEdgeSwipe$ } from "./zero-page/pwa-edge-swipe.ts";
 
 /**
  * Catch-all fallback — redirects unknown paths to /.
@@ -319,6 +320,7 @@ export const bootstrap$ = command(
       set(registerServiceWorker$, signal),
       set(setupNotificationListener$, signal),
       set(setupInstallPrompt$, signal),
+      set(setupPwaEdgeSwipe$, signal),
       set(startSkeletonCycling$, signal),
       (async () => {
         await set(setupClerk$, signal);

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/pwa-edge-swipe.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/pwa-edge-swipe.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  EDGE_THRESHOLD_PX,
+  isEdgeStart,
+  isOpenSwipe,
+  MAX_GESTURE_MS,
+  OPEN_DISTANCE_PX,
+} from "../pwa-edge-swipe.ts";
+
+describe("isEdgeStart", () => {
+  it("accepts coordinates at or within the edge threshold", () => {
+    expect(isEdgeStart(0)).toBeTruthy();
+    expect(isEdgeStart(EDGE_THRESHOLD_PX)).toBeTruthy();
+  });
+
+  it("rejects coordinates beyond the edge threshold", () => {
+    expect(isEdgeStart(EDGE_THRESHOLD_PX + 1)).toBeFalsy();
+    expect(isEdgeStart(200)).toBeFalsy();
+  });
+});
+
+describe("isOpenSwipe", () => {
+  it("accepts a horizontal swipe past the open distance within the time window", () => {
+    expect(
+      isOpenSwipe(
+        { x: 5, y: 200, t: 0 },
+        { x: 5 + OPEN_DISTANCE_PX, y: 205, t: 150 },
+      ),
+    ).toBeTruthy();
+  });
+
+  it("rejects short horizontal movements (a tap)", () => {
+    expect(
+      isOpenSwipe({ x: 5, y: 200, t: 0 }, { x: 20, y: 200, t: 50 }),
+    ).toBeFalsy();
+  });
+
+  it("rejects gestures that take longer than the max window", () => {
+    expect(
+      isOpenSwipe(
+        { x: 5, y: 200, t: 0 },
+        { x: 200, y: 200, t: MAX_GESTURE_MS + 1 },
+      ),
+    ).toBeFalsy();
+  });
+
+  it("rejects gestures that are mostly vertical", () => {
+    expect(
+      isOpenSwipe({ x: 5, y: 100, t: 0 }, { x: 80, y: 400, t: 200 }),
+    ).toBeFalsy();
+  });
+
+  it("rejects leftward movement (dx < 0)", () => {
+    expect(
+      isOpenSwipe({ x: 5, y: 200, t: 0 }, { x: -100, y: 200, t: 100 }),
+    ).toBeFalsy();
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/pwa-edge-swipe.ts
+++ b/turbo/apps/platform/src/signals/zero-page/pwa-edge-swipe.ts
@@ -1,0 +1,100 @@
+// PWA-only left-edge swipe-in gesture for opening the mobile sidebar.
+//
+// Only active in standalone display mode. In a regular browser tab the
+// left-edge area is owned by the native back-navigation gesture (iOS Safari,
+// Android Chrome), which has priority over any JS handler — attaching there
+// would be a no-op at best and a user confusion at worst. Standalone PWAs
+// have no back gesture, so the edge is free.
+
+import { command } from "ccstate";
+import { setSidebarExpanded$ } from "./zero-nav.ts";
+
+export const EDGE_THRESHOLD_PX = 24;
+export const OPEN_DISTANCE_PX = 60;
+export const MAX_GESTURE_MS = 500;
+const HORIZONTAL_RATIO = 2;
+
+interface SwipePoint {
+  x: number;
+  y: number;
+  t: number;
+}
+
+function isStandaloneDisplayMode(): boolean {
+  return window.matchMedia("(display-mode: standalone)").matches;
+}
+
+export function isEdgeStart(x: number): boolean {
+  return x <= EDGE_THRESHOLD_PX;
+}
+
+export function isOpenSwipe(start: SwipePoint, end: SwipePoint): boolean {
+  const dx = end.x - start.x;
+  const dy = Math.abs(end.y - start.y);
+  const elapsed = end.t - start.t;
+  if (elapsed > MAX_GESTURE_MS) {
+    return false;
+  }
+  if (dx < OPEN_DISTANCE_PX) {
+    return false;
+  }
+  if (dx < dy * HORIZONTAL_RATIO) {
+    return false;
+  }
+  return true;
+}
+
+export const setupPwaEdgeSwipe$ = command(({ set }, signal: AbortSignal) => {
+  if (!isStandaloneDisplayMode()) {
+    return;
+  }
+
+  let start: SwipePoint | null = null;
+
+  document.addEventListener(
+    "touchstart",
+    (event: TouchEvent) => {
+      if (event.touches.length !== 1) {
+        start = null;
+        return;
+      }
+      const touch = event.touches[0];
+      if (!isEdgeStart(touch.clientX)) {
+        start = null;
+        return;
+      }
+      start = { x: touch.clientX, y: touch.clientY, t: Date.now() };
+    },
+    { passive: true, signal },
+  );
+
+  document.addEventListener(
+    "touchend",
+    (event: TouchEvent) => {
+      if (!start) {
+        return;
+      }
+      const touch = event.changedTouches[0];
+      if (touch) {
+        const end: SwipePoint = {
+          x: touch.clientX,
+          y: touch.clientY,
+          t: Date.now(),
+        };
+        if (isOpenSwipe(start, end)) {
+          set(setSidebarExpanded$, true);
+        }
+      }
+      start = null;
+    },
+    { passive: true, signal },
+  );
+
+  document.addEventListener(
+    "touchcancel",
+    () => {
+      start = null;
+    },
+    { passive: true, signal },
+  );
+});


### PR DESCRIPTION
## Summary
- Adds a left-edge swipe gesture that expands the mobile sidebar, but **only when running as an installed PWA** (`display-mode: standalone`). In a regular browser tab, iOS Safari / Android Chrome own the left-edge area for native back-navigation and would pre-empt any JS handler, so we no-op there.
- Gesture rules: start within 24 px of the left edge, drag right ≥ 60 px, horizontal component must exceed vertical × 2, complete within 500 ms.
- DOM wiring lives in a ccstate command (`setupPwaEdgeSwipe$`) that's attached once in `bootstrap.ts` via the root `AbortSignal`, matching how the other global listeners (install prompt, service worker, notifications) are set up.
- Decision logic (`isEdgeStart`, `isOpenSwipe`) is a pair of pure predicates so it can be unit-tested without any DOM event dispatching (`prefer-user-event` lint rule forbids `dispatchEvent`).

## Why not rely on swipe in the browser too?
Native edge-swipe-back has higher priority than any page-level handler and cannot be `preventDefault`ed from a passive listener — attaching there would just cause user confusion (browser navigates back; sidebar also slides in). Standalone PWAs have no back gesture, so the edge is free.

## Test plan
- [x] `pnpm test pwa-edge-swipe` — 7 new tests pass (edge threshold, distance, duration, direction, negative deltas)
- [x] `pnpm test sidebar-layout pwa` — 27 existing tests still pass
- [x] `pnpm lint` — clean
- [x] `pnpm check-types` — clean
- [ ] Manual QA on iOS Safari PWA (installed via Add to Home Screen): swipe from the left edge opens the sidebar
- [ ] Manual QA in a regular Safari tab: left-edge swipe still does native back, sidebar does not open

🤖 Generated with [Claude Code](https://claude.com/claude-code)