### PR TITLE
feat: add zero web upload-file and file:read/file:write caps

### DIFF
--- a/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for zero web upload-file command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): backend uploads route via MSW
+ * - Real (internal): All CLI code, FormData, fetch, filesystem reads
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { uploadFileCommand } from "../upload-file";
+import chalk from "chalk";
+
+const UPLOAD_URL = "http://localhost:3000/api/zero/uploads";
+
+describe("zero web upload-file command", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  let tmpDir: string;
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    tmpDir = join(tmpdir(), `web-upload-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("successful upload", () => {
+    it("should POST multipart form-data with inferred MIME and print JSON result", async () => {
+      const filePath = join(tmpDir, "report.pdf");
+      writeFileSync(filePath, Buffer.from("%PDF-1.4 fake"));
+
+      const responseBody = {
+        id: "file-uuid-1",
+        filename: "report.pdf",
+        contentType: "application/pdf",
+        size: 14,
+        url: "https://presigned.example.com/file-uuid-1/report.pdf?sig=abc",
+      };
+
+      server.use(
+        http.post(UPLOAD_URL, async ({ request }) => {
+          expect(request.headers.get("authorization")).toBe(
+            "Bearer test-token",
+          );
+          const contentType = request.headers.get("content-type") ?? "";
+          expect(contentType).toContain("multipart/form-data");
+
+          const formData = await request.formData();
+          const file = formData.get("file");
+          expect(file).toBeInstanceOf(File);
+          if (file instanceof File) {
+            expect(file.name).toBe("report.pdf");
+            expect(file.type).toBe("application/pdf");
+          }
+
+          return HttpResponse.json(responseBody, { status: 200 });
+        }),
+      );
+
+      await uploadFileCommand.parseAsync(["node", "cli", "-f", filePath]);
+
+      const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+      const parsed = JSON.parse(stdout) as Record<string, unknown>;
+      expect(parsed).toMatchObject(responseBody);
+    });
+
+    it("should respect --content-type override", async () => {
+      const filePath = join(tmpDir, "data.bin");
+      writeFileSync(filePath, Buffer.from("col1,col2\n1,2"));
+
+      server.use(
+        http.post(UPLOAD_URL, async ({ request }) => {
+          const formData = await request.formData();
+          const file = formData.get("file");
+          expect(file).toBeInstanceOf(File);
+          if (file instanceof File) {
+            expect(file.type).toBe("text/csv");
+          }
+
+          return HttpResponse.json(
+            {
+              id: "csv-uuid",
+              filename: "data.bin",
+              contentType: "text/csv",
+              size: 13,
+              url: "https://presigned.example.com/csv-uuid/data.bin?sig=xyz",
+            },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await uploadFileCommand.parseAsync([
+        "node",
+        "cli",
+        "-f",
+        filePath,
+        "--content-type",
+        "text/csv",
+      ]);
+
+      const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+      const parsed = JSON.parse(stdout) as Record<string, unknown>;
+      expect(parsed.contentType).toBe("text/csv");
+    });
+  });
+
+  describe("validation errors", () => {
+    it("should throw when the file does not exist", async () => {
+      await expect(async () => {
+        await uploadFileCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          join(tmpDir, "missing.txt"),
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalled();
+    });
+  });
+
+  describe("API errors", () => {
+    it("should surface 401 unauthorized", async () => {
+      const filePath = join(tmpDir, "hello.txt");
+      writeFileSync(filePath, "hi");
+
+      server.use(
+        http.post(UPLOAD_URL, () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await uploadFileCommand.parseAsync(["node", "cli", "-f", filePath]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+    });
+
+    it("should surface 400 file too large", async () => {
+      const filePath = join(tmpDir, "big.txt");
+      writeFileSync(filePath, "small");
+
+      server.use(
+        http.post(UPLOAD_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "File too large (max 10 MB)",
+                code: "BAD_REQUEST",
+              },
+            },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await uploadFileCommand.parseAsync(["node", "cli", "-f", filePath]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("File too large"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/web/index.ts
+++ b/turbo/apps/cli/src/commands/zero/web/index.ts
@@ -1,13 +1,16 @@
 import { Command } from "commander";
 import { downloadFileCommand } from "./download-file";
+import { uploadFileCommand } from "./upload-file";
 
 export const zeroWebCommand = new Command()
   .name("web")
-  .description("Download files uploaded via the web chat UI")
+  .description("Upload and download files via the web chat endpoint")
   .addCommand(downloadFileCommand)
+  .addCommand(uploadFileCommand)
   .addHelpText(
     "after",
     `
 Examples:
+  Upload a file:    zero web upload-file -f /tmp/report.pdf
   Download a file:  zero web download-file <file-id> -o /tmp/out.pdf`,
   );

--- a/turbo/apps/cli/src/commands/zero/web/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/web/upload-file.ts
@@ -1,0 +1,36 @@
+import { Command } from "commander";
+import { uploadWebFile } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const uploadFileCommand = new Command()
+  .name("upload-file")
+  .description("Upload a local file and print a 7-day presigned URL")
+  .requiredOption("-f, --file <path>", "Local file path to upload")
+  .option("--content-type <mime>", "Override inferred content type")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Upload a file:           zero web upload-file -f /tmp/report.pdf
+  Override content-type:   zero web upload-file -f /tmp/data --content-type text/csv
+
+Output:
+  Prints a JSON object to stdout on success:
+    {"id":"...","filename":"...","contentType":"...","size":N,"url":"https://..."}
+
+Notes:
+  - Authenticates via ZERO_TOKEN (requires file:write capability)
+  - Returned URL is a presigned GET valid for 7 days
+  - Max file size: 10 MB
+  - Allowed types: png / jpeg / gif / webp / svg / mp4 / webm / mov / pdf / txt / csv / md / json`,
+  )
+  .action(
+    withErrorHandler(
+      async (options: { file: string; contentType?: string }) => {
+        const result = await uploadWebFile(options.file, {
+          contentType: options.contentType,
+        });
+        console.log(JSON.stringify(result));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -1,8 +1,36 @@
-import { createWriteStream } from "node:fs";
+import { createWriteStream, readFileSync, statSync } from "node:fs";
+import { basename, extname } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { ApiRequestError, getBaseUrl } from "../core/client-factory";
 import { getActiveToken } from "../config";
+
+/**
+ * Minimal extension → MIME map covering the server allowlist for
+ * `/api/zero/uploads`. Kept in this file rather than a shared module to
+ * match the YAGNI pattern used elsewhere in the CLI.
+ */
+const MIME_BY_EXTENSION: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".pdf": "application/pdf",
+  ".txt": "text/plain",
+  ".csv": "text/csv",
+  ".md": "text/markdown",
+  ".json": "application/json",
+};
+
+function inferContentType(localPath: string): string {
+  const ext = extname(localPath).toLowerCase();
+  return MIME_BY_EXTENSION[ext] ?? "application/octet-stream";
+}
 
 interface DownloadWebFileResult {
   path: string;
@@ -77,4 +105,77 @@ export async function downloadWebFile(
   const size = contentLengthHeader ? Number(contentLengthHeader) : 0;
 
   return { path: outPath, mimetype, size };
+}
+
+interface UploadWebFileResult {
+  id: string;
+  filename: string;
+  contentType: string;
+  size: number;
+  url: string;
+}
+
+/**
+ * Upload a local file to the zero uploads endpoint and receive back metadata
+ * including a 7-day presigned GET URL. Authenticates via ZERO_TOKEN
+ * (`file:write` capability) or a CLI PAT / Clerk session.
+ */
+export async function uploadWebFile(
+  localPath: string,
+  options?: { contentType?: string },
+): Promise<UploadWebFileResult> {
+  const stats = statSync(localPath);
+  if (!stats.isFile()) {
+    throw new ApiRequestError(
+      `Not a regular file: ${localPath}`,
+      "BAD_REQUEST",
+      400,
+    );
+  }
+
+  const baseUrl = await getBaseUrl();
+  const token = await getActiveToken();
+  if (!token) {
+    throw new ApiRequestError("Not authenticated", "UNAUTHORIZED", 401);
+  }
+
+  const filename = basename(localPath);
+  const contentType = options?.contentType ?? inferContentType(localPath);
+  const bytes = readFileSync(localPath);
+  const blob = new Blob([new Uint8Array(bytes)], { type: contentType });
+
+  const formData = new FormData();
+  formData.append("file", blob, filename);
+
+  const url = new URL("/api/zero/uploads", baseUrl);
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypassSecret) {
+    headers["x-vercel-protection-bypass"] = bypassSecret;
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: formData,
+  });
+
+  if (!response.ok) {
+    let message = `Failed to upload file (HTTP ${response.status})`;
+    let code = "UNKNOWN";
+    try {
+      const body = (await response.json()) as {
+        error?: { message?: string; code?: string };
+      };
+      if (body.error?.message) message = body.error.message;
+      if (body.error?.code) code = body.error.code;
+    } catch {
+      // ignore parse errors — keep generic message
+    }
+    throw new ApiRequestError(message, code, response.status);
+  }
+
+  return (await response.json()) as UploadWebFileResult;
 }

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -194,4 +194,4 @@ export {
 export { completeVoiceChatPreparation } from "./domains/zero-voice-chat-prepare";
 
 // Domain modules - Web
-export { downloadWebFile } from "./domains/web";
+export { downloadWebFile, uploadWebFile } from "./domains/web";

--- a/turbo/apps/web/app/api/zero/uploads/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/uploads/__tests__/route.test.ts
@@ -5,12 +5,18 @@ import {
   testContext,
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import {
+  generateZeroToken,
+  generateSandboxToken,
+} from "../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
 function createUploadRequest(
   file: File | null,
   userId?: string | null,
+  authToken?: string,
 ): NextRequest {
   const formData = new FormData();
   if (file) {
@@ -22,6 +28,9 @@ function createUploadRequest(
   if (userId === null) {
     // explicitly unauthenticated
     headers["x-no-auth"] = "true";
+  }
+  if (authToken) {
+    headers["authorization"] = `Bearer ${authToken}`;
   }
 
   return new NextRequest("http://localhost:3000/api/zero/uploads", {
@@ -41,12 +50,38 @@ describe("POST /api/zero/uploads", () => {
 
   describe("Authentication", () => {
     it("should reject unauthenticated requests", async () => {
-      const { mockClerk } =
-        await import("../../../../../src/__tests__/clerk-mock");
       mockClerk({ userId: null });
 
       const file = new File(["hello"], "test.txt", { type: "text/plain" });
       const request = createUploadRequest(file, null);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("should accept ZERO_TOKEN with file:write capability", async () => {
+      mockClerk({ userId: null });
+      const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+
+      const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+      const request = createUploadRequest(file, undefined, token);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.filename).toBe("hello.txt");
+    });
+
+    it("should reject sandbox token without file:write capability", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-1");
+
+      const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+      const request = createUploadRequest(file, undefined, token);
 
       const response = await POST(request);
 

--- a/turbo/apps/web/app/api/zero/uploads/route.ts
+++ b/turbo/apps/web/app/api/zero/uploads/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-auth-context";
+import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
 import {
   uploadS3Buffer,
   generatePresignedUrl,
@@ -30,15 +30,17 @@ const ALLOWED_TYPES = new Set([
 export async function POST(request: NextRequest) {
   initServices();
 
-  const userId = await getUserId(
+  const authCtx = await getAuthContext(
     request.headers.get("authorization") ?? undefined,
+    { requiredCapability: "file:write" },
   );
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const userId = authCtx.userId;
 
   const formData = await request.formData();
   const file = formData.get("file");
@@ -77,8 +79,8 @@ export async function POST(request: NextRequest) {
   const buffer = Buffer.from(await file.arrayBuffer());
   await uploadS3Buffer(bucket, s3Key, buffer, file.type);
 
-  // Generate a presigned GET URL valid for 24 hours
-  const url = await generatePresignedUrl(bucket, s3Key, 86400, sanitizedName);
+  // Generate a presigned GET URL valid for 7 days (max SigV4 TTL)
+  const url = await generatePresignedUrl(bucket, s3Key, 604800, sanitizedName);
 
   log.debug(
     `Uploaded ${sanitizedName} (${file.size} bytes) for user ${userId}`,

--- a/turbo/apps/web/app/api/zero/web/download-file/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/web/download-file/__tests__/route.test.ts
@@ -6,7 +6,10 @@ import {
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
-import { generateZeroToken } from "../../../../../../src/lib/auth/sandbox-token";
+import {
+  generateZeroToken,
+  generateSandboxToken,
+} from "../../../../../../src/lib/auth/sandbox-token";
 
 const URL = "http://localhost:3000/api/zero/web/download-file";
 
@@ -33,6 +36,19 @@ describe("GET /api/zero/web/download-file", () => {
     mockClerk({ userId: null });
 
     const request = createTestRequest(`${URL}?file_id=abc`, { method: "GET" });
+    const response = await GET(request as never);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 401 for sandbox token without file:read capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-1");
+
+    const request = createTestRequest(`${URL}?file_id=abc`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    });
     const response = await GET(request as never);
 
     expect(response.status).toBe(401);

--- a/turbo/apps/web/app/api/zero/web/download-file/route.ts
+++ b/turbo/apps/web/app/api/zero/web/download-file/route.ts
@@ -23,7 +23,8 @@ function errorResponse(
  * GET /api/zero/web/download-file?file_id=<id>
  *
  * Downloads a web-uploaded file from S3 and streams it to the caller.
- * Authenticates via ZERO_TOKEN (any sandbox capability accepted).
+ * Authenticates via ZERO_TOKEN with file:read capability (CLI PAT and Clerk
+ * session bypass the capability check).
  * File ownership is enforced by S3 key structure: uploads/${userId}/${fileId}/...
  */
 export async function GET(request: NextRequest): Promise<Response> {
@@ -31,7 +32,7 @@ export async function GET(request: NextRequest): Promise<Response> {
 
   const authHeader = request.headers.get("authorization") ?? undefined;
   const authCtx = await getAuthContext(authHeader, {
-    acceptAnySandboxCapability: true,
+    requiredCapability: "file:read",
   });
   if (!authCtx) {
     return errorResponse(401, "Not authenticated", "UNAUTHORIZED");

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -270,6 +270,8 @@ describe("sandbox-token", () => {
         "chat-message:write",
         "chat-message:read",
         "connector:read",
+        "file:read",
+        "file:write",
       ]);
       expect(auth?.capabilities).not.toContain("agent-run:write");
       expect(auth?.capabilities).not.toContain("computer-use:write");
@@ -296,7 +298,19 @@ describe("sandbox-token", () => {
         "connector:read",
         "computer-use:write",
         "voice-chat:write",
+        "file:read",
+        "file:write",
       ]);
+    });
+
+    it("should include file:read and file:write capabilities by default", async () => {
+      mockIsFeatureEnabled.mockReturnValue(false);
+
+      const token = await generateZeroToken("user-123", "run-456", "org-789");
+      const auth = verifyZeroToken(token);
+
+      expect(auth?.capabilities).toContain("file:read");
+      expect(auth?.capabilities).toContain("file:write");
     });
 
     it("should exclude agent-excluded capabilities from zero tokens", async () => {

--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -71,6 +71,7 @@ function buildAgentToolsPrompt(): string {
     "- Slack messaging, file uploads, and file downloads: `zero slack --help`. Your replies are automatically sent to the originating thread — only use these commands for different channels/threads. Never use SLACK_TOKEN directly — it's a user OAuth token.",
     "- Download a Slack file attachment to local disk: `zero slack download-file -h` for usage and how to read different file types. Use this whenever a Slack message context includes a `[Slack file]` block.",
     "- Download a web-uploaded file to local disk: `zero web download-file -h` for usage and how to read different file types. Use this whenever a web chat message includes a `[Web file]` block.",
+    "- Upload a local file and get a shareable URL: `zero web upload-file -h` for usage. Outputs JSON including a 7-day presigned URL you can share with the user or include in a message.",
     "- Third-party services (GitHub, Slack, Notion, 100+ more) are accessed via connectors that expose env vars like `GH_TOKEN`. Find: `zero connector search <keyword>`. List connected: `zero connector list`. Inspect: `zero connector status <type>`.",
     "- Diagnose connector health (token presence, firewall rules, permission policies): `zero doctor check-connector --help`.",
     "- Troubleshoot permission denials: `zero doctor permission-deny --help` to identify which permission covers a blocked request.",

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -23,8 +23,8 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 14 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(14);
+  it("should have exactly 16 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(16);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {
@@ -41,6 +41,11 @@ describe("ZERO_CAPABILITIES", () => {
   it("should use slack:write not integration-slack:write", () => {
     expect(ZERO_CAPABILITIES).toContain("slack:write");
     expect(ZERO_CAPABILITIES).not.toContain("integration-slack:write");
+  });
+
+  it("should include file read and write capabilities", () => {
+    expect(ZERO_CAPABILITIES).toContain("file:read");
+    expect(ZERO_CAPABILITIES).toContain("file:write");
   });
 });
 

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -41,6 +41,8 @@ export const ZERO_CAPABILITIES = [
   "connector:read",
   "computer-use:write",
   "voice-chat:write",
+  "file:read",
+  "file:write",
 ] as const;
 
 /** Inferred union type of all zero capability strings. */
@@ -88,6 +90,8 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
       group: "Voice Chat",
       label: "Read and write voice chat context",
     },
+    "file:read": { group: "Files", label: "Download uploaded files" },
+    "file:write": { group: "Files", label: "Upload files" },
   };
 
 /**


### PR DESCRIPTION
## Summary

- Add `file:read` / `file:write` to `ZERO_CAPABILITIES` + `ZERO_CAPABILITY_META`; generated zero tokens now carry both by default
- Gate `POST /api/zero/uploads` on `file:write` and extend presigned URL TTL 24h → 7d; Clerk session and CLI PAT bypass capability checks so the frontend chat composer is unaffected
- Hard cutover on `GET /api/zero/web/download-file`: `acceptAnySandboxCapability: true` → `requiredCapability: "file:read"`
- New `zero web upload-file -f <path>` command posting multipart/form-data; prints `{id, filename, contentType, size, url}` JSON to stdout, mirroring the sibling download-file command

## Test plan

- [x] `pnpm -F @vm0/core exec vitest run composes` — 7 passed
- [x] `pnpm -F web exec vitest run src/lib/auth/__tests__/sandbox-token.test.ts app/api/zero/uploads/__tests__ app/api/zero/web/download-file/__tests__` — 74 passed
- [x] `pnpm -F cli exec vitest run` — 1078 passed
- [x] `pnpm format` — clean
- [x] `pnpm knip` — no issues
- [x] ESLint clean on touched files
- [ ] Frontend chat composer upload verified unaffected in manual smoke (Clerk session path bypasses capability check — covered by existing passing uploads route test)

## Rollout note

In-flight ZERO_TOKENs issued before this deploy do not carry `file:read` / `file:write` and will 401 on the gated routes for up to the 2h token TTL until they refresh on the next agent run. Accepted per hard-cutover decision in #10253.

Closes #10253

🤖 Generated with [Claude Code](https://claude.com/claude-code)