### PR TITLE
feat: add ts-rest contract for file uploads and use accept()

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -1,7 +1,9 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { resetSignal, createDeferredPromise } from "../utils.ts";
 import { currentChatThreadId$ } from "../agent-chat.ts";
-import { fetch$ } from "../fetch.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { accept } from "../../lib/accept.ts";
+import { zeroUploadsContract } from "@vm0/core";
 import type { PersistedAttachment } from "@vm0/core";
 
 // ---------------------------------------------------------------------------
@@ -42,7 +44,8 @@ function createChatAttachment(file: File): ZeroChatAttachment {
   });
 
   const upload$ = command(async ({ get, set }, signal: AbortSignal) => {
-    const fetchFn = get(fetch$);
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroUploadsContract);
     const formData = new FormData();
     formData.append("file", file);
 
@@ -50,33 +53,13 @@ function createChatAttachment(file: File): ZeroChatAttachment {
     const deferred = createDeferredPromise<FileInfo>(uploadSignal);
     set(internalPromise$, deferred.promise);
 
-    const res = await fetchFn("/api/zero/uploads", {
-      method: "POST",
-      body: formData,
-      signal: uploadSignal,
-    });
+    const result = await accept(
+      client.upload({ body: formData }, { signal: uploadSignal }),
+      [200],
+    );
     signal.throwIfAborted();
 
-    if (!res.ok) {
-      const err = (await res.json().catch(() => {
-        return null;
-      })) as {
-        error?: { message?: string };
-      } | null;
-      throw new Error(
-        err?.error?.message ?? `Upload failed: ${res.statusText}`,
-      );
-    }
-
-    const data = (await res.json()) as {
-      id: string;
-      filename: string;
-      contentType: string;
-      size: number;
-      url: string;
-    };
-
-    deferred.resolve({ id: data.id, url: data.url });
+    deferred.resolve({ id: result.body.id, url: result.body.url });
   });
 
   return {

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -3,8 +3,7 @@ import { resetSignal, createDeferredPromise } from "../utils.ts";
 import { currentChatThreadId$ } from "../agent-chat.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
-import { zeroUploadsContract } from "@vm0/core";
-import type { PersistedAttachment } from "@vm0/core";
+import { zeroUploadsContract, type PersistedAttachment } from "@vm0/core";
 
 // ---------------------------------------------------------------------------
 // Attachment types (moved from zero-chat.ts)
@@ -54,7 +53,7 @@ function createChatAttachment(file: File): ZeroChatAttachment {
     set(internalPromise$, deferred.promise);
 
     const result = await accept(
-      client.upload({ body: formData }, { signal: uploadSignal }),
+      client.upload({ body: formData, fetchOptions: { signal: uploadSignal } }),
       [200],
     );
     signal.throwIfAborted();

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -950,6 +950,11 @@ export {
   type PhoneStatusResponse,
 } from "./zero-phone";
 export {
+  zeroUploadsContract,
+  type ZeroUploadsContract,
+  type UploadResponse,
+} from "./zero-uploads";
+export {
   zeroIntegrationsTelegramContract,
   type ZeroIntegrationsTelegramContract,
   type TelegramStatusResponse,

--- a/turbo/packages/core/src/contracts/zero-uploads.ts
+++ b/turbo/packages/core/src/contracts/zero-uploads.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+// ---------------------------------------------------------------------------
+// Response schema
+// ---------------------------------------------------------------------------
+
+const uploadResponseSchema = z.object({
+  id: z.string(),
+  filename: z.string(),
+  contentType: z.string(),
+  size: z.number(),
+  url: z.string().url(),
+});
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Zero contract for POST /api/zero/uploads
+ *
+ * Handles multipart/form-data file uploads with validation.
+ * Uses FormData body for binary file transmission.
+ */
+export const zeroUploadsContract = c.router({
+  upload: {
+    method: "POST",
+    path: "/api/zero/uploads",
+    headers: authHeadersSchema,
+    contentType: "multipart/form-data",
+    body: c.type<FormData>(),
+    responses: {
+      200: uploadResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      413: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Upload a file",
+  },
+});
+
+export type ZeroUploadsContract = typeof zeroUploadsContract;
+
+// Inferred types
+export type UploadResponse = z.infer<typeof uploadResponseSchema>;


### PR DESCRIPTION
## Summary

Add ts-rest contract for `/api/zero/uploads` endpoint to enable consistent error handling using the `accept()` utility function.

## Changes

- **New contract** (`packages/core/src/contracts/zero-uploads.ts`):  
  - Defines `zeroUploadsContract` with multipart/form-data support
  - Response schema matching server response (id, filename, contentType, size, url)
  - Proper error response codes (400, 401, 403, 413, 500)

- **Updated chat-draft.ts**:  
  - Replaces native `fetch$` with typed `zeroClient$`
  - Uses `accept()` for automatic toast notifications on errors
  - Removes manual error parsing and toast handling

## Benefits

1. Type-safe API calls with full TypeScript support
2. Consistent error handling via `accept()` (toast + throw)
3. No manual response parsing needed

Closes #9782