### PR TITLE
test(runner): drive mock wait_completion by notify instead of polling

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -2627,9 +2627,13 @@ mod tests {
         let run_id = RunId::new_v4();
         push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
+        // `wait_completion` is event-driven (fires on `provider.complete`), so
+        // this duration is a diagnostic cap for genuine hangs — not a budget
+        // for the run. A large cap absorbs coverage-CI slowdown of the full
+        // dispatch→executor→complete chain without flaking (see #10146).
         let c = env
             .handle
-            .wait_completion(run_id, Duration::from_secs(5))
+            .wait_completion(run_id, Duration::from_secs(30))
             .await;
         assert!(
             c.is_some(),

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -60,6 +60,12 @@ pub struct MockJobProvider {
     /// sleeping. `notify_one` queues a permit, so a test that waits after
     /// the signal fired still wakes immediately.
     discover_entered: Arc<Notify>,
+    /// Fired by `complete()` after a completion is appended to `completions`.
+    /// `wait_completion` subscribes to this before checking the vec, so any
+    /// completion that lands between the check and the wake is still observed.
+    /// Event-driven waiting eliminates the polling loop whose wall-clock
+    /// deadline was racing coverage-CI slowdown (see #10146).
+    completion_notify: Arc<Notify>,
 }
 
 /// Test-side handle for driving the mock provider.
@@ -69,6 +75,8 @@ pub struct MockProviderHandle {
     pub heartbeats: Arc<StdMutex<Vec<HeartbeatState>>>,
     /// See [`MockJobProvider::discover_entered`].
     pub discover_entered: Arc<Notify>,
+    /// See [`MockJobProvider::completion_notify`].
+    completion_notify: Arc<Notify>,
 }
 
 impl MockJobProvider {
@@ -94,6 +102,7 @@ impl MockJobProvider {
         let completions = Arc::new(StdMutex::new(Vec::new()));
         let heartbeats = Arc::new(StdMutex::new(Vec::new()));
         let discover_entered = Arc::new(Notify::new());
+        let completion_notify = Arc::new(Notify::new());
         let provider = Arc::new(Self {
             discovery: Mutex::new(rx),
             poll_delay,
@@ -102,12 +111,14 @@ impl MockJobProvider {
             heartbeats: Arc::clone(&heartbeats),
             cancel,
             discover_entered: Arc::clone(&discover_entered),
+            completion_notify: Arc::clone(&completion_notify),
         });
         let handle = MockProviderHandle {
             discover_tx: tx,
             completions,
             heartbeats,
             discover_entered,
+            completion_notify,
         };
         (provider, handle)
     }
@@ -124,19 +135,36 @@ impl MockJobProvider {
 
 impl MockProviderHandle {
     /// Wait for a specific run's completion to appear, with timeout.
+    ///
+    /// Event-driven: subscribes to `completion_notify` *before* checking the
+    /// vec, so a completion landing between the check and the wait still
+    /// wakes us. No polling sleep — the `timeout` is a diagnostic safety
+    /// cap for genuine hangs, not a wall-clock budget for the work itself.
+    /// This matters under coverage CI, where a polling loop with a 5 s
+    /// deadline raced instrumentation slowdown (see #10146).
     pub async fn wait_completion(&self, run_id: RunId, timeout: Duration) -> Option<Completion> {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
+            let notified = self.completion_notify.notified();
+            tokio::pin!(notified);
+            // Register interest before checking the vec — any notify_waiters
+            // fired after this enable() will wake this future.
+            notified.as_mut().enable();
+
             {
                 let comps = self.completions.lock().unwrap_or_else(|e| e.into_inner());
                 if let Some(c) = comps.iter().find(|c| c.run_id == run_id) {
                     return Some(c.clone());
                 }
             }
-            if tokio::time::Instant::now() >= deadline {
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
                 return None;
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            if tokio::time::timeout(remaining, notified).await.is_err() {
+                return None;
+            }
         }
     }
 
@@ -194,6 +222,9 @@ impl JobProvider for MockJobProvider {
                 exit_code,
                 error: error.map(String::from),
             });
+        // Wake all pending `wait_completion` waiters — they re-scan the vec
+        // and return if their run_id is now present.
+        self.completion_notify.notify_waiters();
     }
 
     async fn heartbeat(&self, state: &HeartbeatState) {

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -136,12 +136,9 @@ impl MockJobProvider {
 impl MockProviderHandle {
     /// Wait for a specific run's completion to appear, with timeout.
     ///
-    /// Event-driven: subscribes to `completion_notify` *before* checking the
-    /// vec, so a completion landing between the check and the wait still
-    /// wakes us. No polling sleep — the `timeout` is a diagnostic safety
-    /// cap for genuine hangs, not a wall-clock budget for the work itself.
-    /// This matters under coverage CI, where a polling loop with a 5 s
-    /// deadline raced instrumentation slowdown (see #10146).
+    /// Event-driven — see [`MockJobProvider::completion_notify`] for the
+    /// full rationale. `timeout` is a diagnostic cap for genuine hangs,
+    /// not a wall-clock work budget.
     pub async fn wait_completion(&self, run_id: RunId, timeout: Duration) -> Option<Completion> {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {


### PR DESCRIPTION
## Summary

- Fix #10146 flake recurrence observed on PR #10180's merge-queue run (job [72062591747](https://github.com/vm0-ai/vm0/actions/runs/24647302897/job/72062591747)) — `claim_after_stopping_sent_cancels_new_job` failed with "job must report cancellation even when the handler missed the token" after `wait_completion(5s)` timed out.
- Root cause: `wait_completion` polled `completions` every 10 ms and gave up at a fixed 5 s wall-clock deadline. Under coverage CI, the full dispatch→executor→complete chain occasionally exceeds 5 s — the completion eventually arrives, but the poller has already returned None. #10158 only made the *setup* side of this test deterministic; the completion side kept racing the timer.
- Make `wait_completion` event-driven: `complete()` fires `Notify::notify_waiters` after pushing to the vec; `wait_completion` uses the `pin!(notified) + enable()` pattern to register interest **before** checking the vec, so a completion that lands between the check and the await still wakes us. Timeout is now a diagnostic cap for genuine hangs, not a wall-clock work budget.
- Raise the `claim_after_stopping` cap from 5 s → 30 s to absorb coverage-CI slowdown without flaking. Under the event-driven waiter a larger cap costs nothing on passing runs — the test wakes as soon as `complete()` fires.

## Test plan

- [x] `cargo test --package runner cmd::start::tests` — 57/57 pass
- [x] 100× coverage-mode stress of `claim_after_stopping_sent_cancels_new_job` — 0 failures (vs. 1/40 before the timeout bump)
- [x] 10× coverage-mode stress of the full `cmd::start::tests` suite — 0 failures
- [x] `cargo clippy --package runner --all-targets --all-features -- -D warnings`
- [ ] CI `check` job green on a merge-queue dry run

🤖 Generated with [Claude Code](https://claude.com/claude-code)