### PR TITLE
fix(firewall): force-refresh oauth token when provider returns 401 (#9860)

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -31,6 +31,59 @@ _firewall_header_cache: dict[tuple[str, str], dict] = {}
 # Per-key locks to coalesce concurrent fetches for the same (run_id, api_id)
 _cache_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
+# (run_id, api_id) pairs for which the upstream just returned 401 — the next
+# /firewall/auth fetch must force a token refresh regardless of the DB's
+# tokenExpiresAt, since the provider has silently invalidated it (user
+# revoked, admin rotated, clock skew). Consumed + cleared in
+# get_firewall_headers before each fetch. See #9860.
+_force_refresh_markers: set[tuple[str, str]] = set()
+
+# Timestamp of the last consumed force-refresh per (run_id, api_id). Used to
+# rate-limit amplification when an upstream persistently returns 401 for a
+# non-token reason (scope mismatch, resource-level reject, IP block).
+# Without this, every 401 would trigger an OAuth refresh call — hitting
+# provider rate limits and potentially tripping abuse detection. See #9860.
+_last_force_refresh_at: dict[tuple[str, str], float] = {}
+
+# Cooldown window for re-marking a force-refresh. Caps amplification at
+# 30 refreshes/hour/key under a persistent non-token 401 loop — safely
+# below Google's 50/hour/user OAuth refresh limit (the tightest known).
+# The first force-refresh after a real token invalidation always fires
+# immediately; the cooldown only affects REPEATED forced refreshes, so
+# happy-path recovery is unaffected.
+_FORCE_REFRESH_COOLDOWN_SECS = 120.0
+
+
+def request_force_refresh(cache_key: tuple[str, str]) -> None:
+    """Request a forced token refresh on the next /firewall/auth fetch.
+
+    No-op if a forced refresh already completed within
+    ``_FORCE_REFRESH_COOLDOWN_SECS`` — rate limiter for the case where the
+    token is actually fine but the endpoint rejects for another reason
+    (scope, resource-level permission). See #9860.
+
+    Design notes for future changes:
+
+    * The consume timestamp in ``_last_force_refresh_at`` is written **before**
+      ``fetch_firewall_headers`` is awaited in ``get_firewall_headers``, not
+      after. Recording after would allow a 401 arriving during the fetch to
+      re-add the marker; after the fetch completes and writes the cache, a
+      later cache miss would then consume the stale marker and trigger an
+      unnecessary second refresh. The trade-off is that a failed fetch
+      (webhook down, ``TOKEN_REFRESH_FAILED``, etc.) still burns the
+      cooldown — intentional, because if the refresh grant itself is broken,
+      retrying faster than once per cooldown wouldn't help and would hammer
+      the provider.
+    * ``time.time()`` is used for the cooldown (not ``time.monotonic()``) for
+      consistency with the rest of this module, which compares wall-clock
+      ``expiresAt`` values from the webhook. An NTP backward step could
+      freeze the cooldown until wall-clock catches up; on NTP-slewed runners
+      this is not a realistic concern.
+    """
+    last = _last_force_refresh_at.get(cache_key, 0.0)
+    if time.time() - last >= _FORCE_REFRESH_COOLDOWN_SECS:
+        _force_refresh_markers.add(cache_key)
+
 
 def evict_stale_cache_keys(active_run_ids: set[str]) -> None:
     """Remove cache entries for runs no longer in the registry."""
@@ -38,6 +91,12 @@ def evict_stale_cache_keys(active_run_ids: set[str]) -> None:
     for k in stale:
         _firewall_header_cache.pop(k, None)
         _cache_locks.pop(k, None)
+    stale_markers = [k for k in _force_refresh_markers if k[0] not in active_run_ids]
+    for k in stale_markers:
+        _force_refresh_markers.discard(k)
+    stale_ts = [k for k in _last_force_refresh_at if k[0] not in active_run_ids]
+    for k in stale_ts:
+        _last_force_refresh_at.pop(k, None)
 
 
 def get_api_url() -> str:
@@ -78,6 +137,7 @@ def _fetch_firewall_headers_sync(
     vars_map: dict | None = None,
     auth_base: str | None = None,
     auth_query: dict | None = None,
+    force_refresh: bool = False,
 ) -> dict:
     """Synchronous helper — runs in a thread to avoid blocking the event loop.
 
@@ -94,6 +154,8 @@ def _fetch_firewall_headers_sync(
         body["secretConnectorMap"] = secret_connector_map
     if vars_map:
         body["vars"] = vars_map
+    if force_refresh:
+        body["forceRefresh"] = True
     data = json.dumps(body).encode()
     req = make_api_request(url, data, sandbox_token)
     try:
@@ -122,11 +184,15 @@ async def fetch_firewall_headers(
     vars_map: dict | None = None,
     auth_base: str | None = None,
     auth_query: dict | None = None,
+    force_refresh: bool = False,
 ) -> dict:
     """Resolve auth headers via server-side decryption.
 
     When secret_connector_map is provided, the auth endpoint can refresh
     expired OAuth tokens and returns an expiresAt timestamp for TTL caching.
+
+    When force_refresh is True, the endpoint refreshes OAuth tokens regardless
+    of DB tokenExpiresAt — used after the upstream returns 401 (#9860).
 
     Uses asyncio.to_thread to avoid blocking mitmproxy's event loop.
     """
@@ -141,6 +207,7 @@ async def fetch_firewall_headers(
         vars_map,
         auth_base,
         auth_query,
+        force_refresh,
     )
 
 
@@ -280,6 +347,17 @@ async def get_firewall_headers(
             if hit:
                 return hit
 
+        # Consume the force-refresh marker inside the lock so concurrent
+        # coroutines for the same (run_id, api_id) cannot both trigger a
+        # refresh — the one that loses the lock will see the fresh cache
+        # on its double-check above and never reach this path. Record the
+        # consume timestamp so request_force_refresh() suppresses re-marking
+        # within the cooldown window (guards against 401-amplification).
+        force_refresh = cache_key in _force_refresh_markers
+        _force_refresh_markers.discard(cache_key)
+        if force_refresh:
+            _last_force_refresh_at[cache_key] = time.time()
+
         result = await fetch_firewall_headers(
             encrypted_secrets,
             auth_headers,
@@ -288,6 +366,7 @@ async def get_firewall_headers(
             vars_map,
             auth_base,
             auth_query,
+            force_refresh=force_refresh,
         )
         headers = result["headers"]
         resolved_secrets = result.get("resolvedSecrets", [])

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -34,6 +34,7 @@ from auth import (
     _firewall_header_cache,
     evict_stale_cache_keys,
     handle_firewall_request,
+    request_force_refresh,
 )
 from logging_utils import add_firewall_metadata, log_network_entry, log_proxy_entry
 from matching import FirewallAllow, FirewallBlock, match_firewall_request
@@ -483,12 +484,18 @@ def response(flow: http.HTTPFlow) -> None:
     # Billable connector usage observation (issue #9504, stage 0).
     usage.log_connector_usage(flow, run_id)
 
-    # Invalidate firewall header cache on 401 so next request gets fresh headers
+    # Invalidate firewall header cache on 401 so next request gets fresh headers.
+    # Also request a force-refresh so the next /firewall/auth fetch refreshes
+    # the OAuth token regardless of DB tokenExpiresAt — the provider just told
+    # us the token is no longer valid, overriding whatever the DB believes.
+    # request_force_refresh enforces a cooldown so a persistent non-token 401
+    # can't amplify into a loop of provider OAuth refresh calls (#9860).
     if flow.response and flow.response.status_code == 401 and flow.metadata.get("firewall_base"):
         api_id = flow.metadata.get("firewall_api_id", "")
         if api_id:
             cache_key = (run_id, api_id)
             _firewall_header_cache.pop(cache_key, None)
+            request_force_refresh(cache_key)
 
     # Log errors to per-job proxy log and mitmproxy console
     if flow.response and flow.response.status_code >= 400:

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -46,6 +46,8 @@ def _reset_module_state() -> None:
     mitm_addon._registry_cache_key = (0, 0)
     auth._firewall_header_cache.clear()
     auth._cache_locks.clear()
+    auth._force_refresh_markers.clear()
+    auth._last_force_refresh_at.clear()
 
 
 def _headers(*pairs: tuple[str, str]) -> http.Headers:

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1212,7 +1212,14 @@ class TestGetFirewallHeaders:
         assert headers["cache_hit"] is False
         # fetch_firewall_headers wraps urllib; args-once-with pins the cache-miss contract (#9991).
         mock_fetch.assert_called_once_with(
-            encrypted, auth_templates, "tok-xyz", None, None, None, None
+            encrypted,
+            auth_templates,
+            "tok-xyz",
+            None,
+            None,
+            None,
+            None,
+            force_refresh=False,
         )
 
         # Verify the cache was populated
@@ -1332,6 +1339,54 @@ class TestGetFirewallHeaders:
 
         assert "base" not in result
         assert result["cache_hit"] is True
+
+    async def test_force_refresh_marker_triggers_forced_fetch(self, headers):
+        """When a force-refresh marker is set, the next fetch passes
+        force_refresh=True, the marker is cleared, and the consume timestamp
+        is recorded so the cooldown can suppress re-marking (#9860)."""
+        cache_key = ("run-1", "api-1")
+        auth._force_refresh_markers.add(cache_key)
+        before = time.time()
+
+        mock_fetch = AsyncMock(return_value={"headers": {"Authorization": "Bearer new"}})
+        with patch.object(auth, "fetch_firewall_headers", mock_fetch):
+            await auth.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+
+        # force_refresh kwarg must be True
+        assert mock_fetch.call_args.kwargs["force_refresh"] is True
+        # Marker cleared after consumption
+        assert cache_key not in auth._force_refresh_markers
+        # Consume timestamp recorded for cooldown enforcement
+        assert auth._last_force_refresh_at[cache_key] >= before
+
+    async def test_force_refresh_absent_passes_false(self, headers):
+        """Without a marker, fetch is called with force_refresh=False (#9860)."""
+        mock_fetch = AsyncMock(return_value={"headers": {}})
+        with patch.object(auth, "fetch_firewall_headers", mock_fetch):
+            await auth.get_firewall_headers("run-1", "api-2", "iv:tag:data", {}, "tok-xyz")
+
+        assert mock_fetch.call_args.kwargs["force_refresh"] is False
+        # No consume timestamp written when force-refresh didn't happen
+        assert ("run-1", "api-2") not in auth._last_force_refresh_at
+
+    async def test_force_refresh_marker_ignored_on_cache_hit(self, headers):
+        """Fast-path cache hit does NOT consume the force-refresh marker —
+        marker survives until the next actual fetch (#9860)."""
+        cache_key = ("run-1", "api-1")
+        auth._firewall_header_cache[cache_key] = {
+            "headers": {"Authorization": "Bearer cached"},
+            "expiresAt": None,
+        }
+        auth._force_refresh_markers.add(cache_key)
+
+        mock_fetch = AsyncMock()
+        with patch.object(auth, "fetch_firewall_headers", mock_fetch):
+            result = await auth.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+
+        assert result["cache_hit"] is True
+        mock_fetch.assert_not_called()
+        # Marker preserved for next real fetch
+        assert cache_key in auth._force_refresh_markers
 
 
 # =========================================================================

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -753,7 +753,7 @@ class TestResponseHandler:
         assert entry["response_size"] == 50000  # from Content-Length header
 
     def test_401_firewall_cache_invalidation(self, real_flow, mitm_ctx, headers):
-        """401 response with firewall_base pops the cache entry."""
+        """401 response with firewall_base pops the cache entry and marks force-refresh (#9860)."""
         flow = real_flow(with_response=False, host="api.github.com")
         flow.metadata["vm_run_id"] = "run-conn-1"
         flow.metadata["vm_client_ip"] = "10.200.0.5"
@@ -777,6 +777,58 @@ class TestResponseHandler:
 
         # Cache entry should have been removed
         assert cache_key not in auth._firewall_header_cache
+        # Force-refresh marker must be set so the next /firewall/auth fetch
+        # refreshes the token regardless of DB tokenExpiresAt (#9860).
+        assert cache_key in auth._force_refresh_markers
+
+    def test_401_within_cooldown_does_not_re_mark(self, real_flow, mitm_ctx, headers):
+        """A second 401 within the force-refresh cooldown window must NOT
+        re-mark — otherwise a persistent non-token 401 (scope, resource-
+        level reject) would amplify into a loop of OAuth refresh calls and
+        hit the provider's rate limits (#9860)."""
+        flow = real_flow(with_response=False, host="api.github.com")
+        flow.metadata["vm_run_id"] = "run-conn-cd"
+        flow.metadata["vm_client_ip"] = "10.200.0.5"
+        flow.metadata["vm_network_log_path"] = ""
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_base"] = "https://api.github.com"
+        flow.metadata["firewall_api_id"] = "run-conn-cd:0"
+        flow.metadata["original_url"] = "https://api.github.com/repos"
+        flow.response = tutils.tresp(status_code=401, headers=http.Headers())
+
+        cache_key = ("run-conn-cd", "run-conn-cd:0")
+        # Simulate: a forced refresh JUST completed a moment ago
+        auth._last_force_refresh_at[cache_key] = time.time()
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        # Marker was suppressed by the cooldown
+        assert cache_key not in auth._force_refresh_markers
+
+    def test_401_after_cooldown_re_marks(self, real_flow, mitm_ctx, headers):
+        """Once the cooldown has elapsed, a subsequent 401 re-marks — the
+        rate limit only throttles, it doesn't permanently lock out real
+        token-invalidation recovery (#9860)."""
+        flow = real_flow(with_response=False, host="api.github.com")
+        flow.metadata["vm_run_id"] = "run-conn-re"
+        flow.metadata["vm_client_ip"] = "10.200.0.5"
+        flow.metadata["vm_network_log_path"] = ""
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_base"] = "https://api.github.com"
+        flow.metadata["firewall_api_id"] = "run-conn-re:0"
+        flow.metadata["original_url"] = "https://api.github.com/repos"
+        flow.response = tutils.tresp(status_code=401, headers=http.Headers())
+
+        cache_key = ("run-conn-re", "run-conn-re:0")
+        # Simulate: last forced refresh happened well before the cooldown window
+        auth._last_force_refresh_at[cache_key] = time.time() - auth._FORCE_REFRESH_COOLDOWN_SECS - 1
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        # Cooldown elapsed → marker re-added
+        assert cache_key in auth._force_refresh_markers
 
     def test_error_status_logs_warning(self, tmp_path, real_flow, headers):
         """Response with status >= 400 writes to per-job proxy log."""

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -63,16 +63,21 @@ class TestLoadRegistry:
         with patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)):
             mitm_addon.load_registry()  # initial load (has run-abc-123)
 
-            # Simulate cached headers and locks for run-abc-123
+            # Simulate cached headers, locks, markers, and refresh timestamps
+            # for run-abc-123
             auth._firewall_header_cache[("run-abc-123", "api-0")] = {
                 "headers": {"Authorization": "Bearer tok"},
             }
             auth._cache_locks[("run-abc-123", "api-0")] = asyncio.Lock()
+            auth._force_refresh_markers.add(("run-abc-123", "api-0"))
+            auth._last_force_refresh_at[("run-abc-123", "api-0")] = 100.0
             # Also cache for run-other (will appear in new registry)
             auth._firewall_header_cache[("run-other", "api-0")] = {
                 "headers": {"Authorization": "Bearer other"},
             }
             auth._cache_locks[("run-other", "api-0")] = asyncio.Lock()
+            auth._force_refresh_markers.add(("run-other", "api-0"))
+            auth._last_force_refresh_at[("run-other", "api-0")] = 200.0
 
             # Update registry: remove run-abc-123, add run-other
             new_data = {"vms": {"10.200.0.99": {"runId": "run-other"}}, "updatedAt": 0}
@@ -80,12 +85,16 @@ class TestLoadRegistry:
 
             mitm_addon.load_registry()  # reload triggers eviction
 
-        # run-abc-123 cache and lock should be evicted (no longer in registry)
+        # run-abc-123 state should be evicted (no longer in registry)
         assert ("run-abc-123", "api-0") not in auth._firewall_header_cache
         assert ("run-abc-123", "api-0") not in auth._cache_locks
-        # run-other cache and lock should remain (still in registry)
+        assert ("run-abc-123", "api-0") not in auth._force_refresh_markers
+        assert ("run-abc-123", "api-0") not in auth._last_force_refresh_at
+        # run-other state should remain (still in registry)
         assert ("run-other", "api-0") in auth._firewall_header_cache
         assert ("run-other", "api-0") in auth._cache_locks
+        assert ("run-other", "api-0") in auth._force_refresh_markers
+        assert ("run-other", "api-0") in auth._last_force_refresh_at
 
 
 class TestGetVmInfo:

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -1049,6 +1049,50 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(tokenExpiresAt).not.toBeNull();
     });
 
+    it("should refresh when forceRefresh=true even if DB expiry is in the future", async () => {
+      // Regression for #9860: provider silently invalidates a token (user
+      // revoked, admin rotated) while DB tokenExpiresAt is still in the
+      // future. Mitm observes 401 and sets forceRefresh on the next fetch;
+      // the webhook must bypass the DB-expiry check and refresh regardless.
+      const futureExpiry = new Date(Date.now() + 30 * 60 * 1000);
+      await setupNotionConnector({ tokenExpiresAt: futureExpiry });
+
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, () => {
+          return HttpResponse.json({
+            access_token: "force-refreshed-token",
+            refresh_token: "new-refresh-token",
+            expires_in: 3600,
+          });
+        }),
+      );
+
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "old-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
+            },
+            secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
+            forceRefresh: true,
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers.Authorization).toBe("Bearer force-refreshed-token");
+      expect(data.refreshedConnectors).toEqual(["notion"]);
+      expect(data.refreshedSecrets).toEqual(["NOTION_ACCESS_TOKEN"]);
+    });
+
     it("should return null expiresAt without secretConnectorMap", async () => {
       const encrypted = encryptTestSecrets({
         GITHUB_TOKEN: "ghp_test_token_123",

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -22,6 +22,11 @@ const bodySchema = z.object({
   authQuery: z.record(z.string(), z.string()).optional(),
   secretConnectorMap: z.record(z.string(), z.string()).optional(),
   vars: z.record(z.string(), z.string()).optional(),
+  // Set by the mitm addon after an upstream 401 so the refresh filter
+  // below overrides DB tokenExpiresAt. Covers the case where the provider
+  // silently invalidates a token while DB expiry is still in the future
+  // (user revoked, admin rotated, clock skew). See #9860.
+  forceRefresh: z.boolean().optional(),
 });
 
 const log = logger("webhook:firewall-auth");
@@ -77,6 +82,7 @@ async function refreshExpiredTokens(
   secrets: Record<string, string>,
   secretConnectorMap: Record<string, string>,
   referencedKeys: Set<string>,
+  forceRefresh: boolean,
 ): Promise<RefreshResult> {
   // Find which referenced secrets are refreshable OAuth tokens
   const refreshable = new Map<string, string>();
@@ -123,7 +129,14 @@ async function refreshExpiredTokens(
   // "needs refresh" so we backfill tokenExpiresAt. All connectors reaching this
   // filter are refreshable OAuth (pre-filtered in resolve-connectors.ts), so
   // their access tokens DO expire by definition. See #9836.
+  //
+  // `forceRefresh` overrides DB expiry entirely: the mitm addon sets this
+  // after the upstream returns 401, indicating the provider invalidated the
+  // token out-of-band. Without this, a future tokenExpiresAt would cause the
+  // filter to skip the refresh and the 401 loop would continue until DB
+  // expiry elapses (#9860).
   const toRefresh = connectorTypes.filter((ct) => {
+    if (forceRefresh) return true;
     const tokenExpiry = expiryMap.get(ct);
     if (tokenExpiry === undefined || tokenExpiry === null) return true;
     return tokenExpiry <= now + REFRESH_BUFFER_SECS;
@@ -403,7 +416,7 @@ function resolveTemplates(
  * on demand and an expiresAt timestamp is returned for addon-side TTL caching.
  *
  * Auth: Sandbox JWT
- * Body: { encryptedSecrets, authHeaders, authBase?, authQuery?, secretConnectorMap?, vars? }
+ * Body: { encryptedSecrets, authHeaders, authBase?, authQuery?, secretConnectorMap?, vars?, forceRefresh? }
  * Response: { headers, base?, query?, expiresAt?, resolvedSecrets, refreshedConnectors, refreshedSecrets }
  *           or 424 { error } when referenced secrets/vars are missing (connector not configured)
  *           or 502 { error } when token refresh fails
@@ -458,6 +471,7 @@ export async function POST(request: Request) {
     authQuery,
     secretConnectorMap,
     vars,
+    forceRefresh,
   } = parsed.data;
 
   // Decrypt secrets
@@ -512,6 +526,7 @@ export async function POST(request: Request) {
       secrets,
       secretConnectorMap,
       referenced.secrets,
+      forceRefresh ?? false,
     );
     expiresAt = result.expiresAt;
     refreshedConnectors = result.refreshedConnectors;


### PR DESCRIPTION
## Summary

Close #9860. Covers the second half of the firewall-auth 401 loop: when the provider silently invalidates a token (user revoked, admin rotated, clock skew) while DB `tokenExpiresAt` is still in the future, the webhook's existing `toRefresh` filter skipped the refresh and served the same stale token again, looping until DB expiry elapsed (up to ~1h).

- **Mitm addon**: new module-global `_force_refresh_markers: set[(run_id, api_id)]`. `response()` pops the cache and calls `request_force_refresh(key)` on 401. `get_firewall_headers` consumes + clears the marker inside its per-key lock (so concurrent coroutines for the same key cannot double-refresh) and threads `force_refresh` through `fetch_firewall_headers` → `_fetch_firewall_headers_sync` → webhook body. `evict_stale_cache_keys` sweeps the marker set and the cooldown-timestamp dict too.
- **Webhook** (`/api/webhooks/agent/firewall/auth`): `bodySchema` gains optional `forceRefresh: boolean`. `refreshExpiredTokens`'s `toRefresh` filter gains a top-level `if (forceRefresh) return true;`, overriding the DB-expiry check.
- **Cooldown** (`_FORCE_REFRESH_COOLDOWN_SECS = 120.0`): `_last_force_refresh_at[key]` records each consume; `request_force_refresh` is a no-op within 2 minutes. Caps amplification at 30 refreshes/hour/key — safely below Google's 50/hour OAuth refresh cap (the tightest known provider limit). Timestamp is recorded before the fetch await so 401s arriving mid-fetch can't re-add the marker and cause ghost refreshes.

\#9842 handled `tokenExpiresAt = null`; this covers the future-expiry case.

## Test plan

- [x] `python3 -m pytest crates/runner/mitm-addon/tests/` — 883 passed. New/extended integration coverage:
  - `test_401_firewall_cache_invalidation` (extended): 401 pops cache + sets marker
  - `test_401_within_cooldown_does_not_re_mark`: second 401 within 120s is suppressed
  - `test_401_after_cooldown_re_marks`: cooldown expires → marker re-added
  - `test_force_refresh_marker_triggers_forced_fetch`: consume threads `force_refresh=True` and records timestamp
  - `test_force_refresh_absent_passes_false`: default path unchanged
  - `test_force_refresh_marker_ignored_on_cache_hit`: fast-path cache hit preserves marker
  - `test_evicts_header_cache_on_run_removal` (extended): registry reload sweeps marker set + timestamp dict
- [x] `pnpm -F web exec vitest run app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts` — 48 passed (includes `should refresh when forceRefresh=true even if DB expiry is in the future` — seeds Notion connector with future `tokenExpiresAt`, posts `forceRefresh: true`, asserts MSW-stubbed Notion token endpoint was hit and refreshed token returned)
- [x] `pnpm -F web exec tsc --noEmit` — clean
- [x] `python3 -m ruff check` + `ruff format --check` — clean
- [x] Pre-commit hooks (lint / prettier / knip / commitlint) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)