### PR TITLE
refactor(platform): migrate server.use() overrides to mockApi (phase 3 / #10083)

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -17,8 +17,31 @@ import {
   chatThreadByIdContract,
   chatThreadMarkReadContract,
   chatThreadMessagesContract,
+  type ComposeListItem,
 } from "@vm0/core";
 import { mockApi } from "../msw-contract.ts";
+
+const DEFAULT_COMPOSES_LIST: ComposeListItem[] = [
+  {
+    id: "c0000000-0000-4000-a000-000000000001",
+    name: "zero",
+    displayName: null,
+    description: null,
+    sound: null,
+    headVersionId: "version_1",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
+];
+
+let mockComposesList: ComposeListItem[] = [...DEFAULT_COMPOSES_LIST];
+
+export function setMockComposesList(composes: ComposeListItem[]): void {
+  mockComposesList = composes;
+}
+
+export function resetMockComposesList(): void {
+  mockComposesList = [...DEFAULT_COMPOSES_LIST];
+}
 
 export const apiAgentsHandlers = [
   // GET /api/zero/team
@@ -38,19 +61,7 @@ export const apiAgentsHandlers = [
 
   // GET /api/zero/composes/list
   mockApi(zeroComposesListContract.list, ({ respond }) => {
-    return respond(200, {
-      composes: [
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ],
-    });
+    return respond(200, { composes: mockComposesList });
   }),
 
   // GET /api/zero/composes/:id (kept for backwards compat with other tests)

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -8,7 +8,6 @@ import {
   CONNECTOR_TYPES,
   type ConnectorResponse,
   type ConnectorType,
-  type ScopeDiffResponse,
   zeroConnectorsByTypeContract,
   zeroConnectorScopeDiffContract,
   zeroConnectorsMainContract,
@@ -23,18 +22,8 @@ export function setMockConnectors(connectors: ConnectorResponse[]): void {
   mockConnectors = connectors;
 }
 
-const DEFAULT_SCOPE_DIFF: ScopeDiffResponse = {
-  addedScopes: [],
-  removedScopes: [],
-  currentScopes: [],
-  storedScopes: [],
-};
-
-let mockScopeDiff: ScopeDiffResponse = { ...DEFAULT_SCOPE_DIFF };
-
 export function resetMockConnectors(): void {
   mockConnectors = [];
-  mockScopeDiff = { ...DEFAULT_SCOPE_DIFF };
 }
 
 export const apiConnectorsHandlers = [
@@ -65,6 +54,11 @@ export const apiConnectorsHandlers = [
   }),
 
   mockApi(zeroConnectorScopeDiffContract.getScopeDiff, ({ respond }) => {
-    return respond(200, mockScopeDiff);
+    return respond(200, {
+      addedScopes: [],
+      removedScopes: [],
+      currentScopes: [],
+      storedScopes: [],
+    });
   }),
 ];

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -8,7 +8,9 @@ import {
   CONNECTOR_TYPES,
   type ConnectorResponse,
   type ConnectorType,
+  type ScopeDiffResponse,
   zeroConnectorsByTypeContract,
+  zeroConnectorScopeDiffContract,
   zeroConnectorsMainContract,
 } from "@vm0/core";
 import { mockApi } from "../msw-contract.ts";
@@ -17,8 +19,22 @@ const ALL_CONNECTOR_TYPES = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
 
 let mockConnectors: ConnectorResponse[] = [];
 
+export function setMockConnectors(connectors: ConnectorResponse[]): void {
+  mockConnectors = connectors;
+}
+
+const DEFAULT_SCOPE_DIFF: ScopeDiffResponse = {
+  addedScopes: [],
+  removedScopes: [],
+  currentScopes: [],
+  storedScopes: [],
+};
+
+let mockScopeDiff: ScopeDiffResponse = { ...DEFAULT_SCOPE_DIFF };
+
 export function resetMockConnectors(): void {
   mockConnectors = [];
+  mockScopeDiff = { ...DEFAULT_SCOPE_DIFF };
 }
 
 export const apiConnectorsHandlers = [
@@ -46,5 +62,9 @@ export const apiConnectorsHandlers = [
       return c.type !== type;
     });
     return respond(204);
+  }),
+
+  mockApi(zeroConnectorScopeDiffContract.getScopeDiff, ({ respond }) => {
+    return respond(200, mockScopeDiff);
   }),
 ];

--- a/turbo/apps/platform/src/mocks/handlers/api-permission-access-requests.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-permission-access-requests.ts
@@ -1,0 +1,29 @@
+/**
+ * Permission Access Requests API Handlers
+ *
+ * Mock handlers for /api/zero/permission-access-requests endpoints.
+ */
+
+import {
+  permissionAccessRequestsListContract,
+  type PermissionAccessRequestResponse,
+} from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
+
+let mockPermissionRequests: PermissionAccessRequestResponse[] = [];
+
+export function setMockPermissionRequests(
+  requests: PermissionAccessRequestResponse[],
+): void {
+  mockPermissionRequests = requests;
+}
+
+export function resetMockPermissionRequests(): void {
+  mockPermissionRequests = [];
+}
+
+export const apiPermissionAccessRequestsHandlers = [
+  mockApi(permissionAccessRequestsListContract.list, ({ respond }) => {
+    return respond(200, mockPermissionRequests);
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/api-permission-policies.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-permission-policies.ts
@@ -1,0 +1,23 @@
+/**
+ * Permission Policies API Handlers
+ *
+ * Mock handlers for /api/zero/permission-policies endpoints.
+ */
+
+import { zeroAgentPermissionPoliciesContract } from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
+
+export const apiPermissionPoliciesHandlers = [
+  mockApi(zeroAgentPermissionPoliciesContract.update, ({ body, respond }) => {
+    return respond(200, {
+      agentId: body.agentId,
+      ownerId: "test-user-123",
+      description: null,
+      displayName: null,
+      sound: null,
+      avatarUrl: null,
+      permissionPolicies: body.policies,
+      customSkills: [],
+    });
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -26,7 +26,7 @@ import {
   apiIntegrationsTelegramHandlers,
   resetMockTelegramIntegration,
 } from "./api-integrations-telegram.ts";
-import { apiAgentsHandlers } from "./api-agents.ts";
+import { apiAgentsHandlers, resetMockComposesList } from "./api-agents.ts";
 import {
   apiFeatureSwitchesHandlers,
   resetMockFeatureSwitches,
@@ -43,6 +43,11 @@ import {
   apiIntegrationsSlackConnectHandlers,
   resetMockSlackConnect,
 } from "./api-integrations-slack-connect.ts";
+import {
+  apiPermissionAccessRequestsHandlers,
+  resetMockPermissionRequests,
+} from "./api-permission-access-requests.ts";
+import { apiPermissionPoliciesHandlers } from "./api-permission-policies.ts";
 
 export const handlers = [
   ...apiConnectorsHandlers,
@@ -61,6 +66,8 @@ export const handlers = [
   ...apiIntegrationsSlackConnectHandlers,
   ...apiFeatureSwitchesHandlers,
   ...apiRealtimeHandlers,
+  ...apiPermissionAccessRequestsHandlers,
+  ...apiPermissionPoliciesHandlers,
 ];
 
 export function resetAllMockHandlers(): void {
@@ -75,4 +82,6 @@ export function resetAllMockHandlers(): void {
   resetMockSlackConnect();
   resetMockFeatureSwitches();
   resetAblySubscriptions();
+  resetMockPermissionRequests();
+  resetMockComposesList();
 }

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/poll-slack-connection.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/poll-slack-connection.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -8,6 +7,8 @@ import {
   pollSlackConnection$,
   setSlackPollIntervalMs$,
 } from "../zero-slack.ts";
+import { zeroIntegrationsSlackContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -34,14 +35,13 @@ function mockSlackEndpoint(getIsConnected: (callCount: number) => boolean) {
     },
   };
   server.use(
-    http.get("*/api/zero/integrations/slack", () => {
+    mockApi(zeroIntegrationsSlackContract.getStatus, ({ respond }) => {
       callCount++;
-      return HttpResponse.json({
+      return respond(200, {
         isConnected: getIsConnected(callCount),
         isInstalled: true,
         workspaceName: "Test Workspace",
         isAdmin: false,
-        defaultAgentId: null,
         agentOrgSlug: null,
         environment: {
           requiredSecrets: [],
@@ -90,7 +90,7 @@ describe("pollSlackConnection$", () => {
     const deferred = createDeferredPromise<void>(context.signal);
     let callCount = 0;
     server.use(
-      http.get("*/api/zero/integrations/slack", async () => {
+      mockApi(zeroIntegrationsSlackContract.getStatus, async ({ respond }) => {
         callCount++;
         // The second call is the first real poll — block it and abort the controller
         if (callCount === 2) {
@@ -98,12 +98,11 @@ describe("pollSlackConnection$", () => {
           deferred.resolve();
           await deferred.promise;
         }
-        return HttpResponse.json({
+        return respond(200, {
           isConnected: false,
           isInstalled: true,
           workspaceName: "Test Workspace",
           isAdmin: false,
-          defaultAgentId: null,
           agentOrgSlug: null,
           environment: {
             requiredSecrets: [],

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -9,7 +9,8 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { allConnectorTypes$ } from "../settings/connectors.ts";
 import { zeroAddedConnectors$ } from "../zero-connectors.ts";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import type { ConnectorType } from "@vm0/core";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 
 const context = testContext();
 
@@ -40,28 +41,20 @@ describe("connectors", () => {
   });
 
   it("should sort connected connectors before unconnected ones", async () => {
-    server.use(
-      http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json({
-          connectors: [
-            {
-              id: "d0000001-0000-4000-a000-000000000001",
-              type: "github",
-              authMethod: "oauth",
-              externalId: null,
-              externalUsername: "testuser",
-              externalEmail: null,
-              oauthScopes: ["repo", "project"],
-              needsReconnect: false,
-              createdAt: "2026-01-01T00:00:00Z",
-              updatedAt: "2026-01-01T00:00:00Z",
-            },
-          ],
-          configuredTypes: Object.keys(CONNECTOR_TYPES),
-          connectorProvidedSecretNames: [],
-        });
-      }),
-    );
+    setMockConnectors([
+      {
+        id: "d0000001-0000-4000-a000-000000000001",
+        type: "github",
+        authMethod: "oauth",
+        externalId: null,
+        externalUsername: "testuser",
+        externalEmail: null,
+        oauthScopes: ["repo", "project"],
+        needsReconnect: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    ]);
 
     detachedSetupPage({
       context,

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-slack-connect.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-slack-connect.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -11,6 +10,8 @@ import {
 } from "../slack-connect-signals.ts";
 import { updateSearchParams$ } from "../../route.ts";
 import { setMockSlackConnectData } from "../../../mocks/handlers/api-integrations-slack-connect.ts";
+import { zeroSlackConnectContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -45,9 +46,9 @@ describe("slack-connect-page signals", () => {
     it("should stay idle when not connected", async () => {
       let checkCalled = false;
       server.use(
-        http.get("*/api/zero/integrations/slack/connect", () => {
+        mockApi(zeroSlackConnectContract.getStatus, ({ respond }) => {
           checkCalled = true;
-          return HttpResponse.json({ isConnected: false, isAdmin: false });
+          return respond(200, { isConnected: false, isAdmin: false });
         }),
       );
       await setup("/settings/slack?w=ws1&u=user1");

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../../__tests__/page-helper.ts";
@@ -11,7 +10,11 @@ import {
   STANDALONE_POLLING_TIMEOUT_MS,
 } from "../connectors.ts";
 import { createDeferredPromise } from "../../../utils.ts";
-import type { ConnectorListResponse } from "@vm0/core";
+import {
+  type ConnectorListResponse,
+  zeroConnectorsMainContract,
+} from "@vm0/core";
+import { mockApi } from "../../../../mocks/msw-contract.ts";
 
 vi.mock("signal-timers", async (importOriginal) => {
   const mod = await importOriginal<typeof import("signal-timers")>();
@@ -78,16 +81,16 @@ describe("connectConnector$", () => {
     const secondPollDeferred = createDeferredPromise<void>(context.signal);
     let deferredResolved = false;
     server.use(
-      http.get("*/api/zero/connectors", () => {
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
         pollCount++;
         if (pollCount <= 1) {
-          return HttpResponse.json(makeEmptyConnectorResponse());
+          return respond(200, makeEmptyConnectorResponse());
         }
         if (!deferredResolved) {
           deferredResolved = true;
           secondPollDeferred.resolve();
         }
-        return HttpResponse.json(makeGithubConnectorResponse());
+        return respond(200, makeGithubConnectorResponse());
       }),
     );
 
@@ -131,15 +134,15 @@ describe("connectConnector$", () => {
     let pollCount = 0;
     const reconnectedUpdatedAt = "2026-02-01T00:00:00.000Z";
     server.use(
-      http.get("*/api/zero/connectors", () => {
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
         pollCount++;
         // First poll captures initialUpdatedAt; second poll still shows the
         // stale value (OAuth callback not yet complete); third poll reflects
         // the completed reconnect with a new updatedAt.
         if (pollCount <= 2) {
-          return HttpResponse.json(initialResponse);
+          return respond(200, initialResponse);
         }
-        return HttpResponse.json({
+        return respond(200, {
           ...initialResponse,
           connectors: [
             {
@@ -173,12 +176,12 @@ describe("connectConnector$", () => {
 
     let pollCount = 0;
     server.use(
-      http.get("*/api/zero/connectors", () => {
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
         pollCount++;
         if (pollCount >= 2) {
           mockWindow.closed = true;
         }
-        return HttpResponse.json(makeEmptyConnectorResponse());
+        return respond(200, makeEmptyConnectorResponse());
       }),
     );
 
@@ -201,8 +204,8 @@ describe("connectConnector$", () => {
     vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
 
     server.use(
-      http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json(makeGithubConnectorResponse());
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
+        return respond(200, makeGithubConnectorResponse());
       }),
     );
 
@@ -219,12 +222,12 @@ describe("connectConnector$", () => {
 
     let pollCount = 0;
     server.use(
-      http.get("*/api/zero/connectors", () => {
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
         pollCount++;
         if (pollCount >= 1) {
           mockWindow.closed = true;
         }
-        return HttpResponse.json(makeEmptyConnectorResponse());
+        return respond(200, makeEmptyConnectorResponse());
       }),
     );
 
@@ -240,8 +243,8 @@ describe("connectConnector$", () => {
     vi.spyOn(window, "open").mockReturnValue(null);
 
     server.use(
-      http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json(makeGithubConnectorResponse());
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
+        return respond(200, makeGithubConnectorResponse());
       }),
     );
 
@@ -267,12 +270,12 @@ describe("connectConnector$", () => {
     // simulating the user completing OAuth in external Safari then returning.
     let pollCount = 0;
     server.use(
-      http.get("*/api/zero/connectors", () => {
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
         pollCount++;
         if (pollCount < 3) {
-          return HttpResponse.json(makeEmptyConnectorResponse());
+          return respond(200, makeEmptyConnectorResponse());
         }
-        return HttpResponse.json(makeGithubConnectorResponse());
+        return respond(200, makeGithubConnectorResponse());
       }),
     );
 
@@ -308,8 +311,8 @@ describe("connectConnector$", () => {
     });
 
     server.use(
-      http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json(makeEmptyConnectorResponse());
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
+        return respond(200, makeEmptyConnectorResponse());
       }),
     );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/permissions.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/permissions.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../../__tests__/page-helper.ts";
@@ -7,6 +6,8 @@ import {
   hasConnectorPermissions,
   savePermissionPolicies$,
 } from "../permissions.ts";
+import { zeroAgentPermissionPoliciesContract } from "@vm0/core";
+import { mockApi } from "../../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -36,22 +37,25 @@ describe("savePermissionPolicies$", () => {
     const policies = {
       slack: { policies: { "channels:read": "allow" as const } },
     };
-    let capturedBody: Record<string, unknown> | null = null;
+    let capturedBody: { agentId: string; policies: unknown } | null = null;
 
     server.use(
-      http.put("*/api/zero/permission-policies", async ({ request }) => {
-        capturedBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json({
-          agentId: "compose-1",
-          ownerId: "test-user-123",
-          description: null,
-          displayName: null,
-          sound: null,
-          avatarUrl: null,
-          connectors: [],
-          permissionPolicies: policies,
-        });
-      }),
+      mockApi(
+        zeroAgentPermissionPoliciesContract.update,
+        ({ body, respond }) => {
+          capturedBody = body;
+          return respond(200, {
+            agentId: "compose-1",
+            ownerId: "test-user-123",
+            description: null,
+            displayName: null,
+            sound: null,
+            avatarUrl: null,
+            permissionPolicies: policies,
+            customSkills: [],
+          });
+        },
+      ),
     );
 
     const result = await context.store.set(
@@ -71,13 +75,10 @@ describe("savePermissionPolicies$", () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
 
     server.use(
-      http.put("*/api/zero/permission-policies", () => {
-        return HttpResponse.json(
-          {
-            error: { message: "Only org admins can update", code: "FORBIDDEN" },
-          },
-          { status: 403 },
-        );
+      mockApi(zeroAgentPermissionPoliciesContract.update, ({ respond }) => {
+        return respond(403, {
+          error: { message: "Only org admins can update", code: "FORBIDDEN" },
+        });
       }),
     );
 

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -8,6 +8,7 @@ import type {
   LogDetail,
   AgentEventsResponse,
 } from "../../../signals/zero-page/log-types.ts";
+import { setMockComposesList } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 
@@ -39,10 +40,8 @@ describe("activity detail polling with initially empty events", () => {
   it("should pick up events that appear after the initial empty fetch", async () => {
     let eventFetchCount = 0;
 
+    setMockComposesList([]);
     server.use(
-      http.get("*/api/zero/composes/list", () => {
-        return HttpResponse.json({ composes: [] });
-      }),
       http.get("*/api/zero/chat-threads", () => {
         return HttpResponse.json({ threads: [] });
       }),

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-stale.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-stale.test.tsx
@@ -10,6 +10,7 @@ import type {
   LogDetail,
   AgentEventsResponse,
 } from "../../../signals/zero-page/log-types.ts";
+import { setMockComposesList } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 
@@ -100,6 +101,7 @@ function mockAPIs() {
     },
   ];
 
+  setMockComposesList([]);
   server.use(
     http.get("*/api/zero/logs", () => {
       return HttpResponse.json({
@@ -107,9 +109,6 @@ function mockAPIs() {
         pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
         filters: { statuses: [], sources: [], agents: [] },
       });
-    }),
-    http.get("*/api/zero/composes/list", () => {
-      return HttpResponse.json({ composes: [] });
     }),
     http.get("*/api/zero/logs/:id", ({ params }) => {
       if (params["id"] === "a0000000-0000-4000-a000-000000000001") {

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-navigation.test.tsx
@@ -9,6 +9,7 @@ import type {
   LogDetail,
   AgentEventsResponse,
 } from "../../../signals/zero-page/log-types.ts";
+import { setMockComposesList } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 
@@ -66,6 +67,7 @@ function mockActivityAPIs() {
     framework: "claude-code",
   };
 
+  setMockComposesList([]);
   server.use(
     http.get("*/api/zero/logs", () => {
       return HttpResponse.json({
@@ -73,9 +75,6 @@ function mockActivityAPIs() {
         pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
         filters: { statuses: [], sources: [], agents: [] },
       });
-    }),
-    http.get("*/api/zero/composes/list", () => {
-      return HttpResponse.json({ composes: [] });
     }),
     http.get("*/api/zero/logs/:id", ({ params }) => {
       if (params["id"] === "a0000000-0000-4000-a000-000000000001") {

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-error.test.ts
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-error.test.ts
@@ -4,20 +4,19 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockComposesList } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 
 describe("activity page error", () => {
   it("should show error state when /api/zero/logs returns 500", async () => {
+    setMockComposesList([]);
     server.use(
       http.get("*/api/zero/logs", () => {
         return HttpResponse.json(
           { error: { message: "Internal Server Error", code: "INTERNAL" } },
           { status: 500 },
         );
-      }),
-      http.get("*/api/zero/composes/list", () => {
-        return HttpResponse.json({ composes: [] });
       }),
       http.get("*/api/zero/chat-threads", () => {
         return HttpResponse.json({ threads: [] });

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-routing.test.ts
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-routing.test.ts
@@ -10,6 +10,7 @@ import type {
   LogDetail,
   AgentEventsResponse,
 } from "../../../signals/zero-page/log-types.ts";
+import { setMockComposesList } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 
@@ -69,20 +70,18 @@ function mockActivityAPIs() {
     framework: "claude-code",
   };
 
+  setMockComposesList([
+    {
+      id: "c0000000-0000-4000-a000-000000000001",
+      name: "test-agent",
+      displayName: "Test Agent",
+      description: null,
+      sound: null,
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
   server.use(
-    http.get("*/api/zero/composes/list", () => {
-      return HttpResponse.json({
-        composes: [
-          {
-            id: "c0000000-0000-4000-a000-000000000001",
-            name: "test-agent",
-            displayName: "Test Agent",
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-          },
-        ],
-      });
-    }),
     http.get("*/api/zero/logs", () => {
       return HttpResponse.json({
         data: logs,
@@ -179,20 +178,18 @@ describe("activity page routing", () => {
   });
 
   it("should display 'Agent (displayName)' for delegated runs with triggerAgentName", async () => {
+    setMockComposesList([
+      {
+        id: "c0000000-0000-4000-a000-000000000001",
+        name: "child-agent",
+        displayName: "Child Agent",
+        description: null,
+        sound: null,
+        headVersionId: null,
+        updatedAt: "2026-03-10T00:00:00Z",
+      },
+    ]);
     server.use(
-      http.get("*/api/zero/composes/list", () => {
-        return HttpResponse.json({
-          composes: [
-            {
-              id: "c0000000-0000-4000-a000-000000000001",
-              name: "child-agent",
-              displayName: "Child Agent",
-              headVersionId: null,
-              updatedAt: "2026-03-10T00:00:00Z",
-            },
-          ],
-        });
-      }),
       http.get("*/api/zero/logs", () => {
         return HttpResponse.json({
           data: [

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
@@ -10,6 +10,7 @@ import type {
   LogDetail,
   AgentEventsResponse,
 } from "../../../signals/zero-page/log-types.ts";
+import { setMockComposesList } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 
@@ -59,10 +60,8 @@ describe("activity paged events", () => {
       createdAt: "2026-03-10T14:56:10Z",
     };
 
+    setMockComposesList([]);
     server.use(
-      http.get("*/api/zero/composes/list", () => {
-        return HttpResponse.json({ composes: [] });
-      }),
       http.get("*/api/zero/chat-threads", () => {
         return HttpResponse.json({ threads: [] });
       }),
@@ -129,10 +128,8 @@ describe("activity paged events", () => {
   it("should stop polling when navigating away from the run page", async () => {
     let eventFetchCount = 0;
 
+    setMockComposesList([]);
     server.use(
-      http.get("*/api/zero/composes/list", () => {
-        return HttpResponse.json({ composes: [] });
-      }),
       http.get("*/api/zero/chat-threads", () => {
         return HttpResponse.json({ threads: [] });
       }),

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -11,12 +11,13 @@ import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { type ConnectorType, zeroConnectorsMainContract } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { setSelectedConnectorType$ } from "../../../signals/zero-page/settings/connectors.ts";
 import { mockConnectors } from "../../zero-page/__tests__/zero-connectors-page-test-helpers.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -86,12 +87,12 @@ describe("connect modal - loading states", () => {
     // subsequent polling calls so the polling loop stays in flight.
     let callCount = 0;
     server.use(
-      http.get("*/api/zero/connectors", () => {
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
         callCount++;
         if (callCount === 1) {
-          return HttpResponse.json({
+          return respond(200, {
             connectors: [],
-            configuredTypes: Object.keys(CONNECTOR_TYPES),
+            configuredTypes: [],
             connectorProvidedSecretNames: [],
           });
         }

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -2,10 +2,15 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import {
+  type ConnectorType,
+  zeroAgentPermissionPoliciesContract,
+} from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -64,35 +69,27 @@ function mockAPIs({
     http.get("*/api/zero/schedules", () => {
       return HttpResponse.json({ schedules: [] });
     }),
-    http.get("*/api/zero/connectors", () => {
-      return HttpResponse.json({
-        connectors: [
-          {
-            id: "d0000001-0000-4000-a000-000000000001",
-            type: connectorType,
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: "testuser",
-            externalEmail: null,
-            oauthScopes: [],
-            needsReconnect: false,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-          },
-        ],
-        configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
-        connectorProvidedSecretNames: [],
-      });
-    }),
     http.get("*/api/zero/agents/:id/user-connectors", () => {
       return HttpResponse.json({ enabledTypes: [connectorType] });
     }),
-    http.put("*/api/zero/permission-policies", async ({ request }) => {
-      const body = (await request.json()) as {
-        agentId: string;
-        policies: Record<string, Record<string, string>>;
-      };
-      return HttpResponse.json({
+  );
+  setMockConnectors([
+    {
+      id: "d0000001-0000-4000-a000-000000000001",
+      type: connectorType,
+      authMethod: "oauth",
+      externalId: null,
+      externalUsername: "testuser",
+      externalEmail: null,
+      oauthScopes: [],
+      needsReconnect: false,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+  ]);
+  server.use(
+    mockApi(zeroAgentPermissionPoliciesContract.update, ({ body, respond }) => {
+      return respond(200, {
         agentId: "e0000000-0000-4000-a000-000000000010",
         ownerId,
         description: "A helpful agent",
@@ -230,9 +227,9 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     let putCalled = false;
     mockAPIs({ connectorType: "slack" });
     server.use(
-      http.put("*/api/zero/permission-policies", () => {
+      mockApi(zeroAgentPermissionPoliciesContract.update, ({ respond }) => {
         putCalled = true;
-        return HttpResponse.json({
+        return respond(200, {
           agentId: "e0000000-0000-4000-a000-000000000010",
           ownerId: "test-user-123",
           description: "A helpful agent",

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-display.test.tsx
@@ -11,6 +11,8 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import type { PermissionAccessRequestResponse } from "@vm0/core";
+import { setMockPermissionRequests } from "../../../mocks/handlers/api-permission-access-requests.ts";
 
 const context = testContext();
 
@@ -58,12 +60,10 @@ function mockAgent(agent: AgentResponse) {
   );
 }
 
-function mockPermissionRequests(requests: unknown[] = []) {
-  server.use(
-    http.get("*/api/zero/permission-access-requests", () => {
-      return HttpResponse.json(requests);
-    }),
-  );
+function mockPermissionRequests(
+  requests: PermissionAccessRequestResponse[] = [],
+) {
+  setMockPermissionRequests(requests);
 }
 
 function setupMemberContext(agentOverrides: Partial<AgentResponse> = {}) {

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
@@ -12,6 +12,15 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
+import {
+  type PermissionAccessRequestResponse,
+  zeroAgentPermissionPoliciesContract,
+  permissionAccessRequestsListContract,
+  permissionAccessRequestsResolveContract,
+  permissionAccessRequestsCreateContract,
+} from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import { setMockPermissionRequests } from "../../../mocks/handlers/api-permission-access-requests.ts";
 
 const context = testContext();
 
@@ -46,12 +55,10 @@ function mockAgent(overrides?: Record<string, unknown>) {
   );
 }
 
-function mockPermissionRequests(requests: unknown[] = []) {
-  server.use(
-    http.get("*/api/zero/permission-access-requests", () => {
-      return HttpResponse.json(requests);
-    }),
-  );
+function mockPermissionRequests(
+  requests: PermissionAccessRequestResponse[] = [],
+) {
+  setMockPermissionRequests(requests);
 }
 
 function setupMemberContext(agentOverrides?: Record<string, unknown>) {
@@ -81,7 +88,9 @@ function setupMemberContext(agentOverrides?: Record<string, unknown>) {
   );
 }
 
-function pendingRequest(overrides?: Record<string, unknown>) {
+function pendingRequest(
+  overrides?: Partial<PermissionAccessRequestResponse>,
+): PermissionAccessRequestResponse {
   return {
     id: REQUEST_ID,
     agentId: AGENT_ID,
@@ -109,10 +118,13 @@ describe("permission allow page - admin doctor mode", () => {
   it("fw-d-018: Confirm button saves the policy", async () => {
     let savedBody: unknown;
     server.use(
-      http.put("*/api/zero/permission-policies", async ({ request }) => {
-        savedBody = await request.json();
-        return HttpResponse.json(defaultAgentResponse());
-      }),
+      mockApi(
+        zeroAgentPermissionPoliciesContract.update,
+        ({ body, respond }) => {
+          savedBody = body;
+          return respond(200, defaultAgentResponse());
+        },
+      ),
     );
     mockAgent();
     mockPermissionRequests();
@@ -141,8 +153,9 @@ describe("permission allow page - admin doctor mode", () => {
 
   it("fw-d-019: Confirm shows result card after save", async () => {
     server.use(
-      http.put("*/api/zero/permission-policies", () => {
-        return HttpResponse.json(
+      mockApi(zeroAgentPermissionPoliciesContract.update, ({ respond }) => {
+        return respond(
+          200,
           defaultAgentResponse({
             permissionPolicies: {
               slack: { policies: { "channels:read": "deny" } },
@@ -174,8 +187,9 @@ describe("permission allow page - admin doctor mode", () => {
 
   it("fw-d-020: shows Permissions denied card for deny action", async () => {
     server.use(
-      http.put("*/api/zero/permission-policies", () => {
-        return HttpResponse.json(
+      mockApi(zeroAgentPermissionPoliciesContract.update, ({ respond }) => {
+        return respond(
+          200,
           defaultAgentResponse({
             permissionPolicies: {
               slack: { policies: { "channels:read": "deny" } },
@@ -216,21 +230,22 @@ describe("permission allow page - admin doctor mode", () => {
 
 describe("permission allow page - admin request mode", () => {
   it("fw-d-021: Approve change button approves pending request", async () => {
-    let requestStatus = "pending";
+    let requestStatus: PermissionAccessRequestResponse["status"] = "pending";
     server.use(
-      http.put("*/api/zero/permission-access-requests", () => {
-        requestStatus = "approved";
-        return HttpResponse.json({
-          ...pendingRequest(),
-          status: "approved",
-          resolvedBy: "test-user-123",
-          resolvedAt: "2026-04-03T00:00:00Z",
-        });
-      }),
-      http.get("*/api/zero/permission-access-requests", () => {
-        return HttpResponse.json([
-          { ...pendingRequest(), status: requestStatus },
-        ]);
+      mockApi(
+        permissionAccessRequestsResolveContract.resolve,
+        ({ respond }) => {
+          requestStatus = "approved";
+          return respond(200, {
+            ...pendingRequest(),
+            status: "approved",
+            resolvedBy: "test-user-123",
+            resolvedAt: "2026-04-03T00:00:00Z",
+          });
+        },
+      ),
+      mockApi(permissionAccessRequestsListContract.list, ({ respond }) => {
+        return respond(200, [{ ...pendingRequest(), status: requestStatus }]);
       }),
     );
     mockAgent();
@@ -253,21 +268,22 @@ describe("permission allow page - admin request mode", () => {
   });
 
   it("fw-d-022: Deny change button rejects pending request", async () => {
-    let requestStatus = "pending";
+    let requestStatus: PermissionAccessRequestResponse["status"] = "pending";
     server.use(
-      http.put("*/api/zero/permission-access-requests", () => {
-        requestStatus = "rejected";
-        return HttpResponse.json({
-          ...pendingRequest(),
-          status: "rejected",
-          resolvedBy: "test-user-123",
-          resolvedAt: "2026-04-03T00:00:00Z",
-        });
-      }),
-      http.get("*/api/zero/permission-access-requests", () => {
-        return HttpResponse.json([
-          { ...pendingRequest(), status: requestStatus },
-        ]);
+      mockApi(
+        permissionAccessRequestsResolveContract.resolve,
+        ({ respond }) => {
+          requestStatus = "rejected";
+          return respond(200, {
+            ...pendingRequest(),
+            status: "rejected",
+            resolvedBy: "test-user-123",
+            resolvedAt: "2026-04-03T00:00:00Z",
+          });
+        },
+      ),
+      mockApi(permissionAccessRequestsListContract.list, ({ respond }) => {
+        return respond(200, [{ ...pendingRequest(), status: requestStatus }]);
       }),
     );
     mockAgent();
@@ -318,29 +334,26 @@ describe("permission allow page - member request form", () => {
   it("fw-d-027: Request approval button sends the request", async () => {
     let requestBody: unknown;
     server.use(
-      http.post(
-        "*/api/zero/permission-access-requests",
-        async ({ request }) => {
-          requestBody = await request.json();
-          return HttpResponse.json(
-            {
-              id: "d1111111-0000-4000-a000-000000000002",
-              agentId: AGENT_ID,
-              connectorRef: "slack",
-              permission: "channels:read",
-              action: "deny",
-              method: null,
-              path: null,
-              reason: null,
-              status: "pending",
-              requesterUserId: "test-user-123",
-              requesterName: "Test User",
-              resolvedBy: null,
-              resolvedAt: null,
-              createdAt: "2026-04-03T00:00:00Z",
-            },
-            { status: 201 },
-          );
+      mockApi(
+        permissionAccessRequestsCreateContract.create,
+        ({ body, respond }) => {
+          requestBody = body;
+          return respond(201, {
+            id: "d1111111-0000-4000-a000-000000000002",
+            agentId: AGENT_ID,
+            connectorRef: "slack",
+            permission: "channels:read",
+            action: "deny",
+            method: null,
+            path: null,
+            reason: null,
+            status: "pending",
+            requesterUserId: "test-user-123",
+            requesterName: "Test User",
+            resolvedBy: null,
+            resolvedAt: null,
+            createdAt: "2026-04-03T00:00:00Z",
+          });
         },
       ),
     );
@@ -423,31 +436,28 @@ describe("permission allow page - member request form", () => {
   });
 
   it("fw-d-031: Pre-filled reason can be edited before submission", async () => {
-    let requestBody: Record<string, unknown> | undefined;
+    let requestBody: unknown;
     server.use(
-      http.post(
-        "*/api/zero/permission-access-requests",
-        async ({ request }) => {
-          requestBody = (await request.json()) as Record<string, unknown>;
-          return HttpResponse.json(
-            {
-              id: "d0000000-0000-4000-a000-000000000099",
-              agentId: AGENT_ID,
-              connectorRef: "slack",
-              permission: "channels:read",
-              action: "deny",
-              method: null,
-              path: null,
-              reason: "Edited reason",
-              status: "pending",
-              requesterUserId: "user_abc",
-              requesterName: null,
-              resolvedBy: null,
-              resolvedAt: null,
-              createdAt: "2026-04-03T00:00:00Z",
-            },
-            { status: 201 },
-          );
+      mockApi(
+        permissionAccessRequestsCreateContract.create,
+        ({ body, respond }) => {
+          requestBody = body;
+          return respond(201, {
+            id: "d0000000-0000-4000-a000-000000000099",
+            agentId: AGENT_ID,
+            connectorRef: "slack",
+            permission: "channels:read",
+            action: "deny",
+            method: null,
+            path: null,
+            reason: "Edited reason",
+            status: "pending",
+            requesterUserId: "user_abc",
+            requesterName: null,
+            resolvedBy: null,
+            resolvedAt: null,
+            createdAt: "2026-04-03T00:00:00Z",
+          });
         },
       ),
     );

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -5,18 +5,18 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import type { PermissionAccessRequestResponse } from "@vm0/core";
+import { setMockPermissionRequests } from "../../../mocks/handlers/api-permission-access-requests.ts";
 
 const context = testContext();
 
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const REQUEST_ID = "d0000000-0000-4000-a000-000000000001";
 
-function mockPermissionRequests(requests: unknown[] = []) {
-  server.use(
-    http.get("*/api/zero/permission-access-requests", () => {
-      return HttpResponse.json(requests);
-    }),
-  );
+function mockPermissionRequests(
+  requests: PermissionAccessRequestResponse[] = [],
+) {
+  setMockPermissionRequests(requests);
 }
 
 function mockMemberOrg() {
@@ -61,7 +61,9 @@ function mockAgentWithPolicy(
   );
 }
 
-function makePendingRequest(overrides?: Record<string, unknown>) {
+function makePendingRequest(
+  overrides?: Partial<PermissionAccessRequestResponse>,
+): PermissionAccessRequestResponse {
   return {
     id: REQUEST_ID,
     agentId: AGENT_ID,

--- a/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
@@ -12,19 +12,18 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
+import { setMockComposesList } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 
 function mockAPIs() {
+  setMockComposesList([]);
   server.use(
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });
     }),
     http.get("*/api/zero/team", () => {
       return HttpResponse.json([]);
-    }),
-    http.get("*/api/zero/composes/list", () => {
-      return HttpResponse.json({ composes: [] });
     }),
   );
 }

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -4,6 +4,8 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { zeroComposesMainContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -38,17 +40,22 @@ function mockAPIs() {
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });
     }),
-    http.get("*/api/zero/composes", () => {
-      return HttpResponse.json({
+    mockApi(zeroComposesMainContract.getByName, ({ respond }) => {
+      return respond(200, {
         id: "agent-2",
+        name: "research-agent",
+        headVersionId: "version_2",
         content: {
+          version: "1",
           agents: {
             "research-agent": {
               description: "Finds and summarizes information",
-              framework: null,
+              framework: "claude-code",
             },
           },
         },
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-02T00:00:00Z",
       });
     }),
     http.get("*/api/zero/agents/:name", ({ params }) => {

--- a/turbo/apps/platform/src/views/works-page/__tests__/works-page.test.tsx
+++ b/turbo/apps/platform/src/views/works-page/__tests__/works-page.test.tsx
@@ -5,18 +5,19 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { type SlackOrgStatus, zeroIntegrationsSlackContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
-function mockSlackAPI(overrides: Record<string, unknown> = {}) {
-  const defaults = {
+function mockSlackAPI(overrides: Partial<SlackOrgStatus> = {}) {
+  const defaults: SlackOrgStatus = {
     isConnected: true,
     isInstalled: true,
     workspaceName: "Test Workspace",
     isAdmin: true,
     installUrl: "/api/zero/integrations/slack/install",
     connectUrl: "/api/zero/integrations/slack/connect",
-    defaultAgentId: "zero",
     agentOrgSlug: "test-org",
     environment: {
       requiredSecrets: [],
@@ -27,8 +28,8 @@ function mockSlackAPI(overrides: Record<string, unknown> = {}) {
   };
 
   server.use(
-    http.get("*/api/zero/integrations/slack", () => {
-      return HttpResponse.json({ ...defaults, ...overrides });
+    mockApi(zeroIntegrationsSlackContract.getStatus, ({ respond }) => {
+      return respond(200, { ...defaults, ...overrides });
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });
@@ -280,13 +281,15 @@ describe("zero works page - uninstall confirmation dialog", () => {
 
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     server.use(
-      http.delete("*/api/zero/integrations/slack", ({ request }) => {
-        const url = new URL(request.url);
-        if (url.searchParams.get("action") === "uninstall") {
-          uninstallCalled = true;
-        }
-        return HttpResponse.json({ ok: true });
-      }),
+      mockApi(
+        zeroIntegrationsSlackContract.disconnect,
+        ({ query, respond }) => {
+          if (query.action === "uninstall") {
+            uninstallCalled = true;
+          }
+          return respond(200, { ok: true });
+        },
+      ),
     );
 
     await renderWorksPage();
@@ -366,13 +369,15 @@ describe("zero works page - disconnect", () => {
 
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     server.use(
-      http.delete("*/api/zero/integrations/slack", ({ request }) => {
-        const url = new URL(request.url);
-        if (!url.searchParams.get("action")) {
-          disconnectCalled = true;
-        }
-        return HttpResponse.json({ ok: true });
-      }),
+      mockApi(
+        zeroIntegrationsSlackContract.disconnect,
+        ({ query, respond }) => {
+          if (!query.action) {
+            disconnectCalled = true;
+          }
+          return respond(200, { ok: true });
+        },
+      ),
     );
 
     await renderWorksPage();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-to-activity-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-to-activity-navigation.test.tsx
@@ -9,6 +9,7 @@ import type {
   LogDetail,
   AgentEventsResponse,
 } from "../../../signals/zero-page/log-types.ts";
+import { setMockComposesList } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 
@@ -96,20 +97,18 @@ function mockActivityDetailAPIs() {
     framework: "claude-code",
   };
 
+  setMockComposesList([
+    {
+      id: "c0000000-0000-4000-a000-000000000001",
+      name: "test-agent",
+      displayName: "Test Agent",
+      description: null,
+      sound: null,
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
   server.use(
-    http.get("*/api/zero/composes/list", () => {
-      return HttpResponse.json({
-        composes: [
-          {
-            id: "c0000000-0000-4000-a000-000000000001",
-            name: "test-agent",
-            displayName: "Test Agent",
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-          },
-        ],
-      });
-    }),
     http.get("*/api/zero/logs/:id", ({ params }) => {
       if (params["id"] === "a0000000-0000-4000-a000-000000000011") {
         return HttpResponse.json(logDetail);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/connector-permission-scope.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/connector-permission-scope.test.tsx
@@ -10,12 +10,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { setScopeReviewType$ } from "../../../signals/zero-page/settings/connectors.ts";
-import type { ConnectorType } from "@vm0/core";
+import { type ConnectorType, zeroConnectorScopeDiffContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -29,8 +29,8 @@ async function openScopeReviewModal(
   },
 ) {
   server.use(
-    http.get("*/api/zero/connectors/:type/scope-diff", () => {
-      return HttpResponse.json(scopeDiff);
+    mockApi(zeroConnectorScopeDiffContract.getScopeDiff, ({ respond }) => {
+      return respond(200, scopeDiff);
     }),
   );
   detachedSetupPage({ context, path: "/connectors" });
@@ -131,7 +131,7 @@ describe("scope review modal - display", () => {
 describe("scope review modal - states", () => {
   it("loading state shows dialog without Reconnect button (CONN-S-037)", async () => {
     server.use(
-      http.get("*/api/zero/connectors/:type/scope-diff", () => {
+      mockApi(zeroConnectorScopeDiffContract.getScopeDiff, () => {
         return new Promise<never>(() => {
           // Never resolves — keeps component in loading state
         });
@@ -158,11 +158,10 @@ describe("scope review modal - states", () => {
 
   it("error state shows dialog without Reconnect button (CONN-C-038)", async () => {
     server.use(
-      http.get("*/api/zero/connectors/:type/scope-diff", () => {
-        return HttpResponse.json(
-          { message: "Internal error" },
-          { status: 500 },
-        );
+      mockApi(zeroConnectorScopeDiffContract.getScopeDiff, ({ respond }) => {
+        return respond(404, {
+          error: { message: "Internal error", code: "NOT_FOUND" },
+        });
       }),
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
@@ -6,7 +6,11 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { permissionDialogType$ } from "../../../signals/zero-page/settings/connectors.ts";
-import type { ConnectorListResponse } from "@vm0/core";
+import {
+  type ConnectorListResponse,
+  zeroConnectorsMainContract,
+} from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 vi.mock("signal-timers", async (importOriginal) => {
   const mod = await importOriginal<typeof import("signal-timers")>();
@@ -94,8 +98,8 @@ describe("onboarding connector permission dialog suppression", () => {
     // Mock the connectors API to return GitHub as connected (simulates
     // successful OAuth — the polling inside connectConnector$ will pick it up).
     server.use(
-      http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json(makeGithubConnectedResponse());
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
+        return respond(200, makeGithubConnectedResponse());
       }),
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
@@ -7,6 +7,8 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { pathname, search } from "../../../signals/location.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
+import { zeroIntegrationsSlackContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -87,8 +89,8 @@ function switchToMemberComplete() {
 
 function mockSlackInstallReady() {
   server.use(
-    http.get("*/api/zero/integrations/slack", () => {
-      return HttpResponse.json({
+    mockApi(zeroIntegrationsSlackContract.getStatus, ({ respond }) => {
+      return respond(200, {
         isConnected: false,
         isInstalled: false,
         isAdmin: true,
@@ -97,7 +99,6 @@ function mockSlackInstallReady() {
         reinstallUrl: null,
         scopeMismatch: false,
         workspaceName: null,
-        defaultAgentId: null,
         agentOrgSlug: null,
         environment: {
           requiredSecrets: [],
@@ -112,8 +113,8 @@ function mockSlackInstallReady() {
 
 function mockSlackConnectReady() {
   server.use(
-    http.get("*/api/zero/integrations/slack", () => {
-      return HttpResponse.json({
+    mockApi(zeroIntegrationsSlackContract.getStatus, ({ respond }) => {
+      return respond(200, {
         isConnected: false,
         isInstalled: true,
         isAdmin: false,
@@ -122,7 +123,6 @@ function mockSlackConnectReady() {
         reinstallUrl: null,
         scopeMismatch: false,
         workspaceName: "Acme",
-        defaultAgentId: null,
         agentOrgSlug: null,
         environment: {
           requiredSecrets: [],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/permissions-dialog.test.tsx
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { zeroAgentPermissionPoliciesContract } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -64,38 +66,27 @@ function mockAPIs({
     http.get("*/api/zero/schedules", () => {
       return HttpResponse.json({ schedules: [] });
     }),
-    http.get("*/api/zero/connectors", () => {
-      return HttpResponse.json({
-        connectors: [
-          {
-            id: "d0000001-0000-4000-a000-000000000001",
-            type: "slack",
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: "testuser",
-            externalEmail: null,
-            oauthScopes: ["chat:write", "channels:read"],
-            needsReconnect: false,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-          },
-        ],
-        configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
-        connectorProvidedSecretNames: [],
-      });
-    }),
     http.get("*/api/zero/agents/:id/user-connectors", () => {
       return HttpResponse.json({ enabledTypes: ["slack"] });
     }),
-    http.put("*/api/zero/permission-policies", async ({ request }) => {
-      const body = (await request.json()) as {
-        agentId: string;
-        policies: Record<
-          string,
-          { policies: Record<string, string>; unknownPolicy?: string }
-        >;
-      };
-      return HttpResponse.json({
+  );
+  setMockConnectors([
+    {
+      id: "d0000001-0000-4000-a000-000000000001",
+      type: "slack",
+      authMethod: "oauth",
+      externalId: null,
+      externalUsername: "testuser",
+      externalEmail: null,
+      oauthScopes: ["chat:write", "channels:read"],
+      needsReconnect: false,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+  ]);
+  server.use(
+    mockApi(zeroAgentPermissionPoliciesContract.update, ({ body, respond }) => {
+      return respond(200, {
         agentId: "e0000000-0000-4000-a000-000000000010",
         ownerId: "test-user-123",
         description: null,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-page.test.tsx
@@ -9,6 +9,7 @@ import type {
   LogEntry,
   LogsListResponse,
 } from "../../../signals/zero-page/log-types.ts";
+import { setMockComposesList } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 
@@ -78,26 +79,22 @@ describe("zeroActivityPage", () => {
   });
 
   it("should render agent filter options from availableAgentsLoadable", async () => {
+    setMockComposesList([
+      {
+        id: "agent-1",
+        name: "agent-1",
+        displayName: "My Agent",
+        description: null,
+        sound: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
     server.use(
       http.get("*/api/zero/logs", () => {
         return HttpResponse.json(
           makeLogsResponse([makeLog()], {}, { agents: ["agent-1"] }),
         );
-      }),
-      http.get("*/api/zero/composes/list", () => {
-        return HttpResponse.json({
-          composes: [
-            {
-              id: "agent-1",
-              name: "agent-1",
-              displayName: "My Agent",
-              description: null,
-              sound: null,
-              headVersionId: "version_1",
-              updatedAt: "2024-01-01T00:00:00Z",
-            },
-          ],
-        });
       }),
     );
     detachedSetupPage({ context, path: "/activities" });
@@ -226,6 +223,17 @@ describe("zeroActivityPage", () => {
 
   it("should filter log table when agent filter changes", async () => {
     const captured = { name: null as string | null };
+    setMockComposesList([
+      {
+        id: "agent-1",
+        name: "agent-1",
+        displayName: "My Agent",
+        description: null,
+        sound: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
     server.use(
       http.get("*/api/zero/logs", ({ request }) => {
         const url = new URL(request.url);
@@ -238,21 +246,6 @@ describe("zeroActivityPage", () => {
         return HttpResponse.json(
           makeLogsResponse(logs, {}, { agents: ["agent-1"] }),
         );
-      }),
-      http.get("*/api/zero/composes/list", () => {
-        return HttpResponse.json({
-          composes: [
-            {
-              id: "agent-1",
-              name: "agent-1",
-              displayName: "My Agent",
-              description: null,
-              sound: null,
-              headVersionId: "version_1",
-              updatedAt: "2024-01-01T00:00:00Z",
-            },
-          ],
-        });
       }),
     );
     detachedSetupPage({ context, path: "/activities" });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-display.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import type { ConnectorType } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
@@ -11,6 +11,7 @@ import {
   sendMessageInUI,
   PLACEHOLDER,
 } from "./chat-test-helpers.ts";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 
 const context = testContext();
 
@@ -22,27 +23,21 @@ function mockChatAPI() {
   );
 }
 
-function mockConnectedConnectors(types: string[]) {
-  server.use(
-    http.get("*/api/zero/connectors", () => {
-      return HttpResponse.json({
-        connectors: types.map((type, i) => {
-          return {
-            id: `d000000${i}-0000-4000-a000-000000000001`,
-            type,
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: `user-${type}`,
-            externalEmail: null,
-            oauthScopes: [],
-            needsReconnect: false,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-          };
-        }),
-        configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
-        connectorProvidedSecretNames: [],
-      });
+function mockConnectedConnectors(types: ConnectorType[]) {
+  setMockConnectors(
+    types.map((type, i) => {
+      return {
+        id: `d000000${i}-0000-4000-a000-000000000001`,
+        type,
+        authMethod: "oauth",
+        externalId: null,
+        externalUsername: `user-${type}`,
+        externalEmail: null,
+        oauthScopes: [],
+        needsReconnect: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      };
     }),
   );
 }
@@ -200,15 +195,7 @@ describe("chat-d-020: connectors popover after load", () => {
   it("should render the Add connectors button in the popover after connectors load", async () => {
     const user = userEvent.setup();
     mockChatAPI();
-    server.use(
-      http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json({
-          connectors: [],
-          configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
-          connectorProvidedSecretNames: [],
-        });
-      }),
-    );
+    setMockConnectors([]);
 
     detachedSetupPage({ context, path: "/" });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { zeroConnectorsMainContract } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
@@ -11,6 +11,8 @@ import {
   sendMessageInUI,
   PLACEHOLDER,
 } from "./chat-test-helpers.ts";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -18,39 +20,33 @@ const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const CHAT_PATH = `/agents/${AGENT_ID}/chat`;
 
 function mockConnectors() {
+  setMockConnectors([
+    {
+      id: "d0000001-0000-4000-a000-000000000001",
+      type: "github",
+      authMethod: "oauth",
+      externalId: null,
+      externalUsername: "testuser",
+      externalEmail: null,
+      oauthScopes: ["repo"],
+      needsReconnect: false,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "d0000002-0000-4000-a000-000000000002",
+      type: "linear",
+      authMethod: "oauth",
+      externalId: null,
+      externalUsername: "linearuser",
+      externalEmail: null,
+      oauthScopes: [],
+      needsReconnect: false,
+      createdAt: "2026-01-02T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+    },
+  ]);
   server.use(
-    http.get("*/api/zero/connectors", () => {
-      return HttpResponse.json({
-        connectors: [
-          {
-            id: "d0000001-0000-4000-a000-000000000001",
-            type: "github",
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: "testuser",
-            externalEmail: null,
-            oauthScopes: ["repo"],
-            needsReconnect: false,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-          },
-          {
-            id: "d0000002-0000-4000-a000-000000000002",
-            type: "linear",
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: "linearuser",
-            externalEmail: null,
-            oauthScopes: [],
-            needsReconnect: false,
-            createdAt: "2026-01-02T00:00:00Z",
-            updatedAt: "2026-01-02T00:00:00Z",
-          },
-        ],
-        configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
-        connectorProvidedSecretNames: [],
-      });
-    }),
     http.get(`*/api/zero/agents/${AGENT_ID}/user-connectors`, () => {
       return HttpResponse.json({ enabledTypes: ["github"] });
     }),
@@ -143,8 +139,8 @@ describe("zero chat composer - connectors popover", () => {
     // Stateful connector: starts with GitHub enabled; after PUT, GET returns empty
     let githubEnabled = true;
     server.use(
-      http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json({
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
+        return respond(200, {
           connectors: [
             {
               id: "d0000001-0000-4000-a000-000000000001",
@@ -159,7 +155,7 @@ describe("zero chat composer - connectors popover", () => {
               updatedAt: "2026-01-01T00:00:00Z",
             },
           ],
-          configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+          configuredTypes: [],
           connectorProvidedSecretNames: [],
         });
       }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -6,6 +6,7 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { getCategories } from "../zero-ideation-data.ts";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 
 const context = testContext();
 
@@ -272,39 +273,33 @@ describe("zero chat page - connectors popover", () => {
 
   it("should sort connected connectors by added status in popover", async () => {
     // Set up: axiom and github are org-connected, only axiom is added to agent
+    setMockConnectors([
+      {
+        id: crypto.randomUUID(),
+        type: "axiom",
+        authMethod: "api-token",
+        externalId: null,
+        externalUsername: null,
+        externalEmail: null,
+        oauthScopes: null,
+        needsReconnect: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: crypto.randomUUID(),
+        type: "github",
+        authMethod: "oauth",
+        externalId: null,
+        externalUsername: null,
+        externalEmail: null,
+        oauthScopes: ["repo"],
+        needsReconnect: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    ]);
     server.use(
-      http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json({
-          connectors: [
-            {
-              id: crypto.randomUUID(),
-              type: "axiom",
-              authMethod: "api-token",
-              externalId: null,
-              externalUsername: null,
-              externalEmail: null,
-              oauthScopes: null,
-              needsReconnect: false,
-              createdAt: "2026-01-01T00:00:00Z",
-              updatedAt: "2026-01-01T00:00:00Z",
-            },
-            {
-              id: crypto.randomUUID(),
-              type: "github",
-              authMethod: "oauth",
-              externalId: null,
-              externalUsername: null,
-              externalEmail: null,
-              oauthScopes: ["repo"],
-              needsReconnect: false,
-              createdAt: "2026-01-01T00:00:00Z",
-              updatedAt: "2026-01-01T00:00:00Z",
-            },
-          ],
-          configuredTypes: ["axiom", "github"],
-          connectorProvidedSecretNames: [],
-        });
-      }),
       http.get(
         "*/api/zero/agents/c0000000-0000-4000-a000-000000000001/user-connectors",
         () => {
@@ -365,28 +360,22 @@ describe("zero chat page - connector label casing", () => {
           return HttpResponse.json({ enabledTypes: ["axiom"] });
         },
       ),
-      // Axiom must be connected at org level for it to appear in the popover
-      http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json({
-          connectors: [
-            {
-              id: crypto.randomUUID(),
-              authMethod: "api-token",
-              externalId: null,
-              externalUsername: null,
-              externalEmail: null,
-              oauthScopes: null,
-              needsReconnect: false,
-              createdAt: "2026-01-01T00:00:00Z",
-              updatedAt: "2026-01-01T00:00:00Z",
-              type: "axiom",
-            },
-          ],
-          configuredTypes: ["axiom"],
-          connectorProvidedSecretNames: [],
-        });
-      }),
     );
+    // Axiom must be connected at org level for it to appear in the popover
+    setMockConnectors([
+      {
+        id: crypto.randomUUID(),
+        authMethod: "api-token",
+        externalId: null,
+        externalUsername: null,
+        externalEmail: null,
+        oauthScopes: null,
+        needsReconnect: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+        type: "axiom",
+      },
+    ]);
     mockChatAPI();
     detachedSetupPage({ context, path: "/" });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
@@ -4,11 +4,8 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorResponse,
-  type ConnectorType,
-} from "@vm0/core";
+import type { ConnectorResponse, ConnectorType } from "@vm0/core";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 
 const context = testContext();
 
@@ -46,15 +43,7 @@ function makeConnector(
 }
 
 function mockConnectors(connectors: ConnectorResponse[]) {
-  server.use(
-    http.get("*/api/zero/connectors", () => {
-      return HttpResponse.json({
-        connectors,
-        configuredTypes: Object.keys(CONNECTOR_TYPES),
-        connectorProvidedSecretNames: [],
-      });
-    }),
-  );
+  setMockConnectors(connectors);
 }
 
 /**

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
@@ -10,11 +10,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { mockConnectors } from "./zero-connectors-page-test-helpers.ts";
+import { zeroConnectorsMainContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -70,7 +71,7 @@ describe("connectors page - connector status indicators", () => {
     // in flight and "Connecting…" remains visible. The never-resolving promise
     // is cancelled by the abort signal via fetchOptions.signal in setLoop.
     server.use(
-      http.get("*/api/zero/connectors", () => {
+      mockApi(zeroConnectorsMainContract.list, () => {
         return new Promise<never>(() => {});
       }),
     );
@@ -136,7 +137,7 @@ describe("connectors page - connector status indicators", () => {
 describe("connectors page - loading state", () => {
   it("loading skeleton shown while connectors load (CONN-D-007)", async () => {
     server.use(
-      http.get("*/api/zero/connectors", () => {
+      mockApi(zeroConnectorsMainContract.list, () => {
         return new Promise<never>(() => {
           // Never resolves — keeps component in loading state
         });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-interaction.test.tsx
@@ -11,11 +11,12 @@
 import { expect, test } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { mockConnectors } from "./zero-connectors-page-test-helpers.ts";
+import { zeroConnectorScopeDiffContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -78,8 +79,8 @@ test("review button opens scope diff with added permissions (CONN-I-013)", async
   mockConnectors([{ type: "github", oauthScopes: [] }]);
 
   server.use(
-    http.get("*/api/zero/connectors/:type/scope-diff", () => {
-      return HttpResponse.json({
+    mockApi(zeroConnectorScopeDiffContract.getScopeDiff, ({ respond }) => {
+      return respond(200, {
         addedScopes: ["repo", "project"],
         removedScopes: [],
         currentScopes: [],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-test-helpers.ts
@@ -1,6 +1,5 @@
-import { http, HttpResponse } from "msw";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
-import { server } from "../../../mocks/server.ts";
+import type { ConnectorType } from "@vm0/core";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 
 export function mockConnectors(
   connectors: {
@@ -10,26 +9,20 @@ export function mockConnectors(
     oauthScopes?: string[];
   }[],
 ) {
-  server.use(
-    http.get("*/api/zero/connectors", () => {
-      return HttpResponse.json({
-        connectors: connectors.map((c) => {
-          return {
-            id: crypto.randomUUID(),
-            type: c.type,
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: c.externalUsername ?? null,
-            externalEmail: null,
-            oauthScopes: c.oauthScopes ?? null,
-            needsReconnect: c.needsReconnect ?? false,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-          };
-        }),
-        configuredTypes: Object.keys(CONNECTOR_TYPES),
-        connectorProvidedSecretNames: [],
-      });
+  setMockConnectors(
+    connectors.map((c) => {
+      return {
+        id: crypto.randomUUID(),
+        type: c.type,
+        authMethod: "oauth",
+        externalId: null,
+        externalUsername: c.externalUsername ?? null,
+        externalEmail: null,
+        oauthScopes: c.oauthScopes ?? null,
+        needsReconnect: c.needsReconnect ?? false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      };
     }),
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -10,11 +10,12 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { mockConnectors } from "./zero-connectors-page-test-helpers.ts";
+import { zeroConnectorsByTypeContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -99,9 +100,9 @@ describe("connectors page", () => {
     });
 
     server.use(
-      http.delete("*/api/zero/connectors/:type", async () => {
+      mockApi(zeroConnectorsByTypeContract.delete, async ({ respond }) => {
         await deletePromise;
-        return new HttpResponse(null, { status: 204 });
+        return respond(204);
       }),
     );
 
@@ -140,8 +141,10 @@ describe("connectors page", () => {
     mockConnectors([{ type: "github", externalUsername: "testuser" }]);
 
     server.use(
-      http.delete("*/api/zero/connectors/:type", () => {
-        return new HttpResponse(null, { status: 500 });
+      mockApi(zeroConnectorsByTypeContract.delete, ({ respond }) => {
+        return respond(404, {
+          error: { message: "Failed to disconnect", code: "NOT_FOUND" },
+        });
       }),
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -13,7 +13,8 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import { CONNECTOR_TYPES } from "@vm0/core";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 
 const context = testContext();
 
@@ -37,29 +38,21 @@ function mockAgentWithName(agentId: string, displayName: string) {
   );
 }
 
-function mockConnectorsConnected(type: string) {
-  server.use(
-    http.get("*/api/zero/connectors", () => {
-      return HttpResponse.json({
-        connectors: [
-          {
-            id: crypto.randomUUID(),
-            type,
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: null,
-            externalEmail: null,
-            oauthScopes: null,
-            needsReconnect: false,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-          },
-        ],
-        configuredTypes: Object.keys(CONNECTOR_TYPES),
-        connectorProvidedSecretNames: [],
-      });
-    }),
-  );
+function mockConnectorsConnected(type: ConnectorType) {
+  setMockConnectors([
+    {
+      id: crypto.randomUUID(),
+      type,
+      authMethod: "oauth",
+      externalId: null,
+      externalUsername: null,
+      externalEmail: null,
+      oauthScopes: null,
+      needsReconnect: false,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+  ]);
 }
 
 describe("directed authorize page", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -14,32 +14,27 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 
 const context = testContext();
 
 function mockConnectors(
   connectors: { type: ConnectorType; externalUsername?: string }[],
 ) {
-  server.use(
-    http.get("*/api/zero/connectors", () => {
-      return HttpResponse.json({
-        connectors: connectors.map((c) => {
-          return {
-            id: crypto.randomUUID(),
-            type: c.type,
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: c.externalUsername ?? null,
-            externalEmail: null,
-            oauthScopes: null,
-            needsReconnect: false,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-          };
-        }),
-        configuredTypes: Object.keys(CONNECTOR_TYPES),
-        connectorProvidedSecretNames: [],
-      });
+  setMockConnectors(
+    connectors.map((c) => {
+      return {
+        id: crypto.randomUUID(),
+        type: c.type,
+        authMethod: "oauth",
+        externalId: null,
+        externalUsername: c.externalUsername ?? null,
+        externalEmail: null,
+        oauthScopes: null,
+        needsReconnect: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      };
     }),
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -7,6 +7,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { getCategories } from "../zero-ideation-data.ts";
 import { pathname } from "../../../signals/location.ts";
+import { setMockComposesList } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 
@@ -309,22 +310,18 @@ describe("ideation page - navigation", () => {
   it("should preserve agent ID from URL across navigation", async () => {
     const customAgentId = "custom-agent-42";
     mockChatAPI();
+    setMockComposesList([
+      {
+        id: customAgentId,
+        name: "custom-agent",
+        displayName: "Custom Agent",
+        description: null,
+        sound: null,
+        headVersionId: "v1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
     server.use(
-      http.get("*/api/zero/composes/list", () => {
-        return HttpResponse.json({
-          composes: [
-            {
-              id: customAgentId,
-              displayName: "Custom Agent",
-              description: null,
-              sound: null,
-              avatarUrl: null,
-              headVersionId: "v1",
-              updatedAt: "2024-01-01T00:00:00Z",
-            },
-          ],
-        });
-      }),
       http.get("*/api/zero/team", () => {
         return HttpResponse.json([
           {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 
 const context = testContext();
 
@@ -62,39 +62,33 @@ function mockAPIs() {
 
 function mockAPIsWithConnectors() {
   mockAPIs();
+  setMockConnectors([
+    {
+      id: "d0000001-0000-4000-a000-000000000001",
+      type: "slack",
+      authMethod: "oauth",
+      externalId: null,
+      externalUsername: "testuser",
+      externalEmail: null,
+      oauthScopes: ["channels:read", "chat:write"],
+      needsReconnect: false,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "d0000002-0000-4000-a000-000000000002",
+      type: "linear",
+      authMethod: "oauth",
+      externalId: null,
+      externalUsername: "linearuser",
+      externalEmail: null,
+      oauthScopes: [],
+      needsReconnect: false,
+      createdAt: "2026-01-02T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+    },
+  ]);
   server.use(
-    http.get("*/api/zero/connectors", () => {
-      return HttpResponse.json({
-        connectors: [
-          {
-            id: "d0000001-0000-4000-a000-000000000001",
-            type: "slack",
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: "testuser",
-            externalEmail: null,
-            oauthScopes: ["channels:read", "chat:write"],
-            needsReconnect: false,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-          },
-          {
-            id: "d0000002-0000-4000-a000-000000000002",
-            type: "linear",
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: "linearuser",
-            externalEmail: null,
-            oauthScopes: [],
-            needsReconnect: false,
-            createdAt: "2026-01-02T00:00:00Z",
-            updatedAt: "2026-01-02T00:00:00Z",
-          },
-        ],
-        configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
-        connectorProvidedSecretNames: [],
-      });
-    }),
     http.get("*/api/zero/agents/:id/user-connectors", () => {
       return HttpResponse.json({ enabledTypes: ["slack"] });
     }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
@@ -2,15 +2,41 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 
 const context = testContext();
 
 function mockAPIs() {
+  setMockConnectors([
+    {
+      id: "d0000001-0000-4000-a000-000000000001",
+      type: "slack",
+      authMethod: "oauth",
+      externalId: null,
+      externalUsername: "testuser",
+      externalEmail: null,
+      oauthScopes: ["channels:read", "chat:write"],
+      needsReconnect: false,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "d0000002-0000-4000-a000-000000000002",
+      type: "linear",
+      authMethod: "oauth",
+      externalId: null,
+      externalUsername: "linearuser",
+      externalEmail: null,
+      oauthScopes: [],
+      needsReconnect: false,
+      createdAt: "2026-01-02T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+    },
+  ]);
   server.use(
     http.get("*/api/zero/team", () => {
       return HttpResponse.json([
@@ -57,38 +83,6 @@ function mockAPIs() {
     }),
     http.get("*/api/zero/schedules", () => {
       return HttpResponse.json({ schedules: [] });
-    }),
-    http.get("*/api/zero/connectors", () => {
-      return HttpResponse.json({
-        connectors: [
-          {
-            id: "d0000001-0000-4000-a000-000000000001",
-            type: "slack",
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: "testuser",
-            externalEmail: null,
-            oauthScopes: ["channels:read", "chat:write"],
-            needsReconnect: false,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-          },
-          {
-            id: "d0000002-0000-4000-a000-000000000002",
-            type: "linear",
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: "linearuser",
-            externalEmail: null,
-            oauthScopes: [],
-            needsReconnect: false,
-            createdAt: "2026-01-02T00:00:00Z",
-            updatedAt: "2026-01-02T00:00:00Z",
-          },
-        ],
-        configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
-        connectorProvidedSecretNames: [],
-      });
     }),
     http.get("*/api/zero/agents/:id/user-connectors", () => {
       return HttpResponse.json({ enabledTypes: ["slack"] });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
@@ -16,6 +16,8 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
+import { zeroIntegrationsSlackContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
@@ -339,8 +341,8 @@ describe("zero sidebar - pinned agents display (SIDEBAR-D-008)", () => {
 describe("zero sidebar - Slack scope mismatch indicator (SIDEBAR-D-009)", () => {
   it("shows the Where Zero works link when Slack scope mismatch is true", async () => {
     server.use(
-      http.get("*/api/zero/integrations/slack", () => {
-        return HttpResponse.json({
+      mockApi(zeroIntegrationsSlackContract.getStatus, ({ respond }) => {
+        return respond(200, {
           isConnected: true,
           isInstalled: true,
           isAdmin: true,
@@ -349,7 +351,6 @@ describe("zero sidebar - Slack scope mismatch indicator (SIDEBAR-D-009)", () => 
           installUrl: null,
           connectUrl: null,
           reinstallUrl: null,
-          defaultAgentId: null,
           agentOrgSlug: null,
           environment: {
             requiredSecrets: [],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -11,10 +11,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { type SlackOrgStatus, zeroIntegrationsSlackContract } from "@vm0/core";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 
@@ -22,8 +23,8 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-function mockSlackAPI(overrides: Record<string, unknown> = {}) {
-  const defaults = {
+function mockSlackAPI(overrides: Partial<SlackOrgStatus> = {}) {
+  const defaults: SlackOrgStatus = {
     isConnected: false,
     isInstalled: false,
     isAdmin: false,
@@ -32,7 +33,6 @@ function mockSlackAPI(overrides: Record<string, unknown> = {}) {
     reinstallUrl: null,
     scopeMismatch: false,
     workspaceName: null,
-    defaultAgentId: null,
     agentOrgSlug: null,
     environment: {
       requiredSecrets: [],
@@ -42,8 +42,8 @@ function mockSlackAPI(overrides: Record<string, unknown> = {}) {
     },
   };
   server.use(
-    http.get("*/api/zero/integrations/slack", () => {
-      return HttpResponse.json({ ...defaults, ...overrides });
+    mockApi(zeroIntegrationsSlackContract.getStatus, ({ respond }) => {
+      return respond(200, { ...defaults, ...overrides });
     }),
   );
 }
@@ -194,13 +194,15 @@ describe("works page - more options dropdown", () => {
 
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     server.use(
-      http.delete("*/api/zero/integrations/slack", ({ request }) => {
-        const url = new URL(request.url);
-        if (!url.searchParams.get("action")) {
-          disconnectCalled = true;
-        }
-        return HttpResponse.json({ ok: true });
-      }),
+      mockApi(
+        zeroIntegrationsSlackContract.disconnect,
+        ({ query, respond }) => {
+          if (!query.action) {
+            disconnectCalled = true;
+          }
+          return respond(200, { ok: true });
+        },
+      ),
     );
 
     await renderWorksPage();
@@ -229,10 +231,10 @@ describe("works page - disconnect loading state", () => {
 
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     server.use(
-      http.delete("*/api/zero/integrations/slack", () => {
-        return new Promise<Response>((resolve) => {
+      mockApi(zeroIntegrationsSlackContract.disconnect, ({ respond }) => {
+        return new Promise<ReturnType<typeof respond>>((resolve) => {
           resolveDisconnect = () => {
-            return resolve(HttpResponse.json({ ok: true }));
+            resolve(respond(200, { ok: true }));
           };
         });
       }),
@@ -270,10 +272,10 @@ describe("works page - uninstall loading state", () => {
 
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     server.use(
-      http.delete("*/api/zero/integrations/slack", () => {
-        return new Promise<Response>((resolve) => {
+      mockApi(zeroIntegrationsSlackContract.disconnect, ({ respond }) => {
+        return new Promise<ReturnType<typeof respond>>((resolve) => {
           resolveUninstall = () => {
-            return resolve(HttpResponse.json({ ok: true }));
+            resolve(respond(200, { ok: true }));
           };
         });
       }),


### PR DESCRIPTION
## Summary

Closes #10087

Migrates all remaining raw `http.*` overrides for connectors, integrations/slack, permission-access-requests, permission-policies, and composes in platform test files to the contract-driven `mockApi()` helper and typed `setMock*()` helpers.

### Infrastructure changes

- **`api-connectors.ts`**: Added `setMockConnectors()` export and scope-diff default handler (`zeroConnectorScopeDiffContract.getScopeDiff`)
- **`api-permission-access-requests.ts`** (new): Default handler for `GET /api/zero/permission-access-requests` + `setMockPermissionRequests()` + `resetMockPermissionRequests()`
- **`api-permission-policies.ts`** (new): Default handler for `PUT /api/zero/permission-policies` returning typed agent response
- **`api-agents.ts`**: Added `setMockComposesList()` and `resetMockComposesList()` for compose list overrides
- **`index.ts`**: Registered all new handlers and reset functions in `resetAllMockHandlers()`

### Test file migrations (~45 files)

- **Connector list**: `zero-connectors-page-test-helpers.ts`, `zero-connector-card`, `zero-directed-connect-page`, `zero-directed-authorize-page`, `permissions-dialog` (fw + zero-page), `zero-connectors`, `connect-connector`, `add-connection-dialog`, `zero-chat-page`, `zero-chat-composer-*`, `zero-job-detail-page-*`, `onboarding-connect-permission`
- **Connector delete/scope-diff**: `zero-connectors-page`, `zero-connectors-page-interaction`, `connector-permission-scope`
- **Slack integrations**: `poll-slack-connection`, `zero-slack-connect`, `zero-works-page`, `works-page`, `zero-sidebar-display`, `onboarding-continue-web`
- **Permission access requests**: `permission-allow-page`, `permission-allow-page-display`, `permission-allow-page-interaction`
- **Permission policies**: `permissions.test.ts`, `permission-allow-page-interaction`, `fw/permissions-dialog`, `zero-page/permissions-dialog`
- **Composes list/main**: `activity-detail-stale`, `activity-detail-polling`, `activity-page-error`, `activity-page-routing`, `activity-navigation`, `activity-paged-events`, `link-navigation`, `chat-to-activity-navigation`, `zero-ideation-page`, `zero-activity-page`, `team-navigation`

## Test plan

- [x] `pnpm -F @vm0/app check-types` — clean (pre-existing generated-file errors excluded)
- [x] `pnpm -F @vm0/app lint` — clean (pre-existing `tsgolint` failure excluded)
- [x] knip — no unused exports
- [ ] `pnpm -F @vm0/app exec vitest run` — pre-existing infrastructure failure (missing `.generated` firewall files) affects all 212 test files on both main and this branch; not caused by these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)