### PR TITLE
fix(guest-agent): bump stuck tool timeout from 60s to 180s

### DIFF
--- a/crates/guest-agent/src/constants.rs
+++ b/crates/guest-agent/src/constants.rs
@@ -29,7 +29,7 @@ pub const HTTP_UPLOAD_TIMEOUT_SECS: u64 = 60;
 /// Kill the CLI process if a network tool hasn't returned a result within
 /// this duration.  Override with `VM0_STUCK_TOOL_TIMEOUT_SECS` env var.
 /// See: https://github.com/anthropics/claude-code/issues/11650
-pub const STUCK_TOOL_TIMEOUT_SECS: u64 = 60;
+pub const STUCK_TOOL_TIMEOUT_SECS: u64 = 180;
 
 /// How often (in seconds) to check for stuck tools in the select loop.
 pub const STUCK_TOOL_CHECK_INTERVAL_SECS: u64 = 5;


### PR DESCRIPTION
## Summary
- Bump `STUCK_TOOL_TIMEOUT_SECS` default from 60s to 180s
- WebSearch occasionally takes longer than 60s, killing otherwise-healthy runs (see #10450)
- Still bounded so genuinely stuck CLI (Claude Code bug anthropics/claude-code#11650) gets killed
- Escape hatch unchanged: `VM0_STUCK_TOOL_TIMEOUT_SECS` env var still overrides

Closes #10450

## Test plan
- [x] `cargo check -p guest-agent` passes
- [x] E2E test `t43-stuck-tool-watchdog.bats` unaffected (uses env var override, not default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)