### PR TITLE
feat(web): extend voice-chat-cleanup cron for candidate sessions + reasoner stuck-recovery

### DIFF
--- a/turbo/apps/web/app/api/cron/voice-chat-cleanup/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/voice-chat-cleanup/__tests__/route.test.ts
@@ -7,7 +7,12 @@ import {
   getTestVoiceChatEvents,
   insertTestVoiceChatPreparation,
   getTestVoiceChatPreparation,
+  insertTestVoiceChatCandidateSession,
+  getTestVoiceChatCandidateSession,
+  countTestVoiceChatCandidateSessionsByStatus,
+  countTestVoiceChatCandidateSessionsByReasoningStatus,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { mockAblyPublish } from "../../../../../src/__tests__/ably-mock";
 import { reloadEnv } from "../../../../../src/env";
 
 vi.hoisted(() => {
@@ -26,6 +31,7 @@ function cronRequest(secret?: string) {
 describe("GET /api/cron/voice-chat-cleanup", () => {
   beforeEach(() => {
     context.setupMocks();
+    mockAblyPublish.mockClear();
     vi.stubEnv("CRON_SECRET", "test-cron-secret");
     reloadEnv();
   });
@@ -216,5 +222,220 @@ describe("GET /api/cron/voice-chat-cleanup", () => {
     expect(response.status).toBe(200);
     expect(body.preparationsCleaned).toBe(2);
     expect(body.cleaned).toBe(0);
+  });
+
+  describe("voice-chat-candidate passes", () => {
+    it("T1 — times out candidate sessions with stale heartbeat and publishes signal", async () => {
+      const mocks = context.setupMocks();
+      const staleTime = new Date(Date.now() - 3 * 60 * 1000);
+      const sessionId = await insertTestVoiceChatCandidateSession({
+        orgId: "org_test",
+        userId: "user_test",
+        lastHeartbeatAt: staleTime,
+      });
+
+      const response = await GET(cronRequest("test-cron-secret"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.candidateCleaned).toBe(1);
+      expect(body.reasonerReset).toBe(0);
+
+      const row = await getTestVoiceChatCandidateSession(sessionId);
+      expect(row?.status).toBe("timeout");
+      expect(row?.endedAt).not.toBeNull();
+
+      await mocks.flushAfter();
+      expect(mockAblyPublish).toHaveBeenCalledWith(
+        `voice-chat-candidate:${sessionId}`,
+        null,
+      );
+    });
+
+    it("T2 — times out candidate sessions exceeding max duration (>30 min)", async () => {
+      const oldTime = new Date(Date.now() - 31 * 60 * 1000);
+      const sessionId = await insertTestVoiceChatCandidateSession({
+        orgId: "org_test",
+        userId: "user_test",
+        createdAt: oldTime,
+        lastHeartbeatAt: new Date(),
+      });
+
+      const response = await GET(cronRequest("test-cron-secret"));
+      const body = await response.json();
+
+      expect(body.candidateCleaned).toBe(1);
+      const row = await getTestVoiceChatCandidateSession(sessionId);
+      expect(row?.status).toBe("timeout");
+    });
+
+    it("T3 — does not touch fresh candidate sessions within thresholds", async () => {
+      const recentTime = new Date(Date.now() - 30 * 1000);
+      const sessionId = await insertTestVoiceChatCandidateSession({
+        orgId: "org_test",
+        userId: "user_test",
+        createdAt: recentTime,
+        lastHeartbeatAt: recentTime,
+      });
+
+      const response = await GET(cronRequest("test-cron-secret"));
+      const body = await response.json();
+
+      expect(body.candidateCleaned).toBe(0);
+      const row = await getTestVoiceChatCandidateSession(sessionId);
+      expect(row?.status).toBe("active");
+    });
+
+    it("T4 — does not touch already-ended candidate sessions", async () => {
+      const staleTime = new Date(Date.now() - 10 * 60 * 1000);
+      const sessionId = await insertTestVoiceChatCandidateSession({
+        orgId: "org_test",
+        userId: "user_test",
+        status: "ended",
+        lastHeartbeatAt: staleTime,
+      });
+
+      const response = await GET(cronRequest("test-cron-secret"));
+      const body = await response.json();
+
+      expect(body.candidateCleaned).toBe(0);
+      const row = await getTestVoiceChatCandidateSession(sessionId);
+      expect(row?.status).toBe("ended");
+    });
+
+    it("T5 — resets stuck reasoner and queues a triggerReasoning re-tick", async () => {
+      const staleReasoningAt = new Date(Date.now() - 6 * 60 * 1000);
+      const sessionId = await insertTestVoiceChatCandidateSession({
+        orgId: "org_test",
+        userId: "user_test",
+        reasoningStatus: "running",
+        lastReasoningAt: staleReasoningAt,
+      });
+
+      // Pre-cron: after() queue is empty.
+      expect(globalThis.nextAfterCallbacks.length).toBe(0);
+
+      const response = await GET(cronRequest("test-cron-secret"));
+      const body = await response.json();
+
+      expect(body.reasonerReset).toBe(1);
+      expect(body.candidateCleaned).toBe(0);
+      const row = await getTestVoiceChatCandidateSession(sessionId);
+      expect(row?.reasoningStatus).toBe("idle");
+
+      // Exactly one after() callback was queued: the re-tick for this session.
+      // publishUserSignal was not queued because the session is not timed out.
+      expect(globalThis.nextAfterCallbacks.length).toBe(1);
+    });
+
+    it("T6 — does not touch a non-stuck reasoner (lastReasoningAt within 5 min)", async () => {
+      const freshReasoningAt = new Date(Date.now() - 2 * 60 * 1000);
+      const sessionId = await insertTestVoiceChatCandidateSession({
+        orgId: "org_test",
+        userId: "user_test",
+        reasoningStatus: "running",
+        lastReasoningAt: freshReasoningAt,
+      });
+
+      const response = await GET(cronRequest("test-cron-secret"));
+      const body = await response.json();
+
+      expect(body.reasonerReset).toBe(0);
+      const row = await getTestVoiceChatCandidateSession(sessionId);
+      expect(row?.reasoningStatus).toBe("running");
+      expect(row?.lastReasoningAt?.getTime()).toBe(freshReasoningAt.getTime());
+    });
+
+    it("T7 — idempotent: a second run within the same tick processes nothing", async () => {
+      const staleTime = new Date(Date.now() - 3 * 60 * 1000);
+      const sessionId = await insertTestVoiceChatCandidateSession({
+        orgId: "org_test",
+        userId: "user_test",
+        lastHeartbeatAt: staleTime,
+      });
+
+      const first = await GET(cronRequest("test-cron-secret"));
+      expect((await first.json()).candidateCleaned).toBe(1);
+
+      const second = await GET(cronRequest("test-cron-secret"));
+      const secondBody = await second.json();
+      expect(secondBody.candidateCleaned).toBe(0);
+
+      const row = await getTestVoiceChatCandidateSession(sessionId);
+      expect(row?.status).toBe("timeout");
+    });
+
+    it("T8 — caps candidate cleanup at 50 per tick (LIMIT 50)", async () => {
+      const orgId = `org_t8_${Date.now()}`;
+      const staleTime = new Date(Date.now() - 3 * 60 * 1000);
+      for (let i = 0; i < 60; i++) {
+        await insertTestVoiceChatCandidateSession({
+          orgId,
+          userId: `user_t8_${i}`,
+          lastHeartbeatAt: staleTime,
+        });
+      }
+
+      const first = await GET(cronRequest("test-cron-secret"));
+      expect((await first.json()).candidateCleaned).toBe(50);
+      expect(
+        await countTestVoiceChatCandidateSessionsByStatus(orgId, "active"),
+      ).toBe(10);
+      expect(
+        await countTestVoiceChatCandidateSessionsByStatus(orgId, "timeout"),
+      ).toBe(50);
+
+      const second = await GET(cronRequest("test-cron-secret"));
+      expect((await second.json()).candidateCleaned).toBe(10);
+      expect(
+        await countTestVoiceChatCandidateSessionsByStatus(orgId, "active"),
+      ).toBe(0);
+      expect(
+        await countTestVoiceChatCandidateSessionsByStatus(orgId, "timeout"),
+      ).toBe(60);
+    });
+
+    it("T9 — caps reasoner stuck-recovery at 50 per tick (LIMIT 50)", async () => {
+      const orgId = `org_t9_${Date.now()}`;
+      const staleReasoningAt = new Date(Date.now() - 6 * 60 * 1000);
+      for (let i = 0; i < 60; i++) {
+        await insertTestVoiceChatCandidateSession({
+          orgId,
+          userId: `user_t9_${i}`,
+          reasoningStatus: "running",
+          lastReasoningAt: staleReasoningAt,
+        });
+      }
+
+      const first = await GET(cronRequest("test-cron-secret"));
+      expect((await first.json()).reasonerReset).toBe(50);
+      expect(
+        await countTestVoiceChatCandidateSessionsByReasoningStatus(
+          orgId,
+          "running",
+        ),
+      ).toBe(10);
+      expect(
+        await countTestVoiceChatCandidateSessionsByReasoningStatus(
+          orgId,
+          "idle",
+        ),
+      ).toBe(50);
+
+      const second = await GET(cronRequest("test-cron-secret"));
+      expect((await second.json()).reasonerReset).toBe(10);
+      expect(
+        await countTestVoiceChatCandidateSessionsByReasoningStatus(
+          orgId,
+          "running",
+        ),
+      ).toBe(0);
+      expect(
+        await countTestVoiceChatCandidateSessionsByReasoningStatus(
+          orgId,
+          "idle",
+        ),
+      ).toBe(60);
+    });
   });
 });

--- a/turbo/apps/web/app/api/cron/voice-chat-cleanup/route.ts
+++ b/turbo/apps/web/app/api/cron/voice-chat-cleanup/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
-import { inArray, and, or, lt } from "drizzle-orm";
+import { NextResponse, after } from "next/server";
+import { inArray, and, or, lt, eq } from "drizzle-orm";
 import { initServices } from "../../../../src/lib/init-services";
 import { logger } from "../../../../src/lib/shared/logger";
 import { env } from "../../../../src/env";
@@ -7,13 +7,23 @@ import {
   voiceChatSessions,
   voiceChatEvents,
 } from "../../../../src/db/schema/voice-chat";
+import { featureCandidateVoiceChatSessions } from "../../../../src/db/schema/voice-chat-candidate";
 import { deleteExpiredPreparations } from "../../../../src/lib/zero/voice-chat/preparation-service";
+import { triggerReasoning } from "../../../../src/lib/zero/voice-chat-candidate/trigger-reasoning";
+import { publishUserSignal } from "../../../../src/lib/infra/realtime/client";
+
+export const maxDuration = 60;
 
 const log = logger("cron:voice-chat-cleanup");
 
 const STALE_HEARTBEAT_MS = 2 * 60 * 1000; // 2 minutes
 const MAX_SESSION_DURATION_MS = 60 * 60 * 1000; // 60 minutes
 const PREPARATION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+const CANDIDATE_STALE_HEARTBEAT_MS = 2 * 60 * 1000; // 2 minutes
+const CANDIDATE_MAX_SESSION_MS = 30 * 60 * 1000; // 30 minutes
+const CANDIDATE_REASONER_STUCK_MS = 5 * 60 * 1000; // 5 minutes
+const CANDIDATE_BATCH_LIMIT = 50;
 
 export async function GET(request: Request): Promise<Response> {
   initServices();
@@ -61,9 +71,114 @@ export async function GET(request: Request): Promise<Response> {
   // Clean up expired preparations (>24h)
   const expiredPreps = await deleteExpiredPreparations(PREPARATION_TTL_MS);
 
+  // === voice-chat-candidate session cleanup ===
+  // LIMIT 50 per tick caps worst-case runtime under catastrophic backlog.
+  const candidateStaleThreshold = new Date(
+    now.getTime() - CANDIDATE_STALE_HEARTBEAT_MS,
+  );
+  const candidateTimeoutThreshold = new Date(
+    now.getTime() - CANDIDATE_MAX_SESSION_MS,
+  );
+
+  const staleCandidateIds = globalThis.services.db
+    .select({ id: featureCandidateVoiceChatSessions.id })
+    .from(featureCandidateVoiceChatSessions)
+    .where(
+      and(
+        eq(featureCandidateVoiceChatSessions.status, "active"),
+        or(
+          lt(
+            featureCandidateVoiceChatSessions.lastHeartbeatAt,
+            candidateStaleThreshold,
+          ),
+          lt(
+            featureCandidateVoiceChatSessions.createdAt,
+            candidateTimeoutThreshold,
+          ),
+        ),
+      ),
+    )
+    .limit(CANDIDATE_BATCH_LIMIT);
+
+  // Belt-and-braces: the outer status='active' predicate guards against a
+  // concurrent status change landing between subselect eval and row lock
+  // under READ COMMITTED.
+  const timedOutCandidates = await globalThis.services.db
+    .update(featureCandidateVoiceChatSessions)
+    .set({ status: "timeout", endedAt: now })
+    .where(
+      and(
+        eq(featureCandidateVoiceChatSessions.status, "active"),
+        inArray(featureCandidateVoiceChatSessions.id, staleCandidateIds),
+      ),
+    )
+    .returning({
+      id: featureCandidateVoiceChatSessions.id,
+      userId: featureCandidateVoiceChatSessions.userId,
+    });
+
+  for (const row of timedOutCandidates) {
+    after(() => {
+      return publishUserSignal([row.userId], `voice-chat-candidate:${row.id}`);
+    });
+  }
+
+  if (timedOutCandidates.length > 0) {
+    log.info("Voice chat candidate cleanup completed", {
+      cleaned: timedOutCandidates.length,
+    });
+  }
+
+  // === voice-chat-candidate reasoner stuck recovery ===
+  // LIMIT 50 per tick caps worst-case runtime under catastrophic backlog.
+  const reasonerStuckThreshold = new Date(
+    now.getTime() - CANDIDATE_REASONER_STUCK_MS,
+  );
+
+  const stuckReasonerIds = globalThis.services.db
+    .select({ id: featureCandidateVoiceChatSessions.id })
+    .from(featureCandidateVoiceChatSessions)
+    .where(
+      and(
+        eq(featureCandidateVoiceChatSessions.reasoningStatus, "running"),
+        lt(
+          featureCandidateVoiceChatSessions.lastReasoningAt,
+          reasonerStuckThreshold,
+        ),
+      ),
+    )
+    .limit(CANDIDATE_BATCH_LIMIT);
+
+  // Belt-and-braces: predicates repeated on the UPDATE itself so a concurrent
+  // Reasoner flipping idle→running between subselect eval and row lock under
+  // READ COMMITTED cannot get its status reset out from under it.
+  const recoveredReasoners = await globalThis.services.db
+    .update(featureCandidateVoiceChatSessions)
+    .set({ reasoningStatus: "idle" })
+    .where(
+      and(
+        eq(featureCandidateVoiceChatSessions.reasoningStatus, "running"),
+        lt(
+          featureCandidateVoiceChatSessions.lastReasoningAt,
+          reasonerStuckThreshold,
+        ),
+        inArray(featureCandidateVoiceChatSessions.id, stuckReasonerIds),
+      ),
+    )
+    .returning({ id: featureCandidateVoiceChatSessions.id });
+
+  for (const row of recoveredReasoners) {
+    log.warn("Candidate reasoner stuck-reset", { sessionId: row.id });
+    after(() => {
+      return triggerReasoning(row.id);
+    });
+  }
+
   return NextResponse.json({
     success: true,
     cleaned: result.length,
     preparationsCleaned: expiredPreps.length,
+    candidateCleaned: timedOutCandidates.length,
+    reasonerReset: recoveredReasoners.length,
   });
 }

--- a/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
@@ -20,6 +20,7 @@ export {
   insertTestVoiceChatSession,
   insertTestVoiceChatPreparation,
 } from "../db-test-seeders/users";
+export { insertTestVoiceChatCandidateSession } from "../db-test-seeders/voice-chat-candidate";
 
 // Re-exports: read-only assertions
 export {
@@ -30,6 +31,11 @@ export {
   getTestVoiceChatEvents,
   getTestVoiceChatPreparation,
 } from "../db-test-assertions/users";
+export {
+  getTestVoiceChatCandidateSession,
+  countTestVoiceChatCandidateSessionsByStatus,
+  countTestVoiceChatCandidateSessionsByReasoningStatus,
+} from "../db-test-assertions/voice-chat-candidate";
 
 /**
  * Get a VM0 API key from the pool for a vendor.

--- a/turbo/apps/web/src/__tests__/db-test-assertions/voice-chat-candidate.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/voice-chat-candidate.ts
@@ -1,0 +1,74 @@
+import { eq, and } from "drizzle-orm";
+import { initServices } from "../../lib/init-services";
+import { featureCandidateVoiceChatSessions } from "../../db/schema/voice-chat-candidate";
+
+/**
+ * Read a candidate voice-chat session's mutable state.
+ * @why-db-direct Cron tests verify the timeout/reasoning state transitions
+ * the route handler writes; no read API exists for the candidate table.
+ */
+export async function getTestVoiceChatCandidateSession(id: string): Promise<
+  | {
+      status: string;
+      endedAt: Date | null;
+      reasoningStatus: string;
+      lastReasoningAt: Date | null;
+    }
+  | undefined
+> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({
+      status: featureCandidateVoiceChatSessions.status,
+      endedAt: featureCandidateVoiceChatSessions.endedAt,
+      reasoningStatus: featureCandidateVoiceChatSessions.reasoningStatus,
+      lastReasoningAt: featureCandidateVoiceChatSessions.lastReasoningAt,
+    })
+    .from(featureCandidateVoiceChatSessions)
+    .where(eq(featureCandidateVoiceChatSessions.id, id));
+  return row;
+}
+
+/**
+ * Count candidate sessions by `status`, scoped to a single org to keep
+ * large-batch test assertions hermetic across a shared dev database.
+ * @why-db-direct Aggregations across many seeded rows have no API surface.
+ */
+export async function countTestVoiceChatCandidateSessionsByStatus(
+  orgId: string,
+  status: "active" | "ended" | "timeout",
+): Promise<number> {
+  initServices();
+  const rows = await globalThis.services.db
+    .select({ id: featureCandidateVoiceChatSessions.id })
+    .from(featureCandidateVoiceChatSessions)
+    .where(
+      and(
+        eq(featureCandidateVoiceChatSessions.orgId, orgId),
+        eq(featureCandidateVoiceChatSessions.status, status),
+      ),
+    );
+  return rows.length;
+}
+
+/**
+ * Count candidate sessions by `reasoningStatus`, scoped to a single org
+ * to keep large-batch assertions hermetic across a shared dev database.
+ * @why-db-direct Aggregations across many seeded rows have no API surface.
+ */
+export async function countTestVoiceChatCandidateSessionsByReasoningStatus(
+  orgId: string,
+  reasoningStatus: "idle" | "running",
+): Promise<number> {
+  initServices();
+  const rows = await globalThis.services.db
+    .select({ id: featureCandidateVoiceChatSessions.id })
+    .from(featureCandidateVoiceChatSessions)
+    .where(
+      and(
+        eq(featureCandidateVoiceChatSessions.orgId, orgId),
+        eq(featureCandidateVoiceChatSessions.reasoningStatus, reasoningStatus),
+      ),
+    );
+  return rows.length;
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/voice-chat-candidate.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/voice-chat-candidate.ts
@@ -1,0 +1,35 @@
+import { initServices } from "../../lib/init-services";
+import { featureCandidateVoiceChatSessions } from "../../db/schema/voice-chat-candidate";
+
+/**
+ * Insert a voice-chat-candidate session directly.
+ * @why-db-direct Cron tests need to construct impossible states (stale
+ * heartbeats, stuck reasoner) that no public API would produce.
+ */
+export async function insertTestVoiceChatCandidateSession(overrides: {
+  orgId: string;
+  userId: string;
+  agentId?: string | null;
+  status?: "active" | "ended" | "timeout";
+  reasoningStatus?: "idle" | "running";
+  lastReasoningAt?: Date | null;
+  createdAt?: Date;
+  lastHeartbeatAt?: Date;
+}): Promise<string> {
+  initServices();
+  const now = new Date();
+  const [row] = await globalThis.services.db
+    .insert(featureCandidateVoiceChatSessions)
+    .values({
+      orgId: overrides.orgId,
+      userId: overrides.userId,
+      agentId: overrides.agentId ?? null,
+      status: overrides.status ?? "active",
+      reasoningStatus: overrides.reasoningStatus ?? "idle",
+      lastReasoningAt: overrides.lastReasoningAt ?? null,
+      createdAt: overrides.createdAt ?? now,
+      lastHeartbeatAt: overrides.lastHeartbeatAt ?? now,
+    })
+    .returning({ id: featureCandidateVoiceChatSessions.id });
+  return row!.id;
+}


### PR DESCRIPTION
## Summary

Adds two strictly-additive passes to the existing `/api/cron/voice-chat-cleanup` GET handler (epic #10297, closes #10312):

1. **Candidate session cleanup** — times out `active` candidate sessions whose heartbeat is stale (>2 min) or whose lifetime exceeds 30 min, then re-pokes the owning browser via `publishUserSignal` over Ably.
2. **Reasoner stuck-recovery** — resets `reasoning_status='running'` rows whose `lastReasoningAt` is older than 5 min back to `'idle'`, then re-fires `triggerReasoning` via `after()` so stuck Reasoner work resumes cleanly.

Both UPDATEs are bounded by a 50-row subselect (`CANDIDATE_BATCH_LIMIT`) to cap worst-case runtime under catastrophic backlog. **Belt-and-braces** predicates are repeated on the UPDATE's own WHERE to harden against concurrent state changes between subselect evaluation and row lock under READ COMMITTED (per reviewer feedback on the plan).

`maxDuration = 60` is set on the route. The pre-existing non-candidate pass (on `voice_chat_sessions`) is **untouched**, per the epic-level rule.

Response body extended with `candidateCleaned` and `reasonerReset` counts for test-side observability.

## Implementation notes

- `after()` fan-out per row: one after-callback per affected session (`publishUserSignal` for pass 1, `triggerReasoning` for pass 2). Failure isolation per session.
- Idempotent by construction: both gates mutate the state they filter on (`status='active'` → `'timeout'`, `reasoning_status='running'` → `'idle'`), so a repeat tick within the same second processes each row at most once.
- Order: session cleanup runs before Reasoner recovery. A session that is both "heartbeat stale" AND "reasoner stuck" gets timed out first, so by the time the after()-scheduled `triggerReasoning` fires, the session is non-active and `triggerReasoning` bails on its own guard (`trigger-reasoning.ts:30-31`).

## Deviation from plan

The approved plan proposed mocking `triggerReasoning` via `vi.mock("../../.../trigger-reasoning", ...)` in T5. This is blocked by the repo's `web/no-relative-vi-mock` ESLint rule (tests may only mock external dependencies). Instead, T5 verifies the cron's DB reset work *and* asserts that exactly one `after()` callback was queued (`globalThis.nextAfterCallbacks.length === 1`) without flushing it. This preserves integration-test purity without needing an internal mock.

## Known unrelated issue flagged (NOT fixed here)

The pre-existing non-candidate voice-chat-cleanup pass in this file has a latent idempotency issue (running the cron twice within the same minute can double-write session-end events). This PR does NOT touch that code path per epic #10297 constraint "no modifications to existing voice-chat code". A follow-up issue should be opened to address it. The new candidate passes added here are idempotent by construction (both use WHERE-conditional UPDATEs gated on mutable state that transitions in the same statement).

## Test plan

- [x] `pnpm check-types` (apps/web) — clean
- [x] `pnpm turbo run lint --filter=web` — clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — no new issues (only pre-existing config hints)
- [x] `pnpm -F web exec vitest run app/api/cron/voice-chat-cleanup` — 21/21 tests pass (12 pre-existing + 9 new)
- [x] Broader sweep `pnpm -F web exec vitest run` — no new failures introduced by this PR (one pre-existing flake on `voice_chat_sessions` test pollution reproduces on main without my changes)

### New tests added (T1–T9)

- T1 stale-heartbeat timeout + Ably publish
- T2 max-duration timeout
- T3 fresh session untouched
- T4 already-ended session untouched
- T5 stuck reasoner reset + `after()` re-tick queued
- T6 non-stuck reasoner untouched
- T7 idempotent double-run
- T8 LIMIT-50 pagination on session cleanup
- T9 LIMIT-50 pagination on reasoner recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)