### PR TITLE
feat(runner): emit sandbox_reuse_hit/miss telemetry on every job

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1152,6 +1152,7 @@ fn spawn_job(
                     sandbox_id,
                     &exec_config,
                     &params,
+                    reuse_result,
                     cancel,
                 )
                 .await

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -23,7 +23,10 @@ use crate::kmsg_log;
 use crate::paths::{LogPaths, guest};
 use crate::proxy::{self, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
-use crate::types::{ArtifactEntry, ExecutionContext, ResumeSession, StorageEntry, StorageManifest};
+use crate::types::{
+    ArtifactEntry, ExecutionContext, ResumeSession, SandboxReuseResult, StorageEntry,
+    StorageManifest,
+};
 
 /// Shared configuration for all executions (profile-independent).
 pub struct ExecutorConfig {
@@ -69,12 +72,14 @@ pub async fn execute_job(
     sandbox_id: SandboxId,
     config: &ExecutorConfig,
     params: &JobParams,
+    reuse_result: SandboxReuseResult,
     cancel: CancellationToken,
 ) -> (ExecuteOutcome, JobTelemetry) {
     let run_id = context.run_id;
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
 
+    record_reuse_result(&mut telemetry, reuse_result);
     record_api_latency("api_to_vm_start", &context, &mut telemetry);
 
     let outcome = match execute_new_sandbox(
@@ -122,8 +127,8 @@ pub async fn execute_job_reuse(
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
 
+    record_reuse_result(&mut telemetry, SandboxReuseResult::Reused);
     record_api_latency("api_to_vm_start", &context, &mut telemetry);
-    telemetry.record("vm_reuse", Duration::ZERO, true, None);
 
     let source_ip = idle_entry.source_ip.clone();
     let prev_storage = idle_entry.storage_fingerprints;
@@ -144,6 +149,26 @@ pub async fn execute_job_reuse(
 
     info!(run_id = %run_id, exit_code = outcome.exit_code, reused = true, "job finished");
     (outcome, telemetry)
+}
+
+/// Emit a single telemetry event capturing the outcome of the reuse decision.
+/// `Reused` emits `sandbox_reuse_hit`; every miss variant (including
+/// `FeatureDisabled`) emits `sandbox_reuse_miss`. Firing on every job makes
+/// the reuse success rate queryable in Axiom as
+/// `countif(op_type == "sandbox_reuse_hit") / countif(op_type startswith "sandbox_reuse_")`.
+/// Miss-reason breakdown lives on the `agent_runs.sandbox_reuse_result`
+/// column in Postgres, so it's not duplicated here. Duration is zero — this
+/// is a marker, not a timing.
+fn record_reuse_result(telemetry: &mut JobTelemetry, result: SandboxReuseResult) {
+    let action_type = match result {
+        SandboxReuseResult::Reused => "sandbox_reuse_hit",
+        SandboxReuseResult::FeatureDisabled
+        | SandboxReuseResult::NoSessionId
+        | SandboxReuseResult::PoolMiss
+        | SandboxReuseResult::ProfileMismatch
+        | SandboxReuseResult::UnparkFailed => "sandbox_reuse_miss",
+    };
+    telemetry.record(action_type, Duration::ZERO, true, None);
 }
 
 fn record_api_latency(action_type: &str, context: &ExecutionContext, telemetry: &mut JobTelemetry) {
@@ -2418,6 +2443,7 @@ mod tests {
             SandboxId::new_v4(),
             &config,
             &default_params(),
+            SandboxReuseResult::NoSessionId,
             cancel,
         )
         .await;
@@ -2441,6 +2467,7 @@ mod tests {
             SandboxId::new_v4(),
             &config,
             &default_params(),
+            SandboxReuseResult::NoSessionId,
             cancel,
         )
         .await;
@@ -2468,6 +2495,7 @@ mod tests {
             SandboxId::new_v4(),
             &config,
             &default_params(),
+            SandboxReuseResult::NoSessionId,
             cancel,
         )
         .await;
@@ -2522,6 +2550,7 @@ mod tests {
             SandboxId::new_v4(),
             &config,
             &default_params(),
+            SandboxReuseResult::NoSessionId,
             cancel,
         )
         .await;
@@ -2579,6 +2608,7 @@ mod tests {
             SandboxId::new_v4(),
             &config,
             &default_params(),
+            SandboxReuseResult::NoSessionId,
             cancel,
         )
         .await;
@@ -2798,6 +2828,7 @@ mod tests {
             SandboxId::new_v4(),
             &config,
             &default_params(),
+            SandboxReuseResult::NoSessionId,
             cancel,
         )
         .await;
@@ -3124,5 +3155,118 @@ mod tests {
         let result = filter_unchanged_storages(&manifest, &prev);
         assert!(result.storages[0].cached);
         assert!(result.storages[0].archive_url.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Reuse-outcome telemetry (issue #10360: sandbox reuse success rate)
+    // -----------------------------------------------------------------------
+
+    fn new_telemetry() -> JobTelemetry {
+        let http = HttpClient::new("http://localhost".to_string()).unwrap();
+        JobTelemetry::new(http, RunId::nil(), "tok".to_string())
+    }
+
+    #[test]
+    fn record_reuse_result_emits_hit_for_reuse() {
+        let mut telemetry = new_telemetry();
+        record_reuse_result(&mut telemetry, SandboxReuseResult::Reused);
+        let ops = telemetry.pending_ops_snapshot();
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].0, "sandbox_reuse_hit");
+    }
+
+    #[test]
+    fn record_reuse_result_emits_miss_for_every_miss_variant() {
+        let variants = [
+            SandboxReuseResult::FeatureDisabled,
+            SandboxReuseResult::NoSessionId,
+            SandboxReuseResult::PoolMiss,
+            SandboxReuseResult::ProfileMismatch,
+            SandboxReuseResult::UnparkFailed,
+        ];
+        for variant in variants {
+            let mut telemetry = new_telemetry();
+            record_reuse_result(&mut telemetry, variant);
+            let ops = telemetry.pending_ops_snapshot();
+            assert_eq!(ops.len(), 1, "{variant:?}");
+            assert_eq!(ops[0].0, "sandbox_reuse_miss", "{variant:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_job_records_sandbox_reuse_miss_in_telemetry() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory::new();
+        factory.startup().await.unwrap();
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (_outcome, telemetry) = execute_job(
+            &factory,
+            minimal_context(),
+            SandboxId::new_v4(),
+            &config,
+            &default_params(),
+            SandboxReuseResult::PoolMiss,
+            cancel,
+        )
+        .await;
+
+        let ops = telemetry.pending_ops_snapshot();
+        let reuse_events: Vec<_> = ops
+            .iter()
+            .filter(|op| op.0.starts_with("sandbox_reuse_"))
+            .collect();
+        assert_eq!(reuse_events.len(), 1);
+        assert_eq!(reuse_events[0].0, "sandbox_reuse_miss");
+    }
+
+    #[tokio::test]
+    async fn execute_job_reuse_records_sandbox_reuse_hit_in_telemetry() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory::new();
+        factory.startup().await.unwrap();
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (outcome, _telemetry) = execute_job(
+            &factory,
+            minimal_context(),
+            SandboxId::new_v4(),
+            &config,
+            &default_params(),
+            SandboxReuseResult::NoSessionId,
+            cancel,
+        )
+        .await;
+        let sandbox = outcome.sandbox.expect("sandbox should be alive");
+
+        let idle_entry = crate::idle_pool::IdleEntry {
+            sandbox,
+            factory: std::sync::Arc::new(
+                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+            ),
+            session_id: "test-session".into(),
+            sandbox_id: SandboxId::new_v4(),
+            profile_name: "vm0/default".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+            source_ip: outcome.source_ip,
+            parked_at: std::time::Instant::now(),
+            idle_timeout: std::time::Duration::from_secs(300),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        };
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (_outcome, telemetry) =
+            execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
+
+        let ops = telemetry.pending_ops_snapshot();
+        let reuse_events: Vec<_> = ops
+            .iter()
+            .filter(|op| op.0.starts_with("sandbox_reuse_"))
+            .collect();
+        assert_eq!(reuse_events.len(), 1);
+        assert_eq!(reuse_events[0].0, "sandbox_reuse_hit");
     }
 }

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -92,6 +92,16 @@ impl JobTelemetry {
         send_telemetry(&self.http, self.run_id, &self.sandbox_token, ops).await;
     }
 
+    /// Snapshot of buffered ops for tests. Returns `(action_type, success, error)`
+    /// tuples in insertion order.
+    #[cfg(test)]
+    pub(crate) fn pending_ops_snapshot(&self) -> Vec<(String, bool, Option<String>)> {
+        self.pending_ops
+            .iter()
+            .map(|op| (op.action_type.clone(), op.success, op.error.clone()))
+            .collect()
+    }
+
     /// Spawn a fire-and-forget flush for auto-threshold flushes.
     fn fire_and_forget_flush(&mut self) {
         let ops = std::mem::take(&mut self.pending_ops);


### PR DESCRIPTION
## Summary

- Record a reuse-decision telemetry event on **every** job. `Reused` emits `op_type: "sandbox_reuse_hit"`; every miss variant (`featureDisabled` / `noSessionId` / `poolMiss` / `profileMismatch` / `unparkFailed`) emits `op_type: "sandbox_reuse_miss"`.
- Threads the already-computed `SandboxReuseResult` from `cmd/start.rs` into `execute_job` so both new-VM and reuse paths emit through one shared helper; old inline `vm_reuse` record in `execute_job_reuse` now goes through the same helper.
- Renames the existing `vm_reuse` action_type to the symmetric `sandbox_reuse_hit` (sole in-tree occurrence; grep confirms no other callers).

## Why

Closes #10360. The reuse decision was already structurally captured (6-variant `SandboxReuseResult` enum, persisted to `agent_runs.sandbox_reuse_result`), and `vm_reuse` fired to Axiom via the telemetry webhook — but **only on the success path**, so the denominator for a reuse-success-rate metric was missing.

The existing `/api/webhooks/agent/telemetry` → `ingestSandboxOpLog` pipeline only preserves the `op_type` field end-to-end (`success` and `error` are both dropped server-side before reaching Axiom — see `turbo/apps/web/src/lib/infra/metrics/instruments.ts:19-33`). So the decision is encoded directly into `op_type`: zero server-side changes, and miss-reason breakdown stays on the Postgres `sandbox_reuse_result` column where it already lives.

## APL

```kusto
// Reuse success rate over time
| where op_type startswith "sandbox_reuse_"
| summarize total=count(), hit=countif(op_type == "sandbox_reuse_hit") by bin(_time, 1h)
| extend rate = todouble(hit) / total
```

## Test plan

- [x] `cargo test --bin runner` (715 passed, 0 failed)
- [x] `cargo clippy -p runner --all-targets -- -D warnings` clean
- [x] `cargo fmt -p runner --check` clean
- [x] New tests:
  - `record_reuse_result_emits_hit_for_reuse` — pure-function: `Reused` → `sandbox_reuse_hit`
  - `record_reuse_result_emits_miss_for_every_miss_variant` — table-driven across all 5 miss variants
  - `execute_job_records_sandbox_reuse_miss_in_telemetry` — end-to-end miss path through `execute_job`
  - `execute_job_reuse_records_sandbox_reuse_hit_in_telemetry` — end-to-end hit path through `execute_job_reuse`
- [ ] Verify in staging that both `op_type=sandbox_reuse_hit` and `op_type=sandbox_reuse_miss` events appear in Axiom's `sandbox_op_log` dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)
