### PR TITLE
fix(guest-agent): fail fast on empty session id before checkpoint

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -62,6 +62,16 @@ async fn create_checkpoint_impl(
             return Err(AgentError::Checkpoint(msg));
         }
     };
+    if session_id.is_empty() {
+        log_error!(LOG_TAG, "Session ID is empty");
+        record_sandbox_op(
+            "session_id_read",
+            session_id_start.elapsed(),
+            false,
+            Some("Empty"),
+        );
+        return Err(AgentError::Checkpoint("Session ID is empty".into()));
+    }
     record_sandbox_op("session_id_read", session_id_start.elapsed(), true, None);
 
     // Read session history path


### PR DESCRIPTION
## Summary
Follow-up to PR #10141. `session_history` already has an explicit empty-string guard with a `session_history_read` failure telemetry row (`checkpoint.rs:139-148`), but `session_id` did not — a zero-byte or whitespace-only session ID file would silently flow into the checkpoint payload as `cliAgentSessionId: ""`, producing a success telemetry row and deferring the defect to the server.

This patch adds a symmetric guard: after `trim().to_string()`, if the result is empty, emit a `session_id_read` failure row (reason `"Empty"`) and return an `AgentError::Checkpoint`.

## Test plan
- [x] `cargo test -p guest-agent --lib` — 87 passed
- [x] `cargo clippy -p guest-agent --all-targets -- -D warnings`
- [x] `cargo fmt -p guest-agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)