### PR TITLE
refactor(platform): migrate api-feature-switches.ts to mockApi helper

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-feature-switches.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-feature-switches.ts
@@ -4,7 +4,9 @@
  * Mock handlers for /api/zero/feature-switches endpoint.
  */
 
-import { http, HttpResponse } from "msw";
+import { zeroFeatureSwitchesContract } from "@vm0/core";
+
+import { mockApi } from "../msw-contract.ts";
 
 let mockSwitches: Record<string, boolean> = {};
 
@@ -19,17 +21,12 @@ export function setMockFeatureSwitches(
 }
 
 export const apiFeatureSwitchesHandlers = [
-  // GET /api/zero/feature-switches
-  http.get("*/api/zero/feature-switches", () => {
-    return HttpResponse.json({ switches: mockSwitches });
+  mockApi(zeroFeatureSwitchesContract.get, ({ respond }) => {
+    return respond(200, { switches: mockSwitches });
   }),
 
-  // POST /api/zero/feature-switches
-  http.post("*/api/zero/feature-switches", async ({ request }) => {
-    const body = (await request.json()) as {
-      switches: Record<string, boolean>;
-    };
+  mockApi(zeroFeatureSwitchesContract.update, ({ body, respond }) => {
     mockSwitches = { ...mockSwitches, ...body.switches };
-    return HttpResponse.json({ switches: mockSwitches });
+    return respond(200, { switches: mockSwitches });
   }),
 ];


### PR DESCRIPTION
## Summary

- Replaces raw `http.*` MSW calls in `api-feature-switches.ts` with the contract-driven `mockApi` helper
- `body` is now typed from `zeroFeatureSwitchesContract` — removes the manual `as { switches: Record<string, boolean> }` cast
- Response shape is compile-time checked via `respond(200, { switches: mockSwitches })`
- All exported symbols (`apiFeatureSwitchesHandlers`, `resetMockFeatureSwitches`, `setMockFeatureSwitches`) are preserved unchanged

Closes #9948. Part of #9707 Phase 1.

## Test plan

- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm -F @vm0/app lint` — clean (0 warnings, 0 errors)
- [x] `feature-switch.test.ts` — all 7 tests pass
- [x] `voice-banner.test.tsx` — all tests pass
- [x] `auto-read-toggle.test.tsx` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)