### PR TITLE
ci(e2e): gate browser e2e enforcement on a repo variable

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1119,7 +1119,7 @@ jobs:
       - name: Install E2E dependencies
         run: npm install -g agent-browser@0.22.0
       - name: Run browser E2E tests
-        continue-on-error: true
+        continue-on-error: ${{ vars.CI_CHECK_BROWSER_E2E != '1' }}
         run: |
           BATS_TEST_TIMEOUT=180 ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/02-browser/*.bats
         env:
@@ -2214,7 +2214,7 @@ jobs:
           check_result "deploy-app" "${{ needs.deploy-app.result }}" "true"
           check_result "build-cli" "${{ needs.build-cli.result }}" "true"
           check_result "build-e2b-template" "${{ needs.build-e2b-template.result }}" "true"
-          check_result "cli-e2e-02-browser" "${{ needs.cli-e2e-02-browser.result }}" "informational"
+          check_result "cli-e2e-02-browser" "${{ needs.cli-e2e-02-browser.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
           check_result "cli-e2e-02-playwright" "${{ needs.cli-e2e-02-playwright.result }}" "true"
           check_result "cli-e2e-01-serial" "${{ needs.cli-e2e-01-serial.result }}" "true"
           check_result "deploy-runner-prepare" "${{ needs.deploy-runner-prepare.result }}" "true"

--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -107,7 +107,7 @@ accept_legal_consent() {
   local snap_i
   snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
   local ref
-  ref=$(echo "$snap_i" | grep -iE 'checkbox.*(terms|legal|agree|privacy|consent)' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  ref=$(echo "$snap_i" | grep -iE 'checkbox.*(terms|legal|agree|privacy|consent)' | grep -oE 'ref=e[0-9]+' | head -1 | sed 's/ref=/@/')
   if [[ -n "$ref" ]]; then
     agent-browser click "$ref" 2>/dev/null || true
     agent-browser wait 300
@@ -120,7 +120,7 @@ accept_legal_consent() {
 click_continue() {
   local snap_i ref
   snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
-  ref=$(echo "$snap_i" | grep -E 'button "Continue" \[ref=' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  ref=$(echo "$snap_i" | grep -E 'button "Continue".*ref=e[0-9]+' | grep -oE 'ref=e[0-9]+' | head -1 | sed 's/ref=/@/')
   if [[ -n "$ref" ]]; then
     agent-browser scrollintoview "$ref" 2>/dev/null || true
     agent-browser wait 300


### PR DESCRIPTION
## Summary
- Drive `cli-e2e-02-browser`'s `continue-on-error` and the `ci-gate` enforcement level from a single repo variable `CI_CHECK_BROWSER_E2E`.
- When the variable is `"1"`, the step fails hard and the gate treats the job like other e2e jobs (success or skipped required).
- When the variable is unset or any other value, the previous soft-fail / informational behavior is preserved so this can be rolled back without a code change.

## Context
Run [24718894802](https://github.com/vm0-ai/vm0/actions/runs/24718894802) is an example: both browser e2e cases failed (sign-up stuck, sign-in stuck), the step exited with code 1, but the job was still marked green because of `continue-on-error: true` and the gate entry was `"informational"`. Regressions in browser e2e are currently invisible to the merge queue.

The repo variable `CI_CHECK_BROWSER_E2E=1` is already set, so this PR should make the gate blocking on merge. If the current failures turn out to be environmental, flip the variable off (delete or set to anything other than `"1"`) and CI reverts to the old soft-fail behavior without needing another PR.

## Test plan
- [ ] Confirm this PR's own `cli-e2e-02-browser` job result reflects the new behavior (either passes, or fails with the gate blocking).
- [ ] If it fails, investigate the sign-up/sign-in stuck issue before merging.
- [ ] Verify the ci-gate job log shows `cli-e2e-02-browser` being checked with the `"true"` severity rather than `"informational"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)