### PR TITLE
fix(platform): clear just-connected flag on connector disconnect

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/disconnect-clears-just-connected.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/disconnect-clears-just-connected.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test for #10272.
+ *
+ * `justConnectedTypes$` is populated by the connect flow so the UI doesn't
+ * flash between "connecting" and "connected". The disconnect flow must clear
+ * that flag, otherwise the Connectors page keeps the card in the Connected
+ * section after a successful disconnect (because the optimistic override
+ * overrides the freshly-fetched `connected=false`).
+ */
+
+import { describe, expect, it } from "vitest";
+import { testContext } from "../../../__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../../__tests__/page-helper.ts";
+import { mockConnectors } from "../../../../views/zero-page/__tests__/zero-connectors-page-test-helpers.ts";
+import {
+  disconnectConnector$,
+  justConnectedTypes$,
+  submitApiToken$,
+} from "../connectors.ts";
+
+const context = testContext();
+
+describe("deleteConnector$ + justConnectedTypes$", () => {
+  it("clears the optimistic just-connected flag on successful disconnect", async () => {
+    mockConnectors([{ type: "ahrefs" }]);
+
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    await context.store.set(
+      submitApiToken$,
+      "ahrefs",
+      { AHREFS_API_KEY: "test" },
+      context.signal,
+    );
+
+    expect(context.store.get(justConnectedTypes$).has("ahrefs")).toBe(true);
+
+    await context.store.set(disconnectConnector$, "ahrefs", context.signal);
+
+    expect(context.store.get(justConnectedTypes$).has("ahrefs")).toBe(false);
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/disconnect-clears-just-connected.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/disconnect-clears-just-connected.test.ts
@@ -33,10 +33,10 @@ describe("deleteConnector$ + justConnectedTypes$", () => {
       context.signal,
     );
 
-    expect(context.store.get(justConnectedTypes$).has("ahrefs")).toBe(true);
+    expect(context.store.get(justConnectedTypes$).has("ahrefs")).toBeTruthy();
 
     await context.store.set(disconnectConnector$, "ahrefs", context.signal);
 
-    expect(context.store.get(justConnectedTypes$).has("ahrefs")).toBe(false);
+    expect(context.store.get(justConnectedTypes$).has("ahrefs")).toBeFalsy();
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -13,7 +13,11 @@ import {
   type ConnectorResponse,
 } from "@vm0/core";
 import { featureSwitch$ } from "../../external/feature-switch.ts";
-import { connectors$, reloadConnectors$ } from "../../external/connectors.ts";
+import {
+  connectors$,
+  deleteConnector$,
+  reloadConnectors$,
+} from "../../external/connectors.ts";
 import { apiBaseForNavigation$ } from "../../fetch.ts";
 import { zeroClient$ } from "../../api-client.ts";
 import { jsonParseOr, setLoop } from "../../utils.ts";
@@ -275,6 +279,28 @@ const internalJustConnectedTypes$ = state<Set<string>>(new Set());
 export const justConnectedTypes$ = computed((get) => {
   return get(internalJustConnectedTypes$);
 });
+
+/**
+ * Disconnect a connector and clear its optimistic "just connected" flag.
+ *
+ * Without this cleanup, a connector that was connected earlier in the session
+ * stays in the Connected section of /connectors after disconnect because the
+ * optimistic override in allConnectorTypes$ wins over the fresh
+ * `connected = false` from the API (regression #10272).
+ */
+export const disconnectConnector$ = command(
+  async ({ set }, type: ConnectorType, signal: AbortSignal): Promise<void> => {
+    await set(deleteConnector$, type, signal);
+    set(internalJustConnectedTypes$, (prev) => {
+      if (!prev.has(type)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.delete(type);
+      return next;
+    });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Post-connect permission dialog state

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-disconnect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-disconnect.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Disconnect interaction tests for the /connectors page.
+ *
+ * Regression coverage for #10272: after a user connected a connector in the
+ * same session (api-token or OAuth), the optimistic "just connected" override
+ * (justConnectedTypes$) kept the card in the Connected section even after a
+ * successful disconnect, because the set was never cleaned up on disconnect.
+ */
+
+import { expect, test } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  setPermissionDialogType$,
+  submitApiToken$,
+} from "../../../signals/zero-page/settings/connectors.ts";
+import { mockConnectors } from "./zero-connectors-page-test-helpers.ts";
+
+const context = testContext();
+
+test("disconnect moves a just-connected connector out of Connected (regression #10272)", async () => {
+  const user = userEvent.setup();
+
+  // Start with Ahrefs already connected — mirrors the screenshot in #10272.
+  mockConnectors([{ type: "ahrefs" }]);
+
+  // Populate justConnectedTypes$ as if the user connected Ahrefs earlier in
+  // this session via the api-token flow, then dismiss the post-connect
+  // permission dialog so it doesn't swallow clicks in this test.
+  await context.store.set(
+    submitApiToken$,
+    "ahrefs",
+    { AHREFS_API_KEY: "test" },
+    context.signal,
+  );
+  context.store.set(setPermissionDialogType$, null);
+
+  detachedSetupPage({ context, path: "/connectors" });
+
+  await waitFor(() => {
+    expect(screen.getByText("Connected (1)")).toBeInTheDocument();
+  });
+
+  await user.click(screen.getByLabelText("More options"));
+  await user.click(screen.getByText("Disconnect"));
+
+  // After a successful disconnect the card must leave the Connected section
+  // regardless of whether a search filter is active.
+  await waitFor(() => {
+    expect(screen.queryByText("Connected (1)")).not.toBeInTheDocument();
+  });
+
+  expect(screen.getByLabelText("Connect Ahrefs")).toBeInTheDocument();
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -24,6 +24,7 @@ import {
   allConnectorTypes$,
   connectConnector$,
   connectorsSearch$,
+  disconnectConnector$,
   setConnectorsSearch$,
   selectedConnectorType$,
   setSelectedConnectorType$,
@@ -36,7 +37,6 @@ import {
   isStandaloneMode,
   type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
-import { deleteConnector$ } from "../../signals/external/connectors.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { ScopeReviewModal } from "./components/settings/scope-review-modal.tsx";
@@ -272,7 +272,7 @@ export function ZeroConnectorsPage() {
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
   const pollingType = useGet(pollingConnectorType$);
   const connect = useSet(connectConnector$);
-  const disconnect = useSet(deleteConnector$);
+  const disconnect = useSet(disconnectConnector$);
   const signal = useGet(pageSignal$);
   const selectedType = useGet(selectedConnectorType$);
   const setSelected = useSet(setSelectedConnectorType$);


### PR DESCRIPTION
## Summary

Fixes #10272 — after a successful disconnect, the connector card stayed in the Connected section on `/connectors`, showing a green dot and "Connected" status despite the API call succeeding. Easy to hit with a search filter active because the filtered list contained only the stale card.

## Root cause

`justConnectedTypes$` (populated by `submitApiToken$` and `connectConnector$` so the UI doesn't flash "connecting → connected" during OAuth) was never cleared on disconnect. The filter at `zero-connectors-page.tsx:304-315` treats `optimisticConnected.has(type)` as a hard override over the fresh `connected = false` from the API, so the card persisted in the Connected section until full page reload.

## Fix

Added `disconnectConnector$` in `signals/zero-page/settings/connectors.ts` that wraps `deleteConnector$` (external) and removes the type from `internalJustConnectedTypes$` after the DELETE succeeds. The Connectors page uses the wrapper instead of calling `deleteConnector$` directly.

## Tests

- `signals/zero-page/settings/__tests__/disconnect-clears-just-connected.test.ts` — signal-level regression: confirmed to FAIL without the fix and PASS with it.
- `views/zero-page/__tests__/zero-connectors-page-disconnect.test.tsx` — UI integration covering the full api-token connect → disconnect flow.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest --run src/views/zero-page/__tests__/zero-connectors-page src/signals/zero-page/settings/__tests__ src/signals/zero-page/__tests__/zero-connectors` → 51 tests green
- [x] `pnpm format` clean, `pnpm knip` clean
- [ ] CI: lint, types, vitest, e2e