### PR TITLE
fix(platform): filter empty model values in ModelSelector to avoid radix crash

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
@@ -295,8 +295,11 @@ function ModelSelector({
     return null;
   }
 
-  const models =
-    type === "vm0" ? getVm0VisibleModels(features) : (getModels(type) ?? []);
+  const models = (
+    type === "vm0" ? getVm0VisibleModels(features) : (getModels(type) ?? [])
+  ).filter((m) => {
+    return m !== "";
+  });
   const defaultModel = getUIDefaultModel(type) ?? getDefaultModel(type) ?? "";
   const canCustom = allowsCustomModel(type);
   const placeholder = getCustomModelPlaceholder(type) ?? "Enter model name";

--- a/turbo/packages/ui/src/components/ui/__tests__/select.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/select.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import {
   Select,
@@ -9,16 +9,6 @@ import {
 } from "../select";
 
 describe("SelectItem", () => {
-  let errSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("renders items with non-empty values", () => {
     render(
       <Select defaultValue="a" open>
@@ -34,41 +24,5 @@ describe("SelectItem", () => {
     const listbox = within(screen.getByRole("listbox"));
     expect(listbox.getByText("Alpha")).toBeInTheDocument();
     expect(listbox.getByText("Beta")).toBeInTheDocument();
-  });
-
-  it("skips items with empty string value without throwing", () => {
-    expect(() => {
-      render(
-        <Select defaultValue="ok" open>
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="">Bad</SelectItem>
-            <SelectItem value="ok">Good</SelectItem>
-          </SelectContent>
-        </Select>,
-      );
-    }).not.toThrow();
-    const listbox = within(screen.getByRole("listbox"));
-    expect(listbox.queryByText("Bad")).not.toBeInTheDocument();
-    expect(listbox.getByText("Good")).toBeInTheDocument();
-  });
-
-  it("logs an error when value is empty so prod observability is preserved", () => {
-    render(
-      <Select defaultValue="ok" open>
-        <SelectTrigger>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="">Bad</SelectItem>
-          <SelectItem value="ok">Good</SelectItem>
-        </SelectContent>
-      </Select>,
-    );
-    expect(errSpy).toHaveBeenCalledWith(
-      expect.stringContaining("empty string `value`"),
-    );
   });
 });

--- a/turbo/packages/ui/src/components/ui/__tests__/select.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/select.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../select";
+
+describe("SelectItem", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("renders items with non-empty values", () => {
+    render(
+      <Select defaultValue="a" open>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="a">Alpha</SelectItem>
+          <SelectItem value="b">Beta</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    const listbox = within(screen.getByRole("listbox"));
+    expect(listbox.getByText("Alpha")).toBeInTheDocument();
+    expect(listbox.getByText("Beta")).toBeInTheDocument();
+  });
+
+  it("skips items with empty string value without throwing", () => {
+    process.env.NODE_ENV = "development";
+    expect(() => {
+      render(
+        <Select defaultValue="ok" open>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">Bad</SelectItem>
+            <SelectItem value="ok">Good</SelectItem>
+          </SelectContent>
+        </Select>,
+      );
+    }).not.toThrow();
+    const listbox = within(screen.getByRole("listbox"));
+    expect(listbox.queryByText("Bad")).not.toBeInTheDocument();
+    expect(listbox.getByText("Good")).toBeInTheDocument();
+  });
+
+  it("logs a dev-only error when value is empty", () => {
+    process.env.NODE_ENV = "development";
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <Select defaultValue="ok" open>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="">Bad</SelectItem>
+          <SelectItem value="ok">Good</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("empty string `value`"),
+    );
+  });
+});

--- a/turbo/packages/ui/src/components/ui/__tests__/select.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/select.test.tsx
@@ -9,15 +9,14 @@ import {
 } from "../select";
 
 describe("SelectItem", () => {
-  const originalNodeEnv = process.env.NODE_ENV;
+  let errSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    process.env.NODE_ENV = originalNodeEnv;
   });
 
   it("renders items with non-empty values", () => {
@@ -38,7 +37,6 @@ describe("SelectItem", () => {
   });
 
   it("skips items with empty string value without throwing", () => {
-    process.env.NODE_ENV = "development";
     expect(() => {
       render(
         <Select defaultValue="ok" open>
@@ -57,9 +55,7 @@ describe("SelectItem", () => {
     expect(listbox.getByText("Good")).toBeInTheDocument();
   });
 
-  it("logs a dev-only error when value is empty", () => {
-    process.env.NODE_ENV = "development";
-    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  it("logs an error when value is empty so prod observability is preserved", () => {
     render(
       <Select defaultValue="ok" open>
         <SelectTrigger>

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -6,8 +6,6 @@ import { IconCheck, IconChevronDown, IconChevronUp } from "@tabler/icons-react";
 
 import { cn } from "../../lib/utils";
 
-declare const process: { env: { NODE_ENV?: string } };
-
 const Select = SelectPrimitive.Root;
 
 const SelectGroup = SelectPrimitive.Group;
@@ -133,11 +131,12 @@ const SelectItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
 >(({ className, children, value, ...props }, ref) => {
   if (value === "") {
-    if (process.env.NODE_ENV !== "production") {
-      console.error(
-        '[@vm0/ui] <SelectItem> received an empty string `value`; skipping render to avoid Radix invariant crash. Use a non-empty sentinel such as "all" instead.',
-      );
-    }
+    // Log in every environment so the upstream data defect stays discoverable
+    // in production monitoring (via browser devtools or console-capturing error
+    // reporters) instead of being silently swallowed.
+    console.error(
+      '[@vm0/ui] <SelectItem> received an empty string `value`; skipping render to avoid Radix invariant crash. Use a non-empty sentinel such as "all" instead.',
+    );
     return null;
   }
   return (

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -6,6 +6,8 @@ import { IconCheck, IconChevronDown, IconChevronUp } from "@tabler/icons-react";
 
 import { cn } from "../../lib/utils";
 
+declare const process: { env: { NODE_ENV?: string } };
+
 const Select = SelectPrimitive.Root;
 
 const SelectGroup = SelectPrimitive.Group;
@@ -129,10 +131,19 @@ SelectLabel.displayName = SelectPrimitive.Label.displayName;
 const SelectItem = React.forwardRef<
   React.ComponentRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => {
+>(({ className, children, value, ...props }, ref) => {
+  if (value === "") {
+    if (process.env.NODE_ENV !== "production") {
+      console.error(
+        '[@vm0/ui] <SelectItem> received an empty string `value`; skipping render to avoid Radix invariant crash. Use a non-empty sentinel such as "all" instead.',
+      );
+    }
+    return null;
+  }
   return (
     <SelectPrimitive.Item
       ref={ref}
+      value={value}
       className={cn(
         "relative flex w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 transition-colors",
         className,

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -129,20 +129,10 @@ SelectLabel.displayName = SelectPrimitive.Label.displayName;
 const SelectItem = React.forwardRef<
   React.ComponentRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, value, ...props }, ref) => {
-  if (value === "") {
-    // Log in every environment so the upstream data defect stays discoverable
-    // in production monitoring (via browser devtools or console-capturing error
-    // reporters) instead of being silently swallowed.
-    console.error(
-      '[@vm0/ui] <SelectItem> received an empty string `value`; skipping render to avoid Radix invariant crash. Use a non-empty sentinel such as "all" instead.',
-    );
-    return null;
-  }
+>(({ className, children, ...props }, ref) => {
   return (
     <SelectPrimitive.Item
       ref={ref}
-      value={value}
       className={cn(
         "relative flex w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 transition-colors",
         className,


### PR DESCRIPTION
## Summary
- Filter empty strings out of `ModelSelector`'s model list before iterating, so Radix's `<Select.Item>` never receives `value=""`.
- Sentry breadcrumbs (PLATFORM-2M) most strongly implicate this callsite on `/schedules/:id` after a fetch to `/api/zero/model-providers` and the user opening the provider-edit dialog.

Closes #10166 (Sentry PLATFORM-2M — 7 events, 2 users).

## Why targeted instead of a wrapper-level guard
An earlier revision of this PR trapped empty `value` inside `@vm0/ui`'s shared `SelectItem` wrapper. We dropped that layer in favor of fixing the single most-implicated callsite to keep the change minimal and avoid silently swallowing empty-value renders elsewhere — Radix's built-in invariant is preserved for every other `SelectItem` callsite.

## Test plan
- [x] `pnpm -F @vm0/ui exec vitest run` — 20 tests pass.
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-provider-dialog.test.tsx` — 18 existing ModelSelector/provider tests still green.
- [x] `pnpm -F @vm0/ui run lint` — clean.
- [x] `pnpm -F @vm0/app run lint` — clean.
- [x] `pnpm -F @vm0/ui run check-types` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)