### PR TITLE
refactor(runs): remove legacy session-creation fallback and require sessionId in response

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -90,15 +90,16 @@ async function enforceCaptureNetworkBodiesGate(
  */
 function handleCreateRunError(error: unknown) {
   if (isApiError(error)) {
-    // Post-INSERT errors have runId attached by markRunFailed().
+    // Post-INSERT errors have runId + sessionId attached by markRunFailed().
     // Return 201 with failed status so the client can track the run.
     const dispatchError = error as RunDispatchError;
-    if (dispatchError.runId) {
+    if (dispatchError.runId && dispatchError.sessionId) {
       return {
         status: 201 as const,
         body: {
           runId: dispatchError.runId,
           status: "failed" as const,
+          sessionId: dispatchError.sessionId,
           error: error.message,
         },
       };
@@ -118,12 +119,13 @@ function handleCreateRunError(error: unknown) {
 
   // Non-API errors with runId (unexpected dispatch failures)
   const dispatchError = error as RunDispatchError;
-  if (dispatchError.runId) {
+  if (dispatchError.runId && dispatchError.sessionId) {
     return {
       status: 201 as const,
       body: {
         runId: dispatchError.runId,
         status: "failed" as const,
+        sessionId: dispatchError.sessionId,
         error: "Run failed",
       },
     };

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -8,7 +8,6 @@ import {
   findTestCheckpoint,
   findTestRunRecord,
   getTestAgentSessionWithConversation,
-  createTestAgentSession,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import {
@@ -687,111 +686,6 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       // run.sessionId unchanged
       const runAfter = await findTestRunRecord(testRunId);
       expect(runAfter?.sessionId).toBe(preCreatedSessionId);
-    });
-
-    // Branch B: legacy continuation pre-deploy — continuedFromSessionId set, sessionId unset.
-    // TODO(#10324): Remove this test together with checkpoint-service Branch B.
-    // Skipped because agent_runs.session_id is now NOT NULL; the legacy
-    // null-sessionId state this test reproduces is no longer reachable after
-    // issue #10323 tightened the schema. Branch B code still exists as dead
-    // code pending the follow-up cleanup PR.
-    it.skip("should reuse continuedFromSessionId for legacy continuation runs", async () => {
-      // Pre-create a session and seed a run that continues from it WITHOUT
-      // populating sessionId (simulates an in-flight continuation at deploy time).
-      const priorSession = await createTestAgentSession(
-        user.userId,
-        testComposeId,
-      );
-      const { runId } = await seedTestRun(user.userId, testComposeId, {
-        status: "running",
-        continuedFromSessionId: priorSession.id,
-      });
-
-      const runBefore = await findTestRunRecord(runId);
-      expect(runBefore?.sessionId).toBeNull();
-      expect(runBefore?.continuedFromSessionId).toBe(priorSession.id);
-
-      const token = await createTestSandboxToken(user.userId, runId);
-      const request = createTestRequest(
-        "http://localhost:3000/api/webhooks/agent/checkpoints",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            runId,
-            cliAgentType: "claude-code",
-            cliAgentSessionId: "branch-b-session",
-            cliAgentSessionHistoryHash: sha256("branch-b"),
-          }),
-        },
-      );
-      const response = await POST(request);
-      expect(response.status).toBe(200);
-      const body = (await response.json()) as {
-        agentSessionId: string;
-        conversationId: string;
-      };
-
-      expect(body.agentSessionId).toBe(priorSession.id);
-
-      const session = await getTestAgentSessionWithConversation(
-        priorSession.id,
-      );
-      expect(session?.conversationId).toBe(body.conversationId);
-    });
-
-    // Branch C: legacy first-run pre-deploy — neither sessionId nor continuedFromSessionId set.
-    // TODO(#10324): Remove this test together with checkpoint-service Branch C.
-    // Skipped because agent_runs.session_id is now NOT NULL; the legacy
-    // null-sessionId state this test reproduces is no longer reachable after
-    // issue #10323 tightened the schema. Branch C code still exists as dead
-    // code pending the follow-up cleanup PR.
-    it.skip("should create a new session and backfill run.sessionId", async () => {
-      const { runId } = await seedTestRun(user.userId, testComposeId, {
-        status: "running",
-      });
-
-      const runBefore = await findTestRunRecord(runId);
-      expect(runBefore?.sessionId).toBeNull();
-      expect(runBefore?.continuedFromSessionId).toBeNull();
-
-      const token = await createTestSandboxToken(user.userId, runId);
-      const request = createTestRequest(
-        "http://localhost:3000/api/webhooks/agent/checkpoints",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            runId,
-            cliAgentType: "claude-code",
-            cliAgentSessionId: "branch-c-session",
-            cliAgentSessionHistoryHash: sha256("branch-c"),
-          }),
-        },
-      );
-      const response = await POST(request);
-      expect(response.status).toBe(200);
-      const body = (await response.json()) as {
-        agentSessionId: string;
-        conversationId: string;
-      };
-
-      expect(body.agentSessionId).toBeTruthy();
-
-      // Run.sessionId was backfilled to the newly created session
-      const runAfter = await findTestRunRecord(runId);
-      expect(runAfter?.sessionId).toBe(body.agentSessionId);
-
-      const session = await getTestAgentSessionWithConversation(
-        body.agentSessionId,
-      );
-      expect(session?.conversationId).toBe(body.conversationId);
     });
   });
 });

--- a/turbo/apps/web/src/lib/infra/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/infra/agent-session/agent-session-service.ts
@@ -2,11 +2,7 @@ import { eq } from "drizzle-orm";
 import { agentSessions } from "../../../db/schema/agent-session";
 import { conversations } from "../../../db/schema/conversation";
 import { notFound } from "../../shared/errors";
-import type {
-  AgentSessionData,
-  AgentSessionWithConversation,
-  CreateAgentSessionInput,
-} from "./types";
+import type { AgentSessionData, AgentSessionWithConversation } from "./types";
 
 /**
  * Agent Session Service - Pure Infra Functions
@@ -49,31 +45,6 @@ export async function getAgentSessionWithConversation(
         }
       : null,
   };
-}
-
-/**
- * Create a new agent session
- */
-export async function createAgentSession(
-  input: CreateAgentSessionInput,
-): Promise<AgentSessionData> {
-  const [session] = await globalThis.services.db
-    .insert(agentSessions)
-    .values({
-      userId: input.userId,
-      orgId: input.orgId,
-      agentComposeId: input.agentComposeId,
-      artifactName: input.artifactName,
-      memoryName: input.memoryName,
-      conversationId: input.conversationId,
-    })
-    .returning();
-
-  if (!session) {
-    throw new Error("Failed to create agent session");
-  }
-
-  return mapToAgentSessionData(session);
 }
 
 /**

--- a/turbo/apps/web/src/lib/infra/agent-session/index.ts
+++ b/turbo/apps/web/src/lib/infra/agent-session/index.ts
@@ -1,5 +1,4 @@
 export {
   getAgentSessionWithConversation,
-  createAgentSession,
   updateAgentSession,
 } from "./agent-session-service";

--- a/turbo/apps/web/src/lib/infra/agent-session/types.ts
+++ b/turbo/apps/web/src/lib/infra/agent-session/types.ts
@@ -20,18 +20,6 @@ export interface AgentSessionData {
 }
 
 /**
- * Input for creating a new agent session
- */
-export interface CreateAgentSessionInput {
-  userId: string;
-  orgId: string;
-  agentComposeId: string;
-  artifactName?: string;
-  memoryName?: string;
-  conversationId?: string;
-}
-
-/**
  * Agent session with related data for continue operations
  */
 export interface AgentSessionWithConversation extends AgentSessionData {

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -4,7 +4,7 @@ import { agentComposeVersions } from "../../../db/schema/agent-compose";
 import { conversations } from "../../../db/schema/conversation";
 import { checkpoints } from "../../../db/schema/checkpoint";
 import { notFound } from "../../shared/errors";
-import { createAgentSession, updateAgentSession } from "../agent-session";
+import { updateAgentSession } from "../agent-session";
 import { registerSessionHistoryBlob } from "../session-history";
 import { logger } from "../../shared/logger";
 import type {
@@ -173,9 +173,10 @@ export async function createCheckpoint(
 
   log.debug(`Checkpoint created successfully: ${checkpoint.id}`);
 
-  // Resolve agent session
-  // For session continuations, update the existing session's conversation reference.
-  // For new runs, always create a new session (with artifact name if present).
+  // Bind the pre-created agent session (always populated since #10323 made
+  // agent_runs.session_id NOT NULL) to this conversation and record per-run
+  // snapshot fields that were not known when the session was created eagerly
+  // at run insertion.
   const artifactSnapshot = request.artifactSnapshot as
     | ArtifactSnapshot
     | undefined;
@@ -184,39 +185,14 @@ export async function createCheckpoint(
     | VolumeVersionsSnapshot
     | undefined;
 
-  let agentSession;
-  if (run.sessionId) {
-    // New path: session was pre-created at run insertion (common case post-deploy).
-    // Bind the conversation and record any per-run snapshot fields that were
-    // not known at insertion time (e.g., memoryName from the runtime snapshot).
-    agentSession = await updateAgentSession(run.sessionId, conversation.id, {
+  const agentSession = await updateAgentSession(
+    run.sessionId,
+    conversation.id,
+    {
       artifactName: artifactSnapshot?.artifactName,
       memoryName: memorySnapshot?.memoryName,
-    });
-  } else if (run.continuedFromSessionId) {
-    // Legacy continuation in flight at deploy time: pre-existing session gets
-    // its conversation reference updated.
-    agentSession = await updateAgentSession(
-      run.continuedFromSessionId,
-      conversation.id,
-    );
-  } else {
-    // Legacy first-run created by old web before this deploy. Create the
-    // session now AND backfill agent_runs.session_id so downstream consumers
-    // (and the Release 2 migration) see a populated value.
-    agentSession = await createAgentSession({
-      userId: run.userId,
-      orgId: run.orgId,
-      agentComposeId: version.composeId,
-      artifactName: artifactSnapshot?.artifactName,
-      memoryName: memorySnapshot?.memoryName,
-      conversationId: conversation.id,
-    });
-    await globalThis.services.db
-      .update(agentRuns)
-      .set({ sessionId: agentSession.id })
-      .where(eq(agentRuns.id, run.id));
-  }
+    },
+  );
 
   log.debug(`Agent session updated/created: ${agentSession.id}`);
 

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -66,11 +66,13 @@ async function dispatchRun(context: PreparedContext): Promise<ExecutorResult> {
 /**
  * Extended error type for dispatch failures that includes run metadata.
  * When createRun() fails after the run record is created (post-INSERT),
- * the error is augmented with runId so callers can return partial
- * results if needed.
+ * the error is augmented with runId and sessionId so callers can return
+ * partial results (e.g. 201 with status=failed) that still satisfy the
+ * required-sessionId response contract.
  */
 export interface RunDispatchError extends Error {
   runId?: string;
+  sessionId?: string;
 }
 
 export function isRunDispatchError(error: unknown): error is RunDispatchError {
@@ -276,9 +278,18 @@ export async function markRunFailed(
     await dispatchTerminalSideEffects(runId, "failed", errorMessage);
   }
 
-  // Attach run metadata so callers can return partial results
+  // Attach run metadata so callers can return partial results. sessionId is
+  // always populated post-INSERT (see #10323 — agent_runs.session_id NOT NULL).
   if (error instanceof Error) {
     (error as RunDispatchError).runId = runId;
+    const [row] = await globalThis.services.db
+      .select({ sessionId: agentRuns.sessionId })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId))
+      .limit(1);
+    if (row) {
+      (error as RunDispatchError).sessionId = row.sessionId;
+    }
   }
 }
 

--- a/turbo/apps/web/src/lib/zero/zero-run-errors.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-errors.ts
@@ -7,13 +7,15 @@ import { isRunDispatchError } from "../infra/run";
  * Mirrors the handleCreateRunError pattern from /api/agent/runs.
  */
 export function handleCreateRunError(error: unknown) {
-  // Dispatch errors with a runId take priority -- return partial result
-  if (isRunDispatchError(error) && error.runId) {
+  // Dispatch errors with a runId take priority -- return partial result.
+  // sessionId is populated by markRunFailed() post-INSERT (see #10323).
+  if (isRunDispatchError(error) && error.runId && error.sessionId) {
     return {
       status: 201 as const,
       body: {
         runId: error.runId,
         status: "failed" as const,
+        sessionId: error.sessionId,
         error: error.message,
       },
     };

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -90,10 +90,8 @@ const createRunResponseSchema = z.object({
   runId: z.string(),
   status: runStatusSchema,
   sandboxId: z.string().optional(),
-  // Agent session id — eagerly created at run insertion so the first POST
-  // response carries it. Optional for backward compatibility with runs created
-  // before the eager-session rollout (Release 2 will tighten to required).
-  sessionId: z.string().uuid().optional(),
+  // Agent session id — eagerly created at run insertion, always present.
+  sessionId: z.string().uuid(),
   output: z.string().optional(),
   error: z.string().optional(),
   executionTimeMs: z.number().optional(),


### PR DESCRIPTION
## Summary

- Collapses the three-branch session-resolution logic in `checkpoint-service.ts` to a single `updateAgentSession(run.sessionId, conversation.id, {...})` call. Branches B and C became dead code after #10323 tightened `agent_runs.session_id` to `NOT NULL`.
- Deletes `createAgentSession()` and `CreateAgentSessionInput`. The only remaining session-creation site is the eager path in `insertRunRecord()`.
- Flips `createRunResponseSchema.sessionId` from `z.string().uuid().optional()` to `z.string().uuid()` — the server has been populating it unconditionally since Release 1 (#10290).
- Threads `sessionId` through `RunDispatchError` so the post-INSERT 201-failed path still satisfies the now-required contract. `markRunFailed()` fetches the sessionId from the run row (guaranteed non-null post-#10323) and attaches it to the error.
- Removes the two `.skip` webhook tests that were explicitly marked `TODO(#10324)` in #10323.

## Depends on

- #10323 (merged as 8e4decbf on 2026-04-20) — must reach production before this PR is deployed. The migration sets `agent_runs.session_id NOT NULL`; this PR removes the code that handled the now-impossible NULL case.

## Test plan

- [x] `pnpm turbo run lint` — 0 errors.
- [x] `pnpm check-types` — all 6 tasks pass.
- [x] `pnpm knip` — no unused exports (Excellent, Knip found no issues.).
- [x] `pnpm format` — no files modified.
- [x] Webhook checkpoint tests: 15/15 pass (two `.skip` Branch B/C blocks deleted).
- [x] Agent runs route tests: 87/87 pass — eager-sessionId and continuation paths still covered.
- [x] Zero runs route tests: 49/49 pass.
- [x] Infra unit tests (checkpoint, agent-session, run): 35/35 pass.
- [x] Full web suite: 3595/3595 pass.
- [x] Core contracts tests: 841/841 pass.
- [x] `grep -rn "createAgentSession" turbo/ --include="*.ts"` returns zero matches.
- [x] `grep -rn "continuedFromSessionId" turbo/apps/web/src/lib/infra/checkpoint/ --include="*.ts"` returns zero matches.

Closes #10324.