### PR TITLE
feat(runner): add manual rollback workflow and playbook

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1243,6 +1243,7 @@ jobs:
           AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
+          API_URL: ${{ vars.VM0_API_URL }}
           GRAFANA_CLOUD_PROMETHEUS_URL: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_URL }}
           GRAFANA_CLOUD_PROMETHEUS_USER: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_USER }}
           GRAFANA_CLOUD_API_KEY: ${{ secrets.GRAFANA_CLOUD_API_KEY }}
@@ -1275,7 +1276,7 @@ jobs:
             playbooks/build-runner.yml \
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
-            -e "api_url=https://www.vm0.ai" \
+            -e "api_url=${API_URL}" \
             -e "runner_version=${RUNNER_VERSION}" \
             -e "r2_account_id=${R2_ACCOUNT_ID:-}" \
             -e "r2_access_key_id=${R2_ACCESS_KEY_ID:-}" \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -731,10 +731,12 @@ jobs:
 
   # Update rollback dashboard issue after deployments
   update-rollback-dashboard:
-    needs: [release-please, promote-web-production, promote-app-production]
+    needs: [release-please, promote-web-production, promote-app-production, promote-runner-production]
     if: >-
       always() &&
-      (needs.promote-web-production.result == 'success' || needs.promote-app-production.result == 'success')
+      (needs.promote-web-production.result == 'success' ||
+       needs.promote-app-production.result == 'success' ||
+       needs.promote-runner-production.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -806,12 +808,15 @@ jobs:
         env:
           WEB_VERSION: ${{ needs.release-please.outputs.web_version }}
           APP_VERSION: ${{ needs.release-please.outputs.app_version }}
+          RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
           WEB_RESULT: ${{ needs.promote-web-production.result }}
           APP_RESULT: ${{ needs.promote-app-production.result }}
+          RUNNER_RESULT: ${{ needs.promote-runner-production.result }}
           WEB_DASHBOARD_URL: ${{ needs.promote-web-production.outputs.vercel_dashboard_url }}
           APP_DASHBOARD_URL: ${{ needs.promote-app-production.outputs.vercel_dashboard_url }}
           SAFETY: ${{ steps.migration-safety.outputs.indicator }}
           MIGRATION_FILES: ${{ steps.migration-safety.outputs.details }}
+          RUNNER_ROLLBACK_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/rollback-runner.yml
         run: |
           DATE=$(date -u +%Y-%m-%d)
 
@@ -823,8 +828,11 @@ jobs:
           if [ "$APP_RESULT" = "success" ] && [ -n "$APP_VERSION" ]; then
             TITLE_PARTS="${TITLE_PARTS:+$TITLE_PARTS / }app v${APP_VERSION}"
           fi
+          if [ "$RUNNER_RESULT" = "success" ] && [ -n "$RUNNER_VERSION" ]; then
+            TITLE_PARTS="${TITLE_PARTS:+$TITLE_PARTS / }runner v${RUNNER_VERSION}"
+          fi
 
-          # Safety indicator
+          # Web/app migration-safety indicator (applies to web+app rollbacks)
           case "$SAFETY" in
             destructive)
               INDICATOR="🔴 **Warning: destructive migration** ($MIGRATION_FILES)"
@@ -840,41 +848,76 @@ jobs:
               ;;
           esac
 
+          # Helper: append a row, handling empty ROWS without a leading newline.
+          append_row() {
+            if [ -n "$ROWS" ]; then
+              ROWS="${ROWS}
+          $1"
+            else
+              ROWS="$1"
+            fi
+          }
+
           # Build table rows
           ROWS=""
           if [ -n "$WEB_VERSION" ]; then
             if [ "$WEB_RESULT" = "success" ] && [ -n "$WEB_DASHBOARD_URL" ]; then
-              ROWS="| web | v${WEB_VERSION} | [Rollback in Vercel](${WEB_DASHBOARD_URL}) |"
+              append_row "| web | v${WEB_VERSION} | [Rollback in Vercel](${WEB_DASHBOARD_URL}) |"
             elif [ "$WEB_RESULT" = "success" ]; then
-              ROWS="| web | v${WEB_VERSION} | _URL unavailable_ |"
+              append_row "| web | v${WEB_VERSION} | _URL unavailable_ |"
             else
-              ROWS="| web | v${WEB_VERSION} | ❌ Deploy failed |"
+              append_row "| web | v${WEB_VERSION} | ❌ Deploy failed |"
             fi
           fi
 
           if [ -n "$APP_VERSION" ]; then
-            ROW=""
             if [ "$APP_RESULT" = "success" ] && [ -n "$APP_DASHBOARD_URL" ]; then
-              ROW="| app | v${APP_VERSION} | [Rollback in Vercel](${APP_DASHBOARD_URL}) |"
+              append_row "| app | v${APP_VERSION} | [Rollback in Vercel](${APP_DASHBOARD_URL}) |"
             elif [ "$APP_RESULT" = "success" ]; then
-              ROW="| app | v${APP_VERSION} | _URL unavailable_ |"
+              append_row "| app | v${APP_VERSION} | _URL unavailable_ |"
             else
-              ROW="| app | v${APP_VERSION} | ❌ Deploy failed |"
-            fi
-            if [ -n "$ROWS" ]; then
-              ROWS="${ROWS}
-          ${ROW}"
-            else
-              ROWS="$ROW"
+              append_row "| app | v${APP_VERSION} | ❌ Deploy failed |"
             fi
           fi
 
-          # Build full entry
+          # Runner row. Link points to the rollback-runner.yml workflow
+          # dispatch page — GitHub's UI does not currently accept URL-param
+          # pre-fill for workflow_dispatch inputs, so we spell out the
+          # value to paste into `target_version` in the cell itself (no
+          # leading `v`, matching the workflow's semver regex). The
+          # operator still picks `rollback_mode` and toggles the
+          # `confirmed_compatible` gate manually in the dispatch form.
+          # HTML <code> tags (rather than markdown backticks) avoid bash
+          # command-substitution inside this double-quoted string.
+          if [ -n "$RUNNER_VERSION" ]; then
+            if [ "$RUNNER_RESULT" = "success" ]; then
+              append_row "| runner-rs | v${RUNNER_VERSION} | [🔄 Rollback workflow](${RUNNER_ROLLBACK_URL}) — input <code>target_version</code>: <code>${RUNNER_VERSION}</code> |"
+            else
+              append_row "| runner-rs | v${RUNNER_VERSION} | ❌ Deploy failed |"
+            fi
+          fi
+
+          # Build full entry.
+          # - The migration-safety INDICATOR only describes web migrations
+          #   (see Detect migration safety step), so suppress it for release
+          #   cycles with no web/app changes — otherwise a runner-only
+          #   release would print a misleading "🟢 Safe to rollback".
+          # - Runner has no auto-computed compatibility indicator. We print
+          #   a static advisory whenever the release includes runner so the
+          #   operator doesn't silently treat runner rollbacks the same as
+          #   web/app (which are Vercel-level atomic flips). Deliberately
+          #   NOT naming specific compat surfaces — that would encourage a
+          #   checklist mindset and miss cases the list doesn't anticipate.
           {
             echo "### ${DATE} — ${TITLE_PARTS}"
-            echo "${INDICATOR}"
-            echo "| Component | Version | Rollback via Vercel |"
-            echo "|-----------|---------|---------------------|"
+            if [ -n "$WEB_VERSION" ] || [ -n "$APP_VERSION" ]; then
+              echo "${INDICATOR}"
+            fi
+            if [ -n "$RUNNER_VERSION" ]; then
+              echo "⚠️ **Runner rollback needs manual diff review.** The \`confirmed_compatible\` input gates it."
+            fi
+            echo "| Component | Version | Rollback |"
+            echo "|-----------|---------|----------|"
             echo "${ROWS}"
           } > /tmp/dashboard-entry.md
 

--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -1,0 +1,209 @@
+# Manual runner rollback — switches all production metal hosts from the
+# currently-active runner version back to a prior `target_version`. Invoked
+# via workflow_dispatch. Sister to the forward path in `release-please.yml`
+# (`build-runner-production` + `promote-runner-production`).
+#
+# Entry point: rollback dashboard issue (`vars.ROLLBACK_ISSUE_NUMBER`,
+# maintained by release-please.yml's `update-rollback-dashboard` job).
+# Each successful runner promote appends a row with a "🔄 Rollback
+# workflow" link pointing here; operator clicks the link, types the
+# target_version from the row, selects mode + confirms compatibility,
+# and runs.
+
+name: Rollback Runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_version:
+        description: "Version to roll back TO (semver, e.g. 0.81.0 — no leading v)"
+        required: true
+        type: string
+      rollback_mode:
+        description: "graceful (drain, ≤2h) or emergency (SIGTERM stop, ≤5min)"
+        required: true
+        type: choice
+        options:
+          - graceful
+          - emergency
+        default: graceful
+      confirmed_compatible:
+        description: "I confirm the target version has no breaking API / guest / on-disk changes vs current live version"
+        required: true
+        type: choice
+        options:
+          - "no"
+          - "yes"
+        default: "no"
+
+# Mutex between concurrent rollback runs only.
+# TODO: release-please.yml currently scopes its own concurrency to
+# `${{ github.workflow }}-${{ github.ref }}`, so a rollback triggered
+# while a release is mid-deploy would run in parallel. Proper cross-
+# workflow mutex requires changing release-please.yml's deploy jobs to
+# share the same group name — follow-up per issue #9746 constraint #6.
+concurrency:
+  group: runner-deploy
+  cancel-in-progress: false
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260416
+    permissions:
+      contents: read
+    environment: production
+
+    steps:
+      # Hard gate — refuse to proceed unless the operator explicitly
+      # confirmed compatibility. Prevents one-click rollback to a version
+      # with breaking API/guest/on-disk changes that would poison state.
+      - name: Gate confirmed_compatible
+        if: inputs.confirmed_compatible != 'yes'
+        run: |
+          echo "::error::'confirmed_compatible' must be 'yes'. Operator must vet the target version for API / guest ABI / on-disk state compatibility before rolling back."
+          exit 1
+
+      # Reject shell-unsafe / semver-ish injection in target_version. This
+      # string flows into systemd unit names, file paths, URLs, and --name
+      # flags; keep it strictly numeric + dots to match `validate_name` in
+      # crates/runner/src/runner_dirname.rs.
+      - name: Validate target_version format
+        env:
+          VERSION: ${{ inputs.target_version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::target_version='$VERSION' is not semver (e.g. 0.81.0). Reject."
+            exit 1
+          fi
+
+      - name: Notify Slack - Starting
+        id: slack-start
+        if: ${{ vars.SLACK_RELEASE_CHANNEL_ID != '' }}
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
+            text: "*Runner RS* ⏪ rolling back to v${{ inputs.target_version }} (${{ inputs.rollback_mode }})..."
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*Runner RS* ⏪ rolling back to v${{ inputs.target_version }}...\n📦 Mode: `${{ inputs.rollback_mode }}`\n👤 Triggered by: `${{ github.actor }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ inputs.target_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+
+      - name: Record start time
+        id: timer
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      # Use main's rollback-runner.yml — this playbook did not exist in
+      # older tags. The playbook only calls stable runner CLI surfaces
+      # (`service install` / `service drain` / `service stop` / `service
+      # resume` / `doctor` / `gc` / `setup` / `build` / `config`), so it
+      # works against any target binary the runner CLI contract supports.
+      - uses: actions/checkout@v6
+
+      # Preflight: confirm the release asset is downloadable before we go
+      # SSH-tinkering with production hosts. gc typically keeps the last
+      # 6 versions on-host so this is a fallback check, but if a host
+      # recently replaced its disk the playbook's binary-download branch
+      # will need the asset — fail fast rather than mid-rollout.
+      - name: Verify target release asset exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.target_version }}
+        run: |
+          TAG="runner-rs-v${VERSION}"
+          ASSET_NAME="runner-v${VERSION}-aarch64-linux"
+          if ! gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -qx "$ASSET_NAME"; then
+            echo "::error::Release $TAG does not exist or is missing asset $ASSET_NAME."
+            exit 1
+          fi
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      # Invokes rollback-runner.yml against every production host. The
+      # playbook is idempotent and per-host state-machine-driven, so one
+      # invocation converges heterogeneous fleet states (some hosts with
+      # target inactive, some with target still draining, some with target
+      # already running, etc.) to "target is the sole live version".
+      #
+      # R2 credentials are NOT passed: on the happy path (target artifacts
+      # still on disk thanks to gc --keep-latest 6), the playbook only
+      # re-runs idempotent `runner build` which hits the local content-
+      # addressed cache. On the rebuild path (gc evicted the target bin
+      # dir), the build falls back to local rootfs construction — slower
+      # but works offline. R2 sweep in `runner gc` is likewise a nice-to-
+      # have, not required for correctness.
+      - name: Roll back runner on production hosts with Ansible
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          SENTRY_DSN_RUNNER: ${{ secrets.SENTRY_DSN_RUNNER }}
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNNER_VERSION: ${{ inputs.target_version }}
+          ROLLBACK_MODE: ${{ inputs.rollback_mode }}
+        run: |
+          cd ansible
+          ansible-playbook \
+            -i "${AWS_METAL_RUNNER_HOSTS}," \
+            playbooks/rollback-runner.yml \
+            -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
+            -e "runner_version=${RUNNER_VERSION}" \
+            -e "rollback_mode=${ROLLBACK_MODE}" \
+            -e "sentry_dsn=${SENTRY_DSN_RUNNER}" \
+            -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
+            -e "api_url=https://www.vm0.ai" \
+            -e "github_token=${GH_TOKEN}" \
+            -v
+
+      - name: Calculate duration
+        id: duration
+        if: ${{ always() && steps.timer.outputs.start }}
+        run: |
+          elapsed=$(( $(date +%s) - ${{ steps.timer.outputs.start }} ))
+          h=$((elapsed / 3600)) m=$(( (elapsed % 3600) / 60 )) s=$((elapsed % 60))
+          if [ $h -gt 0 ]; then text="${h}h ${m}m ${s}s"
+          elif [ $m -gt 0 ]; then text="${m}m ${s}s"
+          else text="${s}s"; fi
+          echo "text=$text" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack - Success
+        if: ${{ success() && steps.slack-start.outputs.ts }}
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.update
+          token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
+            ts: "${{ steps.slack-start.outputs.ts }}"
+            text: "*Runner RS* ✅ Rolled back to v${{ inputs.target_version }}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*Runner RS* ✅ Rolled back to v${{ inputs.target_version }} (${{ inputs.rollback_mode }})\n⏱️ `${{ steps.duration.outputs.text }}`\n👤 Triggered by: `${{ github.actor }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ inputs.target_version }}|View Release>\n\n⚠️ Remember to land a `revert` PR on main so the next release doesn't re-ship the bad version."
+
+      - name: Notify Slack - Failure
+        if: ${{ failure() && steps.slack-start.outputs.ts }}
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.update
+          token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
+            ts: "${{ steps.slack-start.outputs.ts }}"
+            text: "*Runner RS* ❌ Rollback to v${{ inputs.target_version }} FAILED"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*Runner RS* ❌ Rollback to v${{ inputs.target_version }} FAILED\n📦 Mode: `${{ inputs.rollback_mode }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n👤 Triggered by: `${{ github.actor }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>\n\n⚠️ Fleet may be in a split-version state. Inspect per-host and decide whether to re-run or SSH manually."

--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -151,6 +151,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNNER_VERSION: ${{ inputs.target_version }}
           ROLLBACK_MODE: ${{ inputs.rollback_mode }}
+          API_URL: ${{ vars.VM0_API_URL }}
         run: |
           cd ansible
           ansible-playbook \
@@ -161,7 +162,7 @@ jobs:
             -e "rollback_mode=${ROLLBACK_MODE}" \
             -e "sentry_dsn=${SENTRY_DSN_RUNNER}" \
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
-            -e "api_url=https://www.vm0.ai" \
+            -e "api_url=${API_URL}" \
             -e "github_token=${GH_TOKEN}" \
             -v
 

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -1,0 +1,434 @@
+# Rollback VM0 Runner (Rust) — Downgrade to a Previously-Deployed Version
+#
+# This playbook switches a host from its currently-active runner version to a
+# target version. The target version's per-version bin dir and config are
+# typically already on disk — preserved by `runner gc --keep-latest 6` that
+# runs at the tail of every promote (the `--protect-version` flag pins the
+# version being promoted; older versions stay until they're pushed out of
+# the 6-slot window):
+#
+#   /var/lib/vm0-runner/bin/v{runner_version}/runner
+#   /var/lib/vm0-runner/runners/v{runner_version}/runner.yaml
+#
+# Phase 5 mirrors build-runner.yml on the install path: always runs
+# `runner setup` + `runner build` + `runner config` (each is idempotent and
+# cheap when state is current — happy path adds ~2-5s per host). This
+# guarantees the post-rollback host state matches a fresh promote, and
+# normalizes any drift in runner.yaml. The binary download is the only
+# conditional step — it fires only if the per-version bin dir was evicted
+# by gc (6+ newer releases since).
+#
+# The install path (Phase 5 + 6) is skipped entirely when the target is
+# already Running on the host — either because it was the live version
+# at Phase 1, or because Phase 3's SIGUSR2 resume brought it back from
+# Draining. In those cases only Phase 7/8 run (reconcile non-target
+# runners + gc + final doctor).
+#
+# Usage:
+#   ansible-playbook -i "host1,host2," playbooks/rollback-runner.yml \
+#     -e "ansible_user=ubuntu" \
+#     -e "runner_version=0.81.0" \
+#     -e "rollback_mode=graceful"
+#
+# Required Variables:
+#   - runner_version: Semantic version to roll back TO (e.g. 0.81.0)
+#   - rollback_mode: graceful | emergency
+#       graceful  — `runner service drain` (SIGUSR1). Active jobs finish
+#                   naturally (bounded by JOB_TIMEOUT=2h).
+#       emergency — `runner service stop --force` (SIGTERM via systemctl).
+#                   Active jobs are cancelled mid-run. The runner still runs
+#                   its shutdown path, so Firecracker VMs are destroyed
+#                   cleanly — no orphan cleanup required. Worst-case wait
+#                   is TimeoutStopSec=5min before systemd escalates to
+#                   SIGKILL (only matters if the runner is wedged).
+#
+# Conditionally Required (Phase 5 consumes them only on the install path —
+# skipped when target is already Running. CI callers cannot predict the
+# target state a priori, so they should always pass these; the "conditional"
+# qualifier only matters for manual invocations against a known-Running
+# target where the variables can legitimately be omitted):
+#   - official_runner_secret: Runner auth secret, baked into runner.yaml by
+#                             `runner config`.
+#   - api_url: vm0 API URL, baked into runner.yaml.
+#
+# Conditionally Required (binary fallback only — ignored when the target
+# bin dir survives on the host, which is the common case):
+#   - github_token: GitHub API token for downloading the release binary if
+#                   the repo is private. Omit for public repos.
+#
+# Optional Variables:
+#   - sentry_dsn: Forwarded to the systemd unit as SENTRY_DSN
+#   - r2_account_id / r2_access_key_id / r2_secret_access_key / r2_bucket:
+#       Passed to `runner build` (speeds up rootfs cache hit on fresh hosts)
+#       and to `runner gc` (R2-side cache cleanup). If omitted, local-only
+#       behavior is used in both cases.
+
+- name: Rollback VM0 Runner
+  hosts: all
+  become: true
+
+  vars:
+    runner_name: "v{{ runner_version }}"
+    runner_group: vm0/production
+    data_dir: /var/lib/vm0-runner
+    bin_dir: "{{ data_dir }}/bin/{{ runner_name }}"
+    runner_dir: "{{ data_dir }}/runners/{{ runner_name }}"
+
+  tasks:
+    # ========================================
+    # Phase 0: Input validation
+    # ========================================
+    #
+    # Typos like rollback_mode=greaceful silently no-op both Phase 7 drain
+    # branches, leaving the fleet in a mixed-version state while the play
+    # reports success. Catch that upfront.
+    - name: Validate required inputs
+      assert:
+        that:
+          - runner_version is defined and runner_version | length > 0
+          - rollback_mode is defined and rollback_mode in ["graceful", "emergency"]
+        fail_msg: >-
+          Missing or invalid inputs. Required: `runner_version` (e.g. 0.81.0)
+          and `rollback_mode` (graceful | emergency). Got
+          runner_version='{{ runner_version | default('<undefined>') }}',
+          rollback_mode='{{ rollback_mode | default('<undefined>') }}'.
+
+    # ========================================
+    # Phase 1: Probe target service state
+    # ========================================
+    #
+    # Combine systemctl's ActiveState with the runner's own status.json mode
+    # into a single `target_state` fact, one of:
+    #
+    #   running   — target is already live (log + skip install; Phase 7/8 still run)
+    #   draining  — SIGUSR1 was sent; process is soft-draining, resumable
+    #   stopping  — irreversible teardown committed; about to exit
+    #   stopped   — teardown finished; process about to exit
+    #   inactive  — unit is not active (fresh-start path)
+    #
+    # Subsequent phases dispatch on `target_state` and short-circuit at the
+    # first sufficient action.
+    - name: Probe target ActiveState
+      command: systemctl show vm0-runner-{{ runner_name }}.service --property=ActiveState --value
+      register: tgt_active
+      changed_when: false
+
+    # Retry to absorb the narrow window where systemd has marked the unit
+    # active but StatusTracker hasn't yet flushed its first status.json
+    # (proxy/dns port allocation + initial fact collection). If the file
+    # is still missing after retries, fail loudly rather than silently
+    # falling back — an active unit without a readable status is a
+    # degraded state, not a `running` target.
+    - name: Read target status.json
+      slurp:
+        src: "{{ runner_dir }}/status.json"
+      register: tgt_status_raw
+      when: tgt_active.stdout == "active"
+      retries: 5
+      delay: 1
+      until: tgt_status_raw is not failed
+
+    - name: Resolve target_state
+      set_fact:
+        target_state: >-
+          {%- if tgt_active.stdout != "active" -%}
+            inactive
+          {%- else -%}
+            {{ (tgt_status_raw.content | b64decode | from_json).mode }}
+          {%- endif -%}
+
+    - name: Reject unknown target mode
+      fail:
+        msg: >-
+          Target v{{ runner_version }} is active but status.json reports
+          unknown mode '{{ target_state }}'. Refusing to proceed — manual
+          inspection required.
+      when:
+        - tgt_active.stdout == "active"
+        - target_state not in ["running", "draining", "stopping", "stopped"]
+
+    # ========================================
+    # Phase 2: target_state=running → log only
+    # ========================================
+    #
+    # This phase is observability-only. It does NOT set skip_install and does
+    # NOT end_host. The actual "skip install" decision lives at the tail of
+    # Phase 3 (the "Mark install as not needed — target is running" task),
+    # which fires for both this case and the resume-to-Running case so the
+    # two flows converge on the same set_fact.
+    #
+    # We do NOT end_host because fleet drift (e.g. a previous rollback
+    # partially succeeded and left a non-target version also live on this
+    # host) requires Phase 7 to run for convergence.
+    - name: Report target already running
+      when: target_state == "running"
+      debug:
+        msg: >-
+          Runner v{{ runner_version }} is already running on this host —
+          skipping install; Phase 7/8 will reconcile any non-target drift.
+
+    # ========================================
+    # Phase 3: target_state=draining → SIGUSR2 resume (best-effort)
+    # ========================================
+    #
+    # Try to flip mode back to Running. The existing process's signal handler
+    # does it in-place (discover / Ably / proxy / factories stayed alive —
+    # see start.rs:521-598). `resume` also re-enables the unit for reboot.
+    #
+    # Race caveat: the runner may have auto-transitioned Draining→Stopping
+    # (start.rs:543-551) between our Phase 1 status.json read and SIGUSR2
+    # arrival. In that case Rust `service resume`'s preflight rejects with
+    # "already shutting down" (service.rs:729-739), or the signal handler
+    # drops SIGUSR2 because mode != Draining (start.rs:1430-1432). We
+    # tolerate the resume command's non-zero exit and re-probe status.json
+    # to learn the actual post-signal state, then update target_state so
+    # downstream phases re-dispatch correctly:
+    #   - resume won     → target_state=running → skip_install=true, go to P7/8
+    #   - race lost      → target_state=stopping/stopped → P4 waits, P5/6 install
+    # Either way P7 (drain non-target) and P8 (gc + doctor) always run.
+    # Only set skip_install once we confirm mode is running.
+    - name: Attempt resume from Draining
+      when: target_state == "draining"
+      command: "{{ bin_dir }}/runner service resume --name {{ runner_name }}"
+      failed_when: false
+
+    - name: Re-read target status.json after resume
+      when: target_state == "draining"
+      slurp:
+        src: "{{ runner_dir }}/status.json"
+      register: tgt_status_after_resume
+      retries: 10
+      delay: 1
+      until: >-
+        tgt_status_after_resume is not failed
+        and (tgt_status_after_resume.content | b64decode | from_json).mode
+            in ["running", "stopping", "stopped"]
+
+    - name: Update target_state after resume
+      when: target_state == "draining"
+      set_fact:
+        target_state: "{{ (tgt_status_after_resume.content | b64decode | from_json).mode }}"
+
+    # Confluence point for two flows that both end at target=Running:
+    #   (a) Phase 1 saw mode=running already → target_state never changed,
+    #       Phase 2 only logged, this task sets skip_install.
+    #   (b) Phase 1 saw mode=draining → Phase 3 sent SIGUSR2 and re-read
+    #       status.json; if the re-read settled on "running", the preceding
+    #       "Update target_state" flipped target_state here, and this task
+    #       fires. If instead the race was lost and mode settled on
+    #       stopping/stopped, target_state is now "stopping"/"stopped" and
+    #       this task is skipped, falling through to Phase 4 + install.
+    - name: Mark install as not needed — target is running
+      when: target_state == "running"
+      set_fact:
+        skip_install: true
+
+    # ========================================
+    # Phase 4: target_state ∈ {stopping, stopped} → wait for inactive
+    # ========================================
+    #
+    # Draining→Stopping has committed; teardown is irreversible. Wait for
+    # systemd to mark the unit inactive (bounded by shutdown overhead —
+    # seconds, not minutes, since active jobs no longer gate teardown),
+    # then fall through to the normal install path.
+    - name: Wait for target to go inactive
+      when: target_state in ["stopping", "stopped"]
+      command: systemctl is-active --quiet vm0-runner-{{ runner_name }}.service
+      register: wait_inactive
+      retries: 30
+      delay: 2
+      until: wait_inactive.rc != 0
+      # systemctl is-active returns 0 when active, non-zero when inactive.
+      # We WANT non-zero — override ansible's default "rc != 0 is failure"
+      # so intermediate retries don't get marked failed, and so that retry
+      # exhaustion (final rc == 0) surfaces correctly as a timeout failure.
+      failed_when: wait_inactive.rc == 0
+      changed_when: false
+
+    # ========================================
+    # Phase 5: Prepare target artifacts (install path only)
+    # ========================================
+    #
+    # Skipped when skip_install=true (either target was already running at
+    # Phase 1, or Phase 3 resume brought it back from Draining).
+    #
+    # On the install path, we mirror build-runner.yml exactly: always run
+    # `runner setup` + `runner build` + `runner config`. Each is idempotent
+    # and cheap when state is already current:
+    #   - `runner setup`   — no-op if FC / kernel / mitmproxy already present
+    #   - `runner build`   — cache hit on content-addressed rootfs/snapshot
+    #                        hashes; just stats local / R2 cache
+    #   - `runner config`  — rewrites runner.yaml with deterministic content
+    #
+    # Unconditional re-run (vs "regenerate only if missing") guarantees the
+    # host ends in the same canonical state as a fresh promote, and catches
+    # silent drift like a manually-edited runner.yaml. Happy-path cost on
+    # pre-populated hosts is ~2-5s per host.
+    #
+    # The only conditional step is binary download: the binary is content-
+    # identical across invocations (deterministic build output), so
+    # re-downloading on every rollback is pure waste.
+    - name: Probe target binary
+      when: not (skip_install | default(false))
+      stat:
+        path: "{{ bin_dir }}/runner"
+      register: tgt_bin
+
+    - name: Download target runner binary if missing
+      when:
+        - not (skip_install | default(false))
+        - not (tgt_bin.stat.exists and tgt_bin.stat.executable)
+      block:
+        - name: Ensure bin directory exists
+          file:
+            path: "{{ bin_dir }}"
+            state: directory
+            mode: "0755"
+
+        # Pre-compute headers as a proper dict fact so `get_url` receives
+        # a real dict rather than an inline Jinja-to-dict string coercion
+        # (the inline form works on recent Ansible but has been brittle on
+        # older 2.9-2.11 releases). Empty dict when no token is provided —
+        # uniformly handled by `get_url` without the nested-omit fragility.
+        - name: Prepare download headers
+          set_fact:
+            download_headers: "{{ {'Authorization': 'token ' + github_token} if (github_token is defined and github_token | length > 0) else {} }}"
+
+        # Release asset naming matches release-please.yml's upload step
+        # (runner-rs-v{version} tag, runner-v{version}-aarch64-linux asset).
+        - name: Download runner binary from GitHub Release
+          get_url:
+            url: "https://github.com/vm0-ai/vm0/releases/download/runner-rs-{{ runner_name }}/runner-{{ runner_name }}-aarch64-linux"
+            dest: "{{ bin_dir }}/runner"
+            mode: "0755"
+            headers: "{{ download_headers }}"
+
+    - name: Verify artifact-regen inputs are provided
+      when: not (skip_install | default(false))
+      assert:
+        that:
+          - official_runner_secret is defined and official_runner_secret | length > 0
+          - api_url is defined and api_url | length > 0
+        fail_msg: >-
+          Install path requires `official_runner_secret` and `api_url`
+          (always consumed by `runner config`). Provide them via -e.
+
+    # Always runs on install path. Idempotent — downloads Firecracker /
+    # kernel / mitmproxy to /opt/firecracker/ only on first run per host;
+    # subsequent invocations verify and return immediately.
+    - name: Download runner dependencies
+      when: not (skip_install | default(false))
+      command: "{{ bin_dir }}/runner setup"
+
+    # Always runs on install path. Content-addressed by hash of embedded
+    # guests + recipe; if target's rootfs/snapshot are already on disk at
+    # the matching hash path, this returns in ~1s. If R2 creds are passed,
+    # remote cache can satisfy a local miss in seconds instead of rebuilding.
+    - name: Rebuild default rootfs and snapshot
+      when: not (skip_install | default(false))
+      command: >
+        {{ bin_dir }}/runner build
+        --profile vm0/default
+      environment:
+        R2_ACCOUNT_ID: "{{ r2_account_id | default('') }}"
+        R2_ACCESS_KEY_ID: "{{ r2_access_key_id | default('') }}"
+        R2_SECRET_ACCESS_KEY: "{{ r2_secret_access_key | default('') }}"
+        R2_USER_STORAGES_BUCKET_NAME: "{{ r2_bucket | default('') }}"
+      register: default_build_output
+
+    - name: Parse default build hashes
+      when: not (skip_install | default(false))
+      set_fact:
+        default_rootfs_hash: "{{ default_build_output.stdout_lines | select('match', '^rootfs_hash=') | first | regex_replace('^rootfs_hash=', '') }}"
+        default_snapshot_hash: "{{ default_build_output.stdout_lines | select('match', '^snapshot_hash=') | first | regex_replace('^snapshot_hash=', '') }}"
+
+    # Always runs on install path. Rewrites runner.yaml deterministically;
+    # output is byte-identical to the original build-runner.yml generation
+    # so re-run produces no effective change, but normalizes any drift.
+    - name: Write runner config
+      when: not (skip_install | default(false))
+      command: >
+        {{ bin_dir }}/runner config
+        --profile vm0/default
+        --rootfs-hash {{ default_rootfs_hash }}
+        --snapshot-hash {{ default_snapshot_hash }}
+        --name {{ runner_name }}
+        --group {{ runner_group }}
+        --runner-dirname {{ runner_name }}
+        --api-url {{ api_url }}
+        --token vm0_official_{{ official_runner_secret }}
+
+    # ========================================
+    # Phase 6: Install target service + verify health (install path only)
+    # ========================================
+    #
+    # Rewrites the unit file, daemon-reloads, and `enable --now` starts the
+    # unit. A fresh process initializes mode=Running (StatusTracker::new
+    # hard-codes it; status.json is an export, not a control input).
+    - name: Install and start target runner service
+      when: not (skip_install | default(false))
+      command: >
+        {{ bin_dir }}/runner service install
+        --name {{ runner_name }}
+        --config {{ runner_dir }}/runner.yaml
+        {% if sentry_dsn is defined and sentry_dsn %}
+        --env SENTRY_DSN={{ sentry_dsn }}
+        {% endif %}
+
+    - name: Verify target runner health
+      when: not (skip_install | default(false))
+      command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"
+
+    # ========================================
+    # Phase 7: Transition non-target runners out
+    # ========================================
+    #
+    # `rollback_mode` selects the policy. Both branches go through the runner
+    # CLI so the runner's own shutdown path runs — FC VMs are torn down
+    # cleanly in either case; emergency differs from graceful only in how
+    # the currently-running jobs are treated.
+    #
+    #   graceful  — `runner service drain` (SIGUSR1). Active jobs finish
+    #               naturally (bounded by JOB_TIMEOUT=2h). Default — use
+    #               when the bad version isn't actively harming users.
+    #   emergency — `runner service stop --force` (SIGTERM via systemctl).
+    #               Active jobs are cancelled mid-run; Firecracker VMs are
+    #               still destroyed cleanly by the runner's shutdown code.
+    #               Worst-case wait is TimeoutStopSec=5min before systemd
+    #               escalates to SIGKILL (only hit if the runner is wedged).
+    #               Use during active incidents where continuing to serve
+    #               the bad version is worse than the cost of aborting
+    #               in-flight user tasks.
+    - name: Find running runner services
+      shell: >
+        systemctl list-units 'vm0-runner-*.service' --state=running
+        --plain --no-legend | awk '{print $1}'
+        | sed 's/^vm0-runner-//;s/\.service$//'
+      register: running_runners
+      changed_when: false
+
+    - name: Drain non-target runners (graceful)
+      command: "{{ bin_dir }}/runner service drain --name {{ item }}"
+      loop: "{{ running_runners.stdout_lines | default([]) }}"
+      when: item != runner_name and rollback_mode == "graceful"
+
+    - name: Stop non-target runners (emergency)
+      command: "{{ bin_dir }}/runner service stop --name {{ item }} --force"
+      loop: "{{ running_runners.stdout_lines | default([]) }}"
+      when: item != runner_name and rollback_mode == "emergency"
+
+    # ========================================
+    # Phase 8: Garbage collect + final health check
+    # ========================================
+    #
+    # gc respects `--protect-version` so the rollback target is never swept.
+    - name: Garbage collect old artifacts
+      command: "{{ bin_dir }}/runner gc --keep-latest 6 --protect-version {{ runner_name }}"
+      environment:
+        R2_ACCOUNT_ID: "{{ r2_account_id | default('') }}"
+        R2_ACCESS_KEY_ID: "{{ r2_access_key_id | default('') }}"
+        R2_SECRET_ACCESS_KEY: "{{ r2_secret_access_key | default('') }}"
+        R2_USER_STORAGES_BUCKET_NAME: "{{ r2_bucket | default('') }}"
+
+    - name: Verify runner health after cleanup
+      command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -82,14 +82,22 @@
     # Typos like rollback_mode=greaceful silently no-op both Phase 7 drain
     # branches, leaving the fleet in a mixed-version state while the play
     # reports success. Catch that upfront.
+    # Semver regex is enforced at the workflow layer too (rollback-runner.yml
+    # Validate target_version format), but we re-check here as defense in
+    # depth for direct `ansible-playbook` invocations: `runner_version`
+    # flows into systemd unit names and `command:` tasks (Ansible splits
+    # on whitespace), so a malformed value containing spaces or shell
+    # metachars could inject extra CLI flags.
     - name: Validate required inputs
       assert:
         that:
           - runner_version is defined and runner_version | length > 0
+          - runner_version is match('^[0-9]+\.[0-9]+\.[0-9]+$')
           - rollback_mode is defined and rollback_mode in ["graceful", "emergency"]
         fail_msg: >-
-          Missing or invalid inputs. Required: `runner_version` (e.g. 0.81.0)
-          and `rollback_mode` (graceful | emergency). Got
+          Missing or invalid inputs. Required: `runner_version` in semver
+          form (e.g. 0.81.0, no leading v) and `rollback_mode` (graceful |
+          emergency). Got
           runner_version='{{ runner_version | default('<undefined>') }}',
           rollback_mode='{{ rollback_mode | default('<undefined>') }}'.
 
@@ -427,15 +435,24 @@
       register: running_runners
       changed_when: false
 
+    # `failed_when: false` tolerates non-zero exits from individual
+    # runners — e.g. a runner already in `draining` (operator pre-drained
+    # it) rejects a second `service drain` with non-zero; a runner mid-
+    # teardown rejects `service stop`. We don't want one stuck unit to
+    # abort the fleet-wide rollback; Phase 8's final `runner doctor` on
+    # the target is the real convergence check. Per-item errors are
+    # still visible in Ansible's per-host log.
     - name: Drain non-target runners (graceful)
       command: "{{ bin_dir }}/runner service drain --name {{ item }}"
       loop: "{{ running_runners.stdout_lines | default([]) }}"
       when: item != runner_name and rollback_mode == "graceful"
+      failed_when: false
 
     - name: Stop non-target runners (emergency)
       command: "{{ bin_dir }}/runner service stop --name {{ item }} --force"
       loop: "{{ running_runners.stdout_lines | default([]) }}"
       when: item != runner_name and rollback_mode == "emergency"
+      failed_when: false
 
     # ========================================
     # Phase 8: Garbage collect + final health check

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -229,13 +229,21 @@
     #
     # Draining→Stopping has committed; teardown is irreversible. Wait for
     # systemd to mark the unit inactive (bounded by shutdown overhead —
-    # seconds, not minutes, since active jobs no longer gate teardown),
-    # then fall through to the normal install path.
+    # seconds, not minutes on the nominal path, since active jobs no
+    # longer gate teardown), then fall through to the normal install
+    # path.
+    #
+    # Retry budget is 60 × 2s = 120s, deliberately larger than nominal
+    # teardown (a few seconds) so FC-VM cleanup variance doesn't flake
+    # the rollback. Still shorter than systemd's TimeoutStopSec=5min;
+    # if shutdown wedges past 120s, fail here rather than block the
+    # rollback for another 3 minutes — the operator can SSH in and
+    # SIGKILL.
     - name: Wait for target to go inactive
       when: target_state in ["stopping", "stopped"]
       command: systemctl is-active --quiet vm0-runner-{{ runner_name }}.service
       register: wait_inactive
-      retries: 30
+      retries: 60
       delay: 2
       until: wait_inactive.rc != 0
       # systemctl is-active returns 0 when active, non-zero when inactive.
@@ -399,6 +407,18 @@
     #               Use during active incidents where continuing to serve
     #               the bad version is worse than the cost of aborting
     #               in-flight user tasks.
+    #
+    # Both branches shell out to `{{ bin_dir }}/runner`. On the
+    # skip_install path, Phase 5/6 were skipped so no prior task has
+    # touched the binary — assert it exists so a host where gc evicted
+    # the target (yet somehow still has the unit active) surfaces a
+    # clear error instead of a confusing "No such file or directory".
+    - name: Assert target binary present before drain/stop
+      stat:
+        path: "{{ bin_dir }}/runner"
+      register: tgt_bin_precheck
+      failed_when: not (tgt_bin_precheck.stat.exists and tgt_bin_precheck.stat.executable)
+
     - name: Find running runner services
       shell: >
         systemctl list-units 'vm0-runner-*.service' --state=running


### PR DESCRIPTION
## Summary

Closes #9746 — adds a one-click rollback path for the Rust runner fleet. Operator clicks the row in the rollback dashboard issue → lands on the workflow dispatch page → fills `target_version`, picks mode, toggles the compatibility gate, dispatches. Every host converges to "target is the sole live version".

- **`ansible/playbooks/rollback-runner.yml`** — per-host state-machine playbook (8 phases). Short-circuits when target is already Running; attempts SIGUSR2 resume from Draining with race handling (Draining→Stopping auto-transition); falls through to the full install path (`runner setup` + `runner build` + `runner config`) when target is past the point of no return. Phase 7 drains or force-stops non-target runners per `rollback_mode`; both routes exit via the runner CLI so Firecracker VMs get torn down cleanly.
- **`.github/workflows/rollback-runner.yml`** — workflow_dispatch entry point. Semver-validates `target_version`, gates on `confirmed_compatible` (operator self-certification that target has no breaking API / guest ABI / on-disk changes), verifies the release asset exists, then invokes the playbook over the Cloudflare SSH tunnel. Slack start/success/failure notifications mirror the release path.
- **`.github/workflows/release-please.yml`** — rollback dashboard job now also consumes `promote-runner-production`. When a runner release ships, the dashboard row links directly to the workflow dispatch page with the `target_version` value spelled out (GitHub does not support URL-param prefill for workflow_dispatch inputs). Added a static advisory since runner compatibility can't be auto-detected.

### Design notes

- **`graceful` vs `emergency`**: graceful = SIGUSR1 drain (active jobs finish, ≤2h per JOB_TIMEOUT). emergency = `runner service stop --force` (SIGTERM via systemctl; runner still runs its shutdown path so FC VMs are clean — not SIGKILL).
- **Phase 5 always runs `setup + build + config`** on the install path, matching `build-runner.yml` exactly. Each is idempotent and cheap (~2-5s happy path); guarantees post-rollback state = fresh-promote state and catches silent drift on `runner.yaml`.
- **Concurrency**: `concurrency.group: runner-deploy` mutex between rollback runs. Does **not** currently mutex with release-please deploys (its group is `${{ github.workflow }}-${{ github.ref }}`) — follow-up TODO inline, per #9746 constraint #6.
- **No URL-param prefill**: confirmed via community threads (#51159, #158341, #28505) that GitHub doesn't support prefilling `workflow_dispatch` inputs via URL params. Dashboard row instead spells out the value in the cell.

## Test plan

- [ ] Dashboard: trigger a release-please run locally, verify the runner row renders with correct link + target_version value
- [ ] Dispatch form: paste a non-semver `target_version` → validation rejects
- [ ] Dispatch form: pick `confirmed_compatible=no` → hard gate rejects
- [ ] Happy path (staging): roll back to a version already on-host → Phase 2/3 short-circuits, Phase 7/8 reconciles
- [ ] Drain path (staging): roll back to a version in `draining` state → SIGUSR2 resume wins race, skip install
- [ ] Install path (staging): roll back to a version whose bin dir was gc-evicted → binary download + setup + build + config runs
- [ ] Emergency mode (staging): verify FC VMs are cleanly destroyed (no orphans after stop)
- [ ] Slack: verify start/success/failure messages render and `ts` threading works

🤖 Generated with [Claude Code](https://claude.com/claude-code)