### PR TITLE
feat(agent-prompt): surface zero search in agent tools prompt

### DIFF
--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -67,6 +67,7 @@ function buildAgentToolsPrompt(): string {
     "# Agent Tools",
     "You have access to the Zero CLI. Run commands with: `npx -p @vm0/cli zero <command>`",
     "- Discover available commands: `zero --help`.",
+    "- Search agent run logs, web chat messages, or external services via connectors: `zero search --help`.",
     "- Schedule recurring tasks: `zero schedule --help`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "- Slack messaging, file uploads, and file downloads: `zero slack --help`. Your replies are automatically sent to the originating thread — only use these commands for different channels/threads. Never use SLACK_TOKEN directly — it's a user OAuth token.",
     "- Download a Slack file attachment to local disk: `zero slack download-file -h` for usage and how to read different file types. Use this whenever a Slack message context includes a `[Slack file]` block.",


### PR DESCRIPTION
## Summary

Adds one line to `buildAgentToolsPrompt()` in `turbo/apps/web/src/lib/zero/agent-prompt.ts` so zero sandbox agents discover the unified `zero search` entry point.

Epic #10238 shipped a unified `zero search` CLI (PRs #10251, #10273, #10270, #10275 — all merged), but the agent tool prompt was never updated. Agents running in zero sandboxes had no way to know the command existed.

The new line is inserted immediately after `- Discover available commands: \`zero --help\`.` to position it as the default starting point for any search task. The distinct `zero connector search <keyword>` line (which searches the connector catalog) is left untouched.

## Test plan
- [x] Lint passes (`pnpm turbo run lint --filter=web`)
- [x] Type-check passes (`pnpm check-types`)
- [x] Format unchanged
- [x] Knip clean
- [x] No snapshot/prompt tests cover `buildAgentToolsPrompt()` directly; existing integration test in `app/api/zero/runs/__tests__/route.test.ts` only asserts the `# Agent Tools` header, which is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)