### PR TITLE
fix(zero): send chat message with rootSignal

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -10,6 +10,7 @@ import {
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { rootSignal$ } from "../../signals/root-signal.ts";
 import { user$ } from "../../signals/auth.ts";
 import {
   IconArrowUpRight,
@@ -239,13 +240,16 @@ export function AgentChatPage() {
   const startNewSession = useSet(startNewZeroSession$);
   const resetTalkSendSignal = useSet(resetTalkSendSignal$);
   const navigateToChatFn = useSet(navigateToChat$);
+  const { signal: rootSignal } = useGet(rootSignal$);
 
   const handleSendMessage = (message: string) => {
     if (!currentChatAgentId) {
       return;
     }
     startNewSession();
-    const talkSignal = resetTalkSendSignal();
+    // Link to rootSignal so the send is cancellable on app/test teardown,
+    // but not on page navigation (unlike pageSignal).
+    const talkSignal = resetTalkSendSignal(rootSignal);
     detach(
       sendNewThread(currentChatAgentId, message, talkSignal).then(
         (threadId) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6,6 +6,7 @@ import {
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { rootSignal$ } from "../../signals/root-signal.ts";
 import {
   IconAlertCircle,
   IconLoader2,
@@ -307,6 +308,7 @@ function ChatThreadComposer({
   const setInputRef = useSet(thread.setInputRef$);
   const scheduleDraftSync = useSet(thread.scheduleDraftSync$);
   const pageSignal = useGet(pageSignal$);
+  const { signal: rootSignal } = useGet(rootSignal$);
 
   const handleInputChange = (text: string) => {
     setInput(text);
@@ -319,7 +321,9 @@ function ChatThreadComposer({
 
   const handleSend = (text: string) => {
     setInput("");
-    detach(send(text, pageSignal), Reason.DomCallback);
+    // Use rootSignal so in-run page navigation (e.g. IPA internal nav) doesn't
+    // cancel the pending send.
+    detach(send(text, rootSignal), Reason.DomCallback);
   };
 
   return (


### PR DESCRIPTION
## Summary
Two related fixes so that sending a chat message isn't cancelled by in-run page navigation, while remaining cancellable on app/test teardown.

1. **`ChatThreadComposer.handleSend`** (`zero-chat-thread-page.tsx`): was passing `pageSignal` into `thread.sendMessage$`. Any IPA-internal page switch during an in-flight send would abort the request. Pass `rootSignal` instead.
2. **`AgentChatPage.handleSendMessage`** (`agent-chat-page.tsx`): `resetTalkSendSignal()` returns `AbortSignal.any([controller, ...parents])`. It was being called with no parent, so the resulting `talkSignal` had no link to `rootSignal` — couldn't be cancelled on app teardown or in tests. Pass `rootSignal` as the parent.

Adjacent draft-sync calls (`scheduleDraftSync`) still use `pageSignal` intentionally — cancelling a draft-sync on page change is fine.

## Test plan
- [ ] Start a chat, click send, navigate within the app immediately after — message should still reach the backend.
- [ ] New-thread entry on AgentChatPage: send then navigate — same expectation.
- [ ] Verify existing `zero-chat-composer-interaction.test.tsx` still passes.
- [ ] Confirm tests that trigger rootSignal teardown also cancel the talkSignal.