### PR TITLE
fix(chat): restore structured attach-files flow for web chat uploads

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -13,16 +13,13 @@ import {
   chatMessagesContract,
   chatThreadsContract,
   chatThreadByIdContract,
-  type AttachFile,
   type ModelSelectionRequest,
   type PagedChatMessage,
 } from "@vm0/core";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
-import {
-  talkDraft$,
-  type ZeroChatAttachment,
-} from "../zero-page/chat-draft.ts";
+import { talkDraft$ } from "../zero-page/chat-draft.ts";
+import { prepareUserMessageFromDraft$ } from "./resolve-draft-attachments.ts";
 
 export {
   chatThreads$,
@@ -142,59 +139,26 @@ export const sendNewThreadMessage$ = command(
     // attachments so the first message carries structured `attachFiles` just
     // like follow-ups do (fixes #10243 for the new-thread entry point).
     const draft = get(talkDraft$);
-    const allAttachments = get(draft.attachments$);
-    const allInfos = await Promise.all(
-      allAttachments.map((a) => {
-        return get(a.fileInfo$);
-      }),
+    const prepared = await set(
+      prepareUserMessageFromDraft$,
+      draft,
+      prompt,
+      signal,
     );
-    signal.throwIfAborted();
-
-    const ready = allAttachments
-      .map((a, i) => {
-        return { attachment: a, info: allInfos[i] };
-      })
-      .filter(
-        (
-          r,
-        ): r is {
-          attachment: ZeroChatAttachment;
-          info: { id: string; url: string };
-        } => {
-          return r.info !== null;
-        },
-      );
-
-    const trimmedPrompt = prompt.trim();
-    if (!trimmedPrompt && ready.length === 0) {
+    if (!prepared) {
       return null;
     }
-
-    const finalPrompt =
-      trimmedPrompt || (ready.length > 0 ? "(see attached files)" : "");
-
-    const attachFiles: AttachFile[] | undefined =
-      ready.length > 0
-        ? ready.map((r) => {
-            return {
-              id: r.info.id,
-              filename: r.attachment.filename,
-              contentType: r.attachment.contentType,
-              size: r.attachment.size,
-            };
-          })
-        : undefined;
 
     const client = get(zeroClient$)(chatMessagesContract);
     const result = await accept(
       client.send({
         body: {
           agentId,
-          prompt: finalPrompt,
-          hasTextContent: trimmedPrompt.length > 0,
+          prompt: prepared.prompt,
+          hasTextContent: prepared.hasTextContent,
           clientMessageId: crypto.randomUUID(),
           modelSelection,
-          attachFiles,
+          attachFiles: prepared.attachFiles,
         },
         fetchOptions: { signal },
       }),

--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -13,11 +13,16 @@ import {
   chatMessagesContract,
   chatThreadsContract,
   chatThreadByIdContract,
+  type AttachFile,
   type ModelSelectionRequest,
   type PagedChatMessage,
 } from "@vm0/core";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
+import {
+  talkDraft$,
+  type ZeroChatAttachment,
+} from "../zero-page/chat-draft.ts";
 
 export {
   chatThreads$,
@@ -133,19 +138,63 @@ export const sendNewThreadMessage$ = command(
     modelSelection: ModelSelectionRequest | null,
     signal: AbortSignal,
   ): Promise<string | null> => {
-    if (!prompt.trim()) {
+    // Mirror the in-thread send path: resolve the talk-page draft's uploaded
+    // attachments so the first message carries structured `attachFiles` just
+    // like follow-ups do (fixes #10243 for the new-thread entry point).
+    const draft = get(talkDraft$);
+    const allAttachments = get(draft.attachments$);
+    const allInfos = await Promise.all(
+      allAttachments.map((a) => {
+        return get(a.fileInfo$);
+      }),
+    );
+    signal.throwIfAborted();
+
+    const ready = allAttachments
+      .map((a, i) => {
+        return { attachment: a, info: allInfos[i] };
+      })
+      .filter(
+        (
+          r,
+        ): r is {
+          attachment: ZeroChatAttachment;
+          info: { id: string; url: string };
+        } => {
+          return r.info !== null;
+        },
+      );
+
+    const trimmedPrompt = prompt.trim();
+    if (!trimmedPrompt && ready.length === 0) {
       return null;
     }
+
+    const finalPrompt =
+      trimmedPrompt || (ready.length > 0 ? "(see attached files)" : "");
+
+    const attachFiles: AttachFile[] | undefined =
+      ready.length > 0
+        ? ready.map((r) => {
+            return {
+              id: r.info.id,
+              filename: r.attachment.filename,
+              contentType: r.attachment.contentType,
+              size: r.attachment.size,
+            };
+          })
+        : undefined;
 
     const client = get(zeroClient$)(chatMessagesContract);
     const result = await accept(
       client.send({
         body: {
           agentId,
-          prompt,
-          hasTextContent: prompt.trim().length > 0,
+          prompt: finalPrompt,
+          hasTextContent: trimmedPrompt.length > 0,
           clientMessageId: crypto.randomUUID(),
           modelSelection,
+          attachFiles,
         },
         fetchOptions: { signal },
       }),
@@ -153,6 +202,8 @@ export const sendNewThreadMessage$ = command(
     );
     signal.throwIfAborted();
 
+    // Drop the now-persisted attachments from the talk draft.
+    set(draft.clear$);
     set(reloadChatThreads$);
     return result.body.threadId;
   },

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -8,6 +8,7 @@ import {
   type DraftSignals,
   type ZeroChatAttachment,
 } from "../zero-page/chat-draft.ts";
+import { prepareUserMessageFromDraft$ } from "./resolve-draft-attachments.ts";
 import {
   currentChatThreadId$,
   reloadChatThreads$,
@@ -20,7 +21,6 @@ import {
   chatThreadMarkReadContract,
   chatThreadMessagesContract,
   zeroRunsCancelContract,
-  type AttachFile,
   type ModelSelectionRequest,
   type PersistedAttachment,
   type PagedChatMessage,
@@ -191,91 +191,6 @@ function createComposerFileInput() {
     }),
   );
   return { composerFileInput$, setComposerFileInput$ };
-}
-
-interface PreparedUserMessage {
-  prompt: string;
-  attachFiles: AttachFile[] | undefined;
-  attachments: PagedChatMessage["attachFiles"];
-  hasTextContent: boolean;
-}
-
-function createPrepareUserMessage(draft: DraftSignals) {
-  return command(
-    async (
-      { get },
-      prompt: string,
-      signal: AbortSignal,
-    ): Promise<PreparedUserMessage | null> => {
-      const allAttachments = get(draft.attachments$);
-      const allInfos = await Promise.all(
-        allAttachments.map((a) => {
-          return get(a.fileInfo$);
-        }),
-      );
-      signal.throwIfAborted();
-
-      const ready = allAttachments
-        .map((a, i) => {
-          return { attachment: a, info: allInfos[i] };
-        })
-        .filter(
-          (
-            r,
-          ): r is {
-            attachment: ZeroChatAttachment;
-            info: { id: string; url: string };
-          } => {
-            return r.info !== null;
-          },
-        );
-
-      if (!prompt.trim() && ready.length === 0) {
-        return null;
-      }
-
-      // User prompt is clean text only — file description blocks are appended
-      // server-side via buildFullPrompt so the agent gets the [Web file] [ID]
-      // format it knows how to download with `zero web download-file`.
-      // When the user sends only files with no text, use a placeholder so the
-      // contract's min(1) validation passes.
-      const trimmedPrompt = prompt.trim();
-      const finalPrompt =
-        trimmedPrompt || (ready.length > 0 ? "(see attached files)" : "");
-
-      const attachFiles: AttachFile[] | undefined =
-        ready.length > 0
-          ? ready.map((r) => {
-              return {
-                id: r.info.id,
-                filename: r.attachment.filename,
-                contentType: r.attachment.contentType,
-                size: r.attachment.size,
-              };
-            })
-          : undefined;
-
-      const attachments: PagedChatMessage["attachFiles"] =
-        ready.length > 0
-          ? ready.map((r) => {
-              return {
-                id: r.info.id,
-                filename: r.attachment.filename,
-                contentType: r.attachment.contentType,
-                size: r.attachment.size,
-                url: r.info.url,
-              };
-            })
-          : undefined;
-
-      return {
-        prompt: finalPrompt,
-        attachFiles,
-        attachments,
-        hasTextContent: trimmedPrompt.length > 0,
-      };
-    },
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -853,10 +768,6 @@ interface SendMessageDeps {
   threadId: string;
   threadData$: Computed<Promise<ChatThread | null>>;
   draft: DraftSignals;
-  prepareUserMessage$: Command<
-    Promise<PreparedUserMessage | null>,
-    [string, AbortSignal]
-  >;
   cancelDraftSync$: Command<void, []>;
   flushDraftClear$: Command<Promise<void>, [AbortSignal]>;
   insertOptimisticMessage$: Command<void, [PagedChatMessage]>;
@@ -868,7 +779,6 @@ function createSendMessage(deps: SendMessageDeps) {
     threadId,
     threadData$,
     draft,
-    prepareUserMessage$,
     cancelDraftSync$,
     flushDraftClear$,
     insertOptimisticMessage$,
@@ -890,7 +800,12 @@ function createSendMessage(deps: SendMessageDeps) {
         return;
       }
 
-      const result = await set(prepareUserMessage$, prompt, signal);
+      const result = await set(
+        prepareUserMessageFromDraft$,
+        draft,
+        prompt,
+        signal,
+      );
       if (!result) {
         L.debug("sendMessage$ prepare returned null, abort", { threadId });
         return;
@@ -985,8 +900,6 @@ export function createChatThreadSignals(
   const { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ } =
     createDraftSync(threadId, draft);
 
-  const prepareUserMessage$ = createPrepareUserMessage(draft);
-
   const { allFinished$, loadPagedMessages$, cancelRun$ } = createRunTracking(
     threadId,
     reloadThread$,
@@ -999,7 +912,6 @@ export function createChatThreadSignals(
     threadId,
     threadData$,
     draft,
-    prepareUserMessage$,
     cancelDraftSync$,
     flushDraftClear$,
     insertOptimisticMessage$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -20,6 +20,7 @@ import {
   chatThreadMarkReadContract,
   chatThreadMessagesContract,
   zeroRunsCancelContract,
+  type AttachFile,
   type ModelSelectionRequest,
   type PersistedAttachment,
   type PagedChatMessage,
@@ -192,13 +193,20 @@ function createComposerFileInput() {
   return { composerFileInput$, setComposerFileInput$ };
 }
 
+interface PreparedUserMessage {
+  prompt: string;
+  attachFiles: AttachFile[] | undefined;
+  attachments: PagedChatMessage["attachFiles"];
+  hasTextContent: boolean;
+}
+
 function createPrepareUserMessage(draft: DraftSignals) {
   return command(
     async (
       { get },
       prompt: string,
       signal: AbortSignal,
-    ): Promise<{ fullPrompt: string; hasTextContent: boolean } | null> => {
+    ): Promise<PreparedUserMessage | null> => {
       const allAttachments = get(draft.attachments$);
       const allInfos = await Promise.all(
         allAttachments.map((a) => {
@@ -226,18 +234,46 @@ function createPrepareUserMessage(draft: DraftSignals) {
         return null;
       }
 
-      const attachmentLines = ready.map((r) => {
-        return `[Attached file: ${r.attachment.filename}](${r.info.url})\nDownload with: curl -sL -o "${r.attachment.filename}" "${r.info.url}"`;
-      });
-
+      // User prompt is clean text only — file description blocks are appended
+      // server-side via buildFullPrompt so the agent gets the [Web file] [ID]
+      // format it knows how to download with `zero web download-file`.
+      // When the user sends only files with no text, use a placeholder so the
+      // contract's min(1) validation passes.
       const trimmedPrompt = prompt.trim();
-      const fullPrompt = trimmedPrompt
-        ? attachmentLines.length > 0
-          ? `${trimmedPrompt}\n\n${attachmentLines.join("\n")}`
-          : trimmedPrompt
-        : attachmentLines.join("\n");
+      const finalPrompt =
+        trimmedPrompt || (ready.length > 0 ? "(see attached files)" : "");
 
-      return { fullPrompt, hasTextContent: trimmedPrompt.length > 0 };
+      const attachFiles: AttachFile[] | undefined =
+        ready.length > 0
+          ? ready.map((r) => {
+              return {
+                id: r.info.id,
+                filename: r.attachment.filename,
+                contentType: r.attachment.contentType,
+                size: r.attachment.size,
+              };
+            })
+          : undefined;
+
+      const attachments: PagedChatMessage["attachFiles"] =
+        ready.length > 0
+          ? ready.map((r) => {
+              return {
+                id: r.info.id,
+                filename: r.attachment.filename,
+                contentType: r.attachment.contentType,
+                size: r.attachment.size,
+                url: r.info.url,
+              };
+            })
+          : undefined;
+
+      return {
+        prompt: finalPrompt,
+        attachFiles,
+        attachments,
+        hasTextContent: trimmedPrompt.length > 0,
+      };
     },
   );
 }
@@ -818,7 +854,7 @@ interface SendMessageDeps {
   threadData$: Computed<Promise<ChatThread | null>>;
   draft: DraftSignals;
   prepareUserMessage$: Command<
-    Promise<{ fullPrompt: string; hasTextContent: boolean } | null>,
+    Promise<PreparedUserMessage | null>,
     [string, AbortSignal]
   >;
   cancelDraftSync$: Command<void, []>;
@@ -868,7 +904,8 @@ function createSendMessage(deps: SendMessageDeps) {
       set(insertOptimisticMessage$, {
         id: clientMessageId,
         role: "user",
-        content: result.fullPrompt,
+        content: result.prompt,
+        attachFiles: result.attachments,
         createdAt: new Date().toISOString(),
       });
       animationFrame(
@@ -885,11 +922,12 @@ function createSendMessage(deps: SendMessageDeps) {
           client.send({
             body: {
               agentId,
-              prompt: result.fullPrompt,
+              prompt: result.prompt,
               threadId: threadId,
               hasTextContent: result.hasTextContent,
               clientMessageId,
               modelSelection,
+              attachFiles: result.attachFiles,
             },
             fetchOptions: { signal },
           }),

--- a/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
+++ b/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
@@ -1,0 +1,119 @@
+import { command } from "ccstate";
+import type { AttachFile, PagedChatMessage } from "@vm0/core";
+import type {
+  DraftSignals,
+  ZeroChatAttachment,
+} from "../zero-page/chat-draft.ts";
+
+/**
+ * Placeholder stored as the prompt when the user sends only files with no
+ * typed text, so the `chatMessagesContract.send` body passes its `min(1)`
+ * validation. The UI strips this placeholder from `PagedUserMessage` so the
+ * bubble shows only the download chips.
+ */
+export const ATTACH_ONLY_PLACEHOLDER = "(see attached files)";
+
+/**
+ * Prepared send-message payload derived from a draft.
+ *
+ * - `prompt` — clean text (or `ATTACH_ONLY_PLACEHOLDER` for file-only sends).
+ * - `attachFiles` — structured `AttachFile[]` for the outbound request body.
+ * - `attachments` — optimistic-UI shape including resolved URLs, matching the
+ *   server's paged response so the optimistic row looks identical to a refetch.
+ * - `hasTextContent` — whether the user typed any non-whitespace text;
+ *   used by the server to decide prompt-only vs. attachment-only rendering.
+ */
+interface PreparedUserMessage {
+  prompt: string;
+  attachFiles: AttachFile[] | undefined;
+  attachments: PagedChatMessage["attachFiles"];
+  hasTextContent: boolean;
+}
+
+/**
+ * Resolves a draft's pending attachments (waits for uploads to finish,
+ * filters out cancelled/failed entries) and shapes the result into both the
+ * outbound `AttachFile[]` for the send contract and the optimistic-UI
+ * `PagedChatMessage["attachFiles"]` shape.
+ *
+ * Returns `null` when the user has typed nothing and no attachments are
+ * ready — callers should abort the send in that case.
+ *
+ * Shared by `sendMessage$` (in-thread follow-ups) and `sendNewThreadMessage$`
+ * (first message on a new thread) so both entry points produce identical
+ * request bodies.
+ */
+export const prepareUserMessageFromDraft$ = command(
+  async (
+    { get },
+    draft: DraftSignals,
+    prompt: string,
+    signal: AbortSignal,
+  ): Promise<PreparedUserMessage | null> => {
+    const allAttachments = get(draft.attachments$);
+    const allInfos = await Promise.all(
+      allAttachments.map((a) => {
+        return get(a.fileInfo$);
+      }),
+    );
+    signal.throwIfAborted();
+
+    const ready = allAttachments
+      .map((a, i) => {
+        return { attachment: a, info: allInfos[i] };
+      })
+      .filter(
+        (
+          r,
+        ): r is {
+          attachment: ZeroChatAttachment;
+          info: { id: string; url: string };
+        } => {
+          return r.info !== null;
+        },
+      );
+
+    const trimmedPrompt = prompt.trim();
+    if (!trimmedPrompt && ready.length === 0) {
+      return null;
+    }
+
+    // User prompt is clean text only — file description blocks are appended
+    // server-side via buildFullPrompt so the agent gets the [Web file] [ID]
+    // format it knows how to download with `zero web download-file`.
+    const finalPrompt =
+      trimmedPrompt || (ready.length > 0 ? ATTACH_ONLY_PLACEHOLDER : "");
+
+    const attachFiles: AttachFile[] | undefined =
+      ready.length > 0
+        ? ready.map((r) => {
+            return {
+              id: r.info.id,
+              filename: r.attachment.filename,
+              contentType: r.attachment.contentType,
+              size: r.attachment.size,
+            };
+          })
+        : undefined;
+
+    const attachments: PagedChatMessage["attachFiles"] =
+      ready.length > 0
+        ? ready.map((r) => {
+            return {
+              id: r.info.id,
+              filename: r.attachment.filename,
+              contentType: r.attachment.contentType,
+              size: r.attachment.size,
+              url: r.info.url,
+            };
+          })
+        : undefined;
+
+    return {
+      prompt: finalPrompt,
+      attachFiles,
+      attachments,
+      hasTextContent: trimmedPrompt.length > 0,
+    };
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -179,6 +179,13 @@ export function mockChatLifecycle(options?: {
     error?: string;
     status?: string;
     createdAt: string;
+    attachFiles?: {
+      id: string;
+      filename: string;
+      contentType: string;
+      size: number;
+      url: string;
+    }[];
   }[];
   threadTitle?: string | null;
   onRunCreate?: () => void;
@@ -216,6 +223,13 @@ export function mockChatLifecycle(options?: {
         error?: string;
         status?: string;
         createdAt: string;
+        attachFiles?: {
+          id: string;
+          filename: string;
+          contentType: string;
+          size: number;
+          url: string;
+        }[];
       }[] = [];
 
       // Seed with pre-existing chatMessages (e.g. history on resume)

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -411,6 +411,43 @@ describe("chat-d-063: download link renders for file attachment", () => {
       expect(link?.getAttribute("href")).toBe(fileUrl);
     });
   });
+
+  it("renders a download anchor from the structured attachFiles field", async () => {
+    const fileUrl = "https://example.com/spec.pdf";
+    const filename = "spec.pdf";
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "Please review",
+          createdAt: "2026-03-10T00:00:00Z",
+          attachFiles: [
+            {
+              id: "file-struct-1",
+              filename,
+              contentType: "application/pdf",
+              size: 4096,
+              url: fileUrl,
+            },
+          ],
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+    });
+
+    await waitFor(() => {
+      const link = document.querySelector<HTMLAnchorElement>(
+        `a[download="${filename}"]`,
+      );
+      expect(link).toBeInTheDocument();
+      expect(link?.getAttribute("href")).toBe(fileUrl);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2,10 +2,16 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
+import { chatMessagesContract } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import {
+  mockChatLifecycle,
+  PLACEHOLDER,
+  sendMessageInUI,
+} from "./chat-test-helpers.ts";
 
 const context = testContext();
 
@@ -505,5 +511,86 @@ describe("chat-d-064: video attachment chip shows neither image thumbnail nor fi
     expect(
       chipDiv?.querySelector('img[aria-hidden="true"]'),
     ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CHAT-I-065: sendNewThreadMessage$ forwards uploaded attachments as
+// structured `attachFiles` in the first-message POST (fixes #10243 for the
+// /agents/:agentId/chat new-thread entry point).
+// ---------------------------------------------------------------------------
+
+describe("chat-i-065: new-thread send includes structured attachFiles", () => {
+  it("posts attachFiles when the first message carries an uploaded file", async () => {
+    const user = userEvent.setup();
+    const fileUrl = "https://example.com/notes.pdf";
+    let capturedAttachFiles: unknown = "not-called";
+
+    server.use(
+      // mockApi cannot be used here: /api/zero/uploads accepts multipart FormData,
+      // which is out of scope for the mockApi helper (Phase 0 of #9707).
+      http.post("*/api/zero/uploads", () => {
+        return HttpResponse.json({
+          id: "upload-new-1",
+          filename: "notes.pdf",
+          contentType: "application/pdf",
+          size: 321,
+          url: fileUrl,
+        });
+      }),
+    );
+    mockChatLifecycle();
+    // Register AFTER mockChatLifecycle so this handler matches first and can
+    // capture the request body before the lifecycle mock responds.
+    server.use(
+      mockApi(chatMessagesContract.send, ({ body, respond }) => {
+        capturedAttachFiles = body.attachFiles;
+        return respond(201, {
+          runId: "run-new-1",
+          threadId: "thread-test-1",
+          status: "pending",
+          createdAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+    });
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    await user.upload(
+      fileInput!,
+      new File(["pdf"], "notes.pdf", { type: "application/pdf" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Remove notes.pdf")).toBeInTheDocument();
+    });
+
+    const textarea = screen.getByPlaceholderText(
+      PLACEHOLDER,
+    ) as HTMLTextAreaElement;
+    await sendMessageInUI(user, textarea, "Please review");
+
+    await waitFor(() => {
+      // size is sourced from the client File (3 bytes for "pdf"), not the
+      // upload response — the important assertion is that attachFiles is
+      // populated with the uploaded id.
+      expect(capturedAttachFiles).toStrictEqual([
+        {
+          id: "upload-new-1",
+          filename: "notes.pdf",
+          contentType: "application/pdf",
+          size: 3,
+        },
+      ]);
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -677,21 +677,44 @@ function PagedUserGroup({ group }: { group: GroupedChatMessageGroup }) {
 
 function PagedUserMessage({ message }: { message: PagedChatMessage }) {
   const content = message.content ?? "";
+  // Two attachment sources coexist: the structured `attachFiles` field
+  // (current flow) and legacy `[Attached file: ...](url)` inline lines left
+  // over from messages sent before #10243 split the flows. Use the structured
+  // source when it's present and fall back to inline parsing otherwise.
   const { cleanContent, parsed } = parseInlineAttachments(content);
-  const displayContent = cleanContent.replace(/\n/g, "  \n");
+  // `(see attached files)` is the server-side placeholder stored when the
+  // user sent only files with no typed text — strip it so the bubble shows
+  // just the attachments.
+  const strippedContent =
+    message.attachFiles &&
+    message.attachFiles.length > 0 &&
+    cleanContent.trim() === "(see attached files)"
+      ? ""
+      : cleanContent;
+  const displayContent = strippedContent.replace(/\n/g, "  \n");
   const setLightboxUrl = useSet(setAttachmentLightboxUrl$);
   const openLightbox = (url: string) => {
     setLightboxUrl(url);
   };
 
-  const allAttachments = parsed.map((p) => {
-    return {
-      filename: p.filename,
-      url: p.url,
-      isImage: isImageFilename(p.filename),
-      isVideo: isVideoFilename(p.filename),
-    };
-  });
+  const allAttachments =
+    message.attachFiles && message.attachFiles.length > 0
+      ? message.attachFiles.map((f) => {
+          return {
+            filename: f.filename,
+            url: f.url,
+            isImage: isImageFilename(f.filename),
+            isVideo: isVideoFilename(f.filename),
+          };
+        })
+      : parsed.map((p) => {
+          return {
+            filename: p.filename,
+            url: p.url,
+            isImage: isImageFilename(p.filename),
+            isVideo: isVideoFilename(p.filename),
+          };
+        });
 
   return (
     <div data-role="user">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -57,6 +57,7 @@ import {
   currentChatThreadSignals$,
   type ChatThreadSignals,
 } from "../../signals/chat-page/create-chat-thread.ts";
+import { ATTACH_ONLY_PLACEHOLDER } from "../../signals/chat-page/resolve-draft-attachments.ts";
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
 import { orgModelProviders$ } from "../../signals/external/org-model-providers.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
@@ -682,13 +683,13 @@ function PagedUserMessage({ message }: { message: PagedChatMessage }) {
   // over from messages sent before #10243 split the flows. Use the structured
   // source when it's present and fall back to inline parsing otherwise.
   const { cleanContent, parsed } = parseInlineAttachments(content);
-  // `(see attached files)` is the server-side placeholder stored when the
+  // `ATTACH_ONLY_PLACEHOLDER` is the server-side placeholder stored when the
   // user sent only files with no typed text — strip it so the bubble shows
   // just the attachments.
   const strippedContent =
     message.attachFiles &&
     message.attachFiles.length > 0 &&
-    cleanContent.trim() === "(see attached files)"
+    cleanContent.trim() === ATTACH_ONLY_PLACEHOLDER
       ? ""
       : cleanContent;
   const displayContent = strippedContent.replace(/\n/g, "  \n");

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
@@ -259,6 +259,59 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     expect(data.messages[0].role).toBe("user");
   });
 
+  it("should resolve attach files with presigned URLs in paged messages", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+
+    await insertTestChatMessage({
+      chatThreadId: threadId,
+      userId: testUserId,
+      role: "user",
+      content: "Analyze this data",
+      attachFiles: ["paged-resolve-uuid"],
+    });
+
+    context.mocks.s3.listS3Objects.mockImplementation(
+      async (_bucket: string, prefix: string) => {
+        if (prefix.includes("paged-resolve-uuid")) {
+          return [
+            {
+              key: `uploads/${testUserId}/paged-resolve-uuid/data.csv`,
+              size: 512,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+    context.mocks.s3.generatePresignedUrl.mockResolvedValue(
+      "https://presigned-url/data.csv",
+    );
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/messages`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.messages).toHaveLength(1);
+    const userMsg = data.messages[0];
+    expect(userMsg.role).toBe("user");
+    expect(userMsg.attachFiles).toBeDefined();
+    expect(userMsg.attachFiles).toHaveLength(1);
+    expect(userMsg.attachFiles[0].id).toBe("paged-resolve-uuid");
+    expect(userMsg.attachFiles[0].filename).toBe("data.csv");
+    expect(userMsg.attachFiles[0].url).toBe("https://presigned-url/data.csv");
+  });
+
   it("should not expose run-level error on event-backed assistant rows", async () => {
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
@@ -9,6 +9,7 @@ import { getUserId } from "../../../../../../src/lib/auth/get-auth-context";
 import {
   getChatThread,
   getMessagesSince,
+  resolveAttachFileUrls,
 } from "../../../../../../src/lib/zero/chat-thread";
 import { isNotFound } from "../../../../../../src/lib/shared/errors";
 
@@ -36,24 +37,31 @@ const router = tsr.router(chatThreadMessagesContract, {
         query.limit,
       );
 
-      const messages = rows.map((row) => {
-        // Legacy placeholder rows (sequenceNumber IS NULL) fall back to runError;
-        // event-backed rows and error rows use their own error field.
-        const isLegacyPlaceholder =
-          row.sequenceNumber === null && row.content === null && !row.error;
-        const effectiveError = isLegacyPlaceholder
-          ? (row.runError ?? undefined)
-          : (row.error ?? undefined);
-        return {
-          id: row.id,
-          role: row.role as "user" | "assistant",
-          content: row.content,
-          runId: row.runId ?? undefined,
-          error: effectiveError,
-          status: row.runStatus ?? undefined,
-          createdAt: row.createdAt.toISOString(),
-        };
-      });
+      const messages = await Promise.all(
+        rows.map(async (row) => {
+          // Legacy placeholder rows (sequenceNumber IS NULL) fall back to runError;
+          // event-backed rows and error rows use their own error field.
+          const isLegacyPlaceholder =
+            row.sequenceNumber === null && row.content === null && !row.error;
+          const effectiveError = isLegacyPlaceholder
+            ? (row.runError ?? undefined)
+            : (row.error ?? undefined);
+          const attachFiles =
+            row.attachFiles && row.attachFiles.length > 0
+              ? await resolveAttachFileUrls(userId, row.attachFiles)
+              : undefined;
+          return {
+            id: row.id,
+            role: row.role as "user" | "assistant",
+            content: row.content,
+            runId: row.runId ?? undefined,
+            error: effectiveError,
+            status: row.runStatus ?? undefined,
+            attachFiles,
+            createdAt: row.createdAt.toISOString(),
+          };
+        }),
+      );
 
       return {
         status: 200 as const,

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -412,6 +412,7 @@ export async function insertTestChatMessage(params: {
   content: string | null;
   runId?: string | null;
   archivedAt?: Date | null;
+  attachFiles?: string[];
 }): Promise<{ id: string; createdAt: Date }> {
   initServices();
   const [row] = await globalThis.services.db
@@ -422,6 +423,7 @@ export async function insertTestChatMessage(params: {
       content: params.content,
       runId: params.runId ?? null,
       archivedAt: params.archivedAt ?? null,
+      attachFiles: params.attachFiles ?? null,
     })
     .returning({ id: chatMessages.id, createdAt: chatMessages.createdAt });
   if (!row) {

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
@@ -221,6 +221,7 @@ export async function getMessagesSince(
     createdAt: Date;
     runStatus: string | null;
     runError: string | null;
+    attachFiles: ChatMessageAttachFiles | null;
   }>
 > {
   const db = globalThis.services.db;
@@ -235,6 +236,7 @@ export async function getMessagesSince(
     createdAt: chatMessages.createdAt,
     runStatus: agentRuns.status,
     runError: agentRuns.error,
+    attachFiles: chatMessages.attachFiles,
   };
 
   if (sinceId === undefined) {

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -287,7 +287,7 @@ type ChatMessage = {
  * Resolve file IDs to presigned S3 URLs with metadata for the frontend.
  * Lists S3 objects at each file's prefix to discover filename and size.
  */
-async function resolveAttachFileUrls(
+export async function resolveAttachFileUrls(
   userId: string,
   fileIds: string[],
 ): Promise<ResolvedAttachFile[]> {

--- a/turbo/apps/web/src/lib/zero/chat-thread/index.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/index.ts
@@ -8,5 +8,6 @@ export {
   updateChatThreadDraft,
   deleteChatThread,
   markThreadRead,
+  resolveAttachFileUrls,
 } from "./chat-thread-service";
 export { getMessagesSince } from "./chat-message-service";

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -292,6 +292,7 @@ const pagedChatMessageSchema = z.object({
   runId: z.string().optional(),
   error: z.string().optional(),
   status: z.string().optional(),
+  attachFiles: z.array(resolvedAttachFileSchema).optional(),
   createdAt: z.string(),
 });
 


### PR DESCRIPTION
## Summary
- Closes #10243 — web chat attachments regressed after #9618
- Root cause: the paged-messages refactor accidentally reverted the client-side split introduced by #9584, so the prompt carried inline `[Attached file: ...](url)` again and `attachFiles` never reached the server. The agent no longer saw the `[Web file] [ID]` block, and `zero web download-file` had no id to consume.
- Restore the intended split: client sends a clean prompt + structured `attachFiles`; the paged endpoint returns resolved presigned URLs via `resolveAttachFileUrls`; the UI prefers the structured field and keeps inline parsing only as a fallback for legacy rows.

## Changes
- `packages/core`: `pagedChatMessageSchema` gains an optional `attachFiles` using the existing `resolvedAttachFileSchema`.
- `apps/web`: `getMessagesSince` selects the `attach_files` column; paged route resolves URLs; `resolveAttachFileUrls` is exported from the chat-thread service barrel.
- `apps/platform`: `prepareUserMessage$` returns `{ prompt, attachFiles, attachments, hasTextContent }`; `sendMessage$` POSTs `attachFiles` and seeds the optimistic row from the structured field; `PagedUserMessage` renders from `message.attachFiles` first, falling back to `parseInlineAttachments` so rows saved during the regression still show download chips.
- Tests: new paged-endpoint test asserting presigned-URL resolution; new UI test for the structured `attachFiles` render path; helpers updated accordingly.

## Test plan
- [x] `pnpm -F web exec vitest run app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts` (10 tests pass)
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx` (11 tests pass)
- [x] `pnpm -F @vm0/app exec vitest run` (1836 tests pass)
- [x] `pnpm -F web exec vitest run` (3499 pass; 1 unrelated flake in `cleanup-sandboxes` that passes on retry)
- [x] `pnpm lint` / `pnpm format` / `pnpm knip`
- [ ] Manual: upload a PDF in web chat, verify the bubble shows the download chip and the agent sees the `[Web file]` block with `[ID]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)