### PR TITLE
fix(platform): opt out of browser translation to prevent react reconciler errors

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <title>Zero</title>
     <meta charset="UTF-8" />
@@ -11,6 +11,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Zero" />
+    <meta name="google" content="notranslate" />
     <meta
       name="theme-color"
       content="#ffffff"

--- a/turbo/apps/platform/src/__tests__/index-html.test.ts
+++ b/turbo/apps/platform/src/__tests__/index-html.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// The platform app is an English-only admin UI. Browser auto-translation
+// (notably Chrome Mobile on zh-TW locales) wraps text nodes in <font>
+// elements, desyncing React 19's fiber tree from the real DOM and producing
+// `removeChild` / `insertBefore` NotFoundError — see #10365. We ship
+// `translate="no"` and `<meta name="google" content="notranslate">` in
+// index.html as the opt-out; this test guards the attributes from being
+// accidentally removed.
+describe("platform index.html translation opt-out", () => {
+  const html = readFileSync(resolve(__dirname, "../../index.html"), "utf8");
+
+  it('sets translate="no" on the <html> element', () => {
+    expect(html).toMatch(/<html[^>]*\btranslate="no"/);
+  });
+
+  it("includes the legacy Google notranslate meta tag", () => {
+    expect(html).toMatch(
+      /<meta[^>]*\bname="google"[^>]*\bcontent="notranslate"/,
+    );
+  });
+});

--- a/turbo/apps/platform/src/__tests__/index-html.test.ts
+++ b/turbo/apps/platform/src/__tests__/index-html.test.ts
@@ -1,6 +1,5 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import indexHtml from "../../index.html?raw";
 
 // The platform app is an English-only admin UI. Browser auto-translation
 // (notably Chrome Mobile on zh-TW locales) wraps text nodes in <font>
@@ -10,14 +9,12 @@ import { describe, expect, it } from "vitest";
 // index.html as the opt-out; this test guards the attributes from being
 // accidentally removed.
 describe("platform index.html translation opt-out", () => {
-  const html = readFileSync(resolve(__dirname, "../../index.html"), "utf8");
-
   it('sets translate="no" on the <html> element', () => {
-    expect(html).toMatch(/<html[^>]*\btranslate="no"/);
+    expect(indexHtml).toMatch(/<html[^>]*\btranslate="no"/);
   });
 
   it("includes the legacy Google notranslate meta tag", () => {
-    expect(html).toMatch(
+    expect(indexHtml).toMatch(
       /<meta[^>]*\bname="google"[^>]*\bcontent="notranslate"/,
     );
   });

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
@@ -129,8 +129,8 @@ export function CustomConnectorsPanel() {
     <section className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-medium text-muted-foreground">
-          Custom connectors
-          {connectors ? ` (${connectors.length})` : ""}
+          <span>Custom connectors</span>
+          {connectors && <span> ({connectors.length})</span>}
         </h2>
         {isAdmin && (
           <Button size="sm" onClick={openCreate}>

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -258,7 +258,7 @@ function AvailableConnectorCard({
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
-              {connector.helpText ? `: ${connector.helpText}` : ""}
+              {connector.helpText && <span>: {connector.helpText}</span>}
             </>
           ) : (
             (connector.helpText ?? "")


### PR DESCRIPTION
## Summary

- Set `translate=\"no\"` on the platform app's `<html>` element and add `<meta name=\"google\" content=\"notranslate\">`, opting the platform admin UI out of browser translation that wraps text nodes in `<font>` elements and desyncs React 19's fiber tree from the real DOM.
- Wrap two bare-text-as-JSX-child call sites (`zero-connectors-page.tsx` help text, `custom-connectors-panel.tsx` heading) in `<span>` so each text node is owned by an element React controls — defense in depth against password managers, Grammarly, and other DOM-mutating extensions.
- Add an integration test that asserts the `translate=\"no\"` attribute and legacy Google notranslate meta tag remain on `index.html`.

Root cause analysis, trade-offs, and plan are in the issue thread (#10365): research → innovate → plan comments.

## Test plan

- [x] `pnpm format`
- [x] `pnpm turbo run lint --filter=@vm0/app` — clean
- [x] `pnpm -F @vm0/app exec vitest run` — 1887/1887 tests pass (1 unrelated SSL teardown warning in `zero-chat-thread-page-interaction.test.tsx`, pre-existing on main)
- [x] `pnpm knip` — only pre-existing configuration hints, no new issues
- [ ] CI pipeline green

Closes #10365

🤖 Generated with [Claude Code](https://claude.com/claude-code)