### PR TITLE
fix(web): restore trigger condition for agent self-update prompt

### DIFF
--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -76,7 +76,7 @@ function buildAgentToolsPrompt(): string {
     "- Troubleshoot permission denials: `zero doctor permission-deny --help` to identify which permission covers a blocked request.",
     "- Request permission changes: `zero doctor permission-change --help` to enable or disable a permission.",
     "- Inspect yourself: `zero whoami` for identity and permissions, `zero agent view $ZERO_AGENT_ID --instructions` for your current settings.",
-    "- Update your own configuration: `zero agent edit --help`.",
+    "- When the user asks to change your behavior, update your own configuration (instructions, tone, description): `zero agent edit --help`.",
     "- Manage custom skills: `zero skill --help`.",
     "- Send a direct message to the user via web chat: `zero chat message send --help`.",
     "- Report issues to the dev team: `zero developer-support --help`. Requires a two-step consent flow: (1) call without --consent-code to get a code, (2) ask the user to type it, (3) call again with --consent-code. Never submit without the user typing the consent code.",


### PR DESCRIPTION
## Summary

Restores the "when to act" trigger on the `zero agent edit` bullet in `buildAgentToolsPrompt()`. The trigger got stripped during PR #7504 (commit `abc90d82a`) when all bullets were reformatted from `- When you need to X, use Y` → `- X: Y.`.

**Before:**
```
- Update your own configuration: `zero agent edit --help`.
```

**After:**
```
- When the user asks to change your behavior, update your own configuration (instructions, tone, description): `zero agent edit --help`.
```

## Why

Ethan hit a case where Claude Code tried to edit `CLAUDE.md` (read-only, non-persistent) in response to a "remember this" request, instead of calling `zero agent edit`. Without an explicit trigger condition, the LLM has no signal that "update my own behavior" should route through `zero agent edit`. This restores the trigger and clarifies the three configurable fields (instructions, tone, description) so the LLM can recognize which ask maps to this command.

Scope intentionally kept to this single bullet — other simplified bullets (`permission-deny`, `check-connector`, `skill`, etc.) have similar issues and will be handled separately.

## Test plan

- [ ] Agent prompt builder still compiles and renders the expected string
- [ ] Trigger a run where the user says "from now on, reply in English" and verify the agent calls `zero agent edit` (not Read/Edit on CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)