### PR TITLE
fix(web): publish queue:changed on dispatch failure paths

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -25,7 +25,6 @@ import {
   dispatchQueuedZeroRun,
 } from "../../../../../src/lib/zero/zero-run-queue-service";
 import { processOrgCredits } from "../../../../../src/lib/zero/credit/credit-service";
-import { publishOrgSignal } from "../../../../../src/lib/zero/realtime";
 import { after } from "next/server";
 import { env } from "../../../../../src/env";
 
@@ -44,9 +43,6 @@ function scheduleTerminalSideEffects(
     await dispatchTerminalSideEffects(runId, status, errorMsg, () => {
       return drainOrgQueue(orgId, dispatchQueuedZeroRun);
     });
-    // Terminal transition frees a concurrency slot — notify the queue view
-    // even if the drain above was a no-op (empty queue).
-    await publishOrgSignal(orgId, "queue:changed");
     await processOrgCredits(orgId);
   });
 }

--- a/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
@@ -13,6 +13,7 @@ import {
   expireQueueEntry,
   setTestRunStatus,
   updateOrgTier,
+  insertOrgMembersCacheEntry,
 } from "../../../__tests__/api-test-helpers";
 import { reloadEnv } from "../../../env";
 import type { CreateRunParams } from "../../infra/run/run-service";
@@ -25,6 +26,7 @@ import {
   dispatchQueuedZeroRun,
 } from "../zero-run-queue-service";
 import { seedTestRun } from "../../../__tests__/db-test-seeders/runs";
+import { mockAblyPublish } from "../../../__tests__/ably-mock";
 
 const context = testContext();
 
@@ -94,6 +96,20 @@ describe("run-queue-service", () => {
     it("should be a no-op when queue is empty", async () => {
       // Should not throw
       await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
+    });
+
+    it("should publish queue:changed even when queue is empty", async () => {
+      // Regression: a failed dispatch frees a concurrency slot; the queue view
+      // must refresh even when there are no queued runs waiting. Ably only fires
+      // when the org has members in cache, so we seed one entry here.
+      await insertOrgMembersCacheEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        role: "admin",
+      });
+      mockAblyPublish.mockClear();
+      await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
+      expect(mockAblyPublish).toHaveBeenCalledWith("queue:changed", null);
     });
 
     it("should dequeue and execute the oldest entry", async () => {

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -255,7 +255,11 @@ export async function drainOrgQueue(
     }
   } finally {
     if (anyTransition) {
-      await publishOrgSignal(orgId, "queue:changed");
+      // Swallow Ably failures so they don't mask an original throw propagating
+      // through this finally (finally-throw would replace the real error).
+      await publishOrgSignal(orgId, "queue:changed").catch((err: unknown) => {
+        log.error("Failed to publish queue:changed after drain", { err });
+      });
     }
   }
 }
@@ -630,6 +634,17 @@ export async function dispatchQueuedZeroRun(
     });
   } catch (error) {
     await markRunFailed(runId, error);
+    // markRunFailed transitions the run to "failed" (a queue-relevant state
+    // change) but does not publish a signal itself. drainOrgQueue only
+    // publishes when it transitions a queued run, so a failure with an empty
+    // queue would otherwise leave the queue view stale.
+    await publishOrgSignal(params.orgId, "queue:changed").catch(
+      (err: unknown) => {
+        nonZeroLog.error("Failed to publish queue:changed after run failure", {
+          err,
+        });
+      },
+    );
     await drainOrgQueue(params.orgId, dispatchQueuedZeroRun).catch(
       (drainErr) => {
         nonZeroLog.error("Failed to drain org queue after run failure", {

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -207,20 +207,11 @@ export async function drainOrgQueue(
   const db = globalThis.services.db;
   const encryptionKey = env().SECRETS_ENCRYPTION_KEY;
 
-  // anyTransition is set to true only after dequeueNextAtomic() returns a non-null
-  // result, meaning at least one run was successfully dequeued and transitioned to
-  // "pending". The outer try/finally guarantees publishOrgSignal() fires exactly once
-  // after all iterations complete (or after an unexpected throw). An unexpected throw
-  // from dequeueNextAtomic() or decryptSecretsMap() would only reach the finally block
-  // with anyTransition=true if a prior loop iteration had already dequeued a run, so
-  // the signal is always accurate: it fires only when real state has changed.
-  let anyTransition = false;
   try {
     for (;;) {
       // Single transaction: advisory lock → concurrency check → dequeue → status update
       const dequeued = await dequeueNextAtomic(db, orgId);
       if (!dequeued) return; // Queue empty, entry skipped, or concurrency full
-      anyTransition = true;
 
       // Decrypt CreateRunParams (outside transaction — no lock held)
       const decryptedMap = decryptSecretsMap(
@@ -254,13 +245,14 @@ export async function drainOrgQueue(
       }
     }
   } finally {
-    if (anyTransition) {
-      // Swallow Ably failures so they don't mask an original throw propagating
-      // through this finally (finally-throw would replace the real error).
-      await publishOrgSignal(orgId, "queue:changed").catch((err: unknown) => {
-        log.error("Failed to publish queue:changed after drain", { err });
-      });
-    }
+    // Always publish after drain — either a run was dequeued (anyTransition) or
+    // the caller freed a concurrency slot and the queue view must refresh even
+    // when the queue was already empty. Swallow Ably failures so they don't mask
+    // an original throw propagating through this finally (finally-throw would
+    // replace the real error).
+    await publishOrgSignal(orgId, "queue:changed").catch((err: unknown) => {
+      log.error("Failed to publish queue:changed after drain", { err });
+    });
   }
 }
 
@@ -634,17 +626,8 @@ export async function dispatchQueuedZeroRun(
     });
   } catch (error) {
     await markRunFailed(runId, error);
-    // markRunFailed transitions the run to "failed" (a queue-relevant state
-    // change) but does not publish a signal itself. drainOrgQueue only
-    // publishes when it transitions a queued run, so a failure with an empty
-    // queue would otherwise leave the queue view stale.
-    await publishOrgSignal(params.orgId, "queue:changed").catch(
-      (err: unknown) => {
-        nonZeroLog.error("Failed to publish queue:changed after run failure", {
-          err,
-        });
-      },
-    );
+    // drainOrgQueue always publishes queue:changed in its finally block —
+    // including the empty-queue case — so no explicit publish is needed here.
     await drainOrgQueue(params.orgId, dispatchQueuedZeroRun).catch(
       (drainErr) => {
         nonZeroLog.error("Failed to drain org queue after run failure", {

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -36,6 +36,7 @@ import {
   drainOrgQueue,
   dispatchQueuedZeroRun,
 } from "./zero-run-queue-service";
+import { publishOrgSignal } from "./realtime";
 import { generateZeroToken, generateSandboxToken } from "../auth/sandbox-token";
 import { loadFeatureSwitchOverrides } from "./user/feature-switches-service";
 import {
@@ -668,6 +669,13 @@ async function dispatchZeroRun(
     return dispatchResult;
   } catch (error) {
     await markRunFailed(record.run.id, error);
+    // markRunFailed transitions the run to "failed" (a queue-relevant state
+    // change) but does not publish a signal itself. drainOrgQueue only
+    // publishes when it transitions a queued run, so a failure with an empty
+    // queue would otherwise leave the queue view stale.
+    await publishOrgSignal(orgId, "queue:changed").catch((err: unknown) => {
+      log.error("Failed to publish queue:changed after run failure", { err });
+    });
     await drainOrgQueue(orgId, dispatchQueuedZeroRun).catch((drainErr) => {
       log.error("Failed to drain org queue after run failure", { drainErr });
     });

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -36,7 +36,6 @@ import {
   drainOrgQueue,
   dispatchQueuedZeroRun,
 } from "./zero-run-queue-service";
-import { publishOrgSignal } from "./realtime";
 import { generateZeroToken, generateSandboxToken } from "../auth/sandbox-token";
 import { loadFeatureSwitchOverrides } from "./user/feature-switches-service";
 import {
@@ -669,13 +668,8 @@ async function dispatchZeroRun(
     return dispatchResult;
   } catch (error) {
     await markRunFailed(record.run.id, error);
-    // markRunFailed transitions the run to "failed" (a queue-relevant state
-    // change) but does not publish a signal itself. drainOrgQueue only
-    // publishes when it transitions a queued run, so a failure with an empty
-    // queue would otherwise leave the queue view stale.
-    await publishOrgSignal(orgId, "queue:changed").catch((err: unknown) => {
-      log.error("Failed to publish queue:changed after run failure", { err });
-    });
+    // drainOrgQueue always publishes queue:changed in its finally block —
+    // including the empty-queue case — so no explicit publish is needed here.
     await drainOrgQueue(orgId, dispatchQueuedZeroRun).catch((drainErr) => {
       log.error("Failed to drain org queue after run failure", { drainErr });
     });


### PR DESCRIPTION
## Summary

Close realtime signal gaps around run dispatch failures so the queue view never goes stale:

- **Publish after failed dispatch**: `dispatchZeroRun` and `dispatchQueuedZeroRun` now publish `queue:changed` after `markRunFailed`. Previously, if an empty queue followed the failure, `drainOrgQueue` had nothing to transition and skipped its publish, leaving subscribed clients stuck on a pre-failure snapshot.
- **Don't let Ably mask real errors**: the publish inside `drainOrgQueue`'s `finally` now swallows (and logs) its own error. A throw from `publishOrgSignal` in a `finally` would replace any in-flight error propagating out of the `try`.
- **Drop redundant webhook publish**: the `queue:changed` publish in `agent/complete` webhook ran right after `drainOrgQueue`, which already publishes on transition. Removed to avoid the duplicate signal.

## Test plan

- [x] `pnpm --filter web check-types`
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web exec vitest run` for `run-queue-service`, `realtime`, `credit-check`, `webhooks/agent/complete`, `agent/runs/[id]/cancel` (66 tests passed)
- [ ] CI green