### PR TITLE
feat(cli): scaffold zero search command and chat-message:read capability

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -19,6 +19,7 @@ describe("zero CLI program", () => {
       "connector",
       "doctor",
       "logs",
+      "search",
       "phone",
       "preference",
       "run",
@@ -55,7 +56,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 19 commands", () => {
-    expect(commandNames).toHaveLength(19);
+  it("should have exactly 20 commands", () => {
+    expect(commandNames).toHaveLength(20);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/index.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for zero search command scaffold (#10244).
+ *
+ * Entry point: zeroSearchCommand.parseAsync()
+ * Mock (external): none — no API calls in the scaffold
+ * Real (internal): all CLI validation and help wiring
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { zeroSearchCommand, SEARCH_EXPLAINER } from "../index";
+
+describe("zero search command (scaffold)", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    // Commander retains parsed option state across parseAsync calls on the
+    // same Command instance. Reset the collector value before each test so
+    // ordering does not leak state between cases.
+    zeroSearchCommand.setOptionValue("source", []);
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  it("prints the explainer and exits 0 when --source is omitted", async () => {
+    await zeroSearchCommand.parseAsync(["node", "cli", "hello"]);
+
+    expect(mockExit).not.toHaveBeenCalled();
+    const logs = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logs).toContain("Available sources:");
+    expect(logs).toContain("logs   full agent event stream");
+    expect(logs).toContain("chat   user/assistant text messages");
+    expect(logs).toContain("slack  returns a recipe");
+  });
+
+  it("rejects multiple --source flags", async () => {
+    await expect(
+      zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "logs",
+        "--source",
+        "chat",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("Only one --source is allowed.");
+  });
+
+  it("rejects an unknown --source value", async () => {
+    await expect(
+      zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "nope",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain('Unknown --source "nope"');
+    expect(errors).toContain("logs, chat, slack");
+  });
+
+  it("routes --source logs to the not-yet-implemented placeholder", async () => {
+    await expect(
+      zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "logs",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("zero search --source logs: not yet implemented");
+  });
+
+  it("--help output includes the three source descriptions", () => {
+    let captured = "";
+    zeroSearchCommand.configureOutput({
+      writeOut: (s) => {
+        captured += s;
+      },
+      writeErr: (s) => {
+        captured += s;
+      },
+    });
+    zeroSearchCommand.outputHelp();
+    expect(captured).toContain("logs   full agent event stream");
+    expect(captured).toContain("chat   user/assistant text messages");
+    expect(captured).toContain("slack  returns a recipe");
+  });
+
+  it("SEARCH_EXPLAINER is the single source of truth for source descriptions", () => {
+    expect(SEARCH_EXPLAINER).toContain("logs   full agent event stream");
+    expect(SEARCH_EXPLAINER).toContain("chat   user/assistant text messages");
+    expect(SEARCH_EXPLAINER).toContain("slack  returns a recipe");
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/search/index.ts
+++ b/turbo/apps/cli/src/commands/zero/search/index.ts
@@ -1,0 +1,102 @@
+import { Command } from "commander";
+import { withErrorHandler } from "../../../lib/command";
+
+const SUPPORTED_SOURCES = ["logs", "chat", "slack"] as const;
+type Source = (typeof SUPPORTED_SOURCES)[number];
+
+export const SEARCH_EXPLAINER = `
+Available sources:
+  logs   full agent event stream (tool calls, tokens, system events) from agent runs
+  chat   user/assistant text messages as shown in the web chat UI
+  slack  returns a recipe for calling the Slack API directly; requires the Slack connector
+
+Usage: zero search <query> --source <logs|chat|slack> [flags]
+Run 'zero search --help' for all flags.`;
+
+interface SearchOptions {
+  source: string[];
+  agent?: string;
+  run?: string;
+  since?: string;
+  limit?: string;
+  afterContext?: string;
+  beforeContext?: string;
+  context?: string;
+}
+
+function collectSource(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+async function runLogsSource(
+  _query: string,
+  _options: SearchOptions,
+): Promise<void> {
+  throw new Error("zero search --source logs: not yet implemented");
+}
+
+async function runChatSource(
+  _query: string,
+  _options: SearchOptions,
+): Promise<void> {
+  throw new Error("zero search --source chat: not yet implemented");
+}
+
+async function runSlackSource(
+  _query: string,
+  _options: SearchOptions,
+): Promise<void> {
+  throw new Error("zero search --source slack: not yet implemented");
+}
+
+export const zeroSearchCommand = new Command()
+  .name("search")
+  .description("Search logs, chat, or get a recipe for external sources")
+  .argument("<query>", "Search query")
+  .option(
+    "--source <type>",
+    "Source to search: logs | chat | slack (pass once)",
+    collectSource,
+    [] as string[],
+  )
+  .option("--agent <name>", "Filter by agent name")
+  .option("--run <id>", "Filter by run ID")
+  .option("--since <time>", "Time window (e.g., 7d, 2h)")
+  .option("--limit <n>", "Maximum number of matches")
+  .option("-A, --after-context <n>", "Show n items after each match")
+  .option("-B, --before-context <n>", "Show n items before each match")
+  .option("-C, --context <n>", "Show n items before and after each match")
+  .addHelpText("after", SEARCH_EXPLAINER)
+  .action(
+    withErrorHandler(async (query: string, options: SearchOptions) => {
+      const sources = options.source;
+
+      if (sources.length === 0) {
+        console.log(SEARCH_EXPLAINER);
+        return;
+      }
+
+      if (sources.length > 1) {
+        throw new Error("Only one --source is allowed.");
+      }
+
+      const source = sources[0]!;
+      if (!SUPPORTED_SOURCES.includes(source as Source)) {
+        throw new Error(
+          `Unknown --source "${source}". Expected one of: ${SUPPORTED_SOURCES.join(", ")}`,
+        );
+      }
+
+      switch (source as Source) {
+        case "logs":
+          await runLogsSource(query, options);
+          return;
+        case "chat":
+          await runChatSource(query, options);
+          return;
+        case "slack":
+          await runSlackSource(query, options);
+          return;
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -17,6 +17,7 @@ import { zeroVariableCommand } from "./commands/zero/variable";
 import { zeroWhoamiCommand } from "./commands/zero/whoami";
 import { zeroSkillCommand } from "./commands/zero/skill";
 import { zeroLogsCommand } from "./commands/zero/logs";
+import { zeroSearchCommand } from "./commands/zero/search";
 import { zeroDeveloperSupportCommand } from "./commands/zero/developer-support";
 import { zeroComputerUseCommand } from "./commands/zero/computer-use";
 import { zeroPhoneCommand } from "./commands/zero/phone";
@@ -40,6 +41,7 @@ const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   schedule: "schedule:read",
   doctor: null,
   logs: "agent-run:read",
+  search: "chat-message:read",
   chat: "chat-message:write",
   slack: "slack:write",
   whoami: null,
@@ -63,6 +65,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroSlackCommand,
   zeroVariableCommand,
   zeroLogsCommand,
+  zeroSearchCommand,
   zeroWhoamiCommand,
   zeroSkillCommand,
   zeroDeveloperSupportCommand,

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -268,6 +268,7 @@ describe("sandbox-token", () => {
         "schedule:write",
         "slack:write",
         "chat-message:write",
+        "chat-message:read",
         "connector:read",
       ]);
       expect(auth?.capabilities).not.toContain("agent-run:write");
@@ -291,6 +292,7 @@ describe("sandbox-token", () => {
         "schedule:write",
         "slack:write",
         "chat-message:write",
+        "chat-message:read",
         "connector:read",
         "computer-use:write",
         "voice-chat:write",

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -23,8 +23,8 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 13 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(13);
+  it("should have exactly 14 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(14);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -37,6 +37,7 @@ export const ZERO_CAPABILITIES = [
   "schedule:delete",
   "slack:write",
   "chat-message:write",
+  "chat-message:read",
   "connector:read",
   "computer-use:write",
   "voice-chat:write",
@@ -73,6 +74,10 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     "chat-message:write": {
       group: "Integrations",
       label: "Send chat messages",
+    },
+    "chat-message:read": {
+      group: "Integrations",
+      label: "Read chat messages",
     },
     "connector:read": { group: "Connectors", label: "View connected services" },
     "computer-use:write": {


### PR DESCRIPTION
## Summary

- Adds the `chat-message:read` capability to `ZERO_CAPABILITIES` / `ZERO_CAPABILITY_META` so the compile-time exhaustive `Record` contract is preserved.
- Scaffolds the new top-level `zero search <query> --source <logs|chat|slack>` command with three placeholder dispatch functions (each throws "not yet implemented"). Wave-2 sub-issues fill each branch without restructuring.
- Wires the command into `turbo/apps/cli/src/zero.ts` via `DEFAULT_COMMANDS` + `COMMAND_CAPABILITY_MAP`.

**Command behavior:**
- `zero search "foo"` (no `--source`) → prints explainer, exits 0.
- `zero search "foo" --source logs --source chat` → "Only one --source is allowed.", non-zero exit.
- `zero search "foo" --source nope` → "Unknown --source \"nope\". Expected one of: logs, chat, slack", non-zero exit.
- `zero search "foo" --source logs` → placeholder "not yet implemented" fires.
- `zero search --help` output contains the three source descriptions.

Closes #10244
Part of #10238

## Test plan

- [x] `pnpm -F @vm0/cli exec vitest run src/commands/zero/search` — 6/6 pass (scaffold integration tests).
- [x] `pnpm -F @vm0/core check-types` — capability addition satisfies the `Record<ZeroCapability, ZeroCapabilityMeta>` exhaustiveness contract.
- [x] `pnpm -F @vm0/cli lint` — no new warnings.
- [x] `pnpm knip` — no unused exports/files.
- [x] `pnpm format` — no changes.
- [ ] CI green on turbo workflow.