### PR TITLE
refactor(platform): migrate api-secrets.ts to mockApi helper

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-secrets.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-secrets.ts
@@ -4,8 +4,8 @@
  * Mock handlers for /api/zero/secrets endpoints.
  */
 
-import { http, HttpResponse } from "msw";
-import type { SecretResponse } from "@vm0/core";
+import { zeroSecretsContract, type SecretResponse } from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
 
 let mockSecrets: SecretResponse[] = [];
 
@@ -13,45 +13,27 @@ export function resetMockSecrets(): void {
   mockSecrets = [];
 }
 
-function handleSetSecret(body: {
-  name: string;
-  value: string;
-  description?: string;
-}) {
-  const now = new Date().toISOString();
-  const existing = mockSecrets.find((s) => {
-    return s.name === body.name;
-  });
-  const created = !existing;
-
-  const secret: SecretResponse = {
-    id: existing?.id ?? crypto.randomUUID(),
-    name: body.name,
-    description: body.description ?? null,
-    type: "user",
-    createdAt: existing?.createdAt ?? now,
-    updatedAt: now,
-  };
-
-  if (existing) {
-    mockSecrets = mockSecrets.map((s) => {
-      return s.name === body.name ? secret : s;
-    });
-  } else {
-    mockSecrets.push(secret);
-  }
-
-  return HttpResponse.json(secret, { status: created ? 201 : 200 });
-}
-
 export const apiSecretsHandlers = [
-  // POST /api/zero/secrets - Create or update a secret (zero proxy)
-  http.post("*/api/zero/secrets", async ({ request }) => {
-    const body = (await request.json()) as {
-      name: string;
-      value: string;
-      description?: string;
+  mockApi(zeroSecretsContract.set, ({ body, respond }) => {
+    const now = new Date().toISOString();
+    const existing = mockSecrets.find((s) => s.name === body.name);
+    const created = !existing;
+
+    const secret: SecretResponse = {
+      id: existing?.id ?? crypto.randomUUID(),
+      name: body.name,
+      description: body.description ?? null,
+      type: "user",
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
     };
-    return handleSetSecret(body);
+
+    if (existing) {
+      mockSecrets = mockSecrets.map((s) => (s.name === body.name ? secret : s));
+    } else {
+      mockSecrets.push(secret);
+    }
+
+    return respond(created ? 201 : 200, secret);
   }),
 ];


### PR DESCRIPTION
## Summary

- Replaces raw `http.post("*/api/zero/secrets", ...)` with `mockApi(zeroSecretsContract.set, ...)` so the mock's request body and response shapes are compile-time checked against the ts-rest contract
- Removes the `handleSetSecret` helper function (logic inlined into the `mockApi` callback, following the `api-variables.ts` pattern)
- Both 200 (update) and 201 (create) response shapes are now type-checked against the contract via the `respond()` helper

Closes #9945. Part of #9707 Phase 1.

**Reference files:**
- `turbo/apps/platform/src/mocks/handlers/api-variables.ts` — same create-or-update pattern (the template followed here)
- `turbo/apps/platform/src/mocks/msw-contract.ts` — the `mockApi` helper source

## Acceptance criteria

- [x] File uses only `mockApi`; no remaining raw `http.*` calls
- [x] Exported handler symbols unchanged (`apiSecretsHandlers`, `resetMockSecrets`)
- [x] `pnpm -F @vm0/app check-types` clean
- [x] `pnpm -F @vm0/app lint` clean
- [x] `pnpm -F @vm0/app exec vitest run` — no regressions (210 files, 1775 tests passed)

## Test plan

- Ran `pnpm -F @vm0/app check-types` — clean
- Ran `pnpm -F @vm0/app lint` — clean
- Ran `pnpm -F @vm0/app exec vitest run` — 210 test files, 1775 tests, all passed
- Key files verified: `zero-directed-connect-page.test.tsx` and `add-connection-dialog.test.tsx` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)