### PR TITLE
feat(chat): escape first thread to agent chat page via mod+shift+up

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -2,6 +2,7 @@ import { command } from "ccstate";
 import { matchShortcut } from "@vm0/ui";
 import { chatThreads$, currentChatThreadId$ } from "../agent-chat.ts";
 import { navigateToChat$ } from "../zero-page/zero-nav.ts";
+import { detachedNavigateTo$ } from "../route.ts";
 import { onDomEventFn } from "../utils.ts";
 import { currentChatThreadSignals$ } from "./create-chat-thread.ts";
 
@@ -21,6 +22,14 @@ const navigateToAdjacentThread$ = command(
       return t.id === currentId;
     });
     if (idx === -1) {
+      return;
+    }
+    if (direction === "prev" && idx === 0) {
+      // Escape upwards from the first thread to the agent chat page.
+      const agentId = threads[0]!.agentId;
+      set(detachedNavigateTo$, "/agents/:agentId/chat", {
+        pathParams: { agentId },
+      });
       return;
     }
     const targetIdx = direction === "prev" ? idx - 1 : idx + 1;
@@ -53,7 +62,8 @@ const scrollCurrentThread$ = command(
 //
 // - mod+up / mod+down        → scroll messages to top / bottom
 // - mod+shift+up / shift+down → jump to previous / next thread in the list
-//   (no-op at the boundaries)
+//   (mod+shift+up on the first thread escapes to /agents/:agentId/chat;
+//    mod+shift+down on the last thread is a no-op)
 export const setupChatPageKeyboard$ = command(
   ({ set }, signal: AbortSignal) => {
     document.addEventListener(

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-keyboard.ts
@@ -1,0 +1,41 @@
+import { command } from "ccstate";
+import { matchShortcut } from "@vm0/ui";
+import { chatThreads$ } from "../agent-chat.ts";
+import { navigateToChat$ } from "./zero-nav.ts";
+import { onDomEventFn } from "../utils.ts";
+
+const navigateToFirstThread$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const threads = await get(chatThreads$);
+    signal.throwIfAborted();
+    if (threads.length === 0) {
+      return;
+    }
+    set(navigateToChat$, threads[0]!.id);
+  },
+);
+
+// Keyboard shortcuts for the agent chat landing page (/agents/:agentId/chat).
+//
+// Listener is attached to `document` so it fires even while focus is inside
+// the composer textarea, mirroring setupChatPageKeyboard$ on the thread page.
+//
+// - mod+shift+down → jump into the first thread in the list (no-op when empty)
+export const setupAgentChatPageKeyboard$ = command(
+  ({ set }, signal: AbortSignal) => {
+    document.addEventListener(
+      "keydown",
+      onDomEventFn(async (e: KeyboardEvent) => {
+        if (e.defaultPrevented) {
+          return;
+        }
+        if (matchShortcut("mod+shift+arrowdown", e)) {
+          e.preventDefault();
+          await set(navigateToFirstThread$, signal);
+          return;
+        }
+      }),
+      { signal },
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -15,6 +15,7 @@ import { setChatAgentId$, currentChatAgent$ } from "../agent-chat.ts";
 import { talkDraft$ } from "./chat-draft.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { reloadTagline$ } from "./zero-chat-page.ts";
+import { setupAgentChatPageKeyboard$ } from "./agent-chat-keyboard.ts";
 
 export const setupAgentChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -24,6 +25,7 @@ export const setupAgentChatPage$ = command(
     );
     set(updateDocumentTitle$, "Chat");
     set(reloadTagline$);
+    set(setupAgentChatPageKeyboard$, signal);
 
     // Reset the talk draft on entrance
     set(get(talkDraft$).clear$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-keyboard.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+const AGENT_ID = "agent-alpha";
+
+function mockAgent() {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: AGENT_ID,
+          displayName: "Alpha Bot",
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
+    }),
+  );
+}
+
+function mockThreadList(threads: { id: string; title: string }[]) {
+  server.use(
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({
+        threads: threads.map((t) => {
+          return {
+            id: t.id,
+            title: t.title,
+            agentId: AGENT_ID,
+            createdAt: "2026-03-10T00:00:00Z",
+            updatedAt: "2026-03-10T00:00:00Z",
+            isRead: true,
+            isArchived: false,
+          };
+        }),
+      });
+    }),
+  );
+}
+
+function mockEmptyMessages(threadId: string) {
+  server.use(
+    http.get(`*/api/zero/chat-threads/${threadId}/messages`, () => {
+      return HttpResponse.json({ messages: [], hasMore: false });
+    }),
+    http.get(`*/api/zero/chat-threads/${threadId}`, () => {
+      return HttpResponse.json({
+        id: threadId,
+        title: `Thread ${threadId}`,
+        agentId: AGENT_ID,
+        chatMessages: [],
+        latestSessionId: null,
+        activeRunIds: [],
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      });
+    }),
+  );
+}
+
+describe("agent chat page keyboard shortcuts", () => {
+  it("mod+shift+down navigates to the first thread", async () => {
+    const user = userEvent.setup();
+    mockAgent();
+    mockThreadList([
+      { id: "thread-1", title: "First" },
+      { id: "thread-2", title: "Second" },
+    ]);
+    mockEmptyMessages("thread-1");
+    mockEmptyMessages("thread-2");
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-tagline")).toBeInTheDocument();
+    });
+
+    await user.keyboard("{Control>}{Shift>}{ArrowDown}{/Shift}{/Control}");
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-1");
+    });
+  });
+
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-keyboard.test.tsx
@@ -92,5 +92,4 @@ describe("agent chat page keyboard shortcuts", () => {
       expect(pathname()).toBe("/chats/thread-1");
     });
   });
-
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
@@ -104,6 +104,30 @@ describe("chat page keyboard shortcuts", () => {
     });
   });
 
+  it("mod+shift+up on the first thread escapes to the agent chat page", async () => {
+    const user = userEvent.setup();
+    mockThreadList([
+      { id: "thread-1", title: "First" },
+      { id: "thread-2", title: "Second" },
+    ]);
+    mockEmptyMessages("thread-1");
+    mockEmptyMessages("thread-2");
+
+    detachedSetupPage({ context, path: "/chats/thread-1" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Send a message to start the conversation/i),
+      ).toBeInTheDocument();
+    });
+
+    await user.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
+    });
+  });
+
   it("mod+shift+down is a no-op on the last thread", async () => {
     const user = userEvent.setup();
     mockThreadList([


### PR DESCRIPTION
## Summary
- `mod+shift+up` on the first chat thread now navigates up to `/agents/:agentId/chat` instead of silently doing nothing.
- On `/agents/:agentId/chat`, added a global `mod+shift+down` shortcut that dives into the first thread (no-op when the thread list is empty).
- The two shortcuts now form a symmetric pair for entering and exiting the thread list.

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run chat-keyboard-shortcuts agent-chat-keyboard` — 7 passed
- [x] `pnpm turbo run lint --filter=@vm0/app`
- [x] `pnpm check-types`
- [ ] Manual: open a chat thread, press `mod+shift+up` repeatedly, confirm landing on `/agents/:agentId/chat` at the top
- [ ] Manual: on `/agents/:agentId/chat`, press `mod+shift+down`, confirm it opens the first thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)