### PR TITLE
feat(platform): render image and video links inline in chat

### DIFF
--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -122,6 +122,94 @@ describe("chat-d-065: theme signal applied to markdown rendering", () => {
   });
 });
 
+describe("chat-d-067: markdown image URL renders inline", () => {
+  it("should render an <img> for image link and hide the plain <a>", async () => {
+    const src = "https://example.com/cat.png";
+    server.use(
+      mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
+        if (query.sinceId) {
+          return respond(200, { messages: [] });
+        }
+        return respond(200, {
+          messages: [
+            {
+              id: "msg-1",
+              role: "assistant",
+              content: `[cat](${src})`,
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+      mockApi(chatThreadByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          id: "thread-img",
+          ...makeThreadBase(),
+          chatMessages: [
+            {
+              role: "assistant",
+              content: `[cat](${src})`,
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-img" });
+
+    await waitFor(() => {
+      const img = document.querySelector(`img[src="${src}"]`);
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute("alt", "cat");
+    });
+  });
+});
+
+describe("chat-d-068: markdown video URL renders inline", () => {
+  it("should render a <video controls> for video link", async () => {
+    const src = "https://example.com/clip.mp4";
+    server.use(
+      mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
+        if (query.sinceId) {
+          return respond(200, { messages: [] });
+        }
+        return respond(200, {
+          messages: [
+            {
+              id: "msg-1",
+              role: "assistant",
+              content: `[clip](${src})`,
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+      mockApi(chatThreadByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          id: "thread-video",
+          ...makeThreadBase(),
+          chatMessages: [
+            {
+              role: "assistant",
+              content: `[clip](${src})`,
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-video" });
+
+    await waitFor(() => {
+      const video = document.querySelector(`video[src="${src}"]`);
+      expect(video).toBeInTheDocument();
+      expect(video).toHaveAttribute("controls");
+    });
+  });
+});
+
 describe("chat-d-066: markdown links open in new tab", () => {
   it("should render links with target=_blank and rel=noopener noreferrer", async () => {
     server.use(

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -1,10 +1,9 @@
 import MarkdownPreview, {
   type MarkdownPreviewProps,
 } from "@uiw/react-markdown-preview";
-import { useGet, useSet } from "ccstate-react";
+import { useGet } from "ccstate-react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { theme$ } from "../../signals/theme.ts";
-import { setLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
 
 type RewriteArgs = Parameters<
   NonNullable<MarkdownPreviewProps["rehypeRewrite"]>
@@ -184,8 +183,21 @@ function ResponsiveTable({ children }: ComponentPropsWithoutRef<"table">) {
   );
 }
 
-const IMAGE_URL_RE = /\.(png|jpe?g|gif|webp|svg|bmp|avif)(?:\?|#|$)/i;
-const VIDEO_URL_RE = /\.(mp4|webm|mov|ogv)(?:\?|#|$)/i;
+function isImageUrl(href: string): boolean {
+  return /\.(png|jpe?g|gif|webp|svg|bmp|avif)(?:\?|#|$)/i.test(href);
+}
+
+function isVideoUrl(href: string): boolean {
+  return /\.(mp4|webm|mov|ogv)(?:\?|#|$)/i.test(href);
+}
+
+/**
+ * Only `http:` / `https:` URLs are safe to render as `<img src>` or `<video src>`.
+ * Blocks `javascript:`, `data:`, `file:`, etc. in assistant-rendered markdown.
+ */
+function isSafeMediaUrl(href: string): boolean {
+  return /^https?:\/\//i.test(href);
+}
 
 function PlainLink({ href, children, ...rest }: ComponentPropsWithoutRef<"a">) {
   return (
@@ -195,20 +207,29 @@ function PlainLink({ href, children, ...rest }: ComponentPropsWithoutRef<"a">) {
   );
 }
 
-function MediaLink({ href, children, ...rest }: ComponentPropsWithoutRef<"a">) {
-  const openLightbox = useSet(setLightboxUrl$);
-
-  if (!href) {
-    return <PlainLink {...rest}>{children}</PlainLink>;
+function MediaLink({
+  href,
+  children,
+  onImageClick,
+  ...rest
+}: ComponentPropsWithoutRef<"a"> & {
+  onImageClick?: (url: string) => void;
+}) {
+  if (!href || !isSafeMediaUrl(href)) {
+    return (
+      <PlainLink href={href} {...rest}>
+        {children}
+      </PlainLink>
+    );
   }
 
-  if (IMAGE_URL_RE.test(href)) {
+  if (isImageUrl(href)) {
     const alt = typeof children === "string" ? children : "";
     return (
       <button
         type="button"
         onClick={() => {
-          openLightbox(href);
+          onImageClick?.(href);
         }}
         className="block max-w-full my-1 rounded-lg overflow-hidden cursor-zoom-in border border-foreground/10"
       >
@@ -221,7 +242,7 @@ function MediaLink({ href, children, ...rest }: ComponentPropsWithoutRef<"a">) {
     );
   }
 
-  if (VIDEO_URL_RE.test(href)) {
+  if (isVideoUrl(href)) {
     return (
       <video
         src={href}
@@ -238,28 +259,45 @@ function MediaLink({ href, children, ...rest }: ComponentPropsWithoutRef<"a">) {
   );
 }
 
-function renderMarkdownLink(
-  mediaPreview: boolean,
-): (
-  props: { children?: ReactNode } & ComponentPropsWithoutRef<"a">,
-) => ReactNode {
+function MarkdownLinkRenderer(
+  props: { children?: ReactNode } & ComponentPropsWithoutRef<"a"> & {
+      mediaPreview: boolean;
+      onImageClick: ((url: string) => void) | undefined;
+    },
+) {
+  const { mediaPreview, onImageClick, children, ...rest } = props;
   if (mediaPreview) {
-    return ({ children, ...props }) => {
-      return <MediaLink {...props}>{children}</MediaLink>;
-    };
+    return (
+      <MediaLink {...rest} onImageClick={onImageClick}>
+        {children}
+      </MediaLink>
+    );
   }
-  return ({ children, ...props }) => {
-    return <PlainLink {...props}>{children}</PlainLink>;
-  };
+  return <PlainLink {...rest}>{children}</PlainLink>;
 }
 
 export function Markdown({
   className,
   style,
   mediaPreview = false,
+  onImageClick,
   ...rest
-}: MarkdownPreviewProps & { mediaPreview?: boolean }) {
+}: MarkdownPreviewProps & {
+  mediaPreview?: boolean;
+  onImageClick?: (url: string) => void;
+}) {
   const theme = useGet(theme$);
+  const renderLink = (
+    props: { children?: ReactNode } & ComponentPropsWithoutRef<"a">,
+  ) => {
+    return (
+      <MarkdownLinkRenderer
+        {...props}
+        mediaPreview={mediaPreview}
+        onImageClick={onImageClick}
+      />
+    );
+  };
   return (
     <MarkdownPreview
       className={`!bg-transparent !text-foreground text-sm ${className ?? ""}`}
@@ -274,7 +312,7 @@ export function Markdown({
       rehypeRewrite={rehypeRewriteHandler}
       components={{
         table: ResponsiveTable,
-        a: renderMarkdownLink(mediaPreview),
+        a: renderLink,
       }}
       {...rest}
     />

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -1,9 +1,10 @@
 import MarkdownPreview, {
   type MarkdownPreviewProps,
 } from "@uiw/react-markdown-preview";
-import { useGet } from "ccstate-react";
-import type { ComponentPropsWithoutRef } from "react";
+import { useGet, useSet } from "ccstate-react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { theme$ } from "../../signals/theme.ts";
+import { setLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
 
 type RewriteArgs = Parameters<
   NonNullable<MarkdownPreviewProps["rehypeRewrite"]>
@@ -183,7 +184,81 @@ function ResponsiveTable({ children }: ComponentPropsWithoutRef<"table">) {
   );
 }
 
-export function Markdown({ className, style, ...rest }: MarkdownPreviewProps) {
+const IMAGE_URL_RE = /\.(png|jpe?g|gif|webp|svg|bmp|avif)(?:\?|#|$)/i;
+const VIDEO_URL_RE = /\.(mp4|webm|mov|ogv)(?:\?|#|$)/i;
+
+function PlainLink({ href, children, ...rest }: ComponentPropsWithoutRef<"a">) {
+  return (
+    <a {...rest} href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  );
+}
+
+function MediaLink({ href, children, ...rest }: ComponentPropsWithoutRef<"a">) {
+  const openLightbox = useSet(setLightboxUrl$);
+
+  if (!href) {
+    return <PlainLink {...rest}>{children}</PlainLink>;
+  }
+
+  if (IMAGE_URL_RE.test(href)) {
+    const alt = typeof children === "string" ? children : "";
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          openLightbox(href);
+        }}
+        className="block max-w-full my-1 rounded-lg overflow-hidden cursor-zoom-in border border-foreground/10"
+      >
+        <img
+          src={href}
+          alt={alt}
+          className="max-h-32 max-w-full object-contain"
+        />
+      </button>
+    );
+  }
+
+  if (VIDEO_URL_RE.test(href)) {
+    return (
+      <video
+        src={href}
+        controls
+        className="max-h-96 max-w-full my-1 rounded-lg border border-foreground/10"
+      />
+    );
+  }
+
+  return (
+    <PlainLink href={href} {...rest}>
+      {children}
+    </PlainLink>
+  );
+}
+
+function renderMarkdownLink(
+  mediaPreview: boolean,
+): (
+  props: { children?: ReactNode } & ComponentPropsWithoutRef<"a">,
+) => ReactNode {
+  if (mediaPreview) {
+    return ({ children, ...props }) => {
+      return <MediaLink {...props}>{children}</MediaLink>;
+    };
+  }
+  return ({ children, ...props }) => {
+    return <PlainLink {...props}>{children}</PlainLink>;
+  };
+}
+
+export function Markdown({
+  className,
+  style,
+  mediaPreview = false,
+  ...rest
+}: MarkdownPreviewProps & { mediaPreview?: boolean }) {
   const theme = useGet(theme$);
   return (
     <MarkdownPreview
@@ -199,13 +274,7 @@ export function Markdown({ className, style, ...rest }: MarkdownPreviewProps) {
       rehypeRewrite={rehypeRewriteHandler}
       components={{
         table: ResponsiveTable,
-        a: ({ children, ...props }) => {
-          return (
-            <a {...props} target="_blank" rel="noopener noreferrer">
-              {children}
-            </a>
-          );
-        },
+        a: renderMarkdownLink(mediaPreview),
       }}
       {...rest}
     />

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -9,6 +9,7 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import type { ZeroChatAttachment } from "../../signals/chat-page/chat-message.ts";
+import { logger } from "../../signals/log.ts";
 import {
   lightboxUrl$,
   setLightboxUrl$,
@@ -17,6 +18,8 @@ import {
 import docPdfIcon from "./assets/doc-pdf.svg";
 import docDocIcon from "./assets/doc-doc.svg";
 import docCsvIcon from "./assets/doc-csv.svg";
+
+const log = logger("zero-attachment-chips");
 
 /**
  * Return the icon path for a known file extension, or null for unknown types.
@@ -54,27 +57,45 @@ function filenameFromUrl(url: string): string {
   return last && last.length > 0 ? last : "image";
 }
 
-async function downloadUrl(url: string): Promise<void> {
+function triggerBlobDownload(blob: Blob, filename: string): void {
+  const blobUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = blobUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(blobUrl);
+}
+
+// Fetch the asset as a blob, degrading to a new-tab fallback on network /
+// CORS failure. The `.catch` is intentionally scoped to the fetch branch so
+// only network failures fall back — any synchronous DOM / blob failure after
+// a successful fetch is a real bug and propagates to the caller. The
+// fallback logs the underlying error so unexpected failures surface in
+// Sentry instead of being silently mis-classified as "CORS".
+function fetchBlobOrOpen(url: string): Promise<Blob | null> {
+  return fetch(url, { mode: "cors" })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`fetch failed: ${String(res.status)}`);
+      }
+      return res.blob();
+    })
+    .catch((error: unknown) => {
+      log.warn("downloadUrl: fetch failed, falling back to window.open", error);
+      window.open(url, "_blank", "noopener,noreferrer");
+      return null;
+    });
+}
+
+function downloadUrl(url: string): Promise<void> {
   const filename = filenameFromUrl(url);
-  try {
-    const res = await fetch(url, { mode: "cors" });
-    if (!res.ok) {
-      throw new Error(`fetch failed: ${String(res.status)}`);
+  return fetchBlobOrOpen(url).then((blob) => {
+    if (blob !== null) {
+      triggerBlobDownload(blob, filename);
     }
-    const blob = await res.blob();
-    const blobUrl = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = blobUrl;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(blobUrl);
-  } catch {
-    // CORS / network failure — fall back to opening the asset in a new tab
-    // so the user can save it manually via the browser context menu.
-    window.open(url, "_blank", "noopener,noreferrer");
-  }
+  });
 }
 
 export function ImageLightbox({ url }: { url: string }) {
@@ -100,7 +121,9 @@ export function ImageLightbox({ url }: { url: string }) {
         <button
           type="button"
           onClick={() => {
-            void downloadUrl(url);
+            downloadUrl(url).catch((error: unknown) => {
+              log.error("downloadUrl: unexpected failure", error);
+            });
           }}
           className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
           aria-label="Download"

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent } from "react";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
+  IconDownload,
   IconFile,
   IconPhoto,
   IconVideo,
@@ -47,6 +48,35 @@ function getFileTypeIcon(filename: string): string | null {
 // ImageLightbox — full-screen image viewer
 // ---------------------------------------------------------------------------
 
+function filenameFromUrl(url: string): string {
+  const path = url.split("?")[0].split("#")[0];
+  const last = path.split("/").pop();
+  return last && last.length > 0 ? last : "image";
+}
+
+async function downloadUrl(url: string): Promise<void> {
+  const filename = filenameFromUrl(url);
+  try {
+    const res = await fetch(url, { mode: "cors" });
+    if (!res.ok) {
+      throw new Error(`fetch failed: ${String(res.status)}`);
+    }
+    const blob = await res.blob();
+    const blobUrl = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = blobUrl;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(blobUrl);
+  } catch {
+    // CORS / network failure — fall back to opening the asset in a new tab
+    // so the user can save it manually via the browser context menu.
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+}
+
 export function ImageLightbox({ url }: { url: string }) {
   const dialogRef = useSet(lightboxDialogRef$);
   const closeLightbox = useSet(setLightboxUrl$);
@@ -66,16 +96,28 @@ export function ImageLightbox({ url }: { url: string }) {
       role="dialog"
       aria-modal="true"
     >
-      <button
-        type="button"
-        onClick={() => {
-          return closeLightbox(null);
-        }}
-        className="absolute top-4 right-4 p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"
-        aria-label="Close"
-      >
-        <IconX size={20} stroke={2} />
-      </button>
+      <div className="absolute top-4 right-4 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            void downloadUrl(url);
+          }}
+          className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
+          aria-label="Download"
+        >
+          <IconDownload size={20} stroke={2} />
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            return closeLightbox(null);
+          }}
+          className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"
+          aria-label="Close"
+        >
+          <IconX size={20} stroke={2} />
+        </button>
+      </div>
       <img
         src={url}
         alt=""

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -680,6 +680,9 @@ function PagedUserMessage({ message }: { message: PagedChatMessage }) {
   const { cleanContent, parsed } = parseInlineAttachments(content);
   const displayContent = cleanContent.replace(/\n/g, "  \n");
   const setLightboxUrl = useSet(setAttachmentLightboxUrl$);
+  const openLightbox = (url: string) => {
+    setLightboxUrl(url);
+  };
 
   const allAttachments = parsed.map((p) => {
     return {
@@ -698,7 +701,11 @@ function PagedUserMessage({ message }: { message: PagedChatMessage }) {
           <div className="zero-chat-bubble-user rounded-xl max-w-[85%] text-sm leading-relaxed break-words overflow-hidden">
             {displayContent && (
               <div className="px-4 py-3">
-                <Markdown source={displayContent} mediaPreview />
+                <Markdown
+                  source={displayContent}
+                  mediaPreview
+                  onImageClick={openLightbox}
+                />
               </div>
             )}
             {allAttachments.length > 0 && (
@@ -792,6 +799,11 @@ function PagedAssistantGroup({
 }
 
 function PagedAssistantMessageItem({ message }: { message: PagedChatMessage }) {
+  const setLightboxUrl = useSet(setAttachmentLightboxUrl$);
+  const openLightbox = (url: string) => {
+    setLightboxUrl(url);
+  };
+
   if (message.error) {
     return (
       <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
@@ -803,7 +815,11 @@ function PagedAssistantMessageItem({ message }: { message: PagedChatMessage }) {
   if (message.content) {
     return (
       <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
-        <Markdown source={message.content} mediaPreview />
+        <Markdown
+          source={message.content}
+          mediaPreview
+          onImageClick={openLightbox}
+        />
       </div>
     );
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -227,6 +227,7 @@ export function ZeroChatThreadPageInner({
   const groups = groupsLoadable.state === "hasData" ? groupsLoadable.data : [];
   const setScrollContainer = useSet(thread.setScrollContainer$);
   const skeletonVisible = useGet(thread.skeletonVisible$);
+  const lightboxUrl = useGet(attachmentLightboxUrl$);
 
   return (
     <div className="flex flex-1 flex-col min-h-0 bg-transparent">
@@ -290,6 +291,7 @@ export function ZeroChatThreadPageInner({
       </div>
 
       <ChatThreadComposer thread={thread} autoFocus={autoFocus} />
+      {lightboxUrl && <ImageLightbox url={lightboxUrl} />}
     </div>
   );
 }
@@ -677,7 +679,6 @@ function PagedUserMessage({ message }: { message: PagedChatMessage }) {
   const content = message.content ?? "";
   const { cleanContent, parsed } = parseInlineAttachments(content);
   const displayContent = cleanContent.replace(/\n/g, "  \n");
-  const lightboxUrl = useGet(attachmentLightboxUrl$);
   const setLightboxUrl = useSet(setAttachmentLightboxUrl$);
 
   const allAttachments = parsed.map((p) => {
@@ -697,7 +698,7 @@ function PagedUserMessage({ message }: { message: PagedChatMessage }) {
           <div className="zero-chat-bubble-user rounded-xl max-w-[85%] text-sm leading-relaxed break-words overflow-hidden">
             {displayContent && (
               <div className="px-4 py-3">
-                <Markdown source={displayContent} />
+                <Markdown source={displayContent} mediaPreview />
               </div>
             )}
             {allAttachments.length > 0 && (
@@ -750,7 +751,6 @@ function PagedUserMessage({ message }: { message: PagedChatMessage }) {
           </div>
         </div>
       </div>
-      {lightboxUrl && <ImageLightbox url={lightboxUrl} />}
     </div>
   );
 }
@@ -803,7 +803,7 @@ function PagedAssistantMessageItem({ message }: { message: PagedChatMessage }) {
   if (message.content) {
     return (
       <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
-        <Markdown source={message.content} />
+        <Markdown source={message.content} mediaPreview />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- `Markdown` component gains an opt-in `mediaPreview` prop. When enabled, markdown links whose URL ends in a common image extension (png/jpe?g/gif/webp/svg/bmp/avif) or video extension (mp4/webm/mov/ogv) render inline as `<img>` / `<video controls>` instead of a plain anchor.
- Chat bubbles (user + assistant) opt into `mediaPreview`. Inline images are compact (`max-h-32`) and open the shared `ImageLightbox` on click.
- `ImageLightbox` now has a Download button next to Close — it fetches the asset as a blob and triggers a real download; if CORS blocks the fetch, it falls back to opening the asset in a new tab.
- Lifted `<ImageLightbox>` from `PagedUserMessage` to `ZeroChatThreadPageInner` so assistant-side images can open the lightbox too, and there is only one lightbox instance per page.

## Test plan
- [ ] Send a user message with `[img](https://example.com/foo.png)` — thumbnail renders inline in the bubble.
- [ ] Click thumbnail → lightbox opens at full size.
- [ ] In lightbox, click the new Download button — browser downloads the file (CORS-allowed URLs) or opens it in a new tab (CORS-blocked).
- [ ] Assistant message returning `[clip](https://example.com/foo.mp4)` renders as an inline `<video controls>`.
- [ ] Regular non-media links (e.g. `[docs](https://example.com)`) still render as plain anchors opening in a new tab.
- [ ] `vitest run src/views/components/__tests__/markdown.test.tsx` — new media-preview tests pass alongside existing link/theme tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)