### PR TITLE
perf(platform): reduce activity log poll interval from 10s to 3s

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -269,7 +269,7 @@ export const setupActivityLogLoop$ = command(
         set(autoScrollActivityDetail$);
         return finished;
       },
-      10_000,
+      3_000,
       signal,
     );
   },

--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -269,7 +269,7 @@ export const setupActivityLogLoop$ = command(
         set(autoScrollActivityDetail$);
         return finished;
       },
-      3_000,
+      3000,
       signal,
     );
   },


### PR DESCRIPTION
## Summary

Reduce the activity log polling interval in `setupActivityLogLoop$` from 10 seconds to 3 seconds so the activity detail view picks up run updates and new events more responsively.

## Changes

- `turbo/apps/platform/src/signals/activity-page/activity-signals.ts`: change `setLoop` interval from `10_000` to `3_000` ms.