### PR TITLE
fix(platform): preserve agent model selection on job detail profile tab

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -658,6 +658,64 @@ describe("zero-job-detail signals", () => {
       // The PATCH is always sent — idempotency is handled server-side
       expect(patchCalled).toBeTruthy();
     });
+
+    it("should not include modelProviderId/selectedModel when the update omits them", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      await setupSettings();
+
+      server.use(
+        mockApi(zeroAgentsByIdContract.updateMetadata, ({ body, respond }) => {
+          capturedBody = body as Record<string, unknown>;
+          return respond(200, mockAgentResponse());
+        }),
+        mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+          return respond(200, mockAgentResponse());
+        }),
+      );
+
+      await context.store.set(
+        zeroJobUpdateSettings$,
+        { displayName: "Just a rename" },
+        context.signal,
+      );
+
+      // Regression: partial updates must not clobber stored model selection
+      // with `null`. Callers that don't touch the model picker should send a
+      // payload that omits these keys entirely.
+      expect(capturedBody).not.toHaveProperty("modelProviderId");
+      expect(capturedBody).not.toHaveProperty("selectedModel");
+    });
+  });
+
+  describe("zeroJobDetail$ model provider fields", () => {
+    it("should expose modelProviderId and selectedModel from the agent response", async () => {
+      setMockSchedules([]);
+      server.use(
+        mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+          return respond(200, {
+            ...mockAgentResponse(),
+            modelProviderId: "a1111111-1111-4111-a111-111111111111",
+            selectedModel: "claude-opus-4-7",
+          });
+        }),
+        mockApi(zeroAgentInstructionsContract.get, ({ respond }) => {
+          return respond(200, mockInstructions());
+        }),
+      );
+
+      detachedSetupPage({ context, path: "/", withoutRender: true });
+      context.store.set(setActiveAgent$, "my-agent");
+      const detail = await context.store.get(zeroJobDetail$);
+
+      // Regression: the AgentDetail type must preserve these fields so the
+      // profile tab can render the saved selection instead of "from org
+      // default" after a page refresh.
+      expect(detail?.modelProviderId).toBe(
+        "a1111111-1111-4111-a111-111111111111",
+      );
+      expect(detail?.selectedModel).toBe("claude-opus-4-7");
+    });
   });
 
   describe("connectors management", () => {

--- a/turbo/apps/platform/src/signals/zero-page/agent-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-types.ts
@@ -8,6 +8,8 @@ export interface AgentDetail {
   sound: string | null;
   avatarUrl: string | null;
   permissionPolicies: FirewallPolicies | null;
+  modelProviderId: string | null;
+  selectedModel: string | null;
 }
 
 export interface AgentInstructions {

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/settings.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/settings.ts
@@ -14,6 +14,8 @@ interface ZeroJobSettingsUpdate {
   description?: string;
   sound?: string;
   avatarUrl?: string | null;
+  modelProviderId?: string | null;
+  selectedModel?: string | null;
 }
 
 export const zeroJobUpdateSettings$ = command(

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -819,6 +819,8 @@ function AgentTabContent({
   resolvedSound,
   isDefaultAgent,
   ownerId,
+  modelProviderId,
+  selectedModel,
 }: {
   activeTab: string;
   agentId: string;
@@ -828,6 +830,8 @@ function AgentTabContent({
   resolvedSound: Tone;
   isDefaultAgent: boolean;
   ownerId: string;
+  modelProviderId: string | null;
+  selectedModel: string | null;
 }) {
   const deleteAgent = useSet(deleteZeroJobAgent$);
   const nav = useSet(detachedNavigateTo$);
@@ -854,11 +858,13 @@ function AgentTabContent({
     case "profile": {
       return (
         <ZeroSettingsTab
-          key={`${displayName}\0${description}\0${resolvedSound}\0${avatarUrl}`}
+          key={`${displayName}\0${description}\0${resolvedSound}\0${avatarUrl}\0${modelProviderId ?? ""}\0${selectedModel ?? ""}`}
           displayName={displayName}
           description={description}
           sound={resolvedSound}
           avatarUrl={avatarUrl}
+          modelProviderId={modelProviderId}
+          selectedModel={selectedModel}
           updateSettings$={zeroJobUpdateSettings$}
           inputId="job-agent-name"
           isDefaultAgent={isDefaultAgent}
@@ -889,6 +895,8 @@ function useAgentFields() {
     avatarUrl: source?.avatarUrl ?? null,
     resolvedSound: resolveSound(source?.sound ?? "professional"),
     ownerId: source?.ownerId ?? "",
+    modelProviderId: source?.modelProviderId ?? null,
+    selectedModel: source?.selectedModel ?? null,
   };
 }
 
@@ -959,6 +967,8 @@ export function ZeroJobDetailPage() {
           resolvedSound={fields.resolvedSound}
           isDefaultAgent={isDefaultAgent}
           ownerId={fields.ownerId}
+          modelProviderId={fields.modelProviderId}
+          selectedModel={fields.selectedModel}
         />
       </main>
     </div>


### PR DESCRIPTION
## Summary

- Thread `modelProviderId` and `selectedModel` through `AgentDetail`, the partial update payload, and `AgentTabContent` -> `ZeroSettingsTab` so the saved selection survives a page refresh on the job detail profile tab.
- Previously the picker fell back to "from org default" after refresh because these fields were absent from the zero-job-detail signal pipeline.
- Add regression tests: partial updates must omit the model keys (not send `null`), and `zeroJobDetail$` must surface both fields from the agent response.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/signals/zero-page/__tests__/zero-job-detail.test.ts` (23/23 pass)
- [x] `pnpm -F @vm0/app exec vitest run zero-job-detail-page` (30/30 pass)
- [x] `pnpm -F @vm0/app exec eslint` on modified files (clean)
- [x] `tsc --noEmit` on modified files (clean; pre-existing errors elsewhere unrelated)