### PR TITLE
fix(platform): avoid empty select item value in model provider picker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -23,12 +23,16 @@ interface ModelProviderPickerProps {
   placeholder?: string;
 }
 
+// Radix Select reserves the empty string for "no value" and throws if a
+// SelectItem uses it, so use a sentinel to represent the inherit option.
+const INHERIT_SENTINEL = "__inherit_default__";
+
 function encodeValue(v: ModelProviderSelection | null): string {
-  return v ? `${v.modelProviderId}::${v.selectedModel}` : "";
+  return v ? `${v.modelProviderId}::${v.selectedModel}` : INHERIT_SENTINEL;
 }
 
 function decodeValue(s: string): ModelProviderSelection | null {
-  if (!s) {
+  if (s === INHERIT_SENTINEL) {
     return null;
   }
   const idx = s.indexOf("::");
@@ -76,7 +80,7 @@ export function ModelProviderPicker({
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="">{placeholder}</SelectItem>
+        <SelectItem value={INHERIT_SENTINEL}>{placeholder}</SelectItem>
         {options.map((opt) => {
           return (
             <SelectItem key={opt.value} value={opt.value}>


### PR DESCRIPTION
## Summary
- Replace `<SelectItem value="">` (the "inherit org default" option) with a sentinel, which Radix Select forbids and crashes on at render time
- Pre-existing crash introduced in #10077: any user with the `modelProviderSelection` flag on **and** at least one org model provider configured hits the `Oops! Something went sideways` error boundary when opening the agent Profile tab or the Schedule dialog

## Why empty string breaks
Radix UI reserves `""` as the controlled value meaning "no selection — show placeholder." A `<Select.Item value="">` throws:

> A `<Select.Item />` must have a value prop that is not an empty string.

Since the picker uses a controlled `<Select value={encodeValue(value)} />` where `encodeValue(null) === ""`, the empty-value item is rendered eagerly and crashes the tab.

## Fix
Use `"__inherit_default__"` as the sentinel for the null (inherit) option, both in `encodeValue` / `decodeValue` and on the corresponding `SelectItem`. No API change — all three call sites (`zero-settings-tab.tsx`, `schedule-dialog.tsx`, `zero-schedule-detail-page.tsx`) keep passing `ModelProviderSelection | null`.

## Test plan
- [x] `pnpm -F @vm0/app exec tsc --noEmit` — clean
- [x] `pnpm -F @vm0/app run lint` — 0 warnings, 0 errors
- [x] `pnpm format` — no changes
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-job-detail-page.test.tsx src/views/zero-page/__tests__/permissions-dialog.test.tsx` — 15 passed
- [x] Manually verified in dev: Profile tab no longer errors; picker opens and selects correctly; schedule dialog picker works (screenshots in handoff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)