### PR TITLE
perf(platform): reduce re-renders in billing dialog and auto-recharge section

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -1,4 +1,4 @@
-// TODO(#8609): split large components to comply with max-lines-per-function (128)
+// TODO(#8609): split AutoRechargeSection to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import {
   useGet,
@@ -6,7 +6,6 @@ import {
   useLastLoadable,
   useLastResolved,
 } from "ccstate-react";
-import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
@@ -16,7 +15,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@vm0/ui/components/ui/dialog";
-import { Button, Input, Switch } from "@vm0/ui";
+import { Input, Switch } from "@vm0/ui";
 import { IconCheck } from "@tabler/icons-react";
 import {
   type BillingTier,
@@ -24,7 +23,6 @@ import {
   billingDialogOpen$,
   billingStatusAsync$,
   setBillingDialogOpen$,
-  startCheckout$,
   openDowngradeDialog$,
   saveAutoRecharge$,
   autoRechargeConfig$,
@@ -39,6 +37,8 @@ import {
   selectedPlanTier$,
   setSelectedPlanTier$,
 } from "../../signals/zero-page/billing-dialog-state.ts";
+import { SaveAutoRechargeButton } from "./save-auto-recharge-button.tsx";
+import { CheckoutButton } from "./checkout-button.tsx";
 
 const PLANS = [
   {
@@ -134,36 +134,6 @@ const CREDITS_PER_DOLLAR = 1000;
 const settingsCardBorder = {
   border: "0.7px solid hsl(var(--gray-400))",
 } as const;
-
-function SaveAutoRechargeButton({
-  getFormValues,
-  pageSignal,
-}: {
-  getFormValues: () => {
-    enabled: boolean;
-    threshold?: number;
-    amount?: number;
-  } | null;
-  pageSignal: AbortSignal;
-}) {
-  const [loadable, save] = useLoadableSet(saveAutoRecharge$);
-  const loading = loadable.state === "loading";
-  return (
-    <Button
-      size="sm"
-      variant="outline"
-      disabled={loading}
-      onClick={() => {
-        const values = getFormValues();
-        if (values) {
-          detach(save(values, pageSignal), Reason.DomCallback);
-        }
-      }}
-    >
-      {loading ? "Saving..." : "Save"}
-    </Button>
-  );
-}
 
 export function AutoRechargeSection({
   currentTier,
@@ -446,52 +416,6 @@ export function AutoRechargeSection({
           pageSignal={pageSignal}
         />
       </div>
-    </div>
-  );
-}
-
-function CheckoutButton({
-  selectedTier,
-  isUpgrade,
-  isDowngrade,
-  pageSignal,
-  openDowngrade,
-}: {
-  selectedTier: BillingTier;
-  isUpgrade: boolean;
-  isDowngrade: boolean;
-  pageSignal: AbortSignal;
-  openDowngrade: () => void;
-}) {
-  const [checkoutLoadable, checkout] = useLoadableSet(startCheckout$);
-  const loading = checkoutLoadable.state === "loading";
-
-  if (!isUpgrade && !isDowngrade) {
-    return null;
-  }
-
-  const handleAction = (e: React.MouseEvent) => {
-    if (isUpgrade && (selectedTier === "pro" || selectedTier === "team")) {
-      const newTab = e.metaKey || e.ctrlKey;
-      detach(checkout(selectedTier, newTab, pageSignal), Reason.DomCallback);
-    } else if (isDowngrade) {
-      openDowngrade();
-    }
-  };
-
-  return (
-    <div className="flex justify-end mt-4">
-      <Button
-        disabled={loading}
-        variant={isDowngrade ? "outline" : "default"}
-        onClick={handleAction}
-      >
-        {loading
-          ? "Redirecting..."
-          : isUpgrade
-            ? `Upgrade to ${selectedTier.charAt(0).toUpperCase() + selectedTier.slice(1)}`
-            : "Downgrade"}
-      </Button>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -135,19 +135,48 @@ const settingsCardBorder = {
   border: "0.7px solid hsl(var(--gray-400))",
 } as const;
 
+function SaveAutoRechargeButton({
+  getFormValues,
+  pageSignal,
+}: {
+  getFormValues: () => {
+    enabled: boolean;
+    threshold?: number;
+    amount?: number;
+  } | null;
+  pageSignal: AbortSignal;
+}) {
+  const [loadable, save] = useLoadableSet(saveAutoRecharge$);
+  const loading = loadable.state === "loading";
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      disabled={loading}
+      onClick={() => {
+        const values = getFormValues();
+        if (values) {
+          detach(save(values, pageSignal), Reason.DomCallback);
+        }
+      }}
+    >
+      {loading ? "Saving..." : "Save"}
+    </Button>
+  );
+}
+
 export function AutoRechargeSection({
   currentTier,
-  loading: externalLoading,
+  loading = false,
   variant = "dialog",
 }: {
   currentTier: BillingTier;
-  loading: boolean;
+  loading?: boolean;
   /** `settings`: General-tab style section + card (org manage). `dialog`: compact block for billing modal. */
   variant?: "dialog" | "settings";
 }) {
   const pageSignal = useGet(pageSignal$);
-  const [autoRechargeLoadable, save] = useLoadableSet(saveAutoRecharge$);
-  const loading = externalLoading || autoRechargeLoadable.state === "loading";
+  const save = useSet(saveAutoRecharge$);
   const configLoadable = useLastLoadable(autoRechargeConfig$);
   const config =
     configLoadable.state === "hasData"
@@ -203,13 +232,32 @@ export function AutoRechargeSection({
     );
   };
 
-  const persistIfValid = () => {
+  const getFormValues = (): {
+    enabled: boolean;
+    threshold?: number;
+    amount?: number;
+  } | null => {
     const { threshold: t, amount: a } = parseFormNumbers();
     if (!loading && (!displayEnabled || (t > 0 && a >= CREDITS_PER_DOLLAR))) {
       if (displayEnabled) {
         setPendingEnabled(null);
       }
-      saveCurrent({ enabled: displayEnabled, threshold: t, amount: a });
+      return {
+        enabled: displayEnabled,
+        ...(displayEnabled ? { threshold: t, amount: a } : {}),
+      };
+    }
+    return null;
+  };
+
+  const persistIfValid = () => {
+    const values = getFormValues();
+    if (values) {
+      saveCurrent({
+        enabled: values.enabled,
+        threshold: values.threshold,
+        amount: values.amount,
+      });
     }
   };
 
@@ -393,17 +441,57 @@ export function AutoRechargeSection({
       )}
 
       <div className="flex justify-end mt-3">
-        <Button
-          size="sm"
-          variant="outline"
-          disabled={loading}
-          onClick={() => {
-            return persistIfValid();
-          }}
-        >
-          {loading ? "Saving..." : "Save"}
-        </Button>
+        <SaveAutoRechargeButton
+          getFormValues={getFormValues}
+          pageSignal={pageSignal}
+        />
       </div>
+    </div>
+  );
+}
+
+function CheckoutButton({
+  selectedTier,
+  isUpgrade,
+  isDowngrade,
+  pageSignal,
+  openDowngrade,
+}: {
+  selectedTier: BillingTier;
+  isUpgrade: boolean;
+  isDowngrade: boolean;
+  pageSignal: AbortSignal;
+  openDowngrade: () => void;
+}) {
+  const [checkoutLoadable, checkout] = useLoadableSet(startCheckout$);
+  const loading = checkoutLoadable.state === "loading";
+
+  if (!isUpgrade && !isDowngrade) {
+    return null;
+  }
+
+  const handleAction = (e: React.MouseEvent) => {
+    if (isUpgrade && (selectedTier === "pro" || selectedTier === "team")) {
+      const newTab = e.metaKey || e.ctrlKey;
+      detach(checkout(selectedTier, newTab, pageSignal), Reason.DomCallback);
+    } else if (isDowngrade) {
+      openDowngrade();
+    }
+  };
+
+  return (
+    <div className="flex justify-end mt-4">
+      <Button
+        disabled={loading}
+        variant={isDowngrade ? "outline" : "default"}
+        onClick={handleAction}
+      >
+        {loading
+          ? "Redirecting..."
+          : isUpgrade
+            ? `Upgrade to ${selectedTier.charAt(0).toUpperCase() + selectedTier.slice(1)}`
+            : "Downgrade"}
+      </Button>
     </div>
   );
 }
@@ -415,12 +503,9 @@ export function BillingDialog() {
   const status =
     statusLoadable.state === "hasData" ? statusLoadable.data : null;
   const close = useSet(setBillingDialogOpen$);
-  const [checkoutLoadable, checkout] = useLoadableSet(startCheckout$);
   const openDowngrade = useSet(openDowngradeDialog$);
   const selectedTier = useGet(selectedPlanTier$);
   const setSelectedTier = useSet(setSelectedPlanTier$);
-
-  const loading = checkoutLoadable.state === "loading";
 
   const currentTier: BillingTier = apiTierToBillingTier(status?.tier);
 
@@ -428,15 +513,6 @@ export function BillingDialog() {
   const currentOrder = TIER_ORDER[currentTier];
   const isUpgrade = selectedOrder > currentOrder;
   const isDowngrade = selectedOrder < currentOrder;
-
-  const handleAction = (e: React.MouseEvent) => {
-    if (isUpgrade && (selectedTier === "pro" || selectedTier === "team")) {
-      const newTab = e.metaKey || e.ctrlKey;
-      detach(checkout(selectedTier, newTab, pageSignal), Reason.DomCallback);
-    } else if (isDowngrade) {
-      openDowngrade();
-    }
-  };
 
   return (
     <Dialog
@@ -471,25 +547,15 @@ export function BillingDialog() {
           })}
         </div>
 
-        {(isUpgrade || isDowngrade) && (
-          <div className="flex justify-end mt-4">
-            <Button
-              disabled={loading}
-              variant={isDowngrade ? "outline" : "default"}
-              onClick={handleAction}
-            >
-              {loading
-                ? "Redirecting..."
-                : isUpgrade
-                  ? `Upgrade to ${selectedTier.charAt(0).toUpperCase() + selectedTier.slice(1)}`
-                  : "Downgrade"}
-            </Button>
-          </div>
-        )}
+        <CheckoutButton
+          selectedTier={selectedTier}
+          isUpgrade={isUpgrade}
+          isDowngrade={isDowngrade}
+          pageSignal={pageSignal}
+          openDowngrade={openDowngrade}
+        />
 
-        {status && (
-          <AutoRechargeSection currentTier={currentTier} loading={loading} />
-        )}
+        {status && <AutoRechargeSection currentTier={currentTier} />}
       </DialogContent>
     </Dialog>
   );

--- a/turbo/apps/platform/src/views/zero-page/checkout-button.tsx
+++ b/turbo/apps/platform/src/views/zero-page/checkout-button.tsx
@@ -1,0 +1,53 @@
+import { useLoadableSet } from "ccstate-react/experimental";
+import { Button } from "@vm0/ui";
+import {
+  type BillingTier,
+  startCheckout$,
+} from "../../signals/zero-page/billing.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+
+export function CheckoutButton({
+  selectedTier,
+  isUpgrade,
+  isDowngrade,
+  pageSignal,
+  openDowngrade,
+}: {
+  selectedTier: BillingTier;
+  isUpgrade: boolean;
+  isDowngrade: boolean;
+  pageSignal: AbortSignal;
+  openDowngrade: () => void;
+}) {
+  const [checkoutLoadable, checkout] = useLoadableSet(startCheckout$);
+  const loading = checkoutLoadable.state === "loading";
+
+  if (!isUpgrade && !isDowngrade) {
+    return null;
+  }
+
+  const handleAction = (e: React.MouseEvent) => {
+    if (isUpgrade && (selectedTier === "pro" || selectedTier === "team")) {
+      const newTab = e.metaKey || e.ctrlKey;
+      detach(checkout(selectedTier, newTab, pageSignal), Reason.DomCallback);
+    } else if (isDowngrade) {
+      openDowngrade();
+    }
+  };
+
+  return (
+    <div className="flex justify-end mt-4">
+      <Button
+        disabled={loading}
+        variant={isDowngrade ? "outline" : "default"}
+        onClick={handleAction}
+      >
+        {loading
+          ? "Redirecting..."
+          : isUpgrade
+            ? `Upgrade to ${selectedTier.charAt(0).toUpperCase() + selectedTier.slice(1)}`
+            : "Downgrade"}
+      </Button>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/save-auto-recharge-button.tsx
+++ b/turbo/apps/platform/src/views/zero-page/save-auto-recharge-button.tsx
@@ -1,0 +1,34 @@
+import { useLoadableSet } from "ccstate-react/experimental";
+import { Button } from "@vm0/ui";
+import { saveAutoRecharge$ } from "../../signals/zero-page/billing.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+
+export function SaveAutoRechargeButton({
+  getFormValues,
+  pageSignal,
+}: {
+  getFormValues: () => {
+    enabled: boolean;
+    threshold?: number;
+    amount?: number;
+  } | null;
+  pageSignal: AbortSignal;
+}) {
+  const [loadable, save] = useLoadableSet(saveAutoRecharge$);
+  const loading = loadable.state === "loading";
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      disabled={loading}
+      onClick={() => {
+        const values = getFormValues();
+        if (values) {
+          detach(save(values, pageSignal), Reason.DomCallback);
+        }
+      }}
+    >
+      {loading ? "Saving..." : "Save"}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract `SaveAutoRechargeButton` leaf component: moves `useLoadableSet(saveAutoRecharge$)` out of `AutoRechargeSection` so save loading state changes no longer re-render the entire form section
- Extract `CheckoutButton` leaf component: moves `useLoadableSet(startCheckout$)` out of `BillingDialog` so checkout loading state changes no longer re-render the plan selection UI
- `AutoRechargeSection` now uses `useSet(saveAutoRecharge$)` for Switch-driven saves (no loadable subscription) and makes the `loading` prop optional (default `false`)
- `BillingDialog` top-level drops from 2 async subscriptions to 1 (only `billingStatusAsync$`)

Fixes #9959

## Test plan

- [ ] All 54 billing tests pass (`billing-dialog-display`, `billing-dialog-interaction`, `org-billing-tab`)
- [ ] Save button correctly shows "Saving..." / disabled during save and returns to "Save" after
- [ ] Upgrade/Checkout button correctly shows "Redirecting..." / disabled during checkout
- [ ] Settings variant of `AutoRechargeSection` continues to work (blur auto-save)
- [ ] TypeScript check passes, lint clean, knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)