### PR TITLE
refactor(mitm-addon): delete redundant tests and annotate kept assertions (#9991)

### DIFF
--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1070,6 +1070,7 @@ class TestGetFirewallHeaders:
 
         assert headers["headers"] == mock_headers
         assert headers["cache_hit"] is False
+        # fetch_firewall_headers wraps urllib; args-once-with pins the cache-miss contract (#9991).
         mock_fetch.assert_called_once_with(
             encrypted, auth_templates, "tok-xyz", None, None, None, None
         )
@@ -1134,6 +1135,7 @@ class TestGetFirewallHeaders:
 
         assert headers["headers"] == fresh_headers
         assert headers["cache_hit"] is False
+        # fetch_firewall_headers wraps urllib; pins the TTL-expiry→re-fetch contract (#9991).
         mock_fetch.assert_called_once()
         # Verify cache was updated with new entry
         assert auth._firewall_header_cache[cache_key]["headers"] == fresh_headers
@@ -1438,7 +1440,7 @@ class TestFetchFirewallHeaders:
 
         assert result == {"headers": {"Authorization": "Bearer tok"}}
 
-        # Verify the request was constructed correctly
+        # urllib.request.Request construction is the external boundary (#9991).
         mock_req_cls.assert_called_once()
         call_args = mock_req_cls.call_args
         assert call_args[0][0] == "https://api.vm0.ai/api/webhooks/agent/firewall/auth"
@@ -1463,6 +1465,7 @@ class TestFetchFirewallHeaders:
         ):
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
 
+        # urllib Request.add_header is the external boundary (#9991).
         mock_req_instance.add_header.assert_called_once_with(
             "x-vercel-protection-bypass", "secret-bypass-value"
         )

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1175,7 +1175,7 @@ class TestPostWebhook:
         with patch.object(usage, "_opener") as mock_opener:
             mock_opener.open.return_value = MagicMock()
             usage._post_webhook("https://api.vm0.ai/api/webhooks/agent/usage", "tok-123", payload)
-        mock_opener.open.assert_called_once()
+        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
         req = mock_opener.open.call_args[0][0]
         assert req.full_url == "https://api.vm0.ai/api/webhooks/agent/usage"
         assert req.get_header("Content-type") == "application/json"
@@ -1210,7 +1210,7 @@ class TestPostWebhook:
         ):
             with pytest.raises(urllib.error.HTTPError):
                 usage._post_webhook("https://api.vm0.ai/hook", "tok", {})
-        http_err.close.assert_called_once()
+        http_err.close.assert_called_once()  # urllib HTTPError cleanup contract (#9991)
 
     def test_adds_vercel_bypass_header(self):
         with (
@@ -1316,35 +1316,6 @@ class TestResponseHeadersSseParser:
 
 class TestResponseUsageReporting:
     """Tests for usage extraction and reporting in response() hook."""
-
-    def test_reports_proxy_usage_from_sse(self, tmp_path, real_flow, mitm_ctx, headers):
-        """When proxy_usage is set by SSE parser, it should trigger a usage report."""
-        flow = real_flow(with_response=False, host="api.anthropic.com")
-        log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["proxy_usage"] = {
-            "model": "claude-sonnet-4-6",
-            "input_tokens": 100,
-            "output_tokens": 500,
-        }
-        flow.response = tutils.tresp(
-            status_code=200, headers=http.Headers(**{"content-type": "text/event-stream"})
-        )
-        mitm_addon._request_start_times[flow.id] = time.time()
-
-        with (
-            mitm_ctx(),
-            patch.object(usage, "maybe_report_proxy_usage") as mock_report,
-        ):
-            mitm_addon.response(flow)
-
-        mock_report.assert_called_once_with(flow, "run-abc-123")
 
     def test_non_streaming_json_fallback(self, tmp_path, real_flow, mitm_ctx, headers):
         """Non-streaming JSON response should extract usage from buffer."""
@@ -1508,7 +1479,7 @@ class TestResponseUsageReporting:
             usage.usage_executor.shutdown(wait=True)
 
         # Verify the webhook POST reached _opener with correct payload
-        mock_opener.open.assert_called_once()
+        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
         req = mock_opener.open.call_args[0][0]
         assert req.full_url == "https://api.vm0.ai/api/webhooks/agent/usage"
         body = json.loads(req.data)
@@ -1545,7 +1516,7 @@ class TestResponseUsageReporting:
             mitm_addon.error(flow)
             usage.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_called_once()
+        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
         req = mock_opener.open.call_args[0][0]
         body = json.loads(req.data)
         assert body["runId"] == "run-int-002"
@@ -1588,7 +1559,7 @@ class TestResponseUsageReporting:
             mitm_addon.response(flow)
             usage.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_called_once()
+        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
         req = mock_opener.open.call_args[0][0]
         body = json.loads(req.data)
         assert body["usage"]["message_id"] == "flow-uuid-xyz-123"
@@ -1626,7 +1597,7 @@ class TestResponseUsageReporting:
             mitm_addon.response(flow)
             usage.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_called_once()
+        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
         req = mock_opener.open.call_args[0][0]
         body = json.loads(req.data)
         assert body["usage"]["message_id"] == "msg_real_anthropic_id"
@@ -2387,35 +2358,6 @@ class TestLogConnectorUsage:
         flow.response = None
         assert self._call_and_get_billing(flow) == []
 
-    # ---- integration: response() hook wiring ----
-
-    def test_response_hook_invokes_log_connector_usage(
-        self, tmp_path, real_flow, mitm_ctx, headers
-    ):
-        """response() hook should call usage.log_connector_usage."""
-        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
-        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.x.com/2/tweets"
-        flow.metadata["firewall_name"] = "x"
-        flow.metadata["firewall_permission"] = "tweet.write"
-        flow.response = tutils.tresp(
-            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
-        )
-        mitm_addon._request_start_times[flow.id] = time.time()
-
-        with (
-            mitm_ctx(),
-            patch.object(usage, "maybe_report_proxy_usage"),
-            patch.object(usage, "log_connector_usage") as mock_log_connector,
-        ):
-            mitm_addon.response(flow)
-
-        mock_log_connector.assert_called_once_with(flow, "run-abc-123")
-
     # ---- webhook skip ----
 
     def test_skips_webhook_without_sandbox_token(self, tmp_path, real_flow):
@@ -2481,29 +2423,6 @@ class TestLogConnectorUsage:
         assert by_cat["users.read"] == 3
 
 
-class TestErrorUsageReporting:
-    """Tests that error() hook calls maybe_report_proxy_usage."""
-
-    def test_error_calls_maybe_report(self, tmp_path, real_flow, mitm_ctx):
-        """error() should invoke maybe_report_proxy_usage."""
-        flow = real_flow(with_response=False, host="api.anthropic.com")
-        log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.error = Error("connection reset by peer")
-        mitm_addon._request_start_times[flow.id] = time.time()
-
-        with (
-            mitm_ctx(),
-            patch.object(usage, "maybe_report_proxy_usage") as mock_report,
-        ):
-            mitm_addon.error(flow)
-
-        mock_report.assert_called_once_with(flow, "run-abc-123")
-
-
 class TestReportUsageWithRetry:
     """Tests for _post_webhook_with_retry retry logic."""
 
@@ -2543,7 +2462,7 @@ class TestReportUsageWithRetry:
             patch.object(usage.time, "sleep") as mock_sleep,
         ):
             usage._post_webhook_with_retry("url", "tok", {}, "", "usage")
-        mock_sleep.assert_called_once_with(0.5)
+        mock_sleep.assert_called_once_with(0.5)  # syscall boundary; pins retry backoff (#9991)
 
 
 class TestEnqueueWebhook:
@@ -2565,17 +2484,6 @@ class TestEnqueueWebhook:
         assert len(captured) == 1
         assert captured[0]["input_tokens"] == 100
 
-    def test_enqueue_submits_to_executor(self):
-        """_enqueue_webhook should submit work to the thread pool."""
-        mock_executor = MagicMock()
-        with patch.object(usage, "usage_executor", mock_executor):
-            usage._enqueue_webhook("url", "tok", {"k": 1}, "", "usage")
-        mock_executor.submit.assert_called_once()
-        args = mock_executor.submit.call_args[0]
-        assert args[0] == usage._post_webhook_with_retry
-        assert args[1] == "url"
-        assert args[2] == "tok"
-
     def test_enqueue_falls_back_to_sync_after_shutdown(self, fresh_usage_executor):
         """After executor shutdown, _enqueue_webhook should deliver synchronously with retry."""
         usage.usage_executor.shutdown(wait=True)
@@ -2594,6 +2502,7 @@ class TestDoneHook:
         mock_executor = MagicMock()
         with patch.object(usage, "usage_executor", mock_executor):
             mitm_addon.done()
+        # concurrent.futures boundary: done() must gracefully shut down the pool (#9991).
         mock_executor.shutdown.assert_called_once_with(wait=True)
 
 


### PR DESCRIPTION
## Summary

Phase 3 PR-a of the mitm-addon test-suite refactor — the mechanical, low-risk portion of the 24-site `assert_called*` audit ([design comment](https://github.com/vm0-ai/vm0/issues/9991#issuecomment-4275239791)).

- **Delete 4 tests** whose observable coverage is already provided by existing integration tests:
  - `test_reports_proxy_usage_from_sse` → subsumed by `test_full_path_response_to_opener`
  - `test_response_hook_invokes_log_connector_usage` → subsumed by `test_full_streaming_pipeline_filtered_stream`
  - `test_error_calls_maybe_report` → subsumed by `test_full_path_error_to_opener`
  - `test_enqueue_submits_to_executor` → subsumed by `test_enqueue_copies_payload_dict`
- **Annotate 12 remaining `assert_called*` sites** with inline comments citing the external boundary (urllib `_opener` / `Request`, urllib `HTTPError` cleanup, `time.sleep`, `concurrent.futures`, and the cache layer's `fetch_firewall_headers` dependency). Fulfils #9991 acceptance criterion for kept assertions.

Reduces the `assert_called*` count from 24 → 20. The remaining 20 will be handled in PR-b (R-meta / R-simp / R-invert, 5 sites) and PR-c (R-boundary class-level rework, ~10 tests).

## Test plan

- [x] `pytest crates/runner/mitm-addon/tests/` — 844 passed (was 848; −4 is the deletes)
- [x] `ruff check crates/runner/mitm-addon/tests/`
- [x] `ruff format --check crates/runner/mitm-addon/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)