### PR TITLE
fix(seo): make / return 200 via middleware rewrite

### DIFF
--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -5,14 +5,6 @@ const withNextIntl = createNextIntlPlugin("./i18n.ts");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  async rewrites() {
-    return [
-      // Serve root as English without redirecting, so "/" stays indexable.
-      // A redirect would remove "/" from Google's index; a rewrite preserves it.
-      { source: "/", destination: "/en" },
-    ];
-  },
-
   async headers() {
     return [
       {

--- a/turbo/apps/web/proxy.layers.ts
+++ b/turbo/apps/web/proxy.layers.ts
@@ -186,22 +186,20 @@ export const localeGuardLayer: ProxyLayer = (ctx) => {
  * Apply i18n for page routes.
  *
  * next-intl redirects locale-less paths (e.g. /use-cases/foo) with 307
- * (temporary).  We convert those to 301 (permanent) so search engines
- * consolidate PageRank on the canonical /en/… URL.
+ * (temporary). We normalise these:
+ * - "/" → rewrite to "/en" so the root URL stays indexable as 200
+ * - everything else → 301 so search engines consolidate PageRank on the
+ *   canonical /en/… URL
  */
 export const i18nLayer: ProxyLayer = (ctx) => {
   if (ctx.routeKind === "page") {
-    // Root path is served via rewrite in next.config.js so that "/" returns
-    // 200 and stays indexable. Skip i18n here to prevent next-intl from
-    // redirecting it to "/en" before the rewrite can apply.
-    if (ctx.request.nextUrl.pathname === "/") return null;
-
     const response = intlMiddleware(ctx.request);
-    if (response.status === 307 && response.headers.get("location")) {
-      const url = new URL(
-        response.headers.get("location")!,
-        ctx.request.nextUrl.origin,
-      );
+    const location = response.headers.get("location");
+    if (location) {
+      const url = new URL(location, ctx.request.nextUrl.origin);
+      if (ctx.request.nextUrl.pathname === "/") {
+        return NextResponse.rewrite(url);
+      }
       return NextResponse.redirect(url, 301);
     }
     return response;


### PR DESCRIPTION
## Problem

After the previous SEO PR merged, `www.vm0.ai/` was still returning 307 instead of 200.

**Root cause:** The previous fix returned `null` from `i18nLayer` for `/`, bypassing `intlMiddleware` entirely. But next-intl's server components (`getLocale()` in `app/layout.tsx`) depend on headers that `intlMiddleware` sets. Skipping it meant those calls failed and next-intl re-emitted a 307 from the app layer.

## Fix

Let `intlMiddleware` run for all paths, then intercept its redirect response:

- `"/"` → `NextResponse.rewrite(url)` → **200, URL stays `"/"`**
- any other locale-less path → `NextResponse.redirect(url, 301)` (unchanged)

Also removes the now-redundant `async rewrites()` entry from `next.config.js`.

## Test plan

- [ ] `curl -I https://www.vm0.ai/` returns `HTTP/2 200`
- [ ] `curl -I https://www.vm0.ai/pricing` returns `301 → /en/pricing`
- [ ] `/en`, `/de`, `/es`, `/ja` all return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)