### PR TITLE
feat(platform): make mod+b shortcut toggle desktop sidebar globally

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -49,6 +49,7 @@ import { startSkeletonCycling$ } from "./app-skeleton.ts";
 import { setupMissionControlPage$ } from "./mission-control-page/mission-control-page.ts";
 import { setupRealtime$ } from "./realtime.ts";
 import { setupPwaEdgeSwipe$ } from "./zero-page/pwa-edge-swipe.ts";
+import { setupSidebarShortcut$ } from "./zero-page/zero-nav.ts";
 
 /**
  * Catch-all fallback — redirects unknown paths to /.
@@ -321,6 +322,7 @@ export const bootstrap$ = command(
       set(setupNotificationListener$, signal),
       set(setupInstallPrompt$, signal),
       set(setupPwaEdgeSwipe$, signal),
+      set(setupSidebarShortcut$, signal),
       set(startSkeletonCycling$, signal),
       (async () => {
         await set(setupClerk$, signal);

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
@@ -3,7 +3,6 @@ import { matchShortcut } from "@vm0/ui";
 import {
   activePanelId$,
   toggleMaximizeTask$,
-  toggleTaskList$,
 } from "./mission-control-panels.ts";
 import {
   addOptimisticTask$,
@@ -129,9 +128,6 @@ export const setupMissionControlKeyboard$ = command(
         },
         j: () => {
           set(navigateTaskList$, "next");
-        },
-        "mod+b": () => {
-          set(toggleTaskList$);
         },
         c: () => {
           set(setNewChatDialogOpen$, true);

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -3,6 +3,7 @@ import { detachedNavigateTo$ } from "../route.ts";
 import { ROUTES, type RouteKey } from "../route-paths.ts";
 import { localStorageSignals } from "../external/local-storage.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
+import { setupGlobalShortcut } from "../../lib/setup-global-shortcut.ts";
 
 export const navigateToChat$ = command(({ set }, chatThreadId: string) => {
   set(detachedNavigateTo$, "/chats/:threadId", {
@@ -36,6 +37,17 @@ export const toggleSidebarOff$ = command(({ get, set }) => {
   } else {
     set(setSidebarOffRaw$, "1");
   }
+});
+
+export const setupSidebarShortcut$ = command(({ set }, signal: AbortSignal) => {
+  setupGlobalShortcut(
+    {
+      "mod+b": () => {
+        set(toggleSidebarOff$);
+      },
+    },
+    signal,
+  );
 });
 
 const internalSidebarExpanded$ = state(false);

--- a/turbo/apps/platform/src/views/mission-control-page/shortcut-help-dialog.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/shortcut-help-dialog.tsx
@@ -30,7 +30,7 @@ export function ShortcutHelpDialog({
               { key: "shift+?", label: "Show shortcuts" },
               { key: "j", label: "Next task" },
               { key: "k", label: "Previous task" },
-              { key: "mod+b", label: "Toggle task list" },
+              { key: "mod+b", label: "Toggle sidebar" },
               { key: "c", label: "New chat" },
               { key: "y", label: "Archive task" },
             ]}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -16,7 +16,10 @@ import userEvent from "@testing-library/user-event";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
-import { setSidebarExpanded$ } from "../../../signals/zero-page/zero-nav.ts";
+import {
+  setSidebarExpanded$,
+  sidebarOff$,
+} from "../../../signals/zero-page/zero-nav.ts";
 import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 import { setMockOrgMembers } from "../../../mocks/handlers/api-org-members.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
@@ -204,6 +207,26 @@ describe("sidebar layout - invite button opens member dialog (SIDEBAR-D-052)", (
         screen.getByRole("heading", { name: "Members" }),
       ).toBeInTheDocument();
     });
+  });
+});
+
+describe("sidebar layout - mod+b toggles desktop sidebar (SIDEBAR-D-055)", () => {
+  it("toggles sidebarOff$ each time mod+b is pressed", async () => {
+    const user = userEvent.setup();
+    mockBaseAPIs();
+    detachedSetupPage({ context, path: "/agents" });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Open menu")).toBeInTheDocument();
+    });
+
+    expect(context.store.get(sidebarOff$)).toBeFalsy();
+
+    await user.keyboard("{Control>}b{/Control}");
+    expect(context.store.get(sidebarOff$)).toBeTruthy();
+
+    await user.keyboard("{Control>}b{/Control}");
+    expect(context.store.get(sidebarOff$)).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
## Summary

- Promote the `mod+b` shortcut from a mission-control-only task-list toggle to a globally registered desktop-sidebar toggle.
- Register `setupSidebarShortcut$` once from `bootstrap$` so every page honors the shortcut for the app's lifetime.
- Update the mission-control shortcut help dialog label to reflect the new behavior.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/sidebar-layout.test.tsx`
- [x] `pnpm -F @vm0/app exec vitest run` (full app suite, 1805 tests)
- [x] `pnpm turbo run lint --filter=@vm0/app`
- [x] `pnpm -F @vm0/app check-types`
- [x] `pnpm knip`