### PR TITLE
refactor(platform): migrate api-billing.ts to mock-api helper (#9707 Phase 1)

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-billing.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-billing.ts
@@ -4,10 +4,17 @@
  * Mock handlers for /api/zero/billing endpoints.
  */
 
-import { http, HttpResponse } from "msw";
-import type { BillingStatus } from "../../signals/zero-page/billing.ts";
+import {
+  zeroBillingStatusContract,
+  zeroBillingCheckoutContract,
+  zeroBillingPortalContract,
+  zeroBillingDowngradeContract,
+  zeroBillingAutoRechargeContract,
+  type BillingStatusResponse,
+} from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
 
-let mockBillingStatus: BillingStatus = {
+let mockBillingStatus: BillingStatusResponse = {
   tier: "free",
   credits: 100_000,
   subscriptionStatus: null,
@@ -18,7 +25,9 @@ let mockBillingStatus: BillingStatus = {
   creditExpiry: { expiringNextCycle: 0, nextExpiryDate: null },
 };
 
-export function setMockBillingStatus(status: Partial<BillingStatus>): void {
+export function setMockBillingStatus(
+  status: Partial<BillingStatusResponse>,
+): void {
   mockBillingStatus = { ...mockBillingStatus, ...status };
 }
 
@@ -36,49 +45,39 @@ export function resetMockBilling(): void {
 }
 
 export const apiBillingHandlers = [
-  http.get("*/api/zero/billing/status", () => {
-    return HttpResponse.json(mockBillingStatus);
+  mockApi(zeroBillingStatusContract.get, ({ respond }) => {
+    return respond(200, mockBillingStatus);
   }),
 
-  http.post("*/api/zero/billing/checkout", async ({ request }) => {
-    const body = (await request.json()) as {
-      tier: string;
-      successUrl: string;
-      cancelUrl: string;
-    };
-    return HttpResponse.json({
+  mockApi(zeroBillingCheckoutContract.create, ({ body, respond }) => {
+    return respond(200, {
       url: `https://checkout.stripe.com/test?tier=${body.tier}`,
     });
   }),
 
-  http.post("*/api/zero/billing/portal", () => {
-    return HttpResponse.json({
+  mockApi(zeroBillingPortalContract.create, ({ respond }) => {
+    return respond(200, {
       url: "https://billing.stripe.com/test-portal",
     });
   }),
 
-  http.post("*/api/zero/billing/downgrade", () => {
-    return HttpResponse.json({
+  mockApi(zeroBillingDowngradeContract.create, ({ respond }) => {
+    return respond(200, {
       success: true,
       effectiveDate: null,
     });
   }),
 
-  http.get("*/api/zero/billing/auto-recharge", () => {
-    return HttpResponse.json(mockBillingStatus.autoRecharge);
+  mockApi(zeroBillingAutoRechargeContract.get, ({ respond }) => {
+    return respond(200, mockBillingStatus.autoRecharge);
   }),
 
-  http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
-    const body = (await request.json()) as {
-      enabled: boolean;
-      threshold?: number;
-      amount?: number;
-    };
+  mockApi(zeroBillingAutoRechargeContract.update, ({ body, respond }) => {
     mockBillingStatus.autoRecharge = {
       enabled: body.enabled,
       threshold: body.enabled ? (body.threshold ?? null) : null,
       amount: body.enabled ? (body.amount ?? null) : null,
     };
-    return HttpResponse.json(mockBillingStatus.autoRecharge);
+    return respond(200, mockBillingStatus.autoRecharge);
   }),
 ];

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -6,7 +6,6 @@ import {
   zeroBillingAutoRechargeContract,
   zeroBillingInvoicesContract,
   zeroBillingDowngradeContract,
-  type BillingStatusResponse,
 } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
@@ -16,8 +15,6 @@ import { accept } from "../../lib/accept.ts";
 // ---------------------------------------------------------------------------
 
 export type BillingTier = "free" | "pro" | "team";
-
-export type BillingStatus = BillingStatusResponse;
 
 export function apiTierToBillingTier(tier: string | undefined): BillingTier {
   if (tier === "free" || tier === "pro" || tier === "team") {


### PR DESCRIPTION
## Summary

- Replaces all 6 raw `http.*` MSW handlers in `api-billing.ts` with contract-driven `mockApi` calls, type-checking response shapes against ts-rest contracts at compile time
- Fixes two drift bugs: `POST /api/zero/billing/portal` and `POST /api/zero/billing/downgrade` handlers previously ignored required request body fields declared by their contracts
- Removes the now-unused `BillingStatus` type alias from `billing.ts` (it was a re-export of `BillingStatusResponse` from `@vm0/core` only consumed by the mock handler)

Closes #9941

## Test plan

- [x] `pnpm -F @vm0/app check-types` clean
- [x] `pnpm -F @vm0/app lint` clean
- [x] `pnpm -F @vm0/app exec vitest run "billing"` — 3 test files, 54 tests, all passing
- [x] knip — no unused exports or dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)