### PR TITLE
feat(platform): add redeem-code gift icon behind feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/redeem-code-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/redeem-code-dialog.ts
@@ -1,0 +1,23 @@
+import { command, computed, state } from "ccstate";
+
+const internalOpen$ = state(false);
+const internalCode$ = state("");
+
+export const redeemCodeDialogOpen$ = computed((get) => {
+  return get(internalOpen$);
+});
+
+export const redeemCodeInput$ = computed((get) => {
+  return get(internalCode$);
+});
+
+export const setRedeemCodeDialogOpen$ = command(({ set }, open: boolean) => {
+  set(internalOpen$, open);
+  if (!open) {
+    set(internalCode$, "");
+  }
+});
+
+export const setRedeemCodeInput$ = command(({ set }, value: string) => {
+  set(internalCode$, value);
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/redeem-code-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/redeem-code-dialog.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Tests for the redeem-code gift icon and dialog in the agent chat page header.
+ *
+ * Gated on the `redeemCode` feature switch. When enabled, a gift-icon button
+ * (aria-label "Redeem code") appears in the chat page header. Clicking it
+ * opens a dialog with an input and a Redeem button that stays disabled until
+ * the input has non-whitespace content. Closing the dialog clears the input.
+ *
+ * See: turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+ * See: turbo/apps/platform/src/signals/zero-page/redeem-code-dialog.ts
+ */
+
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FeatureSwitchKey } from "@vm0/core";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const CHAT_PATH = `/agents/${AGENT_ID}/chat`;
+
+function getButtonByText(label: string): HTMLButtonElement {
+  const match = screen.getAllByRole("button").find((el) => {
+    return el.textContent?.trim() === label;
+  });
+  if (!match) {
+    throw new Error(`No button with text "${label}"`);
+  }
+  return match as HTMLButtonElement;
+}
+
+describe("redeem-code gift icon visibility (RC-001)", () => {
+  it("does not render the gift icon when redeemCode is off", async () => {
+    detachedSetupPage({ context, path: CHAT_PATH });
+
+    // Wait for the chat page header to be ready by checking a stable sibling.
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-tagline")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText("Redeem code")).not.toBeInTheDocument();
+  });
+
+  it("renders the gift icon when redeemCode is on", async () => {
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.RedeemCode]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Redeem code")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("redeem-code dialog interaction (RC-002)", () => {
+  it("opens the dialog with a disabled Redeem button when gift icon is clicked", async () => {
+    const user = userEvent.setup();
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.RedeemCode]: true },
+    });
+
+    const giftButton = await waitFor(() => {
+      return screen.getByLabelText("Redeem code");
+    });
+
+    await user.click(giftButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    expect(screen.getByPlaceholderText("Enter code")).toBeInTheDocument();
+    expect(getButtonByText("Redeem")).toBeDisabled();
+  });
+
+  it("enables the Redeem button once non-whitespace input is entered", async () => {
+    const user = userEvent.setup();
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.RedeemCode]: true },
+    });
+
+    const giftButton = await waitFor(() => {
+      return screen.getByLabelText("Redeem code");
+    });
+    await user.click(giftButton);
+
+    const input = await waitFor(() => {
+      return screen.getByPlaceholderText("Enter code");
+    });
+
+    await user.type(input, "   ");
+    expect(getButtonByText("Redeem")).toBeDisabled();
+
+    await user.type(input, "CODE123");
+    expect(getButtonByText("Redeem")).toBeEnabled();
+  });
+
+  it("clears the input after closing via Cancel and reopening", async () => {
+    const user = userEvent.setup();
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.RedeemCode]: true },
+    });
+
+    const giftButton = await waitFor(() => {
+      return screen.getByLabelText("Redeem code");
+    });
+    await user.click(giftButton);
+
+    const input = (await waitFor(() => {
+      return screen.getByPlaceholderText("Enter code");
+    })) as HTMLInputElement;
+    await user.type(input, "CODE123");
+    expect(input.value).toBe("CODE123");
+
+    await user.click(getButtonByText("Cancel"));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Redeem code"));
+
+    const reopenedInput = (await waitFor(() => {
+      return screen.getByPlaceholderText("Enter code");
+    })) as HTMLInputElement;
+    expect(reopenedInput.value).toBe("");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -14,6 +14,7 @@ import { rootSignal$ } from "../../signals/root-signal.ts";
 import { user$ } from "../../signals/auth.ts";
 import {
   IconArrowUpRight,
+  IconGift,
   IconMicrophone,
   IconPin,
   IconPlus,
@@ -21,13 +22,28 @@ import {
 } from "@tabler/icons-react";
 import {
   Button,
+  Input,
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@vm0/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
 import { FeatureSwitchKey } from "@vm0/core";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import {
+  redeemCodeDialogOpen$,
+  redeemCodeInput$,
+  setRedeemCodeDialogOpen$,
+  setRedeemCodeInput$,
+} from "../../signals/zero-page/redeem-code-dialog.ts";
 import {
   currentChatAgentId$,
   currentChatAgentDisplayName$,
@@ -160,6 +176,79 @@ class TypewriterText extends Component<
       </>
     );
   }
+}
+
+function RedeemCodeButton() {
+  const setOpen = useSet(setRedeemCodeDialogOpen$);
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(true);
+            }}
+            className="shrink-0 flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground cursor-pointer"
+            aria-label="Redeem code"
+            data-testid="redeem-code-button"
+          >
+            <IconGift size={20} stroke={1.5} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p className="text-xs">Redeem code</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function RedeemCodeDialog() {
+  const open = useGet(redeemCodeDialogOpen$);
+  const code = useGet(redeemCodeInput$);
+  const setOpen = useSet(setRedeemCodeDialogOpen$);
+  const setCode = useSet(setRedeemCodeInput$);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        return !v && setOpen(false);
+      }}
+    >
+      <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>Redeem code</DialogTitle>
+          <DialogDescription>
+            Enter your redemption code to claim your reward.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-2">
+          <Input
+            value={code}
+            onChange={(e) => {
+              setCode(e.target.value);
+            }}
+            placeholder="Enter code"
+            autoFocus
+            data-testid="redeem-code-input"
+          />
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setOpen(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button disabled={!code.trim()}>Redeem</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 function InviteButton({ pageSignal }: { pageSignal: AbortSignal }) {
@@ -358,6 +447,8 @@ export function AgentChatPage() {
 
   const suggestedPrompts = useGet(suggestedPrompts$);
   const navigate = useSet(detachedNavigateTo$);
+  const features = useLastResolved(featureSwitch$);
+  const redeemCodeEnabled = features?.[FeatureSwitchKey.RedeemCode] ?? false;
   const pageSignal = useGet(pageSignal$);
 
   const handleSend = (text: string) => {
@@ -368,7 +459,8 @@ export function AgentChatPage() {
   return (
     <div className="relative flex flex-1 flex-col min-h-0">
       <header className="hidden md:block shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-2">
-        <div className="flex justify-end">
+        <div className="flex justify-end items-center gap-2">
+          {redeemCodeEnabled && <RedeemCodeButton />}
           <ChatHeaderAction pageSignal={pageSignal} />
         </div>
       </header>
@@ -518,6 +610,7 @@ export function AgentChatPage() {
           </div>
         </div>
       </main>
+      {redeemCodeEnabled && <RedeemCodeDialog />}
     </div>
   );
 }

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -55,4 +55,5 @@ export enum FeatureSwitchKey {
   OrgCustomConnectors = "orgCustomConnectors",
   ModelProviderSelection = "modelProviderSelection",
   Vm0GlmModel = "vm0GlmModel",
+  RedeemCode = "redeemCode",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -328,6 +328,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: true,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.RedeemCode]: {
+    maintainer: "yuma@vm0.ai",
+    description:
+      "Show redeem-code gift icon and dialog in the agent chat page header",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary
- Adds a gift icon (`IconGift`) to the agent chat page header at `/agents/:agentId/chat`, which opens a dialog with a code input and Redeem button.
- Gated behind a new `RedeemCode` feature switch — default off, enabled for staff orgs only.
- UI-only: no submit handler wired up yet, per the ask to "add the toggle first, implementation later".

## Test plan
- [ ] With `RedeemCode` off (default): visit `/agents/:agentId/chat` — no gift icon visible in top-right.
- [ ] Flip the flag on via Lab page or `window._vm0.featureSwitches.redeemCode = true` — gift icon appears next to "Invite people".
- [ ] Click gift icon — dialog opens with an input field and Cancel/Redeem buttons.
- [ ] Redeem button is disabled until input is non-empty; clicking it currently does nothing.
- [ ] Close via Cancel / Esc / overlay click — input value resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)