### PR TITLE
fix(ci): use bash shell for rollback target_version semver check

### DIFF
--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Validate target_version format
         env:
           VERSION: ${{ inputs.target_version }}
+        shell: bash
         run: |
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::target_version='$VERSION' is not semver (e.g. 0.81.0). Reject."


### PR DESCRIPTION
## Summary

- Real rollback attempt with `target_version=0.86.1` failed today with `[[: not found` even though the input was valid semver. Root cause: the container image defaults to `sh -e` which lacks `[[ =~ ]]`.
- Add `shell: bash` to the semver-validation step. The regex stays byte-identical; only the invocation shell changes. Matches the pattern already used in `release-please.yml` and `turbo.yml`.
- Audited every other `run:` block in the file (5 total) — all POSIX-compatible. No further `[[`, arrays, `<<<`, `==` in `[`, or other bash-only syntax.

## Test plan

- [x] `gh workflow run` is operator-gated; verification will happen on the next rollback invocation
- [x] Diff is 1 line — low risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)