### PR TITLE
chore(ci): drop post-rollback revert reminder from slack notification

### DIFF
--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -204,7 +204,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Runner RS* ✅ Rolled back to v${{ inputs.target_version }} (${{ inputs.rollback_mode }})\n⏱️ `${{ steps.duration.outputs.text }}`\n👤 Triggered by: `${{ github.actor }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ inputs.target_version }}|View Release>\n\n⚠️ Remember to land a `revert` PR on main so the next release doesn't re-ship the bad version."
+                  text: "*Runner RS* ✅ Rolled back to v${{ inputs.target_version }} (${{ inputs.rollback_mode }})\n⏱️ `${{ steps.duration.outputs.text }}`\n👤 Triggered by: `${{ github.actor }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ inputs.target_version }}|View Release>"
 
       - name: Notify Slack - Failure
         if: ${{ failure() && steps.slack-start.outputs.ts }}


### PR DESCRIPTION
## Summary

- Removes the \`⚠️ Remember to land a \`revert\` PR on main...\` breadcrumb from the rollback success Slack notification.
- Rationale: rollback is incident-response work driven by a team runbook; \"remember to revert on main\" is a process step that belongs in the runbook, not embedded in tool output. The success notification should focus on what the workflow did, not on what the operator should do next.
- Trivially revertable if the team later prefers the reminder back.

## Test plan

- [x] YAML-only edit to \`.github/workflows/rollback-runner.yml\` — covered by \`security.yml\`'s \`actionlint\` job on CI.
- [ ] No functional change to the rollback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)