### PR TITLE
feat(platform): add dedicated usage page at /_/usage route

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -43,6 +43,7 @@ import { setupLabPage$ } from "./lab-page/lab-page-setup.ts";
 import { setupPhonePage$ } from "./phone-page/phone-page-setup.ts";
 import { setupVoiceChatPage$ } from "./voice-chat/voice-chat-setup.ts";
 import { setupNetworkInsightsPage$ } from "./network-insights/network-insights-page-setup.ts";
+import { setupUsagePage$ } from "./usage-page/usage-page-setup.ts";
 import { initSlackOrg$ as handleSlackRedirect$ } from "./zero-page/zero-slack.ts";
 import { setupSkeletonPage$, setupErrorPage$ } from "./skeleton-page-setup.ts";
 import { startSkeletonCycling$ } from "./app-skeleton.ts";
@@ -188,6 +189,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.voiceChat,
     setup: setupAuthPageWrapper(setupVoiceChatPage$),
+  },
+  {
+    path: ROUTES.usage,
+    setup: setupAuthPageWrapper(setupUsagePage$),
   },
   {
     path: ROUTES.onboarding,

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -26,6 +26,7 @@ export const ROUTES = {
   lab: "/_/lab",
   voiceChat: "/voice-chat",
   insights: "/insights",
+  usage: "/_/usage",
   internalConnectorLogos: "/__internal-connector-logos",
   reportError: "/runs/:runId/report-error",
   missionControl: "/_/mission-control",

--- a/turbo/apps/platform/src/signals/usage-page/usage-page-setup.ts
+++ b/turbo/apps/platform/src/signals/usage-page/usage-page-setup.ts
@@ -1,0 +1,19 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { SidebarLayout } from "../../views/zero-page/sidebar-layout.tsx";
+import { ZeroUsagePage } from "../../views/zero-page/zero-usage-page.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+
+export const setupUsagePage$ = command(async ({ set }, signal: AbortSignal) => {
+  set(
+    updatePage$,
+    createElement(SidebarLayout, null, createElement(ZeroUsagePage)),
+  );
+  set(updateDocumentTitle$, "Usage");
+  await set(hideAppSkeleton$, signal);
+
+  await set(onboardGuard$, signal);
+});

--- a/turbo/apps/platform/src/signals/usage-page/usage-page-setup.ts
+++ b/turbo/apps/platform/src/signals/usage-page/usage-page-setup.ts
@@ -15,5 +15,7 @@ export const setupUsagePage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updateDocumentTitle$, "Usage");
   await set(hideAppSkeleton$, signal);
 
-  await set(onboardGuard$, signal);
+  if (await set(onboardGuard$, signal)) {
+    return;
+  }
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -73,7 +73,8 @@ export type SidebarNavId =
   | "phone"
   | "voiceChat"
   | "missionControl"
-  | "lab";
+  | "lab"
+  | "usage";
 
 export function isChatRoute(key: RouteKey | null): boolean {
   return (
@@ -101,6 +102,7 @@ export const handleZeroNavSelect$ = command(({ set }, id: SidebarNavId) => {
       voiceChat: ROUTES.voiceChat,
       missionControl: ROUTES.missionControl,
       lab: ROUTES.lab,
+      usage: ROUTES.usage,
     } satisfies Record<
       Exclude<SidebarNavId, "queues">,
       (typeof ROUTES)[keyof typeof ROUTES]

--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
@@ -2,11 +2,8 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
-import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.ts";
 import { setMockUsageInsight } from "../../../mocks/handlers/api-usage-insight.ts";
 import { resetAllMockHandlers } from "../../../mocks/handlers/index.ts";
-import { FeatureSwitchKey } from "@vm0/core";
 
 const context = testContext();
 
@@ -14,15 +11,8 @@ beforeEach(() => {
   resetAllMockHandlers();
 });
 
-describe("org usage tab — usage insight view", () => {
-  it("renders UsageInsightView when usageAnalytics feature switch is on", async () => {
-    setMockBillingStatus({
-      tier: "pro",
-      credits: 10_000,
-      subscriptionStatus: "active",
-      hasSubscription: true,
-    });
-    setMockFeatureSwitches({ [FeatureSwitchKey.UsageAnalytics]: true });
+describe("/_/usage page", () => {
+  it("renders the page header and usage insight content", async () => {
     setMockUsageInsight({
       buckets: [
         {
@@ -55,36 +45,19 @@ describe("org usage tab — usage insight view", () => {
       grandTotalTokens: 2600,
     });
 
-    detachedSetupPage({ context, path: "/?settings=usage" });
+    detachedSetupPage({ context, path: "/_/usage" });
 
     await waitFor(() => {
-      expect(screen.getByText("Usage Insights")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Usage" }),
+      ).toBeInTheDocument();
     });
 
-    // Detail sections render
+    expect(screen.getByText("Usage Insights")).toBeInTheDocument();
+
     await waitFor(() => {
       expect(screen.getByText("My Schedule")).toBeInTheDocument();
     });
     expect(screen.getByText("Chat with Agent")).toBeInTheDocument();
-  });
-
-  it("shows OverviewSection (credit balance) when usageAnalytics is disabled", async () => {
-    setMockBillingStatus({
-      tier: "pro",
-      credits: 8000,
-      subscriptionStatus: "active",
-      hasSubscription: true,
-    });
-    setMockFeatureSwitches({ [FeatureSwitchKey.UsageAnalytics]: false });
-
-    detachedSetupPage({ context, path: "/?settings=usage" });
-
-    // OverviewSection shows credit balance, not the Usage Insights heading
-    await waitFor(() => {
-      const info = screen.getByTestId("credit-balance-info");
-      expect(info).toHaveTextContent("8,000");
-    });
-
-    expect(screen.queryByText("Usage Insights")).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-view.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-view.tsx
@@ -55,7 +55,7 @@ export function UsageInsightView() {
         <h2 className="text-sm font-medium text-foreground">Usage Insights</h2>
         <div className="flex items-center gap-2">
           <Select value={range} onValueChange={handleRangeChange}>
-            <SelectTrigger className="h-8 w-[90px] text-xs">
+            <SelectTrigger className="h-8 w-[120px] text-xs">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -1,16 +1,14 @@
-import { useGet, useLoadable, useSet, useLastResolved } from "ccstate-react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { createPortal } from "react-dom";
-import { FeatureSwitchKey, type OrgMember, type MemberUsage } from "@vm0/core";
+import type { OrgMember, MemberUsage } from "@vm0/core";
 import { IconUsers, IconPencil, IconLoader2 } from "@tabler/icons-react";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { Button, Input } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { usageMembersAsync$ } from "../../../../signals/usage-page/usage-signals.ts";
 import { orgMembers$ } from "../../../../signals/external/org-members.ts";
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
-import { UsageInsightView } from "../../../usage-page/components/usage-insight-view.tsx";
 import {
   billingStatusAsync$,
   apiTierToBillingTier,
@@ -383,12 +381,5 @@ function MembersTable({
 // ---------------------------------------------------------------------------
 
 export function OrgUsageTab() {
-  const features = useLastResolved(featureSwitch$);
-  const analyticsEnabled = features?.[FeatureSwitchKey.UsageAnalytics] ?? false;
-
-  if (analyticsEnabled) {
-    return <UsageInsightView />;
-  }
-
   return <OverviewSection />;
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -12,6 +12,7 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   IconChartLine,
+  IconChartBar,
   IconLayoutGrid,
   IconCalendar,
   IconUsers,
@@ -176,6 +177,15 @@ const FOOTER_NAV = [
     icon: IconFlask as NavIcon,
     iconImg: undefined,
     featureGate: FeatureSwitchKey.Lab,
+  },
+  {
+    id: "usage",
+    activeKeys: ["usage"],
+    pathname: "/_/usage",
+    label: "Usage",
+    icon: IconChartBar as NavIcon,
+    iconImg: undefined,
+    featureGate: FeatureSwitchKey.UsageAnalytics,
   },
 ] as const satisfies readonly FooterNavItem[];
 

--- a/turbo/apps/platform/src/views/zero-page/zero-usage-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-usage-page.tsx
@@ -1,0 +1,27 @@
+import { UsageInsightView } from "../usage-page/components/usage-insight-view.tsx";
+
+export function ZeroUsagePage() {
+  return (
+    <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
+      <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-3 md:pt-10 pb-0 md:pb-3">
+        <div className="mx-auto w-full max-w-[900px]">
+          <div className="hidden md:block">
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">
+              Usage
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Your credit and token consumption across chats, schedules, and
+              channels.
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 px-4 sm:px-6 pt-3 pb-16">
+        <div className="mx-auto w-full max-w-[900px]">
+          <UsageInsightView />
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a dedicated `/_/usage` route that renders `ZeroUsagePage` with the existing `UsageInsightView`
- Wire up sidebar navigation (gated behind `FeatureSwitchKey.UsageAnalytics`) and route setup
- Remove the feature-gated in-tab rendering from `OrgUsageTab`, moving the insight view to the new page
- Widen the range select trigger from 90px to 120px so the label fits

## Test plan
- [x] New integration test `usage-page.test.tsx` verifies `/_/usage` renders header and insight content
- [x] `pnpm turbo run lint` passes
- [x] `pnpm check-types` passes
- [x] `pnpm -F @vm0/app exec vitest run src/views/usage-page` passes
- [x] `pnpm knip` clean