### PR TITLE
fix(platform): align custom connector ui with platform conventions

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
@@ -73,9 +73,15 @@ export function CustomConnectorConnectDialog({
           requests by the firewall. It&apos;s never exposed to the agent as an
           environment variable.
         </p>
-        <label className="flex flex-col gap-1.5 text-sm">
-          <span className="text-foreground">Credential</span>
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="cc-connect-credential"
+            className="text-sm font-medium text-foreground"
+          >
+            Credential
+          </label>
           <Input
+            id="cc-connect-credential"
             type="password"
             value={value}
             onChange={(e) => {
@@ -83,7 +89,7 @@ export function CustomConnectorConnectDialog({
             }}
             autoFocus
           />
-        </label>
+        </div>
         <DialogFooter>
           <Button variant="outline" onClick={close} disabled={submitting}>
             Cancel

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
@@ -84,58 +84,78 @@ export function CustomConnectorCreateDialog() {
           <DialogTitle>New custom connector</DialogTitle>
         </DialogHeader>
         <div className="flex flex-col gap-4">
-          <label className="flex flex-col gap-1.5 text-sm">
-            <span className="text-foreground">Display name</span>
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="cc-display-name"
+              className="text-sm font-medium text-foreground"
+            >
+              Display name
+            </label>
             <Input
+              id="cc-display-name"
               value={form.displayName}
               onChange={(e) => {
                 return setField("displayName", e.target.value);
               }}
               placeholder="Acme API"
             />
-          </label>
-          <label className="flex flex-col gap-1.5 text-sm">
-            <span className="text-foreground">
-              Prefixes{" "}
-              <span className="text-muted-foreground">
+          </div>
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="cc-prefixes"
+              className="text-sm font-medium text-foreground"
+            >
+              Prefixes
+              <span className="text-muted-foreground font-normal ml-1">
                 (one per line, https only)
               </span>
-            </span>
+            </label>
             <textarea
+              id="cc-prefixes"
               value={form.prefixesRaw}
               onChange={(e) => {
                 return setField("prefixesRaw", e.target.value);
               }}
               placeholder="https://api.acme.com/v1/"
               rows={3}
-              className="flex min-h-[72px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono shadow-sm outline-none placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-ring"
+              className="w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm font-mono text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 resize-y min-h-[72px]"
             />
-          </label>
-          <label className="flex flex-col gap-1.5 text-sm">
-            <span className="text-foreground">Header name</span>
+          </div>
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="cc-header-name"
+              className="text-sm font-medium text-foreground"
+            >
+              Header name
+            </label>
             <Input
+              id="cc-header-name"
               value={form.headerName}
               onChange={(e) => {
                 return setField("headerName", e.target.value);
               }}
               placeholder="Authorization"
             />
-          </label>
-          <label className="flex flex-col gap-1.5 text-sm">
-            <span className="text-foreground">
-              Header template{" "}
-              <span className="text-muted-foreground">
+          </div>
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="cc-header-template"
+              className="text-sm font-medium text-foreground"
+            >
+              Header template
+              <span className="text-muted-foreground font-normal ml-1">
                 (must contain {`{{secret}}`})
               </span>
-            </span>
+            </label>
             <Input
+              id="cc-header-template"
               value={form.headerTemplate}
               onChange={(e) => {
                 return setField("headerTemplate", e.target.value);
               }}
               placeholder="Bearer {{secret}}"
             />
-          </label>
+          </div>
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={close} disabled={submitting}>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
@@ -40,7 +40,10 @@ function CreateFormFields({
     headerName: string;
     headerTemplate: string;
   };
-  setField: (field: string, value: string) => void;
+  setField: (
+    field: "displayName" | "prefixesRaw" | "headerName" | "headerTemplate",
+    value: string,
+  ) => void;
 }) {
   return (
     <div className="flex flex-col gap-4">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
@@ -30,6 +30,96 @@ function parsePrefixLines(raw: string): string[] {
     });
 }
 
+function CreateFormFields({
+  form,
+  setField,
+}: {
+  form: {
+    displayName: string;
+    prefixesRaw: string;
+    headerName: string;
+    headerTemplate: string;
+  };
+  setField: (field: string, value: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <label
+          htmlFor="cc-display-name"
+          className="text-sm font-medium text-foreground"
+        >
+          Display name
+        </label>
+        <Input
+          id="cc-display-name"
+          value={form.displayName}
+          onChange={(e) => {
+            return setField("displayName", e.target.value);
+          }}
+          placeholder="Acme API"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <label
+          htmlFor="cc-prefixes"
+          className="text-sm font-medium text-foreground"
+        >
+          Prefixes
+          <span className="text-muted-foreground font-normal ml-1">
+            (one per line, https only)
+          </span>
+        </label>
+        <textarea
+          id="cc-prefixes"
+          value={form.prefixesRaw}
+          onChange={(e) => {
+            return setField("prefixesRaw", e.target.value);
+          }}
+          placeholder="https://api.acme.com/v1/"
+          rows={3}
+          className="w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm font-mono text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 resize-y min-h-[72px]"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <label
+          htmlFor="cc-header-name"
+          className="text-sm font-medium text-foreground"
+        >
+          Header name
+        </label>
+        <Input
+          id="cc-header-name"
+          value={form.headerName}
+          onChange={(e) => {
+            return setField("headerName", e.target.value);
+          }}
+          placeholder="Authorization"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <label
+          htmlFor="cc-header-template"
+          className="text-sm font-medium text-foreground"
+        >
+          Header template
+          <span className="text-muted-foreground font-normal ml-1">
+            (must contain {`{{secret}}`})
+          </span>
+        </label>
+        <Input
+          id="cc-header-template"
+          value={form.headerTemplate}
+          onChange={(e) => {
+            return setField("headerTemplate", e.target.value);
+          }}
+          placeholder="Bearer {{secret}}"
+        />
+      </div>
+    </div>
+  );
+}
+
 export function CustomConnectorCreateDialog() {
   const form = useGet(customConnectorCreateForm$);
   const setField = useSet(setCustomConnectorCreateField$);
@@ -83,80 +173,7 @@ export function CustomConnectorCreateDialog() {
         <DialogHeader>
           <DialogTitle>New custom connector</DialogTitle>
         </DialogHeader>
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <label
-              htmlFor="cc-display-name"
-              className="text-sm font-medium text-foreground"
-            >
-              Display name
-            </label>
-            <Input
-              id="cc-display-name"
-              value={form.displayName}
-              onChange={(e) => {
-                return setField("displayName", e.target.value);
-              }}
-              placeholder="Acme API"
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <label
-              htmlFor="cc-prefixes"
-              className="text-sm font-medium text-foreground"
-            >
-              Prefixes
-              <span className="text-muted-foreground font-normal ml-1">
-                (one per line, https only)
-              </span>
-            </label>
-            <textarea
-              id="cc-prefixes"
-              value={form.prefixesRaw}
-              onChange={(e) => {
-                return setField("prefixesRaw", e.target.value);
-              }}
-              placeholder="https://api.acme.com/v1/"
-              rows={3}
-              className="w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm font-mono text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 resize-y min-h-[72px]"
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <label
-              htmlFor="cc-header-name"
-              className="text-sm font-medium text-foreground"
-            >
-              Header name
-            </label>
-            <Input
-              id="cc-header-name"
-              value={form.headerName}
-              onChange={(e) => {
-                return setField("headerName", e.target.value);
-              }}
-              placeholder="Authorization"
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <label
-              htmlFor="cc-header-template"
-              className="text-sm font-medium text-foreground"
-            >
-              Header template
-              <span className="text-muted-foreground font-normal ml-1">
-                (must contain {`{{secret}}`})
-              </span>
-            </label>
-            <Input
-              id="cc-header-template"
-              value={form.headerTemplate}
-              onChange={(e) => {
-                return setField("headerTemplate", e.target.value);
-              }}
-              placeholder="Bearer {{secret}}"
-            />
-          </div>
-        </div>
+        <CreateFormFields form={form} setField={setField} />
         <DialogFooter>
           <Button variant="outline" onClick={close} disabled={submitting}>
             Cancel

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-rename-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-rename-dialog.tsx
@@ -59,16 +59,22 @@ export function CustomConnectorRenameDialog({
         <DialogHeader>
           <DialogTitle>Rename custom connector</DialogTitle>
         </DialogHeader>
-        <label className="flex flex-col gap-1.5 text-sm">
-          <span className="text-foreground">Display name</span>
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="cc-rename-name"
+            className="text-sm font-medium text-foreground"
+          >
+            Display name
+          </label>
           <Input
+            id="cc-rename-name"
             value={displayName}
             onChange={(e) => {
               return setDisplayName(e.target.value);
             }}
             autoFocus
           />
-        </label>
+        </div>
         <DialogFooter>
           <Button variant="outline" onClick={closeDialog} disabled={submitting}>
             Cancel

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
@@ -1,10 +1,5 @@
 import { useGet, useLastResolved, useSet } from "ccstate-react";
-import {
-  IconDotsVertical,
-  IconPlus,
-  IconCheck,
-  IconPlug,
-} from "@tabler/icons-react";
+import { IconDotsVertical } from "@tabler/icons-react";
 import {
   Button,
   DropdownMenu,
@@ -18,7 +13,6 @@ import {
   customConnectorDialog$,
   customConnectors$,
   openCustomConnectorConnectDialog$,
-  openCustomConnectorCreateDialog$,
   openCustomConnectorDeleteDialog$,
   openCustomConnectorRenameDialog$,
   setCustomConnectorRenameInput$,
@@ -47,6 +41,8 @@ function CustomConnectorRow({
   onRename: () => void;
   onDelete: () => void;
 }) {
+  const hasActions = connector.hasSecret || isAdmin;
+
   return (
     <div className="zero-card flex flex-col">
       <div className="flex h-14 items-center gap-2.5 px-5">
@@ -55,28 +51,48 @@ function CustomConnectorRow({
           displayName={connector.displayName}
           size={20}
         />
-        <span className="truncate text-sm font-medium text-foreground">
+        <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
           {connector.displayName}
         </span>
-        <div className="ml-auto flex items-center gap-1">
+      </div>
+      <div className="flex h-11 items-center justify-between border-t border-border/50 pl-5 pr-2">
+        <div className="flex items-center gap-2 min-w-0">
           {connector.hasSecret ? (
-            <span className="flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
-              <IconCheck size={12} stroke={1.5} />
+            <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
+              <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
               Connected
             </span>
           ) : (
-            <Button size="sm" variant="outline" onClick={onConnect}>
-              <IconPlug size={14} stroke={1.5} className="mr-1" />
+            <button
+              type="button"
+              onClick={onConnect}
+              className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+            >
               Connect
-            </Button>
+            </button>
           )}
+          {connector.prefixes[0] && (
+            <span className="truncate text-xs text-muted-foreground/60 font-mono">
+              {connector.prefixes[0]}
+            </span>
+          )}
+        </div>
+        {hasActions && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-7 w-7">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+                aria-label="More options"
+              >
                 <IconDotsVertical size={14} stroke={1.5} />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
+            <DropdownMenuContent align="end" className="w-44">
+              {!connector.hasSecret && (
+                <DropdownMenuItem onClick={onConnect}>Connect</DropdownMenuItem>
+              )}
               {connector.hasSecret && (
                 <DropdownMenuItem onClick={onDisconnect}>
                   Disconnect
@@ -95,10 +111,7 @@ function CustomConnectorRow({
               )}
             </DropdownMenuContent>
           </DropdownMenu>
-        </div>
-      </div>
-      <div className="flex h-11 items-center border-t border-border/30 px-5 text-xs text-muted-foreground">
-        <span className="truncate font-mono">{connector.prefixes[0]}</span>
+        )}
       </div>
     </div>
   );
@@ -108,7 +121,6 @@ export function CustomConnectorsPanel() {
   const connectors = useLastResolved(customConnectors$);
   const isAdmin = useLastResolved(isOrgAdmin$) ?? false;
   const dialog = useGet(customConnectorDialog$);
-  const openCreate = useSet(openCustomConnectorCreateDialog$);
   const openRename = useSet(openCustomConnectorRenameDialog$);
   const openConnect = useSet(openCustomConnectorConnectDialog$);
   const openDelete = useSet(openCustomConnectorDeleteDialog$);
@@ -127,25 +139,14 @@ export function CustomConnectorsPanel() {
 
   return (
     <section className="flex flex-col gap-3">
-      <div className="flex items-center justify-between">
-        <h2 className="text-sm font-medium text-muted-foreground">
-          <span>Custom connectors</span>
-          {connectors && <span> ({connectors.length})</span>}
-        </h2>
-        {isAdmin && (
-          <Button size="sm" onClick={openCreate}>
-            <IconPlus size={14} stroke={1.5} className="mr-1" />
-            New
-          </Button>
-        )}
-      </div>
-
       {connectors && connectors.length === 0 && (
-        <p className="text-sm text-muted-foreground">
-          {isAdmin
-            ? "No custom connectors yet. Create one to register an API for every member to use."
-            : "Your org hasn't registered any custom connectors yet."}
-        </p>
+        <div className="zero-card py-12 text-center">
+          <p className="text-sm text-muted-foreground">
+            {isAdmin
+              ? "No custom connectors yet. Create one to register an API for every member to use."
+              : "Your org hasn't registered any custom connectors yet."}
+          </p>
+        </div>
       )}
 
       {connectors && connectors.length > 0 && (

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -1,6 +1,11 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
-import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import {
+  useGet,
+  useSet,
+  useLastLoadable,
+  useLastResolved,
+} from "ccstate-react";
 import {
   IconSearch,
   IconPlug,
@@ -17,7 +22,9 @@ import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
   connectorsPageTab$,
   setConnectorsPageTab$,
+  openCustomConnectorCreateDialog$,
 } from "../../signals/zero-page/settings/custom-connectors.ts";
+import { isOrgAdmin$ } from "../../signals/org.ts";
 import { CustomConnectorsPanel } from "./components/settings/custom-connectors-panel.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
@@ -284,6 +291,8 @@ export function ZeroConnectorsPage() {
   const optimisticConnected = useGet(justConnectedTypes$);
   const activeTab = useGet(connectorsPageTab$);
   const setActiveTab = useSet(setConnectorsPageTab$);
+  const isAdmin = useLastResolved(isOrgAdmin$) ?? false;
+  const openCreateCustom = useSet(openCustomConnectorCreateDialog$);
 
   const search = useGet(connectorsSearch$);
   const setSearch = useSet(setConnectorsSearch$);
@@ -373,12 +382,12 @@ export function ZeroConnectorsPage() {
     <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-3 md:pt-10 pb-0 md:pb-3">
         <div className="mx-auto max-w-[900px]">
-          <div className="flex items-center justify-between gap-4">
-            <div className="hidden md:block">
-              <h1 className="text-xl font-semibold tracking-tight text-foreground">
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div className="min-w-0 hidden md:block">
+              <h1 className="text-lg font-semibold tracking-tight text-foreground">
                 Connectors
               </h1>
-              <p className="text-sm text-muted-foreground mt-1">
+              <p className="mt-0.5 text-sm text-muted-foreground">
                 Connect third-party services for your agents to use.
               </p>
             </div>
@@ -404,17 +413,30 @@ export function ZeroConnectorsPage() {
 
       <main className="flex-1 px-4 sm:px-6 pt-3 pb-16">
         <div className="mx-auto max-w-[900px] flex flex-col gap-6">
-          <Tabs
-            value={activeTab}
-            onValueChange={(v) => {
-              return setActiveTab(v === "custom" ? "custom" : "builtin");
-            }}
-          >
-            <TabsList>
-              <TabsTrigger value="builtin">Built-in</TabsTrigger>
-              <TabsTrigger value="custom">Custom</TabsTrigger>
-            </TabsList>
-          </Tabs>
+          <div className="flex items-center justify-between">
+            <Tabs
+              value={activeTab}
+              onValueChange={(v) => {
+                return setActiveTab(v === "custom" ? "custom" : "builtin");
+              }}
+            >
+              <TabsList>
+                <TabsTrigger value="builtin">Built-in</TabsTrigger>
+                <TabsTrigger value="custom">Custom</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            {activeTab === "custom" && isAdmin && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="zero-btn-morandi h-9 gap-2 shrink-0 rounded-lg border"
+                onClick={openCreateCustom}
+              >
+                <IconPlus size={14} stroke={2} />
+                New connector
+              </Button>
+            )}
+          </div>
 
           {activeTab === "builtin" && (
             <>


### PR DESCRIPTION
## Summary
- Redesign custom connector card layout to match built-in `GlobalConnectorCard` (status + actions in footer, green dot indicator, text-link connect button)
- Align all dialog form fields with schedule-dialog pattern (`div` wrapper, `font-medium` label, `htmlFor`/`id` association, consistent textarea styling)
- Move "New connector" button to tabs row, matching agents page pattern
- Wrap empty state in `zero-card` container

## Test plan
- [ ] Open Connectors → Custom tab, verify empty state shows in a card container
- [ ] Create a custom connector, verify dialog form fields match schedule dialog styling
- [ ] Verify connector card footer matches built-in connector card (green dot, text connect link, dropdown on right)
- [ ] Verify "New connector" button appears next to tabs on Custom tab only
- [ ] Switch between Built-in and Custom tabs, verify layout is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)