### PR TITLE
feat(runs): eagerly create agent session at run insertion

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -27,8 +27,10 @@ import {
   findTestRunnerJobEntry,
   findTestStorage,
   createTestCheckpoint,
+  getTestAgentSessionWithConversation,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { POST as checkpointWebhook } from "../../../webhooks/agent/checkpoints/route";
+import { POST as completeWebhook } from "../../../webhooks/agent/complete/route";
 import { POST as pollRoute } from "../../../runners/poll/route";
 import type { AgentComposeYaml } from "../../../../../src/lib/infra/agent-compose/types";
 import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
@@ -1033,6 +1035,107 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
     // Note: "Missing required secrets" validation is tested in the Validation
     // describe block above (lines 138-197).
+  });
+
+  describe("Eager Agent Session", () => {
+    const UUID_REGEX =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+    it("should return sessionId on first POST and persist it on agent_runs", async () => {
+      const data = await createTestRun(testComposeId, "Eager session test");
+
+      expect(data.status).toBe("pending");
+      expect(data.sessionId).toBeDefined();
+      expect(data.sessionId).toMatch(UUID_REGEX);
+
+      const run = await findTestRunRecord(data.runId);
+      expect(run?.sessionId).toBe(data.sessionId);
+
+      const session = await getTestAgentSessionWithConversation(
+        data.sessionId!,
+      );
+      expect(session).toBeDefined();
+      expect(session?.userId).toBe(user.userId);
+      expect(session?.agentComposeId).toBe(testComposeId);
+      expect(session?.conversationId).toBeNull();
+    });
+
+    it("should reuse the existing session when continuing via sessionId", async () => {
+      // First run establishes a session
+      const first = await createTestRun(testComposeId, "First run");
+      expect(first.sessionId).toBeDefined();
+
+      // Bind a claude-code conversation (matches compose default framework)
+      // and mark the run complete so continuation validation passes and the
+      // concurrency limit does not block the follow-up run.
+      const sandboxToken = await generateSandboxToken(user.userId, first.runId);
+      const checkpointResponse = await checkpointWebhook(
+        createTestRequest(
+          "http://localhost:3000/api/webhooks/agent/checkpoints",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${sandboxToken}`,
+            },
+            body: JSON.stringify({
+              runId: first.runId,
+              cliAgentType: "claude-code",
+              cliAgentSessionId: "reuse-session-test",
+              cliAgentSessionHistoryHash:
+                "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
+            }),
+          },
+        ),
+      );
+      expect(checkpointResponse.status).toBe(200);
+
+      const completeResponse = await completeWebhook(
+        createTestRequest("http://localhost:3000/api/webhooks/agent/complete", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${sandboxToken}`,
+          },
+          body: JSON.stringify({ runId: first.runId, exitCode: 0 }),
+        }),
+      );
+      expect(completeResponse.status).toBe(200);
+
+      // Continue using the returned sessionId
+      const continued = await createTestRun(testComposeId, "Continue run", {
+        sessionId: first.sessionId,
+      });
+
+      expect(continued.sessionId).toBe(first.sessionId);
+
+      const continuedRun = await findTestRunRecord(continued.runId);
+      expect(continuedRun?.sessionId).toBe(first.sessionId);
+    });
+
+    it("should populate conversation_id after the checkpoint webhook fires", async () => {
+      const created = await createTestRun(testComposeId, "Checkpoint flow");
+      expect(created.sessionId).toBeDefined();
+
+      const beforeCheckpoint = await getTestAgentSessionWithConversation(
+        created.sessionId!,
+      );
+      expect(beforeCheckpoint?.conversationId).toBeNull();
+
+      const { agentSessionId, conversationId } = await completeTestRun(
+        user.userId,
+        created.runId,
+      );
+
+      // The checkpoint webhook should bind the conversation to the pre-created
+      // session (not allocate a new session).
+      expect(agentSessionId).toBe(created.sessionId);
+
+      const afterCheckpoint = await getTestAgentSessionWithConversation(
+        created.sessionId!,
+      );
+      expect(afterCheckpoint?.conversationId).toBe(conversationId);
+    });
   });
 
   describe("Checkpoint Resume", () => {

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -345,6 +345,7 @@ const router = tsr.router(runsMainContract, {
         return insertRunRecord(tx, {
           userId,
           orgId: org.orgId,
+          agentComposeId: compose.id,
           agentComposeVersionId: composeMeta.agentComposeVersionId,
           prompt: body.prompt,
           appendSystemPrompt: body.appendSystemPrompt,
@@ -353,6 +354,8 @@ const router = tsr.router(runsMainContract, {
           additionalVolumes: finalAdditionalVolumes,
           resumedFromCheckpointId: body.checkpointId,
           sessionId: body.sessionId,
+          artifactName: resolved.artifactName ?? body.artifactName,
+          memoryName: resolved.memoryName ?? body.memoryName,
         });
       });
       const transactionTime = Date.now();
@@ -427,6 +430,7 @@ const router = tsr.router(runsMainContract, {
               | "failed"
               | "timeout",
             sandboxId: dispatchResult.sandboxId,
+            sessionId: run.sessionId,
             createdAt: run.createdAt.toISOString(),
           },
         };

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -6,6 +6,9 @@ import {
   createTestRun,
   createTestSandboxToken,
   findTestCheckpoint,
+  findTestRunRecord,
+  getTestAgentSessionWithConversation,
+  createTestAgentSession,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import {
@@ -638,6 +641,147 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       expect(snapshot.additionalVolumes).toEqual([
         { name: "my-vol", versionId: "v1.0", mountPath: "/mnt" },
       ]);
+    });
+  });
+
+  describe("Session Resolution", () => {
+    // Branch A: run already has sessionId (eager creation path)
+    it("should bind conversation to the pre-created session", async () => {
+      // testRunId was created via createTestRun in beforeEach — the eager path
+      // already populated session_id on that run.
+      const runBefore = await findTestRunRecord(testRunId);
+      expect(runBefore?.sessionId).toBeTruthy();
+      const preCreatedSessionId = runBefore!.sessionId!;
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "branch-a-session",
+            cliAgentSessionHistoryHash: sha256("branch-a"),
+          }),
+        },
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        agentSessionId: string;
+        conversationId: string;
+      };
+
+      // Webhook returns the same session id that was pre-created
+      expect(body.agentSessionId).toBe(preCreatedSessionId);
+
+      // Session now references the new conversation
+      const session =
+        await getTestAgentSessionWithConversation(preCreatedSessionId);
+      expect(session?.conversationId).toBe(body.conversationId);
+
+      // run.sessionId unchanged
+      const runAfter = await findTestRunRecord(testRunId);
+      expect(runAfter?.sessionId).toBe(preCreatedSessionId);
+    });
+
+    // Branch B: legacy continuation pre-deploy — continuedFromSessionId set, sessionId unset
+    it("should reuse continuedFromSessionId for legacy continuation runs", async () => {
+      // Pre-create a session and seed a run that continues from it WITHOUT
+      // populating sessionId (simulates an in-flight continuation at deploy time).
+      const priorSession = await createTestAgentSession(
+        user.userId,
+        testComposeId,
+      );
+      const { runId } = await seedTestRun(user.userId, testComposeId, {
+        status: "running",
+        continuedFromSessionId: priorSession.id,
+      });
+
+      const runBefore = await findTestRunRecord(runId);
+      expect(runBefore?.sessionId).toBeNull();
+      expect(runBefore?.continuedFromSessionId).toBe(priorSession.id);
+
+      const token = await createTestSandboxToken(user.userId, runId);
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            runId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "branch-b-session",
+            cliAgentSessionHistoryHash: sha256("branch-b"),
+          }),
+        },
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        agentSessionId: string;
+        conversationId: string;
+      };
+
+      expect(body.agentSessionId).toBe(priorSession.id);
+
+      const session = await getTestAgentSessionWithConversation(
+        priorSession.id,
+      );
+      expect(session?.conversationId).toBe(body.conversationId);
+    });
+
+    // Branch C: legacy first-run pre-deploy — neither sessionId nor continuedFromSessionId set
+    it("should create a new session and backfill run.sessionId", async () => {
+      const { runId } = await seedTestRun(user.userId, testComposeId, {
+        status: "running",
+      });
+
+      const runBefore = await findTestRunRecord(runId);
+      expect(runBefore?.sessionId).toBeNull();
+      expect(runBefore?.continuedFromSessionId).toBeNull();
+
+      const token = await createTestSandboxToken(user.userId, runId);
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            runId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "branch-c-session",
+            cliAgentSessionHistoryHash: sha256("branch-c"),
+          }),
+        },
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        agentSessionId: string;
+        conversationId: string;
+      };
+
+      expect(body.agentSessionId).toBeTruthy();
+
+      // Run.sessionId was backfilled to the newly created session
+      const runAfter = await findTestRunRecord(runId);
+      expect(runAfter?.sessionId).toBe(body.agentSessionId);
+
+      const session = await getTestAgentSessionWithConversation(
+        body.agentSessionId,
+      );
+      expect(session?.conversationId).toBe(body.conversationId);
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -754,6 +754,7 @@ describe("POST /api/webhooks/agent/complete", () => {
         agentComposeVersionId: versionId,
         prompt: "Queued run",
         orgId: qUser.orgId,
+        composeId,
       });
       expect(run2.status).toBe("queued");
 

--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -116,6 +116,33 @@ describe("POST /api/zero/runs", () => {
       const data = await response.json();
       expect(response.status).toBe(201);
       expect(data.runId).toBeTruthy();
+      // Continuation runs should echo back the same session id (eager path)
+      expect(data.sessionId).toBe(session.id);
+    });
+
+    it("should eagerly create and return sessionId for a new zero run", async () => {
+      await insertOrgDefaultModelProvider(user.orgId, "anthropic-api-key");
+
+      const response = await POST(
+        createTestRequest(URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentId,
+            prompt: "eager zero run",
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.runId).toBeTruthy();
+      expect(data.sessionId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+
+      const run = await findTestRunRecord(data.runId);
+      expect(run?.sessionId).toBe(data.sessionId);
     });
 
     it("should return 403 when ZERO_TOKEN is used (agent-run:write excluded)", async () => {

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -139,6 +139,7 @@ const router = tsr.router(zeroRunsMainContract, {
         body: {
           runId: result.runId,
           status: result.status,
+          sessionId: result.sessionId,
           createdAt: result.createdAt.toISOString(),
         },
       };

--- a/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
@@ -55,7 +55,7 @@ export async function createTestRun(
     permissionPolicies?: Record<string, Record<string, string>>;
     triggerSource?: string;
   },
-): Promise<{ runId: string; status: string }> {
+): Promise<{ runId: string; status: string; sessionId?: string }> {
   const request = createTestRequest("http://localhost:3000/api/agent/runs", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -549,6 +549,7 @@ export async function enqueueTestRun(params: {
   agentComposeVersionId: string;
   orgId: string;
   prompt: string;
+  composeId: string;
 }): Promise<{ runId: string; status: string; queuedAt: Date }> {
   initServices();
   const result = await enqueueRun(params);

--- a/turbo/apps/web/src/lib/infra/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/infra/agent-session/agent-session-service.ts
@@ -77,17 +77,27 @@ export async function createAgentSession(
 }
 
 /**
- * Update an existing agent session's conversation reference
+ * Update an existing agent session's conversation reference. Optional
+ * artifactName/memoryName let the checkpoint webhook record the per-run
+ * snapshot fields on sessions that were created eagerly at run insertion
+ * (when those names were not yet known).
  */
 export async function updateAgentSession(
   id: string,
   conversationId: string,
+  options?: { artifactName?: string; memoryName?: string },
 ): Promise<AgentSessionData> {
   const [session] = await globalThis.services.db
     .update(agentSessions)
     .set({
       conversationId,
       updatedAt: new Date(),
+      ...(options?.artifactName !== undefined
+        ? { artifactName: options.artifactName }
+        : {}),
+      ...(options?.memoryName !== undefined
+        ? { memoryName: options.memoryName }
+        : {}),
     })
     .where(eq(agentSessions.id, id))
     .returning();

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -185,14 +185,25 @@ export async function createCheckpoint(
     | undefined;
 
   let agentSession;
-  if (run.continuedFromSessionId) {
-    // Continue: update existing session's conversation reference
+  if (run.sessionId) {
+    // New path: session was pre-created at run insertion (common case post-deploy).
+    // Bind the conversation and record any per-run snapshot fields that were
+    // not known at insertion time (e.g., memoryName from the runtime snapshot).
+    agentSession = await updateAgentSession(run.sessionId, conversation.id, {
+      artifactName: artifactSnapshot?.artifactName,
+      memoryName: memorySnapshot?.memoryName,
+    });
+  } else if (run.continuedFromSessionId) {
+    // Legacy continuation in flight at deploy time: pre-existing session gets
+    // its conversation reference updated.
     agentSession = await updateAgentSession(
       run.continuedFromSessionId,
       conversation.id,
     );
   } else {
-    // New run: always create a new session (with artifact/memory name if present)
+    // Legacy first-run created by old web before this deploy. Create the
+    // session now AND backfill agent_runs.session_id so downstream consumers
+    // (and the Release 2 migration) see a populated value.
     agentSession = await createAgentSession({
       userId: run.userId,
       orgId: run.orgId,
@@ -201,6 +212,10 @@ export async function createCheckpoint(
       memoryName: memorySnapshot?.memoryName,
       conversationId: conversation.id,
     });
+    await globalThis.services.db
+      .update(agentRuns)
+      .set({ sessionId: agentSession.id })
+      .where(eq(agentRuns.id, run.id));
   }
 
   log.debug(`Agent session updated/created: ${agentSession.id}`);

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -1,6 +1,7 @@
 import { eq, and, or } from "drizzle-orm";
 import { env } from "../../../env";
 import { agentRuns } from "../../../db/schema/agent-run";
+import { agentSessions } from "../../../db/schema/agent-session";
 import { transitionRunStatus, dispatchTerminalSideEffects } from "./run-status";
 import {
   agentComposeVersions,
@@ -139,6 +140,7 @@ export interface CreateRunResult {
   status: RunStatus;
   sandboxId?: string;
   createdAt: Date;
+  sessionId: string;
 }
 
 /**
@@ -405,6 +407,7 @@ export interface CreateRunRecordResult {
 interface InsertRunParams {
   userId: string;
   orgId: string;
+  agentComposeId: string;
   agentComposeVersionId: string;
   prompt: string;
   appendSystemPrompt?: string;
@@ -418,17 +421,43 @@ interface InsertRunParams {
   }>;
   resumedFromCheckpointId?: string;
   sessionId?: string;
+  artifactName?: string;
+  memoryName?: string;
 }
 
 /**
  * Pure INSERT into agent_runs within an existing transaction.
- * No business logic — caller is responsible for authorization,
- * validation, and concurrency checks.
+ * For new runs, also creates the agent_sessions row in the same tx so
+ * sessionId is known on the first POST response. For continuations, reuses
+ * the caller-supplied sessionId. No business logic — caller is responsible
+ * for authorization, validation, and concurrency checks.
  */
 export async function insertRunRecord(
   tx: Database,
   params: InsertRunParams,
-): Promise<{ id: string; createdAt: Date }> {
+): Promise<{ id: string; createdAt: Date; sessionId: string }> {
+  let sessionId: string;
+  if (params.sessionId) {
+    sessionId = params.sessionId;
+  } else {
+    const [newSession] = await tx
+      .insert(agentSessions)
+      .values({
+        userId: params.userId,
+        orgId: params.orgId,
+        agentComposeId: params.agentComposeId,
+        artifactName: params.artifactName,
+        memoryName: params.memoryName,
+        conversationId: null,
+      })
+      .returning({ id: agentSessions.id });
+
+    if (!newSession) {
+      throw new Error("Failed to create agent session");
+    }
+    sessionId = newSession.id;
+  }
+
   const [newRun] = await tx
     .insert(agentRuns)
     .values({
@@ -443,6 +472,7 @@ export async function insertRunRecord(
       additionalVolumes: params.additionalVolumes ?? null,
       resumedFromCheckpointId: params.resumedFromCheckpointId ?? null,
       continuedFromSessionId: params.sessionId ?? null,
+      sessionId,
       lastHeartbeatAt: new Date(),
     })
     .returning();
@@ -451,7 +481,7 @@ export async function insertRunRecord(
     throw new Error("Failed to create run record");
   }
 
-  return newRun;
+  return { id: newRun.id, createdAt: newRun.createdAt, sessionId };
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -48,6 +48,7 @@ describe("credit check (infra queue path)", () => {
       agentComposeVersionId: versionId,
       prompt: "Credit check test",
       orgId: user.orgId,
+      composeId,
       ...overrides,
     };
   }
@@ -255,6 +256,7 @@ describe("model provider check (queue dispatch path)", () => {
       agentComposeVersionId: compose.versionId,
       prompt: "Queued no provider",
       orgId: user.orgId,
+      composeId: compose.composeId,
       vars: { ZERO_AGENT_ID: agentId },
       agentName,
     });

--- a/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
@@ -47,6 +47,7 @@ describe("run-queue-service", () => {
       agentComposeVersionId: versionId,
       prompt: "Queue test",
       orgId: user.orgId,
+      composeId,
       ...overrides,
     };
   }

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -14,6 +14,7 @@ import {
 } from "drizzle-orm";
 import { agentRuns } from "../../db/schema/agent-run";
 import { agentRunQueue } from "../../db/schema/agent-run-queue";
+import { agentSessions } from "../../db/schema/agent-session";
 import { zeroRuns } from "../../db/schema/zero-run";
 import {
   agentComposeVersions,
@@ -89,6 +90,13 @@ export async function enqueueRun(
   // Org context is required from caller
   const orgId = params.orgId;
 
+  // composeId must be present on the zero path (resolved before enqueue).
+  // Without it we cannot stamp agent_sessions.agent_compose_id.
+  if (!params.composeId) {
+    throw new Error("enqueueRun requires params.composeId to be set");
+  }
+  const agentComposeId = params.composeId;
+
   // Encrypt the full CreateRunParams for later replay
   const paramsJson = JSON.stringify(params);
   const encryptedParams = encryptSecretsMap(
@@ -96,10 +104,34 @@ export async function enqueueRun(
     env().SECRETS_ENCRYPTION_KEY,
   );
 
-  // Insert agent_runs + queue entry atomically to prevent orphaned records
+  // Insert agent_runs + queue entry atomically to prevent orphaned records.
+  // Eagerly create the agent_sessions row too so sessionId is known on the
+  // POST response even for queued runs (same promise as synchronous runs).
   const expiresAt = new Date(Date.now() + QUEUE_TTL_MS);
 
   const run = await globalThis.services.db.transaction(async (tx) => {
+    let sessionId: string;
+    if (params.sessionId) {
+      sessionId = params.sessionId;
+    } else {
+      const [newSession] = await tx
+        .insert(agentSessions)
+        .values({
+          userId,
+          orgId,
+          agentComposeId,
+          artifactName: params.artifactName,
+          memoryName: params.memoryName,
+          conversationId: null,
+        })
+        .returning({ id: agentSessions.id });
+
+      if (!newSession) {
+        throw new Error("Failed to create queued agent session");
+      }
+      sessionId = newSession.id;
+    }
+
     const [inserted] = await tx
       .insert(agentRuns)
       .values({
@@ -113,6 +145,7 @@ export async function enqueueRun(
         secretNames: params.secrets ? Object.keys(params.secrets) : null,
         resumedFromCheckpointId: params.resumedFromCheckpointId ?? null,
         continuedFromSessionId: params.sessionId ?? null,
+        sessionId,
         lastHeartbeatAt: new Date(),
       })
       .returning();
@@ -130,7 +163,7 @@ export async function enqueueRun(
       expiresAt,
     });
 
-    return inserted;
+    return { ...inserted, sessionId };
   });
 
   log.debug(`Enqueued run ${run.id} for user ${userId}`);
@@ -139,6 +172,7 @@ export async function enqueueRun(
     runId: run.id,
     status: "queued",
     createdAt: run.createdAt,
+    sessionId: run.sessionId,
   };
 }
 

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -259,6 +259,7 @@ interface ZeroRunRecordResult {
   runId: string;
   status: RunStatus;
   createdAt: Date;
+  sessionId: string;
   /** Undefined when run was enqueued (concurrency limit) — dispatch already deferred via queue */
   record?: CreateRunRecordResult;
   runParams?: CreateRunParams;
@@ -482,7 +483,7 @@ async function createZeroRunRecord(
     userId: params.userId,
     agentComposeVersionId: resolved.agentComposeVersionId,
     prompt: params.prompt,
-    composeId: resolved.composeId,
+    composeId: preloadedCompose.compose.id,
     sessionId: params.sessionId,
     appendSystemPrompt,
     modelProvider: params.modelProvider,
@@ -531,7 +532,21 @@ async function createZeroRunRecord(
         sql`SELECT pg_advisory_xact_lock(hashtext(${resolved.orgId}))`,
       );
       await checkRunConcurrencyLimit(resolved.orgId, orgTier, tx);
-      return insertRunRecord(tx, runParams);
+      return insertRunRecord(tx, {
+        userId: runParams.userId,
+        orgId: resolved.orgId,
+        agentComposeId: preloadedCompose.compose.id,
+        agentComposeVersionId: runParams.agentComposeVersionId,
+        prompt: runParams.prompt,
+        appendSystemPrompt: runParams.appendSystemPrompt,
+        vars: runParams.vars,
+        secrets: runParams.secrets,
+        additionalVolumes: runParams.additionalVolumes,
+        resumedFromCheckpointId: runParams.resumedFromCheckpointId,
+        sessionId: runParams.sessionId,
+        artifactName: runParams.artifactName,
+        memoryName: runParams.memoryName,
+      });
     });
   } catch (error) {
     if (isConcurrentRunLimit(error)) {
@@ -546,6 +561,7 @@ async function createZeroRunRecord(
         runId: queueResult.runId,
         status: queueResult.status,
         createdAt: queueResult.createdAt,
+        sessionId: queueResult.sessionId,
       };
     }
     throw error;
@@ -571,6 +587,7 @@ async function createZeroRunRecord(
     runId: run.id,
     status: "pending",
     createdAt: run.createdAt,
+    sessionId: run.sessionId,
     record,
     runParams,
     orgId: resolved.orgId,
@@ -673,6 +690,7 @@ export interface CreateZeroRunResult {
   runId: string;
   status: RunStatus;
   createdAt: Date;
+  sessionId: string;
 }
 
 /**
@@ -708,6 +726,7 @@ export async function createZeroRun(
     runId: result.runId,
     status: result.status,
     createdAt: result.createdAt,
+    sessionId: result.sessionId,
   };
 }
 

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -90,6 +90,10 @@ const createRunResponseSchema = z.object({
   runId: z.string(),
   status: runStatusSchema,
   sandboxId: z.string().optional(),
+  // Agent session id — eagerly created at run insertion so the first POST
+  // response carries it. Optional for backward compatibility with runs created
+  // before the eager-session rollout (Release 2 will tighten to required).
+  sessionId: z.string().uuid().optional(),
   output: z.string().optional(),
   error: z.string().optional(),
   executionTimeMs: z.number().optional(),


### PR DESCRIPTION
## Summary

- Eagerly insert an `agent_sessions` row in the same transaction as `agent_runs`, so `sessionId` is returned on the first `POST /api/agent/runs` and `/api/zero/runs` response (no more waiting on the checkpoint webhook).
- Applies to all three insert paths: CLI sync route, zero-run sync route, and `enqueueRun` queue-path.
- Checkpoint webhook session resolution is now a three-branch fallback:
  - **A. Pre-created session (new path):** bind the conversation to the run's `session_id` — also records `artifactName` / `memoryName` from the runtime snapshot.
  - **B. Legacy continuation in-flight at deploy:** bind the conversation to `continued_from_session_id`.
  - **C. Legacy first-run pre-deploy:** create the session inline and backfill `agent_runs.session_id` so downstream consumers (and the Release 2 migration) see a populated value.
- Response contract (`createRunResponseSchema`) gains an optional `sessionId: z.string().uuid()` field. Staying optional for Release 1 preserves wire-compat with older servers; Release 2 will tighten to required.

Closes #10249. Part of epic #10247. Depends on #10259 (merged).

## Test plan

- [x] New integration tests in `app/api/agent/runs/__tests__/route.test.ts` — eager-create happy path, continuation reuses existing session, conversation binding on checkpoint.
- [x] New integration tests in `app/api/webhooks/agent/checkpoints/__tests__/route.test.ts` — Branch A / B / C coverage, including run.sessionId backfill for Branch C.
- [x] New integration tests in `app/api/zero/runs/__tests__/route.test.ts` — new zero run returns sessionId, continuation echoes sessionId.
- [x] Full web suite: 3523 / 3524 pass (the 1 flake is unrelated voice-chat-cleanup test isolation, passes in isolation).
- [x] Pre-commit: `pnpm check-types`, `pnpm turbo run lint`, `pnpm format`, `pnpm knip` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)