### PR TITLE
fix(core): route glm-5.1 through openrouter with upstream model override

### DIFF
--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -11,6 +11,7 @@ import { mockClerk } from "./clerk-mock";
 import {
   getVm0ConcreteProviderType,
   getVm0Vendor,
+  getVm0ApiModel,
   VM0_MODEL_TO_PROVIDER,
 } from "@vm0/core";
 
@@ -137,6 +138,16 @@ describe("VM0 managed model provider", () => {
         "anthropic-api-key",
       );
       expect(getVm0Vendor("claude-opus-4-6")).toBe("anthropic");
+    });
+
+    it("should resolve glm-5.1 to openrouter-api-key with z-ai/glm-5.1 upstream id", () => {
+      expect(getVm0ConcreteProviderType("glm-5.1")).toBe("openrouter-api-key");
+      expect(getVm0Vendor("glm-5.1")).toBe("openrouter");
+      expect(getVm0ApiModel("glm-5.1")).toBe("z-ai/glm-5.1");
+    });
+
+    it("should fall back to display name when no apiModel override is set", () => {
+      expect(getVm0ApiModel("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
     });
 
     it("should throw for unknown models", () => {

--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -5,6 +5,7 @@ import {
   createTestOrg,
   insertVm0ApiKeys,
   getTestVm0ApiKey,
+  insertOrgDefaultModelProvider,
 } from "./api-test-helpers";
 import { testContext, uniqueId } from "./test-helpers";
 import { mockClerk } from "./clerk-mock";
@@ -14,6 +15,7 @@ import {
   getVm0ApiModel,
   VM0_MODEL_TO_PROVIDER,
 } from "@vm0/core";
+import { resolveModelProviderSecrets } from "../lib/zero/context/resolve-model-provider";
 
 const context = testContext();
 
@@ -156,6 +158,12 @@ describe("VM0 managed model provider", () => {
       }).toThrow('Unknown VM0 model "unknown-model"');
     });
 
+    it("should throw for unknown models in getVm0ApiModel", () => {
+      expect(() => {
+        return getVm0ApiModel("unknown-model");
+      }).toThrow('Unknown VM0 model "unknown-model"');
+    });
+
     it("should have all VM0 provider models mapped", () => {
       const vm0Models = [
         "claude-opus-4-7",
@@ -170,6 +178,36 @@ describe("VM0 managed model provider", () => {
         expect(VM0_MODEL_TO_PROVIDER[model]).toBeDefined();
       }
       expect(Object.keys(VM0_MODEL_TO_PROVIDER)).toHaveLength(vm0Models.length);
+    });
+  });
+
+  describe("glm-5.1 openrouter routing integration", () => {
+    it("should inject z-ai/glm-5.1 as ANTHROPIC_MODEL when resolving vm0 glm-5.1 provider", async () => {
+      const userId = uniqueId("glm-route");
+      const { orgId } = await setupOrg(userId, "org:admin", uniqueId("glm"));
+
+      await insertOrgDefaultModelProvider(orgId, "vm0", "glm-5.1");
+      await insertVm0ApiKeys([
+        {
+          vendor: "openrouter",
+          model: "z-ai/glm-5.1",
+          apiKey: "sk-or-v1-glmtestkey",
+          label: "glm-5.1 test key",
+        },
+      ]);
+
+      const result = await resolveModelProviderSecrets(
+        orgId,
+        "claude-code",
+        false,
+      );
+
+      expect(result.resolvedModelProvider).toBe("vm0");
+      expect(result.concreteProviderType).toBe("openrouter-api-key");
+      expect(result.selectedModel).toBe("glm-5.1");
+      // The apiModel override must flow through to ANTHROPIC_MODEL — this is the core fix
+      expect(result.injectedEnvironment?.ANTHROPIC_MODEL).toBe("z-ai/glm-5.1");
+      expect(result.secrets?.OPENROUTER_API_KEY).toBeDefined();
     });
   });
 });

--- a/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
@@ -8,6 +8,7 @@ import {
   MODEL_PROVIDER_TYPES,
   getVm0ConcreteProviderType,
   getVm0Vendor,
+  getVm0ApiModel,
   type ModelProviderType,
   type ModelProviderFramework,
 } from "@vm0/core";
@@ -171,6 +172,7 @@ async function resolveVm0Provider(
 ): Promise<ModelProviderSecretResult> {
   const concreteType = getVm0ConcreteProviderType(selectedModel);
   const vendor = getVm0Vendor(selectedModel);
+  const apiModel = getVm0ApiModel(selectedModel);
   const poolKey = await getVm0ApiKey(vendor);
   if (!poolKey) {
     throw badRequest(`No API key available for vendor "${vendor}"`);
@@ -183,7 +185,7 @@ async function resolveVm0Provider(
   const injectedEnvironment = resolveEnvironmentMapping(
     concreteType,
     concreteSecretName,
-    selectedModel,
+    apiModel,
   );
 
   log.debug(

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -266,6 +266,7 @@ export {
   VM0_MODEL_TO_PROVIDER,
   getVm0ConcreteProviderType,
   getVm0Vendor,
+  getVm0ApiModel,
   getVm0VisibleModels,
 } from "./model-providers";
 export {

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -37,6 +37,11 @@ export const VM0_ORG_SLUG = "vm0";
 interface Vm0ModelConfig {
   concreteType: string;
   vendor: string;
+  // Overrides the display-name when substituting `$model` in the concrete
+  // provider's environment mapping. Needed when the upstream API expects a
+  // different identifier than what we show to users (e.g. OpenRouter uses
+  // "z-ai/glm-5.1" while our UI shows "glm-5.1").
+  apiModel?: string;
   featureFlag?: FeatureSwitchKey;
 }
 
@@ -57,8 +62,9 @@ export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
     vendor: "anthropic",
   },
   "glm-5.1": {
-    concreteType: "zai-api-key",
-    vendor: "zai",
+    concreteType: "openrouter-api-key",
+    vendor: "openrouter",
+    apiModel: "z-ai/glm-5.1",
     featureFlag: FeatureSwitchKey.Vm0GlmModel,
   },
   "claude-haiku-4-5": {
@@ -166,6 +172,7 @@ export const MODEL_PROVIDER_TYPES = {
       "anthropic/claude-sonnet-4.5",
       "anthropic/claude-opus-4.5",
       "anthropic/claude-haiku-4.5",
+      "z-ai/glm-5.1",
     ] as string[],
     defaultModel: "",
   },
@@ -612,6 +619,20 @@ export function getVm0Vendor(model: string): string {
     );
   }
   return entry.vendor;
+}
+
+/**
+ * Get the upstream API model identifier for a VM0 managed model.
+ * Falls back to the display name when no override is configured.
+ */
+export function getVm0ApiModel(model: string): string {
+  const entry = VM0_MODEL_TO_PROVIDER[model];
+  if (!entry) {
+    throw new Error(
+      `Unknown VM0 model "${model}". Valid models: ${Object.keys(VM0_MODEL_TO_PROVIDER).join(", ")}`,
+    );
+  }
+  return entry.apiModel ?? model;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Switch the vm0-managed `glm-5.1` model from the `zai-api-key` provider to `openrouter-api-key`.
- Add an optional `apiModel` override on `Vm0ModelConfig` so a model's upstream identifier can differ from the display name (OpenRouter expects `z-ai/glm-5.1`, UI stays `glm-5.1`).
- Thread the override through `resolveVm0Provider` when substituting `$model` in the concrete provider's environment mapping.
- Add `z-ai/glm-5.1` to the OpenRouter `apiModels` allowlist.

## Test plan

- [x] `pnpm -F web exec vitest run src/__tests__/vm0-provider.test.ts` (10/10 passing, including two new cases covering the override and fallback)
- [x] `pnpm -F @vm0/core exec tsc --noEmit`
- [x] `pnpm -F web exec tsc --noEmit`
- [x] Lint (eslint) on changed files