### PR TITLE
fix(web): ts-rest api error triage and observability

### DIFF
--- a/turbo/apps/platform/src/lib/__tests__/accept.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/accept.test.ts
@@ -1,6 +1,11 @@
+import * as Sentry from "@sentry/react";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError, accept } from "../accept";
+
+vi.mock("@sentry/react", () => {
+  return { addBreadcrumb: vi.fn() };
+});
 
 vi.mock("@vm0/ui/components/ui/sonner", () => {
   return { toast: { error: vi.fn() } };
@@ -112,5 +117,50 @@ describe("accept", () => {
         );
       },
     );
+  });
+
+  it("adds a warning breadcrumb for 4xx errors", async () => {
+    type OkOrBad =
+      | { status: 200; body: { id: string } }
+      | { status: 400; body: { error: { message: string; code: string } } };
+    const response: OkOrBad = {
+      status: 400,
+      body: { error: { message: "Bad input", code: "BAD_REQUEST" } },
+    };
+
+    await expect(
+      accept(Promise.resolve(response), [200]),
+    ).rejects.toBeInstanceOf(ApiError);
+    expect(vi.mocked(Sentry.addBreadcrumb)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(Sentry.addBreadcrumb)).toHaveBeenCalledWith({
+      category: "api",
+      level: "warning",
+      message: "API 400 BAD_REQUEST",
+      data: { status: 400, code: "BAD_REQUEST" },
+    });
+  });
+
+  it("adds an error breadcrumb for 5xx errors", async () => {
+    type OkOrFail =
+      | { status: 200; body: { id: string } }
+      | { status: 500; body: null };
+    const response: OkOrFail = { status: 500, body: null };
+
+    await expect(
+      accept(Promise.resolve(response), [200]),
+    ).rejects.toBeInstanceOf(ApiError);
+    expect(vi.mocked(Sentry.addBreadcrumb)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(Sentry.addBreadcrumb)).toHaveBeenCalledWith({
+      category: "api",
+      level: "error",
+      message: "API 500 UNKNOWN",
+      data: { status: 500, code: "UNKNOWN" },
+    });
+  });
+
+  it("does not add a breadcrumb for accepted responses", async () => {
+    const response = { status: 200 as const, body: { id: "x" } };
+    await accept(Promise.resolve(response), [200]);
+    expect(vi.mocked(Sentry.addBreadcrumb)).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/platform/src/lib/accept.ts
+++ b/turbo/apps/platform/src/lib/accept.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react";
 import { toast } from "@vm0/ui/components/ui/sonner";
 
 class ApiError extends Error {
@@ -61,6 +62,15 @@ async function accept<
   if (options?.toast !== false) {
     toast.error(message);
   }
+  // Trail of a breadcrumb so the next captured exception in this scope
+  // carries enough context to triage. The breadcrumb persists across
+  // async boundaries within the current Sentry scope.
+  Sentry.addBreadcrumb({
+    category: "api",
+    level: result.status >= 500 ? "error" : "warning",
+    message: `API ${result.status} ${code}`,
+    data: { status: result.status, code },
+  });
   throw new ApiError(message, code, result.status);
 }
 

--- a/turbo/apps/platform/src/lib/sentry.ts
+++ b/turbo/apps/platform/src/lib/sentry.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/react";
+import { ApiError } from "./accept";
 
 // Initialize Sentry synchronously so that global error/unhandledrejection
 // handlers are installed before the app bootstraps. Errors during bootstrap
@@ -40,24 +41,19 @@ export function initSentry(): void {
       //  (b) for 5xx, regroup by (status, code) so Sentry stops collapsing
       //      every API error under the generic accept.ts frame.
       const original = hint?.originalException;
-      if (
-        original instanceof Error &&
-        original.name === "ApiError" &&
-        "status" in original &&
-        "code" in original &&
-        typeof (original as { status: unknown }).status === "number" &&
-        typeof (original as { code: unknown }).code === "string"
-      ) {
-        const status = (original as { status: number }).status;
-        const code = (original as { code: string }).code;
-        if (status >= 400 && status < 500) {
+      if (original instanceof ApiError) {
+        if (original.status >= 400 && original.status < 500) {
           return null;
         }
-        event.fingerprint = ["api-error", String(status), code];
+        event.fingerprint = [
+          "api-error",
+          String(original.status),
+          original.code,
+        ];
         event.tags = {
           ...event.tags,
-          "api.status": status,
-          "api.code": code,
+          "api.status": original.status,
+          "api.code": original.code,
         };
       }
 

--- a/turbo/apps/platform/src/lib/sentry.ts
+++ b/turbo/apps/platform/src/lib/sentry.ts
@@ -24,7 +24,7 @@ export function initSentry(): void {
     tracesSampleRate: 0,
 
     // Filter out expected errors
-    beforeSend(event) {
+    beforeSend(event, hint) {
       // Filter out 4xx client errors that are expected
       const statusCode = event.contexts?.response?.status_code;
       if (
@@ -34,6 +34,33 @@ export function initSentry(): void {
       ) {
         return null;
       }
+
+      // ApiError thrown by accept() carries status+code. Use them to:
+      //  (a) drop 4xx, which are expected business states, and
+      //  (b) for 5xx, regroup by (status, code) so Sentry stops collapsing
+      //      every API error under the generic accept.ts frame.
+      const original = hint?.originalException;
+      if (
+        original instanceof Error &&
+        original.name === "ApiError" &&
+        "status" in original &&
+        "code" in original &&
+        typeof (original as { status: unknown }).status === "number" &&
+        typeof (original as { code: unknown }).code === "string"
+      ) {
+        const status = (original as { status: number }).status;
+        const code = (original as { code: string }).code;
+        if (status >= 400 && status < 500) {
+          return null;
+        }
+        event.fingerprint = ["api-error", String(status), code];
+        event.tags = {
+          ...event.tags,
+          "api.status": status,
+          "api.code": code,
+        };
+      }
+
       return event;
     },
 

--- a/turbo/apps/web/app/api/agent/checkpoints/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/checkpoints/[id]/route.ts
@@ -141,6 +141,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(checkpointsByIdContract, router, {
+  routeName: "agent.checkpoints.byId",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -198,6 +198,8 @@ const router = tsr.router(composesInstructionsContract, {
   },
 });
 
-const handler = createHandler(composesInstructionsContract, router);
+const handler = createHandler(composesInstructionsContract, router, {
+  routeName: "agent.composes.instructions",
+});
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/agent/composes/[id]/metadata/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/metadata/route.ts
@@ -44,6 +44,8 @@ const router = tsr.router(composesMetadataContract, {
   },
 });
 
-const handler = createHandler(composesMetadataContract, router);
+const handler = createHandler(composesMetadataContract, router, {
+  routeName: "agent.composes.metadata",
+});
 
 export { handler as PATCH };

--- a/turbo/apps/web/app/api/agent/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/route.ts
@@ -124,6 +124,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(composesByIdContract, router, {
+  routeName: "agent.composes.byId",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -50,6 +50,8 @@ const router = tsr.router(composesListContract, {
   },
 });
 
-const handler = createHandler(composesListContract, router);
+const handler = createHandler(composesListContract, router, {
+  routeName: "agent.composes.list",
+});
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -331,6 +331,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(composesMainContract, router, {
+  routeName: "agent.composes",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/agent/composes/versions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/versions/route.ts
@@ -178,6 +178,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(composesVersionsContract, router, {
+  routeName: "agent.composes.versions",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -121,6 +121,8 @@ const router = tsr.router(runsCancelContract, {
   },
 });
 
-const handler = createHandler(runsCancelContract, router);
+const handler = createHandler(runsCancelContract, router, {
+  routeName: "agent.runs.cancel",
+});
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -184,6 +184,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(runEventsContract, router, {
+  routeName: "agent.runs.events",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/route.ts
@@ -34,6 +34,8 @@ const router = tsr.router(runsByIdContract, {
   },
 });
 
-const handler = createHandler(runsByIdContract, router);
+const handler = createHandler(runsByIdContract, router, {
+  routeName: "agent.runs.byId",
+});
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
@@ -98,6 +98,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(runAgentEventsContract, router, {
+  routeName: "agent.runs.telemetry.agent",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
@@ -155,6 +155,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(runMetricsContract, router, {
+  routeName: "agent.runs.telemetry.metrics",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -171,6 +171,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(runNetworkLogsContract, router, {
+  routeName: "agent.runs.telemetry.network",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/route.ts
@@ -126,6 +126,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(runTelemetryContract, router, {
+  routeName: "agent.runs.telemetry",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
@@ -146,6 +146,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(runSystemLogContract, router, {
+  routeName: "agent.runs.telemetry.system-log",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/agent/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/route.ts
@@ -30,6 +30,8 @@ const router = tsr.router(runsQueueContract, {
   },
 });
 
-const handler = createHandler(runsQueueContract, router);
+const handler = createHandler(runsQueueContract, router, {
+  routeName: "agent.runs.queue",
+});
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -497,6 +497,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(runsMainContract, router, {
+  routeName: "agent.runs",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
@@ -148,6 +148,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(sessionsByIdContract, router, {
+  routeName: "agent.sessions.byId",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/auth/me/route.ts
+++ b/turbo/apps/web/app/api/auth/me/route.ts
@@ -25,6 +25,8 @@ const router = tsr.router(authContract, {
   },
 });
 
-const handler = createHandler(authContract, router);
+const handler = createHandler(authContract, router, {
+  routeName: "auth.me",
+});
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/cli/auth/device/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/device/route.ts
@@ -32,6 +32,8 @@ const router = tsr.router(cliAuthDeviceContract, {
   },
 });
 
-const handler = createHandler(cliAuthDeviceContract, router);
+const handler = createHandler(cliAuthDeviceContract, router, {
+  routeName: "cli.auth.device",
+});
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/cli/auth/org/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/org/route.ts
@@ -112,6 +112,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(cliAuthOrgContract, router, {
+  routeName: "cli.auth.org",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -144,6 +144,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(cliAuthTokenContract, router, {
+  routeName: "cli.auth.token",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -295,6 +295,8 @@ const router = tsr.router(cronCleanupSandboxesContract, {
   },
 });
 
-const handler = createHandler(cronCleanupSandboxesContract, router);
+const handler = createHandler(cronCleanupSandboxesContract, router, {
+  routeName: "cron.cleanup-sandboxes",
+});
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/logs/search/route.ts
+++ b/turbo/apps/web/app/api/logs/search/route.ts
@@ -55,6 +55,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(logsSearchContract, router, {
+  routeName: "logs.search",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/runners/heartbeat/route.ts
+++ b/turbo/apps/web/app/api/runners/heartbeat/route.ts
@@ -106,6 +106,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(runnersHeartbeatContract, router, {
+  routeName: "runners.heartbeat",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -232,6 +232,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(runnersJobClaimContract, router, {
+  routeName: "runners.jobs.claim",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/runners/poll/route.ts
+++ b/turbo/apps/web/app/api/runners/poll/route.ts
@@ -153,6 +153,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(runnersPollContract, router, {
+  routeName: "runners.poll",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/runners/realtime/token/route.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/route.ts
@@ -50,6 +50,8 @@ const router = tsr.router(runnerRealtimeTokenContract, {
   },
 });
 
-const handler = createHandler(runnerRealtimeTokenContract, router);
+const handler = createHandler(runnerRealtimeTokenContract, router, {
+  routeName: "runners.realtime.token",
+});
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  tsr,
-  createSafeErrorHandler,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { storagesCommitContract, VOLUME_ORG_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
@@ -320,7 +316,7 @@ const router = tsr.router(storagesCommitContract, {
 });
 
 const handler = createHandler(storagesCommitContract, router, {
-  errorHandler: createSafeErrorHandler("storages:commit"),
+  routeName: "storages.commit",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  tsr,
-  createSafeErrorHandler,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { storagesDownloadContract, VOLUME_ORG_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
@@ -199,7 +195,7 @@ const router = tsr.router(storagesDownloadContract, {
 });
 
 const handler = createHandler(storagesDownloadContract, router, {
-  errorHandler: createSafeErrorHandler("storages:download"),
+  routeName: "storages.download",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  tsr,
-  createSafeErrorHandler,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { storagesListContract, VOLUME_ORG_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { storages } from "../../../../src/db/schema/storage";
@@ -95,7 +91,7 @@ const router = tsr.router(storagesListContract, {
 });
 
 const handler = createHandler(storagesListContract, router, {
-  errorHandler: createSafeErrorHandler("storages:list"),
+  routeName: "storages.list",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  tsr,
-  createSafeErrorHandler,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import {
   storagesPrepareContract,
   VOLUME_ORG_USER_ID,
@@ -335,7 +331,7 @@ const router = tsr.router(storagesPrepareContract, {
 });
 
 const handler = createHandler(storagesPrepareContract, router, {
-  errorHandler: createSafeErrorHandler("storages:prepare"),
+  routeName: "storages.prepare",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/v1/chat-threads/[threadId]/messages/route.ts
+++ b/turbo/apps/web/app/api/v1/chat-threads/[threadId]/messages/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { chatThreadV1MessagesContract } from "@vm0/core";
 import { z } from "zod";
 import { initServices } from "../../../../../../src/lib/init-services";
@@ -70,7 +66,7 @@ const router = tsr.router(chatThreadV1MessagesContract, {
 });
 
 const handler = createHandler(chatThreadV1MessagesContract, router, {
-  errorHandler: createSafeErrorHandler("v1-chat-thread-messages"),
+  routeName: "v1.chat-threads.messages",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/v1/chat-threads/[threadId]/route.ts
+++ b/turbo/apps/web/app/api/v1/chat-threads/[threadId]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { chatThreadV1GetContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -45,7 +41,7 @@ const router = tsr.router(chatThreadV1GetContract, {
 });
 
 const handler = createHandler(chatThreadV1GetContract, router, {
-  errorHandler: createSafeErrorHandler("v1-chat-thread-get"),
+  routeName: "v1.chat-threads.byId",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/v1/chat-threads/messages/route.ts
+++ b/turbo/apps/web/app/api/v1/chat-threads/messages/route.ts
@@ -1,9 +1,5 @@
 import { after } from "next/server";
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { chatThreadV1SendContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -150,7 +146,7 @@ const router = tsr.router(chatThreadV1SendContract, {
 });
 
 const handler = createHandler(chatThreadV1SendContract, router, {
-  errorHandler: createSafeErrorHandler("v1-chat-thread-send"),
+  routeName: "v1.chat-threads.messages.send",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/prepare-history/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/prepare-history/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  tsr,
-  createSafeErrorHandler,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { webhookCheckpointsPrepareHistoryContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
@@ -115,7 +111,7 @@ const handler = createHandler(
   webhookCheckpointsPrepareHistoryContract,
   router,
   {
-    errorHandler: createSafeErrorHandler("webhook:checkpoints:prepare-history"),
+    routeName: "webhooks.agent.checkpoints.prepare-history",
   },
 );
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
@@ -105,6 +105,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(webhookCheckpointsContract, router, {
+  routeName: "webhooks.agent.checkpoints",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -297,6 +297,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(webhookCompleteContract, router, {
+  routeName: "webhooks.agent.complete",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/webhooks/agent/connector-billing/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/connector-billing/route.ts
@@ -109,6 +109,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(webhookConnectorBillingContract, router, {
+  routeName: "webhooks.agent.connector-billing",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/webhooks/agent/events/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/route.ts
@@ -122,6 +122,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(webhookEventsContract, router, {
+  routeName: "webhooks.agent.events",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
@@ -92,6 +92,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(webhookHeartbeatContract, router, {
+  routeName: "webhooks.agent.heartbeat",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  tsr,
-  createSafeErrorHandler,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { webhookStoragesCommitContract, VOLUME_ORG_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
@@ -329,7 +325,7 @@ const router = tsr.router(webhookStoragesCommitContract, {
 });
 
 const handler = createHandler(webhookStoragesCommitContract, router, {
-  errorHandler: createSafeErrorHandler("webhook:storages:commit"),
+  routeName: "webhooks.agent.storages.commit",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  tsr,
-  createSafeErrorHandler,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import {
   webhookStoragesPrepareContract,
   VOLUME_ORG_USER_ID,
@@ -289,7 +285,7 @@ const router = tsr.router(webhookStoragesPrepareContract, {
 });
 
 const handler = createHandler(webhookStoragesPrepareContract, router, {
-  errorHandler: createSafeErrorHandler("webhook:storages:prepare"),
+  routeName: "webhooks.agent.storages.prepare",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
@@ -173,6 +173,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(webhookTelemetryContract, router, {
+  routeName: "webhooks.agent.telemetry",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/webhooks/agent/usage/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/usage/route.ts
@@ -128,6 +128,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(webhookUsageContract, router, {
+  routeName: "webhooks.agent.usage",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/zero/agents/[id]/custom-connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/custom-connectors/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { zeroAgentCustomConnectorsContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
@@ -167,7 +163,7 @@ const router = tsr.router(zeroAgentCustomConnectorsContract, {
 });
 
 const handler = createHandler(zeroAgentCustomConnectorsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-agents:custom-connectors"),
+  routeName: "zero.agents.custom-connectors",
 });
 
 export { handler as GET, handler as PUT };

--- a/turbo/apps/web/app/api/zero/agents/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/instructions/route.ts
@@ -1,9 +1,5 @@
 import { gunzipSync } from "node:zlib";
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import {
   zeroAgentInstructionsContract,
   getInstructionsStorageName,
@@ -304,7 +300,7 @@ const router = tsr.router(zeroAgentInstructionsContract, {
 });
 
 const handler = createHandler(zeroAgentInstructionsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-agents:instructions"),
+  routeName: "zero.agents.instructions",
 });
 
 export { handler as GET, handler as PUT };

--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroAgentsByIdContract, toFirewallPolicies } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -426,7 +422,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
 });
 
 const handler = createHandler(zeroAgentsByIdContract, router, {
-  errorHandler: createSafeErrorHandler("zero-agents:id"),
+  routeName: "zero.agents.byId",
 });
 
 export { handler as GET, handler as PUT, handler as PATCH, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { zeroUserConnectorsContract, connectorTypeSchema } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
@@ -185,7 +181,7 @@ const router = tsr.router(zeroUserConnectorsContract, {
 });
 
 const handler = createHandler(zeroUserConnectorsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-agents:user-connectors"),
+  routeName: "zero.agents.user-connectors",
 });
 
 export { handler as GET, handler as PUT };

--- a/turbo/apps/web/app/api/zero/agents/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroAgentsMainContract, toFirewallPolicies } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -161,7 +157,7 @@ const router = tsr.router(zeroAgentsMainContract, {
 });
 
 const handler = createHandler(zeroAgentsMainContract, router, {
-  errorHandler: createSafeErrorHandler("zero-agents"),
+  routeName: "zero.agents",
 });
 
 export { handler as POST, handler as GET };

--- a/turbo/apps/web/app/api/zero/billing/auto-recharge/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/auto-recharge/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   zeroBillingAutoRechargeContract,
   createErrorResponse,
@@ -58,7 +54,7 @@ const router = tsr.router(zeroBillingAutoRechargeContract, {
 });
 
 const handler = createHandler(zeroBillingAutoRechargeContract, router, {
-  errorHandler: createSafeErrorHandler("zero-billing-auto-recharge"),
+  routeName: "zero.billing.auto-recharge",
 });
 
 export { handler as GET, handler as PUT };

--- a/turbo/apps/web/app/api/zero/billing/checkout/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/checkout/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroBillingCheckoutContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { env } from "../../../../../src/env";
@@ -60,7 +56,7 @@ const router = tsr.router(zeroBillingCheckoutContract, {
 });
 
 const handler = createHandler(zeroBillingCheckoutContract, router, {
-  errorHandler: createSafeErrorHandler("zero-billing-checkout"),
+  routeName: "zero.billing.checkout",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/billing/downgrade/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/downgrade/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroBillingDowngradeContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { env } from "../../../../../src/env";
@@ -44,7 +40,7 @@ const router = tsr.router(zeroBillingDowngradeContract, {
 });
 
 const handler = createHandler(zeroBillingDowngradeContract, router, {
-  errorHandler: createSafeErrorHandler("zero-billing-downgrade"),
+  routeName: "zero.billing.downgrade",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/billing/invoices/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/invoices/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroBillingInvoicesContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -37,7 +33,7 @@ const router = tsr.router(zeroBillingInvoicesContract, {
 });
 
 const handler = createHandler(zeroBillingInvoicesContract, router, {
-  errorHandler: createSafeErrorHandler("zero-billing-invoices"),
+  routeName: "zero.billing.invoices",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/billing/portal/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/portal/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroBillingPortalContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { env } from "../../../../../src/env";
@@ -43,7 +39,7 @@ const router = tsr.router(zeroBillingPortalContract, {
 });
 
 const handler = createHandler(zeroBillingPortalContract, router, {
-  errorHandler: createSafeErrorHandler("zero-billing-portal"),
+  routeName: "zero.billing.portal",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/billing/status/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroBillingStatusContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -39,7 +35,7 @@ const router = tsr.router(zeroBillingStatusContract, {
 });
 
 const handler = createHandler(zeroBillingStatusContract, router, {
-  errorHandler: createSafeErrorHandler("zero-billing-status"),
+  routeName: "zero.billing.status",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/mark-read/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/mark-read/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { chatThreadMarkReadContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../../src/lib/auth/get-auth-context";
@@ -56,7 +52,7 @@ const router = tsr.router(chatThreadMarkReadContract, {
 });
 
 const handler = createHandler(chatThreadMarkReadContract, router, {
-  errorHandler: createSafeErrorHandler("zero-chat-thread-mark-read"),
+  routeName: "zero.chat-threads.mark-read",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { chatThreadMessagesContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../../src/lib/auth/get-auth-context";
@@ -82,7 +78,7 @@ const router = tsr.router(chatThreadMessagesContract, {
 });
 
 const handler = createHandler(chatThreadMessagesContract, router, {
-  errorHandler: createSafeErrorHandler("zero-chat-thread-messages"),
+  routeName: "zero.chat-threads.messages",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { chatThreadByIdContract, modelProviderTypeSchema } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../src/lib/auth/get-auth-context";
@@ -147,7 +143,7 @@ const router = tsr.router(chatThreadByIdContract, {
 });
 
 const handler = createHandler(chatThreadByIdContract, router, {
-  errorHandler: createSafeErrorHandler("zero-chat-thread-by-id"),
+  routeName: "zero.chat-threads.byId",
 });
 
 export { handler as GET, handler as PATCH, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/chat-threads/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { chatThreadsContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
@@ -140,7 +136,7 @@ const router = tsr.router(chatThreadsContract, {
 });
 
 const handler = createHandler(chatThreadsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-chat-threads"),
+  routeName: "zero.chat-threads",
 });
 
 export { handler as GET, handler as POST };

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -1,10 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { after } from "next/server";
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { chatMessagesContract, type AttachFile } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -433,7 +429,7 @@ const router = tsr.router(chatMessagesContract, {
 });
 
 const handler = createHandler(chatMessagesContract, router, {
-  errorHandler: createSafeErrorHandler("zero-chat-messages"),
+  routeName: "zero.chat.messages",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/chat/search/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/search/route.ts
@@ -19,11 +19,7 @@ import {
   lt,
 } from "drizzle-orm";
 import { z } from "zod";
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { chatSearchContract, type ChatSearchMessage } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -201,7 +197,7 @@ const router = tsr.router(chatSearchContract, {
 });
 
 const handler = createHandler(chatSearchContract, router, {
-  errorHandler: createSafeErrorHandler("zero-chat-search"),
+  routeName: "zero.chat.search",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroComposesByIdContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -69,7 +65,7 @@ const router = tsr.router(zeroComposesByIdContract, {
 });
 
 const handler = createHandler(zeroComposesByIdContract, router, {
-  errorHandler: createSafeErrorHandler("zero-composes:id"),
+  routeName: "zero.composes.byId",
 });
 
 export { handler as GET, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/composes/list/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/list/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroComposesListContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -53,7 +49,7 @@ const router = tsr.router(zeroComposesListContract, {
 });
 
 const handler = createHandler(zeroComposesListContract, router, {
-  errorHandler: createSafeErrorHandler("zero-composes:list"),
+  routeName: "zero.composes.list",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/composes/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroComposesMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -61,7 +57,7 @@ const router = tsr.router(zeroComposesMainContract, {
 });
 
 const handler = createHandler(zeroComposesMainContract, router, {
-  errorHandler: createSafeErrorHandler("zero-composes"),
+  routeName: "zero.composes",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/computer-use/host/route.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/host/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   zeroComputerUseHostContract,
   createErrorResponse,
@@ -51,7 +47,7 @@ const router = tsr.router(zeroComputerUseHostContract, {
 });
 
 const handler = createHandler(zeroComputerUseHostContract, router, {
-  errorHandler: createSafeErrorHandler("zero-computer-use:host"),
+  routeName: "zero.computer-use.host",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/computer-use/register/route.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/register/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   zeroComputerUseRegisterContract,
   createErrorResponse,
@@ -44,7 +40,7 @@ const router = tsr.router(zeroComputerUseRegisterContract, {
 });
 
 const handler = createHandler(zeroComputerUseRegisterContract, router, {
-  errorHandler: createSafeErrorHandler("zero-computer-use:register"),
+  routeName: "zero.computer-use.register",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/computer-use/unregister/route.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/unregister/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   zeroComputerUseUnregisterContract,
   createErrorResponse,
@@ -52,7 +48,7 @@ const router = tsr.router(zeroComputerUseUnregisterContract, {
 });
 
 const handler = createHandler(zeroComputerUseUnregisterContract, router, {
-  errorHandler: createSafeErrorHandler("zero-computer-use:unregister"),
+  routeName: "zero.computer-use.unregister",
 });
 
 export { handler as DELETE };

--- a/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroConnectorsByTypeContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -63,7 +59,7 @@ const router = tsr.router(zeroConnectorsByTypeContract, {
 });
 
 const handler = createHandler(zeroConnectorsByTypeContract, router, {
-  errorHandler: createSafeErrorHandler("zero-connectors:type"),
+  routeName: "zero.connectors.byType",
 });
 
 export { handler as GET, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/connectors/[type]/scope-diff/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/scope-diff/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import {
   zeroConnectorScopeDiffContract,
   createErrorResponse,
@@ -36,7 +32,7 @@ const router = tsr.router(zeroConnectorScopeDiffContract, {
 });
 
 const handler = createHandler(zeroConnectorScopeDiffContract, router, {
-  errorHandler: createSafeErrorHandler("zero-connectors:scope-diff"),
+  routeName: "zero.connectors.scope-diff",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/connectors/[type]/sessions/[sessionId]/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/sessions/[sessionId]/route.ts
@@ -1,7 +1,6 @@
 import { eq, and } from "drizzle-orm";
 import {
   createHandler,
-  createSafeErrorHandler,
   tsr,
 } from "../../../../../../../src/lib/ts-rest-handler";
 import {
@@ -66,7 +65,7 @@ const router = tsr.router(zeroConnectorSessionByIdContract, {
 });
 
 const handler = createHandler(zeroConnectorSessionByIdContract, router, {
-  errorHandler: createSafeErrorHandler("zero-connectors:session-by-id"),
+  routeName: "zero.connectors.sessions.bySessionId",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/connectors/[type]/sessions/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/sessions/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { zeroConnectorSessionsContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
@@ -59,7 +55,7 @@ const router = tsr.router(zeroConnectorSessionsContract, {
 });
 
 const handler = createHandler(zeroConnectorSessionsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-connectors:sessions"),
+  routeName: "zero.connectors.sessions",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/connectors/computer/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/computer/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroComputerConnectorContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -82,7 +78,7 @@ const router = tsr.router(zeroComputerConnectorContract, {
 });
 
 const handler = createHandler(zeroComputerConnectorContract, router, {
-  errorHandler: createSafeErrorHandler("zero-connectors:computer"),
+  routeName: "zero.connectors.computer",
 });
 
 export { handler as GET, handler as POST, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import {
   zeroConnectorsMainContract,
   getConnectorProvidedSecretNames,
@@ -51,7 +47,7 @@ const router = tsr.router(zeroConnectorsMainContract, {
 });
 
 const handler = createHandler(zeroConnectorsMainContract, router, {
-  errorHandler: createSafeErrorHandler("zero-connectors"),
+  routeName: "zero.connectors",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/connectors/search/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   zeroConnectorsSearchContract,
   createErrorResponse,
@@ -83,7 +79,7 @@ const router = tsr.router(zeroConnectorsSearchContract, {
 });
 
 const handler = createHandler(zeroConnectorsSearchContract, router, {
-  errorHandler: createSafeErrorHandler("zero-connectors:search"),
+  routeName: "zero.connectors.search",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/custom-connectors/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/custom-connectors/[id]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   zeroCustomConnectorByIdContract,
   createErrorResponse,
@@ -88,7 +84,7 @@ const router = tsr.router(zeroCustomConnectorByIdContract, {
 });
 
 const handler = createHandler(zeroCustomConnectorByIdContract, router, {
-  errorHandler: createSafeErrorHandler("zero-custom-connectors"),
+  routeName: "zero.custom-connectors.byId",
 });
 
 export { handler as DELETE, handler as PATCH };

--- a/turbo/apps/web/app/api/zero/custom-connectors/[id]/secret/route.ts
+++ b/turbo/apps/web/app/api/zero/custom-connectors/[id]/secret/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import {
   zeroCustomConnectorSecretContract,
   createErrorResponse,
@@ -58,7 +54,7 @@ const router = tsr.router(zeroCustomConnectorSecretContract, {
 });
 
 const handler = createHandler(zeroCustomConnectorSecretContract, router, {
-  errorHandler: createSafeErrorHandler("zero-custom-connectors"),
+  routeName: "zero.custom-connectors.secret",
 });
 
 export { handler as PUT, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/custom-connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/custom-connectors/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroCustomConnectorsContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -88,7 +84,7 @@ const router = tsr.router(zeroCustomConnectorsContract, {
 });
 
 const handler = createHandler(zeroCustomConnectorsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-custom-connectors"),
+  routeName: "zero.custom-connectors",
 });
 
 export { handler as GET, handler as POST };

--- a/turbo/apps/web/app/api/zero/default-agent/route.ts
+++ b/turbo/apps/web/app/api/zero/default-agent/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { orgDefaultAgentContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
@@ -114,7 +110,7 @@ const router = tsr.router(orgDefaultAgentContract, {
 });
 
 const handler = createHandler(orgDefaultAgentContract, router, {
-  errorHandler: createSafeErrorHandler("zero-default-agent"),
+  routeName: "zero.default-agent",
 });
 
 export { handler as PUT };

--- a/turbo/apps/web/app/api/zero/developer-support/route.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/route.ts
@@ -137,6 +137,8 @@ const router = tsr.router(zeroDeveloperSupportContract, {
   },
 });
 
-const handler = createHandler(zeroDeveloperSupportContract, router);
+const handler = createHandler(zeroDeveloperSupportContract, router, {
+  routeName: "zero.developer-support",
+});
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/feature-switches/route.ts
+++ b/turbo/apps/web/app/api/zero/feature-switches/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroFeatureSwitchesContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -71,7 +67,7 @@ const router = tsr.router(zeroFeatureSwitchesContract, {
 });
 
 const handler = createHandler(zeroFeatureSwitchesContract, router, {
-  errorHandler: createSafeErrorHandler("zero-feature-switches"),
+  routeName: "zero.feature-switches",
 });
 
 export { handler as GET, handler as POST, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/integrations/chat/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/chat/message/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { integrationsChatMessageContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
@@ -81,7 +77,7 @@ const router = tsr.router(integrationsChatMessageContract, {
 });
 
 const handler = createHandler(integrationsChatMessageContract, router, {
-  errorHandler: createSafeErrorHandler("integrations-chat-message"),
+  routeName: "zero.integrations.chat.message",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
@@ -267,6 +267,8 @@ const router = tsr.router(integrationsSlackMessageContract, {
   },
 });
 
-const handler = createHandler(integrationsSlackMessageContract, router);
+const handler = createHandler(integrationsSlackMessageContract, router, {
+  routeName: "zero.integrations.slack.message",
+});
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/integrations/slack/upload-file/complete/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/upload-file/complete/route.ts
@@ -56,6 +56,8 @@ const router = tsr.router(integrationsSlackUploadCompleteContract, {
   },
 });
 
-const handler = createHandler(integrationsSlackUploadCompleteContract, router);
+const handler = createHandler(integrationsSlackUploadCompleteContract, router, {
+  routeName: "zero.integrations.slack.upload-file.complete",
+});
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/integrations/slack/upload-file/init/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/upload-file/init/route.ts
@@ -62,6 +62,8 @@ const router = tsr.router(integrationsSlackUploadInitContract, {
   },
 });
 
-const handler = createHandler(integrationsSlackUploadInitContract, router);
+const handler = createHandler(integrationsSlackUploadInitContract, router, {
+  routeName: "zero.integrations.slack.upload-file.init",
+});
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/logs/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/[id]/route.ts
@@ -252,6 +252,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(logsByIdContract, router, {
+  routeName: "zero.logs.byId",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/zero/logs/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/route.ts
@@ -402,6 +402,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(logsListContract, router, {
+  routeName: "zero.logs",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/zero/logs/search/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/search/route.ts
@@ -58,6 +58,7 @@ function errorHandler(err: unknown): TsRestResponse | void {
 }
 
 const handler = createHandler(zeroLogsSearchContract, router, {
+  routeName: "zero.logs.search",
   errorHandler,
 });
 

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/default/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/default/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import {
   zeroModelProvidersDefaultContract,
   createErrorResponse,
@@ -68,7 +64,7 @@ const router = tsr.router(zeroModelProvidersDefaultContract, {
 });
 
 const handler = createHandler(zeroModelProvidersDefaultContract, router, {
-  errorHandler: createSafeErrorHandler("zero-model-providers"),
+  routeName: "zero.model-providers.default",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/model/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/model/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import {
   zeroModelProvidersUpdateModelContract,
   createErrorResponse,
@@ -73,7 +69,7 @@ const router = tsr.router(zeroModelProvidersUpdateModelContract, {
 });
 
 const handler = createHandler(zeroModelProvidersUpdateModelContract, router, {
-  errorHandler: createSafeErrorHandler("zero-model-providers"),
+  routeName: "zero.model-providers.model",
 });
 
 export { handler as PATCH };

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   zeroModelProvidersByTypeContract,
   createErrorResponse,
@@ -57,7 +53,7 @@ const router = tsr.router(zeroModelProvidersByTypeContract, {
 });
 
 const handler = createHandler(zeroModelProvidersByTypeContract, router, {
-  errorHandler: createSafeErrorHandler("zero-model-providers"),
+  routeName: "zero.model-providers.byType",
 });
 
 export { handler as DELETE };

--- a/turbo/apps/web/app/api/zero/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import {
   zeroModelProvidersMainContract,
   createErrorResponse,
@@ -152,7 +148,7 @@ const router = tsr.router(zeroModelProvidersMainContract, {
 });
 
 const handler = createHandler(zeroModelProvidersMainContract, router, {
-  errorHandler: createSafeErrorHandler("zero-model-providers"),
+  routeName: "zero.model-providers",
 });
 
 export { handler as GET, handler as POST };

--- a/turbo/apps/web/app/api/zero/onboarding/complete/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/complete/route.ts
@@ -1,11 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { onboardingCompleteContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { orgMembersMetadata } from "../../../../../src/db/schema/org-members-metadata";
@@ -98,7 +94,7 @@ const router = tsr.router(onboardingCompleteContract, {
 });
 
 const handler = createHandler(onboardingCompleteContract, router, {
-  errorHandler: createSafeErrorHandler("onboarding-complete"),
+  routeName: "zero.onboarding.complete",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
@@ -1,11 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { onboardingSetupContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   requireAuth,
   isAuthError,
@@ -291,7 +287,7 @@ const router = tsr.router(onboardingSetupContract, {
 });
 
 const handler = createHandler(onboardingSetupContract, router, {
-  errorHandler: createSafeErrorHandler("onboarding-setup"),
+  routeName: "zero.onboarding.setup",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/status/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { onboardingStatusContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
@@ -152,7 +148,7 @@ const router = tsr.router(onboardingStatusContract, {
 });
 
 const handler = createHandler(onboardingStatusContract, router, {
-  errorHandler: createSafeErrorHandler("zero-onboarding-status"),
+  routeName: "zero.onboarding.status",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/org/delete/route.ts
+++ b/turbo/apps/web/app/api/zero/org/delete/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroOrgDeleteContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -61,7 +57,7 @@ const router = tsr.router(zeroOrgDeleteContract, {
 });
 
 const handler = createHandler(zeroOrgDeleteContract, router, {
-  errorHandler: createSafeErrorHandler("zero-org-delete"),
+  routeName: "zero.org.delete",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/org/domains/route.ts
+++ b/turbo/apps/web/app/api/zero/org/domains/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroOrgDomainsContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -113,7 +109,7 @@ const router = tsr.router(zeroOrgDomainsContract, {
 });
 
 const handler = createHandler(zeroOrgDomainsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-org-domains"),
+  routeName: "zero.org.domains",
 });
 
 export { handler as GET, handler as POST, handler as DELETE, handler as PATCH };

--- a/turbo/apps/web/app/api/zero/org/invite/route.ts
+++ b/turbo/apps/web/app/api/zero/org/invite/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroOrgInviteContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -83,7 +79,7 @@ const router = tsr.router(zeroOrgInviteContract, {
 });
 
 const handler = createHandler(zeroOrgInviteContract, router, {
-  errorHandler: createSafeErrorHandler("zero-org-invite"),
+  routeName: "zero.org.invite",
 });
 
 export { handler as POST, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/org/leave/route.ts
+++ b/turbo/apps/web/app/api/zero/org/leave/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroOrgLeaveContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -47,7 +43,7 @@ const router = tsr.router(zeroOrgLeaveContract, {
 });
 
 const handler = createHandler(zeroOrgLeaveContract, router, {
-  errorHandler: createSafeErrorHandler("zero-org-leave"),
+  routeName: "zero.org.leave",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/org/list/route.ts
+++ b/turbo/apps/web/app/api/zero/org/list/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroOrgListContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -28,7 +24,7 @@ const router = tsr.router(zeroOrgListContract, {
 });
 
 const handler = createHandler(zeroOrgListContract, router, {
-  errorHandler: createSafeErrorHandler("zero-org-list"),
+  routeName: "zero.org.list",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/org/members/route.ts
+++ b/turbo/apps/web/app/api/zero/org/members/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroOrgMembersContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -108,7 +104,7 @@ const router = tsr.router(zeroOrgMembersContract, {
 });
 
 const handler = createHandler(zeroOrgMembersContract, router, {
-  errorHandler: createSafeErrorHandler("zero-org-members"),
+  routeName: "zero.org.members",
 });
 
 export { handler as GET, handler as PATCH, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/org/membership-requests/route.ts
+++ b/turbo/apps/web/app/api/zero/org/membership-requests/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   zeroOrgMembershipRequestsContract,
   createErrorResponse,
@@ -73,7 +69,7 @@ const router = tsr.router(zeroOrgMembershipRequestsContract, {
 });
 
 const handler = createHandler(zeroOrgMembershipRequestsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-org-membership-requests"),
+  routeName: "zero.org.membership-requests",
 });
 
 export { handler as POST, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/org/route.ts
+++ b/turbo/apps/web/app/api/zero/org/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroOrgContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -96,7 +92,7 @@ const router = tsr.router(zeroOrgContract, {
 });
 
 const handler = createHandler(zeroOrgContract, router, {
-  errorHandler: createSafeErrorHandler("zero-org"),
+  routeName: "zero.org",
 });
 
 export { handler as GET, handler as PUT };

--- a/turbo/apps/web/app/api/zero/permission-access-requests/route.ts
+++ b/turbo/apps/web/app/api/zero/permission-access-requests/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import {
   permissionAccessRequestsCreateContract,
   permissionAccessRequestsListContract,
@@ -446,19 +442,19 @@ const resolveRouter = tsr.router(permissionAccessRequestsResolveContract, {
 const postHandler = createHandler(
   permissionAccessRequestsCreateContract,
   createRouter,
-  { errorHandler: createSafeErrorHandler("zero:permission-access-requests") },
+  { routeName: "zero.permission-access-requests.create" },
 );
 
 const getHandler = createHandler(
   permissionAccessRequestsListContract,
   listRouter,
-  { errorHandler: createSafeErrorHandler("zero:permission-access-requests") },
+  { routeName: "zero.permission-access-requests.list" },
 );
 
 const putHandler = createHandler(
   permissionAccessRequestsResolveContract,
   resolveRouter,
-  { errorHandler: createSafeErrorHandler("zero:permission-access-requests") },
+  { routeName: "zero.permission-access-requests.resolve" },
 );
 
 export { postHandler as POST, getHandler as GET, putHandler as PUT };

--- a/turbo/apps/web/app/api/zero/permission-policies/route.ts
+++ b/turbo/apps/web/app/api/zero/permission-policies/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import {
   zeroAgentPermissionPoliciesContract,
   getConnectorFirewall,
@@ -154,7 +150,7 @@ function buildAgentResponse(
 }
 
 const handler = createHandler(zeroAgentPermissionPoliciesContract, router, {
-  errorHandler: createSafeErrorHandler("zero:permission-policies"),
+  routeName: "zero.permission-policies",
 });
 
 export { handler as PUT };

--- a/turbo/apps/web/app/api/zero/platform-connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/platform-connectors/[type]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   zeroPlatformConnectorContract,
   createErrorResponse,
@@ -50,7 +46,7 @@ const router = tsr.router(zeroPlatformConnectorContract, {
 });
 
 const handler = createHandler(zeroPlatformConnectorContract, router, {
-  errorHandler: createSafeErrorHandler("zero-platform-connectors:type"),
+  routeName: "zero.platform-connectors.byType",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/push-subscriptions/route.ts
+++ b/turbo/apps/web/app/api/zero/push-subscriptions/route.ts
@@ -1,9 +1,5 @@
 import { eq, and, lt, sql } from "drizzle-orm";
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { pushSubscriptionsContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -62,7 +58,7 @@ const router = tsr.router(pushSubscriptionsContract, {
 });
 
 const handler = createHandler(pushSubscriptionsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-push-subscriptions"),
+  routeName: "zero.push-subscriptions",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/realtime/token/route.ts
+++ b/turbo/apps/web/app/api/zero/realtime/token/route.ts
@@ -22,6 +22,8 @@ const router = tsr.router(platformRealtimeTokenContract, {
   },
 });
 
-const handler = createHandler(platformRealtimeTokenContract, router);
+const handler = createHandler(platformRealtimeTokenContract, router, {
+  routeName: "zero.realtime.token",
+});
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/redemption-codes/redeem/route.ts
+++ b/turbo/apps/web/app/api/zero/redemption-codes/redeem/route.ts
@@ -6,11 +6,7 @@
  * check and no feature-switch check here. Single-use is enforced atomically
  * inside `redeemRedemptionCode`.
  */
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroRedemptionCodesRedeemContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -40,7 +36,7 @@ const router = tsr.router(zeroRedemptionCodesRedeemContract, {
 });
 
 const handler = createHandler(zeroRedemptionCodesRedeemContract, router, {
-  errorHandler: createSafeErrorHandler("zero-redemption-codes:redeem"),
+  routeName: "zero.redemption-codes.redeem",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/redemption-codes/route.ts
+++ b/turbo/apps/web/app/api/zero/redemption-codes/route.ts
@@ -18,11 +18,7 @@
  * above in place even if you add a `FeatureSwitchKey.RedemptionCodes` check
  * elsewhere — they are what makes minting and tracing safe.
  */
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import {
   zeroRedemptionCodesMintContract,
   zeroRedemptionCodesListContract,
@@ -117,10 +113,10 @@ const listRouter = tsr.router(zeroRedemptionCodesListContract, {
 });
 
 const mintHandler = createHandler(zeroRedemptionCodesMintContract, mintRouter, {
-  errorHandler: createSafeErrorHandler("zero-redemption-codes:mint"),
+  routeName: "zero.redemption-codes.mint",
 });
 const listHandler = createHandler(zeroRedemptionCodesListContract, listRouter, {
-  errorHandler: createSafeErrorHandler("zero-redemption-codes:list"),
+  routeName: "zero.redemption-codes.list",
 });
 
 export { mintHandler as POST, listHandler as GET };

--- a/turbo/apps/web/app/api/zero/report-error/route.ts
+++ b/turbo/apps/web/app/api/zero/report-error/route.ts
@@ -1,4 +1,8 @@
-import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
+import {
+  createHandler,
+  createSilentErrorHandler,
+  tsr,
+} from "../../../../src/lib/ts-rest-handler";
 import { zeroReportErrorContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -99,8 +103,12 @@ const router = tsr.router(zeroReportErrorContract, {
   },
 });
 
+// Use the silent variant: this endpoint *is* the error sink. If it fails,
+// forwarding that failure to Sentry would create a self-referential echo —
+// server logs already carry full context at error level.
 const handler = createHandler(zeroReportErrorContract, router, {
   routeName: "zero.report-error",
+  errorHandler: createSilentErrorHandler("zero.report-error"),
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/report-error/route.ts
+++ b/turbo/apps/web/app/api/zero/report-error/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroReportErrorContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -104,7 +100,7 @@ const router = tsr.router(zeroReportErrorContract, {
 });
 
 const handler = createHandler(zeroReportErrorContract, router, {
-  errorHandler: createSafeErrorHandler("zero-report-error"),
+  routeName: "zero.report-error",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { zeroRunsCancelContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
@@ -77,7 +73,7 @@ const router = tsr.router(zeroRunsCancelContract, {
 });
 
 const handler = createHandler(zeroRunsCancelContract, router, {
-  errorHandler: createSafeErrorHandler("zero-runs:cancel"),
+  routeName: "zero.runs.cancel",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { zeroRunContextContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
@@ -70,7 +66,7 @@ const router = tsr.router(zeroRunContextContract, {
 });
 
 const handler = createHandler(zeroRunContextContract, router, {
-  errorHandler: createSafeErrorHandler("zero-runs:context"),
+  routeName: "zero.runs.context",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { zeroRunNetworkLogsContract, type AxiomNetworkEvent } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
@@ -105,7 +101,7 @@ ${sinceFilter}
 });
 
 const handler = createHandler(zeroRunNetworkLogsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-runs:network"),
+  routeName: "zero.runs.network",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroRunsByIdContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -39,7 +35,7 @@ const router = tsr.router(zeroRunsByIdContract, {
 });
 
 const handler = createHandler(zeroRunsByIdContract, router, {
-  errorHandler: createSafeErrorHandler("zero-runs:id"),
+  routeName: "zero.runs.byId",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/runs/[id]/runner/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/runner/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { zeroRunRunnerContract, type SandboxReuseResult } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
@@ -57,7 +53,7 @@ const router = tsr.router(zeroRunRunnerContract, {
 });
 
 const handler = createHandler(zeroRunRunnerContract, router, {
-  errorHandler: createSafeErrorHandler("zero-runs:runner"),
+  routeName: "zero.runs.runner",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
@@ -1,6 +1,5 @@
 import {
   createHandler,
-  createSafeErrorHandler,
   tsr,
 } from "../../../../../../../src/lib/ts-rest-handler";
 import { zeroRunAgentEventsContract } from "@vm0/core";
@@ -48,7 +47,7 @@ const router = tsr.router(zeroRunAgentEventsContract, {
 });
 
 const handler = createHandler(zeroRunAgentEventsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-runs:telemetry:agent"),
+  routeName: "zero.runs.telemetry.agent",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroRunsQueueContract, orgTierSchema } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -31,7 +27,7 @@ const router = tsr.router(zeroRunsQueueContract, {
 });
 
 const handler = createHandler(zeroRunsQueueContract, router, {
-  errorHandler: createSafeErrorHandler("zero-runs:queue"),
+  routeName: "zero.runs.queue",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -1,9 +1,5 @@
 import { eq } from "drizzle-orm";
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroRunsMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -154,7 +150,7 @@ const router = tsr.router(zeroRunsMainContract, {
 });
 
 const handler = createHandler(zeroRunsMainContract, router, {
-  errorHandler: createSafeErrorHandler("zero-runs"),
+  routeName: "zero.runs",
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroSchedulesByNameContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -49,7 +45,7 @@ const router = tsr.router(zeroSchedulesByNameContract, {
 });
 
 const handler = createHandler(zeroSchedulesByNameContract, router, {
-  errorHandler: createSafeErrorHandler("zero-schedules:name"),
+  routeName: "zero.schedules.byName",
 });
 
 export { handler as DELETE };

--- a/turbo/apps/web/app/api/zero/schedules/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroSchedulesMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -121,7 +117,7 @@ const router = tsr.router(zeroSchedulesMainContract, {
 });
 
 const handler = createHandler(zeroSchedulesMainContract, router, {
-  errorHandler: createSafeErrorHandler("zero-schedules"),
+  routeName: "zero.schedules",
 });
 
 export { handler as GET, handler as POST };

--- a/turbo/apps/web/app/api/zero/secrets/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/secrets/[name]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroSecretsByNameContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -47,7 +43,7 @@ const router = tsr.router(zeroSecretsByNameContract, {
 });
 
 const handler = createHandler(zeroSecretsByNameContract, router, {
-  errorHandler: createSafeErrorHandler("zero-secrets"),
+  routeName: "zero.secrets.byName",
 });
 
 export { handler as DELETE };

--- a/turbo/apps/web/app/api/zero/secrets/route.ts
+++ b/turbo/apps/web/app/api/zero/secrets/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroSecretsContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -89,7 +85,7 @@ const router = tsr.router(zeroSecretsContract, {
 });
 
 const handler = createHandler(zeroSecretsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-secrets"),
+  routeName: "zero.secrets",
 });
 
 export { handler as GET, handler as POST };

--- a/turbo/apps/web/app/api/zero/skills/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/skills/[name]/route.ts
@@ -1,9 +1,5 @@
 import { gunzipSync } from "node:zlib";
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   zeroSkillsDetailContract,
   getCustomSkillStorageName,
@@ -323,7 +319,7 @@ const router = tsr.router(zeroSkillsDetailContract, {
 });
 
 const handler = createHandler(zeroSkillsDetailContract, router, {
-  errorHandler: createSafeErrorHandler("zero-skills:detail"),
+  routeName: "zero.skills.byName",
 });
 
 export { handler as GET, handler as PUT, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/skills/route.ts
+++ b/turbo/apps/web/app/api/zero/skills/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import {
   zeroSkillsCollectionContract,
   getCustomSkillStorageName,
@@ -134,7 +130,7 @@ const router = tsr.router(zeroSkillsCollectionContract, {
 });
 
 const handler = createHandler(zeroSkillsCollectionContract, router, {
-  errorHandler: createSafeErrorHandler("zero-skills"),
+  routeName: "zero.skills",
 });
 
 export { handler as GET, handler as POST };

--- a/turbo/apps/web/app/api/zero/tasks/route.ts
+++ b/turbo/apps/web/app/api/zero/tasks/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { tasksContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
@@ -108,7 +104,7 @@ const router = tsr.router(tasksContract, {
 });
 
 const handler = createHandler(tasksContract, router, {
-  errorHandler: createSafeErrorHandler("zero-tasks"),
+  routeName: "zero.tasks",
 });
 
 export { handler as GET, handler as POST };

--- a/turbo/apps/web/app/api/zero/usage/insight/route.ts
+++ b/turbo/apps/web/app/api/zero/usage/insight/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroUsageInsightContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -43,7 +39,7 @@ const router = tsr.router(zeroUsageInsightContract, {
 });
 
 const handler = createHandler(zeroUsageInsightContract, router, {
-  errorHandler: createSafeErrorHandler("zero-usage-insight"),
+  routeName: "zero.usage.insight",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/usage/members/route.ts
+++ b/turbo/apps/web/app/api/zero/usage/members/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroUsageMembersContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -28,7 +24,7 @@ const router = tsr.router(zeroUsageMembersContract, {
 });
 
 const handler = createHandler(zeroUsageMembersContract, router, {
-  errorHandler: createSafeErrorHandler("zero-usage-members"),
+  routeName: "zero.usage.members",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/usage/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/usage/runs/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroUsageRunsContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -51,7 +47,7 @@ const router = tsr.router(zeroUsageRunsContract, {
 });
 
 const handler = createHandler(zeroUsageRunsContract, router, {
-  errorHandler: createSafeErrorHandler("zero-usage-runs"),
+  routeName: "zero.usage.runs",
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/zero/user-preferences/route.ts
+++ b/turbo/apps/web/app/api/zero/user-preferences/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroUserPreferencesContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -73,7 +69,7 @@ const router = tsr.router(zeroUserPreferencesContract, {
 });
 
 const handler = createHandler(zeroUserPreferencesContract, router, {
-  errorHandler: createSafeErrorHandler("zero-user-preferences"),
+  routeName: "zero.user-preferences",
 });
 
 export { handler as GET, handler as POST };

--- a/turbo/apps/web/app/api/zero/variables/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/variables/[name]/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroVariablesByNameContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -47,7 +43,7 @@ const router = tsr.router(zeroVariablesByNameContract, {
 });
 
 const handler = createHandler(zeroVariablesByNameContract, router, {
-  errorHandler: createSafeErrorHandler("zero-variables"),
+  routeName: "zero.variables.byName",
 });
 
 export { handler as DELETE };

--- a/turbo/apps/web/app/api/zero/variables/route.ts
+++ b/turbo/apps/web/app/api/zero/variables/route.ts
@@ -1,8 +1,4 @@
-import {
-  createHandler,
-  createSafeErrorHandler,
-  tsr,
-} from "../../../../src/lib/ts-rest-handler";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroVariablesContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -89,7 +85,7 @@ const router = tsr.router(zeroVariablesContract, {
 });
 
 const handler = createHandler(zeroVariablesContract, router, {
-  errorHandler: createSafeErrorHandler("zero-variables"),
+  routeName: "zero.variables",
 });
 
 export { handler as GET, handler as POST };

--- a/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
@@ -74,4 +74,15 @@ describe("createSafeErrorHandler", () => {
       captureContext: { tags: { route: "test-route" } },
     });
   });
+
+  it("maps malformed JSON body SyntaxError to 400 without Sentry", async () => {
+    const err = new SyntaxError("Bad escaped character in JSON at position 18");
+    const response = handler(err);
+    expect(response).toBeDefined();
+    expect(response!.status).toBe(400);
+    const body = await response!.json();
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toBe("Invalid JSON in request body");
+    expect(vi.mocked(Sentry.captureException)).not.toHaveBeenCalled();
+  });
 });

--- a/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as Sentry from "@sentry/nextjs";
+import type { TsRestRequest } from "@ts-rest/serverless";
+import type { AppRouter } from "@ts-rest/core";
 
 vi.mock("@sentry/nextjs", () => {
   return {
@@ -8,7 +10,33 @@ vi.mock("@sentry/nextjs", () => {
   };
 });
 
-import { createSafeErrorHandler } from "../ts-rest-handler";
+// Capture the errorHandler passed to createNextHandler so tests can invoke it
+// directly without spinning up a real Next.js server.
+type ResolvedErrorHandler = (err: unknown, req: TsRestRequest) => unknown;
+let capturedErrorHandler: ResolvedErrorHandler | undefined;
+
+vi.mock("@ts-rest/serverless/next", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@ts-rest/serverless/next")>();
+  return {
+    ...original,
+    createNextHandler: (
+      _contract: AppRouter,
+      _router: unknown,
+      options: { errorHandler?: ResolvedErrorHandler },
+    ) => {
+      capturedErrorHandler = options.errorHandler;
+      // Return a no-op handler — tests only exercise the errorHandler
+      return () => {
+        return Promise.resolve(new Response());
+      };
+    },
+  };
+});
+
+import { initContract } from "@ts-rest/core";
+import { z } from "zod";
+import { createSafeErrorHandler, createHandler, tsr } from "../ts-rest-handler";
 import { badRequest, notFound, forbidden } from "../shared/errors";
 
 describe("createSafeErrorHandler", () => {
@@ -83,6 +111,98 @@ describe("createSafeErrorHandler", () => {
     const body = await response!.json();
     expect(body.error.code).toBe("BAD_REQUEST");
     expect(body.error.message).toBe("Invalid JSON in request body");
+    expect(vi.mocked(Sentry.captureException)).not.toHaveBeenCalled();
+  });
+});
+
+describe("createHandler per-operation dispatch", () => {
+  // Minimal two-operation contract: one GET (list) and one POST (create).
+  const c = initContract();
+  const twoOpContract = c.router({
+    list: {
+      method: "GET",
+      path: "/api/test",
+      responses: { 200: z.object({ items: z.array(z.string()) }) },
+    },
+    create: {
+      method: "POST",
+      path: "/api/test",
+      body: z.object({ name: z.string() }),
+      responses: { 201: z.object({ id: z.string() }) },
+    },
+  });
+
+  // Minimal router stubs — createNextHandler is mocked so these are never called.
+  const router = tsr.router(twoOpContract, {
+    list: async () => {
+      return { status: 200 as const, body: { items: [] } };
+    },
+    create: async () => {
+      return { status: 201 as const, body: { id: "x" } };
+    },
+  });
+
+  beforeEach(() => {
+    capturedErrorHandler = undefined;
+  });
+
+  it("routes GET errors to the list operation handler", async () => {
+    createHandler(twoOpContract, router, { routeName: "test" });
+    expect(capturedErrorHandler).toBeDefined();
+
+    const fakeReq = { method: "GET", route: "/api/test" } as TsRestRequest;
+    const err = new Error("list failure");
+    const response = await capturedErrorHandler!(err, fakeReq);
+    expect(response).toBeDefined();
+    // Sentry tag should carry the per-operation route name
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(err, {
+      mechanism: { type: "ts-rest-handler", handled: true },
+      captureContext: { tags: { route: "test.list" } },
+    });
+  });
+
+  it("routes POST errors to the create operation handler", async () => {
+    createHandler(twoOpContract, router, { routeName: "test" });
+    expect(capturedErrorHandler).toBeDefined();
+
+    const fakeReq = { method: "POST", route: "/api/test" } as TsRestRequest;
+    const err = new Error("create failure");
+    const response = await capturedErrorHandler!(err, fakeReq);
+    expect(response).toBeDefined();
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(err, {
+      mechanism: { type: "ts-rest-handler", handled: true },
+      captureContext: { tags: { route: "test.create" } },
+    });
+  });
+
+  it("falls back to base routeName when operation is not found in the map", async () => {
+    createHandler(twoOpContract, router, { routeName: "test" });
+    expect(capturedErrorHandler).toBeDefined();
+
+    const fakeReq = {
+      method: "DELETE",
+      route: "/api/unknown",
+    } as TsRestRequest;
+    const err = new Error("unknown failure");
+    await capturedErrorHandler!(err, fakeReq);
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(err, {
+      mechanism: { type: "ts-rest-handler", handled: true },
+      captureContext: { tags: { route: "test" } },
+    });
+  });
+
+  it("uses custom errorHandler when provided, bypassing per-operation dispatch", async () => {
+    const customHandler = vi.fn().mockReturnValue(undefined);
+    createHandler(twoOpContract, router, {
+      routeName: "test",
+      errorHandler: customHandler,
+    });
+    expect(capturedErrorHandler).toBeDefined();
+
+    const fakeReq = { method: "GET", route: "/api/test" } as TsRestRequest;
+    const err = new Error("custom error");
+    await capturedErrorHandler!(err, fakeReq);
+    expect(customHandler).toHaveBeenCalledWith(err);
     expect(vi.mocked(Sentry.captureException)).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -227,10 +227,12 @@ export function createHandler<T extends AppRouter>(
   const perOpHandlers =
     opMap && opMap.size > 1
       ? new Map(
-          [...new Set(opMap.values())].map((op) => [
-            op,
-            createSafeErrorHandler(`${options.routeName}.${op}`),
-          ]),
+          [...new Set(opMap.values())].map((op) => {
+            return [
+              op,
+              createSafeErrorHandler(`${options.routeName}.${op}`),
+            ] as const;
+          }),
         )
       : null;
   const defaultHandler = createSafeErrorHandler(options.routeName);

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -15,7 +15,7 @@ import "server-only";
 import { createNextHandler, tsr } from "@ts-rest/serverless/next";
 import { TsRestResponse } from "@ts-rest/serverless";
 import type { TsRestRequest } from "@ts-rest/serverless";
-import type { AppRouter } from "@ts-rest/core";
+import type { AppRoute, AppRouter } from "@ts-rest/core";
 import * as Sentry from "@sentry/nextjs";
 import { flushLogs, logger } from "./shared/logger";
 import { ingestRequestLog, flushAxiom } from "./shared/axiom";
@@ -29,6 +29,30 @@ export { tsr, TsRestResponse };
  * This is the return type of `tsr.router(contract, { ... })`.
  */
 type TsRestRouter<T extends AppRouter> = ReturnType<typeof tsr.router<T>>;
+
+/**
+ * Walk a ts-rest contract and build a `${method}:${path}` → operation-name
+ * map. Nested sub-routers get dot-joined keys (e.g. `billing.checkout`).
+ * Used to attach an operation suffix to `routeName` in the default error
+ * handler so multi-op handlers produce distinct log labels.
+ */
+function buildOperationMap(contract: AppRouter): Map<string, string> {
+  const map = new Map<string, string>();
+  const walk = (node: AppRouter, prefix: string): void => {
+    for (const [key, value] of Object.entries(node)) {
+      if (!value || typeof value !== "object") continue;
+      if ("method" in value && "path" in value) {
+        const route = value as AppRoute;
+        const op = prefix ? `${prefix}.${key}` : key;
+        map.set(`${route.method}:${route.path}`, op);
+      } else {
+        walk(value as AppRouter, prefix ? `${prefix}.${key}` : key);
+      }
+    }
+  };
+  walk(contract, "");
+  return map;
+}
 
 /**
  * Create a safe error handler that sanitizes error messages for API responses.
@@ -156,17 +180,41 @@ export function createHandler<T extends AppRouter>(
   router: TsRestRouter<T>,
   options: CreateHandlerOptions,
 ) {
-  const resolvedOptions = {
-    errorHandler:
-      options.errorHandler ?? createSafeErrorHandler(options.routeName),
+  // Pre-build per-operation error handlers for multi-op contracts so each
+  // operation surfaces its own label (e.g. `zero.chat-threads.create` vs
+  // `zero.chat-threads.list`). Single-op contracts keep `options.routeName`
+  // directly — the name already uniquely identifies the operation.
+  const opMap = options.errorHandler ? null : buildOperationMap(contract);
+  const perOpHandlers =
+    opMap && opMap.size > 1
+      ? new Map(
+          [...new Set(opMap.values())].map((op) => [
+            op,
+            createSafeErrorHandler(`${options.routeName}.${op}`),
+          ]),
+        )
+      : null;
+  const defaultHandler = createSafeErrorHandler(options.routeName);
+
+  const resolvedErrorHandler = (
+    err: unknown,
+    req: TsRestRequest,
+  ): TsRestResponse | void => {
+    if (options.errorHandler) return options.errorHandler(err);
+    if (perOpHandlers && opMap) {
+      const op = opMap.get(`${req.method}:${req.route}`);
+      const h = op ? perOpHandlers.get(op) : undefined;
+      if (h) return h(err);
+    }
+    return defaultHandler(err);
   };
 
   return createNextHandler(contract, router, {
+    errorHandler: resolvedErrorHandler,
     handlerType: "app-router",
     // jsonQuery is intentionally disabled: JSON.parse() misinterprets hex strings
     // like "846e3519" as scientific notation, corrupting version query params (#2666)
     jsonQuery: false,
-    ...resolvedOptions,
     requestMiddleware: [
       (request) => {
         // Record request start time

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -120,8 +120,16 @@ export function createSafeErrorHandler(
 
 /**
  * Options for createHandler.
+ *
+ * Route naming convention: `<area>.<resource>[.<sub>][.<op|byId>]`, mirroring
+ * the URL path with parameters collapsed to the operation name. Examples:
+ *   /api/agent/runs/[id]          → "agent.runs.byId"
+ *   /api/zero/chat-threads        → "zero.chat-threads"
+ *   /api/webhooks/agent/complete  → "webhooks.agent.complete"
  */
 interface CreateHandlerOptions {
+  /** Stable route identifier used for structured logs and error tags. */
+  routeName: string;
   /** Custom error handler for validation and other errors */
   errorHandler?: (err: unknown) => TsRestResponse | void;
 }
@@ -137,17 +145,16 @@ const requestStartTimes = new WeakMap<TsRestRequest, number>();
  *
  * @param contract - The ts-rest contract definition
  * @param router - The ts-rest router implementation (from tsr.router)
- * @param options - Additional options (errorHandler, etc.)
+ * @param options - Must include `routeName`; may override `errorHandler`.
  */
 export function createHandler<T extends AppRouter>(
   contract: T,
   router: TsRestRouter<T>,
-  options?: CreateHandlerOptions,
+  options: CreateHandlerOptions,
 ) {
   const resolvedOptions = {
-    ...options,
     errorHandler:
-      options?.errorHandler ?? createSafeErrorHandler("unknown-route"),
+      options.errorHandler ?? createSafeErrorHandler(options.routeName),
   };
 
   return createNextHandler(contract, router, {

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -66,6 +66,26 @@ function buildOperationMap(contract: AppRouter): Map<string, string> {
 export function createSafeErrorHandler(
   routeName: string,
 ): (err: unknown) => TsRestResponse | void {
+  return makeErrorHandler(routeName, { reportToSentry: true });
+}
+
+/**
+ * Like {@link createSafeErrorHandler} but does NOT forward unhandled errors
+ * to Sentry. Use for routes whose *own* purpose is to report errors (e.g.
+ * the client-error sink endpoint) — otherwise a failing report can echo
+ * back into Sentry as a fresh issue, creating a self-referential loop.
+ * Server logs still record the failure at error level.
+ */
+export function createSilentErrorHandler(
+  routeName: string,
+): (err: unknown) => TsRestResponse | void {
+  return makeErrorHandler(routeName, { reportToSentry: false });
+}
+
+function makeErrorHandler(
+  routeName: string,
+  options: { reportToSentry: boolean },
+): (err: unknown) => TsRestResponse | void {
   const log = logger(`api:${routeName}`);
 
   return function safeErrorHandler(err: unknown): TsRestResponse | void {
@@ -127,13 +147,15 @@ export function createSafeErrorHandler(
 
     // Non-validation errors: log full details server-side, return generic message
     log.error(`${routeName} error:`, err);
-    // Report to Sentry. Without this, ts-rest-handled 5xx never reaches
-    // Sentry because the error is caught here and a 500 JSON is returned,
-    // so Next.js's onRequestError instrumentation hook never fires.
-    Sentry.captureException(err, {
-      mechanism: { type: "ts-rest-handler", handled: true },
-      captureContext: { tags: { route: routeName } },
-    });
+    if (options.reportToSentry) {
+      // Report to Sentry. Without this, ts-rest-handled 5xx never reaches
+      // Sentry because the error is caught here and a 500 JSON is returned,
+      // so Next.js's onRequestError instrumentation hook never fires.
+      Sentry.captureException(err, {
+        mechanism: { type: "ts-rest-handler", handled: true },
+        captureContext: { tags: { route: routeName } },
+      });
+    }
     return TsRestResponse.fromJson(
       {
         error: {

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -145,6 +145,23 @@ function makeErrorHandler(
       );
     }
 
+    // Malformed JSON in the request body thrown from the ts-rest
+    // `evaluateContent` middleware (via undici `parseJSONFromBytes`).
+    // This is a client bug, not ours — classify as 400 so it doesn't
+    // page oncall or burn a Sentry event.
+    if (err instanceof SyntaxError && err.message.includes("JSON")) {
+      log.warn(`${routeName} invalid json body: ${err.message}`);
+      return TsRestResponse.fromJson(
+        {
+          error: {
+            message: "Invalid JSON in request body",
+            code: "BAD_REQUEST",
+          },
+        },
+        { status: 400 },
+      );
+    }
+
     // Non-validation errors: log full details server-side, return generic message
     log.error(`${routeName} error:`, err);
     if (options.reportToSentry) {

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -90,7 +90,11 @@ export function createSafeErrorHandler(
 
     // Application errors with explicit status codes (BadRequest, NotFound, etc.)
     if (isApiError(err)) {
-      log.error(`${routeName} error:`, err);
+      if (err.statusCode >= 500) {
+        log.error(`${routeName} error:`, err);
+      } else {
+        log.warn(`${routeName} client error:`, err);
+      }
       return TsRestResponse.fromJson(
         { error: { message: err.message, code: err.code } },
         { status: err.statusCode },


### PR DESCRIPTION
## Summary

Broad cleanup of the ts-rest API error path in `apps/web` plus the Sentry fingerprinting it feeds into. Motivated by the Sentry triage in #10172, #10174, #10364, #10372, #10373, #10375.

- **Route naming**: make `routeName` mandatory on `createHandler` and migrate ~130 call sites under `apps/web/app/api/**` to the convention `<area>.<resource>[.<sub>][.<op|byId>]`. Multi-op handlers (e.g. chat-threads) now emit per-operation names like `zero.chat-threads.create` / `.list` instead of a single ambiguous label.
- **Log severity**: 4xx `ApiError` now logs at `warn` in `createSafeErrorHandler`; 5xx stays at `error`. Stops expected business states (not-found, org-not-selected) from polluting oncall alerts.
- **Malformed JSON bodies**: ts-rest-serverless's `evaluateContent` middleware surfaces undici JSON.parse SyntaxErrors as 5xx. Handler now classifies JSON-parse SyntaxError as 400 `BAD_REQUEST`, logs at warn, and skips Sentry.
- **Sentry grouping for platform ApiError**: `accept()` drops an `api-category` breadcrumb; `beforeSend` drops 4xx events entirely and sets `fingerprint: ["api-error", status, code]` + `api.status`/`api.code` tags for 5xx. Groups by error type rather than by the generic `accept.ts` frame.
- **Stop the self-echo**: `/api/zero/report-error` (the client error sink) now uses a silent handler variant that skips `Sentry.captureException`. Server logs still capture failures via Axiom.

Heads up: this **resets the existing Sentry grouping** for errors thrown by `accept()`. Unresolved issues grouped under the old `accept.ts` fingerprint become orphans once deployed.

## Issues closed

- Fixes #10172 (per-operation naming)
- Fixes pattern 3 of #10174 (self-echo)
- Fixes #10364 (malformed JSON → 400)
- Fixes #10372 (Sentry regrouping by status+code)
- Fixes #10373 (mandatory routeName)
- Fixes #10375 (log severity + route identifier)

## Test plan

- [ ] `cd turbo && pnpm turbo run lint`
- [ ] `cd turbo && pnpm check-types`
- [ ] `cd turbo && pnpm -F @vm0/web exec vitest`
- [ ] Manual: hit an API with malformed JSON body, confirm 400 + no Sentry event
- [ ] Manual: trigger a 5xx in `accept()`, confirm Sentry issue groups by `(status, code)` with correct tags
- [ ] Manual: force `/api/zero/report-error` to fail, confirm no Sentry self-echo but Axiom still logs at error