### PR TITLE
refactor(mitm-addon): remove remaining private-entry test sites (#10101)

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -273,6 +273,31 @@ def fake_firewall_headers():
 
 
 @pytest.fixture
+def sync_usage_executor():
+    """Swap ``usage.usage_executor`` for a synchronous stub.
+
+    Tests that mock ``usage._opener`` and want the webhook payloads to
+    appear on the mock by the time they inspect it need submission to
+    happen inline rather than on a background thread — otherwise they
+    have to thread ``fresh_usage_executor`` + ``shutdown(wait=True)``
+    boilerplate through every caller.  The stub's ``submit`` just runs
+    the function synchronously; the original executor is restored on
+    teardown.
+    """
+
+    class _SyncExecutor:
+        def submit(self, fn, *args, **kwargs):
+            fn(*args, **kwargs)
+
+    original = usage.usage_executor
+    usage.usage_executor = _SyncExecutor()
+    try:
+        yield usage.usage_executor
+    finally:
+        usage.usage_executor = original
+
+
+@pytest.fixture
 def fresh_usage_executor():
     """Swap ``usage.usage_executor`` for a throw-away pool for one test.
 

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1862,6 +1862,13 @@ class TestIsXStreamPath:
 class TestLogConnectorUsage:
     """Tests for log_connector_usage helper (issue #9504)."""
 
+    @pytest.fixture(autouse=True)
+    def _sync_executor(self, sync_usage_executor):
+        """All tests here route billing through ``_call_and_get_billing`` which
+        inspects ``_opener.open`` inline; the sync executor makes that work
+        without each test needing its own ``fresh_usage_executor`` + shutdown.
+        """
+
     def _make_x_flow(
         self,
         real_flow,
@@ -1900,19 +1907,11 @@ class TestLogConnectorUsage:
     def _call_and_get_billing(self, flow, run_id="run-abc-123"):
         """Call log_connector_usage and return the webhook payload(s).
 
-        Mocks the urllib boundary (``usage._opener``) rather than an internal
-        helper.  ``usage_executor`` is swapped for a synchronous stub so
-        payloads appear on ``_opener.open`` by the time we inspect it without
-        every caller needing ``fresh_usage_executor``.
+        Relies on the class-level ``_sync_executor`` autouse fixture to
+        route submissions inline; only the urllib boundary is mocked here.
         """
-
-        class _SyncExecutor:
-            def submit(self, fn, *args, **kwargs):
-                fn(*args, **kwargs)
-
         with (
             patch.object(usage, "get_api_url", return_value="https://app.test"),
-            patch.object(usage, "usage_executor", _SyncExecutor()),
             patch.object(usage, "_opener") as mock_opener,  # urllib external boundary (#9991)
         ):
             mock_opener.open.return_value = MagicMock()
@@ -2443,8 +2442,9 @@ class TestUsageWebhookDelivery:
             usage.maybe_report_proxy_usage(flow, "run-1")
             usage.usage_executor.shutdown(wait=True)
 
-        # 2 attempts (max_retries=1) → cleanup called once per attempt.
-        assert http_err.close.call_count == 2  # urllib HTTPError cleanup contract (#9991)
+        # Cleanup must run once per HTTPError — tracks attempt count so the
+        # invariant survives future changes to max_retries.
+        assert http_err.close.call_count == mock_opener.open.call_count  # (#9991)
 
     def test_adds_vercel_bypass_header(self, tmp_path, real_flow, fresh_usage_executor):
         flow = self._model_flow(real_flow, tmp_path)

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1156,62 +1156,6 @@ class TestNdjsonExtractor:
         assert state["data_count"] == 1
 
 
-class TestPostWebhook:
-    """Tests for _post_webhook HTTP request construction."""
-
-    def test_posts_correct_payload(self):
-        payload = {"runId": "run-1", "usage": {"model": "claude-sonnet-4-6", "input_tokens": 100}}
-        with patch.object(usage, "_opener") as mock_opener:
-            mock_opener.open.return_value = MagicMock()
-            usage._post_webhook("https://api.vm0.ai/api/webhooks/agent/usage", "tok-123", payload)
-        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
-        req = mock_opener.open.call_args[0][0]
-        assert req.full_url == "https://api.vm0.ai/api/webhooks/agent/usage"
-        assert req.get_header("Content-type") == "application/json"
-        assert req.get_header("Authorization") == "Bearer tok-123"
-        assert req.get_header("User-agent") == "vm0-mitm-addon/1.0"
-        body = json.loads(req.data)
-        assert body["runId"] == "run-1"
-        assert body["usage"]["model"] == "claude-sonnet-4-6"
-
-    def test_raises_on_network_error(self):
-        """Network failures should propagate (retry handled by caller)."""
-        with patch.object(
-            usage,
-            "_opener",
-            **{"open.side_effect": ConnectionError("refused")},
-        ):
-            with pytest.raises(ConnectionError):
-                usage._post_webhook("https://api.vm0.ai/hook", "tok", {})
-
-    def test_closes_http_error_response(self):
-        """HTTPError (non-2xx) should be closed to avoid socket leak."""
-        import urllib.error
-
-        http_err = urllib.error.HTTPError(
-            "https://api.vm0.ai", 500, "Internal Server Error", {}, None
-        )
-        http_err.close = MagicMock()
-        with patch.object(
-            usage,
-            "_opener",
-            **{"open.side_effect": http_err},
-        ):
-            with pytest.raises(urllib.error.HTTPError):
-                usage._post_webhook("https://api.vm0.ai/hook", "tok", {})
-        http_err.close.assert_called_once()  # urllib HTTPError cleanup contract (#9991)
-
-    def test_adds_vercel_bypass_header(self):
-        with (
-            patch.object(usage, "_opener") as mock_opener,
-            patch.object(auth, "VERCEL_BYPASS", "bypass-secret"),
-        ):
-            mock_opener.open.return_value = MagicMock()
-            usage._post_webhook("https://api.vm0.ai/hook", "tok", {})
-        req = mock_opener.open.call_args[0][0]
-        assert req.get_header("X-vercel-protection-bypass") == "bypass-secret"
-
-
 class TestResponseHeadersSseParser:
     """Tests for SSE parser setup in responseheaders()."""
 
@@ -1306,7 +1250,9 @@ class TestResponseHeadersSseParser:
 class TestResponseUsageReporting:
     """Tests for usage extraction and reporting in response() hook."""
 
-    def test_non_streaming_json_fallback(self, tmp_path, real_flow, mitm_ctx, headers):
+    def test_non_streaming_json_fallback(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+    ):
         """Non-streaming JSON response should extract usage from buffer."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
@@ -1338,11 +1284,11 @@ class TestResponseUsageReporting:
 
         with (
             mitm_ctx(),
-            # Silence the background webhook; end-to-end JSON→webhook wiring
-            # is covered by test_full_path_response_to_opener's SSE variant.
-            patch.object(usage, "_enqueue_webhook"),
+            patch.object(usage, "_opener") as mock_opener,  # urllib external boundary (#9991)
         ):
+            mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.usage_executor.shutdown(wait=True)
 
         # JSON fallback should populate proxy_usage in metadata
         extracted = flow.metadata["proxy_usage"]
@@ -1408,7 +1354,9 @@ class TestResponseUsageReporting:
         assert len(buf) == len(large_chunk)
         assert not state["truncated"]
 
-    def test_no_usage_report_for_non_model_provider(self, tmp_path, real_flow, mitm_ctx, headers):
+    def test_no_usage_report_for_non_model_provider(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+    ):
         """Non-model-provider requests should not trigger usage reporting."""
         flow = real_flow(with_response=False, host="api.github.com")
         log_path = str(tmp_path / "network.jsonl")
@@ -1425,13 +1373,14 @@ class TestResponseUsageReporting:
 
         with (
             mitm_ctx(),
-            # Let real maybe_report_proxy_usage run; it early-returns on the
-            # firewall_name == "github" filter and should never reach _enqueue.
-            patch.object(usage, "_enqueue_webhook") as mock_enqueue,
+            # maybe_report_proxy_usage early-returns on the firewall_name == "github"
+            # filter, so no urllib request should ever reach the external boundary.
+            patch.object(usage, "_opener") as mock_opener,
         ):
             mitm_addon.response(flow)
+            usage.usage_executor.shutdown(wait=True)
 
-        assert mock_enqueue.call_count == 0
+        assert mock_opener.open.call_count == 0  # urllib external boundary (#9991)
 
     def test_full_path_response_to_opener(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
@@ -1683,7 +1632,9 @@ class TestErrorHandler:
         assert "connection reset by peer" in content
         assert "slack.com" in content
 
-    def test_error_logs_connector_usage_for_x_stream(self, tmp_path, real_flow, headers):
+    def test_error_logs_connector_usage_for_x_stream(
+        self, tmp_path, real_flow, headers, fresh_usage_executor
+    ):
         """Mid-flight stream crash: partial counts still reported (issue #9534)."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         log_path = str(tmp_path / "network.jsonl")
@@ -1711,19 +1662,23 @@ class TestErrorHandler:
         flow.metadata["vm_sandbox_token"] = "test-token"
 
         with (
-            patch("usage.get_api_url", return_value="https://app.test"),
-            patch("usage._enqueue_webhook") as mock_enqueue,
+            patch.object(usage, "get_api_url", return_value="https://app.test"),
+            patch.object(usage, "_opener") as mock_opener,  # urllib external boundary (#9991)
         ):
+            mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
+            usage.usage_executor.shutdown(wait=True)
 
-        # Connector billing webhook should have been enqueued
-        assert mock_enqueue.called
-        payloads = [call[0][2] for call in mock_enqueue.call_args_list]
+        # Connector billing webhook should have been posted to _opener.
+        assert mock_opener.open.called
+        payloads = [json.loads(call[0][0].data) for call in mock_opener.open.call_args_list]
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat["tweet.read"] == 23
         assert by_cat["users.read"] == 5
 
-    def test_full_pipeline_stream_error_midflight(self, tmp_path, real_flow, headers):
+    def test_full_pipeline_stream_error_midflight(
+        self, tmp_path, real_flow, headers, fresh_usage_executor
+    ):
         """End-to-end: responseheaders → partial chunks → error() logs observed counts.
 
         Simulates a real scenario: stream opens successfully, a few tweets
@@ -1760,13 +1715,15 @@ class TestErrorHandler:
         flow.metadata["vm_sandbox_token"] = "test-token"
 
         with (
-            patch("usage.get_api_url", return_value="https://app.test"),
-            patch("usage._enqueue_webhook") as mock_enqueue,
+            patch.object(usage, "get_api_url", return_value="https://app.test"),
+            patch.object(usage, "_opener") as mock_opener,  # urllib external boundary (#9991)
         ):
+            mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
+            usage.usage_executor.shutdown(wait=True)
 
         # 4. Billing must reflect the 2 complete tweets (partial 3rd is dropped)
-        payloads = [call[0][2] for call in mock_enqueue.call_args_list]
+        payloads = [json.loads(call[0][0].data) for call in mock_opener.open.call_args_list]
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat["tweet.read"] == 2  # not 3 — partial trailing dropped
         assert by_cat["users.read"] == 1
@@ -1941,15 +1898,26 @@ class TestLogConnectorUsage:
         return flow
 
     def _call_and_get_billing(self, flow, run_id="run-abc-123"):
-        """Call log_connector_usage and return the webhook payload(s)."""
+        """Call log_connector_usage and return the webhook payload(s).
+
+        Mocks the urllib boundary (``usage._opener``) rather than an internal
+        helper.  ``usage_executor`` is swapped for a synchronous stub so
+        payloads appear on ``_opener.open`` by the time we inspect it without
+        every caller needing ``fresh_usage_executor``.
+        """
+
+        class _SyncExecutor:
+            def submit(self, fn, *args, **kwargs):
+                fn(*args, **kwargs)
+
         with (
-            patch("usage.get_api_url", return_value="https://app.test"),
-            patch("usage._enqueue_webhook") as mock_enqueue,
+            patch.object(usage, "get_api_url", return_value="https://app.test"),
+            patch.object(usage, "usage_executor", _SyncExecutor()),
+            patch.object(usage, "_opener") as mock_opener,  # urllib external boundary (#9991)
         ):
+            mock_opener.open.return_value = MagicMock()
             usage.log_connector_usage(flow, run_id)
-        if not mock_enqueue.called:
-            return []
-        return [call[0][2] for call in mock_enqueue.call_args_list]
+        return [json.loads(call[0][0].data) for call in mock_opener.open.call_args_list]
 
     def _call_and_get_single_billing(self, flow, run_id="run-abc-123"):
         """Call log_connector_usage and return the single webhook payload."""
@@ -2368,7 +2336,9 @@ class TestLogConnectorUsage:
 
     # ---- full pipeline: responseheaders -> stream chunks -> response (issue #9534) ----
 
-    def test_full_streaming_pipeline_filtered_stream(self, tmp_path, real_flow, mitm_ctx, headers):
+    def test_full_streaming_pipeline_filtered_stream(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+    ):
         """End-to-end: responseheaders registers parser, chunks accumulate, response() logs."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["vm_run_id"] = "run-abc-123"
@@ -2406,13 +2376,15 @@ class TestLogConnectorUsage:
         # 3. Simulated disconnect - response() fires and logs via webhook
         with (
             mitm_ctx(),
-            patch("usage.get_api_url", return_value="https://app.test"),
-            patch("usage._enqueue_webhook") as mock_enqueue,
+            patch.object(usage, "get_api_url", return_value="https://app.test"),
+            patch.object(usage, "_opener") as mock_opener,  # urllib external boundary (#9991)
         ):
+            mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.usage_executor.shutdown(wait=True)
 
         # 4. Verify billing payloads
-        payloads = [call[0][2] for call in mock_enqueue.call_args_list]
+        payloads = [json.loads(call[0][0].data) for call in mock_opener.open.call_args_list]
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         # 3 tweets primary + 0 from includes.tweets (none here) = 3
         assert by_cat["tweet.read"] == 3
@@ -2434,6 +2406,7 @@ class TestUsageWebhookDelivery:
 
     def test_succeeds_on_first_attempt(self, tmp_path, real_flow, fresh_usage_executor):
         flow = self._model_flow(real_flow, tmp_path)
+        flow.metadata["proxy_usage"] = {"model": "claude-sonnet-4-6", "input_tokens": 100}
         with (
             patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(usage, "_opener") as mock_opener,
@@ -2443,6 +2416,49 @@ class TestUsageWebhookDelivery:
             usage.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
+        req = mock_opener.open.call_args[0][0]
+        assert req.full_url == "https://api.vm0.ai/api/webhooks/agent/usage"
+        assert req.get_header("Content-type") == "application/json"
+        assert req.get_header("Authorization") == "Bearer tok"
+        assert req.get_header("User-agent") == "vm0-mitm-addon/1.0"
+        body = json.loads(req.data)
+        assert body["runId"] == "run-1"
+        assert body["usage"]["model"] == "claude-sonnet-4-6"
+        assert body["usage"]["input_tokens"] == 100
+
+    def test_closes_http_error_response(self, tmp_path, real_flow, fresh_usage_executor):
+        """HTTPError sockets must be closed to avoid leaking; retries still apply."""
+        import urllib.error
+
+        http_err = urllib.error.HTTPError(
+            "https://api.vm0.ai", 500, "Internal Server Error", {}, None
+        )
+        http_err.close = MagicMock()
+        flow = self._model_flow(real_flow, tmp_path)
+        with (
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage, "_opener") as mock_opener,
+        ):
+            mock_opener.open.side_effect = http_err
+            usage.maybe_report_proxy_usage(flow, "run-1")
+            usage.usage_executor.shutdown(wait=True)
+
+        # 2 attempts (max_retries=1) → cleanup called once per attempt.
+        assert http_err.close.call_count == 2  # urllib HTTPError cleanup contract (#9991)
+
+    def test_adds_vercel_bypass_header(self, tmp_path, real_flow, fresh_usage_executor):
+        flow = self._model_flow(real_flow, tmp_path)
+        with (
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(auth, "VERCEL_BYPASS", "bypass-secret"),
+            patch.object(usage, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            usage.maybe_report_proxy_usage(flow, "run-1")
+            usage.usage_executor.shutdown(wait=True)
+
+        req = mock_opener.open.call_args[0][0]
+        assert req.get_header("X-vercel-protection-bypass") == "bypass-secret"
 
     def test_retries_on_failure(self, tmp_path, real_flow, fresh_usage_executor):
         flow = self._model_flow(real_flow, tmp_path)
@@ -2844,35 +2860,46 @@ class TestUsagePendingCounter:
         assert usage._in_flight_flows == 0
         assert usage._pending_reports == 0
 
-    def test_report_decrements_after_completion(self, tmp_path):
-        """_post_webhook_with_retry must decrement even on failure."""
+    def test_report_decrements_after_completion(self, tmp_path, real_flow, fresh_usage_executor):
+        """Retry exhaustion still runs the decrement finally-block."""
         usage.set_pending_path(str(tmp_path / "usage-pending"))
-        usage._increment_reports()
-        assert usage._pending_reports == 1
 
-        with patch.object(usage, "_post_webhook", side_effect=Exception("boom")):
-            usage._post_webhook_with_retry(
-                "http://localhost/webhook", "tok", {}, str(tmp_path / "proxy.log"), "usage"
-            )
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["vm_sandbox_token"] = "tok"
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["proxy_usage"] = {"input_tokens": 1}
+
+        with (
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage, "_opener") as mock_opener,
+        ):
+            mock_opener.open.side_effect = ConnectionError("boom")
+            usage.maybe_report_proxy_usage(flow, "run-1")
+            usage.usage_executor.shutdown(wait=True)
 
         assert usage._pending_reports == 0
         content = (tmp_path / "usage-pending").read_text()
         assert content == "0:0"
 
-    def test_enqueue_increments_and_drains_reports(self, tmp_path, fresh_usage_executor):
-        """_enqueue_webhook increments pending; executor drain decrements to 0."""
+    def test_enqueue_increments_and_drains_reports(self, tmp_path, real_flow, fresh_usage_executor):
+        """Public entry increments pending on enqueue; executor drain decrements to 0."""
         usage.set_pending_path(str(tmp_path / "usage-pending"))
 
-        with patch.object(usage, "_post_webhook"):
-            usage._enqueue_webhook(
-                "http://localhost/webhook",
-                "tok",
-                {"model": "x"},
-                str(tmp_path / "p.log"),
-                "usage",
-            )
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["vm_sandbox_token"] = "tok"
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["proxy_usage"] = {"input_tokens": 1}
+
+        with (
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            usage.maybe_report_proxy_usage(flow, "run-1")
             usage.usage_executor.shutdown(wait=True)
-        # After executor drains, counter must be back to 0.
+
         assert usage._pending_reports == 0
         content = (tmp_path / "usage-pending").read_text()
         assert content == "0:0"
@@ -2912,20 +2939,25 @@ class TestUsagePendingCounter:
         fake_handler(flow)
         assert usage._in_flight_flows == 1  # unchanged
 
-    def test_sync_fallback_decrements_reports(self, tmp_path, fresh_usage_executor):
-        """When executor is shut down, sync fallback must still decrement."""
+    def test_sync_fallback_decrements_reports(self, tmp_path, real_flow, fresh_usage_executor):
+        """When the executor is already shut down, the sync fallback still decrements."""
         usage.set_pending_path(str(tmp_path / "usage-pending"))
-
         # Shut down the executor so _enqueue_webhook takes the sync fallback.
         usage.usage_executor.shutdown(wait=True)
-        with patch.object(usage, "_post_webhook"):
-            usage._enqueue_webhook(
-                "http://localhost/webhook",
-                "tok",
-                {"model": "x"},
-                str(tmp_path / "p.log"),
-                "usage",
-            )
+
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["vm_sandbox_token"] = "tok"
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["proxy_usage"] = {"input_tokens": 1}
+
+        with (
+            patch.object(usage, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            usage.maybe_report_proxy_usage(flow, "run-1")
+
         assert usage._pending_reports == 0
         content = (tmp_path / "usage-pending").read_text()
         assert content == "0:0"


### PR DESCRIPTION
## Summary

Closes #10101. Completes the #9991 follow-up that was explicitly carved out of PR #10097. Zero direct calls to `usage._post_webhook`, `_post_webhook_with_retry`, or `_enqueue_webhook` remain as test entry points; zero mocks of those names remain.

- Delete `TestPostWebhook` (4 tests calling `usage._post_webhook` directly). URL / headers / payload / HTTPError-close / Vercel-bypass assertions fold into `TestUsageWebhookDelivery` and now exercise the full chain via `maybe_report_proxy_usage`.
- Rewrite the three `TestUsagePendingCounter` tests that called `_post_webhook_with_retry` / `_enqueue_webhook` directly and mocked `usage._post_webhook`. They now drive through `maybe_report_proxy_usage` and observe the pending-counter file.
- Replace six `patch.object(usage, "_enqueue_webhook")` sites (lines 1287, 1374, 1659, 1708, 1891, 2354) with `patch.object(usage, "_opener")` at the urllib boundary. For the `TestLogConnectorUsage._call_and_get_billing` helper, swap `usage_executor` for a synchronous stub so the 30+ callers do not need a `fresh_usage_executor` fixture.

## Test plan

- [x] `pytest tests/` — 861 passed
- [x] `ruff check tests/test_handlers.py` — clean
- [x] `ruff format tests/test_handlers.py` — applied
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)