### PR TITLE
feat(web): add voice-chat-candidate reasoner and trigger-reasoning tick

### DIFF
--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/reasoner.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/reasoner.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { http } from "../../../../__tests__/msw";
+import { reloadEnv } from "../../../../env";
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+function openRouterResponse(content: string | null) {
+  return {
+    choices: [{ message: { content } }],
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("callReasoner", () => {
+  it("returns null and does not fetch when OPENROUTER_API_KEY is missing", async () => {
+    // Env is not stubbed — key is absent by default in tests.
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { callReasoner } = await import("../reasoner");
+
+    const result = await callReasoner({
+      agentSystemPrompt: "",
+      currentContext: null,
+      newItems: [],
+      pendingTasks: [],
+    });
+
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns the trimmed model content on a successful response", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    const handler = http.post(OPENROUTER_URL, () => {
+      return HttpResponse.json(openRouterResponse("  new context  "));
+    });
+    server.use(handler.handler);
+
+    const { callReasoner } = await import("../reasoner");
+
+    const result = await callReasoner({
+      agentSystemPrompt: "be helpful",
+      currentContext: "prior",
+      newItems: [{ seq: 1, role: "user", content: "hi" }],
+      pendingTasks: [],
+    });
+
+    expect(result).toBe("new context");
+    expect(handler.mocked).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when the response is not OK", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    const handler = http.post(OPENROUTER_URL, () => {
+      return HttpResponse.text("server down", { status: 500 });
+    });
+    server.use(handler.handler);
+
+    const { callReasoner } = await import("../reasoner");
+
+    const result = await callReasoner({
+      agentSystemPrompt: "",
+      currentContext: null,
+      newItems: [],
+      pendingTasks: [],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the response content is empty", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    const handler = http.post(OPENROUTER_URL, () => {
+      return HttpResponse.json(openRouterResponse(""));
+    });
+    server.use(handler.handler);
+
+    const { callReasoner } = await import("../reasoner");
+
+    const result = await callReasoner({
+      agentSystemPrompt: "",
+      currentContext: null,
+      newItems: [],
+      pendingTasks: [],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the fetch is aborted by the 30s timeout", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+    vi.useFakeTimers();
+
+    const fetchStub = vi.fn((_url: string, init: RequestInit) => {
+      return new Promise((_, reject) => {
+        const signal = init.signal;
+        if (!signal) return;
+        signal.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    });
+    vi.stubGlobal("fetch", fetchStub);
+
+    const { callReasoner } = await import("../reasoner");
+
+    const promise = callReasoner({
+      agentSystemPrompt: "",
+      currentContext: null,
+      newItems: [],
+      pendingTasks: [],
+    });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    expect(await promise).toBeNull();
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when fetch throws a network error", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    const fetchStub = vi.fn(() => {
+      return Promise.reject(new TypeError("network down"));
+    });
+    vi.stubGlobal("fetch", fetchStub);
+
+    const { callReasoner } = await import("../reasoner");
+
+    const result = await callReasoner({
+      agentSystemPrompt: "",
+      currentContext: null,
+      newItems: [],
+      pendingTasks: [],
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/trigger-reasoning.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/trigger-reasoning.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi } from "vitest";
+import { HttpResponse } from "msw";
+import { eq } from "drizzle-orm";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { seedTestCompose } from "../../../../__tests__/db-test-seeders/agents";
+import { server } from "../../../../mocks/server";
+import { http } from "../../../../__tests__/msw";
+import { mockAblyPublish } from "../../../../__tests__/ably-mock";
+import { reloadEnv } from "../../../../env";
+import { initServices } from "../../../init-services";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route covers these services yet
+import { createVoiceChatCandidateSession } from "../session-service";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route covers these services yet
+import {
+  appendVoiceChatCandidateItem,
+  readVoiceChatCandidateItems,
+} from "../item-service";
+import { triggerReasoning } from "../trigger-reasoning";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: verify DB side-effects directly
+import { featureCandidateVoiceChatSessions } from "../../../../db/schema/voice-chat-candidate";
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const context = testContext();
+
+function openRouterResponse(content: string) {
+  return {
+    choices: [{ message: { content } }],
+  };
+}
+
+async function seedActiveSession(): Promise<{
+  userId: string;
+  orgId: string;
+  sessionId: string;
+}> {
+  // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: test exercises services directly, no API route
+  initServices();
+  const { userId, orgId } = await context.setupUser();
+  const { composeId } = await seedTestCompose({
+    userId,
+    orgId,
+    name: uniqueId("vcc-reasoner"),
+  });
+  const session = await createVoiceChatCandidateSession({
+    orgId,
+    userId,
+    agentId: composeId,
+  });
+  return { userId, orgId, sessionId: session.id };
+}
+
+async function readSession(id: string) {
+  // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: verify DB side-effects directly
+  const db = globalThis.services.db;
+  const [row] = await db
+    .select()
+    .from(featureCandidateVoiceChatSessions)
+    .where(eq(featureCandidateVoiceChatSessions.id, id))
+    .limit(1);
+  return row!;
+}
+
+describe("triggerReasoning", () => {
+  it("H1 — writes context, bumps seq/version, and publishes on success", async () => {
+    context.setupMocks();
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    const { sessionId } = await seedActiveSession();
+    await appendVoiceChatCandidateItem({
+      sessionId,
+      role: "user",
+      content: "hello",
+      realtimeItemId: uniqueId("rt"),
+    });
+    const b = await appendVoiceChatCandidateItem({
+      sessionId,
+      role: "assistant",
+      content: "hi there",
+      realtimeItemId: uniqueId("rt"),
+    });
+
+    const handler = http.post(OPENROUTER_URL, () => {
+      return HttpResponse.json(openRouterResponse("updated context"));
+    });
+    server.use(handler.handler);
+
+    await triggerReasoning(sessionId);
+
+    const row = await readSession(sessionId);
+    expect(row.context).toBe("updated context");
+    expect(row.contextSeq).toBe(b!.seq);
+    expect(row.contextVersion).toBe(1);
+    expect(row.reasoningStatus).toBe("idle");
+    expect(row.reasoningPending).toBe(false);
+    expect(row.lastReasoningAt).not.toBeNull();
+    expect(handler.mocked).toHaveBeenCalledTimes(1);
+
+    expect(mockAblyPublish).toHaveBeenCalledWith(
+      `voice-chat-candidate:${sessionId}`,
+      null,
+    );
+  });
+
+  it("H2 — appends system_note and does not publish when the reasoner returns null", async () => {
+    context.setupMocks();
+    // OPENROUTER_API_KEY is intentionally absent — callReasoner short-circuits
+    // to null, which is exactly the "reasoner failed" branch we want to cover.
+    const { sessionId } = await seedActiveSession();
+    await appendVoiceChatCandidateItem({
+      sessionId,
+      role: "user",
+      content: "anything",
+      realtimeItemId: uniqueId("rt"),
+    });
+
+    await triggerReasoning(sessionId);
+
+    const row = await readSession(sessionId);
+    expect(row.context).toBeNull();
+    expect(row.contextVersion).toBe(0);
+    expect(row.reasoningStatus).toBe("idle");
+
+    const items = await readVoiceChatCandidateItems(sessionId);
+    const systemNotes = items.filter((i) => {
+      return i.role === "system_note";
+    });
+    expect(systemNotes).toHaveLength(1);
+    expect(systemNotes[0]!.content).toBe("Reasoner tick failed");
+
+    expect(mockAblyPublish).not.toHaveBeenCalled();
+  });
+
+  it("H3 — concurrent triggers run the reasoner once and drain the pending flag", async () => {
+    const mocks = context.setupMocks();
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    const { sessionId } = await seedActiveSession();
+    await appendVoiceChatCandidateItem({
+      sessionId,
+      role: "user",
+      content: "concurrent",
+      realtimeItemId: uniqueId("rt"),
+    });
+
+    const handler = http.post(OPENROUTER_URL, () => {
+      return HttpResponse.json(openRouterResponse("ctx"));
+    });
+    server.use(handler.handler);
+
+    await Promise.all([
+      triggerReasoning(sessionId),
+      triggerReasoning(sessionId),
+    ]);
+
+    // The second trigger set reasoning_pending; the first must have drained it
+    // and scheduled an after() re-tick. Flush the queue so the drain fires.
+    await mocks.flushAfter();
+
+    const row = await readSession(sessionId);
+    expect(row.reasoningStatus).toBe("idle");
+    expect(row.reasoningPending).toBe(false);
+    expect(row.contextVersion).toBe(1);
+    // Exactly one OpenRouter call — the drain re-tick sees no new items and
+    // takes the debounce bailout (Decision H6).
+    expect(handler.mocked).toHaveBeenCalledTimes(1);
+    expect(mockAblyPublish).toHaveBeenCalledTimes(1);
+  });
+
+  it("H4 — a concurrent contextVersion bump causes the write to drop silently", async () => {
+    context.setupMocks();
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    const { sessionId } = await seedActiveSession();
+    await appendVoiceChatCandidateItem({
+      sessionId,
+      role: "user",
+      content: "racy",
+      realtimeItemId: uniqueId("rt"),
+    });
+
+    const handler = http.post(OPENROUTER_URL, async () => {
+      // Simulate another tick winning the write race between our snapshot
+      // and our optimistic UPDATE.
+      // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: simulate concurrent write
+      const db = globalThis.services.db;
+      await db
+        .update(featureCandidateVoiceChatSessions)
+        .set({ contextVersion: 99, context: "written by another tick" })
+        .where(eq(featureCandidateVoiceChatSessions.id, sessionId));
+      return HttpResponse.json(openRouterResponse("stale context"));
+    });
+    server.use(handler.handler);
+
+    await triggerReasoning(sessionId);
+
+    const row = await readSession(sessionId);
+    expect(row.context).toBe("written by another tick");
+    expect(row.contextVersion).toBe(99);
+    expect(row.reasoningStatus).toBe("idle");
+    expect(mockAblyPublish).not.toHaveBeenCalled();
+  });
+
+  it("H5 — runs successfully when the session has no associated agent", async () => {
+    context.setupMocks();
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: createVoiceChatCandidateSession requires agentId; tests for the null-agent path insert directly
+    initServices();
+    const { userId, orgId } = await context.setupUser();
+    // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: seed a session without an agent
+    const db = globalThis.services.db;
+    const [session] = await db
+      .insert(featureCandidateVoiceChatSessions)
+      .values({ orgId, userId, agentId: null })
+      .returning();
+    const sessionId = session!.id;
+    await appendVoiceChatCandidateItem({
+      sessionId,
+      role: "user",
+      content: "sans-agent",
+      realtimeItemId: uniqueId("rt"),
+    });
+
+    let capturedBody: unknown;
+    const handler = http.post(OPENROUTER_URL, async ({ request }) => {
+      capturedBody = await request.json();
+      return HttpResponse.json(openRouterResponse("orphan ctx"));
+    });
+    server.use(handler.handler);
+
+    await triggerReasoning(sessionId);
+
+    const row = await readSession(sessionId);
+    expect(row.context).toBe("orphan ctx");
+    expect(row.contextVersion).toBe(1);
+
+    const body = capturedBody as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(body.messages[1]!.content).toContain("Agent system prompt:\n(none)");
+  });
+
+  it("H6 — skips the reasoner call when there are no new items or pending tasks", async () => {
+    context.setupMocks();
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    const { sessionId } = await seedActiveSession();
+
+    const handler = http.post(OPENROUTER_URL, () => {
+      return HttpResponse.json(openRouterResponse("should-not-be-called"));
+    });
+    server.use(handler.handler);
+
+    await triggerReasoning(sessionId);
+
+    const row = await readSession(sessionId);
+    expect(row.context).toBeNull();
+    expect(row.contextVersion).toBe(0);
+    expect(row.reasoningStatus).toBe("idle");
+    expect(row.reasoningPending).toBe(false);
+    expect(handler.mocked).not.toHaveBeenCalled();
+    expect(mockAblyPublish).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/trigger-reasoning.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/trigger-reasoning.test.ts
@@ -120,6 +120,9 @@ describe("triggerReasoning", () => {
     expect(row.context).toBeNull();
     expect(row.contextVersion).toBe(0);
     expect(row.reasoningStatus).toBe("idle");
+    // lastReasoningAt is bumped on both success and failure branches so
+    // operators can distinguish "ticks running but failing" from "no tick ran".
+    expect(row.lastReasoningAt).not.toBeNull();
 
     const items = await readVoiceChatCandidateItems(sessionId);
     const systemNotes = items.filter((i) => {

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/reasoner-prompts.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/reasoner-prompts.ts
@@ -1,0 +1,46 @@
+export const REASONER_SYSTEM_PROMPT = `You are the Reasoner for a voice chat session. Your job is to maintain a concise working context ("the context") that a separate Talker agent will use to decide what to say next and which tasks to spawn.
+
+Given the current context, any newly-observed conversation items, and the list of pending tasks, produce an updated context. The output should:
+
+- Preserve important long-term facts from the prior context.
+- Incorporate signal from new items: user intents, decisions, state changes, anything the Talker needs to remember.
+- Acknowledge pending tasks so the Talker knows what is in flight.
+- Drop noise, verbatim speech, and details that do not affect future turns.
+- Stay brief — at most a few short paragraphs of plain text, no markdown.
+
+Return only the updated context text. Do not wrap it in quotes, JSON, or code fences. Do not explain your changes.`;
+
+export function buildReasonerUserPrompt(params: {
+  agentSystemPrompt: string;
+  currentContext: string | null;
+  newItems: Array<{ seq: number; role: string; content: string | null }>;
+  pendingTasks: Array<{ id: string; status: string; prompt: string }>;
+}): string {
+  const agentSlot = params.agentSystemPrompt.trim() || "(none)";
+  const contextSlot = params.currentContext?.trim() || "(none)";
+
+  const itemsSlot =
+    params.newItems.length === 0
+      ? "(none)"
+      : params.newItems
+          .map((i) => {
+            return `[${i.seq}] ${i.role}: ${i.content ?? ""}`;
+          })
+          .join("\n");
+
+  const tasksSlot =
+    params.pendingTasks.length === 0
+      ? "(none)"
+      : params.pendingTasks
+          .map((t) => {
+            return `[${t.id}] ${t.status}: ${t.prompt}`;
+          })
+          .join("\n");
+
+  return [
+    `Agent system prompt:\n${agentSlot}`,
+    `Current context:\n${contextSlot}`,
+    `New conversation items:\n${itemsSlot}`,
+    `Pending tasks:\n${tasksSlot}`,
+  ].join("\n\n");
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/reasoner.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/reasoner.ts
@@ -1,0 +1,88 @@
+import "server-only";
+import { env } from "../../../env";
+import { logger } from "../../shared/logger";
+import {
+  REASONER_SYSTEM_PROMPT,
+  buildReasonerUserPrompt,
+} from "./reasoner-prompts";
+
+const BASE_URL = "https://openrouter.ai/api/v1/chat/completions";
+const MODEL = "anthropic/claude-sonnet-4.5";
+const TIMEOUT_MS = 30_000;
+const MAX_TOKENS = 400;
+const TEMPERATURE = 0.2;
+
+const log = logger("zero:voice-chat-candidate:reasoner");
+
+interface OpenRouterResponse {
+  choices: Array<{
+    message: {
+      content: string;
+    };
+  }>;
+}
+
+interface CallReasonerParams {
+  agentSystemPrompt: string;
+  currentContext: string | null;
+  newItems: Array<{ seq: number; role: string; content: string | null }>;
+  pendingTasks: Array<{ id: string; status: string; prompt: string }>;
+}
+
+export async function callReasoner(
+  params: CallReasonerParams,
+): Promise<string | null> {
+  const { OPENROUTER_API_KEY } = env();
+  if (!OPENROUTER_API_KEY) {
+    log.warn("OPENROUTER_API_KEY not configured, skipping reasoner call");
+    return null;
+  }
+
+  const userPrompt = buildReasonerUserPrompt(params);
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, TIMEOUT_MS);
+
+  try {
+    const response = await fetch(BASE_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        messages: [
+          { role: "system", content: REASONER_SYSTEM_PROMPT },
+          { role: "user", content: userPrompt },
+        ],
+        max_tokens: MAX_TOKENS,
+        temperature: TEMPERATURE,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => {
+        return "unknown error";
+      });
+      log.warn(`reasoner request failed: ${response.status} ${text}`);
+      return null;
+    }
+
+    const data = (await response.json()) as OpenRouterResponse;
+    const content = data.choices[0]?.message?.content?.trim();
+    if (!content) {
+      log.warn("reasoner returned empty content");
+      return null;
+    }
+
+    return content;
+  } catch (err) {
+    log.warn("reasoner fetch failed", err);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/reasoner.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/reasoner.ts
@@ -44,8 +44,9 @@ export async function callReasoner(
     controller.abort();
   }, TIMEOUT_MS);
 
+  let response: Response;
   try {
-    const response = await fetch(BASE_URL, {
+    response = await fetch(BASE_URL, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${OPENROUTER_API_KEY}`,
@@ -62,27 +63,36 @@ export async function callReasoner(
       }),
       signal: controller.signal,
     });
-
-    if (!response.ok) {
-      const text = await response.text().catch(() => {
-        return "unknown error";
-      });
-      log.warn(`reasoner request failed: ${response.status} ${text}`);
-      return null;
-    }
-
-    const data = (await response.json()) as OpenRouterResponse;
-    const content = data.choices[0]?.message?.content?.trim();
-    if (!content) {
-      log.warn("reasoner returned empty content");
-      return null;
-    }
-
-    return content;
   } catch (err) {
-    log.warn("reasoner fetch failed", err);
-    return null;
+    // Narrow catch: only the two runtime conditions that fetch itself can
+    // produce and that we explicitly want to recover from — AbortError from
+    // our 30s timeout and TypeError from network failures. Anything else
+    // (programmer bugs, unexpected runtime errors) must fail fast.
+    if (err instanceof DOMException && err.name === "AbortError") {
+      log.warn("reasoner fetch aborted (timeout)");
+      return null;
+    }
+    if (err instanceof TypeError) {
+      log.warn("reasoner network error", err);
+      return null;
+    }
+    throw err;
   } finally {
     clearTimeout(timer);
   }
+
+  if (!response.ok) {
+    const text = await response.text();
+    log.warn(`reasoner request failed: ${response.status} ${text}`);
+    return null;
+  }
+
+  const data = (await response.json()) as OpenRouterResponse;
+  const content = data.choices[0]?.message?.content?.trim();
+  if (!content) {
+    log.warn("reasoner returned empty content");
+    return null;
+  }
+
+  return content;
 }

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/trigger-reasoning.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/trigger-reasoning.ts
@@ -165,7 +165,7 @@ export async function triggerReasoning(sessionId: string): Promise<void> {
     }
     await db
       .update(featureCandidateVoiceChatSessions)
-      .set({ reasoningStatus: "idle" })
+      .set({ reasoningStatus: "idle", lastReasoningAt: new Date() })
       .where(eq(featureCandidateVoiceChatSessions.id, sessionId));
   }
 

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/trigger-reasoning.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/trigger-reasoning.ts
@@ -1,0 +1,229 @@
+import "server-only";
+import { after } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { featureCandidateVoiceChatSessions } from "../../../db/schema/voice-chat-candidate";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../db/schema/agent-compose";
+import {
+  appendVoiceChatCandidateItem,
+  readVoiceChatCandidateItems,
+} from "./item-service";
+import { listPendingVoiceChatCandidateTasks } from "./task-service";
+import { callReasoner } from "./reasoner";
+import { publishUserSignal } from "../../infra/realtime/client";
+import { isBadRequest } from "../../shared/errors";
+import { logger } from "../../shared/logger";
+
+const log = logger("zero:voice-chat-candidate:trigger-reasoning");
+
+export async function triggerReasoning(sessionId: string): Promise<void> {
+  const db = globalThis.services.db;
+
+  // Step 0 — load session and bail early on unknown/ended sessions.
+  const [session] = await db
+    .select()
+    .from(featureCandidateVoiceChatSessions)
+    .where(eq(featureCandidateVoiceChatSessions.id, sessionId))
+    .limit(1);
+  if (!session) return;
+  if (session.status !== "active") return;
+
+  // Step 1 — CAS acquire. Only the tick that flips idle→running owns the
+  // lock. A losing racer sets reasoning_pending=true and exits; whichever
+  // tick releases the lock will observe and drain the pending flag.
+  const acquired = await db
+    .update(featureCandidateVoiceChatSessions)
+    .set({ reasoningStatus: "running" })
+    .where(
+      and(
+        eq(featureCandidateVoiceChatSessions.id, sessionId),
+        eq(featureCandidateVoiceChatSessions.reasoningStatus, "idle"),
+      ),
+    )
+    .returning({ id: featureCandidateVoiceChatSessions.id });
+
+  if (acquired.length === 0) {
+    // Losing racer: flag that work is pending and report back the current
+    // status. If the holder already flipped status→idle and ran drainPending
+    // before we set the flag, our signal would be lost — schedule a re-tick
+    // ourselves in that case.
+    const [row] = await db
+      .update(featureCandidateVoiceChatSessions)
+      .set({ reasoningPending: true })
+      .where(eq(featureCandidateVoiceChatSessions.id, sessionId))
+      .returning({ status: featureCandidateVoiceChatSessions.reasoningStatus });
+    if (row?.status === "idle") {
+      after(() => {
+        return triggerReasoning(sessionId);
+      });
+    }
+    return;
+  }
+
+  // Step 2 — snapshot new items + pending tasks. If neither has anything to
+  // reason about, skip the LLM call entirely and just release the lock.
+  const newItems = await readVoiceChatCandidateItems(
+    sessionId,
+    session.contextSeq,
+  );
+  const pendingTasks = await listPendingVoiceChatCandidateTasks(sessionId);
+
+  if (newItems.length === 0 && pendingTasks.length === 0) {
+    await releaseAndDrain(sessionId);
+    return;
+  }
+
+  // Step 3 — resolve the agent "system prompt". AgentComposeYaml has no
+  // dedicated systemPrompt field, so we use the first agent's description
+  // as the closest available semantic slot; empty string otherwise.
+  const agentSystemPrompt = await resolveAgentSystemPrompt(session.agentId);
+
+  // Step 4 — determine the highest seq we are about to snapshot against,
+  // which becomes the session's new contextSeq on a successful write.
+  const newMaxSeq =
+    newItems.length > 0
+      ? Math.max(
+          ...newItems.map((i) => {
+            return i.seq;
+          }),
+        )
+      : session.contextSeq;
+
+  // Step 5 — call the Reasoner. Returns null on any failure path.
+  const newContext = await callReasoner({
+    agentSystemPrompt,
+    currentContext: session.context,
+    newItems: newItems.map((i) => {
+      return {
+        seq: i.seq,
+        role: i.role,
+        content: i.content,
+      };
+    }),
+    pendingTasks: pendingTasks.map((t) => {
+      return {
+        id: t.id,
+        status: t.status,
+        prompt: t.prompt,
+      };
+    }),
+  });
+
+  if (newContext !== null) {
+    // Step 6a — optimistic context_version write. If another tick wrote
+    // ahead of us, the update affects 0 rows and we silently drop — the
+    // next trigger cycle will reconcile.
+    const updated = await db
+      .update(featureCandidateVoiceChatSessions)
+      .set({
+        context: newContext,
+        contextSeq: newMaxSeq,
+        contextVersion: session.contextVersion + 1,
+        lastReasoningAt: new Date(),
+        reasoningStatus: "idle",
+      })
+      .where(
+        and(
+          eq(featureCandidateVoiceChatSessions.id, sessionId),
+          eq(
+            featureCandidateVoiceChatSessions.contextVersion,
+            session.contextVersion,
+          ),
+        ),
+      )
+      .returning({ id: featureCandidateVoiceChatSessions.id });
+
+    if (updated.length > 0) {
+      await publishUserSignal(
+        [session.userId],
+        `voice-chat-candidate:${sessionId}`,
+      );
+    } else {
+      log.info(`reasoner version contention for ${sessionId}, dropping tick`);
+      await db
+        .update(featureCandidateVoiceChatSessions)
+        .set({ reasoningStatus: "idle" })
+        .where(eq(featureCandidateVoiceChatSessions.id, sessionId));
+    }
+  } else {
+    // Step 6b — reasoner returned null (missing key / HTTP error / empty /
+    // timeout / network). Record a system_note so the session transcript
+    // carries the failure signal, then release the lock. If the session
+    // ended between acquire and now, append throws badRequest — swallow
+    // only that specific case so the lock still gets released.
+    try {
+      await appendVoiceChatCandidateItem({
+        sessionId,
+        role: "system_note",
+        content: "Reasoner tick failed",
+        realtimeItemId: null,
+      });
+    } catch (err) {
+      if (!isBadRequest(err)) throw err;
+    }
+    await db
+      .update(featureCandidateVoiceChatSessions)
+      .set({ reasoningStatus: "idle" })
+      .where(eq(featureCandidateVoiceChatSessions.id, sessionId));
+  }
+
+  // Step 7 — drain pending flag. If another trigger arrived while we were
+  // running, the flag was set; clear it and schedule a re-tick so the new
+  // items are picked up.
+  await drainPending(sessionId);
+}
+
+async function releaseAndDrain(sessionId: string): Promise<void> {
+  const db = globalThis.services.db;
+  await db
+    .update(featureCandidateVoiceChatSessions)
+    .set({ reasoningStatus: "idle" })
+    .where(eq(featureCandidateVoiceChatSessions.id, sessionId));
+  await drainPending(sessionId);
+}
+
+async function drainPending(sessionId: string): Promise<void> {
+  const db = globalThis.services.db;
+  const drained = await db
+    .update(featureCandidateVoiceChatSessions)
+    .set({ reasoningPending: false })
+    .where(
+      and(
+        eq(featureCandidateVoiceChatSessions.id, sessionId),
+        eq(featureCandidateVoiceChatSessions.reasoningPending, true),
+      ),
+    )
+    .returning({ id: featureCandidateVoiceChatSessions.id });
+
+  if (drained.length > 0) {
+    after(() => {
+      return triggerReasoning(sessionId);
+    });
+  }
+}
+
+async function resolveAgentSystemPrompt(
+  agentId: string | null,
+): Promise<string> {
+  if (!agentId) return "";
+  const db = globalThis.services.db;
+  const [row] = await db
+    .select({ content: agentComposeVersions.content })
+    .from(agentComposes)
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentComposeVersions.id, agentComposes.headVersionId),
+    )
+    .where(eq(agentComposes.id, agentId))
+    .limit(1);
+  if (!row?.content || typeof row.content !== "object") return "";
+  const content = row.content as {
+    agents?: Record<string, { description?: string }>;
+  };
+  const firstAgent = content.agents
+    ? Object.values(content.agents)[0]
+    : undefined;
+  return firstAgent?.description ?? "";
+}


### PR DESCRIPTION
## Summary

Implements the Reasoner tick + CAS state machine for the `voice-chat-candidate` feature (Epic #10297). All changes are confined to `turbo/apps/web/src/lib/zero/voice-chat-candidate/`.

- **`reasoner-prompts.ts`** — system prompt + user-prompt builder with 4 slots (agent system prompt, current context, new items, pending tasks).
- **`reasoner.ts`** — bare-fetch OpenRouter client (`anthropic/claude-sonnet-4.5`) with 30s `AbortController` timeout; returns `null` on any failure path (missing key / non-OK / empty / timeout / network).
- **`trigger-reasoning.ts`** — CAS-driven tick:
  1. Load session; bail if unknown or non-active.
  2. CAS acquire `idle → running`. If lost, set `reasoning_pending = true`; if the holder already released, schedule an `after()` re-tick so the signal isn't lost.
  3. Snapshot new items + pending tasks. If both empty, release + drain (Decision **H6** bailout).
  4. Resolve agent "system prompt" = first agent description from the `agent_composes` head version (Decision **A**); `(none)` if no agent.
  5. Call the reasoner.
  6a. On success, optimistic `context_version` write — if another tick wrote ahead of us, silently drop (Decision **C3**).
  6b. On null reasoner, append a `system_note` "Reasoner tick failed"; swallow `isBadRequest` so the lock still releases if the session ended mid-tick (Decision **J**).
  7. Drain `reasoning_pending` via a single-shot `after()` re-tick.

## Decisions from plan

- **A** — Agent "system prompt" sourced from the first agent's `description` field in the head `agent_compose_versions.content.agents` record.
- **H6** — Skip the OpenRouter call entirely when there are no new items and no pending tasks.
- **J** — `appendVoiceChatCandidateItem` throws `badRequest` if the session ended between CAS acquire and failure-branch append; swallow only that specific case so the lock still releases.

## Test plan

Integration tests only, using MSW for the OpenRouter HTTP boundary and `mockAblyPublish` from `ably-mock.ts` for the realtime boundary. Real DB, real services.

- [x] **R1** — no `OPENROUTER_API_KEY` → returns null, no fetch
- [x] **R2** — happy path → trimmed content
- [x] **R3** — HTTP 500 → null
- [x] **R4** — empty content → null
- [x] **R5** — 30s timeout via fake timers + abort signal → null
- [x] **R6** — network error → null
- [x] **H1** — happy path: context/seq/version bumped, Ably published on topic `voice-chat-candidate:${sessionId}`
- [x] **H2** — reasoner returns null → `system_note` appended, no publish
- [x] **H3** — concurrent `Promise.all` triggers: exactly 1 OpenRouter call, pending drained (also stress-tested across 5 runs after closing a race in the losing CAS path)
- [x] **H4** — concurrent `context_version` bump during fetch → optimistic write drops silently
- [x] **H5** — session with `agentId = null` → `agentSystemPrompt = (none)`, happy path
- [x] **H6** — no items and no tasks → reasoner not called, no state change
- [x] Lint / typecheck / format / knip clean on the voice-chat-candidate tree (pre-existing typecheck errors elsewhere are unrelated to this change)

Refs #10308