### PR TITLE
fix(platform): polish model picker sizing and dropdown styling

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -154,6 +154,7 @@ export interface ChatThreadSignals {
   // ── Agent info (derived from threadData$.agentId) ─────────────────────────
   agentId$: Computed<Promise<string | null>>;
   agentDisplayName$: Computed<Promise<string | null>>;
+  agentModelDefault$: Computed<Promise<ModelProviderSelection | null>>;
   agentPinned$: Computed<Promise<boolean | null>>;
   // ── Per-thread UI state ───────────────────────────────────────────────────
   timelineExpandedIds$: Computed<Set<string>>;
@@ -324,6 +325,23 @@ function createAgentInfoSignals(
     return agent?.displayName ?? null;
   });
 
+  const agentModelDefault$ = computed(
+    async (get): Promise<ModelProviderSelection | null> => {
+      const agentId = await get(agentId$);
+      if (!agentId) {
+        return null;
+      }
+      const agent = await get(agentById(agentId));
+      if (!agent?.modelProviderId || !agent.selectedModel) {
+        return null;
+      }
+      return {
+        modelProviderId: agent.modelProviderId,
+        selectedModel: agent.selectedModel,
+      };
+    },
+  );
+
   const agentPinned$ = computed(async (get): Promise<boolean | null> => {
     const agentId = await get(agentId$);
     if (!agentId) {
@@ -333,7 +351,7 @@ function createAgentInfoSignals(
     return ids.includes(agentId);
   });
 
-  return { agentId$, agentDisplayName$, agentPinned$ };
+  return { agentId$, agentDisplayName$, agentModelDefault$, agentPinned$ };
 }
 
 // ---------------------------------------------------------------------------
@@ -977,58 +995,13 @@ function createSendMessage(deps: SendMessageDeps) {
 }
 
 // ---------------------------------------------------------------------------
-// Factory: createChatThreadSignals
+// Sub-factory: thinking phrase animation
 // ---------------------------------------------------------------------------
 
-export function createChatThreadSignals(
-  threadId: string,
-  draft: DraftSignals,
-): ChatThreadSignals {
-  const { threadData$, reloadThread$ } = createThreadData(threadId);
-  const { modelSelection$, setModelSelection$ } =
-    createModelSelection(threadData$);
-  const { setScrollContainer$, autoScroll$, scrollToBottom$, scrollToTop$ } =
-    createScrollSignals(threadId);
-  const { skeletonVisible$, hideSkeleton$ } = createSkeletonSignals();
-  const { composerFileInput$, setComposerFileInput$ } =
-    createComposerFileInput();
-  const { agentId$, agentDisplayName$, agentPinned$ } =
-    createAgentInfoSignals(threadData$);
-  const {
-    timelineExpandedIds$,
-    toggleTimelineExpanded$,
-    copiedMessageId$,
-    copyMessage$,
-  } = createThreadUIState();
-  const {
-    latestChatMessageId$,
-    groupedChatMessages$,
-    fetchNextPage$,
-    insertOptimisticMessage$,
-  } = createPagedMessages(threadId);
-
-  const { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ } =
-    createDraftSync(threadId, draft);
-
-  const { allFinished$, loadPagedMessages$, cancelRun$ } = createRunTracking(
-    threadId,
-    reloadThread$,
-    threadData$,
-    fetchNextPage$,
-    autoScroll$,
-  );
-
-  const { sendMessage$ } = createSendMessage({
-    threadId,
-    threadData$,
-    draft,
-    cancelDraftSync$,
-    flushDraftClear$,
-    insertOptimisticMessage$,
-    scrollToBottom$,
-  });
-
-  const { setInputRef$, focusInput$ } = createInputRef();
+function createPhraseLoop(
+  groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>,
+  allFinished$: Computed<Promise<boolean>>,
+) {
   const internalBlockColors$ =
     state<[string, string, string]>(shuffleBlockColors());
   const blockColors$ = computed((get) => {
@@ -1078,6 +1051,64 @@ export function createChatThreadSignals(
     },
   );
 
+  return { blockColors$, rotatingPhrase$, donePhrase$, runPhraseLoop$ };
+}
+
+// ---------------------------------------------------------------------------
+// Factory: createChatThreadSignals
+// ---------------------------------------------------------------------------
+
+export function createChatThreadSignals(
+  threadId: string,
+  draft: DraftSignals,
+): ChatThreadSignals {
+  const { threadData$, reloadThread$ } = createThreadData(threadId);
+  const { modelSelection$, setModelSelection$ } =
+    createModelSelection(threadData$);
+  const { setScrollContainer$, autoScroll$, scrollToBottom$, scrollToTop$ } =
+    createScrollSignals(threadId);
+  const { skeletonVisible$, hideSkeleton$ } = createSkeletonSignals();
+  const { composerFileInput$, setComposerFileInput$ } =
+    createComposerFileInput();
+  const { agentId$, agentDisplayName$, agentModelDefault$, agentPinned$ } =
+    createAgentInfoSignals(threadData$);
+  const {
+    timelineExpandedIds$,
+    toggleTimelineExpanded$,
+    copiedMessageId$,
+    copyMessage$,
+  } = createThreadUIState();
+  const {
+    latestChatMessageId$,
+    groupedChatMessages$,
+    fetchNextPage$,
+    insertOptimisticMessage$,
+  } = createPagedMessages(threadId);
+
+  const { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ } =
+    createDraftSync(threadId, draft);
+  const { allFinished$, loadPagedMessages$, cancelRun$ } = createRunTracking(
+    threadId,
+    reloadThread$,
+    threadData$,
+    fetchNextPage$,
+    autoScroll$,
+  );
+
+  const { sendMessage$ } = createSendMessage({
+    threadId,
+    threadData$,
+    draft,
+    cancelDraftSync$,
+    flushDraftClear$,
+    insertOptimisticMessage$,
+    scrollToBottom$,
+  });
+
+  const { setInputRef$, focusInput$ } = createInputRef();
+  const { blockColors$, rotatingPhrase$, donePhrase$, runPhraseLoop$ } =
+    createPhraseLoop(groupedChatMessages$, allFinished$);
+
   return {
     threadData$,
     modelSelection$,
@@ -1095,6 +1126,7 @@ export function createChatThreadSignals(
     setComposerFileInput$,
     agentId$,
     agentDisplayName$,
+    agentModelDefault$,
     agentPinned$,
     timelineExpandedIds$,
     toggleTimelineExpanded$,

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-form.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-form.ts
@@ -1,4 +1,6 @@
-import { command, computed, state } from "ccstate";
+import { command, computed, state, type Computed } from "ccstate";
+import { agentById } from "../agent.ts";
+import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 
 // ---------------------------------------------------------------------------
 // Schedule form data — single state object for all form fields
@@ -195,3 +197,31 @@ export const syncInstructionDraftEntry$ = command(
     }
   },
 );
+
+// ---------------------------------------------------------------------------
+// Agent model default — derived from form agentId for the model picker
+// ---------------------------------------------------------------------------
+
+function createAgentModelDefault$(
+  form$: Computed<ScheduleFormData>,
+): Computed<Promise<ModelProviderSelection | null>> {
+  return computed(async (get) => {
+    const { agentId } = get(form$);
+    if (!agentId) {
+      return null;
+    }
+    const agent = await get(agentById(agentId));
+    if (!agent?.modelProviderId || !agent.selectedModel) {
+      return null;
+    }
+    return {
+      modelProviderId: agent.modelProviderId,
+      selectedModel: agent.selectedModel,
+    };
+  });
+}
+
+export const scheduleAgentModelDefault$ =
+  createAgentModelDefault$(scheduleForm$);
+
+export const dialogAgentModelDefault$ = createAgentModelDefault$(dialogForm$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-agent-default.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-agent-default.test.tsx
@@ -12,10 +12,10 @@
  * signals, MSW handlers, and rendering all run for real — only the Web API
  * is mocked, per project testing principles.
  *
- * Note: tests that require useLastResolved(currentChatAgent$) to propagate
- * agent-level model defaults to the component are omitted — the ccstate-react
- * reactive chain does not settle reliably within the 5 s test timeout in CI.
- * The workspace-default tests (AD-002, AD-004) cover the critical regressions.
+ * Agent-has-a-model tests wait on `document.title` (set by the same reactive
+ * chain that feeds the picker) to confirm the agent data has propagated
+ * before asserting on the trigger label — the pattern used throughout
+ * `chat-default-model-resolution.test.tsx`.
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
@@ -32,6 +32,10 @@ import {
   resetMockOrgModelProviders,
 } from "../../../mocks/handlers/api-org-model-providers.ts";
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.ts";
+import {
+  setMockOnboardingStatus,
+  resetMockOnboardingStatus,
+} from "../../../mocks/handlers/api-onboarding.ts";
 
 const context = testContext();
 
@@ -90,6 +94,18 @@ function setupProviders() {
   ]);
 }
 
+/**
+ * Wait for the agent chat page to finish initialising. `document.title` is
+ * updated by the same reactive chain (`currentChatAgent$` -> display name)
+ * that feeds the picker's `agentDefault` prop, so once the title contains
+ * the agent name, the picker has received the agent-level default.
+ */
+async function expectAgentChatLoaded(): Promise<void> {
+  await waitFor(() => {
+    expect(document.title).toContain("Scout");
+  });
+}
+
 async function openPickerOnAgentChat(
   user: ReturnType<typeof userEvent.setup>,
   initialLabel: string,
@@ -109,7 +125,11 @@ async function openPickerOnAgentChat(
 describe("model-provider-picker - agent/workspace default source", () => {
   beforeEach(() => {
     resetMockOrgModelProviders();
+    resetMockOnboardingStatus();
     setMockFeatureSwitches({ [FeatureSwitchKey.ModelProviderSelection]: true });
+    // Pin currentChatAgentId$ resolution to the test agent so route setup
+    // on `/agents/:id/chat` doesn't race with the default-agent lookup.
+    setMockOnboardingStatus({ defaultAgentId: AGENT_ID });
     setupProviders();
   });
 
@@ -139,5 +159,52 @@ describe("model-provider-picker - agent/workspace default source", () => {
     const toggle = screen.getByLabelText("Use agent default model");
     expect(toggle).toBeInTheDocument();
     expect(screen.getAllByText("Claude Sonnet 4.6").length).toBeGreaterThan(0);
+  });
+
+  // MPKR-AD-005: When the agent specifies its own default (Opus 4.7), the
+  // picker trigger shows the agent model — not the workspace default. This
+  // pins the primary regression scenario for Bug 1 (agent default mislabel).
+  it("trigger shows the agent model when the agent specifies one (MPKR-AD-005)", async () => {
+    mockAgentWith({
+      modelProviderId: ANTHROPIC_PROVIDER_ID,
+      selectedModel: "claude-opus-4-7",
+    });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+    await expectAgentChatLoaded();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: "Claude Opus 4.7" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // MPKR-AD-006: Opening the dropdown when the agent has its own model still
+  // surfaces the "Use agent default" toggle, reflecting the agent's model
+  // (Opus 4.7) — not the workspace default (Sonnet 4.6).
+  it("toggle reflects the agent model as the inherited default (MPKR-AD-006)", async () => {
+    const user = userEvent.setup();
+    mockAgentWith({
+      modelProviderId: ANTHROPIC_PROVIDER_ID,
+      selectedModel: "claude-opus-4-7",
+    });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+    await expectAgentChatLoaded();
+
+    const trigger = await waitFor(() => {
+      return screen.getByRole("combobox", { name: "Claude Opus 4.7" });
+    });
+    await user.click(trigger);
+
+    const toggle = await waitFor(() => {
+      return screen.getByLabelText("Use agent default model");
+    });
+    expect(toggle).toBeInTheDocument();
+    // The toggle row must show the agent's model as the inherited value,
+    // and the Sonnet-based workspace default must not leak through as the
+    // inherited label.
+    expect(screen.getAllByText("Claude Opus 4.7").length).toBeGreaterThan(0);
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-agent-default.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-agent-default.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for the agent-vs-workspace default labeling and the
+ * "Use default" reset option in ModelProviderPicker.
+ *
+ * Background (refactor/chat-optimization):
+ *   Bug 1 — when an agent did not specify a default, the picker fell back to
+ *   the workspace default but mislabeled it as "Agent default".
+ *   Bug 2 — the INHERIT_SENTINEL item was removed, so a user who had
+ *   overridden the model had no way to revert to the inherited default.
+ *
+ * These tests exercise the picker via the agent chat page entry point so
+ * signals, MSW handlers, and rendering all run for real — only the Web API
+ * is mocked, per project testing principles.
+ *
+ * Note: tests that require useLastResolved(currentChatAgent$) to propagate
+ * agent-level model defaults to the component are omitted — the ccstate-react
+ * reactive chain does not settle reliably within the 5 s test timeout in CI.
+ * The workspace-default tests (AD-002, AD-004) cover the critical regressions.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FeatureSwitchKey, zeroAgentsByIdContract } from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import {
+  setMockOrgModelProviders,
+  resetMockOrgModelProviders,
+} from "../../../mocks/handlers/api-org-model-providers.ts";
+import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.ts";
+
+const context = testContext();
+
+const AGENT_ID = "e0000000-0000-4000-a000-000000000010";
+const ANTHROPIC_PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
+
+function mockAgentWith(params: {
+  modelProviderId: string | null;
+  selectedModel: string | null;
+}) {
+  setMockTeam([
+    {
+      id: AGENT_ID,
+      displayName: "Scout",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
+  server.use(
+    mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+      return respond(200, {
+        agentId: AGENT_ID,
+        ownerId: "test-user-123",
+        displayName: "Scout",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        permissionPolicies: null,
+        customSkills: [] as string[],
+        modelProviderId: params.modelProviderId,
+        selectedModel: params.selectedModel,
+      });
+    }),
+  );
+}
+
+function setupProviders() {
+  // Single provider (Anthropic, workspace default = Sonnet). Keeps model
+  // names unique in the dropdown so getByRole("option") is unambiguous.
+  setMockOrgModelProviders([
+    {
+      id: ANTHROPIC_PROVIDER_ID,
+      type: "anthropic-api-key",
+      framework: "claude-code",
+      secretName: "ANTHROPIC_API_KEY",
+      authMethod: null,
+      secretNames: null,
+      isDefault: true,
+      selectedModel: "claude-sonnet-4-6",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
+}
+
+async function openPickerOnAgentChat(
+  user: ReturnType<typeof userEvent.setup>,
+  initialLabel: string,
+) {
+  detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+  const trigger = await waitFor(() => {
+    return screen.getByRole("combobox", { name: initialLabel });
+  });
+  await user.click(trigger);
+  await waitFor(() => {
+    expect(
+      screen.getByRole("option", { name: /Use .+ default/ }),
+    ).toBeInTheDocument();
+  });
+}
+
+describe("model-provider-picker - agent/workspace default source", () => {
+  beforeEach(() => {
+    resetMockOrgModelProviders();
+    setMockFeatureSwitches({ [FeatureSwitchKey.ModelProviderSelection]: true });
+    setupProviders();
+  });
+
+  // MPKR-AD-002: Chat picker uses inheritLabel="agent", so the badge and
+  // toggle always say "Agent default" even when the agent has no model set
+  // and the resolved default comes from the workspace.
+  it("shows model options without default badge in chat context (MPKR-AD-002)", async () => {
+    const user = userEvent.setup();
+    mockAgentWith({ modelProviderId: null, selectedModel: null });
+
+    await openPickerOnAgentChat(user, "Claude Sonnet 4.6");
+
+    // Model items no longer carry a default badge — the toggle row
+    // already communicates which model is the inherited default.
+    expect(screen.queryByText("Agent default")).not.toBeInTheDocument();
+    expect(screen.queryByText("Workspace default")).not.toBeInTheDocument();
+  });
+
+  // MPKR-AD-004: The inherit toggle in chat shows "Use agent default" with
+  // the effective model name.
+  it("toggle shows 'Use agent default' with model name (MPKR-AD-004)", async () => {
+    const user = userEvent.setup();
+    mockAgentWith({ modelProviderId: null, selectedModel: null });
+
+    await openPickerOnAgentChat(user, "Claude Sonnet 4.6");
+
+    const toggle = screen.getByLabelText("Use agent default model");
+    expect(toggle).toBeInTheDocument();
+    expect(screen.getAllByText("Claude Sonnet 4.6").length).toBeGreaterThan(0);
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
@@ -7,7 +7,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import {
   setMockSchedules,
   createMockScheduleResponse,
@@ -30,24 +30,20 @@ function mockAPIs(overrides: Partial<ScheduleResponse> = {}) {
   ]);
 }
 
-async function loadAndMakeDirty(user: ReturnType<typeof userEvent.setup>) {
+async function loadAndMakeDirty() {
   detachedSetupPage({ context, path: `/schedules/${SCHEDULE_ID}` });
-  await waitFor(() => {
-    expect(
-      screen.getByPlaceholderText("Leave blank to auto-generate"),
-    ).toBeInTheDocument();
+  const input = await waitFor(() => {
+    const el = screen.getByPlaceholderText("Leave blank to auto-generate");
+    expect(el).toBeInTheDocument();
+    return el;
   });
-  await user.type(
-    screen.getByPlaceholderText("Leave blank to auto-generate"),
-    "My description",
-  );
+  await fill(input, "My description");
 }
 
 describe("zero unsaved bar - unsaved changes indicator (SCHED-D-093)", () => {
   it("shows unsaved changes indicator when settings form is dirty", async () => {
-    const user = userEvent.setup();
     mockAPIs();
-    await loadAndMakeDirty(user);
+    await loadAndMakeDirty();
 
     await waitFor(() => {
       expect(screen.getByTestId("unsaved-bar")).toBeInTheDocument();
@@ -59,7 +55,7 @@ describe("zero unsaved bar - discard button reverts changes (SCHED-D-095)", () =
   it("hides unsaved changes bar when Discard is clicked", async () => {
     const user = userEvent.setup();
     mockAPIs();
-    await loadAndMakeDirty(user);
+    await loadAndMakeDirty();
 
     await waitFor(() => {
       expect(screen.getByTestId("unsaved-bar")).toBeInTheDocument();
@@ -81,7 +77,7 @@ describe("zero unsaved bar - save button persists changes (SCHED-D-096)", () => 
           schedule: createMockScheduleResponse({
             displayName: "Zero",
             timezone: "America/New_York",
-            description: "Daily morning briefingMy description",
+            description: "My description",
           }),
           created: false,
         });
@@ -90,7 +86,7 @@ describe("zero unsaved bar - save button persists changes (SCHED-D-096)", () => 
 
     const user = userEvent.setup();
     mockAPIs();
-    await loadAndMakeDirty(user);
+    await loadAndMakeDirty();
 
     await waitFor(() => {
       expect(screen.getByTestId("unsaved-bar")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -30,6 +30,7 @@ import { FeatureSwitchKey } from "@vm0/core";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   currentChatAgentId$,
+  currentChatAgent$,
   currentChatAgentDisplayName$,
 } from "../../signals/agent-chat.ts";
 import {
@@ -299,6 +300,47 @@ function VoiceChatLauncher() {
   );
 }
 
+function ChatAgentAvatar({ agentId }: { agentId: string | null | undefined }) {
+  return (
+    <div className="relative shrink-0">
+      {agentId ? (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Link
+                pathname="/agents/:agentId"
+                options={{
+                  pathParams: { agentId },
+                }}
+                aria-label="View agent profile"
+                className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-accent cursor-pointer"
+              >
+                <AgentAvatarImg
+                  name={agentId}
+                  alt=""
+                  className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
+                />
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">View agent profile</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        <div className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl">
+          <AgentAvatarImg
+            name=""
+            alt=""
+            className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
+          />
+        </div>
+      )}
+      <PinPill />
+    </div>
+  );
+}
+
 export function AgentChatPage() {
   const currentChatAgentId = useLastResolved(currentChatAgentId$);
   const currentChatAgentDisplayName = useLastResolved(
@@ -318,6 +360,14 @@ export function AgentChatPage() {
   const orgProviders = useLastResolved(orgModelProviders$);
   const modelSelection = useLastResolved(chatPageModelSelection$) ?? null;
   const setModelSelection = useSet(setChatPageModelSelection$);
+  const currentAgent = useLastResolved(currentChatAgent$);
+  const agentModelDefault =
+    currentAgent?.modelProviderId && currentAgent?.selectedModel
+      ? {
+          modelProviderId: currentAgent.modelProviderId,
+          selectedModel: currentAgent.selectedModel,
+        }
+      : null;
 
   const handleSendMessage = (message: string) => {
     if (!currentChatAgentId) {
@@ -376,42 +426,7 @@ export function AgentChatPage() {
       <main className="flex-1 min-h-0 overflow-y-auto px-4 sm:px-6">
         <div className="mx-auto w-full max-w-[900px] flex flex-col items-stretch gap-6 pt-8 pb-12 sm:pt-[15vh] sm:pb-[10vh]">
           <div className="flex items-center gap-4 w-full">
-            <div className="relative shrink-0">
-              {currentChatAgentId ? (
-                <TooltipProvider delayDuration={200}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Link
-                        pathname="/agents/:agentId"
-                        options={{
-                          pathParams: { agentId: currentChatAgentId },
-                        }}
-                        aria-label="View agent profile"
-                        className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-accent cursor-pointer"
-                      >
-                        <AgentAvatarImg
-                          name={currentChatAgentId}
-                          alt=""
-                          className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
-                        />
-                      </Link>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      <p className="text-xs">View agent profile</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              ) : (
-                <div className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl">
-                  <AgentAvatarImg
-                    name=""
-                    alt=""
-                    className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
-                  />
-                </div>
-              )}
-              <PinPill />
-            </div>
+            <ChatAgentAvatar agentId={currentChatAgentId} />
             <div className="flex-1 min-w-0 flex items-center gap-3">
               <VoiceChatLauncher />
               <h2
@@ -442,6 +457,7 @@ export function AgentChatPage() {
                     onChange: setModelSelection,
                     // No prior session exists on the landing page.
                     sessionProviderType: null,
+                    agentDefault: agentModelDefault,
                   }
                 : undefined
             }

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import React from "react";
 import {
   Select,
   SelectContent,
@@ -177,7 +177,20 @@ function InheritToggleRow({
       : undefined;
   return (
     <>
-      {/* Hidden item so Radix recognises the sentinel as a valid value */}
+      {/*
+       * Radix `<Select>` validates that the controlled `value` matches a
+       * registered `<SelectItem>`; otherwise it falls back to the placeholder
+       * and logs a warning. We drive the Select with `encodeValue(value)` —
+       * which returns `INHERIT_SENTINEL` when the caller inherits — but the
+       * inherit affordance is a non-item `<div>` with a `<Switch>` (a normal
+       * `<SelectItem>` here would close the menu on click, breaking the UX).
+       *
+       * This hidden `<SelectItem>` registers the sentinel so Radix accepts it
+       * as a valid value. `hidden absolute` keeps it out of the layout and
+       * keyboard focus while still being a mounted descendant of
+       * `<SelectContent>`. See Radix issue radix-ui/primitives#2090 for the
+       * long-standing request to allow non-item rows inside `SelectContent`.
+       */}
       <SelectItem value={INHERIT_SENTINEL} className="hidden absolute">
         Use {sourceLabel} default
       </SelectItem>
@@ -399,14 +412,27 @@ function ModelSelectDropdown({
   const triggerAriaLabel = resolved
     ? getModelDisplayName(resolved.selectedModel)
     : placeholder;
+  // Mirror the controlled `open` prop into local state so the inherit-toggle
+  // handler can close the dropdown deterministically (via `setOpen(false)`)
+  // without reaching through `document.dispatchEvent`. When the caller
+  // provides `open`/`onOpenChange`, we propagate to them as well.
+  const [internalOpen, setInternalOpen] = React.useState(false);
+  const isOpen = open ?? internalOpen;
+  const setOpen = React.useCallback(
+    (next: boolean) => {
+      setInternalOpen(next);
+      onOpenChange?.(next);
+    },
+    [onOpenChange],
+  );
   return (
     <Select
       value={encodeValue(value)}
       onValueChange={(raw) => {
         onChange(decodeValue(raw));
       }}
-      open={open}
-      onOpenChange={onOpenChange}
+      open={isOpen}
+      onOpenChange={setOpen}
     >
       <SelectTrigger
         aria-label={triggerAriaLabel}
@@ -432,10 +458,8 @@ function ModelSelectDropdown({
             onToggle={(inherit) => {
               if (inherit) {
                 onChange(null);
-                // Close dropdown — user is done (reverted to default)
-                document.dispatchEvent(
-                  new KeyboardEvent("keydown", { key: "Escape" }),
-                );
+                // Close dropdown — user is done (reverted to default).
+                setOpen(false);
               } else {
                 // Seed with the effective default; dropdown stays open
                 // so the user can pick a different model if they want.

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -8,6 +8,11 @@ import {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
+  Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
   cn,
 } from "@vm0/ui";
 import {
@@ -20,27 +25,9 @@ import {
   type ModelProviderType,
 } from "@vm0/core";
 import {
-  getUIDefaultModel,
   getUILabel,
   getVm0ModelMultiplier,
 } from "./settings/provider-ui-config";
-
-function resolveDefaultModel(
-  providers: ModelProviderResponse[],
-): string | null {
-  const defaultProvider = providers.find((p) => {
-    return p.isDefault;
-  });
-  if (!defaultProvider) {
-    return null;
-  }
-  return (
-    defaultProvider.selectedModel ??
-    getUIDefaultModel(defaultProvider.type) ??
-    getDefaultModel(defaultProvider.type) ??
-    null
-  );
-}
 
 export interface ModelProviderSelection {
   modelProviderId: string;
@@ -50,7 +37,7 @@ export interface ModelProviderSelection {
 interface ModelProviderPickerProps {
   providers: ModelProviderResponse[];
   value: ModelProviderSelection | null;
-  onChange?: (value: ModelProviderSelection | null) => void;
+  onChange: (value: ModelProviderSelection | null) => void;
   placeholder?: string;
   /**
    * Classes applied to the SelectTrigger. Defaults to `h-9 w-full`. The
@@ -76,6 +63,19 @@ interface ModelProviderPickerProps {
   onOpenChange?: (open: boolean) => void;
   // When true, picker is read-only (e.g. existing chat thread).
   disabled?: boolean;
+  /**
+   * The agent-level default model. When set, a "Default" tag is shown next
+   * to the matching model in the dropdown.
+   */
+  agentDefault?: ModelProviderSelection | null;
+  /**
+   * Override the label shown in the "Use default" toggle row.
+   * Defaults to the auto-detected source ("agent" or "workspace").
+   * Chat and schedule pickers should pass `"agent"` since they
+   * always inherit from the agent level regardless of whether
+   * the agent itself falls back to workspace.
+   */
+  inheritLabel?: "agent" | "workspace";
 }
 
 // Radix Select reserves the empty string for "no value" and throws if a
@@ -98,13 +98,129 @@ function decodeValue(s: string): ModelProviderSelection | null {
 }
 
 function formatMultiplier(multiplier: number): string {
-  return `${multiplier}x`;
+  return `×${multiplier}`;
+}
+
+function MultiplierBadge({ multiplier }: { multiplier: number }) {
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="shrink-0 rounded border border-border/60 bg-muted/50 px-1.5 py-px text-[11px] font-medium tabular-nums text-muted-foreground">
+            {formatMultiplier(multiplier)}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          Credit cost multiplier
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+type DefaultSource = "agent" | "workspace";
+
+/**
+ * Resolve the effective default model: agent override → workspace default.
+ * The source is "agent" only when the agent itself specifies a default;
+ * any fallback to workspace is labeled "workspace", so the dropdown never
+ * tells users an inherited workspace default is "Agent default".
+ */
+function resolveEffectiveDefault(
+  agentDefault: ModelProviderSelection | null | undefined,
+  providers: ModelProviderResponse[],
+): {
+  effectiveDefault: ModelProviderSelection | null;
+  defaultSource: DefaultSource;
+} {
+  if (agentDefault) {
+    return { effectiveDefault: agentDefault, defaultSource: "agent" };
+  }
+  const wsDefault = providers.find((p) => {
+    return p.isDefault;
+  });
+  if (!wsDefault) {
+    return { effectiveDefault: null, defaultSource: "workspace" };
+  }
+  const model = wsDefault.selectedModel ?? getDefaultModel(wsDefault.type);
+  if (!model) {
+    return { effectiveDefault: null, defaultSource: "workspace" };
+  }
+  return {
+    effectiveDefault: { modelProviderId: wsDefault.id, selectedModel: model },
+    defaultSource: "workspace",
+  };
+}
+
+function InheritToggleRow({
+  effectiveDefault,
+  defaultSource,
+  providers,
+  isInheriting,
+  onToggle,
+}: {
+  effectiveDefault: ModelProviderSelection | null;
+  defaultSource: DefaultSource;
+  providers: ModelProviderResponse[];
+  isInheriting: boolean;
+  onToggle: (inherit: boolean) => void;
+}) {
+  const sourceLabel = defaultSource === "agent" ? "agent" : "workspace";
+  const defaultProvider = effectiveDefault
+    ? providers.find((p) => {
+        return p.id === effectiveDefault.modelProviderId;
+      })
+    : undefined;
+  const multiplier =
+    effectiveDefault && defaultProvider?.type === "vm0"
+      ? getVm0ModelMultiplier(effectiveDefault.selectedModel)
+      : undefined;
+  return (
+    <>
+      {/* Hidden item so Radix recognises the sentinel as a valid value */}
+      <SelectItem value={INHERIT_SENTINEL} className="hidden absolute">
+        Use {sourceLabel} default
+      </SelectItem>
+      <div
+        className="flex items-center justify-between gap-3 rounded-md px-2 py-1.5 text-sm cursor-pointer hover:bg-accent transition-colors"
+        onClick={(e) => {
+          e.preventDefault();
+          onToggle(!isInheriting);
+        }}
+      >
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="font-medium text-foreground">
+            Use {sourceLabel} default
+          </span>
+          {effectiveDefault && (
+            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span className="truncate">
+                {getModelDisplayName(effectiveDefault.selectedModel)}
+              </span>
+              {multiplier !== undefined && (
+                <MultiplierBadge multiplier={multiplier} />
+              )}
+            </span>
+          )}
+        </div>
+        <Switch
+          size="sm"
+          checked={isInheriting}
+          onCheckedChange={onToggle}
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+          }}
+          aria-label={`Use ${sourceLabel} default model`}
+        />
+      </div>
+    </>
+  );
 }
 
 interface TriggerLabelProps {
   providers: ModelProviderResponse[];
   value: ModelProviderSelection | null;
-  defaultModelName: string | null;
+  effectiveDefault: ModelProviderSelection | null;
   placeholder: string;
   compact: boolean;
 }
@@ -112,55 +228,28 @@ interface TriggerLabelProps {
 function TriggerLabel({
   providers,
   value,
-  defaultModelName,
+  effectiveDefault,
   placeholder,
   compact,
 }: TriggerLabelProps) {
-  if (!value) {
-    if (!defaultModelName) {
-      return <span>{placeholder}</span>;
-    }
-    const displayName = getModelDisplayName(defaultModelName);
-    if (compact) {
-      return <span className="truncate">{displayName}</span>;
-    }
-    const defaultProvider = providers.find((p) => {
-      return p.isDefault;
-    });
-    if (!defaultProvider) {
-      return <span className="truncate">{displayName}</span>;
-    }
-    const multiplier =
-      defaultProvider.type === "vm0"
-        ? getVm0ModelMultiplier(defaultModelName)
-        : undefined;
-    return (
-      <span className="flex items-center gap-1.5 min-w-0">
-        <span className="truncate">{displayName}</span>
-        <span className="shrink-0 text-xs text-muted-foreground">
-          · {getUILabel(defaultProvider.type)}
-        </span>
-        {multiplier !== undefined && (
-          <span className="shrink-0 rounded border border-border/60 bg-muted/50 px-1 text-[10px] font-medium tabular-nums text-muted-foreground">
-            {formatMultiplier(multiplier)}
-          </span>
-        )}
-      </span>
-    );
+  // When no explicit value, show the effective default model name
+  const resolved = value ?? effectiveDefault;
+  if (!resolved) {
+    return <span>{placeholder}</span>;
   }
-  const displayName = getModelDisplayName(value.selectedModel);
+  const displayName = getModelDisplayName(resolved.selectedModel);
   if (compact) {
     return <span className="truncate">{displayName}</span>;
   }
   const provider = providers.find((p) => {
-    return p.id === value.modelProviderId;
+    return p.id === resolved.modelProviderId;
   });
   if (!provider) {
     return <span>{displayName}</span>;
   }
   const multiplier =
     provider.type === "vm0"
-      ? getVm0ModelMultiplier(value.selectedModel)
+      ? getVm0ModelMultiplier(resolved.selectedModel)
       : undefined;
   return (
     <span className="flex items-center gap-1.5 min-w-0">
@@ -168,11 +257,7 @@ function TriggerLabel({
       <span className="shrink-0 text-xs text-muted-foreground">
         · {getUILabel(provider.type)}
       </span>
-      {multiplier !== undefined && (
-        <span className="shrink-0 rounded border border-border/60 bg-muted/50 px-1 text-[10px] font-medium tabular-nums text-muted-foreground">
-          {formatMultiplier(multiplier)}
-        </span>
-      )}
+      {multiplier !== undefined && <MultiplierBadge multiplier={multiplier} />}
     </span>
   );
 }
@@ -183,19 +268,24 @@ function DisabledPickerLabel({
   placeholder,
   compactTrigger,
   triggerClassName,
+  agentDefault,
 }: Pick<
   ModelProviderPickerProps,
-  "providers" | "value" | "placeholder" | "compactTrigger" | "triggerClassName"
+  | "providers"
+  | "value"
+  | "placeholder"
+  | "compactTrigger"
+  | "triggerClassName"
+  | "agentDefault"
 > & {
   placeholder: string;
   compactTrigger: boolean;
 }) {
-  const defaultModelName = resolveDefaultModel(providers);
-  const triggerAriaLabel = value
-    ? getModelDisplayName(value.selectedModel)
-    : defaultModelName !== null
-      ? getModelDisplayName(defaultModelName)
-      : placeholder;
+  const { effectiveDefault } = resolveEffectiveDefault(agentDefault, providers);
+  const resolved = value ?? effectiveDefault;
+  const triggerAriaLabel = resolved
+    ? getModelDisplayName(resolved.selectedModel)
+    : placeholder;
   return (
     <span
       aria-label={triggerAriaLabel}
@@ -207,7 +297,7 @@ function DisabledPickerLabel({
       <TriggerLabel
         providers={providers}
         value={value}
-        defaultModelName={defaultModelName}
+        effectiveDefault={effectiveDefault}
         placeholder={placeholder}
         compact={compactTrigger}
       />
@@ -261,43 +351,42 @@ function buildProviderGroups(
     });
 }
 
-export function ModelProviderPicker({
-  providers,
+function ModelSelectDropdown({
+  groups,
   value,
-  onChange,
-  placeholder = "Inherit from org default",
+  effectiveDefault,
+  defaultSource,
+  providers,
+  placeholder,
   triggerClassName,
-  sessionProviderType,
-  compactTrigger = false,
+  compactTrigger,
+  onChange,
   open,
   onOpenChange,
-  disabled = false,
-}: ModelProviderPickerProps) {
-  if (disabled) {
-    return (
-      <DisabledPickerLabel
-        providers={providers}
-        value={value}
-        placeholder={placeholder}
-        compactTrigger={compactTrigger}
-        triggerClassName={triggerClassName}
-      />
-    );
-  }
-
-  const groups = buildProviderGroups(providers, sessionProviderType);
-  const defaultModelName = resolveDefaultModel(providers);
-  const triggerAriaLabel = value
-    ? getModelDisplayName(value.selectedModel)
-    : defaultModelName !== null
-      ? getModelDisplayName(defaultModelName)
-      : placeholder;
-
+  showUseDefault,
+}: {
+  groups: ProviderGroup[];
+  value: ModelProviderSelection | null;
+  effectiveDefault: ModelProviderSelection | null;
+  defaultSource: DefaultSource;
+  providers: ModelProviderResponse[];
+  placeholder: string;
+  triggerClassName: string | undefined;
+  compactTrigger: boolean;
+  onChange: (value: ModelProviderSelection | null) => void;
+  open: boolean | undefined;
+  onOpenChange: ((open: boolean) => void) | undefined;
+  showUseDefault: boolean;
+}) {
+  const resolved = value ?? effectiveDefault;
+  const triggerAriaLabel = resolved
+    ? getModelDisplayName(resolved.selectedModel)
+    : placeholder;
   return (
     <Select
       value={encodeValue(value)}
       onValueChange={(raw) => {
-        onChange?.(decodeValue(raw));
+        onChange(decodeValue(raw));
       }}
       open={open}
       onOpenChange={onOpenChange}
@@ -310,57 +399,130 @@ export function ModelProviderPicker({
           <TriggerLabel
             providers={providers}
             value={value}
-            defaultModelName={defaultModelName}
+            effectiveDefault={effectiveDefault}
             placeholder={placeholder}
             compact={compactTrigger}
           />
         </SelectValue>
       </SelectTrigger>
-      <SelectContent>
-        <SelectItem value={INHERIT_SENTINEL}>{placeholder}</SelectItem>
-        {groups.length > 0 && <SelectSeparator key="sep-inherit" />}
-        {groups.flatMap((group, idx) => {
-          const rendered: React.ReactNode[] = [
-            <SelectGroup key={group.provider.id}>
-              <SelectLabel className="px-2 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                {group.label}
-                {group.incompatible && (
-                  <span className="ml-1.5 font-normal normal-case text-[10px] text-muted-foreground/80">
-                    (incompatible with current session)
-                  </span>
-                )}
-              </SelectLabel>
-              {group.models.map((model) => {
-                const multiplier = group.isVm0
-                  ? getVm0ModelMultiplier(model)
-                  : undefined;
-                return (
-                  <SelectItem
-                    key={`${group.provider.id}::${model}`}
-                    value={`${group.provider.id}::${model}`}
-                    disabled={group.incompatible}
-                  >
-                    <span className="flex items-center gap-3 w-full">
-                      <span className="truncate">
-                        {getModelDisplayName(model)}
-                      </span>
-                      {multiplier !== undefined && (
-                        <span className="ml-auto shrink-0 rounded border border-border/60 bg-muted/50 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-muted-foreground">
-                          {formatMultiplier(multiplier)}
-                        </span>
-                      )}
-                    </span>
-                  </SelectItem>
+      <SelectContent className="max-h-64">
+        {showUseDefault && (
+          <InheritToggleRow
+            effectiveDefault={effectiveDefault}
+            defaultSource={defaultSource}
+            providers={providers}
+            isInheriting={value === null}
+            onToggle={(inherit) => {
+              if (inherit) {
+                onChange(null);
+                // Close dropdown — user is done (reverted to default)
+                document.dispatchEvent(
+                  new KeyboardEvent("keydown", { key: "Escape" }),
                 );
-              })}
-            </SelectGroup>,
-          ];
-          if (idx < groups.length - 1) {
-            rendered.push(<SelectSeparator key={`sep-${group.provider.id}`} />);
-          }
-          return rendered;
-        })}
+              } else {
+                // Seed with the effective default; dropdown stays open
+                // so the user can pick a different model if they want.
+                onChange(effectiveDefault);
+              }
+            }}
+          />
+        )}
+        {(!showUseDefault || value !== null) && groups.length > 0 && (
+          <SelectSeparator key="sep-inherit" className="my-0" />
+        )}
+        {(!showUseDefault || value !== null) &&
+          groups.flatMap((group, idx) => {
+            const rendered: React.ReactNode[] = [
+              <SelectGroup key={group.provider.id}>
+                <SelectLabel className="pl-2 pr-8 py-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
+                  {group.label}
+                  {group.incompatible && (
+                    <span className="ml-1.5 font-normal normal-case text-[10px] text-muted-foreground/80">
+                      (incompatible with current session)
+                    </span>
+                  )}
+                </SelectLabel>
+                {group.models.map((model) => {
+                  const multiplier = group.isVm0
+                    ? getVm0ModelMultiplier(model)
+                    : undefined;
+                  return (
+                    <SelectItem
+                      key={`${group.provider.id}::${model}`}
+                      value={`${group.provider.id}::${model}`}
+                      disabled={group.incompatible}
+                    >
+                      <span className="flex items-center gap-3 w-full">
+                        <span className="truncate">
+                          {getModelDisplayName(model)}
+                        </span>
+                        {multiplier !== undefined && (
+                          <MultiplierBadge multiplier={multiplier} />
+                        )}
+                      </span>
+                    </SelectItem>
+                  );
+                })}
+              </SelectGroup>,
+            ];
+            if (idx < groups.length - 1) {
+              rendered.push(
+                <SelectSeparator key={`sep-${group.provider.id}`} />,
+              );
+            }
+            return rendered;
+          })}
       </SelectContent>
     </Select>
+  );
+}
+
+export function ModelProviderPicker({
+  providers,
+  value,
+  onChange,
+  placeholder = "Inherit from org default",
+  triggerClassName,
+  sessionProviderType,
+  compactTrigger = false,
+  open,
+  onOpenChange,
+  disabled = false,
+  agentDefault,
+  inheritLabel,
+}: ModelProviderPickerProps) {
+  if (disabled) {
+    return (
+      <DisabledPickerLabel
+        providers={providers}
+        value={value}
+        placeholder={placeholder}
+        compactTrigger={compactTrigger}
+        triggerClassName={triggerClassName}
+        agentDefault={agentDefault}
+      />
+    );
+  }
+
+  const { effectiveDefault, defaultSource: autoSource } =
+    resolveEffectiveDefault(agentDefault, providers);
+  const defaultSource: DefaultSource = inheritLabel ?? autoSource;
+
+  const groups = buildProviderGroups(providers, sessionProviderType);
+  return (
+    <ModelSelectDropdown
+      groups={groups}
+      value={value}
+      effectiveDefault={effectiveDefault}
+      defaultSource={defaultSource}
+      providers={providers}
+      placeholder={placeholder}
+      triggerClassName={triggerClassName}
+      compactTrigger={compactTrigger}
+      onChange={onChange}
+      open={open}
+      onOpenChange={onOpenChange}
+      showUseDefault
+    />
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type { MouseEvent, ReactNode } from "react";
 import {
   Select,
   SelectContent,
@@ -220,7 +220,7 @@ function InheritToggleRow({
           size="sm"
           checked={isInheriting}
           onCheckedChange={onToggle}
-          onClick={(e: React.MouseEvent) => {
+          onClick={(e: MouseEvent) => {
             e.stopPropagation();
           }}
           aria-label={`Use ${sourceLabel} default model`}
@@ -279,7 +279,9 @@ function TriggerLabel({
 // its interactive affordances (hover/focus/open-state), so callers don't
 // have to branch their className for the disabled case.
 function stripInteractiveClasses(cls: string | undefined): string | undefined {
-  if (!cls) return cls;
+  if (!cls) {
+    return cls;
+  }
   return cls
     .split(/\s+/)
     .filter((c) => {
@@ -381,6 +383,48 @@ function buildProviderGroups(
     });
 }
 
+function renderProviderGroup(
+  group: ProviderGroup,
+  idx: number,
+  last: number,
+): ReactNode[] {
+  const rendered: ReactNode[] = [
+    <SelectGroup key={group.provider.id}>
+      <SelectLabel className="pl-2 pr-8 py-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
+        {group.label}
+        {group.incompatible && (
+          <span className="ml-1.5 font-normal normal-case text-[10px] text-muted-foreground/80">
+            (incompatible with current session)
+          </span>
+        )}
+      </SelectLabel>
+      {group.models.map((model) => {
+        const multiplier = group.isVm0
+          ? getVm0ModelMultiplier(model)
+          : undefined;
+        return (
+          <SelectItem
+            key={`${group.provider.id}::${model}`}
+            value={`${group.provider.id}::${model}`}
+            disabled={group.incompatible}
+          >
+            <span className="flex items-center gap-3 w-full">
+              <span className="truncate">{getModelDisplayName(model)}</span>
+              {multiplier !== undefined && (
+                <MultiplierBadge multiplier={multiplier} />
+              )}
+            </span>
+          </SelectItem>
+        );
+      })}
+    </SelectGroup>,
+  ];
+  if (idx < last) {
+    rendered.push(<SelectSeparator key={`sep-${group.provider.id}`} />);
+  }
+  return rendered;
+}
+
 function ModelSelectDropdown({
   groups,
   value,
@@ -412,27 +456,15 @@ function ModelSelectDropdown({
   const triggerAriaLabel = resolved
     ? getModelDisplayName(resolved.selectedModel)
     : placeholder;
-  // Mirror the controlled `open` prop into local state so the inherit-toggle
-  // handler can close the dropdown deterministically (via `setOpen(false)`)
-  // without reaching through `document.dispatchEvent`. When the caller
-  // provides `open`/`onOpenChange`, we propagate to them as well.
-  const [internalOpen, setInternalOpen] = React.useState(false);
-  const isOpen = open ?? internalOpen;
-  const setOpen = React.useCallback(
-    (next: boolean) => {
-      setInternalOpen(next);
-      onOpenChange?.(next);
-    },
-    [onOpenChange],
-  );
+  const lastGroupIdx = groups.length - 1;
   return (
     <Select
       value={encodeValue(value)}
       onValueChange={(raw) => {
         onChange(decodeValue(raw));
       }}
-      open={isOpen}
-      onOpenChange={setOpen}
+      open={open}
+      onOpenChange={onOpenChange}
     >
       <SelectTrigger
         aria-label={triggerAriaLabel}
@@ -459,7 +491,8 @@ function ModelSelectDropdown({
               if (inherit) {
                 onChange(null);
                 // Close dropdown — user is done (reverted to default).
-                setOpen(false);
+                // No-op for uncontrolled callers; they dismiss via click-outside.
+                onOpenChange?.(false);
               } else {
                 // Seed with the effective default; dropdown stays open
                 // so the user can pick a different model if they want.
@@ -473,45 +506,7 @@ function ModelSelectDropdown({
         )}
         {(!showUseDefault || value !== null) &&
           groups.flatMap((group, idx) => {
-            const rendered: React.ReactNode[] = [
-              <SelectGroup key={group.provider.id}>
-                <SelectLabel className="pl-2 pr-8 py-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
-                  {group.label}
-                  {group.incompatible && (
-                    <span className="ml-1.5 font-normal normal-case text-[10px] text-muted-foreground/80">
-                      (incompatible with current session)
-                    </span>
-                  )}
-                </SelectLabel>
-                {group.models.map((model) => {
-                  const multiplier = group.isVm0
-                    ? getVm0ModelMultiplier(model)
-                    : undefined;
-                  return (
-                    <SelectItem
-                      key={`${group.provider.id}::${model}`}
-                      value={`${group.provider.id}::${model}`}
-                      disabled={group.incompatible}
-                    >
-                      <span className="flex items-center gap-3 w-full">
-                        <span className="truncate">
-                          {getModelDisplayName(model)}
-                        </span>
-                        {multiplier !== undefined && (
-                          <MultiplierBadge multiplier={multiplier} />
-                        )}
-                      </span>
-                    </SelectItem>
-                  );
-                })}
-              </SelectGroup>,
-            ];
-            if (idx < groups.length - 1) {
-              rendered.push(
-                <SelectSeparator key={`sep-${group.provider.id}`} />,
-              );
-            }
-            return rendered;
+            return renderProviderGroup(group, idx, lastGroupIdx);
           })}
       </SelectContent>
     </Select>

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -262,6 +262,23 @@ function TriggerLabel({
   );
 }
 
+// Read-only span reuses the trigger's geometry classes but must not echo
+// its interactive affordances (hover/focus/open-state), so callers don't
+// have to branch their className for the disabled case.
+function stripInteractiveClasses(cls: string | undefined): string | undefined {
+  if (!cls) return cls;
+  return cls
+    .split(/\s+/)
+    .filter((c) => {
+      return (
+        !c.startsWith("hover:") &&
+        !c.startsWith("focus:") &&
+        !c.startsWith("data-[state=")
+      );
+    })
+    .join(" ");
+}
+
 function DisabledPickerLabel({
   providers,
   value,
@@ -290,8 +307,8 @@ function DisabledPickerLabel({
     <span
       aria-label={triggerAriaLabel}
       className={cn(
-        "inline-flex items-center px-2 text-sm text-muted-foreground",
-        triggerClassName,
+        "inline-flex items-center px-2 text-sm text-muted-foreground cursor-default",
+        stripInteractiveClasses(triggerClassName),
       )}
     >
       <TriggerLabel

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -31,6 +31,7 @@ import {
   updateDialogForm$,
   showConfirm$,
   setShowConfirm$,
+  dialogAgentModelDefault$,
 } from "../../signals/schedule-page/schedule-form.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { orgModelProviders$ } from "../../signals/external/org-model-providers.ts";
@@ -567,6 +568,8 @@ function ScheduleFormDialogInner({
     features?.[FeatureSwitchKey.ModelProviderSelection] ?? false;
   const orgProviders = useLastResolved(orgModelProviders$);
 
+  const agentModelDefault = useLastResolved(dialogAgentModelDefault$) ?? null;
+
   const current: ScheduleFormValues = {
     prompt: form.prompt,
     description: form.description,
@@ -754,10 +757,7 @@ function ScheduleFormDialogInner({
             orgProviders &&
             orgProviders.modelProviders.length > 0 && (
               <div className="flex flex-col gap-2">
-                <label
-                  htmlFor="schedule-dialog-model"
-                  className="text-sm font-medium text-foreground"
-                >
+                <label className="text-sm font-medium text-foreground">
                   Model
                   <span className="text-muted-foreground font-normal ml-1">
                     (optional)
@@ -779,6 +779,8 @@ function ScheduleFormDialogInner({
                       selectedModel: sel?.selectedModel ?? null,
                     });
                   }}
+                  agentDefault={agentModelDefault}
+                  inheritLabel="agent"
                 />
               </div>
             )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -168,6 +168,8 @@ interface ZeroChatComposerProps {
     sessionProviderType: ModelProviderType | null;
     // When true, picker is read-only (e.g. existing chat thread).
     disabled?: boolean;
+    /** The agent-level default model, shown as a "Default" tag in the dropdown. */
+    agentDefault?: ModelProviderSelection | null;
   };
 }
 
@@ -943,7 +945,7 @@ export function ZeroChatComposer({
                     triggerClassName={cn(
                       // Resting state: borderless ghost — trigger reads like
                       // plain text in the toolbar.
-                      "h-8 w-auto max-w-[12rem] gap-1 border-transparent bg-transparent px-2 text-xs text-muted-foreground transition-colors",
+                      "h-9 w-auto max-w-[12rem] gap-1 border-transparent bg-transparent px-2 text-sm text-muted-foreground transition-colors",
                       // Discoverable affordance only when the user targets it.
                       "hover:bg-accent hover:text-foreground focus:bg-accent focus:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
                     )}
@@ -952,6 +954,8 @@ export function ZeroChatComposer({
                     open={modelPickerOpen}
                     onOpenChange={setModelPickerOpen}
                     disabled={modelPicker.disabled}
+                    agentDefault={modelPicker.agentDefault}
+                    inheritLabel="agent"
                   />
                 )}
                 <MicButton

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -32,6 +32,7 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
+  Skeleton,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -151,6 +152,14 @@ interface ZeroChatComposerProps {
   setInputRef?: (el: HTMLElement | null) => void;
   /** Called after attachment upload/remove mutations so the caller can trigger side-effects (e.g. draft sync). */
   onDraftChange?: () => void;
+  /**
+   * When true, render skeleton placeholders in place of the right-side
+   * action cluster (model picker, mic, send/stop). Used during thread switch
+   * while thread data is still resolving — prevents briefly flashing stale
+   * picker state and a wrong send/stop button derived from prior
+   * `allFinished`.
+   */
+  actionsLoading?: boolean;
   /**
    * Per-run model picker wiring. When present, a compact picker is rendered
    * immediately to the left of the Send button; the parent owns the selected
@@ -646,6 +655,7 @@ export function ZeroChatComposer({
   setComposerFileInput$: setComposerFileInputProp$,
   setInputRef,
   onDraftChange,
+  actionsLoading = false,
   modelPicker,
 }: ZeroChatComposerProps) {
   const showAddDialog = useGet(showAddDialog$);
@@ -936,57 +946,68 @@ export function ZeroChatComposer({
                 />
               </div>
               <div className="flex items-center gap-2">
-                {modelPicker && (
-                  <ModelProviderPicker
-                    providers={modelPicker.providers}
-                    value={modelPicker.value}
-                    onChange={modelPicker.onChange}
-                    placeholder="Default"
-                    triggerClassName={cn(
-                      // Resting state: borderless ghost — trigger reads like
-                      // plain text in the toolbar.
-                      "h-9 w-auto max-w-[12rem] gap-1 border-transparent bg-transparent px-2 text-sm text-muted-foreground transition-colors",
-                      // Discoverable affordance only when the user targets it.
-                      "hover:bg-accent hover:text-foreground focus:bg-accent focus:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
+                {actionsLoading ? (
+                  <Skeleton
+                    className={cn(
+                      "h-9 rounded-md",
+                      modelPicker ? "w-[184px]" : "w-20",
                     )}
-                    sessionProviderType={modelPicker.sessionProviderType}
-                    compactTrigger
-                    open={modelPickerOpen}
-                    onOpenChange={setModelPickerOpen}
-                    disabled={modelPicker.disabled}
-                    agentDefault={modelPicker.agentDefault}
-                    inheritLabel="agent"
                   />
-                )}
-                <MicButton
-                  onTranscribed={(text) => {
-                    const base = input;
-                    const separator =
-                      base.length > 0 && !base.endsWith(" ") ? " " : "";
-                    onInputChange(base + separator + text);
-                    onDraftChange?.();
-                  }}
-                />
-                {sending && onCancel ? (
-                  <Button
-                    size="sm"
-                    variant="destructive"
-                    className="rounded-lg h-9 w-9 p-0 shrink-0"
-                    onClick={onCancel}
-                    aria-label="Stop"
-                  >
-                    <IconPlayerStop size={16} />
-                  </Button>
                 ) : (
-                  <Button
-                    size="sm"
-                    className="rounded-lg h-9 w-9 p-0 shrink-0"
-                    onClick={handleSend}
-                    disabled={!canSend || !!sending}
-                    aria-label="Send"
-                  >
-                    <IconArrowUp size={18} stroke={2} />
-                  </Button>
+                  <>
+                    {modelPicker && (
+                      <ModelProviderPicker
+                        providers={modelPicker.providers}
+                        value={modelPicker.value}
+                        onChange={modelPicker.onChange}
+                        placeholder="Default"
+                        triggerClassName={cn(
+                          // Resting state: borderless ghost — trigger reads like
+                          // plain text in the toolbar.
+                          "h-9 w-auto max-w-[12rem] gap-1 border-transparent bg-transparent px-2 text-sm text-muted-foreground transition-colors",
+                          // Discoverable affordance only when the user targets it.
+                          "hover:bg-accent hover:text-foreground focus:bg-accent focus:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
+                        )}
+                        sessionProviderType={modelPicker.sessionProviderType}
+                        compactTrigger
+                        open={modelPickerOpen}
+                        onOpenChange={setModelPickerOpen}
+                        disabled={modelPicker.disabled}
+                        agentDefault={modelPicker.agentDefault}
+                        inheritLabel="agent"
+                      />
+                    )}
+                    <MicButton
+                      onTranscribed={(text) => {
+                        const base = input;
+                        const separator =
+                          base.length > 0 && !base.endsWith(" ") ? " " : "";
+                        onInputChange(base + separator + text);
+                        onDraftChange?.();
+                      }}
+                    />
+                    {sending && onCancel ? (
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        className="rounded-lg h-9 w-9 p-0 shrink-0"
+                        onClick={onCancel}
+                        aria-label="Stop"
+                      >
+                        <IconPlayerStop size={16} />
+                      </Button>
+                    ) : (
+                      <Button
+                        size="sm"
+                        className="rounded-lg h-9 w-9 p-0 shrink-0"
+                        onClick={handleSend}
+                        disabled={!canSend || !!sending}
+                        aria-label="Send"
+                      >
+                        <IconArrowUp size={18} stroke={2} />
+                      </Button>
+                    )}
+                  </>
                 )}
               </div>
             </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -381,6 +381,7 @@ function ChatThreadComposer({
   const orgProviders = useLastResolved(orgModelProviders$);
   const modelSelection = useLastResolved(thread.modelSelection$) ?? null;
   const setModelSelection = useSet(thread.setModelSelection$);
+  const agentModelDefault = useLastResolved(thread.agentModelDefault$) ?? null;
 
   const handleInputChange = (text: string) => {
     setInput(text);
@@ -440,6 +441,7 @@ function ChatThreadComposer({
                   disabled: Boolean(
                     threadData?.modelProviderId && threadData?.selectedModel,
                   ),
+                  agentDefault: agentModelDefault,
                 }
               : undefined
           }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -382,6 +382,11 @@ function ChatThreadComposer({
   const modelSelection = useLastResolved(thread.modelSelection$) ?? null;
   const setModelSelection = useSet(thread.setModelSelection$);
   const agentModelDefault = useLastResolved(thread.agentModelDefault$) ?? null;
+  // During thread switch the thread-level skeleton is visible and
+  // `threadData` / `allFinished$` may still reflect the previous thread;
+  // render the whole action cluster as a skeleton so we don't flash stale
+  // picker state or a wrong send/stop button.
+  const skeletonVisible = useGet(thread.skeletonVisible$);
 
   const handleInputChange = (text: string) => {
     setInput(text);
@@ -426,6 +431,7 @@ function ChatThreadComposer({
           composerFileInput$={thread.composerFileInput$}
           setComposerFileInput$={thread.setComposerFileInput$}
           setInputRef={setInputRef}
+          actionsLoading={skeletonVisible}
           modelPicker={
             modelFeatureEnabled &&
             orgProviders &&

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -98,6 +98,7 @@ import {
   incrementDiscardNonce$,
   syncSettingsFormEntry$,
   syncInstructionDraftEntry$,
+  scheduleAgentModelDefault$,
   type ScheduleSettingsSnapshot,
 } from "../../signals/schedule-page/schedule-form.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
@@ -323,6 +324,8 @@ function ScheduleSettingsForm({
     features?.[FeatureSwitchKey.ModelProviderSelection] ?? false;
   const orgProviders = useLastResolved(orgModelProviders$);
 
+  const agentModelDefault = useLastResolved(scheduleAgentModelDefault$) ?? null;
+
   // Reset form when entry changes (component is keyed by entry.id)
   useSet(syncSettingsFormEntry$)(entry.id, entry.prompt, initial);
 
@@ -488,7 +491,7 @@ function ScheduleSettingsForm({
             orgProviders.modelProviders.length > 0 && (
               <InlineSettingsRow
                 label="Model"
-                description="Override the org default model for this schedule."
+                description="Override the agent's default model for this schedule."
               >
                 <div className={SCHEDULE_DETAIL_CONTROL_WIDTH}>
                   <ModelProviderPicker
@@ -507,6 +510,8 @@ function ScheduleSettingsForm({
                         selectedModel: sel?.selectedModel ?? null,
                       });
                     }}
+                    agentDefault={agentModelDefault}
+                    inheritLabel="agent"
                   />
                 </div>
               </InlineSettingsRow>

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -328,16 +328,13 @@ export function ZeroSettingsTab({
               orgProviders.modelProviders.length > 0 && (
                 <InlineSettingsRow
                   label="Model"
-                  description="Override the org default model for this agent."
-                  wideControls
+                  description="The model used by this agent. Defaults to the workspace setting."
                 >
-                  <div className="min-w-0 w-full">
-                    <ModelProviderPicker
-                      providers={orgProviders.modelProviders}
-                      value={modelSelection}
-                      onChange={setModelSelection}
-                    />
-                  </div>
+                  <ModelProviderPicker
+                    providers={orgProviders.modelProviders}
+                    value={modelSelection}
+                    onChange={setModelSelection}
+                  />
                 </InlineSettingsRow>
               )}
           </CardContent>


### PR DESCRIPTION
## Summary
- Align model selector trigger height (`h-9`) and font size (`text-sm`) with the send button for visual consistency
- Unify multiplier badge styles (`text-[11px]`, `px-1.5 py-px`) between trigger label and dropdown items
- Lighten section header color (`text-muted-foreground/60`) to match navigation styling
- Remove redundant "Default" option from the model picker dropdown
- Add agent-level default model override with inherit toggle (replaces the per-item "Default" badge with a single "Use \<source\> default" switch)
- Skeleton action cluster on thread switch so the picker/send buttons don't flash stale state
- Strip hover/focus/data-state styles on the disabled picker so it reads as read-only

## Behavioral / API notes
- **Breaking (internal):** `ModelProviderPicker.onChange` is now a required prop. All in-repo call sites are updated; external consumers (none today) would need to supply a handler.
- New optional props: `agentDefault`, `inheritLabel` (agent | workspace), `actionsLoading` (composer-level skeleton).
- New signals: `agentModelDefault$` in both `create-chat-thread.ts` and `schedule-form.ts`, resolving the effective default (agent override → workspace default → null).

## Test plan
- [ ] Open chat composer and verify model selector button is the same height as the send button
- [ ] Open model picker dropdown and verify section headers have consistent lighter color
- [ ] Verify multiplier badges (1.7x, 1x, etc.) are consistently sized in both trigger and dropdown
- [ ] Verify "Default" option no longer appears in the dropdown
- [ ] Toggle "Use agent default" on/off; verify dropdown closes cleanly on enable and stays open on disable
- [ ] Switch between threads with different models; verify the action cluster shows a skeleton instead of the previous thread's picker/send

🤖 Generated with [Claude Code](https://claude.com/claude-code)
