### PR TITLE
test(runner): make claim_after_stopping_sent test deterministic

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -2603,7 +2603,12 @@ mod tests {
         let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Deterministic barrier: wait for run()'s main loop to have polled
+        // `discover_fut` into its await state. Only then is the Running-arm
+        // `select!` provably in place, which is the precondition for the
+        // silent `send_if_modified` below to land without waking the loop.
+        // A wall-clock sleep here flakes under coverage CI — see #10146.
+        env.handle.discover_entered.notified().await;
 
         // Flip the watch value to Stopping without firing changed().
         env.mode_tx.send_if_modified(|v| {

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -2608,7 +2608,15 @@ mod tests {
         // `select!` provably in place, which is the precondition for the
         // silent `send_if_modified` below to land without waking the loop.
         // A wall-clock sleep here flakes under coverage CI — see #10146.
-        env.handle.discover_entered.notified().await;
+        // The 2s timeout gives a clear diagnostic if the "loop parks on
+        // discover" invariant ever regresses, rather than hanging until
+        // the outer test harness kills us.
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            env.handle.discover_entered.notified(),
+        )
+        .await
+        .expect("run() did not enter discover_fut select! within 2s");
 
         // Flip the watch value to Stopping without firing changed().
         env.mode_tx.send_if_modified(|v| {
@@ -2645,7 +2653,19 @@ mod tests {
         let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Wait for the main loop to park on `discover_fut` so the subsequent
+        // `trigger_stopping` lands on a steady-state loop rather than racing
+        // against startup. This test does not depend on the silent-flip
+        // semantics of `claim_after_stopping_sent_cancels_new_job` (it uses
+        // `trigger_stopping`, which fires `changed()`), but the same barrier
+        // is still the right "main loop is idle" signal — and deterministic
+        // under coverage CI, unlike the 50 ms sleep this replaces.
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            env.handle.discover_entered.notified(),
+        )
+        .await
+        .expect("run() did not enter discover_fut select! within 2s");
 
         // Enter Stopping first.
         env.trigger_stopping().await;

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{Mutex, Notify, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use super::JobProvider;
@@ -52,6 +52,14 @@ pub struct MockJobProvider {
     completions: Arc<StdMutex<Vec<Completion>>>,
     heartbeats: Arc<StdMutex<Vec<HeartbeatState>>>,
     cancel: CancellationToken,
+    /// Fired each time `discover()` has reached its inner `select!` await
+    /// point (lock + optional `poll_delay` complete, about to park on
+    /// `rx.recv()`). Tests that need to order actions against that state —
+    /// e.g. a silent `send_if_modified` that must land *after* the main loop
+    /// has entered its `discover_fut` select — await `notified()` instead of
+    /// sleeping. `notify_one` queues a permit, so a test that waits after
+    /// the signal fired still wakes immediately.
+    discover_entered: Arc<Notify>,
 }
 
 /// Test-side handle for driving the mock provider.
@@ -59,6 +67,8 @@ pub struct MockProviderHandle {
     pub discover_tx: mpsc::UnboundedSender<(RunId, String)>,
     pub completions: Arc<StdMutex<Vec<Completion>>>,
     pub heartbeats: Arc<StdMutex<Vec<HeartbeatState>>>,
+    /// See [`MockJobProvider::discover_entered`].
+    pub discover_entered: Arc<Notify>,
 }
 
 impl MockJobProvider {
@@ -83,6 +93,7 @@ impl MockJobProvider {
         let (tx, rx) = mpsc::unbounded_channel();
         let completions = Arc::new(StdMutex::new(Vec::new()));
         let heartbeats = Arc::new(StdMutex::new(Vec::new()));
+        let discover_entered = Arc::new(Notify::new());
         let provider = Arc::new(Self {
             discovery: Mutex::new(rx),
             poll_delay,
@@ -90,11 +101,13 @@ impl MockJobProvider {
             completions: Arc::clone(&completions),
             heartbeats: Arc::clone(&heartbeats),
             cancel,
+            discover_entered: Arc::clone(&discover_entered),
         });
         let handle = MockProviderHandle {
             discover_tx: tx,
             completions,
             heartbeats,
+            discover_entered,
         };
         (provider, handle)
     }
@@ -153,6 +166,11 @@ impl JobProvider for MockJobProvider {
         if let Some(delay) = self.poll_delay {
             tokio::time::sleep(delay).await;
         }
+        // Signal tests that the future has reached its await point — the
+        // main loop has polled `discover_fut`, the discovery Mutex is held,
+        // and we are about to park on `rx.recv()`. Tests ordering actions
+        // against this state use `handle.discover_entered.notified()`.
+        self.discover_entered.notify_one();
         tokio::select! {
             result = rx.recv() => result,
             () = self.cancel.cancelled() => None,


### PR DESCRIPTION
## Summary
- Add `discover_entered: Arc<Notify>` to `MockJobProvider` and `MockProviderHandle`.
- `MockJobProvider::discover()` fires `notify_one()` at the entry of its inner `select!`, after the discovery lock and optional `poll_delay`.
- Rewrite `claim_after_stopping_sent_cancels_new_job` to await the notify instead of `sleep(50ms)`, turning the wait for "main loop is parked on `discover_fut`" from a wall-clock bet into a direct signal.

The flake showed up in the merge-queue coverage job ([run 24629383172](https://github.com/vm0-ai/vm0/actions/runs/24629383172/job/72013994607)): under `cargo llvm-cov` the 50 ms sleep was not long enough for `run()` to reach the `Running`-arm `select!`, so the silent `send_if_modified(Stopping)` landed first, the loop read Stopping at loop top and broke to teardown without ever polling `discover_fut`. `wait_completion(5s)` then timed out on the TOCTOU cancel assertion.

Test-only change — no production code touched.

## Test plan
- [x] `cargo test -p runner cmd::start::tests::claim_after_stopping_sent_cancels_new_job`
- [x] `cargo test -p runner` (698 passed)
- [x] `cargo clippy -p runner --all-targets` (clean)
- [x] `cargo fmt --check` (clean)
- [ ] Merge-queue "Run tests with coverage" job green on this branch

Closes #10146