### PR TITLE
feat(platform): add voice-chat-candidate views and signals (physically separate)

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
@@ -1,0 +1,616 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { zeroVoiceChatCandidateContract } from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { triggerAblyEvent } from "../../../mocks/ably.ts";
+import { detach, Reason } from "../../utils.ts";
+import {
+  startVoiceChatCandidate$,
+  endVoiceChatCandidate$,
+  vccStatus$,
+  vccError$,
+  vccSessionId$,
+  vccConversationItems$,
+  vccTasksById$,
+} from "../voice-chat-candidate-session.ts";
+
+const context = testContext();
+
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+const ITEM_ID = "22222222-2222-4222-8222-222222222222";
+const TASK_ID = "33333333-3333-4333-8333-333333333333";
+
+function sessionPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SESSION_ID,
+    orgId: "org_default",
+    userId: "test-user-123",
+    agentId: DEFAULT_AGENT_ID,
+    mode: "chat" as const,
+    status: "active" as const,
+    context: null,
+    contextSeq: 0,
+    contextVersion: 0,
+    createdAt: "2026-04-20T00:00:00Z",
+    lastHeartbeatAt: "2026-04-20T00:00:00Z",
+    endedAt: null,
+    ...overrides,
+  };
+}
+
+function itemPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ITEM_ID,
+    sessionId: SESSION_ID,
+    seq: 1,
+    role: "user" as const,
+    content: "hello",
+    taskId: null,
+    realtimeItemId: "realtime-1",
+    createdAt: "2026-04-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function taskPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TASK_ID,
+    sessionId: SESSION_ID,
+    runId: null,
+    callId: "call-1",
+    prompt: "do the thing",
+    status: "pending" as const,
+    result: null,
+    error: null,
+    createdAt: "2026-04-20T00:00:00Z",
+    startedAt: null,
+    finishedAt: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// WebRTC stub types
+// ---------------------------------------------------------------------------
+
+type OpenAIRealtimeEvent = { type: string; [key: string]: unknown };
+
+interface FakeDC {
+  readyState: "open" | "closed";
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  addEventListener: (event: string, cb: (ev?: unknown) => void) => void;
+  emitOpen: () => void;
+  emitMessage: (event: OpenAIRealtimeEvent) => void;
+  emitClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Mock endpoint helpers
+// ---------------------------------------------------------------------------
+
+function mockCreateSessionOk() {
+  const calls: unknown[] = [];
+  server.use(
+    mockApi(
+      zeroVoiceChatCandidateContract.createSession,
+      ({ body, respond }) => {
+        calls.push(body);
+        return respond(200, { session: sessionPayload() });
+      },
+    ),
+  );
+  return calls;
+}
+
+function mockCreateSessionError(
+  status: 400 | 401 | 403 = 400,
+  message = "nope",
+) {
+  server.use(
+    mockApi(zeroVoiceChatCandidateContract.createSession, ({ respond }) => {
+      return respond(status, {
+        error: { message, code: "BAD_REQUEST" },
+      });
+    }),
+  );
+}
+
+function mockTokenOk() {
+  server.use(
+    mockApi(zeroVoiceChatCandidateContract.token, ({ respond }) => {
+      return respond(200, {
+        client_secret: { value: "ek_test", expires_at: 9_999_999_999 },
+      });
+    }),
+  );
+}
+
+function mockTokenError() {
+  server.use(
+    mockApi(zeroVoiceChatCandidateContract.token, ({ respond }) => {
+      return respond(500, {
+        error: { message: "token failed", code: "INTERNAL_SERVER_ERROR" },
+      });
+    }),
+  );
+}
+
+function mockEndSessionOk() {
+  const calls: string[] = [];
+  server.use(
+    mockApi(
+      zeroVoiceChatCandidateContract.endSession,
+      ({ params, respond }) => {
+        calls.push(params.id);
+        return respond(200, { ok: true as const });
+      },
+    ),
+  );
+  return calls;
+}
+
+function mockHeartbeatOk() {
+  const calls: string[] = [];
+  server.use(
+    mockApi(zeroVoiceChatCandidateContract.heartbeat, ({ params, respond }) => {
+      calls.push(params.id);
+      return respond(200, { ok: true as const });
+    }),
+  );
+  return calls;
+}
+
+function mockAppendItemOk() {
+  const calls: { role: string; content: string; realtimeItemId: string }[] = [];
+  let nextSeq = 10;
+  server.use(
+    mockApi(zeroVoiceChatCandidateContract.appendItem, ({ body, respond }) => {
+      calls.push(body);
+      const seq = nextSeq++;
+      return respond(200, {
+        item: itemPayload({
+          id: `${ITEM_ID.slice(0, -2)}${seq.toString().padStart(2, "0")}`,
+          seq,
+          role: body.role,
+          content: body.content,
+          realtimeItemId: body.realtimeItemId,
+        }),
+      });
+    }),
+  );
+  return calls;
+}
+
+function mockReadItemsEmpty() {
+  server.use(
+    mockApi(zeroVoiceChatCandidateContract.readItems, ({ respond }) => {
+      return respond(200, { items: [] });
+    }),
+  );
+}
+
+function mockGetSessionOk() {
+  server.use(
+    mockApi(zeroVoiceChatCandidateContract.getSession, ({ respond }) => {
+      return respond(200, { session: sessionPayload() });
+    }),
+  );
+}
+
+function mockCreateTaskOk() {
+  const calls: { prompt: string; callId: string }[] = [];
+  server.use(
+    mockApi(zeroVoiceChatCandidateContract.createTask, ({ body, respond }) => {
+      calls.push(body);
+      return respond(200, {
+        task: taskPayload({
+          callId: body.callId,
+          prompt: body.prompt,
+        }),
+      });
+    }),
+  );
+  return calls;
+}
+
+function mockCreateTaskError() {
+  server.use(
+    mockApi(zeroVoiceChatCandidateContract.createTask, ({ respond }) => {
+      return respond(400, {
+        error: { message: "bad task", code: "BAD_REQUEST" },
+      });
+    }),
+  );
+}
+
+async function setup() {
+  await setupPage({
+    context,
+    path: "/voice-chat-candidate",
+    withoutRender: true,
+    featureSwitches: { voiceChat: true },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("voice-chat-candidate session", () => {
+  const dcRef: { current: FakeDC | null } = { current: null };
+
+  function stubWebRTC() {
+    const mediaStreamStub = {
+      getAudioTracks() {
+        return [{ enabled: true }];
+      },
+      getTracks() {
+        return [{ stop: vi.fn() }];
+      },
+    } as unknown as MediaStream;
+
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia: vi.fn().mockResolvedValue(mediaStreamStub) },
+      writable: true,
+      configurable: true,
+    });
+
+    class FakeRTCPeerConnection {
+      iceConnectionState = "new";
+      private trackListeners: ((ev: unknown) => void)[] = [];
+      private iceListeners: (() => void)[] = [];
+      addTrack = vi.fn();
+      close = vi.fn();
+      createOffer = vi.fn().mockResolvedValue({ sdp: "offer-sdp" });
+      setLocalDescription = vi.fn().mockResolvedValue(undefined);
+      setRemoteDescription = vi.fn().mockResolvedValue(undefined);
+
+      createDataChannel(): FakeDC {
+        const openListeners: (() => void)[] = [];
+        const messageListeners: ((ev: MessageEvent) => void)[] = [];
+        const closeListeners: (() => void)[] = [];
+
+        const dc: FakeDC = {
+          readyState: "open",
+          send: vi.fn(),
+          close: vi.fn(() => {
+            dc.readyState = "closed";
+            for (const l of closeListeners) {
+              l();
+            }
+          }),
+          addEventListener: (event, cb) => {
+            if (event === "open") {
+              openListeners.push(cb as () => void);
+            }
+            if (event === "message") {
+              messageListeners.push(cb as (ev: MessageEvent) => void);
+            }
+            if (event === "close") {
+              closeListeners.push(cb as () => void);
+            }
+          },
+          emitOpen: () => {
+            for (const l of openListeners) {
+              l();
+            }
+          },
+          emitMessage: (event: OpenAIRealtimeEvent) => {
+            for (const l of messageListeners) {
+              l({ data: JSON.stringify(event) } as MessageEvent);
+            }
+          },
+          emitClose: () => {
+            dc.readyState = "closed";
+            for (const l of closeListeners) {
+              l();
+            }
+          },
+        };
+
+        dcRef.current = dc;
+        return dc;
+      }
+
+      addEventListener(event: string, cb: (ev?: unknown) => void) {
+        if (event === "track") {
+          this.trackListeners.push(cb);
+        }
+        if (event === "iceconnectionstatechange") {
+          this.iceListeners.push(cb as () => void);
+        }
+      }
+    }
+
+    vi.stubGlobal("RTCPeerConnection", FakeRTCPeerConnection);
+
+    class FakeAudio {
+      autoplay = false;
+      srcObject: unknown = null;
+      pause = vi.fn();
+    }
+    vi.stubGlobal("Audio", FakeAudio);
+
+    const originalFetch = globalThis.fetch;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input).includes("api.openai.com")) {
+          return Promise.resolve(new Response("answer-sdp", { status: 200 }));
+        }
+        return originalFetch(input, init);
+      }),
+    );
+  }
+
+  function clearWebRTC() {
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    dcRef.current = null;
+    vi.unstubAllGlobals();
+  }
+
+  async function startSuccessfully() {
+    mockCreateSessionOk();
+    mockTokenOk();
+    mockReadItemsEmpty();
+    mockGetSessionOk();
+    mockHeartbeatOk();
+    detach(
+      context.store.set(startVoiceChatCandidate$, context.signal),
+      Reason.DomCallback,
+    );
+    await vi.waitFor(() => {
+      expect(dcRef.current).not.toBeNull();
+    });
+    dcRef.current?.emitOpen();
+    await vi.waitFor(() => {
+      expect(context.store.get(vccStatus$)).toBe("connected");
+    });
+  }
+
+  beforeEach(() => {
+    stubWebRTC();
+  });
+
+  afterEach(() => {
+    clearWebRTC();
+  });
+
+  describe("startVoiceChatCandidate$", () => {
+    it("transitions to connected on happy path", async () => {
+      await setup();
+      await startSuccessfully();
+
+      expect(context.store.get(vccSessionId$)).toBe(SESSION_ID);
+      expect(context.store.get(vccStatus$)).toBe("connected");
+
+      // First DC send is the session.update with instructions + tools.
+      const sent = dcRef.current?.send.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(sent) as {
+        type: string;
+        session: { tools: { name: string }[] };
+      };
+      expect(parsed.type).toBe("session.update");
+      expect(parsed.session.tools[0]?.name).toBe("create_task");
+    });
+
+    it("surfaces create-session error in vccError$", async () => {
+      await setup();
+      mockCreateSessionError(400, "forbidden");
+
+      await context.store.set(startVoiceChatCandidate$, context.signal);
+
+      expect(context.store.get(vccStatus$)).toBe("error");
+      expect(context.store.get(vccError$)).toBe("forbidden");
+    });
+
+    it("surfaces token error in vccError$", async () => {
+      await setup();
+      mockCreateSessionOk();
+      mockTokenError();
+
+      await context.store.set(startVoiceChatCandidate$, context.signal);
+
+      expect(context.store.get(vccStatus$)).toBe("error");
+      expect(context.store.get(vccError$)).toBe("token failed");
+    });
+  });
+
+  describe("item forwarding", () => {
+    it("posts user transcript on input_audio_transcription.completed", async () => {
+      await setup();
+      const appendCalls = mockAppendItemOk();
+      await startSuccessfully();
+
+      dcRef.current?.emitMessage({
+        type: "conversation.item.input_audio_transcription.completed",
+        item_id: "rt-user-1",
+        transcript: "hello world",
+      });
+
+      await vi.waitFor(() => {
+        expect(appendCalls).toHaveLength(1);
+      });
+      expect(appendCalls[0]).toStrictEqual({
+        role: "user",
+        content: "hello world",
+        realtimeItemId: "rt-user-1",
+      });
+    });
+
+    it("posts assistant transcript on response.audio_transcript.done", async () => {
+      await setup();
+      const appendCalls = mockAppendItemOk();
+      await startSuccessfully();
+
+      dcRef.current?.emitMessage({
+        type: "response.audio_transcript.done",
+        response_id: "resp-1",
+        item_id: "rt-asst-1",
+        transcript: "hi there",
+      });
+
+      await vi.waitFor(() => {
+        expect(appendCalls).toHaveLength(1);
+      });
+      expect(appendCalls[0]).toStrictEqual({
+        role: "assistant",
+        content: "hi there",
+        realtimeItemId: "rt-asst-1",
+      });
+    });
+
+    it("falls back to response_id + length when item_id is missing", async () => {
+      await setup();
+      const appendCalls = mockAppendItemOk();
+      await startSuccessfully();
+
+      dcRef.current?.emitMessage({
+        type: "response.audio_transcript.done",
+        response_id: "resp-2",
+        transcript: "fallback",
+      });
+
+      await vi.waitFor(() => {
+        expect(appendCalls).toHaveLength(1);
+      });
+      expect(appendCalls[0]?.realtimeItemId).toBe("resp-2:8");
+    });
+  });
+
+  describe("create_task tool", () => {
+    it("posts /tasks and sends function_call_output with truncated prompt", async () => {
+      await setup();
+      const taskCalls = mockCreateTaskOk();
+      await startSuccessfully();
+
+      // Clear session.update from first DC open
+      dcRef.current?.send.mockClear();
+
+      dcRef.current?.emitMessage({
+        type: "response.function_call_arguments.done",
+        call_id: "call-abc",
+        name: "create_task",
+        arguments: JSON.stringify({ prompt: "do the laundry" }),
+      });
+
+      await vi.waitFor(() => {
+        expect(taskCalls).toHaveLength(1);
+      });
+      expect(taskCalls[0]).toStrictEqual({
+        prompt: "do the laundry",
+        callId: "call-abc",
+      });
+
+      await vi.waitFor(() => {
+        expect(dcRef.current?.send.mock.calls.length).toBeGreaterThan(0);
+      });
+      const sent = dcRef.current?.send.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(sent) as {
+        type: string;
+        item: { type: string; call_id: string; output: string };
+      };
+      expect(parsed.type).toBe("conversation.item.create");
+      expect(parsed.item.type).toBe("function_call_output");
+      expect(parsed.item.call_id).toBe("call-abc");
+      expect(parsed.item.output).toContain("queued");
+
+      const tasks = context.store.get(vccTasksById$);
+      expect(Object.values(tasks)).toHaveLength(1);
+    });
+
+    it("sends error function_call_output when server rejects", async () => {
+      await setup();
+      mockCreateTaskError();
+      await startSuccessfully();
+
+      dcRef.current?.send.mockClear();
+
+      dcRef.current?.emitMessage({
+        type: "response.function_call_arguments.done",
+        call_id: "call-err",
+        name: "create_task",
+        arguments: JSON.stringify({ prompt: "oops" }),
+      });
+
+      await vi.waitFor(() => {
+        expect(dcRef.current?.send.mock.calls.length).toBeGreaterThan(0);
+      });
+      const sent = dcRef.current?.send.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(sent) as { item: { output: string } };
+      expect(parsed.item.output).toMatch(/failed/i);
+    });
+  });
+
+  describe("ably poke triggers re-fetch", () => {
+    it("upserts new items into vccConversationItems$ on ably event", async () => {
+      await setup();
+      mockCreateSessionOk();
+      mockTokenOk();
+      mockGetSessionOk();
+      mockHeartbeatOk();
+      let itemsBatch: ReturnType<typeof itemPayload>[] = [];
+      server.use(
+        mockApi(zeroVoiceChatCandidateContract.readItems, ({ respond }) => {
+          const batch = itemsBatch;
+          itemsBatch = [];
+          return respond(200, { items: batch });
+        }),
+      );
+
+      detach(
+        context.store.set(startVoiceChatCandidate$, context.signal),
+        Reason.DomCallback,
+      );
+      await vi.waitFor(() => {
+        expect(dcRef.current).not.toBeNull();
+      });
+      dcRef.current?.emitOpen();
+      await vi.waitFor(() => {
+        expect(context.store.get(vccStatus$)).toBe("connected");
+      });
+
+      itemsBatch = [
+        itemPayload({
+          id: "99999999-9999-4999-8999-999999999999",
+          seq: 5,
+          role: "assistant",
+          content: "from server",
+          realtimeItemId: "rt-srv-1",
+        }),
+      ];
+      triggerAblyEvent(`voice-chat-candidate:${SESSION_ID}`);
+
+      await vi.waitFor(() => {
+        const items = context.store.get(vccConversationItems$).filter((e) => {
+          return e.kind === "server";
+        });
+        expect(items).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("endVoiceChatCandidate$", () => {
+    it("posts /end and resets state to idle", async () => {
+      await setup();
+      const endCalls = mockEndSessionOk();
+      await startSuccessfully();
+
+      context.store.set(endVoiceChatCandidate$);
+
+      await vi.waitFor(() => {
+        expect(endCalls).toContain(SESSION_ID);
+      });
+      expect(context.store.get(vccStatus$)).toBe("idle");
+      expect(context.store.get(vccSessionId$)).toBeNull();
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
 import { zeroVoiceChatCandidateContract } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { mockApi } from "../../../mocks/msw-contract.ts";
@@ -335,14 +336,9 @@ describe("voice-chat-candidate session", () => {
     }
     vi.stubGlobal("Audio", FakeAudio);
 
-    const originalFetch = globalThis.fetch;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
-        if (String(input).includes("api.openai.com")) {
-          return Promise.resolve(new Response("answer-sdp", { status: 200 }));
-        }
-        return originalFetch(input, init);
+    server.use(
+      http.post("https://api.openai.com/v1/realtime", () => {
+        return new HttpResponse("answer-sdp", { status: 200 });
       }),
     );
   }

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-setup.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-setup.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { setupVoiceChatCandidatePage$ } from "../voice-chat-candidate-setup.ts";
+import { vccStatus$ } from "../voice-chat-candidate-session.ts";
+
+const context = testContext();
+
+async function setup() {
+  await setupPage({
+    context,
+    path: "/voice-chat-candidate",
+    withoutRender: true,
+  });
+}
+
+describe("setupVoiceChatCandidatePage$", () => {
+  it("completes without throwing and leaves status idle", async () => {
+    await setup();
+
+    await context.store.set(setupVoiceChatCandidatePage$, context.signal);
+
+    expect(context.store.get(vccStatus$)).toBe("idle");
+  });
+});

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-auto-scroll.ts
@@ -1,0 +1,6 @@
+import { createScrollSignals } from "../auto-scroll.ts";
+
+// --- Voice chat candidate scroll container ---
+
+export const { setScrollContainer$: setVoiceChatCandidateScrollContainer$ } =
+  createScrollSignals();

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -1,0 +1,962 @@
+// TODO(#10313): split large commands to comply with max-lines-per-function (128)
+// oxlint-disable max-lines-per-function
+import { command, computed, state } from "ccstate";
+import {
+  FeatureSwitchKey,
+  zeroVoiceChatCandidateContract,
+  type VoiceChatCandidateItem,
+  type VoiceChatCandidateItemRole,
+  type VoiceChatCandidateTask,
+} from "@vm0/core";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { defaultAgentId$ } from "../agent.ts";
+import { resetSignal, throwIfAbort, onDomEventFn, setLoop } from "../utils.ts";
+import { setAblyLoop$ } from "../realtime.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { accept } from "../../lib/accept.ts";
+import { logger } from "../log.ts";
+
+const L = logger("VoiceChatCandidate");
+
+type ConnectionStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "error";
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+// Hardcoded Talker model per epic #10297. No model picker in candidate v1.
+const TALKER_MODEL = "gpt-realtime-mini";
+
+const HANDS_FREE_VAD_CONFIG = {
+  type: "semantic_vad",
+  eagerness: "medium",
+} as const;
+
+const SESSION_TOOLS = [
+  {
+    type: "function",
+    name: "create_task",
+    description:
+      "Spawn a background task when the user asks for something that requires action beyond conversation.",
+    parameters: {
+      type: "object",
+      properties: {
+        prompt: {
+          type: "string",
+          description: "The task prompt to spawn.",
+        },
+      },
+      required: ["prompt"],
+    },
+  },
+] as const;
+
+const TALKER_INSTRUCTIONS_BASE = `
+You are Zero, vm0's AI workspace assistant. You are speaking with the user in real time through voice.
+
+## Tools
+
+Call create_task(prompt) when the user asks for something that requires action beyond conversation — code, data lookups, external systems like GitHub or Slack, file operations, or any task that needs tool use. Include all relevant details in the prompt.
+
+After calling create_task, acknowledge naturally:
+- "Let me look into that."
+- "I'll check on that for you."
+- "Give me a moment to work on that."
+
+Do NOT say "I can't do that." You CAN do it — it just takes a moment.
+
+## Receiving task results
+
+When you receive a message starting with [Task ...], it is the result of a task you created. Incorporate the information naturally. Use your own voice — do not read it verbatim.
+
+## Communication style
+
+- Keep responses concise and natural. You are speaking, not writing.
+- No markdown, bullet points, or code blocks.
+- Be warm and conversational.
+`.trim();
+
+function composeInstructions(context: string): string {
+  if (!context.trim()) {
+    return TALKER_INSTRUCTIONS_BASE;
+  }
+  return `${TALKER_INSTRUCTIONS_BASE}\n\n## Context\n${context}`;
+}
+
+function shortPrompt(prompt: string, max = 60): string {
+  const trimmed = prompt.trim();
+  if (trimmed.length <= max) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, max - 1)}…`;
+}
+
+function ablyTopic(sessionId: string): string {
+  return `voice-chat-candidate:${sessionId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+const internalStatus$ = state<ConnectionStatus>("idle");
+const internalSessionId$ = state<string | null>(null);
+const internalItems$ = state<VoiceChatCandidateItem[]>([]);
+const internalMaxSeq$ = state<number>(0);
+const internalTasksByCallId$ = state<Record<string, VoiceChatCandidateTask>>(
+  {},
+);
+const internalTasksById$ = state<Record<string, VoiceChatCandidateTask>>({});
+const internalContext$ = state<string>("");
+const internalContextVersion$ = state<number>(0);
+const internalStreamingAssistant$ = state<{
+  responseId: string;
+  itemId: string | null;
+  text: string;
+} | null>(null);
+const internalPendingUserItemId$ = state<string | null>(null);
+const internalMuted$ = state<boolean>(false);
+const internalError$ = state<string | null>(null);
+const internalPc$ = state<RTCPeerConnection | null>(null);
+const internalDc$ = state<RTCDataChannel | null>(null);
+const internalStream$ = state<MediaStream | null>(null);
+const internalAudioEl$ = state<HTMLAudioElement | null>(null);
+const internalWakeLock$ = state<WakeLockSentinel | null>(null);
+const internalParentSignal$ = state<AbortSignal | null>(null);
+
+const resetSessionSignal$ = resetSignal();
+
+// ---------------------------------------------------------------------------
+// Exported computed getters
+// ---------------------------------------------------------------------------
+
+export const vccStatus$ = computed((get) => {
+  return get(internalStatus$);
+});
+
+export const vccError$ = computed((get) => {
+  return get(internalError$);
+});
+
+export const vccMuted$ = computed((get) => {
+  return get(internalMuted$);
+});
+
+export const vccEnabled$ = computed(async (get) => {
+  const features = await get(featureSwitch$);
+  return features[FeatureSwitchKey.VoiceChat] ?? false;
+});
+
+export const vccAgentId$ = computed(async (get) => {
+  return await get(defaultAgentId$);
+});
+
+export const vccSessionId$ = computed((get) => {
+  return get(internalSessionId$);
+});
+
+export const vccTasksById$ = computed((get) => {
+  return get(internalTasksById$);
+});
+
+type StreamingItem = {
+  kind: "streaming";
+  key: string;
+  role: "user" | "assistant";
+  content: string;
+};
+
+type ServerItem = {
+  kind: "server";
+  key: string;
+  item: VoiceChatCandidateItem;
+};
+
+type VccConversationEntry = StreamingItem | ServerItem;
+
+/**
+ * Merged stream: finalized server items (ordered by seq) followed by any
+ * in-flight streaming text from the active Realtime turn. Server items are
+ * the source of truth; streaming text is a per-turn UX nicety.
+ */
+export const vccConversationItems$ = computed((get) => {
+  const items = get(internalItems$);
+  const streamingAssistant = get(internalStreamingAssistant$);
+  const pendingUserItemId = get(internalPendingUserItemId$);
+
+  const seenRealtimeIds = new Set(
+    items.map((i) => {
+      return i.realtimeItemId;
+    }),
+  );
+
+  const sorted = [...items].sort((a, b) => {
+    return a.seq - b.seq;
+  });
+
+  const entries: VccConversationEntry[] = sorted.map((item) => {
+    return { kind: "server", key: item.id, item };
+  });
+
+  if (pendingUserItemId && !seenRealtimeIds.has(pendingUserItemId)) {
+    entries.push({
+      kind: "streaming",
+      key: `streaming-user-${pendingUserItemId}`,
+      role: "user",
+      content: "…",
+    });
+  }
+
+  if (
+    streamingAssistant &&
+    streamingAssistant.text.trim() !== "" &&
+    !(
+      streamingAssistant.itemId &&
+      seenRealtimeIds.has(streamingAssistant.itemId)
+    )
+  ) {
+    entries.push({
+      kind: "streaming",
+      key: `streaming-assistant-${streamingAssistant.responseId}`,
+      role: "assistant",
+      content: streamingAssistant.text,
+    });
+  }
+
+  return entries;
+});
+
+// ---------------------------------------------------------------------------
+// Item store helpers
+// ---------------------------------------------------------------------------
+
+function upsertItem(
+  prev: VoiceChatCandidateItem[],
+  next: VoiceChatCandidateItem,
+): VoiceChatCandidateItem[] {
+  const existing = prev.findIndex((i) => {
+    return i.id === next.id || i.realtimeItemId === next.realtimeItemId;
+  });
+  if (existing === -1) {
+    return [...prev, next];
+  }
+  const updated = [...prev];
+  updated[existing] = next;
+  return updated;
+}
+
+// ---------------------------------------------------------------------------
+// Internal commands
+// ---------------------------------------------------------------------------
+
+const appendItem$ = command(
+  async (
+    { get, set },
+    role: VoiceChatCandidateItemRole,
+    content: string,
+    realtimeItemId: string,
+    signal: AbortSignal,
+  ) => {
+    const sid = get(internalSessionId$);
+    if (!sid) {
+      return;
+    }
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroVoiceChatCandidateContract);
+    const res = await accept(
+      client.appendItem({
+        params: { id: sid },
+        body: { role, content, realtimeItemId },
+      }),
+      [200, 400, 401, 404],
+      { toast: false },
+    );
+    signal.throwIfAborted();
+    if (res.status !== 200) {
+      L.warn("appendItem failed", { status: res.status, sid });
+      return;
+    }
+    const item = res.body.item;
+    set(internalItems$, (prev) => {
+      return upsertItem(prev, item);
+    });
+    set(internalMaxSeq$, (prev) => {
+      return Math.max(prev, item.seq);
+    });
+  },
+);
+
+const handleCreateTask$ = command(
+  async (
+    { get, set },
+    callId: string,
+    argsJson: string,
+    signal: AbortSignal,
+  ) => {
+    const sid = get(internalSessionId$);
+    const dc = get(internalDc$);
+    if (!sid || !dc || dc.readyState !== "open") {
+      return;
+    }
+
+    let parsed: { prompt?: unknown };
+    // eslint-disable-next-line no-restricted-syntax -- JSON.parse can throw on malformed Realtime function args; we recover with an error output so Talker doesn't hang on the pending call
+    try {
+      parsed = JSON.parse(argsJson) as { prompt?: unknown };
+    } catch (error) {
+      throwIfAbort(error);
+      L.warn("Failed to parse create_task args", { callId, argsJson });
+      sendFunctionOutput(dc, callId, "Task creation failed: invalid args.");
+      return;
+    }
+
+    const prompt = typeof parsed.prompt === "string" ? parsed.prompt : "";
+    if (!prompt.trim()) {
+      sendFunctionOutput(dc, callId, "Task creation failed: empty prompt.");
+      return;
+    }
+
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroVoiceChatCandidateContract);
+    const res = await accept(
+      client.createTask({
+        params: { id: sid },
+        body: { prompt, callId },
+      }),
+      [200, 400, 401, 404],
+      { toast: false },
+    );
+    signal.throwIfAborted();
+
+    if (res.status !== 200) {
+      L.warn("createTask failed", { status: res.status, sid });
+      sendFunctionOutput(
+        dc,
+        callId,
+        "Task creation failed. Please try again or rephrase.",
+      );
+      return;
+    }
+
+    const task = res.body.task;
+    set(internalTasksByCallId$, (prev) => {
+      return { ...prev, [task.callId]: task };
+    });
+    set(internalTasksById$, (prev) => {
+      return { ...prev, [task.id]: task };
+    });
+    sendFunctionOutput(
+      dc,
+      callId,
+      `Task '${shortPrompt(prompt)}' queued. I'll report back when it's ready.`,
+    );
+  },
+);
+
+function sendFunctionOutput(
+  dc: RTCDataChannel,
+  callId: string,
+  output: string,
+): void {
+  // Epic decision: no `response.create` — the next user turn absorbs the
+  // function_call_output. This keeps Talker quiet while a task runs.
+  dc.send(
+    JSON.stringify({
+      type: "conversation.item.create",
+      item: {
+        type: "function_call_output",
+        call_id: callId,
+        output,
+      },
+    }),
+  );
+}
+
+type RealtimeDCEvent = {
+  type: string;
+  item_id?: string;
+  item?: { id: string; type: string; role?: string };
+  transcript?: string;
+  response_id?: string;
+  delta?: string;
+  call_id?: string;
+  name?: string;
+  arguments?: string;
+};
+
+const handleConversationItemCreated$ = command(
+  ({ get, set }, event: RealtimeDCEvent) => {
+    if (event.item?.role === "user" && event.item.type === "message") {
+      set(internalPendingUserItemId$, event.item.id);
+      return;
+    }
+    if (
+      event.item?.role === "assistant" &&
+      event.item.type === "message" &&
+      event.response_id
+    ) {
+      const streaming = get(internalStreamingAssistant$);
+      if (streaming && streaming.responseId === event.response_id) {
+        set(internalStreamingAssistant$, {
+          ...streaming,
+          itemId: event.item.id,
+        });
+      }
+    }
+  },
+);
+
+const handleAudioTranscriptDelta$ = command(
+  ({ get, set }, event: RealtimeDCEvent) => {
+    const deltaText = event.delta ?? "";
+    const responseId = event.response_id ?? "";
+    if (!responseId) {
+      return;
+    }
+    const current = get(internalStreamingAssistant$);
+    if (current && current.responseId === responseId) {
+      set(internalStreamingAssistant$, {
+        ...current,
+        text: current.text + deltaText,
+      });
+    } else {
+      set(internalStreamingAssistant$, {
+        responseId,
+        itemId: event.item_id ?? null,
+        text: deltaText,
+      });
+    }
+  },
+);
+
+const handleAudioTranscriptDone$ = command(
+  async ({ get, set }, event: RealtimeDCEvent, signal: AbortSignal) => {
+    const current = get(internalStreamingAssistant$);
+    const finalText = event.transcript ?? current?.text ?? "";
+    const responseId = event.response_id ?? current?.responseId ?? "";
+    const itemId =
+      event.item_id ??
+      current?.itemId ??
+      (responseId ? `${responseId}:${finalText.length.toString()}` : null);
+    set(internalStreamingAssistant$, null);
+    if (finalText.trim() && itemId) {
+      await set(appendItem$, "assistant", finalText, itemId, signal);
+    }
+  },
+);
+
+const handleInputAudioTranscriptionCompleted$ = command(
+  async ({ set }, event: RealtimeDCEvent, signal: AbortSignal) => {
+    if (event.transcript && event.item_id) {
+      set(internalPendingUserItemId$, null);
+      await set(appendItem$, "user", event.transcript, event.item_id, signal);
+    }
+  },
+);
+
+const handleDCMessage$ = command(
+  async ({ set }, data: string, signal: AbortSignal) => {
+    const event = JSON.parse(data) as RealtimeDCEvent;
+
+    switch (event.type) {
+      case "conversation.item.created": {
+        set(handleConversationItemCreated$, event);
+        break;
+      }
+      case "conversation.item.input_audio_transcription.completed": {
+        await set(handleInputAudioTranscriptionCompleted$, event, signal);
+        break;
+      }
+      case "response.audio_transcript.delta": {
+        set(handleAudioTranscriptDelta$, event);
+        break;
+      }
+      case "response.audio_transcript.done": {
+        await set(handleAudioTranscriptDone$, event, signal);
+        break;
+      }
+      case "response.function_call_arguments.done": {
+        if (event.call_id && event.name === "create_task" && event.arguments) {
+          await set(handleCreateTask$, event.call_id, event.arguments, signal);
+        }
+        break;
+      }
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// WebRTC setup
+// ---------------------------------------------------------------------------
+
+const setupWebRTC$ = command(
+  async (
+    { get, set },
+    stream: MediaStream,
+    token: string,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const pc = new RTCPeerConnection();
+    set(internalPc$, pc);
+
+    for (const track of stream.getAudioTracks()) {
+      pc.addTrack(track, stream);
+    }
+
+    const audioEl = new Audio();
+    audioEl.autoplay = true;
+    set(internalAudioEl$, audioEl);
+
+    pc.addEventListener("track", (e) => {
+      if (e.streams[0]) {
+        audioEl.srcObject = e.streams[0];
+      }
+    });
+
+    const dc = pc.createDataChannel("oai-events");
+    set(internalDc$, dc);
+
+    dc.addEventListener("open", () => {
+      const context = get(internalContext$);
+      dc.send(
+        JSON.stringify({
+          type: "session.update",
+          session: {
+            modalities: ["text", "audio"],
+            instructions: composeInstructions(context),
+            input_audio_transcription: { model: "gpt-4o-mini-transcribe" },
+            input_audio_noise_reduction: { type: "far_field" },
+            turn_detection: HANDS_FREE_VAD_CONFIG,
+            tools: SESSION_TOOLS,
+          },
+        }),
+      );
+      set(internalStatus$, "connected");
+    });
+
+    dc.addEventListener(
+      "message",
+      onDomEventFn((ev: MessageEvent) => {
+        return set(handleDCMessage$, ev.data as string, signal);
+      }),
+    );
+
+    dc.addEventListener("close", () => {
+      if (get(internalStatus$) === "connected") {
+        set(internalStatus$, "disconnected");
+      }
+    });
+
+    pc.addEventListener("iceconnectionstatechange", () => {
+      if (
+        pc.iceConnectionState === "failed" ||
+        pc.iceConnectionState === "disconnected"
+      ) {
+        if (get(internalStatus$) === "connected") {
+          set(internalStatus$, "disconnected");
+        }
+      }
+    });
+
+    const offer = await pc.createOffer();
+    signal.throwIfAborted();
+    await pc.setLocalDescription(offer);
+    signal.throwIfAborted();
+
+    const sdpRes = await globalThis.fetch(
+      `https://api.openai.com/v1/realtime?model=${TALKER_MODEL}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/sdp",
+        },
+        body: offer.sdp,
+      },
+    );
+    signal.throwIfAborted();
+
+    if (!sdpRes.ok) {
+      set(internalError$, "Failed to connect to OpenAI Realtime API");
+      set(internalStatus$, "error");
+      return false;
+    }
+
+    const answerSdp = await sdpRes.text();
+    signal.throwIfAborted();
+    await pc.setRemoteDescription({ type: "answer", sdp: answerSdp });
+    signal.throwIfAborted();
+    return true;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Heartbeat + Ably loops
+// ---------------------------------------------------------------------------
+
+const startHeartbeat$ = command(async ({ get }, signal: AbortSignal) => {
+  await setLoop(
+    async () => {
+      const sid = get(internalSessionId$);
+      if (!sid) {
+        return true;
+      }
+      const createClient = get(zeroClient$);
+      const client = createClient(zeroVoiceChatCandidateContract);
+      await accept(
+        client.heartbeat({ params: { id: sid }, body: {} }),
+        [200, 401, 404],
+        { toast: false },
+      );
+      return false;
+    },
+    HEARTBEAT_INTERVAL_MS,
+    signal,
+  );
+});
+
+const refreshInstructionsIfChanged$ = command(({ get }, context: string) => {
+  const dc = get(internalDc$);
+  if (!dc || dc.readyState !== "open") {
+    return;
+  }
+  dc.send(
+    JSON.stringify({
+      type: "session.update",
+      session: { instructions: composeInstructions(context) },
+    }),
+  );
+});
+
+const startAblyLoop$ = command(
+  async ({ set }, sessionId: string, signal: AbortSignal) => {
+    const pollBody$ = command(async ({ get, set }, loopSignal: AbortSignal) => {
+      const sid = get(internalSessionId$);
+      if (!sid) {
+        return true;
+      }
+      const createClient = get(zeroClient$);
+      const client = createClient(zeroVoiceChatCandidateContract);
+
+      const maxSeq = get(internalMaxSeq$);
+      const itemsRes = await accept(
+        client.readItems({
+          params: { id: sid },
+          query: { after: maxSeq },
+        }),
+        [200, 401, 404],
+        { toast: false },
+      );
+      loopSignal.throwIfAborted();
+
+      if (itemsRes.status === 200 && itemsRes.body.items.length > 0) {
+        const newItems = itemsRes.body.items;
+        set(internalItems$, (prev) => {
+          let next = prev;
+          for (const item of newItems) {
+            next = upsertItem(next, item);
+          }
+          return next;
+        });
+        const lastSeq = newItems.reduce((acc, item) => {
+          return Math.max(acc, item.seq);
+        }, maxSeq);
+        set(internalMaxSeq$, lastSeq);
+      }
+
+      const sessionRes = await accept(
+        client.getSession({ params: { id: sid } }),
+        [200, 401, 404],
+        { toast: false },
+      );
+      loopSignal.throwIfAborted();
+
+      if (sessionRes.status === 200) {
+        const session = sessionRes.body.session;
+        const prevVersion = get(internalContextVersion$);
+        const nextContext = session.context ?? "";
+        if (session.contextVersion > prevVersion) {
+          set(internalContext$, nextContext);
+          set(internalContextVersion$, session.contextVersion);
+          set(refreshInstructionsIfChanged$, nextContext);
+        }
+        if (session.status !== "active") {
+          set(internalStatus$, "disconnected");
+          return true;
+        }
+      }
+      return false;
+    });
+
+    await set(setAblyLoop$, ablyTopic(sessionId), pollBody$, signal);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Wake lock (parity with non-candidate voice-chat UX)
+// ---------------------------------------------------------------------------
+
+const MAX_WAKE_LOCK_REACQUIRE_ATTEMPTS = 3;
+
+const acquireWakeLock$ = command(async ({ set }, signal: AbortSignal) => {
+  if (!("wakeLock" in navigator)) {
+    return;
+  }
+
+  let pending = false;
+  let reacquireCount = 0;
+
+  const requestAndTrack = async (): Promise<void> => {
+    if (pending) {
+      return;
+    }
+    if (document.visibilityState !== "visible") {
+      return;
+    }
+    pending = true;
+    let lock: WakeLockSentinel | undefined;
+    // eslint-disable-next-line no-restricted-syntax -- wakeLock.request rejects if the document is hidden; treat as non-critical
+    try {
+      lock = await navigator.wakeLock.request("screen");
+    } catch {
+      pending = false;
+      return;
+    }
+    pending = false;
+    if (signal.aborted) {
+      lock.release().catch(() => {
+        return undefined;
+      });
+      return;
+    }
+    set(internalWakeLock$, lock);
+    lock.addEventListener("release", () => {
+      if (
+        !signal.aborted &&
+        reacquireCount < MAX_WAKE_LOCK_REACQUIRE_ATTEMPTS
+      ) {
+        reacquireCount++;
+        requestAndTrack().catch(() => {
+          return undefined;
+        });
+      }
+    });
+  };
+
+  signal.throwIfAborted();
+
+  const onVisibilityChange = (): void => {
+    if (document.visibilityState === "visible" && !signal.aborted) {
+      reacquireCount = 0;
+      requestAndTrack().catch(() => {
+        return undefined;
+      });
+    }
+  };
+  document.addEventListener("visibilitychange", onVisibilityChange);
+  signal.addEventListener("abort", () => {
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+  });
+
+  await requestAndTrack();
+});
+
+const releaseWakeLock$ = command(({ get, set }) => {
+  const lock = get(internalWakeLock$);
+  if (lock) {
+    lock.release().catch(() => {
+      return undefined;
+    });
+    set(internalWakeLock$, null);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Public commands
+// ---------------------------------------------------------------------------
+
+export const startVoiceChatCandidate$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const status = get(internalStatus$);
+    if (status === "connecting" || status === "connected") {
+      return;
+    }
+
+    set(internalStatus$, "connecting");
+    set(internalError$, null);
+    set(internalItems$, []);
+    set(internalMaxSeq$, 0);
+    set(internalTasksByCallId$, {});
+    set(internalTasksById$, {});
+    set(internalContext$, "");
+    set(internalContextVersion$, 0);
+    set(internalStreamingAssistant$, null);
+    set(internalPendingUserItemId$, null);
+    set(internalMuted$, false);
+    set(internalSessionId$, null);
+    set(internalParentSignal$, signal);
+
+    const sessionSignal = set(resetSessionSignal$, signal);
+
+    const agentId = await get(defaultAgentId$);
+    signal.throwIfAborted();
+
+    if (!agentId) {
+      set(internalError$, "No agent selected");
+      set(internalStatus$, "error");
+      return;
+    }
+
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroVoiceChatCandidateContract);
+
+    const sessionRes = await accept(
+      client.createSession({ body: { agentId } }),
+      [200, 400, 401, 403],
+      { toast: false },
+    );
+    signal.throwIfAborted();
+
+    if (sessionRes.status !== 200) {
+      set(internalError$, sessionRes.body.error.message);
+      set(internalStatus$, "error");
+      return;
+    }
+
+    const session = sessionRes.body.session;
+    set(internalSessionId$, session.id);
+    set(internalContext$, session.context ?? "");
+    set(internalContextVersion$, session.contextVersion);
+
+    const tokenRes = await accept(
+      client.token({ body: { model: TALKER_MODEL } }),
+      [200, 401, 403, 500, 503],
+      { toast: false },
+    );
+    signal.throwIfAborted();
+
+    if (tokenRes.status !== 200) {
+      set(internalError$, tokenRes.body.error.message);
+      set(internalStatus$, "error");
+      return;
+    }
+
+    const { client_secret: clientSecret } = tokenRes.body;
+
+    let stream: MediaStream;
+    // eslint-disable-next-line no-restricted-syntax -- getUserMedia can reject on permission denial or missing hardware
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+    } catch (error) {
+      throwIfAbort(error);
+      set(
+        internalError$,
+        "Microphone access denied. Please allow microphone access.",
+      );
+      set(internalStatus$, "error");
+      return;
+    }
+    signal.throwIfAborted();
+    set(internalStream$, stream);
+
+    const ok = await set(
+      setupWebRTC$,
+      stream,
+      clientSecret.value,
+      sessionSignal,
+    );
+    signal.throwIfAborted();
+    if (!ok) {
+      return;
+    }
+
+    await set(acquireWakeLock$, sessionSignal);
+    signal.throwIfAborted();
+
+    await Promise.allSettled([
+      set(startHeartbeat$, sessionSignal),
+      set(startAblyLoop$, session.id, sessionSignal),
+    ]);
+  },
+);
+
+export const endVoiceChatCandidate$ = command(({ get, set }) => {
+  const sid = get(internalSessionId$);
+
+  if (sid) {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroVoiceChatCandidateContract);
+    accept(
+      client.endSession({ params: { id: sid }, body: {} }),
+      [200, 401, 404],
+      { toast: false },
+    ).catch(() => {
+      return undefined;
+    });
+  }
+
+  set(resetSessionSignal$);
+  set(releaseWakeLock$);
+
+  const dc = get(internalDc$);
+  if (dc) {
+    dc.close();
+    set(internalDc$, null);
+  }
+
+  const pc = get(internalPc$);
+  if (pc) {
+    pc.close();
+    set(internalPc$, null);
+  }
+
+  const stream = get(internalStream$);
+  if (stream) {
+    for (const track of stream.getTracks()) {
+      track.stop();
+    }
+    set(internalStream$, null);
+  }
+
+  const audioEl = get(internalAudioEl$);
+  if (audioEl) {
+    audioEl.pause();
+    audioEl.srcObject = null;
+    set(internalAudioEl$, null);
+  }
+
+  set(internalSessionId$, null);
+  set(internalItems$, []);
+  set(internalMaxSeq$, 0);
+  set(internalTasksByCallId$, {});
+  set(internalTasksById$, {});
+  set(internalContext$, "");
+  set(internalContextVersion$, 0);
+  set(internalStreamingAssistant$, null);
+  set(internalPendingUserItemId$, null);
+  set(internalParentSignal$, null);
+  set(internalStatus$, "idle");
+});
+
+export const toggleVoiceChatCandidateMute$ = command(({ get, set }) => {
+  const stream = get(internalStream$);
+  if (!stream) {
+    return;
+  }
+  const track = stream.getAudioTracks()[0];
+  if (!track) {
+    return;
+  }
+  const wasMuted = get(internalMuted$);
+  track.enabled = wasMuted;
+  set(internalMuted$, !wasMuted);
+});

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -1,4 +1,4 @@
-// TODO(#10313): split large commands to comply with max-lines-per-function (128)
+// TODO(#10334): split large commands to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import { command, computed, state } from "ccstate";
 import {
@@ -29,6 +29,10 @@ const HEARTBEAT_INTERVAL_MS = 30_000;
 
 // Hardcoded Talker model per epic #10297. No model picker in candidate v1.
 const TALKER_MODEL = "gpt-realtime-mini";
+
+// Hardcoded per epic #10297 parity with voice-chat-session.ts. Follow-up tracked
+// in a separate issue to route through env() alongside the sibling implementation.
+const OPENAI_REALTIME_BASE_URL = "https://api.openai.com/v1/realtime";
 
 const HANDS_FREE_VAD_CONFIG = {
   type: "semantic_vad",
@@ -567,7 +571,7 @@ const setupWebRTC$ = command(
     signal.throwIfAborted();
 
     const sdpRes = await globalThis.fetch(
-      `https://api.openai.com/v1/realtime?model=${TALKER_MODEL}`,
+      `${OPENAI_REALTIME_BASE_URL}?model=${TALKER_MODEL}`,
       {
         method: "POST",
         headers: {

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-setup.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-setup.ts
@@ -1,0 +1,35 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { SidebarLayout } from "../../views/zero-page/sidebar-layout.tsx";
+import { VoiceChatCandidatePage } from "../../views/voice-chat-candidate/voice-chat-candidate-page.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import {
+  endVoiceChatCandidate$,
+  vccStatus$,
+} from "./voice-chat-candidate-session.ts";
+
+export const setupVoiceChatCandidatePage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(
+      updatePage$,
+      createElement(SidebarLayout, null, createElement(VoiceChatCandidatePage)),
+    );
+    set(updateDocumentTitle$, "Voice Chat (Candidate)");
+
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+
+    await set(hideAppSkeleton$, signal);
+
+    signal.addEventListener("abort", () => {
+      const status = get(vccStatus$);
+      if (status === "connecting" || status === "connected") {
+        set(endVoiceChatCandidate$);
+      }
+    });
+  },
+);

--- a/turbo/apps/platform/src/views/voice-chat-candidate/__tests__/voice-chat-candidate-page.test.tsx
+++ b/turbo/apps/platform/src/views/voice-chat-candidate/__tests__/voice-chat-candidate-page.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createStore } from "ccstate";
+import { StoreProvider } from "ccstate-react";
+import type { ReactElement } from "react";
+import {
+  VoiceCandidateItemBubble,
+  VoiceCandidateTaskResultBubble,
+  VoiceCandidateSystemNoteBubble,
+  VoiceCandidateUserBubble,
+  VoiceCandidateAssistantBubble,
+} from "../voice-chat-candidate-bubbles.tsx";
+
+function renderWithStore(element: ReactElement) {
+  const store = createStore();
+  return render(<StoreProvider value={store}>{element}</StoreProvider>);
+}
+
+// Note: full page rendering (feature-gate, start button, connected-state UI)
+// depends on the /voice-chat-candidate route being registered — that's the
+// responsibility of sibling issue #10315. Page-level render tests will ship
+// alongside the route wiring in that PR.
+
+describe("voice-candidate-item-bubble dispatcher", () => {
+  const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+
+  function item(
+    overrides: Partial<{
+      id: string;
+      role: "user" | "assistant" | "task_result" | "system_note";
+      content: string | null;
+      taskId: string | null;
+      realtimeItemId: string | null;
+      seq: number;
+    }>,
+  ) {
+    return {
+      id: "00000000-0000-4000-8000-000000000001",
+      sessionId: SESSION_ID,
+      seq: 1,
+      role: "user" as const,
+      content: "",
+      taskId: null,
+      realtimeItemId: null,
+      createdAt: "2026-04-20T00:00:00Z",
+      ...overrides,
+    };
+  }
+
+  it("renders user role via user bubble", () => {
+    renderWithStore(
+      <VoiceCandidateItemBubble
+        item={item({ role: "user", content: "hello" })}
+        taskById={{}}
+      />,
+    );
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("renders assistant role via assistant bubble", () => {
+    renderWithStore(
+      <VoiceCandidateItemBubble
+        item={item({ role: "assistant", content: "hi there" })}
+        taskById={{}}
+      />,
+    );
+    expect(screen.getByText("hi there")).toBeInTheDocument();
+  });
+
+  it("renders task_result role with task prompt from taskById", () => {
+    const taskId = "33333333-3333-4333-8333-333333333333";
+    const task = {
+      id: taskId,
+      sessionId: SESSION_ID,
+      runId: null,
+      callId: "call-1",
+      prompt: "do the thing",
+      status: "done" as const,
+      result: "done!",
+      error: null,
+      createdAt: "2026-04-20T00:00:00Z",
+      startedAt: null,
+      finishedAt: null,
+    };
+    renderWithStore(
+      <VoiceCandidateItemBubble
+        item={item({
+          role: "task_result",
+          content: "done!",
+          taskId,
+        })}
+        taskById={{ [taskId]: task }}
+      />,
+    );
+    expect(screen.getByText(/task result/i)).toBeInTheDocument();
+    expect(screen.getByText("do the thing")).toBeInTheDocument();
+    expect(screen.getByText("done!")).toBeInTheDocument();
+  });
+
+  it("renders system_note role via system-note bubble", () => {
+    renderWithStore(
+      <VoiceCandidateItemBubble
+        item={item({ role: "system_note", content: "connection restored" })}
+        taskById={{}}
+      />,
+    );
+    expect(screen.getByText("connection restored")).toBeInTheDocument();
+  });
+});
+
+describe("bubble components (direct)", () => {
+  it("user bubble returns null for whitespace-only content", () => {
+    const { container } = renderWithStore(
+      <VoiceCandidateUserBubble content="   " />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("assistant bubble returns null for empty content", () => {
+    const { container } = renderWithStore(
+      <VoiceCandidateAssistantBubble content="" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("task-result bubble shows error when error is present", () => {
+    renderWithStore(
+      <VoiceCandidateTaskResultBubble
+        prompt="a prompt"
+        result={null}
+        error="it broke"
+      />,
+    );
+    expect(screen.getByText("it broke")).toBeInTheDocument();
+  });
+
+  it("system-note bubble shows the note content", () => {
+    renderWithStore(<VoiceCandidateSystemNoteBubble content="heads up" />);
+    expect(screen.getByText("heads up")).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/voice-chat-candidate/voice-chat-candidate-bubbles.tsx
+++ b/turbo/apps/platform/src/views/voice-chat-candidate/voice-chat-candidate-bubbles.tsx
@@ -1,0 +1,121 @@
+import { IconInfoCircle, IconSparkles } from "@tabler/icons-react";
+import type { VoiceChatCandidateItem, VoiceChatCandidateTask } from "@vm0/core";
+import { Markdown } from "../components/markdown.tsx";
+
+// ---------------------------------------------------------------------------
+// Bubble components — one per VoiceChatCandidateItem role
+// ---------------------------------------------------------------------------
+
+export function VoiceCandidateUserBubble({ content }: { content: string }) {
+  if (!content.trim()) {
+    return null;
+  }
+  return (
+    <div className="flex justify-end">
+      <div className="zero-chat-bubble-user rounded-xl max-w-[85%] px-4 py-3 text-sm leading-relaxed break-words overflow-hidden">
+        <Markdown source={content} />
+      </div>
+    </div>
+  );
+}
+
+export function VoiceCandidateAssistantBubble({
+  content,
+}: {
+  content: string;
+}) {
+  if (!content.trim()) {
+    return null;
+  }
+  return (
+    <div className="flex justify-start">
+      <div className="zero-chat-bubble-assistant rounded-xl max-w-[85%] px-4 py-3 text-sm leading-relaxed break-words overflow-hidden">
+        <Markdown source={content} />
+      </div>
+    </div>
+  );
+}
+
+export function VoiceCandidateTaskResultBubble({
+  prompt,
+  result,
+  error,
+}: {
+  prompt: string | null;
+  result: string | null;
+  error: string | null;
+}) {
+  return (
+    <div className="flex justify-start">
+      <div className="rounded-xl max-w-[85%] bg-muted/60 border border-border px-4 py-3 text-sm leading-relaxed">
+        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground mb-1">
+          <IconSparkles size={14} />
+          Task result
+        </div>
+        {prompt && (
+          <p className="text-xs text-muted-foreground mb-2 break-words">
+            {prompt}
+          </p>
+        )}
+        {error ? (
+          <div className="text-destructive break-words">{error}</div>
+        ) : (
+          result && (
+            <div className="break-words">
+              <Markdown source={result} />
+            </div>
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function VoiceCandidateSystemNoteBubble({
+  content,
+}: {
+  content: string;
+}) {
+  return (
+    <div className="flex justify-center">
+      <div className="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs italic text-muted-foreground">
+        <IconInfoCircle size={12} />
+        <span className="break-words">{content}</span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+export function VoiceCandidateItemBubble({
+  item,
+  taskById,
+}: {
+  item: VoiceChatCandidateItem;
+  taskById: Record<string, VoiceChatCandidateTask>;
+}) {
+  switch (item.role) {
+    case "user": {
+      return <VoiceCandidateUserBubble content={item.content ?? ""} />;
+    }
+    case "assistant": {
+      return <VoiceCandidateAssistantBubble content={item.content ?? ""} />;
+    }
+    case "task_result": {
+      const task = item.taskId ? taskById[item.taskId] : undefined;
+      return (
+        <VoiceCandidateTaskResultBubble
+          prompt={task?.prompt ?? null}
+          result={item.content ?? task?.result ?? null}
+          error={task?.error ?? null}
+        />
+      );
+    }
+    case "system_note": {
+      return <VoiceCandidateSystemNoteBubble content={item.content ?? ""} />;
+    }
+  }
+}

--- a/turbo/apps/platform/src/views/voice-chat-candidate/voice-chat-candidate-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat-candidate/voice-chat-candidate-page.tsx
@@ -1,0 +1,240 @@
+import { useGet, useLastResolved, useSet } from "ccstate-react";
+import { Button, cn } from "@vm0/ui";
+import {
+  IconMicrophone,
+  IconMicrophoneOff,
+  IconPhoneOff,
+  IconLoader2,
+} from "@tabler/icons-react";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import {
+  vccStatus$,
+  vccMuted$,
+  vccError$,
+  vccEnabled$,
+  vccAgentId$,
+  vccTasksById$,
+  vccConversationItems$,
+  startVoiceChatCandidate$,
+  endVoiceChatCandidate$,
+  toggleVoiceChatCandidateMute$,
+} from "../../signals/voice-chat-candidate/voice-chat-candidate-session.ts";
+import { setVoiceChatCandidateScrollContainer$ } from "../../signals/voice-chat-candidate/voice-chat-candidate-auto-scroll.ts";
+import {
+  VoiceCandidateAssistantBubble,
+  VoiceCandidateItemBubble,
+  VoiceCandidateUserBubble,
+} from "./voice-chat-candidate-bubbles.tsx";
+
+type ConnectionStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "error";
+
+function StatusBadge({ status }: { status: ConnectionStatus }) {
+  const label: Record<ConnectionStatus, string> = {
+    idle: "Ready",
+    connecting: "Connecting...",
+    connected: "Connected",
+    disconnected: "Disconnected",
+    error: "Error",
+  };
+  const color: Record<ConnectionStatus, string> = {
+    idle: "bg-muted text-muted-foreground",
+    connecting:
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    connected:
+      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    disconnected: "bg-muted text-muted-foreground",
+    error: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+  };
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium",
+        color[status],
+      )}
+    >
+      {status === "connecting" && (
+        <IconLoader2 size={12} className="animate-spin" />
+      )}
+      {status === "connected" && (
+        <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+      )}
+      {label[status]}
+    </span>
+  );
+}
+
+function VoiceChatCandidateHeader({ status }: { status: ConnectionStatus }) {
+  return (
+    <div className="shrink-0 border-b px-4 py-2 hidden md:flex items-center gap-2">
+      <span className="text-sm font-medium text-foreground">
+        Voice Chat (Candidate)
+      </span>
+      <StatusBadge status={status} />
+    </div>
+  );
+}
+
+function VoiceChatCandidateFooter({
+  status,
+  muted,
+  toggleMute,
+  onEnd,
+}: {
+  status: ConnectionStatus;
+  muted: boolean;
+  toggleMute: () => void;
+  onEnd: () => void;
+}) {
+  return (
+    <div className="shrink-0 border-t">
+      <div className="px-4 pt-3 pb-3 flex items-center justify-center gap-3">
+        <Button
+          variant={muted ? "destructive" : "secondary"}
+          className="h-10 rounded-full px-5"
+          disabled={status !== "connected"}
+          onClick={toggleMute}
+        >
+          {muted ? (
+            <IconMicrophoneOff size={18} className="mr-2" />
+          ) : (
+            <IconMicrophone size={18} className="mr-2" />
+          )}
+          {muted ? "Unmute" : "Mute"}
+        </Button>
+        <Button
+          variant="destructive"
+          size="sm"
+          className="h-10 rounded-full px-5"
+          onClick={onEnd}
+        >
+          <IconPhoneOff size={18} className="mr-2" />
+          End Session
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function VoiceChatCandidatePage() {
+  const pageSignal = useGet(pageSignal$);
+  const enabled = useLastResolved(vccEnabled$);
+  const agentId = useLastResolved(vccAgentId$);
+  const status = useGet(vccStatus$);
+  const muted = useGet(vccMuted$);
+  const error = useGet(vccError$);
+  const tasksById = useGet(vccTasksById$);
+  const conversationItems = useGet(vccConversationItems$);
+  const startSession = useSet(startVoiceChatCandidate$);
+  const endSession = useSet(endVoiceChatCandidate$);
+  const toggleMute = useSet(toggleVoiceChatCandidateMute$);
+  const setScrollContainer = useSet(setVoiceChatCandidateScrollContainer$);
+
+  if (enabled === false) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center min-h-0 gap-4 p-8">
+        <h1 className="text-2xl font-bold">Voice Chat (Candidate)</h1>
+        <p className="text-muted-foreground">
+          Voice chat is not available for your account.
+        </p>
+      </div>
+    );
+  }
+
+  if (status === "idle") {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center min-h-0 gap-6 p-8">
+        <h1 className="text-2xl font-bold">Voice Chat (Candidate)</h1>
+        {error && (
+          <p className="text-sm text-destructive max-w-md text-center">
+            {error}
+          </p>
+        )}
+        {!agentId && (
+          <p className="text-xs text-muted-foreground">
+            No agent selected. Please select an agent first.
+          </p>
+        )}
+        <div className="w-full max-w-md rounded-lg border border-input p-5 flex flex-col gap-3">
+          <h2 className="text-lg font-semibold">Quick Chat</h2>
+          <p className="text-sm text-muted-foreground">
+            Jump into a voice conversation with the AI agent.
+          </p>
+          <Button
+            size="lg"
+            className="w-full"
+            onClick={() => {
+              detach(startSession(pageSignal), Reason.DomCallback);
+            }}
+            disabled={!agentId}
+          >
+            <IconMicrophone size={18} className="mr-2" />
+            Start Voice Chat
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      <VoiceChatCandidateHeader status={status} />
+
+      {error && (
+        <div className="shrink-0 bg-destructive/10 text-destructive px-4 py-2 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div ref={setScrollContainer} className="flex-1 min-h-0 overflow-y-auto">
+        <div className="mx-auto w-full max-w-[900px] px-4 pt-4 pb-8">
+          <div className="flex flex-col gap-4">
+            {conversationItems.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-8">
+                {status === "connecting"
+                  ? "Connecting..."
+                  : "Speak to start the conversation."}
+              </p>
+            )}
+            {conversationItems.map((entry) => {
+              if (entry.kind === "streaming") {
+                return entry.role === "user" ? (
+                  <VoiceCandidateUserBubble
+                    key={entry.key}
+                    content={entry.content}
+                  />
+                ) : (
+                  <VoiceCandidateAssistantBubble
+                    key={entry.key}
+                    content={entry.content}
+                  />
+                );
+              }
+              return (
+                <VoiceCandidateItemBubble
+                  key={entry.key}
+                  item={entry.item}
+                  taskById={tasksById}
+                />
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <VoiceChatCandidateFooter
+        status={status}
+        muted={muted}
+        toggleMute={toggleMute}
+        onEnd={() => {
+          endSession();
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a physically separate copy of voice-chat UI under `voice-chat-candidate/` folders (session, setup, auto-scroll signals; page, bubbles views + tests).
- Zero imports from non-candidate `voice-chat/` paths — maintains the hard isolation boundary required by Epic #10297.
- Route registration at `/voice-chat-candidate` is deferred to sibling issue #10315 (the `setup-page-render` lint rule forbids `withoutRender` in view tests, so page-level render tests will ship in that PR).

## DoD

- [x] New folders only: `src/signals/voice-chat-candidate/`, `src/views/voice-chat-candidate/`
- [x] No modifications to `src/views/voice-chat/`, `src/signals/voice-chat/`, `app/api/zero/voice-chat/`, `src/db/schema/voice-chat.ts`, `src/lib/zero/voice-chat/` (non-candidate)
- [x] All signals use `vccXxx$` naming / `vccXxx$` commands — no public name collisions with non-candidate code
- [x] Tests: 19 new (bubbles dispatcher + direct bubbles, setup signal, session signal happy path + error paths + item forwarding + create_task tool + Ably poke + end session)
- [x] Pre-commit: eslint (0), oxlint (0), knip (0), typecheck (app, 0), full app vitest (1874 passed)

## Test plan

- [ ] CI lint + typecheck green
- [ ] CI vitest green (platform)
- [ ] Reviewer diff-check grep returns empty: `src/views/voice-chat/|src/signals/voice-chat/|app/api/zero/voice-chat/|src/db/schema/voice-chat.ts|src/lib/zero/voice-chat/(?!candidate)`
- [ ] Sibling #10315 wires the route and adds page-level render tests

Closes #10313
Refs #10297

🤖 Generated with [Claude Code](https://claude.com/claude-code)