### PR TITLE
feat: add kimi/glm/minimax models to vm0 managed provider

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
@@ -7,11 +7,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@vm0/ui/components/ui/select";
+import { useLastResolved } from "ccstate-react";
 import {
   MODEL_PROVIDER_TYPES,
   getAuthMethodsForType,
   getSecretsForAuthMethod,
   getModels,
+  getVm0VisibleModels,
   getDefaultModel,
   hasModelSelection,
   allowsCustomModel,
@@ -25,6 +27,7 @@ import {
   getModelDisplayName,
 } from "./provider-ui-config.ts";
 import { ClaudeCodeSetupPrompt } from "./setup-prompt.tsx";
+import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 
 export function OAuthFields({
   secret,
@@ -286,12 +289,14 @@ function ModelSelector({
   onUseDefaultModelChange: (value: boolean) => void;
 }) {
   const type = providerType as keyof typeof MODEL_PROVIDER_TYPES;
+  const features = useLastResolved(featureSwitch$);
 
   if (!hasModelSelection(type)) {
     return null;
   }
 
-  const models = getModels(type) ?? [];
+  const models =
+    type === "vm0" ? getVm0VisibleModels(features) : (getModels(type) ?? []);
   const defaultModel = getUIDefaultModel(type) ?? getDefaultModel(type) ?? "";
   const canCustom = allowsCustomModel(type);
   const placeholder = getCustomModelPlaceholder(type) ?? "Enter model name";

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -224,6 +224,7 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   // DeepSeek
   "deepseek-chat": "DeepSeek Chat",
   // MiniMax
+  "MiniMax-M2.7": "MiniMax M2.7",
   "MiniMax-M2.1": "MiniMax M2.1",
   "minimax/minimax-m2.5": "MiniMax M2.5",
   // Kimi / Moonshot
@@ -232,6 +233,7 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   "kimi-k2-thinking-turbo": "Kimi K2 Thinking Turbo",
   "moonshotai/kimi-k2.5": "Kimi K2.5",
   // GLM / ZhipuAI
+  "glm-5.1": "GLM-5.1",
   "glm-5": "GLM-5",
   "glm-4.7": "GLM-4.7",
   "glm-4.5-air": "GLM-4.5 Air",

--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -52,6 +52,30 @@ const MODEL_PRICING: (typeof creditPricing.$inferInsert)[] = [
     cacheReadTokenPrice: usd(0.5),
     cacheCreationTokenPrice: usd(6.25),
   },
+  {
+    model: "kimi-k2.5",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(0.6),
+    outputTokenPrice: usd(3),
+    cacheReadTokenPrice: usd(0.1),
+    cacheCreationTokenPrice: usd(0.6),
+  },
+  {
+    model: "glm-5.1",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(1.4),
+    outputTokenPrice: usd(4.4),
+    cacheReadTokenPrice: usd(0.26),
+    cacheCreationTokenPrice: usd(1.4),
+  },
+  {
+    model: "MiniMax-M2.7",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(0.3),
+    outputTokenPrice: usd(1.2),
+    cacheReadTokenPrice: usd(0.06),
+    cacheCreationTokenPrice: usd(0.375),
+  },
 ];
 
 /**

--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -150,11 +150,14 @@ describe("VM0 managed model provider", () => {
         "claude-sonnet-4-6",
         "claude-opus-4-6",
         "claude-opus-4-7",
+        "kimi-k2.5",
+        "glm-5.1",
+        "MiniMax-M2.7",
       ];
       for (const model of vm0Models) {
         expect(VM0_MODEL_TO_PROVIDER[model]).toBeDefined();
       }
-      expect(Object.keys(VM0_MODEL_TO_PROVIDER)).toHaveLength(3);
+      expect(Object.keys(VM0_MODEL_TO_PROVIDER)).toHaveLength(vm0Models.length);
     });
   });
 });

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -264,6 +264,7 @@ export {
   VM0_MODEL_TO_PROVIDER,
   getVm0ConcreteProviderType,
   getVm0Vendor,
+  getVm0VisibleModels,
 } from "./model-providers";
 export {
   sessionsByIdContract,

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ExpandedFirewallConfig } from "./firewalls";
 
 /**
@@ -33,10 +34,13 @@ export const VM0_ORG_SLUG = "vm0";
  * NOTE: Defined before MODEL_PROVIDER_TYPES so the vm0 entry can derive its
  * models list from this mapping via Object.keys().
  */
-export const VM0_MODEL_TO_PROVIDER: Record<
-  string,
-  { concreteType: string; vendor: string }
-> = {
+interface Vm0ModelConfig {
+  concreteType: string;
+  vendor: string;
+  featureFlag?: FeatureSwitchKey;
+}
+
+export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
   "claude-sonnet-4-6": {
     concreteType: "anthropic-api-key",
     vendor: "anthropic",
@@ -49,7 +53,40 @@ export const VM0_MODEL_TO_PROVIDER: Record<
     concreteType: "anthropic-api-key",
     vendor: "anthropic",
   },
+  "kimi-k2.5": {
+    concreteType: "moonshot-api-key",
+    vendor: "moonshot",
+    featureFlag: FeatureSwitchKey.Vm0KimiModel,
+  },
+  "glm-5.1": {
+    concreteType: "zai-api-key",
+    vendor: "zai",
+    featureFlag: FeatureSwitchKey.Vm0GlmModel,
+  },
+  "MiniMax-M2.7": {
+    concreteType: "minimax-api-key",
+    vendor: "minimax",
+    featureFlag: FeatureSwitchKey.Vm0MinimaxModel,
+  },
 };
+
+/**
+ * Return the VM0 managed models visible to the caller, filtered by feature
+ * switches. Models without a featureFlag are always visible; models with a
+ * flag require the flag to be enabled in the supplied feature map.
+ */
+export function getVm0VisibleModels(
+  features?: Partial<Record<FeatureSwitchKey, boolean>>,
+): string[] {
+  return Object.entries(VM0_MODEL_TO_PROVIDER)
+    .filter(([, { featureFlag }]) => {
+      if (!featureFlag) return true;
+      return features?.[featureFlag] === true;
+    })
+    .map(([model]) => {
+      return model;
+    });
+}
 
 /**
  * Model Provider type configuration
@@ -168,8 +205,8 @@ export const MODEL_PROVIDER_TYPES = {
       API_TIMEOUT_MS: "3000000",
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
     } as Record<string, string>,
-    models: ["MiniMax-M2.1"] as string[],
-    defaultModel: "MiniMax-M2.1",
+    models: ["MiniMax-M2.7", "MiniMax-M2.1"] as string[],
+    defaultModel: "MiniMax-M2.7",
   },
   "deepseek-api-key": {
     framework: "claude-code" as const,
@@ -207,8 +244,8 @@ export const MODEL_PROVIDER_TYPES = {
       CLAUDE_CODE_SUBAGENT_MODEL: "$model",
       API_TIMEOUT_MS: "3000000",
     } as Record<string, string>,
-    models: ["glm-5", "glm-4.7", "glm-4.5-air"] as string[],
-    defaultModel: "glm-4.7",
+    models: ["glm-5.1", "glm-5", "glm-4.7", "glm-4.5-air"] as string[],
+    defaultModel: "glm-5.1",
   },
   "vercel-ai-gateway": {
     framework: "claude-code" as const,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -51,4 +51,7 @@ export enum FeatureSwitchKey {
   FreshdeskConnector = "freshdeskConnector",
   ZoomConnector = "zoomConnector",
   ModelProviderSelection = "modelProviderSelection",
+  Vm0KimiModel = "vm0KimiModel",
+  Vm0GlmModel = "vm0GlmModel",
+  Vm0MinimaxModel = "vm0MinimaxModel",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -278,6 +278,27 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the Zoom connector (OAuth 2.0) for meetings, past participants, and cloud recordings access",
     enabled: false,
   },
+  [FeatureSwitchKey.Vm0KimiModel]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Expose Moonshot Kimi K2.5 as a selectable model under the VM0 managed provider",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
+  [FeatureSwitchKey.Vm0GlmModel]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Expose Z.AI GLM-5.1 as a selectable model under the VM0 managed provider",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
+  [FeatureSwitchKey.Vm0MinimaxModel]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Expose MiniMax M2.7 as a selectable model under the VM0 managed provider",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.SlackAgentSwitch]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Adds Moonshot **Kimi K2.5**, Z.AI **GLM-5.1**, and MiniMax **M2.7** as selectable models under the vm0 managed meta-provider, each gated by an independent feature switch (staff-only by default).
- Extends BYOK providers (`moonshot-api-key`, `zai-api-key`, `minimax-api-key`) with the new versions and sets GLM-5.1 / MiniMax-M2.7 as the new defaults for their respective BYOK flows.
- `VM0_MODEL_TO_PROVIDER` entries now carry an optional `featureFlag`; new helper `getVm0VisibleModels(features)` filters the vm0 model picker at the UI layer.

## Feature switches

| Key | Description | Default |
|---|---|---|
| `vm0KimiModel` | Expose `kimi-k2.5` under vm0 | off (staff only) |
| `vm0GlmModel` | Expose `glm-5.1` under vm0 | off (staff only) |
| `vm0MinimaxModel` | Expose `MiniMax-M2.7` under vm0 | off (staff only) |

Server-side resolve path is intentionally **not** gated — the switches only control UI visibility. Staff and any org with the flag flipped can freely use the new models.

## Out of scope

- Production `credit_pricing` rows for the three new vm0 models have already been populated manually.
- Production `vm0_api_keys` entries have been inserted manually.
- No DB migration needed in this PR.

## Test plan

- [x] `pnpm turbo run lint --filter=@vm0/core --filter=@vm0/app --filter=web` — clean
- [x] `pnpm check-types` — clean across all workspaces
- [x] `pnpm knip` — no issues
- [x] `pnpm -F web exec vitest run src/__tests__/vm0-provider.test.ts` — 8/8 pass (updated `VM0_MODEL_TO_PROVIDER` length assertion)
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-provider-dialog.test.tsx` — 18/18 pass
- [ ] Verify in staff org: vm0 provider picker shows `kimi-k2.5`, `glm-5.1`, `MiniMax-M2.7`
- [ ] Verify in non-staff org: vm0 provider picker hides the three new models
- [ ] Verify a staff run against each new model produces non-zero credit charges

🤖 Generated with [Claude Code](https://claude.com/claude-code)