### PR TITLE
feat: close staff-org defaults except sandbox reuse

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -17,10 +17,8 @@ import {
 } from "../../../../../../../src/__tests__/db-test-seeders/slack";
 import { POST } from "../route";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
-
-// The staff org ID whose FNV-1a hash (afce210e) is listed in STAFF_ORG_ID_HASHES,
-// enabling the AuditLink feature switch for that org.
-const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+import { seedUserFeatureSwitches } from "../../../../../../../src/__tests__/db-test-seeders/feature-switches";
+import { FeatureSwitchKey } from "@vm0/core";
 
 const context = testContext();
 
@@ -402,10 +400,12 @@ describe("POST /api/internal/callbacks/slack/org", () => {
   it("includes audit link block when AuditLink switch is on", async () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));
-    // Use the staff orgId whose hash is in STAFF_ORG_ID_HASHES, enabling AuditLink
+    // Enable AuditLink for the test user via a DB override
+    await seedUserFeatureSwitches(user.orgId, user.userId, {
+      [FeatureSwitchKey.AuditLink]: true,
+    });
     const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
-      orgId: STAFF_ORG_ID,
     });
     await completeTestRun(user.userId, runId);
 

--- a/turbo/apps/web/src/__tests__/db-test-seeders/feature-switches.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/feature-switches.ts
@@ -1,0 +1,20 @@
+import { userFeatureSwitches } from "../../db/schema/user-feature-switches";
+
+/**
+ * Seed user feature switch overrides for testing.
+ * @why-db-direct Feature switch overrides have no user-facing API in tests;
+ *   the admin API requires an authenticated session which is not available here.
+ */
+export async function seedUserFeatureSwitches(
+  orgId: string,
+  userId: string,
+  switches: Record<string, boolean>,
+): Promise<void> {
+  await globalThis.services.db
+    .insert(userFeatureSwitches)
+    .values({ orgId, userId, switches, updatedAt: new Date() })
+    .onConflictDoUpdate({
+      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+      set: { switches, updatedAt: new Date() },
+    });
+}

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -30,9 +30,9 @@ describe("isFeatureEnabled", () => {
   });
 
   it("should return true when orgId hash matches enabledOrgIdHashes", () => {
-    // Lab has enabledOrgIdHashes: STAFF_ORG_ID_HASHES
+    // SandboxReuse has enabledOrgIdHashes: STAFF_ORG_ID_HASHES
     expect(
-      isFeatureEnabled(FeatureSwitchKey.Lab, {
+      isFeatureEnabled(FeatureSwitchKey.SandboxReuse, {
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
     ).toBe(true);
@@ -40,19 +40,19 @@ describe("isFeatureEnabled", () => {
 
   it("should return false when orgId does not match enabledOrgIdHashes", () => {
     expect(
-      isFeatureEnabled(FeatureSwitchKey.Lab, {
+      isFeatureEnabled(FeatureSwitchKey.SandboxReuse, {
         orgId: "org_nonexistent",
       }),
     ).toBe(false);
   });
 
   it("should return false when no orgId provided but switch has enabledOrgIdHashes", () => {
-    expect(isFeatureEnabled(FeatureSwitchKey.Lab)).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.SandboxReuse)).toBe(false);
   });
 
   it("should return true when orgId matches even if userId does not", () => {
     expect(
-      isFeatureEnabled(FeatureSwitchKey.Lab, {
+      isFeatureEnabled(FeatureSwitchKey.SandboxReuse, {
         userId: "non-matching-user",
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
@@ -71,8 +71,8 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates({
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
-    // Lab has STAFF_ORG_ID_HASHES and should be true
-    expect(states[FeatureSwitchKey.Lab]).toBe(true);
+    // SandboxReuse has STAFF_ORG_ID_HASHES and should be true
+    expect(states[FeatureSwitchKey.SandboxReuse]).toBe(true);
     // Globally enabled should still be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
     // Switches without org hashes should remain false
@@ -83,7 +83,7 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates({
       orgId: "org_nonexistent",
     });
-    expect(states[FeatureSwitchKey.Lab]).toBe(false);
+    expect(states[FeatureSwitchKey.SandboxReuse]).toBe(false);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -174,7 +174,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show admin-only daily credits chart and per-run records on Usage page",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ModelDetail]: {
     maintainer: "ethan@vm0.ai",
@@ -195,44 +194,37 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description: "Enable remote desktop host registration",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.Lab]: {
     maintainer: "ethan@vm0.ai",
     description: "Show the Lab page for toggling experimental features",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.AuditLink]: {
     maintainer: "ethan@vm0.ai",
     description: "Show audit log links in Slack messages",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PhoneIntegration]: {
     maintainer: "ethan@vm0.ai",
     description: "Show the Phone page for voice call integration",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.VoiceChat]: {
     maintainer: "lancy@vm0.ai",
     description: "Enable the Voice Chat feature and API endpoints",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.AudioIO]: {
     maintainer: "lancy@vm0.ai",
     description:
       "Enable audio input/output features in chat (TTS read-aloud, auto-read, voice input)",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.MissionControlSidebar]: {
     maintainer: "ethan@vm0.ai",
     description: "Show the Mission Control page entry in the sidebar",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.AutoSkill]: {
     maintainer: "lancy@vm0.ai",
@@ -250,7 +242,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show Run History tab on schedules page and Chat-from-schedule button on activity detail",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.TestOauthConnector]: {
     maintainer: "liangyou@vm0.ai",
@@ -263,21 +254,18 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Replace the Invite people button in the agent chat page header with a New button that creates a new chat thread",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.InlineThinkingDot]: {
     maintainer: "ethan@vm0.ai",
     description:
       "Show an inline streaming cursor on the last assistant message while the agent run is still active, so users see the agent is still working even after it has produced output",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ZoomConnector]: {
     maintainer: "ethan@vm0.ai",
     description:
       "Enable the Zoom connector (OAuth 2.0) for meetings, past participants, and cloud recordings access",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.SlackAgentSwitch]: {
     maintainer: "yuma@vm0.ai",
@@ -295,7 +283,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "user falls back to the org default agent with no footer. Staff-only during the " +
       "rollout window defined by `enabledOrgIdHashes`.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
 };
 


### PR DESCRIPTION
## Summary

Close the staff-org default rollout (`STAFF_ORG_ID_HASHES`) for all feature switches **except** `SandboxReuse`. Every affected switch is still defined; it just no longer auto-enables for the staff org via `enabledOrgIdHashes`. Turning any of them on now requires a per-user override.

## Affected switches

Removed `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` from:
- `UsageAnalytics`
- `ComputerUse`
- `Lab`
- `AuditLink`
- `PhoneIntegration`
- `VoiceChat`
- `AudioIO`
- `MissionControlSidebar`
- `ScheduleRunHistory`
- `ChatHeaderNewButton`
- `InlineThinkingDot`
- `ZoomConnector`
- `SlackAgentSwitch`

**Unchanged:** `SandboxReuse` keeps its staff-org default rollout.

## Tests

Updated `feature-switch.test.ts` to use `SandboxReuse` (the remaining staff-gated switch) wherever the tests asserted on staff-org hash behaviour via `Lab`.

## Test plan

- [ ] `pnpm -F @vm0/core exec vitest run feature-switch`
- [ ] CI lint / type-check / test / knip green