### PR TITLE
feat(platform): swap streaming cursor spinner for dot-trail pulse

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -68,6 +68,22 @@
   animation: zero-shimmer 3.5s linear infinite;
 }
 
+/* Inline streaming indicator: staggered dot-trail pulse wave */
+@keyframes zero-dot-trail {
+  0%,
+  100% {
+    opacity: 0.25;
+    transform: scale(0.75);
+  }
+  30% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+.zero-dot-trail-item {
+  animation: zero-dot-trail 1.2s ease-in-out infinite;
+}
+
 /* Zero app: inherits global cool gray tokens; only card-specific tokens defined here */
 .zero-app {
   --zero-card-radius: 0.75rem;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -477,9 +477,17 @@ function InlineStreamingCursor({
   return (
     <span
       aria-hidden
-      className="absolute -bottom-0.5 right-0 pointer-events-none animate-in fade-in duration-200"
+      className="pointer-events-none absolute -bottom-2 left-0 flex gap-1.5 animate-in fade-in duration-200"
     >
-      <IconLoader2 size={12} className="animate-spin text-foreground/50" />
+      {Array.from({ length: 8 }).map((_, i) => {
+        return (
+          <span
+            key={i}
+            className="zero-dot-trail-item inline-block size-1 rounded-full bg-foreground/50"
+            style={{ animationDelay: `${i * 120}ms` }}
+          />
+        );
+      })}
     </span>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -479,12 +479,12 @@ function InlineStreamingCursor({
       aria-hidden
       className="pointer-events-none absolute -bottom-2 left-0 flex gap-1.5 animate-in fade-in duration-200"
     >
-      {Array.from({ length: 8 }).map((_, i) => {
+      {[0, 120, 240, 360, 480, 600, 720, 840].map((delay) => {
         return (
           <span
-            key={i}
+            key={delay}
             className="zero-dot-trail-item inline-block size-1 rounded-full bg-foreground/50"
-            style={{ animationDelay: `${i * 120}ms` }}
+            style={{ animationDelay: `${delay}ms` }}
           />
         );
       })}


### PR DESCRIPTION
## Summary
- Replace the `IconLoader2` spinner inside `InlineStreamingCursor` with a row of 8 dots that pulse in a staggered wave (120ms step, 1.2s cycle).
- Keep the same `FeatureSwitchKey.InlineThinkingDot` gating and the same "absolutely positioned, zero layout impact" guarantee.
- Reposition from bottom-right to bottom-left so the indicator sits under the assistant message text rather than conflicting with any nearby right-aligned bubble.
- Add `@keyframes zero-dot-trail` + `.zero-dot-trail-item` helper to `views/css/index.css` (next to the existing `zero-shimmer` keyframes).

## Test plan
- [ ] Enable the `inlineThinkingDot` flag via the Lab page, start a long-running agent turn, and verify the 8-dot wave appears under the last assistant message while the run is active and disappears the instant `allFinished` flips to true.
- [ ] Toggle the flag off and confirm no indicator renders.
- [ ] Verify that mounting/unmounting the indicator does not cause any layout shift in the message column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)