### PR TITLE
fix(web): guard [locale] page against asset-like paths before auth()

### DIFF
--- a/turbo/apps/web/app/[locale]/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/[locale]/__tests__/page.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Home from "../page";
+
+const { authMock, notFoundMock } = vi.hoisted(() => {
+  return {
+    authMock: vi.fn(),
+    // Mirror React's notFound(): throw a tagged error so any code running
+    // after this call short-circuits, matching production behaviour.
+    notFoundMock: vi.fn(() => {
+      throw new Error("NEXT_NOT_FOUND");
+    }),
+  };
+});
+
+vi.mock("@clerk/nextjs/server", () => {
+  return {
+    auth: authMock,
+  };
+});
+
+vi.mock("next/navigation", () => {
+  return {
+    notFound: notFoundMock,
+  };
+});
+
+vi.mock("next-intl/server", () => {
+  return {
+    getRequestConfig: vi.fn((fn: unknown) => {
+      return fn;
+    }),
+  };
+});
+
+vi.mock("next-intl", () => {
+  return {
+    useTranslations: vi.fn(() => {
+      return (key: string) => {
+        return key;
+      };
+    }),
+    useLocale: vi.fn(() => {
+      return "en";
+    }),
+  };
+});
+
+vi.mock("next-intl/navigation", () => {
+  return {
+    createNavigation: vi.fn(() => {
+      return {
+        Link: () => {
+          return null;
+        },
+        redirect: vi.fn(),
+        usePathname: vi.fn(),
+        useRouter: vi.fn(),
+      };
+    }),
+  };
+});
+
+describe("Home page locale guard", () => {
+  beforeEach(() => {
+    authMock.mockReset();
+    notFoundMock.mockClear();
+    authMock.mockResolvedValue({ userId: null });
+  });
+
+  it("renders for a supported locale by calling auth()", async () => {
+    await Home({ params: Promise.resolve({ locale: "en" }) });
+
+    expect(notFoundMock).not.toHaveBeenCalled();
+    expect(authMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls notFound() for an unsupported locale before auth()", async () => {
+    // Reproduces issue #10363: bots hit asset-like paths (e.g.
+    // /apple-touch-icon-precomposed.png) which Next.js routes to this
+    // dynamic segment. Middleware's matcher excludes dotted paths, so
+    // clerkMiddleware never ran — auth() here would throw.
+    await expect(
+      Home({
+        params: Promise.resolve({ locale: "apple-touch-icon-precomposed.png" }),
+      }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(notFoundMock).toHaveBeenCalledTimes(1);
+    expect(authMock).not.toHaveBeenCalled();
+  });
+
+  it("calls notFound() for non-dotted invalid locales too", async () => {
+    await expect(
+      Home({ params: Promise.resolve({ locale: "zh" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(authMock).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/web/app/[locale]/page.tsx
+++ b/turbo/apps/web/app/[locale]/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { auth } from "@clerk/nextjs/server";
+import { notFound } from "next/navigation";
 import { LandingPage } from "../components/LandingPage";
-import type { Locale } from "../../i18n";
+import { locales, type Locale } from "../../i18n";
 import { buildLocaleAlternates } from "../lib/seo/alternates";
 
 const BASE_URL = "https://www.vm0.ai";
@@ -48,7 +49,17 @@ export async function generateMetadata({
   };
 }
 
-export default async function Home() {
+export default async function Home({ params }: PageProps) {
+  // Must short-circuit before auth() because the middleware matcher excludes
+  // asset-like paths (e.g. /apple-touch-icon-precomposed.png), so those
+  // requests reach this segment without clerkMiddleware having run — calling
+  // auth() there throws. The parent layout also calls notFound(), but pages
+  // render concurrently with layouts in App Router, so we can race it.
+  const { locale } = await params;
+  if (!locales.includes(locale as Locale)) {
+    notFound();
+  }
+
   const { userId } = await auth();
   return <LandingPage initialIsSignedIn={!!userId} />;
 }


### PR DESCRIPTION
## Summary

- Fixes #10363: 65 Sentry occurrences of *"Clerk: auth() was called but Clerk can't detect usage of clerkMiddleware()"*
- Bots hitting legacy asset paths (`/apple-touch-icon-precomposed.png` and similar) get routed to the `[locale]` dynamic segment because they don't exist in `public/`. The middleware matcher excludes dotted paths, so `clerkMiddleware` never runs — and `auth()` in `app/[locale]/page.tsx` throws.
- The parent layout already calls `notFound()` for invalid locales, but pages render concurrently with layouts in App Router, so the page's `auth()` fires before the layout aborts the tree. This adds an explicit locale check in `Home` that wins the race.

## Test plan

- [x] `app/[locale]/__tests__/page.test.tsx` — new; verifies valid locale reaches `auth()`, invalid locale (`apple-touch-icon-precomposed.png`, `zh`) short-circuits with `notFound()` and never calls `auth()`
- [x] `pnpm turbo run lint --filter=web` passes
- [x] `pnpm check-types` passes
- [x] `pnpm -F web exec vitest run 'app/[locale]' '__tests__/proxy'` — 78 tests pass
- [ ] Sentry: verify issue #7420114896 stops firing after deploy