### PR TITLE
fix(platform): scroll chat to bottom before hiding skeleton

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { animationFrame } from "signal-timers";
 import { SidebarLayout } from "../../views/zero-page/sidebar-layout.tsx";
 import { ZeroChatThreadPage } from "../../views/zero-page/zero-chat-thread-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -76,7 +77,30 @@ export const setupChatPage$ = command(
 
     await get(thread.groupedChatMessages$);
     signal.throwIfAborted();
+
+    // Wait one animation frame so React flushes the message DOM before we
+    // scroll. The list is mounted with visibility:hidden under the skeleton,
+    // so scrollHeight is already correct — we just need the commit to land.
+    await new Promise<void>((resolve, reject) => {
+      if (signal.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      const onAbort = () => {
+        reject(signal.reason);
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      animationFrame(
+        () => {
+          signal.removeEventListener("abort", onAbort);
+          resolve();
+        },
+        { signal },
+      );
+    });
+    signal.throwIfAborted();
     set(thread.scrollToBottom$);
+    set(thread.hideSkeleton$);
 
     await set(thread.loadPagedMessages$, signal);
   },

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -78,29 +78,16 @@ export const setupChatPage$ = command(
     await get(thread.groupedChatMessages$);
     signal.throwIfAborted();
 
-    // Wait one animation frame so React flushes the message DOM before we
-    // scroll. The list is mounted with visibility:hidden under the skeleton,
-    // so scrollHeight is already correct — we just need the commit to land.
-    await new Promise<void>((resolve, reject) => {
-      if (signal.aborted) {
-        reject(signal.reason);
-        return;
-      }
-      const onAbort = () => {
-        reject(signal.reason);
-      };
-      signal.addEventListener("abort", onAbort, { once: true });
-      animationFrame(
-        () => {
-          signal.removeEventListener("abort", onAbort);
-          resolve();
-        },
-        { signal },
-      );
-    });
-    signal.throwIfAborted();
-    set(thread.scrollToBottom$);
-    set(thread.hideSkeleton$);
+    // The list is mounted with visibility:hidden under the skeleton so
+    // scrollHeight is already correct; wait one frame for React to commit
+    // the message DOM, then scroll and reveal in the same tick.
+    animationFrame(
+      () => {
+        set(thread.scrollToBottom$);
+        set(thread.hideSkeleton$);
+      },
+      { signal },
+    );
 
     await set(thread.loadPagedMessages$, signal);
   },

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -45,6 +45,12 @@ export interface ChatThreadSignals {
   setScrollContainer$: Command<(() => void) | undefined, [HTMLElement | null]>;
   autoScroll$: Command<void, []>;
   scrollToBottom$: Command<void, []>;
+  // ── Initial-load skeleton ────────────────────────────────────────────────
+  // True until the page setup has fetched messages and scrolled into place.
+  // Keeps the list mounted (visibility:hidden) while the skeleton covers the
+  // viewport, so the first paint the user sees is already at the bottom.
+  skeletonVisible$: Computed<boolean>;
+  hideSkeleton$: Command<void, []>;
   draft: DraftSignals;
   composerFileInput$: Computed<HTMLElement | null>;
   setComposerFileInput$: Command<
@@ -575,6 +581,17 @@ export const ensureDraft$ = command(
   },
 );
 
+function createSkeletonSignals() {
+  const internalSkeletonVisible$ = state(true);
+  const skeletonVisible$ = computed((get) => {
+    return get(internalSkeletonVisible$);
+  });
+  const hideSkeleton$ = command(({ set }) => {
+    set(internalSkeletonVisible$, false);
+  });
+  return { skeletonVisible$, hideSkeleton$ };
+}
+
 function createInputRef() {
   const internalInputRef$ = state<HTMLElement | null>(null);
   const setInputRef$ = onRef(
@@ -702,6 +719,7 @@ export function createChatThreadSignals(
   const { threadData$, reloadThread$ } = createThreadData(threadId);
   const { setScrollContainer$, autoScroll$, scrollToBottom$ } =
     createScrollSignals(threadId);
+  const { skeletonVisible$, hideSkeleton$ } = createSkeletonSignals();
   const { composerFileInput$, setComposerFileInput$ } =
     createComposerFileInput();
   const { agentId$, agentDisplayName$, agentPinned$ } =
@@ -807,6 +825,8 @@ export function createChatThreadSignals(
     setScrollContainer$,
     autoScroll$,
     scrollToBottom$,
+    skeletonVisible$,
+    hideSkeleton$,
     draft,
     composerFileInput$,
     setComposerFileInput$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
@@ -5,6 +5,7 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { detachedNavigateTo$ } from "../../../signals/route.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
 
@@ -364,5 +365,121 @@ describe("zero chat thread page - messages remain visible during re-fetch", () =
     await waitFor(() => {
       expect(screen.getByText("Thread B message")).toBeInTheDocument();
     });
+  });
+});
+
+// CHAT-SCROLL-009: regression guard for the "skeleton → jump → bottom" glitch.
+// `setupChatPage$` must scroll the list to the bottom BEFORE hiding the
+// skeleton, and the message container must stay `visibility: hidden` while
+// the skeleton overlay is up so the first paint the user sees is already at
+// the bottom. Covers the fix in PR #9995.
+describe("zero chat thread page - scrolls before hiding skeleton", () => {
+  it("message container is visibility:hidden under the skeleton, and scrollTop lands at scrollHeight before the skeleton is removed (CHAT-SCROLL-009)", async () => {
+    const messagesDeferred = createDeferredPromise<void>(context.signal);
+
+    server.use(
+      http.get(
+        "*/api/zero/chat-threads/thread-pre-scroll/messages",
+        async ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("sinceId")) {
+            return HttpResponse.json({ messages: [], hasMore: false });
+          }
+          // Defer the initial page so we can observe the skeleton overlay
+          // covering the message container with visibility:hidden beneath it.
+          await messagesDeferred.promise;
+          return HttpResponse.json({
+            messages: [
+              {
+                id: "msg-pre-1",
+                role: "user" as const,
+                content: "Pre-scroll user message",
+                createdAt: "2026-03-10T00:00:00Z",
+              },
+              {
+                id: "msg-pre-2",
+                role: "assistant" as const,
+                content: "Pre-scroll assistant reply",
+                createdAt: "2026-03-10T00:00:01Z",
+              },
+            ],
+            hasMore: false,
+          });
+        },
+      ),
+      http.get("*/api/zero/chat-threads/thread-pre-scroll", () => {
+        return HttpResponse.json({
+          id: "thread-pre-scroll",
+          title: null,
+          agentId: "c0000000-0000-4000-a000-000000000001",
+          chatMessages: [],
+          latestSessionId: null,
+          activeRunIds: [],
+          unsavedRuns: [],
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    // Intercept the scroll container as soon as it mounts and give it a
+    // non-zero scrollHeight so `scrollToBottom$` has something to scroll to.
+    const observer = new MutationObserver(() => {
+      const el = document.querySelector<HTMLElement>("[data-scroll-container]");
+      if (!el) {
+        return;
+      }
+      Object.defineProperty(el, "scrollHeight", {
+        get: () => {
+          return 800;
+        },
+        configurable: true,
+      });
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    try {
+      detachedSetupPage({ context, path: "/chats/thread-pre-scroll" });
+
+      // While the messages fetch is pending, the skeleton overlay should be
+      // up AND the message container should be rendered with
+      // visibility:hidden (so its scrollHeight is already correct when we
+      // eventually scroll).
+      await waitFor(() => {
+        const skeleton = document.querySelector("[data-chat-skeleton]");
+        const container = document.querySelector<HTMLElement>(
+          "[data-message-container]",
+        );
+        expect(skeleton).not.toBeNull();
+        expect(container).not.toBeNull();
+        expect(container!.style.visibility).toBe("hidden");
+      });
+
+      // Resolve the messages fetch — `setupChatPage$` should now scroll to
+      // the bottom BEFORE hiding the skeleton.
+      messagesDeferred.resolve();
+
+      // After setup completes: skeleton is gone, container is visible, and
+      // scrollTop landed at scrollHeight.
+      await waitFor(() => {
+        expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+      });
+
+      const scrollContainer = document.querySelector<HTMLElement>(
+        "[data-scroll-container]",
+      );
+      const container = document.querySelector<HTMLElement>(
+        "[data-message-container]",
+      );
+      expect(scrollContainer).not.toBeNull();
+      expect(container).not.toBeNull();
+      expect(container!.style.visibility).toBe("visible");
+      expect(scrollContainer!.scrollTop).toBe(800);
+    } finally {
+      observer.disconnect();
+    }
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -233,51 +233,67 @@ export function ZeroChatThreadPageInner({
   const messagesLoading = groupsLoadable.state === "loading";
   const groups = groupsLoadable.state === "hasData" ? groupsLoadable.data : [];
   const setScrollContainer = useSet(thread.setScrollContainer$);
+  const skeletonVisible = useGet(thread.skeletonVisible$);
 
   return (
     <div className="flex flex-1 flex-col min-h-0 bg-transparent">
       <ChatThreadHeader thread={thread} />
 
-      <div
-        ref={setScrollContainer}
-        data-scroll-container
-        className="flex-1 overflow-y-auto [scrollbar-gutter:stable] min-h-0"
-      >
-        <main className="px-4 sm:px-6 py-4 items-center @container">
-          <div
-            data-message-container
-            className="w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4 overflow-visible"
-          >
-            {sessionError && (
-              <div className="flex-1 flex items-center justify-center py-16">
-                <div className="flex items-center gap-2 text-destructive">
-                  <IconAlertCircle size={16} />
-                  <p className="text-sm">{sessionError}</p>
+      <div className="flex-1 min-h-0 relative">
+        <div
+          ref={setScrollContainer}
+          data-scroll-container
+          className="absolute inset-0 overflow-y-auto [scrollbar-gutter:stable]"
+        >
+          <main className="px-4 sm:px-6 py-4 items-center @container">
+            <div
+              data-message-container
+              className="w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4 overflow-visible"
+              style={{ visibility: skeletonVisible ? "hidden" : "visible" }}
+            >
+              {sessionError && (
+                <div className="flex-1 flex items-center justify-center py-16">
+                  <div className="flex items-center gap-2 text-destructive">
+                    <IconAlertCircle size={16} />
+                    <p className="text-sm">{sessionError}</p>
+                  </div>
                 </div>
+              )}
+              {!sessionError &&
+                groups.length === 0 &&
+                !messagesLoading &&
+                !skeletonVisible && (
+                  <div className="flex-1 flex items-center justify-center py-16">
+                    <p className="text-sm text-muted-foreground">
+                      Send a message to start the conversation
+                    </p>
+                  </div>
+                )}
+              {groups.map((group) => {
+                return (
+                  <PagedGroupRow
+                    key={group.beginMessageId}
+                    group={group}
+                    thread={thread}
+                  />
+                );
+              })}
+              <ThinkingIndicator thread={thread} />
+            </div>
+          </main>
+        </div>
+        {skeletonVisible && !sessionError && (
+          <div
+            data-chat-skeleton
+            className="absolute inset-0 overflow-hidden pointer-events-none"
+          >
+            <main className="px-4 sm:px-6 py-4 items-center @container">
+              <div className="w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4">
+                <ChatSkeleton />
               </div>
-            )}
-            {!sessionError && groups.length === 0 && messagesLoading && (
-              <ChatSkeleton />
-            )}
-            {!sessionError && groups.length === 0 && !messagesLoading && (
-              <div className="flex-1 flex items-center justify-center py-16">
-                <p className="text-sm text-muted-foreground">
-                  Send a message to start the conversation
-                </p>
-              </div>
-            )}
-            {groups.map((group) => {
-              return (
-                <PagedGroupRow
-                  key={group.beginMessageId}
-                  group={group}
-                  thread={thread}
-                />
-              );
-            })}
-            <ThinkingIndicator thread={thread} />
+            </main>
           </div>
-        </main>
+        )}
       </div>
 
       <ChatThreadComposer thread={thread} autoFocus={autoFocus} />


### PR DESCRIPTION
## Summary

The chat thread page used to drop the skeleton the moment messages resolved, then scroll a render-tick later — producing a few-hundred-ms visual jump as the list appeared and then snapped to bottom.

This change restructures the initial-load sequence so the first paint the user sees is already at the bottom:

- New per-thread \`skeletonVisible\$\` signal (starts \`true\`, set to \`false\` by \`hideSkeleton\$\`).
- Message list is always mounted, but wrapped in \`visibility: hidden\` while \`skeletonVisible\$\` is true. That keeps \`scrollHeight\` correct for the eventual \`scrollToBottom\$\` call.
- Skeleton is rendered as an \`absolute inset-0\` overlay inside the scroll-container wrapper, so it covers the viewport without contributing to scroll height.
- \`setupChatPage\$\` now: await messages → one animation frame (for React to flush DOM) → \`scrollToBottom\$\` → \`hideSkeleton\$\`.

## Test plan

- [x] \`pnpm -F @vm0/app check-types\` — clean
- [x] \`pnpm -F @vm0/app lint\` — clean
- [x] Targeted vitest run (\`chat-skeleton-switch\`, \`chat-scroll-behavior\`, \`zero-chat-thread-page-*\`, \`chat-session-switch\`, etc.): 53 tests pass
- [ ] Manual QA: open a chat with long history — should land at the bottom on first paint with no visible "jump"
- [ ] Manual QA: switch between two chats with different saved scroll positions — restored position should still be correct under the new sequencing
- [ ] Manual QA: open a brand-new empty thread — "Send a message to start the conversation" placeholder still appears (only after skeleton flips off)