### PR TITLE
feat(scripts): enable r2 image cache in pnpm runner

### DIFF
--- a/scripts/.env.local.tpl
+++ b/scripts/.env.local.tpl
@@ -9,3 +9,9 @@ CF_ACCOUNT_ID=op://Development/cloudflare/CF_ACCOUNT_ID
 # Metal host for runner deployment (e.g. dev-1.aws.vm3.ai)
 RUNNER_LOCAL_HOST=op://Development/vm0/RUNNER_LOCAL_HOST
 OFFICIAL_RUNNER_SECRET=0000000000000000000000000000000000000000000000000000000000000000
+
+# R2 image cache for `pnpm runner` (leave all four empty to skip — rootfs will be rebuilt locally)
+R2_ACCOUNT_ID=op://Development/cloudflare/R2_ACCOUNT_ID
+R2_ACCESS_KEY_ID=op://Development/cloudflare/R2_ACCESS_KEY_ID
+R2_SECRET_ACCESS_KEY=op://Development/cloudflare/R2_SECRET_ACCESS_KEY
+R2_USER_STORAGES_BUCKET_NAME=op://Development/cloudflare/R2_USER_STORAGES_BUCKET_NAME

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -87,8 +87,15 @@ cmd_deploy() {
   log "Running setup..."
   ssh_cmd "$RUNNER_BIN setup"
 
+  # R2 creds passed as sudo args so they survive sudo's env scrub. Empty
+  # values are treated as "unset" by r2_cache.rs, matching
+  # ansible/playbooks/build-runner.yml's R2 env block. Applied to both
+  # `gc` (sweeps shared R2 objects older than 7d) and `build` (pulls
+  # cached rootfs instead of rebuilding ~3-5min locally).
+  R2_ENV="R2_ACCOUNT_ID='${R2_ACCOUNT_ID:-}' R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID:-}' R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY:-}' R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME:-}'"
+
   # Clean up old images (keep 3 most recent deploys)
-  ssh_cmd "$RUNNER_BIN gc --keep-latest 3"
+  ssh_cmd "sudo $R2_ENV $REMOTE_BIN_DIR/runner gc --keep-latest 3"
 
   # Build unified image (rootfs + snapshot)
   PROFILES=("vm0/default")
@@ -97,7 +104,7 @@ cmd_deploy() {
   for PROFILE in "${PROFILES[@]}"; do
     log "Building $PROFILE..."
     BUILD_LOG=$(mktemp)
-    ssh_cmd "$RUNNER_BIN build --profile $PROFILE" | tee "$BUILD_LOG"
+    ssh_cmd "sudo $R2_ENV $REMOTE_BIN_DIR/runner build --profile $PROFILE" | tee "$BUILD_LOG"
     ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG" | cut -d= -f2)
     SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG" | cut -d= -f2)
     rm -f "$BUILD_LOG"


### PR DESCRIPTION
## Summary

- `scripts/.env.local.tpl` now lists the four `R2_*` vars (same 1Password paths as `turbo/apps/web/.env.local.tpl`), so `sync-env.sh` populates them for the dev-runner flow
- `scripts/dev-runner.sh` injects the four vars via `sudo argv` into the two remote subcommands that consume them — `runner gc` (shared R2 cache sweep) and `runner build` (cached rootfs pull). Passing via a shell prefix would be dropped because `$RUNNER_BIN` already prefixes `sudo`
- All four empty → `R2ImageCache::from_env()` returns `Ok(None)` (empty strings count as unset per `crates/runner/src/r2_cache.rs:194-200`), matching today's behaviour

## Test plan

- [ ] Run `scripts/sync-env.sh`, confirm all four `R2_*` vars are populated in `scripts/.env.local`
- [ ] `pnpm runner` against a dev metal host — verify the `gc` and `build` remote calls observe `R2_*` vars (rootfs pulled from R2 cache rather than rebuilt from scratch; per-deploy time drops ~3-5 min)
- [ ] With R2 vars commented out → deploy still succeeds, falls back to local rootfs build; `gc` logs `r2: cache not configured, skipping R2 GC`

Closes #10266