### PR TITLE
fix(chat): align input box with chat content by adding scrollbar-gutter

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -403,7 +403,7 @@ function ChatThreadComposer({
   return (
     <footer
       data-chat-composer
-      className="relative shrink-0 px-4 sm:px-6 pt-3 pb-2 bg-[hsl(var(--background))]"
+      className="relative shrink-0 overflow-y-auto [scrollbar-gutter:stable] px-4 sm:px-6 pt-3 pb-2 bg-[hsl(var(--background))]"
     >
       <div className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-t from-[hsl(var(--background))] to-transparent" />
       <div className="mx-auto max-w-[900px]">


### PR DESCRIPTION
## Summary

Fixes #10279 - Input box misalignment due to scrollbar gutter inconsistency.

## Problem

The chat content area uses `[scrollbar-gutter:stable]` to reserve space for the scrollbar, but the input box footer did not. This caused the input box to appear shifted to the right compared to the message content above it.

## Solution

Add `overflow-y-auto [scrollbar-gutter:stable]` to the chat composer footer to match the scroll container styling above it.

### Changes
- `turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx`
  - Added `overflow-y-auto [scrollbar-gutter:stable]` to footer className

## Visual Impact

Before: Input box left edge was misaligned with message content
After: Both elements now have consistent left alignment

## Testing

- [x] Verified on staging environment with agent-browser
- [x] Screenshots captured showing the fix

## Related

- Issue: #10279