### PR TITLE
refactor(mitm-addon): promote shared fixtures and drop test-local flow mocks

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -16,6 +16,7 @@ Fixtures here exist for two reasons:
 import contextlib
 import json
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -25,6 +26,7 @@ from mitmproxy.test import tflow, tutils
 
 import auth
 import mitm_addon
+import usage
 
 
 @pytest.fixture(autouse=True)
@@ -242,22 +244,16 @@ def fresh_usage_executor():
     reports need a fresh executor afterwards so later tests still see a
     live pool.  This fixture owns the lifecycle: a new
     :class:`ThreadPoolExecutor` is installed before the test and the
-    original is restored after, regardless of whether the test shut it
-    down.
+    original is restored after.  ``ThreadPoolExecutor.shutdown`` is
+    idempotent, so we always call it on the way out regardless of
+    whether the test already did.
     """
-    from concurrent.futures import ThreadPoolExecutor
-
-    import usage
-
     original = usage.usage_executor
     usage.usage_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage-test")
     try:
         yield usage.usage_executor
     finally:
-        try:
-            usage.usage_executor.shutdown(wait=True)
-        except RuntimeError:
-            pass
+        usage.usage_executor.shutdown(wait=True)
         usage.usage_executor = original
 
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -197,14 +197,24 @@ def real_tcp_flow():
     return _build
 
 
+class _StubOptions:
+    """Plain stand-in for the two addon-specific ``ctx.options`` fields."""
+
+    def __init__(self, *, registry_path: str, api_url: str) -> None:
+        self.vm0_proxy_registry_path = registry_path
+        self.vm0_api_url = api_url
+
+
 @pytest.fixture
 def mitm_ctx():
     """Stub ``mitmproxy.ctx.options`` and ``ctx.log`` for a test block.
 
     Returns a context-manager factory: calling ``mitm_ctx(registry_path=...)``
     patches in a stub ``Options`` object exposing the two addon-specific
-    settings plus a ``MagicMock`` log.  Yielded value is the log mock so
-    tests that need to inspect warnings can do so.
+    settings plus a ``MagicMock`` log.  The log stays on MagicMock so tests
+    that need to assert on warn/debug calls can do so; ``options`` doesn't
+    get that treatment because the addon only ever reads two named
+    attributes from it.
     """
 
     @contextlib.contextmanager
@@ -213,9 +223,7 @@ def mitm_ctx():
         registry_path: str = "/tmp/proxy-registry.json",
         api_url: str = "https://api.vm0.ai",
     ) -> Iterator[MagicMock]:
-        options = MagicMock()
-        options.vm0_api_url = api_url
-        options.vm0_proxy_registry_path = registry_path
+        options = _StubOptions(registry_path=registry_path, api_url=api_url)
         log = MagicMock()
         with (
             patch.object(mitm_addon.ctx, "options", options, create=True),
@@ -224,6 +232,33 @@ def mitm_ctx():
             yield log
 
     return _stub
+
+
+@pytest.fixture
+def fresh_usage_executor():
+    """Swap ``usage.usage_executor`` for a throw-away pool for one test.
+
+    Tests that call ``shutdown(wait=True)`` to flush pending webhook
+    reports need a fresh executor afterwards so later tests still see a
+    live pool.  This fixture owns the lifecycle: a new
+    :class:`ThreadPoolExecutor` is installed before the test and the
+    original is restored after, regardless of whether the test shut it
+    down.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    import usage
+
+    original = usage.usage_executor
+    usage.usage_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage-test")
+    try:
+        yield usage.usage_executor
+    finally:
+        try:
+            usage.usage_executor.shutdown(wait=True)
+        except RuntimeError:
+            pass
+        usage.usage_executor = original
 
 
 @pytest.fixture

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -1,12 +1,235 @@
+"""Shared pytest fixtures for mitm-addon tests.
+
+Fixtures here exist for two reasons:
+
+1. **Real mitmproxy objects in place of MagicMock**. ``real_flow`` /
+   ``headers`` produce genuine :class:`mitmproxy.http.HTTPFlow`,
+   :class:`mitmproxy.http.Request`, :class:`mitmproxy.http.Response`, and
+   :class:`mitmproxy.http.Headers` via ``mitmproxy.test`` helpers so tests
+   exercise real attribute/property semantics (``pretty_host``,
+   ``pretty_url``, ``content`` decompression, header casing, …).
+2. **Stubbing at the genuine external boundary (``mitmproxy.ctx``)**.
+   ``mitm_ctx`` replaces ``ctx.options`` and ``ctx.log`` for handler tests
+   that cannot rely on a running ``mitmdump`` process.
+"""
+
+import contextlib
 import json
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
+from mitmproxy import http, tcp
+from mitmproxy.test import tflow, tutils
+
+import auth
+import mitm_addon
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Clear cached singletons between tests.
+
+    ``mitm_addon`` and ``auth`` cache registry data and firewall header
+    lookups in module-level dicts.  Without a reset, earlier tests leak
+    entries that change later tests' behaviour (e.g. a request from IP X
+    in test A primes ``_request_start_times`` seen by test B).
+    """
+    mitm_addon._request_start_times.clear()
+    mitm_addon._registry_cache = {}
+    mitm_addon._registry_cache_key = (0, 0)
+    auth._firewall_header_cache.clear()
+    auth._cache_locks.clear()
+    yield
+
+
+def _headers(*pairs: tuple[str, str]) -> http.Headers:
+    return http.Headers([(k.encode(), v.encode()) for k, v in pairs])
+
+
+@pytest.fixture
+def headers():
+    """Build ``mitmproxy.http.Headers`` from ``(name, value)`` string pairs."""
+    return _headers
+
+
+@pytest.fixture
+def real_flow():
+    """Factory that builds a real :class:`mitmproxy.http.HTTPFlow`.
+
+    Parameters mirror the handful of attributes the addon reads from the
+    flow: client IP, request method/host/port/path/body/headers, response
+    status/body/headers/encoding.  The returned flow has ``flow.metadata``
+    empty (addon fills it in) and, when ``with_response=False``, no
+    response attached.
+    """
+
+    def _build(
+        *,
+        client_ip: str = "10.200.0.1",
+        host: str = "example.com",
+        port: int = 443,
+        path: str = "/",
+        method: str = "GET",
+        request_body: bytes | None = None,
+        request_headers: http.Headers | None = None,
+        request_content_type: str | None = None,
+        with_response: bool = True,
+        response_status: int = 200,
+        response_body: bytes | None = None,
+        response_headers: http.Headers | None = None,
+        response_content_type: str | None = None,
+        response_encoding: str | None = None,
+        include_request_id: bool = False,
+    ) -> http.HTTPFlow:
+        if request_headers is not None:
+            req_headers = request_headers
+        else:
+            pairs: list[tuple[str, str]] = [("Host", host)]
+            if request_content_type:
+                pairs.insert(0, ("Content-Type", request_content_type))
+            req_headers = _headers(*pairs)
+        req = tutils.treq(
+            scheme=b"https",
+            method=method.encode(),
+            host=host.encode(),
+            port=port,
+            path=path.encode(),
+            headers=req_headers,
+            content=request_body,
+        )
+
+        resp: http.Response | bool
+        if with_response:
+            if response_headers is not None:
+                resp_headers = response_headers
+            else:
+                pairs = []
+                if response_content_type:
+                    pairs.append(("Content-Type", response_content_type))
+                if include_request_id:
+                    pairs.append(("X-Request-Id", "req-123"))
+                resp_headers = _headers(*pairs)
+            if response_encoding:
+                resp_headers[b"Content-Encoding"] = response_encoding.encode()
+            resp = tutils.tresp(
+                status_code=response_status,
+                headers=resp_headers,
+                content=response_body,
+            )
+        else:
+            resp = False
+
+        flow = tflow.tflow(req=req, resp=resp)
+        flow.client_conn.peername = (client_ip, 12345)
+        return flow
+
+    return _build
+
+
+class _StubTLSClient:
+    """Minimal stand-in for ``mitmproxy.connection.Client`` in TLS tests."""
+
+    def __init__(self, peername: tuple[str, int] | None, sni: str) -> None:
+        self.peername = peername
+        self.sni = sni
+
+
+class _StubTLSContext:
+    def __init__(self, client: _StubTLSClient) -> None:
+        self.client = client
+
+
+class _StubClientHelloData:
+    """Plain stub for ``mitmproxy.tls.ClientHelloData``.
+
+    ``ClientHelloData`` is constructed inside mitmproxy's TLS layer from
+    protocol state we don't have access to at test time, so we can't
+    build a real one.  The addon only reads
+    ``data.context.client.peername`` / ``data.context.client.sni`` and
+    writes ``data.ignore_connection``; a dataclass-shaped stub covers
+    that surface without pulling in MagicMock's attribute-proliferation.
+    """
+
+    def __init__(self, peername: tuple[str, int] | None, sni: str) -> None:
+        self.context = _StubTLSContext(_StubTLSClient(peername, sni))
+        self.ignore_connection = False
+
+
+@pytest.fixture
+def make_tls_data():
+    def _make(*, client_ip: str = "10.200.0.1", sni: str = "example.com") -> _StubClientHelloData:
+        return _StubClientHelloData(peername=(client_ip, 12345), sni=sni)
+
+    return _make
+
+
+@pytest.fixture
+def real_tcp_flow():
+    """Factory that builds a real :class:`mitmproxy.tcp.TCPFlow`.
+
+    Mirrors the addon's access surface: ``flow.client_conn.peername``,
+    ``flow.server_conn.address``, ``flow.metadata``, ``flow.messages``,
+    ``flow.error``.  Default messages are a 2-way client/server handshake
+    (``b"hello"`` / ``b"SSH-2.0-babeld"``) that the TCP log tests exercise.
+    """
+
+    def _build(
+        *,
+        client_ip: str = "10.200.0.1",
+        server_address: tuple[str, int] = ("140.82.116.3", 22),
+        messages: list[tcp.TCPMessage] | None = None,
+    ) -> tcp.TCPFlow:
+        flow = tflow.ttcpflow()
+        flow.client_conn.peername = (client_ip, 12345)
+        flow.server_conn.address = server_address
+        flow.error = None
+        if messages is None:
+            flow.messages = [
+                tcp.TCPMessage(True, b"hello"),
+                tcp.TCPMessage(False, b"SSH-2.0-babeld"),
+            ]
+        else:
+            flow.messages = messages
+        return flow
+
+    return _build
+
+
+@pytest.fixture
+def mitm_ctx():
+    """Stub ``mitmproxy.ctx.options`` and ``ctx.log`` for a test block.
+
+    Returns a context-manager factory: calling ``mitm_ctx(registry_path=...)``
+    patches in a stub ``Options`` object exposing the two addon-specific
+    settings plus a ``MagicMock`` log.  Yielded value is the log mock so
+    tests that need to inspect warnings can do so.
+    """
+
+    @contextlib.contextmanager
+    def _stub(
+        *,
+        registry_path: str = "/tmp/proxy-registry.json",
+        api_url: str = "https://api.vm0.ai",
+    ) -> Iterator[MagicMock]:
+        options = MagicMock()
+        options.vm0_api_url = api_url
+        options.vm0_proxy_registry_path = registry_path
+        log = MagicMock()
+        with (
+            patch.object(mitm_addon.ctx, "options", options, create=True),
+            patch.object(mitm_addon.ctx, "log", log, create=True),
+        ):
+            yield log
+
+    return _stub
 
 
 @pytest.fixture
 def registry_file(tmp_path):
     """Create a sample proxy registry JSON file and return its path."""
-    registry = {
+    registry: dict[str, Any] = {
         "vms": {
             "10.200.0.1": {
                 "runId": "run-abc-123",

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -4,7 +4,6 @@ import base64
 import json
 
 from mitmproxy import http
-from mitmproxy.test import tflow, tutils
 
 from body_utils import (
     STREAM_BUFFER_LIMIT,
@@ -16,50 +15,6 @@ from body_utils import (
     add_capture_fields,
 )
 from usage import extract_usage_from_json
-
-
-def _headers(*pairs: tuple[str, str]) -> http.Headers:
-    """Construct mitmproxy Headers from (name, value) string pairs."""
-    return http.Headers([(k.encode(), v.encode()) for k, v in pairs])
-
-
-def _make_flow(
-    *,
-    request_body: bytes | None = None,
-    response_body: bytes | None = None,
-    request_ct: str = "application/json",
-    response_ct: str = "application/json",
-    response_encoding: str | None = None,
-    with_response: bool = True,
-) -> http.HTTPFlow:
-    """Build a real mitmproxy HTTPFlow with request/response fixtures.
-
-    Defaults mirror the shape used throughout the body-capture tests:
-    a JSON POST to ``api.example.com`` and, unless ``with_response=False``,
-    a JSON 200 response whose headers include ``X-Request-Id``.
-    """
-    req = tutils.treq(
-        method=b"POST",
-        host=b"api.example.com",
-        path=b"/",
-        headers=_headers(("Content-Type", request_ct), ("Host", "api.example.com")),
-        content=request_body,
-    )
-
-    resp: http.Response | bool
-    if with_response:
-        resp_header_pairs = [("Content-Type", response_ct), ("X-Request-Id", "req-123")]
-        if response_encoding:
-            resp_header_pairs.append(("Content-Encoding", response_encoding))
-        resp = tutils.tresp(
-            status_code=200,
-            headers=_headers(*resp_header_pairs),
-            content=response_body,
-        )
-    else:
-        resp = False
-
-    return tflow.tflow(req=req, resp=resp)
 
 
 class TestIsTextContent:
@@ -197,8 +152,8 @@ class TestIsSensitiveHeader:
 
 
 class TestRedactHeaders:
-    def test_redacts_sensitive_keeps_others(self):
-        headers = _headers(
+    def test_redacts_sensitive_keeps_others(self, headers):
+        headers = headers(
             ("Content-Type", "application/json"),
             ("Authorization", "Bearer sk-secret-123"),
             ("Host", "api.example.com"),
@@ -210,8 +165,8 @@ class TestRedactHeaders:
         assert result["Host"] == "api.example.com"
         assert result["Cookie"] == "***"
 
-    def test_duplicate_headers_keeps_first(self):
-        headers = _headers(
+    def test_duplicate_headers_keeps_first(self, headers):
+        headers = headers(
             ("Set-Cookie", "a=1"),
             ("Set-Cookie", "b=2"),
             ("Host", "example.com"),
@@ -223,40 +178,72 @@ class TestRedactHeaders:
 
 
 class TestAddCaptureFields:
-    def test_captures_request_body(self):
-        flow = _make_flow(request_body=b'{"prompt": "hello"}')
+    def test_captures_request_body(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+            request_body=b'{"prompt": "hello"}',
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["request_body"] == '{"prompt": "hello"}'
         assert entry["request_body_encoding"] == "utf-8"
         assert "request_body_truncated" not in entry
 
-    def test_captures_response_body(self):
-        flow = _make_flow(response_body=b'{"result": "ok"}')
+    def test_captures_response_body(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+            response_body=b'{"result": "ok"}',
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "ok"}'
         assert entry["response_body_encoding"] == "utf-8"
 
-    def test_captures_request_headers(self):
-        flow = _make_flow()
+    def test_captures_request_headers(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert "request_headers" in entry
         assert entry["request_headers"]["Content-Type"] == "application/json"
         assert entry["request_headers"]["Host"] == "api.example.com"
 
-    def test_captures_response_headers(self):
-        flow = _make_flow()
+    def test_captures_response_headers(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_headers" in entry
         assert entry["response_headers"]["Content-Type"] == "application/json"
         assert entry["response_headers"]["X-Request-Id"] == "req-123"
 
-    def test_response_headers_redacts_sensitive(self):
-        flow = _make_flow()
-        flow.response.headers = _headers(
+    def test_response_headers_redacts_sensitive(self, real_flow, headers):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.response.headers = headers(
             ("Set-Cookie", "session=abc"),
             ("Content-Type", "text/html"),
         )
@@ -265,30 +252,59 @@ class TestAddCaptureFields:
         assert entry["response_headers"]["Set-Cookie"] == "***"
         assert entry["response_headers"]["Content-Type"] == "text/html"
 
-    def test_no_response_headers_when_no_response(self):
-        flow = _make_flow(with_response=False)
+    def test_no_response_headers_when_no_response(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+            with_response=False,
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_headers" not in entry
 
-    def test_truncates_large_request_body(self):
+    def test_truncates_large_request_body(self, real_flow):
         body = b"x" * (STREAM_BUFFER_LIMIT + 1000)
-        flow = _make_flow(request_body=body, request_ct="text/plain")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="application/json",
+            include_request_id=True,
+            request_body=body,
+            request_content_type="text/plain",
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["request_body_truncated"] is True
         assert len(entry["request_body"]) == STREAM_BUFFER_LIMIT
 
-    def test_truncates_large_response_body(self):
+    def test_truncates_large_response_body(self, real_flow):
         body = b"y" * (STREAM_BUFFER_LIMIT + 1000)
-        flow = _make_flow(response_body=body, response_ct="text/plain")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            include_request_id=True,
+            response_body=body,
+            response_content_type="text/plain",
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body_truncated"] is True
         assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
 
-    def test_no_body_fields_when_empty(self):
-        flow = _make_flow(request_body=None, response_body=None)
+    def test_no_body_fields_when_empty(self, real_flow, headers):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+            request_body=None,
+            response_body=None,
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert "request_body" not in entry
@@ -298,10 +314,15 @@ class TestAddCaptureFields:
         assert "request_headers" in entry  # headers always captured
         assert "response_headers" in entry  # headers captured despite empty body
 
-    def test_response_decompression_error_skips_body(self):
+    def test_response_decompression_error_skips_body(self, real_flow, headers):
         # Content-Encoding: gzip + non-gzip bytes makes flow.response.content
         # raise ValueError, which add_capture_fields is expected to catch.
-        flow = _make_flow(
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
             request_body=b"ok",
             response_body=b"not gzip at all",
             response_encoding="gzip",
@@ -313,41 +334,76 @@ class TestAddCaptureFields:
         assert "response_body" not in entry  # response body skipped
         assert entry["response_body_encoding"] == "binary"  # marked as binary
 
-    def test_binary_request_body_marks_encoding(self):
-        flow = _make_flow(request_body=b"\x89PNG\r\n", request_ct="image/png")
+    def test_binary_request_body_marks_encoding(self, real_flow, headers):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="application/json",
+            include_request_id=True,
+            request_body=b"\x89PNG\r\n",
+            request_content_type="image/png",
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert "request_body" not in entry
         assert entry["request_body_encoding"] == "binary"
         assert "request_headers" in entry  # headers still captured
 
-    def test_binary_response_body_marks_encoding(self):
-        flow = _make_flow(response_body=b"\x00\x01\x02", response_ct="application/octet-stream")
+    def test_binary_response_body_marks_encoding(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            include_request_id=True,
+            response_body=b"\x00\x01\x02",
+            response_content_type="application/octet-stream",
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body" not in entry
         assert entry["response_body_encoding"] == "binary"
 
-    def test_request_body_exactly_at_limit_not_truncated(self):
+    def test_request_body_exactly_at_limit_not_truncated(self, real_flow):
         body = b"x" * STREAM_BUFFER_LIMIT
-        flow = _make_flow(request_body=body, request_ct="text/plain")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="application/json",
+            include_request_id=True,
+            request_body=body,
+            request_content_type="text/plain",
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert "request_body_truncated" not in entry
         assert len(entry["request_body"]) == STREAM_BUFFER_LIMIT
 
-    def test_response_body_exactly_at_limit_not_truncated(self):
+    def test_response_body_exactly_at_limit_not_truncated(self, real_flow):
         body = b"y" * STREAM_BUFFER_LIMIT
-        flow = _make_flow(response_body=body, response_ct="text/plain")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            include_request_id=True,
+            response_body=body,
+            response_content_type="text/plain",
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body_truncated" not in entry
         assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
 
-    def test_truncation_preserves_utf8_boundary(self):
+    def test_truncation_preserves_utf8_boundary(self, real_flow):
         # Body is STREAM_BUFFER_LIMIT + a 3-byte char "€" (\xe2\x82\xac)
         body = b"x" * STREAM_BUFFER_LIMIT + "\u20ac".encode("utf-8")
-        flow = _make_flow(request_body=body, request_ct="text/plain")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="application/json",
+            include_request_id=True,
+            request_body=body,
+            request_content_type="text/plain",
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["request_body_truncated"] is True
@@ -355,12 +411,15 @@ class TestAddCaptureFields:
         assert entry["request_body_encoding"] == "utf-8"
         assert len(entry["request_body"]) == STREAM_BUFFER_LIMIT  # all ASCII before the €
 
-    def test_text_request_with_binary_response(self):
-        flow = _make_flow(
+    def test_text_request_with_binary_response(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            include_request_id=True,
             request_body=b'{"q": "test"}',
             response_body=b"\x89PNG\r\n",
-            request_ct="application/json",
-            response_ct="image/png",
+            request_content_type="application/json",
+            response_content_type="image/png",
         )
         entry = {}
         add_capture_fields(flow, entry)
@@ -368,12 +427,15 @@ class TestAddCaptureFields:
         assert "response_body" not in entry
         assert entry["response_body_encoding"] == "binary"
 
-    def test_both_bodies_binary(self):
-        flow = _make_flow(
+    def test_both_bodies_binary(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            include_request_id=True,
             request_body=b"\x89PNG",
             response_body=b"\x1f\x8b\x08",
-            request_ct="image/png",
-            response_ct="application/gzip",
+            request_content_type="image/png",
+            response_content_type="application/gzip",
         )
         entry = {}
         add_capture_fields(flow, entry)
@@ -384,8 +446,13 @@ class TestAddCaptureFields:
         assert "request_headers" in entry
         assert "response_headers" in entry
 
-    def test_both_request_and_response(self):
-        flow = _make_flow(
+    def test_both_request_and_response(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
             request_body=b'{"q": "test"}',
             response_body=b'{"a": "result"}',
         )
@@ -395,9 +462,16 @@ class TestAddCaptureFields:
         assert entry["response_body"] == '{"a": "result"}'
         assert entry["request_headers"]["Host"] == "api.example.com"
 
-    def test_captures_response_body_from_stream_buffer(self):
+    def test_captures_response_body_from_stream_buffer(self, real_flow):
         """When stream_buffer is present, response body should be read from it."""
-        flow = _make_flow(response_body=b"should-be-ignored")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+            response_body=b"should-be-ignored",
+        )
         body = b'{"streamed": true}'
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.metadata["stream_buffer_state"] = {"truncated": False}
@@ -407,9 +481,15 @@ class TestAddCaptureFields:
         assert entry["response_body_encoding"] == "utf-8"
         assert "response_body_truncated" not in entry
 
-    def test_empty_stream_buffer_skips_body(self):
+    def test_empty_stream_buffer_skips_body(self, real_flow, headers):
         """Empty stream_buffer (e.g. synthetic 403) should not produce body fields."""
-        flow = _make_flow()
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
         flow.metadata["stream_buffer"] = bytearray()
         flow.metadata["stream_buffer_state"] = {"truncated": False}
         entry = {}
@@ -418,23 +498,36 @@ class TestAddCaptureFields:
         assert "response_body_encoding" not in entry
         assert "response_headers" in entry  # headers still captured
 
-    def test_stream_buffer_truncated_marks_truncation(self):
+    def test_stream_buffer_truncated_marks_truncation(self, real_flow):
         """When stream_buffer was truncated, response_body_truncated should be set."""
         body = b"x" * STREAM_BUFFER_LIMIT
-        flow = _make_flow()
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.metadata["stream_buffer_state"] = {"truncated": True}
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body_truncated"] is True
 
-    def test_stream_buffer_gzip_decompressed(self):
+    def test_stream_buffer_gzip_decompressed(self, real_flow):
         """Gzip-compressed stream_buffer should be decompressed for capture."""
         import gzip
 
         original = b'{"result": "ok"}'
         compressed = gzip.compress(original)
-        flow = _make_flow(response_ct="application/json", response_encoding="gzip")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            include_request_id=True,
+            response_content_type="application/json",
+            response_encoding="gzip",
+        )
         flow.metadata["stream_buffer"] = bytearray(compressed)
         flow.metadata["stream_buffer_state"] = {"truncated": False}
         entry = {}
@@ -447,83 +540,73 @@ class TestDecompression:
     """Integration tests for decompression through add_capture_fields."""
 
     def _make_flow_with_compressed_buffer(
-        self, data: bytes, encoding: str, content_type: str = "application/json"
+        self, real_flow, data: bytes, encoding: str, content_type: str = "application/json"
     ) -> http.HTTPFlow:
-        resp_header_pairs = [("Content-Type", content_type)]
-        if encoding:
-            resp_header_pairs.append(("Content-Encoding", encoding))
-        flow = tflow.tflow(
-            req=tutils.treq(
-                method=b"POST",
-                host=b"api.example.com",
-                path=b"/",
-                headers=_headers(("Content-Type", "application/json")),
-                content=None,
-            ),
-            resp=tutils.tresp(
-                status_code=200,
-                headers=_headers(*resp_header_pairs),
-                content=b"",
-            ),
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type=content_type,
+            response_encoding=encoding or None,
         )
         flow.metadata["stream_buffer"] = bytearray(data)
         flow.metadata["stream_buffer_state"] = {"truncated": False}
         return flow
 
-    def test_no_encoding_captures_plain_text(self):
-        flow = self._make_flow_with_compressed_buffer(b'{"ok": true}', "")
+    def test_no_encoding_captures_plain_text(self, real_flow):
+        flow = self._make_flow_with_compressed_buffer(real_flow, b'{"ok": true}', "")
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"ok": true}'
 
-    def test_identity_encoding_captures_body(self):
-        flow = self._make_flow_with_compressed_buffer(b'{"ok": true}', "identity")
+    def test_identity_encoding_captures_body(self, real_flow):
+        flow = self._make_flow_with_compressed_buffer(real_flow, b'{"ok": true}', "identity")
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"ok": true}'
 
-    def test_gzip_decompressed(self):
+    def test_gzip_decompressed(self, real_flow):
         import gzip
 
         original = b'{"result": "hello world"}'
-        flow = self._make_flow_with_compressed_buffer(gzip.compress(original), "gzip")
+        flow = self._make_flow_with_compressed_buffer(real_flow, gzip.compress(original), "gzip")
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
         assert entry["response_body_encoding"] == "utf-8"
 
-    def test_deflate_decompressed(self):
+    def test_deflate_decompressed(self, real_flow):
         import zlib
 
         original = b'{"result": "hello world"}'
-        flow = self._make_flow_with_compressed_buffer(zlib.compress(original), "deflate")
+        flow = self._make_flow_with_compressed_buffer(real_flow, zlib.compress(original), "deflate")
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
 
-    def test_brotli_decompressed(self):
+    def test_brotli_decompressed(self, real_flow):
         import brotli
 
         original = b'{"result": "hello world"}'
-        flow = self._make_flow_with_compressed_buffer(brotli.compress(original), "br")
+        flow = self._make_flow_with_compressed_buffer(real_flow, brotli.compress(original), "br")
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
 
-    def test_zstd_decompressed(self):
+    def test_zstd_decompressed(self, real_flow):
         import zstandard
 
         original = b'{"result": "hello world"}'
         compressed = zstandard.ZstdCompressor().compress(original)
-        flow = self._make_flow_with_compressed_buffer(compressed, "zstd")
+        flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "zstd")
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
 
-    def test_invalid_gzip_marks_binary(self):
+    def test_invalid_gzip_marks_binary(self, real_flow):
         """Invalid gzip data should fall back to original bytes and be marked binary."""
         flow = self._make_flow_with_compressed_buffer(
-            b"not gzip at all", "gzip", content_type="text/plain"
+            real_flow, b"not gzip at all", "gzip", content_type="text/plain"
         )
         entry = {}
         add_capture_fields(flow, entry)
@@ -532,27 +615,27 @@ class TestDecompression:
         assert "response_body" in entry
         assert entry["response_body"] == "not gzip at all"
 
-    def test_unknown_encoding_passes_through(self):
-        flow = self._make_flow_with_compressed_buffer(b'{"ok": true}', "x-custom")
+    def test_unknown_encoding_passes_through(self, real_flow):
+        flow = self._make_flow_with_compressed_buffer(real_flow, b'{"ok": true}', "x-custom")
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"ok": true}'
 
-    def test_truncated_gzip_partial_decompress(self):
+    def test_truncated_gzip_partial_decompress(self, real_flow):
         """Truncated gzip buffer should yield partial decompressed content."""
         import gzip
 
         original = b"x" * 10000
         compressed = gzip.compress(original)
         truncated = compressed[: len(compressed) // 2]
-        flow = self._make_flow_with_compressed_buffer(truncated, "gzip", "text/plain")
+        flow = self._make_flow_with_compressed_buffer(real_flow, truncated, "gzip", "text/plain")
         flow.metadata["stream_buffer_state"]["truncated"] = True
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body" in entry
         assert entry["response_body_truncated"] is True
 
-    def test_gzip_zip_bomb_capped(self):
+    def test_gzip_zip_bomb_capped(self, real_flow):
         """Decompressed output should not exceed buffer limit (zip bomb protection)."""
         import gzip
 
@@ -561,34 +644,34 @@ class TestDecompression:
         compressed = gzip.compress(original)
         # Compressed data fits in buffer limit
         assert len(compressed) < STREAM_BUFFER_LIMIT
-        flow = self._make_flow_with_compressed_buffer(compressed, "gzip", "text/plain")
+        flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "gzip", "text/plain")
         entry = {}
         add_capture_fields(flow, entry)
         # Body should be capped, not 1MB
         assert len(entry.get("response_body", "")) <= STREAM_BUFFER_LIMIT
 
-    def test_truncated_brotli_falls_back(self):
+    def test_truncated_brotli_falls_back(self, real_flow):
         """Truncated brotli data should fall back gracefully."""
         import brotli
 
         original = b"hello world " * 1000
         compressed = brotli.compress(original)
         truncated = compressed[: len(compressed) // 2]
-        flow = self._make_flow_with_compressed_buffer(truncated, "br", "text/plain")
+        flow = self._make_flow_with_compressed_buffer(real_flow, truncated, "br", "text/plain")
         flow.metadata["stream_buffer_state"]["truncated"] = True
         entry = {}
         add_capture_fields(flow, entry)
         # Should not crash; body is either partial decompressed or original
         assert entry.get("response_body_truncated") is True or "response_body" not in entry
 
-    def test_truncated_zstd_falls_back(self):
+    def test_truncated_zstd_falls_back(self, real_flow):
         """Truncated zstd data should fall back gracefully."""
         import zstandard
 
         original = b"hello world " * 1000
         compressed = zstandard.ZstdCompressor().compress(original)
         truncated = compressed[: len(compressed) // 2]
-        flow = self._make_flow_with_compressed_buffer(truncated, "zstd", "text/plain")
+        flow = self._make_flow_with_compressed_buffer(real_flow, truncated, "zstd", "text/plain")
         flow.metadata["stream_buffer_state"]["truncated"] = True
         entry = {}
         add_capture_fields(flow, entry)
@@ -617,12 +700,12 @@ class TestExtractUsageFromJson:
         assert result["cache_read_input_tokens"] == 50
         assert result["cache_creation_input_tokens"] == 0
 
-    def test_gzip_compressed(self):
+    def test_gzip_compressed(self, headers):
         import gzip
 
         original = b'{"model":"test","usage":{"input_tokens":42}}'
         compressed = gzip.compress(original)
-        headers = _headers(("Content-Encoding", "gzip"))
+        headers = headers(("Content-Encoding", "gzip"))
         result = extract_usage_from_json(compressed, headers)
         assert result["model"] == "test"
         assert result["input_tokens"] == 42
@@ -646,7 +729,7 @@ class TestExtractUsageFromJson:
         assert result["web_search_requests"] == 2
         assert result["input_tokens"] == 10
 
-    def test_handles_large_gzipped_body(self):
+    def test_handles_large_gzipped_body(self, headers):
         """Body that decompresses past the legacy 64 KB cap should still parse.
 
         Regression test for the silent 64 KB default in body_utils.decompress_body
@@ -667,7 +750,7 @@ class TestExtractUsageFromJson:
             }
         ).encode()
         compressed = gzip.compress(payload)
-        headers = _headers(("Content-Encoding", "gzip"))
+        headers = headers(("Content-Encoding", "gzip"))
         result = extract_usage_from_json(compressed, headers)
         assert result is not None
         assert result["input_tokens"] == 50

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1056,10 +1056,6 @@ class TestAnthropicFirewallScope:
 
 
 class TestGetFirewallHeaders:
-    def setup_method(self):
-        auth._firewall_header_cache.clear()
-        auth._cache_locks.clear()
-
     async def test_cache_miss_fetches_and_caches(self, headers):
         mock_headers = {"Authorization": "Bearer fresh-token"}
         mock_result = {"headers": mock_headers}
@@ -1202,10 +1198,6 @@ class TestGetFirewallHeaders:
 
 
 class TestHandleFirewallRequest:
-    def setup_method(self):
-        auth._firewall_header_cache.clear()
-        auth._cache_locks.clear()
-
     async def test_success_injects_headers_and_audit_metadata(self, real_flow, headers, mitm_ctx):
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"
@@ -1633,10 +1625,6 @@ class TestForwardRequestSecurity:
 class TestAuthBaseUrlRewrite:
     """Tests for auth.base URL rewriting via forward_request in handle_firewall_request."""
 
-    def setup_method(self):
-        auth._firewall_header_cache.clear()
-        auth._cache_locks.clear()
-
     async def test_url_rewrite_with_rel_path_root(self, real_flow, headers, mitm_ctx):
         """When rel_path is '/', resolved base URL is forwarded as-is."""
         flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path="/hook")
@@ -2006,10 +1994,6 @@ class TestBuildRewriteUrl:
 
 class TestAuthBaseUrlRewriteEdgeCases:
     """Integration tests for auth.base URL rewriting via forward_request."""
-
-    def setup_method(self):
-        auth._firewall_header_cache.clear()
-        auth._cache_locks.clear()
 
     def _make_rewrite_inputs(
         self,

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -20,24 +20,6 @@ from matching import (
 )
 
 
-def _make_http_flow(client_ip="10.200.0.1", host="api.github.com", port=443, path="/repos"):
-    """Create a mock HTTP flow for firewall tests."""
-    flow = MagicMock()
-    flow.id = f"flow-{id(flow)}"
-    flow.client_conn.peername = (client_ip, 12345)
-    flow.request.pretty_host = host
-    flow.request.port = port
-    flow.request.path = path
-    flow.request.pretty_url = f"https://{host}{path}"
-    flow.request.method = "GET"
-    flow.request.content = b""
-    flow.request.headers = {}
-    flow.request.query = {}
-    flow.metadata = {"vm_run_id": "test-run"}
-    flow.response = None
-    return flow
-
-
 def _wrap_firewalls(apis, name="test", ref="test"):
     """Wrap a list of API entries into a firewall entry list."""
     return [{"name": name, "ref": ref, "apis": apis}]
@@ -146,7 +128,7 @@ class TestMatchPath:
 class TestMatchFirewallRequest:
     """Tests for the three-state matching: allow, block, or None (pass-through)."""
 
-    def test_no_permissions_blocks(self):
+    def test_no_permissions_blocks(self, headers):
         """Missing permissions field → block (fail-closed)."""
         fw_configs = _wrap_firewalls(
             [
@@ -168,7 +150,7 @@ class TestMatchFirewallRequest:
         assert result.path == "/repos"
         assert result.permissions == ()
 
-    def test_permission_match_allows(self):
+    def test_permission_match_allows(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -192,7 +174,7 @@ class TestMatchFirewallRequest:
         assert result.match_info["params"] == {"owner": "octocat", "repo": "hello"}
         assert result.match_info["rule"] == "GET /repos/{owner}/{repo}"
 
-    def test_any_method_matches(self):
+    def test_any_method_matches(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -211,7 +193,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "full-access"
 
-    def test_method_case_insensitive(self):
+    def test_method_case_insensitive(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -229,7 +211,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, FirewallAllow)
 
-    def test_wrong_method_blocks(self):
+    def test_wrong_method_blocks(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -247,7 +229,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, FirewallBlock)
 
-    def test_wrong_path_blocks(self):
+    def test_wrong_path_blocks(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -265,7 +247,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, FirewallBlock)
 
-    def test_no_base_match_returns_none(self):
+    def test_no_base_match_returns_none(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -299,7 +281,7 @@ class TestMatchFirewallRequest:
             is None
         )
 
-    def test_exact_base_no_path(self):
+    def test_exact_base_no_path(self, headers):
         """URL equals base exactly (rest='') → rel_path='/' → matches root rule."""
         fw_configs = _wrap_firewalls(
             [
@@ -316,7 +298,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "root"
 
-    def test_trailing_slash_on_url(self):
+    def test_trailing_slash_on_url(self, headers):
         """URL trailing slash doesn't affect matching (split filters empty segments)."""
         fw_configs = _wrap_firewalls(
             [
@@ -335,7 +317,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, FirewallAllow)
 
-    def test_trailing_slash_on_base_config(self):
+    def test_trailing_slash_on_base_config(self, headers):
         """Base URL with trailing slash still matches (rstrip strips it)."""
         fw_configs = _wrap_firewalls(
             [
@@ -354,7 +336,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, FirewallAllow)
 
-    def test_port_boundary_rejected(self):
+    def test_port_boundary_rejected(self, headers):
         """Port in URL (rest starts with ':') is not a valid path boundary."""
         fw_configs = _wrap_firewalls(
             [
@@ -373,7 +355,7 @@ class TestMatchFirewallRequest:
         )
         assert result is None
 
-    def test_evil_domain_not_matched(self):
+    def test_evil_domain_not_matched(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -391,7 +373,7 @@ class TestMatchFirewallRequest:
         )
         assert result is None
 
-    def test_multiple_permissions_first_match_wins(self):
+    def test_multiple_permissions_first_match_wins(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -413,7 +395,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "messages-send"
 
-    def test_malformed_rules_skipped(self):
+    def test_malformed_rules_skipped(self, headers):
         """Rules without 'METHOD /path' format are silently skipped, not crash or false-allow."""
         fw_configs = _wrap_firewalls(
             [
@@ -443,7 +425,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result2, FirewallBlock)
 
-    def test_path_case_sensitive(self):
+    def test_path_case_sensitive(self, headers):
         """URL paths are case-sensitive — /REPOS must not match /repos."""
         fw_configs = _wrap_firewalls(
             [
@@ -462,7 +444,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, FirewallBlock)
 
-    def test_multiple_services_match_across(self):
+    def test_multiple_services_match_across(self, headers):
         fw_configs = [
             {
                 "name": "github",
@@ -505,7 +487,7 @@ class TestMatchFirewallRequest:
         assert isinstance(sl, FirewallAllow)
         assert sl.match_info["name"] == "slack"
 
-    def test_query_string_stripped_for_matching(self):
+    def test_query_string_stripped_for_matching(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -523,7 +505,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, FirewallAllow)
 
-    def test_fragment_stripped_for_matching(self):
+    def test_fragment_stripped_for_matching(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -541,7 +523,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, FirewallAllow)
 
-    def test_empty_permissions_list_blocks(self):
+    def test_empty_permissions_list_blocks(self, headers):
         """If permissions is present but empty, no rules can match → block."""
         fw_configs = _wrap_firewalls(
             [
@@ -560,7 +542,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, FirewallBlock)
 
-    def test_different_bases_same_permission_name(self):
+    def test_different_bases_same_permission_name(self, headers):
         """Same permission name across different api_entries — each matches its own base."""
         fw_configs = _wrap_firewalls(
             [
@@ -598,7 +580,7 @@ class TestMatchFirewallRequest:
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer files-token"
         assert result.match_info["permission"] == "full-access"
 
-    def test_same_base_different_permissions(self):
+    def test_same_base_different_permissions(self, headers):
         """Same base URL with different permissions/auth — second api_entry can match."""
         fw_configs = _wrap_firewalls(
             [
@@ -624,7 +606,7 @@ class TestMatchFirewallRequest:
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer user"
         assert result.match_info["permission"] == "send"
 
-    def test_parameterized_host_allows(self):
+    def test_parameterized_host_allows(self, headers):
         """Base URL with {subdomain} in host matches dynamically."""
         fw_configs = _wrap_firewalls(
             [
@@ -648,7 +630,7 @@ class TestMatchFirewallRequest:
         assert result.match_info["permission"] == "tickets"
         assert result.match_info["params"] == {"subdomain": "acme"}
 
-    def test_parameterized_host_blocks_no_permission(self):
+    def test_parameterized_host_blocks_no_permission(self, headers):
         """Base URL with host param matches but no rule → block."""
         fw_configs = _wrap_firewalls(
             [
@@ -670,7 +652,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallBlock)
         assert result.name == "zendesk"
 
-    def test_parameterized_host_no_match_returns_none(self):
+    def test_parameterized_host_no_match_returns_none(self, headers):
         """Different domain entirely → None (pass-through)."""
         fw_configs = _wrap_firewalls(
             [
@@ -689,7 +671,7 @@ class TestMatchFirewallRequest:
         )
         assert result is None
 
-    def test_parameterized_path_allows(self):
+    def test_parameterized_path_allows(self, headers):
         """Base URL with {param} in path matches dynamically."""
         fw_configs = _wrap_firewalls(
             [
@@ -709,7 +691,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["params"] == {"org": "acme", "id": "123"}
 
-    def test_parameterized_host_and_path(self):
+    def test_parameterized_host_and_path(self, headers):
         """Both host and path params extracted."""
         fw_configs = _wrap_firewalls(
             [
@@ -729,7 +711,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["params"] == {"tenant": "us", "org": "acme"}
 
-    def test_greedy_host_param_matches_multi_level(self):
+    def test_greedy_host_param_matches_multi_level(self, headers):
         """Greedy {sub+} in host matches multiple subdomain levels."""
         fw_configs = _wrap_firewalls(
             [
@@ -749,7 +731,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["params"]["sub"] == "a.b.c"
 
-    def test_greedy_star_host_param_matches_zero(self):
+    def test_greedy_star_host_param_matches_zero(self, headers):
         """Greedy {sub*} in host matches zero subdomains."""
         fw_configs = _wrap_firewalls(
             [
@@ -766,7 +748,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["params"]["sub"] == ""
 
-    def test_mixed_static_and_parameterized_bases(self):
+    def test_mixed_static_and_parameterized_bases(self, headers):
         """Static and parameterized bases in same config both work."""
         fw_configs = [
             {
@@ -811,7 +793,7 @@ class TestMatchFirewallRequest:
         assert zd.match_info["name"] == "zendesk"
         assert zd.match_info["params"]["sub"] == "acme"
 
-    def test_parameterized_host_with_query_string(self):
+    def test_parameterized_host_with_query_string(self, headers):
         """Parameterized base URL + query string in request."""
         fw_configs = _wrap_firewalls(
             [
@@ -831,7 +813,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["params"]["sub"] == "acme"
 
-    def test_parameterized_host_rejects_nonstandard_port(self):
+    def test_parameterized_host_rejects_nonstandard_port(self, headers):
         """Non-standard port must NOT match — prevents auth header leaking to rogue server."""
         fw_configs = _wrap_firewalls(
             [
@@ -1078,7 +1060,7 @@ class TestGetFirewallHeaders:
         auth._firewall_header_cache.clear()
         auth._cache_locks.clear()
 
-    async def test_cache_miss_fetches_and_caches(self):
+    async def test_cache_miss_fetches_and_caches(self, headers):
         mock_headers = {"Authorization": "Bearer fresh-token"}
         mock_result = {"headers": mock_headers}
         encrypted = "iv:tag:data"
@@ -1101,7 +1083,7 @@ class TestGetFirewallHeaders:
         assert cache_key in auth._firewall_header_cache
         assert auth._firewall_header_cache[cache_key]["headers"] == mock_headers
 
-    async def test_cache_hit_returns_cached(self):
+    async def test_cache_hit_returns_cached(self, headers):
         cache_key = ("run-1", "https://api.github.com")
         cached_headers = {"Authorization": "Bearer cached-token"}
         auth._firewall_header_cache[cache_key] = {
@@ -1118,7 +1100,7 @@ class TestGetFirewallHeaders:
         assert headers["cache_hit"] is True
         mock_fetch.assert_not_called()
 
-    async def test_cache_hit_with_valid_ttl_returns_cached(self):
+    async def test_cache_hit_with_valid_ttl_returns_cached(self, headers):
         """Cached entry with expiresAt in the future should be returned without fetching."""
         cache_key = ("run-1", "api-1")
         cached_headers = {"Authorization": "Bearer valid-token"}
@@ -1137,7 +1119,7 @@ class TestGetFirewallHeaders:
         assert headers["cache_hit"] is True
         mock_fetch.assert_not_called()
 
-    async def test_cache_evicted_when_ttl_expired(self):
+    async def test_cache_evicted_when_ttl_expired(self, headers):
         """Cached entry with expiresAt in the past should trigger a re-fetch."""
         cache_key = ("run-1", "api-1")
         auth._firewall_header_cache[cache_key] = {
@@ -1160,7 +1142,7 @@ class TestGetFirewallHeaders:
         # Verify cache was updated with new entry
         assert auth._firewall_header_cache[cache_key]["headers"] == fresh_headers
 
-    async def test_cache_with_null_expires_at_never_evicts(self):
+    async def test_cache_with_null_expires_at_never_evicts(self, headers):
         """Cached entry with expiresAt=None (non-expiring) should never be evicted by TTL."""
         cache_key = ("run-1", "api-1")
         cached_headers = {"Authorization": "Bearer permanent-token"}
@@ -1179,7 +1161,7 @@ class TestGetFirewallHeaders:
         assert headers["cache_hit"] is True
         mock_fetch.assert_not_called()
 
-    async def test_cache_hit_includes_base_when_present(self):
+    async def test_cache_hit_includes_base_when_present(self, headers):
         """Cached entry with 'base' returns it on cache hit."""
         cache_key = ("run-1", "api-1")
         auth._firewall_header_cache[cache_key] = {
@@ -1197,7 +1179,7 @@ class TestGetFirewallHeaders:
         assert result["cache_hit"] is True
         mock_fetch.assert_not_called()
 
-    async def test_cache_hit_omits_base_when_absent(self):
+    async def test_cache_hit_omits_base_when_absent(self, headers):
         """Cached entry without 'base' does not include it in result."""
         cache_key = ("run-1", "api-1")
         auth._firewall_header_cache[cache_key] = {
@@ -1224,8 +1206,9 @@ class TestHandleFirewallRequest:
         auth._firewall_header_cache.clear()
         auth._cache_locks.clear()
 
-    async def test_success_injects_headers_and_audit_metadata(self):
-        flow = _make_http_flow()
+    async def test_success_injects_headers_and_audit_metadata(self, real_flow, headers, mitm_ctx):
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "id": "run-1:0",
             "base": "https://api.github.com",
@@ -1254,7 +1237,7 @@ class TestHandleFirewallRequest:
 
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
 
@@ -1280,8 +1263,9 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_rule_match"] == "GET /repos/{owner}/{repo}"
         assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
 
-    async def test_failure_returns_502(self):
-        flow = _make_http_flow()
+    async def test_failure_returns_502(self, real_flow, headers, mitm_ctx):
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
         vm_info = {
             "runId": "run-1",
@@ -1297,7 +1281,7 @@ class TestHandleFirewallRequest:
                 "get_firewall_headers",
                 AsyncMock(side_effect=Exception("API unreachable")),
             ),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
@@ -1311,9 +1295,10 @@ class TestHandleFirewallRequest:
         assert "API unreachable" in body["message"]
         assert body["permission"] == "github"
 
-    async def test_no_response_set_on_success(self):
+    async def test_no_response_set_on_success(self, real_flow, headers, mitm_ctx):
         """On success, flow.response should remain None (request continues to origin)."""
-        flow = _make_http_flow()
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
         vm_info = {
             "runId": "run-1",
@@ -1337,15 +1322,16 @@ class TestHandleFirewallRequest:
                     }
                 ),
             ),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
 
         assert flow.response is None
 
-    async def test_connector_not_configured_returns_424(self):
+    async def test_connector_not_configured_returns_424(self, real_flow, headers, mitm_ctx):
         """When connector is enabled but not linked, return 424 with missing secrets."""
-        flow = _make_http_flow()
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
         vm_info = {
             "runId": "run-1",
@@ -1365,7 +1351,7 @@ class TestHandleFirewallRequest:
                     )
                 ),
             ),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
@@ -1380,9 +1366,10 @@ class TestHandleFirewallRequest:
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
 
-    async def test_missing_vars_only_returns_424(self):
+    async def test_missing_vars_only_returns_424(self, real_flow, headers, mitm_ctx):
         """When connector not configured, return 424 with connector ref."""
-        flow = _make_http_flow()
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {"base": "https://hcti.io", "auth": {"headers": {}}}
         vm_info = {
             "runId": "run-1",
@@ -1402,7 +1389,7 @@ class TestHandleFirewallRequest:
                     )
                 ),
             ),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
@@ -1413,14 +1400,15 @@ class TestHandleFirewallRequest:
         assert body["error"] == "connector_not_configured"
         assert body["connectors"] == ["htmlcsstoimage"]
 
-    async def test_missing_encrypted_secrets_returns_502(self):
+    async def test_missing_encrypted_secrets_returns_502(self, real_flow, headers, mitm_ctx):
         """When encryptedSecrets is missing from vm_info, return 502."""
-        flow = _make_http_flow()
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
         vm_info = {"runId": "run-1", "sandboxToken": "tok-xyz", "networkLogPath": ""}
         match_info = {"name": "github", "ref": "github"}
 
-        with patch.object(auth.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
 
         assert flow.response is not None
@@ -1438,7 +1426,7 @@ class TestHandleFirewallRequest:
 
 
 class TestFetchFirewallHeaders:
-    def test_builds_correct_request(self):
+    def test_builds_correct_request(self, headers):
         mock_resp = MagicMock()
         mock_resp.read.return_value = json.dumps(
             {"headers": {"Authorization": "Bearer tok"}}
@@ -1470,7 +1458,7 @@ class TestFetchFirewallHeaders:
         assert call_args[1]["headers"]["Authorization"] == "Bearer tok-xyz"
         assert call_args[1]["headers"]["Content-Type"] == "application/json"
 
-    def test_includes_vercel_bypass_header(self):
+    def test_includes_vercel_bypass_header(self, headers):
         mock_resp = MagicMock()
         mock_resp.read.return_value = json.dumps({"headers": {}}).encode()
 
@@ -1487,7 +1475,7 @@ class TestFetchFirewallHeaders:
             "x-vercel-protection-bypass", "secret-bypass-value"
         )
 
-    def test_no_vercel_bypass_when_empty(self):
+    def test_no_vercel_bypass_when_empty(self, headers):
         mock_resp = MagicMock()
         mock_resp.read.return_value = json.dumps({"headers": {}}).encode()
 
@@ -1502,7 +1490,7 @@ class TestFetchFirewallHeaders:
 
         mock_req_instance.add_header.assert_not_called()
 
-    def test_includes_auth_base_in_request_body(self):
+    def test_includes_auth_base_in_request_body(self, headers):
         mock_resp = MagicMock()
         mock_resp.read.return_value = json.dumps(
             {"headers": {}, "base": "https://discord.com/api/webhooks/123/abc"}
@@ -1577,7 +1565,7 @@ class TestFetchFirewallHeaders:
                     "iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai"
                 )
 
-    async def test_async_wrapper_passes_api_url_from_ctx(self):
+    async def test_async_wrapper_passes_api_url_from_ctx(self, headers):
         """fetch_firewall_headers reads api_url on the event loop and passes it to the sync fn."""
         mock_resp = MagicMock()
         mock_resp.read.return_value = json.dumps({"headers": {"Auth": "tok"}}).encode()
@@ -1649,9 +1637,10 @@ class TestAuthBaseUrlRewrite:
         auth._firewall_header_cache.clear()
         auth._cache_locks.clear()
 
-    async def test_url_rewrite_with_rel_path_root(self):
+    async def test_url_rewrite_with_rel_path_root(self, real_flow, headers, mitm_ctx):
         """When rel_path is '/', resolved base URL is forwarded as-is."""
-        flow = _make_http_flow(host="firewall-placeholder.vm3.ai", path="/hook")
+        flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path="/hook")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
             "auth": {"headers": {}, "base": "${{ secrets.DISCORD_WEBHOOK_URL }}"},
@@ -1682,18 +1671,21 @@ class TestAuthBaseUrlRewrite:
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             patch.object(auth, "forward_request", mock_forward),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert mock_forward.call_args[0][0] == "https://discord.com/api/webhooks/123/abc"
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.response.status_code == 200
 
-    async def test_url_rewrite_with_remaining_path(self):
+    async def test_url_rewrite_with_remaining_path(self, real_flow, headers, mitm_ctx):
         """When rel_path has content, it's appended to resolved base in forwarded URL."""
-        flow = _make_http_flow(
-            host="bitrix.internal", path="/rest/0/placeholder/crm.deal.list.json"
+        flow = real_flow(
+            with_response=False,
+            host="bitrix.internal",
+            path="/rest/0/placeholder/crm.deal.list.json",
         )
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://bitrix.internal/rest/{uid}/{code}",
             "auth": {"headers": {}, "base": "${{ secrets.BITRIX_WEBHOOK_URL }}"},
@@ -1724,7 +1716,7 @@ class TestAuthBaseUrlRewrite:
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             patch.object(auth, "forward_request", mock_forward),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert (
@@ -1733,12 +1725,14 @@ class TestAuthBaseUrlRewrite:
         )
         assert flow.metadata["firewall_action"] == "ALLOW"
 
-    async def test_url_rewrite_preserves_query_string(self):
+    async def test_url_rewrite_preserves_query_string(self, real_flow, headers, mitm_ctx):
         """Query string from original request is preserved in forwarded URL."""
-        flow = _make_http_flow(host="firewall-placeholder.vm3.ai", path="/hook")
-        flow.request.pretty_url = (
-            "https://firewall-placeholder.vm3.ai/discord-webhook/hook?wait=true"
+        flow = real_flow(
+            with_response=False,
+            host="firewall-placeholder.vm3.ai",
+            path="/discord-webhook/hook?wait=true",
         )
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
             "auth": {"headers": {}, "base": "${{ secrets.DISCORD_WEBHOOK_URL }}"},
@@ -1769,16 +1763,21 @@ class TestAuthBaseUrlRewrite:
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             patch.object(auth, "forward_request", mock_forward),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert mock_forward.call_args[0][0] == "https://discord.com/api/webhooks/123/abc?wait=true"
 
-    async def test_url_rewrite_resolved_base_with_trailing_slash(self):
+    async def test_url_rewrite_resolved_base_with_trailing_slash(
+        self, real_flow, headers, mitm_ctx
+    ):
         """Trailing slash on resolved base is stripped before appending rel_path."""
-        flow = _make_http_flow(
-            host="firewall-placeholder.vm3.ai", path="/bitrix/rest/0/placeholder/crm.deal.list"
+        flow = real_flow(
+            with_response=False,
+            host="firewall-placeholder.vm3.ai",
+            path="/bitrix/rest/0/placeholder/crm.deal.list",
         )
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://firewall-placeholder.vm3.ai/bitrix/rest/{uid}/{code}",
             "auth": {"headers": {}, "base": "${{ secrets.BITRIX_WEBHOOK_URL }}"},
@@ -1809,7 +1808,7 @@ class TestAuthBaseUrlRewrite:
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             patch.object(auth, "forward_request", mock_forward),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert (
@@ -1817,12 +1816,14 @@ class TestAuthBaseUrlRewrite:
             == "https://mycompany.bitrix24.com/rest/1/token/crm.deal.list"
         )
 
-    async def test_url_rewrite_merges_query_strings(self):
+    async def test_url_rewrite_merges_query_strings(self, real_flow, headers, mitm_ctx):
         """When resolved base has query string and original request also has one, merge with &."""
-        flow = _make_http_flow(host="firewall-placeholder.vm3.ai", path="/discord-webhook/hook")
-        flow.request.pretty_url = (
-            "https://firewall-placeholder.vm3.ai/discord-webhook/hook?wait=true"
+        flow = real_flow(
+            with_response=False,
+            host="firewall-placeholder.vm3.ai",
+            path="/discord-webhook/hook?wait=true",
         )
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
             "auth": {"headers": {}, "base": "${{ secrets.WEBHOOK_URL }}"},
@@ -1853,14 +1854,15 @@ class TestAuthBaseUrlRewrite:
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             patch.object(auth, "forward_request", mock_forward),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert mock_forward.call_args[0][0] == "https://example.com/hook?token=abc&wait=true"
 
-    async def test_no_url_rewrite_when_auth_base_absent(self):
+    async def test_no_url_rewrite_when_auth_base_absent(self, real_flow, headers, mitm_ctx):
         """Without auth.base, no URL rewriting happens (existing behavior)."""
-        flow = _make_http_flow()
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
         original_url = flow.request.url
         api_entry = {
             "base": "https://api.github.com",
@@ -1888,7 +1890,7 @@ class TestAuthBaseUrlRewrite:
         }
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         # URL should not be modified
@@ -1899,7 +1901,7 @@ class TestAuthBaseUrlRewrite:
 class TestMatchFirewallRequestRelPath:
     """Tests that match_firewall_request includes rel_path in match_info."""
 
-    def test_rel_path_included_in_match_info(self):
+    def test_rel_path_included_in_match_info(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -1920,7 +1922,7 @@ class TestMatchFirewallRequestRelPath:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["rel_path"] == "/"
 
-    def test_rel_path_with_remaining_segments(self):
+    def test_rel_path_with_remaining_segments(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -2011,15 +2013,28 @@ class TestAuthBaseUrlRewriteEdgeCases:
 
     def _make_rewrite_inputs(
         self,
+        real_flow,
         *,
         path="/hook",
         pretty_url=None,
         resolved_base="https://discord.com/api/webhooks/123/abc",
         rel_path="/",
     ):
-        flow = _make_http_flow(host="firewall-placeholder.vm3.ai", path=path)
+        # ``pretty_url`` lets callers seed a specific scheme://host/path?query
+        # on the request.  We parse it back into ``real_flow`` kwargs rather
+        # than mutating the read-only ``Request.pretty_url`` property.
         if pretty_url:
-            flow.request.pretty_url = pretty_url
+            from urllib.parse import urlparse
+
+            parsed = urlparse(pretty_url)
+            host = parsed.hostname or "firewall-placeholder.vm3.ai"
+            real_path = parsed.path or "/"
+            if parsed.query:
+                real_path = f"{real_path}?{parsed.query}"
+            flow = real_flow(with_response=False, host=host, path=real_path)
+        else:
+            flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path=path)
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
             "auth": {"headers": {}, "base": "${{ secrets.WEBHOOK }}"},
@@ -2046,16 +2061,16 @@ class TestAuthBaseUrlRewriteEdgeCases:
         }
         return flow, api_entry, vm_info, match_info, token_meta
 
-    async def test_sets_auth_url_rewrite_metadata_and_response(self):
+    async def test_sets_auth_url_rewrite_metadata_and_response(self, real_flow, mitm_ctx):
         """auth_url_rewrite metadata is set and flow.response is populated via forward_request."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs()
+        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(real_flow)
         mock_forward = AsyncMock(
             return_value=(200, b'{"ok":true}', {"Content-Type": "application/json"})
         )
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             patch.object(auth, "forward_request", mock_forward),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.metadata["auth_url_rewrite"] is True
@@ -2065,9 +2080,10 @@ class TestAuthBaseUrlRewriteEdgeCases:
         call_args = mock_forward.call_args
         assert call_args[0][0] == "https://discord.com/api/webhooks/123/abc"
 
-    async def test_no_auth_url_rewrite_metadata_when_no_base(self):
+    async def test_no_auth_url_rewrite_metadata_when_no_base(self, real_flow, headers, mitm_ctx):
         """auth_url_rewrite metadata is absent when no URL rewrite happens."""
-        flow = _make_http_flow()
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://api.github.com",
             "auth": {"headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"}},
@@ -2092,16 +2108,17 @@ class TestAuthBaseUrlRewriteEdgeCases:
         }
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert "auth_url_rewrite" not in flow.metadata
         # Standard header injection happened
         assert flow.request.headers["Authorization"] == "Bearer real"
 
-    async def test_forward_request_includes_auth_headers(self):
+    async def test_forward_request_includes_auth_headers(self, headers, real_flow, mitm_ctx):
         """auth.headers are included in the forwarded request to the real URL."""
         flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
+            real_flow,
             resolved_base="https://discord.com/api/webhooks/123/abc",
         )
         token_meta["headers"] = {"X-Custom": "injected-value"}
@@ -2109,7 +2126,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             patch.object(auth, "forward_request", mock_forward),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.metadata["auth_url_rewrite"] is True
@@ -2118,28 +2135,28 @@ class TestAuthBaseUrlRewriteEdgeCases:
         req_headers = call_args[0][2]
         assert req_headers["X-Custom"] == "injected-value"
 
-    async def test_forward_failure_returns_502(self):
+    async def test_forward_failure_returns_502(self, real_flow, mitm_ctx):
         """forward_request exception produces a 502 error response."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs()
+        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(real_flow)
         mock_forward = AsyncMock(side_effect=Exception("connection refused"))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             patch.object(auth, "forward_request", mock_forward),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert flow.metadata["auth_url_rewrite"] is True
 
-    async def test_no_rewrite_when_resolved_base_empty_string(self):
+    async def test_no_rewrite_when_resolved_base_empty_string(self, real_flow, mitm_ctx):
         """Empty string base from server is treated as absent — no URL rewrite."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs()
+        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(real_flow)
         token_meta["base"] = ""
         original_url = flow.request.url
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.request.url == original_url
@@ -2154,9 +2171,10 @@ class TestAuthBaseUrlRewriteEdgeCases:
 class TestAuthQueryInjection:
     """Tests for query parameter injection via auth.query."""
 
-    async def test_query_params_injected_on_standard_path(self):
+    async def test_query_params_injected_on_standard_path(self, real_flow, headers, mitm_ctx):
         """Resolved auth.query params are injected into flow.request.query."""
-        flow = _make_http_flow()
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://serpapi.com",
             "auth": {"headers": {}, "query": {"api_key": "${{ secrets.SERPAPI_TOKEN }}"}},
@@ -2181,17 +2199,20 @@ class TestAuthQueryInjection:
         }
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert "auth_url_rewrite" not in flow.metadata
         assert flow.request.query["api_key"] == "resolved-key-123"
 
-    async def test_query_param_overwrites_existing_key(self):
+    async def test_query_param_overwrites_existing_key(self, real_flow, headers, mitm_ctx):
         """auth.query overwrites a query param already present in the original request."""
-        flow = _make_http_flow(path="/search?api_key=agent-value&q=test")
-        flow.request.pretty_url = "https://serpapi.com/search?api_key=agent-value&q=test"
-        flow.request.query = {"api_key": "agent-value", "q": "test"}
+        flow = real_flow(
+            with_response=False,
+            host="serpapi.com",
+            path="/search?api_key=agent-value&q=test",
+        )
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://serpapi.com",
             "auth": {"headers": {}, "query": {"api_key": "${{ secrets.SERPAPI_TOKEN }}"}},
@@ -2216,7 +2237,7 @@ class TestAuthQueryInjection:
         }
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         # auth.query overwrites the agent's api_key
@@ -2224,9 +2245,10 @@ class TestAuthQueryInjection:
         # Other query params are preserved
         assert flow.request.query["q"] == "test"
 
-    async def test_query_params_with_headers_simultaneously(self):
+    async def test_query_params_with_headers_simultaneously(self, real_flow, headers, mitm_ctx):
         """auth.query and auth.headers can coexist on the standard path."""
-        flow = _make_http_flow()
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://example.com",
             "auth": {
@@ -2254,15 +2276,16 @@ class TestAuthQueryInjection:
         }
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.request.headers["Authorization"] == "Bearer real-token"
         assert flow.request.query["key"] == "resolved-query-value"
 
-    async def test_query_params_merged_into_rewrite_url(self):
+    async def test_query_params_merged_into_rewrite_url(self, real_flow, headers, mitm_ctx):
         """auth.query params are appended to the forwarded URL in the URL rewrite path."""
-        flow = _make_http_flow(host="firewall-placeholder.vm3.ai", path="/hook")
+        flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path="/hook")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
             "auth": {
@@ -2295,7 +2318,7 @@ class TestAuthQueryInjection:
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             patch.object(auth, "forward_request", mock_forward),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.metadata["auth_url_rewrite"] is True
@@ -2305,9 +2328,10 @@ class TestAuthQueryInjection:
         assert "api_key=resolved-key-456" in forwarded_url
         assert forwarded_url.startswith("https://real-api.com/webhook/secret")
 
-    async def test_no_query_injection_when_absent(self):
+    async def test_no_query_injection_when_absent(self, real_flow, headers, mitm_ctx):
         """No query modification when auth.query is not present."""
-        flow = _make_http_flow()
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://api.github.com",
             "auth": {"headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"}},
@@ -2331,7 +2355,7 @@ class TestAuthQueryInjection:
         }
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            patch.object(auth.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.request.headers["Authorization"] == "Bearer real"
@@ -2585,7 +2609,7 @@ class TestGraphQLMatching:
         )
         assert isinstance(result, FirewallAllow)
 
-    def test_multiple_rules_first_match_wins(self):
+    def test_multiple_rules_first_match_wins(self, headers):
         """Multiple GraphQL rules — first match wins."""
         body = _gql_body("mutation { issueCreate(input: {}) { id } }", "issueCreate")
         result = matching.match_firewall_request(
@@ -3186,7 +3210,7 @@ class TestGraphQLFieldMatching:
         )
         assert isinstance(result, FirewallAllow)
 
-    def test_field_multiple_aliases(self):
+    def test_field_multiple_aliases(self, headers):
         """Multiple aliased fields are all extracted correctly."""
         body = _gql_body(
             'mutation { a: createIssue(input: {}) { id } b: closeIssue(id: "1") { id } }',
@@ -3332,7 +3356,7 @@ class TestGraphQLFieldMatching:
         )
         assert isinstance(result, FirewallBlock)
 
-    def test_field_multiple_permissions_correct_match(self):
+    def test_field_multiple_permissions_correct_match(self, headers):
         """With multiple permissions, the correct one is matched by field."""
         body = _gql_body('mutation { closeIssue(id: "1") { id } }', "CloseIssue")
         fws = _wrap_firewalls(
@@ -4166,7 +4190,7 @@ class TestThreeLevelMatching:
         )
         assert isinstance(result, FirewallAllow)
 
-    def test_empty_permissions_with_unknown_policy_allow(self):
+    def test_empty_permissions_with_unknown_policy_allow(self, headers):
         """Firewall with no permission rules + unknownPolicy=allow allows all."""
         fws = _wrap_firewalls(
             [
@@ -4189,7 +4213,7 @@ class TestThreeLevelMatching:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == ""
 
-    def test_overlapping_permissions_allows_if_any_not_blocked(self):
+    def test_overlapping_permissions_allows_if_any_not_blocked(self, headers):
         """Same endpoint in two permissions — one denied, one allowed → ALLOW."""
         fws = _wrap_firewalls(
             [
@@ -4217,7 +4241,7 @@ class TestThreeLevelMatching:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "repo-admin"
 
-    def test_overlapping_permissions_denies_if_all_blocked(self):
+    def test_overlapping_permissions_denies_if_all_blocked(self, headers):
         """Same endpoint in two permissions — both denied → DENY."""
         fws = _wrap_firewalls(
             [
@@ -4249,7 +4273,7 @@ class TestThreeLevelMatching:
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ("repo-read", "repo-admin")
 
-    def test_multi_firewall_different_refs(self):
+    def test_multi_firewall_different_refs(self, headers):
         """Two firewalls with different refs, each with own policies."""
         fws = [
             {
@@ -4313,7 +4337,7 @@ class TestThreeLevelMatching:
         assert result.match_info["ref"] == "slack"
         assert result.match_info["permission"] == ""
 
-    def test_different_unknown_policy_per_ref(self):
+    def test_different_unknown_policy_per_ref(self, headers):
         """unknownPolicy differs per ref — github strict, slack permissive."""
         fws = [
             {
@@ -4349,7 +4373,7 @@ class TestThreeLevelMatching:
         )
         assert isinstance(result, FirewallAllow)
 
-    def test_denied_known_not_overridden_by_unknown_policy(self):
+    def test_denied_known_not_overridden_by_unknown_policy(self, headers):
         """A known permission that is denied must stay denied even with unknownPolicy=allow."""
         fws = _wrap_firewalls(
             [
@@ -4375,7 +4399,7 @@ class TestThreeLevelMatching:
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ("repo-write",)
 
-    def test_denied_permission_deduped_across_rules(self):
+    def test_denied_permission_deduped_across_rules(self, headers):
         """Same permission with multiple matching rules appears once in permissions."""
         fws = _wrap_firewalls(
             [
@@ -4406,7 +4430,7 @@ class TestThreeLevelMatching:
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ("repo-read",)
 
-    def test_empty_permissions_list_denies_all_known(self):
+    def test_empty_permissions_list_denies_all_known(self, headers):
         """All permissions in deny list — all known endpoints denied."""
         fws = _wrap_firewalls(
             [
@@ -4433,7 +4457,7 @@ class TestThreeLevelMatching:
         )
         assert isinstance(result, FirewallBlock)
 
-    def test_ref_absent_from_policies_allows(self):
+    def test_ref_absent_from_policies_allows(self, headers):
         """Firewall ref not in networkPolicies → fully permissive."""
         fws = _wrap_firewalls(
             [
@@ -4467,7 +4491,7 @@ class TestThreeLevelMatching:
         )
         assert isinstance(result, FirewallAllow)
 
-    def test_multi_api_mixed_permissions(self):
+    def test_multi_api_mixed_permissions(self, headers):
         """One API has permissions, another doesn't — mixed within same firewall."""
         fws = _wrap_firewalls(
             [

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1317,14 +1317,6 @@ class TestResponseHeadersSseParser:
 class TestResponseUsageReporting:
     """Tests for usage extraction and reporting in response() hook."""
 
-    def teardown_method(self):
-        try:
-            usage.usage_executor.submit(lambda: None)
-        except RuntimeError:
-            usage.usage_executor = usage.ThreadPoolExecutor(
-                max_workers=4, thread_name_prefix="usage"
-            )
-
     def test_reports_proxy_usage_from_sse(self, tmp_path, real_flow, mitm_ctx, headers):
         """When proxy_usage is set by SSE parser, it should trigger a usage report."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -1479,7 +1471,9 @@ class TestResponseUsageReporting:
         # maybe_report_proxy_usage is always called; it checks firewall_name internally
         mock_report.assert_called_once()
 
-    def test_full_path_response_to_opener(self, tmp_path, real_flow, mitm_ctx, headers):
+    def test_full_path_response_to_opener(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+    ):
         """Integration: response() → _maybe_report → _enqueue → _retry → _opener.
 
         Only _opener is mocked — verifies wiring between all intermediate layers.
@@ -1513,9 +1507,6 @@ class TestResponseUsageReporting:
             # Flush the executor to ensure the background POST completes
             usage.usage_executor.shutdown(wait=True)
 
-        # Restore executor
-        usage.usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
-
         # Verify the webhook POST reached _opener with correct payload
         mock_opener.open.assert_called_once()
         req = mock_opener.open.call_args[0][0]
@@ -1525,7 +1516,7 @@ class TestResponseUsageReporting:
         assert body["usage"]["input_tokens"] == 100
         assert body["usage"]["output_tokens"] == 500
 
-    def test_full_path_error_to_opener(self, tmp_path, real_flow, mitm_ctx):
+    def test_full_path_error_to_opener(self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor):
         """Integration: error() → _maybe_report → _enqueue → _retry → _opener.
 
         Verifies that error() hook delivers partial usage all the way to _opener.
@@ -1554,15 +1545,15 @@ class TestResponseUsageReporting:
             mitm_addon.error(flow)
             usage.usage_executor.shutdown(wait=True)
 
-        usage.usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
-
         mock_opener.open.assert_called_once()
         req = mock_opener.open.call_args[0][0]
         body = json.loads(req.data)
         assert body["runId"] == "run-int-002"
         assert body["usage"]["input_tokens"] == 80
 
-    def test_uses_flow_id_when_message_id_missing(self, tmp_path, real_flow, mitm_ctx, headers):
+    def test_uses_flow_id_when_message_id_missing(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+    ):
         """Missing message_id in proxy_usage falls back to flow.id.
 
         Without a stable per-flow key, server-side dedup of usage webhook
@@ -1597,14 +1588,14 @@ class TestResponseUsageReporting:
             mitm_addon.response(flow)
             usage.usage_executor.shutdown(wait=True)
 
-        usage.usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
-
         mock_opener.open.assert_called_once()
         req = mock_opener.open.call_args[0][0]
         body = json.loads(req.data)
         assert body["usage"]["message_id"] == "flow-uuid-xyz-123"
 
-    def test_preserves_message_id_from_response(self, tmp_path, real_flow, mitm_ctx, headers):
+    def test_preserves_message_id_from_response(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+    ):
         """When proxy_usage already has a message_id, flow.id fallback
         must not override it."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -1634,8 +1625,6 @@ class TestResponseUsageReporting:
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
             usage.usage_executor.shutdown(wait=True)
-
-        usage.usage_executor = usage.ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
 
         mock_opener.open.assert_called_once()
         req = mock_opener.open.call_args[0][0]
@@ -2560,16 +2549,7 @@ class TestReportUsageWithRetry:
 class TestEnqueueWebhook:
     """Tests for _enqueue_webhook (ThreadPoolExecutor submission)."""
 
-    def teardown_method(self):
-        """Ensure executor is always restored even if a test fails mid-way."""
-        try:
-            usage.usage_executor.submit(lambda: None)
-        except RuntimeError:
-            usage.usage_executor = usage.ThreadPoolExecutor(
-                max_workers=4, thread_name_prefix="usage"
-            )
-
-    def test_enqueue_copies_payload_dict(self):
+    def test_enqueue_copies_payload_dict(self, fresh_usage_executor):
         """Mutating the original dict after enqueue should not affect the submitted task."""
         original = {"input_tokens": 100}
         captured = []
@@ -2596,7 +2576,7 @@ class TestEnqueueWebhook:
         assert args[1] == "url"
         assert args[2] == "tok"
 
-    def test_enqueue_falls_back_to_sync_after_shutdown(self):
+    def test_enqueue_falls_back_to_sync_after_shutdown(self, fresh_usage_executor):
         """After executor shutdown, _enqueue_webhook should deliver synchronously with retry."""
         usage.usage_executor.shutdown(wait=True)
 
@@ -2958,29 +2938,23 @@ class TestUsagePendingCounter:
         content = (tmp_path / "usage-pending").read_text()
         assert content == "0:0"
 
-    def test_enqueue_increments_and_drains_reports(self, tmp_path):
+    def test_enqueue_increments_and_drains_reports(self, tmp_path, fresh_usage_executor):
         """_enqueue_webhook increments pending; executor drain decrements to 0."""
         usage.set_pending_path(str(tmp_path / "usage-pending"))
 
-        # Replace executor with a fresh one for isolation.
-        old_executor = usage.usage_executor
-        usage.usage_executor = usage.ThreadPoolExecutor(max_workers=1, thread_name_prefix="test")
-        try:
-            with patch.object(usage, "_post_webhook"):
-                usage._enqueue_webhook(
-                    "http://localhost/webhook",
-                    "tok",
-                    {"model": "x"},
-                    str(tmp_path / "p.log"),
-                    "usage",
-                )
-                usage.usage_executor.shutdown(wait=True)
-            # After executor drains, counter must be back to 0.
-            assert usage._pending_reports == 0
-            content = (tmp_path / "usage-pending").read_text()
-            assert content == "0:0"
-        finally:
-            usage.usage_executor = old_executor
+        with patch.object(usage, "_post_webhook"):
+            usage._enqueue_webhook(
+                "http://localhost/webhook",
+                "tok",
+                {"model": "x"},
+                str(tmp_path / "p.log"),
+                "usage",
+            )
+            usage.usage_executor.shutdown(wait=True)
+        # After executor drains, counter must be back to 0.
+        assert usage._pending_reports == 0
+        content = (tmp_path / "usage-pending").read_text()
+        assert content == "0:0"
 
     def test_decorator_pop_prevents_double_decrement(self, tmp_path, real_flow):
         """If both response() and error() fire for the same flow, decrement only once."""
@@ -3017,25 +2991,20 @@ class TestUsagePendingCounter:
         fake_handler(flow)
         assert usage._in_flight_flows == 1  # unchanged
 
-    def test_sync_fallback_decrements_reports(self, tmp_path):
+    def test_sync_fallback_decrements_reports(self, tmp_path, fresh_usage_executor):
         """When executor is shut down, sync fallback must still decrement."""
         usage.set_pending_path(str(tmp_path / "usage-pending"))
 
         # Shut down the executor so _enqueue_webhook takes the sync fallback.
         usage.usage_executor.shutdown(wait=True)
-        try:
-            with patch.object(usage, "_post_webhook"):
-                usage._enqueue_webhook(
-                    "http://localhost/webhook",
-                    "tok",
-                    {"model": "x"},
-                    str(tmp_path / "p.log"),
-                    "usage",
-                )
-            assert usage._pending_reports == 0
-            content = (tmp_path / "usage-pending").read_text()
-            assert content == "0:0"
-        finally:
-            usage.usage_executor = usage.ThreadPoolExecutor(
-                max_workers=4, thread_name_prefix="usage"
+        with patch.object(usage, "_post_webhook"):
+            usage._enqueue_webhook(
+                "http://localhost/webhook",
+                "tok",
+                {"model": "x"},
+                str(tmp_path / "p.log"),
+                "usage",
             )
+        assert usage._pending_reports == 0
+        content = (tmp_path / "usage-pending").read_text()
+        assert content == "0:0"

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from mitmproxy import http
+from mitmproxy.flow import Error
+from mitmproxy.test import tutils
 
 import auth
 import body_utils
@@ -16,70 +19,28 @@ import usage
 from usage import create_sse_usage_extractor
 
 
-def _make_http_flow(client_ip="10.200.0.1", host="example.com", port=443, path="/"):
-    """Create a mock HTTP flow."""
-    flow = MagicMock()
-    flow.id = f"flow-{id(flow)}"
-    flow.client_conn.peername = (client_ip, 12345)
-    flow.request.pretty_host = host
-    flow.request.port = port
-    flow.request.path = path
-    flow.request.pretty_url = f"https://{host}{path}"
-    flow.request.method = "GET"
-    flow.request.content = b""
-    flow.request.headers = {}
-    flow.metadata = {}
-    flow.response = None
-    return flow
-
-
-def _make_tls_data(client_ip="10.200.0.1", sni="example.com"):
-    """Create a mock TLS ClientHelloData."""
-    data = MagicMock()
-    data.context.client.peername = (client_ip, 12345)
-    data.context.client.sni = sni
-    data.ignore_connection = False
-    return data
-
-
-def _reset():
-    """Reset module state."""
-    mitm_addon._request_start_times.clear()
-    mitm_addon._registry_cache = {}
-    mitm_addon._registry_cache_key = (0, 0)
-    auth._firewall_header_cache.clear()
-    auth._cache_locks.clear()
-
-
 class TestRequestHandler:
-    def setup_method(self):
-        _reset()
-
-    async def test_allowed_domain_passes_through(self, registry_file):
-        flow = _make_http_flow(host="api.anthropic.com")
+    async def test_allowed_domain_passes_through(self, registry_file, real_flow, mitm_ctx):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
         ):
             await mitm_addon.request(flow)
 
         assert flow.metadata["firewall_action"] == "ALLOW"
 
-    async def test_vm0_api_auto_allowed(self, registry_file):
-        flow = _make_http_flow(host="api.vm0.ai")
+    async def test_vm0_api_auto_allowed(self, registry_file, real_flow, mitm_ctx):
+        flow = real_flow(with_response=False, host="api.vm0.ai")
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
         ):
             await mitm_addon.request(flow)
 
         assert flow.metadata["firewall_action"] == "ALLOW"
 
-    async def test_vm0_api_test_paths_skip_auto_allow(self, tmp_path):
+    async def test_vm0_api_test_paths_skip_auto_allow(self, tmp_path, real_flow, mitm_ctx, headers):
         """`/api/test/*` routes exist to exercise the firewall pipeline itself.
 
         If they fell into Step 1's auto-allow fast path, the test-oauth E2E
@@ -115,13 +76,13 @@ class TestRequestHandler:
         reg_path = tmp_path / "proxy-registry.json"
         reg_path.write_text(json.dumps(registry))
 
-        flow = _make_http_flow(host="api.vm0.ai", path="/api/test/oauth-provider/echo")
+        flow = real_flow(
+            with_response=False, host="api.vm0.ai", path="/api/test/oauth-provider/echo"
+        )
 
         mock_handler = AsyncMock()
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
             patch.object(mitm_addon, "handle_firewall_request", mock_handler),
         ):
             await mitm_addon.request(flow)
@@ -131,25 +92,21 @@ class TestRequestHandler:
         # invoking the handler).
         mock_handler.assert_called_once()
 
-    async def test_tracks_start_time(self, registry_file):
-        flow = _make_http_flow(host="api.anthropic.com")
+    async def test_tracks_start_time(self, registry_file, real_flow, mitm_ctx):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
         ):
             await mitm_addon.request(flow)
 
         assert flow.id in mitm_addon._request_start_times
 
-    async def test_unregistered_vm_passes_through(self, registry_file):
-        flow = _make_http_flow(client_ip="192.168.99.99", host="anything.com")
+    async def test_unregistered_vm_passes_through(self, registry_file, real_flow, mitm_ctx):
+        flow = real_flow(with_response=False, client_ip="192.168.99.99", host="anything.com")
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
         ):
             await mitm_addon.request(flow)
 
@@ -157,14 +114,12 @@ class TestRequestHandler:
         assert flow.response is None
         assert "firewall_action" not in flow.metadata
 
-    async def test_mitm_allowed_passes_through(self, registry_file):
+    async def test_mitm_allowed_passes_through(self, registry_file, real_flow, mitm_ctx):
         """Allowed request passes through without rewrite."""
-        flow = _make_http_flow(host="api.anthropic.com", path="/v1/messages")
+        flow = real_flow(with_response=False, host="api.anthropic.com", path="/v1/messages")
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
         ):
             await mitm_addon.request(flow)
 
@@ -173,7 +128,7 @@ class TestRequestHandler:
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.metadata.get("original_url") == "https://api.anthropic.com/v1/messages"
 
-    async def test_firewall_match_calls_handler(self, tmp_path):
+    async def test_firewall_match_calls_handler(self, tmp_path, real_flow, mitm_ctx, headers):
         """When URL matches a firewall rule, handle_firewall_request is called."""
         registry = {
             "vms": {
@@ -215,13 +170,13 @@ class TestRequestHandler:
         reg_path = tmp_path / "registry.json"
         reg_path.write_text(json.dumps(registry))
 
-        flow = _make_http_flow(client_ip="10.200.0.5", host="api.github.com", path="/repos")
+        flow = real_flow(
+            with_response=False, client_ip="10.200.0.5", host="api.github.com", path="/repos"
+        )
 
         mock_handler = AsyncMock()
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
             patch.object(mitm_addon, "handle_firewall_request", mock_handler),
         ):
             await mitm_addon.request(flow)
@@ -235,7 +190,9 @@ class TestRequestHandler:
         assert match_info["ref"] == "github"
         assert match_info["permission"] == "full-access"
 
-    async def test_firewall_permission_blocks_unmatched(self, tmp_path):
+    async def test_firewall_permission_blocks_unmatched(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
         """Firewall with permissions but no matching rule returns 403."""
         registry = {
             "vms": {
@@ -280,13 +237,13 @@ class TestRequestHandler:
         reg_path = tmp_path / "registry.json"
         reg_path.write_text(json.dumps(registry))
 
-        flow = _make_http_flow(client_ip="10.200.0.5", host="api.github.com", path="/orgs")
+        flow = real_flow(
+            with_response=False, client_ip="10.200.0.5", host="api.github.com", path="/orgs"
+        )
 
         mock_handler = AsyncMock()
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
             patch.object(mitm_addon, "handle_firewall_request", mock_handler),
         ):
             await mitm_addon.request(flow)
@@ -304,7 +261,7 @@ class TestRequestHandler:
         assert body["permissions"] == []
         assert body["base"] == "https://api.github.com"
 
-    async def test_firewall_permission_allows_matched(self, tmp_path):
+    async def test_firewall_permission_allows_matched(self, tmp_path, real_flow, mitm_ctx, headers):
         """Firewall with permissions and matching rule calls handler with match_info."""
         registry = {
             "vms": {
@@ -349,15 +306,16 @@ class TestRequestHandler:
         reg_path = tmp_path / "registry.json"
         reg_path.write_text(json.dumps(registry))
 
-        flow = _make_http_flow(
-            client_ip="10.200.0.5", host="api.github.com", path="/repos/octocat/hello"
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            path="/repos/octocat/hello",
         )
 
         mock_handler = AsyncMock()
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
             patch.object(mitm_addon, "handle_firewall_request", mock_handler),
         ):
             await mitm_addon.request(flow)
@@ -373,7 +331,9 @@ class TestRequestHandler:
         assert match_info["rule"] == "GET /repos/{owner}/{repo}"
         assert match_info["params"] == {"owner": "octocat", "repo": "hello"}
 
-    async def test_firewall_no_base_match_passes_through(self, tmp_path):
+    async def test_firewall_no_base_match_passes_through(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
         """URL not matching any firewall base → pass-through (not block)."""
         registry = {
             "vms": {
@@ -412,13 +372,13 @@ class TestRequestHandler:
         reg_path.write_text(json.dumps(registry))
 
         # Request to example.com — not a firewall match, passes through
-        flow = _make_http_flow(client_ip="10.200.0.5", host="api.example.com", path="/data")
+        flow = real_flow(
+            with_response=False, client_ip="10.200.0.5", host="api.example.com", path="/data"
+        )
 
         mock_handler = AsyncMock()
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
             patch.object(mitm_addon, "handle_firewall_request", mock_handler),
         ):
             await mitm_addon.request(flow)
@@ -432,12 +392,12 @@ class TestRequestHandler:
 class TestResponseHeadersHandler:
     """Tests for the responseheaders() hook that enables streaming."""
 
-    def test_enables_streaming_with_buffer(self):
+    def test_enables_streaming_with_buffer(self, real_flow, headers):
         """All responses should be streamed via a buffer callback."""
-        flow = _make_http_flow(host="api.example.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow = real_flow(with_response=False, host="api.example.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         mitm_addon.responseheaders(flow)
 
@@ -445,12 +405,12 @@ class TestResponseHeadersHandler:
         assert "stream_buffer" in flow.metadata
         assert isinstance(flow.metadata["stream_buffer"], bytearray)
 
-    def test_stream_callback_buffers_chunks(self):
+    def test_stream_callback_buffers_chunks(self, real_flow, headers):
         """The stream callback should accumulate chunks in the buffer."""
-        flow = _make_http_flow(host="api.example.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow = real_flow(with_response=False, host="api.example.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         mitm_addon.responseheaders(flow)
 
@@ -463,12 +423,12 @@ class TestResponseHeadersHandler:
         assert bytes(flow.metadata["stream_buffer"]) == b"hello world"
         assert flow.metadata["stream_buffer_state"]["truncated"] is False
 
-    def test_stream_callback_stops_buffering_at_limit(self):
+    def test_stream_callback_stops_buffering_at_limit(self, real_flow, headers):
         """Buffering should stop when exceeding the size limit."""
-        flow = _make_http_flow(host="api.example.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow = real_flow(with_response=False, host="api.example.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         mitm_addon.responseheaders(flow)
 
@@ -486,12 +446,12 @@ class TestResponseHeadersHandler:
         assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
-    def test_stream_callback_large_single_chunk(self):
+    def test_stream_callback_large_single_chunk(self, real_flow, headers):
         """A single chunk larger than the limit should still capture the first part."""
-        flow = _make_http_flow(host="api.example.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow = real_flow(with_response=False, host="api.example.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         mitm_addon.responseheaders(flow)
 
@@ -502,12 +462,12 @@ class TestResponseHeadersHandler:
         assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
-    def test_stream_callback_partial_fill_then_overflow(self):
+    def test_stream_callback_partial_fill_then_overflow(self, real_flow, headers):
         """Partial fill followed by an oversized chunk should capture up to the limit."""
-        flow = _make_http_flow(host="api.example.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow = real_flow(with_response=False, host="api.example.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         mitm_addon.responseheaders(flow)
 
@@ -524,12 +484,12 @@ class TestResponseHeadersHandler:
         assert flow.metadata["stream_buffer"][half:] == bytearray(b"B" * remaining)
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
-    def test_capture_body_also_streams(self):
+    def test_capture_body_also_streams(self, real_flow, headers):
         """When capture_body is set, streaming should still be enabled."""
-        flow = _make_http_flow(host="api.example.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow = real_flow(with_response=False, host="api.example.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
         flow.metadata["capture_body"] = True
 
         mitm_addon.responseheaders(flow)
@@ -537,12 +497,12 @@ class TestResponseHeadersHandler:
         assert callable(flow.response.stream)
         assert "stream_buffer" in flow.metadata
 
-    def test_stream_callback_empty_chunk(self):
+    def test_stream_callback_empty_chunk(self, real_flow, headers):
         """Empty chunks should be forwarded without affecting the buffer."""
-        flow = _make_http_flow(host="api.example.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow = real_flow(with_response=False, host="api.example.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         mitm_addon.responseheaders(flow)
 
@@ -556,29 +516,28 @@ class TestResponseHeadersHandler:
         callback(b"hello")
         assert bytes(flow.metadata["stream_buffer"]) == b"hello"
 
-    def test_no_response_is_noop(self):
+    def test_no_response_is_noop(self, real_flow):
         """Flow without response should not raise."""
-        flow = _make_http_flow(host="api.example.com")
+        flow = real_flow(with_response=False, host="api.example.com")
         flow.response = None
 
         mitm_addon.responseheaders(flow)  # Should not raise
 
     # ---- X NDJSON streaming parser registration (issue #9534) ----
 
-    def test_x_stream_endpoint_registers_ndjson_parser(self):
+    def test_x_stream_endpoint_registers_ndjson_parser(self, real_flow, headers):
         """X filtered-stream endpoint wires incremental NDJSON parser.
 
         Note: X streams return ``content-type: application/json`` with chunked
         transfer encoding — same as non-stream endpoints.  Stream detection is
         URL-based, not content-type-based.
         """
-        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["firewall_name"] = "x"
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         mitm_addon.responseheaders(flow)
 
@@ -590,15 +549,14 @@ class TestResponseHeadersHandler:
         assert state["data_count"] == 2
         assert state["includes"] == {"users": 2}
 
-    def test_x_stream_buffer_capped_at_stream_limit(self):
+    def test_x_stream_buffer_capped_at_stream_limit(self, real_flow, headers):
         """Stream endpoint must NOT buffer multi-MB bodies — uses 64 KB cap."""
-        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["firewall_name"] = "x"
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         mitm_addon.responseheaders(flow)
 
@@ -610,15 +568,14 @@ class TestResponseHeadersHandler:
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
         assert flow.metadata["x_ndjson_state"]["data_count"] == 1
 
-    def test_x_non_stream_endpoint_keeps_unbounded_buffer(self):
+    def test_x_non_stream_endpoint_keeps_unbounded_buffer(self, real_flow, headers):
         """Non-stream X requests still need full body for json.loads."""
-        flow = _make_http_flow(host="api.x.com", path="/2/users/by")
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/users/by")
         flow.metadata["firewall_name"] = "x"
         flow.metadata["original_url"] = "https://api.x.com/2/users/by?ids=1,2,3"
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         mitm_addon.responseheaders(flow)
 
@@ -628,35 +585,35 @@ class TestResponseHeadersHandler:
         assert flow.metadata["stream_buffer_state"]["truncated"] is False
         assert "x_ndjson_state" not in flow.metadata
 
-    def test_x_stream_rules_is_not_registered_as_stream(self):
+    def test_x_stream_rules_is_not_registered_as_stream(self, real_flow, headers):
         """/2/tweets/search/stream/rules is rules mgmt, not a stream — no NDJSON parser."""
-        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream/rules")
+        flow = real_flow(
+            with_response=False, host="api.x.com", path="/2/tweets/search/stream/rules"
+        )
         flow.metadata["firewall_name"] = "x"
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream/rules"
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         mitm_addon.responseheaders(flow)
 
         # No NDJSON state registered; regular unbounded X buffer path
         assert "x_ndjson_state" not in flow.metadata
 
-    def test_x_stream_error_response_keeps_unbounded_buffer(self):
+    def test_x_stream_error_response_keeps_unbounded_buffer(self, real_flow, headers):
         """4xx/5xx on stream endpoints must preserve full error body (no NDJSON parser).
 
         Error responses on stream endpoints return a single JSON error object,
         not NDJSON.  The NDJSON parser gate on 2xx prevents the stream buffer
         from being capped at 64 KB so forensic logging sees the full body.
         """
-        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["firewall_name"] = "x"
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
-        flow.response = MagicMock()
-        flow.response.status_code = 401  # unauthorized — returns JSON error, not NDJSON
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow.response = tutils.tresp(
+            status_code=401, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         mitm_addon.responseheaders(flow)
 
@@ -669,7 +626,7 @@ class TestResponseHeadersHandler:
         assert len(flow.metadata["stream_buffer"]) == len(error_body)
         assert flow.metadata["stream_buffer_state"]["truncated"] is False
 
-    def test_x_stream_gzip_compressed_body(self):
+    def test_x_stream_gzip_compressed_body(self, real_flow, headers):
         """Gzip-encoded NDJSON stream: decompressor + parser wire up correctly."""
         ndjson_body = (
             b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n'
@@ -678,16 +635,18 @@ class TestResponseHeadersHandler:
         )
         compressed = gzip.compress(ndjson_body)
 
-        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["firewall_name"] = "x"
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {
-            "content-type": "application/json",
-            "content-encoding": "gzip",
-        }
-        flow.response.stream = False
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(
+                **{
+                    "content-type": "application/json",
+                    "content-encoding": "gzip",
+                }
+            ),
+        )
 
         mitm_addon.responseheaders(flow)
 
@@ -702,11 +661,10 @@ class TestResponseHeadersHandler:
 
 
 class TestResponseHandler:
-    def setup_method(self):
-        _reset()
-
-    def test_calculates_latency_and_logs(self, registry_file, tmp_path):
-        flow = _make_http_flow(host="api.anthropic.com")
+    def test_calculates_latency_and_logs(
+        self, registry_file, tmp_path, real_flow, mitm_ctx, headers
+    ):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
 
         # Simulate request handler setting metadata
@@ -718,19 +676,22 @@ class TestResponseHandler:
         flow.metadata["original_url"] = "https://api.anthropic.com/"
 
         # Add response
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {
-            "content-length": "256",
-            "content-type": "application/json",
-            "content-encoding": "gzip",
-            "transfer-encoding": "chunked",
-        }
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(
+                **{
+                    "content-length": "256",
+                    "content-type": "application/json",
+                    "content-encoding": "gzip",
+                    "transfer-encoding": "chunked",
+                }
+            ),
+        )
 
         # Simulate tracked start time
         mitm_addon._request_start_times[flow.id] = time.time() - 0.1
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.response(flow)
 
         # Start time should be cleaned up
@@ -745,9 +706,11 @@ class TestResponseHandler:
         assert entry["latency_ms"] > 0
         assert entry["response_size"] == 256
 
-    def test_response_size_from_stream_buffer(self, registry_file, tmp_path):
+    def test_response_size_from_stream_buffer(
+        self, registry_file, tmp_path, real_flow, mitm_ctx, headers
+    ):
         """response_size should use stream_buffer length when not truncated."""
-        flow = _make_http_flow(host="api.example.com")
+        flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
         flow.metadata["vm_run_id"] = "run-abc-123"
@@ -759,22 +722,24 @@ class TestResponseHandler:
         flow.metadata["stream_buffer"] = bytearray(b"x" * 100)
         flow.metadata["stream_buffer_state"] = {"truncated": False}
 
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-length": "999"}  # should be ignored
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-length": "999"})
+        )
 
         mitm_addon._request_start_times[flow.id] = time.time()
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.response(flow)
 
         lines = Path(log_path).read_text().splitlines()
         entry = json.loads(lines[0])
         assert entry["response_size"] == 100  # from buffer, not Content-Length
 
-    def test_response_size_falls_back_when_truncated(self, registry_file, tmp_path):
+    def test_response_size_falls_back_when_truncated(
+        self, registry_file, tmp_path, real_flow, mitm_ctx, headers
+    ):
         """response_size should fall back to Content-Length when buffer is truncated."""
-        flow = _make_http_flow(host="api.example.com")
+        flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
         flow.metadata["vm_run_id"] = "run-abc-123"
@@ -785,22 +750,22 @@ class TestResponseHandler:
         flow.metadata["stream_buffer"] = bytearray(b"x" * 100)
         flow.metadata["stream_buffer_state"] = {"truncated": True}
 
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-length": "50000"}
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-length": "50000"})
+        )
 
         mitm_addon._request_start_times[flow.id] = time.time()
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.response(flow)
 
         lines = Path(log_path).read_text().splitlines()
         entry = json.loads(lines[0])
         assert entry["response_size"] == 50000  # from Content-Length header
 
-    def test_401_firewall_cache_invalidation(self):
+    def test_401_firewall_cache_invalidation(self, real_flow, mitm_ctx, headers):
         """401 response with firewall_base pops the cache entry."""
-        flow = _make_http_flow(host="api.github.com")
+        flow = real_flow(with_response=False, host="api.github.com")
         flow.metadata["vm_run_id"] = "run-conn-1"
         flow.metadata["vm_client_ip"] = "10.200.0.5"
 
@@ -810,9 +775,7 @@ class TestResponseHandler:
         flow.metadata["firewall_api_id"] = "run-conn-1:0"
         flow.metadata["original_url"] = "https://api.github.com/repos"
 
-        flow.response = MagicMock()
-        flow.response.status_code = 401
-        flow.response.headers = {}
+        flow.response = tutils.tresp(status_code=401, headers=http.Headers(**{}))
 
         # Pre-populate firewall header cache keyed by api_id
         cache_key = ("run-conn-1", "run-conn-1:0")
@@ -820,15 +783,15 @@ class TestResponseHandler:
             "headers": {"Authorization": "Bearer old-token"},
         }
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.response(flow)
 
         # Cache entry should have been removed
         assert cache_key not in auth._firewall_header_cache
 
-    def test_error_status_logs_warning(self, tmp_path):
+    def test_error_status_logs_warning(self, tmp_path, real_flow, headers):
         """Response with status >= 400 writes to per-job proxy log."""
-        flow = _make_http_flow(host="api.example.com")
+        flow = real_flow(with_response=False, host="api.example.com")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
 
@@ -839,9 +802,7 @@ class TestResponseHandler:
         flow.metadata["firewall_rule"] = "domain:*.example.com"
         flow.metadata["original_url"] = "https://api.example.com/"
 
-        flow.response = MagicMock()
-        flow.response.status_code = 500
-        flow.response.headers = {}
+        flow.response = tutils.tresp(status_code=500, headers=http.Headers(**{}))
 
         mitm_addon.response(flow)
 
@@ -1265,11 +1226,11 @@ class TestPostWebhook:
 class TestResponseHeadersSseParser:
     """Tests for SSE parser setup in responseheaders()."""
 
-    def test_sets_up_sse_parser_for_model_provider(self):
-        flow = _make_http_flow(host="api.anthropic.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "text/event-stream"}
-        flow.response.stream = False
+    def test_sets_up_sse_parser_for_model_provider(self, real_flow, headers):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "text/event-stream"})
+        )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
 
         mitm_addon.responseheaders(flow)
@@ -1287,15 +1248,18 @@ class TestResponseHeadersSseParser:
         assert flow.metadata["proxy_usage"]["model"] == "claude-sonnet-4-6"
         assert flow.metadata["proxy_usage"]["input_tokens"] == 42
 
-    def test_decompresses_gzip_sse_before_parsing(self):
+    def test_decompresses_gzip_sse_before_parsing(self, real_flow, headers):
         """Compressed SSE streams must be decompressed before usage extraction."""
-        flow = _make_http_flow(host="api.anthropic.com")
-        flow.response = MagicMock()
-        flow.response.headers = {
-            "content-type": "text/event-stream; charset=utf-8",
-            "content-encoding": "gzip",
-        }
-        flow.response.stream = False
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(
+                **{
+                    "content-type": "text/event-stream; charset=utf-8",
+                    "content-encoding": "gzip",
+                }
+            ),
+        )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
 
         mitm_addon.responseheaders(flow)
@@ -1316,33 +1280,33 @@ class TestResponseHeadersSseParser:
         assert flow.metadata["proxy_usage"]["model"] == "claude-sonnet-4-6"
         assert flow.metadata["proxy_usage"]["input_tokens"] == 99
 
-    def test_no_sse_parser_for_non_model_provider(self):
-        flow = _make_http_flow(host="api.github.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "text/event-stream"}
-        flow.response.stream = False
+    def test_no_sse_parser_for_non_model_provider(self, real_flow, headers):
+        flow = real_flow(with_response=False, host="api.github.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "text/event-stream"})
+        )
         flow.metadata["firewall_name"] = "github"
 
         mitm_addon.responseheaders(flow)
 
         assert "proxy_usage" not in flow.metadata
 
-    def test_no_sse_parser_for_non_sse_response(self):
-        flow = _make_http_flow(host="api.anthropic.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+    def test_no_sse_parser_for_non_sse_response(self, real_flow, headers):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
 
         mitm_addon.responseheaders(flow)
 
         assert "proxy_usage" not in flow.metadata
 
-    def test_no_sse_parser_without_firewall_name(self):
-        flow = _make_http_flow(host="api.anthropic.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "text/event-stream"}
-        flow.response.stream = False
+    def test_no_sse_parser_without_firewall_name(self, real_flow, headers):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "text/event-stream"})
+        )
         # No firewall_name set (e.g. auto-allowed VM0 API request)
 
         mitm_addon.responseheaders(flow)
@@ -1353,9 +1317,6 @@ class TestResponseHeadersSseParser:
 class TestResponseUsageReporting:
     """Tests for usage extraction and reporting in response() hook."""
 
-    def setup_method(self):
-        _reset()
-
     def teardown_method(self):
         try:
             usage.usage_executor.submit(lambda: None)
@@ -1364,9 +1325,9 @@ class TestResponseUsageReporting:
                 max_workers=4, thread_name_prefix="usage"
             )
 
-    def test_reports_proxy_usage_from_sse(self, tmp_path):
+    def test_reports_proxy_usage_from_sse(self, tmp_path, real_flow, mitm_ctx, headers):
         """When proxy_usage is set by SSE parser, it should trigger a usage report."""
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
@@ -1380,22 +1341,22 @@ class TestResponseUsageReporting:
             "input_tokens": 100,
             "output_tokens": 500,
         }
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "text/event-stream"}
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "text/event-stream"})
+        )
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(usage, "maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.response(flow)
 
         mock_report.assert_called_once_with(flow, "run-abc-123")
 
-    def test_non_streaming_json_fallback(self, tmp_path):
+    def test_non_streaming_json_fallback(self, tmp_path, real_flow, mitm_ctx, headers):
         """Non-streaming JSON response should extract usage from buffer."""
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
@@ -1415,18 +1376,16 @@ class TestResponseUsageReporting:
         ).encode()
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.metadata["stream_buffer_state"] = {"truncated": False}
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = MagicMock()
-        flow.response.headers.get = lambda k, d="": {
-            "content-type": "application/json",
-            "content-encoding": "",
-            "content-length": str(len(body)),
-        }.get(k, d)
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(
+                **{"content-type": "application/json", "content-length": str(len(body))}
+            ),
+        )
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(usage, "maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.response(flow)
@@ -1438,12 +1397,12 @@ class TestResponseUsageReporting:
         assert extracted["output_tokens"] == 200
         mock_report.assert_called_once_with(flow, "run-abc-123")
 
-    def test_model_provider_buffer_not_truncated(self):
+    def test_model_provider_buffer_not_truncated(self, real_flow, headers):
         """Model provider responses should buffer without truncation."""
-        flow = _make_http_flow(host="api.anthropic.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
 
         mitm_addon.responseheaders(flow)
@@ -1458,12 +1417,12 @@ class TestResponseUsageReporting:
         assert len(buf) == len(large_chunk)
         assert not state["truncated"]
 
-    def test_non_model_provider_buffer_truncated(self):
+    def test_non_model_provider_buffer_truncated(self, real_flow, headers):
         """Non-model-provider responses should truncate at 64KB."""
-        flow = _make_http_flow(host="api.github.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow = real_flow(with_response=False, host="api.github.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
         # No firewall_name — not a model provider
 
         mitm_addon.responseheaders(flow)
@@ -1477,13 +1436,12 @@ class TestResponseUsageReporting:
         assert len(buf) == body_utils.STREAM_BUFFER_LIMIT
         assert state["truncated"]
 
-    def test_billable_connector_buffer_not_truncated(self):
+    def test_billable_connector_buffer_not_truncated(self, real_flow, headers):
         """Billable connector responses should buffer the full body (no 64KB cap)."""
-        flow = _make_http_flow(host="api.x.com")
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow = real_flow(with_response=False, host="api.x.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
         flow.metadata["firewall_name"] = "x"
 
         mitm_addon.responseheaders(flow)
@@ -1497,9 +1455,9 @@ class TestResponseUsageReporting:
         assert len(buf) == len(large_chunk)
         assert not state["truncated"]
 
-    def test_no_usage_report_for_non_model_provider(self, tmp_path):
+    def test_no_usage_report_for_non_model_provider(self, tmp_path, real_flow, mitm_ctx, headers):
         """Non-model-provider requests should not trigger usage reporting."""
-        flow = _make_http_flow(host="api.github.com")
+        flow = real_flow(with_response=False, host="api.github.com")
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
@@ -1507,13 +1465,13 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.github.com/repos"
         flow.metadata["firewall_name"] = "github"
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "application/json"}
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(usage, "maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.response(flow)
@@ -1521,12 +1479,12 @@ class TestResponseUsageReporting:
         # maybe_report_proxy_usage is always called; it checks firewall_name internally
         mock_report.assert_called_once()
 
-    def test_full_path_response_to_opener(self, tmp_path):
+    def test_full_path_response_to_opener(self, tmp_path, real_flow, mitm_ctx, headers):
         """Integration: response() → _maybe_report → _enqueue → _retry → _opener.
 
         Only _opener is mocked — verifies wiring between all intermediate layers.
         """
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-int-001"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
@@ -1540,14 +1498,14 @@ class TestResponseUsageReporting:
             "input_tokens": 100,
             "output_tokens": 500,
         }
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "text/event-stream"}
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "text/event-stream"})
+        )
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(usage, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
@@ -1567,12 +1525,12 @@ class TestResponseUsageReporting:
         assert body["usage"]["input_tokens"] == 100
         assert body["usage"]["output_tokens"] == 500
 
-    def test_full_path_error_to_opener(self, tmp_path):
+    def test_full_path_error_to_opener(self, tmp_path, real_flow, mitm_ctx):
         """Integration: error() → _maybe_report → _enqueue → _retry → _opener.
 
         Verifies that error() hook delivers partial usage all the way to _opener.
         """
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-int-002"
         flow.metadata["vm_network_log_path"] = log_path
@@ -1584,13 +1542,12 @@ class TestResponseUsageReporting:
             "model": "claude-sonnet-4-6",
             "input_tokens": 80,
         }
-        flow.error = MagicMock()
-        flow.error.msg = "connection reset by peer"
+        flow.error = Error("connection reset by peer")
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(usage, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
@@ -1605,14 +1562,14 @@ class TestResponseUsageReporting:
         assert body["runId"] == "run-int-002"
         assert body["usage"]["input_tokens"] == 80
 
-    def test_uses_flow_id_when_message_id_missing(self, tmp_path):
+    def test_uses_flow_id_when_message_id_missing(self, tmp_path, real_flow, mitm_ctx, headers):
         """Missing message_id in proxy_usage falls back to flow.id.
 
         Without a stable per-flow key, server-side dedup of usage webhook
         retries fails, which would double-charge.  flow.id is stable
         across retries because _enqueue_webhook copies the dict once.
         """
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.id = "flow-uuid-xyz-123"
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-fallback"
@@ -1626,14 +1583,14 @@ class TestResponseUsageReporting:
             "input_tokens": 10,
             # no message_id set
         }
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "text/event-stream"}
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "text/event-stream"})
+        )
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(usage, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
@@ -1647,10 +1604,10 @@ class TestResponseUsageReporting:
         body = json.loads(req.data)
         assert body["usage"]["message_id"] == "flow-uuid-xyz-123"
 
-    def test_preserves_message_id_from_response(self, tmp_path):
+    def test_preserves_message_id_from_response(self, tmp_path, real_flow, mitm_ctx, headers):
         """When proxy_usage already has a message_id, flow.id fallback
         must not override it."""
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.id = "flow-should-not-win"
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-preserved"
@@ -1664,14 +1621,14 @@ class TestResponseUsageReporting:
             "message_id": "msg_real_anthropic_id",
             "input_tokens": 10,
         }
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "text/event-stream"}
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "text/event-stream"})
+        )
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(usage, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
@@ -1687,44 +1644,38 @@ class TestResponseUsageReporting:
 
 
 class TestErrorHandler:
-    def setup_method(self):
-        _reset()
-
-    def test_cleans_up_start_time(self, tmp_path):
-        flow = _make_http_flow()
+    def test_cleans_up_start_time(self, tmp_path, real_flow, mitm_ctx):
+        flow = real_flow(with_response=False)
         flow.id = "flow-err-1"
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "net.jsonl")
-        flow.error = MagicMock()
-        flow.error.msg = "connection reset"
+        flow.error = Error("connection reset")
         mitm_addon._request_start_times["flow-err-1"] = 12345.0
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.error(flow)
 
         assert "flow-err-1" not in mitm_addon._request_start_times
 
-    def test_skips_log_when_no_metadata(self):
-        flow = _make_http_flow()
-        flow.error = MagicMock()
-        flow.error.msg = "connection reset"
+    def test_skips_log_when_no_metadata(self, real_flow, mitm_ctx):
+        flow = real_flow(with_response=False)
+        flow.error = Error("connection reset")
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.error(flow)  # Should not raise, no JSONL written
 
-    def test_logs_error_to_jsonl(self, tmp_path):
-        flow = _make_http_flow(host="slack.com", path="/api/chat.postMessage")
+    def test_logs_error_to_jsonl(self, tmp_path, real_flow, mitm_ctx):
+        flow = real_flow(with_response=False, host="slack.com", path="/api/chat.postMessage")
         flow.request.method = "POST"
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["original_url"] = "https://slack.com/api/chat.postMessage"
         flow.metadata["firewall_action"] = "ALLOW"
-        flow.error = MagicMock()
-        flow.error.msg = "connection reset by peer"
+        flow.error = Error("connection reset by peer")
         mitm_addon._request_start_times[flow.id] = time.time() - 1.5
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.error(flow)
 
         lines = Path(log_path).read_text().splitlines()
@@ -1739,8 +1690,8 @@ class TestErrorHandler:
         assert entry["error"] == "connection reset by peer"
         assert entry["latency_ms"] > 0
 
-    def test_error_includes_firewall_context(self, tmp_path):
-        flow = _make_http_flow(host="slack.com")
+    def test_error_includes_firewall_context(self, tmp_path, real_flow, mitm_ctx):
+        flow = real_flow(with_response=False, host="slack.com")
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
@@ -1751,10 +1702,9 @@ class TestErrorHandler:
         flow.metadata["firewall_name"] = "Slack API"
         flow.metadata["firewall_permission"] = "chat:write"
         flow.metadata["firewall_rule_match"] = "POST /chat.postMessage"
-        flow.error = MagicMock()
-        flow.error.msg = "timed out"
+        flow.error = Error("timed out")
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.error(flow)
 
         entry = json.loads(Path(log_path).read_text().strip())
@@ -1765,16 +1715,15 @@ class TestErrorHandler:
         assert entry["firewall_rule_match"] == "POST /chat.postMessage"
         assert entry["error"] == "timed out"
 
-    def test_error_logs_warning_to_proxy_log(self, tmp_path):
-        flow = _make_http_flow(host="slack.com")
+    def test_error_logs_warning_to_proxy_log(self, tmp_path, real_flow):
+        flow = real_flow(with_response=False, host="slack.com")
         log_path = str(tmp_path / "network.jsonl")
         proxy_log = tmp_path / "proxy-run-abc-123.jsonl"
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["vm_proxy_log_path"] = str(proxy_log)
         flow.metadata["original_url"] = "https://slack.com/api/test"
-        flow.error = MagicMock()
-        flow.error.msg = "connection reset by peer"
+        flow.error = Error("connection reset by peer")
 
         mitm_addon.error(flow)
 
@@ -1783,9 +1732,9 @@ class TestErrorHandler:
         assert "connection reset by peer" in content
         assert "slack.com" in content
 
-    def test_error_logs_connector_usage_for_x_stream(self, tmp_path):
+    def test_error_logs_connector_usage_for_x_stream(self, tmp_path, real_flow, headers):
         """Mid-flight stream crash: partial counts still reported (issue #9534)."""
-        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         log_path = str(tmp_path / "network.jsonl")
         proxy_log = tmp_path / "proxy.jsonl"
         flow.metadata["vm_run_id"] = "run-abc-123"
@@ -1804,12 +1753,10 @@ class TestErrorHandler:
         }
         flow.metadata["stream_buffer"] = bytearray()
         flow.metadata["stream_buffer_state"] = {"truncated": False}
-        flow.response = MagicMock()
-        flow.response.status_code = 200
+        flow.response = tutils.tresp(status_code=200)
         # X streams return application/json with chunked transfer, not x-ndjson.
         flow.response.headers = {"content-type": "application/json"}
-        flow.error = MagicMock()
-        flow.error.msg = "connection reset by peer"
+        flow.error = Error("connection reset by peer")
         flow.metadata["vm_sandbox_token"] = "test-token"
 
         with (
@@ -1825,14 +1772,14 @@ class TestErrorHandler:
         assert by_cat["tweet.read"] == 23
         assert by_cat["users.read"] == 5
 
-    def test_full_pipeline_stream_error_midflight(self, tmp_path):
+    def test_full_pipeline_stream_error_midflight(self, tmp_path, real_flow, headers):
         """End-to-end: responseheaders → partial chunks → error() logs observed counts.
 
         Simulates a real scenario: stream opens successfully, a few tweets
         arrive, then the connection resets.  No pre-populated state — the
         incremental parser must have accumulated counts from the chunks.
         """
-        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         log_path = str(tmp_path / "network.jsonl")
         proxy_log = tmp_path / "proxy.jsonl"
         flow.metadata["vm_run_id"] = "run-abc-123"
@@ -1843,10 +1790,9 @@ class TestErrorHandler:
         flow.metadata["firewall_name"] = "x"
         flow.metadata["firewall_permission"] = "tweet.read"
         flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "application/json"}
-        flow.response.stream = False
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
 
         # 1. Register parser
         mitm_addon.responseheaders(flow)
@@ -1859,8 +1805,7 @@ class TestErrorHandler:
         callback(b'{"data":{"id":"3"}')  # no trailing \n — connection dies here
 
         # 3. Connection aborts
-        flow.error = MagicMock()
-        flow.error.msg = "connection reset by peer"
+        flow.error = Error("connection reset by peer")
         flow.metadata["vm_sandbox_token"] = "test-token"
 
         with (
@@ -1879,12 +1824,9 @@ class TestErrorHandler:
 class TestMaybeReportProxyUsage:
     """Tests for maybe_report_proxy_usage helper."""
 
-    def setup_method(self):
-        _reset()
-
-    def test_reports_usage_for_model_provider(self):
+    def test_reports_usage_for_model_provider(self, real_flow):
         """Should enqueue usage when proxy_usage exists for model provider."""
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["proxy_usage"] = {
@@ -1906,9 +1848,9 @@ class TestMaybeReportProxyUsage:
         assert payload["runId"] == "run-abc-123"
         assert payload["usage"]["input_tokens"] == 100
 
-    def test_skips_non_model_provider(self):
+    def test_skips_non_model_provider(self, real_flow):
         """Should NOT enqueue usage for non-model-provider requests."""
-        flow = _make_http_flow(host="api.github.com")
+        flow = real_flow(with_response=False, host="api.github.com")
         flow.metadata["firewall_name"] = "github"
         flow.metadata["proxy_usage"] = {"input_tokens": 50}
 
@@ -1917,9 +1859,9 @@ class TestMaybeReportProxyUsage:
 
         mock_enqueue.assert_not_called()
 
-    def test_skips_when_no_proxy_usage(self):
+    def test_skips_when_no_proxy_usage(self, real_flow):
         """Should NOT enqueue when proxy_usage is absent."""
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         # No proxy_usage in metadata
@@ -1932,9 +1874,9 @@ class TestMaybeReportProxyUsage:
 
         mock_enqueue.assert_not_called()
 
-    def test_skips_when_no_run_id(self):
+    def test_skips_when_no_run_id(self, real_flow):
         """Should NOT enqueue when run_id is empty."""
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["proxy_usage"] = {"input_tokens": 50}
 
@@ -1943,9 +1885,9 @@ class TestMaybeReportProxyUsage:
 
         mock_enqueue.assert_not_called()
 
-    def test_warns_when_missing_sandbox_token(self, tmp_path):
+    def test_warns_when_missing_sandbox_token(self, tmp_path, real_flow):
         """Should write to proxy log and skip when sandbox_token is empty."""
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["vm_sandbox_token"] = ""
         flow.metadata["proxy_usage"] = {"input_tokens": 50}
@@ -1962,9 +1904,9 @@ class TestMaybeReportProxyUsage:
         assert proxy_log.exists()
         assert "missing sandbox_token or api_url" in proxy_log.read_text()
 
-    def test_warns_when_missing_api_url(self, tmp_path):
+    def test_warns_when_missing_api_url(self, tmp_path, real_flow):
         """Should write to proxy log and skip when api_url is empty."""
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["proxy_usage"] = {"input_tokens": 50}
@@ -2006,11 +1948,9 @@ class TestIsXStreamPath:
 class TestLogConnectorUsage:
     """Tests for log_connector_usage helper (issue #9504)."""
 
-    def setup_method(self):
-        _reset()
-
     def _make_x_flow(
         self,
+        real_flow,
         tmp_path,
         *,
         path="/2/tweets",
@@ -2021,7 +1961,7 @@ class TestLogConnectorUsage:
         rule="GET /2/tweets",
         content_encoding="",
     ):
-        flow = _make_http_flow(host="api.x.com", path=path)
+        flow = real_flow(with_response=False, host="api.x.com", path=path)
         flow.metadata["original_url"] = (
             f"https://api.x.com{path}?{query}" if query else f"https://api.x.com{path}"
         )
@@ -2032,12 +1972,15 @@ class TestLogConnectorUsage:
         flow.metadata["firewall_rule_match"] = rule
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.metadata["stream_buffer_state"] = {"truncated": False}
-        flow.response = MagicMock()
-        flow.response.status_code = status
-        flow.response.headers = {
-            "content-type": "application/json",
-            "content-encoding": content_encoding,
-        }
+        flow.response = tutils.tresp(
+            status_code=status,
+            headers=http.Headers(
+                **{
+                    "content-type": "application/json",
+                    "content-encoding": content_encoding,
+                }
+            ),
+        )
         return flow
 
     def _call_and_get_billing(self, flow, run_id="run-abc-123"):
@@ -2059,31 +2002,33 @@ class TestLogConnectorUsage:
 
     # ---- positive cases ----
 
-    def test_logs_single_resource_get(self, tmp_path):
+    def test_logs_single_resource_get(self, tmp_path, real_flow):
         """GET /2/tweets/:id -> category=tweet.read, quantity=1."""
         body = json.dumps({"data": {"id": "1", "text": "hi"}}).encode()
-        flow = self._make_x_flow(tmp_path, path="/2/tweets/1", body=body, rule="GET /2/tweets/{id}")
+        flow = self._make_x_flow(
+            real_flow, tmp_path, path="/2/tweets/1", body=body, rule="GET /2/tweets/{id}"
+        )
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 1
 
-    def test_logs_batch_ids(self, tmp_path):
+    def test_logs_batch_ids(self, tmp_path, real_flow):
         """GET /2/tweets?ids=1,2,3 -> category=tweet.read, quantity=3."""
         body = json.dumps({"data": [{"id": "1"}, {"id": "2"}, {"id": "3"}]}).encode()
-        flow = self._make_x_flow(tmp_path, query="ids=1,2,3", body=body)
+        flow = self._make_x_flow(real_flow, tmp_path, query="ids=1,2,3", body=body)
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 3
 
-    def test_logs_batch_ids_with_deletions(self, tmp_path):
+    def test_logs_batch_ids_with_deletions(self, tmp_path, real_flow):
         """Batch with some missing ids -> bills actual data returned."""
         body = json.dumps({"data": [{"id": "1"}, {"id": "3"}]}).encode()
-        flow = self._make_x_flow(tmp_path, query="ids=1,2,3", body=body)
+        flow = self._make_x_flow(real_flow, tmp_path, query="ids=1,2,3", body=body)
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 2
 
-    def test_logs_expansions_includes(self, tmp_path):
+    def test_logs_expansions_includes(self, tmp_path, real_flow):
         """?expansions=author_id -> three billing payloads for each resource type."""
         body = json.dumps(
             {
@@ -2095,6 +2040,7 @@ class TestLogConnectorUsage:
             }
         ).encode()
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             query="expansions=author_id,attachments.media_keys",
             body=body,
@@ -2103,10 +2049,11 @@ class TestLogConnectorUsage:
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat == {"tweet.read": 1, "users.read": 1, "media.read": 2}
 
-    def test_logs_empty_search_bills_zero(self, tmp_path):
+    def test_logs_empty_search_bills_zero(self, tmp_path, real_flow):
         """Search returning zero results bills 0."""
         body = json.dumps({"data": [], "meta": {"result_count": 0}}).encode()
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             path="/2/tweets/search/recent",
             query="query=nothing",
@@ -2117,7 +2064,7 @@ class TestLogConnectorUsage:
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 0
 
-    def test_soft_error_bills_zero(self, tmp_path):
+    def test_soft_error_bills_zero(self, tmp_path, real_flow):
         """HTTP 200 + errors array + no data field -> bills 0 (issue #9620)."""
         body = json.dumps(
             {
@@ -2134,16 +2081,21 @@ class TestLogConnectorUsage:
             }
         ).encode()
         flow = self._make_x_flow(
-            tmp_path, path="/2/tweets/999999999999999999", body=body, rule="GET /2/tweets/{id}"
+            real_flow,
+            tmp_path,
+            path="/2/tweets/999999999999999999",
+            body=body,
+            rule="GET /2/tweets/{id}",
         )
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 0
 
-    def test_zero_result_search_with_max_results_bills_zero(self, tmp_path):
+    def test_zero_result_search_with_max_results_bills_zero(self, tmp_path, real_flow):
         """Search with max_results=10 returning 0 results -> bills 0 (issue #9620)."""
         body = json.dumps({"meta": {"result_count": 0, "newest_id": None}}).encode()
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             path="/2/tweets/search/recent",
             query="query=xyzzy_no_results&max_results=10",
@@ -2154,7 +2106,7 @@ class TestLogConnectorUsage:
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 0
 
-    def test_logs_expansions_users_and_referenced_tweets(self, tmp_path):
+    def test_logs_expansions_users_and_referenced_tweets(self, tmp_path, real_flow):
         """includes.users and includes.tweets produce two billing payloads."""
         body = json.dumps(
             {
@@ -2166,6 +2118,7 @@ class TestLogConnectorUsage:
             }
         ).encode()
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             query="expansions=author_id,referenced_tweets.id",
             body=body,
@@ -2177,7 +2130,7 @@ class TestLogConnectorUsage:
             "users.read": 2,
         }
 
-    def test_handles_unknown_includes_key(self, tmp_path):
+    def test_handles_unknown_includes_key(self, tmp_path, real_flow):
         """Unknown includes.<key> types get a synthetic <key>.read billing key."""
         body = json.dumps(
             {
@@ -2188,7 +2141,7 @@ class TestLogConnectorUsage:
                 },
             }
         ).encode()
-        flow = self._make_x_flow(tmp_path, query="expansions=author_id", body=body)
+        flow = self._make_x_flow(real_flow, tmp_path, query="expansions=author_id", body=body)
         payloads = self._call_and_get_billing(flow)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat == {
@@ -2197,7 +2150,7 @@ class TestLogConnectorUsage:
             "future_widget.read": 3,
         }
 
-    def test_logs_search_meta_result_count(self, tmp_path):
+    def test_logs_search_meta_result_count(self, tmp_path, real_flow):
         """Search response with meta.result_count -> quantity=20."""
         body = json.dumps(
             {
@@ -2206,6 +2159,7 @@ class TestLogConnectorUsage:
             }
         ).encode()
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             path="/2/tweets/search/recent",
             query="query=hello&max_results=100",
@@ -2217,12 +2171,13 @@ class TestLogConnectorUsage:
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 20
 
-    def test_logs_users_by_usernames_batch(self, tmp_path):
+    def test_logs_users_by_usernames_batch(self, tmp_path, real_flow):
         """GET /2/users/by?usernames=a,b,c -> category=users.read, quantity=2."""
         body = json.dumps(
             {"data": [{"id": "1", "username": "a"}, {"id": "2", "username": "b"}]}
         ).encode()
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             path="/2/users/by",
             query="usernames=a,b,c",
@@ -2234,7 +2189,7 @@ class TestLogConnectorUsage:
         assert p["category"] == "users.read"
         assert p["quantity"] == 2
 
-    def test_logs_tweet_counts_total_tweet_count(self, tmp_path):
+    def test_logs_tweet_counts_total_tweet_count(self, tmp_path, real_flow):
         """GET /2/tweets/counts/recent -> category=tweet.read, quantity=12567."""
         body = json.dumps(
             {
@@ -2246,6 +2201,7 @@ class TestLogConnectorUsage:
             }
         ).encode()
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             path="/2/tweets/counts/recent",
             query="query=hello",
@@ -2256,19 +2212,20 @@ class TestLogConnectorUsage:
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 12567
 
-    def test_handles_gzip_body(self, tmp_path):
+    def test_handles_gzip_body(self, tmp_path, real_flow):
         """gzip-encoded response body decompresses before parsing."""
         raw = json.dumps({"data": [{"id": "1"}], "meta": {"result_count": 1}}).encode()
         body = gzip.compress(raw)
-        flow = self._make_x_flow(tmp_path, body=body, content_encoding="gzip")
+        flow = self._make_x_flow(real_flow, tmp_path, body=body, content_encoding="gzip")
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 1
 
-    def test_logs_write_operation_charges_one(self, tmp_path):
+    def test_logs_write_operation_charges_one(self, tmp_path, real_flow):
         """POST /2/tweets -> category=tweet.write, quantity=1."""
         body = json.dumps({"data": {"id": "99", "text": "new tweet"}}).encode()
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             path="/2/tweets",
             body=body,
@@ -2281,9 +2238,10 @@ class TestLogConnectorUsage:
         assert p["category"] == "tweet.write"
         assert p["quantity"] == 1
 
-    def test_delete_method_charges_one(self, tmp_path):
+    def test_delete_method_charges_one(self, tmp_path, real_flow):
         """DELETE /2/tweets/:id -> category=tweet.write, quantity=1."""
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             path="/2/tweets/123",
             body=b"",
@@ -2295,7 +2253,7 @@ class TestLogConnectorUsage:
         assert p["category"] == "tweet.write"
         assert p["quantity"] == 1
 
-    def test_expansion_with_empty_includes_array(self, tmp_path):
+    def test_expansion_with_empty_includes_array(self, tmp_path, real_flow):
         """includes.users is empty array -> no users.read billing record."""
         body = json.dumps(
             {
@@ -2303,12 +2261,12 @@ class TestLogConnectorUsage:
                 "includes": {"users": []},
             }
         ).encode()
-        flow = self._make_x_flow(tmp_path, query="expansions=author_id", body=body)
+        flow = self._make_x_flow(real_flow, tmp_path, query="expansions=author_id", body=body)
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 1
 
-    def test_empty_search_with_includes_sends_both(self, tmp_path):
+    def test_empty_search_with_includes_sends_both(self, tmp_path, real_flow):
         """Search returns 0 data but non-empty includes -> two billing records,
         primary with quantity=0."""
         body = json.dumps(
@@ -2319,6 +2277,7 @@ class TestLogConnectorUsage:
             }
         ).encode()
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             path="/2/tweets/search/recent",
             query="query=test&expansions=author_id",
@@ -2332,9 +2291,10 @@ class TestLogConnectorUsage:
 
     # ---- streaming: x_ndjson_state feeds billing directly (issue #9534) ----
 
-    def test_logs_x_stream_with_ndjson_state(self, tmp_path):
+    def test_logs_x_stream_with_ndjson_state(self, tmp_path, real_flow):
         """Stream with pre-populated x_ndjson_state -> two billing payloads."""
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             path="/2/tweets/search/stream",
             body=b"",
@@ -2352,9 +2312,10 @@ class TestLogConnectorUsage:
         assert by_cat["tweet.read"] == 62
         assert by_cat["users.read"] == 47
 
-    def test_logs_x_stream_empty_no_fallback(self, tmp_path):
+    def test_logs_x_stream_empty_no_fallback(self, tmp_path, real_flow):
         """Stream that delivered 0 tweets bills 0, NOT _X_UNPARSEABLE_READ_FALLBACK."""
         flow = self._make_x_flow(
+            real_flow,
             tmp_path,
             path="/2/tweets/search/stream",
             body=b"",
@@ -2372,76 +2333,78 @@ class TestLogConnectorUsage:
 
     # ---- fallback / unparseable cases ----
 
-    def test_handles_truncated_buffer(self, tmp_path):
+    def test_handles_truncated_buffer(self, tmp_path, real_flow):
         """Truncated buffer -> unparseable fallback quantity=100."""
-        flow = self._make_x_flow(tmp_path, body=b"{")
+        flow = self._make_x_flow(real_flow, tmp_path, body=b"{")
         flow.metadata["stream_buffer_state"] = {"truncated": True}
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 100
 
-    def test_handles_invalid_json(self, tmp_path):
+    def test_handles_invalid_json(self, tmp_path, real_flow):
         """Malformed body -> unparseable fallback quantity=100."""
-        flow = self._make_x_flow(tmp_path, body=b"not json")
+        flow = self._make_x_flow(real_flow, tmp_path, body=b"not json")
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 100
 
-    def test_billable_counts_fallback_only_when_no_hints(self, tmp_path):
+    def test_billable_counts_fallback_only_when_no_hints(self, tmp_path, real_flow):
         """body unparseable but ?ids= present -> uses ids_count, no fallback."""
-        flow = self._make_x_flow(tmp_path, query="ids=1,2,3", body=b"not json")
+        flow = self._make_x_flow(real_flow, tmp_path, query="ids=1,2,3", body=b"not json")
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 3
 
-    def test_billable_counts_fallback_only_when_no_max_results(self, tmp_path):
+    def test_billable_counts_fallback_only_when_no_max_results(self, tmp_path, real_flow):
         """body unparseable but ?max_results=50 present -> uses max_results."""
-        flow = self._make_x_flow(tmp_path, query="max_results=50", body=b"not json")
+        flow = self._make_x_flow(real_flow, tmp_path, query="max_results=50", body=b"not json")
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "tweet.read"
         assert p["quantity"] == 50
 
     # ---- skip cases ----
 
-    def test_skips_on_server_error(self, tmp_path):
-        flow = self._make_x_flow(tmp_path, status=500)
+    def test_skips_on_server_error(self, tmp_path, real_flow):
+        flow = self._make_x_flow(real_flow, tmp_path, status=500)
         assert self._call_and_get_billing(flow) == []
 
-    def test_skips_on_rate_limit(self, tmp_path):
-        flow = self._make_x_flow(tmp_path, status=429)
+    def test_skips_on_rate_limit(self, tmp_path, real_flow):
+        flow = self._make_x_flow(real_flow, tmp_path, status=429)
         assert self._call_and_get_billing(flow) == []
 
-    def test_skips_on_empty_permission(self, tmp_path):
+    def test_skips_on_empty_permission(self, tmp_path, real_flow):
         """Unknown-endpoint-allow has no stable pricing key."""
-        flow = self._make_x_flow(tmp_path, permission="")
+        flow = self._make_x_flow(real_flow, tmp_path, permission="")
         assert self._call_and_get_billing(flow) == []
 
-    def test_skips_on_empty_run_id(self, tmp_path):
-        flow = self._make_x_flow(tmp_path)
+    def test_skips_on_empty_run_id(self, tmp_path, real_flow):
+        flow = self._make_x_flow(real_flow, tmp_path)
         assert self._call_and_get_billing(flow, run_id="") == []
 
-    def test_skips_for_model_provider(self, tmp_path):
+    def test_skips_for_model_provider(self, tmp_path, real_flow):
         """Model providers go through maybe_report_proxy_usage instead."""
-        flow = self._make_x_flow(tmp_path)
+        flow = self._make_x_flow(real_flow, tmp_path)
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         assert self._call_and_get_billing(flow) == []
 
-    def test_skips_for_non_billable_connector(self, tmp_path):
+    def test_skips_for_non_billable_connector(self, tmp_path, real_flow):
         """Connectors not in _BILLABLE_CONNECTORS are not logged."""
-        flow = self._make_x_flow(tmp_path)
+        flow = self._make_x_flow(real_flow, tmp_path)
         flow.metadata["firewall_name"] = "gamma"
         assert self._call_and_get_billing(flow) == []
 
-    def test_skips_when_no_response(self, tmp_path):
-        flow = self._make_x_flow(tmp_path)
+    def test_skips_when_no_response(self, tmp_path, real_flow):
+        flow = self._make_x_flow(real_flow, tmp_path)
         flow.response = None
         assert self._call_and_get_billing(flow) == []
 
     # ---- integration: response() hook wiring ----
 
-    def test_response_hook_invokes_log_connector_usage(self, tmp_path):
+    def test_response_hook_invokes_log_connector_usage(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
         """response() hook should call usage.log_connector_usage."""
-        flow = _make_http_flow(host="api.x.com", path="/2/tweets")
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
@@ -2450,13 +2413,13 @@ class TestLogConnectorUsage:
         flow.metadata["original_url"] = "https://api.x.com/2/tweets"
         flow.metadata["firewall_name"] = "x"
         flow.metadata["firewall_permission"] = "tweet.write"
-        flow.response = MagicMock()
-        flow.response.status_code = 200
-        flow.response.headers = {"content-type": "application/json"}
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(usage, "maybe_report_proxy_usage"),
             patch.object(usage, "log_connector_usage") as mock_log_connector,
         ):
@@ -2466,18 +2429,20 @@ class TestLogConnectorUsage:
 
     # ---- webhook skip ----
 
-    def test_skips_webhook_without_sandbox_token(self, tmp_path):
+    def test_skips_webhook_without_sandbox_token(self, tmp_path, real_flow):
         """When sandbox token is empty, no webhook is enqueued."""
         body = json.dumps({"data": {"id": "1", "text": "hi"}}).encode()
-        flow = self._make_x_flow(tmp_path, path="/2/tweets/1", body=body, rule="GET /2/tweets/{id}")
+        flow = self._make_x_flow(
+            real_flow, tmp_path, path="/2/tweets/1", body=body, rule="GET /2/tweets/{id}"
+        )
         flow.metadata["vm_sandbox_token"] = ""
         assert self._call_and_get_billing(flow) == []
 
     # ---- full pipeline: responseheaders -> stream chunks -> response (issue #9534) ----
 
-    def test_full_streaming_pipeline_filtered_stream(self, tmp_path):
+    def test_full_streaming_pipeline_filtered_stream(self, tmp_path, real_flow, mitm_ctx, headers):
         """End-to-end: responseheaders registers parser, chunks accumulate, response() logs."""
-        flow = _make_http_flow(host="api.x.com", path="/2/tweets/search/stream")
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
@@ -2488,8 +2453,7 @@ class TestLogConnectorUsage:
         flow.metadata["firewall_name"] = "x"
         flow.metadata["firewall_permission"] = "tweet.read"
         flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
-        flow.response = MagicMock()
-        flow.response.status_code = 200
+        flow.response = tutils.tresp(status_code=200)
         # X streams return application/json with chunked transfer, not x-ndjson.
         flow.response.headers = {"content-type": "application/json"}
         flow.response.stream = False
@@ -2513,7 +2477,7 @@ class TestLogConnectorUsage:
 
         # 3. Simulated disconnect - response() fires and logs via webhook
         with (
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch("usage.get_api_url", return_value="https://app.test"),
             patch("usage._enqueue_webhook") as mock_enqueue,
         ):
@@ -2531,23 +2495,19 @@ class TestLogConnectorUsage:
 class TestErrorUsageReporting:
     """Tests that error() hook calls maybe_report_proxy_usage."""
 
-    def setup_method(self):
-        _reset()
-
-    def test_error_calls_maybe_report(self, tmp_path):
+    def test_error_calls_maybe_report(self, tmp_path, real_flow, mitm_ctx):
         """error() should invoke maybe_report_proxy_usage."""
-        flow = _make_http_flow(host="api.anthropic.com")
+        flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
         flow.metadata["firewall_action"] = "ALLOW"
-        flow.error = MagicMock()
-        flow.error.msg = "connection reset by peer"
+        flow.error = Error("connection reset by peer")
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(),
             patch.object(usage, "maybe_report_proxy_usage") as mock_report,
         ):
             mitm_addon.error(flow)
@@ -2658,43 +2618,34 @@ class TestDoneHook:
 
 
 class TestTlsClienthello:
-    def setup_method(self):
-        _reset()
-
-    def test_unregistered_vm_ignored(self, registry_file):
-        data = _make_tls_data(client_ip="192.168.99.99")
+    def test_unregistered_vm_ignored(self, registry_file, make_tls_data, mitm_ctx):
+        data = make_tls_data(client_ip="192.168.99.99")
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
         ):
             mitm_addon.tls_clienthello(data)
 
         assert data.ignore_connection is True
 
-    def test_mitm_enabled_returns_early(self, registry_file):
+    def test_mitm_enabled_returns_early(self, registry_file, make_tls_data, mitm_ctx):
         """When MITM is enabled, tls_clienthello should return without setting ignore_connection."""
-        data = _make_tls_data(client_ip="10.200.0.1", sni="blocked.com")
+        data = make_tls_data(client_ip="10.200.0.1", sni="blocked.com")
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
         ):
             mitm_addon.tls_clienthello(data)
 
         # MITM VM (10.200.0.1) should NOT set ignore_connection
         assert data.ignore_connection is False
 
-    def test_registered_vm_allows_mitm(self, registry_file):
+    def test_registered_vm_allows_mitm(self, registry_file, make_tls_data, mitm_ctx):
         """Registered VM does NOT set ignore_connection (allows MITM interception)."""
-        data = _make_tls_data(client_ip="10.200.0.2", sni="anything.com")
+        data = make_tls_data(client_ip="10.200.0.2", sni="anything.com")
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
         ):
             mitm_addon.tls_clienthello(data)
 
@@ -2702,34 +2653,12 @@ class TestTlsClienthello:
         assert data.ignore_connection is False
 
 
-def _make_tcp_flow(client_ip="10.200.0.1"):
-    """Create a mock TCP flow."""
-    flow = MagicMock()
-    flow.client_conn.peername = (client_ip, 12345)
-    flow.server_conn.address = ("140.82.116.3", 22)
-    flow.metadata = {}
-    flow.error = None
-    # Two messages: one from client, one from server
-    client_msg = MagicMock()
-    client_msg.content = b"hello"
-    client_msg.from_client = True
-    server_msg = MagicMock()
-    server_msg.content = b"SSH-2.0-babeld"
-    server_msg.from_client = False
-    flow.messages = [client_msg, server_msg]
-    return flow
-
-
 class TestTcpStart:
-    def setup_method(self):
-        _reset()
-
-    def test_sets_metadata_for_registered_vm(self, registry_file):
-        flow = _make_tcp_flow(client_ip="10.200.0.1")
+    def test_sets_metadata_for_registered_vm(self, registry_file, mitm_ctx, real_tcp_flow):
+        flow = real_tcp_flow(client_ip="10.200.0.1")
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(registry_file)),
         ):
             mitm_addon.tcp_start(flow)
 
@@ -2737,24 +2666,22 @@ class TestTcpStart:
         assert "vm_network_log_path" in flow.metadata
         assert "tcp_start_time" in flow.metadata
 
-    def test_skips_when_no_client_ip(self, registry_file):
-        flow = _make_tcp_flow()
+    def test_skips_when_no_client_ip(self, registry_file, mitm_ctx, real_tcp_flow):
+        flow = real_tcp_flow()
         flow.client_conn.peername = None
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(registry_file)),
         ):
             mitm_addon.tcp_start(flow)
 
         assert "vm_run_id" not in flow.metadata
 
-    def test_skips_when_vm_not_registered(self, registry_file):
-        flow = _make_tcp_flow(client_ip="192.168.99.99")
+    def test_skips_when_vm_not_registered(self, registry_file, mitm_ctx, real_tcp_flow):
+        flow = real_tcp_flow(client_ip="192.168.99.99")
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(registry_file)),
         ):
             mitm_addon.tcp_start(flow)
 
@@ -2762,17 +2689,14 @@ class TestTcpStart:
 
 
 class TestTcpLog:
-    def setup_method(self):
-        _reset()
-
-    def test_logs_tcp_connection(self, registry_file, tmp_path):
-        flow = _make_tcp_flow(client_ip="10.200.0.1")
+    def test_logs_tcp_connection(self, registry_file, tmp_path, mitm_ctx, real_tcp_flow):
+        flow = real_tcp_flow(client_ip="10.200.0.1")
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["tcp_start_time"] = time.time() - 0.05
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.tcp_end(flow)
 
         lines = Path(log_path).read_text().splitlines()
@@ -2786,16 +2710,15 @@ class TestTcpLog:
         assert entry["response_size"] == 14  # b"SSH-2.0-babeld"
         assert "error" not in entry
 
-    def test_logs_tcp_error(self, registry_file, tmp_path):
-        flow = _make_tcp_flow(client_ip="10.200.0.1")
+    def test_logs_tcp_error(self, registry_file, tmp_path, mitm_ctx, real_tcp_flow):
+        flow = real_tcp_flow(client_ip="10.200.0.1")
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["tcp_start_time"] = time.time()
-        flow.error = MagicMock()
-        flow.error.msg = "connection reset by peer"
+        flow.error = Error("connection reset by peer")
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.tcp_error(flow)
 
         lines = Path(log_path).read_text().splitlines()
@@ -2803,38 +2726,38 @@ class TestTcpLog:
         assert entry["type"] == "tcp"
         assert entry["error"] == "connection reset by peer"
 
-    def test_skips_when_no_run_id(self, tmp_path):
-        flow = _make_tcp_flow()
+    def test_skips_when_no_run_id(self, tmp_path, mitm_ctx, real_tcp_flow):
+        flow = real_tcp_flow()
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_network_log_path"] = log_path
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.tcp_end(flow)
 
         assert not Path(log_path).exists()
 
-    def test_handles_missing_server_addr(self, tmp_path):
-        flow = _make_tcp_flow()
+    def test_handles_missing_server_addr(self, tmp_path, mitm_ctx, real_tcp_flow):
+        flow = real_tcp_flow()
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["tcp_start_time"] = time.time()
         flow.server_conn = None
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.tcp_end(flow)
 
         entry = json.loads(Path(log_path).read_text().strip())
         assert entry["host"] == "unknown"
         assert entry["port"] == 0
 
-    def test_handles_missing_start_time(self, tmp_path):
-        flow = _make_tcp_flow()
+    def test_handles_missing_start_time(self, tmp_path, mitm_ctx, real_tcp_flow):
+        flow = real_tcp_flow()
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+        with mitm_ctx():
             mitm_addon.tcp_end(flow)
 
         entry = json.loads(Path(log_path).read_text().strip())
@@ -2844,10 +2767,7 @@ class TestTcpLog:
 class TestFirewallHeaderCache:
     """Tests for get_firewall_headers caching and concurrency protection."""
 
-    def setup_method(self):
-        _reset()
-
-    async def test_concurrent_fetches_coalesce(self):
+    async def test_concurrent_fetches_coalesce(self, headers):
         """Multiple concurrent get_firewall_headers calls should make only one HTTP request."""
         fetch_count = 0
 
@@ -2873,7 +2793,7 @@ class TestFirewallHeaderCache:
         assert all(r["headers"] == {"Authorization": "Bearer token"} for r in results)
         assert all(r["cache_hit"] is False or r["cache_hit"] is True for r in results)
 
-    async def test_different_keys_fetch_independently(self):
+    async def test_different_keys_fetch_independently(self, headers):
         """Different (run_id, api_id) pairs should fetch independently."""
         fetch_count = 0
 
@@ -2896,7 +2816,7 @@ class TestFirewallHeaderCache:
 
         assert fetch_count == 2
 
-    async def test_cache_hit_skips_fetch(self):
+    async def test_cache_hit_skips_fetch(self, headers):
         """Cached entry should be returned without fetching."""
         auth._firewall_header_cache[("run-1", "api-1")] = {
             "headers": {"Authorization": "Bearer cached"},
@@ -2912,7 +2832,7 @@ class TestFirewallHeaderCache:
         assert "refreshed_connectors" not in result
         assert "refreshed_secrets" not in result
 
-    async def test_expired_cache_triggers_fetch(self):
+    async def test_expired_cache_triggers_fetch(self, headers):
         """Expired cache entry should trigger a new fetch."""
         auth._firewall_header_cache[("run-1", "api-1")] = {
             "headers": {"Authorization": "Bearer old"},
@@ -2949,7 +2869,7 @@ class TestFirewallHeaderCache:
 
         assert ("run-1", "api-1") not in auth._firewall_header_cache
 
-    def test_registry_eviction_cleans_locks(self, tmp_path):
+    def test_registry_eviction_cleans_locks(self, tmp_path, mitm_ctx, headers):
         """When a run is evicted from registry, its locks should be cleaned up too."""
         auth._firewall_header_cache[("run-old", "api-1")] = {
             "headers": {},
@@ -2962,8 +2882,7 @@ class TestFirewallHeaderCache:
         reg_path.write_text(json.dumps(registry))
 
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            mitm_ctx(registry_path=str(reg_path)),
         ):
             mitm_addon._registry_cache_key = (0, 0)
             mitm_addon.load_registry()
@@ -3063,13 +2982,13 @@ class TestUsagePendingCounter:
         finally:
             usage.usage_executor = old_executor
 
-    def test_decorator_pop_prevents_double_decrement(self, tmp_path):
+    def test_decorator_pop_prevents_double_decrement(self, tmp_path, real_flow):
         """If both response() and error() fire for the same flow, decrement only once."""
         usage.set_pending_path(str(tmp_path / "usage-pending"))
         usage.increment_flows()
         assert usage._in_flight_flows == 1
 
-        flow = _make_http_flow()
+        flow = real_flow(with_response=False)
         flow.metadata["_usage_flow_tracked"] = True
 
         # Simulate response() followed by error() on the same flow.
@@ -3083,12 +3002,12 @@ class TestUsagePendingCounter:
         fake_handler(flow)  # second call: flag already popped, no decrement
         assert usage._in_flight_flows == 0  # stays at 0, not -1
 
-    def test_untracked_flow_not_decremented(self, tmp_path):
+    def test_untracked_flow_not_decremented(self, tmp_path, real_flow):
         """Flows without _usage_flow_tracked should not touch the counter."""
         usage.set_pending_path(str(tmp_path / "usage-pending"))
         usage.increment_flows()  # simulate one tracked flow in flight
 
-        flow = _make_http_flow()
+        flow = real_flow(with_response=False)
         # No _usage_flow_tracked in metadata — this is a regular flow.
 
         @mitm_addon._track_usage_flow


### PR DESCRIPTION
## Summary

Phase 2 of the mitm-addon test-suite migration started in #9987 (Phase 1 pilot).
Closes #9990.

- Eliminates ~180 `MagicMock()` flow substitutes across `test_handlers.py` (3122 lines) and `test_connectors.py` (4510 lines) in favour of real `mitmproxy.http.HTTPFlow` objects built via `mitmproxy.test.tflow` / `tutils`.
- Consolidates builders into `conftest.py`: `real_flow`, `real_tcp_flow`, `make_tls_data`, `mitm_ctx`, `headers`, plus an autouse module-state reset fixture.
- Drops the per-file helpers `_make_http_flow`, `_make_tls_data`, `_reset`, `_make_tcp_flow`, `_make_flow`, `_headers`, and per-class `setup_method(self): _reset()` copy-paste.
- Collapses the repeated `patch.object(mitm_addon, "get_registry_path", ...)` + `patch.object(mitm_addon, "get_api_url", ...)` + `patch.object(mitm_addon.ctx, "log", ...)` triple into a single `mitm_ctx(...)` call.

## Non-goals (Phase 3 — #9991)

- `AsyncMock` patches on `mitm_addon.handle_firewall_request` + `assert_called_*` — left as-is.
- `MagicMock()` for external boundaries (`usage._opener`, `usage.usage_executor`, urllib `HTTPError`) — AP-4-legal; kept.

## Test plan

- [x] `pytest tests/` — 848 passed
- [x] `ruff check tests/` — clean
- [x] `ruff format tests/` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)