### PR TITLE
perf(platform): push async subscriptions down into leaf components

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -231,9 +231,76 @@ function ChatHeaderAction({ pageSignal }: { pageSignal: AbortSignal }) {
   );
 }
 
+function PinPill() {
+  const currentChatAgentId = useLastResolved(currentChatAgentId$);
+  const pinnedStatus = useLastResolved(currentChatAgentPinned$);
+  const pinnedIds = useLastResolved(pinnedAgentIds$) ?? [];
+  const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
+  const pinSaving = pinLoadable.state === "loading";
+  const pageSignal = useGet(pageSignal$);
+  if (pinnedStatus !== false || !currentChatAgentId) {
+    return null;
+  }
+  const handlePin = () => {
+    const newPinnedIds = [...pinnedIds, currentChatAgentId];
+    detach(savePinnedIds(newPinnedIds, pageSignal), Reason.DomCallback);
+  };
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={handlePin}
+            disabled={pinSaving}
+            className="absolute -top-0.5 -right-0.5 flex h-6 w-6 items-center justify-center rounded-full zero-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground hover:shadow-md cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Pin to sidebar"
+          >
+            <IconPin size={12} stroke={2} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p className="text-xs">Pin to sidebar</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function VoiceChatLauncher() {
+  const vcEnabled = useLastResolved(vcEnabled$) ?? false;
+  const navigate = useSet(detachedNavigateTo$);
+  if (!vcEnabled) {
+    return null;
+  }
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => {
+              navigate(ROUTES.voiceChat);
+            }}
+            className="shrink-0 flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground cursor-pointer"
+            aria-label="Start voice chat"
+          >
+            <IconMicrophone size={20} stroke={1.5} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p className="text-xs">Voice chat</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 export function AgentChatPage() {
-  const currentChatAgentId = useResolved(currentChatAgentId$);
-  const currentChatAgentDisplayName = useResolved(currentChatAgentDisplayName$);
+  const currentChatAgentId = useLastResolved(currentChatAgentId$);
+  const currentChatAgentDisplayName = useLastResolved(
+    currentChatAgentDisplayName$,
+  );
 
   const sendNewThread = useSet(sendNewThreadMessage$);
   const startNewSession = useSet(startNewZeroSession$);
@@ -274,21 +341,7 @@ export function AgentChatPage() {
 
   const suggestedPrompts = useGet(suggestedPrompts$);
   const navigate = useSet(detachedNavigateTo$);
-  const vcEnabled = useLastResolved(vcEnabled$) ?? false;
-
-  const pinnedIds = useLastResolved(pinnedAgentIds$) ?? [];
-  const pinnedStatus = useLastResolved(currentChatAgentPinned$);
-  const showPinPill = pinnedStatus === false;
-  const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
-  const pinSaving = pinLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
-
-  const handlePin = () => {
-    if (currentChatAgentId) {
-      const newPinnedIds = [...pinnedIds, currentChatAgentId];
-      detach(savePinnedIds(newPinnedIds, pageSignal), Reason.DomCallback);
-    }
-  };
 
   const handleSend = (text: string) => {
     setInput("");
@@ -340,49 +393,10 @@ export function AgentChatPage() {
                   />
                 </div>
               )}
-              {showPinPill && (
-                <TooltipProvider delayDuration={200}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        onClick={handlePin}
-                        disabled={pinSaving}
-                        className="absolute -top-0.5 -right-0.5 flex h-6 w-6 items-center justify-center rounded-full zero-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground hover:shadow-md cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Pin to sidebar"
-                      >
-                        <IconPin size={12} stroke={2} />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      <p className="text-xs">Pin to sidebar</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
+              <PinPill />
             </div>
             <div className="flex-1 min-w-0 flex items-center gap-3">
-              {vcEnabled && (
-                <TooltipProvider delayDuration={200}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          navigate(ROUTES.voiceChat);
-                        }}
-                        className="shrink-0 flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground cursor-pointer"
-                        aria-label="Start voice chat"
-                      >
-                        <IconMicrophone size={20} stroke={1.5} />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      <p className="text-xs">Voice chat</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
+              <VoiceChatLauncher />
               <h2
                 aria-label={tagline}
                 data-testid="chat-tagline"

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -2,12 +2,12 @@ import type { ReactNode } from "react";
 import {
   useGet,
   useSet,
-  useLoadable,
   useLastLoadable,
   useLastResolved,
 } from "ccstate-react";
 import { IconMenu2, IconUserPlus, IconVolume2 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/core";
+import type { RouteKey } from "../../signals/route-paths.ts";
 import { cn } from "@vm0/ui";
 import { ZeroSidebar } from "./zero-sidebar.tsx";
 import { currentChatAgent$ } from "../../signals/agent-chat.ts";
@@ -68,6 +68,80 @@ function AgentAvatarInTopBar() {
   );
 }
 
+function VoiceChatStatusLeaf() {
+  const vcStatus = useGet(vcStatus$);
+  const vcReconnectAttempt = useGet(vcReconnectAttempt$);
+  if (vcStatus === "idle") {
+    return null;
+  }
+  return (
+    <StatusBadge status={vcStatus} reconnectAttempt={vcReconnectAttempt} />
+  );
+}
+
+function AutoReadToggleLeaf() {
+  const features = useLastResolved(featureSwitch$);
+  const audioIOEnabled = features?.[FeatureSwitchKey.AudioIO] ?? false;
+  const autoRead = useGet(autoReadEnabled$);
+  const toggleAutoReadFn = useSet(toggleAutoRead$);
+  if (!audioIOEnabled) {
+    return null;
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        toggleAutoReadFn();
+      }}
+      className={cn(
+        "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors",
+        autoRead
+          ? "text-primary bg-primary/10"
+          : "text-muted-foreground hover:text-foreground hover:bg-muted/50",
+      )}
+      aria-label="Toggle auto-read"
+    >
+      <IconVolume2 size={16} stroke={1.5} />
+    </button>
+  );
+}
+
+function InviteButtonLeaf() {
+  const isAdminLoadable = useLastLoadable(isOrgAdmin$);
+  const isAdmin = isAdminLoadable.state === "hasData" && isAdminLoadable.data;
+  const setTab = useSet(setActiveOrgManageTab$);
+  const setSubPage = useSet(setBillingSubPage$);
+  const openManage = useSet(setOrgManageDialogOpen$);
+  const pageSignal = useGet(pageSignal$);
+  if (!isAdmin) {
+    return null;
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setTab("members");
+        setSubPage(false);
+        detach(openManage(true, pageSignal), Reason.DomCallback);
+      }}
+      className="flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
+    >
+      <IconUserPlus size={14} stroke={1.5} />
+      Invite
+    </button>
+  );
+}
+
+function MobileTopBarActions({ activeId }: { activeId: RouteKey | null }) {
+  const inChatRoute = isChatRoute(activeId);
+  return (
+    <>
+      {inChatRoute && <AutoReadToggleLeaf />}
+      {inChatRoute && <InviteButtonLeaf />}
+    </>
+  );
+}
+
 function MobileTopBar() {
   const setExpanded = useSet(setSidebarExpanded$);
 
@@ -76,21 +150,6 @@ function MobileTopBar() {
     breadcrumbLoadable.state === "hasData" ? breadcrumbLoadable.data : null;
 
   const activeId = useGet(activeRoute$);
-  const isAdminLoadable = useLoadable(isOrgAdmin$);
-  const isAdmin = isAdminLoadable.state === "hasData" && isAdminLoadable.data;
-  const setTab = useSet(setActiveOrgManageTab$);
-  const setSubPage = useSet(setBillingSubPage$);
-  const openManage = useSet(setOrgManageDialogOpen$);
-  const pageSignal = useGet(pageSignal$);
-  const features = useLastResolved(featureSwitch$);
-  const audioIOEnabled = features?.[FeatureSwitchKey.AudioIO] ?? false;
-  const autoRead = useGet(autoReadEnabled$);
-  const toggleAutoReadFn = useSet(toggleAutoRead$);
-  const vcStatus = useGet(vcStatus$);
-  const vcReconnectAttempt = useGet(vcReconnectAttempt$);
-
-  const showInvite = isChatRoute(activeId) && isAdmin;
-  const showVoiceChatStatus = activeId === "voiceChat" && vcStatus !== "idle";
 
   return (
     <div className="md:hidden shrink-0 flex items-center h-12 px-3 gap-2 bg-background border-b border-border/50 z-10">
@@ -124,47 +183,12 @@ function MobileTopBar() {
                 </>
               )}
             </div>
-            {showVoiceChatStatus && (
-              <StatusBadge
-                status={vcStatus}
-                reconnectAttempt={vcReconnectAttempt}
-              />
-            )}
+            {activeId === "voiceChat" && <VoiceChatStatusLeaf />}
           </div>
         </div>
       )}
       {!breadcrumb && <div className="flex-1" />}
-      {audioIOEnabled && isChatRoute(activeId) && (
-        <button
-          type="button"
-          onClick={() => {
-            toggleAutoReadFn();
-          }}
-          className={cn(
-            "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors",
-            autoRead
-              ? "text-primary bg-primary/10"
-              : "text-muted-foreground hover:text-foreground hover:bg-muted/50",
-          )}
-          aria-label="Toggle auto-read"
-        >
-          <IconVolume2 size={16} stroke={1.5} />
-        </button>
-      )}
-      {showInvite && (
-        <button
-          type="button"
-          onClick={() => {
-            setTab("members");
-            setSubPage(false);
-            detach(openManage(true, pageSignal), Reason.DomCallback);
-          }}
-          className="flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
-        >
-          <IconUserPlus size={14} stroke={1.5} />
-          Invite
-        </button>
-      )}
+      <MobileTopBarActions activeId={activeId} />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -700,23 +700,145 @@ function OrbitIllustration() {
 // Full-page layout wrapper — reads step/navigation state from signals
 // ---------------------------------------------------------------------------
 
-function OnboardingPageLayout({ children }: { children: React.ReactNode }) {
-  const onAccountAction = useSet(handleZeroAccountAction$);
-  const stepKey = useLastResolved(onboardingStepKey$) ?? "workspace";
+function OnboardingProgressBar() {
   const currentStep = useLastResolved(onboardingCurrentStepIndex$) ?? 0;
   const visibleSteps = useLastResolved(onboardingVisibleSteps$) ?? [];
+  return (
+    <ProgressBar totalSteps={visibleSteps.length} currentStep={currentStep} />
+  );
+}
+
+function OnboardingFooterNav() {
   const showBack = useLastResolved(onboardingShowBack$) ?? false;
   const showNext = useLastResolved(onboardingShowNext$) ?? false;
   const nextDisabled = useLastResolved(onboardingNextDisabled$) ?? false;
   const stepBack = useSet(onboardingStepBack$);
   const stepNext = useSet(onboardingStepNext$);
   const pageSignal = useGet(pageSignal$);
+  return (
+    <div className="shrink-0 border-t border-border/40 flex items-center justify-between px-5 sm:px-10 py-5">
+      <div>
+        {showBack && (
+          <Button
+            variant="ghost"
+            className="rounded-lg text-muted-foreground"
+            onClick={() => {
+              detach(stepBack(pageSignal), Reason.DomCallback);
+            }}
+          >
+            Back
+          </Button>
+        )}
+      </div>
+      <div>
+        {showNext && (
+          <Button
+            onClick={() => {
+              detach(stepNext(pageSignal), Reason.DomCallback);
+            }}
+            className="rounded-lg min-w-[100px]"
+            disabled={nextDisabled}
+          >
+            Next
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function OnboardingOrbitPanel() {
   const effectiveConnectors =
     useLastResolved(onboardingEffectiveConnectors$) ?? [];
+  return (
+    <>
+      <OrbitIllustration />
+      <p className="text-sm text-foreground text-center leading-relaxed mt-6 max-w-[300px]">
+        {effectiveConnectors.length === 0
+          ? "Pick your tools and Zero will handle the rest, securely."
+          : `${effectiveConnectors.length} app${effectiveConnectors.length === 1 ? "" : "s"} selected. Zero will securely manage ${effectiveConnectors.length === 1 ? "it" : "them"} for you so you don\u2019t have to.`}
+      </p>
+      <p className="text-[11px] text-muted-foreground text-center mt-4">
+        Sandboxed VMs&ensp;|&ensp;No credential exposure&ensp;|&ensp;Full audit
+        trail&ensp;|&ensp;Open source
+      </p>
+      <ComplianceTrustBadges />
+    </>
+  );
+}
+
+function OnboardingIllustrationPanel() {
+  const stepKey = useLastResolved(onboardingStepKey$) ?? "workspace";
   const illustration = getStepIllustration(stepKey);
   const showOrbit = stepKey === "connectors";
   const showChat = stepKey === "workspace";
 
+  return (
+    <div
+      className={`hidden lg:flex w-2/5 shrink-0 flex-col items-center p-10 relative overflow-hidden ${showChat ? "pt-[8%]" : "justify-center"}`}
+    >
+      {/* Decorative circles (non-orbit, non-chat steps) */}
+      {!showOrbit && !showChat && (
+        <div className="absolute inset-0 pointer-events-none" aria-hidden>
+          <div className="absolute top-[15%] left-[10%] h-48 w-48 rounded-full border border-border/20" />
+          <div className="absolute top-[25%] left-[20%] h-64 w-64 rounded-full border border-border/15" />
+          <div className="absolute bottom-[20%] right-[5%] h-40 w-40 rounded-full border border-border/20" />
+          <div className="absolute top-[60%] left-[5%] h-32 w-32 rounded-full border border-border/10" />
+        </div>
+      )}
+
+      <div className="relative z-10 flex flex-col items-center">
+        {showChat ? (
+          <ChatPreview />
+        ) : showOrbit ? (
+          <OnboardingOrbitPanel />
+        ) : (
+          <>
+            <img
+              src={zeroAnimatedSrc}
+              alt=""
+              role="presentation"
+              className="h-24 w-24 object-contain mb-8"
+            />
+            <h3 className="text-xl font-semibold text-foreground text-center leading-snug">
+              {illustration.title}
+            </h3>
+            {illustration.subtitle && (
+              <p className="text-sm text-muted-foreground text-center leading-relaxed mt-3 max-w-[300px]">
+                {illustration.subtitle}
+              </p>
+            )}
+            {illustration.showSlackPreview && (
+              <div className="mt-4 w-full flex justify-center">
+                <img
+                  src={slackPreviewImg}
+                  alt="Zero working in Slack"
+                  className="w-full max-w-[380px]"
+                />
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Account dropdown — bottom-left of left panel */}
+      <div className="absolute bottom-6 left-4 z-20">
+        <OnboardingAccountDropdown />
+      </div>
+    </div>
+  );
+}
+
+function OnboardingAccountDropdown() {
+  const onAccountAction = useSet(handleZeroAccountAction$);
+  return (
+    <VM0ClerkProvider>
+      <AccountDropdown onAccountAction={onAccountAction} hidePreferences />
+    </VM0ClerkProvider>
+  );
+}
+
+function OnboardingPageLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="zero-app flex h-dvh bg-muted/30 relative">
       {/* VM0 logo — top left */}
@@ -764,85 +886,14 @@ function OnboardingPageLayout({ children }: { children: React.ReactNode }) {
       </div>
 
       {/* Left panel — brand / illustration */}
-      <div
-        className={`hidden lg:flex w-2/5 shrink-0 flex-col items-center p-10 relative overflow-hidden ${showChat ? "pt-[8%]" : "justify-center"}`}
-      >
-        {/* Decorative circles (non-orbit, non-chat steps) */}
-        {!showOrbit && !showChat && (
-          <div className="absolute inset-0 pointer-events-none" aria-hidden>
-            <div className="absolute top-[15%] left-[10%] h-48 w-48 rounded-full border border-border/20" />
-            <div className="absolute top-[25%] left-[20%] h-64 w-64 rounded-full border border-border/15" />
-            <div className="absolute bottom-[20%] right-[5%] h-40 w-40 rounded-full border border-border/20" />
-            <div className="absolute top-[60%] left-[5%] h-32 w-32 rounded-full border border-border/10" />
-          </div>
-        )}
-
-        <div className="relative z-10 flex flex-col items-center">
-          {showChat ? (
-            <ChatPreview />
-          ) : showOrbit ? (
-            <>
-              <OrbitIllustration />
-              <p className="text-sm text-foreground text-center leading-relaxed mt-6 max-w-[300px]">
-                {effectiveConnectors.length === 0
-                  ? "Pick your tools and Zero will handle the rest, securely."
-                  : `${effectiveConnectors.length} app${effectiveConnectors.length === 1 ? "" : "s"} selected. Zero will securely manage ${effectiveConnectors.length === 1 ? "it" : "them"} for you so you don\u2019t have to.`}
-              </p>
-              <p className="text-[11px] text-muted-foreground text-center mt-4">
-                Sandboxed VMs&ensp;|&ensp;No credential
-                exposure&ensp;|&ensp;Full audit trail&ensp;|&ensp;Open source
-              </p>
-              <ComplianceTrustBadges />
-            </>
-          ) : (
-            <>
-              <img
-                src={zeroAnimatedSrc}
-                alt=""
-                role="presentation"
-                className="h-24 w-24 object-contain mb-8"
-              />
-              <h3 className="text-xl font-semibold text-foreground text-center leading-snug">
-                {illustration.title}
-              </h3>
-              {illustration.subtitle && (
-                <p className="text-sm text-muted-foreground text-center leading-relaxed mt-3 max-w-[300px]">
-                  {illustration.subtitle}
-                </p>
-              )}
-              {illustration.showSlackPreview && (
-                <div className="mt-4 w-full flex justify-center">
-                  <img
-                    src={slackPreviewImg}
-                    alt="Zero working in Slack"
-                    className="w-full max-w-[380px]"
-                  />
-                </div>
-              )}
-            </>
-          )}
-        </div>
-
-        {/* Account dropdown — bottom-left of left panel */}
-        <div className="absolute bottom-6 left-4 z-20">
-          <VM0ClerkProvider>
-            <AccountDropdown
-              onAccountAction={onAccountAction}
-              hidePreferences
-            />
-          </VM0ClerkProvider>
-        </div>
-      </div>
+      <OnboardingIllustrationPanel />
 
       {/* Right panel — form */}
       <div className="flex flex-1 flex-col min-w-0 bg-background items-center">
         <div className="flex flex-col w-full max-w-[750px] flex-1 min-h-0">
           {/* Progress bar */}
           <div className="shrink-0 px-5 sm:px-10 pt-8 pb-4">
-            <ProgressBar
-              totalSteps={visibleSteps.length}
-              currentStep={currentStep}
-            />
+            <OnboardingProgressBar />
           </div>
 
           {/* Content */}
@@ -851,34 +902,7 @@ function OnboardingPageLayout({ children }: { children: React.ReactNode }) {
           </main>
 
           {/* Footer */}
-          <div className="shrink-0 border-t border-border/40 flex items-center justify-between px-5 sm:px-10 py-5">
-            <div>
-              {showBack && (
-                <Button
-                  variant="ghost"
-                  className="rounded-lg text-muted-foreground"
-                  onClick={() => {
-                    detach(stepBack(pageSignal), Reason.DomCallback);
-                  }}
-                >
-                  Back
-                </Button>
-              )}
-            </div>
-            <div>
-              {showNext && (
-                <Button
-                  onClick={() => {
-                    detach(stepNext(pageSignal), Reason.DomCallback);
-                  }}
-                  className="rounded-lg min-w-[100px]"
-                  disabled={nextDisabled}
-                >
-                  Next
-                </Button>
-              )}
-            </div>
-          </div>
+          <OnboardingFooterNav />
         </div>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -1,4 +1,9 @@
-import { useGet, useLastLoadable, useLastResolved, useSet } from "ccstate-react";
+import {
+  useGet,
+  useLastLoadable,
+  useLastResolved,
+  useSet,
+} from "ccstate-react";
 import {
   DropdownMenu,
   DropdownMenuTrigger,

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -1,4 +1,4 @@
-import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useLastResolved, useSet } from "ccstate-react";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -113,7 +113,7 @@ function InvitationRow({
 }
 
 function CreateWorkspaceItem() {
-  const clerkLoadable = useLoadable(clerk$);
+  const clerkLoadable = useLastLoadable(clerk$);
   const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
   const creatingOrg = useGet(creatingOrg$);
   const setCreating = useSet(setCreatingOrg$);
@@ -157,7 +157,7 @@ function CreateWorkspaceItem() {
 }
 
 function OtherMembershipsList() {
-  const clerkLoadable = useLoadable(clerk$);
+  const clerkLoadable = useLastLoadable(clerk$);
   const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
   const memberships = clerk?.user?.organizationMemberships ?? [];
   const currentOrgId = clerk?.organization?.id;
@@ -203,7 +203,7 @@ function OtherMembershipsList() {
 function OrgDropdownContent() {
   const openManage = useSet(setOrgManageDialogOpen$);
   const pageSignal = useGet(pageSignal$);
-  const clerkLoadable = useLoadable(clerk$);
+  const clerkLoadable = useLastLoadable(clerk$);
   const orgData = useLastResolved(org$);
   const pendingInvitations = useLastResolved(userInvitations$);
 
@@ -264,15 +264,27 @@ function OrgDropdownContent() {
   );
 }
 
-export function ZeroOrgSwitcher() {
-  const clerkLoadable = useLoadable(clerk$);
+function PendingInvitationsBadge() {
   const pendingInvitations = useLastResolved(userInvitations$);
+  const hasPendingInvitations =
+    pendingInvitations !== undefined && pendingInvitations.length > 0;
+  if (!hasPendingInvitations) {
+    return null;
+  }
+  return (
+    <span
+      data-testid="pending-invitations-badge"
+      className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-destructive ring-2 ring-sidebar"
+    />
+  );
+}
+
+export function ZeroOrgSwitcher() {
+  const clerkLoadable = useLastLoadable(clerk$);
 
   const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
   const currentOrg = clerk?.organization;
   const orgName = currentOrg?.name ?? "Organization";
-  const hasPendingInvitations =
-    pendingInvitations !== undefined && pendingInvitations.length > 0;
 
   return (
     <div>
@@ -284,12 +296,7 @@ export function ZeroOrgSwitcher() {
           >
             <span className="relative shrink-0">
               <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} />
-              {hasPendingInvitations && (
-                <span
-                  data-testid="pending-invitations-badge"
-                  className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-destructive ring-2 ring-sidebar"
-                />
-              )}
+              <PendingInvitationsBadge />
             </span>
             <span className="min-w-0 flex-1 text-left text-sm font-semibold leading-tight truncate">
               {orgName}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -48,39 +48,62 @@ import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
 import { AgentListDialog } from "./zero-sidebar-dialogs.tsx";
 
-export function PinnedAgentListSection() {
-  const activeRoute = useGet(activeRoute$);
-  const chatThreadId = useGet(currentChatThreadId$);
-  const sidebarAgentId = useLastResolved(currentChatAgentId$) ?? null;
+function UnpinButton({
+  agentId,
+  isPrimarySelected,
+}: {
+  agentId: string;
+  isPrimarySelected: boolean;
+}) {
+  const pinnedIds = useLastResolved(pinnedAgentIds$) ?? [];
+  const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
+  const savingPinned = pinLoadable.state === "loading";
+  const pageSignal = useGet(pageSignal$);
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              const next = pinnedIds.filter((id): id is string => {
+                return id !== null && id !== agentId;
+              });
+              detach(savePinnedIds(next, pageSignal), Reason.DomCallback);
+            }}
+            disabled={savingPinned}
+            className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 disabled:cursor-not-allowed disabled:opacity-50 ${
+              isPrimarySelected
+                ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
+                : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
+            }`}
+            aria-label="Remove from list"
+          >
+            <IconX size={12} stroke={2} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right">
+          <p className="text-xs">Remove from list</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function AgentListDialogContainer() {
+  const open = useGet(chatListOpen$);
+  const onOpenChange = useSet(setChatListOpen$);
   const displayNameLoadable = useLastLoadable(currentChatAgentDisplayName$);
   const displayName =
     displayNameLoadable.state === "hasData"
       ? (displayNameLoadable.data ?? "Zero")
       : "Zero";
-  const pinnedAgentsLoadable = useLastLoadable(pinnedAgents$);
-  const pinnedIds = (useLastResolved(pinnedAgentIds$) ?? []).filter(
-    (id): id is string => {
-      return id !== null;
-    },
-  );
   const subagents = useLastResolved(subagents$) ?? [];
-
-  const chatListOpen = useGet(chatListOpen$);
-  const setChatListOpenFn = useSet(setChatListOpen$);
-  const collapsed = useGet(agentCardCollapsed$);
-  const setCollapsed = useSet(setAgentCardCollapsed$);
-  const reloadAgents = useSet(reloadAgents$);
-  const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
-  const savingPinned = pinLoadable.state === "loading";
   const createNewChat = useSet(createNewChatThread$);
   const navigateToChat = useSet(navigateToChat$);
   const setExpanded = useSet(setSidebarExpanded$);
   const pageSignal = useGet(pageSignal$);
-
-  const onPinnedIdsChange = (ids: string[]) => {
-    detach(savePinnedIds(ids, pageSignal), Reason.DomCallback);
-  };
-
   const onNewChat = (agentId: string | null) => {
     detach(
       createNewChat(agentId, pageSignal).then((threadId) => {
@@ -92,6 +115,27 @@ export function PinnedAgentListSection() {
     );
     setExpanded(false);
   };
+  return (
+    <AgentListDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      displayName={displayName}
+      subagents={subagents}
+      onNewChat={onNewChat}
+    />
+  );
+}
+
+export function PinnedAgentListSection() {
+  const activeRoute = useGet(activeRoute$);
+  const chatThreadId = useGet(currentChatThreadId$);
+  const sidebarAgentId = useLastResolved(currentChatAgentId$) ?? null;
+  const pinnedAgentsLoadable = useLastLoadable(pinnedAgents$);
+
+  const setChatListOpenFn = useSet(setChatListOpen$);
+  const collapsed = useGet(agentCardCollapsed$);
+  const setCollapsed = useSet(setAgentCardCollapsed$);
+  const reloadAgents = useSet(reloadAgents$);
   const defaultAgentId = useLastResolved(defaultAgentId$);
 
   return (
@@ -184,35 +228,10 @@ export function PinnedAgentListSection() {
                   </Link>
                   {agent.id !== defaultAgentId && (
                     <div className="absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
-                      <TooltipProvider delayDuration={200}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onPinnedIdsChange(
-                                  pinnedIds.filter((id) => {
-                                    return id !== agent.id;
-                                  }),
-                                );
-                              }}
-                              disabled={savingPinned}
-                              className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 disabled:cursor-not-allowed disabled:opacity-50 ${
-                                isPrimarySelected
-                                  ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
-                                  : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
-                              }`}
-                              aria-label="Remove from list"
-                            >
-                              <IconX size={12} stroke={2} />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent side="right">
-                            <p className="text-xs">Remove from list</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
+                      <UnpinButton
+                        agentId={agent.id}
+                        isPrimarySelected={isPrimarySelected}
+                      />
                     </div>
                   )}
                 </div>
@@ -221,13 +240,7 @@ export function PinnedAgentListSection() {
         </div>
       )}
 
-      <AgentListDialog
-        open={chatListOpen}
-        onOpenChange={setChatListOpenFn}
-        displayName={displayName}
-        subagents={subagents}
-        onNewChat={onNewChat}
-      />
+      <AgentListDialogContainer />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-upgrade.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-upgrade.tsx
@@ -1,4 +1,4 @@
-import { useGet, useSet, useLastLoadable, useLoadable } from "ccstate-react";
+import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { billingStatusAsync$ } from "../../signals/zero-page/billing.ts";
@@ -26,7 +26,7 @@ export function SidebarUpgradeCard() {
   const billingLoadable = useLastLoadable(billingStatusAsync$);
   const billing =
     billingLoadable.state === "hasData" ? billingLoadable.data : null;
-  const isAdminLoadable = useLoadable(isOrgAdmin$);
+  const isAdminLoadable = useLastLoadable(isOrgAdmin$);
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
   const setTab = useSet(setActiveOrgManageTab$);


### PR DESCRIPTION
## Summary

Refactor 6 zero-page components to eliminate AP1/AP2/AP3 re-render anti-patterns from `turbo/docs/react.md`. The central insight: when a large parent subscribes to async signals at the top, every Promise transition triggers 1–2 extra renders of the entire subtree. Pulling those subscriptions down into the specific leaves that consume them isolates the render to the affected leaf.

### Files changed

- `sidebar-layout.tsx` — split `MobileTopBar` into `VoiceChatStatusLeaf`, `AutoReadToggleLeaf`, `InviteButtonLeaf`, `MobileTopBarActions`
- `zero-sidebar-pinned.tsx` — move pinned-agent subscriptions into `UnpinButton` + `AgentListDialogContainer`; `PinnedAgentListSection` now only reads signals it directly renders
- `zero-sidebar-upgrade.tsx` — `useLoadable(isOrgAdmin$)` → `useLastLoadable(...)`
- `agent-chat-page.tsx` — extract `PinPill` + `VoiceChatLauncher` leaves; swap `useResolved` → `useLastResolved` for the stable sidebar agent id
- `zero-org-switcher.tsx` — all `useLoadable(clerk$)` → `useLastLoadable(clerk$)`; extract `PendingInvitationsBadge` leaf
- `zero-onboarding.tsx` — split `OnboardingPageLayout` into 5 leaves (progress bar, footer nav, orbit panel, illustration, account dropdown); parent shell now has zero direct signal subs

### Benchmark (best-of-2 wall_ms, `time pnpm -F @vm0/app exec vitest run <path> --reporter=dot`)

| Test | Before | After | Δ |
|---|---|---|---|
| `zero-sidebar.test.tsx` | 15.42s | 8.93s | **-42%** |
| `zero-org-switcher.test.tsx` | 15.51s | 10.51s | **-32%** |
| `zero-sidebar-interaction.test.tsx` | 12.97s | 10.25s | **-21%** |
| `zero-sidebar-dialogs.test.tsx` | 14.23s | 13.65s | -4% |
| `zero-sidebar-display.test.tsx` | 10.64s | 12.74s | +20%¹ |
| `sidebar-layout.test.tsx` | 10.26s | 10.23s | flat |
| `zero-chat-page.test.tsx` | 14.13s | 14.12s | flat |
| `zero-chat-page-interaction.test.tsx` | 8.13s | 8.09s | flat |
| `zero-onboarding.test.tsx` | 11.11s | 10.83s | -3% |

¹ Single-run wall_ms variance for small test files is ±15–20% — tests with simpler component trees are dominated by vitest startup rather than React render cost, so only the three largest sidebar trees show clear movement.

### Test plan

- [x] `pnpm -F @vm0/app run check-types` — passes
- [x] `pnpm -F @vm0/app run lint` — 0 warnings/errors (564 files)
- [x] All 9 benchmark tests pass (baseline + after)
- [x] Full `src/views/zero-page/__tests__` run — 826 passing; 2 pre-existing flakes (`schedule-dialog` timezone, `auto-read-toggle` timeout under load) also fail on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)