### PR TITLE
feat(web): add voice-chat-candidate task-run callback and trigger adapter

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/__tests__/route.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import {
+  createTestCallback,
+  createSignedCallbackRequest,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { seedTestCompose } from "../../../../../../src/__tests__/db-test-seeders/agents";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
+import { mockAblyPublish } from "../../../../../../src/__tests__/ably-mock";
+import { initServices } from "../../../../../../src/lib/init-services";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: voice-chat-candidate tasks/sessions route (#10310) not yet on main
+import { createVoiceChatCandidateSession } from "../../../../../../src/lib/zero/voice-chat-candidate/session-service";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: voice-chat-candidate tasks route (#10310) not yet on main
+import { createVoiceChatCandidateTask } from "../../../../../../src/lib/zero/voice-chat-candidate/task-service";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: assert DB-level callback side effects (status, session end, system_note)
+import {
+  featureCandidateVoiceChatSessions,
+  featureCandidateVoiceChatTasks,
+  featureCandidateVoiceChatItems,
+} from "../../../../../../src/db/schema/voice-chat-candidate";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: set vars.ZERO_AGENT_ID on seeded run for agent-mismatch coverage
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { POST } from "../route";
+
+const context = testContext();
+const CALLBACK_URL =
+  "http://localhost/api/internal/callbacks/voice-chat-candidate";
+
+async function setupTaskWithCallback(options: {
+  agentIdOnRun?: string;
+  runStatus?: string;
+}) {
+  // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route for session/task create on this surface yet
+  initServices();
+  const { userId, orgId } = await context.setupUser();
+  const { composeId } = await seedTestCompose({
+    userId,
+    orgId,
+    name: uniqueId("vcc-cb"),
+  });
+
+  const session = await createVoiceChatCandidateSession({
+    orgId,
+    userId,
+    agentId: composeId,
+  });
+
+  const { runId } = await seedTestRun(userId, composeId, {
+    status: options.runStatus ?? "running",
+    orgId,
+  });
+
+  // Set vars.ZERO_AGENT_ID so the callback's readRunAgentId can resolve it.
+  // Defaults to the session's agent (happy path); tests override for mismatch.
+  // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: direct update required — no API surface sets vars for seeded runs
+  await globalThis.services.db
+    .update(agentRuns)
+    .set({ vars: { ZERO_AGENT_ID: options.agentIdOnRun ?? composeId } })
+    .where(eq(agentRuns.id, runId));
+
+  const task = await createVoiceChatCandidateTask({
+    sessionId: session.id,
+    callId: uniqueId("call"),
+    prompt: "do a thing",
+    spawnRun: async () => {
+      return {
+        runId,
+        status: "running",
+        createdAt: new Date(),
+        sessionId: session.id,
+      };
+    },
+  });
+
+  const { secret } = await createTestCallback({
+    runId,
+    url: CALLBACK_URL,
+    payload: { taskId: task.id },
+  });
+
+  return { userId, orgId, composeId, session, runId, task, secret };
+}
+
+async function readTask(id: string) {
+  // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: assert terminal task state written by callback
+  const [row] = await globalThis.services.db
+    .select()
+    .from(featureCandidateVoiceChatTasks)
+    .where(eq(featureCandidateVoiceChatTasks.id, id))
+    .limit(1);
+  return row;
+}
+
+async function readSession(id: string) {
+  // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: assert session termination on agent mismatch
+  const [row] = await globalThis.services.db
+    .select()
+    .from(featureCandidateVoiceChatSessions)
+    .where(eq(featureCandidateVoiceChatSessions.id, id))
+    .limit(1);
+  return row;
+}
+
+async function listItems(sessionId: string) {
+  // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: assert task_result/system_note items written by callback
+  return globalThis.services.db
+    .select()
+    .from(featureCandidateVoiceChatItems)
+    .where(eq(featureCandidateVoiceChatItems.sessionId, sessionId));
+}
+
+describe("POST /api/internal/callbacks/voice-chat-candidate", () => {
+  beforeEach(() => {
+    mockAblyPublish.mockClear();
+    context.setupMocks();
+  });
+
+  it("returns 200 for progress status without touching the task", async () => {
+    const { runId, task, secret } = await setupTaskWithCallback({});
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        CALLBACK_URL,
+        {
+          runId,
+          status: "progress",
+          payload: { taskId: task.id },
+        },
+        secret,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const taskRow = await readTask(task.id);
+    expect(taskRow!.status).toBe("pending");
+  });
+
+  it("completes the task and writes a task_result item on completed", async () => {
+    const { runId, task, session, userId, secret } =
+      await setupTaskWithCallback({});
+
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      { eventData: { result: "final answer" } },
+    ]);
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        CALLBACK_URL,
+        {
+          runId,
+          status: "completed",
+          payload: { taskId: task.id },
+        },
+        secret,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+
+    const taskRow = await readTask(task.id);
+    expect(taskRow!.status).toBe("done");
+    expect(taskRow!.result).toBe("final answer");
+    expect(taskRow!.error).toBeNull();
+
+    const items = await listItems(session.id);
+    const resultItem = items.find((i) => {
+      return i.role === "task_result";
+    });
+    expect(resultItem).toBeDefined();
+    expect(resultItem!.content).toContain("final answer");
+
+    await context.mocks.flushAfter();
+    expect(mockAblyPublish).toHaveBeenCalledWith(
+      `voice-chat-candidate:${session.id}`,
+      null,
+    );
+    // userId is used via publishUserSignal — assert channel lookup indirectly
+    expect(userId).toBeTruthy();
+  });
+
+  it("marks the task failed and records the error text on failed", async () => {
+    const { runId, task, session, secret } = await setupTaskWithCallback({});
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        CALLBACK_URL,
+        {
+          runId,
+          status: "failed",
+          error: "runner crashed",
+          payload: { taskId: task.id },
+        },
+        secret,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+
+    const taskRow = await readTask(task.id);
+    expect(taskRow!.status).toBe("failed");
+    expect(taskRow!.error).toBe("runner crashed");
+
+    const items = await listItems(session.id);
+    const resultItem = items.find((i) => {
+      return i.role === "task_result";
+    });
+    expect(resultItem!.content).toContain("runner crashed");
+  });
+
+  it("returns 401 on invalid signature", async () => {
+    const { runId, task, secret } = await setupTaskWithCallback({});
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        CALLBACK_URL,
+        {
+          runId,
+          status: "completed",
+          payload: { taskId: task.id },
+        },
+        secret,
+        { invalidSignature: true },
+      ),
+    );
+
+    expect(response.status).toBe(401);
+    const taskRow = await readTask(task.id);
+    expect(taskRow!.status).toBe("pending");
+  });
+
+  it("returns 400 when payload is missing taskId", async () => {
+    const { runId, secret } = await setupTaskWithCallback({});
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        CALLBACK_URL,
+        {
+          runId,
+          status: "completed",
+          payload: {},
+        },
+        secret,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("ends the session on agent mismatch (vars.ZERO_AGENT_ID differs from session.agentId)", async () => {
+    const { runId, task, session, secret } = await setupTaskWithCallback({
+      agentIdOnRun: "00000000-0000-0000-0000-000000000000",
+    });
+
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([]);
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        CALLBACK_URL,
+        {
+          runId,
+          status: "completed",
+          payload: { taskId: task.id },
+        },
+        secret,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+
+    const taskRow = await readTask(task.id);
+    expect(taskRow!.status).toBe("failed");
+    expect(taskRow!.error).toMatch(/agent mismatch/i);
+
+    const sessionRow = await readSession(session.id);
+    expect(sessionRow!.status).toBe("ended");
+
+    const items = await listItems(session.id);
+    const note = items.find((i) => {
+      return i.role === "system_note";
+    });
+    expect(note).toBeDefined();
+  });
+
+  it("returns 200 for unknown taskId (defensive per epic risk table)", async () => {
+    const { runId, secret } = await setupTaskWithCallback({});
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        CALLBACK_URL,
+        {
+          runId,
+          status: "completed",
+          payload: { taskId: "00000000-0000-0000-0000-000000000000" },
+        },
+        secret,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse, after } from "next/server";
+import { eq } from "drizzle-orm";
+import { initServices } from "../../../../../src/lib/init-services";
+import { verifyCallback } from "../../../../../src/lib/infra/callback";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import { getRunOutputText } from "../../../../../src/lib/infra/run/extract-run-output";
+import { completeVoiceChatCandidateTask } from "../../../../../src/lib/zero/voice-chat-candidate/task-service";
+import { triggerReasoning } from "../../../../../src/lib/zero/voice-chat-candidate/trigger-reasoning";
+import { publishUserSignal } from "../../../../../src/lib/infra/realtime/client";
+import { isNotFound } from "../../../../../src/lib/shared/errors";
+import type { VoiceChatCandidateCallbackPayload } from "../../../../../src/lib/infra/callback/callback-payloads";
+import { logger } from "../../../../../src/lib/shared/logger";
+
+const log = logger("callback:voice-chat-candidate");
+
+export const maxDuration = 60;
+
+function parsePayload(
+  payload: unknown,
+): VoiceChatCandidateCallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  if (typeof p.taskId !== "string") return null;
+  return { taskId: p.taskId };
+}
+
+async function readRunAgentId(runId: string): Promise<string> {
+  const [run] = await globalThis.services.db
+    .select({ vars: agentRuns.vars })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
+  if (!run) {
+    log.warn("run not found while resolving ZERO_AGENT_ID", { runId });
+    return "";
+  }
+
+  const vars = run.vars as { ZERO_AGENT_ID?: unknown } | null;
+  const zeroAgentId = vars?.ZERO_AGENT_ID;
+  if (typeof zeroAgentId !== "string" || zeroAgentId.length === 0) {
+    log.warn("vars.ZERO_AGENT_ID absent on run", { runId });
+    return "";
+  }
+
+  return zeroAgentId;
+}
+
+/**
+ * POST /api/internal/callbacks/voice-chat-candidate
+ *
+ * Task-run callback for the voice-chat-candidate surface (Epic #10297, Wave 5).
+ * On terminal status, completes the task, then post-response kicks the
+ * Reasoner and pokes the user's Ably channel so the browser picks up the
+ * terminal transition even if the Reasoner is a no-op.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+
+  const result = await verifyCallback<VoiceChatCandidateCallbackPayload>(
+    request,
+    log,
+  );
+  if (!result.ok) return result.response;
+
+  const { runId, status, error } = result.data;
+  const payload = parsePayload(result.data.payload);
+  if (!payload) {
+    return NextResponse.json(
+      { error: "Invalid or missing payload" },
+      { status: 400 },
+    );
+  }
+
+  if (status === "progress") {
+    return NextResponse.json({ success: true });
+  }
+
+  const agentId = await readRunAgentId(runId);
+
+  const resultText =
+    status === "completed"
+      ? await getRunOutputText(runId).catch((err: unknown) => {
+          log.warn("Failed to extract run output text", { runId, err });
+          return undefined;
+        })
+      : undefined;
+  const errorText = status === "failed" ? (error ?? "Run failed") : null;
+
+  let sessionId: string;
+  let userId: string;
+  try {
+    const outcome = await completeVoiceChatCandidateTask({
+      taskId: payload.taskId,
+      result: resultText ?? null,
+      error: errorText,
+      agentId,
+    });
+    sessionId = outcome.session.id;
+    userId = outcome.session.userId;
+  } catch (err) {
+    if (isNotFound(err)) {
+      log.warn("voice-chat-candidate task not found — ignoring callback", {
+        taskId: payload.taskId,
+        runId,
+      });
+      return NextResponse.json({ success: true });
+    }
+    throw err;
+  }
+
+  after(async () => {
+    await triggerReasoning(sessionId);
+    await publishUserSignal([userId], `voice-chat-candidate:${sessionId}`);
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/adapt-task-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/adapt-task-trigger.ts
@@ -1,0 +1,41 @@
+import { generateCallbackSecret, getApiUrl } from "../../infra/callback";
+import type { VoiceChatCandidateCallbackPayload } from "../../infra/callback/callback-payloads";
+import type { CreateZeroRunParams } from "../zero-run-service";
+
+interface VoiceChatCandidateTaskTriggerContext {
+  userId: string;
+  agentId: string;
+  taskId: string;
+  prompt: string;
+  apiStartTime: number;
+  appendSystemPrompt?: string;
+}
+
+/**
+ * Build CreateZeroRunParams for a voice-chat-candidate task-run. Consumed by
+ * the Wave 5 tasks route (#10310); declared in Wave 5 (#10311) alongside the
+ * callback it points at so the two halves of the contract ship together.
+ * @public
+ */
+export function adaptVoiceChatCandidateTaskTrigger(
+  ctx: VoiceChatCandidateTaskTriggerContext,
+): CreateZeroRunParams {
+  const callbackPayload: VoiceChatCandidateCallbackPayload = {
+    taskId: ctx.taskId,
+  };
+  return {
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    prompt: ctx.prompt,
+    appendSystemPrompt: ctx.appendSystemPrompt,
+    triggerSource: "voice-chat",
+    apiStartTime: ctx.apiStartTime,
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/voice-chat-candidate`,
+        secret: generateCallbackSecret(),
+        payload: callbackPayload,
+      },
+    ],
+  };
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/task-service.ts
@@ -58,7 +58,11 @@ export async function completeVoiceChatCandidateTask(params: {
   result: string | null;
   error: string | null;
   agentId: string;
-}): Promise<{ item: ItemRow; task: TaskRow }> {
+}): Promise<{
+  item: ItemRow;
+  task: TaskRow;
+  session: { id: string; userId: string };
+}> {
   const db = globalThis.services.db;
 
   const outcome = await db.transaction(async (tx) => {
@@ -168,7 +172,11 @@ export async function completeVoiceChatCandidateTask(params: {
     await cancelSessionPendingRuns(outcome.session);
   }
 
-  return { task: outcome.task, item: outcome.item };
+  return {
+    task: outcome.task,
+    item: outcome.item,
+    session: { id: outcome.session.id, userId: outcome.session.userId },
+  };
 }
 
 export async function listPendingVoiceChatCandidateTasks(

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -105,6 +105,7 @@
     "apps/cli/src/lib/utils/paginate.ts",
     "apps/web/src/lib/auth/sandbox-token.ts",
     "apps/web/src/lib/infra/storage/volume-upload.ts",
+    "apps/web/src/lib/zero/voice-chat-candidate/adapt-task-trigger.ts",
     "scripts/rebuild-snapshots.ts",
     "scripts/rebuild-snapshots-from-db.ts",
     "scripts/analyze-cpuprofile.mjs",


### PR DESCRIPTION
## Summary

Wave 5 of epic #10297 (voice-chat-candidate — lab-only Reasoner-based surface). Adds the task-run completion callback and the `CreateZeroRunParams` adapter the upcoming tasks route (#10310) will consume.

- `POST /api/internal/callbacks/voice-chat-candidate` — verifies HMAC, resolves `ZERO_AGENT_ID` from `agent_runs.vars` (defensive `""` on missing run or missing key, with distinct warn logs so ops can tell a bug from a hijack attempt), calls `completeVoiceChatCandidateTask` (catching `notFound` → 200), then schedules `triggerReasoning` + `publishUserSignal` via `after()`.
- `adaptVoiceChatCandidateTaskTrigger` — builds `CreateZeroRunParams` pointing at the new callback URL with a typed `VoiceChatCandidateCallbackPayload`. Added to knip ignore list until #10310 lands.
- Extended `completeVoiceChatCandidateTask` return with `session: { id, userId }` so the route dispatches the post-response hooks without a second `getVoiceChatCandidateSession` round-trip.

Closes #10311.

## Test plan

- [x] `vitest` — new `route.test.ts` with 7 cases: progress no-op, completed happy path (assertions on task/result/Ably), failed path, invalid signature (401), invalid payload (400), agent mismatch (session ended + system_note), unknown taskId (200).
- [x] Re-ran `task-service.test.ts` after extending the return shape — all 10 cases still pass, no destructure-exhaustive breakage.
- [x] `vitest` over `src/lib/zero/voice-chat-candidate` + `app/api/internal/callbacks` — 157 tests green.
- [x] `pnpm turbo run lint --filter=web`, `pnpm check-types`, `pnpm format`, `pnpm knip` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)