### PR TITLE
fix(platform): restore chat scroll position at container bind time

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
@@ -372,4 +372,79 @@ describe("createScrollSignals - scroll position persistence", () => {
     context.store.set(scrollToBottom$);
     expect(second.scrollTop).toBe(1000);
   });
+
+  it("restores saved position when ResizeObserver fires before scrollToBottom$ (VC-SCROLL-011)", () => {
+    const threadId = `thread-${Math.random().toString(36).slice(2)}`;
+
+    // Seed a saved position against a normal-sized container.
+    const first = mountContainer(threadId);
+    {
+      const { setScrollContainer$ } = createScrollSignals(threadId);
+      context.store.set(setScrollContainer$, first);
+
+      first.scrollTop = 700;
+      first.dispatchEvent(new Event("scroll"));
+      first.dispatchEvent(new Event("wheel"));
+      first.scrollTop = 250;
+      first.dispatchEvent(new Event("scroll"));
+    }
+
+    // Simulate the real chat-page flow: ResizeObserver fires as messages
+    // render — BEFORE the caller gets to invoke scrollToBottom$ (which is
+    // awaited behind groupedChatMessages$ in chat-page-setup).
+    let roCallback: ResizeObserverCallback | null = null;
+    const originalRO = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        roCallback = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      const second = document.createElement("div");
+      const inner = document.createElement("div");
+      second.appendChild(inner);
+      document.body.appendChild(second);
+
+      let scrollHeight = 300;
+      Object.defineProperty(second, "scrollHeight", {
+        get: () => {
+          return scrollHeight;
+        },
+        configurable: true,
+      });
+      Object.defineProperty(second, "clientHeight", {
+        get: () => {
+          return 300;
+        },
+        configurable: true,
+      });
+
+      const { setScrollContainer$, scrollToBottom$ } =
+        createScrollSignals(threadId);
+      context.store.set(setScrollContainer$, second);
+
+      // Messages render, ResizeObserver fires. Must NOT scroll to bottom
+      // (which would trigger onScroll → clearCachedScrollTop and wipe the
+      // restore target).
+      scrollHeight = 1000;
+      if (!roCallback) {
+        throw new Error("ResizeObserver callback not captured");
+      }
+      (roCallback as ResizeObserverCallback)(
+        [],
+        {} as unknown as ResizeObserver,
+      );
+
+      // chat-page-setup fires scrollToBottom$ after awaiting messages.
+      context.store.set(scrollToBottom$);
+
+      expect(second.scrollTop).toBe(250);
+    } finally {
+      globalThis.ResizeObserver = originalRO;
+    }
+  });
 });

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -53,6 +53,48 @@ function scrollInfo(el: HTMLElement) {
   return `scrollTop=${top} scrollHeight=${height} clientHeight=${client} fromBottom=${fromBottom}`;
 }
 
+interface RestoreState {
+  pendingRestorePosition: number | null;
+  suppressNextScrollToBottom: boolean;
+}
+
+function attachUserInputListeners(
+  el: HTMLElement,
+  markUserInput: () => void,
+  onScroll: () => void,
+  signal: AbortSignal,
+) {
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (isUserScrollKey(e.key)) {
+      markUserInput();
+    }
+  };
+  el.addEventListener("scroll", onScroll, { passive: true });
+  el.addEventListener("wheel", markUserInput, { passive: true });
+  el.addEventListener("touchmove", markUserInput, { passive: true });
+  el.addEventListener("pointerdown", markUserInput, { passive: true });
+  el.addEventListener("keydown", onKeyDown, { passive: true });
+  signal.addEventListener("abort", () => {
+    el.removeEventListener("scroll", onScroll);
+    el.removeEventListener("wheel", markUserInput);
+    el.removeEventListener("touchmove", markUserInput);
+    el.removeEventListener("pointerdown", markUserInput);
+    el.removeEventListener("keydown", onKeyDown);
+  });
+}
+
+function observeContainerResize(
+  el: HTMLElement,
+  onResize: () => void,
+  signal: AbortSignal,
+) {
+  const resizeObserver = new ResizeObserver(onResize);
+  resizeObserver.observe(el.firstElementChild ?? el);
+  signal.addEventListener("abort", () => {
+    resizeObserver.disconnect();
+  });
+}
+
 /**
  * Factory that creates scroll-management signals for a scrollable container.
  *
@@ -79,13 +121,15 @@ function scrollInfo(el: HTMLElement) {
 export function createScrollSignals(id?: string) {
   const internalScrollContainer$ = state<HTMLElement | null>(null);
   const autoScrollDisabled$ = state(false);
-  // Held while ResizeObserver is still growing the container up to a saved
-  // position — set scrollTop clamps early and needs to be re-applied.
-  let pendingRestorePosition: number | null = null;
-  // True when bind-time restore happened and the caller has not yet fired
-  // its post-load scrollToBottom$. That call must be suppressed so it
-  // doesn't override the restored position.
-  let suppressNextScrollToBottom = false;
+  // `pendingRestorePosition` is held while ResizeObserver is still growing the
+  // container up to a saved position — set scrollTop clamps early and needs to
+  // be re-applied. `suppressNextScrollToBottom` is set when bind-time restore
+  // happened and the caller has not yet fired its post-load scrollToBottom$.
+  // That call must be suppressed so it doesn't override the restored position.
+  const restoreState: RestoreState = {
+    pendingRestorePosition: null,
+    suppressNextScrollToBottom: false,
+  };
 
   const setScrollContainer$ = onRef(
     command(({ get, set }, el: HTMLElement, signal: AbortSignal) => {
@@ -95,8 +139,8 @@ export function createScrollSignals(id?: string) {
       const saved =
         id !== undefined ? get(scrollPositionCache$).get(id) : undefined;
       if (saved !== undefined) {
-        pendingRestorePosition = saved;
-        suppressNextScrollToBottom = true;
+        restoreState.pendingRestorePosition = saved;
+        restoreState.suppressNextScrollToBottom = true;
         el.scrollTop = saved;
         set(autoScrollDisabled$, true);
         L.debug("container bound → restoring", `id=${id}`, `saved=${saved}`);
@@ -107,13 +151,7 @@ export function createScrollSignals(id?: string) {
 
       const markUserInput = () => {
         lastUserInputAt = performance.now();
-        suppressNextScrollToBottom = false;
-      };
-
-      const onKeyDown = (e: KeyboardEvent) => {
-        if (isUserScrollKey(e.key)) {
-          markUserInput();
-        }
+        restoreState.suppressNextScrollToBottom = false;
       };
 
       const onScroll = () => {
@@ -121,8 +159,8 @@ export function createScrollSignals(id?: string) {
           el.scrollHeight - el.scrollTop - el.clientHeight;
         const userRecent =
           performance.now() - lastUserInputAt < USER_INPUT_WINDOW_MS;
-        if (pendingRestorePosition !== null && userRecent) {
-          pendingRestorePosition = null;
+        if (restoreState.pendingRestorePosition !== null && userRecent) {
+          restoreState.pendingRestorePosition = null;
         }
         if (distanceFromBottom <= AT_BOTTOM_THRESHOLD) {
           const wasDisabled = get(autoScrollDisabled$);
@@ -156,41 +194,29 @@ export function createScrollSignals(id?: string) {
         lastKnownScrollTop = el.scrollTop;
       };
 
-      el.addEventListener("scroll", onScroll, { passive: true });
-      el.addEventListener("wheel", markUserInput, { passive: true });
-      el.addEventListener("touchmove", markUserInput, { passive: true });
-      el.addEventListener("pointerdown", markUserInput, { passive: true });
-      el.addEventListener("keydown", onKeyDown, { passive: true });
+      attachUserInputListeners(el, markUserInput, onScroll, signal);
 
-      const resizeObserver = new ResizeObserver(() => {
-        const disabled = get(autoScrollDisabled$);
-        L.debug("ResizeObserver fired", scrollInfo(el), `disabled=${disabled}`);
-        if (pendingRestorePosition !== null) {
-          el.scrollTop = pendingRestorePosition;
-          if (el.scrollTop >= pendingRestorePosition) {
-            pendingRestorePosition = null;
+      observeContainerResize(
+        el,
+        () => {
+          const disabled = get(autoScrollDisabled$);
+          L.debug("ResizeObserver fired", scrollInfo(el), `disabled=${disabled}`);
+          if (restoreState.pendingRestorePosition !== null) {
+            el.scrollTop = restoreState.pendingRestorePosition;
+            if (el.scrollTop >= restoreState.pendingRestorePosition) {
+              restoreState.pendingRestorePosition = null;
+            }
+            return;
           }
-          return;
-        }
-        if (!disabled) {
-          el.scrollTop = el.scrollHeight;
-        }
-      });
-      const inner = el.firstElementChild;
-      if (inner) {
-        resizeObserver.observe(inner);
-      } else {
-        resizeObserver.observe(el);
-      }
+          if (!disabled) {
+            el.scrollTop = el.scrollHeight;
+          }
+        },
+        signal,
+      );
 
       signal.addEventListener("abort", () => {
         L.debug("container unbound (abort)");
-        resizeObserver.disconnect();
-        el.removeEventListener("scroll", onScroll);
-        el.removeEventListener("wheel", markUserInput);
-        el.removeEventListener("touchmove", markUserInput);
-        el.removeEventListener("pointerdown", markUserInput);
-        el.removeEventListener("keydown", onKeyDown);
         set(internalScrollContainer$, null);
       });
     }),
@@ -217,8 +243,8 @@ export function createScrollSignals(id?: string) {
       L.debug("scrollToBottom$ SKIPPED (no container)");
       return;
     }
-    if (suppressNextScrollToBottom) {
-      suppressNextScrollToBottom = false;
+    if (restoreState.suppressNextScrollToBottom) {
+      restoreState.suppressNextScrollToBottom = false;
       L.debug("scrollToBottom$ → skipped (restore in progress)");
       return;
     }

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -66,29 +66,48 @@ function scrollInfo(el: HTMLElement) {
  * `scrollToBottom$`  — unconditional force scroll (ignores disabled state).
  *
  * When `id` is provided, the user's last non-bottom scroll position is
- * persisted in a module-level cache. On the first `scrollToBottom$` call
- * after a new container binds with the same id, the saved position is
- * restored instead — this preserves reading position across chat-thread
- * switches. The cache is cleared once the user scrolls back to the bottom.
+ * persisted in a module-level cache. At container-bind time, if the cache
+ * holds a saved position for this id, auto-scroll is disabled and the
+ * position is queued for restore — this preserves reading position across
+ * chat-thread switches. Restore must happen at bind (not on the first
+ * `scrollToBottom$` call) because ResizeObserver fires as soon as messages
+ * render and would otherwise auto-scroll to bottom first, triggering the
+ * "user reached bottom" path that clears the cache before the caller gets
+ * a chance to invoke `scrollToBottom$`. The cache is cleared once the user
+ * scrolls back to the bottom.
  */
 export function createScrollSignals(id?: string) {
   const internalScrollContainer$ = state<HTMLElement | null>(null);
   const autoScrollDisabled$ = state(false);
-  let firstScrollToBottomCall = true;
   // Held while ResizeObserver is still growing the container up to a saved
   // position — set scrollTop clamps early and needs to be re-applied.
   let pendingRestorePosition: number | null = null;
+  // True when bind-time restore happened and the caller has not yet fired
+  // its post-load scrollToBottom$. That call must be suppressed so it
+  // doesn't override the restored position.
+  let suppressNextScrollToBottom = false;
 
   const setScrollContainer$ = onRef(
     command(({ get, set }, el: HTMLElement, signal: AbortSignal) => {
       set(internalScrollContainer$, el);
       L.debug("container bound");
 
+      const saved =
+        id !== undefined ? get(scrollPositionCache$).get(id) : undefined;
+      if (saved !== undefined) {
+        pendingRestorePosition = saved;
+        suppressNextScrollToBottom = true;
+        el.scrollTop = saved;
+        set(autoScrollDisabled$, true);
+        L.debug("container bound → restoring", `id=${id}`, `saved=${saved}`);
+      }
+
       let lastKnownScrollTop = el.scrollTop;
       let lastUserInputAt = 0;
 
       const markUserInput = () => {
         lastUserInputAt = performance.now();
+        suppressNextScrollToBottom = false;
       };
 
       const onKeyDown = (e: KeyboardEvent) => {
@@ -192,23 +211,16 @@ export function createScrollSignals(id?: string) {
     scrollEl.scrollTop = scrollEl.scrollHeight;
   });
 
-  const scrollToBottom$ = command(({ get, set }) => {
+  const scrollToBottom$ = command(({ get }) => {
     const scrollEl = get(internalScrollContainer$);
     if (!scrollEl) {
       L.debug("scrollToBottom$ SKIPPED (no container)");
       return;
     }
-    const wasFirst = firstScrollToBottomCall;
-    firstScrollToBottomCall = false;
-    if (wasFirst && id !== undefined) {
-      const saved = get(scrollPositionCache$).get(id);
-      if (saved !== undefined) {
-        pendingRestorePosition = saved;
-        scrollEl.scrollTop = saved;
-        set(autoScrollDisabled$, true);
-        L.debug("scrollToBottom$ → restored", `id=${id}`, `saved=${saved}`);
-        return;
-      }
+    if (suppressNextScrollToBottom) {
+      suppressNextScrollToBottom = false;
+      L.debug("scrollToBottom$ → skipped (restore in progress)");
+      return;
     }
     L.debug("scrollToBottom$ → scrolling to bottom", scrollInfo(scrollEl));
     scrollEl.scrollTop = scrollEl.scrollHeight;

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -200,7 +200,11 @@ export function createScrollSignals(id?: string) {
         el,
         () => {
           const disabled = get(autoScrollDisabled$);
-          L.debug("ResizeObserver fired", scrollInfo(el), `disabled=${disabled}`);
+          L.debug(
+            "ResizeObserver fired",
+            scrollInfo(el),
+            `disabled=${disabled}`,
+          );
           if (restoreState.pendingRestorePosition !== null) {
             el.scrollTop = restoreState.pendingRestorePosition;
             if (el.scrollTop >= restoreState.pendingRestorePosition) {


### PR DESCRIPTION
## Summary

Move the saved-scroll-position restore from the first `scrollToBottom$` call to `setScrollContainer$` bind time. `ResizeObserver` fires as soon as messages render — before `chat-page-setup` gets a chance to invoke `scrollToBottom$` — so the old flow auto-scrolled to bottom first, which triggered the "user reached bottom" path and wiped the cache before restore could run.

## Changes

- Restore the cached scroll position inline in `setScrollContainer$` when a saved value exists for the thread `id`, disable auto-scroll, and queue the position for `ResizeObserver` re-clamps.
- Add `suppressNextScrollToBottom` flag to swallow the caller's post-load `scrollToBottom$` so the restored position isn't overridden. Cleared on user input.
- Remove the stale `firstScrollToBottomCall` gate.

## Test plan

- [x] Add regression test `VC-SCROLL-011` that mocks `ResizeObserver` to fire before `scrollToBottom$`, asserting the saved position is honored.
- [x] All existing auto-scroll tests still pass (`pnpm -F @vm0/app exec vitest run src/signals/__tests__/auto-scroll.test.ts` — 11/11).
- [x] Type check passes (`pnpm check-types`).