### PR TITLE
chore(rust): update dependencies (2026-04-19)

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -54,7 +54,7 @@ clap = "4"
 flate2 = "1"
 futures-util = "0.3"
 hex = "0.4"
-hmac = "0.13.0-rc.6"
+hmac = "0.13.0"
 httpmock = "0.8"
 libc = "0.2"
 nix = { version = "0.31", default-features = false }


### PR DESCRIPTION
## Summary

Weekly Rust dependency maintenance run (2026-04-19).

- Ran `cargo update --verbose` across the `crates/` workspace.
- Bumped `hmac` constraint in `crates/Cargo.toml` from the pre-release `0.13.0-rc.6` to the stable `0.13.0` (no resolved lockfile version change; the rc spec was already accepting the stable release).
- `cargo test --workspace` passes: all tests green.

## What was updated

- **Manifest bumps:** `hmac` `0.13.0-rc.6` → `0.13.0` (stable release; resolved version unchanged).
- **Lockfile (`Cargo.lock`):** no changes — all compatible-range resolutions were already at latest.

## Dependencies that could NOT be updated

All three are transitive and pinned by upstream crates; they cannot be moved without upstream releases:

- `crc` `3.3.0` → `3.4.0` available. Pinned by `crc-fast 1.9.0` (→ `aws-smithy-checksums 0.64.7` → `aws-sdk-s3 1.129.0`).
- `crc-fast` `1.9.0` → `1.10.0` available. Pinned by `aws-smithy-checksums 0.64.7` (→ `aws-sdk-s3 1.129.0`).
- `generic-array` `0.14.7` → `0.14.9` available. Pinned by `crypto-common 0.1.7` via an exact-version requirement (`=0.14.7`); reaches us through `digest → hmac 0.12 → aws-sdk-s3 1.129.0` and `sha1 / sha2 → headers / tungstenite / aws-sigv4`.

No direct-dependency majors were bumped (per policy: no major bumps without breaking-change verification).

## Manual version bumps

- `crates/Cargo.toml`: `hmac = "0.13.0-rc.6"` → `hmac = "0.13.0"`.

## Test status

- `cargo test --workspace --no-fail-fast`: **PASS**. All crate tests, integration tests, and doc tests succeed. No test code changes required.