### PR TITLE
fix(mitm-addon): log and short-circuit broken stream decompressors

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -55,6 +55,36 @@ _SENSITIVE_HEADER_KEYWORDS = (
 )
 
 
+def _make_streaming_decompressor(decomp_fn, error_cls, encoding_label: str):
+    """Wrap a chunk decompressor with log-once + short-circuit on failure.
+
+    ``zlib`` / ``brotli`` / ``zstd`` streaming decompressors have internal
+    state that becomes undefined after a decompression error — subsequent
+    ``decomp_fn(chunk)`` calls may keep raising or silently produce garbage
+    plaintext.  On first error we log once (at debug, mirroring the
+    non-streaming ``decompress_body`` pattern), latch a broken flag, and
+    return ``b""`` for every subsequent chunk so downstream parsers don't
+    consume corrupt output.
+    """
+    broken = False
+
+    def wrapper(chunk: bytes) -> bytes:
+        nonlocal broken
+        if broken:
+            return b""
+        try:
+            return decomp_fn(chunk)
+        except error_cls as exc:
+            broken = True
+            try:
+                ctx.log.debug(f"Streaming decompression failed ({encoding_label}): {exc}")
+            except AttributeError:
+                pass  # ctx.log unavailable outside mitmproxy runtime
+            return b""
+
+    return wrapper
+
+
 def create_stream_decompressor(headers: http.Headers):
     """Create an incremental decompressor for streaming chunks.
 
@@ -67,34 +97,13 @@ def create_stream_decompressor(headers: http.Headers):
     if encoding in ("gzip", "deflate"):
         wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
         obj = zlib.decompressobj(wbits)
-
-        def decompress_zlib(chunk: bytes) -> bytes:
-            try:
-                return obj.decompress(chunk)
-            except zlib.error:
-                return b""
-
-        return decompress_zlib
+        return _make_streaming_decompressor(obj.decompress, zlib.error, encoding)
     if encoding == "br":
         dec = brotli.Decompressor()
-
-        def decompress_br(chunk: bytes) -> bytes:
-            try:
-                return dec.process(chunk)
-            except brotli.error:
-                return b""
-
-        return decompress_br
+        return _make_streaming_decompressor(dec.process, brotli.error, "br")
     if encoding == "zstd":
         obj = zstandard.ZstdDecompressor().decompressobj()
-
-        def decompress_zstd(chunk: bytes) -> bytes:
-            try:
-                return obj.decompress(chunk)
-            except zstandard.ZstdError:
-                return b""
-
-        return decompress_zstd
+        return _make_streaming_decompressor(obj.decompress, zstandard.ZstdError, "zstd")
     return None
 
 

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -12,6 +12,7 @@ Exports:
 
 import base64
 import zlib
+from collections.abc import Callable
 
 import brotli  # type: ignore[import-untyped]
 import zstandard
@@ -55,7 +56,11 @@ _SENSITIVE_HEADER_KEYWORDS = (
 )
 
 
-def _make_streaming_decompressor(decomp_fn, error_cls, encoding_label: str):
+def _make_streaming_decompressor(
+    decomp_fn: Callable[[bytes], bytes],
+    error_cls: type[Exception],
+    encoding_label: str,
+) -> Callable[[bytes], bytes]:
     """Wrap a chunk decompressor with log-once + short-circuit on failure.
 
     ``zlib`` / ``brotli`` / ``zstd`` streaming decompressors have internal

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -13,6 +13,7 @@ from body_utils import (
     _redact_headers,
     _truncate_bytes_utf8_safe,
     add_capture_fields,
+    create_stream_decompressor,
 )
 from usage import extract_usage_from_json
 
@@ -755,3 +756,110 @@ class TestExtractUsageFromJson:
         assert result is not None
         assert result["input_tokens"] == 50
         assert result["output_tokens"] == 100
+
+
+class TestStreamDecompressor:
+    """Direct tests for ``create_stream_decompressor`` — exercises the
+    log-once + short-circuit guard that protects SSE/ndjson usage
+    extraction from garbage plaintext after a mid-stream failure.
+    """
+
+    def test_gzip_happy_path(self, headers):
+        import gzip
+
+        decomp = create_stream_decompressor(headers(("Content-Encoding", "gzip")))
+        assert decomp is not None
+        assert decomp(gzip.compress(b"hello world")) == b"hello world"
+
+    def test_brotli_happy_path(self, headers):
+        import brotli
+
+        decomp = create_stream_decompressor(headers(("Content-Encoding", "br")))
+        assert decomp is not None
+        assert decomp(brotli.compress(b"hello world")) == b"hello world"
+
+    def test_zstd_happy_path(self, headers):
+        import zstandard
+
+        decomp = create_stream_decompressor(headers(("Content-Encoding", "zstd")))
+        assert decomp is not None
+        assert decomp(zstandard.ZstdCompressor().compress(b"hello world")) == b"hello world"
+
+    def test_no_encoding_returns_none(self, headers):
+        assert create_stream_decompressor(headers()) is None
+
+    def test_identity_returns_none(self, headers):
+        assert create_stream_decompressor(headers(("Content-Encoding", "identity"))) is None
+
+    def test_gzip_error_logs_once_and_short_circuits(self, headers, mitm_ctx):
+        with mitm_ctx() as log:
+            decomp = create_stream_decompressor(headers(("Content-Encoding", "gzip")))
+            assert decomp is not None
+            assert decomp(b"not gzip at all") == b""
+            assert decomp(b"more garbage") == b""
+            assert decomp(b"even more") == b""
+        assert log.debug.call_count == 1
+        msg = log.debug.call_args[0][0]
+        assert "Streaming decompression failed" in msg
+        assert "gzip" in msg
+
+    def test_brotli_error_logs_once_and_short_circuits(self, headers, mitm_ctx):
+        with mitm_ctx() as log:
+            decomp = create_stream_decompressor(headers(("Content-Encoding", "br")))
+            assert decomp is not None
+            assert decomp(b"not brotli at all") == b""
+            assert decomp(b"more garbage") == b""
+        assert log.debug.call_count == 1
+        assert "br" in log.debug.call_args[0][0]
+
+    def test_zstd_error_logs_once_and_short_circuits(self, headers, mitm_ctx):
+        with mitm_ctx() as log:
+            decomp = create_stream_decompressor(headers(("Content-Encoding", "zstd")))
+            assert decomp is not None
+            assert decomp(b"not zstd at all") == b""
+            assert decomp(b"more garbage") == b""
+        assert log.debug.call_count == 1
+        assert "zstd" in log.debug.call_args[0][0]
+
+    def test_error_without_ctx_log_does_not_raise(self, headers):
+        # No mitm_ctx patch — ctx.log is unavailable.  Guard must swallow.
+        decomp = create_stream_decompressor(headers(("Content-Encoding", "gzip")))
+        assert decomp is not None
+        assert decomp(b"garbage") == b""
+        assert decomp(b"more garbage") == b""
+
+    def test_short_circuit_skips_decomp_fn_after_failure(self, headers, mitm_ctx, monkeypatch):
+        # Verify the broken flag actually prevents subsequent ``decomp_fn``
+        # calls — not just that they happen to return b"".  ``zlib.Decompress``
+        # is a C type whose ``decompress`` attribute is read-only, so we wrap
+        # the factory's return value in a proxy that counts delegations.
+        import zlib
+
+        real_factory = zlib.decompressobj
+
+        class CountingProxy:
+            def __init__(self, real):
+                self._real = real
+                self.count = 0
+
+            def decompress(self, chunk, *a, **kw):
+                self.count += 1
+                return self._real.decompress(chunk, *a, **kw)
+
+        proxies: list[CountingProxy] = []
+
+        def factory(*args, **kwargs):
+            proxy = CountingProxy(real_factory(*args, **kwargs))
+            proxies.append(proxy)
+            return proxy
+
+        monkeypatch.setattr("body_utils.zlib.decompressobj", factory)
+        with mitm_ctx():
+            decomp = create_stream_decompressor(headers(("Content-Encoding", "gzip")))
+            assert decomp is not None
+            assert decomp(b"not gzip") == b""
+            assert decomp(b"more garbage") == b""
+            assert decomp(b"and more") == b""
+        # Only the first chunk reaches zlib; later ones are short-circuited.
+        assert len(proxies) == 1
+        assert proxies[0].count == 1


### PR DESCRIPTION
## Summary

- Fix #9933: the three streaming-decompressor closures in `body_utils.create_stream_decompressor` (zlib / brotli / zstd) swallowed errors silently, leaving operators with no signal and — the deeper bug — continuing to call `decomp_fn(chunk)` on a decompressor whose state had been corrupted by the first error, potentially feeding garbage plaintext into SSE / ndjson usage parsers and polluting billing extraction.
- Introduce `_make_streaming_decompressor(decomp_fn, error_cls, label)` that wraps each closure with a `broken` flag. First failure latches the flag, emits a single `ctx.log.debug("Streaming decompression failed ({label}): {exc}")` (guarded by `AttributeError` for non-mitmproxy runs, mirroring `decompress_body`'s existing pattern), and returns `b""`. Subsequent chunks short-circuit to `b""` without re-invoking the broken decompressor.
- The three call sites in `create_stream_decompressor` collapse to one-liners.

## Scope note

Issue #9933 only asked for observability (log the failure). Digging in, the corrupted-state risk on subsequent chunks is a real data-integrity concern for streaming usage extraction, so the fix also short-circuits — same `broken` flag serves both purposes. The separate `decompress_body` (non-streaming) memory-cap bug discovered along the way is tracked independently in #10128.

## Test plan

- [x] `pytest tests/` — 871 passed (including 10 new `TestStreamDecompressor` tests).
- [x] `ruff check` + `ruff format --check` — clean.
- [x] Happy-path coverage added per encoding (prior: zero direct tests for `create_stream_decompressor`).
- [x] Error path verified per encoding: log called exactly once, subsequent chunks return `b""`, `decomp_fn` is not re-invoked (verified via a factory-proxy that counts delegations).
- [x] `AttributeError` guard verified (test without `mitm_ctx` patch does not raise).

Fixes #9933.