### PR TITLE
feat(runner): emit sandbox id and reuse result in completion payload

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -32,7 +32,7 @@ use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::status::{RunnerMode, StatusTracker};
 use crate::telemetry::JobTelemetry;
-use crate::types::{ExecutionContext, HeartbeatState};
+use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 
 /// Initial backoff before retrying mitmproxy after a crash.
 const MITM_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
@@ -738,74 +738,78 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
                 // Check idle pool for a reusable VM (same session + same profile).
                 // Only attempt reuse when the per-job sandboxReuse flag is on.
+                // The `reuse_result` tag is paired with `reuse_entry` so every
+                // fresh-create path names the branch it came from — the server
+                // persists it on the agent_runs row for observability.
                 let reuse_enabled = context.feature_enabled(crate::types::feature_flags::SANDBOX_REUSE);
-                let reuse_entry = if reuse_enabled
-                    && let Some(session_id) = context.session_id()
-                {
-                    // Take the entry under the pool lock, then drop the lock
-                    // before any awaits — the unpark HTTP call below must not
-                    // block other take/park operations.
-                    let taken = {
-                        let mut pool = idle_pool.lock().await;
-                        pool.take(session_id)
-                    };
-                    match taken {
-                        Some(mut entry) if entry.profile_name == profile_name => {
-                            // Deflate the balloon and respawn the reactive
-                            // controller before handing the sandbox to the
-                            // job. On failure, destroy the idle entry and
-                            // fall through to a fresh create — the run
-                            // budget reservation we made above stays in
-                            // place to cover the new sandbox.
-                            match entry.sandbox.unpark().await {
-                                Ok(()) => {
-                                    info!(
-                                        run_id = %run_id,
-                                        session_id,
-                                        "reusing idle VM for session"
-                                    );
-                                    // Idle entry already holds budget — release the new reservation.
-                                    budget.release(job_vcpu, job_memory);
-                                    Some(entry)
-                                }
-                                Err(e) => {
-                                    warn!(
-                                        run_id = %run_id,
-                                        session_id,
-                                        error = %e,
-                                        "unpark failed, destroying idle VM and falling through to fresh create"
-                                    );
-                                    let b = Arc::clone(&budget);
-                                    destroy_tasks.spawn(destroy_idle_entry(entry, b));
-                                    None
+                let (reuse_entry, reuse_result): (Option<IdleEntry>, SandboxReuseResult) =
+                    if !reuse_enabled {
+                        (None, SandboxReuseResult::FeatureDisabled)
+                    } else if let Some(session_id) = context.session_id() {
+                        // Take the entry under the pool lock, then drop the
+                        // lock before any awaits — the unpark HTTP call below
+                        // must not block other take/park operations.
+                        let taken = {
+                            let mut pool = idle_pool.lock().await;
+                            pool.take(session_id)
+                        };
+                        match taken {
+                            Some(mut entry) if entry.profile_name == profile_name => {
+                                // Deflate the balloon and respawn the reactive
+                                // controller before handing the sandbox to the
+                                // job. On failure, destroy the idle entry and
+                                // fall through to a fresh create — the run
+                                // budget reservation we made above stays in
+                                // place to cover the new sandbox.
+                                match entry.sandbox.unpark().await {
+                                    Ok(()) => {
+                                        info!(
+                                            run_id = %run_id,
+                                            session_id,
+                                            "reusing idle VM for session"
+                                        );
+                                        // Idle entry already holds budget — release the new reservation.
+                                        budget.release(job_vcpu, job_memory);
+                                        (Some(entry), SandboxReuseResult::Reused)
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            run_id = %run_id,
+                                            session_id,
+                                            error = %e,
+                                            "unpark failed, destroying idle VM and falling through to fresh create"
+                                        );
+                                        let b = Arc::clone(&budget);
+                                        destroy_tasks.spawn(destroy_idle_entry(entry, b));
+                                        (None, SandboxReuseResult::UnparkFailed)
+                                    }
                                 }
                             }
+                            Some(stale) => {
+                                // Profile mismatch — destroy the stale VM.
+                                info!(
+                                    run_id = %run_id,
+                                    session_id,
+                                    old_profile = %stale.profile_name,
+                                    new_profile = %profile_name,
+                                    "idle VM profile mismatch, destroying"
+                                );
+                                let b = Arc::clone(&budget);
+                                destroy_tasks.spawn(destroy_idle_entry(stale, b));
+                                (None, SandboxReuseResult::ProfileMismatch)
+                            }
+                            None => {
+                                info!(
+                                    run_id = %run_id,
+                                    session_id,
+                                    "no idle VM found for session"
+                                );
+                                (None, SandboxReuseResult::PoolMiss)
+                            }
                         }
-                        Some(stale) => {
-                            // Profile mismatch — destroy the stale VM.
-                            info!(
-                                run_id = %run_id,
-                                session_id,
-                                old_profile = %stale.profile_name,
-                                new_profile = %profile_name,
-                                "idle VM profile mismatch, destroying"
-                            );
-                            let b = Arc::clone(&budget);
-                            destroy_tasks.spawn(destroy_idle_entry(stale, b));
-                            None
-                        }
-                        None => {
-                            info!(
-                                run_id = %run_id,
-                                session_id,
-                                "no idle VM found for session"
-                            );
-                            None
-                        }
-                    }
-                } else {
-                    None
-                };
+                    } else {
+                        (None, SandboxReuseResult::NoSessionId)
+                    };
 
                 // Determine sandbox_id after the reuse decision. On reuse,
                 // the sandbox keeps its original identity; on a fresh create,
@@ -827,7 +831,13 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     cancel: job_cancel,
                 };
                 spawn_job(
-                    context, sandbox_id, job_profile, reuse_entry, &spawn_ctx, &mut jobs,
+                    context,
+                    sandbox_id,
+                    job_profile,
+                    reuse_entry,
+                    reuse_result,
+                    &spawn_ctx,
+                    &mut jobs,
                 );
             }
             // Mitmproxy crash detection
@@ -1061,6 +1071,7 @@ fn spawn_job(
     sandbox_id: SandboxId,
     job_profile: JobProfile,
     reuse_entry: Option<IdleEntry>,
+    reuse_result: SandboxReuseResult,
     ctx: &SpawnContext,
     jobs: &mut JoinSet<Option<RunId>>,
 ) {
@@ -1258,7 +1269,15 @@ fn spawn_job(
         };
 
         // Structural guarantee: claim (in provider) is always paired with complete.
-        provider.complete(run_id, exit_code, err.as_deref()).await;
+        provider
+            .complete(
+                run_id,
+                exit_code,
+                err.as_deref(),
+                Some(sandbox_id),
+                Some(reuse_result),
+            )
+            .await;
         status.remove_run(run_id).await;
 
         // Release budget only if sandbox was NOT parked (parked VMs hold their budget).
@@ -3376,7 +3395,9 @@ mod tests {
         }
     }
 
-    /// Pre-populate idle pool with an entry and reserve its budget.
+    /// Pre-populate idle pool with an entry and reserve its budget. Returns
+    /// the entry's sandbox id so reuse tests can assert it propagates through
+    /// to the completion payload.
     async fn seed_idle_pool(
         pool: &SharedIdlePool,
         budget: &ResourceBudget,
@@ -3384,7 +3405,7 @@ mod tests {
         profile_name: &str,
         vcpu: u32,
         memory_mb: u32,
-    ) {
+    ) -> SandboxId {
         assert!(budget.try_reserve(vcpu, memory_mb));
         let entry = make_test_idle_entry(
             session_id,
@@ -3394,9 +3415,11 @@ mod tests {
             std::time::Instant::now(),
             Duration::from_secs(300),
         );
+        let sandbox_id = entry.sandbox_id;
         let mut guard = pool.lock().await;
         let result = guard.park(session_id.into(), entry);
         assert!(matches!(result, ParkResult::Parked));
+        sandbox_id
     }
 
     /// Poll until `budget.allocated().2` (running_count) reaches `expected`.
@@ -3571,7 +3594,8 @@ mod tests {
         let budget = Arc::clone(&config.budget);
 
         // Pre-seed: park a VM for session "sess-reuse" with matching profile.
-        seed_idle_pool(&idle_pool, &budget, "sess-reuse", "vm0/default", 2, 4096).await;
+        let seeded_sandbox_id =
+            seed_idle_pool(&idle_pool, &budget, "sess-reuse", "vm0/default", 2, 4096).await;
         assert_eq!(budget.allocated().2, 1, "seeded entry holds budget");
 
         let run_handle = tokio::spawn(run(config));
@@ -3590,7 +3614,18 @@ mod tests {
             .wait_completion(run_id, Duration::from_secs(5))
             .await;
         assert!(completion.is_some(), "job should complete");
-        assert_eq!(completion.unwrap().exit_code, 0);
+        let completion = completion.unwrap();
+        assert_eq!(completion.exit_code, 0);
+        assert_eq!(
+            completion.reuse_result,
+            Some(SandboxReuseResult::Reused),
+            "reuse_result should be Reused"
+        );
+        assert_eq!(
+            completion.sandbox_id,
+            Some(seeded_sandbox_id),
+            "reused completion should carry the seeded sandbox id"
+        );
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -3603,6 +3638,71 @@ mod tests {
             budget.allocated().2,
             1,
             "budget should remain at 1 (reused, not additive)"
+        );
+
+        shutdown(&env, run_handle).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 13b: Reuse-enabled job with no session reports NoSessionId
+    // -----------------------------------------------------------------------
+
+    #[tokio::test(start_paused = true)]
+    async fn reuse_enabled_without_session_reports_no_session_id() {
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+
+        let run_handle = tokio::spawn(run(config));
+
+        // Feature on but no resume_session → NoSessionId branch.
+        let run_id = RunId::new_v4();
+        let mut ctx = minimal_context(run_id);
+        ctx.feature_flags = Some(HashMap::from([(
+            crate::types::feature_flags::SANDBOX_REUSE.to_string(),
+            true,
+        )]));
+        push_job(&env, run_id, "vm0/default", Some(ctx));
+
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(completion.is_some(), "job should complete");
+        let completion = completion.unwrap();
+        assert_eq!(completion.exit_code, 0);
+        assert_eq!(
+            completion.reuse_result,
+            Some(SandboxReuseResult::NoSessionId),
+        );
+        assert!(
+            completion.sandbox_id.is_some(),
+            "fresh create still allocates a sandbox id",
+        );
+
+        shutdown(&env, run_handle).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 13c: Feature-disabled job reports FeatureDisabled
+    // -----------------------------------------------------------------------
+
+    #[tokio::test(start_paused = true)]
+    async fn reuse_disabled_job_reports_feature_disabled() {
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+
+        let run_handle = tokio::spawn(run(config));
+
+        // minimal_context has feature_flags = None → SANDBOX_REUSE evaluates false.
+        let run_id = RunId::new_v4();
+        push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        let completion = completion.expect("job should complete");
+        assert_eq!(
+            completion.reuse_result,
+            Some(SandboxReuseResult::FeatureDisabled),
         );
 
         shutdown(&env, run_handle).await;
@@ -3637,7 +3737,17 @@ mod tests {
             .wait_completion(run_id, Duration::from_secs(5))
             .await;
         assert!(completion.is_some(), "job should complete");
-        assert_eq!(completion.unwrap().exit_code, 0);
+        let completion = completion.unwrap();
+        assert_eq!(completion.exit_code, 0);
+        assert_eq!(
+            completion.reuse_result,
+            Some(SandboxReuseResult::ProfileMismatch),
+            "reuse_result should be ProfileMismatch when profile differs"
+        );
+        assert!(
+            completion.sandbox_id.is_some(),
+            "freshly created sandbox still reports its id"
+        );
 
         // Stale VM destruction runs in a background destroy_task. Poll until
         // its budget is released rather than using a fixed sleep.

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -4497,8 +4497,13 @@ mod tests {
             .handle
             .wait_completion(run_id, Duration::from_secs(5))
             .await;
-        assert!(c.is_some(), "fresh-create job should still complete");
-        assert_eq!(c.unwrap().exit_code, 0);
+        let c = c.expect("fresh-create job should still complete");
+        assert_eq!(c.exit_code, 0);
+        assert_eq!(
+            c.reuse_result,
+            Some(SandboxReuseResult::UnparkFailed),
+            "completion must tag the unpark-failure branch",
+        );
 
         // After the dust settles:
         //   - unpark called exactly once (the failed take-side call);
@@ -4513,6 +4518,51 @@ mod tests {
             counter.park_call_count(),
             1,
             "expected exactly one park (the fresh-create's)"
+        );
+
+        shutdown(&env, run_handle).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Reuse-enabled job whose session has no idle entry reports PoolMiss
+    // -----------------------------------------------------------------------
+
+    #[tokio::test(start_paused = true)]
+    async fn reuse_enabled_empty_pool_reports_pool_miss() {
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+        let idle_pool = Arc::clone(&config.idle_pool);
+
+        let run_handle = tokio::spawn(run(config));
+
+        // Empty pool + resume_session set + feature on → PoolMiss branch.
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-missing")),
+        );
+
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .expect("job should complete");
+        assert_eq!(completion.exit_code, 0);
+        assert_eq!(
+            completion.reuse_result,
+            Some(SandboxReuseResult::PoolMiss),
+            "empty-pool reuse attempt must tag PoolMiss",
+        );
+        assert!(
+            completion.sandbox_id.is_some(),
+            "fresh create still allocates a sandbox id",
+        );
+        // Sanity: no one was in the pool to begin with.
+        assert_eq!(
+            idle_pool.lock().await.len(),
+            1,
+            "fresh-create sandbox re-parks into the pool",
         );
 
         shutdown(&env, run_handle).await;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -14,7 +14,10 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::ids::RunId;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
-use crate::types::{CompleteRequest, ExecutionContext, HeartbeatState, Job, PollResponse};
+use crate::types::{
+    CompleteRequest, ExecutionContext, HeartbeatState, Job, PollResponse, SandboxReuseResult,
+};
+use sandbox::SandboxId;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -306,7 +309,14 @@ impl JobProvider for ApiProvider {
         }
     }
 
-    async fn complete(&self, run_id: RunId, exit_code: i32, error: Option<&str>) {
+    async fn complete(
+        &self,
+        run_id: RunId,
+        exit_code: i32,
+        error: Option<&str>,
+        sandbox_id: Option<SandboxId>,
+        reuse_result: Option<SandboxReuseResult>,
+    ) {
         let token = self.tokens.lock().await.remove(&run_id);
         let token = match token {
             Some(t) => t,
@@ -319,10 +329,18 @@ impl JobProvider for ApiProvider {
             }
         };
 
-        if let Err(e) = self.api.complete(&token, run_id, exit_code, error).await {
+        if let Err(e) = self
+            .api
+            .complete(&token, run_id, exit_code, error, sandbox_id, reuse_result)
+            .await
+        {
             warn!(run_id = %run_id, error = %e, "completion report failed, retrying");
             tokio::time::sleep(Duration::from_secs(2)).await;
-            if let Err(e) = self.api.complete(&token, run_id, exit_code, error).await {
+            if let Err(e) = self
+                .api
+                .complete(&token, run_id, exit_code, error, sandbox_id, reuse_result)
+                .await
+            {
                 error!(run_id = %run_id, error = %e, "failed to report completion after retry");
             }
         }
@@ -584,11 +602,15 @@ impl ApiClient {
         run_id: RunId,
         exit_code: i32,
         error: Option<&str>,
+        sandbox_id: Option<SandboxId>,
+        reuse_result: Option<SandboxReuseResult>,
     ) -> RunnerResult<()> {
         let body = CompleteRequest {
             run_id,
             exit_code,
             error: error.map(String::from),
+            sandbox_id,
+            sandbox_reuse_result: reuse_result,
         };
 
         let resp = self

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -15,7 +15,8 @@ use tracing::{info, warn};
 
 use super::JobProvider;
 use crate::ids::RunId;
-use crate::types::{ExecutionContext, HeartbeatState};
+use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
+use sandbox::SandboxId;
 
 /// Poll interval for discovering new job files.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -233,8 +234,14 @@ impl JobProvider for LocalProvider {
                 // same reason — both write the same parse error, last rename
                 // wins, submitter sees one consistent result.
                 let _ = std::fs::remove_file(&claim_file);
-                self.complete(run_id, 1, Some(&format!("invalid job JSON: {e}")))
-                    .await;
+                self.complete(
+                    run_id,
+                    1,
+                    Some(&format!("invalid job JSON: {e}")),
+                    None,
+                    None,
+                )
+                .await;
                 let _ = std::fs::remove_file(&job_file);
                 return None;
             }
@@ -275,7 +282,14 @@ impl JobProvider for LocalProvider {
         })
     }
 
-    async fn complete(&self, run_id: RunId, exit_code: i32, error: Option<&str>) {
+    async fn complete(
+        &self,
+        run_id: RunId,
+        exit_code: i32,
+        error: Option<&str>,
+        _sandbox_id: Option<SandboxId>,
+        _reuse_result: Option<SandboxReuseResult>,
+    ) {
         let response = JobResponse {
             run_id,
             exit_code,
@@ -370,7 +384,7 @@ mod tests {
         assert_eq!(ctx.run_id, run_id);
         assert_eq!(ctx.prompt, "hello world");
 
-        provider.complete(run_id, 0, None).await;
+        provider.complete(run_id, 0, None, None, None).await;
 
         let resp = read_result(dir.path(), job_id);
         assert_eq!(resp.exit_code, 0);
@@ -429,8 +443,10 @@ mod tests {
         assert_eq!(ctx2.prompt, "job2");
         assert_ne!(run_id1, run_id2);
 
-        provider.complete(run_id1, 0, None).await;
-        provider.complete(run_id2, 1, Some("test error")).await;
+        provider.complete(run_id1, 0, None, None, None).await;
+        provider
+            .complete(run_id2, 1, Some("test error"), None, None)
+            .await;
 
         let resp1 = read_result(dir.path(), job1);
         assert_eq!(resp1.exit_code, 0);
@@ -586,7 +602,7 @@ mod tests {
         let cancel_path = dir.path().join(format!("{run_id}.cancel"));
         std::fs::write(&cancel_path, b"").unwrap();
 
-        provider.complete(run_id, 0, None).await;
+        provider.complete(run_id, 0, None, None, None).await;
 
         assert!(
             !cancel_path.exists(),

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -24,7 +24,8 @@ use tokio_util::sync::CancellationToken;
 
 use super::JobProvider;
 use crate::ids::RunId;
-use crate::types::{ExecutionContext, HeartbeatState};
+use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
+use sandbox::SandboxId;
 
 /// Recorded completion from [`JobProvider::complete`].
 #[derive(Debug, Clone)]
@@ -32,6 +33,8 @@ pub struct Completion {
     pub run_id: RunId,
     pub exit_code: i32,
     pub error: Option<String>,
+    pub sandbox_id: Option<SandboxId>,
+    pub reuse_result: Option<SandboxReuseResult>,
 }
 
 /// Channel-driven mock provider.
@@ -210,7 +213,14 @@ impl JobProvider for MockJobProvider {
             .flatten()
     }
 
-    async fn complete(&self, run_id: RunId, exit_code: i32, error: Option<&str>) {
+    async fn complete(
+        &self,
+        run_id: RunId,
+        exit_code: i32,
+        error: Option<&str>,
+        sandbox_id: Option<SandboxId>,
+        reuse_result: Option<SandboxReuseResult>,
+    ) {
         self.completions
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -218,6 +228,8 @@ impl JobProvider for MockJobProvider {
                 run_id,
                 exit_code,
                 error: error.map(String::from),
+                sandbox_id,
+                reuse_result,
             });
         // Wake all pending `wait_completion` waiters — they re-scan the vec
         // and return if their run_id is now present.

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -13,8 +13,10 @@ pub use api::ApiProvider;
 pub use local::LocalProvider;
 pub(crate) use local::{JobRequest, JobResponse};
 
+use sandbox::SandboxId;
+
 use crate::ids::RunId;
-use crate::types::{ExecutionContext, HeartbeatState};
+use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 
 /// Abstraction over job lifecycle — discovery, claiming, and completion reporting.
 ///
@@ -49,8 +51,20 @@ pub trait JobProvider: Send + Sync {
 
     /// Report job completion. Called concurrently from spawned executor tasks.
     ///
+    /// `sandbox_id` is the VM the run executed against (reused or freshly
+    /// allocated). `reuse_result` describes the sandbox-reuse decision made
+    /// before the run started. Both are `Option` so non-runner callers
+    /// (tests, future transports) can omit them.
+    ///
     /// Implementations manage auth tokens and retry logic internally.
-    async fn complete(&self, run_id: RunId, exit_code: i32, error: Option<&str>);
+    async fn complete(
+        &self,
+        run_id: RunId,
+        exit_code: i32,
+        error: Option<&str>,
+        sandbox_id: Option<SandboxId>,
+        reuse_result: Option<SandboxReuseResult>,
+    );
 
     /// Report runner state to the server. Fire-and-forget — failures are
     /// logged but do not affect runner operation.

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use sandbox::SandboxId;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -267,6 +268,30 @@ pub struct CompleteRequest {
     pub exit_code: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Sandbox the run executed against. `None` when no sandbox was
+    /// provisioned (e.g. a pre-claim failure); otherwise set on every
+    /// completion regardless of reuse status.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandbox_id: Option<SandboxId>,
+    /// Outcome of the sandbox-reuse decision made before this run started.
+    /// `None` is reserved for callers that cannot determine it (tests, future
+    /// transports); the runner itself always sets this.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandbox_reuse_result: Option<SandboxReuseResult>,
+}
+
+/// Outcome of the sandbox-reuse decision made at job dispatch time. `Reused`
+/// means the VM was unparked from the idle pool; the other variants name the
+/// branch that caused a fresh create. Wire name: `sandboxReuseResult`.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SandboxReuseResult {
+    Reused,
+    FeatureDisabled,
+    NoSessionId,
+    PoolMiss,
+    ProfileMismatch,
+    UnparkFailed,
 }
 
 #[cfg(test)]
@@ -446,12 +471,16 @@ mod tests {
                 .unwrap(),
             exit_code: 0,
             error: None,
+            sandbox_id: None,
+            sandbox_reuse_result: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("runId").is_some());
         assert!(json.get("exitCode").is_some());
-        // error omitted when None
+        // optionals omitted when None
         assert!(json.get("error").is_none());
+        assert!(json.get("sandboxId").is_none());
+        assert!(json.get("sandboxReuseResult").is_none());
     }
 
     #[test]
@@ -462,9 +491,52 @@ mod tests {
                 .unwrap(),
             exit_code: 1,
             error: Some("timeout".into()),
+            sandbox_id: None,
+            sandbox_reuse_result: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["error"], "timeout");
+    }
+
+    #[test]
+    fn complete_request_with_reuse_fields() {
+        let sid: SandboxId = "11111111-2222-3333-4444-555555555555".parse().unwrap();
+        let req = CompleteRequest {
+            run_id: "550e8400-e29b-41d4-a716-446655440000"
+                .parse::<RunId>()
+                .unwrap(),
+            exit_code: 0,
+            error: None,
+            sandbox_id: Some(sid),
+            sandbox_reuse_result: Some(SandboxReuseResult::Reused),
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["sandboxId"], "11111111-2222-3333-4444-555555555555");
+        assert_eq!(json["sandboxReuseResult"], "reused");
+    }
+
+    #[test]
+    fn sandbox_reuse_result_serializes_camel_case() {
+        assert_eq!(
+            serde_json::to_value(SandboxReuseResult::FeatureDisabled).unwrap(),
+            serde_json::json!("featureDisabled"),
+        );
+        assert_eq!(
+            serde_json::to_value(SandboxReuseResult::NoSessionId).unwrap(),
+            serde_json::json!("noSessionId"),
+        );
+        assert_eq!(
+            serde_json::to_value(SandboxReuseResult::PoolMiss).unwrap(),
+            serde_json::json!("poolMiss"),
+        );
+        assert_eq!(
+            serde_json::to_value(SandboxReuseResult::ProfileMismatch).unwrap(),
+            serde_json::json!("profileMismatch"),
+        );
+        assert_eq!(
+            serde_json::to_value(SandboxReuseResult::UnparkFailed).unwrap(),
+            serde_json::json!("unparkFailed"),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 1, PR 2 of #10233 — runner side. Pairs with the web-side change in #10291 (already merged).

Every completion now carries:
- `sandboxId` — the VM the run executed against, whether reused or freshly allocated. Previously null for every runner-originated row.
- `sandboxReuseResult` — enum naming the reuse-decision branch that ran: `reused`, `featureDisabled`, `noSessionId`, `poolMiss`, `profileMismatch`, `unparkFailed`.

The web handler (shipped in #10291) already persists both when the runner sends them; old runners continue to send nothing and the columns stay null.

### Key changes

- `CompleteRequest` gains two optional fields, mirroring the Zod contract in `packages/core/src/contracts/webhooks.ts`.
- `JobProvider::complete` trait signature now takes `Option<SandboxId>` + `Option<SandboxReuseResult>`; all three impls (`ApiProvider`, `LocalProvider`, `MockJobProvider`) updated.
- Reuse decision in `cmd/start.rs` now returns a `(Option<IdleEntry>, SandboxReuseResult)` pair so every fresh-create path names the branch it came from.
- `MockJobProvider::Completion` captures both so integration tests can assert end-to-end propagation.

## Test plan

- [x] `cargo test -p runner` — 705 tests pass including new/extended integration tests:
  - `session_affinity_reuses_idle_vm` — asserts `reuse_result = Reused` and the seeded sandbox id flows through.
  - `profile_mismatch_destroys_stale_vm` — asserts `reuse_result = ProfileMismatch`.
  - `reuse_enabled_without_session_reports_no_session_id` (new) — `NoSessionId` branch coverage.
  - `reuse_disabled_job_reports_feature_disabled` (new) — `FeatureDisabled` branch coverage.
- [x] `cargo clippy -p runner --all-targets -- -D warnings` clean.
- [ ] Post-deploy: submit two jobs with the same session and confirm `agent_runs[2].sandbox_id == agent_runs[1].sandbox_id` and `sandbox_reuse_result = 'reused'`.

Closes the Phase 1 portion of #10233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)