### PR TITLE
refactor(activity): tighten runner-tab types at api + seeder boundaries

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/[id]/runner/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/runner/route.ts
@@ -1,5 +1,5 @@
 import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
-import { zeroRunRunnerContract, type SandboxReuseResult } from "@vm0/core";
+import { zeroRunRunnerContract, sandboxReuseResultSchema } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -42,12 +42,17 @@ const router = tsr.router(zeroRunRunnerContract, {
       };
     }
 
+    // Validate the DB value at the API boundary instead of blind-casting —
+    // if the runner ever writes an enum value the zod schema doesn't know
+    // about, we want to fail fast here (500) rather than crash the UI on a
+    // missing `SANDBOX_REUSE_LABELS[...]` lookup.
+    const sandboxReuseResult = sandboxReuseResultSchema
+      .nullable()
+      .parse(row.sandboxReuseResult ?? null);
+
     return {
       status: 200 as const,
-      body: {
-        sandboxReuseResult: (row.sandboxReuseResult ??
-          null) as SandboxReuseResult | null,
-      },
+      body: { sandboxReuseResult },
     };
   },
 });

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -1,4 +1,5 @@
 import { and, eq, or } from "drizzle-orm";
+import type { SandboxReuseResult } from "@vm0/core";
 import { agentRuns } from "../../db/schema/agent-run";
 import { agentSessions } from "../../db/schema/agent-session";
 import { zeroRuns } from "../../db/schema/zero-run";
@@ -470,7 +471,7 @@ export async function setTestRunSelectedModel(
  */
 export async function setTestRunSandboxReuseResult(
   runId: string,
-  sandboxReuseResult: string,
+  sandboxReuseResult: SandboxReuseResult,
 ): Promise<void> {
   initServices();
   await globalThis.services.db


### PR DESCRIPTION
## Summary
Follow-up to #10385 addressing the P1 findings from [its review](https://github.com/vm0-ai/vm0/pull/10385#issuecomment-4286142554).

- **Route** (`turbo/apps/web/app/api/zero/runs/[id]/runner/route.ts`): replace the blind \`as SandboxReuseResult | null\` cast with \`sandboxReuseResultSchema.nullable().parse(...)\`. Unknown DB enum values now 500 at the API edge (caught in logs) instead of rendering as \`undefined\` inside \`SANDBOX_REUSE_LABELS[reuse]\` on the UI.
- **Seeder** (\`setTestRunSandboxReuseResult\` in \`db-test-seeders/runs.ts\`): tighten the parameter from \`string\` to \`SandboxReuseResult\` so tests can't seed bogus enum values.

## Not addressed (P2 with rationale)
- **Colocate \`SANDBOX_REUSE_LABELS\` into \`packages/core/src/contracts/webhooks.ts\`** — \`contracts/\` is the API-schema layer; UI copy strings don't belong there, that would be a layering violation. Labels stay in the view file.
- **Split \`loading\` vs \`hasError\` branches in \`ActivityRunnerTab\`** — both currently show the same skeleton placeholder; YAGNI. Can revisit if error UX matters in practice.
- **Add 403 capability test** — route only requires \`agent-run:read\`, which every authenticated user has, so the 403 branch isn't reachable from the current auth graph.

## Test plan
- [x] \`pnpm -F web exec vitest run app/api/zero/runs/[id]/runner/__tests__/route.test.ts\` — 5/5 passing
- [x] \`pnpm -F web check-types\` — clean
- [x] \`pnpm -F web exec eslint ...\` on changed files — clean
- [ ] Manual spot check: hit \`/api/zero/runs/:id/runner\` for an existing run, confirm 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)