### PR TITLE
fix(runner): clarify stderr tracing init doc comment

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -152,7 +152,7 @@ fn init_tracing_with_file(
     Ok(guard)
 }
 
-/// Initialize tracing with stderr output only (no rolling log file).
+/// Initialize tracing with stderr output only (no rolling log file on disk).
 fn init_tracing_stderr() {
     tracing_subscriber::fmt().init();
 }


### PR DESCRIPTION
## Summary
- Trivial comment tweak in `crates/runner/src/main.rs` to trigger a runner patch release via release-please.

## Test plan
- [x] lefthook (cargo-fmt + cargo-clippy + commitlint) passed locally
- [ ] CI green