### PR TITLE
refactor(voice-chat): drop redundant mode type cast

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/route.ts
@@ -114,7 +114,7 @@ export async function POST(request: Request) {
       prompt,
     );
     const run = await dispatchPreparationRun(preparation.id, userId, agentId, {
-      mode: mode as "chat" | "meeting",
+      mode,
       prompt,
       apiStartTime,
     });


### PR DESCRIPTION
## Summary

Follow-up to #10183 addressing the one P2 that pr-review noted as out-of-scope. `parsed.data.mode` in `prepare/route.ts` is already narrowed to `"chat" | "meeting"` by the zod schema's `z.enum(["chat", "meeting"]).default("chat")` at line 20, so the explicit `as "chat" | "meeting"` cast at the `dispatchPreparationRun` call site is dead weight.

One-line change, no behavioral impact.

## Test plan

- [x] `pnpm -F web check-types` clean — confirms the narrowing works without the cast
- [ ] CI lint + format + knip
- [ ] CI cli-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)