### PR TITLE
fix(mitm-addon): use flow.request.scheme for original url

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -436,7 +436,8 @@ async def handle_firewall_request(
 
     resolved_base = token_meta.get("base")
     if resolved_base:
-        new_url = build_rewrite_url(resolved_base, match_info, flow.request.pretty_url)
+        orig_query = urllib.parse.urlparse(flow.request.path).query
+        new_url = build_rewrite_url(resolved_base, match_info, orig_query)
 
         # Merge resolved auth.query params into the forwarded URL.
         # Uses parse_qs + merge so auth.query overwrites duplicate keys

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -402,9 +402,14 @@ def response(flow: http.HTTPFlow) -> None:
     start_time = _request_start_times.pop(flow.id, None)
     latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
 
-    # Get stored info
+    # Get stored info. ``original_url`` fallback uses the same
+    # reconstructor as the request handler so unregistered-VM flows
+    # (where the request handler returned early and never populated
+    # metadata) produce consistent URLs — not mitmproxy's
+    # ``pretty_url``, which reads the Host-header port and drops
+    # non-default destination ports (see #10082).
     run_id = flow.metadata.get("vm_run_id", "")
-    original_url = flow.metadata.get("original_url", flow.request.pretty_url)
+    original_url = flow.metadata.get("original_url") or get_original_url(flow)
     firewall_action = flow.metadata.get("firewall_action", "ALLOW")
 
     # Calculate sizes
@@ -510,7 +515,7 @@ def error(flow: http.HTTPFlow) -> None:
         return
 
     latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
-    original_url = flow.metadata.get("original_url", flow.request.pretty_url)
+    original_url = flow.metadata.get("original_url") or get_original_url(flow)
     firewall_action = flow.metadata.get("firewall_action", "ALLOW")
 
     try:

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -9,8 +9,17 @@ from mitmproxy import http
 
 
 def get_original_url(flow: http.HTTPFlow) -> str:
-    """Reconstruct the original target URL from the request."""
-    scheme = "https" if flow.request.port == 443 else "http"
+    """Reconstruct the original target URL from the request.
+
+    Uses ``flow.request.scheme`` (populated from the TLS handshake) rather
+    than inferring from the destination port, and anchors the authority
+    on ``pretty_host`` (Host header if present) combined with the actual
+    destination port. ``pretty_url`` is intentionally not used: it takes
+    the port from the Host header, so a request to ``host:8443`` with a
+    plain ``Host: host`` (no port) would lose the ``:8443`` and break
+    firewall rule matching.
+    """
+    scheme = flow.request.scheme
     host = flow.request.pretty_host
     port = flow.request.port
 

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -32,15 +32,15 @@ def get_original_url(flow: http.HTTPFlow) -> str:
     return f"{scheme}://{host_with_port}{path}"
 
 
-def build_rewrite_url(resolved_base: str, match_info: dict, orig_url: str) -> str:
+def build_rewrite_url(resolved_base: str, match_info: dict, orig_query: str) -> str:
     """Build the final URL for auth.base URL rewriting.
 
     Combines the resolved base URL (with credentials in path), the relative
     path from the firewall match, and query strings from both base and
-    original request.
+    original request. ``orig_query`` is the raw query string of the
+    incoming request (no leading ``?``).
     """
     base_parsed = urllib.parse.urlparse(resolved_base)
-    orig_parsed = urllib.parse.urlparse(orig_url)
 
     # Append rel_path to the base path portion
     rel_path = match_info.get("rel_path", "/")
@@ -50,8 +50,8 @@ def build_rewrite_url(resolved_base: str, match_info: dict, orig_url: str) -> st
     qs_parts: list[str] = []
     if base_parsed.query:
         qs_parts.append(base_parsed.query)
-    if orig_parsed.query:
-        qs_parts.append(orig_parsed.query)
+    if orig_query:
+        qs_parts.append(orig_query)
     merged_qs = "&".join(qs_parts)
 
     return urllib.parse.urlunparse(

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -76,6 +76,7 @@ def real_flow():
         port: int = 443,
         path: str = "/",
         method: str = "GET",
+        scheme: str = "https",
         request_body: bytes | None = None,
         request_headers: http.Headers | None = None,
         request_content_type: str | None = None,
@@ -95,7 +96,7 @@ def real_flow():
                 pairs.insert(0, ("Content-Type", request_content_type))
             req_headers = _headers(*pairs)
         req = tutils.treq(
-            scheme=b"https",
+            scheme=scheme.encode(),
             method=method.encode(),
             host=host.encode(),
             port=port,

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -63,10 +63,10 @@ def real_flow():
     """Factory that builds a real :class:`mitmproxy.http.HTTPFlow`.
 
     Parameters mirror the handful of attributes the addon reads from the
-    flow: client IP, request method/host/port/path/body/headers, response
-    status/body/headers/encoding.  The returned flow has ``flow.metadata``
-    empty (addon fills it in) and, when ``with_response=False``, no
-    response attached.
+    flow: client IP, request scheme/method/host/port/path/body/headers,
+    response status/body/headers/encoding. The returned flow has
+    ``flow.metadata`` empty (addon fills it in) and, when
+    ``with_response=False``, no response attached.
     """
 
     def _build(

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -2086,7 +2086,7 @@ class TestBuildRewriteUrl:
         url = url_utils.build_rewrite_url(
             "https://discord.com/api/webhooks/123/abc",
             {"rel_path": "/"},
-            "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
+            "",
         )
         assert url == "https://discord.com/api/webhooks/123/abc"
 
@@ -2094,7 +2094,7 @@ class TestBuildRewriteUrl:
         url = url_utils.build_rewrite_url(
             "https://example.com/base",
             {"rel_path": "/a/b/c"},
-            "https://firewall-placeholder.vm3.ai/hook",
+            "",
         )
         assert url == "https://example.com/base/a/b/c"
 
@@ -2102,7 +2102,7 @@ class TestBuildRewriteUrl:
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
             {"rel_path": "/"},
-            "https://firewall-placeholder.vm3.ai/hook",
+            "",
         )
         assert url == "https://example.com/hook?token=secret"
 
@@ -2110,7 +2110,7 @@ class TestBuildRewriteUrl:
         url = url_utils.build_rewrite_url(
             "https://example.com/hook",
             {"rel_path": "/"},
-            "https://firewall-placeholder.vm3.ai/hook?",
+            "",
         )
         assert url == "https://example.com/hook"
 
@@ -2118,7 +2118,7 @@ class TestBuildRewriteUrl:
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=abc",
             {"rel_path": "/sub"},
-            "https://firewall-placeholder.vm3.ai/hook/sub?extra=1",
+            "extra=1",
         )
         assert url == "https://example.com/hook/sub?token=abc&extra=1"
 
@@ -2126,7 +2126,7 @@ class TestBuildRewriteUrl:
         url = url_utils.build_rewrite_url(
             "https://example.com/hook/",
             {"rel_path": "/sub"},
-            "https://firewall-placeholder.vm3.ai/hook/sub",
+            "",
         )
         assert url == "https://example.com/hook/sub"
 
@@ -2134,7 +2134,7 @@ class TestBuildRewriteUrl:
         url = url_utils.build_rewrite_url(
             "https://example.com/hook",
             {},
-            "https://firewall-placeholder.vm3.ai/hook",
+            "",
         )
         assert url == "https://example.com/hook"
 

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -2148,17 +2148,17 @@ class TestAuthBaseUrlRewriteEdgeCases:
         tmp_path,
         *,
         path="/hook",
-        pretty_url=None,
+        seed_url=None,
         resolved_base="https://discord.com/api/webhooks/123/abc",
         rel_path="/",
     ):
-        # ``pretty_url`` lets callers seed a specific scheme://host/path?query
-        # on the request.  We parse it back into ``real_flow`` kwargs rather
-        # than mutating the read-only ``Request.pretty_url`` property.
-        if pretty_url:
+        # ``seed_url`` lets callers specify a scheme://host/path?query to
+        # seed the request. We parse it back into ``real_flow`` kwargs
+        # rather than mutating the read-only ``Request`` properties.
+        if seed_url:
             from urllib.parse import urlparse
 
-            parsed = urlparse(pretty_url)
+            parsed = urlparse(seed_url)
             host = parsed.hostname or "firewall-placeholder.vm3.ai"
             real_path = parsed.path or "/"
             if parsed.query:

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -16,19 +16,13 @@ class TestGetOriginalUrl:
         assert get_original_url(flow) == "http://example.com/"
 
     def test_https_non_standard_port(self, real_flow):
-        # Regression for #10082: scheme must come from the TLS handshake,
-        # not from the destination port. On :8443 the old code inferred
-        # http:// and firewall rules written against https:// stopped
-        # matching.
-        flow = real_flow(host="example.com", port=8443)
-        assert get_original_url(flow) == "https://example.com:8443/"
-
-    def test_non_standard_port_preserved_when_host_header_lacks_port(self, real_flow):
-        # The Host header (``example.com``) does not carry the port, but
-        # the connection is on :8443. The reconstructed URL must still
-        # include :8443 so firewall rules can match the actual target.
-        # mitmproxy's ``pretty_url`` would drop the port here because it
-        # reads the Host header; we intentionally use ``port`` instead.
+        # Pins two invariants at once for the #10082 regression:
+        # - scheme comes from the TLS handshake, not from the port (so
+        #   :8443 stays ``https://``, not ``http://`` as before the fix);
+        # - the destination port is included even when the Host header
+        #   has no port (the Host-lacks-port precondition is asserted
+        #   below — mitmproxy's ``pretty_url`` would drop the port here,
+        #   which is why we don't use it).
         flow = real_flow(host="example.com", port=8443)
         assert flow.request.headers.get("Host") == "example.com"
         assert get_original_url(flow) == "https://example.com:8443/"

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -1,36 +1,43 @@
 """Tests for URL and logging utility functions."""
 
 import json
-from unittest.mock import MagicMock
+
+from mitmproxy.test import tflow, tutils
 
 from logging_utils import log_proxy_entry
 from url_utils import get_original_url
 
 
-def _make_flow(host, port, path="/", scheme=None):
-    """Create a minimal mock flow for get_original_url."""
-    flow = MagicMock()
-    flow.request.pretty_host = host
-    flow.request.port = port
-    flow.request.path = path
-    return flow
-
-
 class TestGetOriginalUrl:
-    def test_https_default_port(self):
-        flow = _make_flow("example.com", 443)
+    def test_https_default_port(self, real_flow):
+        flow = real_flow(host="example.com", port=443)
         assert get_original_url(flow) == "https://example.com/"
 
     def test_http_default_port(self):
-        flow = _make_flow("example.com", 80)
+        # real_flow hardcodes scheme=https; build a cleartext flow directly.
+        flow = tflow.tflow(req=tutils.treq(scheme=b"http", host=b"example.com", port=80, path=b"/"))
         assert get_original_url(flow) == "http://example.com/"
 
-    def test_https_non_standard_port(self):
-        flow = _make_flow("example.com", 8443)
-        assert get_original_url(flow) == "http://example.com:8443/"
+    def test_https_non_standard_port(self, real_flow):
+        # Regression for #10082: scheme must come from the TLS handshake,
+        # not from the destination port. On :8443 the old code inferred
+        # http:// and firewall rules written against https:// stopped
+        # matching.
+        flow = real_flow(host="example.com", port=8443)
+        assert get_original_url(flow) == "https://example.com:8443/"
 
-    def test_with_path_and_query(self):
-        flow = _make_flow("api.example.com", 443, "/v1/data?key=val")
+    def test_non_standard_port_preserved_when_host_header_lacks_port(self, real_flow):
+        # The Host header (``example.com``) does not carry the port, but
+        # the connection is on :8443. The reconstructed URL must still
+        # include :8443 so firewall rules can match the actual target.
+        # mitmproxy's ``pretty_url`` would drop the port here because it
+        # reads the Host header; we intentionally use ``port`` instead.
+        flow = real_flow(host="example.com", port=8443)
+        assert flow.request.headers.get("Host") == "example.com"
+        assert get_original_url(flow) == "https://example.com:8443/"
+
+    def test_with_path_and_query(self, real_flow):
+        flow = real_flow(host="api.example.com", port=443, path="/v1/data?key=val")
         assert get_original_url(flow) == "https://api.example.com/v1/data?key=val"
 
 

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -2,8 +2,6 @@
 
 import json
 
-from mitmproxy.test import tflow, tutils
-
 from logging_utils import log_proxy_entry
 from url_utils import get_original_url
 
@@ -13,9 +11,8 @@ class TestGetOriginalUrl:
         flow = real_flow(host="example.com", port=443)
         assert get_original_url(flow) == "https://example.com/"
 
-    def test_http_default_port(self):
-        # real_flow hardcodes scheme=https; build a cleartext flow directly.
-        flow = tflow.tflow(req=tutils.treq(scheme=b"http", host=b"example.com", port=80, path=b"/"))
+    def test_http_default_port(self, real_flow):
+        flow = real_flow(host="example.com", port=80, scheme="http")
         assert get_original_url(flow) == "http://example.com/"
 
     def test_https_non_standard_port(self, real_flow):


### PR DESCRIPTION
## Summary
- `get_original_url` inferred the URL scheme from the destination port (`443 → https`, else `http`), so HTTPS on non-standard ports (e.g. `:8443`) was reconstructed as `http://...`. Firewall rules written against the correct scheme stopped matching.
- Read `flow.request.scheme` directly — mitmproxy sets it from the TLS handshake.
- Intentionally **not** using `flow.request.pretty_url`: it reads the port from the Host header, which would drop `:8443` when the client sends a bare `Host: example.com`. Firewall matching needs the actual destination port.
- Migrated the tests from `MagicMock` to the existing `real_flow` fixture (real `mitmproxy.http.HTTPFlow`), and added a regression test for the "Host header no port / destination non-default port" edge case.

Closes #10082

## Test plan
- [x] `python -m pytest tests/test_utils.py -v` — 8/8 pass
- [x] `python -m pytest tests/` — 877/877 pass
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)