### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2646,9 +2646,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Updated Rust workspace dependencies via `cargo update --verbose`.

### Updated
- `rustls-webpki` 0.103.12 → 0.103.13

### Could not update
The following dependencies have newer versions available but are blocked by exact or tilde version constraints in upstream transitive crates:

- `crc` 3.3.0 → 3.4.0 — blocked by `crc-fast ~1.9.0` (used by `aws-smithy-checksums 0.64.7`)
- `crc-fast` 1.9.0 → 1.10.0 — blocked by `aws-smithy-checksums 0.64.7` specifying `crc-fast = \"~1.9.0\"`
- `generic-array` 0.14.7 → 0.14.9 — blocked by `crypto-common 0.1.7` specifying `generic-array = \"=0.14.7\"`

### Manual version bumps
None. All workspace `Cargo.toml` version specifiers already allow the latest compatible releases; no direct workspace dependencies required manual bumps.

### Test status
- `cargo test --workspace` — **PASS** (all crates, all unit tests, all doc-tests)
- No compilation warnings or errors introduced.