### PR TITLE
fix(db): keep agent_runs.session_id nullable to unblock production

### DIFF
--- a/turbo/apps/web/src/db/migrations/0282_absurd_shockwave.sql
+++ b/turbo/apps/web/src/db/migrations/0282_absurd_shockwave.sql
@@ -15,6 +15,3 @@ UPDATE "agent_runs"
 SET session_id = continued_from_session_id
 WHERE session_id IS NULL
   AND continued_from_session_id IS NOT NULL;
---> statement-breakpoint
-ALTER TABLE "agent_runs" ALTER COLUMN "session_id" SET NOT NULL;--> statement-breakpoint
-ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_session_id_agent_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."agent_sessions"("id") ON DELETE restrict ON UPDATE no action;

--- a/turbo/apps/web/src/db/migrations/meta/0282_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0282_snapshot.json
@@ -513,7 +513,7 @@
           "name": "session_id",
           "type": "uuid",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "status": {
           "name": "status",
@@ -738,15 +738,6 @@
           "columnsFrom": ["agent_compose_version_id"],
           "columnsTo": ["id"],
           "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "agent_runs_session_id_agent_sessions_id_fk": {
-          "name": "agent_runs_session_id_agent_sessions_id_fk",
-          "tableFrom": "agent_runs",
-          "tableTo": "agent_sessions",
-          "columnsFrom": ["session_id"],
-          "columnsTo": ["id"],
-          "onDelete": "restrict",
           "onUpdate": "no action"
         }
       },

--- a/turbo/apps/web/src/db/schema/agent-run.ts
+++ b/turbo/apps/web/src/db/schema/agent-run.ts
@@ -6,11 +6,9 @@ import {
   jsonb,
   timestamp,
   index,
-  type AnyPgColumn,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { agentComposeVersions } from "./agent-compose";
-import { agentSessions } from "./agent-session";
 
 /**
  * Agent Runs table
@@ -32,14 +30,7 @@ export const agentRuns = pgTable(
     ),
     resumedFromCheckpointId: uuid("resumed_from_checkpoint_id"),
     continuedFromSessionId: uuid("continued_from_session_id"),
-    sessionId: uuid("session_id")
-      .notNull()
-      .references(
-        (): AnyPgColumn => {
-          return agentSessions.id;
-        },
-        { onDelete: "restrict" },
-      ),
+    sessionId: uuid("session_id"),
     status: varchar("status", { length: 20 }).notNull(),
     prompt: text("prompt").notNull(),
     appendSystemPrompt: text("append_system_prompt"),

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -185,6 +185,9 @@ export async function createCheckpoint(
     | VolumeVersionsSnapshot
     | undefined;
 
+  if (!run.sessionId) {
+    throw notFound("Agent run has no session_id");
+  }
   const agentSession = await updateAgentSession(
     run.sessionId,
     conversation.id,

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -288,7 +288,7 @@ export async function markRunFailed(
       .where(eq(agentRuns.id, runId))
       .limit(1);
     if (row) {
-      (error as RunDispatchError).sessionId = row.sessionId;
+      (error as RunDispatchError).sessionId = row.sessionId ?? undefined;
     }
   }
 }


### PR DESCRIPTION
## Summary

Migration [0282 (#10330)](https://github.com/vm0-ai/vm0/pull/10330) tried to enforce `agent_runs.session_id` `NOT NULL` and add an FK to `agent_sessions.id`. In production it is failing because ~4537 legacy rows cannot be fixed by the built-in backfills, blocking the deploy.

This PR drops the two DDL statements (SET NOT NULL + ADD FK) from 0282 so the migration can apply, keeps the two safety-net backfills intact, and brings the Drizzle schema + snapshot in sync with the relaxed shape. We can re-attempt the NOT NULL constraint in a follow-up once the upstream race is fixed.

## What changed

- `0282_absurd_shockwave.sql` — remove `ALTER ... SET NOT NULL` and `ALTER ... ADD CONSTRAINT ... FOREIGN KEY ...` (backfills 1 and 2 retained)
- `schema/agent-run.ts` — drop `.notNull()` and `.references()` from `sessionId`, clean up unused imports
- `meta/0282_snapshot.json` — flip `notNull: true → false` and remove the FK entry so the snapshot matches

## Why just drop them (vs. fixing the data)

Diagnostic on prod:

| Bucket | Count | What |
|---|---|---|
| A1 (continuation rows) | 4254 | fixable by backfill 2 |
| A2a (links to existing session via conversation) | 4145 | fixable by backfill 1 — **still being produced daily** |
| A2b | 2485 | no session yet for the conversation |
| A2c | 1056 | no conversation at all |
| B (dangling FK) | 310 | session_id points to deleted session |
| C (orphan group) | 686 | — |

The **A2a bucket is an ongoing app-layer race** (runs inserted with `session_id=NULL`, session created 20s–6min later, run never backfilled). Fixing the 12k historical rows wouldn't help — the same pattern would reappear the moment the new constraint is live, immediately 500-ing the `agent_runs` insert path.

## Risks

- `sessionId` is permanently nullable again — callers that assume non-null will continue to see the existing behavior; there are no new reads exposed.
- No FK means stale/dangling `session_id` values are now tolerated at the DB level. These already exist today.
- This reverts the data-integrity intent of 0282 — tracked as a follow-up: fix the run-insert race, then re-introduce NOT NULL in a future migration.

## Test plan

- [ ] CI (lint, type-check, test) green
- [ ] Apply migration to staging — migration completes without error (backfills still run)
- [ ] Deploy to production — agent run creation continues to work
- [ ] Verify `agent_runs.session_id` column is nullable in prod: `\d agent_runs`
- [ ] Spot-check: no FK named `agent_runs_session_id_agent_sessions_id_fk` on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)