### PR TITLE
fix(web): emit last_event_to_complete metric from chat callback

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -24,7 +24,10 @@ import { POST } from "../route";
 import { http } from "../../../../../../src/__tests__/msw";
 import { server } from "../../../../../../src/mocks/server";
 import webpush, { WebPushError } from "web-push";
-import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
+import {
+  seedTestRun,
+  setTestRunStatus,
+} from "../../../../../../src/__tests__/db-test-seeders/runs";
 import { mockAblyPublish } from "../../../../../../src/__tests__/ably-mock";
 
 vi.mock("web-push", async (importActual) => {
@@ -456,6 +459,45 @@ describe("POST /api/internal/callbacks/chat", () => {
       // Failed runs don't have agentSessionId in result, so latestSessionId is null
       const threadSessionId = await getThreadSessionId(threadId);
       expect(threadSessionId).toBeNull();
+    });
+  });
+
+  describe("Wrap-up Metric", () => {
+    it("should flush Axiom after recording last_event_to_complete in after()", async () => {
+      // Regression: recordLastEventToComplete runs inside next/server `after()`
+      // in a bare NextResponse route (not ts-rest-handler), so the response-
+      // boundary auto-flush doesn't cover it. Without an explicit flushAxiom(),
+      // Vercel freezes the lambda before the Axiom SDK's batch timer fires
+      // and the sample is dropped in prod. See #10300.
+      const { threadId, runId, secret } = await setupRunAndThread();
+      // Populate agent_runs.completed_at so the metric's guard passes —
+      // seedTestRun doesn't back-fill the timestamp when status='completed'.
+      await setTestRunStatus(runId, "completed");
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          sequenceNumber: 0,
+          eventData: {
+            message: { content: [{ type: "text", text: "done" }] },
+          },
+        },
+      ]);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "completed",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+      expect(response.status).toBe(200);
+
+      context.mocks.axiom.flushAxiom.mockClear();
+      await context.mocks.flushAfter();
+      expect(context.mocks.axiom.flushAxiom).toHaveBeenCalled();
     });
   });
 

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse, after } from "next/server";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../src/lib/infra/callback";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
@@ -21,6 +21,7 @@ import { sendUserPushNotifications } from "../../../../../src/lib/push/send-push
 import { saveRunSummary } from "../../../../../src/lib/zero/run-summary";
 import {
   queryAxiom,
+  flushAxiom,
   getDatasetName,
   DATASETS,
 } from "../../../../../src/lib/shared/axiom";
@@ -111,40 +112,48 @@ async function loadPriorTitleContext(
 
 /**
  * Emit the `last_event_to_complete` metric for Morning Brief wrap-up
- * aggregation. Both timestamps are read from the DB in a single query so
- * the measurement is single-source-of-truth with no cross-host clock skew.
- * Filters on `sequence_number IS NOT NULL` to exclude user messages and
- * placeholder/error rows, keeping the metric grounded in real agent output.
+ * aggregation. Filters on `sequence_number IS NOT NULL` to exclude user
+ * messages and placeholder/error rows, keeping the metric grounded in
+ * real agent output.
  */
 async function recordLastEventToComplete(runId: string): Promise<void> {
-  const [row] = await globalThis.services.db
-    .select({
-      completedAt: agentRuns.completedAt,
-      lastEventAt: sql<Date | null>`(
-        SELECT MAX(${chatMessages.createdAt})
-        FROM ${chatMessages}
-        WHERE ${chatMessages.runId} = ${agentRuns.id}
-          AND ${chatMessages.role} = 'assistant'
-          AND ${chatMessages.sequenceNumber} IS NOT NULL
-      )`,
-    })
+  const [run] = await globalThis.services.db
+    .select({ completedAt: agentRuns.completedAt })
     .from(agentRuns)
     .where(eq(agentRuns.id, runId))
     .limit(1);
+  if (!run?.completedAt) return;
 
-  if (!row?.completedAt || !row.lastEventAt) return;
+  const [msg] = await globalThis.services.db
+    .select({
+      lastEventAt: sql<Date | null>`MAX(${chatMessages.createdAt})`,
+    })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.runId, runId),
+        eq(chatMessages.role, "assistant"),
+        isNotNull(chatMessages.sequenceNumber),
+      ),
+    );
+  if (!msg?.lastEventAt) return;
 
   const lastEventMs =
-    row.lastEventAt instanceof Date
-      ? row.lastEventAt.getTime()
-      : new Date(row.lastEventAt).getTime();
+    msg.lastEventAt instanceof Date
+      ? msg.lastEventAt.getTime()
+      : new Date(msg.lastEventAt).getTime();
   recordSandboxOperation({
     sandboxType: "runner",
     actionType: "last_event_to_complete",
-    durationMs: Math.max(0, row.completedAt.getTime() - lastEventMs),
+    durationMs: Math.max(0, run.completedAt.getTime() - lastEventMs),
     success: true,
     runId,
   });
+  // after() runs post-response; this route isn't a ts-rest handler, so the
+  // response-boundary flush doesn't cover it. Without an explicit flush,
+  // Vercel freezes the lambda before the Axiom SDK's batch timer fires and
+  // the sample is dropped. Same pattern as event-consumers/axiom/route.ts.
+  await flushAxiom();
 }
 
 /**


### PR DESCRIPTION
## Summary

Two independent defects in `recordLastEventToComplete` (introduced in #10257) kept `last_event_to_complete` entirely missing from `vm0-sandbox-op-log-prod`:

1. **Correlated subquery always returned NULL.** The single-query form built `lastEventAt` as a correlated subquery against `agent_runs`; regression test showed the row was in `chat_messages` but the subquery yielded `null`, so the guard below it early-returned every time. Split into two independent queries keyed directly on `runId`.
2. **Axiom buffer never flushed.** The metric emits inside `next/server` `after()` on a bare `NextResponse` route — no `ts-rest-handler` flush at the response boundary. Vercel freezes the lambda before the SDK's batch timer fires. Matches the exact hazard already documented in `app/api/internal/event-consumers/axiom/route.ts:40-44`.

## Test plan
- [x] New regression `Wrap-up Metric > should flush Axiom after recording last_event_to_complete in after()` — seeds a completed run + assistant event, drains the `after()` queue, asserts `flushAxiom` was called. Covers both the subquery fix (test would fail before fix 1) and the flush fix (test would fail before fix 2).
- [x] Full `chat/__tests__/route.test.ts` — 26/26 pass
- [x] lefthook (prettier + knip + commitlint) green
- [ ] Post-deploy: verify samples appear in `vm0-sandbox-op-log-prod` filtered on `op_type == "last_event_to_complete"`

Closes #10300