### PR TITLE
refactor(platform): drop client-only override layer from feature switches

### DIFF
--- a/.claude/skills/feature-switch/SKILL.md
+++ b/.claude/skills/feature-switch/SKILL.md
@@ -146,10 +146,11 @@ const CONDITIONAL_CAPABILITIES: ReadonlyMap<ZeroCapability, FeatureSwitchKey> =
 
 ## Override Layers
 
-The client-side evaluation has three layers (lowest to highest priority):
+Evaluation has two layers (lowest to highest priority):
 
-1. **Core registry** — static config in source code
-2. **Clerk unsafeMetadata** — per-user persistent overrides (set via Lab page)
-3. **localStorage** — per-device overrides (set via `window._vm0.featureSwitches.myFeature = true`)
+1. **Core registry** — static config in source code, evaluated against `userId` / `email` / `orgId` hashes.
+2. **Per-user DB overrides** — row in `user_feature_switches` keyed by `(orgId, userId)`. Written via the Lab page toggles or `window._vm0.featureSwitches.myFeature = true` (both call `POST /api/zero/feature-switches`). Cleared via the Lab page "Reset all" button (`DELETE /api/zero/feature-switches`).
 
-Server-side evaluation only uses Layer 1 (core registry).
+The same two-layer resolution applies on the server: route handlers that call `isFeatureEnabled(..., { userId, orgId, overrides })` pass overrides loaded via `loadFeatureSwitchOverrides(orgId, userId)`.
+
+There is **no** client-only layer. `window._vm0.featureSwitches` requires auth and persists across refreshes; there is no device-local override.

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -22,7 +22,7 @@ import {
 import { updateSearchParams$ } from "../signals/route";
 import { vi } from "vitest";
 import type { FeatureSwitchKey } from "@vm0/core";
-import { setFeatureSwitchLocalStorage$ } from "../signals/external/feature-switch";
+import { setMockFeatureSwitches } from "../mocks/handlers/api-feature-switches";
 import { setDebugLoggerLocalStorage$ } from "../signals/bootstrap/loggers";
 import { detach, Reason } from "../signals/utils";
 
@@ -56,10 +56,7 @@ export async function setupPage(options: {
   }
 
   if (options.featureSwitches) {
-    options.context.store.set(
-      setFeatureSwitchLocalStorage$,
-      JSON.stringify(options.featureSwitches),
-    );
+    setMockFeatureSwitches(options.featureSwitches);
   }
 
   mockUser(

--- a/turbo/apps/platform/src/mocks/handlers/api-feature-switches.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-feature-switches.ts
@@ -15,9 +15,19 @@ export function resetMockFeatureSwitches(): void {
 }
 
 export function setMockFeatureSwitches(
-  switches: Record<string, boolean>,
+  switches: Partial<Record<string, boolean>>,
 ): void {
-  mockSwitches = { ...switches };
+  const next: Record<string, boolean> = {};
+  for (const [key, value] of Object.entries(switches)) {
+    if (value !== undefined) {
+      next[key] = value;
+    }
+  }
+  mockSwitches = next;
+}
+
+export function getMockFeatureSwitches(): Record<string, boolean> {
+  return mockSwitches;
 }
 
 export const apiFeatureSwitchesHandlers = [
@@ -28,5 +38,10 @@ export const apiFeatureSwitchesHandlers = [
   mockApi(zeroFeatureSwitchesContract.update, ({ body, respond }) => {
     mockSwitches = { ...mockSwitches, ...body.switches };
     return respond(200, { switches: mockSwitches });
+  }),
+
+  mockApi(zeroFeatureSwitchesContract.delete, ({ respond }) => {
+    mockSwitches = {};
+    return respond(200, { deleted: true as const });
   }),
 ];

--- a/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { waitFor } from "@testing-library/react";
 import { testContext } from "./test-helpers";
 import { detachedSetupPage } from "../../__tests__/page-helper";
+import { getMockFeatureSwitches } from "../../mocks/handlers/api-feature-switches";
 
 const context = testContext();
 
@@ -74,6 +75,20 @@ describe("global feature switches", () => {
 
     await waitFor(() => {
       expect(window._vm0?.featureSwitches.dummy).toBeFalsy();
+    });
+  });
+
+  it("should write through to server when setter used", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    await waitFor(() => {
+      expect(window._vm0?.featureSwitches).toBeDefined();
+    });
+
+    window._vm0!.featureSwitches.dummy = false;
+
+    await waitFor(() => {
+      expect(getMockFeatureSwitches()).toMatchObject({ dummy: false });
     });
   });
 });

--- a/turbo/apps/platform/src/signals/bootstrap/global-method.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/global-method.ts
@@ -3,8 +3,8 @@ import { getLoggers, Level, logger } from "../log";
 import type { DebugLoggers } from "../../types/global-method";
 import { FeatureSwitchKey } from "@vm0/core";
 import {
+  detachedSetFeatureSwitch$,
   featureSwitch$,
-  overrideFeatureSwitch$,
 } from "../external/feature-switch";
 import { inspectLogInput$ } from "./inspect-log-input";
 import { extendDebugLoggerLocalStorage$ } from "./loggers";
@@ -62,8 +62,8 @@ export const setupGlobalMethod$ = command(
 
     window._vm0.featureSwitches = new Proxy(features, {
       set(_, prop: FeatureSwitchKey, value: boolean) {
-        set(overrideFeatureSwitch$, { [prop]: value });
-        return value;
+        set(detachedSetFeatureSwitch$, { [prop]: value }, signal);
+        return true;
       },
     });
   },

--- a/turbo/apps/platform/src/signals/external/__tests__/feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/feature-switch.test.ts
@@ -4,12 +4,14 @@ import { testContext } from "../../__tests__/test-helpers";
 import { detachedSetupPage } from "../../../__tests__/page-helper";
 import {
   featureSwitch$,
-  syncFeatureSwitchToDB$,
-  resetFeatureSwitchOverrides$,
-  getFeatureSwitchLocalStorage$,
+  setFeatureSwitch$,
+  resetFeatureSwitches$,
 } from "../feature-switch";
 import { FeatureSwitchKey, zeroFeatureSwitchesContract } from "@vm0/core";
-import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches";
+import {
+  getMockFeatureSwitches,
+  setMockFeatureSwitches,
+} from "../../../mocks/handlers/api-feature-switches";
 import { server } from "../../../mocks/server";
 import { mockApi } from "../../../mocks/msw-contract";
 
@@ -33,7 +35,7 @@ describe("feature switch", () => {
     );
   });
 
-  it("should override dummy switch", async () => {
+  it("should override dummy switch via the server record", async () => {
     detachedSetupPage({
       context,
       path: "/",
@@ -47,9 +49,7 @@ describe("feature switch", () => {
     );
   });
 
-  it("should not override keys not present in localStorage", async () => {
-    // When localStorage only has partial overrides, other keys should keep their default values
-    // Setting an empty object should not affect the default value of 'dummy' (which is true)
+  it("should not override keys not present in the server record", async () => {
     detachedSetupPage({
       context,
       path: "/",
@@ -64,7 +64,6 @@ describe("feature switch", () => {
   });
 
   it("should apply DB API overrides", async () => {
-    // Dummy is globally enabled (true). Override it to false via DB API.
     setMockFeatureSwitches({ [FeatureSwitchKey.Dummy]: false });
     detachedSetupPage({ context, path: "/", withoutRender: true });
 
@@ -72,36 +71,21 @@ describe("feature switch", () => {
     expect(result.dummy).toBeFalsy();
   });
 
-  it("should prioritize localStorage over DB API overrides", async () => {
-    // localStorage says dummy=true, DB says dummy=false — localStorage wins
-    setMockFeatureSwitches({ [FeatureSwitchKey.Dummy]: false });
-    detachedSetupPage({
-      context,
-      path: "/",
-      featureSwitches: { dummy: true },
-      withoutRender: true,
-    });
-
-    const result = await context.store.get(featureSwitch$);
-    expect(result.dummy).toBeTruthy();
-  });
-
-  it("should sync feature switch override to DB API", async () => {
+  it("should write a single switch via setFeatureSwitch$", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
 
     await context.store.set(
-      syncFeatureSwitchToDB$,
+      setFeatureSwitch$,
       { [FeatureSwitchKey.Dummy]: false },
       context.signal,
     );
 
-    // After syncing, the DB layer should reflect the override
     const result = await context.store.get(featureSwitch$);
     expect(result.dummy).toBeFalsy();
+    expect(getMockFeatureSwitches()).toMatchObject({ dummy: false });
   });
 
-  it("should reset localStorage overrides", async () => {
-    // Set localStorage override, then reset
+  it("should reset all switches by deleting the server row", async () => {
     detachedSetupPage({
       context,
       path: "/",
@@ -109,65 +93,17 @@ describe("feature switch", () => {
       withoutRender: true,
     });
 
-    // Confirm override is active
     const before = await context.store.get(featureSwitch$);
     expect(before.dummy).toBeFalsy();
 
-    // Reset overrides — dummy should return to its default (true)
-    await context.store.set(resetFeatureSwitchOverrides$, context.signal);
+    await context.store.set(resetFeatureSwitches$, context.signal);
 
     const after = await context.store.get(featureSwitch$);
     expect(after.dummy).toBeTruthy();
+    expect(getMockFeatureSwitches()).toStrictEqual({});
   });
 
-  it("should clear localStorage key after successful DB sync", async () => {
-    detachedSetupPage({
-      context,
-      path: "/",
-      featureSwitches: { dummy: false },
-      withoutRender: true,
-    });
-
-    // Sanity: localStorage holds the optimistic override
-    expect(context.store.get(getFeatureSwitchLocalStorage$)).toContain("dummy");
-
-    await context.store.set(
-      syncFeatureSwitchToDB$,
-      { [FeatureSwitchKey.Dummy]: false },
-      context.signal,
-    );
-
-    // localStorage is cleaned up; DB is now source of truth
-    expect(context.store.get(getFeatureSwitchLocalStorage$)).toBeNull();
-    const result = await context.store.get(featureSwitch$);
-    expect(result.dummy).toBeFalsy();
-  });
-
-  it("should strip synced key and preserve other in-flight overrides", async () => {
-    detachedSetupPage({
-      context,
-      path: "/",
-      featureSwitches: {
-        [FeatureSwitchKey.Dummy]: false,
-        [FeatureSwitchKey.VoiceChat]: true,
-      },
-      withoutRender: true,
-    });
-
-    await context.store.set(
-      syncFeatureSwitchToDB$,
-      { [FeatureSwitchKey.Dummy]: false },
-      context.signal,
-    );
-
-    const stored = context.store.get(getFeatureSwitchLocalStorage$);
-    expect(stored).not.toBeNull();
-    const parsed = JSON.parse(stored ?? "{}") as Record<string, boolean>;
-    expect(parsed).not.toHaveProperty(FeatureSwitchKey.Dummy);
-    expect(parsed).toHaveProperty(FeatureSwitchKey.VoiceChat, true);
-  });
-
-  it("should strip localStorage and toast on DB sync failure", async () => {
+  it("should toast on DB sync failure", async () => {
     server.use(
       mockApi(zeroFeatureSwitchesContract.update, ({ respond }) => {
         return respond(500, {
@@ -176,44 +112,32 @@ describe("feature switch", () => {
       }),
     );
 
-    detachedSetupPage({
-      context,
-      path: "/",
-      featureSwitches: { dummy: false },
-      withoutRender: true,
-    });
+    detachedSetupPage({ context, path: "/", withoutRender: true });
 
     await expect(
       context.store.set(
-        syncFeatureSwitchToDB$,
+        setFeatureSwitch$,
         { [FeatureSwitchKey.Dummy]: false },
         context.signal,
       ),
     ).rejects.toThrow("Server error");
 
     expect(toast.error).toHaveBeenCalledWith("Server error");
-    expect(context.store.get(getFeatureSwitchLocalStorage$)).toBeNull();
   });
 
-  it("should strip localStorage on abort without toasting", async () => {
-    detachedSetupPage({
-      context,
-      path: "/",
-      featureSwitches: { dummy: false },
-      withoutRender: true,
-    });
+  it("should propagate abort without toasting", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
 
     const abortedSignal = AbortSignal.abort(new Error("test abort"));
 
     await expect(
       context.store.set(
-        syncFeatureSwitchToDB$,
+        setFeatureSwitch$,
         { [FeatureSwitchKey.Dummy]: false },
         abortedSignal,
       ),
     ).rejects.toThrow();
 
     expect(toast.error).not.toHaveBeenCalled();
-    expect(context.store.get(getFeatureSwitchLocalStorage$)).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -1,18 +1,12 @@
 import { command, computed, state } from "ccstate";
-import { logger } from "../log";
 import {
   FeatureSwitchKey,
   getAllFeatureStates,
   zeroFeatureSwitchesContract,
 } from "@vm0/core";
-import { localStorageSignals } from "./local-storage";
-import { jsonParseOr } from "../utils";
 import { clerk$, user$ } from "../auth";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
-
-const L = logger("FeatureSwitch");
-const { get$, set$, clear$ } = localStorageSignals("featureSwitch");
 
 const internalReload$ = state(0);
 
@@ -24,10 +18,9 @@ const dbFeatureSwitches$ = computed(async (get) => {
   return result.body.switches;
 });
 
-function applyOverrides(
+function applySwitches(
   result: Record<FeatureSwitchKey, boolean>,
   overrides: Partial<Record<string, boolean>> | undefined,
-  log?: boolean,
 ) {
   if (!overrides) {
     return;
@@ -36,9 +29,6 @@ function applyOverrides(
     const value = overrides[key];
     if (value !== undefined) {
       result[key] = Boolean(value);
-      if (log) {
-        L.warn(`Override feature switch: ${key} = ${Boolean(value)}`);
-      }
     }
   }
 }
@@ -56,68 +46,13 @@ export const featureSwitch$ = computed(async (get) => {
 
   const result = getAllFeatureStates({ userId, email, orgId });
 
-  // Layer 2: DB overrides (lower priority than localStorage)
-  const dbOverrides = await get(dbFeatureSwitches$);
-  applyOverrides(result, dbOverrides);
-
-  // Layer 3: localStorage overrides (highest priority)
-  const override = get(get$);
-  if (override) {
-    const parsed = jsonParseOr<Partial<Record<string, boolean>> | undefined>(
-      override,
-      undefined,
-    );
-    applyOverrides(result, parsed, true);
-  }
+  const dbSwitches = await get(dbFeatureSwitches$);
+  applySwitches(result, dbSwitches);
 
   return result;
 });
 
-export const overrideFeatureSwitch$ = command(
-  ({ get, set }, overrides: Partial<Record<FeatureSwitchKey, boolean>>) => {
-    const current = get(get$);
-    const parsed = {
-      ...(current
-        ? jsonParseOr<Partial<Record<FeatureSwitchKey, boolean>>>(current, {})
-        : {}),
-      ...overrides,
-    };
-    set(set$, JSON.stringify(parsed));
-    set(internalReload$, (v) => {
-      return v + 1;
-    });
-  },
-);
-
-// The localStorage override is an optimistic buffer that bridges the gap
-// between a user toggle and the DB confirming the write. Once the sync
-// settles (success, HTTP error, or abort) the keys must be stripped so
-// `featureSwitch$` falls through to DB truth; otherwise a silently-dropped
-// DB write leaves a permanent phantom state that only the frontend sees.
-const clearFeatureSwitchLocalKeys$ = command(({ get, set }, keys: string[]) => {
-  const current = get(get$);
-  if (!current) {
-    return;
-  }
-  const parsed = jsonParseOr<Partial<Record<string, boolean>>>(current, {});
-  let changed = false;
-  for (const key of keys) {
-    if (key in parsed) {
-      delete parsed[key];
-      changed = true;
-    }
-  }
-  if (!changed) {
-    return;
-  }
-  if (Object.keys(parsed).length === 0) {
-    set(clear$);
-  } else {
-    set(set$, JSON.stringify(parsed));
-  }
-});
-
-export const syncFeatureSwitchToDB$ = command(
+export const setFeatureSwitch$ = command(
   async (
     { get, set },
     overrides: Partial<Record<FeatureSwitchKey, boolean>>,
@@ -125,39 +60,39 @@ export const syncFeatureSwitchToDB$ = command(
   ) => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroFeatureSwitchesContract);
-
-    const work = async () => {
-      signal.throwIfAborted();
-      await accept(client.update({ body: { switches: overrides } }), [200]);
-      signal.throwIfAborted();
-    };
-
-    await work().finally(() => {
-      set(clearFeatureSwitchLocalKeys$, Object.keys(overrides));
-      set(internalReload$, (v) => {
-        return v + 1;
-      });
-    });
-  },
-);
-
-export const resetFeatureSwitchOverrides$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    // Clear localStorage
-    set(clear$);
-
-    // Clear DB overrides by writing empty switches (no-op merge — DB overrides persist)
-    const createClient = get(zeroClient$);
-    const client = createClient(zeroFeatureSwitchesContract);
     signal.throwIfAborted();
-    await accept(client.update({ body: { switches: {} } }), [200]);
+    await accept(client.update({ body: { switches: overrides } }), [200]);
     signal.throwIfAborted();
-
     set(internalReload$, (v) => {
       return v + 1;
     });
   },
 );
 
-export const setFeatureSwitchLocalStorage$ = set$;
-export const getFeatureSwitchLocalStorage$ = get$;
+export const resetFeatureSwitches$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroFeatureSwitchesContract);
+    signal.throwIfAborted();
+    await accept(client.delete(), [200]);
+    signal.throwIfAborted();
+    set(internalReload$, (v) => {
+      return v + 1;
+    });
+  },
+);
+
+export const detachedSetFeatureSwitch$ = command(
+  (
+    { set },
+    overrides: Partial<Record<FeatureSwitchKey, boolean>>,
+    signal: AbortSignal,
+  ) => {
+    set(setFeatureSwitch$, overrides, signal).catch((error: unknown) => {
+      if (error instanceof Error && error.name === "AbortError") {
+        return;
+      }
+      throw error;
+    });
+  },
+);

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -88,11 +88,11 @@ export const detachedSetFeatureSwitch$ = command(
     overrides: Partial<Record<FeatureSwitchKey, boolean>>,
     signal: AbortSignal,
   ) => {
-    set(setFeatureSwitch$, overrides, signal).catch((error: unknown) => {
-      if (error instanceof Error && error.name === "AbortError") {
-        return;
-      }
-      throw error;
+    // toast.error is already shown by accept() on API failure.
+    // Swallow all rejections here so the fire-and-forget proxy setter does
+    // not produce an unhandled promise rejection in the browser console.
+    set(setFeatureSwitch$, overrides, signal).catch((_error: unknown) => {
+      return;
     });
   },
 );

--- a/turbo/apps/platform/src/signals/internal-connector-logos-setup.ts
+++ b/turbo/apps/platform/src/signals/internal-connector-logos-setup.ts
@@ -1,13 +1,11 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { InternalConnectorLogos } from "../views/internal-connector-logos.tsx";
 import { updatePage$ } from "./react-router.ts";
 import { hideAppSkeleton$ } from "./app-skeleton.ts";
 
 export const setupInternalConnectorLogos$ = command(
   async ({ set }, signal: AbortSignal) => {
-    const { InternalConnectorLogos } =
-      await import("../views/internal-connector-logos.tsx");
-    signal.throwIfAborted();
     set(updatePage$, createElement(InternalConnectorLogos));
     await set(hideAppSkeleton$, signal);
   },

--- a/turbo/apps/platform/src/views/lab-page/lab-page.tsx
+++ b/turbo/apps/platform/src/views/lab-page/lab-page.tsx
@@ -1,43 +1,35 @@
-import { useGet, useLastResolved, useSet } from "ccstate-react";
+import { useGet, useLastResolved } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { FeatureSwitchKey, getFeatureSwitchDescriptions } from "@vm0/core";
 import { Switch, Button } from "@vm0/ui";
 import {
   featureSwitch$,
-  overrideFeatureSwitch$,
-  syncFeatureSwitchToDB$,
-  resetFeatureSwitchOverrides$,
+  setFeatureSwitch$,
+  resetFeatureSwitches$,
 } from "../../signals/external/feature-switch.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 
 export function LabPage() {
   const features = useLastResolved(featureSwitch$);
-  const overrideLocal = useSet(overrideFeatureSwitch$);
-  const syncDB = useSet(syncFeatureSwitchToDB$);
-  const [resetLoadable, reset] = useLoadableSet(resetFeatureSwitchOverrides$);
+  const [toggleLoadable, setFeature] = useLoadableSet(setFeatureSwitch$);
+  const [resetLoadable, reset] = useLoadableSet(resetFeatureSwitches$);
   const resetting = resetLoadable.state === "loading";
+  const toggling = toggleLoadable.state === "loading";
+  const busy = resetting || toggling;
   const pageSignal = useGet(pageSignal$);
   const descriptions = getFeatureSwitchDescriptions();
 
   const handleToggle = (key: FeatureSwitchKey, checked: boolean) => {
-    const override = { [key]: checked } as Partial<
-      Record<FeatureSwitchKey, boolean>
-    >;
-    overrideLocal(override);
     detach(
-      syncDB(override, pageSignal),
+      setFeature({ [key]: checked }, pageSignal),
       Reason.DomCallback,
-      "syncFeatureSwitchToDB",
+      "setFeatureSwitch",
     );
   };
 
   const handleReset = () => {
-    detach(
-      reset(pageSignal),
-      Reason.DomCallback,
-      "resetFeatureSwitchOverrides",
-    );
+    detach(reset(pageSignal), Reason.DomCallback, "resetFeatureSwitches");
   };
 
   return (
@@ -55,7 +47,7 @@ export function LabPage() {
           <Button
             variant="outline"
             size="sm"
-            disabled={resetting}
+            disabled={busy}
             onPointerDown={handleReset}
           >
             {resetting ? "Resetting…" : "Reset all"}
@@ -87,6 +79,7 @@ export function LabPage() {
                     </div>
                     <Switch
                       checked={enabled}
+                      disabled={busy}
                       onCheckedChange={(checked) => {
                         handleToggle(key, checked);
                       }}

--- a/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
@@ -50,20 +50,14 @@ describe("internal connector logos - display (ORG-D-118)", () => {
     const connectorTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
     // Verify at least one connector type and its label appears in the document
     // (labels and type keys may appear multiple times due to icon display variants).
-    // Use a longer timeout: the route setup involves a dynamic import which can be
-    // slow under CI load, causing intermittent failures at the default 5000ms.
-    await waitFor(
-      () => {
-        expect(
-          screen.queryAllByText(CONNECTOR_TYPES[connectorTypes[0]].label)
-            .length,
-        ).toBeGreaterThan(0);
-        expect(screen.queryAllByText(connectorTypes[0]).length).toBeGreaterThan(
-          0,
-        );
-      },
-      { timeout: 15000 },
-    );
+    await waitFor(() => {
+      expect(
+        screen.queryAllByText(CONNECTOR_TYPES[connectorTypes[0]].label).length,
+      ).toBeGreaterThan(0);
+      expect(screen.queryAllByText(connectorTypes[0]).length).toBeGreaterThan(
+        0,
+      );
+    });
     // All connectors are rendered at once, so sync checks suffice after the first waitFor
     for (const type of connectorTypes) {
       expect(screen.queryAllByText(type).length).toBeGreaterThan(0);
@@ -75,14 +69,11 @@ describe("internal connector logos - display (ORG-D-119)", () => {
   it("heading displays the count of connector types", async () => {
     detachedSetupPage({ context, path: "/__internal-connector-logos" });
     const connectorTypes = Object.keys(CONNECTOR_TYPES);
-    await waitFor(
-      () => {
-        expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
-          connectorTypes.length.toString(),
-        );
-      },
-      { timeout: 15000 },
-    );
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+        connectorTypes.length.toString(),
+      );
+    });
   });
 });
 
@@ -91,16 +82,13 @@ describe("internal connector logos - interaction (ORG-I-121)", () => {
     const user = userEvent.setup();
     detachedSetupPage({ context, path: "/__internal-connector-logos" });
     // Default size button is "128" — clicking "16" should switch to a smaller size
-    await waitFor(
-      () => {
-        expect(
-          screen.getAllByRole("button").find((el) => {
-            return /128/.test(el.textContent ?? "");
-          }),
-        ).toBeInTheDocument();
-      },
-      { timeout: 15000 },
-    );
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button").find((el) => {
+          return /128/.test(el.textContent ?? "");
+        }),
+      ).toBeInTheDocument();
+    });
     const btn16 = screen.getAllByRole("button").find((el) => {
       return /^16$/.test(el.textContent ?? "");
     });

--- a/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
@@ -49,15 +49,21 @@ describe("internal connector logos - display (ORG-D-118)", () => {
     detachedSetupPage({ context, path: "/__internal-connector-logos" });
     const connectorTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
     // Verify at least one connector type and its label appears in the document
-    // (labels and type keys may appear multiple times due to icon display variants)
-    await waitFor(() => {
-      expect(
-        screen.queryAllByText(CONNECTOR_TYPES[connectorTypes[0]].label).length,
-      ).toBeGreaterThan(0);
-      expect(screen.queryAllByText(connectorTypes[0]).length).toBeGreaterThan(
-        0,
-      );
-    });
+    // (labels and type keys may appear multiple times due to icon display variants).
+    // Use a longer timeout: the route setup involves a dynamic import which can be
+    // slow under CI load, causing intermittent failures at the default 5000ms.
+    await waitFor(
+      () => {
+        expect(
+          screen.queryAllByText(CONNECTOR_TYPES[connectorTypes[0]].label)
+            .length,
+        ).toBeGreaterThan(0);
+        expect(screen.queryAllByText(connectorTypes[0]).length).toBeGreaterThan(
+          0,
+        );
+      },
+      { timeout: 15000 },
+    );
     // All connectors are rendered at once, so sync checks suffice after the first waitFor
     for (const type of connectorTypes) {
       expect(screen.queryAllByText(type).length).toBeGreaterThan(0);
@@ -69,11 +75,14 @@ describe("internal connector logos - display (ORG-D-119)", () => {
   it("heading displays the count of connector types", async () => {
     detachedSetupPage({ context, path: "/__internal-connector-logos" });
     const connectorTypes = Object.keys(CONNECTOR_TYPES);
-    await waitFor(() => {
-      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
-        connectorTypes.length.toString(),
-      );
-    });
+    await waitFor(
+      () => {
+        expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+          connectorTypes.length.toString(),
+        );
+      },
+      { timeout: 15000 },
+    );
   });
 });
 
@@ -82,13 +91,16 @@ describe("internal connector logos - interaction (ORG-I-121)", () => {
     const user = userEvent.setup();
     detachedSetupPage({ context, path: "/__internal-connector-logos" });
     // Default size button is "128" — clicking "16" should switch to a smaller size
-    await waitFor(() => {
-      expect(
-        screen.getAllByRole("button").find((el) => {
-          return /128/.test(el.textContent ?? "");
-        }),
-      ).toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(
+          screen.getAllByRole("button").find((el) => {
+            return /128/.test(el.textContent ?? "");
+          }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 15000 },
+    );
     const btn16 = screen.getAllByRole("button").find((el) => {
       return /^16$/.test(el.textContent ?? "");
     });

--- a/turbo/apps/web/app/api/zero/feature-switches/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/feature-switches/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { GET, POST } from "../route";
+import { GET, POST, DELETE } from "../route";
 import { createTestRequest } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
@@ -20,6 +20,10 @@ function postRequest(switches: Record<string, boolean>) {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ switches }),
   });
+}
+
+function deleteRequest() {
+  return createTestRequest(BASE_URL, { method: "DELETE" });
 }
 
 describe("GET /api/zero/feature-switches", () => {
@@ -110,5 +114,40 @@ describe("POST /api/zero/feature-switches", () => {
 
     expect(response.status).toBe(200);
     expect(data.switches).toEqual({ voiceChat: true, lab: false });
+  });
+});
+
+describe("DELETE /api/zero/feature-switches", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await DELETE(deleteRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.message).toContain("Not authenticated");
+  });
+
+  it("should clear all overrides and subsequent GET returns empty switches", async () => {
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.orgId });
+
+    await POST(postRequest({ voiceChat: true, lab: false }));
+
+    const deleteResponse = await DELETE(deleteRequest());
+    const deleteData = await deleteResponse.json();
+
+    expect(deleteResponse.status).toBe(200);
+    expect(deleteData.deleted).toBe(true);
+
+    const getResponse = await GET(getRequest());
+    const getData = await getResponse.json();
+
+    expect(getResponse.status).toBe(200);
+    expect(getData.switches).toEqual({});
   });
 });

--- a/turbo/apps/web/app/api/zero/feature-switches/route.ts
+++ b/turbo/apps/web/app/api/zero/feature-switches/route.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
 import {
+  deleteUserFeatureSwitches,
   getUserFeatureSwitches,
   updateUserFeatureSwitches,
 } from "../../../../src/lib/zero/user/feature-switches-service";
@@ -51,10 +52,26 @@ const router = tsr.router(zeroFeatureSwitchesContract, {
       body: { switches },
     };
   },
+
+  delete: async ({ headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const { org } = await resolveOrg(authCtx);
+
+    await deleteUserFeatureSwitches(org.orgId, authCtx.userId);
+
+    return {
+      status: 200 as const,
+      body: { deleted: true as const },
+    };
+  },
 });
 
 const handler = createHandler(zeroFeatureSwitchesContract, router, {
   errorHandler: createSafeErrorHandler("zero-feature-switches"),
 });
 
-export { handler as GET, handler as POST };
+export { handler as GET, handler as POST, handler as DELETE };

--- a/turbo/apps/web/src/lib/zero/user/feature-switches-service.ts
+++ b/turbo/apps/web/src/lib/zero/user/feature-switches-service.ts
@@ -42,6 +42,27 @@ export async function loadFeatureSwitchOverrides(
 }
 
 /**
+ * Delete all feature switch overrides for the given org + user.
+ * After deletion, evaluations fall back to the static registry values
+ * computed from userId/orgId.
+ */
+export async function deleteUserFeatureSwitches(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  const db = globalThis.services.db;
+
+  await db
+    .delete(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, orgId),
+        eq(userFeatureSwitches.userId, userId),
+      ),
+    );
+}
+
+/**
  * Update user feature switch overrides with merge strategy.
  * Merges the provided switches with existing ones (shallow merge).
  */

--- a/turbo/packages/core/src/contracts/zero-feature-switches.ts
+++ b/turbo/packages/core/src/contracts/zero-feature-switches.ts
@@ -25,6 +25,7 @@ export type UpdateFeatureSwitchesRequest = z.infer<
  *
  * GET: Get current user's feature switch overrides
  * POST: Update user feature switch overrides (merge strategy)
+ * DELETE: Remove all of the current user's feature switch overrides
  */
 export const zeroFeatureSwitchesContract = c.router({
   get: {
@@ -50,6 +51,18 @@ export const zeroFeatureSwitchesContract = c.router({
       500: apiErrorSchema,
     },
     summary: "Update user feature switch overrides",
+  },
+  delete: {
+    method: "DELETE",
+    path: "/api/zero/feature-switches",
+    headers: authHeadersSchema,
+    body: c.noBody(),
+    responses: {
+      200: z.object({ deleted: z.literal(true) }),
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Delete all of the current user's feature switch overrides",
   },
 });
 


### PR DESCRIPTION
## Summary

- Collapse feature-switch evaluation from three layers to two: the static core registry plus a per-user DB row. The localStorage buffer and its cleanup paths are gone on both the client setter and the test helpers.
- Add `DELETE /api/zero/feature-switches` (contract + route + service) so the Lab page "Reset all" button can actually clear a user's overrides instead of merging `{}` into them (which was a no-op for previously-set keys).
- Make `window._vm0.featureSwitches.xxx = value` write straight through to the DB via `setFeatureSwitch$`, and disable the Lab page toggles/reset button while a write is in flight.
- Update the `feature-switch` skill doc to reflect the new two-layer model and the fact that server-side evaluation also reads DB overrides.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run` (1845 tests pass, including the rewritten `feature-switch.test.ts` and new `global-method.test.ts` write-through case)
- [x] `pnpm -F web exec vitest run` on the feature-switch service + route (35 tests pass)
- [x] `pnpm turbo run lint`
- [x] `pnpm check-types`
- [x] `pnpm knip`