### PR TITLE
fix(ci): align upload-artifact and download-artifact to v7

### DIFF
--- a/.github/workflows/docker-toolchain-publish.yml
+++ b/.github/workflows/docker-toolchain-publish.yml
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           path: /tmp/digests
           pattern: digests-*


### PR DESCRIPTION
## Summary
- `docker-toolchain-publish.yml` had a cross-major version mismatch: `upload-artifact@v7` paired with `download-artifact@v8`
- These versions are incompatible — artifacts uploaded with v7 cannot be reliably downloaded with v8
- Both are now pinned to v7 to resolve the mismatch

## Test plan
- [ ] Verify CI passes for `docker-toolchain-publish` workflow
- [ ] Confirm the `merge` job can successfully download artifacts produced by the `build` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)