### PR TITLE
fix(ts-rest-handler): report unhandled 5xx to Sentry

### DIFF
--- a/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as Sentry from "@sentry/nextjs";
 
 vi.mock("@sentry/nextjs", () => {
@@ -13,6 +13,10 @@ import { badRequest, notFound, forbidden } from "../shared/errors";
 
 describe("createSafeErrorHandler", () => {
   const handler = createSafeErrorHandler("test-route");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("should return correct status for BadRequestError", async () => {
     const response = handler(badRequest("Missing org context"));
@@ -48,6 +52,13 @@ describe("createSafeErrorHandler", () => {
     const body = await response!.json();
     expect(body.error.code).toBe("INTERNAL_ERROR");
     expect(body.error.message).not.toContain("database");
+  });
+
+  it("does not report typed ApiError (4xx) to Sentry", async () => {
+    const response = handler(badRequest("invalid input"));
+    expect(response).toBeDefined();
+    expect(response!.status).toBe(400);
+    expect(vi.mocked(Sentry.captureException)).not.toHaveBeenCalled();
   });
 
   it("reports unknown 5xx errors to Sentry with route tag and returns 500", async () => {

--- a/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
@@ -1,21 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import * as Sentry from "@sentry/nextjs";
 
-const captureException = vi.fn();
 vi.mock("@sentry/nextjs", () => {
   return {
-    captureException: (...args: unknown[]) => {
-      return captureException(...args);
-    },
+    captureException: vi.fn(),
     flush: vi.fn().mockResolvedValue(true),
   };
 });
 
 import { createSafeErrorHandler } from "../ts-rest-handler";
 import { badRequest, notFound, forbidden } from "../shared/errors";
-
-beforeEach(() => {
-  captureException.mockReset();
-});
 
 describe("createSafeErrorHandler", () => {
   const handler = createSafeErrorHandler("test-route");
@@ -63,8 +57,8 @@ describe("createSafeErrorHandler", () => {
     expect(response!.status).toBe(500);
     const body = await response!.json();
     expect(body.error.code).toBe("INTERNAL_ERROR");
-    expect(captureException).toHaveBeenCalledTimes(1);
-    expect(captureException).toHaveBeenCalledWith(err, {
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(err, {
       mechanism: { type: "ts-rest-handler", handled: true },
       captureContext: { tags: { route: "test-route" } },
     });

--- a/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
@@ -60,11 +60,9 @@ describe("createSafeErrorHandler", () => {
     const err = new Error("db timeout");
     handler(err);
     expect(captureException).toHaveBeenCalledTimes(1);
-    const [capturedErr, ctx] = captureException.mock.calls[0];
-    expect(capturedErr).toBe(err);
-    expect(ctx).toMatchObject({
-      tags: { route: "test-route" },
+    expect(captureException).toHaveBeenCalledWith(err, {
       mechanism: { type: "ts-rest-handler", handled: true },
+      captureContext: { tags: { route: "test-route" } },
     });
   });
 

--- a/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
@@ -56,20 +56,17 @@ describe("createSafeErrorHandler", () => {
     expect(body.error.message).not.toContain("database");
   });
 
-  it("reports unknown 5xx errors to Sentry with route tag", () => {
+  it("reports unknown 5xx errors to Sentry with route tag and returns 500", async () => {
     const err = new Error("db timeout");
-    handler(err);
+    const response = handler(err);
+    expect(response).toBeDefined();
+    expect(response!.status).toBe(500);
+    const body = await response!.json();
+    expect(body.error.code).toBe("INTERNAL_ERROR");
     expect(captureException).toHaveBeenCalledTimes(1);
     expect(captureException).toHaveBeenCalledWith(err, {
       mechanism: { type: "ts-rest-handler", handled: true },
       captureContext: { tags: { route: "test-route" } },
     });
-  });
-
-  it("does NOT report typed ApiError (4xx) to Sentry", () => {
-    handler(badRequest("bad input"));
-    handler(notFound("missing"));
-    handler(forbidden("nope"));
-    expect(captureException).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
@@ -1,6 +1,21 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const captureException = vi.fn();
+vi.mock("@sentry/nextjs", () => {
+  return {
+    captureException: (...args: unknown[]) => {
+      return captureException(...args);
+    },
+    flush: vi.fn().mockResolvedValue(true),
+  };
+});
+
 import { createSafeErrorHandler } from "../ts-rest-handler";
 import { badRequest, notFound, forbidden } from "../shared/errors";
+
+beforeEach(() => {
+  captureException.mockReset();
+});
 
 describe("createSafeErrorHandler", () => {
   const handler = createSafeErrorHandler("test-route");
@@ -39,5 +54,24 @@ describe("createSafeErrorHandler", () => {
     const body = await response!.json();
     expect(body.error.code).toBe("INTERNAL_ERROR");
     expect(body.error.message).not.toContain("database");
+  });
+
+  it("reports unknown 5xx errors to Sentry with route tag", () => {
+    const err = new Error("db timeout");
+    handler(err);
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [capturedErr, ctx] = captureException.mock.calls[0];
+    expect(capturedErr).toBe(err);
+    expect(ctx).toMatchObject({
+      tags: { route: "test-route" },
+      mechanism: { type: "ts-rest-handler", handled: true },
+    });
+  });
+
+  it("does NOT report typed ApiError (4xx) to Sentry", () => {
+    handler(badRequest("bad input"));
+    handler(notFound("missing"));
+    handler(forbidden("nope"));
+    expect(captureException).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -103,8 +103,8 @@ export function createSafeErrorHandler(
     // Sentry because the error is caught here and a 500 JSON is returned,
     // so Next.js's onRequestError instrumentation hook never fires.
     Sentry.captureException(err, {
-      tags: { route: routeName },
       mechanism: { type: "ts-rest-handler", handled: true },
+      captureContext: { tags: { route: routeName } },
     });
     return TsRestResponse.fromJson(
       {
@@ -189,7 +189,9 @@ export function createHandler<T extends AppRouter>(
         await Promise.all([
           flushLogs(),
           flushAxiom(),
-          Sentry.flush(2000).catch(() => false),
+          Sentry.flush(2000).catch(() => {
+            return false;
+          }),
         ]);
       },
     ],

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -16,6 +16,7 @@ import { createNextHandler, tsr } from "@ts-rest/serverless/next";
 import { TsRestResponse } from "@ts-rest/serverless";
 import type { TsRestRequest } from "@ts-rest/serverless";
 import type { AppRouter } from "@ts-rest/core";
+import * as Sentry from "@sentry/nextjs";
 import { flushLogs, logger } from "./shared/logger";
 import { ingestRequestLog, flushAxiom } from "./shared/axiom";
 import { isApiError } from "./shared/errors";
@@ -98,6 +99,13 @@ export function createSafeErrorHandler(
 
     // Non-validation errors: log full details server-side, return generic message
     log.error(`${routeName} error:`, err);
+    // Report to Sentry. Without this, ts-rest-handled 5xx never reaches
+    // Sentry because the error is caught here and a 500 JSON is returned,
+    // so Next.js's onRequestError instrumentation hook never fires.
+    Sentry.captureException(err, {
+      tags: { route: routeName },
+      mechanism: { type: "ts-rest-handler", handled: true },
+    });
     return TsRestResponse.fromJson(
       {
         error: {
@@ -175,8 +183,14 @@ export function createHandler<T extends AppRouter>(
           requestStartTimes.delete(request);
         }
 
-        // Flush all pending logs and ingested events to Axiom
-        await Promise.all([flushLogs(), flushAxiom()]);
+        // Flush all pending logs and ingested events to Axiom, and any
+        // pending Sentry events. Sentry.flush is wrapped so delivery
+        // failures don't block the response.
+        await Promise.all([
+          flushLogs(),
+          flushAxiom(),
+          Sentry.flush(2000).catch(() => false),
+        ]);
       },
     ],
   });


### PR DESCRIPTION
## Summary

Every 5xx from a ts-rest route is currently invisible in Sentry. Root cause: `createSafeErrorHandler` catches any non-validation error and returns a JSON 500 response (`ts-rest-handler.ts:99-109`). Because the error is caught before it propagates, Next.js's `onRequestError` instrumentation hook — the only callsite of `Sentry.captureException` in `apps/web` (`instrumentation.ts:43`) — never fires.

This PR explicitly calls `Sentry.captureException` in the 500 branch, tagged with the route name and a `ts-rest-handler` mechanism marker.

- **Scope:** only the unknown-error / fallthrough 500 branch. Typed `ApiError` (BadRequest, NotFound, Forbidden, Conflict, InsufficientCredits, etc.) and Zod validation errors are intentionally **not** reported — they're expected client-side responses, not incidents.
- **Flush:** added `Sentry.flush(2000)` to the existing `Promise.all` in `responseHandlers`, so events are actually delivered before Vercel terminates the serverless function. Wrapped in `.catch()` so Sentry issues can't block the response.

## Why now

Discovered while debugging `/api/zero/report-error` 500 on 2026-04-18: Axiom had the request log but zero signal in Sentry, even though `@sentry/nextjs` is initialized in production. This gap affects **all** ts-rest routes using `createSafeErrorHandler` (15+ routes: `zero-secrets`, `zero-connectors`, `storages:*`, `webhook:*`, etc.).

Companion to #10041 (logger Error-serialization fix). Neither PR depends on the other; together they mean future ts-rest 500s show up with full stacks in Axiom **and** are aggregated/alertable in Sentry.

## Test plan

- [x] Existing `createSafeErrorHandler` tests still pass (BadRequest/NotFound/Forbidden still map to correct status, 500 still returns generic message).
- [x] New test: unknown Error triggers `Sentry.captureException` with correct `tags.route` + `mechanism`.
- [x] New test: typed ApiError (4xx) does NOT call `Sentry.captureException`.
- [ ] CI: lint + type-check + vitest pass.
- [ ] Manual: throw from a route on preview, confirm the event appears in Sentry `web` project with the route tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)