### PR TITLE
fix(platform): hide chat working indicator until displayName and allFinished resolve

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -298,10 +298,15 @@ function ChatThreadComposer({
 }) {
   const groups = useLastResolved(thread.groupedChatMessages$) ?? [];
   const hasMessages = groups.length > 0;
-  const displayName = useLastResolved(thread.agentDisplayName$) ?? "Zero";
-  const allFinished = useLastResolved(thread.allFinished$) ?? false;
+  const rawDisplayName = useLastResolved(thread.agentDisplayName$);
+  const displayName = rawDisplayName ?? "Zero";
+  const allFinishedLoadable = useLastLoadable(thread.allFinished$);
+  const hasAllFinished = allFinishedLoadable.state === "hasData";
+  const allFinished = hasAllFinished ? allFinishedLoadable.data : false;
   const [sendLoadable, send] = useLoadableSet(thread.sendMessage$);
   const sending = !allFinished || sendLoadable.state === "loading";
+  const showWorking =
+    rawDisplayName !== undefined && hasAllFinished && !allFinished;
   const input = useGet(thread.draft.input$);
   const setInput = useSet(thread.draft.setInput$);
   const cancelRun = useSet(thread.cancelRun$);
@@ -354,21 +359,17 @@ function ChatThreadComposer({
           setComposerFileInput$={thread.setComposerFileInput$}
           setInputRef={setInputRef}
         />
-        <div
-          aria-hidden={allFinished}
-          className={cn(
-            "flex items-center justify-end gap-1.5 mt-2 pr-1 transition-opacity",
-            allFinished && "opacity-0",
-          )}
-        >
-          <IconLoader2
-            size={12}
-            className="animate-spin text-foreground/50 shrink-0"
-          />
-          <span className="zero-shimmer-text text-xs">
-            {displayName} is working...
-          </span>
-        </div>
+        {showWorking && (
+          <div className="flex items-center justify-end gap-1.5 mt-2 pr-1">
+            <IconLoader2
+              size={12}
+              className="animate-spin text-foreground/50 shrink-0"
+            />
+            <span className="zero-shimmer-text text-xs">
+              {displayName} is working...
+            </span>
+          </div>
+        )}
       </div>
     </footer>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -359,17 +359,21 @@ function ChatThreadComposer({
           setComposerFileInput$={thread.setComposerFileInput$}
           setInputRef={setInputRef}
         />
-        {showWorking && (
-          <div className="flex items-center justify-end gap-1.5 mt-2 pr-1">
-            <IconLoader2
-              size={12}
-              className="animate-spin text-foreground/50 shrink-0"
-            />
-            <span className="zero-shimmer-text text-xs">
-              {displayName} is working...
-            </span>
-          </div>
-        )}
+        <div
+          aria-hidden={!showWorking}
+          className={cn(
+            "flex items-center justify-end gap-1.5 mt-2 pr-1 transition-opacity",
+            !showWorking && "opacity-0",
+          )}
+        >
+          <IconLoader2
+            size={12}
+            className="animate-spin text-foreground/50 shrink-0"
+          />
+          <span className="zero-shimmer-text text-xs">
+            {displayName} is working...
+          </span>
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Problem

When a chat thread page first mounts, `agentDisplayName$` and `allFinished$` are still resolving asynchronously. The existing code in `zero-chat-thread-page.tsx` fell back to conservative defaults:

```tsx
const displayName  = useLastResolved(thread.agentDisplayName$) ?? "Zero";
const allFinished  = useLastResolved(thread.allFinished$) ?? false;
```

Since the indicator is shown whenever `!allFinished`, a default of `false` meant the "Zero is working..." row appeared on every page load — even when no run was active. `allFinished$` itself also returns `false` while `threadData$` is still loading (`create-chat-thread.ts:604-610`), so the indicator kept flashing until both signals settled.

## Fix

Gate the indicator on the signals actually having resolved:

- Drop the `?? "Zero"` fallback used for the gate (composer still gets `"Zero"` as a display fallback).
- Read `allFinished$` via `useLastLoadable` so we can distinguish `loading` from `hasData: false`.
- Only render the indicator when `rawDisplayName !== undefined && hasAllFinished && !allFinished`.

Net effect: on a fresh page load, nothing is shown until the thread's run state is known. When an active run exists, the indicator appears as before.

## Test plan

- [ ] Open a chat thread with no active run → no "Zero is working..." flash during load
- [ ] Open a chat thread while a run is active → indicator appears after resolve
- [ ] Send a new message → indicator shows until completion, then hides
- [ ] Switch between threads → indicator only shows when the landed thread actually has an active run