### PR TITLE
fix(ci): replace gh with curl in rollback preflight

### DIFF
--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -115,10 +115,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.target_version }}
+        shell: bash
         run: |
+          set -euo pipefail
           TAG="runner-rs-v${VERSION}"
           ASSET_NAME="runner-v${VERSION}-aarch64-linux"
-          if ! gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -qx "$ASSET_NAME"; then
+          # curl + jq instead of `gh` — the toolchain-rust image doesn't
+          # ship `gh` (it's in stage 3 `development`, not stage 2). Same
+          # REST endpoint and auth as the upload step in release-please.yml.
+          # `curl -f` turns HTTP 404 on a missing tag into a non-zero exit
+          # so set -e halts before grep runs.
+          ASSETS=$(curl -sfL \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            | jq -r '.assets[].name')
+          if ! printf '%s\n' "$ASSETS" | grep -qx "$ASSET_NAME"; then
             echo "::error::Release $TAG does not exist or is missing asset $ASSET_NAME."
             exit 1
           fi


### PR DESCRIPTION
## Summary

- The `Verify target release asset exists` step in `rollback-runner.yml` calls `gh release view`, but the job's container (`vm0-toolchain-rust`) doesn't ship `gh` — only the local `development` stage does. With `2>/dev/null` swallowing the `gh: not found` error and POSIX `sh -e` having no pipefail, every production rollback false-fails at the preflight with a misleading "release does not exist" message.
- Swap to `curl` + `jq` against the same Releases REST endpoint `release-please.yml` already uses in this container (see `release-please.yml:1211–1244`). Explicit `shell: bash` + `set -euo pipefail` so future typos fail loudly instead of silently.
- Scope: one step in one file. No Dockerfile changes. No sibling workflow changes — the 7 other `gh` calls in the repo all run on `ubuntu-latest` (gh preinstalled) and work as intended.

Closes #10240

## Test plan

YAML-only change; no unit tests. Dry-runs via `workflow_dispatch`:

- [x] `actionlint` — runs automatically via `security.yml` on every PR
- [ ] **Unhappy-path dry-run** (post-merge): `gh workflow run rollback-runner.yml -f target_version=9.9.9 -f rollback_mode=graceful -f confirmed_compatible=yes` — expect verify step to report release missing and exit non-zero (SSH/Ansible never reached, safe against prod)
- [ ] **Happy-path dry-run** (post-merge): `gh workflow run rollback-runner.yml -f target_version=<current-latest> -f rollback_mode=graceful -f confirmed_compatible=no` — expect verify step to pass, then the `confirmed_compatible` gate aborts before SSH/Ansible

🤖 Generated with [Claude Code](https://claude.com/claude-code)