### PR TITLE
fix(platform): clear feature switch local storage after db sync

### DIFF
--- a/turbo/apps/platform/src/signals/external/__tests__/feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/feature-switch.test.ts
@@ -1,13 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { testContext } from "../../__tests__/test-helpers";
 import { detachedSetupPage } from "../../../__tests__/page-helper";
 import {
   featureSwitch$,
   syncFeatureSwitchToDB$,
   resetFeatureSwitchOverrides$,
+  getFeatureSwitchLocalStorage$,
 } from "../feature-switch";
-import { FeatureSwitchKey } from "@vm0/core";
+import { FeatureSwitchKey, zeroFeatureSwitchesContract } from "@vm0/core";
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches";
+import { server } from "../../../mocks/server";
+import { mockApi } from "../../../mocks/msw-contract";
+
+vi.mock("@vm0/ui/components/ui/sonner", () => {
+  return { toast: { error: vi.fn(), success: vi.fn() } };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 const context = testContext();
 
@@ -106,5 +118,102 @@ describe("feature switch", () => {
 
     const after = await context.store.get(featureSwitch$);
     expect(after.dummy).toBeTruthy();
+  });
+
+  it("should clear localStorage key after successful DB sync", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: { dummy: false },
+      withoutRender: true,
+    });
+
+    // Sanity: localStorage holds the optimistic override
+    expect(context.store.get(getFeatureSwitchLocalStorage$)).toContain("dummy");
+
+    await context.store.set(
+      syncFeatureSwitchToDB$,
+      { [FeatureSwitchKey.Dummy]: false },
+      context.signal,
+    );
+
+    // localStorage is cleaned up; DB is now source of truth
+    expect(context.store.get(getFeatureSwitchLocalStorage$)).toBeNull();
+    const result = await context.store.get(featureSwitch$);
+    expect(result.dummy).toBeFalsy();
+  });
+
+  it("should strip synced key and preserve other in-flight overrides", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: {
+        [FeatureSwitchKey.Dummy]: false,
+        [FeatureSwitchKey.VoiceChat]: true,
+      },
+      withoutRender: true,
+    });
+
+    await context.store.set(
+      syncFeatureSwitchToDB$,
+      { [FeatureSwitchKey.Dummy]: false },
+      context.signal,
+    );
+
+    const stored = context.store.get(getFeatureSwitchLocalStorage$);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored ?? "{}") as Record<string, boolean>;
+    expect(parsed).not.toHaveProperty(FeatureSwitchKey.Dummy);
+    expect(parsed).toHaveProperty(FeatureSwitchKey.VoiceChat, true);
+  });
+
+  it("should strip localStorage and toast on DB sync failure", async () => {
+    server.use(
+      mockApi(zeroFeatureSwitchesContract.update, ({ respond }) => {
+        return respond(500, {
+          error: { message: "Server error", code: "INTERNAL" },
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: { dummy: false },
+      withoutRender: true,
+    });
+
+    await expect(
+      context.store.set(
+        syncFeatureSwitchToDB$,
+        { [FeatureSwitchKey.Dummy]: false },
+        context.signal,
+      ),
+    ).rejects.toThrow("Server error");
+
+    expect(toast.error).toHaveBeenCalledWith("Server error");
+    expect(context.store.get(getFeatureSwitchLocalStorage$)).toBeNull();
+  });
+
+  it("should strip localStorage on abort without toasting", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: { dummy: false },
+      withoutRender: true,
+    });
+
+    const abortedSignal = AbortSignal.abort(new Error("test abort"));
+
+    await expect(
+      context.store.set(
+        syncFeatureSwitchToDB$,
+        { [FeatureSwitchKey.Dummy]: false },
+        abortedSignal,
+      ),
+    ).rejects.toThrow();
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(context.store.get(getFeatureSwitchLocalStorage$)).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -89,6 +89,34 @@ export const overrideFeatureSwitch$ = command(
   },
 );
 
+// The localStorage override is an optimistic buffer that bridges the gap
+// between a user toggle and the DB confirming the write. Once the sync
+// settles (success, HTTP error, or abort) the keys must be stripped so
+// `featureSwitch$` falls through to DB truth; otherwise a silently-dropped
+// DB write leaves a permanent phantom state that only the frontend sees.
+const clearFeatureSwitchLocalKeys$ = command(({ get, set }, keys: string[]) => {
+  const current = get(get$);
+  if (!current) {
+    return;
+  }
+  const parsed = jsonParseOr<Partial<Record<string, boolean>>>(current, {});
+  let changed = false;
+  for (const key of keys) {
+    if (key in parsed) {
+      delete parsed[key];
+      changed = true;
+    }
+  }
+  if (!changed) {
+    return;
+  }
+  if (Object.keys(parsed).length === 0) {
+    set(clear$);
+  } else {
+    set(set$, JSON.stringify(parsed));
+  }
+});
+
 export const syncFeatureSwitchToDB$ = command(
   async (
     { get, set },
@@ -97,11 +125,18 @@ export const syncFeatureSwitchToDB$ = command(
   ) => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroFeatureSwitchesContract);
-    signal.throwIfAborted();
-    await accept(client.update({ body: { switches: overrides } }), [200]);
-    signal.throwIfAborted();
-    set(internalReload$, (v) => {
-      return v + 1;
+
+    const work = async () => {
+      signal.throwIfAborted();
+      await accept(client.update({ body: { switches: overrides } }), [200]);
+      signal.throwIfAborted();
+    };
+
+    await work().finally(() => {
+      set(clearFeatureSwitchLocalKeys$, Object.keys(overrides));
+      set(internalReload$, (v) => {
+        return v + 1;
+      });
     });
   },
 );
@@ -125,3 +160,4 @@ export const resetFeatureSwitchOverrides$ = command(
 );
 
 export const setFeatureSwitchLocalStorage$ = set$;
+export const getFeatureSwitchLocalStorage$ = get$;


### PR DESCRIPTION
## Summary

Fixes #10221

- `syncFeatureSwitchToDB$` now strips the per-feature keys from localStorage in a `.finally()` handler so success, HTTP errors, and aborts all reconcile the optimistic buffer back to the DB-truth path
- Toast on HTTP errors is already provided by `accept()`; abort stays silent (matches existing pageSignal behavior)
- Added 4 integration tests: success clears key, concurrent toggles preserve each other's buffer, HTTP failure clears + toasts, abort clears silently

## Why

The Lab-page localStorage override was an optimistic buffer that bridged the gap between toggle click and DB confirmation, but it was never cleaned up. If the DB write failed or was aborted (navigation, pageSignal abort, network blip, stale orgId), the stale override silently won over DB truth forever — producing permanent phantom ON states only visible to the frontend (e.g. Lab shows `voiceChat: ON` but the API returns `403 Voice chat is not enabled`).

## Test plan

- [x] `pnpm -F @vm0/app exec vitest --run src/signals/external/__tests__/feature-switch.test.ts` — 11/11 pass
- [x] `pnpm -F @vm0/app exec vitest --run` — full platform suite (1831 tests) pass
- [x] `pnpm -F @vm0/app exec oxlint` — 0 errors
- [x] `pnpm -F @vm0/app exec eslint` (changed files) — 0 errors
- [x] `pnpm -F @vm0/app exec tsc --noEmit` — 0 errors
- [x] `pnpm knip --workspace @vm0/app` — no issues
- [ ] Manual verification: toggle a feature in Lab → DevTools shows localStorage `featureSwitch` key disappears after 200 response
- [ ] Manual verification: offline toggle → toast appears → refresh reflects DB truth