### PR TITLE
fix(mitm-addon): return after url rewrite forward failure

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -552,6 +552,8 @@ async def handle_firewall_request(
                 type="firewall",
                 firewall_base=firewall_base,
             )
+            flow.metadata["firewall_action"] = "ALLOW"
+            flow.metadata["firewall_error"] = "url_rewrite_forward_failed"
             flow.response = http.Response.make(
                 502,
                 json.dumps(
@@ -563,6 +565,7 @@ async def handle_firewall_request(
                 ).encode(),
                 {"Content-Type": "application/json"},
             )
+            return
 
         flow.metadata["auth_url_rewrite"] = True
         log_proxy_entry(

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1,9 +1,11 @@
 """Tests for firewall subsystem: matching, caching, header injection, and HTTP fetching."""
 
+import asyncio
 import io
 import json
 import time
 import urllib.error
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
 
@@ -2329,7 +2331,14 @@ class TestAuthBaseUrlRewriteEdgeCases:
         assert req_headers["X-Custom"] == "injected-value"
 
     async def test_forward_failure_returns_502(self, real_flow, mitm_ctx, tmp_path):
-        """forward_request exception produces a 502 error response."""
+        """forward_request exception produces a 502 error response and marks
+        firewall_error without falling through to the success-path metadata.
+
+        Regression for #10341: the except block previously lacked a ``return``,
+        so ``auth_url_rewrite`` and a misleading ``Firewall URL rewrite`` info
+        log were emitted on failure, and ``firewall_error`` was left unset —
+        making failed rewrites indistinguishable from successful ones in
+        dashboards."""
         flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
             real_flow, tmp_path
         )
@@ -2342,7 +2351,18 @@ class TestAuthBaseUrlRewriteEdgeCases:
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["auth_url_rewrite"] is True
+        body = json.loads(flow.response.content)
+        assert body["error"] == "url_rewrite_forward_failed"
+        # Failure must not masquerade as a successful rewrite.
+        assert "auth_url_rewrite" not in flow.metadata
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
+        # Success-path log line must not be written.
+        log_path = Path(vm_info["networkLogPath"])
+        log_text = await asyncio.to_thread(
+            lambda: log_path.read_text() if log_path.exists() else ""
+        )
+        assert "Firewall URL rewrite:" not in log_text
 
     async def test_no_rewrite_when_resolved_base_empty_string(self, real_flow, mitm_ctx, tmp_path):
         """Empty string base from server is treated as absent — no URL rewrite."""


### PR DESCRIPTION
## Summary

- `auth.py`'s URL rewrite path set a 502 on `forward_request` failure but **did not `return`** — execution fell through to success-path metadata (`auth_url_rewrite = True`, `firewall_action = ALLOW` with no `firewall_error`) and emitted a misleading `Firewall URL rewrite: ... -> [redacted]` info log.
- Add `firewall_error = "url_rewrite_forward_failed"` + `return`, consistent with the `auth_unavailable` / `auth_failed` / `connector_not_configured` branches above (auth.py:352/389/413).
- Fix `test_forward_failure_returns_502`, which previously codified the bug (`assert flow.metadata["auth_url_rewrite"] is True`), to assert the corrected behavior — no `auth_url_rewrite`, `firewall_error` set, and the success log line is not written.

Closes #10341

## Test plan

- [x] `python3 -m pytest tests/ -v` — 883 passed
- [x] Verified regression coverage: reverting the one-line fix flips `test_forward_failure_returns_502` from pass to fail on the `auth_url_rewrite not in flow.metadata` assertion.
- [x] `ruff check .` + `ruff format --check .` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)