### PR TITLE
fix(runner): strip dynamic-linker header from static musl binary

### DIFF
--- a/crates/.cargo/config.toml
+++ b/crates/.cargo/config.toml
@@ -1,3 +1,9 @@
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
-rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-fuse-ld=mold"]
+# --no-dynamic-linker strips the PT_INTERP header from the fully-static
+# (`+crt-static`) binary. Without it, arm64-host builds via apt's
+# `musl-dev` gcc wrapper hard-code `-dynamic-linker /lib/ld-musl-aarch64.so.1`
+# in its specs file, so the binary fails to exec on Ubuntu hosts that
+# only ship the glibc loader. The binary has no `.dynamic` section, so
+# the interpreter was never needed at runtime anyway.
+rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-Wl,--no-dynamic-linker", "-C", "link-arg=-fuse-ld=mold"]

--- a/crates/.cargo/config.toml
+++ b/crates/.cargo/config.toml
@@ -6,4 +6,8 @@ linker = "aarch64-linux-musl-gcc"
 # in its specs file, so the binary fails to exec on Ubuntu hosts that
 # only ship the glibc loader. The binary has no `.dynamic` section, so
 # the interpreter was never needed at runtime anyway.
-rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-Wl,--no-dynamic-linker", "-C", "link-arg=-fuse-ld=mold"]
+rustflags = [
+  "-C", "target-feature=+crt-static",
+  "-C", "link-arg=-Wl,--no-dynamic-linker",
+  "-C", "link-arg=-fuse-ld=mold",
+]

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -68,11 +68,11 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 # arm64 host uses apt's musl-dev which ships /usr/bin/aarch64-linux-musl-gcc
 # as a wrapper around gnu gcc + a musl-gcc.specs file that switches
 # include paths to musl headers; the gnu gcc is pulled in transitively
-# via musl-dev's Depends.
-#
-# NOTE: crates/.cargo/config.toml still sets linker to aarch64-linux-gnu-gcc.
-# It is swapped to aarch64-linux-musl-gcc in a follow-up PR that also bumps
-# the workflow image tag to pick up this toolchain.
+# via musl-dev's Depends. That wrapper unconditionally passes
+# `-dynamic-linker /lib/ld-musl-aarch64.so.1` to the linker even under
+# `-static`, so runner and guest targets pass `-Wl,--no-dynamic-linker`
+# via crates/.cargo/config.toml to keep the fully-static output working
+# on Ubuntu hosts that don't ship the musl loader.
 ARG MUSL_CROSS_VERSION=2025.08-1
 ARG MUSL_CROSS_SHA256=defba831ffa1175236f137069333e21ed46d4d19feb5080a90cf248b6fc2cb08
 ENV PATH="/opt/aarch64--musl--stable-${MUSL_CROSS_VERSION}/bin:${PATH}"


### PR DESCRIPTION
## Summary

- arm64 devcontainer builds produced runner binaries with a `PT_INTERP = /lib/ld-musl-aarch64.so.1` header despite `+crt-static` linking. Ubuntu hosts don't ship a musl loader, so `pnpm runner` died at `Running setup...` with `sudo: unable to execute …: No such file or directory` (ENOENT on the missing loader, confusingly pinned on the binary itself)
- Root cause: apt's `musl-dev` wrapper (`aarch64-linux-musl-gcc`) is a shell shim around GNU gcc that force-adds `-dynamic-linker /lib/ld-musl-aarch64.so.1` to every link, even under `-static`. amd64 CI builds via Bootlin's real cross-compiler do the right thing, which is why CI deploys kept working
- Fix: add `-Wl,--no-dynamic-linker` to the aarch64-musl rustflags. The binary has no `.dynamic` section, so the interpreter was only ever a stale header — dropping it makes the static binary portable across any host
- Refresh the stale Dockerfile comment left over from #10102 / #10120 (it still described the pre-#10120 state where `.cargo/config.toml` used `aarch64-linux-gnu-gcc`)

## Test plan

- [x] Rebuild runner locally (arm64 devcontainer): `readelf -l target/.../runner | grep INTERP` → 0 matches (was `/lib/ld-musl-aarch64.so.1` before)
- [x] `pnpm runner` end-to-end: previously failed at `Running setup...` with ENOENT; now deploys cleanly through `Stopping → Deploying → Setup → Build profile → Config → Starting service → Done!` and exits 0
- [ ] CI: Bootlin-built binaries already lack INTERP, so the flag is a no-op there — but verify `lint-types` / `test-other` / `deploy-runner-*` still green
- [ ] Production runners: once this merges, next deploy will reproduce the guarantee across all hosts regardless of host arch

## Notes

- Binary size and architecture unchanged; only the ELF program header table shrinks by one entry (the interpreter was never loaded at runtime anyway)
- Behavior for local dev (arm64 host) and CI (amd64 host) converges — both now always produce PT_INTERP-free binaries
- Related: #10120 (musl cross-toolchain migration that exposed this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)