### PR TITLE
fix(voice-io): capture openai stt error body and file metadata in logs

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
@@ -121,9 +121,14 @@ export async function POST(request: Request): Promise<Response> {
   );
 
   if (!openaiResponse.ok) {
+    const errorBody = await openaiResponse.text();
     log.error("OpenAI STT API error", {
       status: openaiResponse.status,
       statusText: openaiResponse.statusText,
+      body: errorBody,
+      fileMime: file.type,
+      fileSize: file.size,
+      fileName: file.name,
     });
     return NextResponse.json(
       {


### PR DESCRIPTION
## Summary

- STT route only logged HTTP `status`/`statusText` when OpenAI returned a non-ok response, so the real error message was discarded and Sentry captured the stringified object as `[object Object]` (issue #10058).
- Read the response body and include file MIME, size, and name alongside status — matching the pattern already used in `tts/route.ts`.
- Unblocks diagnosing the underlying STT 400s: Axiom currently has zero payload detail for the failed requests (verified on Apr 18 production burst).

## Why this is P0

Without the response body, there is no way to know whether the 400 is due to MIME codec suffix, new `gpt-4o-mini-transcribe` model requirements, audio corruption, or something else. Any root-cause fix before this one is shotgun debugging.

Follow-up (after this deploys and we collect real Axiom payloads): pick the actual STT 400 root cause based on observed messages.

## Test plan

- [x] Existing integration test `app/api/zero/voice-io/stt/__tests__/route.test.ts` — 9/9 passing, including the OpenAI-failure case
- [x] `pnpm check-types` passes
- [x] `pnpm knip --workspace web` passes
- [x] `pnpm format` clean
- [ ] After merge: monitor Axiom `vm0-web-logs-prod` for `api:zero:voice-io:stt` error events with the new fields populated

Refs #10058