### PR TITLE
feat: custom api keys management page with org context support

### DIFF
--- a/turbo/apps/platform/src/signals/api-keys-page/api-keys-page-setup.ts
+++ b/turbo/apps/platform/src/signals/api-keys-page/api-keys-page-setup.ts
@@ -1,0 +1,34 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { FeatureSwitchKey } from "@vm0/core";
+import { SidebarLayout } from "../../views/zero-page/sidebar-layout.tsx";
+import { ApiKeysPage } from "../../views/zero-page/api-keys-page.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { detachedNavigateTo$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
+
+export const setupApiKeysPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const features = await get(featureSwitch$);
+    signal.throwIfAborted();
+    if (!features[FeatureSwitchKey.ApiKeys]) {
+      set(detachedNavigateTo$, ROUTES.home, { replace: true });
+      return;
+    }
+
+    set(
+      updatePage$,
+      createElement(SidebarLayout, null, createElement(ApiKeysPage)),
+    );
+    set(updateDocumentTitle$, "API Keys");
+    await set(hideAppSkeleton$, signal);
+
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/api-keys-page/api-keys-signals.ts
+++ b/turbo/apps/platform/src/signals/api-keys-page/api-keys-signals.ts
@@ -1,0 +1,146 @@
+import { command, computed, state } from "ccstate";
+import {
+  apiKeysContract,
+  apiKeysByIdContract,
+  type ApiKeyItem,
+  type ApiKeyListResponse,
+  type CreateApiKeyResponse,
+} from "@vm0/core";
+import { zeroClient$ } from "../api-client.ts";
+import { accept } from "../../lib/accept.ts";
+
+const internalReloadApiKeys$ = state(0);
+
+export const apiKeys$ = computed(async (get) => {
+  get(internalReloadApiKeys$);
+  const createClient = get(zeroClient$);
+  const client = createClient(apiKeysContract);
+  const result = await accept(client.list(), [200], { toast: false });
+  return result.body as ApiKeyListResponse;
+});
+
+const createApiKey$ = command(
+  async (
+    { get, set },
+    input: { name: string; expiresInDays: number },
+    signal: AbortSignal,
+  ): Promise<CreateApiKeyResponse> => {
+    const createClient = get(zeroClient$);
+    const client = createClient(apiKeysContract);
+    const result = await accept(
+      client.create({ body: input, fetchOptions: { signal } }),
+      [201],
+    );
+    signal.throwIfAborted();
+    set(internalReloadApiKeys$, (x) => {
+      return x + 1;
+    });
+    return result.body as CreateApiKeyResponse;
+  },
+);
+
+const deleteApiKey$ = command(
+  async ({ get, set }, id: string, signal: AbortSignal) => {
+    const createClient = get(zeroClient$);
+    const client = createClient(apiKeysByIdContract);
+    await accept(
+      client.delete({ params: { id }, fetchOptions: { signal } }),
+      [204],
+    );
+    signal.throwIfAborted();
+    set(internalReloadApiKeys$, (x) => {
+      return x + 1;
+    });
+  },
+);
+
+// ── UI state ─────────────────────────────────────────────────────────────
+
+const DEFAULT_EXPIRY_DAYS = 90;
+
+const internalCreateDialogOpen$ = state(false);
+const internalFormName$ = state("");
+const internalFormExpiry$ = state<number>(DEFAULT_EXPIRY_DAYS);
+const internalRevealedToken$ = state<{
+  token: string;
+  name: string;
+} | null>(null);
+const internalRevokeTarget$ = state<ApiKeyItem | null>(null);
+const internalPendingRevokeId$ = state<string | null>(null);
+
+export const apiKeysCreateDialogOpen$ = computed((get) => {
+  return get(internalCreateDialogOpen$);
+});
+export const apiKeysFormName$ = computed((get) => {
+  return get(internalFormName$);
+});
+export const apiKeysFormExpiry$ = computed((get) => {
+  return get(internalFormExpiry$);
+});
+export const apiKeysRevealedToken$ = computed((get) => {
+  return get(internalRevealedToken$);
+});
+export const apiKeysRevokeTarget$ = computed((get) => {
+  return get(internalRevokeTarget$);
+});
+export const apiKeysPendingRevokeId$ = computed((get) => {
+  return get(internalPendingRevokeId$);
+});
+
+export const setApiKeyFormName$ = command(({ set }, value: string) => {
+  set(internalFormName$, value);
+});
+
+export const setApiKeyFormExpiry$ = command(({ set }, value: number) => {
+  set(internalFormExpiry$, value);
+});
+
+export const openCreateApiKeyDialog$ = command(({ set }) => {
+  set(internalFormName$, "");
+  set(internalFormExpiry$, DEFAULT_EXPIRY_DAYS);
+  set(internalCreateDialogOpen$, true);
+});
+
+export const closeCreateApiKeyDialog$ = command(({ set }) => {
+  set(internalCreateDialogOpen$, false);
+});
+
+export const submitCreateApiKey$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const name = get(internalFormName$).trim();
+    const expiresInDays = get(internalFormExpiry$);
+    if (!name) {
+      return;
+    }
+    const result = await set(createApiKey$, { name, expiresInDays }, signal);
+    set(internalCreateDialogOpen$, false);
+    set(internalRevealedToken$, { token: result.token, name: result.name });
+  },
+);
+
+export const closeRevealModal$ = command(({ set }) => {
+  set(internalRevealedToken$, null);
+});
+
+export const openRevokeConfirm$ = command(({ set }, key: ApiKeyItem) => {
+  set(internalRevokeTarget$, key);
+});
+
+export const closeRevokeConfirm$ = command(({ set }) => {
+  set(internalRevokeTarget$, null);
+});
+
+export const confirmRevokeApiKey$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const target = get(internalRevokeTarget$);
+    if (!target) {
+      return;
+    }
+    set(internalPendingRevokeId$, target.id);
+    await set(deleteApiKey$, target.id, signal).finally(() => {
+      set(internalPendingRevokeId$, null);
+    });
+    signal.throwIfAborted();
+    set(internalRevokeTarget$, null);
+  },
+);

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -24,6 +24,7 @@ import { setupAgentsPage$ } from "./agents-page/agents-page-setup.ts";
 import { setupAgentDetailPage$ } from "./agents-page/agent-detail-page-setup.ts";
 import { setupWorksPage$ } from "./works-page/works-page-setup.ts";
 import { setupPreferencesPage$ } from "./preferences-page/preferences-page-setup.ts";
+import { setupApiKeysPage$ } from "./api-keys-page/api-keys-page-setup.ts";
 import { setupSchedulePage$ } from "./schedule-page/schedule-page-setup.ts";
 import { setupScheduleDetailPage$ } from "./schedule-page/schedule-detail-page-setup.ts";
 import { setupAgentChatPage$ } from "./zero-page/agent-chat-page-setup.ts";
@@ -170,6 +171,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.settings,
     setup: setupAuthPageWrapper(setupPreferencesPage$),
+  },
+  {
+    path: ROUTES.settingsApiKeys,
+    setup: setupAuthPageWrapper(setupApiKeysPage$),
   },
   {
     path: ROUTES.scheduleDetail,

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -20,6 +20,7 @@ export const ROUTES = {
   directedAuthorize: "/connectors/:type/authorize",
   settings: "/settings",
   settingsSlack: "/settings/slack",
+  settingsApiKeys: "/settings/api-keys",
   onboarding: "/onboarding",
   signInToken: "/sign-in-token",
   phone: "/phone",

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -114,7 +114,11 @@ export const handleZeroNavSelect$ = command(({ set }, id: SidebarNavId) => {
   set(internalShowAboutPage$, false);
 });
 
-export type ZeroAccountAction = "preferences" | "manage" | "signout";
+export type ZeroAccountAction =
+  | "preferences"
+  | "manage"
+  | "apiKeys"
+  | "signout";
 
 export const handleZeroAccountAction$ = command(
   ({ set }, action: ZeroAccountAction) => {
@@ -123,6 +127,10 @@ export const handleZeroAccountAction$ = command(
     }
     if (action === "preferences") {
       set(detachedNavigateTo$, ROUTES.settings);
+      return;
+    }
+    if (action === "apiKeys") {
+      set(detachedNavigateTo$, ROUTES.settingsApiKeys);
     }
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/api-keys-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/api-keys-page.tsx
@@ -1,0 +1,360 @@
+import { useGet, useSet, useLoadable } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import { IconKey, IconTrash, IconLoader2, IconPlus } from "@tabler/icons-react";
+import type { ApiKeyItem } from "@vm0/core";
+import { Button } from "@vm0/ui/components/ui/button";
+import { Input } from "@vm0/ui/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@vm0/ui/components/ui/table";
+import { CopyButton } from "@vm0/ui/components/ui/copy-button";
+import { detach, Reason } from "../../signals/utils.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import {
+  apiKeys$,
+  apiKeysCreateDialogOpen$,
+  apiKeysFormExpiry$,
+  apiKeysFormName$,
+  apiKeysPendingRevokeId$,
+  apiKeysRevealedToken$,
+  apiKeysRevokeTarget$,
+  closeCreateApiKeyDialog$,
+  closeRevealModal$,
+  closeRevokeConfirm$,
+  confirmRevokeApiKey$,
+  openCreateApiKeyDialog$,
+  openRevokeConfirm$,
+  setApiKeyFormExpiry$,
+  setApiKeyFormName$,
+  submitCreateApiKey$,
+} from "../../signals/api-keys-page/api-keys-signals.ts";
+
+const EXPIRY_OPTIONS = [
+  { value: 30, label: "30 days" },
+  { value: 90, label: "90 days" },
+  { value: 365, label: "1 year" },
+  { value: 3650, label: "Never (10 years)" },
+] as const;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
+
+function formatLastUsed(iso: string | null): string {
+  if (!iso) {
+    return "Never";
+  }
+  return new Date(iso).toLocaleDateString();
+}
+
+function ApiKeysTable({ keys }: { keys: ApiKeyItem[] }) {
+  const pendingRevokeId = useGet(apiKeysPendingRevokeId$);
+  const openRevoke = useSet(openRevokeConfirm$);
+
+  if (keys.length === 0) {
+    return (
+      <div className="rounded-xl zero-border bg-card px-6 py-10 text-center text-sm text-muted-foreground">
+        No API keys yet. Create one to access <code>/api/v1</code>.
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-xl zero-border bg-card overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Token</TableHead>
+            <TableHead>Created</TableHead>
+            <TableHead>Last used</TableHead>
+            <TableHead>Expires</TableHead>
+            <TableHead className="w-[60px]" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {keys.map((k) => {
+            const revoking = pendingRevokeId === k.id;
+            return (
+              <TableRow key={k.id}>
+                <TableCell className="font-medium">{k.name}</TableCell>
+                <TableCell>
+                  <code className="text-xs">{k.tokenPrefix}</code>
+                </TableCell>
+                <TableCell>{formatDate(k.createdAt)}</TableCell>
+                <TableCell>{formatLastUsed(k.lastUsedAt)}</TableCell>
+                <TableCell>{formatDate(k.expiresAt)}</TableCell>
+                <TableCell>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={revoking}
+                    onClick={() => {
+                      openRevoke(k);
+                    }}
+                    aria-label={`Revoke ${k.name}`}
+                  >
+                    {revoking ? (
+                      <IconLoader2
+                        size={16}
+                        className="animate-spin text-muted-foreground"
+                      />
+                    ) : (
+                      <IconTrash size={16} className="text-muted-foreground" />
+                    )}
+                  </Button>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function CreateApiKeyDialog() {
+  const open = useGet(apiKeysCreateDialogOpen$);
+  const name = useGet(apiKeysFormName$);
+  const setName = useSet(setApiKeyFormName$);
+  const expiresInDays = useGet(apiKeysFormExpiry$);
+  const setExpiresInDays = useSet(setApiKeyFormExpiry$);
+  const closeDialog = useSet(closeCreateApiKeyDialog$);
+  const pageSignal = useGet(pageSignal$);
+  const [submitLoadable, submit] = useLoadableSet(submitCreateApiKey$);
+  const submitting = submitLoadable.state === "loading";
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          closeDialog();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create API key</DialogTitle>
+          <DialogDescription>
+            This key grants access to <code>/api/v1</code> for your current
+            organization.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          <div className="flex flex-col gap-2">
+            <label htmlFor="api-key-name" className="text-sm font-medium">
+              Name
+            </label>
+            <Input
+              id="api-key-name"
+              value={name}
+              onChange={(e) => {
+                return setName(e.target.value);
+              }}
+              placeholder="e.g. CI bot"
+              maxLength={100}
+              autoFocus
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="api-key-expiry" className="text-sm font-medium">
+              Expiration
+            </label>
+            <Select
+              value={String(expiresInDays)}
+              onValueChange={(v) => {
+                return setExpiresInDays(Number(v));
+              }}
+            >
+              <SelectTrigger id="api-key-expiry">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {EXPIRY_OPTIONS.map((opt) => {
+                  return (
+                    <SelectItem key={opt.value} value={String(opt.value)}>
+                      {opt.label}
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={closeDialog} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              detach(submit(pageSignal), Reason.DomCallback);
+            }}
+            disabled={submitting || name.trim().length === 0}
+          >
+            {submitting ? (
+              <IconLoader2 size={16} className="animate-spin" />
+            ) : null}
+            Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RevokeConfirmDialog() {
+  const target = useGet(apiKeysRevokeTarget$);
+  const close = useSet(closeRevokeConfirm$);
+  const pageSignal = useGet(pageSignal$);
+  const [loadable, confirm] = useLoadableSet(confirmRevokeApiKey$);
+  const submitting = loadable.state === "loading";
+
+  return (
+    <Dialog
+      open={target !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          close();
+        }
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Revoke {target?.name ?? "this key"}?</DialogTitle>
+          <DialogDescription>
+            The token will stop working immediately for <code>/api/v1</code>.
+            This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={close} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              detach(confirm(pageSignal), Reason.DomCallback);
+            }}
+            disabled={submitting}
+          >
+            {submitting ? "Revoking…" : "Revoke"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RevealTokenModal() {
+  const revealed = useGet(apiKeysRevealedToken$);
+  const close = useSet(closeRevealModal$);
+
+  return (
+    <Dialog
+      open={revealed !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          close();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>API key created</DialogTitle>
+          <DialogDescription>
+            Copy this token now — you won&apos;t be able to see it again.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-2 py-2">
+          <div className="text-sm text-muted-foreground">
+            {revealed?.name ?? ""}
+          </div>
+          <div className="flex items-center gap-2 rounded-lg bg-muted p-3">
+            <code className="flex-1 break-all text-xs">
+              {revealed?.token ?? ""}
+            </code>
+            <CopyButton text={revealed?.token ?? ""} />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={close}>Done</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function ApiKeysPage() {
+  const apiKeysLoadable = useLoadable(apiKeys$);
+  const openCreate = useSet(openCreateApiKeyDialog$);
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
+      <header className="hidden md:block shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-4">
+        <div className="mx-auto max-w-[900px] flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground flex items-center gap-2">
+              <IconKey size={20} stroke={1.5} />
+              API Keys
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Personal access tokens for <code>/api/v1</code>
+            </p>
+          </div>
+          <Button onClick={openCreate}>
+            <IconPlus size={16} />
+            Create API key
+          </Button>
+        </div>
+      </header>
+
+      <main className="shrink-0 px-4 sm:px-6 pt-3 pb-16">
+        <div className="mx-auto max-w-[900px] flex flex-col gap-6">
+          {apiKeysLoadable.state === "loading" && (
+            <div className="flex items-center justify-center py-10 text-muted-foreground">
+              <IconLoader2 size={20} className="animate-spin" />
+            </div>
+          )}
+          {apiKeysLoadable.state === "hasError" && (
+            <div className="rounded-xl zero-border bg-card px-6 py-10 text-center text-sm text-destructive">
+              Failed to load API keys.
+            </div>
+          )}
+          {apiKeysLoadable.state === "hasData" && (
+            <ApiKeysTable keys={apiKeysLoadable.data.apiKeys} />
+          )}
+        </div>
+      </main>
+
+      <CreateApiKeyDialog />
+      <RevokeConfirmDialog />
+      <RevealTokenModal />
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -9,6 +9,7 @@ import {
   IconChevronRight,
   IconSwitchHorizontal,
   IconDatabaseExport,
+  IconKey,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/core";
 import {
@@ -129,12 +130,7 @@ export function AccountDropdown({
       return;
     }
     if (action === "manage") {
-      detach(
-        clerk?.openUserProfile({
-          apiKeysProps: { hide: !apiKeysEnabled },
-        }),
-        Reason.DomCallback,
-      );
+      detach(clerk?.openUserProfile(), Reason.DomCallback);
       return;
     }
     onAccountAction?.(action);
@@ -314,6 +310,17 @@ export function AccountDropdown({
           <IconUser size={18} stroke={1.5} className="text-muted-foreground" />
           <span>Manage account</span>
         </DropdownMenuItem>
+        {apiKeysEnabled && (
+          <DropdownMenuItem
+            onClick={() => {
+              return handleAccountAction("apiKeys");
+            }}
+            className="gap-3 px-3 py-2.5 rounded-lg"
+          >
+            <IconKey size={18} stroke={1.5} className="text-muted-foreground" />
+            <span>API Keys</span>
+          </DropdownMenuItem>
+        )}
         {showExportData && (
           <DropdownMenuItem
             onClick={() => {

--- a/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
@@ -41,7 +41,7 @@ describe("/api/integrations/github", () => {
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",
-        { headers: { Authorization: "Bearer test-token" } },
+        {},
       );
       const response = await GET(request);
       const data = await response.json();
@@ -61,7 +61,7 @@ describe("/api/integrations/github", () => {
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",
-        { headers: { Authorization: "Bearer test-token" } },
+        {},
       );
       const response = await GET(request);
       const data = await response.json();
@@ -83,7 +83,7 @@ describe("/api/integrations/github", () => {
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",
-        { headers: { Authorization: "Bearer test-token" } },
+        {},
       );
       const response = await GET(request);
       const data = await response.json();
@@ -119,7 +119,6 @@ describe("/api/integrations/github", () => {
         "http://localhost:3000/api/integrations/github",
         {
           method: "DELETE",
-          headers: { Authorization: "Bearer test-token" },
         },
       );
       const response = await DELETE(request);
@@ -142,7 +141,6 @@ describe("/api/integrations/github", () => {
         "http://localhost:3000/api/integrations/github",
         {
           method: "DELETE",
-          headers: { Authorization: "Bearer test-token" },
         },
       );
       const response = await DELETE(request);
@@ -175,7 +173,6 @@ describe("/api/integrations/github", () => {
         "http://localhost:3000/api/integrations/github",
         {
           method: "DELETE",
-          headers: { Authorization: "Bearer test-token" },
         },
       );
       const response = await DELETE(request);
@@ -214,7 +211,6 @@ describe("/api/integrations/github", () => {
         "http://localhost:3000/api/integrations/github",
         {
           method: "DELETE",
-          headers: { Authorization: "Bearer test-token" },
         },
       );
       const response = await DELETE(request);
@@ -258,7 +254,6 @@ describe("/api/integrations/github", () => {
         {
           method: "PATCH",
           headers: {
-            Authorization: "Bearer test-token",
             "Content-Type": "application/json",
           },
           body: JSON.stringify({}),
@@ -281,7 +276,6 @@ describe("/api/integrations/github", () => {
         {
           method: "PATCH",
           headers: {
-            Authorization: "Bearer test-token",
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ agentName: "some-agent" }),
@@ -312,7 +306,6 @@ describe("/api/integrations/github", () => {
         {
           method: "PATCH",
           headers: {
-            Authorization: "Bearer test-token",
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ agentName: "some-agent" }),
@@ -351,7 +344,6 @@ describe("/api/integrations/github", () => {
         {
           method: "PATCH",
           headers: {
-            Authorization: "Bearer test-token",
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ agentName: "some-agent" }),
@@ -376,7 +368,6 @@ describe("/api/integrations/github", () => {
         {
           method: "PATCH",
           headers: {
-            Authorization: "Bearer test-token",
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ agentName: "nonexistent-agent" }),
@@ -404,7 +395,6 @@ describe("/api/integrations/github", () => {
         {
           method: "PATCH",
           headers: {
-            Authorization: "Bearer test-token",
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ agentName: "new-agent" }),
@@ -418,9 +408,7 @@ describe("/api/integrations/github", () => {
 
       // Verify the agent was updated by fetching the integration
       const getResponse = await GET(
-        createTestRequest("http://localhost:3000/api/integrations/github", {
-          headers: { Authorization: "Bearer test-token" },
-        }),
+        createTestRequest("http://localhost:3000/api/integrations/github", {}),
       );
       const getData = await getResponse.json();
 

--- a/turbo/apps/web/app/api/v1/chat-threads/[threadId]/messages/route.ts
+++ b/turbo/apps/web/app/api/v1/chat-threads/[threadId]/messages/route.ts
@@ -43,9 +43,7 @@ const router = tsr.router(chatThreadV1MessagesContract, {
           id: row.id,
           role: messageRoleSchema.parse(row.role),
           content: row.content,
-          runId: row.runId ?? undefined,
           error: effectiveError,
-          status: row.runStatus ?? undefined,
           createdAt: row.createdAt.toISOString(),
         };
       });

--- a/turbo/apps/web/app/api/v1/chat-threads/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/v1/chat-threads/__tests__/route.test.ts
@@ -11,14 +11,15 @@ import {
   uniqueId,
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
-import {
-  mockClerk,
-  registerMockApiKey,
-} from "../../../../../src/__tests__/clerk-mock";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import {
   insertTestChatThread,
   insertTestChatMessage,
 } from "../../../../../src/__tests__/db-test-seeders/agents";
+import {
+  createTestCliToken,
+  deleteTestCliToken,
+} from "../../../../../src/__tests__/db-test-seeders/auth";
 import { updateOrgDefaultAgent } from "../../../../../src/__tests__/db-test-seeders/org";
 import { getTestZeroAgentId } from "../../../../../src/__tests__/db-test-assertions/agents";
 import { randomUUID } from "crypto";
@@ -40,18 +41,8 @@ function bearerHeaders(secret: string) {
   };
 }
 
-function seedApiKey(
-  secret: string,
-  user: UserContext,
-  overrides?: { revoked?: boolean; expired?: boolean },
-) {
-  registerMockApiKey(secret, {
-    id: uniqueId("api-key"),
-    subject: user.userId,
-    claims: { orgId: user.orgId },
-    revoked: overrides?.revoked,
-    expired: overrides?.expired,
-  });
+async function mintApiKey(user: UserContext): Promise<string> {
+  return createTestCliToken(user.userId, undefined, user.orgId);
 }
 
 describe("GET /api/v1/chat-threads/:threadId", () => {
@@ -73,35 +64,49 @@ describe("GET /api/v1/chat-threads/:threadId", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 401 for unknown API key", async () => {
+  it("returns 401 for opaque (non-vm0_pat_) bearer token", async () => {
     const res = await getThread(
       createTestRequest(GET_THREAD_URL(threadId), {
         method: "GET",
-        headers: bearerHeaders("ak_unknown"),
+        headers: bearerHeaders("ak_unknown_opaque_secret"),
       }),
     );
     expect(res.status).toBe(401);
   });
 
-  it("returns 401 when key is revoked", async () => {
-    const secret = `ak_${uniqueId("secret")}`;
-    seedApiKey(secret, user, { revoked: true });
+  it("returns 401 when PAT is revoked (row deleted)", async () => {
+    const token = await mintApiKey(user);
+    await deleteTestCliToken(token);
     const res = await getThread(
       createTestRequest(GET_THREAD_URL(threadId), {
         method: "GET",
-        headers: bearerHeaders(secret),
+        headers: bearerHeaders(token),
       }),
     );
     expect(res.status).toBe(401);
   });
 
-  it("returns 200 with thread detail when key owns thread", async () => {
-    const secret = `ak_${uniqueId("secret")}`;
-    seedApiKey(secret, user);
+  it("returns 401 when PAT is expired", async () => {
+    const token = await createTestCliToken(
+      user.userId,
+      new Date(Date.now() - 1000),
+      user.orgId,
+    );
     const res = await getThread(
       createTestRequest(GET_THREAD_URL(threadId), {
         method: "GET",
-        headers: bearerHeaders(secret),
+        headers: bearerHeaders(token),
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 with thread detail when PAT owns thread", async () => {
+    const token = await mintApiKey(user);
+    const res = await getThread(
+      createTestRequest(GET_THREAD_URL(threadId), {
+        method: "GET",
+        headers: bearerHeaders(token),
       }),
     );
     expect(res.status).toBe(200);
@@ -115,13 +120,12 @@ describe("GET /api/v1/chat-threads/:threadId", () => {
   });
 
   it("returns 404 when thread belongs to another user", async () => {
-    const secret = `ak_${uniqueId("secret")}`;
-    seedApiKey(secret, user);
+    const token = await mintApiKey(user);
     const otherThreadId = randomUUID();
     const res = await getThread(
       createTestRequest(GET_THREAD_URL(otherThreadId), {
         method: "GET",
-        headers: bearerHeaders(secret),
+        headers: bearerHeaders(token),
       }),
     );
     expect(res.status).toBe(404);
@@ -158,12 +162,11 @@ describe("GET /api/v1/chat-threads/:threadId/messages", () => {
   });
 
   it("returns 200 with messages", async () => {
-    const secret = `ak_${uniqueId("secret")}`;
-    seedApiKey(secret, user);
+    const token = await mintApiKey(user);
     const res = await getMessages(
       createTestRequest(GET_MESSAGES_URL(threadId), {
         method: "GET",
-        headers: bearerHeaders(secret),
+        headers: bearerHeaders(token),
       }),
     );
     expect(res.status).toBe(200);
@@ -171,18 +174,19 @@ describe("GET /api/v1/chat-threads/:threadId/messages", () => {
     expect(body.messages).toHaveLength(2);
     expect(body.messages[0].role).toBe("user");
     expect(body.messages[0].content).toBe("hello");
+    expect(body.messages[0].runId).toBeUndefined();
+    expect(body.messages[0].status).toBeUndefined();
     expect(body.messages[1].role).toBe("assistant");
     expect(body.messages[1].content).toBe("world");
   });
 
   it("returns 404 when thread belongs to another user", async () => {
-    const secret = `ak_${uniqueId("secret")}`;
-    seedApiKey(secret, user);
+    const token = await mintApiKey(user);
     const otherThreadId = randomUUID();
     const res = await getMessages(
       createTestRequest(GET_MESSAGES_URL(otherThreadId), {
         method: "GET",
-        headers: bearerHeaders(secret),
+        headers: bearerHeaders(token),
       }),
     );
     expect(res.status).toBe(404);
@@ -210,12 +214,11 @@ describe("POST /api/v1/chat-threads/messages", () => {
   });
 
   it("returns 400 when no default agent is configured", async () => {
-    const secret = `ak_${uniqueId("secret")}`;
-    seedApiKey(secret, user);
+    const token = await mintApiKey(user);
     const res = await sendMessage(
       createTestRequest(POST_MESSAGE_URL, {
         method: "POST",
-        headers: bearerHeaders(secret),
+        headers: bearerHeaders(token),
         body: JSON.stringify({ prompt: "hi" }),
       }),
     );
@@ -225,13 +228,12 @@ describe("POST /api/v1/chat-threads/messages", () => {
   });
 
   it("returns 404 when posting to another user's existing thread", async () => {
-    const secret = `ak_${uniqueId("secret")}`;
-    seedApiKey(secret, user);
+    const token = await mintApiKey(user);
     const otherThreadId = randomUUID();
     const res = await sendMessage(
       createTestRequest(POST_MESSAGE_URL, {
         method: "POST",
-        headers: bearerHeaders(secret),
+        headers: bearerHeaders(token),
         body: JSON.stringify({
           prompt: "hi",
           threadId: otherThreadId,
@@ -241,8 +243,8 @@ describe("POST /api/v1/chat-threads/messages", () => {
     expect(res.status).toBe(404);
   });
 
-  it("rejects session auth (Clerk cookie) — v1 is api_key only", async () => {
-    // Session is configured via setupUser() but no Bearer api_key sent.
+  it("rejects session auth (Clerk cookie) — v1 is PAT-only", async () => {
+    // Session is configured via setupUser() but no Bearer PAT sent.
     const res = await sendMessage(
       createTestRequest(POST_MESSAGE_URL, {
         method: "POST",
@@ -253,12 +255,12 @@ describe("POST /api/v1/chat-threads/messages", () => {
     expect(res.status).toBe(401);
   });
 
-  it("rejects a CLI PAT token — v1 is api_key only", async () => {
+  it("rejects opaque (non-vm0_pat_) bearer token — v1 is PAT-only", async () => {
     const res = await sendMessage(
       createTestRequest(POST_MESSAGE_URL, {
         method: "POST",
         headers: {
-          Authorization: "Bearer vm0_pat_not_a_real_token",
+          Authorization: "Bearer ak_opaque_legacy_secret",
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ prompt: "hi" }),
@@ -267,21 +269,20 @@ describe("POST /api/v1/chat-threads/messages", () => {
     expect(res.status).toBe(401);
   });
 
-  // NOTE: Full happy-path coverage (201 with runId) is shared with the
-  // existing /api/zero/chat/messages test — that route uses the same
-  // createZeroRun pipeline we reuse here. We stop at the pre-run validation
-  // layer to avoid duplicating heavy model-provider / runner fixtures.
+  // NOTE: Full happy-path coverage is shared with the existing
+  // /api/zero/chat/messages test — that route uses the same createZeroRun
+  // pipeline we reuse here. We stop at the pre-run validation layer to avoid
+  // duplicating heavy model-provider / runner fixtures.
   it("reaches the run pipeline once default agent is configured", async () => {
     const compose = await createTestCompose(uniqueId("v1-send"));
     const agentId = await getTestZeroAgentId(user.orgId, compose.name);
     await updateOrgDefaultAgent(user.orgId, agentId);
 
-    const secret = `ak_${uniqueId("secret")}`;
-    seedApiKey(secret, user);
+    const token = await mintApiKey(user);
     const res = await sendMessage(
       createTestRequest(POST_MESSAGE_URL, {
         method: "POST",
-        headers: bearerHeaders(secret),
+        headers: bearerHeaders(token),
         body: JSON.stringify({ prompt: "hi" }),
       }),
     );
@@ -293,5 +294,13 @@ describe("POST /api/v1/chat-threads/messages", () => {
     expect(res.status).not.toBe(401);
     expect(res.status).not.toBe(403);
     expect([201, 500]).toContain(res.status);
+    if (res.status === 201) {
+      const body = await res.json();
+      expect(body.runId).toBeUndefined();
+      expect(body.status).toBeUndefined();
+      expect(body.threadId).toBeDefined();
+      expect(body.messageId).toBeDefined();
+      expect(body.createdAt).toBeDefined();
+    }
   });
 });

--- a/turbo/apps/web/app/api/v1/chat-threads/messages/route.ts
+++ b/turbo/apps/web/app/api/v1/chat-threads/messages/route.ts
@@ -120,8 +120,6 @@ const router = tsr.router(chatThreadV1SendContract, {
         body: {
           threadId,
           messageId: userMessage.id,
-          runId: result.runId,
-          status: result.status,
           createdAt: result.createdAt.toISOString(),
         },
       };

--- a/turbo/apps/web/app/api/zero/api-keys/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/api-keys/[id]/route.ts
@@ -1,0 +1,45 @@
+import { and, eq } from "drizzle-orm";
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { apiKeysByIdContract, createErrorResponse } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
+
+const router = tsr.router(apiKeysByIdContract, {
+  delete: async ({ params, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const deleted = await globalThis.services.db
+      .delete(cliTokens)
+      .where(
+        and(eq(cliTokens.id, params.id), eq(cliTokens.userId, authCtx.userId)),
+      )
+      .returning({ id: cliTokens.id });
+
+    if (deleted.length === 0) {
+      return createErrorResponse("NOT_FOUND", "API key not found");
+    }
+
+    return {
+      status: 204 as const,
+      body: undefined,
+    };
+  },
+});
+
+const handler = createHandler(apiKeysByIdContract, router, {
+  routeName: "zero.api-keys.byId",
+  errorHandler: createSafeErrorHandler("zero-api-keys-by-id"),
+});
+
+export { handler as DELETE };

--- a/turbo/apps/web/app/api/zero/api-keys/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/api-keys/__tests__/route.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET, POST } from "../route";
+import { DELETE } from "../[id]/route";
+import { createTestRequest } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { randomUUID } from "crypto";
+
+const context = testContext();
+
+const LIST_URL = "http://localhost:3000/api/zero/api-keys";
+const ITEM_URL = (id: string) => {
+  return `http://localhost:3000/api/zero/api-keys/${id}`;
+};
+
+function jsonHeaders() {
+  return { "Content-Type": "application/json" };
+}
+
+async function listApiKeys() {
+  const res = await GET(createTestRequest(LIST_URL, { method: "GET" }));
+  expect(res.status).toBe(200);
+  return (await res.json()).apiKeys as Array<{ id: string; name: string }>;
+}
+
+describe("GET /api/zero/api-keys", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+    const res = await GET(createTestRequest(LIST_URL, { method: "GET" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty list for a user with no keys", async () => {
+    const res = await GET(createTestRequest(LIST_URL, { method: "GET" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.apiKeys).toEqual([]);
+  });
+});
+
+describe("POST /api/zero/api-keys", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+  });
+
+  it("creates a new PAT and returns the full token exactly once", async () => {
+    const res = await POST(
+      createTestRequest(LIST_URL, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ name: "CI bot", expiresInDays: 90 }),
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.token).toMatch(/^vm0_pat_/);
+    expect(body.name).toBe("CI bot");
+    expect(body.tokenPrefix.length).toBeGreaterThan(8);
+    expect(body.id).toBeDefined();
+    expect(body.createdAt).toBeDefined();
+    expect(body.expiresAt).toBeDefined();
+    expect(body.lastUsedAt).toBeNull();
+
+    // Verify via list endpoint — source of truth for persisted state.
+    const keys = await listApiKeys();
+    const found = keys.find((k) => {
+      return k.id === body.id;
+    });
+    expect(found).toBeDefined();
+    expect(found?.name).toBe("CI bot");
+  });
+
+  it("rejects empty name", async () => {
+    const res = await POST(
+      createTestRequest(LIST_URL, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ name: "", expiresInDays: 90 }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-positive expiresInDays", async () => {
+    const res = await POST(
+      createTestRequest(LIST_URL, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ name: "x", expiresInDays: 0 }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects expiresInDays above the 10-year cap", async () => {
+    const res = await POST(
+      createTestRequest(LIST_URL, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ name: "x", expiresInDays: 4000 }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("list excludes the full token and only exposes the prefix", async () => {
+    const createRes = await POST(
+      createTestRequest(LIST_URL, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ name: "Deploy key", expiresInDays: 30 }),
+      }),
+    );
+    const created = await createRes.json();
+
+    const keys = await listApiKeys();
+    const found = keys.find((k) => {
+      return k.id === created.id;
+    }) as (typeof keys)[number] & { token?: string; tokenPrefix?: string };
+    expect(found).toBeDefined();
+    expect(found.token).toBeUndefined();
+    expect(found.tokenPrefix).toBeDefined();
+  });
+});
+
+describe("DELETE /api/zero/api-keys/:id", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("deletes the caller's own key and returns 204", async () => {
+    const createRes = await POST(
+      createTestRequest(LIST_URL, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ name: "to delete", expiresInDays: 30 }),
+      }),
+    );
+    const created = await createRes.json();
+
+    const delRes = await DELETE(
+      createTestRequest(ITEM_URL(created.id), { method: "DELETE" }),
+    );
+    expect(delRes.status).toBe(204);
+
+    const keys = await listApiKeys();
+    expect(
+      keys.find((k) => {
+        return k.id === created.id;
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns 404 for unknown id", async () => {
+    const delRes = await DELETE(
+      createTestRequest(ITEM_URL(randomUUID()), { method: "DELETE" }),
+    );
+    expect(delRes.status).toBe(404);
+  });
+
+  it("returns 404 when another user owns the key", async () => {
+    const other = await context.setupUser({ prefix: "other-user" });
+    // `other` is now the active session — create a key under `other`.
+    const createRes = await POST(
+      createTestRequest(LIST_URL, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ name: "other's key", expiresInDays: 30 }),
+      }),
+    );
+    const created = await createRes.json();
+
+    // Switch back to the original user and try to delete `other`'s key.
+    mockClerk({ userId: user.userId, orgId: user.orgId, orgRole: "org:admin" });
+
+    const delRes = await DELETE(
+      createTestRequest(ITEM_URL(created.id), { method: "DELETE" }),
+    );
+    expect(delRes.status).toBe(404);
+
+    // The key still exists for `other`.
+    mockClerk({
+      userId: other.userId,
+      orgId: other.orgId,
+      orgRole: "org:admin",
+    });
+    const keys = await listApiKeys();
+    expect(
+      keys.find((k) => {
+        return k.id === created.id;
+      }),
+    ).toBeDefined();
+  });
+});

--- a/turbo/apps/web/app/api/zero/api-keys/route.ts
+++ b/turbo/apps/web/app/api/zero/api-keys/route.ts
@@ -1,0 +1,111 @@
+import crypto from "crypto";
+import { desc, eq } from "drizzle-orm";
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../src/lib/ts-rest-handler";
+import { apiKeysContract } from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
+import { cliTokens } from "../../../../src/db/schema/cli-tokens";
+import { generateCliToken } from "../../../../src/lib/auth/sandbox-token";
+import { isApiError } from "../../../../src/lib/shared/errors";
+
+const PREFIX_LENGTH = 12;
+
+function tokenPrefix(token: string): string {
+  return token.slice(0, PREFIX_LENGTH) + "…";
+}
+
+const router = tsr.router(apiKeysContract, {
+  list: async ({ headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const rows = await globalThis.services.db
+      .select()
+      .from(cliTokens)
+      .where(eq(cliTokens.userId, authCtx.userId))
+      .orderBy(desc(cliTokens.createdAt));
+
+    return {
+      status: 200 as const,
+      body: {
+        apiKeys: rows.map((row) => {
+          return {
+            id: row.id,
+            name: row.name,
+            tokenPrefix: tokenPrefix(row.token),
+            createdAt: row.createdAt.toISOString(),
+            expiresAt: row.expiresAt.toISOString(),
+            lastUsedAt: row.lastUsedAt?.toISOString() ?? null,
+          };
+        }),
+      },
+    };
+  },
+
+  create: async ({ body, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    let orgId: string;
+    try {
+      const { org } = await resolveOrg(authCtx);
+      orgId = org.orgId;
+    } catch (error) {
+      if (isApiError(error)) {
+        return {
+          status: error.statusCode as 400 | 401 | 500,
+          body: { error: { message: error.message, code: error.code } },
+        };
+      }
+      throw error;
+    }
+
+    const tokenId = crypto.randomUUID();
+    const now = new Date();
+    const expiresAt = new Date(
+      now.getTime() + body.expiresInDays * 24 * 60 * 60 * 1000,
+    );
+    const token = await generateCliToken(authCtx.userId, orgId, tokenId);
+
+    await globalThis.services.db.insert(cliTokens).values({
+      id: tokenId,
+      token,
+      userId: authCtx.userId,
+      name: body.name,
+      expiresAt,
+      createdAt: now,
+    });
+
+    return {
+      status: 201 as const,
+      body: {
+        id: tokenId,
+        name: body.name,
+        tokenPrefix: tokenPrefix(token),
+        createdAt: now.toISOString(),
+        expiresAt: expiresAt.toISOString(),
+        lastUsedAt: null,
+        token,
+      },
+    };
+  },
+});
+
+const handler = createHandler(apiKeysContract, router, {
+  routeName: "zero.api-keys",
+  errorHandler: createSafeErrorHandler("zero-api-keys"),
+});
+
+export { handler as GET, handler as POST };

--- a/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/prepare/complete/__tests__/route.test.ts
@@ -66,10 +66,18 @@ describe("POST /api/zero/voice-chat/prepare/complete", () => {
   }
 
   it("should reject non-sandbox callers with 400 (no runId)", async () => {
-    // When Clerk authenticates a regular user, authCtx.runId is undefined.
-    // The endpoint returns 400 "must be called from a sandbox run".
+    // When Clerk authenticates a regular user via session (no Bearer token),
+    // authCtx.runId is undefined. The endpoint returns 400 "must be called
+    // from a sandbox run".
     const response = await POST(
-      makeRequest("invalid-token", { content: "test" }),
+      new Request(
+        "http://localhost:3000/api/zero/voice-chat/prepare/complete",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: "test" }),
+        },
+      ),
     );
     const body = await response.json();
     expect(response.status).toBe(400);

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -47,27 +47,6 @@ let orgSlugOverrides = new Map<string, string>();
 // by this test, avoiding cross-file interference in parallel test runs.
 let mockUserIds: string[] = [];
 
-// Module-level registry mapping API key secret → verify() response.
-// Lets individual tests register Clerk-issued API keys (opaque secrets) that
-// the v1 API surface verifies via clerkClient().apiKeys.verify(secret).
-type MockApiKey = {
-  id: string;
-  subject: string;
-  claims: Record<string, unknown> | null;
-  revoked?: boolean;
-  expired?: boolean;
-};
-const mockApiKeys = new Map<string, MockApiKey>();
-
-/**
- * Register a Clerk-issued API key for a test. The secret is the raw token
- * the client sends as `Authorization: Bearer <secret>`; the rest of the
- * fields shape the APIKey object the backend mock returns from verify().
- */
-export function registerMockApiKey(secret: string, key: MockApiKey): void {
-  mockApiKeys.set(secret, key);
-}
-
 /**
  * Configure Clerk auth mock
  * @param options - Auth configuration
@@ -352,35 +331,6 @@ export function mockClerk(options: {
       deleteOrganizationDomain: vi.fn().mockResolvedValue({}),
       updateOrganizationDomain: vi.fn().mockResolvedValue({}),
     },
-    apiKeys: {
-      verify: vi.fn().mockImplementation((secret: string) => {
-        const key = mockApiKeys.get(secret);
-        if (!key) {
-          const err = new Error("API key not found") as Error & {
-            status?: number;
-          };
-          err.status = 404;
-          return Promise.reject(err);
-        }
-        return Promise.resolve({
-          id: key.id,
-          type: "api_key",
-          name: key.id,
-          subject: key.subject,
-          scopes: [],
-          claims: key.claims,
-          revoked: key.revoked ?? false,
-          revocationReason: null,
-          expired: key.expired ?? false,
-          expiration: null,
-          createdBy: null,
-          description: null,
-          lastUsedAt: null,
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-        });
-      }),
-    },
   } as unknown as Awaited<ReturnType<typeof clerkClient>>);
 }
 
@@ -396,6 +346,5 @@ export function clearClerkMock(): string[] {
   createdOrgs = [];
   orgSlugOverrides = new Map();
   mockUserIds = [];
-  mockApiKeys.clear();
   return userIds;
 }

--- a/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
@@ -264,9 +264,28 @@ describe("getAuthContext auth() call optimization", () => {
     expect(mockAuth).toHaveBeenCalled();
   });
 
-  it("should call auth() for unknown Bearer token", async () => {
+  it("should call auth() for unknown Bearer token (Clerk session fallback)", async () => {
+    // Clerk's session.getToken() hands the platform api-client a standard
+    // JWT that the web api-client forwards as `Authorization: Bearer eyJ...`.
+    // That shape matches neither vm0_pat_ nor vm0_sandbox_ prefixes, so it
+    // must fall through to Clerk session auth, not 401.
     await getAuthContext("Bearer unknown_token_format");
     expect(mockAuth).toHaveBeenCalled();
+  });
+
+  it("should resolve Clerk session auth when a Clerk-shape JWT Bearer is presented", async () => {
+    mockAuth.mockResolvedValue({
+      userId: "clerk-user",
+    } as Awaited<ReturnType<typeof auth>>);
+
+    // clerkMiddleware populates auth() from the Authorization header itself;
+    // getAuthContext must defer to it for any non-vm0 Bearer shape.
+    const result = await getAuthContext(
+      "Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe("clerk-user");
+    expect(result?.tokenType).toBe("session");
   });
 
   it("should not call auth() when zero token is provided", async () => {

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -1,5 +1,5 @@
 import { eq, and, gt } from "drizzle-orm";
-import { auth, clerkClient } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 import type { OrgRole, ZeroCapability } from "@vm0/core";
 import { cliTokens } from "../../db/schema/cli-tokens";
 import {
@@ -14,7 +14,7 @@ import { logger } from "../shared/logger";
 
 const log = logger("auth:user");
 
-export type AuthTokenType = "session" | "pat" | "sandbox" | "zero" | "api_key";
+export type AuthTokenType = "session" | "pat" | "sandbox" | "zero";
 
 /**
  * Authentication context returned by getAuthContext.
@@ -111,55 +111,13 @@ export async function getAuthContext(
       }
       return authenticateSandboxToken(token, options);
     }
-
-    // Non-vm0 opaque bearer — try Clerk API Key verification.
-    const apiKeyAuth = await authenticateClerkApiKey(token);
-    if (apiKeyAuth) return apiKeyAuth;
+    // Unknown Bearer shape (e.g. a Clerk session JWT forwarded by the
+    // platform api-client) — fall through to Clerk session auth below.
+    // clerkMiddleware populates `auth()` from the Authorization header
+    // itself, so we defer the decision to it rather than 401'ing here.
   }
 
-  // Fall back to Clerk session auth
   return getClerkSessionAuth();
-}
-
-/**
- * Verify a Clerk-issued API Key (opaque, created via the Clerk dashboard or
- * `<APIKeys />` component). Returns an AuthContext keyed on the key's subject
- * (a user id for user-scoped keys), including any scopes declared on the key.
- * Returns null for any verification failure — callers treat that as 401.
- */
-export async function authenticateClerkApiKey(
-  secret: string,
-): Promise<AuthContext | null> {
-  let apiKey: Awaited<
-    ReturnType<Awaited<ReturnType<typeof clerkClient>>["apiKeys"]["verify"]>
-  >;
-  try {
-    const client = await clerkClient();
-    apiKey = await client.apiKeys.verify(secret);
-  } catch (err) {
-    log.debug("Clerk API key verify failed", err);
-    return null;
-  }
-  if (apiKey.revoked || apiKey.expired) {
-    log.debug("Clerk API key revoked or expired", { id: apiKey.id });
-    return null;
-  }
-  // Only user-scoped keys are supported in v1. Org-scoped Clerk API keys
-  // carry an `org_`-prefixed subject and are rejected here so downstream
-  // code can assume subject === userId.
-  if (apiKey.subject.startsWith("org_")) {
-    log.debug("Clerk API key is org-scoped; v1 accepts user-scoped only", {
-      subject: apiKey.subject,
-    });
-    return null;
-  }
-  const claimedOrgId =
-    typeof apiKey.claims?.orgId === "string" ? apiKey.claims.orgId : undefined;
-  return {
-    userId: apiKey.subject,
-    orgId: claimedOrgId,
-    tokenType: "api_key",
-  };
 }
 
 /** Authenticate a sandbox-prefixed token (sandbox or zero scope). */

--- a/turbo/apps/web/src/lib/auth/require-auth.ts
+++ b/turbo/apps/web/src/lib/auth/require-auth.ts
@@ -1,10 +1,7 @@
 import type { ZeroCapability } from "@vm0/core";
+import { getAuthContext, type AuthContext } from "./get-auth-context";
 import {
-  authenticateClerkApiKey,
-  getAuthContext,
-  type AuthContext,
-} from "./get-auth-context";
-import {
+  isPatToken,
   isSandboxToken,
   verifySandboxToken,
   verifyZeroToken,
@@ -84,15 +81,19 @@ export function isAuthError(
 }
 
 /**
- * Strict authenticator for the public `/api/v1/*` surface: any valid
- * Clerk-issued API Key for the caller's user acts as a personal access token.
- * Session cookies, CLI PAT (`vm0_pat_`), and sandbox/zero tokens are all
- * rejected so these endpoints can never be reached without an explicit,
- * user-created Clerk API key. Verifies the key directly via
- * `clerkClient.apiKeys.verify` and never consults Clerk's session, so it is
- * safe to use under routes where `clerkMiddleware` has been bypassed.
+ * Strict authenticator for the public `/api/v1/*` surface: the caller must
+ * present a `vm0_pat_…` personal access token minted from `/settings/api-keys`
+ * (or the CLI device flow — the same token artifact). Session cookies,
+ * sandbox/zero tokens, and any other bearer shape are rejected so these
+ * endpoints can never be reached without an explicit, user-created PAT.
  *
- * Missing/invalid/revoked/expired keys return 401.
+ * The PAT JWT carries the orgId stamped at mint time, so `resolveOrg` has
+ * explicit org context without a session lookup. We additionally re-check
+ * that the user is still a member of that org — a PAT must not outlive
+ * membership.
+ *
+ * Missing/invalid/revoked/expired keys (or keys whose user left the org)
+ * return 401.
  */
 export async function requireApiKeyAuth(
   authHeader: string | undefined,
@@ -105,9 +106,10 @@ export async function requireApiKeyAuth(
   };
   if (!authHeader?.startsWith("Bearer ")) return unauthorized;
   const token = authHeader.substring(7);
-  // Reject any self-signed prefix on this surface — v1 is api_key only.
-  if (token.startsWith("vm0_")) return unauthorized;
-  const authCtx = await authenticateClerkApiKey(token);
+  if (!isPatToken(token)) return unauthorized;
+  const authCtx = await getAuthContext(authHeader);
   if (!authCtx) return unauthorized;
+  if (authCtx.tokenType !== "pat") return unauthorized;
+  if (!authCtx.orgId) return unauthorized;
   return authCtx;
 }

--- a/turbo/packages/core/src/contracts/api-keys.ts
+++ b/turbo/packages/core/src/contracts/api-keys.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+import { initContract, authHeadersSchema } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const apiKeyItemSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  tokenPrefix: z.string(),
+  createdAt: z.string(),
+  expiresAt: z.string(),
+  lastUsedAt: z.string().nullable(),
+});
+
+export const apiKeyListResponseSchema = z.object({
+  apiKeys: z.array(apiKeyItemSchema),
+});
+
+export const createApiKeyRequestSchema = z.object({
+  name: z.string().min(1).max(100),
+  expiresInDays: z.number().int().positive().max(3650),
+});
+
+export const createApiKeyResponseSchema = apiKeyItemSchema.extend({
+  token: z.string(),
+});
+
+export type ApiKeyItem = z.infer<typeof apiKeyItemSchema>;
+export type ApiKeyListResponse = z.infer<typeof apiKeyListResponseSchema>;
+export type CreateApiKeyRequest = z.infer<typeof createApiKeyRequestSchema>;
+export type CreateApiKeyResponse = z.infer<typeof createApiKeyResponseSchema>;
+
+export const apiKeysContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/api-keys",
+    headers: authHeadersSchema,
+    responses: {
+      200: apiKeyListResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List caller's API keys (metadata only)",
+  },
+  create: {
+    method: "POST",
+    path: "/api/zero/api-keys",
+    headers: authHeadersSchema,
+    body: createApiKeyRequestSchema,
+    responses: {
+      201: createApiKeyResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Create a new API key (token returned once)",
+  },
+});
+
+export type ApiKeysContract = typeof apiKeysContract;
+
+export const apiKeysByIdContract = c.router({
+  delete: {
+    method: "DELETE",
+    path: "/api/zero/api-keys/:id",
+    headers: authHeadersSchema,
+    pathParams: z.object({ id: z.string().uuid() }),
+    responses: {
+      204: c.noBody(),
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Revoke (delete) an API key",
+  },
+});
+
+export type ApiKeysByIdContract = typeof apiKeysByIdContract;

--- a/turbo/packages/core/src/contracts/chat-threads-v1.ts
+++ b/turbo/packages/core/src/contracts/chat-threads-v1.ts
@@ -1,15 +1,15 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
-import { runStatusSchema } from "./runs";
 
 const c = initContract();
 
 /**
- * Public v1 chat-threads surface. Authenticated exclusively via Clerk-issued
- * API Keys (verified server-side). The caller never addresses an agent id —
- * every thread is created under the caller's default agent, and responses
- * omit agent-related fields so the public contract stays narrow.
+ * Public v1 chat-threads surface. Authenticated exclusively via vm0 personal
+ * access tokens (`vm0_pat_…`) minted from `/settings/api-keys`. The caller
+ * never addresses an agent id — every thread is created under the caller's
+ * default agent, and responses omit agent-related fields so the public
+ * contract stays narrow.
  */
 const v1ThreadSchema = z.object({
   id: z.string(),
@@ -22,9 +22,7 @@ const v1MessageSchema = z.object({
   id: z.string(),
   role: z.enum(["user", "assistant"]),
   content: z.string().nullable(),
-  runId: z.string().optional(),
   error: z.string().optional(),
-  status: z.string().optional(),
   createdAt: z.string(),
 });
 
@@ -80,8 +78,6 @@ export const chatThreadV1SendContract = c.router({
       201: z.object({
         threadId: z.string(),
         messageId: z.string(),
-        runId: z.string(),
-        status: runStatusSchema,
         createdAt: z.string(),
       }),
       400: apiErrorSchema,

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -717,6 +717,20 @@ export {
   type ZeroVariablesByNameContract,
 } from "./zero-secrets";
 export {
+  apiKeysContract,
+  apiKeysByIdContract,
+  apiKeyItemSchema,
+  apiKeyListResponseSchema,
+  createApiKeyRequestSchema,
+  createApiKeyResponseSchema,
+  type ApiKeysContract,
+  type ApiKeysByIdContract,
+  type ApiKeyItem,
+  type ApiKeyListResponse,
+  type CreateApiKeyRequest,
+  type CreateApiKeyResponse,
+} from "./api-keys";
+export {
   zeroCustomConnectorsContract,
   zeroCustomConnectorByIdContract,
   zeroCustomConnectorSecretContract,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -288,7 +288,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ApiKeys]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Show the API Keys tab in Manage Account (Clerk UserProfile). When disabled, the tab is hidden even if API Keys are enabled in the Clerk dashboard.",
+      "Gate the custom /settings/api-keys UI for issuing personal access tokens used by the /api/v1 public surface. When disabled, the settings page redirects to / and the sidebar menu item is hidden. The backend /api/v1 verification does NOT consult this flag — previously issued PATs continue to work.",
     enabled: false,
   },
   [FeatureSwitchKey.SlackAgentSwitch]: {


### PR DESCRIPTION
Close #10355. Re-land of #10421 with the Clerk session Bearer regression fixed. Depends on #10463 (revert of #10421) being merged first.

## Context

#10421 shipped two related changes coupled in one PR:

1. **Intended**: replace Clerk-issued API keys on `/api/v1` with vm0 PATs minted from a new `/settings/api-keys` page, because Clerk's `<APIKeys />` front-end does not expose `claims`, so UI-minted keys had no `orgId` and `/api/v1` rejected them.
2. **Accidentally**: removed the fallback path in `get-auth-context.ts` that routed unknown-shape Bearer tokens to `getClerkSessionAuth()`. The platform's `api-client.ts` always forwards Clerk's short-lived session JWT as `Authorization: Bearer eyJ…`, so every logged-in `/api/zero/*` request started 401'ing — most visibly `/api/zero/realtime/token`, which broke Ably push.

#10463 reverted both. This PR re-lands the first and keeps the second path working.

## Changes

### Backend
- `/api/zero/api-keys` (GET list, POST create) and `/api/zero/api-keys/:id` (DELETE revoke) — issue PATs from the web UI against the same `cli_tokens` table the CLI device flow writes to
- `requireApiKeyAuth` now accepts only `vm0_pat_` bearers. Removed the `authenticateClerkApiKey` path, the `api_key` token type, and the Clerk `apiKeys.verify` mock from `clerk-mock.ts`
- V1 contract: drop `runId` and `status` from message list and send response — keep the public surface minimal
- Cascade cleanup: `deleteUserData` already clears `cli_tokens`, so Clerk user.deleted webhook requires no change

### Frontend
- New route `/settings/api-keys` with a table, create dialog (name + 30d/90d/1y/never expiration), one-time token reveal modal, and revoke confirmation dialog
- `ZeroAccountAction` extended with `apiKeys`; dropdown menu drops `apiKeysProps` from the Clerk UserProfile call and adds a new "API Keys" item gated by `FeatureSwitchKey.ApiKeys`
- Feature switch description updated to reflect UI-only gating

### Fix vs #10421 (`get-auth-context.ts`)
Previous code:
```ts
if (isSandboxToken(token)) { ... }
// Unknown bearer shape — no other token types are supported.
return null;
```
New code:
```ts
if (isSandboxToken(token)) { ... }
// Unknown Bearer shape (e.g. a Clerk session JWT forwarded by the
// platform api-client) — fall through to Clerk session auth below.
// clerkMiddleware populates `auth()` from the Authorization header
// itself, so we defer the decision to it rather than 401'ing here.
```
Two spec cases added in `get-auth-context.spec.ts` lock in the fallthrough: `auth()` is invoked for unknown Bearer shapes, and a Clerk-shape JWT Bearer resolves to `tokenType: "session"`. These would have caught the regression.

## Breaking change (pre-release)
Identical to #10421 — `/api/v1` send/list no longer returns `runId` or `status`; Clerk-issued opaque API keys are rejected by `/api/v1`.

## Test plan
- [ ] CI green (lint, check-types, unit, cli-e2e)
- [ ] Manual: log in on app.vm0.ai, confirm `/api/zero/realtime/token` returns 200 and Ably connects
- [ ] Manual: visit `/settings/api-keys`, mint a PAT, use it against `/api/v1/chat-threads`, revoke it and confirm subsequent calls 401
- [ ] Regression: `Authorization: Bearer <clerk-jwt>` against `/api/zero/*` resolves to the session user (covered by new spec cases)

## Merge order
1. Merge #10463 (revert) first
2. Rebase this PR onto the resulting main (trivial — the single commit on this branch is a re-apply of #10421's tree + the auth-context fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)