### PR TITLE
ci(runner): raise drain wait budget from 5s to 10s

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1317,7 +1317,7 @@ jobs:
           # is still active afterward so the EXIT trap dumps journalctl at the
           # right diagnostic boundary (instead of hanging inside systemctl stop).
           wait_for_exit() {
-            local svc=$1 budget=${2:-5}
+            local svc=$1 budget=${2:-10}
             echo "--- Waiting up to ${budget}s for $svc to exit ---"
             for i in $(seq 1 "$budget"); do
               systemctl is-active --quiet "vm0-runner-${svc}" || return 0


### PR DESCRIPTION
## Summary

- Raise default `wait_for_exit` budget in the `runner-upgrade` job from 5s to 10s.

## Why

The upgrade test observed `pr-10406-test-upgrade-a still active after 5s (stuck on drain?)` on #10406 ([run 24706567152](https://github.com/vm0-ai/vm0/actions/runs/24706567152/job/72261444648?pr=10406)). The runner's heartbeat tick is 10s, so the 5s budget gives less than one tick of headroom — a drain that's legitimately progressing but hasn't been observed by the polling check yet will trip the failure. The same test also failed on #10357's own CI (the PR that introduced this check), confirming the cadence is too tight.

Two follow-ups worth doing separately (not in this PR):

1. Investigate whether `service install` should synchronously wait for the SIGUSR1 handler to be installed before returning — otherwise a drain sent immediately after install can race the runner's initialization (factory/mitmproxy boot takes ~9s in CI).
2. Consider decoupling the post-drain exit check from the heartbeat cadence.

## Test plan

- [ ] `runner-upgrade-local` job passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)