### PR TITLE
feat(core): re-enable slack agent switch for staff orgs

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -311,6 +311,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "user falls back to the org default agent with no footer. Staff-only during the " +
       "rollout window defined by `enabledOrgIdHashes`.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ModelProviderSelection]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Re-add `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` on `SlackAgentSwitch` so the `/zero switch` slash subcommand, App Home Switch button, and agent picker modal are exposed for staff orgs during the rollout window.
- Without this gate, `handleSwitch` in `app/api/zero/slack/commands/route.ts` falls through to `buildHelpMessage({ canSwitch: false })` for every workspace — effectively breaking the feature introduced in #9795.

## Context
#10053 ("close staff-org defaults except sandbox reuse") dropped `enabledOrgIdHashes` from this switch alongside a large batch of others, with the intent that each owner re-enables via per-user overrides. This restores the staff-org default for `SlackAgentSwitch` only — the feature description already documents `Staff-only during the rollout window defined by enabledOrgIdHashes`, which the previous state contradicted.

## Test plan
- [x] `pnpm -F @vm0/core exec vitest run feature-switch` — 19 tests pass
- [ ] Manually verify `/zero switch` opens the agent picker modal in a staff workspace
- [ ] Verify `/zero help` lists the `switch` subcommand in a staff workspace
- [ ] Verify non-staff workspaces still see `canSwitch: false` help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)