### PR TITLE
fix(mitm-addon): warn on log_proxy_entry write failure

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -41,8 +41,8 @@ def log_proxy_entry(proxy_log_path: str, level: str, message: str, **extra: obje
             os.write(fd, (json.dumps(entry) + "\n").encode())
         finally:
             os.close(fd)
-    except Exception:
-        pass
+    except Exception as e:
+        ctx.log.warn(f"Failed to write proxy log: {e}")
 
 
 def add_firewall_metadata(flow: http.HTTPFlow, log_entry: dict) -> None:


### PR DESCRIPTION
## Summary

- Match `log_network_entry` pattern: route `log_proxy_entry` write failures to `ctx.log.warn` instead of silently swallowing
- Operators now get a signal when the per-job proxy diagnostic log cannot be written (disk full, permission, missing parent dir)

## Why

`log_proxy_entry` is the operator diagnostic log — called from ~20 error-path callsites in `auth.py`, `usage.py`, `mitm_addon.py`. When its write fails silently, operators are left blind: the primary code path continues correctly but the "failure reporter" itself is broken with no visibility. Sibling `log_network_entry` at `:24-25` already does the right thing.

## Test plan

- [x] `python -m pytest tests/` — 848 passed
- [x] `ruff check .` / `ruff format --check .` — clean

Closes #9932