### PR TITLE
refactor(platform): migrate v1-runs.ts (logs) to mockApi helper

### DIFF
--- a/turbo/apps/platform/src/mocks/__tests__/msw-contract.test.ts
+++ b/turbo/apps/platform/src/mocks/__tests__/msw-contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, expectTypeOf } from "vitest";
 import type { ServerInferResponseBody } from "@ts-rest/core";
 import {
+  logsListContract,
   zeroConnectorsByTypeContract,
   zeroConnectorsMainContract,
   zeroFeatureSwitchesContract,
@@ -133,6 +134,28 @@ describe("mockApi contract helper", () => {
       keyof (typeof zeroConnectorsByTypeContract)["delete"]["responses"] &
         number
     >();
+  });
+
+  it("applies Zod coercion and defaults to query params", async () => {
+    let seenLimit: number | undefined;
+    server.use(
+      mockApi(logsListContract.list, ({ query, respond }) => {
+        seenLimit = query.limit;
+        return respond(200, {
+          data: [],
+          pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
+          filters: { statuses: [], sources: [], agents: [] },
+        });
+      }),
+    );
+
+    // No `limit` param — contract declares default(20), mockApi must apply it
+    await fetch("/api/zero/logs");
+    expect(seenLimit).toBe(20);
+
+    // String "5" must be coerced to number 5
+    await fetch("/api/zero/logs?limit=5");
+    expect(seenLimit).toBe(5);
   });
 
   it("enforces request body + query shape at compile time", () => {

--- a/turbo/apps/platform/src/mocks/handlers/api-logs.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-logs.ts
@@ -4,11 +4,8 @@
  * Mock handlers for /api/zero/logs endpoints
  */
 
-import { http, HttpResponse } from "msw";
-import type {
-  LogsListResponse,
-  LogDetail,
-} from "../../signals/zero-page/log-types.ts";
+import { logsListContract, logsByIdContract, type LogDetail } from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
 
 // Mock data for log details
 const mockLogDetails: LogDetail[] = [
@@ -62,65 +59,50 @@ const mockLogDetails: LogDetail[] = [
 
 export const appLogsHandlers = [
   // GET /api/zero/logs - List logs with basic fields
-  http.get("*/api/zero/logs", ({ request }) => {
-    const url = new URL(request.url);
-    const cursor = url.searchParams.get("cursor");
-    const limit = Number.parseInt(url.searchParams.get("limit") || "20", 10);
+  mockApi(logsListContract.list, ({ query, respond }) => {
+    const { cursor } = query;
+    const limit = Number(query.limit);
 
-    // Simple pagination logic
     const cursorIndex = cursor
-      ? mockLogDetails.findIndex((r) => {
-          return r.id === cursor;
-        }) + 1
+      ? mockLogDetails.findIndex((r) => r.id === cursor) + 1
       : 0;
     const data = mockLogDetails.slice(cursorIndex, cursorIndex + limit);
     const hasMore = cursorIndex + limit < mockLogDetails.length;
-    const nextCursor = hasMore ? data[data.length - 1]?.id || null : null;
+    const nextCursor = hasMore ? (data[data.length - 1]?.id ?? null) : null;
     const totalPages = Math.max(1, Math.ceil(mockLogDetails.length / limit));
 
-    const response: LogsListResponse = {
-      data: data.map((log) => {
-        return {
-          id: log.id,
-          sessionId: log.sessionId,
-          agentId: log.agentId,
-          displayName: null,
-          framework: log.framework,
-          triggerSource: null,
-          triggerAgentName: null,
-          scheduleId: null,
-          status: log.status,
-          prompt: log.prompt,
-          createdAt: log.createdAt,
-          startedAt: log.startedAt,
-          completedAt: log.completedAt,
-        };
-      }),
-      pagination: {
-        hasMore,
-        nextCursor,
-        totalPages,
-      },
+    return respond(200, {
+      data: data.map((log) => ({
+        id: log.id,
+        sessionId: log.sessionId,
+        agentId: log.agentId,
+        displayName: null,
+        framework: log.framework,
+        triggerSource: null,
+        triggerAgentName: null,
+        scheduleId: null,
+        status: log.status,
+        prompt: log.prompt,
+        createdAt: log.createdAt,
+        startedAt: log.startedAt,
+        completedAt: log.completedAt,
+      })),
+      pagination: { hasMore, nextCursor, totalPages },
       filters: { statuses: [], sources: [], agents: [] },
-    };
-
-    return HttpResponse.json(response);
+    });
   }),
 
   // GET /api/zero/logs/:id - Get log detail
-  http.get("*/api/zero/logs/:id", ({ params }) => {
+  mockApi(logsByIdContract.getById, ({ params, respond }) => {
     const { id } = params;
-    const logDetail = mockLogDetails.find((log) => {
-      return log.id === id;
-    });
+    const logDetail = mockLogDetails.find((log) => log.id === id);
 
     if (!logDetail) {
-      return HttpResponse.json(
-        { error: { message: "Log not found", code: "NOT_FOUND" } },
-        { status: 404 },
-      );
+      return respond(404, {
+        error: { message: "Log not found", code: "NOT_FOUND" },
+      });
     }
 
-    return HttpResponse.json(logDetail);
+    return respond(200, logDetail);
   }),
 ];

--- a/turbo/apps/platform/src/mocks/handlers/api-logs.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-logs.ts
@@ -60,8 +60,7 @@ const mockLogDetails: LogDetail[] = [
 export const appLogsHandlers = [
   // GET /api/zero/logs - List logs with basic fields
   mockApi(logsListContract.list, ({ query, respond }) => {
-    const { cursor } = query;
-    const limit = Number(query.limit);
+    const { cursor, limit } = query;
 
     const cursorIndex = cursor
       ? mockLogDetails.findIndex((r) => r.id === cursor) + 1

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -17,7 +17,7 @@ import {
 import { apiSecretsHandlers, resetMockSecrets } from "./api-secrets.ts";
 import { apiVariablesHandlers, resetMockVariables } from "./api-variables.ts";
 import { exampleHandlers } from "./example.ts";
-import { appLogsHandlers } from "./v1-runs.ts";
+import { appLogsHandlers } from "./api-logs.ts";
 import {
   apiIntegrationsSlackOrgHandlers,
   resetMockSlackOrgIntegration,

--- a/turbo/apps/platform/src/mocks/msw-contract.ts
+++ b/turbo/apps/platform/src/mocks/msw-contract.ts
@@ -76,8 +76,16 @@ export function mockApi<R extends AppRoute>(
   };
   return register(pattern, async ({ params, request }) => {
     const url = new URL(request.url);
-    const query = Object.fromEntries(
-      url.searchParams.entries(),
+    const rawQuery = Object.fromEntries(url.searchParams.entries());
+    // Apply Zod coercion and defaults from the contract's query schema when
+    // present (e.g. `z.coerce.number().default(20)` for `limit`).
+    const querySchema = route.query as
+      | { safeParse: (v: unknown) => { success: boolean; data?: unknown } }
+      | undefined;
+    const query = (
+      querySchema && typeof querySchema.safeParse === "function"
+        ? (querySchema.safeParse(rawQuery).data ?? rawQuery)
+        : rawQuery
     ) as InferQuery<R>;
 
     let body = undefined as InferBody<R>;

--- a/turbo/apps/platform/src/mocks/msw-contract.ts
+++ b/turbo/apps/platform/src/mocks/msw-contract.ts
@@ -82,11 +82,11 @@ export function mockApi<R extends AppRoute>(
     const querySchema = route.query as
       | { safeParse: (v: unknown) => { success: boolean; data?: unknown } }
       | undefined;
-    const query = (
+    const parsed =
       querySchema && typeof querySchema.safeParse === "function"
-        ? (querySchema.safeParse(rawQuery).data ?? rawQuery)
-        : rawQuery
-    ) as InferQuery<R>;
+        ? querySchema.safeParse(rawQuery)
+        : undefined;
+    const query = (parsed?.success ? parsed.data : rawQuery) as InferQuery<R>;
 
     let body = undefined as InferBody<R>;
     if (route.method !== "GET") {


### PR DESCRIPTION
## Summary

- Rename `v1-runs.ts` to `api-logs.ts` and migrate both `GET /api/zero/logs` and `GET /api/zero/logs/:id` MSW handlers from raw `http.*` calls to the contract-driven `mockApi` helper
- Uses existing `logsListContract` and `logsByIdContract` from `@vm0/core` — no new contracts needed
- Exported symbol `appLogsHandlers` is unchanged; consumers are unaffected

Closes #9946

## Test plan

- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm -F @vm0/app lint` — clean (0 warnings, 0 errors)
- [x] Key test files pass: `log-table.test.tsx`, `zero-activity.test.ts`, `pagination-loading-switch.test.tsx`, `activity-page-error.test.ts`, `zero-activity-detail-page.test.tsx`, `activity-page/__tests__/` (all 9 test files, 33 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)