### PR TITLE
fix(runner): tolerate runner-exit race in service drain/resume

### DIFF
--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -319,6 +319,47 @@ async fn get_service_pid(unit: &str) -> RunnerResult<Option<u32>> {
     }
 }
 
+/// Outcome of attempting to signal a systemd unit's main process.
+///
+/// The `AlreadyGone` variant collapses two distinct races into a single
+/// state so callers can encode one policy instead of two:
+///
+/// 1. `systemctl show --property=MainPID` read `0` — the runner either
+///    exited, or systemd is mid-transition and has cleared MainPID.
+/// 2. MainPID resolved to a live value but `kill(2)` returned `ESRCH`
+///    because the process exited in the ~µs window before signal delivery.
+///
+/// Either way the signal was not delivered, and the cause is the same:
+/// the runner is no longer around to receive it.
+enum ServiceSignalOutcome {
+    Sent,
+    AlreadyGone,
+}
+
+/// Send `sig` to the main process of `unit`, tolerating the race between
+/// MainPID lookup and signal delivery.
+///
+/// Callers decide the policy for `AlreadyGone`: `drain` continues to
+/// `systemctl disable` (the unit file must still be rewritten so the
+/// service does not restart on reboot), while `resume` surfaces an error
+/// matching its preflight "not active" branch — a runner that has exited
+/// cannot be resumed.
+async fn signal_service_main(
+    unit: &str,
+    sig: nix::sys::signal::Signal,
+) -> RunnerResult<ServiceSignalOutcome> {
+    let Some(pid) = get_service_pid(unit).await? else {
+        return Ok(ServiceSignalOutcome::AlreadyGone);
+    };
+    let raw_pid =
+        i32::try_from(pid).map_err(|_| RunnerError::Internal(format!("PID {pid} out of range")))?;
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(raw_pid), sig) {
+        Ok(()) => Ok(ServiceSignalOutcome::Sent),
+        Err(nix::errno::Errno::ESRCH) => Ok(ServiceSignalOutcome::AlreadyGone),
+        Err(e) => Err(RunnerError::Internal(format!("{sig:?} to PID {pid}: {e}"))),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Active-jobs gate (shared by `service stop` and `service uninstall`)
 // ---------------------------------------------------------------------------
@@ -679,19 +720,17 @@ async fn drain(args: ServiceDrainArgs) -> RunnerResult<()> {
         return Ok(());
     }
 
-    let pid = get_service_pid(&unit)
-        .await?
-        .ok_or_else(|| RunnerError::Internal(format!("{unit} has no main PID")))?;
-
-    // Send SIGUSR1 to enter drain mode
-    let raw_pid =
-        i32::try_from(pid).map_err(|_| RunnerError::Internal(format!("PID {pid} out of range")))?;
-    nix::sys::signal::kill(
-        nix::unistd::Pid::from_raw(raw_pid),
-        nix::sys::signal::Signal::SIGUSR1,
-    )
-    .map_err(|e| RunnerError::Internal(format!("SIGUSR1 to PID {pid}: {e}")))?;
-    info!(unit = %unit, pid, "sent SIGUSR1 (drain)");
+    // `is_unit_active` above can race against the runner exiting on its own:
+    // by the time we read MainPID or call `kill`, the process may be gone.
+    // Both outcomes ("live, signal delivered" and "already gone") must still
+    // run `systemctl disable` below so the unit does not auto-start at the
+    // next boot.
+    match signal_service_main(&unit, nix::sys::signal::Signal::SIGUSR1).await? {
+        ServiceSignalOutcome::Sent => info!(unit = %unit, "sent SIGUSR1 (drain)"),
+        ServiceSignalOutcome::AlreadyGone => {
+            info!(unit = %unit, "runner already exited; drain signal not needed");
+        }
+    }
 
     // Disable so it won't restart on reboot. The SIGUSR1 has already been
     // delivered, so a disable failure is a partial-success condition — the
@@ -739,18 +778,19 @@ async fn resume(args: ServiceResumeArgs) -> RunnerResult<()> {
         )));
     }
 
-    let pid = get_service_pid(&unit)
-        .await?
-        .ok_or_else(|| RunnerError::Internal(format!("{unit} has no main PID")))?;
-
-    let raw_pid =
-        i32::try_from(pid).map_err(|_| RunnerError::Internal(format!("PID {pid} out of range")))?;
-    nix::sys::signal::kill(
-        nix::unistd::Pid::from_raw(raw_pid),
-        nix::sys::signal::Signal::SIGUSR2,
-    )
-    .map_err(|e| RunnerError::Internal(format!("SIGUSR2 to PID {pid}: {e}")))?;
-    info!(unit = %unit, pid, "sent SIGUSR2 (resume)");
+    // Same race as in `drain`: the runner can exit after the preflight
+    // `is_unit_active` check but before we deliver SIGUSR2. Unlike drain,
+    // there is no useful cleanup left once the runner is gone — resume is
+    // meaningless — so surface the same "not active" error the preflight
+    // branch above already returns.
+    match signal_service_main(&unit, nix::sys::signal::Signal::SIGUSR2).await? {
+        ServiceSignalOutcome::Sent => info!(unit = %unit, "sent SIGUSR2 (resume)"),
+        ServiceSignalOutcome::AlreadyGone => {
+            return Err(RunnerError::Internal(format!(
+                "{unit} is not active — cannot resume an inactive runner"
+            )));
+        }
+    }
 
     // Re-enable so the unit restarts on reboot (undoes the disable from drain).
     // Use `enable` (not `--now`) — the service is already running. SIGUSR2

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -330,9 +330,11 @@ async fn get_service_pid(unit: &str) -> RunnerResult<Option<u32>> {
 ///    because the process exited in the ~µs window before signal delivery.
 ///
 /// Either way the signal was not delivered, and the cause is the same:
-/// the runner is no longer around to receive it.
+/// the runner is no longer around to receive it. `Sent` carries the PID
+/// so callers can keep the pre-refactor `info!(…, pid, …)` structured
+/// field in their journald logs.
 enum ServiceSignalOutcome {
-    Sent,
+    Sent { pid: u32 },
     AlreadyGone,
 }
 
@@ -354,7 +356,7 @@ async fn signal_service_main(
     let raw_pid =
         i32::try_from(pid).map_err(|_| RunnerError::Internal(format!("PID {pid} out of range")))?;
     match nix::sys::signal::kill(nix::unistd::Pid::from_raw(raw_pid), sig) {
-        Ok(()) => Ok(ServiceSignalOutcome::Sent),
+        Ok(()) => Ok(ServiceSignalOutcome::Sent { pid }),
         Err(nix::errno::Errno::ESRCH) => Ok(ServiceSignalOutcome::AlreadyGone),
         Err(e) => Err(RunnerError::Internal(format!("{sig:?} to PID {pid}: {e}"))),
     }
@@ -726,7 +728,7 @@ async fn drain(args: ServiceDrainArgs) -> RunnerResult<()> {
     // run `systemctl disable` below so the unit does not auto-start at the
     // next boot.
     match signal_service_main(&unit, nix::sys::signal::Signal::SIGUSR1).await? {
-        ServiceSignalOutcome::Sent => info!(unit = %unit, "sent SIGUSR1 (drain)"),
+        ServiceSignalOutcome::Sent { pid } => info!(unit = %unit, pid, "sent SIGUSR1 (drain)"),
         ServiceSignalOutcome::AlreadyGone => {
             info!(unit = %unit, "runner already exited; drain signal not needed");
         }
@@ -784,8 +786,12 @@ async fn resume(args: ServiceResumeArgs) -> RunnerResult<()> {
     // meaningless — so surface the same "not active" error the preflight
     // branch above already returns.
     match signal_service_main(&unit, nix::sys::signal::Signal::SIGUSR2).await? {
-        ServiceSignalOutcome::Sent => info!(unit = %unit, "sent SIGUSR2 (resume)"),
+        ServiceSignalOutcome::Sent { pid } => info!(unit = %unit, pid, "sent SIGUSR2 (resume)"),
         ServiceSignalOutcome::AlreadyGone => {
+            info!(
+                unit = %unit,
+                "runner exited between preflight and signal; refusing resume",
+            );
             return Err(RunnerError::Internal(format!(
                 "{unit} is not active — cannot resume an inactive runner"
             )));


### PR DESCRIPTION
## Summary
- `service drain` / `service resume` used to surface confusing `Error: SIGUSR1 to PID N: No such process` or `{unit} has no main PID` when the runner happened to exit between MainPID lookup and signal delivery.
- Adds a `signal_service_main` helper that collapses both timings (`MainPID=0` and `kill → ESRCH`) into a single `AlreadyGone` outcome.
- `drain` treats `AlreadyGone` as a no-op signal but still falls through to `systemctl disable` so the unit file is rewritten. `resume` surfaces the same `"not active — cannot resume an inactive runner"` error as its preflight branch — keeping the error shape consistent regardless of which side of the race loses.

Closes #10289

## Test plan
- [x] `cargo check -p runner`
- [x] `cargo clippy -p runner --all-targets` (no new warnings)
- [x] `cargo fmt -p runner -- --check`
- [x] `cargo test -p runner --bin runner cmd::service` (32 passed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)