### PR TITLE
fix(web): render JSON-LD in SSR and keep sitemap lastmod fresh

### DIFF
--- a/turbo/apps/web/app/[locale]/blog/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/page.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import Script from "next/script";
 import { getTranslations } from "next-intl/server";
 import {
   getPosts,
@@ -95,9 +94,9 @@ export default async function BlogPage({ params }: BlogPageProps) {
 
   return (
     <>
-      <Script
-        id="json-ld-breadcrumb"
+      <script
         type="application/ld+json"
+        suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
       <Suspense

--- a/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Image from "next/image";
-import Script from "next/script";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -181,14 +180,14 @@ export default async function BlogPostPage({
 
   return (
     <>
-      <Script
-        id="json-ld-breadcrumb"
+      <script
         type="application/ld+json"
+        suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
-      <Script
-        id="json-ld-article"
+      <script
         type="application/ld+json"
+        suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
       />
       <Particles />

--- a/turbo/apps/web/app/[locale]/use-cases/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/[slug]/page.tsx
@@ -98,10 +98,38 @@ export default async function UseCaseDetailPage({ params }: PageProps) {
     }),
   };
 
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: `${BASE_URL}/${locale}`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Use Cases",
+        item: `${BASE_URL}/${locale}/use-cases`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: t(`content.${slug}.title`),
+        item: `${BASE_URL}/${locale}/use-cases/${slug}`,
+      },
+    ],
+  };
+
   return (
     <>
       <script type="application/ld+json" suppressHydrationWarning>
         {JSON.stringify(howToJsonLd)}
+      </script>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(breadcrumbJsonLd)}
       </script>
       <UseCaseDetailClient useCase={useCase} />
     </>

--- a/turbo/apps/web/app/[locale]/use-cases/page.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/page.tsx
@@ -69,10 +69,32 @@ export default async function UseCasesPage({ params }: PageProps) {
     }),
   };
 
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: `${BASE_URL}/${locale}`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Use Cases",
+        item: `${BASE_URL}/${locale}/use-cases`,
+      },
+    ],
+  };
+
   return (
     <>
       <script type="application/ld+json" suppressHydrationWarning>
         {JSON.stringify(itemListJsonLd)}
+      </script>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(breadcrumbJsonLd)}
       </script>
       <UseCasesGalleryClient />
     </>

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -180,9 +180,16 @@ export default async function RootLayout({
         <body
           className={`${notoSans.variable} ${firaCode.variable} ${firaMono.variable} ${jetBrainsMono.variable}`}
         >
-          <Script
-            id="json-ld"
+          {/*
+            JSON-LD must render as a native <script> tag in SSR HTML so Googlebot
+            sees it on first-pass crawl. Next.js <Script> (default strategy:
+            afterInteractive) injects scripts client-side and escapes payloads,
+            which hides the structured data from first-wave indexing and most
+            third-party validators.
+          */}
+          <script
             type="application/ld+json"
+            suppressHydrationWarning
             dangerouslySetInnerHTML={{
               __html: JSON.stringify({
                 "@context": "https://schema.org",
@@ -207,9 +214,9 @@ export default async function RootLayout({
               }),
             }}
           />
-          <Script
-            id="json-ld-website"
+          <script
             type="application/ld+json"
+            suppressHydrationWarning
             dangerouslySetInnerHTML={{
               __html: JSON.stringify({
                 "@context": "https://schema.org",
@@ -221,9 +228,9 @@ export default async function RootLayout({
               }),
             }}
           />
-          <Script
-            id="json-ld-software"
+          <script
             type="application/ld+json"
+            suppressHydrationWarning
             dangerouslySetInnerHTML={{
               __html: JSON.stringify({
                 "@context": "https://schema.org",

--- a/turbo/apps/web/app/sitemap.ts
+++ b/turbo/apps/web/app/sitemap.ts
@@ -8,9 +8,10 @@ const locales = ["en", "de", "es", "ja"] as const;
 const defaultLocale = "en";
 const baseUrl = "https://www.vm0.ai";
 
-// Static dates per route category — avoids false "always modified" signals
-const STATIC_DATE = new Date("2025-01-01");
-const BLOG_DATE = new Date("2025-06-01");
+// Build-time date bumps on every deploy so the sitemap stays fresh without
+// anyone having to remember to edit a constant. Marketing pages are generated
+// from code, so "last build = last changed" is a reasonable proxy.
+const BUILD_DATE = new Date();
 
 /**
  * Build hreflang alternates map for a localized path.
@@ -29,36 +30,51 @@ function buildAlternates(
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // Pre-fetch blog posts once so we can both emit post URLs and derive a
+  // realistic lastmod for the /blog index from the most recent post.
+  const defaultPosts = isBlogEnabled()
+    ? await getPosts(defaultLocale).catch(() => {
+        return [];
+      })
+    : [];
+
+  const latestPostDate = defaultPosts.reduce<Date>((latest, post) => {
+    const postDate = new Date(post.publishedAt);
+    return postDate > latest ? postDate : latest;
+  }, new Date(0));
+  const blogIndexLastModified =
+    latestPostDate.getTime() > 0 ? latestPostDate : BUILD_DATE;
+
   const localizedRoutes = [
     {
       path: "",
       priority: 1,
       changeFrequency: "weekly" as const,
-      lastModified: STATIC_DATE,
+      lastModified: BUILD_DATE,
     },
     {
       path: "/pricing",
       priority: 0.9,
       changeFrequency: "monthly" as const,
-      lastModified: STATIC_DATE,
+      lastModified: BUILD_DATE,
     },
     {
       path: "/security",
       priority: 0.8,
       changeFrequency: "monthly" as const,
-      lastModified: STATIC_DATE,
+      lastModified: BUILD_DATE,
     },
     {
       path: "/blog",
       priority: 0.8,
       changeFrequency: "weekly" as const,
-      lastModified: BLOG_DATE,
+      lastModified: blogIndexLastModified,
     },
     {
       path: "/use-cases",
       priority: 0.9,
       changeFrequency: "monthly" as const,
-      lastModified: STATIC_DATE,
+      lastModified: BUILD_DATE,
     },
   ];
 
@@ -67,19 +83,19 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       path: "/privacy-policy",
       priority: 0.3,
       changeFrequency: "yearly" as const,
-      lastModified: STATIC_DATE,
+      lastModified: BUILD_DATE,
     },
     {
       path: "/terms-of-use",
       priority: 0.3,
       changeFrequency: "yearly" as const,
-      lastModified: STATIC_DATE,
+      lastModified: BUILD_DATE,
     },
     {
       path: "/support",
       priority: 0.5,
       changeFrequency: "monthly" as const,
-      lastModified: STATIC_DATE,
+      lastModified: BUILD_DATE,
     },
   ];
 
@@ -115,7 +131,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     for (const locale of locales) {
       urls.push({
         url: `${baseUrl}/${locale}/use-cases/${useCase.slug}`,
-        lastModified: STATIC_DATE,
+        lastModified: BUILD_DATE,
         changeFrequency: "monthly",
         priority: 0.7,
         alternates: { languages: alternates },
@@ -124,14 +140,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }
 
   // Blog post pages — only when blog is enabled
-  if (isBlogEnabled()) {
+  if (defaultPosts.length > 0) {
     const blogBaseUrl = getBlogBaseUrl();
-
-    // Collect unique slugs from default locale, then check each slug's
-    // available translations to avoid emitting URLs that would 404.
-    const defaultPosts = await getPosts(defaultLocale).catch(() => {
-      return [];
-    });
 
     for (const post of defaultPosts) {
       const available = await getPostAvailableLocales(post.slug, locales);


### PR DESCRIPTION
## Summary

One consolidated fix for the three technical-SEO defects that have been recurring on vm0.ai. Each has a narrow root cause that previous patches didn't hit at the source, which is why the symptoms kept coming back.

### 1. JSON-LD invisible to Googlebot (the big one)

All our structured data blocks — Organization, WebSite, SoftwareApplication, BlogPosting, BreadcrumbList — were wrapped in Next.js `<Script>` components. `<Script>` defaults to `strategy="afterInteractive"`, which means:

- Next.js does **not** render the `<script type="application/ld+json">` tag into the SSR HTML.
- Instead it stuffs the payload into `__NEXT_DATA__` and injects the tag client-side during hydration.
- Googlebot's first-pass crawl sees no JSON-LD at all. Most third-party rich-results validators also miss it.

This PR converts every JSON-LD block to a native `<script type="application/ld+json" suppressHydrationWarning>` so the structured data is in the server-rendered HTML from byte zero. The `<Script>` import stays in `layout.tsx` for legitimate client-side scripts (Plausible, Termly, Instatus).

### 2. Sitemap `lastmod` stuck in the past

`sitemap.ts` had two hardcoded constants — `STATIC_DATE = new Date("2025-01-01")` and `BLOG_DATE = new Date("2025-06-01")`. Every crawl saw the same lastmod, so Google learned to ignore our freshness signal.

Replaced both with `BUILD_DATE = new Date()` (bound at sitemap generation time, so it bumps on every deploy), and derived the `/blog` index lastmod from the most recent post's `publishedAt` instead of a fixed date.

### 3. Missing BreadcrumbList on use-case pages

Blog pages emit BreadcrumbList JSON-LD, but `/use-cases` and `/use-cases/[slug]` didn't, even though the UI has a clear hierarchical path (Home → Use Cases → &lt;slug&gt;). Added BreadcrumbList alongside the existing ItemList (index) and HowTo (detail) schemas.

## Why previous fixes didn't stick

The underlying `<Script>`-wraps-JSON-LD pattern was copy-pasted as JSON-LD was added to new pages. Each "SEO fix" PR updated the payload but preserved the wrapper. This PR fixes the pattern everywhere it appears in one pass.

## Out of scope (deliberate)

- **Vercel apex 307 → 308**: the `vm0.ai` → `www.vm0.ai` redirect is currently `307 Temporary` (no link-equity pass-through). That's controlled in the Vercel Dashboard, not the repo — needs to be flipped there.
- **Clerk edge-caching carve-out**: response headers on public marketing pages include `Cache-Control: private, no-cache, ...` from Clerk middleware. Moving public routes off the auth-middleware path has real auth-leakage risk and needs a separate audit PR.
- **hreflang Link header**: headers mirror HTML hreflang correctly today; `next-intl` owns that behavior.

## Test plan

- [x] `pnpm check-types` — passes
- [x] `pnpm turbo run lint --filter=web` — passes (0 new warnings)
- [x] `pnpm format` — no changes
- [x] `pnpm vitest` scoped to blog/layout tests — 10/10 passing (exercises `generateMetadata.alternates.canonical`, unaffected by this PR)
- [x] `pnpm knip --workspace web` — clean
- [ ] After merge + deploy: verify `view-source:https://www.vm0.ai` shows `<script type="application/ld+json">` blocks in the HTML (not just in `__NEXT_DATA__`)
- [ ] After deploy: validate structured data via [Google Rich Results Test](https://search.google.com/test/rich-results) on `/`, `/en/blog`, `/en/blog/posts/<slug>`, `/en/use-cases`, `/en/use-cases/<slug>`
- [ ] After deploy: fetch `https://www.vm0.ai/sitemap.xml` — confirm `lastmod` bumped to recent date
