### PR TITLE
test(runner): drop artificial sleeps from signal-buffering regression test

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1908,6 +1908,11 @@ mod tests {
     /// inside the spawned task, so signals delivered during the startup
     /// window hit the default Term disposition and killed the process.
     ///
+    /// Timing: raising SIGUSR1 before `spawn()` is deterministic in program
+    /// order, and the outer `timeout(2s)` absorbs the
+    /// `kernel → sigaction → pipe → driver → watch → recv` propagation
+    /// regardless of scheduling — no artificial sleep is needed.
+    ///
     /// This test raises SIGUSR1 process-wide. It is safe only because no
     /// other test subscribes to SIGUSR1 — all other tests use
     /// `SignalSource::Override` and never call `signal()`. If another
@@ -1917,15 +1922,7 @@ mod tests {
     async fn signal_buffered_before_spawn_is_delivered() {
         let signals = EarlySignals::register().expect("register");
 
-        // Simulate startup work between registration and spawn — the
-        // window that used to lose signals under the old design.
-        tokio::time::sleep(Duration::from_millis(30)).await;
-
         nix::sys::signal::raise(nix::sys::signal::Signal::SIGUSR1).expect("raise");
-
-        // Let the sigaction handler + tokio signal driver propagate
-        // before the consumer task starts.
-        tokio::time::sleep(Duration::from_millis(30)).await;
 
         let controller = SignalController::spawn(
             CancellationToken::new(),


### PR DESCRIPTION
## Summary

Remove the two `tokio::time::sleep(Duration::from_millis(30))` calls from the `signal_buffered_before_spawn_is_delivered` regression test added in #10419.

## Why

The sleeps were added defensively during the original PR. On review they turn out to be unnecessary:

- **First sleep** ("simulate startup work between `register` and `spawn`") — program order already guarantees `raise(SIGUSR1)` runs before `SignalController::spawn`. No wall-clock delay is needed to model the window.
- **Second sleep** ("let the driver propagate") — the outer `tokio::time::timeout(Duration::from_secs(2), mode_rx.changed())` already absorbs the full `kernel → sigaction → pipe → driver → watch → recv` chain regardless of whether the signal is delivered before or after the consumer task starts polling.

Removing them:

- Trims ~60 ms of wall-clock waiting per invocation to effectively zero (verified: the test now finishes in `0.00s` across 5 consecutive runs).
- Eliminates the only timing dependency reviewers flagged as a potential flake risk on loaded CI runners — the PR #10419 code review called out exactly these two sleeps as the one `#P2` observation worth watching.

Also adds an inline comment documenting why no sleep is needed, so a future contributor doesn't re-introduce them by reflex.

## Test plan

- [x] `cargo clippy -p runner --all-targets` — no warnings
- [x] `cargo test -p runner --bin runner signal_buffered_before_spawn_is_delivered` — ok, 5× in a row
- [x] `cargo test -p runner --bin runner` — 708 passed, 0 failed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)