### PR TITLE
refactor(models): ungate kimi and minimax, disable glm flag

### DIFF
--- a/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
@@ -6,9 +6,11 @@ import {
   getModels,
   getDefaultModel,
   getEnvironmentMapping,
+  getVm0VisibleModels,
   MODEL_PROVIDER_FIREWALL_CONFIGS,
   type ModelProviderType,
 } from "../model-providers";
+import { FeatureSwitchKey } from "../../feature-switch-key";
 
 describe("getProviderBaseUrl", () => {
   it.each([
@@ -130,6 +132,26 @@ describe("model selection for Anthropic-native providers", () => {
   it("Anthropic-native providers have no ANTHROPIC_BASE_URL (use default)", () => {
     expect(getProviderBaseUrl("anthropic-api-key")).toBeNull();
     expect(getProviderBaseUrl("claude-code-oauth-token")).toBeNull();
+  });
+});
+
+describe("getVm0VisibleModels", () => {
+  it("kimi and minimax are always visible (no feature flag required)", () => {
+    const models = getVm0VisibleModels();
+    expect(models).toContain("kimi-k2.5");
+    expect(models).toContain("MiniMax-M2.7");
+  });
+
+  it("glm-5.1 is excluded when Vm0GlmModel flag is absent", () => {
+    const models = getVm0VisibleModels();
+    expect(models).not.toContain("glm-5.1");
+  });
+
+  it("glm-5.1 is included when Vm0GlmModel flag is enabled", () => {
+    const models = getVm0VisibleModels({
+      [FeatureSwitchKey.Vm0GlmModel]: true,
+    });
+    expect(models).toContain("glm-5.1");
   });
 });
 

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -68,12 +68,10 @@ export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
   "kimi-k2.5": {
     concreteType: "moonshot-api-key",
     vendor: "moonshot",
-    featureFlag: FeatureSwitchKey.Vm0KimiModel,
   },
   "MiniMax-M2.7": {
     concreteType: "minimax-api-key",
     vendor: "minimax",
-    featureFlag: FeatureSwitchKey.Vm0MinimaxModel,
   },
 };
 

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -53,7 +53,5 @@ export enum FeatureSwitchKey {
   ZoomConnector = "zoomConnector",
   OrgCustomConnectors = "orgCustomConnectors",
   ModelProviderSelection = "modelProviderSelection",
-  Vm0KimiModel = "vm0KimiModel",
   Vm0GlmModel = "vm0GlmModel",
-  Vm0MinimaxModel = "vm0MinimaxModel",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -295,7 +295,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Expose Z.AI GLM-5.1 as a selectable model under the VM0 managed provider",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.SlackAgentSwitch]: {
     maintainer: "yuma@vm0.ai",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -290,25 +290,11 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: [],
   },
-  [FeatureSwitchKey.Vm0KimiModel]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Expose Moonshot Kimi K2.5 as a selectable model under the VM0 managed provider",
-    enabled: true,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.Vm0GlmModel]: {
     maintainer: "ethan@vm0.ai",
     description:
       "Expose Z.AI GLM-5.1 as a selectable model under the VM0 managed provider",
-    enabled: true,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
-  [FeatureSwitchKey.Vm0MinimaxModel]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Expose MiniMax M2.7 as a selectable model under the VM0 managed provider",
-    enabled: true,
+    enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.SlackAgentSwitch]: {


### PR DESCRIPTION
## Summary

- Remove `Vm0KimiModel` and `Vm0MinimaxModel` feature switches so Kimi K2.5 and MiniMax M2.7 are always visible under the VM0 managed provider.
- Drop the corresponding `featureFlag` entries from `VM0_MODEL_TO_PROVIDER` for these two models.
- Flip `Vm0GlmModel` back to `enabled: false` (staff-only via `enabledOrgIdHashes`).

## Test plan

- [ ] `pnpm check-types` passes
- [ ] `pnpm turbo run lint` passes
- [ ] Confirm Kimi and MiniMax appear in the VM0 built-in model dropdown without any feature flag
- [ ] Confirm GLM remains gated to staff orgs