### PR TITLE
refactor(platform): migrate api-integrations-telegram.ts to mockapi helper

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
@@ -2,16 +2,22 @@
  * Telegram Integration API Handlers
  *
  * Mock handlers for /api/integrations/telegram and /api/telegram/register endpoints.
+ *
+ * Path note: these endpoints use /api/integrations/ and /api/telegram/ (not /api/zero/)
+ * because they are served by the platform app directly, not the Zero sub-application.
+ * This is intentional and matches the real server routing.
+ *
  * Default behavior: user has a linked Telegram bot with an agent configured.
  */
 
 import {
   zeroIntegrationsTelegramContract,
+  type TelegramLinkStatusResponse,
   type TelegramStatusResponse,
 } from "@vm0/core";
 import { mockApi } from "../msw-contract.ts";
 
-let mockTelegramData: TelegramStatusResponse = {
+const defaultTelegramData: TelegramStatusResponse = {
   installationId: "install_123",
   bot: { id: "bot_123", username: "test_bot" },
   agent: { id: "compose_1", name: "default-agent" },
@@ -26,21 +32,17 @@ let mockTelegramData: TelegramStatusResponse = {
   },
 };
 
+let mockTelegramData: TelegramStatusResponse =
+  structuredClone(defaultTelegramData);
+
+// Default link-status: unlinked with no installation. Tests that need the
+// linked (telegramUserId) or unlinked-with-installation variants should
+// override this handler via server.use(mockApi(zeroIntegrationsTelegramContract.getLinkStatus, …)).
+let mockLinkStatus: TelegramLinkStatusResponse = { linked: false };
+
 export function resetMockTelegramIntegration(): void {
-  mockTelegramData = {
-    installationId: "install_123",
-    bot: { id: "bot_123", username: "test_bot" },
-    agent: { id: "compose_1", name: "default-agent" },
-    isAdmin: true,
-    isConnected: true,
-    domainConfigured: false,
-    environment: {
-      requiredSecrets: ["ANTHROPIC_API_KEY"],
-      requiredVars: [],
-      missingSecrets: [],
-      missingVars: [],
-    },
-  };
+  mockTelegramData = structuredClone(defaultTelegramData);
+  mockLinkStatus = { linked: false };
 }
 
 export const apiIntegrationsTelegramHandlers = [
@@ -49,7 +51,7 @@ export const apiIntegrationsTelegramHandlers = [
   }),
 
   mockApi(zeroIntegrationsTelegramContract.update, ({ body, respond }) => {
-    if (body?.agentName && mockTelegramData.agent) {
+    if (body.agentName && mockTelegramData.agent) {
       mockTelegramData.agent.name = body.agentName;
     }
     return respond(200, { ok: true });
@@ -60,7 +62,7 @@ export const apiIntegrationsTelegramHandlers = [
   }),
 
   mockApi(zeroIntegrationsTelegramContract.getLinkStatus, ({ respond }) => {
-    return respond(200, { linked: false });
+    return respond(200, mockLinkStatus);
   }),
 
   mockApi(zeroIntegrationsTelegramContract.register, ({ respond }) => {
@@ -68,7 +70,7 @@ export const apiIntegrationsTelegramHandlers = [
       id: "installation_1",
       botId: "bot_123",
       botUsername: "test_bot",
-      webhookUrl: "https://example.com/api/telegram/webhook/installation_1",
+      webhookUrl: "http://localhost/api/telegram/webhook/installation_1",
       domainConfigured: false,
     });
   }),

--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
@@ -5,24 +5,19 @@
  * Default behavior: user has a linked Telegram bot with an agent configured.
  */
 
-import { http, HttpResponse } from "msw";
+import {
+  zeroIntegrationsTelegramContract,
+  type TelegramStatusResponse,
+} from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
 
-interface MockTelegramIntegrationData {
-  bot: { id: string; username: string };
-  agent: { id: string; name: string } | null;
-  isAdmin: boolean;
-  environment: {
-    requiredSecrets: string[];
-    requiredVars: string[];
-    missingSecrets: string[];
-    missingVars: string[];
-  };
-}
-
-let mockTelegramData: MockTelegramIntegrationData = {
+let mockTelegramData: TelegramStatusResponse = {
+  installationId: "install_123",
   bot: { id: "bot_123", username: "test_bot" },
   agent: { id: "compose_1", name: "default-agent" },
   isAdmin: true,
+  isConnected: true,
+  domainConfigured: false,
   environment: {
     requiredSecrets: ["ANTHROPIC_API_KEY"],
     requiredVars: [],
@@ -33,12 +28,12 @@ let mockTelegramData: MockTelegramIntegrationData = {
 
 export function resetMockTelegramIntegration(): void {
   mockTelegramData = {
+    installationId: "install_123",
     bot: { id: "bot_123", username: "test_bot" },
-    agent: {
-      id: "compose_1",
-      name: "default-agent",
-    },
+    agent: { id: "compose_1", name: "default-agent" },
     isAdmin: true,
+    isConnected: true,
+    domainConfigured: false,
     environment: {
       requiredSecrets: ["ANTHROPIC_API_KEY"],
       requiredVars: [],
@@ -49,35 +44,32 @@ export function resetMockTelegramIntegration(): void {
 }
 
 export const apiIntegrationsTelegramHandlers = [
-  // GET /api/integrations/telegram
-  http.get("*/api/integrations/telegram", () => {
-    return HttpResponse.json(mockTelegramData);
+  mockApi(zeroIntegrationsTelegramContract.getStatus, ({ respond }) => {
+    return respond(200, mockTelegramData);
   }),
 
-  // PATCH /api/integrations/telegram
-  http.patch("*/api/integrations/telegram", async ({ request }) => {
-    const body = (await request.json()) as { agentName?: string };
-    if (body.agentName && mockTelegramData.agent) {
+  mockApi(zeroIntegrationsTelegramContract.update, ({ body, respond }) => {
+    if (body?.agentName && mockTelegramData.agent) {
       mockTelegramData.agent.name = body.agentName;
     }
-    return HttpResponse.json({ ok: true });
+    return respond(200, { ok: true });
   }),
 
-  // DELETE /api/integrations/telegram
-  http.delete("*/api/integrations/telegram", () => {
-    return HttpResponse.json({ ok: true });
+  mockApi(zeroIntegrationsTelegramContract.disconnect, ({ respond }) => {
+    return respond(204);
   }),
 
-  // GET /api/integrations/telegram/link
-  http.get("/api/integrations/telegram/link", () => {
-    return HttpResponse.json({ linked: false });
+  mockApi(zeroIntegrationsTelegramContract.getLinkStatus, ({ respond }) => {
+    return respond(200, { linked: false });
   }),
 
-  // POST /api/telegram/register
-  http.post("*/api/telegram/register", () => {
-    return HttpResponse.json({
+  mockApi(zeroIntegrationsTelegramContract.register, ({ respond }) => {
+    return respond(201, {
       id: "installation_1",
+      botId: "bot_123",
       botUsername: "test_bot",
+      webhookUrl: "https://example.com/api/telegram/webhook/installation_1",
+      domainConfigured: false,
     });
   }),
 ];

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -850,3 +850,10 @@ export {
   zeroPhoneSetupContract,
   type PhoneStatusResponse,
 } from "./zero-phone";
+export {
+  zeroIntegrationsTelegramContract,
+  type ZeroIntegrationsTelegramContract,
+  type TelegramStatusResponse,
+  type TelegramRegisterResponse,
+  type TelegramLinkStatusResponse,
+} from "./zero-integrations-telegram";

--- a/turbo/packages/core/src/contracts/zero-integrations-telegram.ts
+++ b/turbo/packages/core/src/contracts/zero-integrations-telegram.ts
@@ -51,6 +51,10 @@ const telegramRegisterResponseSchema = z.object({
 /**
  * Zero integrations Telegram contract
  * Covers all five Telegram integration endpoints.
+ *
+ * Path note: these endpoints use /api/integrations/ and /api/telegram/ (not /api/zero/)
+ * because they are served by the platform app directly, not the Zero sub-application.
+ * This is intentional and matches the real server routing.
  */
 export const zeroIntegrationsTelegramContract = c.router({
   getStatus: {

--- a/turbo/packages/core/src/contracts/zero-integrations-telegram.ts
+++ b/turbo/packages/core/src/contracts/zero-integrations-telegram.ts
@@ -1,0 +1,132 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const telegramEnvironmentSchema = z.object({
+  requiredSecrets: z.array(z.string()),
+  requiredVars: z.array(z.string()),
+  missingSecrets: z.array(z.string()),
+  missingVars: z.array(z.string()),
+});
+
+const telegramStatusResponseSchema = z.object({
+  installationId: z.string(),
+  bot: z.object({ id: z.string(), username: z.string() }),
+  agent: z.object({ id: z.string(), name: z.string() }).nullable(),
+  isAdmin: z.boolean(),
+  isConnected: z.boolean(),
+  domainConfigured: z.boolean(),
+  environment: telegramEnvironmentSchema,
+});
+
+const telegramUpdateBodySchema = z.object({
+  agentName: z.string().min(1),
+});
+
+const telegramLinkStatusResponseSchema = z.discriminatedUnion("linked", [
+  z.object({ linked: z.literal(true), telegramUserId: z.string() }),
+  z.object({
+    linked: z.literal(false),
+    installation: z
+      .object({ id: z.string(), botUsername: z.string() })
+      .optional(),
+  }),
+]);
+
+const telegramRegisterBodySchema = z.object({
+  botToken: z.string().min(1),
+  defaultAgentId: z.string().optional(),
+});
+
+const telegramRegisterResponseSchema = z.object({
+  id: z.string(),
+  botId: z.string(),
+  botUsername: z.string(),
+  webhookUrl: z.string(),
+  domainConfigured: z.boolean(),
+});
+
+/**
+ * Zero integrations Telegram contract
+ * Covers all five Telegram integration endpoints.
+ */
+export const zeroIntegrationsTelegramContract = c.router({
+  getStatus: {
+    method: "GET",
+    path: "/api/integrations/telegram",
+    headers: authHeadersSchema,
+    responses: {
+      200: telegramStatusResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get Telegram bot integration status for the authenticated user",
+  },
+  update: {
+    method: "PATCH",
+    path: "/api/integrations/telegram",
+    headers: authHeadersSchema,
+    body: telegramUpdateBodySchema,
+    responses: {
+      200: z.object({ ok: z.boolean() }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Update the default agent for the Telegram bot",
+  },
+  disconnect: {
+    method: "DELETE",
+    path: "/api/integrations/telegram",
+    headers: authHeadersSchema,
+    body: c.noBody(),
+    responses: {
+      204: c.noBody(),
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Uninstall the Telegram bot (admin only)",
+  },
+  getLinkStatus: {
+    method: "GET",
+    path: "/api/integrations/telegram/link",
+    headers: authHeadersSchema,
+    query: z.object({ botId: z.string().optional() }),
+    responses: {
+      200: telegramLinkStatusResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Check if the authenticated user is linked to a Telegram bot",
+  },
+  register: {
+    method: "POST",
+    path: "/api/telegram/register",
+    headers: authHeadersSchema,
+    body: telegramRegisterBodySchema,
+    responses: {
+      201: telegramRegisterResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+      502: apiErrorSchema,
+    },
+    summary: "Register a Telegram bot with VM0",
+  },
+});
+
+export type ZeroIntegrationsTelegramContract =
+  typeof zeroIntegrationsTelegramContract;
+export type TelegramStatusResponse = z.infer<
+  typeof telegramStatusResponseSchema
+>;
+export type TelegramRegisterResponse = z.infer<
+  typeof telegramRegisterResponseSchema
+>;
+export type TelegramLinkStatusResponse = z.infer<
+  typeof telegramLinkStatusResponseSchema
+>;


### PR DESCRIPTION
## Summary

- Adds new ts-rest contract `zero-integrations-telegram.ts` in `@vm0/core` covering all 5 Telegram endpoints (`GET/PATCH/DELETE /api/integrations/telegram`, `GET /api/integrations/telegram/link`, `POST /api/telegram/register`)
- Migrates `api-integrations-telegram.ts` mock handler from raw `http.*` calls to the contract-driven `mockApi` helper — response, body, and query shapes are now type-checked at compile time
- Fixes pre-existing response drift: `disconnect` now correctly returns 204 no-body (was 200 `{ok:true}`), and `register` returns 201 with the full server-side shape (was 200 with partial shape)
- Exported handler symbols (`apiIntegrationsTelegramHandlers`, `resetMockTelegramIntegration`) are unchanged

Closes #9949. Part of #9707 Phase 1.

## Test plan

- [x] `pnpm -F @vm0/core check-types` — clean
- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm -F @vm0/app lint` — clean
- [x] `pnpm format` — clean (prettier applied, no changes needed)
- [x] `pnpm knip --workspace apps/platform` — no issues
- [x] Mock-related vitest tests pass (msw-contract tests + mocks directory tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)