### PR TITLE
fix(firewall): allow api entries with empty permissions

### DIFF
--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -5,7 +5,12 @@ import {
   hasBaseUrlVars,
   resolveFirewallBaseUrlVars,
 } from "../firewalls";
-import { resolveFirewallSelections, validateRule } from "../firewall-expander";
+import {
+  collectAndValidatePermissions,
+  resolveFirewallSelections,
+  validateRule,
+} from "../firewall-expander";
+import type { FirewallConfig } from "../firewalls";
 import type { FetchFn } from "../../firewall-loader";
 
 /** Helper to create a mock fetch function returning given body and status */
@@ -210,6 +215,68 @@ describe("resolveFirewallSelections", () => {
     expect(expanded[0]!.name).toBe("slack");
     expect(expanded[0]!.ref).toBe("slack");
     expect(expanded[0]!.apis.length).toBeGreaterThan(0);
+  });
+
+  it("collectAndValidatePermissions accepts mixed empty and non-empty apis", () => {
+    // Pins the per-api continue boundary: one api with empty permissions
+    // (auth-only injection + unknownPolicy fallback) alongside one with
+    // real permissions should both validate and only the latter's names
+    // should appear in the returned set.
+    const config: FirewallConfig = {
+      name: "mixed",
+      apis: [
+        {
+          base: "https://api.example.com",
+          auth: { headers: {} },
+          permissions: [],
+        },
+        {
+          base: "https://uploads.example.com",
+          auth: { headers: {} },
+          permissions: [
+            { name: "upload", rules: ["POST /files"] },
+            { name: "read", rules: ["GET /files/{id}"] },
+          ],
+        },
+      ],
+    };
+    const names = collectAndValidatePermissions("mixed", config);
+    expect([...names].sort()).toEqual(["read", "upload"]);
+  });
+
+  it("should retain api entries with empty permissions when user picks all", async () => {
+    // Regression for the filter bug: api entries configured as
+    // `permissions: []` rely on base URL match + unknownPolicy fallback.
+    // Dropping them would make the firewall inject no auth headers.
+    // Uses a synthetic config so the test's meaning is independent of
+    // any individual builtin connector's permission list evolving.
+    const yaml = `
+name: empty-perm
+placeholders:
+  TOKEN: "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"
+apis:
+  - base: https://api.empty-perm.com
+    auth:
+      headers:
+        Authorization: "Bearer \${{ secrets.TOKEN }}"
+    permissions: []
+  - base: https://uploads.empty-perm.com
+    auth:
+      headers:
+        Authorization: "Bearer \${{ secrets.TOKEN }}"
+    permissions: []
+`;
+    const expanded = await resolveFirewallSelections(
+      { "empty-perm": { permissions: "all" } },
+      mockFetch(yaml),
+    );
+
+    expect(expanded).toHaveLength(1);
+    expect(expanded[0]!.name).toBe("empty-perm");
+    expect(expanded[0]!.apis).toHaveLength(2);
+    for (const api of expanded[0]!.apis) {
+      expect(api.permissions ?? []).toEqual([]);
+    }
   });
 
   it("should support full GitHub URL as ref", async () => {

--- a/turbo/packages/core/src/contracts/__tests__/firewall-rule-validation.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-rule-validation.test.ts
@@ -1,32 +1,29 @@
 import { describe, it, expect } from "vitest";
 import { connectorTypeSchema } from "../connectors";
 import { isFirewallConnectorType, getConnectorFirewall } from "../../firewalls";
-import { validateRule } from "../firewall-expander";
+import { collectAndValidatePermissions } from "../firewall-expander";
 
 /**
- * Validate that every rule in every builtin connector firewall passes
- * the same validation that custom (user-supplied) firewalls go through.
+ * Validate that every builtin connector firewall passes the same full
+ * validation pipeline as custom (user-supplied) firewalls: base URLs,
+ * permission structure (non-empty, no reserved names, no duplicates),
+ * and rule paths.
  *
- * This catches issues like query strings or fragments sneaking in via
- * OpenAPI specs during code generation.
+ * This catches issues like query strings / fragments in rule paths,
+ * malformed base URL patterns, or duplicate permission names sneaking
+ * in via OpenAPI specs during code generation.
  */
-describe("builtin firewall rule validation", () => {
+describe("builtin firewall validation", () => {
   const connectorTypes = connectorTypeSchema.options;
 
   for (const connectorType of connectorTypes) {
     if (!isFirewallConnectorType(connectorType)) continue;
 
-    it(`${connectorType} — all rules pass validateRule`, () => {
+    it(`${connectorType} — passes full firewall validation`, () => {
       const firewall = getConnectorFirewall(connectorType);
-      for (const api of firewall.apis) {
-        for (const perm of api.permissions ?? []) {
-          for (const rule of perm.rules) {
-            expect(() => {
-              return validateRule(rule, perm.name, firewall.name);
-            }).not.toThrow();
-          }
-        }
-      }
+      expect(() => {
+        return collectAndValidatePermissions(connectorType, firewall);
+      }).not.toThrow();
     });
   }
 });

--- a/turbo/packages/core/src/contracts/firewall-expander.ts
+++ b/turbo/packages/core/src/contracts/firewall-expander.ts
@@ -184,9 +184,10 @@ export function collectAndValidatePermissions(
   for (const api of serviceConfig.apis) {
     validateBaseUrl(api.base, serviceConfig.name);
     if (!api.permissions || api.permissions.length === 0) {
-      throw new Error(
-        `API entry "${api.base}" in firewall "${serviceConfig.name}" (ref "${ref}") has no permissions`,
-      );
+      // Empty permissions is a valid shape: every request under this base
+      // falls through to the firewall's unknownPolicy. Auth headers are
+      // still injected on base URL match.
+      continue;
     }
     // Uniqueness is enforced within a single api_entry. The same permission
     // name across different api_entries is allowed (e.g., "full-access" on
@@ -289,6 +290,10 @@ export async function resolveFirewallSelections(
         };
       })
       .filter((api) => {
+        // When user picked "all", keep every api — including
+        // empty-permissions ones where auth-only injection plus
+        // unknownPolicy fallback is the intended semantics.
+        if (selectedSet === null) return true;
         return (api.permissions ?? []).length > 0;
       });
 


### PR DESCRIPTION
## Summary

Firewall api entries with `permissions: []` (or omitted) are a valid shape — every request under the base falls through to the firewall's `unknownPolicy`, while auth headers still get injected on base URL match. This is how the GitHub firewall currently ships (no permission mapping yet, relies on `unknownPolicy=allow`). Two bugs blocked that shape from working.

## Bugs fixed

**1. `collectAndValidatePermissions` rejected empty permissions at validation time.**
It threw `"has no permissions"` for any api with an empty permissions list, preventing the firewall from loading at all. Now it `continue`s past the inner permission/rule checks when permissions is empty or omitted.

**2. `resolveFirewallSelections` silently dropped api entries with empty permissions.**
At line 292 it filtered out any api where `permissions.length === 0`, and at line 297 skipped the whole firewall if every api was filtered. Combined effect: even enabling the firewall with `permissions: "all"` produced zero auth injection.

Fix: keep all apis in the "all" selection mode (including empty-perm ones). Still drop empty-perm apis when the user picks specific permission names — that's correct, since empty means "allow-via-unknownPolicy" which is broader than what was asked for.

## Test coverage upgrade

`firewall-rule-validation.test.ts` previously only iterated rules through `validateRule`. It now calls the full `collectAndValidatePermissions` pipeline per builtin connector, so **base URL validation** and **permission structure checks** are covered alongside rules. Without this, base URL regressions in generator output (including anything touching #10078's mixed-segment grammar) would have slipped through.

## Scope audited

Walked the full pipeline for empty/undefined `api.permissions`:

| Layer | Status |
|---|---|
| `firewallApiSchema` (zod) | `.optional()` — already allows undefined |
| TS `collectAndValidatePermissions` | **fixed** — no longer throws on empty |
| TS `resolveFirewallSelections` | **fixed** — keeps apis with empty permissions in "all" mode |
| TS `findMatchingPermissions` (matcher) | safe — `if (!api.permissions) continue;` |
| TS `getDefaultFirewallPolicies` | safe — `if (api.permissions)` guard |
| TS `applyConnectorPolicies` | safe — normalizes via `api.permissions ?? []` |
| TS UI / CLI consumers | safe — `??` and optional-chain guards throughout |
| Python `match_firewall_request` | safe — `if not permissions: continue`, falls to `unknownPolicy` |
| Rust `FirewallApi` | safe — `permissions: Option<Vec<FirewallPermission>>`; production Rust code doesn't read the field (only reserialized to mitm-addon) |

## Test plan

- [x] `pnpm -F @vm0/core exec vitest run` — 781 tests pass (up from 779 after the validation pipeline upgrade caught more builtins)
- [x] `pnpm check-types` — green
- [x] `pnpm turbo run lint --filter=@vm0/core` — no warnings
- [x] `pnpm knip` — no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)