### PR TITLE
fix(slack): redirect direct install to /settings/slack for org claim

### DIFF
--- a/turbo/apps/web/app/api/zero/slack/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/oauth/callback/__tests__/route.test.ts
@@ -174,6 +174,7 @@ describe("/api/zero/slack/oauth/callback", () => {
     mockOAuthSuccess({
       teamId: workspaceId,
       teamName: "Slack Workspace",
+      authedUserId: "U-slack-installer",
     });
 
     const request = createTestRequest(
@@ -181,11 +182,13 @@ describe("/api/zero/slack/oauth/callback", () => {
     );
     const response = await GET(request);
 
-    // Should redirect to installed page
+    // Should redirect to /settings/slack with w+u so the user can claim
+    // the orphan installation via the connect flow after sign-in.
     expect(response.status).toBe(307);
     const location = response.headers.get("Location");
-    expect(location).toContain("/slack/installed");
-    expect(location).toContain("workspace=Slack%20Workspace");
+    expect(location).toContain("/settings/slack");
+    expect(location).toContain(`w=${workspaceId}`);
+    expect(location).toContain("u=U-slack-installer");
 
     // Verify installation was created with null org_id
     const installation = await findTestSlackOrgInstallation(workspaceId);
@@ -233,9 +236,12 @@ describe("/api/zero/slack/oauth/callback", () => {
     );
     const response = await GET(secondRequest);
 
-    // Re-install without state redirects to installed page
+    // Re-install without state redirects to /settings/slack with w+u context.
     expect(response.status).toBe(307);
-    expect(response.headers.get("Location")).toContain("/slack/installed");
+    const location = response.headers.get("Location");
+    expect(location).toContain("/settings/slack");
+    expect(location).toContain(`w=${workspaceId}`);
+    expect(location).toContain("u=U-different");
 
     // Verify bot token updated, org binding preserved
     const installation = await findTestSlackOrgInstallation(workspaceId);

--- a/turbo/apps/web/app/api/zero/slack/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/oauth/callback/route.ts
@@ -275,9 +275,11 @@ async function handleInstallCallback(params: {
     );
   }
 
-  // Slack flow: redirect to success page
+  // Slack flow: redirect to the settings/slack page with workspace + slack user
+  // context so the user (after sign-in) can claim the installation into their org
+  // via the existing connect flow.
   return NextResponse.redirect(
-    `${appUrl}/slack/installed?workspace=${encodeURIComponent(oauthResult.teamName)}`,
+    `${appUrl}/settings/slack?w=${encodeURIComponent(oauthResult.teamId)}&u=${encodeURIComponent(oauthResult.authedUserId)}`,
   );
 }
 


### PR DESCRIPTION
## Summary
- Slack-initiated install callback was redirecting to `/slack/installed?workspace=...`, a dead URL (no page backs it — 404)
- Point the redirect at the existing `/settings/slack?w=<teamId>&u=<authedUserId>` page, which already has a Connect flow + `adminConnect` path that atomically claims an orphan installation (`orgId IS NULL`) into the current user's org
- Non-admins still get a "Connection Failed — ask your org admin" error when they click Connect (existing 403 branch)

## Test plan
- [x] `pnpm -F web exec vitest run app/api/zero/slack/oauth/callback` — 19/19 passing
- [x] `pnpm -F web check-types` — clean
- [x] `pnpm -F web exec eslint app/api/zero/slack/oauth/callback` — clean
- [ ] Manual: install bot from Slack App Directory with no platform state → should land on `/settings/slack?w=&u=`; admin sees Connect button; clicking it binds installation to the active org

🤖 Generated with [Claude Code](https://claude.com/claude-code)