### PR TITLE
fix(platform): show only toggled-on connectors in trigger icons

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -186,17 +186,17 @@ function ConnectorTriggerIcons({
 }: {
   connectors: ComposerConnectorItem[];
 }) {
-  const connected = connectors
+  const enabled = connectors
     .filter((c) => {
-      return c.connected;
+      return c.added;
     })
     .slice(0, 3);
-  if (connected.length === 0) {
+  if (enabled.length === 0) {
     return <IconPlug size={18} stroke={1.5} />;
   }
   return (
     <span className="flex items-center -space-x-1.5">
-      {connected.map((c) => {
+      {enabled.map((c) => {
         return (
           <span key={c.type} className="relative shrink-0">
             <span className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-background zero-border">


### PR DESCRIPTION
## Summary
- `ConnectorTriggerIcons` was filtering by `connected` (org-level authorization) instead of `added` (user toggle state)
- This caused connector icons to appear outside the dropdown for connectors that were authorized but not actually enabled/toggled-on for the current agent
- Changed filter from `c.connected` to `c.added` so the displayed icons match the toggle state in the dropdown

## Test plan
- [ ] Open the connector picker in the chat composer
- [ ] Toggle some connectors ON and OFF
- [ ] Verify the small icons outside the dropdown only show connectors that are toggled ON
- [ ] Verify toggling a connector OFF removes its icon from the trigger area

🤖 Generated with [Claude Code](https://claude.com/claude-code)