### PR TITLE
fix(billing): skip non-vm0 runs in proxy usage comparison cron

### DIFF
--- a/turbo/apps/web/app/api/cron/compare-proxy-usage/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/compare-proxy-usage/__tests__/route.test.ts
@@ -378,4 +378,119 @@ describe("GET /api/cron/compare-proxy-usage", () => {
     expect(errorMessagesForOrg(logSpy, user1.orgId)).toHaveLength(0);
     expect(errorMessagesForOrg(logSpy, user2.orgId)).toHaveLength(1);
   });
+
+  // ── Non-vm0 provider filter ────────────────────────────────────────
+  //
+  // The proxy only reports usage for `billableFirewalls`, which is
+  // populated *only* when `resolvedModelProvider === "vm0"` (see
+  // build-zero-context.ts).  For user-paid providers (BYOK) the proxy
+  // legitimately writes nothing to `credit_usage`, so comparing against
+  // `client_credit_usage` would false-alarm on every run.
+
+  it("does not log 'missing proxy' for a non-vm0 run (BYOK provider)", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "byok" });
+    const runId = await createCompletedRun(
+      orgId,
+      userId,
+      new Date(Date.now() - 120_000),
+      { modelProvider: "anthropic-api-key" },
+    );
+    // Client-side events still record usage for BYOK runs…
+    await insertTestClientCreditUsage(orgId, {
+      userId,
+      runId,
+      inputTokens: 100,
+    });
+    // …but the proxy deliberately does not write to credit_usage.
+
+    const response = await callCronRoute();
+
+    expect(response.status).toBe(200);
+    expect(errorMessagesForOrg(logSpy, orgId)).toHaveLength(0);
+  });
+
+  it("does not log 'undercount' for a non-vm0 run even with partial proxy data", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "byok-u" });
+    const runId = await createCompletedRun(
+      orgId,
+      userId,
+      new Date(Date.now() - 120_000),
+      { modelProvider: "moonshot-api-key" },
+    );
+    // Pathological state: something wrote proxy rows for a non-vm0 run
+    // (e.g. legacy data, or an inflight migration).  The filter must still
+    // skip it rather than triggering an undercount alert.
+    await insertTestCreditUsageForRun({
+      runId,
+      orgId,
+      userId,
+      inputTokens: 30,
+    });
+    await insertTestClientCreditUsage(orgId, {
+      userId,
+      runId,
+      inputTokens: 100,
+    });
+
+    const response = await callCronRoute();
+
+    expect(response.status).toBe(200);
+    expect(errorMessagesForOrg(logSpy, orgId)).toHaveLength(0);
+  });
+
+  it("does not log for a run without a zero_runs row (plain agent run)", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "no-zero" });
+    const runId = await createCompletedRun(
+      orgId,
+      userId,
+      new Date(Date.now() - 120_000),
+      { modelProvider: null },
+    );
+    await insertTestClientCreditUsage(orgId, {
+      userId,
+      runId,
+      inputTokens: 100,
+    });
+
+    const response = await callCronRoute();
+
+    expect(response.status).toBe(200);
+    expect(errorMessagesForOrg(logSpy, orgId)).toHaveLength(0);
+  });
+
+  it("mixes vm0 and non-vm0 runs: alerts only on the vm0 one", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "mixed" });
+    const completedAt = new Date(Date.now() - 120_000);
+
+    // vm0 run with undercount → should alert
+    const vm0Run = await createCompletedRun(orgId, userId, completedAt);
+    await insertTestCreditUsageForRun({
+      runId: vm0Run,
+      orgId,
+      userId,
+      inputTokens: 30,
+    });
+    await insertTestClientCreditUsage(orgId, {
+      userId,
+      runId: vm0Run,
+      inputTokens: 100,
+    });
+
+    // BYOK run with same undercount shape → should NOT alert
+    const byokRun = await createCompletedRun(orgId, userId, completedAt, {
+      modelProvider: "anthropic-api-key",
+    });
+    await insertTestClientCreditUsage(orgId, {
+      userId,
+      runId: byokRun,
+      inputTokens: 100,
+    });
+
+    const response = await callCronRoute();
+
+    expect(response.status).toBe(200);
+    const entries = errorMessagesForOrg(logSpy, orgId);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.meta).toMatchObject({ runId: vm0Run });
+  });
 });

--- a/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
@@ -12,6 +12,7 @@ import {
   agentComposeVersions,
 } from "../../db/schema/agent-compose";
 import { agentRuns } from "../../db/schema/agent-run";
+import { zeroRuns } from "../../db/schema/zero-run";
 import { ensureTestAgentSession } from "./runs";
 import { grantOrgCredits } from "../../lib/zero/org/org-service";
 import {
@@ -491,6 +492,12 @@ export async function seedInsightsDaily(
  * Create a completed run with a specific completedAt timestamp.
  * Used by proxy usage comparison tests that need to control the time window.
  *
+ * Also inserts a `zero_runs` row so the proxy-usage-comparison cron (which
+ * filters to `zero_runs.modelProvider = "vm0"`) picks the run up.  The
+ * optional `modelProvider` override lets tests simulate non-vm0 runs
+ * (user-paid providers) or skip the `zero_runs` row entirely (plain agent
+ * runs) by passing `null`.
+ *
  * @why-db-direct Run lifecycle is managed by the runner. Tests need precise
  * completedAt timestamp control for time-window queries.
  */
@@ -498,6 +505,7 @@ export async function createCompletedRun(
   orgId: string,
   userId: string,
   completedAt: Date,
+  opts: { modelProvider?: string | null } = {},
 ): Promise<string> {
   initServices();
   const composeName = `compose-${randomBytes(4).toString("hex")}`;
@@ -529,6 +537,15 @@ export async function createCompletedRun(
       sessionId,
     })
     .returning();
+  const modelProvider =
+    opts.modelProvider === undefined ? "vm0" : opts.modelProvider;
+  if (modelProvider !== null) {
+    await globalThis.services.db.insert(zeroRuns).values({
+      id: run!.id,
+      triggerSource: "test",
+      modelProvider,
+    });
+  }
   return run!.id;
 }
 

--- a/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
@@ -2,6 +2,7 @@ import { eq, and, inArray, sum, lte, gte } from "drizzle-orm";
 import { creditUsage } from "../../../db/schema/credit-usage";
 import { clientCreditUsage } from "../../../db/schema/client-credit-usage";
 import { agentRuns } from "../../../db/schema/agent-run";
+import { zeroRuns } from "../../../db/schema/zero-run";
 import { logger } from "../../shared/logger";
 
 const log = logger("service:proxy-usage-comparison");
@@ -16,6 +17,11 @@ const log = logger("service:proxy-usage-comparison");
  * The 30-second floor gives mitmproxy time to deliver all reports.
  * The 5m30s ceiling matches the cron interval (5 min) plus the floor so
  * consecutive runs cover adjacent, non-overlapping windows.
+ *
+ * Only vm0-provider runs are compared.  For other providers the proxy does
+ * not report usage (see `billableFirewalls` in `build-zero-context.ts`),
+ * so `credit_usage` is legitimately empty and the comparison would
+ * false-alarm on every run.
  */
 export async function compareRecentRunsProxyUsage(): Promise<void> {
   const db = globalThis.services.db;
@@ -26,10 +32,12 @@ export async function compareRecentRunsProxyUsage(): Promise<void> {
   const runs = await db
     .select({ id: agentRuns.id, orgId: agentRuns.orgId })
     .from(agentRuns)
+    .innerJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
     .where(
       and(
         gte(agentRuns.completedAt, windowStart),
         lte(agentRuns.completedAt, windowEnd),
+        eq(zeroRuns.modelProvider, "vm0"),
       ),
     )
     // Cap to keep the IN (...) clause in compareProxyUsage bounded.


### PR DESCRIPTION
## Summary

- Follow-up to #10406 (which stopped the proxy from writing `credit_usage` rows for non-vm0 runs). The existing `compareRecentRunsProxyUsage` cron still iterated every completed run, so every BYOK run with a client-reported result event now emits a `Proxy usage missing for run with client data` false alarm.
- Inner-join `zero_runs` in the cron's runs query and filter `modelProvider = "vm0"` so only platform-billable runs enter the comparison. Runs without a `zero_runs` row (plain agent runs that never went through the zero layer) are excluded for the same reason — there is no proxy usage to audit against.
- `createCompletedRun` test helper now seeds a matching `zero_runs(modelProvider="vm0")` row by default; a new `opts.modelProvider` override lets tests simulate BYOK (`"anthropic-api-key"`, `"moonshot-api-key"`) and plain agent-run (`null`) paths.

## Why this is safe

- `billableFirewalls` is populated *only* when `resolvedModelProvider === "vm0"` (see `build-zero-context.ts:265-268`), and `resolvedModelProvider` is what gets persisted into `zero_runs.modelProvider` via `updateZeroRunModelInfo`. So `zero_runs.modelProvider === "vm0"` is the exact same gate the proxy uses on the write side — filtering on it here is the mirror condition.
- If the proxy is truly dropping reports for a vm0 run, the `!proxy` and `proxyVal < clientVal` alerts still fire.

## Test plan

- [x] `pnpm -F web exec vitest run app/api/cron/compare-proxy-usage` — 15/15 pass (4 new cases: BYOK missing-proxy, BYOK undercount, missing-zero-run, mixed vm0 + BYOK)
- [x] `pnpm -F web exec vitest run app/api/cron/process-credits` — 15/15 pass (shares the helper)
- [x] `pnpm check-types`, `pnpm turbo run lint --filter=web`, `pnpm format`, `pnpm knip` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)