### PR TITLE
fix(seo): convert all next-intl locale redirects from 307 to 301

### DIFF
--- a/turbo/apps/web/proxy.layers.ts
+++ b/turbo/apps/web/proxy.layers.ts
@@ -188,10 +188,7 @@ export const localeGuardLayer: ProxyLayer = (ctx) => {
 export const i18nLayer: ProxyLayer = (ctx) => {
   if (ctx.routeKind === "page") {
     const response = intlMiddleware(ctx.request);
-    if (
-      response.status === 307 &&
-      response.headers.get("location")
-    ) {
+    if (response.status === 307 && response.headers.get("location")) {
       const url = new URL(
         response.headers.get("location")!,
         ctx.request.nextUrl.origin,

--- a/turbo/apps/web/proxy.layers.ts
+++ b/turbo/apps/web/proxy.layers.ts
@@ -178,10 +178,27 @@ export const localeGuardLayer: ProxyLayer = (ctx) => {
   return null;
 };
 
-/** Apply i18n for page routes. */
+/**
+ * Apply i18n for page routes.
+ *
+ * next-intl redirects locale-less paths (e.g. /use-cases/foo) with 307
+ * (temporary).  We convert those to 301 (permanent) so search engines
+ * consolidate PageRank on the canonical /en/… URL.
+ */
 export const i18nLayer: ProxyLayer = (ctx) => {
   if (ctx.routeKind === "page") {
-    return intlMiddleware(ctx.request);
+    const response = intlMiddleware(ctx.request);
+    if (
+      response.status === 307 &&
+      response.headers.get("location")
+    ) {
+      const url = new URL(
+        response.headers.get("location")!,
+        ctx.request.nextUrl.origin,
+      );
+      return NextResponse.redirect(url, 301);
+    }
+    return response;
   }
   return null;
 };


### PR DESCRIPTION
## Problem

PR #10121 fixed the root `/` → `/en` redirect (307 → 301) via `next.config.js` `redirects()`, but **all other locale-less paths** still return 307 from the next-intl middleware. For example:

```
curl -sI https://www.vm0.ai/use-cases/marketing-emails
→ HTTP 307
→ Location: /en/use-cases/marketing-emails
```

Every page on the site (use-cases, pricing, blog, etc.) has this issue. Search engines treat 307 as temporary and do not consolidate PageRank.

## Changes

| File | Change |
|---|---|
| `turbo/apps/web/proxy.layers.ts` | Intercept `intlMiddleware` response in `i18nLayer`; convert 307 redirects to 301 |

## Expected outcome

- `/use-cases/marketing-emails` → **301** → `/en/use-cases/marketing-emails`
- `/pricing` → **301** → `/en/pricing`
- `/blog` → **301** → `/en/blog`
- All locale-less page paths now permanent-redirect instead of temporary-redirect

## Testing

Existing `proxy.locale-guard.test.ts` still passes (it mocks `next-intl/middleware` to return `NextResponse.next()`, which our new code handles correctly by passing through non-redirect responses unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)