### PR TITLE
fix(platform): align chat composer model picker display with send body

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -28,6 +28,7 @@ import {
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
+import { orgModelProviders$ } from "../external/org-model-providers.ts";
 import { agentById } from "../agent.ts";
 import { pinnedAgentIds$ } from "../zero-page/zero-pinned-agents.ts";
 import { writeToClipboard } from "../zero-page/clipboard.ts";
@@ -154,13 +155,29 @@ function createModelSelection(
         return user.value;
       }
       const thread = await get(threadData$);
-      if (!thread?.modelProviderId || !thread.selectedModel) {
-        return null;
+      if (thread?.modelProviderId && thread.selectedModel) {
+        return {
+          modelProviderId: thread.modelProviderId,
+          selectedModel: thread.selectedModel,
+        };
       }
-      return {
-        modelProviderId: thread.modelProviderId,
-        selectedModel: thread.selectedModel,
-      };
+      // No thread override → seed from the org default provider so the
+      // picker's displayed model is the one the send body carries. Without
+      // this seed, the picker trigger silently shows the org default (via
+      // its null-value fallback) while the request sends `modelSelection:
+      // null`, which the backend resolves against `zero_agents.selected_model`
+      // — not against the org default — producing a display/run mismatch.
+      const { modelProviders } = await get(orgModelProviders$);
+      const defaultProvider = modelProviders.find((p) => {
+        return p.isDefault;
+      });
+      if (defaultProvider?.selectedModel) {
+        return {
+          modelProviderId: defaultProvider.id,
+          selectedModel: defaultProvider.selectedModel,
+        };
+      }
+      return null;
     },
   );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -2,6 +2,7 @@ import { command, computed, state } from "ccstate";
 import { talkDraft$ } from "./chat-draft.ts";
 import { getRandomPrompts } from "../../views/zero-page/zero-ideation-data.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
+import { orgModelProviders$ } from "../external/org-model-providers.ts";
 
 // ---------------------------------------------------------------------------
 // Landing page local UI state for ZeroChatPage
@@ -36,16 +37,38 @@ export const suggestedPrompts$ = computed((get) => {
 // Landing-page composer model override
 // ---------------------------------------------------------------------------
 
-// Before a thread exists there's nothing on the server to seed from, so a plain
-// state signal is sufficient. `null` = inherit agent/org default.
-const internalChatPageModelSelection$ = state<ModelProviderSelection | null>(
-  null,
+// Discriminated union so "user hasn't picked anything" (→ seed from org
+// default) stays distinguishable from "user explicitly picked inherit" (→
+// null). Mirrors the thread-page model selection factory.
+const internalChatPageUserOverride$ = state<
+  { kind: "unset" } | { kind: "set"; value: ModelProviderSelection | null }
+>({ kind: "unset" });
+
+export const chatPageModelSelection$ = computed(
+  async (get): Promise<ModelProviderSelection | null> => {
+    const user = get(internalChatPageUserOverride$);
+    if (user.kind === "set") {
+      return user.value;
+    }
+    // Seed from the org default so what the picker shows is what the send
+    // body carries. See the matching note in `createModelSelection`
+    // (create-chat-thread.ts) for the full reasoning.
+    const { modelProviders } = await get(orgModelProviders$);
+    const defaultProvider = modelProviders.find((p) => {
+      return p.isDefault;
+    });
+    if (defaultProvider?.selectedModel) {
+      return {
+        modelProviderId: defaultProvider.id,
+        selectedModel: defaultProvider.selectedModel,
+      };
+    }
+    return null;
+  },
 );
-export const chatPageModelSelection$ = computed((get) => {
-  return get(internalChatPageModelSelection$);
-});
+
 export const setChatPageModelSelection$ = command(
   ({ set }, value: ModelProviderSelection | null) => {
-    set(internalChatPageModelSelection$, value);
+    set(internalChatPageUserOverride$, { kind: "set", value });
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-send.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-send.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Regression test: composer model picker display matches outgoing send body.
+ *
+ * Bug history: when the thread had no per-run override
+ * (chat_threads.selected_model = NULL) and the user did not touch the
+ * picker, the picker trigger showed the org default model (e.g. "Claude
+ * Sonnet 4.6") but the POST /api/zero/chat/messages body sent
+ * `modelSelection: null`. The backend's resolveRunModelOverride wrote NULL
+ * to chat_threads and fell through to the agent's own `selected_model`
+ * (= claude-opus-4-7 on the Zero agent), NOT to the org default. Result:
+ * user saw Sonnet, run executed on Opus.
+ *
+ * Fix: `chat-page` model-selection signals seed from the org default when
+ * the user has not explicitly picked, so the picker's displayed model and
+ * the request body's `modelSelection` always agree.
+ *
+ * Entry point: /chats/:id thread page
+ * Mock (external): Web API via MSW (feature switch + org providers + thread
+ *   row with null overrides + send-body capture).
+ * Real (internal): chat-thread-page signals, composer, model-provider-picker.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { chatMessagesContract, FeatureSwitchKey } from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import {
+  setMockOrgModelProviders,
+  resetMockOrgModelProviders,
+} from "../../../mocks/handlers/api-org-model-providers.ts";
+import {
+  setMockFeatureSwitches,
+  resetMockFeatureSwitches,
+} from "../../../mocks/handlers/api-feature-switches.ts";
+import {
+  mockChatLifecycle,
+  sendMessageInUI,
+  PLACEHOLDER,
+} from "./chat-test-helpers.ts";
+
+const context = testContext();
+const THREAD_ID = "thread-test-1";
+
+describe("chat composer — model picker display vs. send body", () => {
+  beforeEach(() => {
+    resetMockOrgModelProviders();
+    resetMockFeatureSwitches();
+  });
+
+  // CHAT-MSEL-001: picker display and send body agree on org default
+  it("sends the org default model in request body when user has not touched the picker", async () => {
+    const user = userEvent.setup();
+
+    const PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
+    const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ModelProviderSelection]: true,
+    });
+    setMockOrgModelProviders([
+      {
+        id: PROVIDER_ID,
+        type: "anthropic-api-key",
+        framework: "claude-code",
+        secretName: "ANTHROPIC_API_KEY",
+        authMethod: null,
+        secretNames: null,
+        isDefault: true,
+        selectedModel: DEFAULT_MODEL,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+
+    // Thread has no per-run override (chat_threads.{modelProviderId,selectedModel}=NULL).
+    // mockChatLifecycle's chatThreadByIdContract.get response omits these
+    // fields, which matches the null-override DB state in production.
+    mockChatLifecycle({ threadId: THREAD_ID });
+
+    // Override send handler to capture the outgoing body. mockChatLifecycle
+    // registers its own send handler first; server.use() here takes priority.
+    let capturedBody:
+      | {
+          modelSelection?: {
+            modelProviderId: string;
+            selectedModel: string;
+          } | null;
+        }
+      | undefined;
+    server.use(
+      mockApi(chatMessagesContract.send, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(201, {
+          runId: "run-test-1",
+          threadId: THREAD_ID,
+          status: "pending",
+          createdAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    // Trigger advertises the org default.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+      ).toBeInTheDocument();
+    });
+
+    // Send without touching the picker.
+    await sendMessageInUI(user, textarea, "Hello");
+
+    await waitFor(() => {
+      expect(capturedBody).toBeDefined();
+    });
+
+    // The request carries the very model the picker was advertising, so the
+    // backend persists it on chat_threads and the run executes on Sonnet.
+    expect(capturedBody?.modelSelection).toStrictEqual({
+      modelProviderId: PROVIDER_ID,
+      selectedModel: DEFAULT_MODEL,
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -453,7 +453,7 @@ export function AgentChatPage() {
       FeatureSwitchKey.ModelProviderSelection
     ] ?? false;
   const orgProviders = useLastResolved(orgModelProviders$);
-  const modelSelection = useGet(chatPageModelSelection$);
+  const modelSelection = useLastResolved(chatPageModelSelection$) ?? null;
   const setModelSelection = useSet(setChatPageModelSelection$);
 
   const handleSendMessage = (message: string) => {


### PR DESCRIPTION
## Summary

- Seed chat-page model selection from the org default when the user has not explicitly picked, so the picker trigger matches the outgoing `modelSelection` in the send body.
- Apply the fix in both signal factories: the landing-page composer (`zero-chat-page.ts`) and the thread-page composer (`create-chat-thread.ts`).
- Switch the landing-page `agent-chat-page.tsx` consumer to `useLastResolved` since the signal is now async.

## Why

Previously, when a thread had no per-run override (`chat_threads.selected_model = NULL`) and the user did not touch the picker, the picker trigger displayed the org default (e.g. Claude Sonnet 4.6) via its null-value fallback, but the POST body sent `modelSelection: null`. The backend's `resolveRunModelOverride` then fell through to the agent's `selected_model` (claude-opus-4-7 on the Zero agent), not the org default — producing a display/run mismatch.

The landing-page signal now uses a discriminated union (`{ kind: "unset" } | { kind: "set"; value }`) so "user hasn't picked anything" stays distinguishable from "user explicitly picked inherit".

## Test plan

- [x] New regression test: `chat-composer-model-selection-send.test.tsx` — asserts picker display matches captured send body on the thread page
- [x] `pnpm -F @vm0/app lint`
- [x] `pnpm -F @vm0/app exec tsc --noEmit`
- [x] `pnpm -F @vm0/app exec vitest run src/signals/chat-page src/signals/zero-page src/views/zero-page` (1034 tests pass)