### PR TITLE
chore(mitm-addon): enable cherry-picked pylint rules

### DIFF
--- a/crates/runner/mitm-addon/pyproject.toml
+++ b/crates/runner/mitm-addon/pyproject.toml
@@ -23,25 +23,33 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = [
-    "E",      # pycodestyle errors
-    "F",      # pyflakes
-    "I",      # isort
-    "B",      # flake8-bugbear (real correctness bugs)
-    "S",      # flake8-bandit (security)
-    "ASYNC",  # flake8-async (this addon is async-heavy)
-    "UP",     # pyupgrade (modernize py3.10+ syntax)
-    "C4",     # flake8-comprehensions
-    "PT",     # flake8-pytest-style
-    "T20",    # flake8-print (force logging through ctx.log)
-    "RET",    # flake8-return
-    "N",      # pep8-naming
-    "G",      # flake8-logging-format
-    "A",      # flake8-builtins (no shadowing)
-    "SIM",    # flake8-simplify
-    "PIE",    # flake8-pie
-    "RUF",    # ruff-specific
-    "TRY",    # tryceratops (exception handling)
-    "PTH",    # flake8-use-pathlib
+    "E",        # pycodestyle errors
+    "F",        # pyflakes
+    "I",        # isort
+    "B",        # flake8-bugbear (real correctness bugs)
+    "S",        # flake8-bandit (security)
+    "ASYNC",    # flake8-async (this addon is async-heavy)
+    "UP",       # pyupgrade (modernize py3.10+ syntax)
+    "C4",       # flake8-comprehensions
+    "PT",       # flake8-pytest-style
+    "T20",      # flake8-print (force logging through ctx.log)
+    "RET",      # flake8-return
+    "N",        # pep8-naming
+    "G",        # flake8-logging-format
+    "A",        # flake8-builtins (no shadowing)
+    "SIM",      # flake8-simplify
+    "PIE",      # flake8-pie
+    "RUF",      # ruff-specific
+    "TRY",      # tryceratops (exception handling)
+    "PTH",      # flake8-use-pathlib
+    # Cherry-picked pylint (PL) rules.  The full PL family adds mostly
+    # stylistic complexity caps (PLR09xx too-many-*) and a global-statement
+    # ban (PLW0603) that fights the addon's deliberate module-level caches.
+    # These three are the subset that catch real hygiene issues without
+    # fighting the existing design — see #10298.
+    "PLC0415",  # pylint — import-outside-top-level
+    "PLR1714",  # pylint — repeated-equality-comparison (x==a or x==b)
+    "PLR2004",  # pylint — magic-value-comparison (source only; tests exempted)
 ]
 
 extend-ignore = [
@@ -65,7 +73,9 @@ extend-ignore = [
 # S101: pytest uses `assert` universally; S105: tests hardcode fixture tokens
 # like "vm_sandbox_token" that bandit flags as "possible password". Both are
 # standard pytest patterns with no security meaning in test-only code.
-"tests/**" = ["S101", "S105"]
+# PLR2004: `assert status == 200` / `assert len(lines) == 2` are idiomatic in
+# tests; naming each threshold as a constant adds noise without catching bugs.
+"tests/**" = ["S101", "S105", "PLR2004"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -22,6 +22,14 @@ from mitmproxy import ctx, http
 # Cap for non-model-provider response body buffering and decompression output.
 STREAM_BUFFER_LIMIT = 64 * 1024  # 64 KB
 
+# UTF-8 byte-boundary markers (RFC 3629).  Continuation bytes match
+# ``0b10xxxxxx`` → ``(byte & 0xC0) == _UTF8_CONT_MARK``.  Lead bytes fall
+# into four ranges by ``lead < _UTF8_LEAD_MAX_{N}BYTE`` for N = 1..3.
+_UTF8_CONT_MARK = 0x80
+_UTF8_LEAD_MAX_1BYTE = 0x80  # ASCII: 0xxxxxxx
+_UTF8_LEAD_MAX_2BYTE = 0xE0  # 2-byte lead: 110xxxxx
+_UTF8_LEAD_MAX_3BYTE = 0xF0  # 3-byte lead: 1110xxxx
+
 # Decompression cap for response bodies that need full parsing for usage
 # extraction (model-provider non-SSE JSON, billable-connector JSON).  Larger
 # than STREAM_BUFFER_LIMIT (which guards capture-mode body logging) so large
@@ -190,17 +198,17 @@ def _truncate_bytes_utf8_safe(data: bytes, max_size: int) -> bytes:
     # Find the start of the last character by scanning backwards
     # past continuation bytes (10xxxxxx = 0x80..0xBF).
     i = len(t)
-    while i > 0 and (t[i - 1] & 0xC0) == 0x80:
+    while i > 0 and (t[i - 1] & 0xC0) == _UTF8_CONT_MARK:
         i -= 1
     if i == 0:
         return t  # all continuation bytes — shouldn't happen in valid UTF-8
     lead = t[i - 1]
     # Determine the expected sequence length from the lead byte.
-    if lead < 0x80:
+    if lead < _UTF8_LEAD_MAX_1BYTE:
         expected = 1
-    elif lead < 0xE0:
+    elif lead < _UTF8_LEAD_MAX_2BYTE:
         expected = 2
-    elif lead < 0xF0:
+    elif lead < _UTF8_LEAD_MAX_3BYTE:
         expected = 3
     else:
         expected = 4

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -10,6 +10,15 @@ from graphql_fields import extract_field_paths
 
 _SEGMENT_ERROR_HINT = 'use "{name}", "prefix{name}", "{name}suffix", or "prefix{name}suffix"'
 
+# A segment with two or more ``{`` braces contains more than one parameter,
+# which the grammar rejects — detected once here rather than scattering the
+# literal ``2`` across the parser.
+_MULTI_PARAM_BRACE_COUNT = 2
+
+# Firewall rules are encoded as ``"METHOD path"`` — a single-whitespace-split
+# yields exactly two tokens.  Rows that fail this shape are malformed.
+_RULE_TOKEN_COUNT = 2
+
 
 def parse_segment(seg: str) -> dict:
     """Parse a single host or path segment into literal / param / error.
@@ -43,7 +52,7 @@ def parse_segment(seg: str) -> dict:
             "reason": f'unbalanced brace in segment "{seg}" — {_SEGMENT_ERROR_HINT}',
         }
 
-    if open_count >= 2:
+    if open_count >= _MULTI_PARAM_BRACE_COUNT:
         open2 = seg.find("{", close1 + 1)
         if close1 + 1 == open2:
             return {
@@ -491,10 +500,10 @@ def _collect_field_patterns(
     for perm in permissions:
         for rule_str in perm.get("rules", []):
             parts = rule_str.split(" ", 1)
-            if len(parts) != 2:
+            if len(parts) != _RULE_TOKEN_COUNT:
                 continue
             rule_method = parts[0].upper()
-            if rule_method != "ANY" and rule_method != method:
+            if rule_method not in ("ANY", method):
                 continue
             gql = parse_graphql_rule(parts[1])
             if gql is None:
@@ -694,11 +703,11 @@ def match_firewall_request(
                 perm_name = perm.get("name", "")
                 for rule_str in perm.get("rules", []):
                     parts = rule_str.split(" ", 1)
-                    if len(parts) != 2:
+                    if len(parts) != _RULE_TOKEN_COUNT:
                         continue
                     rule_method = parts[0].upper()
                     rest = parts[1]
-                    if rule_method != "ANY" and rule_method != upper_method:
+                    if rule_method not in ("ANY", upper_method):
                         continue
 
                     # Check for GraphQL suffix

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -44,7 +44,7 @@ from url_utils import get_original_url
 # in ``usage.py`` for the same reason; kept local because they're RFC-fixed
 # (never drift) and factoring them out for two callers adds no value.
 _HTTP_STATUS_OK_MIN = 200  # inclusive: start of 2xx success range
-_HTTP_STATUS_OK_MAX = 300  # exclusive: one past end of 2xx range
+_HTTP_STATUS_REDIRECT_MIN = 300  # start of 3xx — doubles as the 2xx exclusive upper bound
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 
@@ -323,7 +323,7 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     is_x_stream = False
     if (
         is_billable_connector
-        and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_OK_MAX
+        and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
     ):
         stream_path = urllib.parse.urlparse(flow.metadata.get("original_url", "")).path
         is_x_stream = usage.is_x_stream_path(stream_path)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -40,6 +40,14 @@ from logging_utils import add_firewall_metadata, log_network_entry, log_proxy_en
 from matching import FirewallAllow, FirewallBlock, match_firewall_request
 from url_utils import get_original_url
 
+# HTTP status boundaries used in response-phase classification.  Also defined
+# in ``usage.py`` for the same reason; kept local because they're RFC-fixed
+# (never drift) and factoring them out for two callers adds no value.
+_HTTP_STATUS_OK_MIN = 200  # inclusive: start of 2xx success range
+_HTTP_STATUS_OK_MAX = 300  # exclusive: one past end of 2xx range
+_HTTP_STATUS_UNAUTHORIZED = 401
+_HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
+
 # ============================================================================
 # Addon Configuration
 # ============================================================================
@@ -313,7 +321,10 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     # decision.  For any billable connector flow, ``request()`` has
     # already populated ``original_url`` before ``responseheaders`` fires.
     is_x_stream = False
-    if is_billable_connector and 200 <= flow.response.status_code < 300:
+    if (
+        is_billable_connector
+        and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_OK_MAX
+    ):
         stream_path = urllib.parse.urlparse(flow.metadata.get("original_url", "")).path
         is_x_stream = usage.is_x_stream_path(stream_path)
 
@@ -490,7 +501,11 @@ def response(flow: http.HTTPFlow) -> None:
     # us the token is no longer valid, overriding whatever the DB believes.
     # request_force_refresh enforces a cooldown so a persistent non-token 401
     # can't amplify into a loop of provider OAuth refresh calls (#9860).
-    if flow.response and flow.response.status_code == 401 and flow.metadata.get("firewall_base"):
+    if (
+        flow.response
+        and flow.response.status_code == _HTTP_STATUS_UNAUTHORIZED
+        and flow.metadata.get("firewall_base")
+    ):
         api_id = flow.metadata.get("firewall_api_id", "")
         if api_id:
             cache_key = (run_id, api_id)
@@ -498,7 +513,7 @@ def response(flow: http.HTTPFlow) -> None:
             request_force_refresh(cache_key)
 
     # Log errors to per-job proxy log and mitmproxy console
-    if flow.response and flow.response.status_code >= 400:
+    if flow.response and flow.response.status_code >= _HTTP_STATUS_ERROR_MIN:
         log_proxy_entry(
             proxy_log_path,
             "warn",

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -7,6 +7,11 @@ import urllib.parse
 
 from mitmproxy import http
 
+# Well-known IANA ports for HTTP and HTTPS.  When the connection uses the
+# default port for its scheme we omit ``:port`` from the reconstructed URL.
+_HTTP_DEFAULT_PORT = 80
+_HTTPS_DEFAULT_PORT = 443
+
 
 def get_original_url(flow: http.HTTPFlow) -> str:
     """Reconstruct the original target URL from the request.
@@ -23,7 +28,9 @@ def get_original_url(flow: http.HTTPFlow) -> str:
     host = flow.request.pretty_host
     port = flow.request.port
 
-    if (scheme == "https" and port != 443) or (scheme == "http" and port != 80):
+    if (scheme == "https" and port != _HTTPS_DEFAULT_PORT) or (
+        scheme == "http" and port != _HTTP_DEFAULT_PORT
+    ):
         host_with_port = f"{host}:{port}"
     else:
         host_with_port = host

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -29,14 +29,19 @@ from body_utils import decompress_body
 from logging_utils import log_proxy_entry
 
 # HTTP 2xx success range (RFC 9110).  Also defined in ``mitm_addon.py``; kept
-# local to avoid introducing a constants module for two callers.
+# local to avoid introducing a constants module for two callers.  The upper
+# bound is ``REDIRECT_MIN`` (300) because 300 is the first 3xx status — using
+# ``status < _HTTP_STATUS_REDIRECT_MIN`` reads as "still in 2xx" without the
+# ambiguity of an ``OK_MAX`` that is itself excluded from the OK range.
 _HTTP_STATUS_OK_MIN = 200
-_HTTP_STATUS_OK_MAX = 300
+_HTTP_STATUS_REDIRECT_MIN = 300
 
-# SSE event boundary is ``\r\n\r\n`` (4 bytes).  When no boundary is found in
-# the current buffer we keep the last 3 bytes so a boundary split across the
-# next chunk can still complete.
-_SSE_BOUNDARY_TAIL = 3
+# Longest SSE event boundary we scan for (``\r\n\r\n`` at 4 bytes; the other
+# candidate ``\n\n`` is shorter and therefore covered by the same tail).
+# When no boundary is found we keep ``_MAX_SEPARATOR_LEN - 1`` trailing bytes
+# so a boundary split across the next chunk can still complete — deriving
+# from the separator keeps the invariant visible if the separator set grows.
+_MAX_SEPARATOR_LEN = len(b"\r\n\r\n")
 
 # ---------------------------------------------------------------------------
 # Dual pending counter: in-flight flows + pending reports
@@ -186,11 +191,8 @@ def create_sse_usage_extractor() -> tuple[Callable[[bytes], None], dict]:
             else:
                 # No boundary found — discard everything except the
                 # last few bytes (could be a partial \r\n\r\n).
-                line_buf[:] = (
-                    combined[-_SSE_BOUNDARY_TAIL:]
-                    if len(combined) > _SSE_BOUNDARY_TAIL
-                    else combined
-                )
+                tail = _MAX_SEPARATOR_LEN - 1
+                line_buf[:] = combined[-tail:] if len(combined) > tail else combined
                 return
             # Boundary found — fall through to process line_buf contents.
             # line_buf already has the data, so skip the extend.
@@ -868,7 +870,7 @@ def log_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
     if not is_billable_connector(firewall_name):
         return
     if not flow.response or not (
-        _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_OK_MAX
+        _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
     ):
         return
     endpoint = flow.metadata.get("firewall_permission", "")

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -36,12 +36,12 @@ from logging_utils import log_proxy_entry
 _HTTP_STATUS_OK_MIN = 200
 _HTTP_STATUS_REDIRECT_MIN = 300
 
-# Longest SSE event boundary we scan for (``\r\n\r\n`` at 4 bytes; the other
-# candidate ``\n\n`` is shorter and therefore covered by the same tail).
-# When no boundary is found we keep ``_MAX_SEPARATOR_LEN - 1`` trailing bytes
-# so a boundary split across the next chunk can still complete — deriving
-# from the separator keeps the invariant visible if the separator set grows.
-_MAX_SEPARATOR_LEN = len(b"\r\n\r\n")
+# SSE event boundaries we scan for.  When no boundary is found we keep
+# ``_MAX_SEPARATOR_LEN - 1`` trailing bytes so a boundary split across the
+# next chunk can still complete.  Deriving the max from the tuple means
+# adding a longer separator here updates the tail automatically.
+_SSE_SEPARATORS: tuple[bytes, ...] = (b"\r\n\r\n", b"\n\n")
+_MAX_SEPARATOR_LEN = max(len(s) for s in _SSE_SEPARATORS)
 
 # ---------------------------------------------------------------------------
 # Dual pending counter: in-flight flows + pending reports
@@ -178,7 +178,7 @@ def create_sse_usage_extractor() -> tuple[Callable[[bytes], None], dict]:
         if skipping["active"]:
             # Look for \n\n or \r\n\r\n in existing buf + new chunk.
             combined = line_buf + chunk
-            for sep in (b"\r\n\r\n", b"\n\n"):
+            for sep in _SSE_SEPARATORS:
                 idx = combined.find(sep)
                 if idx != -1:
                     # Found event boundary — line_buf gets the remainder.

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -28,6 +28,16 @@ from auth import _opener, get_api_url, make_api_request
 from body_utils import decompress_body
 from logging_utils import log_proxy_entry
 
+# HTTP 2xx success range (RFC 9110).  Also defined in ``mitm_addon.py``; kept
+# local to avoid introducing a constants module for two callers.
+_HTTP_STATUS_OK_MIN = 200
+_HTTP_STATUS_OK_MAX = 300
+
+# SSE event boundary is ``\r\n\r\n`` (4 bytes).  When no boundary is found in
+# the current buffer we keep the last 3 bytes so a boundary split across the
+# next chunk can still complete.
+_SSE_BOUNDARY_TAIL = 3
+
 # ---------------------------------------------------------------------------
 # Dual pending counter: in-flight flows + pending reports
 #
@@ -176,7 +186,11 @@ def create_sse_usage_extractor() -> tuple[Callable[[bytes], None], dict]:
             else:
                 # No boundary found — discard everything except the
                 # last few bytes (could be a partial \r\n\r\n).
-                line_buf[:] = combined[-3:] if len(combined) > 3 else combined
+                line_buf[:] = (
+                    combined[-_SSE_BOUNDARY_TAIL:]
+                    if len(combined) > _SSE_BOUNDARY_TAIL
+                    else combined
+                )
                 return
             # Boundary found — fall through to process line_buf contents.
             # line_buf already has the data, so skip the extend.
@@ -853,7 +867,9 @@ def log_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
     firewall_name = flow.metadata.get("firewall_name", "")
     if not is_billable_connector(firewall_name):
         return
-    if not flow.response or not (200 <= flow.response.status_code < 300):
+    if not flow.response or not (
+        _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_OK_MAX
+    ):
         return
     endpoint = flow.metadata.get("firewall_permission", "")
     if not endpoint:

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -1,8 +1,12 @@
 """Tests for HTTP body capture helpers in mitm_addon."""
 
 import base64
+import gzip
 import json
+import zlib
 
+import brotli
+import zstandard
 from mitmproxy import http
 
 from body_utils import (
@@ -518,8 +522,6 @@ class TestAddCaptureFields:
 
     def test_stream_buffer_gzip_decompressed(self, real_flow):
         """Gzip-compressed stream_buffer should be decompressed for capture."""
-        import gzip
-
         original = b'{"result": "ok"}'
         compressed = gzip.compress(original)
         flow = real_flow(
@@ -540,8 +542,6 @@ class TestAddCaptureFields:
     def test_stream_buffer_gzip_empty_body_skips_body(self, real_flow):
         """Bug #10287: a gzip frame that decompresses to b"" must not leak
         the ~20 B compressed framing into ``response_body`` as base64."""
-        import gzip
-
         compressed = gzip.compress(b"")
         flow = real_flow(
             method="POST",
@@ -590,8 +590,6 @@ class TestDecompression:
         assert entry["response_body"] == '{"ok": true}'
 
     def test_gzip_decompressed(self, real_flow):
-        import gzip
-
         original = b'{"result": "hello world"}'
         flow = self._make_flow_with_compressed_buffer(real_flow, gzip.compress(original), "gzip")
         entry = {}
@@ -600,8 +598,6 @@ class TestDecompression:
         assert entry["response_body_encoding"] == "utf-8"
 
     def test_deflate_decompressed(self, real_flow):
-        import zlib
-
         original = b'{"result": "hello world"}'
         flow = self._make_flow_with_compressed_buffer(real_flow, zlib.compress(original), "deflate")
         entry = {}
@@ -609,8 +605,6 @@ class TestDecompression:
         assert entry["response_body"] == '{"result": "hello world"}'
 
     def test_brotli_decompressed(self, real_flow):
-        import brotli
-
         original = b'{"result": "hello world"}'
         flow = self._make_flow_with_compressed_buffer(real_flow, brotli.compress(original), "br")
         entry = {}
@@ -618,8 +612,6 @@ class TestDecompression:
         assert entry["response_body"] == '{"result": "hello world"}'
 
     def test_zstd_decompressed(self, real_flow):
-        import zstandard
-
         original = b'{"result": "hello world"}'
         compressed = zstandard.ZstdCompressor().compress(original)
         flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "zstd")
@@ -651,8 +643,6 @@ class TestDecompression:
         truncated.  Input sized so halving the frame leaves zlib with
         enough bytes to emit real payload (42 KB of 'x') rather than the
         empty-output edge case covered by #10287."""
-        import gzip
-
         original = b"x" * 100_000
         compressed = gzip.compress(original)
         truncated = compressed[: len(compressed) // 2]
@@ -667,8 +657,6 @@ class TestDecompression:
 
     def test_gzip_zip_bomb_capped(self, real_flow):
         """Decompressed output should not exceed buffer limit (zip bomb protection)."""
-        import gzip
-
         # 1MB of zeros compresses very small
         original = b"\x00" * (1024 * 1024)
         compressed = gzip.compress(original)
@@ -682,8 +670,6 @@ class TestDecompression:
 
     def test_truncated_brotli_falls_back(self, real_flow):
         """Truncated brotli data should fall back gracefully."""
-        import brotli
-
         original = b"hello world " * 1000
         compressed = brotli.compress(original)
         truncated = compressed[: len(compressed) // 2]
@@ -696,8 +682,6 @@ class TestDecompression:
 
     def test_truncated_zstd_falls_back(self, real_flow):
         """Truncated zstd data should fall back gracefully."""
-        import zstandard
-
         original = b"hello world " * 1000
         compressed = zstandard.ZstdCompressor().compress(original)
         truncated = compressed[: len(compressed) // 2]
@@ -731,8 +715,6 @@ class TestExtractUsageFromJson:
         assert result["cache_creation_input_tokens"] == 0
 
     def test_gzip_compressed(self, headers):
-        import gzip
-
         original = b'{"model":"test","usage":{"input_tokens":42}}'
         compressed = gzip.compress(original)
         headers = headers(("Content-Encoding", "gzip"))
@@ -766,8 +748,6 @@ class TestExtractUsageFromJson:
         which used to truncate large model-provider non-SSE responses and cause
         usage extraction to silently fail.
         """
-        import gzip
-
         # Raw body > 64 KB (legacy STREAM_BUFFER_LIMIT) so the bug, if reintroduced,
         # would truncate decompression output and break json.loads below.
         big_text = "x" * (100 * 1024)
@@ -794,22 +774,16 @@ class TestStreamDecompressor:
     """
 
     def test_gzip_happy_path(self, headers):
-        import gzip
-
         decomp = create_stream_decompressor(headers(("Content-Encoding", "gzip")))
         assert decomp is not None
         assert decomp(gzip.compress(b"hello world")) == b"hello world"
 
     def test_brotli_happy_path(self, headers):
-        import brotli
-
         decomp = create_stream_decompressor(headers(("Content-Encoding", "br")))
         assert decomp is not None
         assert decomp(brotli.compress(b"hello world")) == b"hello world"
 
     def test_zstd_happy_path(self, headers):
-        import zstandard
-
         decomp = create_stream_decompressor(headers(("Content-Encoding", "zstd")))
         assert decomp is not None
         assert decomp(zstandard.ZstdCompressor().compress(b"hello world")) == b"hello world"
@@ -862,8 +836,6 @@ class TestStreamDecompressor:
         # calls — not just that they happen to return b"".  ``zlib.Decompress``
         # is a C type whose ``decompress`` attribute is read-only, so we wrap
         # the factory's return value in a proxy that counts delegations.
-        import zlib
-
         real_factory = zlib.decompressobj
 
         class CountingProxy:
@@ -910,8 +882,6 @@ class TestDecompressBody:
         # Regression: gzip path uses ``decompressobj.decompress(data,
         # max_length=max_output)`` so zlib stops decoding at the cap
         # rather than producing unbounded output.
-        import gzip
-
         plaintext = b"A" * (10 * 1024 * 1024)  # 10 MB, high compression ratio
         compressed = gzip.compress(plaintext)
         hdrs = headers(("Content-Encoding", "gzip"))
@@ -923,8 +893,6 @@ class TestDecompressBody:
         # Bug #10128: before the fix the zstd branch used
         # ``decompressobj.decompress(data)`` which fully materialised
         # the plaintext before slicing — defeating the bomb cap.
-        import zstandard
-
         plaintext = b"A" * (10 * 1024 * 1024)  # 10 MB, high ratio → small payload
         compressed = zstandard.ZstdCompressor().compress(plaintext)
         assert len(compressed) < len(plaintext) // 100  # sanity: real high ratio
@@ -935,8 +903,6 @@ class TestDecompressBody:
 
     def test_zstd_short_payload_returns_full_body(self, headers):
         # When decompressed size is under the cap, return all of it.
-        import zstandard
-
         plaintext = b"hello world"
         compressed = zstandard.ZstdCompressor().compress(plaintext)
         hdrs = headers(("Content-Encoding", "zstd"))
@@ -964,8 +930,6 @@ class TestDecompressBody:
         # ``return result if result else data`` on the success path handed the
         # raw ~20 B framing to the caller, which then base64-encoded it into
         # the network log.
-        import gzip
-
         compressed = gzip.compress(b"")
         hdrs = headers(("Content-Encoding", "gzip"))
         assert decompress_body(compressed, hdrs, max_output=64 * 1024) == b""
@@ -973,24 +937,18 @@ class TestDecompressBody:
     def test_deflate_empty_body_returns_empty(self, headers):
         # Bug #10287: deflate shares the gzip branch but uses a different
         # ``wbits`` — guard that the empty-body behaviour matches.
-        import zlib
-
         compressed = zlib.compress(b"")
         hdrs = headers(("Content-Encoding", "deflate"))
         assert decompress_body(compressed, hdrs, max_output=64 * 1024) == b""
 
     def test_brotli_empty_body_returns_empty(self, headers):
         # Bug #10287: same pattern as gzip for the brotli branch.
-        import brotli
-
         compressed = brotli.compress(b"")
         hdrs = headers(("Content-Encoding", "br"))
         assert decompress_body(compressed, hdrs, max_output=64 * 1024) == b""
 
     def test_zstd_empty_body_returns_empty(self, headers):
         # Bug #10287: same pattern as gzip for the zstd branch.
-        import zstandard
-
         compressed = zstandard.ZstdCompressor().compress(b"")
         hdrs = headers(("Content-Encoding", "zstd"))
         assert decompress_body(compressed, hdrs, max_output=64 * 1024) == b""

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -5,6 +5,7 @@ import json
 import time
 import urllib.error
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -2211,8 +2212,6 @@ class TestAuthBaseUrlRewriteEdgeCases:
         # seed the request. We parse it back into ``real_flow`` kwargs
         # rather than mutating the read-only ``Request`` properties.
         if seed_url:
-            from urllib.parse import urlparse
-
             parsed = urlparse(seed_url)
             host = parsed.hostname or "firewall-placeholder.vm3.ai"
             real_path = parsed.path or "/"

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -4,6 +4,7 @@ import asyncio
 import gzip
 import json
 import time
+import urllib.error
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -2495,8 +2496,6 @@ class TestUsageWebhookDelivery:
 
     def test_closes_http_error_response(self, tmp_path, real_flow, fresh_usage_executor):
         """HTTPError sockets must be closed to avoid leaking; retries still apply."""
-        import urllib.error
-
         http_err = urllib.error.HTTPError(
             "https://api.vm0.ai", 500, "Internal Server Error", {}, None
         )


### PR DESCRIPTION
## Summary

Closes #10298. Instead of enabling the full `PL` family with a long
exclusion list, cherry-pick the three rules that catch real hygiene
issues without fighting the existing design:

- **PLC0415** (`import-outside-top-level`) — codec imports in tests
  hoisted to file top (25 sites).
- **PLR1714** (`repeated-equality-comparison`) — `x != a and x != b`
  folded to `x not in (a, b)` (2 sites in `matching.py`).
- **PLR2004** (`magic-value-comparison`) — enabled for src; tests are
  exempted via `per-file-ignores` (`assert status == 200` is
  idiomatic). 16 src sites replaced with named constants: UTF-8 byte
  boundaries, firewall rule token count, HTTP/HTTPS default ports,
  HTTP 2xx/4xx status ranges, SSE event-boundary tail length.

The remaining PL rules are intentionally skipped:

- **PLW0603** (`global-statement`) — the addon has 7 legitimate
  module-level caches (`_registry_cache`, `_in_flight_flows`,
  `_pending_reports`, `_pending_path`). Enforcing this would require
  rewriting them as classes with no correctness benefit.
- **PLR09xx** (`too-many-arguments`, `too-many-branches`,
  `too-many-return-statements`, `too-many-statements`) — pure
  complexity caps; forcing artificial function splits hurts readability.

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `pytest tests/` passes (888 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)