### PR TITLE
refactor(platform): migrate api-realtime.ts to mockApi helper (#9707 Phase 1)

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-realtime.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-realtime.ts
@@ -1,8 +1,9 @@
-import { http, HttpResponse } from "msw";
+import { platformRealtimeTokenContract } from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
 
 export const apiRealtimeHandlers = [
-  http.post("*/api/zero/realtime/token", () => {
-    return HttpResponse.json({
+  mockApi(platformRealtimeTokenContract.create, ({ respond }) => {
+    return respond(200, {
       keyName: "mock-key",
       clientId: "test-user-123",
       timestamp: Date.now(),


### PR DESCRIPTION
## Summary

- Replaces raw `http.post("*/api/zero/realtime/token", ...)` with `mockApi(platformRealtimeTokenContract.create, ...)` in `api-realtime.ts`
- Response body is now compile-time validated against `ablyTokenRequestSchema` via the contract
- Preserves the `apiRealtimeHandlers` export symbol — no consumer changes needed

## Test plan

- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm -F @vm0/app lint` — clean (0 warnings, 0 errors)
- [x] `pnpm format` — no changes
- [x] `pnpm -F @vm0/app exec vitest run src/signals/__tests__/realtime.test.ts` — 2/2 tests passing

Closes #9952
Part of #9707

🤖 Generated with [Claude Code](https://claude.com/claude-code)