### PR TITLE
feat(platform): persist sidebar collapse state in localStorage

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { localStorageSignals } from "../external/local-storage.ts";
 
 // ---------------------------------------------------------------------------
 // Sidebar search state
@@ -71,28 +72,44 @@ export const setPendingDeleteThreadId$ = command(
 );
 
 // ---------------------------------------------------------------------------
-// Session list collapse state (RecentChatSection)
+// Session list collapse state (RecentChatSection) — persisted in localStorage
 // ---------------------------------------------------------------------------
-const internalSessionListCollapsed$ = state(false);
+const {
+  get$: sessionListCollapsedRaw$,
+  set$: setSessionListCollapsedRaw$,
+  clear$: clearSessionListCollapsed$,
+} = localStorageSignals("sessionListCollapsed");
 export const sessionListCollapsed$ = computed((get) => {
-  return get(internalSessionListCollapsed$);
+  return get(sessionListCollapsedRaw$) !== null;
 });
 export const setSessionListCollapsed$ = command(
   ({ set }, collapsed: boolean) => {
-    set(internalSessionListCollapsed$, collapsed);
+    if (collapsed) {
+      set(setSessionListCollapsedRaw$, "1");
+    } else {
+      set(clearSessionListCollapsed$);
+    }
   },
 );
 
 // ---------------------------------------------------------------------------
-// Manage section collapse state (ZeroSidebar)
+// Manage section collapse state (ZeroSidebar) — persisted in localStorage
 // ---------------------------------------------------------------------------
-const internalManageSectionCollapsed$ = state(false);
+const {
+  get$: manageSectionCollapsedRaw$,
+  set$: setManageSectionCollapsedRaw$,
+  clear$: clearManageSectionCollapsed$,
+} = localStorageSignals("manageCollapsed");
 export const manageSectionCollapsed$ = computed((get) => {
-  return get(internalManageSectionCollapsed$);
+  return get(manageSectionCollapsedRaw$) !== null;
 });
 export const setManageSectionCollapsed$ = command(
   ({ set }, collapsed: boolean) => {
-    set(internalManageSectionCollapsed$, collapsed);
+    if (collapsed) {
+      set(setManageSectionCollapsedRaw$, "1");
+    } else {
+      set(clearManageSectionCollapsed$);
+    }
   },
 );
 
@@ -108,14 +125,22 @@ export const setChatListOpen$ = command(({ set }, open: boolean) => {
 });
 
 // ---------------------------------------------------------------------------
-// Agent card / pinned section collapse state (TalkToSection)
+// Agent card / pinned section collapse state (TalkToSection) — persisted in localStorage
 // ---------------------------------------------------------------------------
-const internalAgentCardCollapsed$ = state(false);
+const {
+  get$: agentCardCollapsedRaw$,
+  set$: setAgentCardCollapsedRaw$,
+  clear$: clearAgentCardCollapsed$,
+} = localStorageSignals("pinnedCollapsed");
 export const agentCardCollapsed$ = computed((get) => {
-  return get(internalAgentCardCollapsed$);
+  return get(agentCardCollapsedRaw$) !== null;
 });
 export const setAgentCardCollapsed$ = command(({ set }, collapsed: boolean) => {
-  set(internalAgentCardCollapsed$, collapsed);
+  if (collapsed) {
+    set(setAgentCardCollapsedRaw$, "1");
+  } else {
+    set(clearAgentCardCollapsed$);
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Swap in-memory `ccstate` atoms for `localStorageSignals` on the three sidebar collapse states (pinned, manage, recent chats) so users' collapse preferences survive a page reload.
- Keys: `pinnedCollapsed`, `manageCollapsed`, `sessionListCollapsed` — flat, matching existing `sidebarOff` / `theme` style.
- Semantics: absent key → expanded (existing default); `"1"` → collapsed. Old users with no value keep seeing the sections expanded, so no behavior change on first load after this ships.
- Public export names and signatures (`manageSectionCollapsed$`, `agentCardCollapsed$`, `sessionListCollapsed$` and their setters) are unchanged, so the three consumer files (`zero-sidebar.tsx`, `zero-sidebar-pinned.tsx`, `sidebar-threads.tsx`) need no edits.

Single-file diff: `turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts`.

## Test plan

- [ ] Collapse the **Pinned** section, reload the page — stays collapsed.
- [ ] Collapse the **Manage** section, reload — stays collapsed.
- [ ] Collapse the **Recent chats** section, reload — stays collapsed.
- [ ] Expand a previously-collapsed section, reload — stays expanded (key cleared).
- [ ] Fresh browser / incognito: all three sections render expanded on first load.
- [ ] Inspect `localStorage` — keys appear/disappear exactly as above.