### PR TITLE
chore(mitm-addon): enable bugbear, bandit and related ruff rules

### DIFF
--- a/crates/runner/mitm-addon/pyproject.toml
+++ b/crates/runner/mitm-addon/pyproject.toml
@@ -22,7 +22,50 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = [
+    "E",      # pycodestyle errors
+    "F",      # pyflakes
+    "I",      # isort
+    "B",      # flake8-bugbear (real correctness bugs)
+    "S",      # flake8-bandit (security)
+    "ASYNC",  # flake8-async (this addon is async-heavy)
+    "UP",     # pyupgrade (modernize py3.10+ syntax)
+    "C4",     # flake8-comprehensions
+    "PT",     # flake8-pytest-style
+    "T20",    # flake8-print (force logging through ctx.log)
+    "RET",    # flake8-return
+    "N",      # pep8-naming
+    "G",      # flake8-logging-format
+    "A",      # flake8-builtins (no shadowing)
+    "SIM",    # flake8-simplify
+    "PIE",    # flake8-pie
+    "RUF",    # ruff-specific
+    "TRY",    # tryceratops (exception handling)
+    "PTH",    # flake8-use-pathlib
+]
+
+extend-ignore = [
+    # TRY003 forces a custom exception class for every interpolated-message
+    # raise (`raise ValueError(f"bad scheme: {x}")`). For one-shot errors that
+    # are never caught by type — only logged or surfaced to the operator —
+    # the extra class adds indirection without catching any real bug.
+    "TRY003",
+    # TRY300 asks for success paths to live in a try/except `else` block. It
+    # misfires when the success path does I/O (logging, etc.) that can in
+    # theory raise but never does in practice, pushing readers to restructure
+    # for a heuristic rather than a genuine error contract.
+    "TRY300",
+    # RUF002/003 flag EN DASH (–) vs HYPHEN-MINUS (-) in docstrings/comments.
+    # Pure typography; no runtime impact.
+    "RUF002",
+    "RUF003",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# S101: pytest uses `assert` universally; S105: tests hardcode fixture tokens
+# like "vm_sandbox_token" that bandit flags as "possible password". Both are
+# standard pytest patterns with no security meaning in test-only code.
+"tests/**" = ["S101", "S105"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -51,7 +51,11 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
     Centralises User-Agent, Authorization, Content-Type, and the optional
     Vercel bypass header so that callers cannot accidentally omit them.
     """
-    req = urllib.request.Request(
+    # S310 (suspicious-url-open-usage): `url` is always built by callers
+    # from `ctx.options.vm0_api_url` (operator-configured at mitmdump launch),
+    # never from user-controlled input, so the file:/custom-scheme risk S310
+    # guards against doesn't apply here.
+    req = urllib.request.Request(  # noqa: S310
         url,
         data=data,
         headers={
@@ -93,7 +97,9 @@ def _fetch_firewall_headers_sync(
     data = json.dumps(body).encode()
     req = make_api_request(url, data, sandbox_token)
     try:
-        resp = urllib.request.urlopen(req, timeout=10)
+        # S310 is satisfied by provenance: `req` always targets
+        # ctx.options.vm0_api_url (operator-set at mitmdump launch).
+        resp = urllib.request.urlopen(req, timeout=10)  # noqa: S310
     except urllib.error.HTTPError as e:
         try:
             error_body = json.loads(e.read())
@@ -196,7 +202,9 @@ def _forward_request_sync(
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme not in ("https", "http"):
         raise ValueError(f"Unsupported URL scheme: {parsed.scheme}")
-    req = urllib.request.Request(url, data=body, method=method)
+    # S310 is satisfied by the explicit scheme whitelist above: file:, ftp:,
+    # and other schemes S310 warns about are rejected before this point.
+    req = urllib.request.Request(url, data=body, method=method)  # noqa: S310
     for k, v in headers.items():
         if k.lower() in HOP_BY_HOP or k.lower() == "host":
             continue

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -11,6 +11,7 @@ Exports:
 """
 
 import base64
+import contextlib
 import zlib
 from collections.abc import Callable
 
@@ -81,10 +82,9 @@ def _make_streaming_decompressor(
             return decomp_fn(chunk)
         except error_cls as exc:
             broken = True
-            try:
+            with contextlib.suppress(AttributeError):
+                # ctx.log unavailable outside mitmproxy runtime
                 ctx.log.debug(f"Streaming decompression failed ({encoding_label}): {exc}")
-            except AttributeError:
-                pass  # ctx.log unavailable outside mitmproxy runtime
             return b""
 
     return wrapper
@@ -146,10 +146,9 @@ def decompress_body(
             result = obj.decompress(data)
             return result[:max_output] if result else data
     except (zlib.error, brotli.error, zstandard.ZstdError) as exc:
-        try:
+        with contextlib.suppress(AttributeError):
+            # ctx.log unavailable outside mitmproxy runtime
             ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
-        except AttributeError:
-            pass  # ctx.log unavailable outside mitmproxy runtime
     return data
 
 

--- a/crates/runner/mitm-addon/src/graphql_fields.py
+++ b/crates/runner/mitm-addon/src/graphql_fields.py
@@ -76,7 +76,7 @@ class Lexer:
     never sees raw characters.
     """
 
-    __slots__ = ("src", "pos", "length")
+    __slots__ = ("length", "pos", "src")
 
     def __init__(self, source: str) -> None:
         self.src = source
@@ -395,5 +395,5 @@ def extract_field_paths(query_str: str) -> list[str]:
         lexer = Lexer(query_str)
         parser = Parser(lexer)
         return parser.parse()
-    except Exception:  # noqa: BLE001 — fail-closed: unparseable → no matches → blocked
+    except Exception:
         return []

--- a/crates/runner/mitm-addon/src/graphql_fields.py
+++ b/crates/runner/mitm-addon/src/graphql_fields.py
@@ -396,4 +396,7 @@ def extract_field_paths(query_str: str) -> list[str]:
         parser = Parser(lexer)
         return parser.parse()
     except Exception:
+        # Fail-closed: unparseable query → no field matches → firewall blocks.
+        # Catching `Exception` (not a narrower type) is deliberate — any
+        # lexer/parser bug must not crash the addon on a malformed query.
         return []

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -11,9 +11,10 @@ This addon runs on the runner HOST (not inside VMs) and:
 
 import functools
 import json
-import os
+import tempfile
 import time
 import urllib.parse
+from pathlib import Path
 
 from mitmproxy import ctx, http, tcp, tls
 from mitmproxy.addonmanager import Loader
@@ -54,16 +55,19 @@ def load(loader: Loader) -> None:
     loader.add_option(
         name="vm0_proxy_registry_path",
         typespec=str,
-        default="/tmp/proxy-registry.json",
+        # This default is a placeholder shown in `mitmdump --help`; the runner
+        # always passes `--set vm0_proxy_registry_path=<per-runner path>` (see
+        # crates/runner/src/proxy.rs:362), so the default is never used in
+        # production. Computed via tempfile.gettempdir() so that standalone
+        # debugging works on platforms where /tmp is not the system temp dir.
+        default=str(Path(tempfile.gettempdir()) / "proxy-registry.json"),
         help="Path to proxy registry file",
     )
 
     # Initialize the usage pending-count file so the runner can poll it
     # before sending SIGTERM.  The file lives next to the addon script,
     # which is written to addon_dir by the runner.
-    usage.set_pending_path(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "usage-pending")
-    )
+    usage.set_pending_path(str(Path(__file__).resolve().parent / "usage-pending"))
 
 
 def get_api_url() -> str:
@@ -93,12 +97,12 @@ def load_registry() -> dict:
     global _registry_cache, _registry_cache_key
 
     try:
-        registry_path = get_registry_path()
-        st = os.stat(registry_path)
+        registry_path = Path(get_registry_path())
+        st = registry_path.stat()
         key = (st.st_mtime_ns, st.st_size)
         if key == _registry_cache_key:
             return _registry_cache
-        with open(registry_path, "r") as f:
+        with registry_path.open() as f:
             new_registry = json.load(f).get("vms", {})
 
         # Evict cache entries for runs no longer in the registry
@@ -201,10 +205,13 @@ async def request(flow: http.HTTPFlow) -> None:
     if api_url:
         parsed_api = urllib.parse.urlparse(api_url)
         api_hostname = parsed_api.hostname.lower() if parsed_api.hostname else ""
-        if api_hostname and (hostname == api_hostname or hostname.endswith(f".{api_hostname}")):
-            if not flow.request.path.startswith("/api/test/"):
-                flow.metadata["firewall_action"] = "ALLOW"
-                return
+        if (
+            api_hostname
+            and (hostname == api_hostname or hostname.endswith(f".{api_hostname}"))
+            and not flow.request.path.startswith("/api/test/")
+        ):
+            flow.metadata["firewall_action"] = "ALLOW"
+            return
 
     # --- Step 2: Firewall match with permission check ---
     # Match base URL, then check permission rules before injecting auth headers.

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -35,10 +35,7 @@ def build_rewrite_url(resolved_base: str, match_info: dict, orig_url: str) -> st
 
     # Append rel_path to the base path portion
     rel_path = match_info.get("rel_path", "/")
-    if rel_path != "/":
-        base_path = base_parsed.path.rstrip("/") + rel_path
-    else:
-        base_path = base_parsed.path
+    base_path = base_parsed.path.rstrip("/") + rel_path if rel_path != "/" else base_parsed.path
 
     # Merge query strings: base qs + original request qs
     qs_parts: list[str] = []

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -12,13 +12,13 @@ Two paths:
 """
 
 import json
-import os
 import threading
 import time
 import urllib.error
 import urllib.parse
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from typing import TypedDict
 
 from mitmproxy import http
@@ -33,7 +33,7 @@ from logging_utils import log_proxy_entry
 #
 # The runner reads this file before sending SIGTERM so it can wait until
 # both counters reach zero (all flows processed, all reports delivered).
-# File format: "<flows>:<reports>" written atomically (tmp + os.replace).
+# File format: "<flows>:<reports>" written atomically (tmp + Path.replace).
 # ---------------------------------------------------------------------------
 
 _counter_lock = threading.Lock()
@@ -53,11 +53,11 @@ def _write_pending() -> None:
     """Atomically write current counters to file."""
     if not _pending_path:
         return
-    tmp = _pending_path + ".tmp"
+    tmp = Path(_pending_path + ".tmp")
     try:
-        with open(tmp, "w") as f:
+        with tmp.open("w") as f:
             f.write(f"{_in_flight_flows}:{_pending_reports}")
-        os.replace(tmp, _pending_path)
+        tmp.replace(_pending_path)
     except OSError:
         pass  # best-effort; runner will timeout if file is stale
 
@@ -122,15 +122,13 @@ def _extract_billing_usage(raw_usage, target: dict) -> None:
     if not raw_usage or not isinstance(raw_usage, dict):
         return
     for k, v in raw_usage.items():
-        if k in _BILLING_FIELDS and isinstance(v, (int, float)):
-            if v > 0 or k not in target:
-                target[k] = v
+        if k in _BILLING_FIELDS and isinstance(v, (int, float)) and (v > 0 or k not in target):
+            target[k] = v
     stu = raw_usage.get("server_tool_use")
     if isinstance(stu, dict):
         wsr = stu.get("web_search_requests")
-        if isinstance(wsr, (int, float)):
-            if wsr > 0 or "web_search_requests" not in target:
-                target["web_search_requests"] = wsr
+        if isinstance(wsr, (int, float)) and (wsr > 0 or "web_search_requests" not in target):
+            target["web_search_requests"] = wsr
 
 
 def create_sse_usage_extractor() -> tuple[Callable[[bytes], None], dict]:

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -43,7 +43,7 @@ def _reset_module_state() -> Iterator[None]:
     mitm_addon._registry_cache_key = (0, 0)
     auth._firewall_header_cache.clear()
     auth._cache_locks.clear()
-    yield
+    return
 
 
 def _headers(*pairs: tuple[str, str]) -> http.Headers:
@@ -208,7 +208,7 @@ class _StubOptions:
 
 
 @pytest.fixture
-def mitm_ctx():
+def mitm_ctx(tmp_path):
     """Stub ``mitmproxy.ctx.options`` and ``ctx.log`` for a test block.
 
     Returns a context-manager factory: calling ``mitm_ctx(registry_path=...)``
@@ -217,14 +217,22 @@ def mitm_ctx():
     that need to assert on warn/debug calls can do so; ``options`` doesn't
     get that treatment because the addon only ever reads two named
     attributes from it.
+
+    When the caller omits ``registry_path`` the default comes from pytest's
+    per-test ``tmp_path`` fixture, so tests never share a /tmp path that
+    could race between parallel workers.
     """
+
+    default_registry_path = str(tmp_path / "proxy-registry.json")
 
     @contextlib.contextmanager
     def _stub(
         *,
-        registry_path: str = "/tmp/proxy-registry.json",
+        registry_path: str | None = None,
         api_url: str = "https://api.vm0.ai",
     ) -> Iterator[MagicMock]:
+        if registry_path is None:
+            registry_path = default_registry_path
         options = _StubOptions(registry_path=registry_path, api_url=api_url)
         log = MagicMock()
         with (

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -30,20 +30,22 @@ import usage
 
 
 @pytest.fixture(autouse=True)
-def _reset_module_state() -> Iterator[None]:
+def _reset_module_state() -> None:
     """Clear cached singletons between tests.
 
     ``mitm_addon`` and ``auth`` cache registry data and firewall header
     lookups in module-level dicts.  Without a reset, earlier tests leak
     entries that change later tests' behaviour (e.g. a request from IP X
     in test A primes ``_request_start_times`` seen by test B).
+
+    No teardown body — the next test's autouse invocation is itself the
+    cleanup, so we use ``return``-style (not ``yield``) per PT022.
     """
     mitm_addon._request_start_times.clear()
     mitm_addon._registry_cache = {}
     mitm_addon._registry_cache_key = (0, 0)
     auth._firewall_header_cache.clear()
     auth._cache_locks.clear()
-    return
 
 
 def _headers(*pairs: tuple[str, str]) -> http.Headers:

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1340,7 +1340,9 @@ class TestGetFirewallHeaders:
 
 
 class TestHandleFirewallRequest:
-    async def test_success_injects_headers_and_audit_metadata(self, real_flow, headers, mitm_ctx):
+    async def test_success_injects_headers_and_audit_metadata(
+        self, real_flow, headers, mitm_ctx, tmp_path
+    ):
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
@@ -1352,7 +1354,7 @@ class TestHandleFirewallRequest:
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {
             "name": "github",
@@ -1397,7 +1399,7 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_rule_match"] == "GET /repos/{owner}/{repo}"
         assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
 
-    async def test_failure_returns_502(self, real_flow, headers, mitm_ctx):
+    async def test_failure_returns_502(self, real_flow, headers, mitm_ctx, tmp_path):
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"
         api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
@@ -1405,7 +1407,7 @@ class TestHandleFirewallRequest:
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {"name": "github", "ref": "github"}
 
@@ -1462,7 +1464,9 @@ class TestHandleFirewallRequest:
 
         assert flow.response is None
 
-    async def test_connector_not_configured_returns_424(self, real_flow, headers, mitm_ctx):
+    async def test_connector_not_configured_returns_424(
+        self, real_flow, headers, mitm_ctx, tmp_path
+    ):
         """When connector is enabled but not linked, return 424 with missing secrets."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"
@@ -1471,7 +1475,7 @@ class TestHandleFirewallRequest:
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {"name": "github", "ref": "github"}
 
@@ -1500,7 +1504,7 @@ class TestHandleFirewallRequest:
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
 
-    async def test_missing_vars_only_returns_424(self, real_flow, headers, mitm_ctx):
+    async def test_missing_vars_only_returns_424(self, real_flow, headers, mitm_ctx, tmp_path):
         """When connector not configured, return 424 with connector ref."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"
@@ -1509,7 +1513,7 @@ class TestHandleFirewallRequest:
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {"name": "htmlcsstoimage", "ref": "htmlcsstoimage"}
 
@@ -1694,11 +1698,9 @@ class TestFetchFirewallHeaders:
             patch("auth.urllib.request.Request"),
             patch("auth.urllib.request.urlopen", side_effect=http_error),
             patch.object(auth, "VERCEL_BYPASS", ""),
+            pytest.raises(urllib.error.HTTPError),
         ):
-            with pytest.raises(urllib.error.HTTPError):
-                auth._fetch_firewall_headers_sync(
-                    "iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai"
-                )
+            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
 
     async def test_async_wrapper_passes_api_url_from_ctx(self, headers):
         """fetch_firewall_headers reads api_url on the event loop and passes it to the sync fn."""
@@ -1768,7 +1770,7 @@ class TestForwardRequestSecurity:
 class TestAuthBaseUrlRewrite:
     """Tests for auth.base URL rewriting via forward_request in handle_firewall_request."""
 
-    async def test_url_rewrite_with_rel_path_root(self, real_flow, headers, mitm_ctx):
+    async def test_url_rewrite_with_rel_path_root(self, real_flow, headers, mitm_ctx, tmp_path):
         """When rel_path is '/', resolved base URL is forwarded as-is."""
         flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path="/hook")
         flow.metadata["vm_run_id"] = "test-run"
@@ -1780,7 +1782,7 @@ class TestAuthBaseUrlRewrite:
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {
             "name": "discord-webhook",
@@ -1809,7 +1811,7 @@ class TestAuthBaseUrlRewrite:
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.response.status_code == 200
 
-    async def test_url_rewrite_with_remaining_path(self, real_flow, headers, mitm_ctx):
+    async def test_url_rewrite_with_remaining_path(self, real_flow, headers, mitm_ctx, tmp_path):
         """When rel_path has content, it's appended to resolved base in forwarded URL."""
         flow = real_flow(
             with_response=False,
@@ -1825,7 +1827,7 @@ class TestAuthBaseUrlRewrite:
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {
             "name": "bitrix",
@@ -1856,7 +1858,7 @@ class TestAuthBaseUrlRewrite:
         )
         assert flow.metadata["firewall_action"] == "ALLOW"
 
-    async def test_url_rewrite_preserves_query_string(self, real_flow, headers, mitm_ctx):
+    async def test_url_rewrite_preserves_query_string(self, real_flow, headers, mitm_ctx, tmp_path):
         """Query string from original request is preserved in forwarded URL."""
         flow = real_flow(
             with_response=False,
@@ -1872,7 +1874,7 @@ class TestAuthBaseUrlRewrite:
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {
             "name": "discord-webhook",
@@ -1900,7 +1902,7 @@ class TestAuthBaseUrlRewrite:
         assert mock_forward.call_args[0][0] == "https://discord.com/api/webhooks/123/abc?wait=true"
 
     async def test_url_rewrite_resolved_base_with_trailing_slash(
-        self, real_flow, headers, mitm_ctx
+        self, real_flow, headers, mitm_ctx, tmp_path
     ):
         """Trailing slash on resolved base is stripped before appending rel_path."""
         flow = real_flow(
@@ -1917,7 +1919,7 @@ class TestAuthBaseUrlRewrite:
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {
             "name": "bitrix",
@@ -1947,7 +1949,7 @@ class TestAuthBaseUrlRewrite:
             == "https://mycompany.bitrix24.com/rest/1/token/crm.deal.list"
         )
 
-    async def test_url_rewrite_merges_query_strings(self, real_flow, headers, mitm_ctx):
+    async def test_url_rewrite_merges_query_strings(self, real_flow, headers, mitm_ctx, tmp_path):
         """When resolved base has query string and original request also has one, merge with &."""
         flow = real_flow(
             with_response=False,
@@ -1963,7 +1965,7 @@ class TestAuthBaseUrlRewrite:
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {
             "name": "test",
@@ -1990,7 +1992,9 @@ class TestAuthBaseUrlRewrite:
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert mock_forward.call_args[0][0] == "https://example.com/hook?token=abc&wait=true"
 
-    async def test_no_url_rewrite_when_auth_base_absent(self, real_flow, headers, mitm_ctx):
+    async def test_no_url_rewrite_when_auth_base_absent(
+        self, real_flow, headers, mitm_ctx, tmp_path
+    ):
         """Without auth.base, no URL rewriting happens (existing behavior)."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"
@@ -2003,7 +2007,7 @@ class TestAuthBaseUrlRewrite:
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {
             "name": "github",
@@ -2141,6 +2145,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
     def _make_rewrite_inputs(
         self,
         real_flow,
+        tmp_path,
         *,
         path="/hook",
         pretty_url=None,
@@ -2170,7 +2175,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
             "runId": "run-1",
             "sandboxToken": "tok",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {
             "name": "test",
@@ -2188,9 +2193,11 @@ class TestAuthBaseUrlRewriteEdgeCases:
         }
         return flow, api_entry, vm_info, match_info, token_meta
 
-    async def test_sets_auth_url_rewrite_metadata_and_response(self, real_flow, mitm_ctx):
+    async def test_sets_auth_url_rewrite_metadata_and_response(self, real_flow, mitm_ctx, tmp_path):
         """auth_url_rewrite metadata is set and flow.response is populated via forward_request."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(real_flow)
+        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
+            real_flow, tmp_path
+        )
         mock_forward = AsyncMock(
             return_value=(200, b'{"ok":true}', {"Content-Type": "application/json"})
         )
@@ -2207,7 +2214,9 @@ class TestAuthBaseUrlRewriteEdgeCases:
         call_args = mock_forward.call_args
         assert call_args[0][0] == "https://discord.com/api/webhooks/123/abc"
 
-    async def test_no_auth_url_rewrite_metadata_when_no_base(self, real_flow, headers, mitm_ctx):
+    async def test_no_auth_url_rewrite_metadata_when_no_base(
+        self, real_flow, headers, mitm_ctx, tmp_path
+    ):
         """auth_url_rewrite metadata is absent when no URL rewrite happens."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"
@@ -2219,7 +2228,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
             "runId": "run-1",
             "sandboxToken": "tok",
             "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": "/tmp/net.jsonl",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
         }
         match_info = {
             "name": "gh",
@@ -2242,10 +2251,13 @@ class TestAuthBaseUrlRewriteEdgeCases:
         # Standard header injection happened
         assert flow.request.headers["Authorization"] == "Bearer real"
 
-    async def test_forward_request_includes_auth_headers(self, headers, real_flow, mitm_ctx):
+    async def test_forward_request_includes_auth_headers(
+        self, headers, real_flow, mitm_ctx, tmp_path
+    ):
         """auth.headers are included in the forwarded request to the real URL."""
         flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
             real_flow,
+            tmp_path,
             resolved_base="https://discord.com/api/webhooks/123/abc",
         )
         token_meta["headers"] = {"X-Custom": "injected-value"}
@@ -2262,9 +2274,11 @@ class TestAuthBaseUrlRewriteEdgeCases:
         req_headers = call_args[0][2]
         assert req_headers["X-Custom"] == "injected-value"
 
-    async def test_forward_failure_returns_502(self, real_flow, mitm_ctx):
+    async def test_forward_failure_returns_502(self, real_flow, mitm_ctx, tmp_path):
         """forward_request exception produces a 502 error response."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(real_flow)
+        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
+            real_flow, tmp_path
+        )
         mock_forward = AsyncMock(side_effect=Exception("connection refused"))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -2276,9 +2290,11 @@ class TestAuthBaseUrlRewriteEdgeCases:
         assert flow.response.status_code == 502
         assert flow.metadata["auth_url_rewrite"] is True
 
-    async def test_no_rewrite_when_resolved_base_empty_string(self, real_flow, mitm_ctx):
+    async def test_no_rewrite_when_resolved_base_empty_string(self, real_flow, mitm_ctx, tmp_path):
         """Empty string base from server is treated as absent — no URL rewrite."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(real_flow)
+        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
+            real_flow, tmp_path
+        )
         token_meta["base"] = ""
         original_url = flow.request.url
         with (

--- a/crates/runner/mitm-addon/tests/test_graphql_fields.py
+++ b/crates/runner/mitm-addon/tests/test_graphql_fields.py
@@ -4,6 +4,8 @@ Test cases reference graphql-core's parser test suite, adapted to our
 field-path-extraction use case.
 """
 
+from typing import ClassVar
+
 import pytest
 
 from graphql_fields import Lexer, T, extract_field_paths
@@ -1234,7 +1236,7 @@ class TestGraphQLCoreKeywordsAsNames:
     which iterates over all GraphQL keywords.
     """
 
-    KEYWORDS = [
+    KEYWORDS: ClassVar[list[str]] = [
         "on",
         "fragment",
         "query",
@@ -1709,7 +1711,7 @@ class TestKeywordsEveryPosition:
     is correct regardless of keyword placement.
     """
 
-    NON_ON_KEYWORDS = [
+    NON_ON_KEYWORDS: ClassVar[list[str]] = [
         "fragment",
         "query",
         "mutation",

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -764,7 +764,7 @@ class TestResponseHandler:
         flow.metadata["firewall_api_id"] = "run-conn-1:0"
         flow.metadata["original_url"] = "https://api.github.com/repos"
 
-        flow.response = tutils.tresp(status_code=401, headers=http.Headers(**{}))
+        flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
         # Pre-populate firewall header cache keyed by api_id
         cache_key = ("run-conn-1", "run-conn-1:0")
@@ -791,7 +791,7 @@ class TestResponseHandler:
         flow.metadata["firewall_rule"] = "domain:*.example.com"
         flow.metadata["original_url"] = "https://api.example.com/"
 
-        flow.response = tutils.tresp(status_code=500, headers=http.Headers(**{}))
+        flow.response = tutils.tresp(status_code=500, headers=http.Headers())
 
         mitm_addon.response(flow)
 
@@ -2780,9 +2780,9 @@ class TestFirewallHeaderCache:
         with (
             patch.object(auth, "get_api_url", return_value="https://test.vm0.ai"),
             patch.object(auth, "_fetch_firewall_headers_sync", side_effect=failing_fetch),
+            pytest.raises(ConnectionError),
         ):
-            with pytest.raises(ConnectionError):
-                await auth.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
+            await auth.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
 
         assert ("run-1", "api-1") not in auth._firewall_header_cache
 


### PR DESCRIPTION
## Summary

Closes #9934. Expands `crates/runner/mitm-addon/pyproject.toml`'s ruff `select` from `[E, F, I]` to a 19-family set — everything relevant to this codebase except `ARG` (too many pytest fixture-param false positives).

Added families: `B`, `S`, `ASYNC`, `UP`, `C4`, `PT`, `T20`, `RET`, `N`, `G`, `A`, `SIM`, `PIE`, `RUF`, `TRY`, `PTH`.

The parent issue specifically called out `B` and `S`; the rest came up as zero-cost additions (0 violations) or cheap cleanups during scanning.

## Rule scope decisions

- **Globally ignored** (inline rationale in `pyproject.toml`): `TRY003`/`TRY300` (force custom exception classes for one-shot interpolated messages), `RUF002`/`RUF003` (EN DASH vs HYPHEN-MINUS typography).
- **tests/** per-file-ignore: `S101` (pytest `assert`) and `S105` (fixture-token string literals like `"vm_sandbox_token"`).

## Real fixes applied

- **S108** `src/mitm_addon.py`: default registry path now derived from `tempfile.gettempdir()` (was `/tmp/...`)
- **S108** tests: 12 `/tmp/net.jsonl` literals in `test_connectors.py` and one `/tmp/proxy-registry.json` default in `conftest.py`'s `mitm_ctx` fixture replaced with `tmp_path`-derived paths — prevents parallel-test collisions
- **SIM102** (3×), **SIM105** (2×), **SIM108**, **SIM117** — simplified nested `if`/`with`, `try-except-pass` → `contextlib.suppress`
- **PIE804** (2×) — auto-fixed unnecessary `**{…}` dict kwargs
- **PTH100/105/116/118/120/123** — `src/mitm_addon.py` and `src/usage.py` migrated `os.path` / `os.stat` / `open` / `os.replace` to `pathlib.Path`
- **RUF012** — mutable class-attribute defaults in `test_graphql_fields.py` now `ClassVar[list[str]]`
- **RUF023** — `Lexer.__slots__` auto-sorted

## Remaining noqa

3× `S310` (suspicious-url-open-usage) in `src/auth.py`. Each has an inline rationale: two sites have operator-controlled URL provenance (`ctx.options.vm0_api_url`), one site has an explicit scheme whitelist at the top of `_forward_request_sync`. Avoiding the noqa would require switching `urllib.request` → `http.client.HTTPSConnection` in firewall-auth-critical code and rewriting coupled tests — out of scope for this ruff-enablement issue.

## Test plan

- [x] `ruff check` — All checks passed
- [x] `pytest tests/` — 871 passed (pre-change 861; the delta is upstream `_make_streaming_decompressor` tests pulled during rebase)
- [ ] CI: turbo lint + tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)