### PR TITLE
refactor(platform): migrate api-user-preferences.ts to mockApi helper (#9707 Phase 1)

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-user-preferences.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-preferences.ts
@@ -4,8 +4,11 @@
  * Mock handlers for /api/zero/user-preferences endpoint.
  */
 
-import { http, HttpResponse } from "msw";
-import type { UserPreferencesResponse } from "@vm0/core";
+import {
+  type UserPreferencesResponse,
+  zeroUserPreferencesContract,
+} from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
 
 let mockPreferences: UserPreferencesResponse = {
   timezone: null,
@@ -30,29 +33,11 @@ export function setMockUserPreferences(
 }
 
 export const apiUserPreferencesHandlers = [
-  // GET /api/zero/user-preferences
-  http.get("*/api/zero/user-preferences", () => {
-    return HttpResponse.json(mockPreferences);
+  mockApi(zeroUserPreferencesContract.get, ({ respond }) => {
+    return respond(200, mockPreferences);
   }),
-
-  // POST /api/zero/user-preferences
-  http.post("*/api/zero/user-preferences", async ({ request }) => {
-    const body = (await request.json()) as Partial<UserPreferencesResponse>;
-
-    if (body.timezone !== undefined) {
-      mockPreferences.timezone = body.timezone;
-    }
-    if (body.pinnedAgentIds !== undefined) {
-      mockPreferences.pinnedAgentIds = body.pinnedAgentIds;
-    }
-    if (body.sendMode !== undefined) {
-      mockPreferences.sendMode = body.sendMode;
-    }
-    if (body.captureNetworkBodiesRemaining !== undefined) {
-      mockPreferences.captureNetworkBodiesRemaining =
-        body.captureNetworkBodiesRemaining;
-    }
-
-    return HttpResponse.json(mockPreferences);
+  mockApi(zeroUserPreferencesContract.update, ({ body, respond }) => {
+    Object.assign(mockPreferences, body);
+    return respond(200, mockPreferences);
   }),
 ];


### PR DESCRIPTION
## Summary

- Replaces raw `http.*` MSW calls in `api-user-preferences.ts` with the contract-driven `mockApi` helper
- Response/body shapes are now type-checked against `zeroUserPreferencesContract` at compile time
- Simplifies POST handler: replaces 8 lines of manual field assignment with `Object.assign(mockPreferences, body)`, which is valid since all `UpdateUserPreferencesRequest` fields are optional
- All exported symbols (`apiUserPreferencesHandlers`, `resetMockUserPreferences`, `setMockUserPreferences`) remain unchanged

Closes #9943. Part of #9707.

## Test plan

- [x] `pnpm -F @vm0/app check-types` clean
- [x] `pnpm -F @vm0/app lint` clean
- [x] Key consumer tests pass: `preferences-page.test.tsx`, `timezone-settings.test.tsx`, `zero-send-key.test.tsx`, `pinned-agent-switch.test.tsx`
- [x] `src/mocks/__tests__/msw-contract.test.ts` passes

No new tests needed — this is a pure mock-layer refactor with no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)