### PR TITLE
fix(mitm-addon): return decompressed bytes for empty-body frames

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -140,7 +140,10 @@ def decompress_body(
       bodies from the pre-configured model-provider and billable-connector
       allowlist (not arbitrary user-supplied URLs).
 
-    Returns the original data unchanged if not compressed or on error.
+    Returns the original data unchanged when the encoding is missing,
+    ``identity``, or unrecognised, and on decompression error.  A valid
+    frame that decodes to an empty body returns ``b""`` — callers that
+    short-circuit via ``if not body`` rely on that (see #10287).
     """
     encoding = headers.get("content-encoding", "").strip().lower()
     if not encoding or encoding == "identity":

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -150,19 +150,16 @@ def decompress_body(
             # wbits: gzip=16+MAX_WBITS, deflate=MAX_WBITS
             wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
             obj = zlib.decompressobj(wbits)
-            result = obj.decompress(data, max_length=max_output)
-            return result if result else data
+            return obj.decompress(data, max_length=max_output)
         if encoding == "br":
             dec = brotli.Decompressor()
-            result = dec.process(data)
-            return result[:max_output] if result else data
+            return dec.process(data)[:max_output]
         if encoding == "zstd":
             # stream_reader.read(n) reads *up to* n bytes: the full frame if
             # smaller than n, exactly n if larger — so total memory is bounded
             # by n plus ZSTD_DStream{In,Out}Size (~128 KB library buffers).
             with zstandard.ZstdDecompressor().stream_reader(data) as reader:
-                result = reader.read(max_output)
-            return result if result else data
+                return reader.read(max_output)
     except (zlib.error, brotli.error, zstandard.ZstdError) as exc:
         with contextlib.suppress(AttributeError):
             # ctx.log unavailable outside mitmproxy runtime

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -646,22 +646,24 @@ class TestDecompression:
         assert entry["response_body"] == '{"ok": true}'
 
     def test_truncated_gzip_partial_decompress(self, real_flow):
-        """Truncated gzip buffer should not crash or leak the compressed
-        framing.  zlib may decompress some partial content (→ capture it
-        truncated) or nothing at all if the cut falls before the first
-        deflate block boundary (→ skip the body); both are acceptable.
-        Before #10287 the "nothing" path leaked ~20 B of gzip framing via
-        base64 — this test guards against a regression of that."""
+        """Truncated gzip buffer should yield the partial decompressed
+        content that zlib managed to decode before the cut, marked
+        truncated.  Input sized so halving the frame leaves zlib with
+        enough bytes to emit real payload (42 KB of 'x') rather than the
+        empty-output edge case covered by #10287."""
         import gzip
 
-        original = b"x" * 10000
+        original = b"x" * 100_000
         compressed = gzip.compress(original)
         truncated = compressed[: len(compressed) // 2]
         flow = self._make_flow_with_compressed_buffer(real_flow, truncated, "gzip", "text/plain")
         flow.metadata["stream_buffer_state"]["truncated"] = True
         entry = {}
         add_capture_fields(flow, entry)
-        assert entry.get("response_body_truncated") is True or "response_body" not in entry
+        assert "response_body" in entry
+        assert entry["response_body_truncated"] is True
+        assert set(entry["response_body"]) == {"x"}  # partial 'x' run, never gzip framing
+        assert len(entry["response_body"]) > 1024  # meaningfully more than just the header
 
     def test_gzip_zip_bomb_capped(self, real_flow):
         """Decompressed output should not exceed buffer limit (zip bomb protection)."""
@@ -966,6 +968,15 @@ class TestDecompressBody:
 
         compressed = gzip.compress(b"")
         hdrs = headers(("Content-Encoding", "gzip"))
+        assert decompress_body(compressed, hdrs, max_output=64 * 1024) == b""
+
+    def test_deflate_empty_body_returns_empty(self, headers):
+        # Bug #10287: deflate shares the gzip branch but uses a different
+        # ``wbits`` — guard that the empty-body behaviour matches.
+        import zlib
+
+        compressed = zlib.compress(b"")
+        hdrs = headers(("Content-Encoding", "deflate"))
         assert decompress_body(compressed, hdrs, max_output=64 * 1024) == b""
 
     def test_brotli_empty_body_returns_empty(self, headers):

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -537,6 +537,28 @@ class TestAddCaptureFields:
         assert entry["response_body"] == '{"result": "ok"}'
         assert entry["response_body_encoding"] == "utf-8"
 
+    def test_stream_buffer_gzip_empty_body_skips_body(self, real_flow):
+        """Bug #10287: a gzip frame that decompresses to b"" must not leak
+        the ~20 B compressed framing into ``response_body`` as base64."""
+        import gzip
+
+        compressed = gzip.compress(b"")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            include_request_id=True,
+            response_content_type="application/json",
+            response_encoding="gzip",
+        )
+        flow.metadata["stream_buffer"] = bytearray(compressed)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "response_body" not in entry
+        assert "response_body_encoding" not in entry
+        assert "response_headers" in entry  # headers still captured
+
 
 class TestDecompression:
     """Integration tests for decompression through add_capture_fields."""
@@ -624,7 +646,12 @@ class TestDecompression:
         assert entry["response_body"] == '{"ok": true}'
 
     def test_truncated_gzip_partial_decompress(self, real_flow):
-        """Truncated gzip buffer should yield partial decompressed content."""
+        """Truncated gzip buffer should not crash or leak the compressed
+        framing.  zlib may decompress some partial content (→ capture it
+        truncated) or nothing at all if the cut falls before the first
+        deflate block boundary (→ skip the body); both are acceptable.
+        Before #10287 the "nothing" path leaked ~20 B of gzip framing via
+        base64 — this test guards against a regression of that."""
         import gzip
 
         original = b"x" * 10000
@@ -634,8 +661,7 @@ class TestDecompression:
         flow.metadata["stream_buffer_state"]["truncated"] = True
         entry = {}
         add_capture_fields(flow, entry)
-        assert "response_body" in entry
-        assert entry["response_body_truncated"] is True
+        assert entry.get("response_body_truncated") is True or "response_body" not in entry
 
     def test_gzip_zip_bomb_capped(self, real_flow):
         """Decompressed output should not exceed buffer limit (zip bomb protection)."""
@@ -929,3 +955,31 @@ class TestDecompressBody:
         data = b'{"hello":"world"}'
         assert decompress_body(data, headers(("Content-Encoding", "identity"))) == data
         assert decompress_body(data, headers()) == data
+
+    def test_gzip_empty_body_returns_empty(self, headers):
+        # Bug #10287: a valid gzip frame that decompresses to b"" must not be
+        # reported back as the compressed bytes.  Before the fix,
+        # ``return result if result else data`` on the success path handed the
+        # raw ~20 B framing to the caller, which then base64-encoded it into
+        # the network log.
+        import gzip
+
+        compressed = gzip.compress(b"")
+        hdrs = headers(("Content-Encoding", "gzip"))
+        assert decompress_body(compressed, hdrs, max_output=64 * 1024) == b""
+
+    def test_brotli_empty_body_returns_empty(self, headers):
+        # Bug #10287: same pattern as gzip for the brotli branch.
+        import brotli
+
+        compressed = brotli.compress(b"")
+        hdrs = headers(("Content-Encoding", "br"))
+        assert decompress_body(compressed, hdrs, max_output=64 * 1024) == b""
+
+    def test_zstd_empty_body_returns_empty(self, headers):
+        # Bug #10287: same pattern as gzip for the zstd branch.
+        import zstandard
+
+        compressed = zstandard.ZstdCompressor().compress(b"")
+        hdrs = headers(("Content-Encoding", "zstd"))
+        assert decompress_body(compressed, hdrs, max_output=64 * 1024) == b""


### PR DESCRIPTION
## Summary

- `decompress_body`'s success path used `return result if result else data` on the gzip/br/zstd branches. When a valid compressed frame decoded to `b""` (e.g. a server gzip-encodes an empty 200 body), the function handed the raw ~20 B compressed framing back to the caller instead of `b""`.
- `add_capture_fields`'s `if not body: return` short-circuit never fired, so the framing bytes fell through to `_encode_body` and were base64-encoded into `response_body` — a garbled, meaningless network log entry.
- Fix: drop the `else data` fallback from the success path. Error paths (`zlib.error` / `brotli.error` / `zstandard.ZstdError`) still fall through to the outer `return data`, preserving the "on failure, return original bytes" contract.
- Updated the pre-existing `test_truncated_gzip_partial_decompress` — it was asserting the bug behavior (compressed framing ending up in `response_body`). Aligned it with the brotli/zstd truncation tests, which already tolerated either "partial decompressed" or "no body captured" outcomes.

Closes #10287

## Test plan

- [x] Added `test_{gzip,brotli,zstd}_empty_body_returns_empty` — compress `b""` via each codec, assert `decompress_body` returns `b""`
- [x] Added `test_stream_buffer_gzip_empty_body_skips_body` — integration test that an empty gzip stream_buffer produces no `response_body` / `response_body_encoding` fields (just headers)
- [x] Full `python -m pytest tests/` passes (882 tests)
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)