### PR TITLE
feat(stripe): add api-token auth method

### DIFF
--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -2438,6 +2438,18 @@ const CONNECTOR_TYPES_DEF = {
           },
         },
       },
+      "api-token": {
+        label: "API Key",
+        helpText:
+          "1. Log in to your [Stripe Dashboard](https://dashboard.stripe.com/apikeys)\n2. Go to **Developers > API keys**\n3. Reveal the **Secret key** (starts with `sk_live_` or `sk_test_`) or create a **Restricted key** (`rk_live_...`) with the scopes you need\n4. Copy the key",
+        secrets: {
+          STRIPE_TOKEN: {
+            label: "API Key",
+            required: true,
+            placeholder: "sk_live_...",
+          },
+        },
+      },
     },
     defaultAuthMethod: "oauth",
     oauth: {


### PR DESCRIPTION
## Summary

- Add `api-token` auth method to the existing Stripe connector, alongside the Connect OAuth flow.
- Users can now connect Stripe with a restricted key (`rk_live_…`) or a secret key (`sk_live_…` / `sk_test_…`) instead of going through Stripe Connect OAuth.
- The api-token secret is stored under `STRIPE_TOKEN`, which matches the existing firewall placeholder in `firewalls/stripe.generated.ts`, so the MITM proxy substitutes it without any further plumbing.

## Why not extend `environmentMapping`?

`environmentMapping` is consumed only by the OAuth secret resolver (`resolveOauthConnectorSecrets` in `resolve-connectors.ts`). API-token secrets are injected via firewall placeholders keyed by the raw secret name. This PR mirrors the existing Mercury / Deel / Dropbox / Figma / Mailchimp / Neon / Supabase / Webflow dual-auth pattern:

- OAuth path stores in `STRIPE_ACCESS_TOKEN` → `environmentMapping` surfaces it as `STRIPE_TOKEN` env var.
- api-token path stores directly in `STRIPE_TOKEN` → firewall placeholder matches by name.

Either path yields `STRIPE_TOKEN` in the sandbox.

## Test plan

- [ ] Type-check passes
- [ ] On the Connectors settings page, the Stripe card offers both "OAuth (Recommended)" and "API Key" options
- [ ] Connecting via API Key persists the `STRIPE_TOKEN` secret and a subsequent agent run can hit `GET https://api.stripe.com/v1/account`
- [ ] Existing OAuth connections still resolve `STRIPE_TOKEN` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)