### PR TITLE
fix(zero): disallow ScheduleWakeup tool for zero agent runs

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -406,7 +406,7 @@ describe("POST /api/zero/runs", () => {
       );
     });
 
-    it("should inject disallowedTools with cron tools", async () => {
+    it("should inject disallowedTools with cron and schedule-wakeup tools", async () => {
       const response = await postRun({ agentId, prompt: "Hello" });
       expect(response.status).toBe(201);
       const data = await response.json();
@@ -415,7 +415,12 @@ describe("POST /api/zero/runs", () => {
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();
       expect(job!.executionContext.disallowedTools).toEqual(
-        expect.arrayContaining(["CronCreate", "CronList", "CronDelete"]),
+        expect.arrayContaining([
+          "CronCreate",
+          "CronList",
+          "CronDelete",
+          "ScheduleWakeup",
+        ]),
       );
     });
 

--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -51,11 +51,13 @@ function buildAgentIdentityPrompt(identity: AgentIdentity): string {
 /**
  * Tools to disallow for all zero agent runs.
  * - Cron tools: agents use `zero schedule` instead.
+ * - ScheduleWakeup: powers /loop dynamic (self-paced) mode; agents use `zero schedule` instead.
  */
 export const DISALLOWED_TOOLS = [
   "CronCreate",
   "CronList",
   "CronDelete",
+  "ScheduleWakeup",
 ] as const;
 
 /**
@@ -68,7 +70,7 @@ function buildAgentToolsPrompt(): string {
     "You have access to the Zero CLI. Run commands with: `npx -p @vm0/cli zero <command>`",
     "- Discover available commands: `zero --help`.",
     "- Search agent run logs, web chat messages, or external services via connectors: `zero search --help`.",
-    "- Schedule recurring tasks: `zero schedule --help`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
+    "- Schedule recurring tasks: `zero schedule --help`. Do NOT use /loop, cron tools (CronCreate, CronList, CronDelete), or ScheduleWakeup — they are not available.",
     "- Slack messaging, file uploads, and file downloads: `zero slack --help`. Your replies are automatically sent to the originating thread — only use these commands for different channels/threads. Never use SLACK_TOKEN directly — it's a user OAuth token.",
     "- Download a Slack file attachment to local disk: `zero slack download-file -h` for usage and how to read different file types. Use this whenever a Slack message context includes a `[Slack file]` block.",
     "- Download a web-uploaded file to local disk: `zero web download-file -h` for usage and how to read different file types. Use this whenever a web chat message includes a `[Web file]` block.",


### PR DESCRIPTION
## Summary
- `ScheduleWakeup` is the tool that powers `/loop`'s **dynamic (self-paced)** mode. The existing `DISALLOWED_TOOLS` list in `agent-prompt.ts` only blocked the cron tools (`CronCreate` / `CronList` / `CronDelete`), which cover `/loop` **fixed-interval** mode — leaving `ScheduleWakeup` fully callable.
- Zero agents are expected to use `zero schedule` for recurring work, not Claude Code's built-in scheduler. This PR closes the gap.
- Updated the injected Agent Tools prompt to mention `ScheduleWakeup` in the "do not use" list and updated the integration test assertion.

## Considered but not included
- `Monitor` (streams background-process output) is also referenced by `/loop` dynamic mode, but it has legitimate general-purpose uses outside `/loop`. Left out of this PR — happy to add in a follow-up if we decide it should also be blocked.

## Test plan
- [x] `pnpm -F web exec vitest run app/api/zero/runs/__tests__/route.test.ts -t "should inject disallowedTools"` — passes
- [x] `pnpm -F web check-types` — passes
- [x] `pnpm -F web exec oxlint` on changed files — 0 warnings
- [x] `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)