### PR TITLE
fix(api): dedupe user-connectors payload to restore put idempotency

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/__tests__/route.test.ts
@@ -153,6 +153,30 @@ describe("User Connectors API", () => {
       expect(getData.enabledTypes).toEqual(["linear"]);
     });
 
+    it("should dedupe duplicate entries in enabledTypes", async () => {
+      const agentId = await createAgent();
+
+      const res = await putUserConnectors(
+        agentId,
+        { enabledTypes: ["slack", "github", "slack"] },
+        testCliToken,
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.enabledTypes).toEqual(
+        expect.arrayContaining(["slack", "github"]),
+      );
+      expect(data.enabledTypes).toHaveLength(2);
+
+      const getRes = await getUserConnectors(agentId, testCliToken);
+      const getData = await getRes.json();
+      expect(getData.enabledTypes).toEqual(
+        expect.arrayContaining(["slack", "github"]),
+      );
+      expect(getData.enabledTypes).toHaveLength(2);
+    });
+
     it("should clear all permissions with empty array", async () => {
       const agentId = await createAgent();
 

--- a/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/route.ts
@@ -130,6 +130,7 @@ const router = tsr.router(zeroUserConnectorsContract, {
     }
 
     const db = globalThis.services.db;
+    const uniqueTypes = Array.from(new Set(body.enabledTypes));
 
     // Replace full list atomically
     await db.transaction(async (tx) => {
@@ -143,9 +144,9 @@ const router = tsr.router(zeroUserConnectorsContract, {
           ),
         );
 
-      if (body.enabledTypes.length > 0) {
+      if (uniqueTypes.length > 0) {
         await tx.insert(userConnectors).values(
-          body.enabledTypes.map((connectorType) => {
+          uniqueTypes.map((connectorType) => {
             return {
               orgId: org.orgId,
               userId,
@@ -177,7 +178,7 @@ const router = tsr.router(zeroUserConnectorsContract, {
 
     return {
       status: 200 as const,
-      body: { enabledTypes: body.enabledTypes },
+      body: { enabledTypes: uniqueTypes },
     };
   },
 });

--- a/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/route.ts
@@ -113,8 +113,10 @@ const router = tsr.router(zeroUserConnectorsContract, {
       };
     }
 
+    const uniqueTypes = Array.from(new Set(body.enabledTypes));
+
     // Validate connector types before storing
-    const invalidTypes = body.enabledTypes.filter((t) => {
+    const invalidTypes = uniqueTypes.filter((t) => {
       return !connectorTypeSchema.safeParse(t).success;
     });
     if (invalidTypes.length > 0) {
@@ -130,7 +132,6 @@ const router = tsr.router(zeroUserConnectorsContract, {
     }
 
     const db = globalThis.services.db;
-    const uniqueTypes = Array.from(new Set(body.enabledTypes));
 
     // Replace full list atomically
     await db.transaction(async (tx) => {


### PR DESCRIPTION
## Summary

- Dedupe `body.enabledTypes` server-side before bulk INSERT.
- Return the canonical (deduped) set in the PUT response so it matches what GET will return.
- Add an integration test covering `["slack", "github", "slack"]`.

Closes #10062.

## Root cause

A PUT with duplicate entries (e.g. `["slack", "slack"]`) caused the bulk INSERT to trip `idx_user_connectors_unique` and surface as a 500. Observed in prod from Axiom (`vm0-web-logs-prod`) at `api:zero-agents:user-connectors`. PUT is supposed to be idempotent — duplicates should collapse to the same persisted state.

Re-authorize flows on the client call `addZeroConnector$` unconditionally on a connector that's already enabled, producing `[...current, name]` with `name` already in `current`. That's a real but separate wart on the client; this PR only fixes the server so every client (current + future) is protected.

## Fix

```ts
const uniqueTypes = Array.from(new Set(body.enabledTypes));
// DELETE + INSERT uniqueTypes inside the existing transaction
return { status: 200, body: { enabledTypes: uniqueTypes } };
```

## Blast radius

Response body for PUT is now deduped. Audited all consumers of `enabledTypes`:
- `apps/cli/.../connector/agent-context.ts` → `new Set(enabledTypes)`
- `apps/cli/.../doctor/check-connector.ts` → `.includes(...)`
- `apps/platform/.../zero-connectors.ts` → `addedSet = new Set(addedConnectors)`
- Tests use `arrayContaining` / `toStrictEqual` on distinct values.

No consumer compares `.length` or relies on echo. No schema / migration / contract change.

## Test plan

- [x] New integration test `should dedupe duplicate entries in enabledTypes` (12/12 pass in `user-connectors/__tests__/route.test.ts`)
- [x] `onboarding-setup.test.ts` (other consumer of `enabledTypes`) 12/12 still green
- [x] `pnpm turbo run lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm format` no-op
- [x] `pnpm knip` no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)