### PR TITLE
revert: enable OrgCustomConnectors feature flag by default (#10157)

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -287,7 +287,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Show the org custom connectors surface — the Custom tab on the Connectors settings page (admin CRUD, member Connect) and the per-agent Custom Connectors section on Agent Authorization. Backend routes remain open; this flag only gates entry points in the UI.",
-    enabled: true,
+    enabled: false,
     enabledOrgIdHashes: [],
   },
   [FeatureSwitchKey.Vm0KimiModel]: {


### PR DESCRIPTION
## Summary
- Reverts #10157 which broke the merge queue.
- Restores the `OrgCustomConnectors` feature flag `enabled` default to `false`.

Once the underlying merge-queue failure is understood and fixed, a new PR can re-enable the default.

## Test plan
- [ ] CI passes on this revert PR
- [ ] Merge queue recovers after landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)