### PR TITLE
chore(platform): add no-raw-msw-http lint rule (#10091)

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/no-raw-msw-http.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-raw-msw-http.test.ts
@@ -1,0 +1,95 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-raw-msw-http.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-raw-msw-http", rule, {
+  valid: [
+    {
+      // Allowed: mockApi() usage
+      code: `server.use(mockApi(contract.route, ({ respond }) => respond(200, {})));`,
+    },
+    {
+      // Allowed: http.* against a third-party host (no internal api path)
+      code: `server.use(http.post("https://slack.com/api/chat.postMessage", () => HttpResponse.json({})));`,
+    },
+    {
+      // Allowed: http.* against a synthetic, non-api path (fetch-wrapper self-tests)
+      code: `server.use(http.get("http://localhost:3000/test", () => HttpResponse.json({})));`,
+    },
+    {
+      // Allowed: method not in the MSW set (e.g. http.options — not enforced)
+      code: `server.use(http.options("*/api/zero/org", () => HttpResponse.json({})));`,
+    },
+    {
+      // Allowed: URL arg is a variable — rule only flags string literals to stay conservative
+      code: `server.use(http.get(url, () => HttpResponse.json({})));`,
+    },
+    {
+      // Allowed: inline marker comment right before the http.* call
+      code: `
+        server.use(
+          // mockApi cannot be used here: 500 is not declared in the contract's responses.
+          http.get("*/api/zero/org", () => HttpResponse.json(null, { status: 500 })),
+        );
+      `,
+    },
+    {
+      // Allowed: marker comment before the enclosing server.use() statement
+      code: `
+        // mockApi cannot be used here: the URL contains a literal slash that MSW resolves as a path separator.
+        server.use(
+          http.get("http://localhost:3000/api/zero/agents/*", () => HttpResponse.json({})),
+        );
+      `,
+    },
+    {
+      // Allowed: marker comment above the variable declaration that holds the handler
+      code: `
+        // mockApi cannot be used here: binary streaming response with no ts-rest contract.
+        const handler = http.post("http://localhost:3000/api/zero/voice-io/tts", () => new Response());
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `server.use(http.get("*/api/zero/org", () => HttpResponse.json({})));`,
+      errors: [{ messageId: "useMockApi" }],
+    },
+    {
+      code: `server.use(http.post("*/api/zero/uploads", () => HttpResponse.json({})));`,
+      errors: [{ messageId: "useMockApi" }],
+    },
+    {
+      code: `server.use(http.put("http://localhost:3000/api/zero/items/1", () => HttpResponse.json({})));`,
+      errors: [{ messageId: "useMockApi" }],
+    },
+    {
+      code: `server.use(http.patch("*/api/zero/team", () => HttpResponse.json({})));`,
+      errors: [{ messageId: "useMockApi" }],
+    },
+    {
+      code: `server.use(http.delete("*/api/zero/secrets/:id", () => HttpResponse.json({})));`,
+      errors: [{ messageId: "useMockApi" }],
+    },
+    {
+      code: `server.use(http.get("*/api/v1/widgets", () => HttpResponse.json({})));`,
+      errors: [{ messageId: "useMockApi" }],
+    },
+    {
+      // Unrelated comment does not exempt
+      code: `
+        server.use(
+          // TODO: revisit this handler
+          http.get("*/api/zero/org", () => HttpResponse.json({})),
+        );
+      `,
+      errors: [{ messageId: "useMockApi" }],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/index.ts
+++ b/turbo/apps/platform/custom-eslint/index.ts
@@ -24,6 +24,7 @@
  * - no-test-delay: Disallow manual delays/timers in tests — use createDeferredPromise + waitFor
  * - require-accept: Enforce that zeroClient$ calls are wrapped in accept()
  * - no-get-by-role-name: Avoid *ByRole(role, { name }) for text-content roles — causes ~300ms/call slowdown in happy-dom
+ * - no-raw-msw-http: Disallow raw http.* MSW handlers for internal /api/zero/* paths — use mockApi(contract.route, ...)
  */
 
 import signalDollarSuffix from "./rules/signal-dollar-suffix.ts";
@@ -54,6 +55,7 @@ import requireAccept from "./rules/require-accept.ts";
 import noGetByRoleName from "./rules/no-get-by-role-name.ts";
 import noUserClearTab from "./rules/no-user-clear-tab.ts";
 import noDuplicateRouteParam from "./rules/no-duplicate-route-param.ts";
+import noRawMswHttp from "./rules/no-raw-msw-http.ts";
 
 const plugin = {
   meta: {
@@ -89,6 +91,7 @@ const plugin = {
     "no-get-by-role-name": noGetByRoleName,
     "no-user-clear-tab": noUserClearTab,
     "no-duplicate-route-param": noDuplicateRouteParam,
+    "no-raw-msw-http": noRawMswHttp,
   },
 };
 

--- a/turbo/apps/platform/custom-eslint/rules/no-raw-msw-http.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-raw-msw-http.ts
@@ -1,0 +1,126 @@
+/**
+ * ESLint rule: no-raw-msw-http
+ *
+ * Disallows raw `http.(get|post|put|patch|delete)(url, ...)` MSW handlers in
+ * platform test files when `url` points at an internal `/api/zero/*` or
+ * `/api/v1/*` route. Those routes have ts-rest contracts — tests should use
+ * `mockApi(contract.route, ...)` so handler shape, path, method, params, and
+ * response body are validated against the same contract the real server uses.
+ *
+ * If migration is genuinely impossible (e.g. simulating a status code not
+ * declared in the contract's responses, or a multipart body without a
+ * ts-rest contract), add a leading comment containing the marker phrase
+ * `mockApi cannot be used here` on the handler call or its enclosing
+ * statement — the rule treats that as an explicit, reviewable exemption.
+ *
+ * Good:
+ *   server.use(mockApi(zeroOrgContract.get, ({ respond }) => respond(200, {...})));
+ *
+ * Bad:
+ *   server.use(http.get("*\/api/zero/org", () => HttpResponse.json({...})));
+ *
+ * Exempted (via marker comment):
+ *   // mockApi cannot be used here: 500 is not declared in the contract's responses.
+ *   server.use(http.get("*\/api/zero/org", () => HttpResponse.json(null, { status: 500 })));
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+const EXEMPTION_MARKER = "mockApi cannot be used here";
+const INTERNAL_API_RE = /\/api\/(zero|v1)\//;
+const MSW_METHODS = new Set(["get", "post", "put", "patch", "delete"]);
+
+export default createRule({
+  name: "no-raw-msw-http",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow raw http.* MSW handlers for internal /api/zero/* or /api/v1/* routes — use mockApi(contract.route, ...) so handlers stay typed against ts-rest contracts",
+    },
+    schema: [],
+    messages: {
+      useMockApi:
+        "Use mockApi(contract.route, ...) instead of raw http.{{method}} for internal /api/{{bucket}}/ paths. If migration is genuinely impossible, add a '// mockApi cannot be used here: <reason>' comment above the call explaining why.",
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    function hasExemptionComment(callNode: TSESTree.CallExpression): boolean {
+      let current: TSESTree.Node = callNode;
+      while (current.parent && current.parent.type !== AST_NODE_TYPES.Program) {
+        const leading = sourceCode.getCommentsBefore(current);
+        for (const comment of leading) {
+          if (comment.value.includes(EXEMPTION_MARKER)) {
+            return true;
+          }
+        }
+        if (
+          current.type === AST_NODE_TYPES.ExpressionStatement ||
+          current.type === AST_NODE_TYPES.VariableDeclaration
+        ) {
+          return false;
+        }
+        current = current.parent;
+      }
+      const leading = sourceCode.getCommentsBefore(current);
+      return leading.some((comment) => {
+        return comment.value.includes(EXEMPTION_MARKER);
+      });
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        const callee = node.callee;
+        if (callee.type !== AST_NODE_TYPES.MemberExpression) {
+          return;
+        }
+        if (callee.computed) {
+          return;
+        }
+        if (
+          callee.object.type !== AST_NODE_TYPES.Identifier ||
+          callee.object.name !== "http"
+        ) {
+          return;
+        }
+        if (callee.property.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+        const method = callee.property.name;
+        if (!MSW_METHODS.has(method)) {
+          return;
+        }
+
+        const [urlArg] = node.arguments;
+        if (!urlArg) {
+          return;
+        }
+        if (
+          urlArg.type !== AST_NODE_TYPES.Literal ||
+          typeof urlArg.value !== "string"
+        ) {
+          return;
+        }
+
+        const match = INTERNAL_API_RE.exec(urlArg.value);
+        if (!match) {
+          return;
+        }
+
+        if (hasExemptionComment(node)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: "useMockApi",
+          data: { method, bucket: match[1] ?? "zero" },
+        });
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -109,6 +109,7 @@ export default [
       "ccstate/no-test-delay": "error",
       "ccstate/no-get-by-role-name": "error",
       "ccstate/no-user-clear-tab": "error",
+      "ccstate/no-raw-msw-http": "error",
       "no-restricted-syntax": [
         "error",
         {
@@ -164,6 +165,16 @@ export default [
     ],
     rules: {
       "ccstate/no-direct-fetch": "off",
+    },
+  },
+  // Allow raw http.* in the fetch$ wrapper self-tests. The file exercises the
+  // wrapper against synthetic URLs (`/test`, `/api/zero/items`) that do not
+  // correspond to any ts-rest contract — see the file-level comment in
+  // src/signals/__tests__/fetch.test.ts for the full rationale.
+  {
+    files: ["src/signals/__tests__/fetch.test.ts"],
+    rules: {
+      "ccstate/no-raw-msw-http": "off",
     },
   },
   // Allow direct localStorage in the abstraction layer only


### PR DESCRIPTION
Closes #10091. Capstone for Phase 3 umbrella #10083.

## Summary

- Adds `ccstate/no-raw-msw-http` under `turbo/apps/platform/custom-eslint/rules/`, enabled on `**/__tests__/**/*.{ts,tsx}`
- Flags `http.(get|post|put|patch|delete)(url, ...)` when the URL string literal matches `/api/(zero|v1)/`
- Honors the existing `// mockApi cannot be used here: <reason>` exemption convention established by #10178 — the rule skips when that marker appears on a leading comment of the call or its enclosing statement
- Third-party fakes (`slack.com/api/...`) and synthetic non-api paths are not flagged because the check is path-scoped
- `src/signals/__tests__/fetch.test.ts` is in the rule's file allowlist (fetch\$ wrapper self-tests against synthetic URLs, already documented by a file-level header comment)

## Why

Phase 3 (#10083) migrated 155 platform test files from raw `http.*` to `mockApi(contract.route, ...)`. Without a guardrail the migration decays — a new raw handler is the easy local choice but silently re-introduces the drift the migration was designed to prevent. This rule turns the convention into a CI failure (`pnpm -F @vm0/app lint`).

## No code fixes needed

After #10178 landed, every remaining `http.*` site under `turbo/apps/platform/src/**/__tests__/` (32 call sites across 15 files) is either:
- Against a third-party or synthetic URL the rule does not flag, or
- Preceded by the `mockApi cannot be used here:` exemption comment.

So this PR is purely additive — no existing test file is modified.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run custom-eslint/__tests__/no-raw-msw-http.test.ts` — 15/15 pass (8 valid / 7 invalid)
- [x] `pnpm -F @vm0/app exec vitest run custom-eslint/` — 212/212 pass across all custom-eslint rules
- [x] `pnpm -F @vm0/app lint` — clean (rule fires on 0 existing sites)
- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)