### PR TITLE
fix(runner): delay first interval tick to avoid racing discover_fut

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -2707,6 +2707,54 @@ mod tests {
         }
     }
 
+    /// Regression for #10146 / #10223: the main-loop `idle_cleanup` and
+    /// `heartbeat_tick` intervals must defer their first tick past the
+    /// configured period, so neither arm is Ready on the first `select!`
+    /// poll. Otherwise they pre-empt `discover_fut` (which parks on
+    /// `rx.recv()` → Pending) and any silent `mode_tx` flip during the
+    /// tick body breaks the loop before the pending job is ever claimed.
+    ///
+    /// The behavioral test `claim_after_stopping_sent_cancels_new_job`
+    /// only triggers the underlying race under `cargo llvm-cov`, so a
+    /// silent revert of `interval_at` → `interval` would not fail it on
+    /// the default CI path. This test pins the invariant directly: a
+    /// job pushed immediately at startup is processed without any tick
+    /// having fired, observable via `heartbeat_count == 0`.
+    #[tokio::test(start_paused = true)]
+    async fn startup_ticks_defer_past_first_select_poll() {
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+        let run_handle = tokio::spawn(run(config));
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            env.handle.discover_entered.notified(),
+        )
+        .await
+        .expect("run() did not enter discover_fut select! within 2s");
+
+        // `minimal_context` → no session → completion path does not trigger
+        // `park_notify`, so any heartbeat observed here came from the
+        // interval tick (the path we want to prove did NOT fire).
+        let run_id = RunId::new_v4();
+        push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(completion.is_some(), "job must complete");
+
+        assert_eq!(
+            env.handle.heartbeat_count(),
+            0,
+            "heartbeat tick fired before the startup job was processed — \
+             is the main-loop interval `interval_at(now + period, period)` \
+             instead of `interval(period)`?"
+        );
+
+        shutdown(&env, run_handle).await;
+    }
+
     /// `handle_drain_signal` state guard: SIGUSR1 is honored only from
     /// Running. Mirrors `handle_resume_signal`'s Draining-only guard.
     #[test]

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -461,13 +461,30 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // -----------------------------------------------------------------------
     // Idle pool cleanup interval (every 10 seconds)
     // -----------------------------------------------------------------------
-    let mut idle_cleanup = tokio::time::interval(Duration::from_secs(10));
+    // `interval` fires its first tick immediately. In the main-loop
+    // `tokio::select!` this can pre-empt `discover_fut` on its very first
+    // poll — the discover future parks on `rx.recv()` (Pending) while the
+    // interval tick is Ready, so select deterministically picks the tick.
+    // Inside the tick arm any silent watch flip (`send_if_modified(.., false)`)
+    // lands before the loop returns to the discover arm, and the top-of-loop
+    // `borrow_and_update()` then breaks out before the pending job is ever
+    // claimed. Delaying the first tick by one period keeps both arms Pending
+    // on entry, so `discover_fut` wins the first wake. No observable prod
+    // effect: idle cleanup on an empty pool and the first heartbeat were
+    // both fine to happen ~10s later.
+    let mut idle_cleanup = tokio::time::interval_at(
+        tokio::time::Instant::now() + Duration::from_secs(10),
+        Duration::from_secs(10),
+    );
     idle_cleanup.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     // -----------------------------------------------------------------------
-    // Heartbeat interval (every 10 seconds)
+    // Heartbeat interval (every 10 seconds) — same first-tick delay as above.
     // -----------------------------------------------------------------------
-    let mut heartbeat_tick = tokio::time::interval(Duration::from_secs(10));
+    let mut heartbeat_tick = tokio::time::interval_at(
+        tokio::time::Instant::now() + Duration::from_secs(10),
+        Duration::from_secs(10),
+    );
     heartbeat_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     // -----------------------------------------------------------------------

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -2721,7 +2721,7 @@ mod tests {
     /// job pushed immediately at startup is processed without any tick
     /// having fired, observable via `heartbeat_count == 0`.
     #[tokio::test(start_paused = true)]
-    async fn startup_ticks_defer_past_first_select_poll() {
+    async fn heartbeat_tick_defers_past_first_select_poll() {
         let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -3480,8 +3480,10 @@ mod tests {
         let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
-        // Wait for the first heartbeat tick to fire (initial interval fires
-        // immediately, but give the loop time to process it).
+        // Snapshot the heartbeat count before pushing a job. The first
+        // interval tick is now deferred by one period (`interval_at`), so
+        // `before` is typically 0; the 100 ms settle time just lets the
+        // main loop reach its idle select state.
         tokio::time::sleep(Duration::from_millis(100)).await;
         let before = env.handle.heartbeat_count();
 


### PR DESCRIPTION
## Summary

Root-cause fix for the `claim_after_stopping_sent_cancels_new_job` flake observed under CI coverage.

`tokio::time::interval` fires its first tick immediately. In the main-loop `select!`, `idle_cleanup` and `heartbeat_tick` first ticks were Ready on entry while `discover_fut` parked on `rx.recv()` and returned Pending. select therefore picked a tick arm instead of discover on the first iteration — any silent `send_if_modified(.., false)` issued against `mode_tx` during the tick body (tests today, any future caller that flips mode without firing `changed()`) landed before the loop returned to discover, and the top-of-loop `borrow_and_update()` broke out of Running before the pending job was ever claimed.

Fix: use `interval_at(now + period, period)` so both tick arms start Pending. `discover_fut` wins the first wake.

## Verification

Reproduced deterministically with `cargo llvm-cov` (matches CI's coverage mode):

| base | run |
| --- | --- |
| `origin/main` (no fix) | 94 / 100 pass, 6 × 30s timeout |
| `origin/main` + this fix | 100 / 100 pass |

Under release/debug without coverage, main passed 100/100 — coverage instrumentation slows function calls enough to reliably land on the tick arm.

## Prod-behavior delta

- First heartbeat at +10s instead of startup. Next heartbeat fires at +10s either way.
- First idle-cleanup tick at +10s instead of startup. Pool is empty at startup, so the deferred tick is a no-op.

## Test plan

- [x] Reproduce the flake under `cargo llvm-cov` (6/100 → 0/100)
- [x] cargo fmt clean
- [ ] CI turbo + crates green