### PR TITLE
fix: address p0/p1 issues from pr #9927 review

### DIFF
--- a/turbo/apps/platform/src/signals/schedule-page/schedule-page-ui.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-page-ui.ts
@@ -39,11 +39,15 @@ export const openCreateScheduleDialog$ = command(
       get(zeroOnboardingStatus$),
     ]);
     signal.throwIfAborted();
+    const agentId = status?.defaultAgentId ?? allAgents[0]?.id;
+    if (!agentId) {
+      return;
+    }
     const defaults = createDefaultFormData();
     set(initDialogForm$, {
       ...defaults,
       timezone: prefs?.timezone ?? defaults.timezone,
-      agentId: status?.defaultAgentId ?? allAgents[0]?.id ?? "",
+      agentId,
     });
     set(internalCreateDialogOpen$, true);
   },

--- a/turbo/apps/platform/src/signals/zero-page/schedule-card.ts
+++ b/turbo/apps/platform/src/signals/zero-page/schedule-card.ts
@@ -81,6 +81,7 @@ export const openEditScheduleDialog$ = command(
     set(editingScheduleIdState$, id);
     set(initDialogForm$, initialValues);
     await set(fetchSlackChannels$, signal);
+    signal.throwIfAborted();
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/schedule-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/schedule-dialog.test.tsx
@@ -162,7 +162,7 @@ async function openEditDialog(user: ReturnType<typeof userEvent.setup>) {
 
 function getOpenListboxOption(text: string): HTMLElement {
   const listbox = screen.getByRole("listbox");
-  return within(listbox).getByText(text);
+  return within(listbox).getByRole("option", { name: text });
 }
 
 async function switchFrequency(

--- a/turbo/packages/core/src/timezone.ts
+++ b/turbo/packages/core/src/timezone.ts
@@ -1,21 +1,16 @@
-const gmtOffsetCache = new Map<string, string>();
-
 /**
- * Returns the GMT offset string for an IANA timezone (e.g. "GMT+05:30").
- * Result is cached per process lifetime since UTC offsets are stable for a
- * given timezone identifier.
+ * Returns the GMT offset string for an IANA timezone at the current instant
+ * (e.g. "GMT+05:30"). Called at render time so DST transitions are reflected
+ * correctly without stale cached values.
  */
 export function getGmtOffset(iana: string): string {
-  const cached = gmtOffsetCache.get(iana);
-  if (cached !== undefined) return cached;
   const parts = new Intl.DateTimeFormat("en", {
     timeZone: iana,
     timeZoneName: "longOffset",
   }).formatToParts(new Date());
-  const offset =
+  return (
     parts.find((p) => {
       return p.type === "timeZoneName";
-    })?.value ?? "GMT+00:00";
-  gmtOffsetCache.set(iana, offset);
-  return offset;
+    })?.value ?? "GMT+00:00"
+  );
 }


### PR DESCRIPTION
## Summary

Follow-up fixes for issues found during the PR #9927 code review that were merged before corrections could be applied.

- **P0**: `getOpenListboxOption` in `schedule-dialog.test.tsx` used `getByText` instead of `getByRole("option")`, bypassing ARIA semantics and creating an internal inconsistency with the rest of the test file
- **P0**: `openCreateScheduleDialog$` silently fell back to `agentId: ""` when no agent was available; now returns early so the dialog cannot open in an invalid state (the UI already disables the button, but this closes the signal-level gap)
- **P1**: Missing `signal.throwIfAborted()` after the `await set(fetchSlackChannels$, signal)` in `openEditScheduleDialog$`, allowing stale state mutations to proceed after abort
- **P1**: `getGmtOffset` cached timezone offsets for the process lifetime, making it blind to DST transitions; now computes the offset against `new Date()` each call

## Test plan

- [ ] All 21 schedule dialog tests pass (`schedule-dialog.test.tsx`)
- [ ] All 30 zero schedule page tests pass (`zero-schedule-page.test.tsx`)
- [ ] All 720 core package tests pass
- [ ] `pnpm turbo run lint` — no errors in changed packages
- [ ] `pnpm check-types` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)