### PR TITLE
feat(cli): implement zero search --source logs

### DIFF
--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -13,7 +13,7 @@ import { isUUID } from "../../run/shared";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
-interface SearchOptions {
+export interface LogsSearchCliOptions {
   afterContext?: string;
   beforeContext?: string;
   context?: string;
@@ -41,7 +41,7 @@ function formatRunHeader(
   return `── Run ${runId} (${agentName}, ${time}) ──────────`;
 }
 
-function parseContextOptions(options: SearchOptions): {
+function parseContextOptions(options: LogsSearchCliOptions): {
   before: number;
   after: number;
 } {
@@ -128,6 +128,48 @@ function renderResults(response: LogsSearchResponse): void {
   }
 }
 
+export async function runLogsSearch(
+  keyword: string,
+  options: LogsSearchCliOptions,
+): Promise<void> {
+  const { before, after } = parseContextOptions(options);
+
+  if (options.run && !isUUID(options.run)) {
+    console.error(
+      chalk.red(`✗ Invalid run ID "${options.run}" — expected a UUID`),
+    );
+    console.error(chalk.dim("  Run: zero logs list    to find run IDs"));
+    process.exit(1);
+  }
+
+  const since = options.since
+    ? parseTime(options.since)
+    : Date.now() - SEVEN_DAYS_MS;
+  const limit = parseLimit(options.limit);
+
+  const response = await searchZeroLogs({
+    keyword,
+    agent: options.agent,
+    runId: options.run,
+    since,
+    limit,
+    before,
+    after,
+  });
+
+  if (response.results.length === 0) {
+    console.log(chalk.dim("No matches found"));
+    console.log(
+      chalk.dim(
+        "  Try a broader search with --since 30d or a different keyword",
+      ),
+    );
+    return;
+  }
+
+  renderResults(response);
+}
+
 export const searchCommand = new Command()
   .name("search")
   .description("Search agent events across runs")
@@ -148,42 +190,7 @@ Examples:
   zero logs search "failed" --since 30d --limit 50`,
   )
   .action(
-    withErrorHandler(async (keyword: string, options: SearchOptions) => {
-      const { before, after } = parseContextOptions(options);
-
-      if (options.run && !isUUID(options.run)) {
-        console.error(
-          chalk.red(`✗ Invalid run ID "${options.run}" — expected a UUID`),
-        );
-        console.error(chalk.dim("  Run: zero logs list    to find run IDs"));
-        process.exit(1);
-      }
-
-      const since = options.since
-        ? parseTime(options.since)
-        : Date.now() - SEVEN_DAYS_MS;
-      const limit = parseLimit(options.limit);
-
-      const response = await searchZeroLogs({
-        keyword,
-        agent: options.agent,
-        runId: options.run,
-        since,
-        limit,
-        before,
-        after,
-      });
-
-      if (response.results.length === 0) {
-        console.log(chalk.dim("No matches found"));
-        console.log(
-          chalk.dim(
-            "  Try a broader search with --since 30d or a different keyword",
-          ),
-        );
-        return;
-      }
-
-      renderResults(response);
+    withErrorHandler(async (keyword: string, options: LogsSearchCliOptions) => {
+      await runLogsSearch(keyword, options);
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/index.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
 import { zeroSearchCommand, SEARCH_EXPLAINER } from "../index";
 
 describe("zero search command (scaffold)", () => {
@@ -75,19 +77,27 @@ describe("zero search command (scaffold)", () => {
     expect(errors).toContain("logs, chat, slack");
   });
 
-  it("routes --source logs to the not-yet-implemented placeholder", async () => {
-    await expect(
-      zeroSearchCommand.parseAsync([
-        "node",
-        "cli",
-        "hello",
-        "--source",
-        "logs",
-      ]),
-    ).rejects.toThrow("process.exit called");
+  it("routes --source logs to the logs-search backend", async () => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
 
-    const errors = mockConsoleError.mock.calls.flat().join("\n");
-    expect(errors).toContain("zero search --source logs: not yet implemented");
+    let called = false;
+    server.use(
+      http.get("http://localhost:3000/api/zero/logs/search", () => {
+        called = true;
+        return HttpResponse.json({ results: [], hasMore: false });
+      }),
+    );
+
+    await zeroSearchCommand.parseAsync([
+      "node",
+      "cli",
+      "hello",
+      "--source",
+      "logs",
+    ]);
+
+    expect(called).toBe(true);
   });
 
   it("--help output includes the three source descriptions", () => {

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
@@ -45,7 +45,7 @@ async function capture(
   const spy = vi
     .spyOn(console, "log")
     .mockImplementation((...args: unknown[]) => {
-      lines.push(args.map((a) => String(a)).join(" "));
+      lines.push(args.map(String).join(" "));
     });
   try {
     await cmd.parseAsync(argv);

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Parity test for `zero search --source logs` vs `zero logs search`.
+ *
+ * Entry point: parseAsync() on both commands
+ * Mock (external): Web API via MSW (same stub for both)
+ * Real (internal): all CLI code, event parsers, renderers
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { zeroSearchCommand } from "../index";
+import { searchCommand } from "../../logs/search";
+
+function stubResponse() {
+  return HttpResponse.json({
+    results: [
+      {
+        runId: "abc12345-1234-1234-1234-123456789abc",
+        agentName: "my-agent",
+        matchedEvent: {
+          sequenceNumber: 3,
+          eventType: "assistant",
+          createdAt: "2024-01-15T10:30:00Z",
+          eventData: {
+            type: "assistant",
+            message: {
+              content: [{ type: "text", text: "Build failed: OOM killed" }],
+            },
+          },
+        },
+        contextBefore: [],
+        contextAfter: [],
+      },
+    ],
+    hasMore: false,
+  });
+}
+
+async function capture(
+  cmd: { parseAsync: (argv: string[]) => Promise<unknown> },
+  argv: string[],
+): Promise<string> {
+  const lines: string[] = [];
+  const spy = vi
+    .spyOn(console, "log")
+    .mockImplementation((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(" "));
+    });
+  try {
+    await cmd.parseAsync(argv);
+  } finally {
+    spy.mockRestore();
+  }
+  return lines.join("\n");
+}
+
+describe("zero search --source logs parity with zero logs search", () => {
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    zeroSearchCommand.setOptionValue("source", []);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("produces identical output for the same query and flags", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/logs/search", stubResponse),
+    );
+
+    const viaSearch = await capture(zeroSearchCommand, [
+      "node",
+      "cli",
+      "OOM",
+      "--source",
+      "logs",
+      "--agent",
+      "my-agent",
+      "--limit",
+      "5",
+      "-C",
+      "1",
+    ]);
+
+    zeroSearchCommand.setOptionValue("source", []);
+
+    const viaLogsSearch = await capture(searchCommand, [
+      "node",
+      "cli",
+      "OOM",
+      "--agent",
+      "my-agent",
+      "--limit",
+      "5",
+      "-C",
+      "1",
+    ]);
+
+    expect(viaSearch).toBe(viaLogsSearch);
+    expect(viaSearch).toContain("OOM killed");
+  });
+
+  it("forwards filter flags to the API identically", async () => {
+    const captured: URL[] = [];
+    server.use(
+      http.get("http://localhost:3000/api/zero/logs/search", ({ request }) => {
+        captured.push(new URL(request.url));
+        return HttpResponse.json({ results: [], hasMore: false });
+      }),
+    );
+
+    await zeroSearchCommand.parseAsync([
+      "node",
+      "cli",
+      "error",
+      "--source",
+      "logs",
+      "--agent",
+      "zero",
+      "--run",
+      "abc12345-1234-1234-1234-123456789abc",
+      "--since",
+      "3d",
+      "--limit",
+      "10",
+      "-A",
+      "2",
+      "-B",
+      "1",
+    ]);
+
+    expect(captured).toHaveLength(1);
+    const url = captured[0]!;
+    expect(url.searchParams.get("keyword")).toBe("error");
+    expect(url.searchParams.get("agent")).toBe("zero");
+    expect(url.searchParams.get("runId")).toBe(
+      "abc12345-1234-1234-1234-123456789abc",
+    );
+    expect(url.searchParams.get("limit")).toBe("10");
+    expect(url.searchParams.get("before")).toBe("1");
+    expect(url.searchParams.get("after")).toBe("2");
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/search/index.ts
+++ b/turbo/apps/cli/src/commands/zero/search/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { withErrorHandler } from "../../../lib/command";
+import { runLogsSearch, type LogsSearchCliOptions } from "../logs/search";
 
 const SUPPORTED_SOURCES = ["logs", "chat", "slack"] as const;
 type Source = (typeof SUPPORTED_SOURCES)[number];
@@ -29,10 +30,19 @@ function collectSource(value: string, previous: string[]): string[] {
 }
 
 async function runLogsSource(
-  _query: string,
-  _options: SearchOptions,
+  query: string,
+  options: SearchOptions,
 ): Promise<void> {
-  throw new Error("zero search --source logs: not yet implemented");
+  const logsOptions: LogsSearchCliOptions = {
+    afterContext: options.afterContext,
+    beforeContext: options.beforeContext,
+    context: options.context,
+    agent: options.agent,
+    run: options.run,
+    since: options.since,
+    limit: options.limit,
+  };
+  await runLogsSearch(query, logsOptions);
 }
 
 async function runChatSource(


### PR DESCRIPTION
## Summary

- Extract `runLogsSearch` handler from `zero logs search` so the action logic lives in a named function, and both `zero logs search` and `zero search --source logs` call it directly — guaranteeing byte-for-byte output parity.
- Replace the `runLogsSource` placeholder in `zero search` with a thin delegate that forwards all supported flags (`--agent`, `--run`, `--since`, `--limit`, `-A`, `-B`, `-C`) to the shared handler.
- Update scaffold test #4 to assert positive routing against an MSW stub (the old "not yet implemented" error is gone) and add a parity integration suite at `__tests__/logs-source.test.ts` covering output equality and flag-forwarding.

Closes #10261 (sub-issue of Epic #10238).

## Commits

1. `refactor(cli): extract zero logs search handler` — pure extraction, pinned by the existing 9 logs/search tests (no behavior change).
2. `feat(cli): implement zero search --source logs` — wires the shared handler, updates the scaffold test, adds parity tests.
3. `style(cli): simplify args map to satisfy arrow-body-style rule` — lint fix.

## Out-of-scope (intentionally untouched)

- `SUPPORTED_SOURCES`, `SEARCH_EXPLAINER`, `chat`/`slack` placeholders.
- Command count (stays at 20), capability count (stays at 14), `chat-message:read` capability mapping.
- `zero logs search` surface behavior (verified via its 9 existing tests).

## Test plan

- [x] `pnpm -F @vm0/cli exec vitest run src/commands/zero/logs/__tests__/search.test.ts` — 9/9 pass (extraction is behavior-preserving)
- [x] `pnpm -F @vm0/cli exec vitest run src/commands/zero/search` — 8/8 pass (6 scaffold + 2 parity)
- [x] `pnpm -F @vm0/cli exec vitest run` — 1085/1085 pass
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — clean
- [x] Manual parity: both commands produce identical stdout against the same MSW stub
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)