### PR TITLE
fix(chat): anchor initial thread load at the latest messages

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -121,7 +121,7 @@ export const apiAgentsHandlers = [
 
   // GET /api/zero/chat-threads/:threadId/messages (paged messages)
   mockApi(chatThreadMessagesContract.list, ({ respond }) => {
-    return respond(200, { messages: [], hasMore: false });
+    return respond(200, { messages: [] });
   }),
 
   // GET /api/zero/chat-threads/:id (thread detail)

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
@@ -22,7 +22,7 @@ function setupBaseHandlers(threadId: string) {
       return HttpResponse.json({ threads: [] });
     }),
     http.get(`*/api/zero/chat-threads/${threadId}/messages`, () => {
-      return HttpResponse.json({ messages: [], hasMore: false });
+      return HttpResponse.json({ messages: [] });
     }),
     http.get(`*/api/zero/chat-threads/${threadId}`, () => {
       return HttpResponse.json({

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -25,7 +25,7 @@ describe("chat-d-064: markdown content renders from props", () => {
         ({ request }) => {
           const url = new URL(request.url);
           if (url.searchParams.get("sinceId")) {
-            return HttpResponse.json({ messages: [], hasMore: false });
+            return HttpResponse.json({ messages: [] });
           }
           return HttpResponse.json({
             messages: [
@@ -36,7 +36,6 @@ describe("chat-d-064: markdown content renders from props", () => {
                 createdAt: "2026-01-01T00:00:00Z",
               },
             ],
-            hasMore: false,
           });
         },
       ),
@@ -76,7 +75,7 @@ describe("chat-d-065: theme signal applied to markdown rendering", () => {
         ({ request }) => {
           const url = new URL(request.url);
           if (url.searchParams.get("sinceId")) {
-            return HttpResponse.json({ messages: [], hasMore: false });
+            return HttpResponse.json({ messages: [] });
           }
           return HttpResponse.json({
             messages: [
@@ -87,7 +86,6 @@ describe("chat-d-065: theme signal applied to markdown rendering", () => {
                 createdAt: "2026-01-01T00:00:00Z",
               },
             ],
-            hasMore: false,
           });
         },
       ),
@@ -141,7 +139,7 @@ describe("chat-d-066: markdown links open in new tab", () => {
         ({ request }) => {
           const url = new URL(request.url);
           if (url.searchParams.get("sinceId")) {
-            return HttpResponse.json({ messages: [], hasMore: false });
+            return HttpResponse.json({ messages: [] });
           }
           return HttpResponse.json({
             messages: [
@@ -152,7 +150,6 @@ describe("chat-d-066: markdown links open in new tab", () => {
                 createdAt: "2026-01-01T00:00:00Z",
               },
             ],
-            hasMore: false,
           });
         },
       ),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
@@ -14,7 +14,7 @@ const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 function mockEmptyMessages(threadId: string) {
   server.use(
     http.get(`*/api/zero/chat-threads/${threadId}/messages`, () => {
-      return HttpResponse.json({ messages: [], hasMore: false });
+      return HttpResponse.json({ messages: [] });
     }),
     http.get(`*/api/zero/chat-threads/${threadId}`, () => {
       return HttpResponse.json({
@@ -167,7 +167,7 @@ describe("chat page keyboard shortcuts", () => {
         ({ request }) => {
           const url = new URL(request.url);
           if (url.searchParams.get("sinceId")) {
-            return HttpResponse.json({ messages: [], hasMore: false });
+            return HttpResponse.json({ messages: [] });
           }
           return HttpResponse.json({
             messages: [
@@ -178,7 +178,6 @@ describe("chat page keyboard shortcuts", () => {
                 createdAt: "2026-03-10T00:00:00Z",
               },
             ],
-            hasMore: false,
           });
         },
       ),
@@ -232,7 +231,7 @@ describe("chat page keyboard shortcuts", () => {
         ({ request }) => {
           const url = new URL(request.url);
           if (url.searchParams.get("sinceId")) {
-            return HttpResponse.json({ messages: [], hasMore: false });
+            return HttpResponse.json({ messages: [] });
           }
           return HttpResponse.json({
             messages: [
@@ -243,7 +242,6 @@ describe("chat page keyboard shortcuts", () => {
                 createdAt: "2026-03-10T00:00:00Z",
               },
             ],
-            hasMore: false,
           });
         },
       ),

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
@@ -101,7 +101,6 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
 
     expect(response.status).toBe(200);
     expect(data.messages).toEqual([]);
-    expect(data.hasMore).toBe(false);
   });
 
   it("should return messages in ascending createdAt order", async () => {
@@ -140,7 +139,6 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     expect(data.messages[0].content).toBe("Hello");
     expect(data.messages[1].role).toBe("assistant");
     expect(data.messages[1].content).toBe("Hi there");
-    expect(data.hasMore).toBe(false);
     // Verify createdAt is a valid ISO 8601 string
     expect(new Date(data.messages[0].createdAt).toISOString()).toBe(
       data.messages[0].createdAt,
@@ -188,10 +186,9 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     expect(data.messages).toHaveLength(2);
     expect(data.messages[0].content).toBe("Second");
     expect(data.messages[1].content).toBe("Third");
-    expect(data.hasMore).toBe(false);
   });
 
-  it("should set hasMore=true when more messages exist beyond the limit", async () => {
+  it("should return the latest N messages (still ASC) when no cursor is provided and total exceeds the limit", async () => {
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {
         method: "POST",
@@ -230,7 +227,8 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
 
     expect(response.status).toBe(200);
     expect(data.messages).toHaveLength(2);
-    expect(data.hasMore).toBe(true);
+    expect(data.messages[0].content).toBe("B");
+    expect(data.messages[1].content).toBe("C");
   });
 
   it("should return only user message when run has no assistant events", async () => {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
@@ -30,7 +30,7 @@ const router = tsr.router(chatThreadMessagesContract, {
       // Ownership check — throws notFound if user doesn't own the thread
       await getChatThread(params.threadId, userId);
 
-      const { messages: rows, hasMore } = await getMessagesSince(
+      const rows = await getMessagesSince(
         params.threadId,
         query.sinceId,
         query.limit,
@@ -57,7 +57,7 @@ const router = tsr.router(chatThreadMessagesContract, {
 
       return {
         status: 200 as const,
-        body: { messages, hasMore },
+        body: { messages },
       };
     } catch (error) {
       if (isNotFound(error)) {

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
@@ -197,22 +197,21 @@ export async function getMessagesByThreadId(chatThreadId: string): Promise<
 }
 
 /**
- * Get messages for a thread after a given cursor message, ordered by
- * (created_at ASC, sequence_number ASC).
+ * Fetch chat messages for a thread, rendered in natural chronological order
+ * (createdAt ASC, sequenceNumber ASC).
  *
- * Cursor-based paginated query for chat messages.
- * Returns messages after the given sinceId in natural order
- * (createdAt ASC, sequenceNumber ASC). When sinceId is undefined,
- * returns from the beginning of the thread.
- *
- * Fetches limit+1 rows to determine hasMore without an extra COUNT query.
+ * - When `sinceId` is provided: returns up to `limit` messages strictly after
+ *   the cursor, forward-paginating through the thread.
+ * - When `sinceId` is omitted: returns the *latest* `limit` messages,
+ *   re-sorted ASC for rendering. This anchors the initial view at the most
+ *   recent activity rather than the thread's beginning.
  */
 export async function getMessagesSince(
   chatThreadId: string,
   sinceId: string | undefined,
   limit: number,
-): Promise<{
-  messages: Array<{
+): Promise<
+  Array<{
     id: string;
     role: string;
     content: string | null;
@@ -222,50 +221,49 @@ export async function getMessagesSince(
     createdAt: Date;
     runStatus: string | null;
     runError: string | null;
-  }>;
-  hasMore: boolean;
-}> {
+  }>
+> {
   const db = globalThis.services.db;
 
-  let cursorCondition;
-  if (sinceId) {
-    cursorCondition = sql`(
-      ${chatMessages.createdAt},
-      COALESCE(${chatMessages.sequenceNumber}, -1)
-    ) > (
-      SELECT ${chatMessages.createdAt}, COALESCE(${chatMessages.sequenceNumber}, -1)
-      FROM ${chatMessages}
-      WHERE ${chatMessages.id} = ${sinceId}
-    )`;
+  const columns = {
+    id: chatMessages.id,
+    role: chatMessages.role,
+    content: chatMessages.content,
+    runId: chatMessages.runId,
+    error: chatMessages.error,
+    sequenceNumber: chatMessages.sequenceNumber,
+    createdAt: chatMessages.createdAt,
+    runStatus: agentRuns.status,
+    runError: agentRuns.error,
+  };
+
+  if (sinceId === undefined) {
+    const rows = await db
+      .select(columns)
+      .from(chatMessages)
+      .leftJoin(agentRuns, eq(chatMessages.runId, agentRuns.id))
+      .where(eq(chatMessages.chatThreadId, chatThreadId))
+      .orderBy(desc(chatMessages.createdAt), desc(chatMessages.sequenceNumber))
+      .limit(limit);
+    return rows.reverse();
   }
 
-  const conditions = [eq(chatMessages.chatThreadId, chatThreadId)];
-  if (cursorCondition) {
-    conditions.push(cursorCondition);
-  }
+  const cursorCondition = sql`(
+    ${chatMessages.createdAt},
+    COALESCE(${chatMessages.sequenceNumber}, -1)
+  ) > (
+    SELECT ${chatMessages.createdAt}, COALESCE(${chatMessages.sequenceNumber}, -1)
+    FROM ${chatMessages}
+    WHERE ${chatMessages.id} = ${sinceId}
+  )`;
 
-  const rows = await db
-    .select({
-      id: chatMessages.id,
-      role: chatMessages.role,
-      content: chatMessages.content,
-      runId: chatMessages.runId,
-      error: chatMessages.error,
-      sequenceNumber: chatMessages.sequenceNumber,
-      createdAt: chatMessages.createdAt,
-      runStatus: agentRuns.status,
-      runError: agentRuns.error,
-    })
+  return db
+    .select(columns)
     .from(chatMessages)
     .leftJoin(agentRuns, eq(chatMessages.runId, agentRuns.id))
-    .where(and(...conditions))
+    .where(and(eq(chatMessages.chatThreadId, chatThreadId), cursorCondition))
     .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber))
-    .limit(limit + 1);
-
-  const hasMore = rows.length > limit;
-  const messages = hasMore ? rows.slice(0, limit) : rows;
-
-  return { messages, hasMore };
+    .limit(limit);
 }
 
 /**

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -275,7 +275,6 @@ export const chatThreadMessagesContract = c.router({
     responses: {
       200: z.object({
         messages: z.array(pagedChatMessageSchema),
-        hasMore: z.boolean(),
       }),
       401: apiErrorSchema,
       404: apiErrorSchema,


### PR DESCRIPTION
## Summary

- When a chat thread has more than 50 messages, opening it now lands on the newest 50 instead of the oldest 50.
- `getMessagesSince` returns the latest `limit` rows (re-sorted ASC for rendering) when `sinceId` is absent; cursor-based forward pagination is unchanged.
- Drop the unused `hasMore` field from the `/api/zero/chat-threads/:threadId/messages` contract — the server returned it but no frontend code consumed it (only test mocks).

Realtime catch-up still only drains one page per Ably event; that secondary issue is tracked separately in #10093.

## Test plan

- [x] `pnpm turbo run lint`
- [x] `pnpm check-types`
- [x] `pnpm format`
- [x] `pnpm -F @vm0/core exec vitest run`
- [x] `pnpm -F @vm0/app exec vitest run`
- [x] `pnpm -F web exec vitest run app/api/zero/chat-threads`
- [x] `pnpm knip`
- [ ] Manual: open a chat thread with more than 50 messages in the web app and confirm the view lands on the latest message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)