### PR TITLE
feat(platform): rename connector search to find, match against description and tags

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -36,6 +36,8 @@ export interface ConnectorTypeWithStatus {
   type: ConnectorType;
   label: string;
   helpText: string;
+  /** Lowercase aliases/keywords used by connector search (from CONNECTOR_TYPES). */
+  tags: readonly string[];
   connected: boolean;
   connector: ConnectorResponse | null;
   /** Auth methods available for this connector (considering feature flags). */
@@ -46,6 +48,38 @@ export interface ConnectorTypeWithStatus {
   scopeMismatch: boolean;
   /** True if OAuth token refresh failed and user needs to reconnect. */
   needsReconnect: boolean;
+}
+
+/**
+ * Case-insensitive substring match across label, type, helpText, and tags.
+ * Returns true when `search` is empty, so callers can use it directly as a filter.
+ */
+export function matchesConnectorSearch(
+  search: string,
+  connector: {
+    label: string;
+    type: string;
+    helpText?: string;
+    tags?: readonly string[];
+  },
+): boolean {
+  const needle = search.trim().toLowerCase();
+  if (!needle) {
+    return true;
+  }
+  if (connector.label.toLowerCase().includes(needle)) {
+    return true;
+  }
+  if (connector.type.toLowerCase().includes(needle)) {
+    return true;
+  }
+  if (connector.helpText?.toLowerCase().includes(needle)) {
+    return true;
+  }
+  if (connector.tags?.some((t) => t.toLowerCase().includes(needle))) {
+    return true;
+  }
+  return false;
 }
 
 export const allConnectorTypes$ = computed(async (get) => {
@@ -83,6 +117,7 @@ export const allConnectorTypes$ = computed(async (get) => {
         type,
         label: isExperimental ? `[Experimental] ${config.label}` : config.label,
         helpText: config.helpText,
+        tags: config.tags ?? [],
         connected: connector !== null,
         connector,
         availableAuthMethods,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -76,7 +76,11 @@ export function matchesConnectorSearch(
   if (connector.helpText?.toLowerCase().includes(needle)) {
     return true;
   }
-  if (connector.tags?.some((t) => t.toLowerCase().includes(needle))) {
+  if (
+    connector.tags?.some((t) => {
+      return t.toLowerCase().includes(needle);
+    })
+  ) {
     return true;
   }
   return false;

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -89,6 +89,7 @@ import {
 } from "../../signals/zero-page/settings/permissions.ts";
 import {
   allConnectorTypes$,
+  matchesConnectorSearch,
   type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
@@ -446,11 +447,9 @@ function JobPermissionsTab({
   const connectedConnectors = allConnectors.filter((c) => {
     return c.connected;
   });
-  const filteredConnectors = search
-    ? connectedConnectors.filter((c) => {
-        return c.label.toLowerCase().includes(search.toLowerCase());
-      })
-    : connectedConnectors;
+  const filteredConnectors = connectedConnectors.filter((c) => {
+    return matchesConnectorSearch(search, c);
+  });
   const addedSet = new Set(addedConnectors);
 
   const handleToggle = (type: string, checked: boolean) => {
@@ -547,7 +546,7 @@ function JobPermissionsTab({
                       return el?.focus();
                     }}
                     type="text"
-                    placeholder="Search connectors..."
+                    placeholder="Find connectors..."
                     value={search}
                     onChange={(e) => {
                       return setSearch(e.target.value);
@@ -580,7 +579,7 @@ function JobPermissionsTab({
                     return setSearchActive(true);
                   }}
                   className="absolute right-3 top-1/2 -translate-y-1/2 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                  aria-label="Search connectors"
+                  aria-label="Find connectors"
                 >
                   <IconSearch size={14} stroke={1.5} />
                 </button>

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-display.test.tsx
@@ -147,7 +147,7 @@ describe("chat-d-018: add dialog with search filtering", () => {
     await user.click(addButton);
 
     const searchInput = await waitFor(() => {
-      return screen.getByPlaceholderText("Search connectors...");
+      return screen.getByPlaceholderText("Find connectors...");
     });
     expect(searchInput).toBeInTheDocument();
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
@@ -327,7 +327,7 @@ describe("zero chat composer - add connectors dialog", () => {
     await user.click(addButton);
 
     const searchInput = await waitFor(() => {
-      return screen.getByPlaceholderText("Search connectors...");
+      return screen.getByPlaceholderText("Find connectors...");
     });
 
     // Before filtering: GitHub should be visible

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -203,7 +203,7 @@ describe("zero chat page - connectors popover", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByPlaceholderText("Search connectors..."),
+        screen.getByPlaceholderText("Find connectors..."),
       ).toBeInTheDocument();
     });
   });
@@ -225,7 +225,7 @@ describe("zero chat page - connectors popover", () => {
     // Dialog should show available (unconnected) connectors with Connect buttons
     await waitFor(() => {
       expect(
-        screen.getByPlaceholderText("Search connectors..."),
+        screen.getByPlaceholderText("Find connectors..."),
       ).toBeInTheDocument();
     });
 
@@ -252,7 +252,7 @@ describe("zero chat page - connectors popover", () => {
     await user.click(addButton);
 
     const searchInput = await waitFor(() => {
-      return screen.getByPlaceholderText("Search connectors...");
+      return screen.getByPlaceholderText("Find connectors...");
     });
 
     // Before filtering: GitHub should be visible

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -88,6 +88,46 @@ describe("connectors page", () => {
     });
   });
 
+  it("matches connectors by tag keyword", async () => {
+    // GitHub declares tags: ["gh", "gh_api_key", "git", "vcs", "scm", "repos"].
+    // "vcs" is not in the GitHub label/type/helpText, so a match on "vcs"
+    // exercises the tags match path specifically.
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText("Find connectors");
+    await fill(searchInput, "vcs");
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+    // Slack's label, type, helpText, and tags do not contain "vcs".
+    expect(screen.queryByText("Slack")).not.toBeInTheDocument();
+  });
+
+  it("matches connectors by helpText (description) keyword", async () => {
+    // Axiom's helpText contains "query logs" but neither its label ("Axiom")
+    // nor its type ("axiom") contains "logs", so matching on "logs"
+    // exercises the helpText match path specifically.
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Axiom")).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText("Find connectors");
+    await fill(searchInput, "logs");
+
+    await waitFor(() => {
+      expect(screen.getByText("Axiom")).toBeInTheDocument();
+    });
+    // GitHub's label, type, helpText, and tags do not contain "logs".
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+  });
+
   it("shows loading toast then success toast on disconnect", async () => {
     const user = userEvent.setup();
     mockConnectors([{ type: "github", externalUsername: "testuser" }]);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -28,9 +28,7 @@ describe("connectors page", () => {
         screen.getByRole("heading", { name: "Connectors" }),
       ).toBeInTheDocument();
     });
-    expect(
-      screen.getByPlaceholderText("Search connectors"),
-    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Find connectors")).toBeInTheDocument();
   });
 
   it("shows available connectors when none are connected", async () => {
@@ -65,7 +63,7 @@ describe("connectors page", () => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
 
-    const searchInput = screen.getByPlaceholderText("Search connectors");
+    const searchInput = screen.getByPlaceholderText("Find connectors");
     await fill(searchInput, "github");
 
     await waitFor(() => {
@@ -82,7 +80,7 @@ describe("connectors page", () => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
 
-    const searchInput = screen.getByPlaceholderText("Search connectors");
+    const searchInput = screen.getByPlaceholderText("Find connectors");
     await fill(searchInput, "nonexistent-connector-xyz");
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
@@ -197,8 +197,8 @@ describe("zero job detail page - connector display", () => {
       expect(screen.getByText("Linear")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByLabelText("Search connectors"));
-    await user.type(screen.getByPlaceholderText("Search connectors..."), "sla");
+    await user.click(screen.getByLabelText("Find connectors"));
+    await user.type(screen.getByPlaceholderText("Find connectors..."), "sla");
 
     await waitFor(() => {
       expect(screen.getByText("Slack")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
@@ -224,10 +224,10 @@ describe("zero job detail page - interaction and state", () => {
     });
 
     // Click search button to activate search
-    await user.click(screen.getByLabelText("Search connectors"));
+    await user.click(screen.getByLabelText("Find connectors"));
 
     // Type search query
-    const searchInput = screen.getByPlaceholderText("Search connectors...");
+    const searchInput = screen.getByPlaceholderText("Find connectors...");
     await user.type(searchInput, "sla");
 
     // Only Slack should be visible
@@ -250,8 +250,8 @@ describe("zero job detail page - interaction and state", () => {
     });
 
     // Activate search and filter
-    await user.click(screen.getByLabelText("Search connectors"));
-    const searchInput = screen.getByPlaceholderText("Search connectors...");
+    await user.click(screen.getByLabelText("Find connectors"));
+    const searchInput = screen.getByPlaceholderText("Find connectors...");
     await user.type(searchInput, "git");
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -90,7 +90,7 @@ describe("zero onboarding - step 2: choose tools", () => {
     // Should reach step 2 (choose tools) — search input is the structural anchor
     await waitFor(() => {
       expect(
-        screen.getByPlaceholderText("Search connectors..."),
+        screen.getByPlaceholderText("Find connectors..."),
       ).toBeInTheDocument();
     });
   });
@@ -239,7 +239,7 @@ describe("step-specific content renders (AGENT-D-057)", () => {
         screen.getByTestId("onboarding-step-select-connectors"),
       ).toBeInTheDocument();
       expect(
-        screen.getByPlaceholderText("Search connectors..."),
+        screen.getByPlaceholderText("Find connectors..."),
       ).toBeInTheDocument();
     });
   });
@@ -382,7 +382,7 @@ describe("connector search input filters list (AGENT-D-065)", () => {
       ).toBeInTheDocument();
     });
 
-    const searchInput = screen.getByPlaceholderText("Search connectors...");
+    const searchInput = screen.getByPlaceholderText("Find connectors...");
     await user.type(searchInput, "GitHub");
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -68,6 +68,7 @@ import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import {
   allConnectorTypes$,
+  matchesConnectorSearch,
   selectedConnectorType$,
   setSelectedConnectorType$,
   justConnectedTypes$,
@@ -160,6 +161,8 @@ interface ZeroChatComposerProps {
 interface ComposerConnectorItem {
   type: string;
   label: string;
+  helpText: string;
+  tags: readonly string[];
   connected: boolean;
   added: boolean;
 }
@@ -216,11 +219,9 @@ function AddConnectorsDialog({
 }) {
   const search = useGet(addDialogSearch$);
   const setSearch = useSet(setAddDialogSearch$);
-  const filtered = search.trim()
-    ? unconnected.filter((item) => {
-        return item.label.toLowerCase().includes(search.toLowerCase());
-      })
-    : unconnected;
+  const filtered = unconnected.filter((item) => {
+    return matchesConnectorSearch(search, item);
+  });
 
   return (
     <Dialog
@@ -241,7 +242,7 @@ function AddConnectorsDialog({
         <div className="shrink-0">
           <Input
             type="text"
-            placeholder="Search connectors..."
+            placeholder="Find connectors..."
             value={search}
             onChange={(e) => {
               return setSearch(e.target.value);
@@ -342,7 +343,7 @@ function ConnectorsPopoverButton({
   const visibleConnectors =
     showSearch && search.trim()
       ? sorted.filter((c) => {
-          return c.label.toLowerCase().includes(search.toLowerCase());
+          return matchesConnectorSearch(search, c);
         })
       : sorted.slice(0, 20);
 
@@ -390,7 +391,7 @@ function ConnectorsPopoverButton({
               <div className="px-3 py-1 border-b border-border/50">
                 <input
                   type="text"
-                  placeholder="Search connectors..."
+                  placeholder="Find connectors..."
                   value={search}
                   onChange={(e) => {
                     return setSearch(e.target.value);
@@ -740,6 +741,8 @@ export function ZeroChatComposer({
     return {
       type: c.type,
       label: c.label,
+      helpText: c.helpText,
+      tags: c.tags,
       connected: c.connected || optimisticConnected.has(c.type),
       added: addedSet.has(c.type),
     };

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -34,6 +34,7 @@ import {
   permissionDialogType$,
   setPermissionDialogType$,
   isStandaloneMode,
+  matchesConnectorSearch,
   type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { deleteConnector$ } from "../../signals/external/connectors.ts";
@@ -290,15 +291,8 @@ export function ZeroConnectorsPage() {
   const allConnectors =
     allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
 
-  const searchLower = search.toLowerCase();
   const filtered = allConnectors.filter((c) => {
-    if (!searchLower) {
-      return true;
-    }
-    return (
-      c.label.toLowerCase().includes(searchLower) ||
-      c.type.toLowerCase().includes(searchLower)
-    );
+    return matchesConnectorSearch(search, c);
   });
 
   const connected = filtered.filter((c) => {
@@ -396,7 +390,7 @@ export function ZeroConnectorsPage() {
               />
               <input
                 type="text"
-                placeholder="Search connectors"
+                placeholder="Find connectors"
                 value={search}
                 onChange={(e) => {
                   return setSearch(e.target.value);

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -46,6 +46,7 @@ import {
 import {
   allConnectorTypes$,
   connectConnector$,
+  matchesConnectorSearch,
   pollingConnectorType$,
   selectedConnectorType$,
   setSelectedConnectorType$,
@@ -156,12 +157,14 @@ function SelectConnectorsContent() {
     (typeof CONNECTOR_TYPES)[ConnectorType],
   ][];
 
-  const needle = search.trim().toLowerCase();
-  const filtered = needle
-    ? connectorEntries.filter(([, config]) => {
-        return config.label.toLowerCase().includes(needle);
-      })
-    : connectorEntries;
+  const filtered = connectorEntries.filter(([type, config]) => {
+    return matchesConnectorSearch(search, {
+      label: config.label,
+      type,
+      helpText: config.helpText,
+      tags: config.tags,
+    });
+  });
 
   const selectedSet = new Set(selectedConnectors);
 
@@ -184,7 +187,7 @@ function SelectConnectorsContent() {
         />
         <Input
           type="text"
-          placeholder="Search connectors..."
+          placeholder="Find connectors..."
           value={search}
           onChange={(e) => {
             return setSearch(e.target.value);


### PR DESCRIPTION
## Summary
- Renames every user-facing "Search connectors" / "Search connectors..." label, placeholder, and aria-label on the connector **page** and in the connector **dialog** (plus the onboarding step, agent-connector panel, and chat-composer popover for consistency) to "Find connectors" / "Find connectors...".
- Filtering now also matches against each connector's `helpText` (description) and its `tags` keyword list from `CONNECTOR_TYPES`, in addition to the existing `label` and `type`. Searches like "git" now match GitHub (via tags), "logs" matches Axiom (via description), "mail" matches Gmail/Outlook (via tags), etc.
- Extracts a single `matchesConnectorSearch(search, connector)` helper in `signals/zero-page/settings/connectors.ts` and uses it everywhere connectors are filtered, so the behavior stays consistent across pages/dialogs.
- Threads `tags` (and `helpText` for the composer popover) through `ConnectorTypeWithStatus` / `ComposerConnectorItem` so every call site has the data it needs.

## Test plan
- [x] `pnpm -F @vm0/app check-types` — passes
- [x] `pnpm -F @vm0/app lint` — 0 warnings, 0 errors
- [x] Touched test files: `zero-connectors-page`, `zero-chat-page`, `zero-onboarding`, `zero-chat-composer-display`, `zero-chat-composer-interaction`, `zero-job-detail-page-display`, `zero-job-detail-page-interaction` + `signals/zero-page/settings` — 118 tests passing.
- [ ] Manual smoke on `/connectors`: placeholder reads "Find connectors"; searching "git" surfaces GitHub; searching "logs" surfaces Axiom.
- [ ] Manual smoke on chat composer "Add connectors" dialog: placeholder reads "Find connectors..."; same fuzzy matches apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)