### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -132,7 +132,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.114"
+CLAUDE_CODE_VERSION="2.1.116"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.26.0"


### PR DESCRIPTION
## Summary

Updated pinned package versions in `crates/runner/scripts/build-rootfs.sh`:

| Package | Old Version | New Version |
|---------|-------------|-------------|
| `claude-code` | 2.1.114 | 2.1.116 |

All other pinned versions are already up to date:
- Go: 1.26.2 ✓
- `@googleworkspace/cli`: 0.22.5 ✓
- `@xdevplatform/xurl`: 1.0.3 ✓
- `agent-browser`: 0.26.0 ✓

## Notes

The updated Claude Code binary is available in the GCS distribution bucket at version 2.1.116 (verified via manifest.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)