### PR TITLE
ci(release): gate promote-web on all component builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -980,6 +980,13 @@ jobs:
 
           echo "Updated rollback dashboard issue #${ISSUE_NUMBER}"
 
+  # CLI npm package is intentionally NOT gated on build-web / build-app /
+  # build-runner. It's a separately-versioned product on its own cadence;
+  # users install at arbitrary times, so CLI <-> web must already be
+  # bidirectionally compatible as a product invariant. Gating here would
+  # couple CLI releases to unrelated infra flakiness in the bundled-product
+  # pipeline. Do not add those builds to needs without rethinking the CLI
+  # compatibility contract.
   publish-npm:
     needs: [release-please, migrate-production]
     if: ${{ needs.release-please.outputs.cli_release_created == 'true' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -390,9 +390,13 @@ jobs:
                   text: "*Web App* ❌ Staged build failed\n📦 Version: `${{ needs.release-please.outputs.web_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/web-v${{ needs.release-please.outputs.web_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
 
   # Promote web staged deployment to production (traffic switch).
-  # Gates on all component builds — if any build fails, no component is
-  # promoted, so production never lands in a partial-release state
-  # (e.g. new web schema live while build-app failed and app/runner still old).
+  # Also acts as the atomic-release gate: if any component build fails,
+  # no component promotes, so production never lands in a partial-release
+  # state (e.g. new web schema live while build-app failed and app/runner
+  # still old). promote-app needs build-app directly, but promote-runner
+  # does NOT need build-app — the gate propagates to promote-runner via
+  # GHA's failure() ancestor-transitivity through this job. Do not relax
+  # these needs without reworking the promote-runner side.
   # build-app and build-runner may be skipped when their release didn't fire
   # this cycle; `!failure() && !cancelled()` lets the job proceed in that case.
   promote-web-production:
@@ -1340,6 +1344,11 @@ jobs:
   # promote-web-production so the new runner only serves traffic after
   # the schema and API it targets are live. Host-level prep
   # (provision-runner, provision-monitoring) already ran in build.
+  # promote-web-production also serves as the atomic-release gate —
+  # if build-app or any sibling build failed, promote-web is skipped and
+  # its failure cascades here via GHA's failure() ancestor-transitivity,
+  # blocking runner promotion too. Keep promote-web in needs so this
+  # cross-component gate stays intact.
   promote-runner-production:
     needs: [release-please, migrate-production, promote-web-production, resolve-image-cache, build-runner-production]
     if: >-

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -389,10 +389,22 @@ jobs:
                   type: mrkdwn
                   text: "*Web App* ❌ Staged build failed\n📦 Version: `${{ needs.release-please.outputs.web_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/web-v${{ needs.release-please.outputs.web_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
 
-  # Promote web staged deployment to production (traffic switch)
+  # Promote web staged deployment to production (traffic switch).
+  # Gates on all component builds — if any build fails, no component is
+  # promoted, so production never lands in a partial-release state
+  # (e.g. new web schema live while build-app failed and app/runner still old).
+  # build-app and build-runner may be skipped when their release didn't fire
+  # this cycle; `!failure() && !cancelled()` lets the job proceed in that case.
   promote-web-production:
-    needs: [release-please, migrate-production, build-web-production]
-    if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
+    needs:
+      - release-please
+      - migrate-production
+      - build-web-production
+      - build-app-production
+      - build-runner-production
+    if: >-
+      !failure() && !cancelled() &&
+      needs.release-please.outputs.web_release_created == 'true'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260419


### PR DESCRIPTION
## Summary

- Add `build-app-production` and `build-runner-production` to `promote-web-production`'s `needs`, so a failure in any component build blocks the entire release — production never lands in a partial-release state (e.g. new web schema live while app/runner stay on the old version because their build failed and promote never ran).
- Switch `promote-web`'s `if` from `success()` (default) to `!failure() && !cancelled() && web_release_created == 'true'`, so cycles that don't release app or runner (their build skipped) still allow web to promote.

## Why

Previously `promote-web` only waited on `build-web` + `migrate`. If `build-app` or `build-runner` failed after `build-web` succeeded, `promote-web` still ran. Downstream `promote-app` was correctly blocked (it needs `build-app-production` directly), but `promote-runner` has no direct dependency on `build-app`, so `build-app ❌ + build-runner ✅` would ship **new web + new runner + old app**.

Routing all promotes through the `promote-web` gate (via GHA's transitive `failure()` ancestor semantics) blocks `promote-runner` too whenever any sibling build fails.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| All builds ✅ | all promote | all promote (unchanged) |
| Only web release this cycle (app/runner builds skipped by their `if`) | web promotes | web promotes (via `!failure() && !cancelled()`) |
| `build-app` fails, web+runner succeed | **new web + new runner + old app** | nothing promotes — release blocked |
| `build-runner` fails, web+app succeed | **new web + new app + old runner** | nothing promotes — release blocked |
| Workflow cancelled | nothing promotes | nothing promotes (unchanged) |

## Intentionally not gated: `publish-npm`

The CLI npm package is a separate product on its own release cadence. Users install it at arbitrary times, so CLI ↔ web must already be bidirectionally compatible as a product invariant — the web/app/runner atomic-release gate doesn't apply. Gating `publish-npm` on unrelated web/app/runner build failures would also couple CLI releases to infra flakiness in the bundled-product pipeline, which is undesirable.

## Test plan

- [ ] YAML syntax validated locally (`python3 -c "yaml.safe_load(...)"`)
- [ ] Behavior manually traced through all 8 `*_release_created` combinations × build outcomes
- [ ] Pattern matches existing `promote-app-production` / `promote-runner-production` `if` expressions already in production use
- [ ] Dry-run on next release (monitor that web-only releases still promote end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)