### PR TITLE
refactor(platform): migrate org/billing/members server.use() overrides to mockApi (Phase 3 / #10083)

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-billing.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-billing.ts
@@ -10,9 +10,17 @@ import {
   zeroBillingPortalContract,
   zeroBillingDowngradeContract,
   zeroBillingAutoRechargeContract,
+  zeroBillingInvoicesContract,
   type BillingStatusResponse,
+  type BillingInvoice,
 } from "@vm0/core";
 import { mockApi } from "../msw-contract.ts";
+
+let mockBillingInvoices: BillingInvoice[] = [];
+
+export function setMockBillingInvoices(invoices: BillingInvoice[]): void {
+  mockBillingInvoices = invoices;
+}
 
 let mockBillingStatus: BillingStatusResponse = {
   tier: "free",
@@ -42,6 +50,7 @@ export function resetMockBilling(): void {
     autoRecharge: { enabled: false, threshold: null, amount: null },
     creditExpiry: { expiringNextCycle: 0, nextExpiryDate: null },
   };
+  mockBillingInvoices = [];
 }
 
 export const apiBillingHandlers = [
@@ -79,5 +88,9 @@ export const apiBillingHandlers = [
       amount: body.enabled ? (body.amount ?? null) : null,
     };
     return respond(200, mockBillingStatus.autoRecharge);
+  }),
+
+  mockApi(zeroBillingInvoicesContract.get, ({ respond }) => {
+    return respond(200, { invoices: mockBillingInvoices });
   }),
 ];

--- a/turbo/apps/platform/src/mocks/handlers/api-org-domains.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org-domains.ts
@@ -1,0 +1,24 @@
+/**
+ * Org Domains API Handlers
+ *
+ * Mock handlers for /api/zero/org/domains endpoint.
+ */
+
+import { zeroOrgDomainsContract, type OrgDomain } from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
+
+let mockOrgDomains: OrgDomain[] = [];
+
+export function setMockOrgDomains(domains: OrgDomain[]): void {
+  mockOrgDomains = domains;
+}
+
+export function resetMockOrgDomains(): void {
+  mockOrgDomains = [];
+}
+
+export const apiOrgDomainsHandlers = [
+  mockApi(zeroOrgDomainsContract.list, ({ respond }) => {
+    return respond(200, { domains: mockOrgDomains });
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/api-org-members.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org-members.ts
@@ -1,0 +1,70 @@
+/**
+ * Org Members API Handlers
+ *
+ * Mock handlers for /api/zero/org/members, /api/zero/org/invite,
+ * and /api/zero/org/membership-requests endpoints.
+ */
+
+import {
+  zeroOrgMembersContract,
+  zeroOrgInviteContract,
+  zeroOrgMembershipRequestsContract,
+  type OrgMembersResponse,
+} from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
+
+let mockOrgMembersResponse: OrgMembersResponse = {
+  slug: "user-12345678",
+  role: "admin",
+  members: [],
+  pendingInvitations: [],
+  membershipRequests: [],
+  createdAt: "2024-01-01T00:00:00Z",
+};
+
+export function setMockOrgMembers(
+  overrides: Partial<OrgMembersResponse>,
+): void {
+  mockOrgMembersResponse = { ...mockOrgMembersResponse, ...overrides };
+}
+
+export function resetMockOrgMembers(): void {
+  mockOrgMembersResponse = {
+    slug: "user-12345678",
+    role: "admin",
+    members: [],
+    pendingInvitations: [],
+    membershipRequests: [],
+    createdAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+export const apiOrgMembersHandlers = [
+  mockApi(zeroOrgMembersContract.members, ({ respond }) => {
+    return respond(200, mockOrgMembersResponse);
+  }),
+
+  mockApi(zeroOrgMembersContract.updateRole, ({ respond }) => {
+    return respond(200, { message: "Role updated" });
+  }),
+
+  mockApi(zeroOrgMembersContract.removeMember, ({ respond }) => {
+    return respond(200, { message: "Member removed" });
+  }),
+
+  mockApi(zeroOrgInviteContract.invite, ({ respond }) => {
+    return respond(200, { message: "Invitation sent" });
+  }),
+
+  mockApi(zeroOrgInviteContract.revoke, ({ respond }) => {
+    return respond(200, { message: "Invitation revoked" });
+  }),
+
+  mockApi(zeroOrgMembershipRequestsContract.accept, ({ respond }) => {
+    return respond(200, { message: "Request accepted" });
+  }),
+
+  mockApi(zeroOrgMembershipRequestsContract.reject, ({ respond }) => {
+    return respond(200, { message: "Request rejected" });
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/api-org-model-providers.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org-model-providers.ts
@@ -15,6 +15,12 @@ import { mockApi } from "../msw-contract.ts";
 // Mock org model providers data — empty by default
 let mockOrgModelProviders: ModelProviderResponse[] = [];
 
+export function setMockOrgModelProviders(
+  providers: ModelProviderResponse[],
+): void {
+  mockOrgModelProviders = [...providers];
+}
+
 /**
  * Reset mock org model providers to default state
  */

--- a/turbo/apps/platform/src/mocks/handlers/api-org.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org.ts
@@ -5,19 +5,65 @@
  * Default behavior: user always has an org (for tests that need auth to work).
  */
 
-import { zeroOrgContract, type OrgResponse } from "@vm0/core";
+import {
+  zeroOrgContract,
+  zeroOrgLeaveContract,
+  zeroOrgDeleteContract,
+  type OrgResponse,
+} from "@vm0/core";
+import { http, HttpResponse } from "msw";
 import { mockApi } from "../msw-contract.ts";
 
 // Mock org data — default to admin role for development
-const mockOrg: OrgResponse = {
+let mockOrg: OrgResponse = {
   id: "org_1",
   slug: "user-12345678",
   name: "User 12345678",
   role: "admin",
 };
 
+let mockLogoUrl: string | null = null;
+
+export function setMockOrg(overrides: Partial<OrgResponse>): void {
+  mockOrg = { ...mockOrg, ...overrides };
+}
+
+export function resetMockOrg(): void {
+  mockOrg = {
+    id: "org_1",
+    slug: "user-12345678",
+    name: "User 12345678",
+    role: "admin",
+  };
+}
+
+export function setMockOrgLogo(logoUrl: string | null): void {
+  mockLogoUrl = logoUrl;
+}
+
+export function resetMockOrgLogo(): void {
+  mockLogoUrl = null;
+}
+
 export const apiOrgHandlers = [
   mockApi(zeroOrgContract.get, ({ respond }) => {
     return respond(200, mockOrg);
+  }),
+
+  mockApi(zeroOrgContract.update, ({ body, respond }) => {
+    mockOrg = { ...mockOrg, ...body };
+    return respond(200, mockOrg);
+  }),
+
+  mockApi(zeroOrgLeaveContract.leave, ({ respond }) => {
+    return respond(200, { message: "Left org" });
+  }),
+
+  mockApi(zeroOrgDeleteContract.delete, ({ respond }) => {
+    return respond(200, { message: "Org deleted" });
+  }),
+
+  http.get("*/api/zero/org/logo", () => {
+    return HttpResponse.json({ logoUrl: mockLogoUrl });
   }),
 ];

--- a/turbo/apps/platform/src/mocks/handlers/api-usage.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-usage.ts
@@ -1,0 +1,80 @@
+/**
+ * Usage API Handlers
+ *
+ * Mock handlers for /api/zero/usage/members and
+ * /api/zero/org/members/credit-cap endpoints.
+ */
+
+import {
+  zeroUsageMembersContract,
+  zeroMemberCreditCapContract,
+  type UsageMembersResponse,
+} from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
+
+let mockUsageMembersResponse: UsageMembersResponse = {
+  period: null,
+  members: [],
+};
+
+const mockCreditCaps = new Map<
+  string,
+  { creditCap: number | null; creditEnabled: boolean }
+>();
+
+export function setMockUsageMembers(
+  overrides: Partial<UsageMembersResponse>,
+): void {
+  mockUsageMembersResponse = { ...mockUsageMembersResponse, ...overrides };
+}
+
+export function resetMockUsageMembers(): void {
+  mockUsageMembersResponse = { period: null, members: [] };
+}
+
+export function setMockMemberCreditCap(
+  userId: string,
+  creditCap: number | null,
+  creditEnabled: boolean,
+): void {
+  mockCreditCaps.set(userId, { creditCap, creditEnabled });
+}
+
+export function resetMockMemberCreditCaps(): void {
+  mockCreditCaps.clear();
+}
+
+export const apiUsageHandlers = [
+  mockApi(zeroUsageMembersContract.get, ({ respond }) => {
+    return respond(200, mockUsageMembersResponse);
+  }),
+
+  mockApi(zeroMemberCreditCapContract.get, ({ query, respond }) => {
+    const entry = mockCreditCaps.get(query.userId);
+    if (!entry) {
+      return respond(200, {
+        userId: query.userId,
+        creditCap: null,
+        creditEnabled: true,
+      });
+    }
+    return respond(200, {
+      userId: query.userId,
+      creditCap: entry.creditCap,
+      creditEnabled: entry.creditEnabled,
+    });
+  }),
+
+  mockApi(zeroMemberCreditCapContract.set, ({ body, respond }) => {
+    const existing = mockCreditCaps.get(body.userId);
+    mockCreditCaps.set(body.userId, {
+      creditCap: body.creditCap,
+      creditEnabled: existing?.creditEnabled ?? true,
+    });
+    return respond(200, {
+      userId: body.userId,
+      creditCap: body.creditCap,
+      creditEnabled: existing?.creditEnabled ?? true,
+    });
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -9,7 +9,20 @@ import {
   apiConnectorsHandlers,
   resetMockConnectors,
 } from "./api-connectors.ts";
-import { apiOrgHandlers } from "./api-org.ts";
+import { apiOrgHandlers, resetMockOrg, resetMockOrgLogo } from "./api-org.ts";
+import {
+  apiOrgMembersHandlers,
+  resetMockOrgMembers,
+} from "./api-org-members.ts";
+import {
+  apiOrgDomainsHandlers,
+  resetMockOrgDomains,
+} from "./api-org-domains.ts";
+import {
+  apiUsageHandlers,
+  resetMockUsageMembers,
+  resetMockMemberCreditCaps,
+} from "./api-usage.ts";
 import {
   apiOrgModelProvidersHandlers,
   resetMockOrgModelProviders,
@@ -52,6 +65,9 @@ import { apiPermissionPoliciesHandlers } from "./api-permission-policies.ts";
 export const handlers = [
   ...apiConnectorsHandlers,
   ...apiOrgHandlers,
+  ...apiOrgMembersHandlers,
+  ...apiOrgDomainsHandlers,
+  ...apiUsageHandlers,
   ...apiOrgModelProvidersHandlers,
   ...apiSecretsHandlers,
   ...apiVariablesHandlers,
@@ -84,4 +100,10 @@ export function resetAllMockHandlers(): void {
   resetAblySubscriptions();
   resetMockPermissionRequests();
   resetMockComposesList();
+  resetMockOrg();
+  resetMockOrgLogo();
+  resetMockOrgMembers();
+  resetMockOrgDomains();
+  resetMockUsageMembers();
+  resetMockMemberCreditCaps();
 }

--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -1,22 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { http, HttpResponse } from "msw";
 import { server } from "../../mocks/server.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { zeroOrgContract } from "@vm0/core";
 import { testContext } from "./test-helpers.ts";
 import { detachedSetupPage } from "../../__tests__/page-helper.ts";
 import { mockedClerk } from "../../__tests__/mock-auth.ts";
+import { mockApi } from "../../mocks/msw-contract.ts";
 
 const context = testContext();
 
 describe("zeroClient$ 401 redirect", () => {
   it("should redirect to sign-in when API returns 401", async () => {
     server.use(
-      http.get("http://localhost:3000/api/zero/org", () => {
-        return HttpResponse.json(
-          { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
-          { status: 401 },
-        );
+      mockApi(zeroOrgContract.get, ({ respond }) => {
+        return respond(401, {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        });
       }),
     );
 
@@ -44,11 +43,10 @@ describe("zeroClient$ 401 redirect", () => {
     });
 
     server.use(
-      http.get("http://localhost:3000/api/zero/org", () => {
-        return HttpResponse.json(
-          { error: { message: "Forbidden", code: "FORBIDDEN" } },
-          { status: 403 },
-        );
+      mockApi(zeroOrgContract.get, ({ respond }) => {
+        return respond(404, {
+          error: { message: "Forbidden", code: "NOT_FOUND" },
+        });
       }),
     );
 
@@ -58,7 +56,7 @@ describe("zeroClient$ 401 redirect", () => {
     const client = createClient(zeroOrgContract);
     const result = await client.get();
 
-    expect(result.status).toBe(403);
+    expect(result.status).toBe(404);
     expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
   });
 
@@ -78,18 +76,19 @@ describe("zeroClient$ 401 redirect", () => {
 
     const authHeaders: string[] = [];
     server.use(
-      http.get("http://localhost:3000/api/zero/org", ({ request }) => {
+      mockApi(zeroOrgContract.get, ({ request, respond }) => {
         authHeaders.push(request.headers.get("authorization") ?? "");
         if (authHeaders.length === 1) {
-          return HttpResponse.json(
-            { error: { message: "Unauthorized", code: "UNAUTHORIZED" } },
-            { status: 401 },
-          );
+          return respond(401, {
+            error: { message: "Unauthorized", code: "UNAUTHORIZED" },
+          });
         }
-        return HttpResponse.json(
-          { id: "org_1", name: "Org", slug: "org-1", imageUrl: "" },
-          { status: 200 },
-        );
+        return respond(200, {
+          id: "org_1",
+          name: "Org",
+          slug: "org-1",
+          role: "admin",
+        });
       }),
     );
 
@@ -124,12 +123,11 @@ describe("zeroClient$ 401 redirect", () => {
 
     const authHeaders: string[] = [];
     server.use(
-      http.get("http://localhost:3000/api/zero/org", ({ request }) => {
+      mockApi(zeroOrgContract.get, ({ request, respond }) => {
         authHeaders.push(request.headers.get("authorization") ?? "");
-        return HttpResponse.json(
-          { error: { message: "Unauthorized", code: "UNAUTHORIZED" } },
-          { status: 401 },
-        );
+        return respond(401, {
+          error: { message: "Unauthorized", code: "UNAUTHORIZED" },
+        });
       }),
     );
 
@@ -161,12 +159,11 @@ describe("zeroClient$ 401 redirect", () => {
 
     const authHeaders: string[] = [];
     server.use(
-      http.get("http://localhost:3000/api/zero/org", ({ request }) => {
+      mockApi(zeroOrgContract.get, ({ request, respond }) => {
         authHeaders.push(request.headers.get("authorization") ?? "");
-        return HttpResponse.json(
-          { error: { message: "Unauthorized", code: "UNAUTHORIZED" } },
-          { status: 401 },
-        );
+        return respond(401, {
+          error: { message: "Unauthorized", code: "UNAUTHORIZED" },
+        });
       }),
     );
 
@@ -193,12 +190,11 @@ describe("zeroClient$ 401 redirect", () => {
 
     const authHeaders: string[] = [];
     server.use(
-      http.get("http://localhost:3000/api/zero/org", ({ request }) => {
+      mockApi(zeroOrgContract.get, ({ request, respond }) => {
         authHeaders.push(request.headers.get("authorization") ?? "");
-        return HttpResponse.json(
-          { error: { message: "Unauthorized", code: "UNAUTHORIZED" } },
-          { status: 401 },
-        );
+        return respond(401, {
+          error: { message: "Unauthorized", code: "UNAUTHORIZED" },
+        });
       }),
     );
 

--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
 import { server } from "../../mocks/server.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { zeroOrgContract } from "@vm0/core";
@@ -42,11 +43,13 @@ describe("zeroClient$ 401 redirect", () => {
       withoutRender: true,
     });
 
+    // Keep raw http.get for 403 since it's not in zeroOrgContract.get's defined responses
     server.use(
-      mockApi(zeroOrgContract.get, ({ respond }) => {
-        return respond(404, {
-          error: { message: "Forbidden", code: "NOT_FOUND" },
-        });
+      http.get("*/api/zero/org", () => {
+        return HttpResponse.json(
+          { error: { message: "Forbidden", code: "FORBIDDEN" } },
+          { status: 403 },
+        );
       }),
     );
 
@@ -56,7 +59,7 @@ describe("zeroClient$ 401 redirect", () => {
     const client = createClient(zeroOrgContract);
     const result = await client.get();
 
-    expect(result.status).toBe(404);
+    expect(result.status).toBe(403);
     expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
   });
 

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/member-credit-caps.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/member-credit-caps.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { creditsMemberList$ } from "../member-credit-caps.ts";
+import {
+  setMockUsageMembers,
+  setMockMemberCreditCap,
+  resetMockUsageMembers,
+  resetMockMemberCreditCaps,
+} from "../../../mocks/handlers/api-usage.ts";
+import { zeroMemberCreditCapContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -49,43 +57,31 @@ function memberB(): MockMember {
   };
 }
 
-function mockUsageMembers(members: MockMember[]) {
-  server.use(
-    http.get("*/api/zero/usage/members", () => {
-      return HttpResponse.json({
-        period: { start: "2026-03-01", end: "2026-03-31" },
-        members,
-      });
-    }),
-  );
+beforeEach(() => {
+  resetMockUsageMembers();
+  resetMockMemberCreditCaps();
+});
+
+function setupUsageMembers(members: MockMember[]) {
+  setMockUsageMembers({
+    period: { start: "2026-03-01", end: "2026-03-31" },
+    members,
+  });
 }
 
-function mockCreditCaps(
+function setupCreditCaps(
   caps: Record<string, { creditCap: number | null; creditEnabled: boolean }>,
 ) {
-  server.use(
-    http.get("*/api/zero/org/members/credit-cap", ({ request }) => {
-      const url = new URL(request.url);
-      const userId = url.searchParams.get("userId");
-      const cap = userId ? caps[userId] : undefined;
-      if (!cap) {
-        return HttpResponse.json({
-          userId,
-          creditCap: null,
-          creditEnabled: false,
-        });
-      }
-      return HttpResponse.json({ userId, ...cap });
-    }),
-  );
+  for (const [userId, cap] of Object.entries(caps)) {
+    setMockMemberCreditCap(userId, cap.creditCap, cap.creditEnabled);
+  }
 }
 
-function mockCreditCapPut(captured: { calls: CapturedCapCall[] }) {
+function setupCreditCapPut(captured: { calls: CapturedCapCall[] }) {
   server.use(
-    http.put("*/api/zero/org/members/credit-cap", async ({ request }) => {
-      const body = (await request.json()) as CapturedCapCall;
-      captured.calls.push(body);
-      return HttpResponse.json({
+    mockApi(zeroMemberCreditCapContract.set, ({ body, respond }) => {
+      captured.calls.push({ userId: body.userId, creditCap: body.creditCap });
+      return respond(200, {
         userId: body.userId,
         creditCap: body.creditCap,
         creditEnabled: body.creditCap !== null,
@@ -100,8 +96,8 @@ function setup() {
 
 describe("creditsMemberList$", () => {
   it("should return member settings with credit caps from API", async () => {
-    mockUsageMembers([memberA(), memberB()]);
-    mockCreditCaps({
+    setupUsageMembers([memberA(), memberB()]);
+    setupCreditCaps({
       "user-a": { creditCap: 1000, creditEnabled: true },
       "user-b": { creditCap: null, creditEnabled: false },
     });
@@ -122,7 +118,8 @@ describe("creditsMemberList$", () => {
   });
 
   it("should throw when API returns non-OK for credit cap fetch", async () => {
-    mockUsageMembers([memberA()]);
+    setupUsageMembers([memberA()]);
+    // Keep raw http.get for 500 since it's not in the contract's defined responses
     server.use(
       http.get("*/api/zero/org/members/credit-cap", () => {
         return HttpResponse.json(
@@ -147,12 +144,12 @@ describe("creditsMemberList$", () => {
 
 describe("save$ command", () => {
   it("should call PUT with parsed credit cap and exit edit mode", async () => {
-    mockUsageMembers([memberA()]);
-    mockCreditCaps({
+    setupUsageMembers([memberA()]);
+    setupCreditCaps({
       "user-a": { creditCap: null, creditEnabled: false },
     });
     const captured: { calls: CapturedCapCall[] } = { calls: [] };
-    mockCreditCapPut(captured);
+    setupCreditCapPut(captured);
 
     await setup();
 
@@ -178,12 +175,12 @@ describe("save$ command", () => {
   });
 
   it("should not call PUT when value is invalid (non-positive)", async () => {
-    mockUsageMembers([memberA()]);
-    mockCreditCaps({
+    setupUsageMembers([memberA()]);
+    setupCreditCaps({
       "user-a": { creditCap: null, creditEnabled: false },
     });
     const captured: { calls: CapturedCapCall[] } = { calls: [] };
-    mockCreditCapPut(captured);
+    setupCreditCapPut(captured);
 
     await setup();
 
@@ -198,12 +195,12 @@ describe("save$ command", () => {
   });
 
   it("should not call PUT when value is NaN", async () => {
-    mockUsageMembers([memberA()]);
-    mockCreditCaps({
+    setupUsageMembers([memberA()]);
+    setupCreditCaps({
       "user-a": { creditCap: null, creditEnabled: false },
     });
     const captured: { calls: CapturedCapCall[] } = { calls: [] };
-    mockCreditCapPut(captured);
+    setupCreditCapPut(captured);
 
     await setup();
 
@@ -218,12 +215,12 @@ describe("save$ command", () => {
   });
 
   it("should call PUT with null creditCap when value is empty", async () => {
-    mockUsageMembers([memberA()]);
-    mockCreditCaps({
+    setupUsageMembers([memberA()]);
+    setupCreditCaps({
       "user-a": { creditCap: 1000, creditEnabled: true },
     });
     const captured: { calls: CapturedCapCall[] } = { calls: [] };
-    mockCreditCapPut(captured);
+    setupCreditCapPut(captured);
 
     await setup();
 
@@ -244,12 +241,12 @@ describe("save$ command", () => {
 
 describe("clearCap$ command", () => {
   it("should call PUT with null creditCap and exit edit mode", async () => {
-    mockUsageMembers([memberA()]);
-    mockCreditCaps({
+    setupUsageMembers([memberA()]);
+    setupCreditCaps({
       "user-a": { creditCap: 1000, creditEnabled: true },
     });
     const captured: { calls: CapturedCapCall[] } = { calls: [] };
-    mockCreditCapPut(captured);
+    setupCreditCapPut(captured);
 
     await setup();
 
@@ -270,8 +267,8 @@ describe("clearCap$ command", () => {
 
 describe("edit mode signals", () => {
   it("should toggle edit mode and reset value on enter", async () => {
-    mockUsageMembers([memberA()]);
-    mockCreditCaps({
+    setupUsageMembers([memberA()]);
+    setupCreditCaps({
       "user-a": { creditCap: 500, creditEnabled: true },
     });
 
@@ -291,8 +288,8 @@ describe("edit mode signals", () => {
   });
 
   it("should initialize value to empty string when creditCap is null", async () => {
-    mockUsageMembers([memberA()]);
-    mockCreditCaps({
+    setupUsageMembers([memberA()]);
+    setupCreditCaps({
       "user-a": { creditCap: null, creditEnabled: false },
     });
 
@@ -308,8 +305,8 @@ describe("edit mode signals", () => {
 
 describe("creditsMemberList$ caching", () => {
   it("should reuse cached setting when creditCap has not changed", async () => {
-    mockUsageMembers([memberA()]);
-    mockCreditCaps({
+    setupUsageMembers([memberA()]);
+    setupCreditCaps({
       "user-a": { creditCap: 1000, creditEnabled: true },
     });
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server.ts";
 import { mockLocation } from "../../../location.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
@@ -14,6 +13,9 @@ import {
 } from "../org-manage-dialog.ts";
 import { orgManageTab$, inviteMember$ } from "../org-manage-tabs-state.ts";
 import { searchParams$ } from "../../../route.ts";
+import { setMockOrg } from "../../../../mocks/handlers/api-org.ts";
+import { zeroOrgInviteContract } from "@vm0/core";
+import { mockApi } from "../../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -103,16 +105,7 @@ describe("checkSettingsParam$", () => {
   it("should redirect non-admin to general tab for admin-only tabs", async () => {
     const { store, signal } = context;
     setupAuth(signal);
-    server.use(
-      http.get("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_1",
-          slug: "user-12345678",
-          name: "User 12345678",
-          role: "member",
-        });
-      }),
-    );
+    setMockOrg({ role: "member" });
     createPushStateMock(signal);
     mockLocation({ pathname: "/", search: "?settings=billing" }, signal);
 
@@ -145,16 +138,13 @@ describe("inviteMember$", () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
 
     server.use(
-      http.post("*/api/zero/org/invite", () => {
-        return HttpResponse.json(
-          {
-            error: {
-              message: "Already a member",
-              code: "INTERNAL_SERVER_ERROR",
-            },
+      mockApi(zeroOrgInviteContract.invite, ({ respond }) => {
+        return respond(400, {
+          error: {
+            message: "Already a member",
+            code: "INTERNAL_SERVER_ERROR",
           },
-          { status: 400 },
-        );
+        });
       }),
     );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-model-providers.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-model-providers.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
 import {
@@ -10,6 +9,8 @@ import {
   orgUpdateFormModel$,
 } from "../org-model-providers.ts";
 import { getProviderShape } from "../../../../views/zero-page/components/settings/provider-ui-config.ts";
+import { zeroModelProvidersMainContract } from "@vm0/core";
+import { mockApi } from "../../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -25,26 +26,23 @@ describe("org-model-providers vm0 provider", () => {
     let capturedBody: Record<string, unknown> | null = null;
 
     server.use(
-      http.post("*/api/zero/model-providers", async ({ request }) => {
-        capturedBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json(
-          {
-            provider: {
-              id: "a1b2c3d4-e5f6-4890-abcd-ef1234567890",
-              type: "vm0",
-              framework: "claude-code",
-              secretName: null,
-              authMethod: null,
-              secretNames: null,
-              isDefault: true,
-              selectedModel: (capturedBody.selectedModel as string) ?? null,
-              createdAt: new Date().toISOString(),
-              updatedAt: new Date().toISOString(),
-            },
-            created: true,
+      mockApi(zeroModelProvidersMainContract.upsert, ({ body, respond }) => {
+        capturedBody = body as Record<string, unknown>;
+        return respond(201, {
+          provider: {
+            id: "a1b2c3d4-e5f6-4890-abcd-ef1234567890",
+            type: "vm0",
+            framework: "claude-code",
+            secretName: null,
+            authMethod: null,
+            secretNames: null,
+            isDefault: true,
+            selectedModel: (capturedBody.selectedModel as string) ?? null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
           },
-          { status: 201 },
-        );
+          created: true,
+        });
       }),
     );
 
@@ -68,26 +66,23 @@ describe("org-model-providers vm0 provider", () => {
     let capturedBody: Record<string, unknown> | null = null;
 
     server.use(
-      http.post("*/api/zero/model-providers", async ({ request }) => {
-        capturedBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json(
-          {
-            provider: {
-              id: "a1b2c3d4-e5f6-4890-abcd-ef1234567890",
-              type: "vm0",
-              framework: "claude-code",
-              secretName: null,
-              authMethod: null,
-              secretNames: null,
-              isDefault: true,
-              selectedModel: (capturedBody.selectedModel as string) ?? null,
-              createdAt: new Date().toISOString(),
-              updatedAt: new Date().toISOString(),
-            },
-            created: true,
+      mockApi(zeroModelProvidersMainContract.upsert, ({ body, respond }) => {
+        capturedBody = body as Record<string, unknown>;
+        return respond(201, {
+          provider: {
+            id: "a1b2c3d4-e5f6-4890-abcd-ef1234567890",
+            type: "vm0",
+            framework: "claude-code",
+            secretName: null,
+            authMethod: null,
+            secretNames: null,
+            isDefault: true,
+            selectedModel: (capturedBody.selectedModel as string) ?? null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
           },
-          { status: 201 },
-        );
+          created: true,
+        });
       }),
     );
 
@@ -111,26 +106,23 @@ describe("org-model-providers vm0 provider", () => {
     let capturedBody: Record<string, unknown> | null = null;
 
     server.use(
-      http.post("*/api/zero/model-providers", async ({ request }) => {
-        capturedBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json(
-          {
-            provider: {
-              id: "a1b2c3d4-e5f6-4890-abcd-ef1234567890",
-              type: "vm0",
-              framework: "claude-code",
-              secretName: null,
-              authMethod: null,
-              secretNames: null,
-              isDefault: true,
-              selectedModel: (capturedBody.selectedModel as string) ?? null,
-              createdAt: new Date().toISOString(),
-              updatedAt: new Date().toISOString(),
-            },
-            created: true,
+      mockApi(zeroModelProvidersMainContract.upsert, ({ body, respond }) => {
+        capturedBody = body as Record<string, unknown>;
+        return respond(201, {
+          provider: {
+            id: "a1b2c3d4-e5f6-4890-abcd-ef1234567890",
+            type: "vm0",
+            framework: "claude-code",
+            secretName: null,
+            authMethod: null,
+            secretNames: null,
+            isDefault: true,
+            selectedModel: (capturedBody.selectedModel as string) ?? null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
           },
-          { status: 201 },
-        );
+          created: true,
+        });
       }),
     );
 

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
@@ -11,6 +11,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 
 const context = testContext();
 
@@ -564,16 +565,7 @@ describe("network insights page - team credit usage card", () => {
     mockInsightsAPI([sampleDay(day1Ago)]);
 
     // Override org API to return member role
-    server.use(
-      http.get("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_1",
-          slug: "user-12345678",
-          name: "User 12345678",
-          role: "member",
-        });
-      }),
-    );
+    setMockOrg({ role: "member" });
 
     detachedSetupPage({ context, path: "/insights" });
 

--- a/turbo/apps/platform/src/views/org/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-general-tab.test.tsx
@@ -1,49 +1,25 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
-import { createDeferredPromise } from "../../../signals/utils.ts";
 import { refreshOrg$ } from "../../../signals/org.ts";
+import {
+  setMockOrg,
+  resetMockOrg,
+  setMockOrgLogo,
+  resetMockOrgLogo,
+} from "../../../mocks/handlers/api-org.ts";
+import { zeroOrgContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
-function mockAPIs(overrides?: { slug?: string; name?: string; role?: string }) {
-  const org = {
-    id: "org_1",
-    slug: overrides?.slug ?? "test-org",
-    name: overrides?.name ?? "Test Org",
-    role: overrides?.role ?? "admin",
-  };
-  server.use(
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json(org);
-    }),
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-  );
-  return org;
-}
+beforeEach(() => {
+  resetMockOrg();
+  resetMockOrgLogo();
+});
 
 async function openGeneralTab() {
   detachedSetupPage({ context, path: "/?settings=general" });
@@ -55,12 +31,8 @@ async function openGeneralTab() {
 describe("org general tab - display", () => {
   // ORG-D-008
   it("logo preview image is displayed", async () => {
-    mockAPIs({ slug: "my-org" });
-    server.use(
-      http.get("*/api/zero/org/logo", () => {
-        return HttpResponse.json({ logoUrl: "https://example.com/logo.png" });
-      }),
-    );
+    setMockOrg({ slug: "my-org" });
+    setMockOrgLogo("https://example.com/logo.png");
     await openGeneralTab();
     const logo = await screen.findByAltText("my-org");
     expect(logo).toBeInTheDocument();
@@ -69,7 +41,7 @@ describe("org general tab - display", () => {
 
   // ORG-D-009
   it("organization name is displayed", async () => {
-    mockAPIs({ name: "Acme Corp" });
+    setMockOrg({ name: "Acme Corp" });
     await openGeneralTab();
     const nameInput = await screen.findByDisplayValue("Acme Corp");
     expect(nameInput).toBeInTheDocument();
@@ -77,7 +49,7 @@ describe("org general tab - display", () => {
 
   // ORG-D-010
   it("organization slug is displayed", async () => {
-    mockAPIs({ slug: "acme-corp" });
+    setMockOrg({ slug: "acme-corp" });
     await openGeneralTab();
     const slugInput = await screen.findByDisplayValue("acme-corp");
     expect(slugInput).toBeInTheDocument();
@@ -86,16 +58,24 @@ describe("org general tab - display", () => {
   // ORG-D-011
   it("loading skeletons are shown while data loads", async () => {
     // First load org so the dialog opens normally
-    mockAPIs({ slug: "test-org" });
+    setMockOrg({ slug: "test-org" });
     await openGeneralTab();
     // Wait for content to be rendered
     await screen.findByDisplayValue("test-org");
 
-    // Now trigger a refresh with a slow (deferred) org response
-    const orgDeferred = createDeferredPromise<Response>(context.signal);
+    // Now trigger a refresh with a never-resolving org response
     server.use(
-      http.get("*/api/zero/org", () => {
-        return orgDeferred.promise;
+      mockApi(zeroOrgContract.get, async ({ respond }) => {
+        // Never resolves — keeps loading state visible
+        await new Promise<void>(() => {
+          /* intentionally never resolves */
+        });
+        return respond(200, {
+          id: "org_1",
+          slug: "test-org",
+          name: "Test Org",
+          role: "admin",
+        });
       }),
     );
     context.store.set(refreshOrg$);
@@ -109,28 +89,20 @@ describe("org general tab - display", () => {
         screen.getByRole("status", { name: "Loading" }),
       ).toBeInTheDocument();
     });
-
-    // Resolve deferred to allow clean teardown
-    orgDeferred.resolve(
-      HttpResponse.json({
-        id: "org_1",
-        slug: "test-org",
-        name: "Test Org",
-        role: "admin",
-      }) as unknown as Response,
-    );
   });
 
   // ORG-D-012
   it("error messages shown during save failure", async () => {
     const user = userEvent.setup();
-    mockAPIs({ slug: "old-slug" });
+    setMockOrg({ slug: "old-slug" });
     server.use(
-      http.put("*/api/zero/org", () => {
-        return HttpResponse.json(
-          { error: { message: "Slug already taken", code: "CONFLICT" } },
-          { status: 409 },
-        );
+      mockApi(zeroOrgContract.update, ({ respond }) => {
+        return respond(409, {
+          error: {
+            message: "Slug already taken",
+            code: "INTERNAL_SERVER_ERROR",
+          },
+        });
       }),
     );
     await openGeneralTab();
@@ -147,7 +119,7 @@ describe("org general tab - display", () => {
     const user = userEvent.setup();
     vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-preview");
     vi.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
-    mockAPIs({ slug: "test-org" });
+    setMockOrg({ slug: "test-org", name: "Test Org" });
     await openGeneralTab();
     // Wait for admin inputs to load
     await screen.findByDisplayValue("Test Org");
@@ -164,7 +136,7 @@ describe("org general tab - display", () => {
 describe("org general tab - interaction", () => {
   // ORG-I-015
   it("name input field is editable", async () => {
-    mockAPIs({ name: "Old Name" });
+    setMockOrg({ name: "Old Name" });
     await openGeneralTab();
     const nameInput = await screen.findByDisplayValue("Old Name");
     await fill(nameInput, "New Name");
@@ -173,7 +145,7 @@ describe("org general tab - interaction", () => {
 
   // ORG-I-016
   it("slug input field is editable", async () => {
-    mockAPIs({ slug: "old-slug" });
+    setMockOrg({ slug: "old-slug" });
     await openGeneralTab();
     const slugInput = await screen.findByDisplayValue("old-slug");
     await fill(slugInput, "new-slug");
@@ -184,26 +156,18 @@ describe("org general tab - interaction", () => {
   it("save changes button submits form", async () => {
     const user = userEvent.setup();
     const requestBody = vi.fn();
-    mockAPIs({ name: "Old Name", slug: "test-org" });
+    setMockOrg({ name: "Old Name", slug: "test-org" });
     server.use(
-      http.put("*/api/zero/org", async ({ request }) => {
-        requestBody(await request.json());
+      mockApi(zeroOrgContract.update, ({ body, respond }) => {
+        requestBody(body);
         // After a successful save, update the GET handler to return the new name
         // so the org refresh reflects the change and hasChanges becomes false
-        server.use(
-          http.get("*/api/zero/org", () => {
-            return HttpResponse.json({
-              id: "org_1",
-              slug: "test-org",
-              name: "New Name",
-              role: "admin",
-            });
-          }),
-        );
-        return HttpResponse.json({
+        setMockOrg({ name: "New Name", slug: "test-org" });
+        return respond(200, {
           id: "org_1",
           slug: "test-org",
           name: "New Name",
+          role: "admin",
         });
       }),
     );
@@ -221,7 +185,7 @@ describe("org general tab - interaction", () => {
   // ORG-I-018
   it("discard button reverts changes", async () => {
     const user = userEvent.setup();
-    mockAPIs({ name: "Original Name" });
+    setMockOrg({ name: "Original Name" });
     await openGeneralTab();
     const nameInput = await screen.findByDisplayValue("Original Name");
     await fill(nameInput, "Changed Name");
@@ -234,7 +198,7 @@ describe("org general tab - interaction", () => {
   // ORG-I-019
   it("leave workspace button opens confirmation dialog", async () => {
     const user = userEvent.setup();
-    mockAPIs({ role: "member" });
+    setMockOrg({ role: "member" });
     await openGeneralTab();
     await waitFor(() => {
       expect(
@@ -256,7 +220,7 @@ describe("org general tab - interaction", () => {
   // ORG-I-020
   it("delete workspace button opens confirmation dialog requiring slug", async () => {
     const user = userEvent.setup();
-    mockAPIs({ slug: "acme-org" });
+    setMockOrg({ slug: "acme-org" });
     await openGeneralTab();
     // Wait for page to load
     await screen.findByDisplayValue("acme-org");
@@ -277,7 +241,7 @@ describe("org general tab - interaction", () => {
 describe("org general tab - validation", () => {
   it("delete workspace requires typing exact slug", async () => {
     const user = userEvent.setup();
-    mockAPIs({ slug: "my-workspace" });
+    setMockOrg({ slug: "my-workspace" });
     await openGeneralTab();
     await screen.findByDisplayValue("my-workspace");
     const deleteWorkspaceBtn = screen.getAllByRole("button").find((el) => {

--- a/turbo/apps/platform/src/views/org/__tests__/org-invoices-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-invoices-tab.test.tsx
@@ -1,11 +1,16 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import { createDeferredPromise } from "../../../signals/utils.ts";
+import {
+  setMockBillingInvoices,
+  resetMockBilling,
+} from "../../../mocks/handlers/api-billing.ts";
+import { setMockOrg, resetMockOrg } from "../../../mocks/handlers/api-org.ts";
+import { zeroBillingInvoicesContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -32,38 +37,16 @@ function makeInvoice(overrides?: InvoiceOverrides) {
   };
 }
 
-function mockAPIs() {
-  server.use(
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "test-org",
-        name: "Test Org",
-        role: "admin",
-      });
-    }),
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-  );
-}
+beforeEach(() => {
+  resetMockOrg();
+  resetMockBilling();
+  setMockOrg({
+    id: "org_1",
+    slug: "test-org",
+    name: "Test Org",
+    role: "admin",
+  });
+});
 
 async function openInvoicesTab() {
   detachedSetupPage({ context, path: "/?settings=invoices" });
@@ -75,16 +58,9 @@ async function openInvoicesTab() {
 // ORG-D-059
 describe("invoice list display", () => {
   it("shows invoice number, date, amount, and status badge", async () => {
-    mockAPIs();
-    server.use(
-      http.get("*/api/zero/billing/invoices", () => {
-        return HttpResponse.json({
-          invoices: [
-            makeInvoice({ number: "INV-001", amount: 4999, status: "paid" }),
-          ],
-        });
-      }),
-    );
+    setMockBillingInvoices([
+      makeInvoice({ number: "INV-001", amount: 4999, status: "paid" }),
+    ]);
     await openInvoicesTab();
     await waitFor(() => {
       expect(screen.getByText("INV-001")).toBeInTheDocument();
@@ -94,14 +70,7 @@ describe("invoice list display", () => {
   });
 
   it("shows invoice id when number is null", async () => {
-    mockAPIs();
-    server.use(
-      http.get("*/api/zero/billing/invoices", () => {
-        return HttpResponse.json({
-          invoices: [makeInvoice({ id: "inv_abc123", number: null })],
-        });
-      }),
-    );
+    setMockBillingInvoices([makeInvoice({ id: "inv_abc123", number: null })]);
     await openInvoicesTab();
     await waitFor(() => {
       expect(screen.getByText("inv_abc123")).toBeInTheDocument();
@@ -113,14 +82,7 @@ describe("invoice list display", () => {
 it("formats date and amount correctly", async () => {
   const timestamp = 1_700_000_000;
   const expectedDate = new Date(timestamp * 1000).toLocaleDateString("en-US");
-  mockAPIs();
-  server.use(
-    http.get("*/api/zero/billing/invoices", () => {
-      return HttpResponse.json({
-        invoices: [makeInvoice({ date: timestamp, amount: 12_050 })],
-      });
-    }),
-  );
+  setMockBillingInvoices([makeInvoice({ date: timestamp, amount: 12_050 })]);
   await openInvoicesTab();
   await waitFor(() => {
     expect(screen.getByText(expectedDate)).toBeInTheDocument();
@@ -130,25 +92,18 @@ it("formats date and amount correctly", async () => {
 
 // ORG-C-061
 it("shows download link only when hostedInvoiceUrl is available", async () => {
-  mockAPIs();
-  server.use(
-    http.get("*/api/zero/billing/invoices", () => {
-      return HttpResponse.json({
-        invoices: [
-          makeInvoice({
-            id: "inv_1",
-            number: "INV-001",
-            hostedInvoiceUrl: "https://invoice.stripe.com/inv_1",
-          }),
-          makeInvoice({
-            id: "inv_2",
-            number: "INV-002",
-            hostedInvoiceUrl: null,
-          }),
-        ],
-      });
+  setMockBillingInvoices([
+    makeInvoice({
+      id: "inv_1",
+      number: "INV-001",
+      hostedInvoiceUrl: "https://invoice.stripe.com/inv_1",
     }),
-  );
+    makeInvoice({
+      id: "inv_2",
+      number: "INV-002",
+      hostedInvoiceUrl: null,
+    }),
+  ]);
   await openInvoicesTab();
   await waitFor(() => {
     expect(screen.getByText("INV-001")).toBeInTheDocument();
@@ -165,12 +120,7 @@ it("shows download link only when hostedInvoiceUrl is available", async () => {
 
 // ORG-C-062
 it("shows empty state when no invoices exist", async () => {
-  mockAPIs();
-  server.use(
-    http.get("*/api/zero/billing/invoices", () => {
-      return HttpResponse.json({ invoices: [] });
-    }),
-  );
+  // Default handler already returns empty invoices, just open the tab
   await openInvoicesTab();
   await waitFor(() => {
     expect(screen.getByText("No invoices yet.")).toBeInTheDocument();
@@ -179,19 +129,21 @@ it("shows empty state when no invoices exist", async () => {
 
 // ORG-D-063
 it("shows loading state while invoices load", async () => {
-  const deferred = createDeferredPromise<void>(context.signal);
-  mockAPIs();
+  let resolveInvoices: (() => void) | null = null;
+  const invoicesPromise = new Promise<void>((resolve) => {
+    resolveInvoices = resolve;
+  });
   server.use(
-    http.get("*/api/zero/billing/invoices", async () => {
-      await deferred.promise;
-      return HttpResponse.json({ invoices: [] });
+    mockApi(zeroBillingInvoicesContract.get, async ({ respond }) => {
+      await invoicesPromise;
+      return respond(200, { invoices: [] });
     }),
   );
   await openInvoicesTab();
   await waitFor(() => {
     expect(screen.getByText("Loading invoices...")).toBeInTheDocument();
   });
-  deferred.resolve();
+  resolveInvoices!();
   await waitFor(() => {
     expect(screen.getByText("No invoices yet.")).toBeInTheDocument();
   });
@@ -200,16 +152,9 @@ it("shows loading state while invoices load", async () => {
 // ORG-I-064
 it("shows tooltip when hovering download link", async () => {
   const user = userEvent.setup();
-  mockAPIs();
-  server.use(
-    http.get("*/api/zero/billing/invoices", () => {
-      return HttpResponse.json({
-        invoices: [
-          makeInvoice({ hostedInvoiceUrl: "https://invoice.stripe.com/inv_1" }),
-        ],
-      });
-    }),
-  );
+  setMockBillingInvoices([
+    makeInvoice({ hostedInvoiceUrl: "https://invoice.stripe.com/inv_1" }),
+  ]);
   await openInvoicesTab();
   await waitFor(() => {
     expect(

--- a/turbo/apps/platform/src/views/org/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-members-tab.test.tsx
@@ -1,7 +1,6 @@
-import { expect, test } from "vitest";
+import { expect, test, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
@@ -10,6 +9,16 @@ import type {
   OrgPendingInvitation,
   OrgMembershipRequest,
 } from "../../../signals/external/org-members.ts";
+import {
+  setMockOrgMembers,
+  resetMockOrgMembers,
+} from "../../../mocks/handlers/api-org-members.ts";
+import {
+  zeroOrgMembersContract,
+  zeroOrgInviteContract,
+  zeroOrgMembershipRequestsContract,
+} from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -70,26 +79,23 @@ const membershipRequest = {
   createdAt: "2026-03-05T00:00:00Z",
 } as const satisfies OrgMembershipRequest;
 
-function mockMembersAPI(options?: {
+beforeEach(() => {
+  resetMockOrgMembers();
+});
+
+function setupMembersAPI(options?: {
   members?: OrgMember[];
   pendingInvitations?: OrgPendingInvitation[];
   membershipRequests?: OrgMembershipRequest[];
 }) {
-  server.use(
-    http.get("*/api/zero/org/members", () => {
-      return HttpResponse.json({
-        slug: "user-12345678",
-        role: "admin",
-        members: options?.members ?? [adminMember, regularMember],
-        pendingInvitations: options?.pendingInvitations ?? [],
-        membershipRequests: options?.membershipRequests ?? [],
-        createdAt: "2026-01-01T00:00:00Z",
-      });
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-  );
+  setMockOrgMembers({
+    slug: "user-12345678",
+    role: "admin",
+    members: options?.members ?? [adminMember, regularMember],
+    pendingInvitations: options?.pendingInvitations ?? [],
+    membershipRequests: options?.membershipRequests ?? [],
+    createdAt: "2026-01-01T00:00:00Z",
+  });
 }
 
 function renderMembersTab() {
@@ -98,7 +104,7 @@ function renderMembersTab() {
 
 // ORG-D-022
 test("shows member name and email in member row", async () => {
-  mockMembersAPI({ members: [regularMember] });
+  setupMembersAPI({ members: [regularMember] });
   await renderMembersTab();
   await waitFor(() => {
     expect(screen.getByText("Regular Member")).toBeInTheDocument();
@@ -108,7 +114,7 @@ test("shows member name and email in member row", async () => {
 
 // ORG-D-023
 test("shows profile image when available and initial letter fallback when not", async () => {
-  mockMembersAPI({ members: [adminMember, memberWithImage] });
+  setupMembersAPI({ members: [adminMember, memberWithImage] });
   await renderMembersTab();
   await waitFor(() => {
     expect(screen.getByRole("img", { name: "Image User" })).toBeInTheDocument();
@@ -119,7 +125,7 @@ test("shows profile image when available and initial letter fallback when not", 
 
 // ORG-D-024
 test("shows pending invitations in the member list", async () => {
-  mockMembersAPI({ pendingInvitations: [pendingInvitation] });
+  setupMembersAPI({ pendingInvitations: [pendingInvitation] });
   await renderMembersTab();
   await waitFor(() => {
     expect(screen.getByText("invited@example.com")).toBeInTheDocument();
@@ -128,7 +134,7 @@ test("shows pending invitations in the member list", async () => {
 
 // ORG-D-025
 test("shows membership requests with Accept and Reject buttons", async () => {
-  mockMembersAPI({ membershipRequests: [membershipRequest] });
+  setupMembersAPI({ membershipRequests: [membershipRequest] });
   await renderMembersTab();
   await waitFor(() => {
     expect(screen.getByTitle("Accept request")).toBeInTheDocument();
@@ -138,7 +144,7 @@ test("shows membership requests with Accept and Reject buttons", async () => {
 
 // ORG-D-026
 test("shows current user indicator on the current user row", async () => {
-  mockMembersAPI({ members: [adminMember] });
+  setupMembersAPI({ members: [adminMember] });
   await renderMembersTab();
   await waitFor(() => {
     expect(screen.getByTestId("current-user-indicator")).toBeInTheDocument();
@@ -147,7 +153,7 @@ test("shows current user indicator on the current user row", async () => {
 
 // ORG-C-028
 test("shows empty state when no members match search", async () => {
-  mockMembersAPI({ members: [regularMember] });
+  setupMembersAPI({ members: [regularMember] });
   await renderMembersTab();
   await waitFor(() => {
     expect(screen.getByText("Regular Member")).toBeInTheDocument();
@@ -162,7 +168,7 @@ test("shows empty state when no members match search", async () => {
 
 // ORG-I-029
 test("filters member list when search input is used", async () => {
-  mockMembersAPI({ members: [adminMember, regularMember] });
+  setupMembersAPI({ members: [adminMember, regularMember] });
   await renderMembersTab();
   await waitFor(() => {
     expect(screen.getByText("admin@example.com")).toBeInTheDocument();
@@ -179,7 +185,7 @@ test("filters member list when search input is used", async () => {
 // ORG-I-030
 test("opens invite dialog when Add member button is clicked", async () => {
   const user = userEvent.setup();
-  mockMembersAPI();
+  setupMembersAPI();
   await renderMembersTab();
   await waitFor(() => {
     expect(screen.getByText("admin@example.com")).toBeInTheDocument();
@@ -200,15 +206,11 @@ test("opens invite dialog when Add member button is clicked", async () => {
 test("sends invite with typed email when Send invitation is clicked", async () => {
   const user = userEvent.setup();
   let capturedEmail: string | null = null;
-  mockMembersAPI();
+  setupMembersAPI();
   server.use(
-    http.post("*/api/zero/org/invite", async ({ request }) => {
-      const body = (await request.json()) as unknown as {
-        email: string;
-        role: string;
-      };
+    mockApi(zeroOrgInviteContract.invite, ({ body, respond }) => {
       capturedEmail = body.email;
-      return HttpResponse.json({ message: "ok" });
+      return respond(200, { message: "ok" });
     }),
   );
   await renderMembersTab();
@@ -241,15 +243,11 @@ test("sends invite with typed email when Send invitation is clicked", async () =
 test("sends invite with Admin role when Admin is selected in role dropdown", async () => {
   const user = userEvent.setup();
   let capturedRole: string | null = null;
-  mockMembersAPI();
+  setupMembersAPI();
   server.use(
-    http.post("*/api/zero/org/invite", async ({ request }) => {
-      const body = (await request.json()) as unknown as {
-        email: string;
-        role: string;
-      };
-      capturedRole = body.role;
-      return HttpResponse.json({ message: "ok" });
+    mockApi(zeroOrgInviteContract.invite, ({ body, respond }) => {
+      capturedRole = body.role ?? "member";
+      return respond(200, { message: "ok" });
     }),
   );
   await renderMembersTab();
@@ -287,14 +285,11 @@ test("sends invite with Admin role when Admin is selected in role dropdown", asy
 test("sends role update when Make admin is clicked in member action menu", async () => {
   const user = userEvent.setup();
   let capturedRoleUpdate: { email: string; role: string } | null = null;
-  mockMembersAPI({ members: [adminMember, regularMember] });
+  setupMembersAPI({ members: [adminMember, regularMember] });
   server.use(
-    http.patch("*/api/zero/org/members", async ({ request }) => {
-      capturedRoleUpdate = (await request.json()) as unknown as {
-        email: string;
-        role: string;
-      };
-      return HttpResponse.json({ message: "ok" });
+    mockApi(zeroOrgMembersContract.updateRole, ({ body, respond }) => {
+      capturedRoleUpdate = body;
+      return respond(200, { message: "ok" });
     }),
   );
   await renderMembersTab();
@@ -317,7 +312,7 @@ test("sends role update when Make admin is clicked in member action menu", async
 // ORG-I-034
 test("shows self-demote confirmation dialog when admin switches to member", async () => {
   const user = userEvent.setup();
-  mockMembersAPI({ members: [adminMember, secondAdmin, regularMember] });
+  setupMembersAPI({ members: [adminMember, secondAdmin, regularMember] });
   await renderMembersTab();
   await waitFor(() => {
     expect(screen.getByTestId("current-user-indicator")).toBeInTheDocument();
@@ -337,7 +332,7 @@ test("shows self-demote confirmation dialog when admin switches to member", asyn
 // ORG-I-035
 test("shows revoke invitation confirmation dialog when revoke is clicked", async () => {
   const user = userEvent.setup();
-  mockMembersAPI({ pendingInvitations: [pendingInvitation] });
+  setupMembersAPI({ pendingInvitations: [pendingInvitation] });
   await renderMembersTab();
   await waitFor(() => {
     expect(screen.getByText("invited@example.com")).toBeInTheDocument();
@@ -358,12 +353,11 @@ test("shows revoke invitation confirmation dialog when revoke is clicked", async
 test("sends accept request when Accept button is clicked", async () => {
   const user = userEvent.setup();
   let capturedRequestId: string | null = null;
-  mockMembersAPI({ membershipRequests: [membershipRequest] });
+  setupMembersAPI({ membershipRequests: [membershipRequest] });
   server.use(
-    http.post("*/api/zero/org/membership-requests", async ({ request }) => {
-      const body = (await request.json()) as unknown as { requestId: string };
+    mockApi(zeroOrgMembershipRequestsContract.accept, ({ body, respond }) => {
       capturedRequestId = body.requestId;
-      return HttpResponse.json({ message: "ok" });
+      return respond(200, { message: "ok" });
     }),
   );
   await renderMembersTab();
@@ -380,12 +374,11 @@ test("sends accept request when Accept button is clicked", async () => {
 test("sends reject request when Reject button is clicked", async () => {
   const user = userEvent.setup();
   let capturedRequestId: string | null = null;
-  mockMembersAPI({ membershipRequests: [membershipRequest] });
+  setupMembersAPI({ membershipRequests: [membershipRequest] });
   server.use(
-    http.delete("*/api/zero/org/membership-requests", async ({ request }) => {
-      const body = (await request.json()) as unknown as { requestId: string };
+    mockApi(zeroOrgMembershipRequestsContract.reject, ({ body, respond }) => {
       capturedRequestId = body.requestId;
-      return HttpResponse.json({ message: "ok" });
+      return respond(200, { message: "ok" });
     }),
   );
   await renderMembersTab();

--- a/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
@@ -12,7 +12,7 @@
  * Internal: real signals, components, rendering
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
@@ -24,29 +24,23 @@ import {
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
+import { setMockOrg, resetMockOrg } from "../../../mocks/handlers/api-org.ts";
 
 const context = testContext();
 
-function mockBaseAPIs() {
-  server.use(
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "test-org",
-        name: "Test Org",
-        role: "admin",
-      });
-    }),
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([]);
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-  );
+beforeEach(() => {
+  resetMockOrg();
+  setMockOrg({
+    id: "org_1",
+    slug: "test-org",
+    name: "Test Org",
+    role: "admin",
+  });
+});
+
+// All default API state (org, chat-threads, team, org/logo) is covered by global handlers.
+function mockBaseAPIs(): void {
+  // No-op: all required endpoints are covered by global default handlers.
 }
 
 // ---------------------------------------------------------------------------
@@ -331,19 +325,6 @@ describe("zero unsaved bar - interaction (ORG-I-114)", () => {
 // ---------------------------------------------------------------------------
 
 async function openSetupPrompt(user: ReturnType<typeof userEvent.setup>) {
-  mockBaseAPIs();
-  server.use(
-    http.get("*/api/zero/model-providers", () => {
-      return HttpResponse.json({ modelProviders: [] });
-    }),
-    http.get("*/api/zero/org/members", () => {
-      return HttpResponse.json({
-        members: [],
-        pendingInvitations: [],
-        membershipRequests: [],
-      });
-    }),
-  );
   detachedSetupPage({ context, path: "/?settings=providers" });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
@@ -38,18 +38,12 @@ beforeEach(() => {
   });
 });
 
-// All default API state (org, chat-threads, team, org/logo) is covered by global handlers.
-function mockBaseAPIs(): void {
-  // No-op: all required endpoints are covered by global default handlers.
-}
-
 // ---------------------------------------------------------------------------
 // InternalConnectorLogos (ORG-D-118, ORG-D-119, ORG-D-120, ORG-I-121)
 // ---------------------------------------------------------------------------
 
 describe("internal connector logos - display (ORG-D-118)", () => {
   it("lists all connector types with labels and type identifiers", async () => {
-    mockBaseAPIs();
     detachedSetupPage({ context, path: "/__internal-connector-logos" });
     const connectorTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
     // Verify at least one connector type and its label appears in the document
@@ -71,7 +65,6 @@ describe("internal connector logos - display (ORG-D-118)", () => {
 
 describe("internal connector logos - display (ORG-D-119)", () => {
   it("heading displays the count of connector types", async () => {
-    mockBaseAPIs();
     detachedSetupPage({ context, path: "/__internal-connector-logos" });
     const connectorTypes = Object.keys(CONNECTOR_TYPES);
     await waitFor(() => {
@@ -85,7 +78,6 @@ describe("internal connector logos - display (ORG-D-119)", () => {
 describe("internal connector logos - interaction (ORG-I-121)", () => {
   it("size selection buttons change the displayed icon size", async () => {
     const user = userEvent.setup();
-    mockBaseAPIs();
     detachedSetupPage({ context, path: "/__internal-connector-logos" });
     // Default size button is "128" — clicking "16" should switch to a smaller size
     await waitFor(() => {
@@ -149,7 +141,6 @@ function testSchedule(
 function mockScheduleDetailAPIs(
   schedules: ScheduleResponse[] = [testSchedule()],
 ) {
-  mockBaseAPIs();
   server.use(
     http.get("*/api/zero/schedules", () => {
       return HttpResponse.json({ schedules });
@@ -394,7 +385,6 @@ describe("setup prompt - state (ORG-S-107)", () => {
 
 describe("clerk provider - display (ORG-D-122)", () => {
   it("clerk provider loads with publishable key from environment", async () => {
-    mockBaseAPIs();
     server.use(
       http.get("*/api/zero/schedules", () => {
         return HttpResponse.json({ schedules: [] });

--- a/turbo/apps/platform/src/views/org/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-providers-tab.test.tsx
@@ -6,14 +6,24 @@
  * Internal: real signals, components, rendering
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
-import { type ModelProviderResponse, MODEL_PROVIDER_TYPES } from "@vm0/core";
+import {
+  type ModelProviderResponse,
+  MODEL_PROVIDER_TYPES,
+  zeroModelProvidersDefaultContract,
+  zeroModelProvidersByTypeContract,
+} from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockOrg, resetMockOrg } from "../../../mocks/handlers/api-org.ts";
+import {
+  setMockOrgModelProviders,
+  resetMockOrgModelProviders,
+} from "../../../mocks/handlers/api-org-model-providers.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -36,42 +46,18 @@ function makeProvider(
   };
 }
 
+beforeEach(() => {
+  resetMockOrg();
+  resetMockOrgModelProviders();
+});
+
 function mockAPIs(options?: {
   providers?: ModelProviderResponse[];
-  role?: string;
+  role?: "admin" | "member";
 }) {
-  const providers = options?.providers ?? [];
   const role = options?.role ?? "admin";
-
-  server.use(
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "user-12345678",
-        name: "Test Org",
-        role,
-      });
-    }),
-    http.get("*/api/zero/model-providers", () => {
-      return HttpResponse.json({ modelProviders: providers });
-    }),
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([]);
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-    http.get("*/api/zero/org/members", () => {
-      return HttpResponse.json({
-        members: [],
-        pendingInvitations: [],
-        membershipRequests: [],
-      });
-    }),
-  );
+  setMockOrg({ id: "org_1", slug: "user-12345678", name: "Test Org", role });
+  setMockOrgModelProviders(options?.providers ?? []);
 }
 
 async function openProvidersPage() {
@@ -201,14 +187,18 @@ describe("org providers tab - interaction", () => {
       ],
     });
     server.use(
-      http.post("*/api/zero/model-providers/:type/default", ({ params }) => {
-        capturedDefaultType = params.type as string;
-        return HttpResponse.json(
-          makeProvider(params.type as ModelProviderResponse["type"], {
-            isDefault: true,
-          }),
-        );
-      }),
+      mockApi(
+        zeroModelProvidersDefaultContract.setDefault,
+        ({ params, respond }) => {
+          capturedDefaultType = params.type;
+          return respond(
+            200,
+            makeProvider(params.type as ModelProviderResponse["type"], {
+              isDefault: true,
+            }),
+          );
+        },
+      ),
     );
     await openProvidersPage();
     await waitFor(() => {
@@ -422,9 +412,9 @@ describe("org delete provider dialog - interaction", () => {
       providers: [makeProvider("anthropic-api-key", { isDefault: true })],
     });
     server.use(
-      http.delete("*/api/zero/model-providers/:type", async () => {
+      mockApi(zeroModelProvidersByTypeContract.delete, async ({ respond }) => {
         await deletePromise;
-        return new HttpResponse(null, { status: 204 });
+        return respond(204);
       }),
     );
     await openProvidersPage();

--- a/turbo/apps/platform/src/views/org/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-usage-tab.test.tsx
@@ -1,11 +1,20 @@
-import { test, expect } from "vitest";
+import { test, expect, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
+import { setMockOrg, resetMockOrg } from "../../../mocks/handlers/api-org.ts";
+import {
+  setMockUsageMembers,
+  resetMockUsageMembers,
+} from "../../../mocks/handlers/api-usage.ts";
+import {
+  zeroUsageMembersContract,
+  zeroMemberCreditCapContract,
+} from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -38,11 +47,16 @@ function makeMember(
   };
 }
 
-function mockAPIs(options?: {
+beforeEach(() => {
+  resetMockOrg();
+  resetMockUsageMembers();
+});
+
+function setupMockAPIs(options?: {
   period?: { start: string; end: string } | null;
   members?: MockMember[];
   errorUsage?: boolean;
-  role?: string;
+  role?: "admin" | "member";
 }) {
   const period =
     options?.period !== undefined
@@ -51,61 +65,24 @@ function mockAPIs(options?: {
   const members = options?.members ?? [];
   const role = options?.role ?? "admin";
 
-  server.use(
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "user-12345678",
-        name: "User 12345678",
-        role,
-      });
-    }),
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-    http.get("*/api/zero/org/members", () => {
-      return HttpResponse.json({
-        members: [],
-        pendingInvitations: [],
-        membershipRequests: [],
-      });
-    }),
-    http.get("*/api/zero/usage/members", () => {
-      if (options?.errorUsage === true) {
-        return HttpResponse.json(
-          {
-            error: {
-              message: "Server error",
-              code: "INTERNAL_SERVER_ERROR",
-            },
-          },
-          { status: 500 },
-        );
-      }
-      return HttpResponse.json({ period, members });
-    }),
-    http.put("*/api/zero/org/members/credit-cap", async ({ request }) => {
-      await request.json();
-      return HttpResponse.json({ ok: true });
-    }),
-  );
+  setMockOrg({
+    id: "org_1",
+    slug: "user-12345678",
+    name: "User 12345678",
+    role,
+  });
+
+  if (options?.errorUsage === true) {
+    server.use(
+      mockApi(zeroUsageMembersContract.get, ({ respond }) => {
+        return respond(500, {
+          error: { message: "Server error", code: "INTERNAL_SERVER_ERROR" },
+        });
+      }),
+    );
+  } else {
+    setMockUsageMembers({ period, members });
+  }
 }
 
 async function openUsageTab() {
@@ -126,7 +103,7 @@ test("shows credit balance with formatted numbers in usage tab", async () => {
     subscriptionStatus: "active",
     hasSubscription: true,
   });
-  mockAPIs({ members: [makeMember("user-a", "alice@example.com", 5000)] });
+  setupMockAPIs({ members: [makeMember("user-a", "alice@example.com", 5000)] });
   await openUsageTab();
   await waitFor(() => {
     const info = screen.getByTestId("credit-balance-info");
@@ -142,7 +119,7 @@ test("shows member email and credits in usage list", async () => {
     subscriptionStatus: "active",
     hasSubscription: true,
   });
-  mockAPIs({
+  setupMockAPIs({
     members: [
       makeMember("user-a", "alice@example.com", 500, null),
       makeMember("user-b", "bob@example.com", 1200, null),
@@ -165,7 +142,9 @@ test("shows editable credit cap input for admins", async () => {
     subscriptionStatus: "active",
     hasSubscription: true,
   });
-  mockAPIs({ members: [makeMember("user-a", "alice@example.com", 500, 3000)] });
+  setupMockAPIs({
+    members: [makeMember("user-a", "alice@example.com", 500, 3000)],
+  });
   await openUsageTab();
   await waitFor(() => {
     expect(screen.getByPlaceholderText("No limit")).toBeInTheDocument();
@@ -180,7 +159,7 @@ test("redirects non-admins to general tab when usage tab is requested", async ()
     subscriptionStatus: "active",
     hasSubscription: true,
   });
-  mockAPIs({
+  setupMockAPIs({
     members: [makeMember("user-a", "alice@example.com", 500, 3000)],
     role: "member",
   });
@@ -206,15 +185,17 @@ test("credit cap input accepts value and saves via unsaved bar", async () => {
     hasSubscription: true,
   });
   let capturedCap: number | null = null;
-  mockAPIs({ members: [makeMember("user-a", "alice@example.com", 500, null)] });
+  setupMockAPIs({
+    members: [makeMember("user-a", "alice@example.com", 500, null)],
+  });
   server.use(
-    http.put("*/api/zero/org/members/credit-cap", async ({ request }) => {
-      const body = (await request.json()) as {
-        userId: string;
-        creditCap: number | null;
-      };
+    mockApi(zeroMemberCreditCapContract.set, ({ body, respond }) => {
       capturedCap = body.creditCap;
-      return HttpResponse.json({ ok: true });
+      return respond(200, {
+        userId: body.userId,
+        creditCap: body.creditCap,
+        creditEnabled: true,
+      });
     }),
   );
   await openUsageTab();
@@ -241,7 +222,7 @@ test("shows error state when usage API fails in usage tab", async () => {
     subscriptionStatus: "active",
     hasSubscription: true,
   });
-  mockAPIs({ errorUsage: true });
+  setupMockAPIs({ errorUsage: true });
   await openUsageTab();
   await waitFor(() => {
     expect(screen.getByTestId("usage-tab-error")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-display.test.tsx
@@ -13,6 +13,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import type { PermissionAccessRequestResponse } from "@vm0/core";
 import { setMockPermissionRequests } from "../../../mocks/handlers/api-permission-access-requests.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 
 const context = testContext();
 
@@ -67,15 +68,8 @@ function mockPermissionRequests(
 }
 
 function setupMemberContext(agentOverrides: Partial<AgentResponse> = {}) {
+  setMockOrg({ role: "member" });
   server.use(
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "user-12345678",
-        name: "User 12345678",
-        role: "member",
-      });
-    }),
     http.get("*/api/zero/agents/:name", ({ params }) => {
       if (
         params.name === "instructions" ||

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
@@ -21,6 +21,7 @@ import {
 } from "@vm0/core";
 import { mockApi } from "../../../mocks/msw-contract.ts";
 import { setMockPermissionRequests } from "../../../mocks/handlers/api-permission-access-requests.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 
 const context = testContext();
 
@@ -62,15 +63,8 @@ function mockPermissionRequests(
 }
 
 function setupMemberContext(agentOverrides?: Record<string, unknown>) {
+  setMockOrg({ role: "member" });
   server.use(
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "user-12345678",
-        name: "User 12345678",
-        role: "member",
-      });
-    }),
     http.get("*/api/zero/agents/:name", ({ params }) => {
       if (
         params.name === "instructions" ||

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -7,6 +7,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import type { PermissionAccessRequestResponse } from "@vm0/core";
 import { setMockPermissionRequests } from "../../../mocks/handlers/api-permission-access-requests.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 
 const context = testContext();
 
@@ -20,16 +21,7 @@ function mockPermissionRequests(
 }
 
 function mockMemberOrg() {
-  server.use(
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "user-12345678",
-        name: "User 12345678",
-        role: "member",
-      });
-    }),
-  );
+  setMockOrg({ role: "member" });
 }
 
 function mockAgentWithPolicy(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-display.test.tsx
@@ -16,7 +16,6 @@ import {
 } from "../../../mocks/handlers/api-billing.ts";
 import { setBillingDialogOpen$ } from "../../../signals/zero-page/billing.ts";
 import { setSelectedPlanTier$ } from "../../../signals/zero-page/billing-dialog-state.ts";
-import { mockBillingPageAPIs } from "./billing-dialog-test-helpers.ts";
 import {
   zeroBillingAutoRechargeContract,
   zeroBillingCheckoutContract,
@@ -38,7 +37,6 @@ async function openBillingDialogAndWait() {
 
 describe("chat-d-067: AutoRechargeSection renders threshold value", () => {
   it("displays the threshold value in the threshold input", async () => {
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -58,7 +56,6 @@ describe("chat-d-067: AutoRechargeSection renders threshold value", () => {
 
 describe("chat-d-068: AutoRechargeSection renders amount value in credits", () => {
   it("displays the recharge amount in the credits input", async () => {
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -78,7 +75,6 @@ describe("chat-d-068: AutoRechargeSection renders amount value in credits", () =
 
 describe("chat-d-069: AutoRechargeSection renders dollarAmount calculated from amount / CREDITS_PER_DOLLAR", () => {
   it("displays the dollar equivalent calculated as amount / 1000", async () => {
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -118,7 +114,6 @@ describe("chat-s-070: Loading state disables Save button during save", () => {
     );
 
     const user = userEvent.setup();
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -165,7 +160,6 @@ describe("chat-s-070: Loading state disables Save button during save", () => {
 
 describe("chat-c-071: AutoRechargeSection fields render conditionally based on displayEnabled", () => {
   it("hides threshold and amount inputs when enabled is false", async () => {
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -187,7 +181,6 @@ describe("chat-c-071: AutoRechargeSection fields render conditionally based on d
   });
 
   it("shows threshold and amount inputs when enabled is true", async () => {
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -207,7 +200,6 @@ describe("chat-c-071: AutoRechargeSection fields render conditionally based on d
 
 describe("chat-d-072-073: BillingDialog renders status.tier and credit count", () => {
   it("displays the current plan tier and locale-formatted credits in the description", async () => {
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -235,7 +227,6 @@ describe("chat-d-072-073: BillingDialog renders status.tier and credit count", (
 
 describe("chat-d-075: Selected plan ring highlight renders on chosen PlanCard", () => {
   it("renders aria-pressed on the selected PlanCard", async () => {
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -256,7 +247,6 @@ describe("chat-d-075: Selected plan ring highlight renders on chosen PlanCard", 
 describe("chat-c-076: Button text changes based on isUpgrade/isDowngrade determination", () => {
   it("shows Upgrade to Team when team is selected and pro is current", async () => {
     const user = userEvent.setup();
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -284,7 +274,6 @@ describe("chat-c-076: Button text changes based on isUpgrade/isDowngrade determi
 
   it("shows Downgrade when free is selected and pro is current", async () => {
     const user = userEvent.setup();
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -329,7 +318,6 @@ describe("chat-c-077: Action button is disabled during redirect", () => {
     );
 
     const user = userEvent.setup();
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-display.test.tsx
@@ -7,7 +7,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -18,6 +17,11 @@ import {
 import { setBillingDialogOpen$ } from "../../../signals/zero-page/billing.ts";
 import { setSelectedPlanTier$ } from "../../../signals/zero-page/billing-dialog-state.ts";
 import { mockBillingPageAPIs } from "./billing-dialog-test-helpers.ts";
+import {
+  zeroBillingAutoRechargeContract,
+  zeroBillingCheckoutContract,
+} from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -98,11 +102,11 @@ describe("chat-s-070: Loading state disables Save button during save", () => {
   it("disables the Save button while the save is in progress", async () => {
     let resolveSave!: () => void;
     server.use(
-      http.put("*/api/zero/billing/auto-recharge", () => {
-        return new Promise<Response>((resolve) => {
+      mockApi(zeroBillingAutoRechargeContract.update, ({ respond }) => {
+        return new Promise((resolve) => {
           resolveSave = () => {
             resolve(
-              HttpResponse.json({
+              respond(200, {
                 enabled: true,
                 threshold: 5000,
                 amount: 10_000,
@@ -311,11 +315,11 @@ describe("chat-c-077: Action button is disabled during redirect", () => {
   it("disables the Upgrade button while checkout is in progress", async () => {
     let resolveCheckout!: () => void;
     server.use(
-      http.post("*/api/zero/billing/checkout", () => {
-        return new Promise<Response>((resolve) => {
+      mockApi(zeroBillingCheckoutContract.create, ({ respond }) => {
+        return new Promise((resolve) => {
           resolveCheckout = () => {
             resolve(
-              HttpResponse.json({
+              respond(200, {
                 url: "https://checkout.stripe.com/test?tier=team",
               }),
             );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
@@ -18,7 +18,6 @@ import {
   downgradeDialogOpen$,
   setBillingDialogOpen$,
 } from "../../../signals/zero-page/billing.ts";
-import { mockBillingPageAPIs } from "./billing-dialog-test-helpers.ts";
 import {
   zeroBillingAutoRechargeContract,
   zeroBillingCheckoutContract,
@@ -53,7 +52,6 @@ describe("chat-i-078: auto-recharge switch toggles enabled state", () => {
     );
 
     const user = userEvent.setup();
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -80,7 +78,6 @@ describe("chat-i-078: auto-recharge switch toggles enabled state", () => {
 
 describe("chat-s-084: auto-recharge toggle state reflects enabled value from server", () => {
   it("shows aria-checked=false when auto-recharge is disabled", async () => {
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -99,7 +96,6 @@ describe("chat-s-084: auto-recharge toggle state reflects enabled value from ser
   });
 
   it("shows aria-checked=true when auto-recharge is enabled", async () => {
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -133,7 +129,6 @@ describe("chat-i-079: threshold input updates form state on change", () => {
     );
 
     const user = userEvent.setup();
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -178,7 +173,6 @@ describe("chat-i-080: amount input updates form state on change", () => {
     );
 
     const user = userEvent.setup();
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -223,7 +217,6 @@ describe("chat-i-081: save button saves auto-recharge settings", () => {
     );
 
     const user = userEvent.setup();
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -269,7 +262,6 @@ describe("chat-i-081: save button saves auto-recharge settings", () => {
 describe("chat-i-082: plan card click updates selected tier", () => {
   it("sets Team card to aria-pressed=true when clicked", async () => {
     const user = userEvent.setup();
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -311,7 +303,6 @@ describe("chat-i-083: upgrade/downgrade button triggers plan change action", () 
     );
 
     const user = userEvent.setup();
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -349,7 +340,6 @@ describe("chat-i-083: upgrade/downgrade button triggers plan change action", () 
 
   it("opens downgrade dialog when Downgrade is clicked after selecting Free", async () => {
     const user = userEvent.setup();
-    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -387,10 +377,6 @@ describe("chat-i-083: upgrade/downgrade button triggers plan change action", () 
 });
 
 describe("chat-i-085: form fields derive from server config via async computed", () => {
-  beforeEach(() => {
-    mockBillingPageAPIs();
-  });
-
   it("displays threshold and amount from autoRechargeConfig$ async computed path", async () => {
     setMockBillingStatus({
       tier: "pro",
@@ -412,10 +398,6 @@ describe("chat-i-085: form fields derive from server config via async computed",
 });
 
 describe("chat-i-086: form overrides clear after successful save", () => {
-  beforeEach(() => {
-    mockBillingPageAPIs();
-  });
-
   it("reverts inputs to server-returned values after save completes", async () => {
     // The default mock PUT handler (apiBillingHandlers) updates mockBillingStatus
     // in place, so after PUT the GET /billing/status will return the new values.

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
@@ -7,7 +7,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
@@ -20,6 +19,11 @@ import {
   setBillingDialogOpen$,
 } from "../../../signals/zero-page/billing.ts";
 import { mockBillingPageAPIs } from "./billing-dialog-test-helpers.ts";
+import {
+  zeroBillingAutoRechargeContract,
+  zeroBillingCheckoutContract,
+} from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -38,9 +42,9 @@ describe("chat-i-078: auto-recharge switch toggles enabled state", () => {
   it("calls PUT auto-recharge with enabled: true when switch is clicked while disabled", async () => {
     let capturedBody: unknown;
     server.use(
-      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
-        capturedBody = await request.json();
-        return HttpResponse.json({
+      mockApi(zeroBillingAutoRechargeContract.update, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(200, {
           enabled: true,
           threshold: null,
           amount: null,
@@ -118,9 +122,9 @@ describe("chat-i-079: threshold input updates form state on change", () => {
   it("calls PUT auto-recharge with new threshold when Save is clicked after changing threshold", async () => {
     let capturedBody: unknown;
     server.use(
-      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
-        capturedBody = await request.json();
-        return HttpResponse.json({
+      mockApi(zeroBillingAutoRechargeContract.update, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(200, {
           enabled: true,
           threshold: 2000,
           amount: 10_000,
@@ -163,9 +167,9 @@ describe("chat-i-080: amount input updates form state on change", () => {
   it("calls PUT auto-recharge with new amount when Save is clicked after changing amount", async () => {
     let capturedBody: unknown;
     server.use(
-      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
-        capturedBody = await request.json();
-        return HttpResponse.json({
+      mockApi(zeroBillingAutoRechargeContract.update, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(200, {
           enabled: true,
           threshold: 1000,
           amount: 20_000,
@@ -208,9 +212,9 @@ describe("chat-i-081: save button saves auto-recharge settings", () => {
   it("calls PUT auto-recharge with correct values when Save is clicked", async () => {
     let capturedBody: unknown;
     server.use(
-      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
-        capturedBody = await request.json();
-        return HttpResponse.json({
+      mockApi(zeroBillingAutoRechargeContract.update, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(200, {
           enabled: true,
           threshold: 2000,
           amount: 5000,
@@ -298,9 +302,9 @@ describe("chat-i-083: upgrade/downgrade button triggers plan change action", () 
   it("calls POST checkout with tier=team when Upgrade to Team is clicked", async () => {
     let capturedCheckoutBody: unknown;
     server.use(
-      http.post("*/api/zero/billing/checkout", async ({ request }) => {
-        capturedCheckoutBody = await request.json();
-        return HttpResponse.json({
+      mockApi(zeroBillingCheckoutContract.create, ({ body, respond }) => {
+        capturedCheckoutBody = body;
+        return respond(200, {
           url: "https://checkout.stripe.com/test?tier=team",
         });
       }),
@@ -417,12 +421,7 @@ describe("chat-i-086: form overrides clear after successful save", () => {
     // in place, so after PUT the GET /billing/status will return the new values.
     // We register a custom PUT that returns 4000/20000 as the saved values.
     server.use(
-      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
-        const body = (await request.json()) as {
-          enabled: boolean;
-          threshold?: number;
-          amount?: number;
-        };
+      mockApi(zeroBillingAutoRechargeContract.update, ({ body, respond }) => {
         // Update mock so subsequent GET /billing/status returns the new values
         setMockBillingStatus({
           autoRecharge: {
@@ -431,7 +430,7 @@ describe("chat-i-086: form overrides clear after successful save", () => {
             amount: body.amount ?? null,
           },
         });
-        return HttpResponse.json({
+        return respond(200, {
           enabled: true,
           threshold: body.threshold ?? null,
           amount: body.amount ?? null,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-test-helpers.ts
@@ -1,8 +1,0 @@
-/**
- * All default API state (chat-threads, team, org/logo) is covered by the
- * global MSW handlers in api-agents.ts and api-org.ts. No additional setup
- * is needed for billing page tests.
- */
-export function mockBillingPageAPIs(): void {
-  // No-op: all required endpoints are covered by global default handlers.
-}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-test-helpers.ts
@@ -1,27 +1,8 @@
-import { http, HttpResponse } from "msw";
-import { server } from "../../../mocks/server.ts";
-
-export function mockBillingPageAPIs() {
-  server.use(
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-  );
+/**
+ * All default API state (chat-threads, team, org/logo) is covered by the
+ * global MSW handlers in api-agents.ts and api-org.ts. No additional setup
+ * is needed for billing page tests.
+ */
+export function mockBillingPageAPIs(): void {
+  // No-op: all required endpoints are covered by global default handlers.
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1,38 +1,25 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
 import { reloadBillingStatus$ } from "../../../signals/zero-page/billing.ts";
+import {
+  zeroBillingStatusContract,
+  zeroBillingAutoRechargeContract,
+  zeroBillingCheckoutContract,
+  zeroBillingPortalContract,
+  zeroBillingDowngradeContract,
+} from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
-function mockAPIs() {
-  server.use(
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-  );
+// All default API state (chat-threads, team, org/logo) is covered by global handlers.
+function mockAPIs(): void {
+  // No-op: all required endpoints are covered by global default handlers.
 }
 
 async function openBillingTab() {
@@ -318,9 +305,9 @@ describe("org billing tab - auto-recharge section", () => {
     const user = userEvent.setup();
     let capturedBody: unknown = null;
     server.use(
-      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
-        capturedBody = await request.json();
-        return HttpResponse.json({
+      mockApi(zeroBillingAutoRechargeContract.update, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(200, {
           enabled: true,
           threshold: 2000,
           amount: 10_000,
@@ -377,9 +364,9 @@ describe("org billing tab - auto-recharge section", () => {
   it("should send correct data when saving auto-recharge config", async () => {
     let capturedBody: unknown = null;
     server.use(
-      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
-        capturedBody = await request.json();
-        return HttpResponse.json({
+      mockApi(zeroBillingAutoRechargeContract.update, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(200, {
           enabled: true,
           threshold: 2000,
           amount: 10_000,
@@ -606,8 +593,13 @@ describe("org billing tab - renewal date display", () => {
 describe("org billing tab - billing states", () => {
   it("should show error state when billing status fails to load", async () => {
     server.use(
-      http.get("*/api/zero/billing/status", () => {
-        return HttpResponse.json({}, { status: 500 });
+      mockApi(zeroBillingStatusContract.get, ({ respond }) => {
+        return respond(500, {
+          error: {
+            message: "Internal server error",
+            code: "INTERNAL_SERVER_ERROR",
+          },
+        });
       }),
     );
     mockAPIs();
@@ -633,9 +625,9 @@ describe("org billing tab - plan card actions", () => {
     const user = userEvent.setup();
     let capturedBody: unknown = null;
     server.use(
-      http.post("*/api/zero/billing/checkout", async ({ request }) => {
-        capturedBody = await request.json();
-        return HttpResponse.json({
+      mockApi(zeroBillingCheckoutContract.create, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(200, {
           url: "https://checkout.stripe.com/test?tier=pro",
         });
       }),
@@ -678,8 +670,8 @@ describe("org billing tab - stripe portal", () => {
   it("should redirect to Stripe portal URL when Manage button is clicked", async () => {
     const user = userEvent.setup();
     server.use(
-      http.post("*/api/zero/billing/portal", () => {
-        return HttpResponse.json({
+      mockApi(zeroBillingPortalContract.create, ({ respond }) => {
+        return respond(200, {
           url: "https://billing.stripe.com/test-portal",
         });
       }),
@@ -843,9 +835,9 @@ describe("org billing tab - downgrade flow", () => {
     const user = userEvent.setup();
     let capturedBody: unknown = null;
     server.use(
-      http.post("*/api/zero/billing/downgrade", async ({ request }) => {
-        capturedBody = await request.json();
-        return HttpResponse.json({ success: true, effectiveDate: null });
+      mockApi(zeroBillingDowngradeContract.create, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(200, { success: true, effectiveDate: null });
       }),
     );
 
@@ -888,9 +880,9 @@ describe("org billing tab - downgrade flow", () => {
     const user = userEvent.setup();
     let apiCalled = false;
     server.use(
-      http.post("*/api/zero/billing/downgrade", () => {
+      mockApi(zeroBillingDowngradeContract.create, ({ respond }) => {
         apiCalled = true;
-        return HttpResponse.json({ success: true, effectiveDate: null });
+        return respond(200, { success: true, effectiveDate: null });
       }),
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -17,11 +17,6 @@ import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
-// All default API state (chat-threads, team, org/logo) is covered by global handlers.
-function mockAPIs(): void {
-  // No-op: all required endpoints are covered by global default handlers.
-}
-
 async function openBillingTab() {
   detachedSetupPage({ context, path: "/?settings=billing" });
   await waitFor(() => {
@@ -31,7 +26,6 @@ async function openBillingTab() {
 
 describe("org billing tab - plan display", () => {
   it("should show Free plan for free tier", async () => {
-    mockAPIs();
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 
     await openBillingTab();
@@ -42,7 +36,6 @@ describe("org billing tab - plan display", () => {
   });
 
   it("should show Pro plan for pro tier", async () => {
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -58,7 +51,6 @@ describe("org billing tab - plan display", () => {
   });
 
   it("should show Upgrade button for free tier", async () => {
-    mockAPIs();
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 
     await openBillingTab();
@@ -75,7 +67,6 @@ describe("org billing tab - plan display", () => {
   });
 
   it("should show Compare all plans link", async () => {
-    mockAPIs();
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 
     await openBillingTab();
@@ -91,7 +82,6 @@ describe("org billing tab - plan display", () => {
 describe("org billing tab - pricing sub-page navigation", () => {
   it("should navigate to pricing page when clicking Compare all plans", async () => {
     const user = userEvent.setup();
-    mockAPIs();
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 
     await openBillingTab();
@@ -114,7 +104,6 @@ describe("org billing tab - pricing sub-page navigation", () => {
 
   it("should navigate back from pricing page via Back button", async () => {
     const user = userEvent.setup();
-    mockAPIs();
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 
     await openBillingTab();
@@ -139,7 +128,6 @@ describe("org billing tab - pricing sub-page navigation", () => {
 
   it("should mark current plan as disabled on pricing page", async () => {
     const user = userEvent.setup();
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -172,7 +160,6 @@ describe("org billing tab - pricing sub-page navigation", () => {
 
 describe("org billing tab - auto-recharge section", () => {
   it("should show auto-recharge section for paid plans", async () => {
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -191,7 +178,6 @@ describe("org billing tab - auto-recharge section", () => {
   });
 
   it("should not show auto-recharge section for free plan", async () => {
-    mockAPIs();
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 
     await openBillingTab();
@@ -204,7 +190,6 @@ describe("org billing tab - auto-recharge section", () => {
   });
 
   it("should hydrate form with server auto-recharge config when enabled", async () => {
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -238,7 +223,6 @@ describe("org billing tab - auto-recharge section", () => {
   });
 
   it("should show toggle off when server auto-recharge is disabled", async () => {
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -266,7 +250,6 @@ describe("org billing tab - auto-recharge section", () => {
 
   it("should enable toggle when clicked with no prior threshold/amount config", async () => {
     const user = userEvent.setup();
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -315,7 +298,6 @@ describe("org billing tab - auto-recharge section", () => {
       }),
     );
 
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -374,7 +356,6 @@ describe("org billing tab - auto-recharge section", () => {
       }),
     );
 
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -416,7 +397,6 @@ describe("org billing tab - cancellation pending", () => {
   const futureDate = new Date(Date.now() + 30 * 86_400 * 1000).toISOString();
 
   it("should show cancellation notice when subscription is pending cancellation", async () => {
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -436,7 +416,6 @@ describe("org billing tab - cancellation pending", () => {
   });
 
   it("should show 'Ends on' instead of 'Renews' when cancelling", async () => {
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -456,7 +435,6 @@ describe("org billing tab - cancellation pending", () => {
   });
 
   it("should hide Downgrade button when cancellation is pending", async () => {
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -480,7 +458,6 @@ describe("org billing tab - cancellation pending", () => {
   });
 
   it("should show Manage button when cancellation is pending", async () => {
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -504,7 +481,6 @@ describe("org billing tab - cancellation pending", () => {
   });
 
   it("should show normal state when cancelAtPeriodEnd is false", async () => {
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -533,7 +509,6 @@ describe("org billing tab - cancellation pending", () => {
 describe("org billing tab - plan card details", () => {
   it("should show plan cards with upgrade buttons on pricing page", async () => {
     const user = userEvent.setup();
-    mockAPIs();
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 
     await openBillingTab();
@@ -571,7 +546,6 @@ describe("org billing tab - plan card details", () => {
 
 describe("org billing tab - renewal date display", () => {
   it("should show renewal date when subscription is active and not cancelling", async () => {
-    mockAPIs();
     const futureDate = new Date(Date.now() + 30 * 86_400 * 1000).toISOString();
     setMockBillingStatus({
       tier: "pro",
@@ -602,7 +576,6 @@ describe("org billing tab - billing states", () => {
         });
       }),
     );
-    mockAPIs();
 
     await openBillingTab();
 
@@ -633,7 +606,6 @@ describe("org billing tab - plan card actions", () => {
       }),
     );
 
-    mockAPIs();
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 
     await openBillingTab();
@@ -677,7 +649,6 @@ describe("org billing tab - stripe portal", () => {
       }),
     );
 
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -707,7 +678,6 @@ describe("org billing tab - stripe portal", () => {
 
 describe("org billing tab - downgrade flow", () => {
   it("should show Downgrade button for paid tier (pro)", async () => {
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -729,7 +699,6 @@ describe("org billing tab - downgrade flow", () => {
   });
 
   it("should show Downgrade button for team tier", async () => {
-    mockAPIs();
     setMockBillingStatus({
       tier: "team",
       credits: 120_000,
@@ -751,7 +720,6 @@ describe("org billing tab - downgrade flow", () => {
   });
 
   it("should not show Downgrade button for free tier", async () => {
-    mockAPIs();
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 
     await openBillingTab();
@@ -769,7 +737,6 @@ describe("org billing tab - downgrade flow", () => {
 
   it("should open downgrade dialog on Downgrade button click for pro user", async () => {
     const user = userEvent.setup();
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -801,7 +768,6 @@ describe("org billing tab - downgrade flow", () => {
 
   it("should open downgrade dialog with plan selection for team user", async () => {
     const user = userEvent.setup();
-    mockAPIs();
     setMockBillingStatus({
       tier: "team",
       credits: 120_000,
@@ -841,7 +807,6 @@ describe("org billing tab - downgrade flow", () => {
       }),
     );
 
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -886,7 +851,6 @@ describe("org billing tab - downgrade flow", () => {
       }),
     );
 
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -928,7 +892,6 @@ describe("org billing tab - downgrade flow", () => {
 
   it("should route pricing page downgrade through dialog", async () => {
     const user = userEvent.setup();
-    mockAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -966,7 +929,6 @@ describe("org billing tab - downgrade flow", () => {
 
 describe("org billing tab - billing status refresh", () => {
   it("should update plan display when billing status is refreshed", async () => {
-    mockAPIs();
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 
     await openBillingTab();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-domains-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-domains-tab.test.tsx
@@ -1,11 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import type { OrgDomain } from "@vm0/core";
+import { type OrgDomain, zeroOrgDomainsContract } from "@vm0/core";
+import { setMockOrg, resetMockOrg } from "../../../mocks/handlers/api-org.ts";
+import {
+  setMockOrgDomains,
+  resetMockOrgDomains,
+} from "../../../mocks/handlers/api-org-domains.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -25,41 +30,10 @@ const unverifiedDomain = {
   createdAt: "2026-02-20T00:00:00Z",
 } as const satisfies OrgDomain;
 
-function mockAPIs(domains: OrgDomain[] = [], overrides?: { role?: string }) {
-  server.use(
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "test-org",
-        name: "Test Org",
-        role: overrides?.role ?? "admin",
-      });
-    }),
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-    http.get("*/api/zero/org/domains", () => {
-      return HttpResponse.json({ domains });
-    }),
-  );
-}
+beforeEach(() => {
+  resetMockOrg();
+  resetMockOrgDomains();
+});
 
 async function openDomainsTab() {
   detachedSetupPage({ context, path: "/?settings=domains" });
@@ -71,7 +45,8 @@ async function openDomainsTab() {
 describe("org domains tab - display", () => {
   it("shows each domain's name in the list", async () => {
     // ORG-D-073
-    mockAPIs([verifiedDomain, unverifiedDomain]);
+    setMockOrg({ slug: "test-org", name: "Test Org", role: "admin" });
+    setMockOrgDomains([verifiedDomain, unverifiedDomain]);
     await openDomainsTab();
 
     await waitFor(() => {
@@ -85,7 +60,7 @@ describe("org domains tab - display", () => {
 describe("org domains tab - conditional", () => {
   it("shows empty state when no domains exist", async () => {
     // ORG-C-075
-    mockAPIs([]);
+    setMockOrg({ role: "admin" });
     await openDomainsTab();
 
     await waitFor(() => {
@@ -97,10 +72,10 @@ describe("org domains tab - conditional", () => {
 describe("org domains tab - display loading", () => {
   it("shows loading skeleton placeholders while domains load", async () => {
     // ORG-D-076
-    mockAPIs([]);
+    setMockOrg({ role: "admin" });
     server.use(
-      http.get("*/api/zero/org/domains", () => {
-        return new Promise<Response>(() => {
+      mockApi(zeroOrgDomainsContract.list, ({ respond: _ }) => {
+        return new Promise(() => {
           // intentionally never resolves to keep loading state
         });
       }),
@@ -120,7 +95,7 @@ describe("org domains tab - interaction", () => {
   it("opens add domain dialog with input field when 'Add domain' button is clicked", async () => {
     // ORG-I-077
     const user = userEvent.setup();
-    mockAPIs([]);
+    setMockOrg({ role: "admin" });
     await openDomainsTab();
 
     await waitFor(() => {
@@ -140,7 +115,7 @@ describe("org domains tab - interaction", () => {
   it("shows all enrollment mode options in the dropdown", async () => {
     // ORG-I-079
     const user = userEvent.setup();
-    mockAPIs([]);
+    setMockOrg({ role: "admin" });
     await openDomainsTab();
 
     await user.click(screen.getByText(/Add domain/i));
@@ -170,7 +145,8 @@ describe("org domains tab - interaction", () => {
   it("shows verify/unverify and remove options in the domain action menu", async () => {
     // ORG-I-080
     const user = userEvent.setup();
-    mockAPIs([verifiedDomain]);
+    setMockOrg({ role: "admin" });
+    setMockOrgDomains([verifiedDomain]);
     await openDomainsTab();
 
     await waitFor(() => {
@@ -189,7 +165,8 @@ describe("org domains tab - interaction", () => {
   it("shows remove confirmation dialog when Remove is clicked from action menu", async () => {
     // ORG-I-081
     const user = userEvent.setup();
-    mockAPIs([verifiedDomain]);
+    setMockOrg({ role: "admin" });
+    setMockOrgDomains([verifiedDomain]);
     await openDomainsTab();
 
     await waitFor(() => {
@@ -216,7 +193,7 @@ describe("org domains tab - validation", () => {
   it("disables the submit button when domain input has invalid format", async () => {
     // ORG-V-078
     const user = userEvent.setup();
-    mockAPIs([]);
+    setMockOrg({ role: "admin" });
     await openDomainsTab();
 
     await user.click(screen.getByText(/Add domain/i));
@@ -243,7 +220,7 @@ describe("org domains tab - validation", () => {
 
 describe("org domains tab - access control", () => {
   it("redirects non-admin users to the general tab when navigating to domains", async () => {
-    mockAPIs([], { role: "member" });
+    setMockOrg({ role: "member" });
     detachedSetupPage({ context, path: "/?settings=domains" });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
@@ -1,48 +1,29 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { mockedClerk } from "../../../__tests__/mock-auth.ts";
+import {
+  setMockOrg,
+  resetMockOrg,
+  setMockOrgLogo,
+  resetMockOrgLogo,
+} from "../../../mocks/handlers/api-org.ts";
+import {
+  zeroOrgContract,
+  zeroOrgLeaveContract,
+  zeroOrgDeleteContract,
+} from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
-function mockAPIs(overrides?: { slug?: string; name?: string; role?: string }) {
-  const org = {
-    id: "org_1",
-    slug: overrides?.slug ?? "test-org",
-    name: overrides?.name ?? "Test Org",
-    role: overrides?.role ?? "admin",
-  };
-  server.use(
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json(org);
-    }),
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-  );
-  return org;
-}
+beforeEach(() => {
+  resetMockOrg();
+  resetMockOrgLogo();
+});
 
 async function openGeneralTab() {
   detachedSetupPage({ context, path: "/?settings=general" });
@@ -53,7 +34,7 @@ async function openGeneralTab() {
 
 describe("org general tab - profile section", () => {
   it("should show name and slug inputs for admin", async () => {
-    mockAPIs({ name: "My Org", slug: "my-org" });
+    setMockOrg({ name: "My Org", slug: "my-org", role: "admin" });
     await openGeneralTab();
 
     const nameInput = await screen.findByDisplayValue("My Org");
@@ -64,7 +45,7 @@ describe("org general tab - profile section", () => {
   });
 
   it("should show name and slug as read-only text for non-admin", async () => {
-    mockAPIs({ name: "My Org", slug: "my-org", role: "member" });
+    setMockOrg({ name: "My Org", slug: "my-org", role: "member" });
     await openGeneralTab();
 
     await waitFor(() => {
@@ -78,7 +59,7 @@ describe("org general tab - profile section", () => {
   });
 
   it("should show save/discard buttons when slug is changed", async () => {
-    mockAPIs({ slug: "old-slug" });
+    setMockOrg({ slug: "old-slug" });
     await openGeneralTab();
 
     const slugInput = await screen.findByDisplayValue("old-slug");
@@ -90,7 +71,7 @@ describe("org general tab - profile section", () => {
 
   it("should discard slug changes when clicking Discard", async () => {
     const user = userEvent.setup();
-    mockAPIs({ slug: "original-slug" });
+    setMockOrg({ slug: "original-slug" });
     await openGeneralTab();
 
     const slugInput = await screen.findByDisplayValue("original-slug");
@@ -107,14 +88,15 @@ describe("org general tab - profile section", () => {
   it("should send slug in PUT request when saving slug change", async () => {
     const user = userEvent.setup();
     const requestBody = vi.fn();
-    mockAPIs({ name: "Test Org", slug: "old-slug" });
+    setMockOrg({ name: "Test Org", slug: "old-slug" });
     server.use(
-      http.put("*/api/zero/org", async ({ request }) => {
-        requestBody(await request.json());
-        return HttpResponse.json({
+      mockApi(zeroOrgContract.update, ({ body, respond }) => {
+        requestBody(body);
+        return respond(200, {
           id: "org_1",
           slug: "new-slug",
           name: "Test Org",
+          role: "admin",
         });
       }),
     );
@@ -137,14 +119,15 @@ describe("org general tab - profile section", () => {
   it("should send both name and slug when both are changed", async () => {
     const user = userEvent.setup();
     const requestBody = vi.fn();
-    mockAPIs({ name: "Old Name", slug: "old-slug" });
+    setMockOrg({ name: "Old Name", slug: "old-slug" });
     server.use(
-      http.put("*/api/zero/org", async ({ request }) => {
-        requestBody(await request.json());
-        return HttpResponse.json({
+      mockApi(zeroOrgContract.update, ({ body, respond }) => {
+        requestBody(body);
+        return respond(200, {
           id: "org_1",
           slug: "new-slug",
           name: "New Name",
+          role: "admin",
         });
       }),
     );
@@ -170,18 +153,15 @@ describe("org general tab - profile section", () => {
 
   it("should show inline error when save fails", async () => {
     const user = userEvent.setup();
-    mockAPIs({ slug: "old-slug" });
+    setMockOrg({ slug: "old-slug" });
     server.use(
-      http.put("*/api/zero/org", () => {
-        return HttpResponse.json(
-          {
-            error: {
-              message: "Slug is already taken",
-              code: "INTERNAL_SERVER_ERROR",
-            },
+      mockApi(zeroOrgContract.update, ({ respond }) => {
+        return respond(409, {
+          error: {
+            message: "Slug is already taken",
+            code: "INTERNAL_SERVER_ERROR",
           },
-          { status: 409 },
-        );
+        });
       }),
     );
 
@@ -199,18 +179,15 @@ describe("org general tab - profile section", () => {
 
   it("should clear inline error on discard", async () => {
     const user = userEvent.setup();
-    mockAPIs({ slug: "old-slug" });
+    setMockOrg({ slug: "old-slug" });
     server.use(
-      http.put("*/api/zero/org", () => {
-        return HttpResponse.json(
-          {
-            error: {
-              message: "Slug is already taken",
-              code: "INTERNAL_SERVER_ERROR",
-            },
+      mockApi(zeroOrgContract.update, ({ respond }) => {
+        return respond(409, {
+          error: {
+            message: "Slug is already taken",
+            code: "INTERNAL_SERVER_ERROR",
           },
-          { status: 409 },
-        );
+        });
       }),
     );
 
@@ -231,18 +208,12 @@ describe("org general tab - profile section", () => {
   });
 
   it("should load and display logo for non-admin members", async () => {
-    mockAPIs({ role: "member" });
-    server.use(
-      http.get("*/api/zero/org/logo", () => {
-        return HttpResponse.json({
-          logoUrl: "https://example.com/logo.png",
-        });
-      }),
-    );
+    setMockOrg({ role: "member" });
+    setMockOrgLogo("https://example.com/logo.png");
 
     await openGeneralTab();
 
-    const logo = await screen.findByAltText("test-org");
+    const logo = await screen.findByAltText("user-12345678");
     expect(logo).toBeInTheDocument();
     expect(logo).toHaveAttribute("src", "https://example.com/logo.png");
   });
@@ -250,14 +221,15 @@ describe("org general tab - profile section", () => {
   it("should not send slug when only name is changed", async () => {
     const user = userEvent.setup();
     const requestBody = vi.fn();
-    mockAPIs({ name: "Old Name", slug: "keep-slug" });
+    setMockOrg({ name: "Old Name", slug: "keep-slug" });
     server.use(
-      http.put("*/api/zero/org", async ({ request }) => {
-        requestBody(await request.json());
-        return HttpResponse.json({
+      mockApi(zeroOrgContract.update, ({ body, respond }) => {
+        requestBody(body);
+        return respond(200, {
           id: "org_1",
           slug: "keep-slug",
           name: "New Name",
+          role: "admin",
         });
       }),
     );
@@ -289,11 +261,11 @@ describe("org general tab - danger zone", () => {
   it("leaves workspace: clears active org then navigates to choose-organization", async () => {
     const user = userEvent.setup();
     const leaveCalled = vi.fn();
-    mockAPIs({ role: "member", slug: "my-org" });
+    setMockOrg({ role: "member", slug: "my-org" });
     server.use(
-      http.post("*/api/zero/org/leave", () => {
+      mockApi(zeroOrgLeaveContract.leave, ({ respond }) => {
         leaveCalled();
-        return HttpResponse.json({ message: "ok" });
+        return respond(200, { message: "ok" });
       }),
     );
 
@@ -338,11 +310,11 @@ describe("org general tab - danger zone", () => {
   it("deletes workspace: clears active org then navigates to choose-organization", async () => {
     const user = userEvent.setup();
     const deleteCalled = vi.fn();
-    mockAPIs({ role: "admin", slug: "my-org" });
+    setMockOrg({ role: "admin", slug: "my-org" });
     server.use(
-      http.post("*/api/zero/org/delete", () => {
+      mockApi(zeroOrgDeleteContract.delete, ({ respond }) => {
         deleteCalled();
-        return HttpResponse.json({ message: "ok" });
+        return respond(200, { message: "ok" });
       }),
     );
 
@@ -389,14 +361,13 @@ describe("org general tab - danger zone", () => {
   it("does not clear active org or navigate when leave API fails", async () => {
     const user = userEvent.setup();
     const leaveCalled = vi.fn();
-    mockAPIs({ role: "member", slug: "my-org" });
+    setMockOrg({ role: "member", slug: "my-org" });
     server.use(
-      http.post("*/api/zero/org/leave", () => {
+      mockApi(zeroOrgLeaveContract.leave, ({ respond }) => {
         leaveCalled();
-        return HttpResponse.json(
-          { error: { message: "boom", code: "INTERNAL_SERVER_ERROR" } },
-          { status: 500 },
-        );
+        return respond(500, {
+          error: { message: "boom", code: "INTERNAL_SERVER_ERROR" },
+        });
       }),
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-manage-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-manage-dialog.test.tsx
@@ -1,45 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
-import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockOrg, resetMockOrg } from "../../../mocks/handlers/api-org.ts";
+import {
+  setMockOrgMembers,
+  resetMockOrgMembers,
+} from "../../../mocks/handlers/api-org-members.ts";
 
 const context = testContext();
 
-function mockAPIs(overrides?: { role?: string }) {
-  server.use(
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "test-org",
-        name: "Test Org",
-        role: overrides?.role ?? "admin",
-      });
-    }),
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-  );
-}
+beforeEach(() => {
+  resetMockOrg();
+  resetMockOrgMembers();
+});
 
 async function openDialog() {
   detachedSetupPage({ context, path: "/?settings=general" });
@@ -50,7 +25,7 @@ async function openDialog() {
 
 describe("org manage dialog - display", () => {
   it("shows tab navigation items in the sidebar", async () => {
-    mockAPIs();
+    setMockOrg({ slug: "test-org", name: "Test Org", role: "admin" });
     await openDialog();
 
     // Always-visible tabs
@@ -70,7 +45,7 @@ describe("org manage dialog - display", () => {
   });
 
   it("shows the active tab heading on initial load", async () => {
-    mockAPIs();
+    setMockOrg({ slug: "test-org", name: "Test Org", role: "admin" });
     await openDialog();
 
     await waitFor(() => {
@@ -83,7 +58,7 @@ describe("org manage dialog - display", () => {
 
 describe("org manage dialog - conditional", () => {
   it("renders both desktop sidebar nav buttons and mobile select dropdown", async () => {
-    mockAPIs();
+    setMockOrg({ slug: "test-org", name: "Test Org", role: "admin" });
     await openDialog();
 
     // Desktop sidebar has tab buttons
@@ -99,7 +74,7 @@ describe("org manage dialog - conditional", () => {
   });
 
   it("shows Configuration and Billing groups for admin users", async () => {
-    mockAPIs({ role: "admin" });
+    setMockOrg({ role: "admin" });
     await openDialog();
 
     const dialog = screen.getByRole("dialog");
@@ -108,7 +83,7 @@ describe("org manage dialog - conditional", () => {
   });
 
   it("hides Configuration and Billing groups for non-admin users", async () => {
-    mockAPIs({ role: "member" });
+    setMockOrg({ role: "member" });
     await openDialog();
 
     const dialog = screen.getByRole("dialog");
@@ -122,18 +97,14 @@ describe("org manage dialog - conditional", () => {
 describe("org manage dialog - interaction", () => {
   it("switches tab content when a sidebar button is clicked", async () => {
     const user = userEvent.setup();
-    mockAPIs();
-    server.use(
-      http.get("*/api/zero/org/members", () => {
-        return HttpResponse.json({
-          slug: "test-org",
-          role: "admin",
-          members: [],
-          pendingInvitations: [],
-          createdAt: "2026-01-01T00:00:00Z",
-        });
-      }),
-    );
+    setMockOrg({ slug: "test-org", name: "Test Org", role: "admin" });
+    setMockOrgMembers({
+      slug: "test-org",
+      role: "admin",
+      members: [],
+      pendingInvitations: [],
+      createdAt: "2026-01-01T00:00:00Z",
+    });
 
     await openDialog();
 
@@ -158,18 +129,14 @@ describe("org manage dialog - interaction", () => {
 
   it("switches tab content when the mobile select dropdown is changed", async () => {
     const user = userEvent.setup();
-    mockAPIs();
-    server.use(
-      http.get("*/api/zero/org/members", () => {
-        return HttpResponse.json({
-          slug: "test-org",
-          role: "admin",
-          members: [],
-          pendingInvitations: [],
-          createdAt: "2026-01-01T00:00:00Z",
-        });
-      }),
-    );
+    setMockOrg({ slug: "test-org", name: "Test Org", role: "admin" });
+    setMockOrgMembers({
+      slug: "test-org",
+      role: "admin",
+      members: [],
+      pendingInvitations: [],
+      createdAt: "2026-01-01T00:00:00Z",
+    });
 
     await openDialog();
 
@@ -200,7 +167,7 @@ describe("org manage dialog - interaction", () => {
 describe("org manage dialog - state", () => {
   it("opens and closes the dialog correctly", async () => {
     const user = userEvent.setup();
-    mockAPIs();
+    setMockOrg({ slug: "test-org", name: "Test Org", role: "admin" });
     await openDialog();
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-members-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-members-dialog.test.tsx
@@ -1,11 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import type { OrgMember } from "../../../signals/external/org-members.ts";
+import {
+  setMockOrgMembers,
+  resetMockOrgMembers,
+} from "../../../mocks/handlers/api-org-members.ts";
+import { zeroOrgMembersContract, zeroOrgInviteContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -39,21 +44,18 @@ const secondAdmin = {
   joinedAt: "2026-01-15T00:00:00Z",
 } as const satisfies OrgMember;
 
-function mockMembersAPI(members: OrgMember[] = [adminMember, regularMember]) {
-  server.use(
-    http.get("*/api/zero/org/members", () => {
-      return HttpResponse.json({
-        slug: "user-12345678",
-        role: "admin",
-        members,
-        pendingInvitations: [],
-        createdAt: "2026-01-01T00:00:00Z",
-      });
-    }),
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-  );
+beforeEach(() => {
+  resetMockOrgMembers();
+});
+
+function setupMembersAPI(members: OrgMember[] = [adminMember, regularMember]) {
+  setMockOrgMembers({
+    slug: "user-12345678",
+    role: "admin",
+    members,
+    pendingInvitations: [],
+    createdAt: "2026-01-01T00:00:00Z",
+  });
 }
 
 function renderMembersTab() {
@@ -65,14 +67,12 @@ describe("org members - invite dialog loading state", () => {
     const user = userEvent.setup();
     let resolveInvite: (() => void) | null = null;
 
-    mockMembersAPI();
+    setupMembersAPI();
     server.use(
-      http.post("*/api/zero/org/invite", () => {
-        return new Promise<Response>((resolve) => {
+      mockApi(zeroOrgInviteContract.invite, ({ respond }) => {
+        return new Promise((resolve) => {
           resolveInvite = () => {
-            return resolve(
-              HttpResponse.json({ message: "ok" }, { status: 200 }),
-            );
+            resolve(respond(200, { message: "ok" }));
           };
         });
       }),
@@ -122,14 +122,12 @@ describe("org members - invite dialog loading state", () => {
     const user = userEvent.setup();
     let resolveInvite: (() => void) | null = null;
 
-    mockMembersAPI();
+    setupMembersAPI();
     server.use(
-      http.post("*/api/zero/org/invite", () => {
-        return new Promise<Response>((resolve) => {
+      mockApi(zeroOrgInviteContract.invite, ({ respond }) => {
+        return new Promise((resolve) => {
           resolveInvite = () => {
-            return resolve(
-              HttpResponse.json({ message: "ok" }, { status: 200 }),
-            );
+            resolve(respond(200, { message: "ok" }));
           };
         });
       }),
@@ -172,12 +170,7 @@ describe("org members - invite dialog loading state", () => {
 describe("org members - invite dialog role selector", () => {
   it("should show role selector defaulting to Member", async () => {
     const user = userEvent.setup();
-    mockMembersAPI();
-    server.use(
-      http.post("*/api/zero/org/invite", () => {
-        return HttpResponse.json({ message: "ok" }, { status: 200 });
-      }),
-    );
+    setupMembersAPI();
 
     await renderMembersTab();
 
@@ -204,11 +197,11 @@ describe("org members - invite dialog role selector", () => {
     const user = userEvent.setup();
     let capturedBody: Record<string, unknown> | null = null;
 
-    mockMembersAPI();
+    setupMembersAPI();
     server.use(
-      http.post("*/api/zero/org/invite", async ({ request }) => {
-        capturedBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json({ message: "ok" }, { status: 200 });
+      mockApi(zeroOrgInviteContract.invite, ({ body, respond }) => {
+        capturedBody = body as Record<string, unknown>;
+        return respond(200, { message: "ok" });
       }),
     );
 
@@ -260,14 +253,12 @@ describe("org members - role change loading state", () => {
     const user = userEvent.setup();
     let resolveRoleChange: (() => void) | null = null;
 
-    mockMembersAPI([adminMember, regularMember]);
+    setupMembersAPI([adminMember, regularMember]);
     server.use(
-      http.patch("*/api/zero/org/members", () => {
-        return new Promise<Response>((resolve) => {
+      mockApi(zeroOrgMembersContract.updateRole, ({ respond }) => {
+        return new Promise((resolve) => {
           resolveRoleChange = () => {
-            return resolve(
-              HttpResponse.json({ message: "Role updated" }, { status: 200 }),
-            );
+            resolve(respond(200, { message: "Role updated" }));
           };
         });
       }),
@@ -309,7 +300,7 @@ describe("org members - role change loading state", () => {
 
 describe("org members - sole admin self-demote protection", () => {
   it("should not show self-demote menu when user is the only admin", async () => {
-    mockMembersAPI([adminMember, regularMember]);
+    setupMembersAPI([adminMember, regularMember]);
 
     await renderMembersTab();
 
@@ -324,7 +315,7 @@ describe("org members - sole admin self-demote protection", () => {
   });
 
   it("should show self-demote menu when multiple admins exist", async () => {
-    mockMembersAPI([adminMember, secondAdmin, regularMember]);
+    setupMembersAPI([adminMember, secondAdmin, regularMember]);
 
     await renderMembersTab();
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
@@ -10,7 +10,6 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -19,7 +18,11 @@ import {
   orgOpenEditDialog$,
   setOrgAddProviderDialogOpen$,
 } from "../../../signals/zero-page/settings/org-model-providers.ts";
-import type { ModelProviderResponse } from "@vm0/core";
+import {
+  type ModelProviderResponse,
+  zeroModelProvidersMainContract,
+} from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -274,15 +277,12 @@ describe("org-provider-dialog - interaction", () => {
     });
 
     server.use(
-      http.post("*/api/zero/model-providers", async () => {
+      mockApi(zeroModelProvidersMainContract.upsert, async ({ respond }) => {
         await postPromise;
-        return HttpResponse.json(
-          {
-            provider: mockProviderResponse({ type: "anthropic-api-key" }),
-            created: true,
-          },
-          { status: 201 },
-        );
+        return respond(201, {
+          provider: mockProviderResponse({ type: "anthropic-api-key" }),
+          created: true,
+        });
       }),
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -1,11 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
+import {
+  setMockUsageMembers,
+  resetMockUsageMembers,
+} from "../../../mocks/handlers/api-usage.ts";
+import {
+  zeroUsageMembersContract,
+  zeroMemberCreditCapContract,
+} from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -20,53 +28,39 @@ interface MockMember {
   creditCap: number | null;
 }
 
-function mockAPIs(members: MockMember[]) {
+beforeEach(() => {
+  resetMockUsageMembers();
+});
+
+function setupMockAPIs(members: MockMember[]) {
   const capStore: Record<string, number | null> = {};
   for (const m of members) {
     capStore[m.userId] = m.creditCap;
   }
 
+  setMockUsageMembers({
+    period: { start: "2026-03-01", end: "2026-03-31" },
+    members: members.map((m) => {
+      return { ...m, creditCap: capStore[m.userId] ?? m.creditCap };
+    }),
+  });
+
+  // Override credit-cap PUT to track changes and reflect in usage response
   server.use(
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-    http.get("*/api/zero/usage/members", () => {
-      // Return members with current cap values from capStore
-      const updatedMembers = members.map((m) => {
-        return {
-          ...m,
-          creditCap: capStore[m.userId] ?? m.creditCap,
-        };
-      });
-      return HttpResponse.json({
-        period: { start: "2026-03-01", end: "2026-03-31" },
-        members: updatedMembers,
-      });
-    }),
-    http.put("*/api/zero/org/members/credit-cap", async ({ request }) => {
-      const body = (await request.json()) as {
-        userId: string;
-        creditCap: number | null;
-      };
+    mockApi(zeroMemberCreditCapContract.set, ({ body, respond }) => {
       capStore[body.userId] = body.creditCap;
-      return HttpResponse.json({ ok: true });
+      // Update the usage members mock to reflect the new cap
+      setMockUsageMembers({
+        period: { start: "2026-03-01", end: "2026-03-31" },
+        members: members.map((m) => {
+          return { ...m, creditCap: capStore[m.userId] ?? m.creditCap };
+        }),
+      });
+      return respond(200, {
+        userId: body.userId,
+        creditCap: body.creditCap,
+        creditEnabled: true,
+      });
     }),
   );
 
@@ -96,7 +90,7 @@ describe("org usage tab - credit balance display", () => {
       hasSubscription: true,
     });
 
-    mockAPIs([
+    setupMockAPIs([
       {
         userId: "user-a",
         email: "alice@example.com",
@@ -127,7 +121,7 @@ describe("org usage tab - member usage table", () => {
       hasSubscription: true,
     });
 
-    mockAPIs([
+    setupMockAPIs([
       {
         userId: "user-a",
         email: "alice@example.com",
@@ -166,7 +160,7 @@ describe("org usage tab - member usage table", () => {
       hasSubscription: true,
     });
 
-    mockAPIs([]);
+    setupMockAPIs([]);
 
     await openUsageTab();
 
@@ -185,7 +179,7 @@ describe("org usage tab - inline cap editing", () => {
       hasSubscription: true,
     });
 
-    const capStore = mockAPIs([
+    const capStore = setupMockAPIs([
       {
         userId: "user-a",
         email: "alice@example.com",
@@ -232,7 +226,7 @@ describe("org usage tab - inline cap editing", () => {
       hasSubscription: true,
     });
 
-    mockAPIs([
+    setupMockAPIs([
       {
         userId: "user-a",
         email: "alice@example.com",
@@ -276,8 +270,8 @@ describe("org usage tab - free tier", () => {
     });
 
     server.use(
-      http.get("*/api/zero/usage/members", () => {
-        return HttpResponse.json({ period: null, members: [] });
+      mockApi(zeroUsageMembersContract.get, ({ respond }) => {
+        return respond(200, { period: null, members: [] });
       }),
     );
 
@@ -297,8 +291,8 @@ describe("org usage tab - free tier", () => {
     });
 
     server.use(
-      http.get("*/api/zero/usage/members", () => {
-        return HttpResponse.json({ period: null, members: [] });
+      mockApi(zeroUsageMembersContract.get, ({ respond }) => {
+        return respond(200, { period: null, members: [] });
       }),
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -19,6 +19,8 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import { setSidebarExpanded$ } from "../../../signals/zero-page/zero-nav.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
+import { setMockOrgMembers } from "../../../mocks/handlers/api-org-members.ts";
 
 const context = testContext();
 
@@ -119,16 +121,12 @@ describe("sidebar layout - invite button shows for admins (SIDEBAR-D-048)", () =
 describe("sidebar layout - invite button hidden for non-admins (SIDEBAR-D-049)", () => {
   it("does not render the Invite button for non-admin users", async () => {
     mockBaseAPIs();
-    server.use(
-      http.get("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_1",
-          slug: "test-org",
-          name: "Test Org",
-          role: "member",
-        });
-      }),
-    );
+    setMockOrg({
+      id: "org_1",
+      slug: "test-org",
+      name: "Test Org",
+      role: "member",
+    });
     detachedSetupPage({ context, path: "/" });
     await waitFor(() => {
       expect(screen.queryByText("Invite")).not.toBeInTheDocument();
@@ -203,20 +201,13 @@ describe("sidebar layout - invite button opens member dialog (SIDEBAR-D-052)", (
   it("opens the org manage dialog on the members tab when Invite is clicked", async () => {
     const user = userEvent.setup();
     mockBaseAPIs();
-    server.use(
-      http.get("*/api/zero/org/logo", () => {
-        return HttpResponse.json({ logoUrl: null });
-      }),
-      http.get("*/api/zero/org/members", () => {
-        return HttpResponse.json({
-          slug: "test-org",
-          role: "admin",
-          members: [],
-          pendingInvitations: [],
-          createdAt: "2024-01-01T00:00:00Z",
-        });
-      }),
-    );
+    setMockOrgMembers({
+      slug: "test-org",
+      role: "admin",
+      members: [],
+      pendingInvitations: [],
+      createdAt: "2024-01-01T00:00:00Z",
+    });
 
     detachedSetupPage({ context, path: "/" });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page-interaction.test.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockOrgMembers } from "../../../mocks/handlers/api-org-members.ts";
 
 const context = testContext();
 
@@ -80,17 +81,13 @@ describe("zero chat page - pin button", () => {
 describe("zero chat page - invite button", () => {
   it("invite button opens manage dialog on members tab (CHAT-I-012)", async () => {
     const user = userEvent.setup();
-    server.use(
-      http.get("*/api/zero/org/members", () => {
-        return HttpResponse.json({
-          slug: "test-org",
-          role: "admin",
-          members: [],
-          pendingInvitations: [],
-          createdAt: "2026-01-01T00:00:00Z",
-        });
-      }),
-    );
+    setMockOrgMembers({
+      slug: "test-org",
+      role: "admin",
+      members: [],
+      pendingInvitations: [],
+      createdAt: "2026-01-01T00:00:00Z",
+    });
     mockChatAPI();
     detachedSetupPage({ context, path: "/" });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { getCategories } from "../zero-ideation-data.ts";
@@ -394,16 +395,7 @@ describe("zero chat page - connector label casing", () => {
 
 describe("zero chat page - invite button", () => {
   it("renders invite button in DOM even when user is not admin", async () => {
-    server.use(
-      http.get("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_1",
-          slug: "user-12345678",
-          name: "User 12345678",
-          role: "member",
-        });
-      }),
-    );
+    setMockOrg({ role: "member" });
 
     await renderChatPage();
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
@@ -6,6 +6,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import type { ConnectorResponse, ConnectorType } from "@vm0/core";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 
 const context = testContext();
 
@@ -197,16 +198,9 @@ function renderTeamPageAsMember(
         defaultAgentMetadata: { displayName: "Zero" },
       });
     }),
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "user-12345678",
-        name: "User 12345678",
-        role: "member",
-      });
-    }),
   );
 
+  setMockOrg({ role: "member" });
   detachedSetupPage({ context, path: "/agents/zero" });
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
@@ -6,6 +6,7 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 
 const context = testContext();
 
@@ -284,16 +285,7 @@ describe("zero job detail page - tab visibility", () => {
   it("should hide Profile and Instructions tabs for non-owner non-admin", async () => {
     mockAPIs();
     // Override org to "member" role and user to non-owner
-    server.use(
-      http.get("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_default",
-          slug: "default-org",
-          name: "Default Org",
-          role: "member",
-        });
-      }),
-    );
+    setMockOrg({ role: "member" });
     detachedSetupPage({
       context,
       path: "/agents/my-agent",
@@ -315,16 +307,7 @@ describe("zero job detail page - tab visibility", () => {
 
   it("should coerce ?tab=profile to authorization for non-owner non-admin", async () => {
     mockAPIs();
-    server.use(
-      http.get("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_default",
-          slug: "default-org",
-          name: "Default Org",
-          role: "member",
-        });
-      }),
-    );
+    setMockOrg({ role: "member" });
     detachedSetupPage({
       context,
       path: "/agents/my-agent?tab=profile",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
@@ -16,14 +16,8 @@ beforeEach(() => {
   resetMockOrg();
 });
 
-// All default API state (team, chat-threads, org/logo) is covered by global handlers.
-function mockAPIs(): void {
-  // No-op: all required endpoints are covered by global default handlers.
-}
-
 describe("zero org switcher - current org avatar and name render (SIDEBAR-D-054)", () => {
   it("displays the current organization name in the sidebar trigger", async () => {
-    mockAPIs();
     detachedSetupPage({
       context,
       path: "/",
@@ -72,7 +66,6 @@ describe("zero org switcher - organization slug renders (SIDEBAR-D-055)", () => 
 
 describe("zero org switcher - pending invitations badge shows count (SIDEBAR-D-056)", () => {
   it("shows a red dot badge when there are pending invitations", async () => {
-    mockAPIs();
     detachedSetupPage({
       context,
       path: "/",
@@ -105,7 +98,6 @@ describe("zero org switcher - pending invitations badge shows count (SIDEBAR-D-0
 
 describe("zero org switcher - pending invitations list renders (SIDEBAR-D-057)", () => {
   it("shows pending invitation items when dropdown is opened", async () => {
-    mockAPIs();
     detachedSetupPage({
       context,
       path: "/",
@@ -144,7 +136,6 @@ describe("zero org switcher - pending invitations list renders (SIDEBAR-D-057)",
 
 describe("zero org switcher - other org memberships list renders (SIDEBAR-D-058)", () => {
   it("shows other organizations the user belongs to when dropdown is opened", async () => {
-    mockAPIs();
     detachedSetupPage({
       context,
       path: "/",
@@ -172,7 +163,6 @@ describe("zero org switcher - other org memberships list renders (SIDEBAR-D-058)
 
 describe("zero org switcher - dropdown opens (SIDEBAR-D-059)", () => {
   it("shows org management options when dropdown is opened", async () => {
-    mockAPIs();
     detachedSetupPage({
       context,
       path: "/",
@@ -265,7 +255,6 @@ describe("zero org switcher - org switch menu item switches organization (SIDEBA
       },
     );
 
-    mockAPIs();
     detachedSetupPage({
       context,
       path: "/",
@@ -299,7 +288,6 @@ describe("zero org switcher - org switch menu item switches organization (SIDEBA
 
 describe("zero org switcher - join button accepts invitation (SIDEBAR-D-062)", () => {
   it("removes the invitation from the list after Join is clicked", async () => {
-    mockAPIs();
     detachedSetupPage({
       context,
       path: "/",
@@ -370,7 +358,6 @@ describe("zero org switcher - create workspace item starts creation flow (SIDEBA
       },
     );
 
-    mockAPIs();
     detachedSetupPage({
       context,
       path: "/",
@@ -402,7 +389,6 @@ describe("zero org switcher - create workspace item starts creation flow (SIDEBA
 
 describe("zero org switcher - pending invitations badge hidden when none (SIDEBAR-D-064)", () => {
   it("should not show red dot when there are no pending invitations", async () => {
-    mockAPIs();
     detachedSetupPage({
       context,
       path: "/",
@@ -424,8 +410,6 @@ describe("zero org switcher - pending invitations badge hidden when none (SIDEBA
 
 describe("zero org switcher - create workspace visibility based on createOrganizationEnabled", () => {
   it("hides create workspace when createOrganizationEnabled is false", async () => {
-    mockAPIs();
-
     detachedSetupPage({
       context,
       path: "/",
@@ -448,8 +432,6 @@ describe("zero org switcher - create workspace visibility based on createOrganiz
   });
 
   it("shows create workspace when createOrganizationEnabled is true", async () => {
-    mockAPIs();
-
     detachedSetupPage({
       context,
       path: "/",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
@@ -1,8 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
-import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import {
@@ -10,28 +8,17 @@ import {
   mockedClerk,
   mockOrganization,
 } from "../../../__tests__/mock-auth.ts";
+import { setMockOrg, resetMockOrg } from "../../../mocks/handlers/api-org.ts";
 
 const context = testContext();
 
-function mockAPIs() {
-  server.use(
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-  );
+beforeEach(() => {
+  resetMockOrg();
+});
+
+// All default API state (team, chat-threads, org/logo) is covered by global handlers.
+function mockAPIs(): void {
+  // No-op: all required endpoints are covered by global default handlers.
 }
 
 describe("zero org switcher - current org avatar and name render (SIDEBAR-D-054)", () => {
@@ -54,32 +41,12 @@ describe("zero org switcher - current org avatar and name render (SIDEBAR-D-054)
 
 describe("zero org switcher - organization slug renders (SIDEBAR-D-055)", () => {
   it("displays the organization slug in the dropdown header", async () => {
-    server.use(
-      http.get("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_1",
-          slug: "acme-corp",
-          name: "Acme Corp",
-          role: "admin",
-        });
-      }),
-      http.get("*/api/zero/team", () => {
-        return HttpResponse.json([
-          {
-            id: "c0000000-0000-4000-a000-000000000001",
-            displayName: null,
-            description: null,
-            sound: null,
-            avatarUrl: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-          },
-        ]);
-      }),
-      http.get("*/api/zero/chat-threads", () => {
-        return HttpResponse.json({ threads: [] });
-      }),
-    );
+    setMockOrg({
+      id: "org_1",
+      slug: "acme-corp",
+      name: "Acme Corp",
+      role: "admin",
+    });
 
     detachedSetupPage({
       context,
@@ -233,35 +200,12 @@ describe("zero org switcher - dropdown opens (SIDEBAR-D-059)", () => {
 
 describe("zero org switcher - manage button opens org management (SIDEBAR-D-060)", () => {
   it("opens the org management dialog when Manage is clicked", async () => {
-    server.use(
-      http.get("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_1",
-          slug: "current-org",
-          name: "Current Org",
-          role: "admin",
-        });
-      }),
-      http.get("*/api/zero/org/logo", () => {
-        return HttpResponse.json({ logoUrl: null });
-      }),
-      http.get("*/api/zero/team", () => {
-        return HttpResponse.json([
-          {
-            id: "c0000000-0000-4000-a000-000000000001",
-            displayName: null,
-            description: null,
-            sound: null,
-            avatarUrl: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-          },
-        ]);
-      }),
-      http.get("*/api/zero/chat-threads", () => {
-        return HttpResponse.json({ threads: [] });
-      }),
-    );
+    setMockOrg({
+      id: "org_1",
+      slug: "current-org",
+      name: "Current Org",
+      role: "admin",
+    });
 
     detachedSetupPage({
       context,


### PR DESCRIPTION
## Summary

- Expand MSW handler layer with 3 new handler files (`api-org-members.ts`, `api-org-domains.ts`, `api-usage.ts`) covering org members, domains, usage, and credit caps
- Extend existing `api-org.ts` with PUT, leave, delete, org/logo handlers plus `setMockOrg`/`resetMockOrg`/`setMockOrgLogo`/`resetMockOrgLogo` setters
- Extend `api-billing.ts` with invoices handler and `setMockBillingInvoices` setter
- Add `setMockOrgModelProviders` setter to `api-org-model-providers.ts`
- Migrate ~35 platform test files from raw `http.*` overrides to `mockApi()` contract-driven helper and handler setter functions
- Remaining raw `http.get` in `member-credit-caps.test.ts` is intentional (500 status not in contract definition)

Closes #10086

## Test plan

- [x] `pnpm -F @vm0/app check-types` — no new errors (pre-existing firewalls generated-file errors unrelated to this change)
- [x] `pnpm -F @vm0/app lint` — no new errors (pre-existing tsgolint executable error unrelated)
- [x] `pnpm -F @vm0/app exec vitest run` — same failure pattern as main (pre-existing missing generated firewall files break all 212 test files on both main and this branch)
- [x] `pnpm knip --workspace @vm0/app` — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)