### PR TITLE
feat(web): add voice-chat-candidate server services

### DIFF
--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/item-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/item-service.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import { randomUUID } from "crypto";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { seedTestCompose } from "../../../../__tests__/db-test-seeders/agents";
+import { initServices } from "../../../init-services";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route covers these services yet
+import {
+  createVoiceChatCandidateSession,
+  endVoiceChatCandidateSession,
+} from "../session-service";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route covers these services yet
+import {
+  appendVoiceChatCandidateItem,
+  readVoiceChatCandidateItems,
+  readVoiceChatCandidateItemsSince,
+} from "../item-service";
+
+const context = testContext();
+
+async function seedActiveSession() {
+  // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: test exercises services directly, no API route
+  initServices();
+  const { userId, orgId } = await context.setupUser();
+  const { composeId } = await seedTestCompose({
+    userId,
+    orgId,
+    name: uniqueId("vcc-compose"),
+  });
+  const session = await createVoiceChatCandidateSession({
+    orgId,
+    userId,
+    agentId: composeId,
+  });
+  return { userId, orgId, agentId: composeId, session };
+}
+
+describe("appendVoiceChatCandidateItem", () => {
+  it("inserts a row and returns it", async () => {
+    context.setupMocks();
+    const { session } = await seedActiveSession();
+
+    const item = await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "user",
+      content: "hello there",
+      realtimeItemId: uniqueId("rt"),
+    });
+
+    expect(item).not.toBeNull();
+    expect(item!.sessionId).toBe(session.id);
+    expect(item!.role).toBe("user");
+    expect(item!.content).toBe("hello there");
+    expect(typeof item!.seq).toBe("number");
+    expect(item!.seq).toBeGreaterThan(0);
+  });
+
+  it("returns null on duplicate (sessionId, realtimeItemId)", async () => {
+    context.setupMocks();
+    const { session } = await seedActiveSession();
+    const realtimeItemId = uniqueId("dup");
+
+    const first = await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "user",
+      content: "first",
+      realtimeItemId,
+    });
+    const second = await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "user",
+      content: "second",
+      realtimeItemId,
+    });
+
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+  });
+
+  it("allows multiple server-written rows with realtimeItemId=null", async () => {
+    context.setupMocks();
+    const { session } = await seedActiveSession();
+
+    const a = await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "system_note",
+      content: "a",
+      realtimeItemId: null,
+    });
+    const b = await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "system_note",
+      content: "b",
+      realtimeItemId: null,
+    });
+
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a!.id).not.toBe(b!.id);
+  });
+
+  it("rejects when the session is ended", async () => {
+    context.setupMocks();
+    const { session } = await seedActiveSession();
+    await endVoiceChatCandidateSession(session.id);
+
+    await expect(
+      appendVoiceChatCandidateItem({
+        sessionId: session.id,
+        role: "user",
+        content: "after end",
+        realtimeItemId: uniqueId("rt"),
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("throws notFound when the session does not exist", async () => {
+    context.setupMocks();
+    await expect(
+      appendVoiceChatCandidateItem({
+        sessionId: randomUUID(),
+        role: "user",
+        content: "ghost",
+        realtimeItemId: uniqueId("rt"),
+      }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe("readVoiceChatCandidateItems", () => {
+  it("returns items ordered by seq ascending", async () => {
+    context.setupMocks();
+    const { session } = await seedActiveSession();
+    await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "user",
+      content: "one",
+      realtimeItemId: uniqueId("rt-a"),
+    });
+    await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "assistant",
+      content: "two",
+      realtimeItemId: uniqueId("rt-b"),
+    });
+    await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "user",
+      content: "three",
+      realtimeItemId: uniqueId("rt-c"),
+    });
+
+    const items = await readVoiceChatCandidateItems(session.id);
+    expect(items).toHaveLength(3);
+    for (let i = 1; i < items.length; i++) {
+      expect(items[i]!.seq).toBeGreaterThan(items[i - 1]!.seq);
+    }
+    expect(
+      items.map((i) => {
+        return i.content;
+      }),
+    ).toEqual(["one", "two", "three"]);
+  });
+
+  it("filters to seq > afterSeq when provided", async () => {
+    context.setupMocks();
+    const { session } = await seedActiveSession();
+    const a = await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "user",
+      content: "a",
+      realtimeItemId: uniqueId("rt-a"),
+    });
+    const b = await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "user",
+      content: "b",
+      realtimeItemId: uniqueId("rt-b"),
+    });
+    const c = await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "user",
+      content: "c",
+      realtimeItemId: uniqueId("rt-c"),
+    });
+
+    const afterA = await readVoiceChatCandidateItems(session.id, a!.seq);
+    expect(
+      afterA.map((i) => {
+        return i.id;
+      }),
+    ).toEqual([b!.id, c!.id]);
+  });
+});
+
+describe("readVoiceChatCandidateItemsSince", () => {
+  it("is equivalent to readVoiceChatCandidateItems with afterSeq", async () => {
+    context.setupMocks();
+    const { session } = await seedActiveSession();
+    const a = await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "user",
+      content: "a",
+      realtimeItemId: uniqueId("rt-a"),
+    });
+    await appendVoiceChatCandidateItem({
+      sessionId: session.id,
+      role: "user",
+      content: "b",
+      realtimeItemId: uniqueId("rt-b"),
+    });
+
+    const viaAfterSeq = await readVoiceChatCandidateItems(session.id, a!.seq);
+    const viaSince = await readVoiceChatCandidateItemsSince(session.id, a!.seq);
+    expect(
+      viaSince.map((i) => {
+        return i.id;
+      }),
+    ).toEqual(
+      viaAfterSeq.map((i) => {
+        return i.id;
+      }),
+    );
+  });
+});

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/session-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/session-service.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import { randomUUID } from "crypto";
+import { eq } from "drizzle-orm";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { seedTestCompose } from "../../../../__tests__/db-test-seeders/agents";
+import { initServices } from "../../../init-services";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route covers these services yet
+import {
+  createVoiceChatCandidateSession,
+  getVoiceChatCandidateSession,
+  heartbeatVoiceChatCandidateSession,
+  endVoiceChatCandidateSession,
+} from "../session-service";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: verify DB side-effects directly
+import { featureCandidateVoiceChatSessions } from "../../../../db/schema/voice-chat-candidate";
+
+const context = testContext();
+
+async function seedAgent() {
+  // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: test exercises services directly, no API route
+  initServices();
+  const { userId, orgId } = await context.setupUser();
+  const { composeId } = await seedTestCompose({
+    userId,
+    orgId,
+    name: uniqueId("vcc-compose"),
+  });
+  return { userId, orgId, agentId: composeId };
+}
+
+describe("createVoiceChatCandidateSession", () => {
+  it("creates a row with the expected defaults", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+
+    const session = await createVoiceChatCandidateSession({
+      orgId,
+      userId,
+      agentId,
+    });
+
+    expect(session.orgId).toBe(orgId);
+    expect(session.userId).toBe(userId);
+    expect(session.agentId).toBe(agentId);
+    expect(session.mode).toBe("chat");
+    expect(session.status).toBe("active");
+    expect(session.context).toBeNull();
+    expect(session.contextSeq).toBe(0);
+    expect(session.contextVersion).toBe(0);
+    expect(session.reasoningStatus).toBe("idle");
+    expect(session.reasoningPending).toBe(false);
+    expect(session.lastReasoningAt).toBeNull();
+    expect(session.endedAt).toBeNull();
+    expect(session.createdAt).toBeInstanceOf(Date);
+    expect(session.lastHeartbeatAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("getVoiceChatCandidateSession", () => {
+  it("returns the session row by id", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+    const created = await createVoiceChatCandidateSession({
+      orgId,
+      userId,
+      agentId,
+    });
+
+    const fetched = await getVoiceChatCandidateSession(created.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.id).toBe(created.id);
+    expect(fetched!.status).toBe("active");
+  });
+
+  it("returns null for a nonexistent id", async () => {
+    context.setupMocks();
+    const fetched = await getVoiceChatCandidateSession(randomUUID());
+    expect(fetched).toBeNull();
+  });
+});
+
+describe("heartbeatVoiceChatCandidateSession", () => {
+  it("advances lastHeartbeatAt when the session is active", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+    const created = await createVoiceChatCandidateSession({
+      orgId,
+      userId,
+      agentId,
+    });
+    const before = created.lastHeartbeatAt;
+
+    // Small delay to ensure the timestamp can move forward at millisecond resolution.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 5);
+    });
+
+    await heartbeatVoiceChatCandidateSession(created.id);
+
+    const after = await getVoiceChatCandidateSession(created.id);
+    expect(after).not.toBeNull();
+    expect(after!.lastHeartbeatAt.getTime()).toBeGreaterThan(before.getTime());
+  });
+
+  it("is a no-op when the session is already ended", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+    const created = await createVoiceChatCandidateSession({
+      orgId,
+      userId,
+      agentId,
+    });
+    await endVoiceChatCandidateSession(created.id);
+
+    const endedBefore = await getVoiceChatCandidateSession(created.id);
+    const beforeHeartbeat = endedBefore!.lastHeartbeatAt;
+
+    await heartbeatVoiceChatCandidateSession(created.id);
+
+    const endedAfter = await getVoiceChatCandidateSession(created.id);
+    expect(endedAfter!.status).toBe("ended");
+    expect(endedAfter!.lastHeartbeatAt.getTime()).toBe(
+      beforeHeartbeat.getTime(),
+    );
+  });
+
+  it("does not throw when the session id does not exist", async () => {
+    context.setupMocks();
+    await expect(
+      heartbeatVoiceChatCandidateSession(randomUUID()),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("endVoiceChatCandidateSession", () => {
+  it("flips status to ended and sets endedAt", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+    const created = await createVoiceChatCandidateSession({
+      orgId,
+      userId,
+      agentId,
+    });
+
+    await endVoiceChatCandidateSession(created.id);
+
+    // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: verify end side-effects
+    const db = globalThis.services.db;
+    const [row] = await db
+      .select()
+      .from(featureCandidateVoiceChatSessions)
+      .where(eq(featureCandidateVoiceChatSessions.id, created.id));
+    expect(row!.status).toBe("ended");
+    expect(row!.endedAt).not.toBeNull();
+  });
+
+  it("is idempotent on a second call", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+    const created = await createVoiceChatCandidateSession({
+      orgId,
+      userId,
+      agentId,
+    });
+
+    await endVoiceChatCandidateSession(created.id);
+    const firstEnd = await getVoiceChatCandidateSession(created.id);
+    const firstEndedAt = firstEnd!.endedAt;
+
+    await expect(
+      endVoiceChatCandidateSession(created.id),
+    ).resolves.toBeUndefined();
+
+    const secondEnd = await getVoiceChatCandidateSession(created.id);
+    expect(secondEnd!.status).toBe("ended");
+    // endedAt should not be overwritten on the idempotent call.
+    expect(secondEnd!.endedAt!.getTime()).toBe(firstEndedAt!.getTime());
+  });
+
+  it("throws notFound when the session id does not exist", async () => {
+    context.setupMocks();
+    await expect(
+      endVoiceChatCandidateSession(randomUUID()),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/task-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/task-service.test.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect } from "vitest";
+import { randomUUID } from "crypto";
+import { and, eq } from "drizzle-orm";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { seedTestCompose } from "../../../../__tests__/db-test-seeders/agents";
+import { seedTestRun } from "../../../../__tests__/db-test-seeders/runs";
+import { initServices } from "../../../init-services";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route covers these services yet
+import { createVoiceChatCandidateSession } from "../session-service";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route covers these services yet
+import {
+  createVoiceChatCandidateTask,
+  completeVoiceChatCandidateTask,
+  listPendingVoiceChatCandidateTasks,
+  cancelSessionPendingRuns,
+  type SpawnRun,
+} from "../task-service";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: verify DB side-effects directly
+import {
+  featureCandidateVoiceChatSessions,
+  featureCandidateVoiceChatTasks,
+} from "../../../../db/schema/voice-chat-candidate";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: verify DB side-effects directly
+import { agentRuns } from "../../../../db/schema/agent-run";
+
+const context = testContext();
+
+async function seedActiveSession() {
+  // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: test exercises services directly, no API route
+  initServices();
+  const { userId, orgId } = await context.setupUser();
+  const { composeId } = await seedTestCompose({
+    userId,
+    orgId,
+    name: uniqueId("vcc-compose"),
+  });
+  const session = await createVoiceChatCandidateSession({
+    orgId,
+    userId,
+    agentId: composeId,
+  });
+  return { userId, orgId, agentId: composeId, composeId, session };
+}
+
+describe("createVoiceChatCandidateTask", () => {
+  it("inserts the task row before calling spawnRun and returns status=pending when spawn returns pending", async () => {
+    context.setupMocks();
+    const { session, userId, orgId, composeId } = await seedActiveSession();
+    const { runId: spawnedRunId } = await seedTestRun(userId, composeId, {
+      status: "pending",
+      orgId,
+    });
+
+    const spawnRun: SpawnRun = async () => {
+      // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: verify row ordering
+      const db = globalThis.services.db;
+      const pre = await db
+        .select()
+        .from(featureCandidateVoiceChatTasks)
+        .where(eq(featureCandidateVoiceChatTasks.sessionId, session.id));
+      expect(pre).toHaveLength(1);
+      expect(pre[0]!.status).toBe("pending");
+      expect(pre[0]!.runId).toBeNull();
+      return {
+        runId: spawnedRunId,
+        status: "pending",
+        createdAt: new Date(),
+        sessionId: session.id,
+      };
+    };
+
+    const task = await createVoiceChatCandidateTask({
+      sessionId: session.id,
+      callId: "call_pending",
+      prompt: "do a thing",
+      spawnRun,
+    });
+
+    expect(task.status).toBe("pending");
+    expect(task.runId).toBe(spawnedRunId);
+    expect(task.callId).toBe("call_pending");
+    expect(task.prompt).toBe("do a thing");
+  });
+
+  it("sets task.status=queued when spawnRun returns queued", async () => {
+    context.setupMocks();
+    const { session, userId, orgId, composeId } = await seedActiveSession();
+    const { runId } = await seedTestRun(userId, composeId, {
+      status: "queued",
+      orgId,
+    });
+    const spawnRun: SpawnRun = async () => {
+      return {
+        runId,
+        status: "queued",
+        createdAt: new Date(),
+        sessionId: session.id,
+      };
+    };
+
+    const task = await createVoiceChatCandidateTask({
+      sessionId: session.id,
+      callId: "call_queued",
+      prompt: "queued",
+      spawnRun,
+    });
+
+    expect(task.status).toBe("queued");
+  });
+
+  it("leaves task row as pending-with-null-runId if spawnRun throws", async () => {
+    context.setupMocks();
+    const { session } = await seedActiveSession();
+    const spawnRun: SpawnRun = async () => {
+      throw new Error("dispatcher down");
+    };
+
+    await expect(
+      createVoiceChatCandidateTask({
+        sessionId: session.id,
+        callId: "call_fail_spawn",
+        prompt: "fail",
+        spawnRun,
+      }),
+    ).rejects.toThrow(/dispatcher down/);
+
+    // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: verify orphaned row
+    const db = globalThis.services.db;
+    const rows = await db
+      .select()
+      .from(featureCandidateVoiceChatTasks)
+      .where(
+        and(
+          eq(featureCandidateVoiceChatTasks.sessionId, session.id),
+          eq(featureCandidateVoiceChatTasks.callId, "call_fail_spawn"),
+        ),
+      );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe("pending");
+    expect(rows[0]!.runId).toBeNull();
+  });
+});
+
+describe("completeVoiceChatCandidateTask", () => {
+  it("transitions to done and writes a task_result item on success", async () => {
+    context.setupMocks();
+    const { session, agentId, userId, orgId, composeId } =
+      await seedActiveSession();
+    const { runId } = await seedTestRun(userId, composeId, {
+      status: "running",
+      startedAt: new Date(),
+      orgId,
+    });
+
+    const spawnRun: SpawnRun = async () => {
+      return {
+        runId,
+        status: "queued",
+        createdAt: new Date(),
+        sessionId: session.id,
+      };
+    };
+    const task = await createVoiceChatCandidateTask({
+      sessionId: session.id,
+      callId: "c_done",
+      prompt: "p",
+      spawnRun,
+    });
+
+    const completed = await completeVoiceChatCandidateTask({
+      taskId: task.id,
+      runId,
+      result: "all good",
+      error: null,
+      agentId,
+    });
+
+    expect(completed.task.status).toBe("done");
+    expect(completed.task.result).toBe("all good");
+    expect(completed.task.finishedAt).not.toBeNull();
+    expect(completed.item.role).toBe("task_result");
+    expect(completed.item.taskId).toBe(task.id);
+    expect(completed.item.content).toContain("all good");
+  });
+
+  it("transitions to failed and formats the error content when error is set", async () => {
+    context.setupMocks();
+    const { session, agentId, userId, orgId, composeId } =
+      await seedActiveSession();
+    const { runId } = await seedTestRun(userId, composeId, {
+      status: "running",
+      startedAt: new Date(),
+      orgId,
+    });
+
+    const spawnRun: SpawnRun = async () => {
+      return {
+        runId,
+        status: "queued",
+        createdAt: new Date(),
+        sessionId: session.id,
+      };
+    };
+    const task = await createVoiceChatCandidateTask({
+      sessionId: session.id,
+      callId: "c_fail",
+      prompt: "p",
+      spawnRun,
+    });
+
+    const completed = await completeVoiceChatCandidateTask({
+      taskId: task.id,
+      runId,
+      result: null,
+      error: "worker timeout",
+      agentId,
+    });
+
+    expect(completed.task.status).toBe("failed");
+    expect(completed.task.error).toBe("worker timeout");
+    expect(completed.item.content).toBe("[task failed] worker timeout");
+  });
+
+  it("ends the session and writes a system_note item on agent mismatch, and cancels other pending runs", async () => {
+    context.setupMocks();
+    const { session, userId, orgId, composeId } = await seedActiveSession();
+
+    const { runId: completeRunId } = await seedTestRun(userId, composeId, {
+      status: "running",
+      startedAt: new Date(),
+      orgId,
+    });
+    const { runId: otherPendingRunId } = await seedTestRun(userId, composeId, {
+      status: "pending",
+      orgId,
+    });
+
+    const completeSpawn: SpawnRun = async () => {
+      return {
+        runId: completeRunId,
+        status: "queued",
+        createdAt: new Date(),
+        sessionId: session.id,
+      };
+    };
+    const completeTask = await createVoiceChatCandidateTask({
+      sessionId: session.id,
+      callId: "c_bad_agent",
+      prompt: "p",
+      spawnRun: completeSpawn,
+    });
+
+    const otherSpawn: SpawnRun = async () => {
+      return {
+        runId: otherPendingRunId,
+        status: "pending",
+        createdAt: new Date(),
+        sessionId: session.id,
+      };
+    };
+    await createVoiceChatCandidateTask({
+      sessionId: session.id,
+      callId: "c_sibling",
+      prompt: "still pending",
+      spawnRun: otherSpawn,
+    });
+
+    const wrongAgentId = randomUUID();
+    const completed = await completeVoiceChatCandidateTask({
+      taskId: completeTask.id,
+      runId: completeRunId,
+      result: "should be ignored",
+      error: null,
+      agentId: wrongAgentId,
+    });
+
+    expect(completed.task.status).toBe("failed");
+    expect(completed.task.error).toMatch(/agent mismatch/i);
+    expect(completed.item.role).toBe("system_note");
+    expect(completed.item.content).toMatch(/agent mismatch/i);
+
+    // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: verify teardown
+    const db = globalThis.services.db;
+    const [sessionRow] = await db
+      .select()
+      .from(featureCandidateVoiceChatSessions)
+      .where(eq(featureCandidateVoiceChatSessions.id, session.id));
+    expect(sessionRow!.status).toBe("ended");
+    expect(sessionRow!.endedAt).not.toBeNull();
+
+    const [otherRun] = await db
+      .select()
+      .from(agentRuns)
+      .where(eq(agentRuns.id, otherPendingRunId));
+    expect(otherRun!.status).toBe("cancelled");
+  });
+
+  it("throws notFound when taskId does not exist", async () => {
+    context.setupMocks();
+    await expect(
+      completeVoiceChatCandidateTask({
+        taskId: randomUUID(),
+        runId: randomUUID(),
+        result: null,
+        error: null,
+        agentId: randomUUID(),
+      }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe("listPendingVoiceChatCandidateTasks", () => {
+  it("returns tasks in pending and queued status and excludes done/failed", async () => {
+    context.setupMocks();
+    const { session, agentId, userId, orgId, composeId } =
+      await seedActiveSession();
+
+    const { runId: pendingRunId } = await seedTestRun(userId, composeId, {
+      status: "pending",
+      orgId,
+    });
+    const spawnPending: SpawnRun = async () => {
+      return {
+        runId: pendingRunId,
+        status: "pending",
+        createdAt: new Date(),
+        sessionId: session.id,
+      };
+    };
+    await createVoiceChatCandidateTask({
+      sessionId: session.id,
+      callId: "list_pending",
+      prompt: "p",
+      spawnRun: spawnPending,
+    });
+
+    const { runId: queuedRunId } = await seedTestRun(userId, composeId, {
+      status: "queued",
+      orgId,
+    });
+    const spawnQueued: SpawnRun = async () => {
+      return {
+        runId: queuedRunId,
+        status: "queued",
+        createdAt: new Date(),
+        sessionId: session.id,
+      };
+    };
+    await createVoiceChatCandidateTask({
+      sessionId: session.id,
+      callId: "list_queued",
+      prompt: "p",
+      spawnRun: spawnQueued,
+    });
+
+    const { runId: doneRunId } = await seedTestRun(userId, composeId, {
+      status: "running",
+      startedAt: new Date(),
+      orgId,
+    });
+    const spawnDone: SpawnRun = async () => {
+      return {
+        runId: doneRunId,
+        status: "queued",
+        createdAt: new Date(),
+        sessionId: session.id,
+      };
+    };
+    const doneTask = await createVoiceChatCandidateTask({
+      sessionId: session.id,
+      callId: "list_done",
+      prompt: "p",
+      spawnRun: spawnDone,
+    });
+    await completeVoiceChatCandidateTask({
+      taskId: doneTask.id,
+      runId: doneRunId,
+      result: "ok",
+      error: null,
+      agentId,
+    });
+
+    const pending = await listPendingVoiceChatCandidateTasks(session.id);
+    const callIds = pending
+      .map((t) => {
+        return t.callId;
+      })
+      .sort();
+    expect(callIds).toEqual(["list_pending", "list_queued"]);
+  });
+});
+
+describe("cancelSessionPendingRuns", () => {
+  it("swallows cancelRun errors for terminal runs", async () => {
+    context.setupMocks();
+    const { session, userId, orgId, composeId } = await seedActiveSession();
+
+    const { runId: terminalRunId } = await seedTestRun(userId, composeId, {
+      status: "completed",
+      startedAt: new Date(),
+      completedAt: new Date(),
+      orgId,
+    });
+    const spawnTerminal: SpawnRun = async () => {
+      return {
+        runId: terminalRunId, // already terminal — cancelRun will throw runNotCancellable
+        status: "queued",
+        createdAt: new Date(),
+        sessionId: session.id,
+      };
+    };
+    await createVoiceChatCandidateTask({
+      sessionId: session.id,
+      callId: "cancel_swallow",
+      prompt: "p",
+      spawnRun: spawnTerminal,
+    });
+
+    await expect(
+      cancelSessionPendingRuns({
+        id: session.id,
+        orgId: session.orgId,
+        userId: session.userId,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does nothing and returns when there are no pending tasks", async () => {
+    context.setupMocks();
+    const { session } = await seedActiveSession();
+    await expect(
+      cancelSessionPendingRuns({
+        id: session.id,
+        orgId: session.orgId,
+        userId: session.userId,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/task-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/task-service.test.ts
@@ -169,7 +169,6 @@ describe("completeVoiceChatCandidateTask", () => {
 
     const completed = await completeVoiceChatCandidateTask({
       taskId: task.id,
-      runId,
       result: "all good",
       error: null,
       agentId,
@@ -210,7 +209,6 @@ describe("completeVoiceChatCandidateTask", () => {
 
     const completed = await completeVoiceChatCandidateTask({
       taskId: task.id,
-      runId,
       result: null,
       error: "worker timeout",
       agentId,
@@ -268,7 +266,6 @@ describe("completeVoiceChatCandidateTask", () => {
     const wrongAgentId = randomUUID();
     const completed = await completeVoiceChatCandidateTask({
       taskId: completeTask.id,
-      runId: completeRunId,
       result: "should be ignored",
       error: null,
       agentId: wrongAgentId,
@@ -300,7 +297,6 @@ describe("completeVoiceChatCandidateTask", () => {
     await expect(
       completeVoiceChatCandidateTask({
         taskId: randomUUID(),
-        runId: randomUUID(),
         result: null,
         error: null,
         agentId: randomUUID(),
@@ -374,7 +370,6 @@ describe("listPendingVoiceChatCandidateTasks", () => {
     });
     await completeVoiceChatCandidateTask({
       taskId: doneTask.id,
-      runId: doneRunId,
       result: "ok",
       error: null,
       agentId,

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/item-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/item-service.ts
@@ -1,0 +1,78 @@
+import { and, asc, eq, gt } from "drizzle-orm";
+import {
+  featureCandidateVoiceChatItems,
+  featureCandidateVoiceChatSessions,
+} from "../../../db/schema/voice-chat-candidate";
+import { badRequest, notFound } from "../../shared/errors";
+
+type ItemRow = typeof featureCandidateVoiceChatItems.$inferSelect;
+type ItemRole = "user" | "assistant" | "task_result" | "system_note";
+
+async function assertSessionActive(sessionId: string): Promise<void> {
+  const db = globalThis.services.db;
+  const [session] = await db
+    .select({ status: featureCandidateVoiceChatSessions.status })
+    .from(featureCandidateVoiceChatSessions)
+    .where(eq(featureCandidateVoiceChatSessions.id, sessionId))
+    .limit(1);
+  if (!session) {
+    throw notFound("Voice-chat-candidate session not found");
+  }
+  if (session.status !== "active") {
+    throw badRequest("Session is not active");
+  }
+}
+
+export async function appendVoiceChatCandidateItem(params: {
+  sessionId: string;
+  role: ItemRole;
+  content: string | null;
+  taskId?: string | null;
+  realtimeItemId?: string | null;
+}): Promise<ItemRow | null> {
+  const db = globalThis.services.db;
+  await assertSessionActive(params.sessionId);
+
+  const [inserted] = await db
+    .insert(featureCandidateVoiceChatItems)
+    .values({
+      sessionId: params.sessionId,
+      role: params.role,
+      content: params.content,
+      taskId: params.taskId ?? null,
+      realtimeItemId: params.realtimeItemId ?? null,
+    })
+    .onConflictDoNothing({
+      target: [
+        featureCandidateVoiceChatItems.sessionId,
+        featureCandidateVoiceChatItems.realtimeItemId,
+      ],
+    })
+    .returning();
+
+  return inserted ?? null;
+}
+
+export async function readVoiceChatCandidateItems(
+  sessionId: string,
+  afterSeq?: number,
+): Promise<ItemRow[]> {
+  const db = globalThis.services.db;
+  const baseCondition = eq(featureCandidateVoiceChatItems.sessionId, sessionId);
+  const condition =
+    afterSeq !== undefined
+      ? and(baseCondition, gt(featureCandidateVoiceChatItems.seq, afterSeq))
+      : baseCondition;
+  return db
+    .select()
+    .from(featureCandidateVoiceChatItems)
+    .where(condition)
+    .orderBy(asc(featureCandidateVoiceChatItems.seq));
+}
+
+export async function readVoiceChatCandidateItemsSince(
+  sessionId: string,
+  fromSeq: number,
+): Promise<ItemRow[]> {
+  return readVoiceChatCandidateItems(sessionId, fromSeq);
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/session-service.ts
@@ -1,0 +1,79 @@
+import { and, eq } from "drizzle-orm";
+import { featureCandidateVoiceChatSessions } from "../../../db/schema/voice-chat-candidate";
+import { cancelSessionPendingRuns } from "./task-service";
+import { notFound } from "../../shared/errors";
+
+type SessionRow = typeof featureCandidateVoiceChatSessions.$inferSelect;
+
+export async function createVoiceChatCandidateSession(params: {
+  orgId: string;
+  userId: string;
+  agentId: string;
+}): Promise<SessionRow> {
+  const db = globalThis.services.db;
+  const [session] = await db
+    .insert(featureCandidateVoiceChatSessions)
+    .values({
+      orgId: params.orgId,
+      userId: params.userId,
+      agentId: params.agentId,
+    })
+    .returning();
+  if (!session) {
+    throw new Error("Failed to insert voice-chat-candidate session");
+  }
+  return session;
+}
+
+export async function getVoiceChatCandidateSession(
+  id: string,
+): Promise<SessionRow | null> {
+  const db = globalThis.services.db;
+  const [session] = await db
+    .select()
+    .from(featureCandidateVoiceChatSessions)
+    .where(eq(featureCandidateVoiceChatSessions.id, id))
+    .limit(1);
+  return session ?? null;
+}
+
+export async function heartbeatVoiceChatCandidateSession(
+  id: string,
+): Promise<void> {
+  const db = globalThis.services.db;
+  await db
+    .update(featureCandidateVoiceChatSessions)
+    .set({ lastHeartbeatAt: new Date() })
+    .where(
+      and(
+        eq(featureCandidateVoiceChatSessions.id, id),
+        eq(featureCandidateVoiceChatSessions.status, "active"),
+      ),
+    );
+}
+
+export async function endVoiceChatCandidateSession(id: string): Promise<void> {
+  const db = globalThis.services.db;
+  const session = await getVoiceChatCandidateSession(id);
+  if (!session) {
+    throw notFound("Voice-chat-candidate session not found");
+  }
+
+  if (session.status === "active") {
+    await db
+      .update(featureCandidateVoiceChatSessions)
+      .set({ status: "ended", endedAt: new Date() })
+      .where(
+        and(
+          eq(featureCandidateVoiceChatSessions.id, id),
+          eq(featureCandidateVoiceChatSessions.status, "active"),
+        ),
+      );
+  }
+
+  await cancelSessionPendingRuns({
+    id: session.id,
+    orgId: session.orgId,
+    userId: session.userId,
+  });
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/task-service.ts
@@ -1,0 +1,216 @@
+import { and, eq, inArray } from "drizzle-orm";
+import {
+  featureCandidateVoiceChatItems,
+  featureCandidateVoiceChatSessions,
+  featureCandidateVoiceChatTasks,
+} from "../../../db/schema/voice-chat-candidate";
+import { type CreateZeroRunResult } from "../zero-run-service";
+import { cancelRun } from "../zero-run-cancel";
+import { notFound } from "../../shared/errors";
+import { logger } from "../../shared/logger";
+
+const log = logger("zero:voice-chat-candidate:task");
+
+export type SpawnRun = () => Promise<CreateZeroRunResult>;
+
+type TaskRow = typeof featureCandidateVoiceChatTasks.$inferSelect;
+type ItemRow = typeof featureCandidateVoiceChatItems.$inferSelect;
+
+export async function createVoiceChatCandidateTask(params: {
+  sessionId: string;
+  callId: string;
+  prompt: string;
+  spawnRun: SpawnRun;
+}): Promise<TaskRow> {
+  const db = globalThis.services.db;
+
+  // Insert the task row BEFORE spawning the run so the callback path can
+  // always locate a task by runId even if the callback beats the post-spawn
+  // UPDATE.
+  const [inserted] = await db
+    .insert(featureCandidateVoiceChatTasks)
+    .values({
+      sessionId: params.sessionId,
+      callId: params.callId,
+      prompt: params.prompt,
+      status: "pending",
+    })
+    .returning();
+
+  if (!inserted) {
+    throw new Error("Failed to insert voice-chat-candidate task");
+  }
+
+  const result = await params.spawnRun();
+
+  const nextStatus = result.status === "queued" ? "queued" : "pending";
+  const [updated] = await db
+    .update(featureCandidateVoiceChatTasks)
+    .set({ runId: result.runId, status: nextStatus })
+    .where(eq(featureCandidateVoiceChatTasks.id, inserted.id))
+    .returning();
+
+  return updated ?? inserted;
+}
+
+export async function completeVoiceChatCandidateTask(params: {
+  taskId: string;
+  runId: string;
+  result: string | null;
+  error: string | null;
+  agentId: string;
+}): Promise<{ item: ItemRow; task: TaskRow }> {
+  const db = globalThis.services.db;
+
+  const outcome = await db.transaction(async (tx) => {
+    const [taskRow] = await tx
+      .select()
+      .from(featureCandidateVoiceChatTasks)
+      .where(eq(featureCandidateVoiceChatTasks.id, params.taskId))
+      .for("update")
+      .limit(1);
+
+    if (!taskRow) {
+      throw notFound(`Voice-chat-candidate task not found: ${params.taskId}`);
+    }
+
+    const [sessionRow] = await tx
+      .select()
+      .from(featureCandidateVoiceChatSessions)
+      .where(eq(featureCandidateVoiceChatSessions.id, taskRow.sessionId))
+      .limit(1);
+
+    if (!sessionRow) {
+      throw notFound(
+        `Voice-chat-candidate session not found: ${taskRow.sessionId}`,
+      );
+    }
+
+    const now = new Date();
+
+    if (sessionRow.agentId !== params.agentId) {
+      const [failedTask] = await tx
+        .update(featureCandidateVoiceChatTasks)
+        .set({
+          status: "failed",
+          error: "agent mismatch",
+          finishedAt: now,
+        })
+        .where(eq(featureCandidateVoiceChatTasks.id, taskRow.id))
+        .returning();
+
+      const [noteItem] = await tx
+        .insert(featureCandidateVoiceChatItems)
+        .values({
+          sessionId: taskRow.sessionId,
+          role: "system_note",
+          content: "agent mismatch — session ended",
+          taskId: taskRow.id,
+          realtimeItemId: null,
+        })
+        .returning();
+
+      await tx
+        .update(featureCandidateVoiceChatSessions)
+        .set({ status: "ended", endedAt: now })
+        .where(eq(featureCandidateVoiceChatSessions.id, taskRow.sessionId));
+
+      return {
+        task: failedTask ?? taskRow,
+        item: noteItem!,
+        mismatch: true,
+        session: {
+          id: sessionRow.id,
+          orgId: sessionRow.orgId,
+          userId: sessionRow.userId,
+        },
+      };
+    }
+
+    const finalStatus = params.error ? "failed" : "done";
+    const [completedTask] = await tx
+      .update(featureCandidateVoiceChatTasks)
+      .set({
+        status: finalStatus,
+        result: params.result,
+        error: params.error,
+        finishedAt: now,
+      })
+      .where(eq(featureCandidateVoiceChatTasks.id, taskRow.id))
+      .returning();
+
+    const [resultItem] = await tx
+      .insert(featureCandidateVoiceChatItems)
+      .values({
+        sessionId: taskRow.sessionId,
+        role: "task_result",
+        content: formatTaskResult({
+          result: params.result,
+          error: params.error,
+        }),
+        taskId: taskRow.id,
+        realtimeItemId: null,
+      })
+      .returning();
+
+    return {
+      task: completedTask ?? taskRow,
+      item: resultItem!,
+      mismatch: false,
+      session: {
+        id: sessionRow.id,
+        orgId: sessionRow.orgId,
+        userId: sessionRow.userId,
+      },
+    };
+  });
+
+  if (outcome.mismatch) {
+    await cancelSessionPendingRuns(outcome.session);
+  }
+
+  return { task: outcome.task, item: outcome.item };
+}
+
+export async function listPendingVoiceChatCandidateTasks(
+  sessionId: string,
+): Promise<TaskRow[]> {
+  const db = globalThis.services.db;
+  return db
+    .select()
+    .from(featureCandidateVoiceChatTasks)
+    .where(
+      and(
+        eq(featureCandidateVoiceChatTasks.sessionId, sessionId),
+        inArray(featureCandidateVoiceChatTasks.status, ["pending", "queued"]),
+      ),
+    );
+}
+
+export async function cancelSessionPendingRuns(session: {
+  id: string;
+  orgId: string;
+  userId: string;
+}): Promise<void> {
+  const pending = await listPendingVoiceChatCandidateTasks(session.id);
+  for (const task of pending) {
+    if (!task.runId) continue;
+    try {
+      await cancelRun(task.runId, session.userId, session.orgId);
+    } catch (err) {
+      log.debug(
+        `cancelRun for task ${task.id} (runId=${task.runId}) swallowed: ${String(
+          err,
+        )}`,
+      );
+    }
+  }
+}
+
+function formatTaskResult(params: {
+  result: string | null;
+  error: string | null;
+}): string {
+  if (params.error) return `[task failed] ${params.error}`;
+  return params.result ?? "[task returned empty result]";
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/task-service.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../db/schema/voice-chat-candidate";
 import { type CreateZeroRunResult } from "../zero-run-service";
 import { cancelRun } from "../zero-run-cancel";
-import { notFound } from "../../shared/errors";
+import { isRunNotCancellable, notFound } from "../../shared/errors";
 import { logger } from "../../shared/logger";
 
 const log = logger("zero:voice-chat-candidate:task");
@@ -55,7 +55,6 @@ export async function createVoiceChatCandidateTask(params: {
 
 export async function completeVoiceChatCandidateTask(params: {
   taskId: string;
-  runId: string;
   result: string | null;
   error: string | null;
   agentId: string;
@@ -198,8 +197,12 @@ export async function cancelSessionPendingRuns(session: {
     try {
       await cancelRun(task.runId, session.userId, session.orgId);
     } catch (err) {
-      log.debug(
-        `cancelRun for task ${task.id} (runId=${task.runId}) swallowed: ${String(
+      // Only swallow the expected "already terminal" signal from the run
+      // state machine. Any other error (DB failure, permission mismatch,
+      // network, etc.) must propagate so the caller can react.
+      if (!isRunNotCancellable(err)) throw err;
+      log.warn(
+        `cancelRun for task ${task.id} (runId=${task.runId}) skipped — run is no longer cancellable: ${String(
           err,
         )}`,
       );


### PR DESCRIPTION
## Summary

Implement the three server services for the voice-chat-candidate feature (Epic #10297, wave 3) under `turbo/apps/web/src/lib/zero/voice-chat-candidate/`:

- **session-service** — `create` / `get` / `heartbeat` / `end`. `endSession(id)` derives org/user from the session row, is idempotent, and always runs the shared pending-run cancellation sweep.
- **item-service** — `append` uses `onConflictDoNothing` on `(sessionId, realtimeItemId)` for silent dedup (NULL-tolerant partial unique index). `read` supports an `afterSeq` filter; `readSince` is a thin wrapper per issue spec.
- **task-service** — `create` inserts the task row *before* calling `spawnRun` (so a failed dispatch leaves an orphaned pending row with `runId=null`). `complete` runs inside a transaction with `FOR UPDATE` on the task and uses an agent-mismatch branch that fails the task, writes a `system_note` item, ends the session, and cancels sibling pending runs. Exports `SpawnRun` type for the downstream #10310 dispatcher callback.

v1 state machine (per Epic #10297): services only ever transition tasks through `pending → queued → done|failed`. `running` is reserved for future incremental-streaming work.

## Test plan

- [x] `pnpm exec vitest run src/lib/zero/voice-chat-candidate/__tests__/` — 27/27 passing against the real test DB
- [x] `pnpm turbo run lint --filter=web` — clean
- [x] `pnpm knip --workspace web` — clean
- [x] DoD grep: `status.*running` in service code — empty
- [x] Integration tests exercise: happy paths, duplicate realtimeItemId dedup, NULL-coexistence, ended-session rejection, agent-mismatch teardown with sibling cancellation, spawn-throws orphan retention, idempotent end.

Refs #10307