### PR TITLE
feat(platform): update thread list indicator behavior

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
@@ -89,11 +89,13 @@ describe("sidebar running indicator", () => {
 
     await waitFor(() => {
       expect(within(getSidebar()).getByText("Active work")).toBeInTheDocument();
+      expect(
+        within(getSidebar()).getByLabelText("Running"),
+      ).toBeInTheDocument();
+      expect(
+        within(getSidebar()).queryByLabelText("Unread"),
+      ).not.toBeInTheDocument();
     });
-    expect(within(getSidebar()).getByLabelText("Running")).toBeInTheDocument();
-    expect(
-      within(getSidebar()).queryByLabelText("Unread"),
-    ).not.toBeInTheDocument();
   });
 
   it("renders Running indicator on the selected thread when running", async () => {
@@ -117,11 +119,13 @@ describe("sidebar running indicator", () => {
       expect(
         within(getSidebar()).getByText("Selected running"),
       ).toBeInTheDocument();
+      expect(
+        within(getSidebar()).getByLabelText("Running"),
+      ).toBeInTheDocument();
+      expect(
+        within(getSidebar()).queryByLabelText("Unread"),
+      ).not.toBeInTheDocument();
     });
-    expect(within(getSidebar()).getByLabelText("Running")).toBeInTheDocument();
-    expect(
-      within(getSidebar()).queryByLabelText("Unread"),
-    ).not.toBeInTheDocument();
   });
 
   it("does not render Unread indicator on the selected thread", async () => {
@@ -145,13 +149,13 @@ describe("sidebar running indicator", () => {
       expect(
         within(getSidebar()).getByText("Selected unread"),
       ).toBeInTheDocument();
+      expect(
+        within(getSidebar()).queryByLabelText("Running"),
+      ).not.toBeInTheDocument();
+      expect(
+        within(getSidebar()).queryByLabelText("Unread"),
+      ).not.toBeInTheDocument();
     });
-    expect(
-      within(getSidebar()).queryByLabelText("Running"),
-    ).not.toBeInTheDocument();
-    expect(
-      within(getSidebar()).queryByLabelText("Unread"),
-    ).not.toBeInTheDocument();
   });
 
   it("prefers Running over Unread when both conditions hold", async () => {
@@ -175,11 +179,13 @@ describe("sidebar running indicator", () => {
       expect(
         within(getSidebar()).getByText("Running and unread"),
       ).toBeInTheDocument();
+      expect(
+        within(getSidebar()).getByLabelText("Running"),
+      ).toBeInTheDocument();
+      expect(
+        within(getSidebar()).queryByLabelText("Unread"),
+      ).not.toBeInTheDocument();
     });
-    expect(within(getSidebar()).getByLabelText("Running")).toBeInTheDocument();
-    expect(
-      within(getSidebar()).queryByLabelText("Unread"),
-    ).not.toBeInTheDocument();
   });
 
   it("does not render the Running dot when ChatThreadReadIndicator flag is off", async () => {
@@ -204,10 +210,10 @@ describe("sidebar running indicator", () => {
       expect(
         within(getSidebar()).getByText("Running but gated"),
       ).toBeInTheDocument();
+      expect(
+        within(getSidebar()).queryByLabelText("Running"),
+      ).not.toBeInTheDocument();
     });
-    expect(
-      within(getSidebar()).queryByLabelText("Running"),
-    ).not.toBeInTheDocument();
   });
 
   it("reloads the list and shows the running dot when threadListChanged fires", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
@@ -2,9 +2,8 @@
  * Sidebar running indicator tests.
  *
  * Covers the truth table for thread-row indicators:
- *  - isSelected            → no indicator
- *  - running && !selected  → sky-600 pulsing dot (Running)
- *  - unread && !running    → blue-500 dot (Unread)
+ *  - running               → sky-600 pulsing dot (Running), shown even when selected
+ *  - unread && !running    → primary (orange) dot (Unread), hidden when selected
  *  - running wins over unread
  *  - running row is not bold (font-medium stays bound to unread only,
  *    to avoid a weight flicker when the run finishes)
@@ -97,7 +96,7 @@ describe("sidebar running indicator", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not render any indicator on the selected thread", async () => {
+  it("renders Running indicator on the selected thread when running", async () => {
     mockAPIs({
       current: [
         {
@@ -117,6 +116,34 @@ describe("sidebar running indicator", () => {
     await waitFor(() => {
       expect(
         within(getSidebar()).getByText("Selected running"),
+      ).toBeInTheDocument();
+    });
+    expect(within(getSidebar()).getByLabelText("Running")).toBeInTheDocument();
+    expect(
+      within(getSidebar()).queryByLabelText("Unread"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render Unread indicator on the selected thread", async () => {
+    mockAPIs({
+      current: [
+        {
+          id: "thread-selected-unread",
+          title: "Selected unread",
+          agentId: DEFAULT_AGENT_ID,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+          isRead: false,
+          isArchived: false,
+          running: false,
+        },
+      ],
+    });
+    detachedSetupPage({ context, path: "/chats/thread-selected-unread" });
+
+    await waitFor(() => {
+      expect(
+        within(getSidebar()).getByText("Selected unread"),
       ).toBeInTheDocument();
     });
     expect(

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -99,15 +99,15 @@ function ChatThreadItem({
               : "text-sidebar-foreground hover:bg-sidebar-accent"
         }`}
       >
-        {!isSelected && isRunning && (
+        {isRunning && (
           <span
             className="shrink-0 h-2 w-2 rounded-full bg-sky-600 animate-pulse"
             aria-label="Running"
           />
         )}
-        {!isSelected && !isRunning && isUnread && (
+        {!isRunning && !isSelected && isUnread && (
           <span
-            className="shrink-0 h-2 w-2 rounded-full bg-blue-500"
+            className="shrink-0 h-2 w-2 rounded-full bg-primary"
             aria-label="Unread"
           />
         )}


### PR DESCRIPTION
## Summary
Update the unread indicator behavior in the thread list:

1. **Show running indicator even when selected** - Previously, no indicator was shown for a selected thread. Now the pulsing dot for the running state is displayed even when the thread is selected.
2. **Use theme color (orange) for the unread indicator** - Changed from `bg-blue-500` to `bg-primary` (theme orange #ed4E01).

## Changes
- `sidebar-threads.tsx`: Update indicator display logic and color.
- `sidebar-running-indicator.test.tsx`: Update test cases to reflect the new behavior.

## Test plan
- [x] Running indicator is shown when a thread is selected.
- [x] Unread indicator is shown in orange when not selected.
- [x] Unread indicator is hidden when selected (the user is already viewing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)