### PR TITLE
test(web): stub stripe key and add restoremocks to prevent usage test flakiness

### DIFF
--- a/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
@@ -57,6 +57,19 @@ describe("GET /api/zero/usage/members", () => {
   beforeEach(async () => {
     context.setupMocks();
     await context.setupUser();
+    // Default so the Stripe refresh path in getOrgBillingPeriod never hits an
+    // undefined response. Tests that exercise a stale/missing period still
+    // benefit from a valid shape here.
+    stripeMocks.subscriptionsRetrieve.mockResolvedValue({
+      items: {
+        data: [
+          {
+            current_period_end:
+              Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+          },
+        ],
+      },
+    });
   });
 
   it("returns 401 when not authenticated", async () => {

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -48,6 +48,9 @@ const resetEnv = vi.hoisted(() => {
     vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/default");
     // AgentPhone integration
     vi.stubEnv("AGENTPHONE_API_KEY", "test-agentphone-api-key");
+    // Stripe billing — `vi.mock("stripe", ...)` replaces the constructor, but
+    // init-services.ts throws before reaching it if STRIPE_SECRET_KEY is unset.
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake_for_testing");
     // API URL for compose job webhooks
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     // App UI URL

--- a/turbo/apps/web/vitest.config.ts
+++ b/turbo/apps/web/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
     // Don't override env vars, let them pass through from system
     // Automatically clear mocks before each test (eliminates manual vi.clearAllMocks() calls)
     clearMocks: true,
+    // Restore original implementations of spies between tests. Without this,
+    // `vi.spyOn(Date, "now").mockReturnValue(...)` from one test leaks into
+    // the next — the next `vi.spyOn(Date, "now")` wraps the already-mocked
+    // function and silently inherits the stale return value, corrupting any
+    // code path that reads the current time.
+    restoreMocks: true,
     // Automatically restore all env stubs after each test (prevents cross-test leakage)
     unstubEnvs: true,
   },


### PR DESCRIPTION
## Summary

Addresses the three deeper flakiness root causes identified in #10193 that remained after #10175 patched the immediate date-bomb.

- **stub `STRIPE_SECRET_KEY`** in `setup.ts` — the lazy Stripe getter in `init-services.ts:93` otherwise throws before `vi.mock("stripe")` can intercept, producing spurious 500s in any test that triggers the Stripe refresh path.
- **add `restoreMocks: true`** to `vitest.config.ts` — `clearMocks: true` only wipes call history, not `mockReturnValue`. Without `restoreMocks`, `vi.spyOn(Date, "now").mockReturnValue(...)` from one test leaks into later tests because the next `vi.spyOn(Date, "now")` wraps the already-mocked function and silently inherits the stale timestamp.
- **set a default `subscriptionsRetrieve` resolved value** in the `members` route test `beforeEach` — a bare `vi.fn()` resolves to `undefined`, so `subscription.items.data[0]` throws a secondary `TypeError` whenever the Stripe refresh path is incidentally reached.

## Test plan

- [x] `pnpm exec vitest run app/api/zero/usage` — 23 passed (3 files)
- [x] `pnpm exec vitest run app/api/zero/integrations/slack` — 55 passed (factory-set Slack mocks in `setup.ts` survive `restoreMocks: true`)
- [x] `pnpm exec vitest run app/api/cron/execute-schedules` — 20 passed
- [x] `pnpm exec vitest run app/api/zero/usage/members/__tests__/route.test.ts` — 5 passed
- [x] `pnpm turbo run lint --filter=web` — 0 errors on affected files
- [x] `pnpm check-types --filter=web` — no new errors (10 pre-existing errors in unrelated route files)
- [x] `pnpm format` — clean
- [x] `pnpm knip --workspace apps/web` — clean

## Note on pre-existing flakiness (not in scope)

The full web-app suite surfaces 3 failures in `app/api/cron/compare-proxy-usage/__tests__/route.test.ts` that pass when the file runs alone — this is inter-file state pollution unrelated to the mocks being fixed here. `app/api/cron/voice-chat-cleanup/__tests__/route.test.ts` has similar cross-file DB-leak flakiness on `main`. Both exist independently of these changes and are out of scope for #10193.

Closes #10193

🤖 Generated with [Claude Code](https://claude.com/claude-code)