### PR TITLE
fix(web): scope sandbox/pat token clerk bypass to /api/* paths

### DIFF
--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -150,4 +150,31 @@ describe("proxy middleware: sandbox token handling", () => {
     expect(capturedClerkRequest).toBeDefined();
     expect(capturedClerkRequest!.headers.get("authorization")).toBe(token);
   });
+
+  it("should strip sandbox token and still call Clerk on non-API paths", async () => {
+    // Bot/scanner traffic: sandbox token sent to a page route. Without this
+    // behavior, Clerk middleware is skipped and any server component calling
+    // auth() throws "clerkMiddleware not detected". See issue #10164.
+    const token = "Bearer vm0_sandbox_header.payload.signature";
+    const request = new NextRequest("https://www.vm0.ai/en", {
+      headers: { authorization: token },
+    });
+
+    await middleware(request, createMockEvent());
+
+    expect(capturedClerkRequest).toBeDefined();
+    expect(capturedClerkRequest!.headers.get("authorization")).toBeNull();
+  });
+
+  it("should strip PAT token and still call Clerk on non-API paths", async () => {
+    const token = "Bearer vm0_pat_header.payload.signature";
+    const request = new NextRequest("https://www.vm0.ai/", {
+      headers: { authorization: token },
+    });
+
+    await middleware(request, createMockEvent());
+
+    expect(capturedClerkRequest).toBeDefined();
+    expect(capturedClerkRequest!.headers.get("authorization")).toBeNull();
+  });
 });

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -123,12 +123,21 @@ export default async function middleware(
     authHeader?.startsWith("Bearer " + SANDBOX_TOKEN_PREFIX) ||
     authHeader?.startsWith("Bearer " + PAT_TOKEN_PREFIX);
 
+  // Self-signed tokens (sandbox, PAT) are only consumed by /api/* endpoints.
+  // Bypass Clerk for those paths so it doesn't try to parse the non-JWT token.
+  // For non-API paths (pages, bot/scanner traffic), strip the header before
+  // calling Clerk so auth() in server components resolves to an anonymous
+  // session instead of throwing "clerkMiddleware not detected".
   if (hasSelfSignedToken) {
-    // Self-signed tokens (sandbox, PAT) are used by API endpoints which don't need Clerk auth.
-    // Skip Clerk entirely and pass the request through with the original
-    // Authorization header intact. This avoids relying on x-middleware-request-*
-    // header restoration which doesn't work reliably in Next.js dev mode.
-    return NextResponse.next();
+    if (request.nextUrl.pathname.startsWith("/api/")) {
+      return NextResponse.next();
+    }
+    const scrubbedHeaders = new Headers(request.headers);
+    scrubbedHeaders.delete("authorization");
+    const scrubbedRequest = new NextRequest(request, {
+      headers: scrubbedHeaders,
+    });
+    return clerk(scrubbedRequest, event);
   }
 
   return clerk(request, event);


### PR DESCRIPTION
## Summary

- Closes #10164 (Sentry WEB-2D: `Clerk: auth() was called but Clerk can't detect usage of clerkMiddleware()`)
- The self-signed token bypass in `proxy.ts` was keyed on header shape alone — any request carrying `Authorization: Bearer vm0_sandbox_*` or `Bearer vm0_pat_*` skipped Clerk middleware, regardless of path. Scanner/bot traffic sending such a header to a page route (e.g. `/`, `/:locale`) caused `app/[locale]/page.tsx`'s server-side `auth()` call to throw.

## Why

Sandbox and PAT tokens are consumed **only** by `/api/*` endpoints; there's no legitimate caller that sends them to a page. Sentry showed 22 events in 24h with 0 users affected — classic scanner traffic.

## Fix

- `/api/*` + self-signed token → unchanged (bypass Clerk, pass through)
- Non-`/api/*` + self-signed token → strip `Authorization` header, then run Clerk so the request renders as anonymous (no "middleware not detected" throw)

## Test plan

- [x] Updated `__tests__/proxy.sandbox-token.test.ts` — added two cases verifying that sandbox/PAT tokens on `/en` and `/` now reach Clerk with the authorization header stripped
- [x] Existing 6 tests still pass (8/8 green)
- [x] `pnpm -F web exec vitest run __tests__/proxy.sandbox-token.test.ts` passes locally
- [x] `pnpm format` clean, lefthook pre-commit (prettier / knip / commitlint) green
- [ ] CI (test-web, lint, lighthouse) stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)