### PR TITLE
ci: gate migration immutability check behind repo variable

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -437,6 +437,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/toolchain-init
       - name: Check Migration Immutability
+        if: vars.CI_CHECK_IMMUTABLE_MIGRATE != '0'
         run: |
           BASE_REF="${{ needs.prepare.outputs.base-ref }}"
           # Check that migration SQL files and snapshots are only added, never modified or deleted


### PR DESCRIPTION
## Summary
- Gate the `Check Migration Immutability` step in `test-migrate` behind a new repo variable `CI_CHECK_IMMUTABLE_MIGRATE`.
- When the variable is set to `"0"` the step is skipped; any other value (or absent) keeps the current behavior.
- `CI_CHECK_IMMUTABLE_MIGRATE` is already set to `0` on the repo to temporarily disable the check.

## Test plan
- [ ] Confirm `test-migrate` job runs `Test Migration Consistency` but skips `Check Migration Immutability` on this PR (since the variable is `0`).
- [ ] After flipping the variable back, verify the immutability check fails on a PR that modifies an existing migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)