### PR TITLE
fix(usage): use relative billing period date in tests to avoid date-bomb

### DIFF
--- a/turbo/apps/web/app/api/zero/usage/daily/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/daily/__tests__/route.test.ts
@@ -79,7 +79,7 @@ describe("GET /api/zero/usage/daily", () => {
 
   it("returns daily credit totals in total mode", async () => {
     const { userId, orgId } = await context.user;
-    const periodEnd = new Date("2026-04-20T00:00:00Z");
+    const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
     await updateOrgStripeFields(orgId, {
       stripeCustomerId: uniqueId("cus"),
@@ -123,7 +123,7 @@ describe("GET /api/zero/usage/daily", () => {
 
   it("returns per-member breakdown in member mode", async () => {
     const { orgId } = await context.user;
-    const periodEnd = new Date("2026-04-20T00:00:00Z");
+    const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
     await updateOrgStripeFields(orgId, {
       stripeCustomerId: uniqueId("cus"),
@@ -164,7 +164,7 @@ describe("GET /api/zero/usage/daily", () => {
 
   it("filters by dateFrom and dateTo query params", async () => {
     const { userId, orgId } = await context.user;
-    const periodEnd = new Date("2026-04-20T00:00:00Z");
+    const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
     await updateOrgStripeFields(orgId, {
       stripeCustomerId: uniqueId("cus"),
@@ -220,7 +220,7 @@ describe("GET /api/zero/usage/daily", () => {
 
   it("excludes pending records", async () => {
     const { userId, orgId } = await context.user;
-    const periodEnd = new Date("2026-04-20T00:00:00Z");
+    const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
     await updateOrgStripeFields(orgId, {
       stripeCustomerId: uniqueId("cus"),

--- a/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
@@ -84,7 +84,7 @@ describe("GET /api/zero/usage/members", () => {
 
   it("returns aggregated usage for single user with processed records", async () => {
     const { userId, orgId } = await context.user;
-    const periodEnd = new Date("2026-04-20T00:00:00Z");
+    const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
     await updateOrgStripeFields(orgId, {
       stripeCustomerId: uniqueId("cus"),
@@ -132,7 +132,7 @@ describe("GET /api/zero/usage/members", () => {
 
   it("returns separate aggregation for multiple users", async () => {
     const { orgId } = await context.user;
-    const periodEnd = new Date("2026-04-20T00:00:00Z");
+    const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
     await updateOrgStripeFields(orgId, {
       stripeCustomerId: uniqueId("cus"),
@@ -177,7 +177,7 @@ describe("GET /api/zero/usage/members", () => {
 
   it("excludes pending records from aggregation", async () => {
     const { userId, orgId } = await context.user;
-    const periodEnd = new Date("2026-04-20T00:00:00Z");
+    const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
     await updateOrgStripeFields(orgId, {
       stripeCustomerId: uniqueId("cus"),


### PR DESCRIPTION
## Summary
- The `usage/daily` and `usage/members` route tests hardcoded `periodEnd = 2026-04-20T00:00:00Z`. Once that moment passed, `getOrgBillingPeriod` saw the period as stale and tried to refresh from Stripe, but the test env has no `STRIPE_SECRET_KEY` so the stripe getter threw → routes returned 500 → assertions failed on main.
- Replace the literal with `Date.now() + 30 days` so the billing period is always in the future relative to the test run.
- `billing/status` test file uses the same literal but its route reads `orgMetadata` directly (no `getOrgBillingPeriod` call), so it is unaffected and left untouched.

## Test plan
- [x] `pnpm exec vitest run app/api/zero/usage/{daily,members}/__tests__/route.test.ts` — 12/12 pass
- [x] `pnpm turbo run lint` — pass
- [x] `pnpm check-types` — pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)