### PR TITLE
feat(platform): add msw handlers for voice-chat-candidate routes

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-voice-chat-candidate.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-voice-chat-candidate.ts
@@ -1,0 +1,175 @@
+/**
+ * Voice Chat Candidate API Handlers
+ *
+ * Mock handlers for /api/zero/voice-chat-candidate endpoints.
+ * Stateful: sessions, items, and tasks persist for the lifetime of a test
+ * run; call resetMockVoiceChatCandidate() between cases for isolation.
+ */
+
+import {
+  zeroVoiceChatCandidateContract,
+  type VoiceChatCandidateSession,
+  type VoiceChatCandidateItem,
+  type VoiceChatCandidateTask,
+} from "@vm0/core";
+import { mockApi } from "../msw-contract.ts";
+
+const MOCK_ORG_ID = "mock-org";
+const MOCK_USER_ID = "mock-user";
+const EPHEMERAL_TOKEN_TTL_SECONDS = 60;
+
+let mockSessions = new Map<string, VoiceChatCandidateSession>();
+let mockItems = new Map<string, VoiceChatCandidateItem[]>();
+let mockTasks = new Map<string, VoiceChatCandidateTask>();
+
+export function resetMockVoiceChatCandidate(): void {
+  mockSessions = new Map();
+  mockItems = new Map();
+  mockTasks = new Map();
+}
+
+export const apiVoiceChatCandidateHandlers = [
+  mockApi(zeroVoiceChatCandidateContract.createSession, ({ body, respond }) => {
+    const now = new Date().toISOString();
+    const session: VoiceChatCandidateSession = {
+      id: crypto.randomUUID(),
+      orgId: MOCK_ORG_ID,
+      userId: MOCK_USER_ID,
+      agentId: body.agentId,
+      mode: "chat",
+      status: "active",
+      context: null,
+      contextSeq: 0,
+      contextVersion: 0,
+      createdAt: now,
+      lastHeartbeatAt: now,
+      endedAt: null,
+    };
+    mockSessions.set(session.id, session);
+    mockItems.set(session.id, []);
+    return respond(200, { session });
+  }),
+
+  mockApi(zeroVoiceChatCandidateContract.getSession, ({ params, respond }) => {
+    const session = mockSessions.get(params.id);
+    if (!session) {
+      return respond(404, {
+        error: { code: "NOT_FOUND", message: "Session not found" },
+      });
+    }
+    return respond(200, { session });
+  }),
+
+  mockApi(zeroVoiceChatCandidateContract.endSession, ({ params, respond }) => {
+    const session = mockSessions.get(params.id);
+    if (!session) {
+      return respond(404, {
+        error: { code: "NOT_FOUND", message: "Session not found" },
+      });
+    }
+    session.status = "ended";
+    session.endedAt = new Date().toISOString();
+    return respond(200, { ok: true });
+  }),
+
+  mockApi(zeroVoiceChatCandidateContract.heartbeat, ({ params, respond }) => {
+    const session = mockSessions.get(params.id);
+    if (!session || session.status !== "active") {
+      return respond(404, {
+        error: { code: "NOT_FOUND", message: "Active session not found" },
+      });
+    }
+    session.lastHeartbeatAt = new Date().toISOString();
+    return respond(200, { ok: true });
+  }),
+
+  mockApi(
+    zeroVoiceChatCandidateContract.appendItem,
+    ({ params, body, respond }) => {
+      const sessionId = params.id;
+      const session = mockSessions.get(sessionId);
+      if (!session) {
+        return respond(404, {
+          error: { code: "NOT_FOUND", message: "Session not found" },
+        });
+      }
+      const sessionItems = mockItems.get(sessionId) ?? [];
+      const existing = sessionItems.find(
+        (i) => i.realtimeItemId === body.realtimeItemId,
+      );
+      if (existing) {
+        return respond(200, { item: existing });
+      }
+      const item: VoiceChatCandidateItem = {
+        id: crypto.randomUUID(),
+        sessionId,
+        seq: sessionItems.length + 1,
+        role: body.role,
+        content: body.content,
+        taskId: null,
+        realtimeItemId: body.realtimeItemId,
+        createdAt: new Date().toISOString(),
+      };
+      sessionItems.push(item);
+      mockItems.set(sessionId, sessionItems);
+      return respond(200, { item });
+    },
+  ),
+
+  mockApi(
+    zeroVoiceChatCandidateContract.readItems,
+    ({ params, query, respond }) => {
+      const sessionId = params.id;
+      const session = mockSessions.get(sessionId);
+      if (!session) {
+        return respond(404, {
+          error: { code: "NOT_FOUND", message: "Session not found" },
+        });
+      }
+      const sessionItems = mockItems.get(sessionId) ?? [];
+      const after = query.after;
+      const items =
+        after !== undefined
+          ? sessionItems.filter((i) => i.seq > after)
+          : sessionItems;
+      return respond(200, { items });
+    },
+  ),
+
+  mockApi(
+    zeroVoiceChatCandidateContract.createTask,
+    ({ params, body, respond }) => {
+      const sessionId = params.id;
+      const session = mockSessions.get(sessionId);
+      if (!session) {
+        return respond(404, {
+          error: { code: "NOT_FOUND", message: "Session not found" },
+        });
+      }
+      const task: VoiceChatCandidateTask = {
+        id: crypto.randomUUID(),
+        sessionId,
+        runId: null,
+        callId: body.callId,
+        prompt: body.prompt,
+        status: "pending",
+        result: null,
+        error: null,
+        createdAt: new Date().toISOString(),
+        startedAt: null,
+        finishedAt: null,
+      };
+      mockTasks.set(task.id, task);
+      return respond(200, { task });
+    },
+  ),
+
+  mockApi(zeroVoiceChatCandidateContract.token, ({ respond }) => {
+    return respond(200, {
+      client_secret: {
+        value: "mock-ephemeral-token",
+        expires_at: Math.floor(Date.now() / 1000) + EPHEMERAL_TOKEN_TTL_SECONDS,
+      },
+    });
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -79,6 +79,10 @@ import {
 } from "./api-permission-access-requests.ts";
 import { apiPermissionPoliciesHandlers } from "./api-permission-policies.ts";
 import { apiVoiceChatHandlers } from "./api-voice-chat.ts";
+import {
+  apiVoiceChatCandidateHandlers,
+  resetMockVoiceChatCandidate,
+} from "./api-voice-chat-candidate.ts";
 import { apiVoiceIoHandlers } from "./api-voice-io.ts";
 
 export const handlers = [
@@ -111,6 +115,7 @@ export const handlers = [
   ...apiInsightsHandlers,
   ...apiQueuePositionHandlers,
   ...apiVoiceChatHandlers,
+  ...apiVoiceChatCandidateHandlers,
   ...apiVoiceIoHandlers,
 ];
 
@@ -140,4 +145,5 @@ export function resetAllMockHandlers(): void {
   resetMockPhoneStatus();
   resetMockTeam();
   resetMockOnboardingStatus();
+  resetMockVoiceChatCandidate();
 }


### PR DESCRIPTION
## Summary

- Adds MSW mock handlers covering all 8 routes of `zeroVoiceChatCandidateContract` so the platform frontend (and its vitest tests) can run offline without a live web server.
- Pure test infrastructure: no runtime behavior added, no existing voice-chat files modified.
- Uses the repo's `mockApi` helper (contract-typed, compile-time response-shape checks) — matches the idiom already in `api-voice-chat.ts`.

## What's inside

### New: `turbo/apps/platform/src/mocks/handlers/api-voice-chat-candidate.ts`
- 8 handlers: `createSession`, `getSession`, `endSession`, `heartbeat`, `appendItem`, `readItems`, `createTask`, `token`.
- In-memory store: `Map<string, Session>`, `Map<string, Item[]>`, `Map<string, Task>` — typed via contract-derived types (`VoiceChatCandidateSession/Item/Task`), no `any`.
- Exports `resetMockVoiceChatCandidate()` for per-test isolation.

### Edit: `turbo/apps/platform/src/mocks/handlers/index.ts`
- Import + spread `apiVoiceChatCandidateHandlers` into `handlers`.
- Wire `resetMockVoiceChatCandidate()` into `resetAllMockHandlers()`.

## Semantics preserved from the contract

- `appendItem` dedupes on `realtimeItemId` (idempotency).
- `heartbeat` returns 404 when the session is missing **or** non-active (can't revive a dead session).
- `readItems` filters by the `after` seq query param (`mockApi` handles Zod coercion).
- `token` returns a 60-second ephemeral token structure.

## Deviations from the issue body (idiomatic corrections)

Per the issue's step 4 ("Optional: schema-validated response helper") and repo conventions:

1. Used `mockApi(contract.op, …)` instead of raw `http.post`/`HttpResponse.json` — this gives compile-time path/method/response-shape safety and matches `api-voice-chat.ts`.
2. Replaced `any` fixture types with contract-derived types (`CLAUDE.md` forbids `any`).
3. Added `resetMockVoiceChatCandidate()` and wired it into `resetAllMockHandlers()` — every other stateful handler in this tree has one (e.g., `resetMockTasks`, `resetMockConnectors`); sub-issue #8's frontend tests will need it.

Plan for these deviations was approved in the issue-plan deep-dive: https://github.com/vm0-ai/vm0/issues/10314#issuecomment-4280665001

## Verification

From `turbo/`:
- [x] `pnpm turbo run check-types --filter=@vm0/app` — green
- [x] `pnpm turbo run lint --filter=@vm0/app` — green
- [x] `pnpm format` — green
- [x] `pnpm -F @vm0/app exec vitest run` — all 1855 existing tests pass
- [x] `pnpm knip` — no issues from this change
- [x] Pre-commit hooks (lefthook) — all green

No modifications to non-candidate voice-chat files:

```
$ git diff --name-only main...HEAD
turbo/apps/platform/src/mocks/handlers/api-voice-chat-candidate.ts
turbo/apps/platform/src/mocks/handlers/index.ts
```

## Test plan

- [x] Type-check passes (contract-typed handlers reject bad response shapes at compile time)
- [x] Full platform vitest suite passes (1855 tests) — regression guard
- [x] Knip reports no dead exports (both `apiVoiceChatCandidateHandlers` and `resetMockVoiceChatCandidate` are consumed by the aggregate index)
- [ ] Downstream: sub-issue #8 (frontend tests) will validate real consumer behavior

Closes #10314
Part of epic #10297

🤖 Generated with [Claude Code](https://claude.com/claude-code)