### PR TITLE
feat(zero): configure model provider and model via cli

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -9,6 +9,72 @@ import {
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 
+interface AgentEditOptions {
+  displayName?: string;
+  description?: string;
+  sound?: string;
+  skills?: string;
+  addSkill?: string;
+  removeSkill?: string;
+  instructionsFile?: string;
+  modelProvider?: string;
+  model?: string;
+}
+
+function parseModelFlag(value: string | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === "default") return null;
+  return value;
+}
+
+function hasAgentFieldUpdate(options: AgentEditOptions): boolean {
+  return (
+    options.displayName !== undefined ||
+    options.description !== undefined ||
+    options.sound !== undefined ||
+    options.skills !== undefined ||
+    options.addSkill !== undefined ||
+    options.removeSkill !== undefined ||
+    options.modelProvider !== undefined ||
+    options.model !== undefined
+  );
+}
+
+async function applyAgentUpdate(
+  agentId: string,
+  options: AgentEditOptions,
+): Promise<void> {
+  const current = await getZeroAgent(agentId);
+  const customSkills = resolveCustomSkills(options, current.customSkills ?? []);
+
+  const modelProviderId =
+    options.modelProvider !== undefined
+      ? parseModelFlag(options.modelProvider)
+      : current.modelProviderId;
+  const selectedModel =
+    options.model !== undefined
+      ? parseModelFlag(options.model)
+      : current.selectedModel;
+
+  await updateZeroAgent(agentId, {
+    displayName:
+      options.displayName !== undefined
+        ? options.displayName
+        : (current.displayName ?? undefined),
+    description:
+      options.description !== undefined
+        ? options.description
+        : (current.description ?? undefined),
+    sound:
+      options.sound !== undefined
+        ? options.sound
+        : (current.sound ?? undefined),
+    customSkills,
+    modelProviderId,
+    selectedModel,
+  });
+}
+
 function validateSkillName(name: string): void {
   const result = zeroAgentCustomSkillNameSchema.safeParse(name);
   if (!result.success) {
@@ -77,6 +143,14 @@ export const editCommand = new Command()
   .option("--add-skill <name>", "Add a custom skill to the agent")
   .option("--remove-skill <name>", "Remove a custom skill from the agent")
   .option("--instructions-file <path>", "Path to new instructions file")
+  .option(
+    "--model-provider <id>",
+    "Model provider UUID, or 'default' to inherit org default",
+  )
+  .option(
+    "--model <name>",
+    "Model name (e.g. claude-sonnet-4-6, MiniMax-M2.7), or 'default' to inherit provider default",
+  )
   .addHelpText(
     "after",
     `
@@ -87,6 +161,8 @@ Examples:
   Add a skill:             zero agent edit <agent-id> --add-skill my-skill
   Remove a skill:          zero agent edit <agent-id> --remove-skill my-skill
   Update instructions:     zero agent edit <agent-id> --instructions-file ./instructions.md
+  Set model:               zero agent edit <agent-id> --model-provider <provider-id> --model MiniMax-M2.7
+  Reset model:             zero agent edit <agent-id> --model-provider default --model default
   Update yourself:         zero agent edit $ZERO_AGENT_ID --description "new role"
 
 Notes:
@@ -94,66 +170,28 @@ Notes:
   - Unspecified fields are preserved (not cleared)
   - --skills replaces the entire skill list; --add-skill/--remove-skill modify incrementally
   - --skills cannot be combined with --add-skill or --remove-skill
+  - Use 'zero org model-provider list' to see available providers and models
   - To create or edit skill content, use: zero skill --help`,
   )
   .action(
-    withErrorHandler(
-      async (
-        agentId: string,
-        options: {
-          displayName?: string;
-          description?: string;
-          sound?: string;
-          skills?: string;
-          addSkill?: string;
-          removeSkill?: string;
-          instructionsFile?: string;
-        },
-      ) => {
-        const hasAgentUpdate =
-          options.displayName !== undefined ||
-          options.description !== undefined ||
-          options.sound !== undefined ||
-          options.skills !== undefined ||
-          options.addSkill !== undefined ||
-          options.removeSkill !== undefined;
+    withErrorHandler(async (agentId: string, options: AgentEditOptions) => {
+      const hasAgentUpdate = hasAgentFieldUpdate(options);
 
-        if (!hasAgentUpdate && !options.instructionsFile) {
-          throw new Error(
-            "At least one option is required (--display-name, --description, --sound, --skills, --add-skill, --remove-skill, --instructions-file)",
-          );
-        }
+      if (!hasAgentUpdate && !options.instructionsFile) {
+        throw new Error(
+          "At least one option is required (--display-name, --description, --sound, --skills, --add-skill, --remove-skill, --model-provider, --model, --instructions-file)",
+        );
+      }
 
-        if (hasAgentUpdate) {
-          const current = await getZeroAgent(agentId);
-          const customSkills = resolveCustomSkills(
-            options,
-            current.customSkills ?? [],
-          );
+      if (hasAgentUpdate) {
+        await applyAgentUpdate(agentId, options);
+      }
 
-          await updateZeroAgent(agentId, {
-            displayName:
-              options.displayName !== undefined
-                ? options.displayName
-                : (current.displayName ?? undefined),
-            description:
-              options.description !== undefined
-                ? options.description
-                : (current.description ?? undefined),
-            sound:
-              options.sound !== undefined
-                ? options.sound
-                : (current.sound ?? undefined),
-            customSkills,
-          });
-        }
+      if (options.instructionsFile) {
+        const content = readFileSync(options.instructionsFile, "utf-8");
+        await updateZeroAgentInstructions(agentId, content);
+      }
 
-        if (options.instructionsFile) {
-          const content = readFileSync(options.instructionsFile, "utf-8");
-          await updateZeroAgentInstructions(agentId, content);
-        }
-
-        console.log(chalk.green(`✓ Agent "${agentId}" updated`));
-      },
-    ),
+      console.log(chalk.green(`✓ Agent "${agentId}" updated`));
+    }),
   );

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -8,6 +8,7 @@ import {
   updateZeroAgentInstructions,
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
+import { parseModelFlag } from "../../../lib/domain/model-provider/shared";
 
 interface AgentEditOptions {
   displayName?: string;
@@ -19,12 +20,6 @@ interface AgentEditOptions {
   instructionsFile?: string;
   modelProvider?: string;
   model?: string;
-}
-
-function parseModelFlag(value: string | undefined): string | null | undefined {
-  if (value === undefined) return undefined;
-  if (value === "default") return null;
-  return value;
 }
 
 function hasAgentFieldUpdate(options: AgentEditOptions): boolean {

--- a/turbo/apps/cli/src/commands/zero/org/model-provider/list.ts
+++ b/turbo/apps/cli/src/commands/zero/org/model-provider/list.ts
@@ -1,5 +1,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import {
+  MODEL_PROVIDER_TYPES,
+  allowsCustomModel,
+  getModels,
+  type ModelProviderType,
+} from "@vm0/core";
 import { listZeroOrgModelProviders } from "../../../../lib/api";
 import { withErrorHandler } from "../../../../lib/command";
 
@@ -45,6 +51,20 @@ export const listCommand = new Command()
             ? chalk.dim(` [${provider.selectedModel}]`)
             : "";
           console.log(`    ${provider.type}${defaultTag}${modelTag}`);
+          console.log(chalk.dim(`      ID: ${provider.id}`));
+          if (provider.type in MODEL_PROVIDER_TYPES) {
+            const type = provider.type as ModelProviderType;
+            const available = getModels(type) ?? [];
+            if (available.length > 0) {
+              console.log(
+                chalk.dim(`      Available models: ${available.join(", ")}`),
+              );
+            } else if (allowsCustomModel(type)) {
+              console.log(
+                chalk.dim("      Available models: (custom — any model name)"),
+              );
+            }
+          }
           console.log(
             chalk.dim(
               `      Updated: ${new Date(provider.updatedAt).toLocaleString()}`,
@@ -56,6 +76,12 @@ export const listCommand = new Command()
 
       console.log(
         chalk.dim(`Total: ${result.modelProviders.length} provider(s)`),
+      );
+      console.log();
+      console.log(
+        chalk.dim(
+          "Use a provider ID with: zero agent edit <agent-id> --model-provider <id> --model <name>",
+        ),
       );
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -25,6 +25,7 @@ import {
   ApiRequestError,
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
+import { parseModelFlag } from "../../../lib/domain/model-provider/shared";
 
 const FREQUENCY_CHOICES = [
   { title: "Daily", value: "daily" as const, description: "Run every day" },
@@ -137,12 +138,6 @@ interface SetupOptions {
   enable?: boolean;
   modelProvider?: string;
   model?: string;
-}
-
-function parseModelFlag(value: string | undefined): string | null | undefined {
-  if (value === undefined) return undefined;
-  if (value === "default") return null;
-  return value;
 }
 
 interface ExistingScheduleDefaults {

--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -135,6 +135,14 @@ interface SetupOptions {
   timezone?: string;
   prompt?: string;
   enable?: boolean;
+  modelProvider?: string;
+  model?: string;
+}
+
+function parseModelFlag(value: string | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === "default") return null;
+  return value;
 }
 
 interface ExistingScheduleDefaults {
@@ -487,6 +495,8 @@ async function buildAndDeploy(params: {
   timezone: string;
   prompt: string;
   existingEnabled: boolean | undefined;
+  modelProviderId: string | null | undefined;
+  selectedModel: string | null | undefined;
 }): Promise<DeployResult> {
   let cronExpression: string | undefined;
   let atTimeISO: string | undefined;
@@ -520,6 +530,12 @@ async function buildAndDeploy(params: {
     prompt: params.prompt,
     ...(params.existingEnabled !== undefined && {
       enabled: params.existingEnabled,
+    }),
+    ...(params.modelProviderId !== undefined && {
+      modelProviderId: params.modelProviderId,
+    }),
+    ...(params.selectedModel !== undefined && {
+      selectedModel: params.selectedModel,
     }),
   });
 
@@ -639,6 +655,14 @@ export const setupCommand = new Command()
   .option("-z, --timezone <tz>", "IANA timezone")
   .option("-p, --prompt <text>", "Prompt to run")
   .option("-e, --enable", "Enable schedule immediately after creation")
+  .option(
+    "--model-provider <id>",
+    "Model provider UUID, or 'default' to inherit from agent/org",
+  )
+  .option(
+    "--model <name>",
+    "Model name (e.g. claude-sonnet-4-6, MiniMax-M2.7), or 'default' to inherit",
+  )
   .addHelpText(
     "after",
     `
@@ -649,10 +673,14 @@ Examples:
   One-time:              zero schedule setup <agent-id> -f once -d 2026-04-01 -t 14:00 -p "one-off task"
   Loop every 5 minutes:  zero schedule setup <agent-id> -f loop -i 300 -p "poll for updates"
   Create and enable:     zero schedule setup <agent-id> -f daily -t 09:00 -p "run report" --enable
+  Override model:        zero schedule setup <agent-id> -f daily -t 09:00 -p "..." --model-provider <id> --model MiniMax-M2.7
+  Reset model override:  zero schedule setup <agent-id> -f daily -t 09:00 -p "..." --model-provider default --model default
 
 Notes:
   - Re-running setup with the same agent updates the existing "default" schedule
   - Use -n to manage multiple named schedules for the same agent
+  - --model-provider and --model default to inheriting the agent's configuration
+  - Use 'zero org model-provider list' to see available providers and models
   - All flags are required in non-interactive mode; interactive mode prompts for missing values
   - If the user wants to be notified when a schedule completes, ask them where they want to receive the notification: web chat or Slack, then include it in the prompt`,
   )
@@ -734,6 +762,8 @@ Notes:
         timezone,
         prompt: promptText_,
         existingEnabled: existingSchedule?.enabled,
+        modelProviderId: parseModelFlag(options.modelProvider),
+        selectedModel: parseModelFlag(options.model),
       });
 
       // 8. Display deployment result

--- a/turbo/apps/cli/src/lib/api/domains/zero-schedules.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-schedules.ts
@@ -27,6 +27,8 @@ export async function deployZeroSchedule(body: {
   appendSystemPrompt?: string;
   volumeVersions?: Record<string, string>;
   enabled?: boolean;
+  modelProviderId?: string | null;
+  selectedModel?: string | null;
 }): Promise<DeployScheduleResponse> {
   const config = await getClientConfig();
   const client = initClient(zeroSchedulesMainContract, config);

--- a/turbo/apps/cli/src/lib/domain/model-provider/shared.ts
+++ b/turbo/apps/cli/src/lib/domain/model-provider/shared.ts
@@ -443,3 +443,19 @@ export async function promptForSecrets(
 export function collectSecrets(value: string, previous: string[]): string[] {
   return previous.concat([value]);
 }
+
+/**
+ * Parse a CLI model/model-provider flag value.
+ *
+ * Returns:
+ *   - `undefined` when the flag was not provided (preserve existing value)
+ *   - `null` when the user passed "default" (clear the override, inherit from org)
+ *   - the string value otherwise (set the specific model/provider)
+ */
+export function parseModelFlag(
+  value: string | undefined,
+): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === "default") return null;
+  return value;
+}

--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -21,7 +21,8 @@ import {
   requireAdminPermission,
 } from "../../../../../src/lib/zero/require-agent-permission";
 import { deleteComposeById } from "../../../../../src/lib/infra/agent-compose/compose-service";
-import { isConflict } from "../../../../../src/lib/shared/errors";
+import { isBadRequest, isConflict } from "../../../../../src/lib/shared/errors";
+import { validateModelSelection } from "../../../../../src/lib/zero/model-provider/validate-model-selection";
 import { logger } from "../../../../../src/lib/shared/logger";
 
 const log = logger("api:zero-agents:id");
@@ -170,6 +171,24 @@ const router = tsr.router(zeroAgentsByIdContract, {
       : requireAdminPermission(member, "update agent configuration");
     if (forbidden) return forbidden;
 
+    try {
+      await validateModelSelection({
+        orgId: org.orgId,
+        modelProviderId: body.modelProviderId,
+        selectedModel: body.selectedModel,
+      });
+    } catch (error) {
+      if (isBadRequest(error)) {
+        return {
+          status: 400 as const,
+          body: {
+            error: { message: error.message, code: "BAD_REQUEST" },
+          },
+        };
+      }
+      throw error;
+    }
+
     // Use provided customSkills if present, otherwise keep existing
     const customSkills = body.customSkills ?? existing.customSkills ?? [];
 
@@ -275,6 +294,24 @@ const router = tsr.router(zeroAgentsByIdContract, {
       "update agent profile",
     );
     if (forbidden) return forbidden;
+
+    try {
+      await validateModelSelection({
+        orgId: org.orgId,
+        modelProviderId: body.modelProviderId,
+        selectedModel: body.selectedModel,
+      });
+    } catch (error) {
+      if (isBadRequest(error)) {
+        return {
+          status: 400 as const,
+          body: {
+            error: { message: error.message, code: "BAD_REQUEST" },
+          },
+        };
+      }
+      throw error;
+    }
 
     // Update metadata — only overwrite fields explicitly provided
     const now = new Date();

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -1532,6 +1532,155 @@ describe("Zero Agents API", () => {
     });
   });
 
+  describe("model selection validation", () => {
+    it("should reject PUT with modelProviderId from a different org", async () => {
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      const response = await putAgent(
+        created.agentId,
+        {
+          modelProviderId: "00000000-0000-4000-8000-000000000001",
+        },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("not found in this org");
+    });
+
+    it("should reject PATCH with modelProviderId from a different org", async () => {
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      const response = await patchAgent(
+        created.agentId,
+        {
+          modelProviderId: "00000000-0000-4000-8000-000000000001",
+        },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("not found in this org");
+    });
+
+    it("should reject PUT with model not in provider allowlist", async () => {
+      const provider = await createTestOrgModelProvider(
+        "anthropic-api-key",
+        "test-key",
+      );
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      const response = await putAgent(
+        created.agentId,
+        {
+          modelProviderId: provider.id,
+          selectedModel: "gpt-4-not-a-claude-model",
+        },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("gpt-4-not-a-claude-model");
+      expect(data.error.message).toContain("not available");
+    });
+
+    it("should reject PATCH with model not in provider allowlist", async () => {
+      const provider = await createTestOrgModelProvider(
+        "anthropic-api-key",
+        "test-key",
+      );
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      const response = await patchAgent(
+        created.agentId,
+        {
+          modelProviderId: provider.id,
+          selectedModel: "gpt-4-not-a-claude-model",
+        },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("gpt-4-not-a-claude-model");
+      expect(data.error.message).toContain("not available");
+    });
+
+    it("should accept PUT with valid modelProviderId and model", async () => {
+      const provider = await createTestOrgModelProvider(
+        "anthropic-api-key",
+        "test-key",
+      );
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      const response = await putAgent(
+        created.agentId,
+        {
+          modelProviderId: provider.id,
+          selectedModel: "claude-sonnet-4-6",
+        },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.modelProviderId).toBe(provider.id);
+      expect(data.selectedModel).toBe("claude-sonnet-4-6");
+    });
+
+    it("should accept PATCH with valid modelProviderId and model", async () => {
+      const provider = await createTestOrgModelProvider(
+        "anthropic-api-key",
+        "test-key",
+      );
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      const response = await patchAgent(
+        created.agentId,
+        {
+          modelProviderId: provider.id,
+          selectedModel: "claude-sonnet-4-6",
+        },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.modelProviderId).toBe(provider.id);
+      expect(data.selectedModel).toBe("claude-sonnet-4-6");
+    });
+
+    it("should accept PUT with null modelProviderId to clear override", async () => {
+      const provider = await createTestOrgModelProvider(
+        "anthropic-api-key",
+        "test-key",
+      );
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      // Set provider first
+      await putAgent(
+        created.agentId,
+        { modelProviderId: provider.id, selectedModel: "claude-sonnet-4-6" },
+        testCliToken,
+      );
+
+      // Clear it
+      const response = await putAgent(
+        created.agentId,
+        { modelProviderId: null, selectedModel: null },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.modelProviderId).toBeNull();
+      expect(data.selectedModel).toBeNull();
+    });
+  });
+
   describe("schedule run integration", () => {
     it("should execute schedule for agent created via POST /api/zero/agents", async () => {
       // Regression: serverSideCompose was called without instructions param,

--- a/turbo/apps/web/src/lib/zero/model-provider/validate-model-selection.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/validate-model-selection.ts
@@ -1,0 +1,68 @@
+import { and, eq } from "drizzle-orm";
+import {
+  MODEL_PROVIDER_TYPES,
+  allowsCustomModel,
+  getModels,
+  type ModelProviderType,
+} from "@vm0/core";
+import { modelProviders } from "../../../db/schema/model-provider";
+import { badRequest } from "../../shared/errors";
+
+interface ModelSelectionInput {
+  orgId: string;
+  modelProviderId?: string | null;
+  selectedModel?: string | null;
+}
+
+/**
+ * Validate that a {modelProviderId, selectedModel} pair is internally consistent
+ * and scoped to the given org.
+ *
+ * Rules:
+ *   - modelProviderId (if non-null) must reference a row in this org.
+ *   - If modelProviderId AND selectedModel are both non-null, the model must be
+ *     in MODEL_PROVIDER_TYPES[type].models, or the provider must allow custom
+ *     models.
+ *   - A selectedModel without a paired modelProviderId is accepted; resolution
+ *     happens at runtime via the agent/org default provider.
+ */
+export async function validateModelSelection({
+  orgId,
+  modelProviderId,
+  selectedModel,
+}: ModelSelectionInput): Promise<void> {
+  if (!modelProviderId) return;
+
+  const [provider] = await globalThis.services.db
+    .select({ type: modelProviders.type })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.id, modelProviderId),
+        eq(modelProviders.orgId, orgId),
+      ),
+    )
+    .limit(1);
+
+  if (!provider) {
+    throw badRequest(
+      `Model provider "${modelProviderId}" not found in this org`,
+    );
+  }
+
+  if (!selectedModel) return;
+
+  const type = provider.type as ModelProviderType;
+  if (!(type in MODEL_PROVIDER_TYPES)) {
+    throw badRequest(`Unknown model provider type "${provider.type}"`);
+  }
+
+  if (allowsCustomModel(type)) return;
+
+  const available = getModels(type) ?? [];
+  if (!available.includes(selectedModel)) {
+    throw badRequest(
+      `Model "${selectedModel}" is not available for provider type "${type}". Available: ${available.join(", ")}`,
+    );
+  }
+}

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -12,6 +12,7 @@ import { createZeroRun } from "../zero-run-service";
 import { buildSchedulePrompt } from "../integration-prompt";
 import { generateScheduleDescription } from "../ai/lightweight-model";
 import { adaptScheduleTrigger } from "./adapt-schedule-trigger";
+import { validateModelSelection } from "../model-provider/validate-model-selection";
 
 const log = logger("service:schedule");
 
@@ -394,6 +395,13 @@ export async function deploySchedule(
 
   // Reject one-time schedules with past atTime when enabled
   validateAtTimeNotPast(request);
+
+  // Validate model provider + model pair against org + provider type
+  await validateModelSelection({
+    orgId,
+    modelProviderId: request.modelProviderId,
+    selectedModel: request.selectedModel,
+  });
 
   // Auto-generate description if not provided (undefined/null means not provided;
   // empty string means the user explicitly cleared it — skip auto-generation)

--- a/turbo/packages/core/src/contracts/zero-agents.ts
+++ b/turbo/packages/core/src/contracts/zero-agents.ts
@@ -144,6 +144,7 @@ export const zeroAgentsByIdContract = c.router({
     body: zeroAgentMetadataRequestSchema,
     responses: {
       200: zeroAgentResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,


### PR DESCRIPTION
## Summary
- Add `--model-provider <uuid|default>` and `--model <name|default>` to `zero agent edit` and `zero schedule setup`; `default` clears the override and falls back to org/agent defaults.
- Server-side validator (`validate-model-selection.ts`) checks the provider belongs to the caller's org and, when both fields are set, that the model is allowed for the provider type (respecting `allowCustomModel`). CLI does no pre-validation — server is the single source of truth.
- `zero org model-provider list` now prints each provider's UUID and its available models so users know what to pass to the new flags.

## Test plan
- [x] `pnpm format` / `pnpm turbo run lint` / `pnpm check-types` / `pnpm knip` — all green
- [x] `pnpm -F @vm0/cli exec vitest` on `agent/edit`, `schedule/setup`, `org/model-provider/list` — 16/16 pass
- [x] `pnpm -F web exec vitest` on `app/api/zero/agents`, `app/api/zero/schedules`, `zero-agent`, `src/lib/zero/schedule` — 93/93 pass
- [ ] Manual: run `zero agent edit <id> --model-provider <uuid> --model MiniMax-M2.7` against dev server and confirm the agent row picks up the new model
- [ ] Manual: run `zero agent edit <id> --model-provider default --model default` and confirm both columns are cleared to null
- [ ] Manual: run `zero schedule setup <id> -f daily -t 09:00 -p "..." --model <invalid>` and confirm server returns 400 with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)