### PR TITLE
refactor(observability): group voice-chat start timestamp into options

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/route.ts
@@ -113,16 +113,11 @@ export async function POST(request: Request) {
       mode,
       prompt,
     );
-    const run = await dispatchPreparationRun(
-      preparation.id,
-      userId,
-      agentId,
+    const run = await dispatchPreparationRun(preparation.id, userId, agentId, {
+      mode: mode as "chat" | "meeting",
+      prompt,
       apiStartTime,
-      {
-        mode: mode as "chat" | "meeting",
-        prompt,
-      },
-    );
+    });
 
     return NextResponse.json({
       preparation: {

--- a/turbo/apps/web/app/api/zero/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/route.ts
@@ -117,17 +117,11 @@ export async function POST(request: Request) {
       });
     }
 
-    const run = await dispatchSlowBrain(
-      session,
-      org.orgId,
-      userId,
-      agentId,
+    const run = await dispatchSlowBrain(session, org.orgId, userId, agentId, {
+      mode,
+      prompt,
       apiStartTime,
-      {
-        mode,
-        prompt,
-      },
-    );
+    });
 
     return NextResponse.json({
       session: {

--- a/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/preparation-service.ts
@@ -164,12 +164,14 @@ export async function dispatchPreparationRun(
   preparationId: string,
   userId: string,
   agentId: string,
-  apiStartTime: number,
-  options?: { mode?: "chat" | "meeting"; prompt?: string },
+  options: {
+    mode?: "chat" | "meeting";
+    prompt?: string;
+    apiStartTime: number;
+  },
 ): Promise<CreateZeroRunResult> {
   const db = globalThis.services.db;
-  const meetingPrompt =
-    options?.mode === "meeting" ? options.prompt : undefined;
+  const meetingPrompt = options.mode === "meeting" ? options.prompt : undefined;
 
   const appendSystemPrompt = meetingPrompt
     ? buildVoiceChatMeetingPreparePrompt(meetingPrompt)
@@ -186,7 +188,7 @@ export async function dispatchPreparationRun(
       prompt,
       appendSystemPrompt,
       preparationId,
-      apiStartTime,
+      apiStartTime: options.apiStartTime,
     }),
   );
 

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -144,12 +144,14 @@ export async function dispatchSlowBrain(
   orgId: string,
   userId: string,
   agentId: string,
-  apiStartTime: number,
-  options?: { mode?: "chat" | "meeting"; prompt?: string },
+  options: {
+    mode?: "chat" | "meeting";
+    prompt?: string;
+    apiStartTime: number;
+  },
 ): Promise<CreateZeroRunResult> {
   const db = globalThis.services.db;
-  const meetingPrompt =
-    options?.mode === "meeting" ? options.prompt : undefined;
+  const meetingPrompt = options.mode === "meeting" ? options.prompt : undefined;
 
   const appendSystemPrompt = meetingPrompt
     ? buildVoiceChatMeetingPrompt(session.id, meetingPrompt)
@@ -176,7 +178,7 @@ export async function dispatchSlowBrain(
       prompt,
       appendSystemPrompt,
       sessionId: session.id,
-      apiStartTime,
+      apiStartTime: options.apiStartTime,
     }),
   );
 

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -444,6 +444,9 @@ export async function dispatchQueuedZeroRun(
   params: CreateRunParams,
 ): Promise<void> {
   if (params.vars?.ZERO_AGENT_ID) {
+    // Queued dispatch anchors apiStart at dequeue, not the original request.
+    // The queue wait time is intentionally excluded from startup latency —
+    // merging it would hide queue-worker lag behind cold-start numbers.
     const apiStartTime = Date.now();
 
     // Generate fresh ZERO_TOKEN for queued dispatch
@@ -530,6 +533,8 @@ export async function dispatchQueuedZeroRun(
 
   // Non-zero path — build infra context and dispatch directly
   const nonZeroLog = logger("zero:run-queue-service:non-zero");
+  // Anchored at dequeue for the same reason as the zero path above —
+  // queue wait is intentionally not part of startup latency.
   const apiStartTime = Date.now();
 
   const { composeContent, compose } = await loadCompose(


### PR DESCRIPTION
## Summary

Follow-up to #10181 addressing two P2 items from code review:

- **Swap-prone positional args**: `dispatchPreparationRun` and `dispatchSlowBrain` took `apiStartTime: number` as a standalone positional parameter next to three positional strings (`preparationId` / `userId` / `agentId` etc.). TypeScript can't catch a string↔string swap, so the layout was fragile. Move `apiStartTime` into the existing `options` object alongside `mode` / `prompt`.
- **Queue path documentation**: `zero-run-queue-service.ts` re-captures `Date.now()` at dequeue instead of threading the original request timestamp through the queue. Added inline comments explaining the intent — queue wait is deliberately excluded from startup latency so queue-worker lag is not hidden behind cold-start numbers.

`dispatchObservationSlowBrain` keeps its two positional args as-is; two-arg positional is not swap-prone and doesn't have an existing `options` object to fold into.

## Test plan

- [x] `pnpm -F web check-types` clean
- [x] `app/api/zero/voice-chat/__tests__/route.test.ts` — 22 tests green (exercises both dispatch functions via the route handler)
- [ ] CI lint + format + knip
- [ ] CI cli-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)