### PR TITLE
feat(ui): auto-focus input on /agents/:id/chat page

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -571,6 +571,7 @@ export function AgentChatPage() {
             onInputChange={setInput}
             onSend={handleSend}
             displayName={currentChatAgentDisplayName ?? ""}
+            autoFocus
             modelPicker={
               modelFeatureEnabled &&
               orgProviders &&


### PR DESCRIPTION
## Summary
Add `autoFocus` prop to `ZeroChatComposer` in `AgentChatPage` so the input field is automatically focused when users navigate to the agent chat landing page (`/agents/:id/chat`).

## Changes
- `turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx`: Add `autoFocus` prop to `<ZeroChatComposer />`

## Test Plan
- [ ] Navigate to `/agents/:id/chat`
- [ ] Verify the text input is automatically focused on page load
- [ ] Verify focus behavior on mobile (should not auto-focus on touch devices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)