### PR TITLE
feat(platform): show inline streaming cursor on last assistant message

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -447,6 +447,39 @@ function ThinkingIndicator({ thread }: { thread: ChatThreadSignals }) {
   );
 }
 
+// Absolutely positioned so it contributes zero layout — the surrounding
+// message bubble's height is unchanged whether the cursor is shown or not.
+function InlineStreamingCursor({
+  thread,
+  groupBeginMessageId,
+}: {
+  thread: ChatThreadSignals;
+  groupBeginMessageId: string;
+}) {
+  const features = useLastResolved(featureSwitch$);
+  const enabled = features?.[FeatureSwitchKey.InlineThinkingDot] ?? false;
+  const allFinished = useLastResolved(thread.allFinished$) ?? false;
+  const groups = useLastResolved(thread.groupedChatMessages$) ?? [];
+  const lastGroup = groups[groups.length - 1];
+  const isLastAssistantGroup =
+    !!lastGroup &&
+    lastGroup.role === "assistant" &&
+    lastGroup.beginMessageId === groupBeginMessageId;
+
+  if (!enabled || allFinished || !isLastAssistantGroup) {
+    return null;
+  }
+
+  return (
+    <span
+      aria-hidden
+      className="absolute -bottom-0.5 right-0 pointer-events-none animate-in fade-in duration-200"
+    >
+      <IconLoader2 size={12} className="animate-spin text-foreground/50" />
+    </span>
+  );
+}
+
 /**
  * Parse inline attachment lines from message content.
  * Matches `[Attached file: name](url)` optionally followed by a curl line.
@@ -690,10 +723,14 @@ function PagedAssistantGroup({
     >
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
         <AssistantBubbleAvatar thread={thread} />
-        <div className="flex flex-col gap-3">
+        <div className="relative flex flex-col gap-3">
           {group.messages.map((msg) => {
             return <PagedAssistantMessageItem key={msg.id} message={msg} />;
           })}
+          <InlineStreamingCursor
+            thread={thread}
+            groupBeginMessageId={group.beginMessageId}
+          />
         </div>
       </div>
       <PagedGroupActions group={group} content={fullContent} thread={thread} />

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -46,4 +46,5 @@ export enum FeatureSwitchKey {
   SlackAgentSwitch = "slackAgentSwitch",
   TestOauthConnector = "testOauthConnector",
   ChatHeaderNewButton = "chatHeaderNewButton",
+  InlineThinkingDot = "inlineThinkingDot",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -265,6 +265,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.InlineThinkingDot]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Show an inline streaming cursor on the last assistant message while the agent run is still active, so users see the agent is still working even after it has produced output",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.SlackAgentSwitch]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

Closes the visibility gap where the existing \`ThinkingIndicator\` hides as soon as the assistant produces any output, even though the agent run is still active — so users temporarily lose the signal that work is still in progress.

Adds a small spinning cursor (12px \`IconLoader2\`) pinned at the bottom-right of the last assistant message bubble. The cursor is:

- **Absolutely positioned** (\`absolute -bottom-0.5 right-0\`) — contributes **zero layout**, so the message list stays strictly append-only. No collapse or jump when the run finishes.
- **Additive only** — the existing \`ThinkingIndicator\` (shown when last group is a user message) is untouched. The new cursor only fills the gap between first assistant output and run completion.
- **Reactively scoped to the last assistant group** — by comparing \`group.beginMessageId\` with the last group in \`groupedChatMessages\$\`, and reading \`thread.allFinished\$\` for run state.

## Feature flag

Gated behind \`FeatureSwitchKey.InlineThinkingDot\` (\`enabled: false\` + \`enabledOrgIdHashes: STAFF_ORG_ID_HASHES\`), so only the vm0 staff org sees it while we dogfood the UX. External users see zero behavior change.

## Files

- \`turbo/packages/core/src/feature-switch-key.ts\` — new \`InlineThinkingDot\` enum entry
- \`turbo/packages/core/src/feature-switch.ts\` — switch registration (staff-only)
- \`turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx\` — new \`InlineStreamingCursor\` component; mounted inside \`PagedAssistantGroup\` with a \`relative\` on the messages flex column

## Test plan

- [ ] With flag OFF: behavior matches main — the existing thinking indicator still shows when last message is user; nothing else appears
- [ ] With flag ON (staff org): after the assistant streams its first message chunk, a small spinner appears at the bottom-right of the last assistant bubble and stays until \`allFinished\` becomes true
- [ ] When the run completes, the spinner disappears without any visible layout shift (the message list height does not collapse)
- [ ] Spinner is only present on the most recent assistant group — older groups don't get one