### PR TITLE
feat: persist chat scroll position across thread switches

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
@@ -267,6 +267,83 @@ describe("createScrollSignals - scroll position persistence", () => {
     expect(second.scrollTop).toBe(1000);
   });
 
+  it("re-applies saved position via ResizeObserver when content grows after restore (VC-SCROLL-010)", () => {
+    const threadId = `thread-${Math.random().toString(36).slice(2)}`;
+
+    // Seed a saved position against a normal-sized container.
+    const first = mountContainer(threadId);
+    {
+      const { setScrollContainer$ } = createScrollSignals(threadId);
+      context.store.set(setScrollContainer$, first);
+
+      first.scrollTop = 700;
+      first.dispatchEvent(new Event("scroll"));
+      first.dispatchEvent(new Event("wheel"));
+      first.scrollTop = 500;
+      first.dispatchEvent(new Event("scroll"));
+    }
+
+    // Second mount: container starts with scrollHeight too small to hold the
+    // saved position, simulating the DOM not yet having rendered messages on
+    // initial page mount. Capture the ResizeObserver callback so we can fire
+    // it manually after "content grows".
+    let roCallback: ResizeObserverCallback | null = null;
+    const originalRO = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        roCallback = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      const second = document.createElement("div");
+      const inner = document.createElement("div");
+      second.appendChild(inner);
+      document.body.appendChild(second);
+
+      let scrollHeight = 300; // DOM empty: scrollTop will clamp to 0
+      Object.defineProperty(second, "scrollHeight", {
+        get: () => {
+          return scrollHeight;
+        },
+        configurable: true,
+      });
+      Object.defineProperty(second, "clientHeight", {
+        get: () => {
+          return 300;
+        },
+        configurable: true,
+      });
+
+      const { setScrollContainer$, scrollToBottom$ } =
+        createScrollSignals(threadId);
+      context.store.set(setScrollContainer$, second);
+
+      // Initial restore is issued while the DOM is still short. Simulate
+      // the browser clamping scrollTop to the current max (0 when empty).
+      context.store.set(scrollToBottom$);
+      second.scrollTop = 0;
+
+      // Messages render — content grows and ResizeObserver fires. The saved
+      // position (500) should now be re-applied since scrollHeight is large
+      // enough to accommodate it.
+      scrollHeight = 1000;
+      if (!roCallback) {
+        throw new Error("ResizeObserver callback not captured");
+      }
+      (roCallback as ResizeObserverCallback)(
+        [],
+        {} as unknown as ResizeObserver,
+      );
+      expect(second.scrollTop).toBe(500);
+    } finally {
+      globalThis.ResizeObserver = originalRO;
+    }
+  });
+
   it("second scrollToBottom$ call after restore goes to bottom (VC-SCROLL-009)", () => {
     const threadId = `thread-${Math.random().toString(36).slice(2)}`;
 

--- a/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
@@ -166,3 +166,133 @@ describe("createScrollSignals - scrollToBottom$ unconditional", () => {
     expect(container.scrollTop).toBe(1000);
   });
 });
+
+// VC-SCROLL-006: scroll position is persisted by id across container re-binds
+describe("createScrollSignals - scroll position persistence", () => {
+  function mountContainer(id: string) {
+    const container = document.createElement("div");
+    container.dataset.testId = id;
+    const inner = document.createElement("div");
+    container.appendChild(inner);
+    document.body.appendChild(container);
+
+    Object.defineProperty(container, "scrollHeight", {
+      get: () => {
+        return 1000;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      get: () => {
+        return 300;
+      },
+      configurable: true,
+    });
+    return container;
+  }
+
+  it("restores saved position on first scrollToBottom$ when id matches (VC-SCROLL-006)", () => {
+    const threadId = `thread-${Math.random().toString(36).slice(2)}`;
+
+    // First mount: user scrolls up to a non-bottom position.
+    const first = mountContainer(threadId);
+    {
+      const { setScrollContainer$ } = createScrollSignals(threadId);
+      context.store.set(setScrollContainer$, first);
+
+      first.scrollTop = 700;
+      first.dispatchEvent(new Event("scroll"));
+      first.dispatchEvent(new Event("wheel"));
+      first.scrollTop = 250;
+      first.dispatchEvent(new Event("scroll"));
+    }
+
+    // Second mount (simulates switching away and back): the first
+    // scrollToBottom$ call should restore 250 instead of going to 1000.
+    const second = mountContainer(threadId);
+    const { setScrollContainer$, scrollToBottom$ } =
+      createScrollSignals(threadId);
+    context.store.set(setScrollContainer$, second);
+    context.store.set(scrollToBottom$);
+
+    expect(second.scrollTop).toBe(250);
+  });
+
+  it("does not restore when id is omitted (VC-SCROLL-007)", () => {
+    const first = mountContainer("no-id");
+    {
+      const { setScrollContainer$ } = createScrollSignals();
+      context.store.set(setScrollContainer$, first);
+
+      first.scrollTop = 700;
+      first.dispatchEvent(new Event("scroll"));
+      first.dispatchEvent(new Event("wheel"));
+      first.scrollTop = 250;
+      first.dispatchEvent(new Event("scroll"));
+    }
+
+    const second = mountContainer("no-id");
+    const { setScrollContainer$, scrollToBottom$ } = createScrollSignals();
+    context.store.set(setScrollContainer$, second);
+    context.store.set(scrollToBottom$);
+
+    expect(second.scrollTop).toBe(1000);
+  });
+
+  it("clears cached position when user scrolls back to bottom (VC-SCROLL-008)", () => {
+    const threadId = `thread-${Math.random().toString(36).slice(2)}`;
+
+    const first = mountContainer(threadId);
+    {
+      const { setScrollContainer$ } = createScrollSignals(threadId);
+      context.store.set(setScrollContainer$, first);
+
+      // User scrolls up, then back down to bottom.
+      first.scrollTop = 700;
+      first.dispatchEvent(new Event("scroll"));
+      first.dispatchEvent(new Event("wheel"));
+      first.scrollTop = 250;
+      first.dispatchEvent(new Event("scroll"));
+      first.scrollTop = 695;
+      first.dispatchEvent(new Event("scroll"));
+    }
+
+    // Because the cache was cleared, the next mount should go to bottom.
+    const second = mountContainer(threadId);
+    const { setScrollContainer$, scrollToBottom$ } =
+      createScrollSignals(threadId);
+    context.store.set(setScrollContainer$, second);
+    context.store.set(scrollToBottom$);
+
+    expect(second.scrollTop).toBe(1000);
+  });
+
+  it("second scrollToBottom$ call after restore goes to bottom (VC-SCROLL-009)", () => {
+    const threadId = `thread-${Math.random().toString(36).slice(2)}`;
+
+    const first = mountContainer(threadId);
+    {
+      const { setScrollContainer$ } = createScrollSignals(threadId);
+      context.store.set(setScrollContainer$, first);
+
+      first.scrollTop = 700;
+      first.dispatchEvent(new Event("scroll"));
+      first.dispatchEvent(new Event("wheel"));
+      first.scrollTop = 250;
+      first.dispatchEvent(new Event("scroll"));
+    }
+
+    const second = mountContainer(threadId);
+    const { setScrollContainer$, scrollToBottom$ } =
+      createScrollSignals(threadId);
+    context.store.set(setScrollContainer$, second);
+
+    // First call restores.
+    context.store.set(scrollToBottom$);
+    expect(second.scrollTop).toBe(250);
+
+    // Second call (e.g. user sent a new message) scrolls all the way down.
+    context.store.set(scrollToBottom$);
+    expect(second.scrollTop).toBe(1000);
+  });
+});

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -75,6 +75,9 @@ export function createScrollSignals(id?: string) {
   const internalScrollContainer$ = state<HTMLElement | null>(null);
   const autoScrollDisabled$ = state(false);
   let firstScrollToBottomCall = true;
+  // Held while ResizeObserver is still growing the container up to a saved
+  // position — set scrollTop clamps early and needs to be re-applied.
+  let pendingRestorePosition: number | null = null;
 
   const setScrollContainer$ = onRef(
     command(({ get, set }, el: HTMLElement, signal: AbortSignal) => {
@@ -97,6 +100,11 @@ export function createScrollSignals(id?: string) {
       const onScroll = () => {
         const distanceFromBottom =
           el.scrollHeight - el.scrollTop - el.clientHeight;
+        const userRecent =
+          performance.now() - lastUserInputAt < USER_INPUT_WINDOW_MS;
+        if (pendingRestorePosition !== null && userRecent) {
+          pendingRestorePosition = null;
+        }
         if (distanceFromBottom <= AT_BOTTOM_THRESHOLD) {
           const wasDisabled = get(autoScrollDisabled$);
           set(autoScrollDisabled$, false);
@@ -113,27 +121,14 @@ export function createScrollSignals(id?: string) {
           // clamps to the new max, and scroll anchoring can nudge position on
           // layout changes. Those programmatic shifts should not disable
           // auto-scroll; we want ResizeObserver to snap back to the bottom.
-          const userRecent =
-            performance.now() - lastUserInputAt < USER_INPUT_WINDOW_MS;
           if (userRecent) {
             const wasDisabled = get(autoScrollDisabled$);
             set(autoScrollDisabled$, true);
-            if (id !== undefined) {
-              set(setCachedScrollTop$, id, el.scrollTop);
-            }
             if (!wasDisabled) {
-              L.debug(
-                "DISABLED (scrolled up)",
-                scrollInfo(el),
-                `lastKnown=${Math.round(lastKnownScrollTop)}`,
-              );
+              L.debug("DISABLED (scrolled up)", scrollInfo(el));
             }
           } else {
-            L.debug(
-              "scrollTop decreased without user input (ignored)",
-              scrollInfo(el),
-              `lastKnown=${Math.round(lastKnownScrollTop)}`,
-            );
+            L.debug("scrollTop decreased without user input", scrollInfo(el));
           }
         }
         if (id !== undefined && get(autoScrollDisabled$)) {
@@ -151,6 +146,13 @@ export function createScrollSignals(id?: string) {
       const resizeObserver = new ResizeObserver(() => {
         const disabled = get(autoScrollDisabled$);
         L.debug("ResizeObserver fired", scrollInfo(el), `disabled=${disabled}`);
+        if (pendingRestorePosition !== null) {
+          el.scrollTop = pendingRestorePosition;
+          if (el.scrollTop >= pendingRestorePosition) {
+            pendingRestorePosition = null;
+          }
+          return;
+        }
         if (!disabled) {
           el.scrollTop = el.scrollHeight;
         }
@@ -201,6 +203,7 @@ export function createScrollSignals(id?: string) {
     if (wasFirst && id !== undefined) {
       const saved = get(scrollPositionCache$).get(id);
       if (saved !== undefined) {
+        pendingRestorePosition = saved;
         scrollEl.scrollTop = saved;
         set(autoScrollDisabled$, true);
         L.debug("scrollToBottom$ → restored", `id=${id}`, `saved=${saved}`);

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -6,6 +6,33 @@ const L = logger("AutoScroll");
 const AT_BOTTOM_THRESHOLD = 10;
 const USER_INPUT_WINDOW_MS = 200;
 
+// Persists a user's last non-bottom scroll position across container
+// re-binds (e.g. when switching between parallel chat threads). Keyed by
+// caller-provided id — typically a threadId. When absent, no caching occurs.
+const scrollPositionCache$ = state(new Map<string, number>());
+
+const setCachedScrollTop$ = command(
+  ({ get, set }, id: string, scrollTop: number) => {
+    const cache = get(scrollPositionCache$);
+    if (cache.get(id) === scrollTop) {
+      return;
+    }
+    const next = new Map(cache);
+    next.set(id, scrollTop);
+    set(scrollPositionCache$, next);
+  },
+);
+
+const clearCachedScrollTop$ = command(({ get, set }, id: string) => {
+  const cache = get(scrollPositionCache$);
+  if (!cache.has(id)) {
+    return;
+  }
+  const next = new Map(cache);
+  next.delete(id);
+  set(scrollPositionCache$, next);
+});
+
 function isUserScrollKey(key: string): boolean {
   return (
     key === "PageUp" ||
@@ -37,10 +64,17 @@ function scrollInfo(el: HTMLElement) {
  *
  * `autoScroll$`     — scroll to bottom only when auto-scroll is enabled.
  * `scrollToBottom$`  — unconditional force scroll (ignores disabled state).
+ *
+ * When `id` is provided, the user's last non-bottom scroll position is
+ * persisted in a module-level cache. On the first `scrollToBottom$` call
+ * after a new container binds with the same id, the saved position is
+ * restored instead — this preserves reading position across chat-thread
+ * switches. The cache is cleared once the user scrolls back to the bottom.
  */
-export function createScrollSignals() {
+export function createScrollSignals(id?: string) {
   const internalScrollContainer$ = state<HTMLElement | null>(null);
   const autoScrollDisabled$ = state(false);
+  let firstScrollToBottomCall = true;
 
   const setScrollContainer$ = onRef(
     command(({ get, set }, el: HTMLElement, signal: AbortSignal) => {
@@ -66,6 +100,9 @@ export function createScrollSignals() {
         if (distanceFromBottom <= AT_BOTTOM_THRESHOLD) {
           const wasDisabled = get(autoScrollDisabled$);
           set(autoScrollDisabled$, false);
+          if (id !== undefined) {
+            set(clearCachedScrollTop$, id);
+          }
           if (wasDisabled) {
             L.debug("re-enabled (at bottom)", scrollInfo(el));
           }
@@ -81,6 +118,9 @@ export function createScrollSignals() {
           if (userRecent) {
             const wasDisabled = get(autoScrollDisabled$);
             set(autoScrollDisabled$, true);
+            if (id !== undefined) {
+              set(setCachedScrollTop$, id, el.scrollTop);
+            }
             if (!wasDisabled) {
               L.debug(
                 "DISABLED (scrolled up)",
@@ -95,6 +135,9 @@ export function createScrollSignals() {
               `lastKnown=${Math.round(lastKnownScrollTop)}`,
             );
           }
+        }
+        if (id !== undefined && get(autoScrollDisabled$)) {
+          set(setCachedScrollTop$, id, el.scrollTop);
         }
         lastKnownScrollTop = el.scrollTop;
       };
@@ -147,11 +190,22 @@ export function createScrollSignals() {
     scrollEl.scrollTop = scrollEl.scrollHeight;
   });
 
-  const scrollToBottom$ = command(({ get }) => {
+  const scrollToBottom$ = command(({ get, set }) => {
     const scrollEl = get(internalScrollContainer$);
     if (!scrollEl) {
       L.debug("scrollToBottom$ SKIPPED (no container)");
       return;
+    }
+    const wasFirst = firstScrollToBottomCall;
+    firstScrollToBottomCall = false;
+    if (wasFirst && id !== undefined) {
+      const saved = get(scrollPositionCache$).get(id);
+      if (saved !== undefined) {
+        scrollEl.scrollTop = saved;
+        set(autoScrollDisabled$, true);
+        L.debug("scrollToBottom$ → restored", `id=${id}`, `saved=${saved}`);
+        return;
+      }
     }
     L.debug("scrollToBottom$ → scrolling to bottom", scrollInfo(scrollEl));
     scrollEl.scrollTop = scrollEl.scrollHeight;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -701,7 +701,7 @@ export function createChatThreadSignals(
 ): ChatThreadSignals {
   const { threadData$, reloadThread$ } = createThreadData(threadId);
   const { setScrollContainer$, autoScroll$, scrollToBottom$ } =
-    createScrollSignals();
+    createScrollSignals(threadId);
   const { composerFileInput$, setComposerFileInput$ } =
     createComposerFileInput();
   const { agentId$, agentDisplayName$, agentPinned$ } =


### PR DESCRIPTION
## Summary

- Users juggling parallel chat threads were getting thrown to the bottom every time they switched back — even if they had been reading a non-bottom position. `createScrollSignals` now takes an optional `id` (wired through as `threadId` from `createChatThreadSignals`) and caches the user's last non-bottom `scrollTop` in a module-level `scrollPositionCache$` signal.
- On the first `scrollToBottom$` call after a container binds with a previously-saved id (i.e. the initial `chat-page-setup` call before paged messages load), the signal restores the saved position and flips `autoScrollDisabled$` to `true` so nothing fights the restored position.
- The cache is cleared automatically the moment the user (or any caller) brings the thread back to the bottom. Subsequent `scrollToBottom$` calls (e.g. after the user sends a message) scroll all the way down as before.
- `voice-chat` and `activity-detail` scroll usages stay on the zero-arg form — `id` is optional, so their behavior is unchanged.

## Test plan

- [x] `pnpm test src/signals/__tests__/auto-scroll.test.ts` — 9 passing, including 4 new cases (VC-SCROLL-006…009) covering save → restore, no-id no-op, clear-on-bottom, and "second call after restore goes to bottom".
- [x] `pnpm check-types` clean.
- [x] `pnpm lint` clean.
- [ ] Manual: open two parallel threads, scroll thread A up to the middle, switch to thread B, switch back → thread A stays at the remembered position.
- [ ] Manual: scroll thread A back to the bottom → cache cleared; next thread switch returns to bottom naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)