### PR TITLE
fix(zero/billing): return 4xx for downgrade preconditions instead of 500

### DIFF
--- a/turbo/apps/web/app/api/zero/billing/downgrade/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/downgrade/__tests__/route.test.ts
@@ -125,14 +125,16 @@ describe("POST /api/zero/billing/downgrade", () => {
     expect(response.status).toBe(400);
   });
 
-  it("returns 500 when org has no subscription", async () => {
+  it("returns 409 when org has no subscription", async () => {
     const request = createDowngradeRequest({ targetTier: "free" });
     const response = await POST(request);
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(409);
+    const data = await response.json();
+    expect(data.error.code).toBe("CONFLICT");
   });
 
-  it("returns 500 when target tier is same or higher", async () => {
+  it("returns 400 when target tier is same or higher", async () => {
     const subId = uniqueId("sub-same");
     await updateOrgStripeFields(user.orgId, {
       stripeSubscriptionId: subId,
@@ -143,7 +145,9 @@ describe("POST /api/zero/billing/downgrade", () => {
     const request = createDowngradeRequest({ targetTier: "pro" });
     const response = await POST(request);
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.code).toBe("BAD_REQUEST");
   });
 
   it("downgrades team to pro via subscription update", async () => {

--- a/turbo/apps/web/app/api/zero/billing/downgrade/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/downgrade/route.ts
@@ -35,7 +35,23 @@ const router = tsr.router(zeroBillingDowngradeContract, {
 
     const result = await downgradeSubscription(org.orgId, body.targetTier);
 
-    return { status: 200 as const, body: result };
+    if (!result.ok) {
+      if (result.reason === "no_subscription") {
+        return createErrorResponse(
+          "CONFLICT",
+          "Org has no active subscription",
+        );
+      }
+      return createErrorResponse(
+        "BAD_REQUEST",
+        `Cannot downgrade from ${result.currentTier} to ${result.targetTier}: target tier is same or higher`,
+      );
+    }
+
+    return {
+      status: 200 as const,
+      body: { success: true, effectiveDate: result.effectiveDate },
+    };
   },
 });
 

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -448,19 +448,31 @@ const TIER_RANK: Record<OrgTier, number> = {
   team: 2,
 };
 
+type DowngradeResult =
+  | { ok: true; effectiveDate: string | null }
+  | { ok: false; reason: "no_subscription" }
+  | {
+      ok: false;
+      reason: "invalid_target_tier";
+      currentTier: OrgTier;
+      targetTier: "free" | "pro";
+    };
+
 /**
  * Downgrade a subscription to a lower tier.
  *
  * - Team -> Pro: updates the subscription's price via Stripe API (immediate).
  * - Paid -> Free: cancels the subscription at period end.
  *
- * Returns `{ success, effectiveDate }` where effectiveDate is non-null only
- * for cancellations (the date access ends).
+ * Expected client-facing validation failures (no active subscription, target
+ * tier not lower than current) are returned as `{ ok: false, reason }` so the
+ * route layer can map them to 4xx responses. Unexpected failures (Stripe
+ * errors, misconfigured price IDs) continue to throw.
  */
 export async function downgradeSubscription(
   orgId: string,
   targetTier: "free" | "pro",
-): Promise<{ success: boolean; effectiveDate: string | null }> {
+): Promise<DowngradeResult> {
   const db = globalThis.services.db;
 
   const [org] = await db
@@ -474,20 +486,22 @@ export async function downgradeSubscription(
     .limit(1);
 
   if (!org?.stripeSubscriptionId) {
-    throw new Error("Org has no active subscription");
+    return { ok: false, reason: "no_subscription" };
   }
 
   const currentTier = org.tier as OrgTier;
   if (TIER_RANK[targetTier] >= TIER_RANK[currentTier]) {
-    throw new Error(
-      `Cannot downgrade from ${currentTier} to ${targetTier}: target tier is same or higher`,
-    );
+    return {
+      ok: false,
+      reason: "invalid_target_tier",
+      currentTier,
+      targetTier,
+    };
   }
 
   const stripe = getStripe();
 
   if (targetTier === "free") {
-    // Cancel at period end
     await stripe.subscriptions.update(org.stripeSubscriptionId, {
       cancel_at_period_end: true,
     });
@@ -503,10 +517,9 @@ export async function downgradeSubscription(
       targetTier,
       effectiveDate,
     });
-    return { success: true, effectiveDate };
+    return { ok: true, effectiveDate };
   }
 
-  // Team -> Pro: update subscription price
   const subscription = await stripe.subscriptions.retrieve(
     org.stripeSubscriptionId,
   );
@@ -530,7 +543,7 @@ export async function downgradeSubscription(
     from: currentTier,
     to: targetTier,
   });
-  return { success: true, effectiveDate: null };
+  return { ok: true, effectiveDate: null };
 }
 
 /**

--- a/turbo/packages/core/src/contracts/zero-billing.ts
+++ b/turbo/packages/core/src/contracts/zero-billing.ts
@@ -218,6 +218,7 @@ export const zeroBillingDowngradeContract = c.router({
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
+      409: apiErrorSchema,
       500: apiErrorSchema,
       503: apiErrorSchema,
     },


### PR DESCRIPTION
## Summary
- `POST /api/zero/billing/downgrade` was throwing for two expected states — org with no active subscription, or a `targetTier` that isn't actually a downgrade — and surfacing them as 500s (Sentry issue #7426557911, closes #10371).
- `downgradeSubscription` now returns a discriminated result for those cases; the route maps them to **409 CONFLICT** (no active subscription) and **400 BAD_REQUEST** (tier same or higher). Stripe errors and config problems still throw → 500 (those are real bugs).
- Contract now declares 409; integration tests updated to assert the new status + `error.code`.

## Test plan
- [x] `pnpm -F web exec vitest run app/api/zero/billing/downgrade` (9 passed)
- [x] `pnpm -F @vm0/app exec vitest run views/zero-page/__tests__/org-billing-tab` (33 passed)
- [x] `pnpm turbo run lint --filter=web --filter=@vm0/core --filter=@vm0/app`
- [x] `pnpm check-types`
- [x] `pnpm knip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)