### PR TITLE
chore(runner): adopt musl cross-toolchain and switch aws-sdk-s3 tls stack

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260416",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260419",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -17,7 +17,7 @@ jobs:
   cleanup-neon-branches:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     steps:
       - name: Install neonctl
         run: npm install -g neonctl@2.15.0

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -82,7 +82,7 @@ jobs:
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -58,7 +58,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
     outputs:
       any-changed: ${{ steps.detect.outputs.any-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
@@ -162,7 +162,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
     needs: [detect]
     if: needs.detect.outputs.any-changed == 'true'
     steps:
@@ -237,7 +237,7 @@ jobs:
   nbd-cow-test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
     needs: [detect]
     if: |
       needs.detect.outputs.ci-changed == 'true' ||
@@ -285,7 +285,7 @@ jobs:
   runner-build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
     needs: [detect]
     if: |
       needs.detect.outputs.ci-changed == 'true' ||

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,7 +72,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     permissions:
       contents: read
     environment: production
@@ -170,7 +170,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     outputs:
       deployment_url: ${{ steps.deploy.outputs.url }}
     permissions:
@@ -395,7 +395,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     outputs:
       deployment_url: ${{ needs.build-web-production.outputs.deployment_url }}
       vercel_dashboard_url: ${{ steps.vercel-dashboard.outputs.url }}
@@ -513,7 +513,7 @@ jobs:
     if: ${{ needs.release-please.outputs.app_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     outputs:
       deployment_url: ${{ steps.deploy.outputs.url }}
     permissions:
@@ -617,7 +617,7 @@ jobs:
       needs.release-please.outputs.app_release_created == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     outputs:
       deployment_url: ${{ needs.build-app-production.outputs.deployment_url }}
       vercel_dashboard_url: ${{ steps.vercel-dashboard.outputs.url }}
@@ -1074,7 +1074,7 @@ jobs:
     if: ${{ needs.release-please.outputs.runner_rs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
     permissions:
       contents: write
     environment: production
@@ -1296,7 +1296,7 @@ jobs:
       needs.release-please.outputs.runner_rs_release_created == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
     permissions:
       contents: read
     environment: production
@@ -1460,7 +1460,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     permissions:
       contents: read
     environment: production
@@ -1484,7 +1484,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     permissions:
       contents: read
     steps:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -67,7 +67,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     outputs:
       job-ref: ${{ steps.set-job-ref.outputs.job-ref }}
       web-preview-url: ${{ steps.preview-urls.outputs.web-url }}
@@ -288,7 +288,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -311,7 +311,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -325,7 +325,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -339,7 +339,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -355,7 +355,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     services:
       postgres:
         image: postgres:17-alpine
@@ -401,7 +401,7 @@ jobs:
     # Only run when migration or schema files changed
     if: needs.prepare.outputs.migration-changed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     services:
       postgres:
         image: postgres:17-alpine
@@ -458,7 +458,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -490,7 +490,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -519,7 +519,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -549,7 +549,7 @@ jobs:
       group: deploy-web-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and web, CLI, runner, or platform changed
     if: |
@@ -1012,7 +1012,7 @@ jobs:
       group: deploy-app-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and platform/e2e/ci changed
     if: >-
@@ -1166,7 +1166,7 @@ jobs:
   build-cli:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     needs: [prepare]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1344,7 +1344,7 @@ jobs:
       group: deploy-runner-prepare-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
     needs: [prepare]
     timeout-minutes: 20
     env:
@@ -1887,7 +1887,7 @@ jobs:
   build-e2b-template:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     needs: [prepare]
     # Build on PR or main push when E2B templates changed, skip release-please commits
     if: |

--- a/crates/.cargo/config.toml
+++ b/crates/.cargo/config.toml
@@ -1,3 +1,3 @@
 [target.aarch64-unknown-linux-musl]
-linker = "aarch64-linux-gnu-gcc"
+linker = "aarch64-linux-musl-gcc"
 rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-fuse-ld=mold"]

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -186,6 +186,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "aws-runtime"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,14 +376,19 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.1",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
+ "hyper 1.9.0",
+ "hyper-rustls",
+ "hyper-util",
  "indexmap",
  "pin-project-lite",
- "rustls 0.21.12",
+ "rustls",
  "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-rustls",
+ "tower",
  "tracing",
 ]
 
@@ -748,6 +775,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1005,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1112,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1545,21 +1593,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
@@ -1567,9 +1600,10 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.38",
+ "rustls",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -2327,7 +2361,7 @@ name = "reqeast"
 version = "0.2.1"
 dependencies = [
  "reqwest",
- "rustls 0.23.38",
+ "rustls",
 ]
 
 [[package]]
@@ -2343,20 +2377,20 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2492,27 +2526,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -2549,10 +2572,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.38",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.12",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -2567,20 +2590,11 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2668,16 +2682,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "security-framework"
@@ -3197,21 +3201,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.38",
+ "rustls",
  "tokio",
 ]
 
@@ -3223,11 +3217,11 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.38",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -3395,7 +3389,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
@@ -3447,7 +3441,7 @@ dependencies = [
  "flate2",
  "log",
  "percent-encoding",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "ureq-proto",

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -10,7 +10,7 @@ nbd-cow = { workspace = true }
 sandbox-fc = { workspace = true }
 
 async-trait = { workspace = true }
-aws-sdk-s3 = { workspace = true, features = ["rustls", "rt-tokio", "behavior-version-latest"] }
+aws-sdk-s3 = { workspace = true, features = ["default-https-client", "rt-tokio", "behavior-version-latest"] }
 base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde", "now"] }


### PR DESCRIPTION
## Summary

Follow-up to #10102. Three tightly-coupled changes that all depend on the new musl cross-toolchain shipped in `vm0-toolchain-rust:20260419`:

1. **Bump image tag** across `.github/workflows/*.yml` and `.devcontainer/devcontainer.json` from `:20260416` → `:20260419`. CI and local dev pick up the image that contains `aarch64-linux-musl-gcc` (Bootlin 2025.08-1 / gcc 14.3.0).

2. **Swap linker** in `crates/.cargo/config.toml` from `aarch64-linux-gnu-gcc` → `aarch64-linux-musl-gcc`. The old driver is no longer installed in the new image, and the new one keeps the C compile and link steps inside a consistent musl toolchain.

3. **Switch aws-sdk-s3 TLS stack** from the legacy `"rustls"` feature to `"default-https-client"`. AWS has [announced](https://github.com/awslabs/aws-sdk-rust/discussions/1257) the legacy alias will be removed from default features. The modern path uses hyper 1.x + rustls 0.23 + aws-lc-rs (supports post-quantum key exchange). Side benefit: removes duplicate TLS stacks (`rustls-webpki 0.101.7`, `rustls 0.21.12`, `hyper-rustls 0.24.2`, `tokio-rustls 0.24.1`) from the dependency tree.

Bundled because the tag bump alone would leave the linker broken (`gcc-aarch64-linux-gnu` is gone from the new image), and the aws-sdk-s3 swap requires the new toolchain to avoid the glibc `_FORTIFY_SOURCE` `__*_chk` link failures that motivated #10102 in the first place.

Closes #10100.

## Test plan

- [x] `cargo check -p runner` locally
- [ ] CI `runner-build` and `deploy-runner-prepare` jobs compile runner+aws-lc-sys for `aarch64-unknown-linux-musl` without undefined-symbol errors.
- [ ] `cli-e2e-03-runner` jobs validate S3 integration end-to-end under the new TLS stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)