### PR TITLE
feat(voice-io): gate audio input by org tier with free-tier quota

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-voice-io.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-voice-io.ts
@@ -1,0 +1,18 @@
+/**
+ * Voice IO API Handlers
+ *
+ * Mock handlers for /api/zero/voice-io endpoints.
+ * Default behavior: quota endpoint returns `allowed: true` with unlimited
+ * (limit: null) so tests that don't care about quota don't produce
+ * unhandled-request warnings. Tests that need specific quota state should
+ * override via `server.use(mockApi(zeroVoiceIoQuotaContract.get, ...))`.
+ */
+
+import { zeroVoiceIoQuotaContract } from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
+
+export const apiVoiceIoHandlers = [
+  mockApi(zeroVoiceIoQuotaContract.get, ({ respond }) => {
+    return respond(200, { allowed: true, count: 0, limit: null });
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -79,6 +79,7 @@ import {
 } from "./api-permission-access-requests.ts";
 import { apiPermissionPoliciesHandlers } from "./api-permission-policies.ts";
 import { apiVoiceChatHandlers } from "./api-voice-chat.ts";
+import { apiVoiceIoHandlers } from "./api-voice-io.ts";
 
 export const handlers = [
   ...apiConnectorsHandlers,
@@ -110,6 +111,7 @@ export const handlers = [
   ...apiInsightsHandlers,
   ...apiQueuePositionHandlers,
   ...apiVoiceChatHandlers,
+  ...apiVoiceIoHandlers,
 ];
 
 export function resetAllMockHandlers(): void {

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -1,10 +1,17 @@
 import { command, computed, state } from "ccstate";
-import { FeatureSwitchKey } from "@vm0/core";
+import {
+  FeatureSwitchKey,
+  zeroVoiceIoQuotaContract,
+  type AudioInputQuotaResponse,
+} from "@vm0/core";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { fetch$ } from "../fetch.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { setBillingDialogOpen$ } from "../zero-page/billing.ts";
 import { logger } from "../log.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { stopTts$ } from "./voice-io-tts.ts";
+import { accept } from "../../lib/accept.ts";
 
 const L = logger("VoiceIO:STT");
 
@@ -17,6 +24,7 @@ const internalTranscribing$ = state(false);
 const internalStream$ = state<MediaStream | null>(null);
 const internalChunks$ = state<Blob[]>([]);
 const internalRecorder$ = state<MediaRecorder | null>(null);
+const audioInputQuotaReload$ = state(0);
 
 // ---------------------------------------------------------------------------
 // Public computed
@@ -37,6 +45,21 @@ export const audioInputAvailable$ = computed(async (get) => {
     typeof navigator !== "undefined" && !!navigator.mediaDevices?.getUserMedia;
   return featureEnabled && hasMic;
 });
+
+/**
+ * Async-loaded audio input quota for the current user/org.
+ * Re-fetches whenever `refreshAudioInputQuota$` is invoked (e.g., after a
+ * successful STT call or a 402 response).
+ */
+export const audioInputQuota$ = computed(
+  async (get): Promise<AudioInputQuotaResponse> => {
+    get(audioInputQuotaReload$);
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroVoiceIoQuotaContract);
+    const result = await accept(client.get(), [200], { toast: false });
+    return result.body;
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -77,6 +100,12 @@ const resetState$ = command(({ set }) => {
 // ---------------------------------------------------------------------------
 // Public commands
 // ---------------------------------------------------------------------------
+
+const refreshAudioInputQuota$ = command(({ set }) => {
+  set(audioInputQuotaReload$, (x) => {
+    return x + 1;
+  });
+});
 
 export const startRecording$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -181,6 +210,19 @@ export const stopAndTranscribe$ = command(
       });
 
       if (!response.ok) {
+        if (response.status === 402) {
+          const body = (await response.json().catch(() => {
+            return null;
+          })) as {
+            error?: { code?: string };
+          } | null;
+          if (body?.error?.code === "AUDIO_INPUT_QUOTA_EXCEEDED") {
+            set(refreshAudioInputQuota$);
+            set(setBillingDialogOpen$, true);
+            set(resetState$);
+            return "";
+          }
+        }
         L.error("STT API error", { status: response.status });
         toast.error("Transcription failed");
         set(resetState$);
@@ -189,6 +231,8 @@ export const stopAndTranscribe$ = command(
 
       const result = (await response.json()) as { text: string };
       text = result.text.trim();
+      // Refresh cached quota so the UI reflects the new count for free-tier users.
+      set(refreshAudioInputQuota$);
     } catch (error) {
       L.error("STT fetch failed", error);
       toast.error("Transcription failed");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { FeatureSwitchKey } from "@vm0/core";
+import { FeatureSwitchKey, zeroVoiceIoQuotaContract } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
@@ -45,6 +46,37 @@ function mockSttEndpoint(text = "transcribed text") {
     // (accepts multipart FormData audio body), so raw http is the only option.
     http.post("*/api/zero/voice-io/stt", () => {
       return HttpResponse.json({ text });
+    }),
+  );
+}
+
+function mockSttQuotaExceededEndpoint() {
+  server.use(
+    // mockApi cannot be used here: /api/zero/voice-io/stt has no ts-rest contract
+    // (accepts multipart FormData audio body), so raw http is the only option.
+    http.post("*/api/zero/voice-io/stt", () => {
+      return HttpResponse.json(
+        {
+          error: {
+            message: "Audio input quota exceeded",
+            code: "AUDIO_INPUT_QUOTA_EXCEEDED",
+          },
+          quota: { count: 3, limit: 3 },
+        },
+        { status: 402 },
+      );
+    }),
+  );
+}
+
+function mockQuotaEndpoint(quota: {
+  allowed: boolean;
+  count: number;
+  limit: number | null;
+}) {
+  server.use(
+    mockApi(zeroVoiceIoQuotaContract.get, ({ respond }) => {
+      return respond(200, quota);
     }),
   );
 }
@@ -286,6 +318,106 @@ describe("chat-i-034: mic button transcription appends to draft", () => {
 
     await waitFor(() => {
       expect(textarea.value).toBe(`hello ${transcribedText}`);
+    });
+  });
+});
+
+describe("chat-i-035: mic button gates on audio input quota", () => {
+  beforeEach(() => {
+    stubMediaDevices();
+    stubMediaRecorder();
+  });
+
+  afterEach(() => {
+    clearMediaDevices();
+    vi.unstubAllGlobals();
+  });
+
+  it("should start recording when quota is available", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+    mockQuotaEndpoint({ allowed: true, count: 1, limit: 3 });
+    mockSttEndpoint();
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.AudioInput]: true },
+    });
+
+    const micButton = await waitFor(() => {
+      return screen.getByLabelText("Voice input");
+    });
+
+    await user.click(micButton);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Choose your plan")).not.toBeInTheDocument();
+  });
+
+  it("should open billing dialog without recording when quota is exhausted", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+    mockQuotaEndpoint({ allowed: false, count: 3, limit: 3 });
+
+    let sttCalls = 0;
+    server.use(
+      // mockApi cannot be used here: /api/zero/voice-io/stt has no ts-rest contract
+      // (accepts multipart FormData audio body), so raw http is the only option.
+      http.post("*/api/zero/voice-io/stt", () => {
+        sttCalls++;
+        return HttpResponse.json({ text: "should-not-be-called" });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.AudioInput]: true },
+    });
+
+    const micButton = await waitFor(() => {
+      return screen.getByLabelText("Voice input");
+    });
+
+    await user.click(micButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Choose your plan")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText("Stop recording")).not.toBeInTheDocument();
+    expect(sttCalls).toBe(0);
+  });
+
+  it("should open billing dialog when STT returns 402 quota-exceeded after recording", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+    mockQuotaEndpoint({ allowed: true, count: 2, limit: 3 });
+    mockSttQuotaExceededEndpoint();
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.AudioInput]: true },
+    });
+
+    const micButton = await waitFor(() => {
+      return screen.getByLabelText("Voice input");
+    });
+
+    await user.click(micButton);
+
+    const stopButton = await waitFor(() => {
+      return screen.getByLabelText("Stop recording");
+    });
+
+    await user.click(stopButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Choose your plan")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -99,11 +99,13 @@ import {
 } from "../../signals/zero-page/zero-chat-composer.ts";
 import {
   audioInputAvailable$,
+  audioInputQuota$,
   sttRecording$,
   sttTranscribing$,
   startRecording$,
   stopAndTranscribe$,
 } from "../../signals/voice-io/voice-io-stt.ts";
+import { setBillingDialogOpen$ } from "../../signals/zero-page/billing.ts";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB — keep in sync with uploads/route.ts
 
@@ -481,10 +483,12 @@ function MicButton({
   onTranscribed: (text: string) => void;
 }) {
   const available = useLastResolved(audioInputAvailable$) ?? false;
+  const quota = useLastResolved(audioInputQuota$) ?? null;
   const recording = useGet(sttRecording$);
   const transcribing = useGet(sttTranscribing$);
   const startRec = useSet(startRecording$);
   const stopAndTranscribe = useSet(stopAndTranscribe$);
+  const openBillingDialog = useSet(setBillingDialogOpen$);
   const signal = useGet(pageSignal$);
 
   if (!available) {
@@ -505,6 +509,10 @@ function MicButton({
         Reason.DomCallback,
       );
     } else {
+      if (quota && !quota.allowed) {
+        openBillingDialog(true);
+        return;
+      }
       detach(startRec(signal), Reason.DomCallback);
     }
   };

--- a/turbo/apps/web/app/api/zero/voice-io/quota/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/quota/__tests__/route.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import {
+  createTestOrg,
+  updateOrgTier,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { seedBehaviorCount } from "../../../../../../src/__tests__/db-test-seeders/behavior";
+import {
+  AUDIO_INPUT_BEHAVIOR_KEY,
+  AUDIO_INPUT_FREE_QUOTA,
+} from "../../../../../../src/lib/zero/voice-io/audio-input-policy";
+
+const { GET } = await import("../route");
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("quota");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function createQuotaRequest(): Request {
+  return new Request("http://localhost:3000/api/zero/voice-io/quota", {
+    method: "GET",
+  });
+}
+
+describe("GET /api/zero/voice-io/quota", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+    const response = await GET(createQuotaRequest());
+    const body = await response.json();
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return allowed=true with count=0 for a free org with no prior records", async () => {
+    const userId = uniqueId("quota-free-empty");
+    await setupOrg(userId);
+    const response = await GET(createQuotaRequest());
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      allowed: true,
+      count: 0,
+      limit: AUDIO_INPUT_FREE_QUOTA,
+    });
+  });
+
+  it("should return allowed=true with accurate count for a free org with partial usage", async () => {
+    const userId = uniqueId("quota-free-partial");
+    const { orgId } = await setupOrg(userId);
+    await seedBehaviorCount(orgId, userId, AUDIO_INPUT_BEHAVIOR_KEY, 2);
+    const response = await GET(createQuotaRequest());
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      allowed: true,
+      count: 2,
+      limit: AUDIO_INPUT_FREE_QUOTA,
+    });
+  });
+
+  it("should return allowed=false when a free org has reached the quota", async () => {
+    const userId = uniqueId("quota-free-full");
+    const { orgId } = await setupOrg(userId);
+    await seedBehaviorCount(
+      orgId,
+      userId,
+      AUDIO_INPUT_BEHAVIOR_KEY,
+      AUDIO_INPUT_FREE_QUOTA,
+    );
+    const response = await GET(createQuotaRequest());
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      allowed: false,
+      count: AUDIO_INPUT_FREE_QUOTA,
+      limit: AUDIO_INPUT_FREE_QUOTA,
+    });
+  });
+
+  it("should return allowed=true with limit=null for a pro org regardless of history", async () => {
+    const userId = uniqueId("quota-pro");
+    const { orgId } = await setupOrg(userId);
+    await updateOrgTier(orgId, "pro");
+    await seedBehaviorCount(orgId, userId, AUDIO_INPUT_BEHAVIOR_KEY, 10);
+    const response = await GET(createQuotaRequest());
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      allowed: true,
+      count: 0,
+      limit: null,
+    });
+  });
+
+  it("should return allowed=true with limit=null for a team org", async () => {
+    const userId = uniqueId("quota-team");
+    const { orgId } = await setupOrg(userId);
+    await updateOrgTier(orgId, "team");
+    const response = await GET(createQuotaRequest());
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      allowed: true,
+      count: 0,
+      limit: null,
+    });
+  });
+});

--- a/turbo/apps/web/app/api/zero/voice-io/quota/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/quota/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getOrgTierSafe } from "../../../../../src/lib/zero/org/org-metadata-service";
+import { checkAudioInputQuota } from "../../../../../src/lib/zero/voice-io/audio-input-policy";
+
+export async function GET(request: Request): Promise<Response> {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx || !authCtx.orgId) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const tier = await getOrgTierSafe(authCtx.orgId);
+  const quota = await checkAudioInputQuota(authCtx.orgId, authCtx.userId, tier);
+  return NextResponse.json(quota, { status: 200 });
+}

--- a/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
@@ -5,9 +5,17 @@ import {
   testContext,
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
-import { createTestOrg } from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestOrg,
+  updateOrgTier,
+} from "../../../../../../src/__tests__/api-test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { reloadEnv } from "../../../../../../src/env";
+import { readBehaviorCount } from "../../../../../../src/__tests__/db-test-seeders/behavior";
+import {
+  AUDIO_INPUT_BEHAVIOR_KEY,
+  AUDIO_INPUT_FREE_QUOTA,
+} from "../../../../../../src/lib/zero/voice-io/audio-input-policy";
 
 vi.mock("@vm0/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@vm0/core")>();
@@ -174,5 +182,110 @@ describe("POST /api/zero/voice-io/stt", () => {
     const body = await response.json();
     expect(response.status).toBe(500);
     expect(body.error.code).toBe("INTERNAL_SERVER_ERROR");
+  });
+
+  describe("org tier quota gating", () => {
+    it("should not increment the counter for a pro org across multiple successes", async () => {
+      const userId = uniqueId("stt-pro");
+      const { orgId } = await setupOrg(userId);
+      await updateOrgTier(orgId, "pro");
+
+      server.use(
+        http.post("https://api.openai.com/v1/audio/transcriptions", () => {
+          return HttpResponse.json({ text: "pro transcript" });
+        }),
+      );
+
+      for (let i = 0; i < 5; i++) {
+        const response = await POST(createSttRequest(createAudioFile()));
+        expect(response.status).toBe(200);
+      }
+
+      const count = await readBehaviorCount(
+        orgId,
+        userId,
+        AUDIO_INPUT_BEHAVIOR_KEY,
+      );
+      expect(count).toBe(0);
+    });
+
+    it("should increment the counter on each successful free-tier call up to the quota", async () => {
+      const userId = uniqueId("stt-free");
+      const { orgId } = await setupOrg(userId);
+
+      server.use(
+        http.post("https://api.openai.com/v1/audio/transcriptions", () => {
+          return HttpResponse.json({ text: "free transcript" });
+        }),
+      );
+
+      for (let i = 1; i <= AUDIO_INPUT_FREE_QUOTA; i++) {
+        const response = await POST(createSttRequest(createAudioFile()));
+        expect(response.status).toBe(200);
+        const count = await readBehaviorCount(
+          orgId,
+          userId,
+          AUDIO_INPUT_BEHAVIOR_KEY,
+        );
+        expect(count).toBe(i);
+      }
+    });
+
+    it("should return 402 once the free-tier quota is exhausted and leave the counter unchanged", async () => {
+      const userId = uniqueId("stt-free-exceed");
+      const { orgId } = await setupOrg(userId);
+
+      server.use(
+        http.post("https://api.openai.com/v1/audio/transcriptions", () => {
+          return HttpResponse.json({ text: "ok" });
+        }),
+      );
+
+      // Exhaust the quota with AUDIO_INPUT_FREE_QUOTA successful calls
+      for (let i = 0; i < AUDIO_INPUT_FREE_QUOTA; i++) {
+        const ok = await POST(createSttRequest(createAudioFile()));
+        expect(ok.status).toBe(200);
+      }
+
+      const response = await POST(createSttRequest(createAudioFile()));
+      const body = await response.json();
+      expect(response.status).toBe(402);
+      expect(body.error.code).toBe("AUDIO_INPUT_QUOTA_EXCEEDED");
+      expect(body.quota).toEqual({
+        count: AUDIO_INPUT_FREE_QUOTA,
+        limit: AUDIO_INPUT_FREE_QUOTA,
+      });
+
+      const count = await readBehaviorCount(
+        orgId,
+        userId,
+        AUDIO_INPUT_BEHAVIOR_KEY,
+      );
+      expect(count).toBe(AUDIO_INPUT_FREE_QUOTA);
+    });
+
+    it("should not increment the counter when OpenAI fails on the first free-tier call", async () => {
+      const userId = uniqueId("stt-free-infra-fail");
+      const { orgId } = await setupOrg(userId);
+
+      server.use(
+        http.post("https://api.openai.com/v1/audio/transcriptions", () => {
+          return HttpResponse.json(
+            { error: { message: "boom" } },
+            { status: 500 },
+          );
+        }),
+      );
+
+      const response = await POST(createSttRequest(createAudioFile()));
+      expect(response.status).toBe(500);
+
+      const count = await readBehaviorCount(
+        orgId,
+        userId,
+        AUDIO_INPUT_BEHAVIOR_KEY,
+      );
+      expect(count).toBe(0);
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
@@ -3,6 +3,12 @@ import { FeatureSwitchKey, isFeatureEnabled } from "@vm0/core";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { initServices } from "../../../../../src/lib/init-services";
 import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
+import { getOrgTierSafe } from "../../../../../src/lib/zero/org/org-metadata-service";
+import { recordBehavior } from "../../../../../src/lib/zero/behavior/user-behavior-count-service";
+import {
+  AUDIO_INPUT_BEHAVIOR_KEY,
+  checkAudioInputQuota,
+} from "../../../../../src/lib/zero/voice-io/audio-input-policy";
 import { env } from "../../../../../src/env";
 import { logger } from "../../../../../src/lib/shared/logger";
 
@@ -29,12 +35,13 @@ export async function POST(request: Request): Promise<Response> {
   // 1. Auth check
   const authHeader = request.headers.get("authorization");
   const authCtx = await getAuthContext(authHeader ?? undefined);
-  if (!authCtx) {
+  if (!authCtx || !authCtx.orgId) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const orgId = authCtx.orgId;
 
   // 2. Feature switch check
   const overrides = await loadFeatureSwitchOverrides(
@@ -53,7 +60,24 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  // 3. API key check
+  // 3. Quota check (free tier has a per-user limit; pro/team are unlimited)
+  const orgTier = await getOrgTierSafe(orgId);
+  const quota = await checkAudioInputQuota(orgId, authCtx.userId, orgTier);
+  if (!quota.allowed) {
+    return NextResponse.json(
+      {
+        error: {
+          message:
+            "Audio input quota exceeded. Upgrade to Pro or Team for unlimited audio input.",
+          code: "AUDIO_INPUT_QUOTA_EXCEEDED",
+        },
+        quota: { count: quota.count, limit: quota.limit },
+      },
+      { status: 402 },
+    );
+  }
+
+  // 4. API key check
   const apiKey = env().OPENAI_API_KEY;
   if (!apiKey) {
     return NextResponse.json(
@@ -67,7 +91,7 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  // 4. Parse multipart form data
+  // 5. Parse multipart form data
   const formData = await request.formData();
   const file = formData.get("file");
 
@@ -78,7 +102,7 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  // 5. Validate file size
+  // 6. Validate file size
   if (file.size > MAX_FILE_SIZE) {
     return NextResponse.json(
       {
@@ -91,7 +115,7 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  // 6. Validate file type (strip codec suffix, e.g. "audio/webm;codecs=opus" → "audio/webm")
+  // 7. Validate file type (strip codec suffix, e.g. "audio/webm;codecs=opus" → "audio/webm")
   const baseMimeType = file.type.split(";")[0] ?? file.type;
   if (!ALLOWED_MIME_TYPES.has(baseMimeType)) {
     return NextResponse.json(
@@ -105,7 +129,7 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  // 7. Call OpenAI STT API
+  // 8. Call OpenAI STT API
   const openaiForm = new FormData();
   openaiForm.append("file", file, file.name || "audio.webm");
   openaiForm.append("model", "gpt-4o-mini-transcribe");
@@ -142,5 +166,12 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const result = (await openaiResponse.json()) as { text: string };
+
+  // 9. Record the successful audio input for free-tier quota accounting.
+  // Skipped on failure so infra errors don't burn the user's free quota.
+  if (orgTier === "free") {
+    await recordBehavior(orgId, authCtx.userId, AUDIO_INPUT_BEHAVIOR_KEY);
+  }
+
   return NextResponse.json({ text: result.text });
 }

--- a/turbo/apps/web/src/__tests__/db-test-seeders/behavior.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/behavior.ts
@@ -1,0 +1,51 @@
+import { and, eq } from "drizzle-orm";
+import { userBehaviorCount } from "../../db/schema/user-behavior-count";
+
+/**
+ * Seed a user behavior count row for testing.
+ * @why-db-direct Behavior counts have no direct write API — production writes
+ *   flow through specific feature routes (e.g., POST /voice-io/stt) that would
+ *   require mocking multiple external dependencies just to populate state.
+ */
+export async function seedBehaviorCount(
+  orgId: string,
+  userId: string,
+  behaviorKey: string,
+  count: number,
+): Promise<void> {
+  const now = new Date();
+  await globalThis.services.db
+    .insert(userBehaviorCount)
+    .values({ orgId, userId, behaviorKey, count, firstAt: now, lastAt: now })
+    .onConflictDoUpdate({
+      target: [
+        userBehaviorCount.orgId,
+        userBehaviorCount.userId,
+        userBehaviorCount.behaviorKey,
+      ],
+      set: { count, lastAt: now },
+    });
+}
+
+/**
+ * Read the current behavior count for test assertions.
+ * @why-db-direct getCount service cannot be imported in test files per
+ *   web/no-direct-db-in-tests; this helper encapsulates the DB read.
+ */
+export async function readBehaviorCount(
+  orgId: string,
+  userId: string,
+  behaviorKey: string,
+): Promise<number> {
+  const rows = await globalThis.services.db
+    .select({ count: userBehaviorCount.count })
+    .from(userBehaviorCount)
+    .where(
+      and(
+        eq(userBehaviorCount.orgId, orgId),
+        eq(userBehaviorCount.userId, userId),
+        eq(userBehaviorCount.behaviorKey, behaviorKey),
+      ),
+    );
+  return rows[0]?.count ?? 0;
+}

--- a/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
+++ b/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
+import { orgTierSchema, type OrgTier } from "@vm0/core";
 import { orgMetadata } from "../../../db/schema/org-metadata";
-import { notFound } from "../../shared/errors";
+import { isNotFound, notFound } from "../../shared/errors";
 import { logger } from "../../shared/logger";
 import { getStripe } from "../stripe";
 
@@ -34,6 +35,21 @@ export async function getOrgMetadata(orgId: string): Promise<OrgMetadata> {
     tier: row.tier,
     credits: row.credits,
   };
+}
+
+/**
+ * Read the org tier from org_metadata, defaulting to "free" for brand-new
+ * orgs that don't have an org_metadata row yet. Unknown tier strings in the
+ * database will fail-fast via Zod parsing rather than silently pass through.
+ */
+export async function getOrgTierSafe(orgId: string): Promise<OrgTier> {
+  try {
+    const { tier } = await getOrgMetadata(orgId);
+    return orgTierSchema.parse(tier);
+  } catch (error) {
+    if (isNotFound(error)) return "free";
+    throw error;
+  }
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/voice-io/audio-input-policy.ts
+++ b/turbo/apps/web/src/lib/zero/voice-io/audio-input-policy.ts
@@ -1,0 +1,27 @@
+import type { OrgTier } from "@vm0/core";
+import { getCount } from "../behavior/user-behavior-count-service";
+
+export const AUDIO_INPUT_FREE_QUOTA = 3;
+export const AUDIO_INPUT_BEHAVIOR_KEY = "audio_input";
+
+interface AudioInputQuotaStatus {
+  allowed: boolean;
+  count: number;
+  limit: number | null;
+}
+
+export async function checkAudioInputQuota(
+  orgId: string,
+  userId: string,
+  orgTier: OrgTier,
+): Promise<AudioInputQuotaStatus> {
+  if (orgTier !== "free") {
+    return { allowed: true, count: 0, limit: null };
+  }
+  const count = await getCount(orgId, userId, AUDIO_INPUT_BEHAVIOR_KEY);
+  return {
+    allowed: count < AUDIO_INPUT_FREE_QUOTA,
+    count,
+    limit: AUDIO_INPUT_FREE_QUOTA,
+  };
+}

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -863,6 +863,12 @@ export {
   type FreshPreparation,
 } from "./zero-voice-chat-prepare";
 export {
+  zeroVoiceIoQuotaContract,
+  audioInputQuotaResponseSchema,
+  type ZeroVoiceIoQuotaContract,
+  type AudioInputQuotaResponse,
+} from "./zero-voice-io-quota";
+export {
   tasksContract,
   taskItemSchema,
   taskTypeSchema,

--- a/turbo/packages/core/src/contracts/zero-voice-io-quota.ts
+++ b/turbo/packages/core/src/contracts/zero-voice-io-quota.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const audioInputQuotaResponseSchema = z.object({
+  allowed: z.boolean(),
+  count: z.number().int().nonnegative(),
+  limit: z.number().int().positive().nullable(),
+});
+export type AudioInputQuotaResponse = z.infer<
+  typeof audioInputQuotaResponseSchema
+>;
+
+/**
+ * Zero contract for GET /api/zero/voice-io/quota
+ *
+ * Returns the current audio input quota state for the authenticated org/user.
+ * Used by the platform to drive mic-button gating without firing a doomed STT
+ * request when a free-tier user has exhausted their quota.
+ */
+export const zeroVoiceIoQuotaContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/voice-io/quota",
+    headers: authHeadersSchema,
+    responses: {
+      200: audioInputQuotaResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get audio input quota for current org/user",
+  },
+});
+
+export type ZeroVoiceIoQuotaContract = typeof zeroVoiceIoQuotaContract;


### PR DESCRIPTION
## Summary
- Adds org-tier gating to the STT (speech-to-text) endpoint: pro/team unlimited, free tier capped at 3 audio inputs per (org, user)
- New `GET /api/zero/voice-io/quota` contract lets the composer gate the mic button before firing a doomed STT request
- On quota exhaustion, existing `BillingDialog` paywall opens; free-tier counter increments only on successful OpenAI transcription
- Closes #10218

## Test plan
- [x] `GET /quota` route tests: 401 unauth, free empty/partial/full, pro + team unlimited
- [x] `POST /stt` route tests: pro unlimited + no counter increment, free 1–3 success with counter, free 4th → 402 `AUDIO_INPUT_QUOTA_EXCEEDED`, OpenAI failure leaves counter unchanged
- [x] Mic button tests: quota available → records, quota exhausted → opens BillingDialog without firing STT, STT 402 → opens BillingDialog + refreshes cache
- [x] `pnpm turbo run lint` — pass
- [x] `pnpm check-types` — pass
- [x] `pnpm format` — pass
- [x] `pnpm knip` — pass
- [x] Full voice-io test runs in web + platform workspaces pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)