### PR TITLE
refactor(mitm-addon): tighten original_url invariant in response/error

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -398,15 +398,19 @@ def response(flow: http.HTTPFlow) -> None:
     """
     Handle response and log network activity.
     """
+    # Pop the start-time tracking entry before any early return so that
+    # flows the request handler tracked (line 181) but whose metadata
+    # indicates we should skip (e.g. registry entry without a runId) do
+    # not leak into ``_request_start_times``. Mirrors ``error()``.
+    start_time = _request_start_times.pop(flow.id, None)
+
     run_id = flow.metadata.get("vm_run_id", "")
     if not run_id:
         # Unregistered VM: the request handler returned before populating
         # metadata, so none of this handler's work applies.
         return
 
-    start_time = _request_start_times.pop(flow.id, None)
     latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
-
     original_url = flow.metadata["original_url"]
     firewall_action = flow.metadata.get("firewall_action", "ALLOW")
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -398,18 +398,16 @@ def response(flow: http.HTTPFlow) -> None:
     """
     Handle response and log network activity.
     """
-    # Calculate latency
+    run_id = flow.metadata.get("vm_run_id", "")
+    if not run_id:
+        # Unregistered VM: the request handler returned before populating
+        # metadata, so none of this handler's work applies.
+        return
+
     start_time = _request_start_times.pop(flow.id, None)
     latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
 
-    # Get stored info. ``original_url`` fallback uses the same
-    # reconstructor as the request handler so unregistered-VM flows
-    # (where the request handler returned early and never populated
-    # metadata) produce consistent URLs — not mitmproxy's
-    # ``pretty_url``, which reads the Host-header port and drops
-    # non-default destination ports (see #10082).
-    run_id = flow.metadata.get("vm_run_id", "")
-    original_url = flow.metadata.get("original_url") or get_original_url(flow)
+    original_url = flow.metadata["original_url"]
     firewall_action = flow.metadata.get("firewall_action", "ALLOW")
 
     # Calculate sizes
@@ -438,7 +436,7 @@ def response(flow: http.HTTPFlow) -> None:
     # [NETWORK_LOG_FIELDS] — source of truth for network log fields
     network_log_path = flow.metadata.get("vm_network_log_path", "")
     proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
-    if run_id and network_log_path:
+    if network_log_path:
         log_entry = {
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
             "type": "http",
@@ -467,7 +465,7 @@ def response(flow: http.HTTPFlow) -> None:
     # Report proxy-extracted usage for model provider responses.
     # For non-streaming responses, fall back to extracting usage from the
     # buffered JSON body (buffer is never truncated for model providers).
-    if not flow.metadata.get("proxy_usage") and stream_buf and run_id:
+    if not flow.metadata.get("proxy_usage") and stream_buf:
         firewall_name = flow.metadata.get("firewall_name", "")
         if firewall_name.startswith("model-provider:"):
             json_usage = usage.extract_usage_from_json(
@@ -515,7 +513,7 @@ def error(flow: http.HTTPFlow) -> None:
         return
 
     latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
-    original_url = flow.metadata.get("original_url") or get_original_url(flow)
+    original_url = flow.metadata["original_url"]
     firewall_action = flow.metadata.get("firewall_action", "ALLOW")
 
     try:

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1549,6 +1549,9 @@ class TestErrorHandler:
         flow.id = "flow-err-1"
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "net.jsonl")
+        # Matches the request handler's invariant: original_url is set
+        # alongside vm_run_id.
+        flow.metadata["original_url"] = "https://example.com/"
         flow.error = Error("connection reset")
         mitm_addon._request_start_times["flow-err-1"] = 12345.0
 

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -800,6 +800,19 @@ class TestResponseHandler:
         assert "500" in content
         assert "api.example.com" in content
 
+    def test_pops_start_time_even_when_run_id_absent(self, real_flow, mitm_ctx):
+        # If the request handler tracked this flow's start time but the
+        # metadata ended up without vm_run_id (registry missing runId),
+        # response() must still pop the entry to avoid leaking into
+        # ``_request_start_times``.
+        flow = real_flow(with_response=False)
+        mitm_addon._request_start_times[flow.id] = 12345.0
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        assert flow.id not in mitm_addon._request_start_times
+
 
 class TestSseUsageExtractor:
     """Tests for the incremental SSE usage parser."""


### PR DESCRIPTION
## Summary
- Request handler sets ``flow.metadata["original_url"]`` **before** ``vm_run_id``. So any downstream handler that passes a ``vm_run_id`` check can trust ``original_url`` is present.
- ``response()`` now early-returns on ``not run_id`` (mirroring ``error()``) and reads ``flow.metadata["original_url"]`` directly. Drops the ``or get_original_url(flow)`` fallback, the 6-line inline comment that explained it, and the now-redundant ``run_id`` terms on the inner guards.
- ``error()`` gets the same direct dict read. Its early-return stays (it guards ``network_log_path`` too, which ``response()`` does not — the two handlers have different output surfaces).
- One test (``test_cleans_up_start_time``) was constructing ``vm_run_id`` without ``original_url``; updated to match the real invariant.

Closes #10184

## Why this is better
- Invariant is **formalized** in the code, not left as lore. KeyError on violation is a louder diagnostic than silent fallback to a reconstructor that might compute the wrong URL (see #10082 for the failure mode that fallback was hiding).
- Shrinks the surface area where a future edit could re-introduce ``flow.request.pretty_url`` through the backdoor.

## Test plan
- [x] ``python -m pytest tests/`` — 876/876 pass
- [x] ``ruff check .`` — clean
- [x] ``ruff format --check .`` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)