### PR TITLE
fix(ui): align error icon baseline with thinking indicator

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -651,11 +651,8 @@ function AssistantErrorContent({ error }: { error: string }) {
 
   if (isNoModelProvider) {
     return (
-      <div className="flex items-start gap-2 text-foreground">
-        <IconAlertCircle
-          size={16}
-          className="shrink-0 mt-[3px] text-amber-500"
-        />
+      <div className="flex items-center gap-2 text-foreground">
+        <IconAlertCircle size={16} className="shrink-0 text-amber-500" />
         <span>
           No model provider configured yet.{" "}
           <button
@@ -683,11 +680,8 @@ function AssistantErrorContent({ error }: { error: string }) {
 
   if (isProviderIncompatible) {
     return (
-      <div className="flex items-start gap-2 text-foreground">
-        <IconAlertCircle
-          size={16}
-          className="shrink-0 mt-[3px] text-amber-500"
-        />
+      <div className="flex items-center gap-2 text-foreground">
+        <IconAlertCircle size={16} className="shrink-0 text-amber-500" />
         <span>
           This session was started with a different model provider and
           can&apos;t be continued with the current one.{" "}
@@ -703,8 +697,8 @@ function AssistantErrorContent({ error }: { error: string }) {
   }
 
   return (
-    <div className="flex items-start gap-2 text-destructive">
-      <IconAlertCircle size={16} className="shrink-0 mt-[3px]" />
+    <div className="flex items-center gap-2 text-destructive">
+      <IconAlertCircle size={16} className="shrink-0" />
       <Markdown source={error} />
     </div>
   );


### PR DESCRIPTION
## Summary
Aligns the error message icon baseline with the thinking indicator blocks for visual consistency in chat bubbles.

## Changes
- Changed `AssistantErrorContent` flex alignment from `items-start` to `items-center`
- Removed the `mt-[3px]` offset hack from all three `IconAlertCircle` instances
- This makes the error icon sit on the same baseline as the thinking blocks (`zero-blocks`) in the assistant message area

## Test plan
- [ ] Verify error message icon aligns with text baseline in chat thread
- [ ] Verify thinking indicator blocks align with text baseline
- [ ] Check both at desktop (@900px) and mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)