### PR TITLE
chore: enable model provider selection and vm0 glm/kimi/minimax flags

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -289,21 +289,21 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Expose Moonshot Kimi K2.5 as a selectable model under the VM0 managed provider",
-    enabled: false,
+    enabled: true,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.Vm0GlmModel]: {
     maintainer: "ethan@vm0.ai",
     description:
       "Expose Z.AI GLM-5.1 as a selectable model under the VM0 managed provider",
-    enabled: false,
+    enabled: true,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.Vm0MinimaxModel]: {
     maintainer: "ethan@vm0.ai",
     description:
       "Expose MiniMax M2.7 as a selectable model under the VM0 managed provider",
-    enabled: false,
+    enabled: true,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.SlackAgentSwitch]: {
@@ -329,7 +329,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show the model provider + model picker on the agent profile page and schedule dialog. " +
       "Allows per-agent and per-schedule model selection, overriding the org default. " +
       "Staff-only during initial rollout.",
-    enabled: false,
+    enabled: true,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
 };


### PR DESCRIPTION
## Summary
- Flip `ModelProviderSelection`, `Vm0KimiModel`, `Vm0GlmModel`, and `Vm0MinimaxModel` feature switches from `enabled: false` to `enabled: true` so the model provider picker and VM0-managed GLM / Kimi / MiniMax models are rolled out to all orgs.
- Flag definitions and `enabledOrgIdHashes` are preserved so the flags can still be gated back to staff-only if a rollback is needed.

## Test plan
- [x] `pnpm -F @vm0/core exec tsc --noEmit` passes
- [x] Lefthook pre-commit hooks (prettier, knip, commitlint) pass
- [ ] CI (lint / test / deploy / cli-e2e) green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)