### PR TITLE
fix(zero): skip firewalls whose base url vars are unset

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/merge-permissions.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/merge-permissions.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { ExpandedFirewallConfig } from "@vm0/core";
+import { mergePermissions } from "../context/resolve-permissions";
+
+function jiraLikeFirewall(): ExpandedFirewallConfig {
+  return {
+    name: "jira",
+    apis: [
+      {
+        base: "https://${{ vars.JIRA_DOMAIN }}",
+        auth: {
+          headers: { Authorization: "Bearer ${{ secrets.JIRA_API_TOKEN }}" },
+        },
+        permissions: [
+          { name: "issues-read", rules: ["GET /rest/api/3/issue"] },
+        ],
+      },
+    ],
+  };
+}
+
+function githubStaticFirewall(): ExpandedFirewallConfig {
+  return {
+    name: "github",
+    apis: [
+      {
+        base: "https://api.github.com",
+        auth: {
+          headers: { Authorization: "Bearer ${{ secrets.GITHUB_TOKEN }}" },
+        },
+        permissions: [{ name: "repo-read", rules: ["GET /repos"] }],
+      },
+    ],
+  };
+}
+
+describe("mergePermissions", () => {
+  it("drops firewall whose base URL var is unset and removes its networkPolicies entry", () => {
+    const result = mergePermissions(
+      null,
+      [githubStaticFirewall(), jiraLikeFirewall()],
+      undefined,
+      {}, // no vars provided — jira's JIRA_DOMAIN is unset
+    );
+
+    expect(result).toBeDefined();
+    expect(
+      result!.firewalls.map((fw) => {
+        return fw.name;
+      }),
+    ).toEqual(["github"]);
+    // Orphan networkPolicies entry must not leak for dropped firewalls
+    expect(Object.keys(result!.networkPolicies)).toEqual(["github"]);
+  });
+
+  it("returns undefined when all firewalls are dropped", () => {
+    const result = mergePermissions(null, [jiraLikeFirewall()], undefined, {});
+    expect(result).toBeUndefined();
+  });
+
+  it("keeps firewall when its base URL var is provided", () => {
+    const result = mergePermissions(null, [jiraLikeFirewall()], undefined, {
+      JIRA_DOMAIN: "acme.atlassian.net",
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.firewalls).toHaveLength(1);
+    expect(result!.firewalls[0]!.apis[0]!.base).toBe(
+      "https://acme.atlassian.net",
+    );
+    expect(result!.networkPolicies.jira).toBeDefined();
+  });
+});

--- a/turbo/apps/web/src/lib/zero/context/resolve-permissions.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-permissions.ts
@@ -62,10 +62,18 @@ export function mergePermissions(
 
   const allConfigs = [...autoConfigs, ...connectorResults];
   if (allConfigs.length === 0) return undefined;
-  return {
-    firewalls: resolveFirewallBaseUrlVars(allConfigs, vars),
-    networkPolicies,
-  };
+  const firewalls = resolveFirewallBaseUrlVars(allConfigs, vars);
+  const remainingNames = new Set(
+    firewalls.map((fw) => {
+      return fw.name;
+    }),
+  );
+  for (const name of Object.keys(networkPolicies)) {
+    if (!remainingNames.has(name)) {
+      delete networkPolicies[name];
+    }
+  }
+  return { firewalls, networkPolicies };
 }
 
 /** Collect all unique permission names from a firewall's APIs. */

--- a/turbo/apps/web/src/lib/zero/context/resolve-permissions.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-permissions.ts
@@ -5,6 +5,9 @@ import {
   type FirewallPolicies,
   type NetworkPolicies,
 } from "@vm0/core";
+import { logger } from "../../shared/logger";
+
+const log = logger("zero:resolve-permissions");
 
 /**
  * Filter secretConnectorMap by removing keys that are overridden by
@@ -61,19 +64,31 @@ export function mergePermissions(
   }
 
   const allConfigs = [...autoConfigs, ...connectorResults];
-  if (allConfigs.length === 0) return undefined;
   const firewalls = resolveFirewallBaseUrlVars(allConfigs, vars);
+  if (firewalls.length === 0) return undefined;
   const remainingNames = new Set(
     firewalls.map((fw) => {
       return fw.name;
     }),
   );
-  for (const name of Object.keys(networkPolicies)) {
-    if (!remainingNames.has(name)) {
-      delete networkPolicies[name];
-    }
+  const droppedNames = allConfigs
+    .map((fw) => {
+      return fw.name;
+    })
+    .filter((name) => {
+      return !remainingNames.has(name);
+    });
+  if (droppedNames.length > 0) {
+    log.warn("firewall dropped: required vars not set", {
+      names: droppedNames,
+    });
   }
-  return { firewalls, networkPolicies };
+  const cleanedNetworkPolicies = Object.fromEntries(
+    Object.entries(networkPolicies).filter(([name]) => {
+      return remainingNames.has(name);
+    }),
+  );
+  return { firewalls, networkPolicies: cleanedNetworkPolicies };
 }
 
 /** Collect all unique permission names from a firewall's APIs. */

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -968,16 +968,23 @@ describe("resolveFirewallBaseUrlVars", () => {
     expect(result[1]!.apis[0]!.base).toBe("https://acme.zendesk.com");
   });
 
-  it("throws when required variable is missing", () => {
-    expect(() => {
-      return resolveFirewallBaseUrlVars([zendeskFirewall], {});
-    }).toThrow('requires variable "ZENDESK_SUBDOMAIN"');
+  it("drops firewall when required variable is missing", () => {
+    const result = resolveFirewallBaseUrlVars([zendeskFirewall], {});
+    expect(result).toEqual([]);
   });
 
-  it("throws when vars is undefined", () => {
-    expect(() => {
-      return resolveFirewallBaseUrlVars([zendeskFirewall], undefined);
-    }).toThrow('requires variable "ZENDESK_SUBDOMAIN"');
+  it("drops firewall when vars is undefined", () => {
+    const result = resolveFirewallBaseUrlVars([zendeskFirewall], undefined);
+    expect(result).toEqual([]);
+  });
+
+  it("keeps static firewalls when another firewall has missing vars", () => {
+    const result = resolveFirewallBaseUrlVars(
+      [staticFirewall, zendeskFirewall],
+      {},
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe("github");
   });
 
   it("validates resolved URL is well-formed", () => {

--- a/turbo/packages/core/src/contracts/firewalls.ts
+++ b/turbo/packages/core/src/contracts/firewalls.ts
@@ -251,35 +251,47 @@ export function hasBaseUrlVars(base: string): boolean {
 
 /**
  * Resolve `${{ vars.X }}` templates in firewall base URLs.
- * Returns a new array with all base URL templates replaced by actual values.
- * Throws if a referenced variable is not provided.
+ * Firewalls whose base URL references a variable that is not provided are
+ * dropped from the result — a connector may be declared by the agent before
+ * the user has set the required variable (e.g. Jira's `JIRA_DOMAIN`), and
+ * that should not abort the entire run.
  */
 export function resolveFirewallBaseUrlVars(
   firewalls: Firewalls,
   vars: Record<string, string> | undefined,
 ): Firewalls {
-  return firewalls.map((fw) => {
-    return {
-      ...fw,
-      apis: fw.apis.map((api) => {
-        if (!hasBaseUrlVars(api.base)) return api;
-        const resolved = api.base.replace(
-          BASE_URL_VARS_PATTERN_G,
-          (_match, name: string) => {
-            const value = vars?.[name];
-            if (!value) {
-              throw new Error(
-                `Firewall "${fw.name}" base URL requires variable "${name}" but it was not provided`,
-              );
-            }
-            return value;
-          },
-        );
-        validateBaseUrl(resolved, fw.name);
-        return { ...api, base: resolved };
-      }),
-    };
-  });
+  const resolved: Firewalls = [];
+  for (const fw of firewalls) {
+    let skipFirewall = false;
+    const apis: FirewallApi[] = [];
+    for (const api of fw.apis) {
+      if (!hasBaseUrlVars(api.base)) {
+        apis.push(api);
+        continue;
+      }
+      let missing = false;
+      const newBase = api.base.replace(
+        BASE_URL_VARS_PATTERN_G,
+        (_match, name: string) => {
+          const value = vars?.[name];
+          if (!value) {
+            missing = true;
+            return "";
+          }
+          return value;
+        },
+      );
+      if (missing) {
+        skipFirewall = true;
+        break;
+      }
+      validateBaseUrl(newBase, fw.name);
+      apis.push({ ...api, base: newBase });
+    }
+    if (skipFirewall) continue;
+    resolved.push({ ...fw, apis });
+  }
+  return resolved;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes production error `Firewall "jira" base URL requires variable "JIRA_DOMAIN" but it was not provided`. When an agent declares a connector whose firewall base URL templates on a user variable (e.g. Jira's `https://${{ vars.JIRA_DOMAIN }}`), and the user hasn't set that variable yet, the entire run aborts. This is a valid partial-setup state, not a fatal error.
- `resolveFirewallBaseUrlVars` now drops firewalls whose `${{ vars.X }}` references an unset variable instead of throwing. Other firewalls in the same manifest are unaffected.
- `mergePermissions` cleans up the matching `networkPolicies` entry for dropped firewalls so the proxy doesn't see orphan policies.

## Root cause

`build-zero-context.ts:237` injects firewalls from `allowedConnectorTypes` (agent-declared) regardless of whether the user has connected. The connector-inference path (`deriveApiTokenConnectedTypes`) is consistent with variable storage, but firewall injection skips that gate by design (so agents can declare permissions before the user links). `resolveFirewallBaseUrlVars` was the strict choke point that turned a half-set connector into a hard failure.

## Test plan

- [x] `pnpm -F @vm0/core exec vitest run firewall-expander` — 102/102 pass, including new cases: drop when var missing, drop when vars undefined, keep static firewall when sibling is dropped
- [x] `pnpm -F web exec vitest run apply-connector-policies` — 7/7 pass
- [x] `pnpm turbo run lint check-types --filter @vm0/core --filter web` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)