### PR TITLE
fix(platform): silence expected 404 agent-not-found errors in sentry

### DIFF
--- a/turbo/apps/platform/src/lib/sentry.ts
+++ b/turbo/apps/platform/src/lib/sentry.ts
@@ -54,6 +54,10 @@ export function initSentry(): void {
       // expected side effect of the in-flight redirect, not a real failure.
       "Not authenticated",
       "Authentication required",
+      // 404 for stale agent references (deleted agents, cross-org bookmarks,
+      // pinned IDs that no longer resolve). Surfaced to users as a toast and
+      // not actionable in Sentry.
+      "Agent not found",
       // Expected API errors surfaced as toasts — not actionable in Sentry
       "Credits depleted",
       "Insufficient credits",


### PR DESCRIPTION
## Summary

- Add `"Agent not found"` to Sentry's `ignoreErrors` list in `apps/platform/src/lib/sentry.ts`.
- Stops PLATFORM-1E (#10167) from polluting Sentry triage — same pattern as the 401 fix in #9716.

## Root cause

The generic 4xx filter in `beforeSend` reads `event.contexts.response.status_code`, which is only populated by Sentry's fetch/XHR auto-instrumentation. Our `accept()` helper throws `ApiError` manually from a resolved Promise, so the status-code context is never attached and 4xx errors bypass the filter.

`"Agent not found: <uuid>"` is the same class of noise as 401s: expected client-side staleness (deleted agents, cross-org bookmarks, pinned IDs that no longer resolve). It is already surfaced to the user as a toast and is not actionable in Sentry.

The note in the issue about a possible provisioning race can be ruled out — only 1 Sentry event for 1 user, and the reported ID is a valid UUID so it did not trip the `z.string().uuid("Invalid agent ID")` validator either (the Axiom "Invalid agent ID" event is a separate non-UUID request, not the same call).

## Test plan

- [ ] CI green
- [ ] After deploy, confirm PLATFORM-1E stops receiving new events
- [ ] Verify other 4xx-from-accept events (e.g. "Credits depleted") still work as before

Closes #10167

🤖 Generated with [Claude Code](https://claude.com/claude-code)