### PR TITLE
feat: add running indicator to sidebar chat threads

### DIFF
--- a/turbo/apps/platform/src/mocks/mock-helpers.ts
+++ b/turbo/apps/platform/src/mocks/mock-helpers.ts
@@ -21,3 +21,8 @@ export function createChatRun(threadId: string): void {
 export function updateChatRun(threadId: string): void {
   triggerAblyEvent(`chatThreadRunUpdated:${threadId}`);
 }
+
+/** Simulate the user-level signal that anything in the thread list changed. */
+export function threadListChanged(): void {
+  triggerAblyEvent("threadListChanged");
+}

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -9,6 +9,12 @@ import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { pathParams$ } from "./route.ts";
 import { activeRoute$ } from "./active-route.ts";
+import {
+  reloadChatThreads$,
+  reloadChatThreadsCounter$,
+} from "./chat-thread-list-reload.ts";
+
+export { reloadChatThreads$ } from "./chat-thread-list-reload.ts";
 
 const internalChatAgentId$ = state<string | null>(null);
 
@@ -84,14 +90,6 @@ export const currentChatThread$ = computed(
   },
 );
 
-const internalReloadChatThreads$ = state(0);
-
-export const reloadChatThreads$ = command(({ set }) => {
-  set(internalReloadChatThreads$, (n) => {
-    return n + 1;
-  });
-});
-
 /**
  * Mark a thread as read in the sidebar by triggering a full reload.
  * Uses reload (rather than in-place patch) so the server's authoritative
@@ -102,7 +100,7 @@ export const patchThreadRead$ = command(({ set }, _threadId: string) => {
 });
 
 export const chatThreads$ = computed(async (get) => {
-  get(internalReloadChatThreads$);
+  get(reloadChatThreadsCounter$);
   const agentId = await get(currentChatAgentId$);
   if (!agentId) {
     return [];

--- a/turbo/apps/platform/src/signals/chat-thread-list-reload.ts
+++ b/turbo/apps/platform/src/signals/chat-thread-list-reload.ts
@@ -1,0 +1,44 @@
+import { command, computed, state } from "ccstate";
+import { awaitRealtimeReady$, setAblyLoop$ } from "./realtime.ts";
+
+const internalReloadChatThreads$ = state(0);
+
+/**
+ * Read-only view of the reload counter. Consumers subscribe to this to
+ * re-run their computeds whenever the counter bumps.
+ */
+export const reloadChatThreadsCounter$ = computed((get) => {
+  return get(internalReloadChatThreads$);
+});
+
+/**
+ * Bump the sidebar thread-list reload counter. Triggers `chatThreads$`
+ * to refetch on the next read.
+ */
+export const reloadChatThreads$ = command(({ set }) => {
+  set(internalReloadChatThreads$, (n) => {
+    return n + 1;
+  });
+});
+
+/**
+ * Subscribe to the user-level `threadListChanged` topic and trigger a
+ * sidebar reload on every signal. Server publishes this on any mutation
+ * that alters the thread list shape (create, delete, new message, run
+ * create/update, title update, mark-read).
+ *
+ * Loop command returns false so it keeps listening until the signal aborts.
+ * Isolated in its own file to avoid an import cycle when `route.ts` wires
+ * this into the per-page setup wrapper.
+ */
+export const subscribeThreadListChanged$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    await set(awaitRealtimeReady$, signal);
+    signal.throwIfAborted();
+    const onChanged$ = command(({ set }) => {
+      set(reloadChatThreads$);
+      return false;
+    });
+    await set(setAblyLoop$, "threadListChanged", onChanged$, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -14,6 +14,55 @@ const L = logger("Realtime");
 const internalUserChannel$ = state<RealtimeChannel | null>(null);
 
 /**
+ * Deferred promise that `setupRealtime$` resolves once the user-scoped Ably
+ * channel has been established. Consumers started from the view layer
+ * before bootstrap finishes realtime setup (e.g. the sidebar thread-list
+ * daemon) can `await` this to avoid racing with the channel.
+ */
+interface ReadyDeferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+const realtimeReadyDeferred$ = state<ReadyDeferred | null>(null);
+
+function createReadyDeferred(): ReadyDeferred {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((_resolve) => {
+    resolve = _resolve;
+  });
+  return { promise, resolve };
+}
+
+export const awaitRealtimeReady$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    let deferred = get(realtimeReadyDeferred$);
+    if (!deferred) {
+      deferred = createReadyDeferred();
+      set(realtimeReadyDeferred$, deferred);
+    }
+    const readyPromise = deferred.promise;
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        signal.removeEventListener("abort", onAbort);
+        reject(signal.reason);
+      };
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener("abort", onAbort);
+      readyPromise
+        .then(() => {
+          signal.removeEventListener("abort", onAbort);
+          resolve();
+        })
+        .catch(reject);
+    });
+  },
+);
+
+/**
  * Initialize the Ably realtime client and subscribe to the user's channel.
  * Call once during app bootstrap, after Clerk auth is ready.
  */
@@ -67,6 +116,13 @@ export const setupRealtime$ = command(
     const channelName = `user:${ably.auth.clientId}`;
     const channel = ably.channels.get(channelName);
     set(internalUserChannel$, channel);
+
+    const existingReady = get(realtimeReadyDeferred$);
+    const readyDeferred = existingReady ?? createReadyDeferred();
+    if (!existingReady) {
+      set(realtimeReadyDeferred$, readyDeferred);
+    }
+    readyDeferred.resolve();
 
     L.debug(`Realtime connected, subscribed to ${channelName}`);
   },

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -4,12 +4,17 @@ import { StoreProvider } from "ccstate-react";
 import { Toaster } from "@vm0/ui/components/ui/sonner";
 import { ErrorBoundary } from "./error-boundary.tsx";
 import { Router } from "./router.tsx";
+import { subscribeThreadListChanged$ } from "../signals/chat-thread-list-reload.ts";
+import { rootSignal$ } from "../signals/root-signal.ts";
+import { detach, Reason } from "../signals/utils.ts";
 import "./css/index.css";
 
 export const setupRouter = (
   store: Store,
   render: (children: React.ReactNode) => void,
 ) => {
+  const { signal } = store.get(rootSignal$);
+  detach(store.set(subscribeThreadListChanged$, signal), Reason.Daemon);
   render(
     <StrictMode>
       <StoreProvider value={store}>

--- a/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-keyboard.test.tsx
@@ -42,6 +42,7 @@ function mockThreadList(threads: { id: string; title: string }[]) {
             updatedAt: "2026-03-10T00:00:00Z",
             isRead: true,
             isArchived: false,
+            running: false,
           };
         }),
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
@@ -44,6 +44,7 @@ function mockThreadList(threads: { id: string; title: string }[]) {
             updatedAt: "2026-03-10T00:00:00Z",
             isRead: true,
             isArchived: false,
+            running: false,
           };
         }),
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -115,6 +115,7 @@ interface ThreadListItem {
   updatedAt: string;
   isRead: boolean;
   isArchived: boolean;
+  running: boolean;
 }
 
 interface MockLifecycleControl {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-title-refresh.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-title-refresh.test.tsx
@@ -35,6 +35,7 @@ describe("chat title refresh", () => {
               updatedAt: "2026-03-10T00:00:00Z",
               isRead: false,
               isArchived: false,
+              running: false,
             },
           ],
         });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/recent-thread-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/recent-thread-skeleton.test.tsx
@@ -48,6 +48,7 @@ function mockAgentsWithThreads() {
             updatedAt: "2026-03-10T00:00:00Z",
             isRead: false,
             isArchived: false,
+            running: false,
           },
         ],
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-agent-scoping.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-agent-scoping.test.tsx
@@ -22,6 +22,7 @@ function mockTwoAgents() {
       updatedAt: "2026-03-10T00:00:00Z",
       isRead: false,
       isArchived: false,
+      running: false,
     },
     {
       id: "thread-beta-1",
@@ -31,6 +32,7 @@ function mockTwoAgents() {
       updatedAt: "2026-03-09T00:00:00Z",
       isRead: false,
       isArchived: false,
+      running: false,
     },
   ];
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -23,6 +23,7 @@ function makeThread(
   updatedAt: string;
   isRead: boolean;
   isArchived: boolean;
+  running: boolean;
 } {
   return {
     id,
@@ -32,6 +33,7 @@ function makeThread(
     updatedAt: createdAt,
     isRead: false,
     isArchived: false,
+    running: false,
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-navigation.test.tsx
@@ -34,6 +34,7 @@ function mockAPIs() {
             updatedAt: "2026-03-10T00:00:00Z",
             isRead: false,
             isArchived: false,
+            running: false,
           },
         ],
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -20,6 +20,7 @@ function mockSubagentAPIs() {
     updatedAt: string;
     isRead: boolean;
     isArchived: boolean;
+    running: boolean;
   }[] = [
     {
       id: "thread-sub-1",
@@ -29,6 +30,7 @@ function mockSubagentAPIs() {
       updatedAt: "2026-03-10T00:00:00Z",
       isRead: false,
       isArchived: false,
+      running: false,
     },
   ];
 
@@ -133,6 +135,7 @@ function mockSubagentAPIs() {
         updatedAt: now,
         isRead: false,
         isArchived: false,
+        running: false,
       };
       threads.unshift(newThread);
       return HttpResponse.json(
@@ -247,6 +250,7 @@ describe("sidebar new chat navigation", () => {
               updatedAt: "2026-03-10T00:00:00Z",
               isRead: false,
               isArchived: false,
+              running: false,
             },
           ],
         });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * Sidebar running indicator tests.
+ *
+ * Covers the truth table for thread-row indicators:
+ *  - isSelected            → no indicator
+ *  - running && !selected  → sky-600 pulsing dot (Running)
+ *  - unread && !running    → blue-500 dot (Unread)
+ *  - running wins over unread
+ *  - running row is not bold (font-medium stays bound to unread only,
+ *    to avoid a weight flicker when the run finishes)
+ *
+ * Also covers the `threadListChanged` Ably signal: when fired, the sidebar
+ * reloads the list and reflects the latest running state.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
+import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.ts";
+import { threadListChanged } from "../../../mocks/mock-helpers.ts";
+
+const context = testContext();
+
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+interface ThreadFixture {
+  id: string;
+  title: string;
+  agentId: string;
+  createdAt: string;
+  updatedAt: string;
+  isRead: boolean;
+  isArchived: boolean;
+  running: boolean;
+}
+
+function mockAPIs(threadsRef: { current: ThreadFixture[] }) {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: DEFAULT_AGENT_ID,
+          displayName: null,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: threadsRef.current });
+    }),
+    http.get("*/api/zero/chat-threads/:id", ({ params }) => {
+      return HttpResponse.json({
+        id: params.id,
+        title: null,
+        agentId: DEFAULT_AGENT_ID,
+        chatMessages: [],
+        latestSessionId: null,
+        activeRunIds: [],
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      });
+    }),
+    http.get("*/api/zero/chat-threads/:id/messages", () => {
+      return HttpResponse.json({ messages: [], hasMore: false });
+    }),
+  );
+}
+
+function getSidebar(): HTMLElement {
+  return screen.getByRole("navigation", { name: "Sidebar" });
+}
+
+beforeEach(() => {
+  setMockUserPreferences({ pinnedAgentIds: [] });
+  setMockFeatureSwitches({ chatThreadReadIndicator: true });
+});
+
+describe("sidebar running indicator", () => {
+  it("renders a Running dot on a running, unselected thread", async () => {
+    mockAPIs({
+      current: [
+        {
+          id: "thread-1",
+          title: "Active work",
+          agentId: DEFAULT_AGENT_ID,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+          isRead: true,
+          isArchived: false,
+          running: true,
+        },
+      ],
+    });
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(within(getSidebar()).getByText("Active work")).toBeInTheDocument();
+    });
+    expect(within(getSidebar()).getByLabelText("Running")).toBeInTheDocument();
+    expect(
+      within(getSidebar()).queryByLabelText("Unread"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render any indicator on the selected thread", async () => {
+    mockAPIs({
+      current: [
+        {
+          id: "thread-selected",
+          title: "Selected running",
+          agentId: DEFAULT_AGENT_ID,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+          isRead: false,
+          isArchived: false,
+          running: true,
+        },
+      ],
+    });
+    detachedSetupPage({ context, path: "/chats/thread-selected" });
+
+    await waitFor(() => {
+      expect(
+        within(getSidebar()).getByText("Selected running"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(getSidebar()).queryByLabelText("Running"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(getSidebar()).queryByLabelText("Unread"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("prefers Running over Unread when both conditions hold", async () => {
+    mockAPIs({
+      current: [
+        {
+          id: "thread-both",
+          title: "Running and unread",
+          agentId: DEFAULT_AGENT_ID,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+          isRead: false,
+          isArchived: false,
+          running: true,
+        },
+      ],
+    });
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(
+        within(getSidebar()).getByText("Running and unread"),
+      ).toBeInTheDocument();
+    });
+    expect(within(getSidebar()).getByLabelText("Running")).toBeInTheDocument();
+    expect(
+      within(getSidebar()).queryByLabelText("Unread"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the Running dot when ChatThreadReadIndicator flag is off", async () => {
+    setMockFeatureSwitches({ chatThreadReadIndicator: false });
+    mockAPIs({
+      current: [
+        {
+          id: "thread-gated",
+          title: "Running but gated",
+          agentId: DEFAULT_AGENT_ID,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+          isRead: true,
+          isArchived: false,
+          running: true,
+        },
+      ],
+    });
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(
+        within(getSidebar()).getByText("Running but gated"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(getSidebar()).queryByLabelText("Running"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reloads the list and shows the running dot when threadListChanged fires", async () => {
+    const threadsRef: { current: ThreadFixture[] } = {
+      current: [
+        {
+          id: "thread-flips",
+          title: "Will flip to running",
+          agentId: DEFAULT_AGENT_ID,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+          isRead: true,
+          isArchived: false,
+          running: false,
+        },
+      ],
+    };
+    mockAPIs(threadsRef);
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(
+        within(getSidebar()).getByText("Will flip to running"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(getSidebar()).queryByLabelText("Running"),
+    ).not.toBeInTheDocument();
+
+    threadsRef.current = [{ ...threadsRef.current[0]!, running: true }];
+    threadListChanged();
+
+    await waitFor(() => {
+      expect(
+        within(getSidebar()).getByLabelText("Running"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
@@ -35,6 +35,7 @@ function mockBaseAPIs(
       updatedAt: string;
       isRead: boolean;
       isArchived: boolean;
+      running: boolean;
     }[];
     agents?: {
       id: string;
@@ -90,6 +91,7 @@ describe("zero sidebar - chat thread list display (SIDEBAR-D-001)", () => {
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,
           isArchived: false,
+          running: false,
         },
         {
           id: "thread-2",
@@ -99,6 +101,7 @@ describe("zero sidebar - chat thread list display (SIDEBAR-D-001)", () => {
           updatedAt: "2026-03-09T00:00:00Z",
           isRead: false,
           isArchived: false,
+          running: false,
         },
       ],
     });
@@ -164,6 +167,7 @@ describe("zero sidebar - search results filter (SIDEBAR-D-003)", () => {
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,
           isArchived: false,
+          running: false,
         },
         {
           id: "thread-2",
@@ -173,6 +177,7 @@ describe("zero sidebar - search results filter (SIDEBAR-D-003)", () => {
           updatedAt: "2026-03-09T00:00:00Z",
           isRead: false,
           isArchived: false,
+          running: false,
         },
       ],
     });
@@ -212,6 +217,7 @@ describe("zero sidebar - search term displays in input (SIDEBAR-D-004)", () => {
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,
           isArchived: false,
+          running: false,
         },
       ],
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -42,6 +42,7 @@ function makeThread(
   updatedAt: string;
   isRead: boolean;
   isArchived: boolean;
+  running: boolean;
 } {
   return {
     id,
@@ -51,6 +52,7 @@ function makeThread(
     updatedAt: createdAt,
     isRead: false,
     isArchived: false,
+    running: false,
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
@@ -39,6 +39,7 @@ function makeThread(
   updatedAt: string;
   isRead: boolean;
   isArchived: boolean;
+  running: boolean;
 } {
   return {
     id,
@@ -48,6 +49,7 @@ function makeThread(
     updatedAt: createdAt,
     isRead: false,
     isArchived: false,
+    running: false,
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -20,6 +20,7 @@ function mockAPIs({
       updatedAt: "2026-03-10T00:00:00Z",
       isRead: false,
       isArchived: false,
+      running: false,
     },
     {
       id: "thread-2",
@@ -29,6 +30,7 @@ function mockAPIs({
       updatedAt: "2026-03-09T00:00:00Z",
       isRead: false,
       isArchived: false,
+      running: false,
     },
   ],
 }: {
@@ -40,6 +42,7 @@ function mockAPIs({
     updatedAt: string;
     isRead: boolean;
     isArchived: boolean;
+    running: boolean;
   }[];
 } = {}) {
   server.use(

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -71,6 +71,7 @@ function ChatThreadItem({
 }) {
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
   const isUnread = showReadIndicator && !session.isRead;
+  const isRunning = showReadIndicator && session.running;
 
   function handleDeleteClick(e: React.MouseEvent) {
     e.preventDefault();
@@ -98,7 +99,13 @@ function ChatThreadItem({
               : "text-sidebar-foreground hover:bg-sidebar-accent"
         }`}
       >
-        {isUnread && !isSelected && (
+        {!isSelected && isRunning && (
+          <span
+            className="shrink-0 h-2 w-2 rounded-full bg-sky-600 animate-pulse"
+            aria-label="Running"
+          />
+        )}
+        {!isSelected && !isRunning && isUnread && (
           <span
             className="shrink-0 h-2 w-2 rounded-full bg-blue-500"
             aria-label="Unread"

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -144,7 +144,7 @@ async function handleCompleted(
       priorRounds: priorRounds.length > 0 ? priorRounds : undefined,
     });
     if (title) {
-      await updateChatThreadTitle(threadId, title);
+      await updateChatThreadTitle(threadId, userId, title);
     }
   } catch (err) {
     log.warn("Failed to generate chat title", { err });

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET, DELETE, PATCH } from "../route";
 import { GET as listThreads, POST } from "../../route";
 import {
@@ -13,6 +13,8 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { mockAblyPublish } from "../../../../../../src/__tests__/ably-mock";
+import { reloadEnv } from "../../../../../../src/env";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import { transitionRunStatus } from "../../../../../../src/lib/infra/run/run-status";
 import { insertTestAssistantEventMessages } from "../../../../../../src/__tests__/db-test-seeders/agents";
@@ -186,7 +188,7 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     const { id: threadId } = await createResponse.json();
 
     // Update title via service (simulates what the complete webhook does)
-    await updateTestChatThreadTitle(threadId, "AI-Generated Title");
+    await updateTestChatThreadTitle(threadId, testUserId, "AI-Generated Title");
 
     // Fetch thread detail and verify title was updated
     const response = await GET(
@@ -217,7 +219,7 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     const { id: threadId } = await createResponse.json();
 
     // Update title
-    await updateTestChatThreadTitle(threadId, "After AI update");
+    await updateTestChatThreadTitle(threadId, testUserId, "After AI update");
 
     // List threads and verify title is reflected
     const listResponse = await listThreads(
@@ -450,6 +452,30 @@ describe("DELETE /api/zero/chat-threads/:id - Delete Thread", () => {
       ),
     );
     expect(deleteResponse.status).toBe(404);
+  });
+
+  it("publishes threadListChanged on successful delete", async () => {
+    vi.stubEnv("ABLY_API_KEY", "test-key:test-secret");
+    reloadEnv();
+
+    const createResponse = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "Deletable" }),
+      }),
+    );
+    const { id: threadId } = await createResponse.json();
+    mockAblyPublish.mockClear();
+
+    await DELETE(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+        { method: "DELETE" },
+      ),
+    );
+
+    expect(mockAblyPublish).toHaveBeenCalledWith("threadListChanged", null);
   });
 });
 

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/mark-read/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/mark-read/__tests__/route.test.ts
@@ -266,5 +266,6 @@ describe("POST /api/zero/chat-threads/:id/mark-read", () => {
       expect.stringContaining(`chatThreadReadCursorUpdated:${threadId}`),
       expect.objectContaining({ lastReadAt: expect.any(String) }),
     );
+    expect(mockAblyPublish).toHaveBeenCalledWith("threadListChanged", null);
   });
 });

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/mark-read/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/mark-read/route.ts
@@ -7,6 +7,7 @@ import { chatThreadMarkReadContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../../src/lib/auth/get-auth-context";
 import { markThreadRead } from "../../../../../../src/lib/zero/chat-thread";
+import { publishThreadListChanged } from "../../../../../../src/lib/zero/chat-thread/chat-message-service";
 import { isNotFound } from "../../../../../../src/lib/shared/errors";
 import { publishUserSignal } from "../../../../../../src/lib/infra/realtime/client";
 
@@ -34,6 +35,7 @@ const router = tsr.router(chatThreadMarkReadContract, {
         `chatThreadReadCursorUpdated:${params.id}`,
         { lastReadAt: newLastReadAt.toISOString() },
       );
+      await publishThreadListChanged(userId);
 
       return {
         status: 200 as const,

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
@@ -13,6 +13,7 @@ import {
   updateChatThreadDraft,
   deleteChatThread,
 } from "../../../../../src/lib/zero/chat-thread";
+import { publishThreadListChanged } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
 import { isNotFound } from "../../../../../src/lib/shared/errors";
 
 const router = tsr.router(chatThreadByIdContract, {
@@ -112,6 +113,7 @@ const router = tsr.router(chatThreadByIdContract, {
 
     try {
       await deleteChatThread(params.id, userId);
+      await publishThreadListChanged(userId);
       return { status: 204 as const, body: undefined };
     } catch (error) {
       if (isNotFound(error)) {

--- a/turbo/apps/web/app/api/zero/chat-threads/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET, POST } from "../route";
 import {
   createTestRequest,
@@ -13,6 +13,10 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { mockAblyPublish } from "../../../../../src/__tests__/ably-mock";
+import { reloadEnv } from "../../../../../src/env";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
+import { addTestRunToThread } from "../../../../../src/__tests__/db-test-seeders/agents";
 
 const context = testContext();
 
@@ -497,6 +501,140 @@ describe("GET /api/zero/chat-threads - List Threads", () => {
     expect(data.threads).toHaveLength(1);
     expect(data.threads[0].id).toBe(threadId);
     expect(data.threads[0].isArchived).toBe(false);
+  });
+
+  it("reports running=false for a thread with no runs", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "No runs" }),
+      }),
+    );
+    await createRes.json();
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.threads[0].running).toBe(false);
+  });
+
+  it("reports running=true when a run is non-terminal", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "Running" }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    const { runId } = await seedTestRun(user.userId, testComposeId, {
+      status: "running",
+    });
+    await addTestRunToThread(threadId, runId, user.userId);
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const thread = data.threads.find((t: { id: string }) => {
+      return t.id === threadId;
+    });
+    expect(thread.running).toBe(true);
+  });
+
+  it("reports running=false when all runs reach terminal states", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "Completed" }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    const { runId } = await seedTestRun(user.userId, testComposeId, {
+      status: "completed",
+    });
+    await addTestRunToThread(threadId, runId, user.userId);
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+      ),
+    );
+    const data = await response.json();
+
+    const thread = data.threads.find((t: { id: string }) => {
+      return t.id === threadId;
+    });
+    expect(thread.running).toBe(false);
+  });
+
+  it("reports running=true when any run is non-terminal even with a terminal sibling", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "Mixed runs" }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    const doneRun = await seedTestRun(user.userId, testComposeId, {
+      status: "completed",
+    });
+    await addTestRunToThread(threadId, doneRun.runId, user.userId);
+    const queuedRun = await seedTestRun(user.userId, testComposeId, {
+      status: "queued",
+    });
+    await addTestRunToThread(threadId, queuedRun.runId, user.userId);
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+      ),
+    );
+    const data = await response.json();
+
+    const thread = data.threads.find((t: { id: string }) => {
+      return t.id === threadId;
+    });
+    expect(thread.running).toBe(true);
+  });
+});
+
+describe("chat-threads - threadListChanged realtime signal", () => {
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    vi.stubEnv("ABLY_API_KEY", "test-key:test-secret");
+    reloadEnv();
+    context.setupMocks();
+    await context.setupUser();
+    mockAblyPublish.mockClear();
+
+    const { composeId } = await createTestCompose(uniqueId("threadlist-ably"));
+    testComposeId = composeId;
+  });
+
+  it("publishes threadListChanged on thread create", async () => {
+    await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "T" }),
+      }),
+    );
+
+    expect(mockAblyPublish).toHaveBeenCalledWith("threadListChanged", null);
   });
 });
 

--- a/turbo/apps/web/app/api/zero/chat-threads/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/route.ts
@@ -10,6 +10,7 @@ import {
   createChatThread,
   listChatThreads,
 } from "../../../../src/lib/zero/chat-thread";
+import { publishThreadListChanged } from "../../../../src/lib/zero/chat-thread/chat-message-service";
 import { agentComposes } from "../../../../src/db/schema/agent-compose";
 import { eq } from "drizzle-orm";
 
@@ -59,6 +60,7 @@ const router = tsr.router(chatThreadsContract, {
       body.title,
       body.sourceScheduleRunId,
     );
+    await publishThreadListChanged(userId);
 
     return {
       status: 201 as const,
@@ -123,6 +125,7 @@ const router = tsr.router(chatThreadsContract, {
             updatedAt: t.updatedAt.toISOString(),
             isRead: t.isRead,
             isArchived: t.lastMessageArchivedAt !== null,
+            running: t.running,
           };
         }),
       },

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -26,6 +26,7 @@ import {
   insertChatMessage,
   getLatestSessionIdForThread,
   getMessagesByThreadId,
+  publishThreadListChanged,
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
 import { generateChatTitle } from "../../../../../src/lib/zero/ai/lightweight-model";
 import { zeroAgents } from "../../../../../src/db/schema/zero-agent";
@@ -190,7 +191,7 @@ const router = tsr.router(chatMessagesContract, {
         })
           .then((title) => {
             if (title) {
-              return updateChatThreadTitle(threadId, title);
+              return updateChatThreadTitle(threadId, authCtx.userId, title);
             }
           })
           .catch((err: unknown) => {
@@ -254,6 +255,7 @@ const router = tsr.router(chatMessagesContract, {
           [authCtx.userId],
           `chatThreadRunCreated:${threadId}`,
         );
+        await publishThreadListChanged(authCtx.userId);
       });
 
       return {

--- a/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
@@ -173,7 +173,8 @@ export async function createTestOrgMultiAuthModelProvider(
  */
 export async function updateTestChatThreadTitle(
   threadId: string,
+  userId: string,
   title: string,
 ): Promise<void> {
-  return updateChatThreadTitle(threadId, title);
+  return updateChatThreadTitle(threadId, userId, title);
 }

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
@@ -52,6 +52,7 @@ export async function insertChatMessage(params: {
     [params.userId],
     `chatThreadMessageCreated:${params.chatThreadId}`,
   );
+  await publishThreadListChanged(params.userId);
 
   return row;
 }
@@ -100,6 +101,7 @@ export async function insertAssistantEventMessages(
 
   if (rows.length > 0) {
     await publishUserSignal([userId], `chatThreadMessageCreated:${threadId}`);
+    await publishThreadListChanged(userId);
   }
 
   return rows.length;
@@ -145,6 +147,17 @@ export async function publishChatThreadRunUpdated(
     [chatThread.userId],
     `chatThreadRunUpdated:${chatThread.chatThreadId}`,
   );
+  await publishThreadListChanged(chatThread.userId);
+}
+
+/**
+ * Fire the user-level "thread list shape changed" signal. The sidebar
+ * subscribes to this topic and reloads the full list on any delivery —
+ * payload is intentionally empty because the server is authoritative and
+ * the client already has a cheap list endpoint to re-fetch.
+ */
+export async function publishThreadListChanged(userId: string): Promise<void> {
+  await publishUserSignal([userId], "threadListChanged");
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -7,6 +7,7 @@ import { notFound } from "../../shared/errors";
 import {
   getMessagesByThreadId,
   getLatestSessionIdForThread,
+  publishThreadListChanged,
 } from "./chat-message-service";
 import {
   type PersistedAttachment,
@@ -72,6 +73,7 @@ export async function listChatThreads(
     updatedAt: Date;
     isRead: boolean;
     lastMessageArchivedAt: Date | null;
+    running: boolean;
   }>
 > {
   const lastMessage = globalThis.services.db
@@ -98,6 +100,13 @@ export async function listChatThreads(
         ELSE ${chatThreads.lastReadAt} >= ${lastMessage.createdAt}
       END`,
       lastMessageArchivedAt: lastMessage.archivedAt,
+      running: sql<boolean>`EXISTS (
+        SELECT 1
+        FROM ${zeroRuns}
+        INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
+        WHERE ${zeroRuns.chatThreadId} = ${chatThreads.id}
+          AND ${agentRuns.status} IN ('queued', 'pending', 'running')
+      )`,
     })
     .from(chatThreads)
     .leftJoin(
@@ -250,12 +259,14 @@ export async function deleteChatThread(
  */
 export async function updateChatThreadTitle(
   threadId: string,
+  userId: string,
   title: string,
 ): Promise<void> {
   await globalThis.services.db
     .update(chatThreads)
     .set({ title })
     .where(eq(chatThreads.id, threadId));
+  await publishThreadListChanged(userId);
 }
 
 type ChatMessage = {

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -42,6 +42,13 @@ const chatThreadListItemSchema = z.object({
    */
   isRead: z.boolean(),
   isArchived: z.boolean(),
+  /**
+   * True when the thread has at least one non-terminal run
+   * (queued / pending / running). Drives the sidebar running indicator,
+   * which is mutually exclusive with the unread dot and shares the
+   * `ChatThreadReadIndicator` feature switch gate.
+   */
+  running: z.boolean(),
 });
 
 const toolSummaryEntrySchema = z.object({


### PR DESCRIPTION
## Summary
- Sidebar chat threads now render a sky-600 `animate-pulse` dot when any associated run is non-terminal. Exclusive with the unread dot (running wins when both apply), hidden on the selected thread, and gated by the existing `ChatThreadReadIndicator` feature switch.
- `GET /api/zero/chat-threads` returns a required `running: boolean` per item, computed by an inline `EXISTS` subquery over `zero_runs`/`agent_runs` filtered on `queued`/`pending`/`running`.
- New user-level realtime topic `threadListChanged` fires on all 7 mutations that change the sidebar shape (create, delete, message insert, run created, run updated, mark-read, title update). `updateChatThreadTitle` now takes `userId` so it can publish.
- Client: sidebar subscribes once via a view-layer daemon (`setupRouter` → `detach(subscribeThreadListChanged$)`), which awaits a new `awaitRealtimeReady$` gate so it is safe to launch before bootstrap finishes realtime setup. Reload state moved to `signals/chat-thread-list-reload.ts` to avoid an import cycle with `route.ts`.

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run` — 1803/1803
- [x] `pnpm -F web exec vitest run app/api/zero/chat-threads app/api/internal/callbacks/chat` — 88/88
- [x] `pnpm turbo run lint`
- [x] `pnpm check-types`
- [x] `pnpm knip`
- [x] New tests: `sidebar-running-indicator.test.tsx` (truth table, feature-switch gating, reload-on-`threadListChanged`); list-endpoint `running` scenarios; `threadListChanged` publish assertions on create/delete/mark-read routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)