### PR TITLE
chore: ignore db migration directories in prettier

### DIFF
--- a/turbo/.prettierignore
+++ b/turbo/.prettierignore
@@ -10,3 +10,5 @@ CHANGELOG.md
 .source
 Caddyfile
 **/codereviews/**
+apps/web/src/db/migrations/
+apps/web/scripts/migrations/


### PR DESCRIPTION
Add `apps/web/src/db/migrations/` and `apps/web/scripts/migrations/` to `.prettierignore` so auto-generated migration files are not reformatted by prettier.