### PR TITLE
refactor(platform): migrate api-onboarding.ts to mockApi helper

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-onboarding.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-onboarding.ts
@@ -5,12 +5,12 @@
  * Default behavior: onboarding is complete (all flags true).
  */
 
-import { http, HttpResponse } from "msw";
+import { onboardingStatusContract } from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
 
 export const apiOnboardingHandlers = [
-  // GET /api/zero/onboarding/status - Get onboarding status
-  http.get("*/api/zero/onboarding/status", () => {
-    return HttpResponse.json({
+  mockApi(onboardingStatusContract.getStatus, ({ respond }) => {
+    return respond(200, {
       needsOnboarding: false,
       isAdmin: true,
       hasOrg: true,


### PR DESCRIPTION
## Summary

- Replace raw `http.*` MSW calls in `api-onboarding.ts` with the contract-driven `mockApi` helper
- Response body for `GET /api/zero/onboarding/status` is now type-checked at compile time against `onboardingStatusContract.getStatus`
- Exported symbol `apiOnboardingHandlers` and runtime behavior are unchanged

## Test plan

- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm -F @vm0/app lint` — clean (0 warnings, 0 errors)
- [x] `pnpm -F @vm0/app exec vitest run` — 209 test files, 1766 tests, all passing

Closes #9951
Part of #9707
Pilot example: PR #9928

🤖 Generated with [Claude Code](https://claude.com/claude-code)