### PR TITLE
fix(composer): mic transcription appends to draft instead of sending

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx
@@ -202,7 +202,7 @@ describe("chat-i-033: mic button recording interaction", () => {
   });
 });
 
-describe("chat-i-034: mic button transcription auto-send", () => {
+describe("chat-i-034: mic button transcription appends to draft", () => {
   beforeEach(() => {
     stubMediaDevices();
     stubMediaRecorder();
@@ -213,9 +213,9 @@ describe("chat-i-034: mic button transcription auto-send", () => {
     vi.unstubAllGlobals();
   });
 
-  it("should send transcribed text after recording stops", async () => {
+  it("should populate composer input with transcribed text without sending", async () => {
     const user = userEvent.setup();
-    const ctrl = mockChatLifecycle();
+    mockChatLifecycle();
 
     const transcribedText = "hello from voice";
     mockSttEndpoint(transcribedText);
@@ -226,30 +226,64 @@ describe("chat-i-034: mic button transcription auto-send", () => {
       featureSwitches: { [FeatureSwitchKey.AudioIO]: true },
     });
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
     });
 
     const micButton = await waitFor(() => {
       return screen.getByLabelText("Voice input");
     });
 
-    // Start recording
     await user.click(micButton);
 
-    // Wait for the stop button to appear (recording state)
     const stopButton = await waitFor(() => {
       return screen.getByLabelText("Stop recording");
     });
 
-    // Stop recording - this should trigger transcription and auto-send
     await user.click(stopButton);
 
-    // After transcription, the run should be created (Stop button appears during sending)
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(textarea.value).toBe(transcribedText);
     });
 
-    ctrl.completeRun("Response to voice input");
+    // Send button is present (not replaced by Stop), meaning no auto-send happened.
+    expect(screen.getByLabelText("Send")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
+  });
+
+  it("should append transcribed text to existing draft with a space separator", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+
+    const transcribedText = "from voice";
+    mockSttEndpoint(transcribedText);
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.AudioIO]: true },
+    });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    await user.type(textarea, "hello");
+
+    const micButton = await waitFor(() => {
+      return screen.getByLabelText("Voice input");
+    });
+
+    await user.click(micButton);
+
+    const stopButton = await waitFor(() => {
+      return screen.getByLabelText("Stop recording");
+    });
+
+    await user.click(stopButton);
+
+    await waitFor(() => {
+      expect(textarea.value).toBe(`hello ${transcribedText}`);
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -450,7 +450,11 @@ function ConnectorsPopoverButton({
 // Voice input mic button
 // ---------------------------------------------------------------------------
 
-function MicButton({ onSend }: { onSend: (text: string) => void }) {
+function MicButton({
+  onTranscribed,
+}: {
+  onTranscribed: (text: string) => void;
+}) {
   const available = useLastResolved(audioIOAvailable$) ?? false;
   const recording = useGet(sttRecording$);
   const transcribing = useGet(sttTranscribing$);
@@ -470,7 +474,7 @@ function MicButton({ onSend }: { onSend: (text: string) => void }) {
       detach(
         stopAndTranscribe(signal).then((text) => {
           if (text) {
-            onSend(text);
+            onTranscribed(text);
           }
         }),
         Reason.DomCallback,
@@ -867,7 +871,15 @@ export function ZeroChatComposer({
                 />
               </div>
               <div className="flex items-center gap-2">
-                <MicButton onSend={onSend} />
+                <MicButton
+                  onTranscribed={(text) => {
+                    const base = input;
+                    const separator =
+                      base.length > 0 && !base.endsWith(" ") ? " " : "";
+                    onInputChange(base + separator + text);
+                    onDraftChange?.();
+                  }}
+                />
                 {sending && onCancel ? (
                   <Button
                     size="sm"


### PR DESCRIPTION
## Summary
- Voice input no longer auto-sends the transcribed text as a chat message.
- The transcribed text is now appended to the composer draft (with a space separator when the draft already has content), so the user can review/edit before hitting Send.
- Draft persistence still runs via `onDraftChange`, so the transcription survives reloads.

## Motivation
From #dev:
> 那个语音输入法我觉得贼好用，感觉可以直接开出去了… 有一点是说，我还是希望它是帮我在对话框里追加内容，而不是直接帮我发出去。因为有时候对方可能在忙，我只是在思考下一条消息要做什么。既然我们现在已经做了草稿持久化了，所以我希望语音输入的时候是直接输入到草稿里，而不是直接发出去。

Other AI assistants (ChatGPT, Doubao) do auto-send; we intentionally diverge here to match the review-before-send flow the team wants.

## Implementation
- `zero-chat-composer.tsx`: `MicButton` prop renamed from `onSend` to `onTranscribed`. The parent `ZeroChatComposer` passes a callback that calls `onInputChange(input + separator + text)` and then `onDraftChange?.()` to trigger draft sync.
- Space separator is only inserted when the existing draft is non-empty and doesn't already end in a space.

## Tests
- Existing `chat-d-032` / `chat-i-033` unchanged.
- `chat-i-034` renamed from _auto-send_ to _appends to draft_ and extended with two cases:
  - transcription populates empty composer and Send button remains (no auto-send)
  - transcription appends to existing draft with a space separator
- Local: `pnpm -F @vm0/app exec vitest --run zero-chat-composer-mic-button` — 6/6 pass. `check-types` and `lint` clean.

## Test plan
- [ ] Open a chat thread with `AudioIO` feature switch on
- [ ] Click mic, speak, click stop — transcribed text lands in the textarea, Send button is enabled but not fired
- [ ] Type some draft text, then record — transcribed text is appended after a space
- [ ] Reload the page — draft (including transcribed text) persists