### PR TITLE
feat(cli): add --prompt and --prompt-file flags to schedule commands

### DIFF
--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
-import { writeFileSync, unlinkSync, mkdtempSync, rmdirSync } from "node:fs";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { server } from "../../../../mocks/server";
@@ -214,8 +214,7 @@ describe("zero schedule setup command", () => {
     });
 
     afterEach(() => {
-      unlinkSync(promptPath);
-      rmdirSync(tmpDir);
+      rmSync(tmpDir, { recursive: true, force: true });
     });
 
     it("should send file content as prompt when --prompt-file is used", async () => {

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { writeFileSync, unlinkSync, mkdtempSync, rmdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { server } from "../../../../mocks/server";
@@ -63,15 +63,10 @@ describe("zero schedule setup command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
+    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
-  });
-
-  afterEach(() => {
-    mockExit.mockClear();
-    mockConsoleLog.mockClear();
-    mockConsoleError.mockClear();
   });
 
   describe("successful setup (non-interactive)", () => {
@@ -209,15 +204,18 @@ describe("zero schedule setup command", () => {
   });
 
   describe("prompt from file", () => {
+    let tmpDir: string;
     let promptPath: string;
 
     beforeEach(() => {
-      promptPath = join(tmpdir(), "schedule-prompt.md");
+      tmpDir = mkdtempSync(join(tmpdir(), "schedule-prompt-"));
+      promptPath = join(tmpDir, "prompt.md");
       writeFileSync(promptPath, "prompt loaded from file");
     });
 
     afterEach(() => {
       unlinkSync(promptPath);
+      rmdirSync(tmpDir);
     });
 
     it("should send file content as prompt when --prompt-file is used", async () => {

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
@@ -9,6 +9,9 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { server } from "../../../../mocks/server";
 import { setupCommand } from "../setup";
 import chalk from "chalk";
@@ -202,6 +205,108 @@ describe("zero schedule setup command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Schedule");
       expect(logCalls).toContain("created");
+    });
+  });
+
+  describe("prompt from file", () => {
+    let promptPath: string;
+
+    beforeEach(() => {
+      promptPath = join(tmpdir(), "schedule-prompt.md");
+      writeFileSync(promptPath, "prompt loaded from file");
+    });
+
+    afterEach(() => {
+      unlinkSync(promptPath);
+    });
+
+    it("should send file content as prompt when --prompt-file is used", async () => {
+      let capturedPrompt: string | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") !== "my-agent") {
+            return HttpResponse.json(
+              { error: { message: "Not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          }
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+        http.post(
+          "http://localhost:3000/api/zero/schedules",
+          async ({ request }) => {
+            const body = (await request.json()) as { prompt: string };
+            capturedPrompt = body.prompt;
+            return HttpResponse.json(mockDeployResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--frequency",
+        "daily",
+        "--time",
+        "09:00",
+        "--timezone",
+        "UTC",
+        "--prompt-file",
+        promptPath,
+      ]);
+
+      expect(capturedPrompt).toBe("prompt loaded from file");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("created");
+    });
+
+    it("should reject combining --prompt and --prompt-file", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") !== "my-agent") {
+            return HttpResponse.json(
+              { error: { message: "Not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          }
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "my-agent",
+          "--frequency",
+          "daily",
+          "--time",
+          "09:00",
+          "--timezone",
+          "UTC",
+          "--prompt",
+          "inline prompt",
+          "--prompt-file",
+          promptPath,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot use --prompt and --prompt-file together",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
@@ -7,7 +7,7 @@
  * - Real (internal): All CLI code, formatters, validators
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
 import { statusCommand } from "../status";

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
@@ -117,6 +117,50 @@ describe("zero schedule status command", () => {
       expect(logCalls).toContain("0 9 * * 1");
     });
 
+    it("should show full prompt without truncation with --prompt flag", async () => {
+      const longPrompt =
+        "a".repeat(120) +
+        " this is clearly past the 60-character preview limit";
+      const longSchedule = { ...mockSchedule, prompt: longPrompt };
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [longSchedule] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "my-agent", "--prompt"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(longPrompt);
+      expect(logCalls).not.toMatch(/a{57}\.\.\./);
+    });
+
+    it("should truncate prompt preview without --prompt flag", async () => {
+      const longPrompt =
+        "a".repeat(120) +
+        " this is clearly past the 60-character preview limit";
+      const longSchedule = { ...mockSchedule, prompt: longPrompt };
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [longSchedule] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).not.toContain(longPrompt);
+      expect(logCalls).toMatch(/a{57}\.\.\./);
+    });
+
     it("should display schedule when agent identifier is a UUID", async () => {
       const testUuid = "550e8400-e29b-41d4-a716-446655440000";
       const uuidCompose = { ...mockCompose, id: testUuid };

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
@@ -57,15 +57,10 @@ describe("zero schedule status command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
+    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
-  });
-
-  afterEach(() => {
-    mockExit.mockClear();
-    mockConsoleLog.mockClear();
-    mockConsoleError.mockClear();
   });
 
   describe("successful status", () => {

--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import {
   isInteractive,
@@ -135,6 +136,7 @@ interface SetupOptions {
   interval?: string;
   timezone?: string;
   prompt?: string;
+  promptFile?: string;
   enable?: boolean;
   modelProvider?: string;
   model?: string;
@@ -358,12 +360,21 @@ async function gatherTimezone(
 
 async function gatherPromptText(
   optionPrompt: string | undefined,
+  optionPromptFile: string | undefined,
   existingPrompt: string | undefined | null,
 ): Promise<string | undefined> {
+  if (optionPrompt && optionPromptFile) {
+    throw new Error("Cannot use --prompt and --prompt-file together");
+  }
+
+  if (optionPromptFile) {
+    return readFileSync(optionPromptFile, "utf-8");
+  }
+
   if (optionPrompt) return optionPrompt;
 
   if (!isInteractive()) {
-    throw new Error("--prompt is required");
+    throw new Error("--prompt or --prompt-file is required");
   }
 
   return await promptText(
@@ -649,6 +660,10 @@ export const setupCommand = new Command()
   .option("-i, --interval <seconds>", "Interval in seconds for loop mode")
   .option("-z, --timezone <tz>", "IANA timezone")
   .option("-p, --prompt <text>", "Prompt to run")
+  .option(
+    "--prompt-file <path>",
+    "Read prompt from file (cannot be used with --prompt)",
+  )
   .option("-e, --enable", "Enable schedule immediately after creation")
   .option(
     "--model-provider <id>",
@@ -667,6 +682,7 @@ Examples:
   Monthly on the 1st:    zero schedule setup <agent-id> -f monthly -d 1 -t 08:00 -p "monthly review"
   One-time:              zero schedule setup <agent-id> -f once -d 2026-04-01 -t 14:00 -p "one-off task"
   Loop every 5 minutes:  zero schedule setup <agent-id> -f loop -i 300 -p "poll for updates"
+  Prompt from file:      zero schedule setup <agent-id> -f daily -t 09:00 --prompt-file ./prompt.md
   Create and enable:     zero schedule setup <agent-id> -f daily -t 09:00 -p "run report" --enable
   Override model:        zero schedule setup <agent-id> -f daily -t 09:00 -p "..." --model-provider <id> --model MiniMax-M2.7
   Reset model override:  zero schedule setup <agent-id> -f daily -t 09:00 -p "..." --model-provider default --model default
@@ -737,6 +753,7 @@ Notes:
       // 6. Gather prompt
       const promptText_ = await gatherPromptText(
         options.prompt,
+        options.promptFile,
         existingSchedule?.prompt,
       );
       if (!promptText_) {

--- a/turbo/apps/cli/src/commands/zero/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/status.ts
@@ -36,7 +36,10 @@ function formatTrigger(schedule: ScheduleResponse): string {
 /**
  * Print run configuration section
  */
-function printRunConfiguration(schedule: ScheduleResponse): void {
+function printRunConfiguration(
+  schedule: ScheduleResponse,
+  showFullPrompt: boolean,
+): void {
   const statusText = schedule.enabled
     ? chalk.green("enabled")
     : chalk.yellow("disabled");
@@ -44,11 +47,15 @@ function printRunConfiguration(schedule: ScheduleResponse): void {
 
   console.log(`${"Agent:".padEnd(16)}${schedule.agentId}`);
 
-  const promptPreview =
-    schedule.prompt.length > 60
-      ? schedule.prompt.slice(0, 57) + "..."
-      : schedule.prompt;
-  console.log(`${"Prompt:".padEnd(16)}${chalk.dim(promptPreview)}`);
+  if (showFullPrompt) {
+    console.log(`${"Prompt:".padEnd(16)}${chalk.dim(schedule.prompt)}`);
+  } else {
+    const promptPreview =
+      schedule.prompt.length > 60
+        ? schedule.prompt.slice(0, 57) + "..."
+        : schedule.prompt;
+    console.log(`${"Prompt:".padEnd(16)}${chalk.dim(promptPreview)}`);
+  }
 
   if (schedule.vars && Object.keys(schedule.vars).length > 0) {
     console.log(
@@ -101,27 +108,34 @@ export const statusCommand = new Command()
     "-n, --name <schedule-name>",
     "Schedule name (required when agent has multiple schedules)",
   )
+  .option("-p, --prompt", "Show full prompt content without truncation")
   .addHelpText(
     "after",
     `
 Examples:
   zero schedule status <agent-id>
-  zero schedule status <agent-id> -n my-schedule`,
+  zero schedule status <agent-id> -n my-schedule
+  zero schedule status <agent-id> --prompt`,
   )
   .action(
-    withErrorHandler(async (agentName: string, options: { name?: string }) => {
-      const schedule = await resolveZeroScheduleByAgent(
-        agentName,
-        options.name,
-      );
+    withErrorHandler(
+      async (
+        agentName: string,
+        options: { name?: string; prompt?: boolean },
+      ) => {
+        const schedule = await resolveZeroScheduleByAgent(
+          agentName,
+          options.name,
+        );
 
-      console.log();
-      console.log(`Schedule for agent: ${chalk.cyan(agentName)}`);
-      console.log(chalk.dim("━".repeat(50)));
+        console.log();
+        console.log(`Schedule for agent: ${chalk.cyan(agentName)}`);
+        console.log(chalk.dim("━".repeat(50)));
 
-      printRunConfiguration(schedule);
-      printTimeSchedule(schedule);
+        printRunConfiguration(schedule, options.prompt ?? false);
+        printTimeSchedule(schedule);
 
-      console.log();
-    }),
+        console.log();
+      },
+    ),
   );


### PR DESCRIPTION
## Summary

Add two flags to improve schedule prompt management, mirroring the existing agent instructions flow (`zero agent view --instructions` / `zero agent edit --instructions-file`).

## Changes

### 1. `zero schedule status --prompt`

Show the full prompt content without truncation.

```bash
zero schedule status <agent-id> --prompt
```

### 2. `zero schedule setup --prompt-file <path>`

Read prompt body from a file instead of the command line.

```bash
zero schedule setup <agent-id> -f daily -t 09:00 --prompt-file ./prompt.md
```

`--prompt` and `--prompt-file` are mutually exclusive.

## Files Modified

- `turbo/apps/cli/src/commands/zero/schedule/status.ts` — add `-p/--prompt` flag
- `turbo/apps/cli/src/commands/zero/schedule/setup.ts` — add `--prompt-file` option
- `turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts` — tests for `--prompt`
- `turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts` — tests for `--prompt-file` (success + conflict)

## Test plan

- [x] `pnpm -F @vm0/cli exec vitest run` — 1077/1077 tests pass
- [x] `pnpm turbo run lint --filter=@vm0/cli` — clean
- [x] `pnpm -F @vm0/cli check-types` — clean
- [x] `pnpm knip --workspace apps/cli` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)