### PR TITLE
feat(slack): add reply-to hint and smarter footer for org agent replies

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -10,11 +10,14 @@ import {
   completeTestRun,
   createSignedCallbackRequest,
   setTestRunSelectedModel,
+  createTestOrgModelProvider,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   createTestSlackOrgInstallation,
   seedTestSlackOrgConnection,
+  insertTestSlackOrgThreadSession,
 } from "../../../../../../../src/__tests__/db-test-seeders/slack";
+import { updateOrgDefaultAgent } from "../../../../../../../src/__tests__/db-test-seeders/org";
 import { POST } from "../route";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 import { seedUserFeatureSwitches } from "../../../../../../../src/__tests__/db-test-seeders/feature-switches";
@@ -46,12 +49,38 @@ describe("POST /api/internal/callbacks/slack/org", () => {
       workspaceId,
       orgId: user.orgId,
     });
+    const slackUserId = uniqueId("U-slack");
     const { connectionId } = await seedTestSlackOrgConnection({
-      slackUserId: uniqueId("U-slack"),
+      slackUserId,
       slackWorkspaceId: slackWorkspaceId,
       vm0UserId: user.userId,
     });
-    return { workspaceId: slackWorkspaceId, connectionId };
+    return { workspaceId: slackWorkspaceId, connectionId, slackUserId };
+  }
+
+  /**
+   * Seed N additional Slack connections with pre-existing thread sessions in
+   * the given thread. Used to simulate other Slack users having mentioned the
+   * agent earlier in the same thread.
+   */
+  async function seedAdditionalMentioners(
+    workspaceId: string,
+    channelId: string,
+    threadTs: string,
+    count: number,
+  ): Promise<void> {
+    for (let i = 0; i < count; i++) {
+      const { connectionId: extraConnId } = await seedTestSlackOrgConnection({
+        slackUserId: uniqueId("U-extra"),
+        slackWorkspaceId: workspaceId,
+        vm0UserId: uniqueId("vm0-u"),
+      });
+      await insertTestSlackOrgThreadSession({
+        connectionId: extraConnId,
+        slackChannelId: channelId,
+        slackThreadTs: threadTs,
+      });
+    }
   }
 
   it("rejects request with invalid payload (missing required fields)", async () => {
@@ -442,7 +471,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     expect(blocksStr).toContain("Audit");
   });
 
-  it("includes model name in footer blocks when selectedModel is set on the run", async () => {
+  it("includes model name when selectedModel is set and org has no default provider", async () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));
     const { runId } = await seedTestRun(user.userId, composeId, {
@@ -484,9 +513,11 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     expect(blocksStr).toContain("Claude Opus 4.7");
   });
 
-  it("omits powered-by footer when no selectedModel is set on the run", async () => {
+  it("omits footer entirely when default agent, no selectedModel, and one thread mentioner", async () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));
+    // Mark this compose as the org default so `Responded by` is suppressed.
+    await updateOrgDefaultAgent(user.orgId, composeId);
     const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
     });
@@ -521,10 +552,332 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     const mockClient = new WebClient();
     const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
       .calls[0]![0] as { blocks: unknown[] };
-    // No model name in footer when selectedModel is not set
     const blocksStr = JSON.stringify(call.blocks);
     expect(blocksStr).not.toContain("Claude");
-    expect(blocksStr).not.toContain("Sonnet");
-    expect(blocksStr).not.toContain("Haiku");
+    expect(blocksStr).not.toContain("Reply to");
+    expect(blocksStr).not.toContain("Responded by");
+  });
+
+  it("shows `Responded by X` when the responding agent is not the org default", async () => {
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const agentName = uniqueId("custom");
+    const { composeId } = await createTestCompose(agentName);
+    // Do NOT set org default — this compose stays non-default.
+    const { runId } = await seedTestRun(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await completeTestRun(user.userId, runId);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createSignedCallbackRequest(
+      "http://localhost/api/internal/callbacks/slack/org",
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { blocks: unknown[] };
+    const blocksStr = JSON.stringify(call.blocks);
+    expect(blocksStr).toContain(`Responded by ${agentName}`);
+  });
+
+  it("omits `Responded by` when the responding agent is the org default", async () => {
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("default-agent"));
+    await updateOrgDefaultAgent(user.orgId, composeId);
+    const { runId } = await seedTestRun(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await completeTestRun(user.userId, runId);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createSignedCallbackRequest(
+      "http://localhost/api/internal/callbacks/slack/org",
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { blocks: unknown[] };
+    const blocksStr = JSON.stringify(call.blocks);
+    expect(blocksStr).not.toContain("Responded by");
+  });
+
+  it("omits model from footer when selectedModel matches org default", async () => {
+    await createTestOrgModelProvider(
+      "anthropic-api-key",
+      "test-api-key",
+      "claude-sonnet-4-6",
+    );
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"), {
+      skipDefaultApiKey: true,
+    });
+    const { runId } = await seedTestRun(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await setTestRunSelectedModel(runId, "claude-sonnet-4-6");
+    await completeTestRun(user.userId, runId);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createSignedCallbackRequest(
+      "http://localhost/api/internal/callbacks/slack/org",
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { blocks: unknown[] };
+    const blocksStr = JSON.stringify(call.blocks);
+    expect(blocksStr).not.toContain("Claude Sonnet 4.6");
+  });
+
+  it("includes model in footer when selectedModel differs from org default", async () => {
+    await createTestOrgModelProvider(
+      "anthropic-api-key",
+      "test-api-key",
+      "claude-sonnet-4-6",
+    );
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"), {
+      skipDefaultApiKey: true,
+    });
+    const { runId } = await seedTestRun(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await setTestRunSelectedModel(runId, "claude-opus-4-7");
+    await completeTestRun(user.userId, runId);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createSignedCallbackRequest(
+      "http://localhost/api/internal/callbacks/slack/org",
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { blocks: unknown[] };
+    const blocksStr = JSON.stringify(call.blocks);
+    expect(blocksStr).toContain("Claude Opus 4.7");
+  });
+
+  it("shows `Reply to <@U>` when the thread has more than two distinct mentioners", async () => {
+    const { workspaceId, connectionId, slackUserId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await seedTestRun(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await completeTestRun(user.userId, runId);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    // Two other Slack users already mentioned the agent in this thread.
+    // Combined with the current user, that brings distinct mentioners to 3.
+    await seedAdditionalMentioners(workspaceId, channelId, threadTs, 2);
+
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createSignedCallbackRequest(
+      "http://localhost/api/internal/callbacks/slack/org",
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { blocks: unknown[] };
+    const blocksStr = JSON.stringify(call.blocks);
+    expect(blocksStr).toContain(`Reply to <@${slackUserId}>`);
+  });
+
+  it("omits `Reply to` when the thread has only two distinct mentioners", async () => {
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await seedTestRun(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await completeTestRun(user.userId, runId);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    // One other mentioner + the current user = 2 distinct, below threshold.
+    await seedAdditionalMentioners(workspaceId, channelId, threadTs, 1);
+
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createSignedCallbackRequest(
+      "http://localhost/api/internal/callbacks/slack/org",
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { blocks: unknown[] };
+    const blocksStr = JSON.stringify(call.blocks);
+    expect(blocksStr).not.toContain("Reply to");
+  });
+
+  it("renders combined footer with `Reply to` and model joined by `·`", async () => {
+    await createTestOrgModelProvider(
+      "anthropic-api-key",
+      "test-api-key",
+      "claude-sonnet-4-6",
+    );
+    const { workspaceId, connectionId, slackUserId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"), {
+      skipDefaultApiKey: true,
+    });
+    const { runId } = await seedTestRun(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await setTestRunSelectedModel(runId, "claude-opus-4-7");
+    await completeTestRun(user.userId, runId);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    await seedAdditionalMentioners(workspaceId, channelId, threadTs, 2);
+
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createSignedCallbackRequest(
+      "http://localhost/api/internal/callbacks/slack/org",
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { blocks: unknown[] };
+    const blocksStr = JSON.stringify(call.blocks);
+    expect(blocksStr).toContain(`Reply to <@${slackUserId}> · Claude Opus 4.7`);
   });
 });

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -169,29 +169,19 @@ async function resolveFooterText(
   selectedModel: string | undefined,
 ): Promise<string | undefined> {
   const [respondedBy, mentionerCount, modelLabel] = await Promise.all([
-    resolveRespondedByLabel(orgId, payload.agentId).catch(() => {
-      return undefined;
-    }),
+    resolveRespondedByLabel(orgId, payload.agentId),
     countThreadMentioners(
       payload.workspaceId,
       payload.channelId,
       payload.threadTs,
-    ).catch(() => {
-      return 0;
-    }),
-    resolveModelIfNonDefault(orgId, selectedModel).catch(() => {
-      return undefined;
-    }),
+    ),
+    resolveModelIfNonDefault(orgId, selectedModel),
   ]);
 
   const parts: string[] = [];
   if (respondedBy) parts.push(respondedBy);
   if (mentionerCount > 2) {
-    const replyTo = await resolveReplyToMention(payload.connectionId).catch(
-      () => {
-        return undefined;
-      },
-    );
+    const replyTo = await resolveReplyToMention(payload.connectionId);
     if (replyTo) parts.push(`Reply to ${replyTo}`);
   }
   if (modelLabel) parts.push(modelLabel);

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -1,12 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../../src/lib/infra/callback";
 import { decryptSecretValue } from "../../../../../../src/lib/shared/crypto/secrets-encryption";
 import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../../../../../src/db/schema/slack-org-connection";
+import { slackOrgThreadSessions } from "../../../../../../src/db/schema/slack-org-thread-session";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { zeroRuns } from "../../../../../../src/db/schema/zero-run";
-import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
+import {
+  isFeatureEnabled,
+  FeatureSwitchKey,
+  getModelDisplayName,
+} from "@vm0/core";
 import { loadFeatureSwitchOverrides } from "../../../../../../src/lib/zero/user/feature-switches-service";
 import { findNewSessionId } from "../../../../../../src/lib/infra/session/find-new-session";
 import {
@@ -22,6 +28,7 @@ import {
   getWorkspaceAgent,
   resolveDefaultComposeId,
 } from "../../../../../../src/lib/zero/slack-org/handlers/shared";
+import { getOrgDefaultModelProvider } from "../../../../../../src/lib/zero/model-provider/model-provider-service";
 import { env } from "../../../../../../src/env";
 import type { SlackOrgCallbackPayload } from "../../../../../../src/lib/infra/callback/callback-payloads";
 import { saveRunSummary } from "../../../../../../src/lib/zero/run-summary";
@@ -50,9 +57,7 @@ function errorResponse(message: string, status: number): NextResponse {
   return NextResponse.json({ error: message }, { status });
 }
 
-/**
- * Look up the run's selected model ID for the footer attribution.
- */
+/** Look up the run's selected model ID. */
 async function resolveSelectedModel(
   runId: string,
 ): Promise<string | undefined> {
@@ -65,22 +70,133 @@ async function resolveSelectedModel(
 }
 
 /**
- * When the run came from a non-default agent, produce the `Sent via X` footer
- * text so users know which agent answered. Returns undefined for default-agent
- * replies, missing orgId, or unknown compose — keeping the existing output
- * byte-for-byte identical to today in those cases.
+ * Look up the Slack user mention (`<@U123>`) for the connection that
+ * triggered this run. The callback payload's `connectionId` always points at
+ * the user who @mentioned the agent.
  */
-async function resolveTriggeredByFooter(
-  orgId: string | undefined,
-  composeId: string | undefined,
+async function resolveReplyToMention(
+  connectionId: string,
 ): Promise<string | undefined> {
-  if (!orgId || !composeId) return undefined;
+  const [row] = await globalThis.services.db
+    .select({ slackUserId: slackOrgConnections.slackUserId })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.id, connectionId))
+    .limit(1);
+  return row?.slackUserId ? `<@${row.slackUserId}>` : undefined;
+}
+
+/**
+ * Count distinct Slack users who've triggered the agent in this thread.
+ *
+ * Each Slack user has their own `slack_org_connections` row, and mentioning
+ * the agent writes one `slack_org_thread_sessions` row keyed on
+ * (connectionId, channelId, threadTs). Counting distinct connections for a
+ * given (workspace, channel, thread) tells us how many humans are in the
+ * conversation. Scoped to `workspaceId` in case channel IDs collide across
+ * workspaces.
+ *
+ * The current run's session is written before this runs, so the current user
+ * is already counted.
+ */
+async function countThreadMentioners(
+  workspaceId: string,
+  channelId: string,
+  threadTs: string,
+): Promise<number> {
+  const [row] = await globalThis.services.db
+    .select({
+      count: sql<number>`count(distinct ${slackOrgThreadSessions.connectionId})::int`,
+    })
+    .from(slackOrgThreadSessions)
+    .innerJoin(
+      slackOrgConnections,
+      eq(slackOrgThreadSessions.connectionId, slackOrgConnections.id),
+    )
+    .where(
+      and(
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+        eq(slackOrgThreadSessions.slackChannelId, channelId),
+        eq(slackOrgThreadSessions.slackThreadTs, threadTs),
+      ),
+    );
+  return row?.count ?? 0;
+}
+
+/**
+ * Produce `Responded by <agent>` when the run came from a non-default agent,
+ * so users can tell which agent answered in an org with several. Returns
+ * undefined for the default agent, missing compose, or unknown compose.
+ */
+async function resolveRespondedByLabel(
+  orgId: string,
+  composeId: string,
+): Promise<string | undefined> {
   const orgDefaultComposeId = await resolveDefaultComposeId(orgId);
   if (composeId === orgDefaultComposeId) return undefined;
   const agent = await getWorkspaceAgent(composeId);
   if (!agent) return undefined;
-  const label = agent.displayName ?? agent.name;
-  return `Sent via ${label}`;
+  return `Responded by ${agent.displayName ?? agent.name}`;
+}
+
+/**
+ * Return the model display name when the run used a non-default model, else
+ * undefined. Comparison is against the org's default `claude-code` provider's
+ * `selectedModel` — Slack agents are claude-code today, so a single framework
+ * lookup covers all current callers. If the org has no default model
+ * configured, any `selectedModel` counts as non-default.
+ */
+async function resolveModelIfNonDefault(
+  orgId: string,
+  selectedModel: string | undefined,
+): Promise<string | undefined> {
+  if (!selectedModel) return undefined;
+  const defaultProvider = await getOrgDefaultModelProvider(
+    orgId,
+    "claude-code",
+  );
+  if (defaultProvider?.selectedModel === selectedModel) return undefined;
+  return getModelDisplayName(selectedModel);
+}
+
+/**
+ * Assemble the agent-reply footer. Returns `undefined` when no hint applies —
+ * the response renders with no footer at all. Parts joined by ` · `, ordered
+ * "who responded · to whom · with which model".
+ */
+async function resolveFooterText(
+  orgId: string,
+  payload: SlackOrgCallbackPayload,
+  selectedModel: string | undefined,
+): Promise<string | undefined> {
+  const [respondedBy, mentionerCount, modelLabel] = await Promise.all([
+    resolveRespondedByLabel(orgId, payload.agentId).catch(() => {
+      return undefined;
+    }),
+    countThreadMentioners(
+      payload.workspaceId,
+      payload.channelId,
+      payload.threadTs,
+    ).catch(() => {
+      return 0;
+    }),
+    resolveModelIfNonDefault(orgId, selectedModel).catch(() => {
+      return undefined;
+    }),
+  ]);
+
+  const parts: string[] = [];
+  if (respondedBy) parts.push(respondedBy);
+  if (mentionerCount > 2) {
+    const replyTo = await resolveReplyToMention(payload.connectionId).catch(
+      () => {
+        return undefined;
+      },
+    );
+    if (replyTo) parts.push(`Reply to ${replyTo}`);
+  }
+  if (modelLabel) parts.push(modelLabel);
+
+  return parts.length > 0 ? parts.join(" · ") : undefined;
 }
 
 function buildResponseText(
@@ -231,13 +347,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     overrides,
   });
 
-  // Resolve session
+  // Save session before computing the footer so `countThreadMentioners`
+  // includes the current user.
   await saveOrgThreadSession(payload, runId, status);
 
-  const triggeredBy = await resolveTriggeredByFooter(
-    runContext?.orgId,
-    payload.agentId,
-  );
+  const footerText = runContext?.orgId
+    ? await resolveFooterText(runContext.orgId, payload, selectedModel)
+    : undefined;
 
   // Post each result as a separate Slack reply (in order)
   for (let i = 0; i < allOutputs.length; i++) {
@@ -251,12 +367,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     await postMessage(client, payload.channelId, responseText, {
       threadTs: payload.threadTs,
-      blocks: buildAgentResponseMessage(
-        responseText,
-        logsUrl,
-        triggeredBy,
-        selectedModel,
-      ),
+      blocks: buildAgentResponseMessage(responseText, logsUrl, footerText),
     });
   }
 

--- a/turbo/apps/web/src/__tests__/db-test-seeders/slack.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/slack.ts
@@ -185,17 +185,24 @@ export async function insertTestSlackOrgConnection(params: {
 /**
  * @why-db-direct Thread session requires pre-existing connection ID; no API
  * creates thread sessions directly.
+ *
+ * `slackChannelId` / `slackThreadTs` default to unique values so callers who
+ * don't care get isolation. Pass explicit values to co-locate several sessions
+ * in the same thread (e.g. to simulate multiple Slack users mentioning the
+ * agent in one conversation).
  */
 export async function insertTestSlackOrgThreadSession(params: {
   connectionId: string;
   agentSessionId?: string;
+  slackChannelId?: string;
+  slackThreadTs?: string;
 }): Promise<{ id: string }> {
   const [row] = await globalThis.services.db
     .insert(slackOrgThreadSessions)
     .values({
       connectionId: params.connectionId,
-      slackChannelId: "C-test",
-      slackThreadTs: uniqueId("ts"),
+      slackChannelId: params.slackChannelId ?? "C-test",
+      slackThreadTs: params.slackThreadTs ?? uniqueId("ts"),
       ...(params.agentSessionId && { agentSessionId: params.agentSessionId }),
     })
     .returning({ id: slackOrgThreadSessions.id });

--- a/turbo/apps/web/src/lib/zero/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/zero/slack/__tests__/blocks.test.ts
@@ -177,11 +177,11 @@ describe("buildAgentResponseMessage", () => {
     expect(markdownBlock.text).toBe(content);
   });
 
-  it("renders triggeredBy as a context block with no divider (weakened footer)", () => {
+  it("renders footerText as a context block with no divider (weakened footer)", () => {
     const blocks = buildAgentResponseMessage(
       "Response text",
       "https://app.vm0.ai/activity/run-123",
-      "Sent via my-agent",
+      "Reply to <@U123> · Claude Opus 4.7",
     );
 
     // Should have: markdown, audit context, attribution context — no divider
@@ -195,24 +195,21 @@ describe("buildAgentResponseMessage", () => {
     });
     expect(contextBlocks).toHaveLength(2);
 
-    // First context: audit link only
     const auditText = (contextBlocks[0] as { elements: { text: string }[] })
       .elements[0]!.text;
     expect(auditText).toContain("Audit");
-    expect(auditText).not.toContain("Sent via");
+    expect(auditText).not.toContain("Reply to");
 
-    // Second context: attribution (no divider above)
     const attrText = (contextBlocks[1] as { elements: { text: string }[] })
       .elements[0]!.text;
-    expect(attrText).toBe("Sent via my-agent");
+    expect(attrText).toBe("Reply to <@U123> · Claude Opus 4.7");
   });
 
-  it("combines triggeredBy and model into one context block joined by ·", () => {
+  it("renders footerText alone when no logs url is provided", () => {
     const blocks = buildAgentResponseMessage(
       "Response text",
       undefined,
-      "Sent via my-agent",
-      "claude-sonnet-4-6",
+      "Claude Sonnet 4.6",
     );
 
     const dividerBlocks = blocks.filter((b) => {
@@ -226,27 +223,10 @@ describe("buildAgentResponseMessage", () => {
     expect(contextBlocks).toHaveLength(1);
     expect(
       (contextBlocks[0] as { elements: { text: string }[] }).elements[0]!.text,
-    ).toBe("Sent via my-agent · Claude Sonnet 4.6");
-  });
-
-  it("renders model-only attribution when triggeredBy is absent", () => {
-    const blocks = buildAgentResponseMessage(
-      "Response text",
-      undefined,
-      undefined,
-      "claude-sonnet-4-6",
-    );
-
-    const contextBlocks = blocks.filter((b) => {
-      return b.type === "context";
-    });
-    expect(contextBlocks).toHaveLength(1);
-    expect(
-      (contextBlocks[0] as { elements: { text: string }[] }).elements[0]!.text,
     ).toBe("Claude Sonnet 4.6");
   });
 
-  it("adds no attribution block when neither triggeredBy nor modelName is provided", () => {
+  it("adds no attribution block when footerText is not provided", () => {
     const blocks = buildAgentResponseMessage(
       "Response text",
       "https://app.vm0.ai/activity/run-123",

--- a/turbo/apps/web/src/lib/zero/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/zero/slack/__tests__/blocks.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect } from "vitest";
-import type { SectionBlock, ActionsBlock, MarkdownBlock } from "@slack/web-api";
+import type { SectionBlock, ActionsBlock } from "@slack/web-api";
 import {
   buildAppHomeView,
   buildErrorMessage,
   buildLoginPromptMessage,
   buildHelpMessage,
   buildSuccessMessage,
-  buildAgentResponseMessage,
   buildFooterBlocks,
 } from "../blocks";
 
@@ -111,134 +110,6 @@ describe("buildSuccessMessage", () => {
     expect((blocks[0] as SectionBlock).text?.text).toContain(
       ":white_check_mark:",
     );
-  });
-});
-
-describe("buildAgentResponseMessage", () => {
-  it("should use markdown block type for agent content", () => {
-    const blocks = buildAgentResponseMessage("Hello **world**");
-
-    const markdownBlock = blocks.find((b) => {
-      return b.type === "markdown";
-    });
-    expect(markdownBlock).toBeDefined();
-    expect((markdownBlock as MarkdownBlock).text).toBe("Hello **world**");
-  });
-
-  it("should pass raw markdown without conversion", () => {
-    const content = "## Header\n\n| Col1 | Col2 |\n|------|------|\n| a | b |";
-    const blocks = buildAgentResponseMessage(content);
-
-    const markdownBlock = blocks.find((b) => {
-      return b.type === "markdown";
-    }) as MarkdownBlock;
-    expect(markdownBlock.text).toBe(content);
-  });
-
-  it("should include context block with logs url when provided", () => {
-    const blocks = buildAgentResponseMessage(
-      "Response text",
-      "https://app.vm0.ai/audit/123",
-    );
-
-    const contextBlock = blocks.find((b) => {
-      return b.type === "context";
-    });
-    expect(contextBlock).toBeDefined();
-    expect(contextBlock).toMatchObject({
-      type: "context",
-      elements: [
-        {
-          type: "mrkdwn",
-          text: expect.stringContaining("Audit"),
-        },
-      ],
-    });
-  });
-
-  it("should truncate content exceeding 12000 characters", () => {
-    const longContent = "x".repeat(13000);
-    const blocks = buildAgentResponseMessage(longContent);
-
-    const markdownBlock = blocks.find((b) => {
-      return b.type === "markdown";
-    }) as MarkdownBlock;
-    expect(markdownBlock.text.length).toBeLessThanOrEqual(12000);
-    expect(markdownBlock.text).toContain("Message too long to view in Slack.");
-  });
-
-  it("should not truncate content under 12000 characters", () => {
-    const content = "x".repeat(11000);
-    const blocks = buildAgentResponseMessage(content);
-
-    const markdownBlock = blocks.find((b) => {
-      return b.type === "markdown";
-    }) as MarkdownBlock;
-    expect(markdownBlock.text).toBe(content);
-  });
-
-  it("renders footerText as a context block with no divider (weakened footer)", () => {
-    const blocks = buildAgentResponseMessage(
-      "Response text",
-      "https://app.vm0.ai/activity/run-123",
-      "Reply to <@U123> · Claude Opus 4.7",
-    );
-
-    // Should have: markdown, audit context, attribution context — no divider
-    const dividerBlocks = blocks.filter((b) => {
-      return b.type === "divider";
-    });
-    expect(dividerBlocks).toHaveLength(0);
-
-    const contextBlocks = blocks.filter((b) => {
-      return b.type === "context";
-    });
-    expect(contextBlocks).toHaveLength(2);
-
-    const auditText = (contextBlocks[0] as { elements: { text: string }[] })
-      .elements[0]!.text;
-    expect(auditText).toContain("Audit");
-    expect(auditText).not.toContain("Reply to");
-
-    const attrText = (contextBlocks[1] as { elements: { text: string }[] })
-      .elements[0]!.text;
-    expect(attrText).toBe("Reply to <@U123> · Claude Opus 4.7");
-  });
-
-  it("renders footerText alone when no logs url is provided", () => {
-    const blocks = buildAgentResponseMessage(
-      "Response text",
-      undefined,
-      "Claude Sonnet 4.6",
-    );
-
-    const dividerBlocks = blocks.filter((b) => {
-      return b.type === "divider";
-    });
-    expect(dividerBlocks).toHaveLength(0);
-
-    const contextBlocks = blocks.filter((b) => {
-      return b.type === "context";
-    });
-    expect(contextBlocks).toHaveLength(1);
-    expect(
-      (contextBlocks[0] as { elements: { text: string }[] }).elements[0]!.text,
-    ).toBe("Claude Sonnet 4.6");
-  });
-
-  it("adds no attribution block when footerText is not provided", () => {
-    const blocks = buildAgentResponseMessage(
-      "Response text",
-      "https://app.vm0.ai/activity/run-123",
-    );
-
-    const contextBlocks = blocks.filter((b) => {
-      return b.type === "context";
-    });
-    expect(contextBlocks).toHaveLength(1);
-    expect(
-      (contextBlocks[0] as { elements: { text: string }[] }).elements[0]!.text,
-    ).toContain("Audit");
   });
 });
 

--- a/turbo/apps/web/src/lib/zero/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/zero/slack/blocks.ts
@@ -1,5 +1,4 @@
 import type { Block, KnownBlock, View, MarkdownBlock } from "@slack/web-api";
-import { getModelDisplayName } from "@vm0/core";
 import { getAppUrl } from "../url";
 
 /**
@@ -425,26 +424,24 @@ function buildMarkdownMessage(content: string): (Block | KnownBlock)[] {
 /**
  * Build an agent response message with optional logs link.
  *
- * The attribution footer (triggeredBy + model) renders as a single context
- * block without a divider — a deliberately weaker visual than
- * `buildFooterBlocks`, which is reserved for longer schedule/user footers
- * from the outbound `/integrations/slack/message` path.
+ * The attribution footer renders as a single context block without a divider —
+ * a deliberately weaker visual than `buildFooterBlocks`, which is reserved for
+ * longer schedule/user footers from the outbound `/integrations/slack/message`
+ * path. Callers pre-assemble `footerText` (e.g. `"Reply to <@U123> · Claude
+ * Opus 4.7"`); this helper only decides how to render it.
  *
  * @param content - The agent's response content
  * @param logsUrl - Optional URL to the run logs
- * @param triggeredBy - Optional agent attribution (e.g. "Sent via my-agent")
- * @param modelName - Optional raw model ID; rendered via `getModelDisplayName`
+ * @param footerText - Optional pre-joined attribution text
  * @returns Block Kit blocks with response content
  */
 export function buildAgentResponseMessage(
   content: string,
   logsUrl?: string,
-  triggeredBy?: string,
-  modelName?: string,
+  footerText?: string,
 ): (Block | KnownBlock)[] {
   const blocks: (Block | KnownBlock)[] = [...buildMarkdownMessage(content)];
 
-  // Add logs link at the end if provided
   // Emoji must be outside the link — Slack mobile doesn't render emoji inside <url|text>
   if (logsUrl) {
     blocks.push({
@@ -458,17 +455,13 @@ export function buildAgentResponseMessage(
     });
   }
 
-  const attributionParts: string[] = [];
-  if (triggeredBy) attributionParts.push(triggeredBy);
-  if (modelName) attributionParts.push(getModelDisplayName(modelName));
-
-  if (attributionParts.length > 0) {
+  if (footerText) {
     blocks.push({
       type: "context",
       elements: [
         {
           type: "mrkdwn",
-          text: attributionParts.join(" · "),
+          text: footerText,
         },
       ],
     });


### PR DESCRIPTION
## Summary

Refactor the Slack org agent reply footer so it communicates who the reply addresses and only surfaces the model name when it's different from the org default.

- `buildAgentResponseMessage` now takes a pre-assembled `footerText` instead of `triggeredBy + modelName`, letting callers decide what to render
- Add `Reply to <@user>` when 3+ distinct Slack users have mentioned the agent in a thread, so multi-person threads stay readable
- Rename `Sent via X` to `Responded by X` and suppress it for the org's default agent
- Suppress the model label when the run's `selectedModel` matches the org's default `claude-code` provider
- Parts joined by ` · `, ordered "who responded · to whom · with which model"

## Test plan

- [x] `pnpm -F web exec vitest` - 39 tests pass in blocks and route test files, including 6 new integration tests covering `Responded by` / `Reply to` / model-default behaviors and combined footer
- [x] `pnpm turbo run lint --filter=web` - 0 errors
- [x] `pnpm -F web check-types` - passes
- [x] `pnpm format` - all files already formatted
- [x] `knip` - no issues