### PR TITLE
feat(platform): lock chat thread model after first send

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -212,6 +212,16 @@ async function expectComposerShowsModel(displayName: string): Promise<void> {
   });
 }
 
+// Thread page composer renders the model as plain text (picker is locked
+// once the thread has stored values). No combobox exists there.
+async function expectThreadComposerShowsModel(
+  displayName: string,
+): Promise<void> {
+  await waitFor(() => {
+    expect(screen.getByLabelText(displayName).tagName).toBe("SPAN");
+  });
+}
+
 async function expectAgentChatLoaded(): Promise<void> {
   // The document title is set to the agent display name once
   // setupAgentChatPage$ has fetched agent data; waiting on it guarantees
@@ -353,7 +363,7 @@ describe("chat composer — default model resolution", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    await expectComposerShowsModel("GLM-5.1");
+    await expectThreadComposerShowsModel("GLM-5.1");
   });
 
   // CHAT-DM-007: When the thread has no override, the composer on the
@@ -373,6 +383,7 @@ describe("chat composer — default model resolution", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
+    // Thread has no stored values yet — picker remains interactive.
     await expectComposerShowsModel("Claude Opus 4.7");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Thread-page model picker is read-only.
+ *
+ * Rule: once a chat thread has been sent (modelProviderId + selectedModel
+ * persisted on the row), the composer's model picker becomes read-only. The
+ * user cannot change the thread's model — the backend also enforces this,
+ * see route.test.ts.
+ *
+ * Entry point: /chats/:threadId thread page.
+ * Mock (external): Web API via MSW (feature switch + org providers + thread
+ *   row with stored overrides).
+ * Real (internal): routing, chat-thread-page signals, composer, picker.
+ *
+ * The parallel "picker is enabled on /agents/:id/chat" case is covered by
+ * chat-default-model-resolution.test.tsx and chat-composer-model-selection-send.test.tsx
+ * (both mount the landing page and interact with the picker), so we only
+ * need to prove the lock is applied on the thread page here.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import {
+  FeatureSwitchKey,
+  chatMessagesContract,
+  chatThreadByIdContract,
+  chatThreadMessagesContract,
+} from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import {
+  setMockOrgModelProviders,
+  resetMockOrgModelProviders,
+} from "../../../mocks/handlers/api-org-model-providers.ts";
+import {
+  setMockFeatureSwitches,
+  resetMockFeatureSwitches,
+} from "../../../mocks/handlers/api-feature-switches.ts";
+import {
+  setMockOnboardingStatus,
+  resetMockOnboardingStatus,
+} from "../../../mocks/handlers/api-onboarding.ts";
+
+const context = testContext();
+
+const PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
+const STORED_MODEL = "claude-opus-4-7";
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const THREAD_ID = "thread-readonly-1";
+
+describe("chat thread page — model picker is read-only on existing threads", () => {
+  beforeEach(() => {
+    resetMockOrgModelProviders();
+    resetMockFeatureSwitches();
+    resetMockOnboardingStatus();
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ModelProviderSelection]: true,
+    });
+    setMockOnboardingStatus({ defaultAgentId: AGENT_ID });
+    setMockOrgModelProviders([
+      {
+        id: PROVIDER_ID,
+        type: "anthropic-api-key",
+        framework: "claude-code",
+        secretName: "ANTHROPIC_API_KEY",
+        authMethod: null,
+        secretNames: null,
+        isDefault: true,
+        selectedModel: "claude-sonnet-4-6",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+  });
+
+  // CHAT-LOCK-001: picker on an existing thread renders as plain text — no
+  // combobox/button — so the user cannot switch models mid-thread.
+  it("renders the picker as plain text on /chats/:threadId when the thread has stored values (CHAT-LOCK-001)", async () => {
+    server.use(
+      mockApi(chatThreadByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          id: THREAD_ID,
+          title: "My thread",
+          agentId: AGENT_ID,
+          chatMessages: [],
+          latestSessionId: null,
+          latestSessionProviderType: null,
+          activeRunIds: [],
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+          draftContent: null,
+          draftAttachments: null,
+          modelProviderId: PROVIDER_ID,
+          selectedModel: STORED_MODEL,
+        });
+      }),
+      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+        return respond(200, { messages: [] });
+      }),
+      mockApi(chatMessagesContract.send, ({ respond }) => {
+        return respond(201, {
+          runId: "run-test-1",
+          threadId: THREAD_ID,
+          status: "pending",
+          createdAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    const label = await waitFor(() => {
+      return screen.getByLabelText("Claude Opus 4.7");
+    });
+    // Plain-text span, not a combobox/button — no dropdown affordance.
+    expect(label.tagName).toBe("SPAN");
+    expect(
+      screen.queryByRole("combobox", { name: "Claude Opus 4.7" }),
+    ).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -50,7 +50,7 @@ export interface ModelProviderSelection {
 interface ModelProviderPickerProps {
   providers: ModelProviderResponse[];
   value: ModelProviderSelection | null;
-  onChange: (value: ModelProviderSelection | null) => void;
+  onChange?: (value: ModelProviderSelection | null) => void;
   placeholder?: string;
   /**
    * Classes applied to the SelectTrigger. Defaults to `h-9 w-full`. The
@@ -277,7 +277,7 @@ export function ModelProviderPicker({
     <Select
       value={encodeValue(value)}
       onValueChange={(raw) => {
-        onChange(decodeValue(raw));
+        onChange?.(decodeValue(raw));
       }}
     >
       <SelectTrigger

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -70,6 +70,8 @@ interface ModelProviderPickerProps {
    * space is tight and the full breakdown lives in the open dropdown.
    */
   compactTrigger?: boolean;
+  // When true, picker is read-only (e.g. existing chat thread).
+  disabled?: boolean;
 }
 
 // Radix Select reserves the empty string for "no value" and throws if a
@@ -171,6 +173,44 @@ function TriggerLabel({
   );
 }
 
+function DisabledPickerLabel({
+  providers,
+  value,
+  placeholder,
+  compactTrigger,
+  triggerClassName,
+}: Pick<
+  ModelProviderPickerProps,
+  "providers" | "value" | "placeholder" | "compactTrigger" | "triggerClassName"
+> & {
+  placeholder: string;
+  compactTrigger: boolean;
+}) {
+  const defaultModelName = resolveDefaultModel(providers);
+  const triggerAriaLabel = value
+    ? getModelDisplayName(value.selectedModel)
+    : defaultModelName !== null
+      ? getModelDisplayName(defaultModelName)
+      : placeholder;
+  return (
+    <span
+      aria-label={triggerAriaLabel}
+      className={cn(
+        "inline-flex items-center px-2 text-sm text-muted-foreground",
+        triggerClassName,
+      )}
+    >
+      <TriggerLabel
+        providers={providers}
+        value={value}
+        defaultModelName={defaultModelName}
+        placeholder={placeholder}
+        compact={compactTrigger}
+      />
+    </span>
+  );
+}
+
 export function ModelProviderPicker({
   providers,
   value,
@@ -179,7 +219,20 @@ export function ModelProviderPicker({
   triggerClassName,
   sessionProviderType,
   compactTrigger = false,
+  disabled = false,
 }: ModelProviderPickerProps) {
+  if (disabled) {
+    return (
+      <DisabledPickerLabel
+        providers={providers}
+        value={value}
+        placeholder={placeholder}
+        compactTrigger={compactTrigger}
+        triggerClassName={triggerClassName}
+      />
+    );
+  }
+
   const groups = providers
     .map((provider) => {
       const typeConfig = MODEL_PROVIDER_TYPES[provider.type];

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -154,6 +154,8 @@ interface ZeroChatComposerProps {
      * base URL differs are disabled to preserve session continuity.
      */
     sessionProviderType: ModelProviderType | null;
+    // When true, picker is read-only (e.g. existing chat thread).
+    disabled?: boolean;
   };
 }
 
@@ -928,6 +930,7 @@ export function ZeroChatComposer({
                     )}
                     sessionProviderType={modelPicker.sessionProviderType}
                     compactTrigger
+                    disabled={modelPicker.disabled}
                   />
                 )}
                 <MicButton

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -434,6 +434,11 @@ function ChatThreadComposer({
                   onChange: setModelSelection,
                   sessionProviderType:
                     threadData?.latestSessionProviderType ?? null,
+                  // Lock once the thread has stored values — mirrors the
+                  // backend guard in rejectIfThreadModelLocked.
+                  disabled: Boolean(
+                    threadData?.modelProviderId && threadData?.selectedModel,
+                  ),
                 }
               : undefined
           }

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -590,50 +590,6 @@ describe("POST /api/zero/chat/messages", () => {
         expect(override.selectedModel).toBe("claude-opus-4-7");
       });
 
-      it("clears the thread override when modelSelection is null", async () => {
-        const providerId = await getTestModelProviderIdByType(
-          user.orgId,
-          "anthropic-api-key",
-        );
-
-        // Seed an override via the first send.
-        const first = await POST(
-          createTestRequest(URL, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              agentId,
-              prompt: "with override",
-              modelSelection: {
-                modelProviderId: providerId,
-                selectedModel: "claude-opus-4-7",
-              },
-            }),
-          }),
-        );
-        expect(first.status).toBe(201);
-        const { threadId } = await first.json();
-
-        // Now clear it explicitly.
-        const clear = await POST(
-          createTestRequest(URL, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              agentId,
-              prompt: "reset to default",
-              threadId,
-              modelSelection: null,
-            }),
-          }),
-        );
-        expect(clear.status).toBe(201);
-
-        const override = await getTestChatThreadModelOverride(threadId);
-        expect(override.modelProviderId).toBeNull();
-        expect(override.selectedModel).toBeNull();
-      });
-
       it("leaves the thread override untouched when modelSelection is omitted", async () => {
         const providerId = await getTestModelProviderIdByType(
           user.orgId,
@@ -675,6 +631,174 @@ describe("POST /api/zero/chat/messages", () => {
         const override = await getTestChatThreadModelOverride(threadId);
         expect(override.modelProviderId).toBe(providerId);
         expect(override.selectedModel).toBe("claude-opus-4-7");
+      });
+
+      it("rejects modelSelection change on an existing thread", async () => {
+        const providerId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+
+        // Seed a thread with stored values on its first send.
+        const first = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "first",
+              modelSelection: {
+                modelProviderId: providerId,
+                selectedModel: "claude-opus-4-7",
+              },
+            }),
+          }),
+        );
+        expect(first.status).toBe(201);
+        const { threadId } = await first.json();
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "switch model",
+              threadId,
+              modelSelection: {
+                modelProviderId: providerId,
+                selectedModel: "claude-sonnet-4-6",
+              },
+            }),
+          }),
+        );
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.error.code).toBe("BAD_REQUEST");
+      });
+
+      it("allows modelSelection on existing thread when values match stored", async () => {
+        const providerId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+
+        const first = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "first",
+              modelSelection: {
+                modelProviderId: providerId,
+                selectedModel: "claude-opus-4-7",
+              },
+            }),
+          }),
+        );
+        expect(first.status).toBe(201);
+        const { threadId } = await first.json();
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "follow up",
+              threadId,
+              modelSelection: {
+                modelProviderId: providerId,
+                selectedModel: "claude-opus-4-7",
+              },
+            }),
+          }),
+        );
+        expect(response.status).toBe(201);
+      });
+
+      it("rejects modelSelection that clears (null) on an existing thread with stored values", async () => {
+        const providerId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+
+        const first = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "first",
+              modelSelection: {
+                modelProviderId: providerId,
+                selectedModel: "claude-opus-4-7",
+              },
+            }),
+          }),
+        );
+        expect(first.status).toBe(201);
+        const { threadId } = await first.json();
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "reset",
+              threadId,
+              modelSelection: null,
+            }),
+          }),
+        );
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.error.code).toBe("BAD_REQUEST");
+      });
+
+      it("accepts first modelSelection on a freshly-created thread", async () => {
+        const providerId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+
+        // Create a thread with no modelSelection — stored values remain null.
+        const create = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "greet",
+            }),
+          }),
+        );
+        expect(create.status).toBe(201);
+        const { threadId } = await create.json();
+
+        const override = await getTestChatThreadModelOverride(threadId);
+        expect(override.modelProviderId).toBeNull();
+        expect(override.selectedModel).toBeNull();
+
+        // First modelSelection on this thread must be accepted.
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "with override",
+              threadId,
+              modelSelection: {
+                modelProviderId: providerId,
+                selectedModel: "claude-opus-4-7",
+              },
+            }),
+          }),
+        );
+        expect(response.status).toBe(201);
       });
 
       it("rejects a providerId from a different org", async () => {

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -145,6 +145,39 @@ async function resolveRunModelOverride(
 }
 
 /**
+ * Once a thread has stored modelProviderId + selectedModel, those values are
+ * immutable. The picker is disabled on existing threads, so this guard
+ * rejects out-of-band/manual API callers that try to change or clear them.
+ */
+async function rejectIfThreadModelLocked(
+  threadId: string,
+  incoming: { modelProviderId: string; selectedModel: string } | null,
+): Promise<boolean> {
+  const [existing] = await globalThis.services.db
+    .select({
+      modelProviderId: chatThreads.modelProviderId,
+      selectedModel: chatThreads.selectedModel,
+    })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, threadId))
+    .limit(1);
+  if (
+    !existing ||
+    existing.modelProviderId === null ||
+    existing.selectedModel === null
+  ) {
+    return false;
+  }
+  if (incoming === null) {
+    return true;
+  }
+  return (
+    existing.modelProviderId !== incoming.modelProviderId ||
+    existing.selectedModel !== incoming.selectedModel
+  );
+}
+
+/**
  * Resolve an existing thread or create a new one.
  * Returns thread metadata needed for run creation and title generation.
  */
@@ -298,6 +331,22 @@ const router = tsr.router(chatMessagesContract, {
           },
         };
       }
+    }
+
+    if (
+      body.threadId !== undefined &&
+      body.modelSelection !== undefined &&
+      (await rejectIfThreadModelLocked(body.threadId, body.modelSelection))
+    ) {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "Cannot change model on an existing thread",
+            code: "BAD_REQUEST" as const,
+          },
+        },
+      };
     }
 
     try {

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -106,23 +106,20 @@ async function resolveRunModelOverride(
     | null
     | undefined,
 ): Promise<{ providerId: string | null; selectedModel: string | null }> {
-  if (modelSelection !== undefined) {
+  if (modelSelection !== undefined && modelSelection !== null) {
     await globalThis.services.db
       .update(chatThreads)
       .set({
-        modelProviderId: modelSelection?.modelProviderId ?? null,
-        selectedModel: modelSelection?.selectedModel ?? null,
+        modelProviderId: modelSelection.modelProviderId,
+        selectedModel: modelSelection.selectedModel,
         updatedAt: new Date(),
       })
       .where(eq(chatThreads.id, threadId));
-    if (modelSelection !== null) {
-      return {
-        providerId: modelSelection.modelProviderId,
-        selectedModel: modelSelection.selectedModel,
-      };
-    }
-    // modelSelection === null means "clear" — fall through to agent default.
-  } else {
+    return {
+      providerId: modelSelection.modelProviderId,
+      selectedModel: modelSelection.selectedModel,
+    };
+  } else if (modelSelection === undefined) {
     const [thread] = await globalThis.services.db
       .select({
         modelProviderId: chatThreads.modelProviderId,


### PR DESCRIPTION
Stacked on #10431.

## Summary
- A chat thread's `modelProviderId` + `selectedModel` become immutable once stored on the row. Backend guard `rejectIfThreadModelLocked` returns **400 BAD_REQUEST** when an incoming `modelSelection` would change or clear stored values on an existing thread.
- Composer on `/chats/:threadId` now renders the model as plain muted text (no dropdown, no chevron) when the thread has stored values. Legacy threads with null stored values keep the interactive picker — matching the backend guard so both sides stay consistent.
- Added `disabled` prop to `ModelProviderPicker`; when true, it renders a standalone `DisabledPickerLabel` span (Radix Select is skipped entirely, so no button/chevron affordance leaks through).

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run chat-thread-page-model-picker-readonly chat-default-model-resolution chat-composer-model-selection-send model-provider-picker-display` — 12/12 pass
- [x] `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/` — 31/31 pass (includes 3 new lock tests)
- [x] `pnpm -F @vm0/app lint`
- [x] `pnpm -F @vm0/app check-types`
- [x] Browser verified: `/chats/:threadId` composer shows "Claude Sonnet 4.6" as plain gray text next to Send; `/agents/:id/chat` picker still opens the full model dropdown.
- [ ] Manual: confirm legacy threads with null `modelProviderId`/`selectedModel` still allow picker interaction.
- [ ] Manual: confirm an API caller hitting POST `/api/zero/chat/messages` with a mismatched `modelSelection` on an existing thread receives 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)