### PR TITLE
chore(feature-switch): remove redeem-code switch and roll out to all users

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/redeem-code-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/redeem-code-dialog.test.tsx
@@ -1,10 +1,10 @@
 /**
  * Tests for the redeem-code gift icon and dialog in the agent chat page header.
  *
- * Gated on the `redeemCode` feature switch. When enabled, a gift-icon button
- * (aria-label "Redeem code") appears in the chat page header. Clicking it
- * opens a dialog with an input and a Redeem button that stays disabled until
- * the input has non-whitespace content. Closing the dialog clears the input.
+ * A gift-icon button (aria-label "Redeem code") appears in the chat page
+ * header. Clicking it opens a dialog with an input and a Redeem button that
+ * stays disabled until the input has non-whitespace content. Closing the
+ * dialog clears the input.
  *
  * See: turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
  * See: turbo/apps/platform/src/signals/zero-page/redeem-code-dialog.ts
@@ -13,7 +13,7 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { FeatureSwitchKey, zeroRedemptionCodesRedeemContract } from "@vm0/core";
+import { zeroRedemptionCodesRedeemContract } from "@vm0/core";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { server } from "../../../mocks/server.ts";
@@ -35,23 +35,8 @@ function getButtonByText(label: string): HTMLButtonElement {
 }
 
 describe("redeem-code gift icon visibility (RC-001)", () => {
-  it("does not render the gift icon when redeemCode is off", async () => {
+  it("renders the gift icon in the chat page header", async () => {
     detachedSetupPage({ context, path: CHAT_PATH });
-
-    // Wait for the chat page header to be ready by checking a stable sibling.
-    await waitFor(() => {
-      expect(screen.getByTestId("chat-tagline")).toBeInTheDocument();
-    });
-
-    expect(screen.queryByLabelText("Redeem code")).not.toBeInTheDocument();
-  });
-
-  it("renders the gift icon when redeemCode is on", async () => {
-    detachedSetupPage({
-      context,
-      path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.RedeemCode]: true },
-    });
 
     await waitFor(() => {
       expect(screen.getByLabelText("Redeem code")).toBeInTheDocument();
@@ -62,11 +47,7 @@ describe("redeem-code gift icon visibility (RC-001)", () => {
 describe("redeem-code dialog interaction (RC-002)", () => {
   it("opens the dialog with a disabled Redeem button when gift icon is clicked", async () => {
     const user = userEvent.setup();
-    detachedSetupPage({
-      context,
-      path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.RedeemCode]: true },
-    });
+    detachedSetupPage({ context, path: CHAT_PATH });
 
     const giftButton = await waitFor(() => {
       return screen.getByLabelText("Redeem code");
@@ -85,11 +66,7 @@ describe("redeem-code dialog interaction (RC-002)", () => {
 
   it("enables the Redeem button once non-whitespace input is entered", async () => {
     const user = userEvent.setup();
-    detachedSetupPage({
-      context,
-      path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.RedeemCode]: true },
-    });
+    detachedSetupPage({ context, path: CHAT_PATH });
 
     const giftButton = await waitFor(() => {
       return screen.getByLabelText("Redeem code");
@@ -118,11 +95,7 @@ describe("redeem-code dialog interaction (RC-002)", () => {
       }),
     );
 
-    detachedSetupPage({
-      context,
-      path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.RedeemCode]: true },
-    });
+    detachedSetupPage({ context, path: CHAT_PATH });
 
     const giftButton = await waitFor(() => {
       return screen.getByLabelText("Redeem code");
@@ -156,11 +129,7 @@ describe("redeem-code dialog interaction (RC-002)", () => {
       }),
     );
 
-    detachedSetupPage({
-      context,
-      path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.RedeemCode]: true },
-    });
+    detachedSetupPage({ context, path: CHAT_PATH });
 
     const giftButton = await waitFor(() => {
       return screen.getByLabelText("Redeem code");
@@ -184,11 +153,7 @@ describe("redeem-code dialog interaction (RC-002)", () => {
 
   it("clears the input after closing via Cancel and reopening", async () => {
     const user = userEvent.setup();
-    detachedSetupPage({
-      context,
-      path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.RedeemCode]: true },
-    });
+    detachedSetupPage({ context, path: CHAT_PATH });
 
     const giftButton = await waitFor(() => {
       return screen.getByLabelText("Redeem code");

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -495,8 +495,6 @@ export function AgentChatPage() {
 
   const suggestedPrompts = useGet(suggestedPrompts$);
   const navigate = useSet(detachedNavigateTo$);
-  const features = useLastResolved(featureSwitch$);
-  const redeemCodeEnabled = features?.[FeatureSwitchKey.RedeemCode] ?? false;
   const pageSignal = useGet(pageSignal$);
 
   const handleSend = (text: string) => {
@@ -508,7 +506,7 @@ export function AgentChatPage() {
     <div className="relative flex flex-1 flex-col min-h-0">
       <header className="hidden md:block shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-2">
         <div className="flex justify-end items-center gap-2">
-          {redeemCodeEnabled && <RedeemCodeButton />}
+          <RedeemCodeButton />
           <ChatHeaderAction pageSignal={pageSignal} />
         </div>
       </header>
@@ -659,7 +657,7 @@ export function AgentChatPage() {
           </div>
         </div>
       </main>
-      {redeemCodeEnabled && <RedeemCodeDialog />}
+      <RedeemCodeDialog />
     </div>
   );
 }

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -55,7 +55,6 @@ export enum FeatureSwitchKey {
   ApiKeys = "apiKeys",
   ModelProviderSelection = "modelProviderSelection",
   NanoBananaConnector = "nanoBananaConnector",
-  RedeemCode = "redeemCode",
   UnifyChatThreads = "unifyChatThreads",
   Vm0GlmModel = "vm0GlmModel",
   RedemptionCodes = "redemptionCodes",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -318,13 +318,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: true,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.RedeemCode]: {
-    maintainer: "yuma@vm0.ai",
-    description:
-      "Show redeem-code gift icon and dialog in the agent chat page header",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.NanoBananaConnector]: {
     maintainer: "liangyou@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Delete the `redeemCode` feature switch entirely (enum + registry).
- Render the gift icon and redemption dialog in the agent chat header unconditionally — the feature is now GA for every user.
- Simplify `redeem-code-dialog.test.tsx`: drop the "off" visibility case and remove per-test `featureSwitches` overrides.

## Test plan
- [x] `pnpm turbo run lint` — 0 errors
- [x] `pnpm check-types` — all workspaces pass
- [x] `pnpm format` — no diff
- [x] `pnpm -F @vm0/core exec vitest run` — 841 pass
- [x] `pnpm -F @vm0/app exec vitest run` — 1884 pass (including `redeem-code-dialog.test.tsx`)
- [x] `pnpm knip` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)