### PR TITLE
ci(runner): wait for drained service to exit before uninstall

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1313,6 +1313,19 @@ jobs:
           FAILED=0
           fail() { FAILED=1; echo "FAIL: $1"; exit 1; }
 
+          # Poll `systemctl is-active` with a bounded budget; fail if the unit
+          # is still active afterward so the EXIT trap dumps journalctl at the
+          # right diagnostic boundary (instead of hanging inside systemctl stop).
+          wait_for_exit() {
+            local svc=$1 budget=${2:-5}
+            echo "--- Waiting up to ${budget}s for $svc to exit ---"
+            for i in $(seq 1 "$budget"); do
+              systemctl is-active --quiet "vm0-runner-${svc}" || return 0
+              sleep 1
+            done
+            fail "$svc still active after ${budget}s (stuck on drain?)"
+          }
+
           cleanup() {
             echo "--- Cleanup: uninstalling services ---"
             sudo "$BIN_DIR/runner" service uninstall --name "$SVC_A" --force 2>/dev/null || true
@@ -1359,14 +1372,8 @@ jobs:
           echo "--- Waiting for job 2 ---"
           wait $SUBMIT2_PID || fail "Job 2 failed"
 
-          # 7. Wait for A to exit after drain (5s budget), then uninstall
-          echo "--- Waiting up to 5s for $SVC_A to exit ---"
-          for i in $(seq 1 5); do
-            systemctl is-active --quiet "vm0-runner-${SVC_A}" || break
-            sleep 1
-          done
-          systemctl is-active --quiet "vm0-runner-${SVC_A}" \
-            && fail "$SVC_A still active after 5s (stuck on drain?)"
+          # 7. Wait for A to exit after drain, then uninstall
+          wait_for_exit "$SVC_A"
           echo "--- Uninstalling runner A ---"
           sudo "$BIN_DIR/runner" service uninstall --name "$SVC_A" --force
 
@@ -1374,16 +1381,10 @@ jobs:
           echo "--- Submit job 3 (only B) ---"
           sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'echo job3' || fail "Job 3 failed"
 
-          # 9. Drain B, wait for it to exit (5s budget), then uninstall
+          # 9. Drain B, wait for it to exit, then uninstall
           echo "--- Draining runner B ---"
           sudo "$BIN_DIR/runner" service drain --name "$SVC_B"
-          echo "--- Waiting up to 5s for $SVC_B to exit ---"
-          for i in $(seq 1 5); do
-            systemctl is-active --quiet "vm0-runner-${SVC_B}" || break
-            sleep 1
-          done
-          systemctl is-active --quiet "vm0-runner-${SVC_B}" \
-            && fail "$SVC_B still active after 5s (stuck on drain?)"
+          wait_for_exit "$SVC_B"
           echo "--- Uninstalling runner B ---"
           sudo "$BIN_DIR/runner" service uninstall --name "$SVC_B" --force
           trap - EXIT

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1359,7 +1359,14 @@ jobs:
           echo "--- Waiting for job 2 ---"
           wait $SUBMIT2_PID || fail "Job 2 failed"
 
-          # 7. Uninstall A (systemctl stop blocks until drain finishes)
+          # 7. Wait for A to exit after drain (5s budget), then uninstall
+          echo "--- Waiting up to 5s for $SVC_A to exit ---"
+          for i in $(seq 1 5); do
+            systemctl is-active --quiet "vm0-runner-${SVC_A}" || break
+            sleep 1
+          done
+          systemctl is-active --quiet "vm0-runner-${SVC_A}" \
+            && fail "$SVC_A still active after 5s (stuck on drain?)"
           echo "--- Uninstalling runner A ---"
           sudo "$BIN_DIR/runner" service uninstall --name "$SVC_A" --force
 
@@ -1367,9 +1374,16 @@ jobs:
           echo "--- Submit job 3 (only B) ---"
           sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'echo job3' || fail "Job 3 failed"
 
-          # 9. Drain and uninstall B
+          # 9. Drain B, wait for it to exit (5s budget), then uninstall
           echo "--- Draining runner B ---"
           sudo "$BIN_DIR/runner" service drain --name "$SVC_B"
+          echo "--- Waiting up to 5s for $SVC_B to exit ---"
+          for i in $(seq 1 5); do
+            systemctl is-active --quiet "vm0-runner-${SVC_B}" || break
+            sleep 1
+          done
+          systemctl is-active --quiet "vm0-runner-${SVC_B}" \
+            && fail "$SVC_B still active after 5s (stuck on drain?)"
           echo "--- Uninstalling runner B ---"
           sudo "$BIN_DIR/runner" service uninstall --name "$SVC_B" --force
           trap - EXIT


### PR DESCRIPTION
## Summary

- In the `runner-upgrade` job, after jobs complete and `service drain` has been issued, poll `systemctl is-active` with a 5s budget before calling `service uninstall --force` for both `SVC_A` and `SVC_B`.
- Fail fast with a specific message (`"$SVC still active after 5s (stuck on drain?)"`) if the unit hasn't reached inactive, so the `trap cleanup EXIT` dumps journalctl at the right diagnostic boundary instead of hanging inside `systemctl stop`.

## Why

The previous code relied on `systemctl stop` (inside `service uninstall`) to block until drain finished. When a runner got stuck during post-job wrap-up, this showed up as an opaque systemctl hang with no indication of which step was slow — CI just timed out.

## Test plan

- [ ] `runner-upgrade` job passes on this PR (happy path — runner exits well within 5s)
- [ ] Manually inducing a stuck runner (local experiment) surfaces `FAIL: ... stuck on drain?` with full journalctl from the trap

🤖 Generated with [Claude Code](https://claude.com/claude-code)