### PR TITLE
test(zero): align test description with renamed firewall field

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
@@ -211,7 +211,7 @@ describe("applyConnectorPolicies", () => {
     });
   });
 
-  it("defaults unknownPolicy to allow when ref absent from unknownPermissionPolicies", () => {
+  it("defaults unknownPolicy to allow when name absent from unknownPermissionPolicies", () => {
     const fw = makeFirewall({
       name: "github",
       apis: [


### PR DESCRIPTION
## Summary

- Follow-up to #10353. Rename the `it(...)` description on
  `apply-connector-policies.test.ts:214` from "when ref absent" to
  "when name absent" — `ExpandedFirewallConfig.ref` no longer exists;
  the map is keyed by `name`.

Purely cosmetic; no code / assertion / behavior change.

## Test plan

- [x] \`pnpm -F web exec vitest run src/lib/zero/__tests__/apply-connector-policies.test.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)