### PR TITLE
feat(cli): implement zero search --source slack static recipe

### DIFF
--- a/turbo/apps/cli/src/commands/zero/search/__tests__/slack-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/slack-source.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for zero search --source slack (#10263).
+ *
+ * Entry point: zeroSearchCommand.parseAsync()
+ * Mock (external): none — the CLI must make zero outbound HTTP calls.
+ *   MSW's global setup (src/test/setup.ts) uses onUnhandledRequest: "error",
+ *   so any accidental network call would fail the test. That IS the guard.
+ * Real (internal): command routing, recipe builder, console output.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { zeroSearchCommand, buildSlackRecipe } from "../index";
+
+describe("zero search --source slack", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    // Commander retains parsed option state across parseAsync calls on the
+    // same Command instance — match the pattern in the scaffold test.
+    zeroSearchCommand.setOptionValue("source", []);
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("zero outbound HTTP", () => {
+    it("makes no network call (MSW would error on any unhandled request)", async () => {
+      await zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "slack",
+      ]);
+
+      expect(mockExit).not.toHaveBeenCalled();
+      expect(mockConsoleError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recipe content", () => {
+    it("includes the Slack search.messages endpoint and SLACK_TOKEN", async () => {
+      await zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "slack",
+      ]);
+
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("search.messages");
+      expect(output).toContain("SLACK_TOKEN");
+    });
+
+    it("includes both diagnostic pointers", async () => {
+      await zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "slack",
+      ]);
+
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("zero connector status slack");
+      expect(output).toContain(
+        "zero doctor check-connector --env-name SLACK_TOKEN",
+      );
+    });
+
+    it("links to Slack's search.messages docs", async () => {
+      await zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "slack",
+      ]);
+
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("https://api.slack.com/methods/search.messages");
+    });
+
+    it("notes that CLI-local flags are ignored for this source", async () => {
+      await zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "slack",
+      ]);
+
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("--limit");
+      expect(output).toContain("--since");
+      expect(output).toContain("ignored");
+    });
+  });
+
+  describe("keyword substitution", () => {
+    it("URL-encodes the query with encodeURIComponent", async () => {
+      await zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "bug report",
+        "--source",
+        "slack",
+      ]);
+
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("query=bug%20report");
+    });
+
+    it("encodes special URL characters in the query", async () => {
+      await zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "foo&bar",
+        "--source",
+        "slack",
+      ]);
+
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("query=foo%26bar");
+    });
+  });
+
+  describe("unconditional emission", () => {
+    it("prints the recipe regardless of connector state (no branching)", async () => {
+      // The recipe path does not import getZeroConnector — emission cannot
+      // depend on connector state. Calling twice yields identical output.
+      await zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "slack",
+      ]);
+      const first = mockConsoleLog.mock.calls.flat().join("\n");
+
+      mockConsoleLog.mockClear();
+      zeroSearchCommand.setOptionValue("source", []);
+
+      await zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "slack",
+      ]);
+      const second = mockConsoleLog.mock.calls.flat().join("\n");
+
+      expect(first).toBe(second);
+    });
+
+    it("ignores unrelated flags without erroring", async () => {
+      await zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "slack",
+        "--limit",
+        "100",
+        "--since",
+        "30d",
+        "-C",
+        "3",
+      ]);
+
+      expect(mockExit).not.toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("search.messages");
+    });
+  });
+
+  describe("buildSlackRecipe (exported helper)", () => {
+    it("is pure and deterministic", () => {
+      expect(buildSlackRecipe("foo")).toBe(buildSlackRecipe("foo"));
+    });
+
+    it("encodes the query once (does not double-encode)", () => {
+      // Raw space → %20 (single encoding). Double-encoding would yield %2520.
+      const recipe = buildSlackRecipe("a b");
+      expect(recipe).toContain("query=a%20b");
+      expect(recipe).not.toContain("query=a%2520b");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/search/index.ts
+++ b/turbo/apps/cli/src/commands/zero/search/index.ts
@@ -13,6 +13,27 @@ Available sources:
 Usage: zero search <query> --source <logs|chat|slack> [flags]
 Run 'zero search --help' for all flags.`;
 
+export function buildSlackRecipe(query: string): string {
+  const encoded = encodeURIComponent(query);
+  return `The \`slack\` source does not call Slack from this CLI. Run the
+following inside an agent sandbox that has $SLACK_TOKEN available:
+
+  curl -H "Authorization: Bearer $SLACK_TOKEN" \\
+    "https://slack.com/api/search.messages?query=${encoded}"
+
+If you don't have $SLACK_TOKEN, check the connector status:
+  zero connector status slack
+
+To verify the token and network policy end-to-end:
+  zero doctor check-connector --env-name SLACK_TOKEN
+
+Slack API docs: https://api.slack.com/methods/search.messages
+
+Note: CLI-local flags (--limit, --since, -A/-B/-C) are ignored for the
+slack source. Pass equivalents to Slack's API via count= / highlight=
+query parameters instead.`;
+}
+
 interface SearchOptions {
   source: string[];
   agent?: string;
@@ -43,10 +64,10 @@ async function runChatSource(
 }
 
 async function runSlackSource(
-  _query: string,
+  query: string,
   _options: SearchOptions,
 ): Promise<void> {
-  throw new Error("zero search --source slack: not yet implemented");
+  console.log(buildSlackRecipe(query));
 }
 
 export const zeroSearchCommand = new Command()


### PR DESCRIPTION
## Summary

- Replaces the `runSlackSource` placeholder with a printer that emits a static recipe — Slack `search.messages` endpoint + curl example with `$SLACK_TOKEN`, diagnostic pointers to `zero connector status slack` and `zero doctor check-connector --env-name SLACK_TOKEN`, and a link to Slack's own docs.
- Uses `encodeURIComponent` for query substitution (single encoding, no doubles).
- CLI makes **zero outbound HTTP calls** — verified by relying on MSW's global `onUnhandledRequest: "error"` policy (any accidental fetch fails the test).
- Emits the recipe unconditionally; the diagnostic pointer tells the agent how to check connector state.

Part of epic #10238. Closes #10263.

## Test plan

- [x] `pnpm -F @vm0/cli exec vitest run src/commands/zero/search` — 17 tests pass (12 new + 5 scaffold)
- [x] `pnpm -F @vm0/cli exec vitest run src/__tests__/zero.test.ts` — 20-commands assertion unchanged
- [x] `pnpm -F @vm0/core exec vitest run src/contracts/__tests__/composes.test.ts` — 14-capabilities assertion unchanged
- [x] `pnpm -F @vm0/cli exec vitest run` — full CLI workspace (1094 tests) passes
- [x] `pnpm turbo run lint --filter=@vm0/cli` — clean
- [x] `pnpm -F @vm0/cli check-types` — clean
- [x] `pnpm format` — unchanged
- [x] `pnpm knip --workspace @vm0/cli` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)