### PR TITLE
fix(chat): avoid default-avatar flicker in chat header during load

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -120,6 +120,30 @@ describe("zero chat thread page display - attachment video preview", () => {
   });
 });
 
+// CHAT-D-066: HeaderAgentAvatar renders null until agentId resolves — no default-avatar flicker
+describe("zero chat thread page display - header agent avatar flicker fix", () => {
+  it("renders the agent avatar link once agentId resolves and never renders a placeholder avatar beforehand", async () => {
+    mockSubagentThread("thread-avatar-test");
+
+    detachedSetupPage({ context, path: "/chats/thread-avatar-test" });
+
+    // The avatar link must appear once the agent id resolves.
+    await waitFor(() => {
+      expect(
+        document.querySelector('a[aria-label="View agent profile"]'),
+      ).toBeInTheDocument();
+    });
+
+    // No blank-name placeholder SVG should have been rendered: the component
+    // returns null before agentId is known, so there is never a second avatar
+    // element without the accessible link wrapper.
+    const avatarLinks = document.querySelectorAll(
+      'a[aria-label="View agent profile"]',
+    );
+    expect(avatarLinks).toHaveLength(1);
+  });
+});
+
 // CHAT-D-043: Message status indicators render in ChatMessageRow
 describe("zero chat thread page display - message status indicators", () => {
   it("displays a Stop button status indicator when a run is active", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -64,42 +64,34 @@ import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-ma
 import { setActiveOrgManageTab$ } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 
 function HeaderAgentAvatar({ thread }: { thread: ChatThreadSignals }) {
-  const agentId = useLastResolved(thread.agentId$) ?? null;
+  const agentId = useLastResolved(thread.agentId$);
 
-  if (agentId) {
-    return (
-      <TooltipProvider delayDuration={200}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Link
-              pathname="/agents/:agentId"
-              options={{ pathParams: { agentId } }}
-              className="h-8 w-8 shrink-0 overflow-hidden rounded-xl transition-colors duration-150 hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              aria-label="View agent profile"
-            >
-              <AgentAvatarImg
-                name={agentId}
-                alt=""
-                className="h-8 w-8 rounded-full object-cover object-top"
-              />
-            </Link>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <p className="text-xs">View agent profile</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    );
+  if (!agentId) {
+    return null;
   }
 
   return (
-    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-xl">
-      <AgentAvatarImg
-        name=""
-        alt=""
-        className="h-8 w-8 rounded-full object-cover object-top"
-      />
-    </div>
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            pathname="/agents/:agentId"
+            options={{ pathParams: { agentId } }}
+            className="h-8 w-8 shrink-0 overflow-hidden rounded-xl transition-colors duration-150 hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-label="View agent profile"
+          >
+            <AgentAvatarImg
+              name={agentId}
+              alt=""
+              className="h-8 w-8 rounded-full object-cover object-top"
+            />
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p className="text-xs">View agent profile</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 


### PR DESCRIPTION
## Summary

- The agent avatar at the top of the chat thread detail page briefly renders a default preset SVG while `thread.agentId$` is still loading, then pops in with the real avatar — a visible flicker.
- Align the header avatar with the display name's loading behavior: both now use `useLastResolved` and render nothing until the value resolves (no fallback content).
- Once the id resolves — including stale-but-last-known values — the avatar renders as before.

## Test plan

- [ ] Navigate to a chat thread while forcing a cold load (cleared agent cache) and confirm no default avatar flashes before the real one appears.
- [ ] Navigate between threads and confirm the avatar updates without a flash of the preset SVG.
- [ ] Confirm the name still appears in sync with the avatar.