### PR TITLE
test(zoom): assert scope= is present in authorization URL

### DIFF
--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/zoom.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/zoom.test.ts
@@ -31,6 +31,7 @@ describe("connector/providers/zoom", () => {
       );
       expect(url).toContain("state=test-state");
       expect(url).toContain("response_type=code");
+      expect(url).toContain("scope=");
       expect(url).toContain("zoom.us/oauth/authorize");
     });
   });


### PR DESCRIPTION
## Summary
- Follow-up to #10018 — carries forward a P1 regression test that was lost to a race with the squash-merge
- Adds `expect(url).toContain("scope=")` to `zoom.test.ts` so a future edit dropping the `scope` param from `buildZoomAuthorizationUrl` URLSearchParams (the bug fixed in 962dc2a2) will fail loudly instead of silently
- Mirrors the pattern in `spotify.test.ts:34`

## Test plan
- [x] `pnpm turbo run lint --filter=web` passes
- [x] `pnpm check-types` passes
- [ ] CI runs `zoom.test.ts`

Generated with [Claude Code](https://claude.com/claude-code)