### PR TITLE
feat: enable OrgCustomConnectors feature flag by default

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -287,7 +287,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Show the org custom connectors surface — the Custom tab on the Connectors settings page (admin CRUD, member Connect) and the per-agent Custom Connectors section on Agent Authorization. Backend routes remain open; this flag only gates entry points in the UI.",
-    enabled: false,
+    enabled: true,
     enabledOrgIdHashes: [],
   },
   [FeatureSwitchKey.Vm0KimiModel]: {


### PR DESCRIPTION
## Summary
- Flips `FeatureSwitchKey.OrgCustomConnectors` default from `false` → `true`
- All orgs will now see the Custom Connectors surface (Custom tab on Connectors settings + per-agent custom connectors section) without manual whitelisting

## Test plan
- [ ] Verify Custom tab appears on Connectors settings page for a default org
- [ ] Verify per-agent Custom Connectors section is visible on Agent Authorization
- [ ] Verify existing backend routes remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)