### PR TITLE
feat(web): sort chat threads by latest message time

### DIFF
--- a/turbo/apps/web/app/api/zero/chat-threads/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/__tests__/route.test.ts
@@ -346,6 +346,113 @@ describe("GET /api/zero/chat-threads - List Threads", () => {
     expect(ids).not.toContain(archivedId);
   });
 
+  it("orders threads by the latest message's createdAt desc", async () => {
+    const olderCreate = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "Older" }),
+      }),
+    );
+    const { id: olderId } = await olderCreate.json();
+    await insertTestChatMessage({
+      chatThreadId: olderId,
+      role: "user",
+      content: "first",
+    });
+
+    await new Promise((resolve) => {
+      return setTimeout(resolve, 10);
+    });
+
+    const newerCreate = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "Newer" }),
+      }),
+    );
+    const { id: newerId } = await newerCreate.json();
+    await insertTestChatMessage({
+      chatThreadId: newerId,
+      role: "user",
+      content: "second",
+    });
+
+    const initial = await (
+      await GET(
+        createTestRequest(
+          `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+        ),
+      )
+    ).json();
+    expect(
+      initial.threads.map((t: { id: string }) => {
+        return t.id;
+      }),
+    ).toEqual([newerId, olderId]);
+
+    // A new message on the older thread should bump it to the top.
+    await new Promise((resolve) => {
+      return setTimeout(resolve, 10);
+    });
+    await insertTestChatMessage({
+      chatThreadId: olderId,
+      role: "assistant",
+      content: "reply",
+    });
+
+    const after = await (
+      await GET(
+        createTestRequest(
+          `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+        ),
+      )
+    ).json();
+    expect(
+      after.threads.map((t: { id: string }) => {
+        return t.id;
+      }),
+    ).toEqual([olderId, newerId]);
+  });
+
+  it("orders empty threads by their own createdAt desc", async () => {
+    const firstCreate = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "First" }),
+      }),
+    );
+    const { id: firstId } = await firstCreate.json();
+
+    await new Promise((resolve) => {
+      return setTimeout(resolve, 10);
+    });
+
+    const secondCreate = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "Second" }),
+      }),
+    );
+    const { id: secondId } = await secondCreate.json();
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(
+      data.threads.map((t: { id: string }) => {
+        return t.id;
+      }),
+    ).toEqual([secondId, firstId]);
+  });
+
   it("keeps a thread visible when only an earlier message is archived", async () => {
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -50,7 +50,11 @@ export async function createChatThread(
 }
 
 /**
- * List chat threads for a user + agent compose, ordered by updatedAt desc.
+ * List chat threads for a user + agent compose, ordered by the latest
+ * message's createdAt desc (threads with no messages fall back to the
+ * thread's own createdAt). This reflects real conversation activity —
+ * `chat_threads.updatedAt` only changes on title/draft edits, not on new
+ * messages, so sorting by it would bury actively-used threads.
  *
  * Joins each thread to its most recent message and returns that message's
  * read/archive state. Threads whose last message is archived are hidden
@@ -73,6 +77,7 @@ export async function listChatThreads(
   const lastMessage = globalThis.services.db
     .select({
       chatThreadId: chatMessages.chatThreadId,
+      createdAt: chatMessages.createdAt,
       readAt: chatMessages.readAt,
       archivedAt: chatMessages.archivedAt,
       rn: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${chatMessages.chatThreadId} ORDER BY ${chatMessages.createdAt} DESC)`.as(
@@ -103,7 +108,9 @@ export async function listChatThreads(
         isNull(lastMessage.archivedAt),
       ),
     )
-    .orderBy(desc(chatThreads.updatedAt));
+    .orderBy(
+      desc(sql`COALESCE(${lastMessage.createdAt}, ${chatThreads.createdAt})`),
+    );
 
   return threads;
 }


### PR DESCRIPTION
## Summary

- Sort the sidebar chat thread list by the latest message's `created_at` (descending), falling back to the thread's own `created_at` for empty threads.
- Previously sorted by `chat_threads.updated_at`, but that column has no `$onUpdate` and is never written when a new message arrives — so active threads got buried under stale ones whose only recent mutation was a title/draft edit.
- Frontend (`sidebar-threads.tsx` + `chatThreads$` signal) already consumes backend order verbatim, so no client changes.

## Test plan

- [ ] `pnpm -F web exec vitest run app/api/zero/chat-threads` — two new cases cover "new message bumps thread to top" and "empty threads order by own createdAt desc".
- [ ] Existing isRead / isArchived / cross-org filter tests still pass (unchanged paths).
- [ ] Manual: open the sidebar, send a message in an older thread, verify it jumps to the top.