### PR TITLE
refactor(platform): clean up residual http.* overrides missed by phase 3 umbrella

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -43,8 +43,9 @@ describe("zeroClient$ 401 redirect", () => {
       withoutRender: true,
     });
 
-    // Keep raw http.get for 403 since it's not in zeroOrgContract.get's defined responses
     server.use(
+      // mockApi cannot be used here: 403 is not declared in zeroOrgContract.get responses,
+      // so this raw handler is the only way to simulate a forbidden response for this test.
       http.get("*/api/zero/org", () => {
         return HttpResponse.json(
           { error: { message: "Forbidden", code: "FORBIDDEN" } },

--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Tests for the fetch$ wrapper itself (401 redirect, token refresh, retry).
+ *
+ * mockApi cannot be used in this file: the wrapper is exercised against
+ * synthetic URLs (`/test`, `/api/zero/items`) that do not correspond to any
+ * ts-rest contract — they exist solely to drive the wrapper's status-code and
+ * retry logic. Migrating them would require inventing contracts for paths
+ * that have no server-side implementation, so the `http.*` usage here is
+ * intentional and should remain exempt from the Phase 3 capstone rule (#10091).
+ */
 import { describe, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../mocks/server.ts";

--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-preparation-list.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-preparation-list.test.ts
@@ -86,8 +86,10 @@ describe("fetchFreshPreparations$", () => {
 
   it("should throw on API error", async () => {
     setup();
-    // raw http override: 500 is not a declared contract status for this endpoint
     server.use(
+      // mockApi cannot be used here: 500 is not declared in
+      // zeroVoiceChatPrepareListContract.list responses, so this raw handler
+      // is the only way to simulate a server error.
       http.get("*/api/zero/voice-chat/prepare/list", () => {
         return new HttpResponse(null, { status: 500 });
       }),

--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-preparation.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-preparation.test.ts
@@ -151,6 +151,9 @@ describe("voice-chat-preparation signals", () => {
   it("should set status to failed when endpoint returns error", async () => {
     await setup();
     server.use(
+      // mockApi cannot be used here: 500 is not declared in
+      // zeroVoiceChatPrepareTriggerContract.trigger responses, so this raw
+      // handler is the only way to simulate a server error.
       http.post("*/api/zero/voice-chat/prepare", () => {
         return new HttpResponse(null, { status: 500 });
       }),

--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session-prepare.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session-prepare.test.ts
@@ -98,6 +98,9 @@ describe("chat mode preparation cache", () => {
     it("should not block page setup when preparation fails", async () => {
       await setup();
       server.use(
+        // mockApi cannot be used here: 500 is not declared in
+        // zeroVoiceChatPrepareTriggerContract.trigger responses, so this raw
+        // handler is the only way to simulate a server error.
         http.post("*/api/zero/voice-chat/prepare", () => {
           return new HttpResponse(null, { status: 500 });
         }),
@@ -179,6 +182,9 @@ describe("chat mode preparation cache", () => {
     it("should proceed to session when preparation API fails", async () => {
       await setup();
       server.use(
+        // mockApi cannot be used here: 500 is not declared in
+        // zeroVoiceChatPrepareTriggerContract.trigger responses, so this raw
+        // handler is the only way to simulate a server error.
         http.post("*/api/zero/voice-chat/prepare", () => {
           return new HttpResponse(null, { status: 500 });
         }),
@@ -364,6 +370,9 @@ describe("chat mode preparation cache", () => {
 
       // Mock context endpoint to fail
       server.use(
+        // mockApi cannot be used here: 500 is not declared in
+        // zeroVoiceChatContextContract.getEvents responses, so this raw
+        // handler is the only way to simulate a server error.
         http.get("*/api/zero/voice-chat/:sessionId/context", () => {
           return new HttpResponse(null, { status: 500 });
         }),

--- a/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
+++ b/turbo/apps/platform/src/signals/voice-io/__tests__/voice-io-tts.test.ts
@@ -53,8 +53,9 @@ function mockWebAudio() {
 function mockTtsEndpoint() {
   let fetchCount = 0;
 
-  // raw http override: binary streaming response is out of scope for mockApi (Phase 0 of #9707); full origin URL intentional for fetch interception
   server.use(
+    // mockApi cannot be used here: /api/zero/voice-io/tts has no ts-rest contract
+    // (binary streaming response); full origin URL is intentional for fetch interception.
     http.post("http://localhost:3000/api/zero/voice-io/tts", () => {
       fetchCount++;
       const body = new ReadableStream({
@@ -120,8 +121,9 @@ describe("playTts$", () => {
     // Allow expected TTS error logs without throwing
     vi.spyOn(console, "error").mockImplementation(() => {});
 
-    // raw http override: binary streaming response is out of scope for mockApi (Phase 0 of #9707); full origin URL intentional for fetch interception
     server.use(
+      // mockApi cannot be used here: /api/zero/voice-io/tts has no ts-rest contract
+      // (binary streaming response); full origin URL is intentional for fetch interception.
       http.post("http://localhost:3000/api/zero/voice-io/tts", () => {
         return HttpResponse.json({ error: "fail" }, { status: 500 });
       }),
@@ -150,8 +152,9 @@ describe("playTts$", () => {
     mockWebAudio();
 
     const fetchGate = createDeferredPromise<void>(context.signal);
-    // raw http override: binary streaming response is out of scope for mockApi (Phase 0 of #9707); full origin URL intentional for fetch interception
     server.use(
+      // mockApi cannot be used here: /api/zero/voice-io/tts has no ts-rest contract
+      // (binary streaming response); full origin URL is intentional for fetch interception.
       http.post("http://localhost:3000/api/zero/voice-io/tts", async () => {
         await fetchGate.promise;
         return HttpResponse.json({});
@@ -178,8 +181,9 @@ describe("playTts$", () => {
     mockWebAudio();
 
     const fetchGate = createDeferredPromise<void>(context.signal);
-    // raw http override: binary streaming response is out of scope for mockApi (Phase 0 of #9707); full origin URL intentional for fetch interception
     server.use(
+      // mockApi cannot be used here: /api/zero/voice-io/tts has no ts-rest contract
+      // (binary streaming response); full origin URL is intentional for fetch interception.
       http.post("http://localhost:3000/api/zero/voice-io/tts", async () => {
         await fetchGate.promise;
         return HttpResponse.json({});

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/member-credit-caps.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/member-credit-caps.test.ts
@@ -119,8 +119,9 @@ describe("creditsMemberList$", () => {
 
   it("should throw when API returns non-OK for credit cap fetch", async () => {
     setupUsageMembers([memberA()]);
-    // Keep raw http.get for 500 since it's not in the contract's defined responses
     server.use(
+      // mockApi cannot be used here: 500 is not declared in zeroMemberCreditCapContract.get responses,
+      // so this raw handler is the only way to simulate a server error for this test.
       http.get("*/api/zero/org/members/credit-cap", () => {
         return HttpResponse.json(
           {

--- a/turbo/apps/platform/src/views/conn/__tests__/zero-slack-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/zero-slack-connect-page.test.tsx
@@ -9,10 +9,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
+import { zeroSlackConnectContract } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 import {
   setMockSlackConnectData,
   resetMockSlackConnect,
@@ -126,17 +127,14 @@ describe("zero-slack-connect-page - connect button (CONN-I-056)", () => {
     let submittedBody: unknown;
 
     server.use(
-      http.post(
-        "*/api/zero/integrations/slack/connect",
-        async ({ request }) => {
-          submittedBody = await request.json();
-          return HttpResponse.json({
-            success: true,
-            connectionId: "conn-001",
-            role: "member",
-          });
-        },
-      ),
+      mockApi(zeroSlackConnectContract.connect, ({ body, respond }) => {
+        submittedBody = body;
+        return respond(200, {
+          success: true,
+          connectionId: "conn-001",
+          role: "member",
+        });
+      }),
     );
 
     detachedSetupPage({ context, path: "/settings/slack?w=ws1&u=u1" });

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor, act } from "@testing-library/react";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { mockApi } from "../../../mocks/msw-contract.ts";
 import {
+  chatThreadsContract,
   zeroComposesMainContract,
   zeroAgentsByIdContract,
   zeroAgentInstructionsContract,
@@ -40,8 +40,8 @@ function createMockTeamWithSubagents() {
 function mockAPIs() {
   setMockTeam(createMockTeamWithSubagents());
   server.use(
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
+    mockApi(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, { threads: [] });
     }),
     mockApi(zeroComposesMainContract.getByName, ({ respond }) => {
       return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -124,6 +124,8 @@ describe("chat draft persistence across thread navigation", () => {
           updatedAt: "2026-03-10T00:00:00Z",
         });
       }),
+      // mockApi cannot be used here: /api/zero/uploads accepts multipart FormData,
+      // which is out of scope for the mockApi helper (Phase 0 of #9707).
       http.post("*/api/zero/uploads", () => {
         // Signal that the upload request has arrived
         resolveUpload?.();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
@@ -15,10 +15,15 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
-import { http, HttpResponse } from "msw";
+import {
+  chatThreadsContract,
+  chatThreadByIdContract,
+  chatThreadMessagesContract,
+} from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.ts";
 import { threadListChanged } from "../../../mocks/mock-helpers.ts";
@@ -40,11 +45,11 @@ interface ThreadFixture {
 
 function mockAPIs(threadsRef: { current: ThreadFixture[] }) {
   server.use(
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: threadsRef.current });
+    mockApi(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, { threads: threadsRef.current });
     }),
-    http.get("*/api/zero/chat-threads/:id", ({ params }) => {
-      return HttpResponse.json({
+    mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
+      return respond(200, {
         id: params.id,
         title: null,
         agentId: DEFAULT_AGENT_ID,
@@ -55,8 +60,8 @@ function mockAPIs(threadsRef: { current: ThreadFixture[] }) {
         updatedAt: "2026-03-10T00:00:00Z",
       });
     }),
-    http.get("*/api/zero/chat-threads/:id/messages", () => {
-      return HttpResponse.json({ messages: [], hasMore: false });
+    mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+      return respond(200, { messages: [] });
     }),
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -82,8 +82,9 @@ describe("chat-d-057: upload progress indicator in AttachmentChip", () => {
   it("shows progress indicator while upload is pending", async () => {
     const user = userEvent.setup();
 
-    // raw http override: multipart FormData body is out of scope for mockApi (Phase 0 of #9707)
     server.use(
+      // mockApi cannot be used here: /api/zero/uploads accepts multipart FormData,
+      // which is out of scope for the mockApi helper (Phase 0 of #9707).
       http.post("*/api/zero/uploads", () => {
         return new Promise<never>(() => {});
       }),
@@ -120,8 +121,9 @@ describe("chat-d-058: image preview thumbnails in AttachmentChip", () => {
     const user = userEvent.setup();
     const imageUrl = "https://example.com/photo.png";
 
-    // raw http override: multipart FormData body is out of scope for mockApi (Phase 0 of #9707)
     server.use(
+      // mockApi cannot be used here: /api/zero/uploads accepts multipart FormData,
+      // which is out of scope for the mockApi helper (Phase 0 of #9707).
       http.post("*/api/zero/uploads", () => {
         return HttpResponse.json({
           id: "upload-1",
@@ -163,8 +165,9 @@ describe("chat-i-059: image preview button opens lightbox", () => {
     const user = userEvent.setup();
     const imageUrl = "https://example.com/photo.png";
 
-    // raw http override: multipart FormData body is out of scope for mockApi (Phase 0 of #9707)
     server.use(
+      // mockApi cannot be used here: /api/zero/uploads accepts multipart FormData,
+      // which is out of scope for the mockApi helper (Phase 0 of #9707).
       http.post("*/api/zero/uploads", () => {
         return HttpResponse.json({
           id: "upload-1",
@@ -215,8 +218,9 @@ describe("chat-i-060: close button closes lightbox", () => {
     const user = userEvent.setup();
     const imageUrl = "https://example.com/photo.png";
 
-    // raw http override: multipart FormData body is out of scope for mockApi (Phase 0 of #9707)
     server.use(
+      // mockApi cannot be used here: /api/zero/uploads accepts multipart FormData,
+      // which is out of scope for the mockApi helper (Phase 0 of #9707).
       http.post("*/api/zero/uploads", () => {
         return HttpResponse.json({
           id: "upload-1",
@@ -273,8 +277,9 @@ describe("chat-i-061: backdrop click closes lightbox", () => {
     const user = userEvent.setup();
     const imageUrl = "https://example.com/photo.png";
 
-    // raw http override: multipart FormData body is out of scope for mockApi (Phase 0 of #9707)
     server.use(
+      // mockApi cannot be used here: /api/zero/uploads accepts multipart FormData,
+      // which is out of scope for the mockApi helper (Phase 0 of #9707).
       http.post("*/api/zero/uploads", () => {
         return HttpResponse.json({
           id: "upload-1",
@@ -332,8 +337,9 @@ describe("chat-i-062: remove button on attachment chip calls onRemove", () => {
   it("removes attachment chip when clicking the Remove button", async () => {
     const user = userEvent.setup();
 
-    // raw http override: multipart FormData body is out of scope for mockApi (Phase 0 of #9707)
     server.use(
+      // mockApi cannot be used here: /api/zero/uploads accepts multipart FormData,
+      // which is out of scope for the mockApi helper (Phase 0 of #9707).
       http.post("*/api/zero/uploads", () => {
         return HttpResponse.json({
           id: "upload-1",
@@ -417,8 +423,9 @@ describe("chat-d-064: video attachment chip shows neither image thumbnail nor fi
     const user = userEvent.setup();
     const videoUrl = "https://example.com/demo.mp4";
 
-    // raw http override: multipart FormData body is out of scope for mockApi (Phase 0 of #9707)
     server.use(
+      // mockApi cannot be used here: /api/zero/uploads accepts multipart FormData,
+      // which is out of scope for the mockApi helper (Phase 0 of #9707).
       http.post("*/api/zero/uploads", () => {
         return HttpResponse.json({
           id: "upload-video-1",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-display.test.tsx
@@ -41,8 +41,9 @@ function mockConnectedConnectors(types: ConnectorType[]) {
 
 describe("chat-d-015: attachment chips in composer", () => {
   beforeEach(() => {
-    // raw http override: multipart FormData body is out of scope for mockApi (Phase 0 of #9707)
     server.use(
+      // mockApi cannot be used here: /api/zero/uploads accepts multipart FormData,
+      // which is out of scope for the mockApi helper (Phase 0 of #9707).
       http.post("*/api/zero/uploads", () => {
         return HttpResponse.json({
           id: "upload-1",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
@@ -3,8 +3,6 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
   zeroConnectorsMainContract,
   zeroUserConnectorsContract,
 } from "@vm0/core";
@@ -52,38 +50,6 @@ function mockConnectors() {
     },
   ]);
   server.use(
-    http.get("*/api/zero/connectors", () => {
-      return HttpResponse.json({
-        connectors: [
-          {
-            id: "d0000001-0000-4000-a000-000000000001",
-            type: "github",
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: "testuser",
-            externalEmail: null,
-            oauthScopes: ["repo"],
-            needsReconnect: false,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-          },
-          {
-            id: "d0000002-0000-4000-a000-000000000002",
-            type: "linear",
-            authMethod: "oauth",
-            externalId: null,
-            externalUsername: "linearuser",
-            externalEmail: null,
-            oauthScopes: [],
-            needsReconnect: false,
-            createdAt: "2026-01-02T00:00:00Z",
-            updatedAt: "2026-01-02T00:00:00Z",
-          },
-        ],
-        configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
-        connectorProvidedSecretNames: [],
-      });
-    }),
     mockApi(zeroUserConnectorsContract.get, ({ respond }) => {
       return respond(200, { enabledTypes: ["github"] });
     }),
@@ -115,8 +81,9 @@ describe("zero chat composer - file input", () => {
   it("shows attachment chip after a file is selected via the file input", async () => {
     const user = userEvent.setup();
     mockChatLifecycle();
-    // raw http override: multipart FormData body is out of scope for mockApi (Phase 0 of #9707)
     server.use(
+      // mockApi cannot be used here: /api/zero/uploads accepts multipart FormData,
+      // which is out of scope for the mockApi helper (Phase 0 of #9707).
       http.post("*/api/zero/uploads", () => {
         return HttpResponse.json({
           id: "upload-1",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx
@@ -40,8 +40,9 @@ function clearMediaDevices() {
 }
 
 function mockSttEndpoint(text = "transcribed text") {
-  // raw http override: multipart FormData body is out of scope for mockApi (Phase 0 of #9707)
   server.use(
+    // mockApi cannot be used here: /api/zero/voice-io/stt has no ts-rest contract
+    // (accepts multipart FormData audio body), so raw http is the only option.
     http.post("*/api/zero/voice-io/stt", () => {
       return HttpResponse.json({ text });
     }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page-interaction.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
@@ -10,6 +9,7 @@ import { mockApi } from "../../../mocks/msw-contract.ts";
 import {
   zeroAgentsMainContract,
   zeroAgentInstructionsContract,
+  zeroTeamContract,
 } from "@vm0/core";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 
@@ -78,12 +78,12 @@ describe("zero jobs page - create agent dialog", () => {
     };
     let teamCallCount = 0;
     server.use(
-      http.get("*/api/zero/team", () => {
+      mockApi(zeroTeamContract.list, ({ respond }) => {
         teamCallCount++;
         if (teamCallCount === 1) {
-          return HttpResponse.json([DEFAULT_AGENT]);
+          return respond(200, [DEFAULT_AGENT]);
         }
-        return HttpResponse.json([DEFAULT_AGENT, NEW_AGENT]);
+        return respond(200, [DEFAULT_AGENT, NEW_AGENT]);
       }),
       mockApi(zeroAgentsMainContract.create, ({ respond }) => {
         return respond(201, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -8,8 +8,8 @@ import {
   FeatureSwitchKey,
   chatThreadsContract,
   zeroAgentsByIdContract,
+  zeroTeamContract,
 } from "@vm0/core";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { mockApi } from "../../../mocks/msw-contract.ts";
 
@@ -51,8 +51,8 @@ function mockAPIs({
   }[];
 } = {}) {
   server.use(
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
+    mockApi(zeroTeamContract.list, ({ respond }) => {
+      return respond(200, [
         {
           id: "c0000000-0000-4000-a000-000000000001",
           displayName: null,


### PR DESCRIPTION
## Summary

Closes #10177. Cleans up residual `server.use(http.*(...))` overrides that were missed by the six Phase 3 child PRs (#10094/#10095/#10096/#10104/#10105/#10119) merged yesterday, so capstone #10091 (ESLint guardrail) can land on a uniform set of allowlisted sites.

### Migrations to `mockApi()`

| File | Contract(s) |
|---|---|
| `views/team-page/__tests__/team-navigation.test.tsx` | `chatThreadsContract.list` |
| `views/zero-page/__tests__/sidebar-running-indicator.test.tsx` | `chatThreadsContract.list`, `chatThreadByIdContract.get`, `chatThreadMessagesContract.list` |
| `views/conn/__tests__/zero-slack-connect-page.test.tsx` | `zeroSlackConnectContract.connect` |
| `views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx` | redundant `GET /connectors` override dropped (default handler serves same response) |
| `views/zero-page/__tests__/zero-jobs-page-interaction.test.tsx` | `zeroTeamContract.list` |
| `views/zero-page/__tests__/zero-sidebar.test.tsx` | `zeroTeamContract.list` |

### Intentional raw-http exemptions — uniform `// mockApi cannot be used here:` comments

Reasons fall into four categories:

1. **500 error not in contract's declared responses:**
   - `signals/zero-page/__tests__/member-credit-caps.test.ts`
   - `signals/__tests__/api-client.test.ts` (403 not in contract)
   - `signals/voice-chat/__tests__/voice-chat-session-prepare.test.ts` (×3)
   - `signals/voice-chat/__tests__/voice-chat-preparation.test.ts`
   - `signals/voice-chat/__tests__/voice-chat-preparation-list.test.ts`

2. **No ts-rest contract exists (binary streaming response):**
   - `signals/voice-io/__tests__/voice-io-tts.test.ts` (×4)

3. **No ts-rest contract exists (multipart body):**
   - `views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx` (voice-io/stt)
   - `views/zero-page/__tests__/zero-attachment-chips.test.tsx` (×7 uploads)
   - `views/zero-page/__tests__/zero-chat-composer-display.test.tsx` (uploads)
   - `views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx` (uploads)
   - `views/zero-page/__tests__/chat-draft.test.tsx` (uploads)

4. **Fetch-wrapper self-tests (synthetic URLs):**
   - `signals/__tests__/fetch.test.ts` — file-level header comment explaining the synthetic `/test` and `/api/zero/items` URLs used to exercise 401 redirect / token-refresh / retry paths

### Post-state

```
grep -rn 'http\.\(get\|post\|put\|patch\|delete\)' turbo/apps/platform/src/**/__tests__/
```

returns only call sites preceded by a `// mockApi cannot be used here:` comment (plus `fetch.test.ts` with its top-of-file exemption). Ready for #10091 to add a URL-inspecting custom ESLint rule.

## Test plan

- [x] `pnpm -F @vm0/app lint` — clean
- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm -F @vm0/app exec vitest run` — 213 files / 1804 tests pass
- [x] knip — no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)