### PR TITLE
refactor(slack): unify agent response footer and move model into outbound footer

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -6,7 +6,6 @@ import { decryptSecretValue } from "../../../../../../src/lib/shared/crypto/secr
 import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { zeroRuns } from "../../../../../../src/db/schema/zero-run";
-import { slackOrgConnections } from "../../../../../../src/db/schema/slack-org-connection";
 import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
 import { loadFeatureSwitchOverrides } from "../../../../../../src/lib/zero/user/feature-switches-service";
 import { findNewSessionId } from "../../../../../../src/lib/infra/session/find-new-session";
@@ -14,9 +13,7 @@ import {
   createSlackClient,
   postMessage,
   setThreadStatus,
-  fetchSlackUserInfo,
 } from "../../../../../../src/lib/zero/slack/client";
-import type { WebClient } from "@slack/web-api";
 import { buildAgentResponseMessage } from "../../../../../../src/lib/zero/slack/blocks";
 import { extractAllRunOutputs } from "../../../../../../src/lib/infra/run/extract-run-output";
 import {
@@ -51,25 +48,6 @@ function parsePayload(payload: unknown): SlackOrgCallbackPayload | null {
 
 function errorResponse(message: string, status: number): NextResponse {
   return NextResponse.json({ error: message }, { status });
-}
-
-/**
- * Look up the Slack user's display name for the `Sent from X` footer.
- * Returns undefined when the connection has no linked slackUserId or the
- * users.info call returns no usable name.
- */
-async function resolveSlackUserName(
-  client: WebClient,
-  connectionId: string,
-): Promise<string | undefined> {
-  const [connection] = await globalThis.services.db
-    .select({ slackUserId: slackOrgConnections.slackUserId })
-    .from(slackOrgConnections)
-    .where(eq(slackOrgConnections.id, connectionId))
-    .limit(1);
-  if (!connection?.slackUserId) return undefined;
-  const userInfo = await fetchSlackUserInfo(client, connection.slackUserId);
-  return userInfo?.name;
 }
 
 /**
@@ -261,11 +239,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     payload.agentId,
   );
 
-  const slackUserName = await resolveSlackUserName(
-    client,
-    payload.connectionId,
-  );
-
   // Post each result as a separate Slack reply (in order)
   for (let i = 0; i < allOutputs.length; i++) {
     const output = allOutputs[i]!;
@@ -283,7 +256,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         logsUrl,
         triggeredBy,
         selectedModel,
-        slackUserName,
       ),
     });
   }

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
@@ -23,7 +23,10 @@ import {
   generateSandboxToken,
   generateZeroToken,
 } from "../../../../../../../src/lib/auth/sandbox-token";
-import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
+import {
+  seedTestRun,
+  setTestRunSelectedModel,
+} from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const URL = "http://localhost:3000/api/zero/integrations/slack/message";
 
@@ -368,7 +371,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
     expect(footerCtx.elements![0]!.text).toBe("Sent via My Assistant");
   });
 
-  it("appends schedule and creator in footer when run is triggered by a schedule", async () => {
+  it("appends schedule, creator, and model in footer when run is triggered by a schedule", async () => {
     const agentName = uniqueId("agent");
     const { composeId } = await createTestCompose(agentName);
     await createTestZeroAgent(user.orgId, agentName, {
@@ -385,6 +388,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
       scheduleId: schedule.id,
       triggerSource: "schedule",
     });
+    await setTestRunSelectedModel(runId, "claude-sonnet-4-6");
 
     // Seed Slack connection so the creator is resolvable
     const slackUserId = uniqueId("U-slack");
@@ -428,7 +432,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
     const footerCtx = blocks[blocks.length - 1]!;
     expect(footerCtx.type).toBe("context");
     expect(footerCtx.elements![0]!.text).toBe(
-      `Sent via My Assistant · Triggered by schedule "Daily standup summary" · Created by <@${slackUserId}>`,
+      `Sent via My Assistant · Triggered by schedule "Daily standup summary" · Created by <@${slackUserId}> · Claude Sonnet 4.6`,
     );
   });
 

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
@@ -1,5 +1,8 @@
 import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
-import { integrationsSlackMessageContract } from "@vm0/core";
+import {
+  integrationsSlackMessageContract,
+  getModelDisplayName,
+} from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { agentComposeVersions } from "../../../../../../src/db/schema/agent-compose";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
@@ -53,6 +56,18 @@ async function resolveScheduleLabel(
     .where(eq(zeroRuns.id, runId))
     .limit(1);
   return row?.description ?? undefined;
+}
+
+/** Best-effort resolution of the selected model for the run. */
+async function resolveSelectedModel(
+  runId: string,
+): Promise<string | undefined> {
+  const [row] = await globalThis.services.db
+    .select({ selectedModel: zeroRuns.selectedModel })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, runId))
+    .limit(1);
+  return row?.selectedModel ?? undefined;
 }
 
 /** Best-effort resolution of the Slack user mention for the run owner. */
@@ -113,17 +128,21 @@ async function resolveFooterParts(
 ): Promise<string[]> {
   if (!authRunId) return [];
 
-  const [agentLabel, scheduleLabel, userMention] = await Promise.all([
-    resolveAgentLabel(authRunId).catch(() => {
-      return undefined;
-    }),
-    resolveScheduleLabel(authRunId).catch(() => {
-      return undefined;
-    }),
-    resolveUserMention(authRunId).catch(() => {
-      return undefined;
-    }),
-  ]);
+  const [agentLabel, scheduleLabel, userMention, selectedModel] =
+    await Promise.all([
+      resolveAgentLabel(authRunId).catch(() => {
+        return undefined;
+      }),
+      resolveScheduleLabel(authRunId).catch(() => {
+        return undefined;
+      }),
+      resolveUserMention(authRunId).catch(() => {
+        return undefined;
+      }),
+      resolveSelectedModel(authRunId).catch(() => {
+        return undefined;
+      }),
+    ]);
 
   const parts: string[] = [];
   if (agentLabel) parts.push(`Sent via ${agentLabel}`);
@@ -135,6 +154,7 @@ async function resolveFooterParts(
         : `Triggered by ${userMention}`,
     );
   }
+  if (selectedModel) parts.push(getModelDisplayName(selectedModel));
   return parts;
 }
 

--- a/turbo/apps/web/src/lib/zero/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/zero/slack/__tests__/blocks.test.ts
@@ -177,18 +177,18 @@ describe("buildAgentResponseMessage", () => {
     expect(markdownBlock.text).toBe(content);
   });
 
-  it("should show triggeredBy as separate context block below audit with divider", () => {
+  it("renders triggeredBy as a context block with no divider (weakened footer)", () => {
     const blocks = buildAgentResponseMessage(
       "Response text",
       "https://app.vm0.ai/activity/run-123",
-      'Triggered by schedule "Send a greeting message daily at 9 AM"',
+      "Sent via my-agent",
     );
 
-    // Should have: markdown, audit context, divider, attribution context
+    // Should have: markdown, audit context, attribution context — no divider
     const dividerBlocks = blocks.filter((b) => {
       return b.type === "divider";
     });
-    expect(dividerBlocks).toHaveLength(1);
+    expect(dividerBlocks).toHaveLength(0);
 
     const contextBlocks = blocks.filter((b) => {
       return b.type === "context";
@@ -199,17 +199,54 @@ describe("buildAgentResponseMessage", () => {
     const auditText = (contextBlocks[0] as { elements: { text: string }[] })
       .elements[0]!.text;
     expect(auditText).toContain("Audit");
-    expect(auditText).not.toContain("Triggered by");
+    expect(auditText).not.toContain("Sent via");
 
-    // Second context: attribution (after divider)
+    // Second context: attribution (no divider above)
     const attrText = (contextBlocks[1] as { elements: { text: string }[] })
       .elements[0]!.text;
-    expect(attrText).toBe(
-      'Triggered by schedule "Send a greeting message daily at 9 AM"',
-    );
+    expect(attrText).toBe("Sent via my-agent");
   });
 
-  it("should not add attribution block when triggeredBy is not provided", () => {
+  it("combines triggeredBy and model into one context block joined by ·", () => {
+    const blocks = buildAgentResponseMessage(
+      "Response text",
+      undefined,
+      "Sent via my-agent",
+      "claude-sonnet-4-6",
+    );
+
+    const dividerBlocks = blocks.filter((b) => {
+      return b.type === "divider";
+    });
+    expect(dividerBlocks).toHaveLength(0);
+
+    const contextBlocks = blocks.filter((b) => {
+      return b.type === "context";
+    });
+    expect(contextBlocks).toHaveLength(1);
+    expect(
+      (contextBlocks[0] as { elements: { text: string }[] }).elements[0]!.text,
+    ).toBe("Sent via my-agent · Claude Sonnet 4.6");
+  });
+
+  it("renders model-only attribution when triggeredBy is absent", () => {
+    const blocks = buildAgentResponseMessage(
+      "Response text",
+      undefined,
+      undefined,
+      "claude-sonnet-4-6",
+    );
+
+    const contextBlocks = blocks.filter((b) => {
+      return b.type === "context";
+    });
+    expect(contextBlocks).toHaveLength(1);
+    expect(
+      (contextBlocks[0] as { elements: { text: string }[] }).elements[0]!.text,
+    ).toBe("Claude Sonnet 4.6");
+  });
+
+  it("adds no attribution block when neither triggeredBy nor modelName is provided", () => {
     const blocks = buildAgentResponseMessage(
       "Response text",
       "https://app.vm0.ai/activity/run-123",

--- a/turbo/apps/web/src/lib/zero/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/zero/slack/blocks.ts
@@ -423,13 +423,17 @@ function buildMarkdownMessage(content: string): (Block | KnownBlock)[] {
 }
 
 /**
- * Build an agent response message with optional logs link
+ * Build an agent response message with optional logs link.
+ *
+ * The attribution footer (triggeredBy + model) renders as a single context
+ * block without a divider — a deliberately weaker visual than
+ * `buildFooterBlocks`, which is reserved for longer schedule/user footers
+ * from the outbound `/integrations/slack/message` path.
  *
  * @param content - The agent's response content
  * @param logsUrl - Optional URL to the run logs
- * @param triggeredBy - Optional attribution text shown as a separate context block below a divider
- * @param modelName - Optional raw model ID shown alongside modelName in footer
- * @param slackUserName - Optional Slack display name shown alongside modelName in footer
+ * @param triggeredBy - Optional agent attribution (e.g. "Sent via my-agent")
+ * @param modelName - Optional raw model ID; rendered via `getModelDisplayName`
  * @returns Block Kit blocks with response content
  */
 export function buildAgentResponseMessage(
@@ -437,7 +441,6 @@ export function buildAgentResponseMessage(
   logsUrl?: string,
   triggeredBy?: string,
   modelName?: string,
-  slackUserName?: string,
 ): (Block | KnownBlock)[] {
   const blocks: (Block | KnownBlock)[] = [...buildMarkdownMessage(content)];
 
@@ -455,15 +458,20 @@ export function buildAgentResponseMessage(
     });
   }
 
-  if (triggeredBy) {
-    blocks.push(...buildFooterBlocks(triggeredBy));
-  }
+  const attributionParts: string[] = [];
+  if (triggeredBy) attributionParts.push(triggeredBy);
+  if (modelName) attributionParts.push(getModelDisplayName(modelName));
 
-  if (modelName || slackUserName) {
-    const parts: string[] = [];
-    if (slackUserName) parts.push(`Sent from ${slackUserName}`);
-    if (modelName) parts.push(getModelDisplayName(modelName));
-    blocks.push(...buildFooterBlocks(parts.join(" · ")));
+  if (attributionParts.length > 0) {
+    blocks.push({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: attributionParts.join(" · "),
+        },
+      ],
+    });
   }
 
   return blocks;


### PR DESCRIPTION
## Summary

Refactors the Slack agent-response footer so that `buildAgentResponseMessage` renders a single combined context block (`triggeredBy · model`) with no divider, while the outbound `/integrations/slack/message` path owns the longer schedule/user footer and now also appends the model.

### Changes

- `buildAgentResponseMessage`: drop `slackUserName` parameter; merge `triggeredBy` + `modelName` into one `context` block (no divider). Updated JSDoc to document the deliberate visual weakness vs `buildFooterBlocks`.
- `/api/internal/callbacks/slack/org` callback: remove `resolveSlackUserName` helper and the unused `slackOrgConnections` / `fetchSlackUserInfo` / `WebClient` imports; stop threading `slackUserName` into `buildAgentResponseMessage`.
- `/api/zero/integrations/slack/message`: add `resolveSelectedModel` and append `getModelDisplayName(selectedModel)` to the outbound footer parts.
- Tests updated to reflect the new single-context-block layout and the model appended to the outbound footer.

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/zero/slack/__tests__/blocks.test.ts`
- [x] `pnpm -F web exec vitest run app/api/zero/integrations/slack/message/__tests__/route.test.ts`
- [x] `pnpm -F web exec vitest run app/api/internal/callbacks/slack/org/__tests__/route.test.ts`
- [x] `pnpm -F web exec tsc --noEmit`
- [x] `pnpm -F web exec eslint` on changed files
- [x] `pnpm format`
- [x] knip (pre-commit hook)