### PR TITLE
refactor(billing): unify connector billing gate on firewall_billable

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -417,7 +417,12 @@ async def handle_firewall_request(
     flow.metadata["firewall_permission"] = match_info.get("permission", "")
     flow.metadata["firewall_rule_match"] = match_info.get("rule", "")
     flow.metadata["firewall_params"] = match_info.get("params", {})
-    flow.metadata["firewall_billable"] = match_info.get("name", "") in vm_info["billableFirewalls"]
+    # billableFirewalls is optional in the TS schema; runner may omit the
+    # field entirely for non-vm0 / no-billable-connector runs.  Fall back
+    # to an empty list so a missing key doesn't KeyError the auth handler.
+    flow.metadata["firewall_billable"] = match_info.get("name", "") in (
+        vm_info.get("billableFirewalls") or []
+    )
 
     if not encrypted_secrets:
         log_proxy_entry(

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -301,7 +301,14 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     ndjson_decompressor = None
     firewall_name = flow.metadata.get("firewall_name", "")
     is_model_provider = firewall_name.startswith("model-provider:")
-    is_billable_connector = usage.is_billable_connector(firewall_name)
+    # Platform-billable firewall flag, sourced from vm_info["billableFirewalls"]
+    # via auth.handle_firewall_request.  Gates log_connector_usage (in response())
+    # and the full-body response buffering that billing payload extraction needs.
+    is_billable_flow = flow.metadata.get("firewall_billable", False)
+    # X-specific NDJSON stream classification — tied to the x firewall itself,
+    # not to billing.  Kept separate so a future non-x billable connector
+    # doesn't accidentally inherit X stream parsing.
+    is_x_flow = firewall_name == "x"
 
     # Classify X NDJSON streams early so we can register an incremental parser
     # and avoid buffering the (potentially multi-GB) stream body.  Only a
@@ -317,19 +324,16 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     # Reads ``original_url`` with no fallback — kept consistent with
     # :func:`usage._parse_x_request_metadata` so the log entry's
     # ``is_stream`` field cannot diverge from the parser registration
-    # decision.  For any billable connector flow, ``request()`` has
-    # already populated ``original_url`` before ``responseheaders`` fires.
+    # decision.  For any x firewall flow, ``request()`` has already
+    # populated ``original_url`` before ``responseheaders`` fires.
     is_x_stream = False
-    if (
-        is_billable_connector
-        and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
-    ):
+    if is_x_flow and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN:
         stream_path = urllib.parse.urlparse(flow.metadata.get("original_url", "")).path
         is_x_stream = usage.is_x_stream_path(stream_path)
 
     # Track flows that will generate webhook POSTs (usage or connector billing)
     # so the runner can wait for them to reach response()/error() before stopping.
-    if is_model_provider or is_billable_connector:
+    if is_model_provider or is_billable_flow:
         usage.increment_flows()
         flow.metadata["_usage_flow_tracked"] = True
 
@@ -349,13 +353,15 @@ def responseheaders(flow: http.HTTPFlow) -> None:
         flow.metadata["x_ndjson_state"] = ndjson_state
         ndjson_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
 
-    # Buffer cap policy:
+    # Buffer cap policy (coupled to billability by design — every billable
+    # connector today needs json.loads on the full body to build the webhook
+    # payload; if that ever diverges, add a separate flag):
     # - Model providers: unbounded — need full body for non-SSE JSON usage extraction.
-    # - X non-stream billable connectors: unbounded — full body feeds json.loads.
+    # - Billable non-stream connectors: unbounded — full body feeds json.loads.
     # - X stream endpoints: STREAM_BUFFER_LIMIT (64 KB) — parser handles bytes
     #   incrementally; the buffer is kept only for forensic network logging.
     # - Everything else: STREAM_BUFFER_LIMIT (default 64 KB).
-    if is_model_provider or (is_billable_connector and not is_x_stream):
+    if is_model_provider or (is_billable_flow and not is_x_stream):
         buf_limit = None
     else:
         buf_limit = body_utils.STREAM_BUFFER_LIMIT

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -5,10 +5,11 @@ Two paths:
 - Model-provider responses (SSE streams and non-streaming JSON): extract
   Anthropic token counts and report them to the platform webhook through
   a background thread pool.
-- Billable connector responses (X API; see :data:`_BILLABLE_CONNECTORS`):
-  compute per-permission billable resource counts and forward them to the
-  platform via ``/api/webhooks/agent/connector-billing`` for persistence
-  in the ``connector_billing`` table.
+- Billable connector responses (flagged by the web layer via
+  ``billableFirewalls`` → ``flow.metadata["firewall_billable"]``): compute
+  per-permission billable resource counts and forward them to the platform
+  via ``/api/webhooks/agent/connector-billing`` for persistence in the
+  ``connector_billing`` table.
 """
 
 import json
@@ -471,30 +472,6 @@ def maybe_report_proxy_usage(flow: http.HTTPFlow, run_id: str) -> None:
 # for persistence in the connector_billing table.
 # ---------------------------------------------------------------------------
 
-# Non-model-provider firewalls whose traffic we intend to bill.  Listing a
-# firewall here triggers full-body buffering in mitm_addon.responseheaders
-# (so log_connector_usage can parse the JSON in response()) and routes the
-# flow through log_connector_usage.  Start with X; expand once observation
-# data validates the pipeline.
-_BILLABLE_CONNECTORS = frozenset({"x"})
-
-
-def is_billable_connector(firewall_name: str) -> bool:
-    """Return True when this firewall is on the billable-connector list.
-
-    Used by ``mitm_addon.responseheaders`` to choose the response-body
-    handling strategy:
-
-    - **Non-stream endpoints**: disable buffer truncation so
-      ``log_connector_usage`` can ``json.loads`` the full body in
-      ``response()``.
-    - **Stream endpoints** (see :data:`_X_STREAM_ENDPOINTS`): register an
-      incremental NDJSON parser via :func:`create_x_ndjson_extractor` so
-      we never buffer the (potentially multi-GB) stream body.
-    """
-    return firewall_name in _BILLABLE_CONNECTORS
-
-
 # X v2 NDJSON streaming endpoint paths (exact match — ``/2/tweets/search/stream/rules``
 # is a regular request/response endpoint for rules management, NOT a stream).
 # Streams deliver one JSON object per line, possibly for hours; responseheaders
@@ -861,15 +838,21 @@ def log_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
     Skipped when:
 
     - ``run_id`` is empty (no billing attribution)
-    - ``firewall_name`` is not in :data:`_BILLABLE_CONNECTORS`
+    - ``flow.metadata["firewall_billable"]`` is False (web layer decided
+      this firewall is not platform-billable for this run)
+    - firewall is a model provider (routed through
+      :func:`maybe_report_proxy_usage` instead — parsing here would emit
+      bogus X-shaped billing records)
     - response status is outside 2xx (failures aren't billable)
     - ``firewall_permission`` is empty (unknown-endpoint-allow has no
       stable pricing key)
     """
     if not run_id:
         return
+    if not flow.metadata.get("firewall_billable", False):
+        return
     firewall_name = flow.metadata.get("firewall_name", "")
-    if not is_billable_connector(firewall_name):
+    if firewall_name.startswith("model-provider:"):
         return
     if not flow.response or not (
         _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN

--- a/crates/runner/mitm-addon/src/usage.py
+++ b/crates/runner/mitm-addon/src/usage.py
@@ -840,9 +840,11 @@ def log_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
     - ``run_id`` is empty (no billing attribution)
     - ``flow.metadata["firewall_billable"]`` is False (web layer decided
       this firewall is not platform-billable for this run)
-    - firewall is a model provider (routed through
-      :func:`maybe_report_proxy_usage` instead — parsing here would emit
-      bogus X-shaped billing records)
+    - ``firewall_name`` is not ``"x"`` (every parser below is X-specific —
+      :func:`_parse_x_request_metadata`, :func:`_compute_x_billable_counts`.
+      Model-provider flows are routed through :func:`maybe_report_proxy_usage`
+      instead; future non-x billable connectors must be dispatched here
+      before the X parser sees their requests)
     - response status is outside 2xx (failures aren't billable)
     - ``firewall_permission`` is empty (unknown-endpoint-allow has no
       stable pricing key)
@@ -852,7 +854,11 @@ def log_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
     if not flow.metadata.get("firewall_billable", False):
         return
     firewall_name = flow.metadata.get("firewall_name", "")
-    if firewall_name.startswith("model-provider:"):
+    if firewall_name != "x":
+        # Current function body is X-specific.  When BILLABLE_CONNECTORS in
+        # @vm0/core grows past ["x"], dispatch to a per-connector handler
+        # here — letting the X parser run on another connector's request
+        # would emit bogus billing records.
         return
     if not flow.response or not (
         _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1448,6 +1448,47 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_rule_match"] == "GET /repos/{owner}/{repo}"
         assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
 
+    async def test_missing_billable_firewalls_falls_back_to_empty(
+        self, real_flow, headers, mitm_ctx, tmp_path
+    ):
+        """billableFirewalls is optional in the TS schema — a vm_info without
+        the key must not KeyError; firewall_billable should be False."""
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
+        api_entry = {
+            "id": "run-1:0",
+            "base": "https://api.github.com",
+            "auth": {"headers": {}},
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok-xyz",
+            "encryptedSecrets": "iv:tag:data",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
+            # intentionally no "billableFirewalls" key
+        }
+        match_info = {
+            "name": "github",
+            "permission": "repo-read",
+            "rule": "GET /repos",
+            "params": {},
+        }
+        token_meta = {
+            "headers": {},
+            "resolved_secrets": [],
+            "refreshed_connectors": [],
+            "refreshed_secrets": [],
+            "cache_hit": False,
+        }
+
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+
+        assert flow.metadata["firewall_billable"] is False
+
     async def test_failure_returns_502(self, real_flow, headers, mitm_ctx, tmp_path):
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -560,6 +560,7 @@ class TestResponseHeadersHandler:
         """Non-stream X requests still need full body for json.loads."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/users/by")
         flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["original_url"] = "https://api.x.com/2/users/by?ids=1,2,3"
         flow.response = tutils.tresp(
             status_code=200, headers=http.Headers(**{"content-type": "application/json"})
@@ -598,6 +599,7 @@ class TestResponseHeadersHandler:
         """
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
         flow.response = tutils.tresp(
             status_code=401, headers=http.Headers(**{"content-type": "application/json"})
@@ -1406,6 +1408,7 @@ class TestResponseUsageReporting:
             status_code=200, headers=http.Headers(**{"content-type": "application/json"})
         )
         flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
 
         mitm_addon.responseheaders(flow)
 
@@ -1715,6 +1718,7 @@ class TestErrorHandler:
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["firewall_permission"] = "tweet.read"
         flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
         flow.metadata["x_ndjson_state"] = {
@@ -1764,6 +1768,7 @@ class TestErrorHandler:
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["firewall_permission"] = "tweet.read"
         flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
         flow.response = tutils.tresp(
@@ -1984,6 +1989,7 @@ class TestLogConnectorUsage:
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["vm_sandbox_token"] = "test-token"
         flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["firewall_permission"] = permission
         flow.metadata["firewall_rule_match"] = rule
         flow.metadata["stream_buffer"] = bytearray(body)
@@ -2401,15 +2407,16 @@ class TestLogConnectorUsage:
         assert self._call_and_get_billing(flow, run_id="") == []
 
     def test_skips_for_model_provider(self, tmp_path, real_flow):
-        """Model providers go through maybe_report_proxy_usage instead."""
+        """Model providers go through maybe_report_proxy_usage instead —
+        log_connector_usage must early-return even when firewall_billable."""
         flow = self._make_x_flow(real_flow, tmp_path)
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         assert self._call_and_get_billing(flow) == []
 
-    def test_skips_for_non_billable_connector(self, tmp_path, real_flow):
-        """Connectors not in _BILLABLE_CONNECTORS are not logged."""
+    def test_skips_when_not_billable(self, tmp_path, real_flow):
+        """Firewalls with firewall_billable=False are not logged."""
         flow = self._make_x_flow(real_flow, tmp_path)
-        flow.metadata["firewall_name"] = "gamma"
+        flow.metadata["firewall_billable"] = False
         assert self._call_and_get_billing(flow) == []
 
     def test_skips_when_no_response(self, tmp_path, real_flow):
@@ -2443,6 +2450,7 @@ class TestLogConnectorUsage:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
         flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["firewall_permission"] = "tweet.read"
         flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
         flow.response = tutils.tresp(status_code=200)

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -2408,9 +2408,19 @@ class TestLogConnectorUsage:
 
     def test_skips_for_model_provider(self, tmp_path, real_flow):
         """Model providers go through maybe_report_proxy_usage instead —
-        log_connector_usage must early-return even when firewall_billable."""
+        log_connector_usage is X-specific and must early-return on
+        non-x firewalls even when firewall_billable=True."""
         flow = self._make_x_flow(real_flow, tmp_path)
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        assert self._call_and_get_billing(flow) == []
+
+    def test_skips_for_non_x_billable_firewall(self, tmp_path, real_flow):
+        """Billable non-x connectors (hypothetical future additions to
+        BILLABLE_CONNECTORS) must NOT reach the X-specific parser.  Catching
+        this at the gate prevents bogus billing records if someone grows the
+        whitelist without also adding per-connector dispatch."""
+        flow = self._make_x_flow(real_flow, tmp_path)
+        flow.metadata["firewall_name"] = "github"
         assert self._call_and_get_billing(flow) == []
 
     def test_skips_when_not_billable(self, tmp_path, real_flow):

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1421,6 +1421,33 @@ class TestResponseUsageReporting:
         assert len(buf) == len(large_chunk)
         assert not state["truncated"]
 
+    def test_non_x_billable_connector_keeps_unbounded_buffer(self, real_flow, headers):
+        """Buffer policy gates on firewall_billable (not firewall_name == 'x').
+
+        When BILLABLE_CONNECTORS grows past ['x'], responseheaders must
+        keep the body unbounded for the new connector too — its future
+        log_*_connector_usage handler will need json.loads on the full body.
+        """
+        flow = real_flow(with_response=False, host="api.gamma.example")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
+        flow.metadata["firewall_name"] = "gamma"  # hypothetical future billable connector
+        flow.metadata["firewall_billable"] = True
+
+        mitm_addon.responseheaders(flow)
+
+        callback = flow.response.stream
+        large_chunk = b"g" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
+        callback(large_chunk)
+
+        buf = flow.metadata["stream_buffer"]
+        state = flow.metadata["stream_buffer_state"]
+        assert len(buf) == len(large_chunk)
+        assert not state["truncated"]
+        # And no X-specific state gets attached to a non-x flow.
+        assert "x_ndjson_state" not in flow.metadata
+
     def test_no_usage_report_for_non_model_provider(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
     ):

--- a/turbo/apps/web/src/db/schema/connector-billing.ts
+++ b/turbo/apps/web/src/db/schema/connector-billing.ts
@@ -17,8 +17,10 @@ import { agentRuns } from "./agent-run";
  * keyed by (runId, flowId, category) for deduplication.  Processed later
  * by a billing processor to charge credits.
  *
- * Only billable connectors (gated by `_BILLABLE_CONNECTORS` in the addon)
- * and successful (2xx) responses produce records.
+ * Only billable connectors (firewalls listed in `BILLABLE_CONNECTORS` in
+ * `@vm0/core`, surfaced to the addon as `flow.metadata["firewall_billable"]`
+ * via `billableFirewalls` on the execution context) and successful (2xx)
+ * responses produce records.
  */
 export const connectorBilling = pgTable(
   "connector_billing",

--- a/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
@@ -10,6 +10,7 @@ import {
   createTestVariable,
   createTestUserConnector,
   findTestRunnerJobEntry,
+  insertTestConnectorSecret,
 } from "../../../__tests__/api-test-helpers";
 import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
@@ -137,6 +138,53 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
       await context.mocks.flushAfter();
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job!.executionContext.billableFirewalls).toEqual([]);
+    });
+
+    it("should include billable connector firewall names when attached", async () => {
+      // The x connector is platform-billable: per-call billing is computed
+      // from firewall_billable metadata, so "x" must appear in
+      // billableFirewalls whenever the firewall is attached to the run.
+      // Build-zero-context only attaches connector firewalls when BOTH the
+      // agent authorized the connector (userConnectors row) AND the user
+      // has linked it (connectors row + OAuth tokens), so seed all three.
+      const agentName = uniqueId("x-connector-agent");
+      await createTestCompose(agentName, {
+        skipDefaultApiKey: true,
+      });
+      const connAgentId = await getTestZeroAgentId(user.orgId, agentName);
+
+      await upsertOrgModelProvider(
+        user.orgId,
+        "anthropic-api-key",
+        "org-api-key",
+      );
+      await context.createConnector(user.orgId, {
+        userId: user.userId,
+        type: "x",
+        authMethod: "oauth",
+      });
+      await insertTestConnectorSecret(
+        user.orgId,
+        user.userId,
+        "X_ACCESS_TOKEN",
+        "user-x-access",
+      );
+      await insertTestConnectorSecret(
+        user.orgId,
+        user.userId,
+        "X_REFRESH_TOKEN",
+        "user-x-refresh",
+      );
+      await createTestUserConnector(user.orgId, user.userId, connAgentId, "x");
+
+      const result = await createZeroRun(baseParams({ agentId: connAgentId }));
+      await context.mocks.flushAfter();
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job!.executionContext.billableFirewalls).toContain("x");
+      // User-paid model provider → model-provider firewall stays off the list.
+      expect(job!.executionContext.billableFirewalls).not.toContain(
+        "model-provider:anthropic-api-key",
+      );
     });
   });
 

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import {
+  BILLABLE_CONNECTORS,
   getModelProviderFirewall,
   getConnectorFirewall,
   isFirewallConnectorType,
@@ -260,12 +261,24 @@ async function resolveSecretsAndEnvironment(
     ],
   );
 
-  // Only the vm0 meta-provider is platform-billable (runs on VM0 key pool).
-  // Every other resolvedModelProvider is user-paid (user supplied their own key).
-  const billableFirewalls =
-    modelProviderResult.resolvedModelProvider === "vm0" && modelProviderConfig
-      ? [modelProviderConfig.name]
-      : [];
+  // Billable firewalls feed flow.metadata["firewall_billable"] in mitm-addon,
+  // gating platform-side billing webhooks and full-body response buffering:
+  // - vm0 meta-provider: platform-paid model tokens (user didn't supply a key).
+  // - Connector firewalls listed in BILLABLE_CONNECTORS: per-call priced APIs
+  //   where the platform covers the upstream cost and bills the user.
+  const billableFirewalls: string[] = [];
+  if (
+    modelProviderResult.resolvedModelProvider === "vm0" &&
+    modelProviderConfig
+  ) {
+    billableFirewalls.push(modelProviderConfig.name);
+  }
+  const billableConnectorSet = new Set<string>(BILLABLE_CONNECTORS);
+  for (const fw of connectorPermissionConfigs) {
+    if (billableConnectorSet.has(fw.name)) {
+      billableFirewalls.push(fw.name);
+    }
+  }
 
   return {
     secrets,

--- a/turbo/packages/core/src/firewalls/billable-connectors.ts
+++ b/turbo/packages/core/src/firewalls/billable-connectors.ts
@@ -1,0 +1,12 @@
+/**
+ * Connector firewalls that are platform-billable.
+ *
+ * Attaching one of these to a run adds its firewall name to the
+ * billableFirewalls whitelist in the execution context, which surfaces as
+ * flow.metadata["firewall_billable"] in mitm-addon. That flag gates
+ * log_connector_usage (per-call billing) and the full-body response
+ * buffering needed to extract the billing payload.
+ */
+export const BILLABLE_CONNECTORS = ["x"] as const;
+
+export type BillableConnector = (typeof BILLABLE_CONNECTORS)[number];

--- a/turbo/packages/core/src/firewalls/index.ts
+++ b/turbo/packages/core/src/firewalls/index.ts
@@ -678,3 +678,8 @@ export function getBuiltinConnectorDisplayName(
 ): string {
   return CONNECTOR_TYPES[type]?.label ?? type;
 }
+
+export {
+  BILLABLE_CONNECTORS,
+  type BillableConnector,
+} from "./billable-connectors";


### PR DESCRIPTION
## Summary

- Introduce `BILLABLE_CONNECTORS` whitelist in `@vm0/core`; web `build-zero-context` appends billable connector firewall names (currently `"x"`) to `billableFirewalls` alongside the vm0 meta-provider case from #10340.
- mitm-addon now reads `flow.metadata["firewall_billable"]` instead of the hardcoded `_BILLABLE_CONNECTORS = frozenset({"x"})` for both `log_connector_usage` (per-call billing) and full-body response buffering.
- X NDJSON stream classification is split onto an explicit `firewall_name == "x"` gate so X-specific transport behavior no longer rides on a general billing flag.
- `log_connector_usage` runs a **defense-in-depth dual gate**: `firewall_billable=True` AND `firewall_name == "x"`. The billable check is the unified policy gate from this refactor; the `== "x"` check keeps the X-specific parser from running on a hypothetical future billable connector before per-connector dispatch is added — misrouting there would emit bogus billing records.

Closes #10380.

## Test plan

- [x] `pytest` mitm-addon (892 passed) — `_make_x_flow` helper sets `firewall_billable=True`; new cases cover non-x billable buffer policy, x-scope guard, and missing-`billableFirewalls`-key auth fallback.
- [x] `pnpm -F web exec vitest run build-zero-context` (13 passed) — new case asserts `"x"` in `billableFirewalls` when the x connector is attached.
- [x] `pnpm check-types` / `pnpm turbo run lint` — green.
- [x] `cargo check -p runner` / `cargo clippy -p runner --all-targets` — green (no Rust changes; sanity only).
- [ ] Manual verification of x connector billing webhook firing for a live run is blocked on X API creds in CI — existing integration tests cover the pipeline end-to-end through webhook payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)