### PR TITLE
feat: add Kimi K2.6 model support

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -218,6 +218,7 @@ const VM0_MODEL_CREDIT_MULTIPLIER = Object.freeze<Record<string, number>>({
   "claude-sonnet-4-6": 1,
   "glm-5.1": 0.4,
   "claude-haiku-4-5": 0.3,
+  "kimi-k2.6": 0.3,
   "kimi-k2.5": 0.2,
   "MiniMax-M2.7": 0.1,
 });

--- a/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
@@ -361,7 +361,7 @@ describe("GET /api/zero/usage/insight", () => {
 
     expect(data.schedules.length).toBe(100);
     expect(data.scheduleOtherCount).toBe(5);
-  });
+  }, 30000);
 
   it("scope isolation — other user's activity in same org is invisible", async () => {
     const { userId, orgId } = await context.user;
@@ -503,5 +503,5 @@ describe("GET /api/zero/usage/insight", () => {
 
     expect(data.schedules.length).toBe(100);
     expect(data.scheduleOtherCount).toBe(5);
-  });
+  }, 30000);
 });

--- a/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
@@ -330,28 +330,30 @@ describe("GET /api/zero/usage/insight", () => {
       orgId,
     });
 
-    // Seed 105 schedules, each with one run + credit usage
-    for (let i = 0; i < 105; i++) {
-      const scheduleId = await seedTestSchedule({
-        agentId: composeId,
-        userId,
-        orgId,
-      });
+    // Seed 105 schedules in parallel, each with one run + credit usage
+    await Promise.all(
+      Array.from({ length: 105 }, async (_, i) => {
+        const scheduleId = await seedTestSchedule({
+          agentId: composeId,
+          userId,
+          orgId,
+        });
 
-      const { runId } = await seedTestRun(userId, composeId, {
-        triggerSource: "schedule",
-        scheduleId,
-        status: "completed",
-      });
+        const { runId } = await seedTestRun(userId, composeId, {
+          triggerSource: "schedule",
+          scheduleId,
+          status: "completed",
+        });
 
-      await insertTestCreditUsageForRun({
-        runId,
-        orgId,
-        userId,
-        creditsCharged: i + 1,
-        status: "processed",
-      });
-    }
+        await insertTestCreditUsageForRun({
+          runId,
+          orgId,
+          userId,
+          creditsCharged: i + 1,
+          status: "processed",
+        });
+      }),
+    );
 
     const response = await GET(
       makeRequest({ range: "28d", groupBy: "source", tz: "UTC" }),
@@ -361,7 +363,7 @@ describe("GET /api/zero/usage/insight", () => {
 
     expect(data.schedules.length).toBe(100);
     expect(data.scheduleOtherCount).toBe(5);
-  }, 30000);
+  });
 
   it("scope isolation — other user's activity in same org is invisible", async () => {
     const { userId, orgId } = await context.user;
@@ -470,30 +472,32 @@ describe("GET /api/zero/usage/insight", () => {
       orgId,
     });
 
-    // Seed 105 schedules where the 5 overflow items have creditsCharged = 0
-    for (let i = 0; i < 105; i++) {
-      const scheduleId = await seedTestSchedule({
-        agentId: composeId,
-        userId,
-        orgId,
-      });
+    // Seed 105 schedules in parallel where the 5 overflow items have creditsCharged = 0
+    await Promise.all(
+      Array.from({ length: 105 }, async (_, i) => {
+        const scheduleId = await seedTestSchedule({
+          agentId: composeId,
+          userId,
+          orgId,
+        });
 
-      const { runId } = await seedTestRun(userId, composeId, {
-        triggerSource: "schedule",
-        scheduleId,
-        status: "completed",
-      });
+        const { runId } = await seedTestRun(userId, composeId, {
+          triggerSource: "schedule",
+          scheduleId,
+          status: "completed",
+        });
 
-      // Top-100 items have credits 6..105; overflow items 1..5 have creditsCharged = 0
-      // so all overflow rows have zero credits — this is the regression case.
-      await insertTestCreditUsageForRun({
-        runId,
-        orgId,
-        userId,
-        creditsCharged: i < 5 ? 0 : i + 1,
-        status: "processed",
-      });
-    }
+        // Top-100 items have credits 6..105; overflow items 1..5 have creditsCharged = 0
+        // so all overflow rows have zero credits — this is the regression case.
+        await insertTestCreditUsageForRun({
+          runId,
+          orgId,
+          userId,
+          creditsCharged: i < 5 ? 0 : i + 1,
+          status: "processed",
+        });
+      }),
+    );
 
     const response = await GET(
       makeRequest({ range: "28d", groupBy: "source", tz: "UTC" }),
@@ -503,5 +507,5 @@ describe("GET /api/zero/usage/insight", () => {
 
     expect(data.schedules.length).toBe(100);
     expect(data.scheduleOtherCount).toBe(5);
-  }, 30000);
+  });
 });

--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -61,6 +61,14 @@ const MODEL_PRICING: (typeof creditPricing.$inferInsert)[] = [
     cacheCreationTokenPrice: usd(1.25),
   },
   {
+    model: "kimi-k2.6",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(0.6),
+    outputTokenPrice: usd(3),
+    cacheReadTokenPrice: usd(0.1),
+    cacheCreationTokenPrice: usd(0.6),
+  },
+  {
     model: "kimi-k2.5",
     modelProvider: "vm0",
     inputTokenPrice: usd(0.6),

--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -148,6 +148,12 @@ describe("VM0 managed model provider", () => {
       expect(getVm0ApiModel("glm-5.1")).toBe("z-ai/glm-5.1");
     });
 
+    it("should resolve kimi-k2.6 to moonshot-api-key", () => {
+      expect(getVm0ConcreteProviderType("kimi-k2.6")).toBe("moonshot-api-key");
+      expect(getVm0Vendor("kimi-k2.6")).toBe("moonshot");
+      expect(getVm0ApiModel("kimi-k2.6")).toBe("kimi-k2.6");
+    });
+
     it("should fall back to display name when no apiModel override is set", () => {
       expect(getVm0ApiModel("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
     });

--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -171,6 +171,7 @@ describe("VM0 managed model provider", () => {
         "claude-sonnet-4-6",
         "claude-haiku-4-5",
         "glm-5.1",
+        "kimi-k2.6",
         "kimi-k2.5",
         "MiniMax-M2.7",
       ];

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -71,6 +71,10 @@ export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
     concreteType: "anthropic-api-key",
     vendor: "anthropic",
   },
+  "kimi-k2.6": {
+    concreteType: "moonshot-api-key",
+    vendor: "moonshot",
+  },
   "kimi-k2.5": {
     concreteType: "moonshot-api-key",
     vendor: "moonshot",
@@ -193,11 +197,12 @@ export const MODEL_PROVIDER_TYPES = {
       CLAUDE_CODE_SUBAGENT_MODEL: "$model",
     } as Record<string, string>,
     models: [
+      "kimi-k2.6",
       "kimi-k2.5",
       "kimi-k2-thinking-turbo",
       "kimi-k2-thinking",
     ] as string[],
-    defaultModel: "kimi-k2.5",
+    defaultModel: "kimi-k2.6",
   },
   "minimax-api-key": {
     framework: "claude-code" as const,
@@ -281,6 +286,7 @@ export const MODEL_PROVIDER_TYPES = {
       "anthropic/claude-sonnet-4.6",
       "anthropic/claude-sonnet-4.5",
       "anthropic/claude-haiku-4.5",
+      "moonshotai/kimi-k2.6",
       "moonshotai/kimi-k2.5",
       "minimax/minimax-m2.5",
       "zai/glm-5-turbo",

--- a/turbo/packages/core/src/model-display-name.ts
+++ b/turbo/packages/core/src/model-display-name.ts
@@ -21,9 +21,11 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   "MiniMax-M2.1": "MiniMax M2.1",
   "minimax/minimax-m2.5": "MiniMax M2.5",
   // Kimi / Moonshot
+  "kimi-k2.6": "Kimi K2.6",
   "kimi-k2.5": "Kimi K2.5",
   "kimi-k2-thinking": "Kimi K2 Thinking",
   "kimi-k2-thinking-turbo": "Kimi K2 Thinking Turbo",
+  "moonshotai/kimi-k2.6": "Kimi K2.6",
   "moonshotai/kimi-k2.5": "Kimi K2.5",
   // GLM / ZhipuAI
   "glm-5.1": "GLM-5.1",


### PR DESCRIPTION
## Summary
- Register `kimi-k2.6` as a new Moonshot model across the core provider contract, VM0 managed provider, and Vercel AI Gateway routing
- Default the BYOK Moonshot provider to `kimi-k2.6` (K2.5 stays selectable)
- Extend display names, credit multiplier (0.3), and dev seed pricing

## Test plan
- [x] `pnpm -F @vm0/core exec vitest run src/contracts/__tests__/model-providers.test.ts` — 34/34 pass
- [x] `pnpm turbo run lint --filter=@vm0/core --filter=@vm0/cli --filter=@vm0/app` — green
- [x] `pnpm format` — no diff
- [ ] Post-merge: verify Built-in model dropdown surfaces Kimi K2.6 in platform UI

## Notes
- Dev-seed pricing copies K2.5 values as a placeholder; update once Moonshot publishes K2.6 pricing