### PR TITLE
fix(platform): skip connector add when already enabled

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-added-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-added-connectors.test.ts
@@ -130,4 +130,23 @@ describe("addZeroConnector$", () => {
     expect(capturedBody!.enabledTypes).toContain("slack");
     expect(capturedBody!.enabledTypes).toContain("github");
   });
+
+  it("should not fire a PUT when the connector is already enabled", async () => {
+    let putCalls = 0;
+
+    mockAgentApi(["slack"]);
+
+    server.use(
+      mockApi(zeroUserConnectorsContract.update, ({ body, respond }) => {
+        putCalls += 1;
+        return respond(200, { enabledTypes: body.enabledTypes });
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    await context.store.set(addZeroConnector$, "slack", context.signal);
+
+    expect(putCalls).toBe(0);
+  });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -64,6 +64,9 @@ export const addZeroConnector$ = command(
   async ({ get, set }, name: string, signal: AbortSignal) => {
     const current = await get(seededConnectors$);
     signal.throwIfAborted();
+    if (current.includes(name)) {
+      return;
+    }
     await set(syncConnectorsToCompose$, [...current, name], signal);
   },
 );


### PR DESCRIPTION
## Summary

- `addZeroConnector$` appended the name to `current` unconditionally — re-authorize flows on an already-enabled connector produced payloads like `["slack", "slack"]`, which previously tripped `idx_user_connectors_unique` and bubbled a 500 to Sentry ([PLATFORM-2J](https://vm0.sentry.io/issues/7423204910/), issue #10057).
- Server-side dedupe already landed in #10145 — that PR called out the client wart explicitly and left it for a follow-up. This is the follow-up.
- Skipping the PUT when `current` already contains `name` also avoids an unnecessary network round-trip / `reloadOnboardingStatus$` tick.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/signals/zero-page/__tests__/zero-added-connectors.test.ts` — new case asserts no PUT fires when the connector is already enabled
- [x] `pnpm -F @vm0/app exec vitest` — full platform suite (213 files / 1806 tests) passes
- [x] `pnpm -F @vm0/app run lint`
- [x] `pnpm -F @vm0/app run check-types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)