### PR TITLE
refactor(platform): split voice-chat-candidate-session.ts large commands

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -825,8 +825,9 @@ const resetVccSessionState$ = command(
 );
 
 const resolveVccAgentId$ = command(
-  async ({ get, set }): Promise<string | null> => {
+  async ({ get, set }, signal: AbortSignal): Promise<string | null> => {
     const agentId = await get(defaultAgentId$);
+    signal.throwIfAborted();
     if (!agentId) {
       set(internalError$, "No agent selected");
       set(internalStatus$, "error");
@@ -914,20 +915,23 @@ interface BootstrapVccTransportArgs {
   token: string;
   sessionId: string;
   sessionSignal: AbortSignal;
-  outerSignal: AbortSignal;
 }
 
 const bootstrapVccTransport$ = command(
-  async ({ set }, args: BootstrapVccTransportArgs): Promise<void> => {
-    const { stream, token, sessionId, sessionSignal, outerSignal } = args;
+  async (
+    { set },
+    args: BootstrapVccTransportArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const { stream, token, sessionId, sessionSignal } = args;
     const ok = await set(setupWebRTC$, stream, token, sessionSignal);
-    outerSignal.throwIfAborted();
+    signal.throwIfAborted();
     if (!ok) {
       return;
     }
 
     await set(acquireWakeLock$, sessionSignal);
-    outerSignal.throwIfAborted();
+    signal.throwIfAborted();
 
     await Promise.allSettled([
       set(startHeartbeat$, sessionSignal),
@@ -949,8 +953,7 @@ export const startVoiceChatCandidate$ = command(
 
     const sessionSignal = set(resetVccSessionState$, signal);
 
-    const agentId = await set(resolveVccAgentId$);
-    signal.throwIfAborted();
+    const agentId = await set(resolveVccAgentId$, signal);
     if (!agentId) {
       return;
     }
@@ -970,13 +973,11 @@ export const startVoiceChatCandidate$ = command(
       return;
     }
 
-    await set(bootstrapVccTransport$, {
-      stream,
-      token,
-      sessionId: session.id,
-      sessionSignal,
-      outerSignal: signal,
-    });
+    await set(
+      bootstrapVccTransport$,
+      { stream, token, sessionId: session.id, sessionSignal },
+      signal,
+    );
   },
 );
 

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -1,5 +1,3 @@
-// TODO(#10334): split large commands to comply with max-lines-per-function (128)
-// oxlint-disable max-lines-per-function
 import { command, computed, state } from "ccstate";
 import {
   FeatureSwitchKey,
@@ -610,7 +608,7 @@ const negotiateSdp$ = command(
 );
 
 const setupWebRTC$ = command(
-  async (
+  (
     { set },
     stream: MediaStream,
     token: string,
@@ -911,15 +909,17 @@ const acquireVccMic$ = command(
   },
 );
 
+interface BootstrapVccTransportArgs {
+  stream: MediaStream;
+  token: string;
+  sessionId: string;
+  sessionSignal: AbortSignal;
+  outerSignal: AbortSignal;
+}
+
 const bootstrapVccTransport$ = command(
-  async (
-    { set },
-    stream: MediaStream,
-    token: string,
-    sessionId: string,
-    sessionSignal: AbortSignal,
-    outerSignal: AbortSignal,
-  ): Promise<void> => {
+  async ({ set }, args: BootstrapVccTransportArgs): Promise<void> => {
+    const { stream, token, sessionId, sessionSignal, outerSignal } = args;
     const ok = await set(setupWebRTC$, stream, token, sessionSignal);
     outerSignal.throwIfAborted();
     if (!ok) {
@@ -970,14 +970,13 @@ export const startVoiceChatCandidate$ = command(
       return;
     }
 
-    await set(
-      bootstrapVccTransport$,
+    await set(bootstrapVccTransport$, {
       stream,
       token,
-      session.id,
+      sessionId: session.id,
       sessionSignal,
-      signal,
-    );
+      outerSignal: signal,
+    });
   },
 );
 

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -6,6 +6,7 @@ import {
   zeroVoiceChatCandidateContract,
   type VoiceChatCandidateItem,
   type VoiceChatCandidateItemRole,
+  type VoiceChatCandidateSession,
   type VoiceChatCandidateTask,
 } from "@vm0/core";
 import { featureSwitch$ } from "../external/feature-switch.ts";
@@ -803,16 +804,11 @@ const releaseWakeLock$ = command(({ get, set }) => {
 });
 
 // ---------------------------------------------------------------------------
-// Public commands
+// Start-flow phase commands
 // ---------------------------------------------------------------------------
 
-export const startVoiceChatCandidate$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const status = get(internalStatus$);
-    if (status === "connecting" || status === "connected") {
-      return;
-    }
-
+const resetVccSessionState$ = command(
+  ({ set }, signal: AbortSignal): AbortSignal => {
     set(internalStatus$, "connecting");
     set(internalError$, null);
     set(internalItems$, []);
@@ -826,54 +822,70 @@ export const startVoiceChatCandidate$ = command(
     set(internalMuted$, false);
     set(internalSessionId$, null);
     set(internalParentSignal$, signal);
+    return set(resetSessionSignal$, signal);
+  },
+);
 
-    const sessionSignal = set(resetSessionSignal$, signal);
-
+const resolveVccAgentId$ = command(
+  async ({ get, set }): Promise<string | null> => {
     const agentId = await get(defaultAgentId$);
-    signal.throwIfAborted();
-
     if (!agentId) {
       set(internalError$, "No agent selected");
       set(internalStatus$, "error");
-      return;
+      return null;
     }
+    return agentId;
+  },
+);
 
+const createVccSession$ = command(
+  async (
+    { get, set },
+    agentId: string,
+    signal: AbortSignal,
+  ): Promise<VoiceChatCandidateSession | null> => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroVoiceChatCandidateContract);
-
-    const sessionRes = await accept(
+    const res = await accept(
       client.createSession({ body: { agentId } }),
       [200, 400, 401, 403],
       { toast: false },
     );
     signal.throwIfAborted();
-
-    if (sessionRes.status !== 200) {
-      set(internalError$, sessionRes.body.error.message);
+    if (res.status !== 200) {
+      set(internalError$, res.body.error.message);
       set(internalStatus$, "error");
-      return;
+      return null;
     }
-
-    const session = sessionRes.body.session;
+    const session = res.body.session;
     set(internalSessionId$, session.id);
     set(internalContext$, session.context ?? "");
     set(internalContextVersion$, session.contextVersion);
+    return session;
+  },
+);
 
-    const tokenRes = await accept(
+const fetchVccRealtimeToken$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<string | null> => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroVoiceChatCandidateContract);
+    const res = await accept(
       client.token({ body: { model: TALKER_MODEL } }),
       [200, 401, 403, 500, 503],
       { toast: false },
     );
     signal.throwIfAborted();
-
-    if (tokenRes.status !== 200) {
-      set(internalError$, tokenRes.body.error.message);
+    if (res.status !== 200) {
+      set(internalError$, res.body.error.message);
       set(internalStatus$, "error");
-      return;
+      return null;
     }
+    return res.body.client_secret.value;
+  },
+);
 
-    const { client_secret: clientSecret } = tokenRes.body;
-
+const acquireVccMic$ = command(
+  async ({ set }, signal: AbortSignal): Promise<MediaStream | null> => {
     let stream: MediaStream;
     // eslint-disable-next-line no-restricted-syntax -- getUserMedia can reject on permission denial or missing hardware
     try {
@@ -891,29 +903,81 @@ export const startVoiceChatCandidate$ = command(
         "Microphone access denied. Please allow microphone access.",
       );
       set(internalStatus$, "error");
-      return;
+      return null;
     }
     signal.throwIfAborted();
     set(internalStream$, stream);
+    return stream;
+  },
+);
 
-    const ok = await set(
-      setupWebRTC$,
-      stream,
-      clientSecret.value,
-      sessionSignal,
-    );
-    signal.throwIfAborted();
+const bootstrapVccTransport$ = command(
+  async (
+    { set },
+    stream: MediaStream,
+    token: string,
+    sessionId: string,
+    sessionSignal: AbortSignal,
+    outerSignal: AbortSignal,
+  ): Promise<void> => {
+    const ok = await set(setupWebRTC$, stream, token, sessionSignal);
+    outerSignal.throwIfAborted();
     if (!ok) {
       return;
     }
 
     await set(acquireWakeLock$, sessionSignal);
-    signal.throwIfAborted();
+    outerSignal.throwIfAborted();
 
     await Promise.allSettled([
       set(startHeartbeat$, sessionSignal),
-      set(startAblyLoop$, session.id, sessionSignal),
+      set(startAblyLoop$, sessionId, sessionSignal),
     ]);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Public commands
+// ---------------------------------------------------------------------------
+
+export const startVoiceChatCandidate$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const status = get(internalStatus$);
+    if (status === "connecting" || status === "connected") {
+      return;
+    }
+
+    const sessionSignal = set(resetVccSessionState$, signal);
+
+    const agentId = await set(resolveVccAgentId$);
+    signal.throwIfAborted();
+    if (!agentId) {
+      return;
+    }
+
+    const session = await set(createVccSession$, agentId, signal);
+    if (!session) {
+      return;
+    }
+
+    const token = await set(fetchVccRealtimeToken$, signal);
+    if (!token) {
+      return;
+    }
+
+    const stream = await set(acquireVccMic$, signal);
+    if (!stream) {
+      return;
+    }
+
+    await set(
+      bootstrapVccTransport$,
+      stream,
+      token,
+      session.id,
+      sessionSignal,
+      signal,
+    );
   },
 );
 

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -496,13 +496,22 @@ const handleDCMessage$ = command(
 // WebRTC setup
 // ---------------------------------------------------------------------------
 
-const setupWebRTC$ = command(
-  async (
-    { get, set },
-    stream: MediaStream,
-    token: string,
-    signal: AbortSignal,
-  ): Promise<boolean> => {
+function buildSessionUpdate(context: string): string {
+  return JSON.stringify({
+    type: "session.update",
+    session: {
+      modalities: ["text", "audio"],
+      instructions: composeInstructions(context),
+      input_audio_transcription: { model: "gpt-4o-mini-transcribe" },
+      input_audio_noise_reduction: { type: "far_field" },
+      turn_detection: HANDS_FREE_VAD_CONFIG,
+      tools: SESSION_TOOLS,
+    },
+  });
+}
+
+const createVccPeerConnection$ = command(
+  ({ set }, stream: MediaStream): RTCPeerConnection => {
     const pc = new RTCPeerConnection();
     set(internalPc$, pc);
 
@@ -520,31 +529,24 @@ const setupWebRTC$ = command(
       }
     });
 
+    return pc;
+  },
+);
+
+const attachVccDataChannel$ = command(
+  ({ get, set }, pc: RTCPeerConnection, sessionSignal: AbortSignal) => {
     const dc = pc.createDataChannel("oai-events");
     set(internalDc$, dc);
 
     dc.addEventListener("open", () => {
-      const context = get(internalContext$);
-      dc.send(
-        JSON.stringify({
-          type: "session.update",
-          session: {
-            modalities: ["text", "audio"],
-            instructions: composeInstructions(context),
-            input_audio_transcription: { model: "gpt-4o-mini-transcribe" },
-            input_audio_noise_reduction: { type: "far_field" },
-            turn_detection: HANDS_FREE_VAD_CONFIG,
-            tools: SESSION_TOOLS,
-          },
-        }),
-      );
+      dc.send(buildSessionUpdate(get(internalContext$)));
       set(internalStatus$, "connected");
     });
 
     dc.addEventListener(
       "message",
       onDomEventFn((ev: MessageEvent) => {
-        return set(handleDCMessage$, ev.data as string, signal);
+        return set(handleDCMessage$, ev.data as string, sessionSignal);
       }),
     );
 
@@ -564,7 +566,16 @@ const setupWebRTC$ = command(
         }
       }
     });
+  },
+);
 
+const negotiateSdp$ = command(
+  async (
+    { set },
+    pc: RTCPeerConnection,
+    token: string,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
     const offer = await pc.createOffer();
     signal.throwIfAborted();
     await pc.setLocalDescription(offer);
@@ -594,6 +605,19 @@ const setupWebRTC$ = command(
     await pc.setRemoteDescription({ type: "answer", sdp: answerSdp });
     signal.throwIfAborted();
     return true;
+  },
+);
+
+const setupWebRTC$ = command(
+  async (
+    { set },
+    stream: MediaStream,
+    token: string,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const pc = set(createVccPeerConnection$, stream);
+    set(attachVccDataChannel$, pc, signal);
+    return set(negotiateSdp$, pc, token, signal);
   },
 );
 


### PR DESCRIPTION
## Summary

- Split `setupWebRTC$` into three phase commands (`createVccPeerConnection$`, `attachVccDataChannel$`, `negotiateSdp$`) and a pure `buildSessionUpdate` helper.
- Split `startVoiceChatCandidate$` into six phase commands (`resetVccSessionState$`, `resolveVccAgentId$`, `createVccSession$`, `fetchVccRealtimeToken$`, `acquireVccMic$`, `bootstrapVccTransport$`); the public command is now a linear 22-line orchestrator.
- Remove the file-wide `// oxlint-disable max-lines-per-function` and the tracking TODO.

Closes #10334. Part of epic #10297. Follow-up to PR #10332 which introduced the suppression.

Public API is unchanged — `startVoiceChatCandidate$`, `endVoiceChatCandidate$`, `toggleVoiceChatCandidateMute$`, and every `vcc*$` getter keep their current signatures. `handleDCMessage$` (the switch that the issue called `handleServerEvent$`) was already a thin per-event dispatcher and is left alone; `endVoiceChatCandidate$` is 57 non-blank lines, also left alone.

Empirical note: removing the disable on `main` found 0 rule violations. Several commands were close to the 128-line cap and would have tripped it on the next Epic #10297 addition — this PR gives them headroom.

## Not covered by this refactor (pre-existing gaps, unchanged)

- `acquireVccMic$` getUserMedia rejection path
- `negotiateSdp$` non-OK SDP response
- Ably poll path transitioning to `disconnected` when server reports `status !== "active"`

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/signals/voice-chat-candidate` — 11/11 pass (unchanged test file)
- [x] `pnpm -F @vm0/app exec vitest run` — full platform suite pass
- [x] `pnpm turbo run lint --filter=@vm0/app` — 0 errors
- [x] `pnpm check-types` — all workspaces pass
- [x] `pnpm knip --cache` — no issues
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)