### PR TITLE
fix(guest-agent): record per-op durations for checkpoint session reads

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -49,10 +49,19 @@ async fn create_checkpoint_impl(
         );
         return Err(AgentError::Checkpoint("No session ID found".into()));
     }
-    let session_id = std::fs::read_to_string(session_id_path)
-        .map_err(|e| AgentError::Checkpoint(format!("Failed to read session ID: {e}")))?
-        .trim()
-        .to_string();
+    let session_id = match std::fs::read_to_string(session_id_path) {
+        Ok(s) => s.trim().to_string(),
+        Err(e) => {
+            let msg = format!("Failed to read session ID: {e}");
+            record_sandbox_op(
+                "session_id_read",
+                session_id_start.elapsed(),
+                false,
+                Some(&msg),
+            );
+            return Err(AgentError::Checkpoint(msg));
+        }
+    };
     record_sandbox_op("session_id_read", session_id_start.elapsed(), true, None);
 
     // Read session history path
@@ -70,12 +79,19 @@ async fn create_checkpoint_impl(
             "No session history path found".into(),
         ));
     }
-    let raw_path = std::fs::read_to_string(history_path_file)
-        .map_err(|e| AgentError::Checkpoint(format!("Failed to read history path: {e}")))?
-        .trim()
-        .to_string();
-
-    let session_history_path = raw_path;
+    let session_history_path = match std::fs::read_to_string(history_path_file) {
+        Ok(s) => s.trim().to_string(),
+        Err(e) => {
+            let msg = format!("Failed to read history path: {e}");
+            record_sandbox_op(
+                "session_history_read",
+                history_read_start.elapsed(),
+                false,
+                Some(&msg),
+            );
+            return Err(AgentError::Checkpoint(msg));
+        }
+    };
 
     // Read session history
     if !Path::new(&session_history_path).exists() {

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -26,24 +26,24 @@ pub async fn create_checkpoint(
     memory_boot_fp: &memory::MemoryBootFingerprint,
 ) -> Result<(), AgentError> {
     let start = std::time::Instant::now();
-    let result = create_checkpoint_impl(start, memory_boot_fp).await;
+    let result = create_checkpoint_impl(memory_boot_fp).await;
     record_sandbox_op("checkpoint_total", start.elapsed(), result.is_ok(), None);
     result
 }
 
 async fn create_checkpoint_impl(
-    start: std::time::Instant,
     memory_boot_fp: &memory::MemoryBootFingerprint,
 ) -> Result<(), AgentError> {
     log_info!(LOG_TAG, "Creating checkpoint...");
 
     // Read session ID
+    let session_id_start = std::time::Instant::now();
     let session_id_path = paths::session_id_file();
     if !Path::new(session_id_path).exists() {
         log_error!(LOG_TAG, "No session ID found, checkpoint creation failed");
         record_sandbox_op(
             "session_id_read",
-            start.elapsed(),
+            session_id_start.elapsed(),
             false,
             Some("Session ID file not found"),
         );
@@ -53,15 +53,16 @@ async fn create_checkpoint_impl(
         .map_err(|e| AgentError::Checkpoint(format!("Failed to read session ID: {e}")))?
         .trim()
         .to_string();
-    record_sandbox_op("session_id_read", start.elapsed(), true, None);
+    record_sandbox_op("session_id_read", session_id_start.elapsed(), true, None);
 
     // Read session history path
+    let history_read_start = std::time::Instant::now();
     let history_path_file = paths::session_history_path_file();
     if !Path::new(history_path_file).exists() {
         log_error!(LOG_TAG, "No session history path found");
         record_sandbox_op(
             "session_history_read",
-            start.elapsed(),
+            history_read_start.elapsed(),
             false,
             Some("Path file not found"),
         );
@@ -84,7 +85,7 @@ async fn create_checkpoint_impl(
         );
         record_sandbox_op(
             "session_history_read",
-            start.elapsed(),
+            history_read_start.elapsed(),
             false,
             Some("File not found"),
         );
@@ -97,7 +98,12 @@ async fn create_checkpoint_impl(
         Ok(s) => s,
         Err(e) => {
             let msg = format!("Failed to read session history: {e}");
-            record_sandbox_op("session_history_read", start.elapsed(), false, Some(&msg));
+            record_sandbox_op(
+                "session_history_read",
+                history_read_start.elapsed(),
+                false,
+                Some(&msg),
+            );
             return Err(AgentError::Checkpoint(msg));
         }
     };
@@ -106,7 +112,7 @@ async fn create_checkpoint_impl(
         log_error!(LOG_TAG, "Session history is empty");
         record_sandbox_op(
             "session_history_read",
-            start.elapsed(),
+            history_read_start.elapsed(),
             false,
             Some("Empty"),
         );
@@ -115,7 +121,12 @@ async fn create_checkpoint_impl(
 
     let line_count = session_history.lines().count();
     log_info!(LOG_TAG, "Session history loaded ({line_count} lines)");
-    record_sandbox_op("session_history_read", start.elapsed(), true, None);
+    record_sandbox_op(
+        "session_history_read",
+        history_read_start.elapsed(),
+        true,
+        None,
+    );
 
     // Compute SHA-256 hash of session history for presigned URL upload
     let history_bytes = session_history.as_bytes();


### PR DESCRIPTION
## Summary
- `session_id_read` and `session_history_read` telemetry records reused the function-entry `Instant`, so `duration_ms` reflected cumulative wall-clock time from checkpoint start instead of the individual op cost.
- Introduces `session_id_start` and `history_read_start` per-op timers, matching the existing `prep_start` / `upload_start` / `api_start` pattern.
- Drops the now-unused `start` parameter on `create_checkpoint_impl` — after the fix, all per-op timing is local, and `checkpoint_total` still uses the outer `start` in `create_checkpoint`.

Closes #10030

## Test plan
- [x] `cargo test -p guest-agent --lib` — 87 passed
- [x] `cargo clippy -p guest-agent --all-targets -- -D warnings`
- [x] `cargo fmt -p guest-agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)