### PR TITLE
ci: add builds-complete fan-in barrier before promote jobs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -403,6 +403,10 @@ jobs:
       - build-e2b-template-production
       - sbom
       - resolve-image-cache
+    # Intentionally uses only !cancelled() (not !failure()) so this job runs even
+    # when upstream build jobs fail. The jq step below performs the actual failure
+    # check and exits 1, making the barrier explicit. Adding !failure() here would
+    # cause this job to be skipped on build failure, hiding the reason for the block.
     if: ${{ !cancelled() && needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -413,6 +417,8 @@ jobs:
         run: |
           set -euo pipefail
           echo "$NEEDS_JSON" | jq .
+          # "skipped" is acceptable: some build jobs (e.g. build-e2b-template-production)
+          # are component-conditional and only run when their component has a release.
           failures=$(echo "$NEEDS_JSON" | jq -r '
             to_entries[]
             | select(.value.result != "success" and .value.result != "skipped")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -390,9 +390,45 @@ jobs:
                   text: "*Web App* ❌ Staged build failed\n📦 Version: `${{ needs.release-please.outputs.web_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/web-v${{ needs.release-please.outputs.web_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
 
   # Promote web staged deployment to production (traffic switch)
+  # Fan-in barrier: all build-phase jobs must finish (success or skipped) before
+  # any promote-phase job starts. If any build fails, this job fails, which in
+  # turn blocks every promote via their `needs: builds-complete` edge.
+  builds-complete:
+    needs:
+      - release-please
+      - migrate-production
+      - build-web-production
+      - build-app-production
+      - build-runner-production
+      - build-e2b-template-production
+      - sbom
+      - resolve-image-cache
+    if: ${{ !cancelled() && needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no build failed
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "$NEEDS_JSON" | jq .
+          failures=$(echo "$NEEDS_JSON" | jq -r '
+            to_entries[]
+            | select(.value.result != "success" and .value.result != "skipped")
+            | .key
+          ')
+          if [ -n "$failures" ]; then
+            echo "::error::Build-phase jobs did not succeed: $failures"
+            exit 1
+          fi
+          echo "✅ All build-phase jobs succeeded or were skipped."
+
   promote-web-production:
-    needs: [release-please, migrate-production, build-web-production]
-    if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
+    needs: [release-please, builds-complete, build-web-production]
+    if: >-
+      !failure() && !cancelled() &&
+      needs.release-please.outputs.web_release_created == 'true'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260419
@@ -611,7 +647,7 @@ jobs:
 
   # Promote app staged deployment to production (traffic switch)
   promote-app-production:
-    needs: [release-please, migrate-production, build-app-production, promote-web-production]
+    needs: [release-please, builds-complete, build-app-production, promote-web-production]
     if: >-
       !failure() && !cancelled() &&
       needs.release-please.outputs.app_release_created == 'true'
@@ -965,8 +1001,10 @@ jobs:
           echo "Updated rollback dashboard issue #${ISSUE_NUMBER}"
 
   publish-npm:
-    needs: [release-please, migrate-production]
-    if: ${{ needs.release-please.outputs.cli_release_created == 'true' }}
+    needs: [release-please, builds-complete]
+    if: >-
+      !failure() && !cancelled() &&
+      needs.release-please.outputs.cli_release_created == 'true'
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -1329,7 +1367,7 @@ jobs:
   # the schema and API it targets are live. Host-level prep
   # (provision-runner, provision-monitoring) already ran in build.
   promote-runner-production:
-    needs: [release-please, migrate-production, promote-web-production, resolve-image-cache, build-runner-production]
+    needs: [release-please, builds-complete, promote-web-production, resolve-image-cache, build-runner-production]
     if: >-
       !failure() && !cancelled() &&
       needs.release-please.outputs.runner_rs_release_created == 'true'


### PR DESCRIPTION
## Summary

Add a `builds-complete` fan-in barrier in `.github/workflows/release-please.yml` that waits for every build-phase job (migrate, web, app, runner, e2b-template, sbom, resolve-image-cache) to finish before any promote-phase job starts. If any build fails or is cancelled, the barrier fails and — via the `needs: builds-complete` edge — blocks every downstream promote, preventing partial production promotions.

## Changes

- New `builds-complete` job inspects `toJSON(needs)` and fails if any build-phase job result is not `success` or `skipped`.
- `promote-web-production`, `promote-app-production`, `promote-runner-production`, and `publish-npm` now depend on `builds-complete` with `!failure() && !cancelled()` guards.

## Test plan

- [ ] Verify on next release that `builds-complete` runs after all build jobs and before any promote job
- [ ] Confirm a simulated build failure blocks all promote jobs (no partial promotions)
- [ ] Confirm skipped build jobs (e.g. component with no release) do not block promotion of other components