### PR TITLE
refactor(platform): migrate api-variables.ts to mockApi helper (#9707 Phase 1)

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-variables.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-variables.ts
@@ -4,8 +4,8 @@
  * Mock handlers for /api/zero/variables endpoints.
  */
 
-import { http, HttpResponse } from "msw";
-import type { VariableResponse } from "@vm0/core";
+import { zeroVariablesContract, type VariableResponse } from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
 
 let mockVariables: VariableResponse[] = [];
 
@@ -13,45 +13,29 @@ export function resetMockVariables(): void {
   mockVariables = [];
 }
 
-function handleSetVariable(body: {
-  name: string;
-  value: string;
-  description?: string;
-}) {
-  const now = new Date().toISOString();
-  const existing = mockVariables.find((v) => {
-    return v.name === body.name;
-  });
-  const created = !existing;
-
-  const variable: VariableResponse = {
-    id: existing?.id ?? crypto.randomUUID(),
-    name: body.name,
-    value: body.value,
-    description: body.description ?? null,
-    createdAt: existing?.createdAt ?? now,
-    updatedAt: now,
-  };
-
-  if (existing) {
-    mockVariables = mockVariables.map((v) => {
-      return v.name === body.name ? variable : v;
-    });
-  } else {
-    mockVariables.push(variable);
-  }
-
-  return HttpResponse.json(variable, { status: created ? 201 : 200 });
-}
-
 export const apiVariablesHandlers = [
-  // POST /api/zero/variables - Create or update a variable (zero proxy)
-  http.post("*/api/zero/variables", async ({ request }) => {
-    const body = (await request.json()) as {
-      name: string;
-      value: string;
-      description?: string;
+  mockApi(zeroVariablesContract.set, ({ body, respond }) => {
+    const now = new Date().toISOString();
+    const existing = mockVariables.find((v) => v.name === body.name);
+    const created = !existing;
+
+    const variable: VariableResponse = {
+      id: existing?.id ?? crypto.randomUUID(),
+      name: body.name,
+      value: body.value,
+      description: body.description ?? null,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
     };
-    return handleSetVariable(body);
+
+    if (existing) {
+      mockVariables = mockVariables.map((v) =>
+        v.name === body.name ? variable : v,
+      );
+    } else {
+      mockVariables.push(variable);
+    }
+
+    return respond(created ? 201 : 200, variable);
   }),
 ];


### PR DESCRIPTION
## Summary

- Replaces the raw `http.post("*/api/zero/variables", ...)` handler and manual body cast with `mockApi(zeroVariablesContract.set, ...)`, making request body and 200/201 response shapes type-checked against the contract at compile time
- Removes the now-unnecessary `handleSetVariable` helper function (YAGNI) by inlining the logic directly in the handler
- Preserves exported symbols `apiVariablesHandlers` and `resetMockVariables` unchanged

Closes #9944. Part of #9707.

## Test plan

- [x] `pnpm -F @vm0/app check-types` — clean (no type errors)
- [x] `pnpm -F @vm0/app lint` — clean (no lint violations)
- [x] `pnpm format` — no formatting changes needed
- [x] Mock tests (`src/mocks`) — all 11 tests pass
- [x] Signals tests (`src/signals`) — all 365 tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)