### PR TITLE
perf(ci): reuse hash-gated provision action in release-please

### DIFF
--- a/.github/actions/provision/action.yml
+++ b/.github/actions/provision/action.yml
@@ -17,6 +17,9 @@ inputs:
   grafana-cloud-api-key:
     description: "Grafana Cloud API key"
     required: true
+  env-label:
+    description: "env_label passed to provision-monitoring (e.g. dev, prod)"
+    required: true
 
 runs:
   using: "composite"
@@ -33,6 +36,7 @@ runs:
         GRAFANA_CLOUD_PROMETHEUS_URL: ${{ inputs.grafana-cloud-prometheus-url }}
         GRAFANA_CLOUD_PROMETHEUS_USER: ${{ inputs.grafana-cloud-prometheus-user }}
         GRAFANA_CLOUD_API_KEY: ${{ inputs.grafana-cloud-api-key }}
+        ENV_LABEL: ${{ inputs.env-label }}
         ANSIBLE_CONFIG: ansible/ansible.cfg
       run: |
         if [ -z "${GRAFANA_CLOUD_API_KEY}" ]; then
@@ -71,7 +75,7 @@ runs:
           -e "grafana_cloud_prometheus_url=${GRAFANA_CLOUD_PROMETHEUS_URL}" \
           -e "grafana_cloud_prometheus_user=${GRAFANA_CLOUD_PROMETHEUS_USER}" \
           -e "grafana_cloud_api_key=${GRAFANA_CLOUD_API_KEY}" \
-          -e "env_label=dev" -v
+          -e "env_label=${ENV_LABEL}" -v
 
         for HOST in $(echo "$STALE_HOSTS" | tr ',' ' '); do
           ssh "${METAL_USER}@${HOST}" "echo ${ANSIBLE_HASH} > ~/.vm0-provision-hash"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -356,6 +356,7 @@ jobs:
           grafana-cloud-prometheus-url: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_URL }}
           grafana-cloud-prometheus-user: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_USER }}
           grafana-cloud-api-key: ${{ secrets.GRAFANA_CLOUD_API_KEY }}
+          env-label: dev
 
       - name: Deploy and build on metal host
         id: build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1276,16 +1276,27 @@ jobs:
             echo "R2_SECRET_ACCESS_KEY=$SK"
           } >> "$GITHUB_ENV"
 
-      - name: Stage runner on production hosts with Ansible
+      # Provision runner + monitoring. The action skips both playbooks when
+      # the remote host's ~/.vm0-provision-hash matches the current
+      # ansible/ tree hash — most releases don't touch ansible/, so this
+      # is typically a no-op (one SSH hash check per host).
+      - name: Provision metal hosts
+        uses: ./.github/actions/provision
+        with:
+          hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          metal-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          grafana-cloud-prometheus-url: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_URL }}
+          grafana-cloud-prometheus-user: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_USER }}
+          grafana-cloud-api-key: ${{ secrets.GRAFANA_CLOUD_API_KEY }}
+          env-label: prod
+
+      - name: Build rootfs and snapshot on production hosts
         env:
           AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
           API_URL: ${{ vars.VM0_API_URL }}
-          GRAFANA_CLOUD_PROMETHEUS_URL: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_URL }}
-          GRAFANA_CLOUD_PROMETHEUS_USER: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_USER }}
-          GRAFANA_CLOUD_API_KEY: ${{ secrets.GRAFANA_CLOUD_API_KEY }}
           # R2 image cache credentials — from resolve-image-cache job (repo-level,
           # not production-scoped) so the runner uses the same bucket as CI.
           # R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY come from $GITHUB_ENV
@@ -1294,22 +1305,6 @@ jobs:
           R2_USER_STORAGES_BUCKET_NAME: ${{ needs.resolve-image-cache.outputs.r2-bucket }}
         run: |
           cd ansible
-          ansible-playbook \
-            -i "${AWS_METAL_RUNNER_HOSTS}," \
-            playbooks/provision-runner.yml \
-            -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
-            -v
-          if [ -n "${GRAFANA_CLOUD_API_KEY}" ]; then
-            ansible-playbook \
-              -i "${AWS_METAL_RUNNER_HOSTS}," \
-              playbooks/provision-monitoring.yml \
-              -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
-              -e "grafana_cloud_prometheus_url=${GRAFANA_CLOUD_PROMETHEUS_URL}" \
-              -e "grafana_cloud_prometheus_user=${GRAFANA_CLOUD_PROMETHEUS_USER}" \
-              -e "grafana_cloud_api_key=${GRAFANA_CLOUD_API_KEY}" \
-              -e "env_label=prod" \
-              -v
-          fi
           ansible-playbook \
             -i "${AWS_METAL_RUNNER_HOSTS}," \
             playbooks/build-runner.yml \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1450,6 +1450,7 @@ jobs:
           grafana-cloud-prometheus-url: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_URL }}
           grafana-cloud-prometheus-user: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_USER }}
           grafana-cloud-api-key: ${{ secrets.GRAFANA_CLOUD_API_KEY }}
+          env-label: dev
 
       - name: Resolve metal hosts
         id: host


### PR DESCRIPTION
## Summary

- `release-please`'s `build-runner-production` ran `provision-runner.yml` and `provision-monitoring.yml` inline on **every** release, taking ~2 min even when `ansible/` was untouched. Typical `build-runner-production` time was 8m 24s, on the critical path of the whole release workflow.
- The existing `./.github/actions/provision` composite action (already used by `crates.yml` and `turbo.yml`) short-circuits both playbooks when the remote host's `~/.vm0-provision-hash` matches the current `ansible/` tree hash. Most releases don't touch `ansible/`, so this collapses to a single SSH hash check per host.
- Added a required `env-label` input so callers declare the monitoring `env_label` explicitly (previously hardcoded to `dev` in the action). Migrated all three callers — `release-please` uses `prod`, `crates.yml` and `turbo.yml` use `dev`.
- `build-runner.yml` (the actual rootfs/snapshot build) stays as a separate inline step in `release-please.yml` since it's not idempotent-skippable.

Expected: `Stage runner on production hosts with Ansible` step drops from ~3 min to a few seconds when `ansible/` is unchanged.

## Test plan

- [ ] First release after merge: provision-hash on prod hosts is stale (previous hash written by inline ansible didn't exist), so provision playbooks **will** run once. Confirm they succeed and write the new hash.
- [ ] Second release without `ansible/` changes: provision step should log `=== Skipping provisioning (hash ... matches on all hosts) ===` and return immediately.
- [ ] Release with `ansible/` changes: provision step re-runs both playbooks.
- [ ] `crates.yml` and `turbo.yml` on a PR: unchanged behavior (still passes `env-label: dev`, monitoring still gets `env=dev` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)