### PR TITLE
chore(zero): disallow ask-user-question tool for zero agent runs

### DIFF
--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -52,12 +52,14 @@ function buildAgentIdentityPrompt(identity: AgentIdentity): string {
  * Tools to disallow for all zero agent runs.
  * - Cron tools: agents use `zero schedule` instead.
  * - ScheduleWakeup: powers /loop dynamic (self-paced) mode; agents use `zero schedule` instead.
+ * - AskUserQuestion: zero agents run unattended and cannot block on interactive input.
  */
 export const DISALLOWED_TOOLS = [
   "CronCreate",
   "CronList",
   "CronDelete",
   "ScheduleWakeup",
+  "AskUserQuestion",
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- Add `AskUserQuestion` to the shared `DISALLOWED_TOOLS` list used by all Zero agent runs.
- Zero agents run unattended in the sandbox and cannot block on interactive approval, so this tool would either hang the run or cause the model to fabricate its own "user reply".

## Test plan
- [ ] Trigger a Zero agent run with a prompt that nudges the model toward asking a question; confirm the model no longer invokes `AskUserQuestion` and proceeds directly.
- [ ] Verify non-Zero entry points (`/api/agent/runs`, `vm0 run --disallowed-tools ...`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)