### PR TITLE
feat(activity): add runner tab with sandbox reuse result

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-runner-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-runner-signals.ts
@@ -1,0 +1,19 @@
+import { computed } from "ccstate";
+import { zeroRunRunnerContract } from "@vm0/core";
+import { zeroClient$ } from "../api-client.ts";
+import { currentRunId$ } from "./activity-signals.ts";
+import { accept } from "../../lib/accept.ts";
+
+export const zeroActivityRunner$ = computed(async (get) => {
+  const runId = get(currentRunId$);
+  if (!runId) {
+    return null;
+  }
+
+  const client = get(zeroClient$)(zeroRunRunnerContract);
+  const result = await accept(
+    client.getRunner({ params: { id: runId } }),
+    [200],
+  );
+  return result.body;
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -29,6 +29,7 @@ import {
   FeatureSwitchKey,
   RUN_ERROR_GUIDANCE,
   type ModelProviderType,
+  type SandboxReuseResult,
 } from "@vm0/core";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { fetchDownloadExtra$ } from "../../signals/activity-page/activity-download.ts";
@@ -62,6 +63,7 @@ import {
 import { GroupedMessageCard } from "./components/log-views/grouped-message-card.tsx";
 import { StatusDot } from "./components/log-views/status-dot.tsx";
 import { zeroActivityContext$ } from "../../signals/activity-page/activity-context-signals.ts";
+import { zeroActivityRunner$ } from "../../signals/activity-page/activity-runner-signals.ts";
 import {
   zeroActivityNetworkLogs$,
   loadNetworkLogsNextPage$,
@@ -401,7 +403,37 @@ function resolveDisplayName(
   return detail.displayName ?? detail.agentId ?? "Agent";
 }
 
-type ActivityTab = "steps" | "context" | "network";
+type ActivityTab = "steps" | "context" | "runner" | "network";
+
+const SANDBOX_REUSE_LABELS = {
+  reused: {
+    label: "Reused",
+    description: "Sandbox was unparked from the idle pool.",
+  },
+  featureDisabled: {
+    label: "Not reused",
+    description: "Sandbox reuse is disabled for this run.",
+  },
+  noSessionId: {
+    label: "Not reused",
+    description: "No session ID available to match against the idle pool.",
+  },
+  poolMiss: {
+    label: "Not reused",
+    description: "No matching sandbox found in the idle pool.",
+  },
+  profileMismatch: {
+    label: "Not reused",
+    description: "Idle pool entry exists but its profile does not match.",
+  },
+  unparkFailed: {
+    label: "Not reused",
+    description: "Unpark attempt failed; a fresh sandbox was provisioned.",
+  },
+} as const satisfies Record<
+  SandboxReuseResult,
+  { label: string; description: string }
+>;
 
 function ActivityStepsContent({
   detail,
@@ -500,6 +532,49 @@ function ActivityContextTab() {
   return <ContextContent context={context} />;
 }
 
+function ActivityRunnerTab() {
+  const runnerLoadable = useLastLoadable(zeroActivityRunner$);
+
+  if (
+    runnerLoadable.state === "loading" ||
+    runnerLoadable.state === "hasError"
+  ) {
+    return (
+      <div className="flex flex-col gap-2 py-4">
+        <div className="h-4 w-24 rounded bg-muted/50 animate-pulse" />
+        <div className="h-8 w-64 rounded bg-muted/50 animate-pulse" />
+      </div>
+    );
+  }
+
+  const runner = runnerLoadable.data;
+  const reuse = runner?.sandboxReuseResult ?? null;
+  const info = reuse ? SANDBOX_REUSE_LABELS[reuse] : null;
+
+  return (
+    <div className="flex flex-col gap-6 pb-8">
+      <section>
+        <h3 className="text-sm font-semibold text-foreground mb-2">Sandbox</h3>
+        {info ? (
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center rounded-md border bg-muted/50 px-2 py-0.5 text-xs font-medium">
+              {info.label}
+            </span>
+            <span className="text-sm text-muted-foreground">
+              {info.description}
+            </span>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Unknown (older run, recorded before sandbox reuse tracking was
+            added).
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}
+
 function ActivityNetworkTab() {
   const logsLoadable = useLastLoadable(zeroActivityNetworkLogs$);
   const loadNextPage = useSet(loadNetworkLogsNextPage$);
@@ -548,6 +623,35 @@ function ActivityNetworkTab() {
   );
 }
 
+function ActivityTabContent({
+  activeTab,
+  detail,
+  eventsData,
+  features,
+}: {
+  activeTab: ActivityTab;
+  detail: LogDetail;
+  eventsData: AgentEvent[];
+  features: Record<FeatureSwitchKey, boolean> | undefined;
+}) {
+  if (activeTab === "steps") {
+    return (
+      <ActivityStepsContent
+        detail={detail}
+        eventsData={eventsData}
+        features={features}
+      />
+    );
+  }
+  if (activeTab === "context") {
+    return <ActivityContextTab />;
+  }
+  if (activeTab === "runner") {
+    return <ActivityRunnerTab />;
+  }
+  return <ActivityNetworkTab />;
+}
+
 function ActivityDetailContent({
   detail,
   displayName,
@@ -563,7 +667,9 @@ function ActivityDetailContent({
   const updateParams = useSet(updateSearchParams$);
   const rawTab = params.get("tab");
   const activeTab: ActivityTab =
-    rawTab === "context" || rawTab === "network" ? rawTab : "steps";
+    rawTab === "context" || rawTab === "runner" || rawTab === "network"
+      ? rawTab
+      : "steps";
   const setActiveTab = (tab: ActivityTab) => {
     const next = new URLSearchParams(params);
     if (tab === "steps") {
@@ -663,6 +769,7 @@ function ActivityDetailContent({
                 <TabsList>
                   <TabsTrigger value="steps">Steps</TabsTrigger>
                   <TabsTrigger value="context">Context</TabsTrigger>
+                  <TabsTrigger value="runner">Runner</TabsTrigger>
                   <TabsTrigger value="network">Network</TabsTrigger>
                 </TabsList>
               </Tabs>
@@ -670,15 +777,12 @@ function ActivityDetailContent({
           )}
 
           <div className="mt-6">
-            {activeTab === "steps" && (
-              <ActivityStepsContent
-                detail={detail}
-                eventsData={eventsData}
-                features={features}
-              />
-            )}
-            {activeTab === "context" && <ActivityContextTab />}
-            {activeTab === "network" && <ActivityNetworkTab />}
+            <ActivityTabContent
+              activeTab={activeTab}
+              detail={detail}
+              eventsData={eventsData}
+              features={features}
+            />
           </div>
         </div>
       </div>

--- a/turbo/apps/web/app/api/zero/runs/[id]/runner/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/runner/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { randomUUID } from "crypto";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+  createTestCompose,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import {
+  seedTestRun,
+  setTestRunSandboxReuseResult,
+} from "../../../../../../../src/__tests__/db-test-seeders/runs";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zrun");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function runnerUrl(runId: string): string {
+  return `http://localhost:3000/api/zero/runs/${runId}/runner`;
+}
+
+describe("GET /api/zero/runs/:id/runner", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("returns sandboxReuseResult when set", async () => {
+    const userId = uniqueId("zrun-set");
+    await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zrun")}`);
+    const { runId } = await seedTestRun(userId, compose.composeId, {
+      status: "completed",
+    });
+    await setTestRunSandboxReuseResult(runId, "reused");
+
+    const response = await GET(createTestRequest(runnerUrl(runId)));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.sandboxReuseResult).toBe("reused");
+  });
+
+  it("returns null sandboxReuseResult for older runs", async () => {
+    const userId = uniqueId("zrun-null");
+    await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zrun")}`);
+    const { runId } = await seedTestRun(userId, compose.composeId, {
+      status: "completed",
+    });
+
+    const response = await GET(createTestRequest(runnerUrl(runId)));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.sandboxReuseResult).toBeNull();
+  });
+
+  it("returns 404 when run not found", async () => {
+    const userId = uniqueId("zrun-nf");
+    await setupOrg(userId);
+
+    const response = await GET(createTestRequest(runnerUrl(randomUUID())));
+    expect(response.status).toBe(404);
+
+    const data = await response.json();
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 404 when run belongs to a different user", async () => {
+    const ownerId = uniqueId("zrun-own");
+    await setupOrg(ownerId);
+    const compose = await createTestCompose(`agent-${uniqueId("zrun")}`);
+    const { runId } = await seedTestRun(ownerId, compose.composeId, {
+      status: "completed",
+    });
+    await setTestRunSandboxReuseResult(runId, "poolMiss");
+
+    const otherUserId = uniqueId("zrun-oth");
+    await setupOrg(otherUserId);
+
+    const response = await GET(createTestRequest(runnerUrl(runId)));
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/runs/some-id/runner"),
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/runs/[id]/runner/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/runner/route.ts
@@ -1,0 +1,63 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../../src/lib/ts-rest-handler";
+import { zeroRunRunnerContract, type SandboxReuseResult } from "@vm0/core";
+import { initServices } from "../../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../../src/lib/zero/org/resolve-org";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { and, eq } from "drizzle-orm";
+
+const router = tsr.router(zeroRunRunnerContract, {
+  getRunner: async ({ params, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    const { org } = await resolveOrg(authCtx);
+
+    const [row] = await globalThis.services.db
+      .select({ sandboxReuseResult: agentRuns.sandboxReuseResult })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.id, params.id),
+          eq(agentRuns.userId, userId),
+          eq(agentRuns.orgId, org.orgId),
+        ),
+      )
+      .limit(1);
+
+    if (!row) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent run not found", code: "NOT_FOUND" },
+        },
+      };
+    }
+
+    return {
+      status: 200 as const,
+      body: {
+        sandboxReuseResult: (row.sandboxReuseResult ??
+          null) as SandboxReuseResult | null,
+      },
+    };
+  },
+});
+
+const handler = createHandler(zeroRunRunnerContract, router, {
+  errorHandler: createSafeErrorHandler("zero-runs:runner"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -462,6 +462,24 @@ export async function setTestRunSelectedModel(
 }
 
 /**
+ * Set the sandbox-reuse-result outcome on an existing run.
+ *
+ * @why-db-direct Runner reports this field via the agent-complete webhook
+ * during normal execution; tests for the runner-tab API need to seed it
+ * directly without invoking the webhook pipeline.
+ */
+export async function setTestRunSandboxReuseResult(
+  runId: string,
+  sandboxReuseResult: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(agentRuns)
+    .set({ sandboxReuseResult })
+    .where(eq(agentRuns.id, runId));
+}
+
+/**
  * Insert a zero_runs record for a run that already exists in agent_runs.
  *
  * @why-db-direct Creates zero_runs record; enqueueRun() does not create this

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -658,6 +658,7 @@ export {
   zeroRunAgentEventsContract,
   zeroRunContextContract,
   zeroRunNetworkLogsContract,
+  zeroRunRunnerContract,
   zeroLogsSearchContract,
   type ZeroRunsMainContract,
   type ZeroRunsByIdContract,
@@ -666,8 +667,10 @@ export {
   type ZeroRunAgentEventsContract,
   type ZeroRunContextContract,
   type ZeroRunNetworkLogsContract,
+  type ZeroRunRunnerContract,
   type ZeroLogsSearchContract,
   type RunContextResponse,
+  type RunRunnerResponse,
 } from "./zero-runs";
 export {
   zeroSchedulesMainContract,

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -12,6 +12,7 @@ import {
   networkLogsResponseSchema,
   logsSearchResponseSchema,
 } from "./runs";
+import { sandboxReuseResultSchema } from "./webhooks";
 
 /**
  * Zero run request schema — subset of unified schema.
@@ -253,6 +254,35 @@ export const zeroRunNetworkLogsContract = c.router({
 });
 
 /**
+ * Zero run runner contract (GET /api/zero/runs/:id/runner)
+ * Returns runner-level metadata about how the run was provisioned
+ * (sandbox reuse decision, etc.). Kept separate from logDetailSchema
+ * so runner-tab fields can grow without polluting the generic log
+ * detail response.
+ */
+const runRunnerResponseSchema = z.object({
+  sandboxReuseResult: sandboxReuseResultSchema.nullable(),
+});
+
+export const zeroRunRunnerContract = c.router({
+  getRunner: {
+    method: "GET",
+    path: "/api/zero/runs/:id/runner",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      id: z.string().min(1, "Run ID is required"),
+    }),
+    responses: {
+      200: runRunnerResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get runner-level metadata for a run",
+  },
+});
+
+/**
  * Zero logs search contract (GET /api/zero/logs/search)
  * Search agent events across runs via zero token auth
  */
@@ -281,6 +311,7 @@ export const zeroLogsSearchContract = c.router({
 
 // Inferred types from Zod schemas
 export type RunContextResponse = z.infer<typeof runContextResponseSchema>;
+export type RunRunnerResponse = z.infer<typeof runRunnerResponseSchema>;
 
 // Type exports
 export type ZeroLogsSearchContract = typeof zeroLogsSearchContract;
@@ -291,3 +322,4 @@ export type ZeroRunsQueueContract = typeof zeroRunsQueueContract;
 export type ZeroRunAgentEventsContract = typeof zeroRunAgentEventsContract;
 export type ZeroRunContextContract = typeof zeroRunContextContract;
 export type ZeroRunNetworkLogsContract = typeof zeroRunNetworkLogsContract;
+export type ZeroRunRunnerContract = typeof zeroRunRunnerContract;


### PR DESCRIPTION
## Summary
- New debug-gated **Runner** tab in the activity detail page (`/activities/:id`), placed between Context and Network
- Surfaces `sandboxReuseResult` (`reused` / `featureDisabled` / `noSessionId` / `poolMiss` / `profileMismatch` / `unparkFailed`) with human-readable labels
- Backed by a new `GET /api/zero/runs/:id/runner` endpoint kept separate from `logDetailSchema` so future runner-tab fields can grow without polluting the generic log detail response

## Why a separate endpoint
Mirrors how Context and Network tabs each have their own contract/route/signal. Adding `sandboxReuseResult` (and future runner-only fields) into `logDetailSchema` would slowly bloat it with tab-specific metadata.

## Files
- `packages/core/src/contracts/zero-runs.ts` — `zeroRunRunnerContract` + `runRunnerResponseSchema`
- `apps/web/app/api/zero/runs/[id]/runner/route.ts` — handler scoped by user + org
- `apps/platform/src/signals/activity-page/activity-runner-signals.ts` — `zeroActivityRunner$`
- `apps/platform/src/views/zero-page/zero-activity-detail-page.tsx` — `ActivityRunnerTab` + label table; `ActivityTabContent` extracted to keep complexity under threshold
- `apps/web/src/__tests__/db-test-seeders/runs.ts` — `setTestRunSandboxReuseResult` seeder

## Test plan
- [x] `pnpm -F web exec vitest run app/api/zero/runs/\[id\]/runner/__tests__/route.test.ts` — 5/5 passing (200, null, 404 not-found, 404 cross-user, 401 unauth)
- [x] `pnpm -F @vm0/core check-types`, `pnpm -F web check-types`, `pnpm -F @vm0/app check-types`
- [x] `pnpm -F @vm0/app lint`, `pnpm -F @vm0/core lint`
- [ ] Manual: open `/activities/:id?tab=runner` with `ZeroDebug` flag enabled, confirm badge + description render for each enum value

🤖 Generated with [Claude Code](https://claude.com/claude-code)