### PR TITLE
feat(observability): add startup and wrap-up latency telemetry

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -75,7 +75,7 @@ pub async fn execute_job(
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
 
-    record_api_latency(&context, &mut telemetry);
+    record_api_latency("api_to_vm_start", &context, &mut telemetry);
 
     let outcome = match execute_new_sandbox(
         factory,
@@ -122,7 +122,7 @@ pub async fn execute_job_reuse(
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
 
-    record_api_latency(&context, &mut telemetry);
+    record_api_latency("api_to_vm_start", &context, &mut telemetry);
     telemetry.record("vm_reuse", Duration::ZERO, true, None);
 
     let source_ip = idle_entry.source_ip.clone();
@@ -146,12 +146,12 @@ pub async fn execute_job_reuse(
     (outcome, telemetry)
 }
 
-fn record_api_latency(context: &ExecutionContext, telemetry: &mut JobTelemetry) {
+fn record_api_latency(action_type: &str, context: &ExecutionContext, telemetry: &mut JobTelemetry) {
     if let Some(api_start_ms) = context.api_start_time {
         let now_ms = chrono::Utc::now().timestamp_millis() as f64;
         let elapsed_ms = (now_ms - api_start_ms).max(0.0);
         telemetry.record(
-            "api_to_vm_start",
+            action_type,
             Duration::from_millis(elapsed_ms as u64),
             true,
             None,
@@ -474,6 +474,9 @@ async fn run_in_sandbox(
             return Err(e.into());
         }
     };
+
+    // Claude Code process has a PID now — record end-to-end startup latency.
+    record_api_latency("api_to_spawn", context, telemetry);
 
     // Spawn background task to drain stdout chunks and write to host log file.
     let host_log_path = config.log_paths.system_log(context.run_id);

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -1,8 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { NextRequest, NextResponse, after } from "next/server";
+import { eq, sql } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../src/lib/infra/callback";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import { chatMessages } from "../../../../../src/db/schema/chat-message";
+import { recordSandboxOperation } from "../../../../../src/lib/infra/metrics/instruments";
 import {
   insertChatMessage,
   insertAssistantEventMessages,
@@ -108,6 +110,44 @@ async function loadPriorTitleContext(
 }
 
 /**
+ * Emit the `last_event_to_complete` metric for Morning Brief wrap-up
+ * aggregation. Both timestamps are read from the DB in a single query so
+ * the measurement is single-source-of-truth with no cross-host clock skew.
+ * Filters on `sequence_number IS NOT NULL` to exclude user messages and
+ * placeholder/error rows, keeping the metric grounded in real agent output.
+ */
+async function recordLastEventToComplete(runId: string): Promise<void> {
+  const [row] = await globalThis.services.db
+    .select({
+      completedAt: agentRuns.completedAt,
+      lastEventAt: sql<Date | null>`(
+        SELECT MAX(${chatMessages.createdAt})
+        FROM ${chatMessages}
+        WHERE ${chatMessages.runId} = ${agentRuns.id}
+          AND ${chatMessages.role} = 'assistant'
+          AND ${chatMessages.sequenceNumber} IS NOT NULL
+      )`,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
+  if (!row?.completedAt || !row.lastEventAt) return;
+
+  const lastEventMs =
+    row.lastEventAt instanceof Date
+      ? row.lastEventAt.getTime()
+      : new Date(row.lastEventAt).getTime();
+  recordSandboxOperation({
+    sandboxType: "runner",
+    actionType: "last_event_to_complete",
+    durationMs: Math.max(0, row.completedAt.getTime() - lastEventMs),
+    success: true,
+    runId,
+  });
+}
+
+/**
  * Handle completed run: final sweep for any events the consumer missed,
  * then generate title and push notification.
  */
@@ -125,6 +165,14 @@ async function handleCompleted(
   if (items.length > 0) {
     await insertAssistantEventMessages(runId, threadId, userId, items);
   }
+
+  // Wrap-up latency: gap from last assistant event row to run terminal
+  // transition. Scheduled via after() so the DB query and Axiom ingest
+  // don't block the callback response. Runs after the final sweep above
+  // so it isn't racing events the live consumer dropped.
+  after(() => {
+    return recordLastEventToComplete(runId);
+  });
 
   // Use last assistant text for downstream (title, summary, notification)
   const lastResultText =


### PR DESCRIPTION
## Summary

Two new telemetry metrics for Morning Brief's 24h p50/p90/p99 aggregates (issue #9936):

- **`api_to_spawn`** (runner) — end-to-end startup latency from Next.js route entry (existing `api_start_time`) to the Claude Code process PID. Reuses the existing `record_api_latency` helper (now parameterised on `action_type`) and the `.max(0.0)` clock-skew guard.
- **`last_event_to_complete`** (web) — wrap-up latency from the run's last assistant event row to terminal transition. Emitted from the chat callback's `handleCompleted` after the final Axiom sweep completes, so the measurement isn't racing events the live consumer dropped. A single correlated-subquery SQL reads `agent_runs.completed_at` and `MAX(chat_messages.created_at)` (filtered on `role='assistant' AND sequence_number IS NOT NULL`) so both endpoints are DB-authoritative with no cross-host clock skew. Scheduled via `after()` so the query and Axiom ingest don't block the callback response.

Scope: chat runs only. Schedule / CLI / agent-run don't produce chat_messages, so they skip silently. Per-run-type semantics were left to the owner in the issue; chat covers the 215-run sample the author analysed.

## Out of scope

- Morning Brief skill integration (lives in the Zero skills layer per the issue) — data is now queryable from Axiom `SANDBOX_OPERATIONS` dataset, filtered by `action_type in ("api_to_spawn", "last_event_to_complete")`.

## Test plan

- [x] `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- [x] `cargo test -p runner --bin runner` (698 passed)
- [x] `cargo fmt -p runner --check`
- [x] `pnpm -F web check-types`
- [x] `pnpm -F web exec eslint` (both modified files, 0 warnings)
- [x] `vitest run app/api/webhooks/agent/complete/__tests__ app/api/internal/callbacks/chat/__tests__` (47 passed)

Closes #9936

🤖 Generated with [Claude Code](https://claude.com/claude-code)