### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3585,11 +3585,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3598,7 +3598,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3951,6 +3951,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"


### PR DESCRIPTION
## Summary

Weekly Rust dependency refresh for the `crates/` workspace. Ran `cargo update --verbose` against the workspace rooted at `crates/Cargo.toml` and committed the resulting `Cargo.lock` changes.

### Updated dependencies

- `wasip2` 1.0.2+wasi-0.2.9 → 1.0.3+wasi-0.2.9 (pulled in `wit-bindgen` 0.57.1 alongside the existing 0.51.0)

### Dependencies that could NOT be updated

These are transitive dependencies whose versions are pinned by upstream crates we do not control. `cargo update` reports them as `Unchanged` — bumping them would require new upstream releases of the parents:

- `crc` 3.3.0 (latest 3.4.0) — held back by `crc-fast` 1.9.0 → `aws-smithy-checksums` → `aws-sdk-s3`
- `crc-fast` 1.9.0 (latest 1.10.0) — held back by `aws-smithy-checksums` → `aws-sdk-s3`
- `generic-array` 0.14.7 (latest 0.14.9) — held back by `hmac`/`sha1`/`sha2`/`crypto-common` (used by `aws-sdk-s3`, `aws-sigv4`, `tungstenite`, `headers`, `httpmock`)

### Manual version bumps

None. All workspace dependencies in `crates/Cargo.toml` already use loose semver specs (`"1"`, `"0.4"`, etc.), so `cargo update` reached the latest compatible versions without any `Cargo.toml` edits. No majors were in scope for this pass.

### Test status

`cargo test --workspace`: **all tests pass**. Every crate's unit tests, integration tests, and doc-tests returned `test result: ok. 0 failed` with the updated lockfile. No code changes were required.

## Test plan

- [x] `cargo update --verbose` in `crates/`
- [x] `cargo test --workspace` in `crates/`
- [ ] CI green on this PR