### PR TITLE
fix(credits): enforce credit expiration for non-subscription orgs

### DIFF
--- a/turbo/apps/web/app/api/cron/process-credits/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/process-credits/__tests__/route.test.ts
@@ -17,6 +17,9 @@ import {
   insertOrgMembersEntry,
   getOrgMembersEntry,
   updateOrgStripeFields,
+  insertCreditExpiresRecord,
+  findCreditExpiresRecords,
+  grantCreditsToOrg,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { reloadEnv } from "../../../../../src/env";
 
@@ -320,6 +323,51 @@ describe("GET /api/cron/process-credits", () => {
       expect(record!.status).toBe("processed");
       expect(record!.creditsCharged).toBe(200);
 
+      const credits = await getOrgCredits(user.orgId);
+      expect(credits).toBe(99_800);
+    });
+
+    it("settles expired credits during consumption on non-subscription org", async () => {
+      // Reproduces the fix for issue #10299: a non-subscription org never hits
+      // `expireCredits` via invoice renewal, so the first consumption event
+      // must settle the expired row itself — otherwise the aggregate balance
+      // stays inflated and the expired row silently backs the spend.
+      await insertTestCreditPricing("gpt-4", {
+        inputTokenPrice: 1_000_000,
+        outputTokenPrice: 1_000_000,
+      });
+
+      const pastDate = new Date();
+      pastDate.setMonth(pastDate.getMonth() - 1);
+      const expiredId = await insertCreditExpiresRecord({
+        orgId: user.orgId,
+        amount: 5000,
+        expiresAt: pastDate,
+        stripeInvoiceId: uniqueId("inv-expired"),
+      });
+      // Mirror the inflated ledger: seed org with the expired amount on top
+      // of the default 100k starter credits
+      await grantCreditsToOrg(user.orgId, 5000);
+
+      // 100 input + 100 output → 200 credits charged
+      await insertTestCreditUsage(user.orgId, {
+        userId: user.userId,
+        model: "gpt-4",
+        inputTokens: 100,
+        outputTokens: 100,
+      });
+
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
+
+      // Expired row is zeroed (not drawn down by the spend)
+      const records = await findCreditExpiresRecords(user.orgId);
+      const expired = records.find((r) => {
+        return r.id === expiredId;
+      })!;
+      expect(expired.remaining).toBe(0);
+
+      // Org balance: 100_000 + 5_000 (granted) − 5_000 (expired) − 200 (spend)
       const credits = await getOrgCredits(user.orgId);
       expect(credits).toBe(99_800);
     });

--- a/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import {
   updateOrgStripeFields,
   insertCreditExpiresRecord,
   insertOrgCacheEntry,
+  grantCreditsToOrg,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -192,6 +193,36 @@ describe("GET /api/zero/billing/status", () => {
     const data = await response.json();
     expect(data.creditExpiry.expiringNextCycle).toBe(0);
     expect(data.creditExpiry.nextExpiryDate).toBeNull();
+  });
+
+  it("displays credits minus not-yet-settled expired amount", async () => {
+    // Dormant non-subscription org: expired row never got settled (no renewal
+    // to trigger expireCredits, no run yet to trigger the eager path), so the
+    // raw credits column is still inflated by the expired amount. The /status
+    // endpoint must subtract it before returning so the UI shows the real
+    // spendable balance.
+    const { orgId } = await context.setupUser({ prefix: "expiry-unsettled" });
+
+    const pastDate = new Date();
+    pastDate.setMonth(pastDate.getMonth() - 1);
+    await insertCreditExpiresRecord({
+      orgId,
+      amount: 3000,
+      expiresAt: pastDate,
+      stripeInvoiceId: uniqueId("inv-expired"),
+    });
+    // Mirror the inflated ledger: default 100k starter + 3k that's expired
+    await grantCreditsToOrg(orgId, 3000);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/status",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    // 100_000 (starter) + 3_000 (granted) − 3_000 (expired) = 100_000
+    expect(data.credits).toBe(100_000);
   });
 
   it("returns defaults when org row does not exist", async () => {

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -10,6 +10,7 @@ import {
   createExpiresRecord,
   expireCredits,
   getExpiresRecordsSummary,
+  getUnsettledExpiredAmount,
 } from "../credit/credit-expires-service";
 import { logger } from "../../shared/logger";
 
@@ -722,9 +723,17 @@ export async function getBillingStatus(orgId: string): Promise<{
 
   const expirySummary = await getExpiresRecordsSummary(orgId);
 
+  // Subtract not-yet-settled expired credits so the displayed balance matches
+  // what the user can actually spend. Dormant non-subscription orgs never hit
+  // `expireCredits` until their next run, so the raw `credits` column can be
+  // inflated until then — this keeps the UI honest in the meantime.
+  const unsettledExpired = await getUnsettledExpiredAmount(orgId);
+  const rawCredits = org?.credits ?? 0;
+  const displayedCredits = Math.max(rawCredits - unsettledExpired, 0);
+
   return {
     tier: org?.tier ?? "free",
-    credits: org?.credits ?? 0,
+    credits: displayedCredits,
     subscriptionStatus: org?.subscriptionStatus ?? null,
     currentPeriodEnd: org?.currentPeriodEnd ?? null,
     cancelAtPeriodEnd: org?.cancelAtPeriodEnd ?? false,

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/credit-expiry.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/credit-expiry.test.ts
@@ -9,7 +9,10 @@ import {
   testExpireCredits,
 } from "../../../../__tests__/api-test-helpers";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
-import { getExpiresRecordsSummary } from "../credit-expires-service";
+import {
+  getExpiresRecordsSummary,
+  getUnsettledExpiredAmount,
+} from "../credit-expires-service";
 
 const context = testContext();
 
@@ -94,6 +97,43 @@ describe("credit expires service", () => {
       const records = await findCreditExpiresRecords(orgId);
       expect(records).toHaveLength(0);
     });
+
+    it("skips expired rows — drains the unexpired row instead", async () => {
+      const { orgId } = await context.setupUser({
+        prefix: "fefo-skip-expired",
+      });
+
+      const pastDate = new Date();
+      pastDate.setMonth(pastDate.getMonth() - 1);
+      const futureDate = new Date();
+      futureDate.setMonth(futureDate.getMonth() + 2);
+
+      const expiredId = await insertCreditExpiresRecord({
+        orgId,
+        amount: 5000,
+        expiresAt: pastDate,
+        stripeInvoiceId: uniqueId("inv-expired"),
+      });
+      const activeId = await insertCreditExpiresRecord({
+        orgId,
+        amount: 5000,
+        expiresAt: futureDate,
+        stripeInvoiceId: uniqueId("inv-active"),
+      });
+
+      await testDeductFromExpiresRecords(orgId, 3000);
+
+      const records = await findCreditExpiresRecords(orgId);
+      const expired = records.find((r) => {
+        return r.id === expiredId;
+      })!;
+      const active = records.find((r) => {
+        return r.id === activeId;
+      })!;
+      // Expired row untouched, active row debited
+      expect(expired.remaining).toBe(5000);
+      expect(active.remaining).toBe(2000);
+    });
   });
 
   describe("expireCredits", () => {
@@ -171,6 +211,77 @@ describe("credit expires service", () => {
       const summary = await getExpiresRecordsSummary(orgId);
       expect(summary.expiringNextCycle).toBe(0);
       expect(summary.nextExpiryDate).toBeNull();
+    });
+  });
+
+  describe("getUnsettledExpiredAmount", () => {
+    it("returns zero when there are no expired rows", async () => {
+      const { orgId } = await context.setupUser({ prefix: "unsettled-none" });
+
+      const futureDate = new Date();
+      futureDate.setMonth(futureDate.getMonth() + 2);
+      await insertCreditExpiresRecord({
+        orgId,
+        amount: 5000,
+        expiresAt: futureDate,
+        stripeInvoiceId: uniqueId("inv-active"),
+      });
+
+      const amount = await getUnsettledExpiredAmount(orgId);
+      expect(amount).toBe(0);
+    });
+
+    it("sums remaining across expired rows only", async () => {
+      const { orgId } = await context.setupUser({ prefix: "unsettled-sum" });
+
+      const pastDate = new Date();
+      pastDate.setMonth(pastDate.getMonth() - 1);
+      const futureDate = new Date();
+      futureDate.setMonth(futureDate.getMonth() + 2);
+
+      await insertCreditExpiresRecord({
+        orgId,
+        amount: 5000,
+        remaining: 3000,
+        expiresAt: pastDate,
+        stripeInvoiceId: uniqueId("inv-expired-a"),
+      });
+      await insertCreditExpiresRecord({
+        orgId,
+        amount: 2000,
+        remaining: 2000,
+        expiresAt: pastDate,
+        stripeInvoiceId: uniqueId("inv-expired-b"),
+      });
+      await insertCreditExpiresRecord({
+        orgId,
+        amount: 10000,
+        remaining: 10000,
+        expiresAt: futureDate,
+        stripeInvoiceId: uniqueId("inv-active"),
+      });
+
+      const amount = await getUnsettledExpiredAmount(orgId);
+      expect(amount).toBe(5000);
+    });
+
+    it("ignores expired rows that have already been settled to zero", async () => {
+      const { orgId } = await context.setupUser({
+        prefix: "unsettled-settled",
+      });
+
+      const pastDate = new Date();
+      pastDate.setMonth(pastDate.getMonth() - 1);
+      await insertCreditExpiresRecord({
+        orgId,
+        amount: 5000,
+        remaining: 0,
+        expiresAt: pastDate,
+        stripeInvoiceId: uniqueId("inv-zeroed"),
+      });
+
+      const amount = await getUnsettledExpiredAmount(orgId);
+      expect(amount).toBe(0);
     });
   });
 });

--- a/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
@@ -46,6 +46,10 @@ export async function createExpiresRecord(
  * Selects active records ordered by expires_at ASC and decrements remaining
  * until the requested amount is covered. If total remaining < amount, the
  * excess comes from non-expiring credits (no error).
+ *
+ * Time-aware: expired rows are skipped so they can never back a spend, even
+ * if the caller forgot to settle first. Paired with `expireCredits` in the
+ * same transaction this is defensive; alone it still prevents the leak.
  */
 export async function deductFromExpiresRecords(
   tx: Tx,
@@ -64,6 +68,7 @@ export async function deductFromExpiresRecords(
       and(
         eq(creditExpiresRecord.orgId, orgId),
         gt(creditExpiresRecord.remaining, 0),
+        gt(creditExpiresRecord.expiresAt, new Date()),
       ),
     )
     .orderBy(asc(creditExpiresRecord.expiresAt))
@@ -131,6 +136,33 @@ export async function expireCredits(tx: Tx, orgId: string): Promise<number> {
 
   log.info("expired credits settled", { orgId, totalExpired });
   return totalExpired;
+}
+
+/**
+ * Sum of credits on rows that are already past their expiry but haven't been
+ * settled yet (i.e. `remaining > 0 AND expires_at <= now()`). These are
+ * already excluded from spend by `deductFromExpiresRecords`, but the
+ * `org_metadata.credits` aggregate still includes them until the next
+ * `expireCredits` call. Use this to present the true spendable balance on
+ * read paths that run outside the settlement transaction.
+ */
+export async function getUnsettledExpiredAmount(
+  orgId: string,
+): Promise<number> {
+  const db = globalThis.services.db;
+  const [row] = await db
+    .select({
+      total: sql<number>`COALESCE(SUM(${creditExpiresRecord.remaining}), 0)::int`,
+    })
+    .from(creditExpiresRecord)
+    .where(
+      and(
+        eq(creditExpiresRecord.orgId, orgId),
+        lte(creditExpiresRecord.expiresAt, new Date()),
+        gt(creditExpiresRecord.remaining, 0),
+      ),
+    );
+  return row?.total ?? 0;
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/credit/credit-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-service.ts
@@ -2,7 +2,10 @@ import { eq, and, sql } from "drizzle-orm";
 import { creditUsage } from "../../../db/schema/credit-usage";
 import { creditPricing } from "../../../db/schema/credit-pricing";
 import { deductOrgCredits } from "../org/org-service";
-import { deductFromExpiresRecords } from "./credit-expires-service";
+import {
+  deductFromExpiresRecords,
+  expireCredits,
+} from "./credit-expires-service";
 import { triggerAutoRecharge } from "../billing/auto-recharge-service";
 import { evaluateMemberCaps } from "./member-credit-cap-service";
 import { logger } from "../../shared/logger";
@@ -110,8 +113,13 @@ export async function processOrgCredits(orgId: string): Promise<void> {
       processedCount++;
     }
 
-    // Deduct total credits from the org table within the same transaction
+    // Deduct total credits from the org table within the same transaction.
+    // Settle expired credits first so the aggregate balance and expires-row
+    // state are correct before this run's deduction lands — otherwise
+    // non-subscription orgs would never converge (no renewal to call
+    // expireCredits on their behalf).
     if (totalCredits > 0) {
+      await expireCredits(tx, orgId);
       await deductOrgCredits(tx, orgId, totalCredits);
       await deductFromExpiresRecords(tx, orgId, totalCredits);
     }


### PR DESCRIPTION
## Summary

- Settle expired credits eagerly inside `processOrgCredits` so non-subscription orgs (redemption-code-only, Starter) self-converge on every consumption event — no longer rely on subscription renewal to trigger `expireCredits`.
- Make `deductFromExpiresRecords` time-aware: expired rows are skipped in the FEFO WHERE clause so they can never back a spend, even if a future caller bypasses eager settlement.
- Discount unsettled expired credits from the displayed balance in `/api/zero/billing/status` via a new `getUnsettledExpiredAmount` helper, so dormant orgs see the real spendable balance in the UI even before their next run triggers settlement.

Closes #10299.

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/zero/credit/ src/lib/zero/billing/ app/api/cron/process-credits/ app/api/zero/billing/` — 88 tests pass
- [x] New unit: `deductFromExpiresRecords` skips expired rows and drains the unexpired one instead
- [x] New unit: `getUnsettledExpiredAmount` sums remaining on expired rows only, ignores settled/active
- [x] New integration: `/api/cron/process-credits` settles an expired row and charges the spend from the active balance on a non-subscription org
- [x] New integration: `/api/zero/billing/status` returns `credits` net of unsettled expired amount
- [x] `pnpm -F web check-types` passes
- [x] `pnpm format` / targeted ESLint pass
- [x] `pnpm knip` no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)