### PR TITLE
fix(runner): close urllib response in firewall auth fetch

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -163,9 +163,9 @@ def _fetch_firewall_headers_sync(
         # ctx.options.vm0_api_url (operator-set at mitmdump launch).
         resp = urllib.request.urlopen(req, timeout=10)  # noqa: S310
     except urllib.error.HTTPError as e:
-        # HTTPError wraps an open socket; close on every exit path to
-        # avoid FD exhaustion under sustained cache-miss load (#10475).
-        try:
+        # HTTPError wraps an open socket; `with e` closes on every exit
+        # path to avoid FD exhaustion under sustained cache-miss load (#10475).
+        with e:
             try:
                 error_body = json.loads(e.read())
             except (json.JSONDecodeError, OSError):
@@ -176,8 +176,6 @@ def _fetch_firewall_headers_sync(
                     error_info.get("message", "Connector not configured"),
                 ) from None
             raise
-        finally:
-            e.close()
     try:
         return json.loads(resp.read())
     finally:

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -163,17 +163,25 @@ def _fetch_firewall_headers_sync(
         # ctx.options.vm0_api_url (operator-set at mitmdump launch).
         resp = urllib.request.urlopen(req, timeout=10)  # noqa: S310
     except urllib.error.HTTPError as e:
+        # HTTPError wraps an open socket; close on every exit path to
+        # avoid FD exhaustion under sustained cache-miss load (#10475).
         try:
-            error_body = json.loads(e.read())
-        except (json.JSONDecodeError, OSError):
-            raise e from None
-        error_info = error_body.get("error", {})
-        if error_info.get("code") == "CONNECTOR_NOT_CONFIGURED":
-            raise ConnectorNotConfiguredError(
-                error_info.get("message", "Connector not configured"),
-            ) from None
-        raise
-    return json.loads(resp.read())
+            try:
+                error_body = json.loads(e.read())
+            except (json.JSONDecodeError, OSError):
+                raise e from None
+            error_info = error_body.get("error", {})
+            if error_info.get("code") == "CONNECTOR_NOT_CONFIGURED":
+                raise ConnectorNotConfiguredError(
+                    error_info.get("message", "Connector not configured"),
+                ) from None
+            raise
+        finally:
+            e.close()
+    try:
+        return json.loads(resp.read())
+    finally:
+        resp.close()
 
 
 async def fetch_firewall_headers(

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1801,6 +1801,44 @@ class TestFetchFirewallHeaders:
         ):
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
 
+    def test_closes_response_on_success(self):
+        """Success path must close the urlopen response — FD leak guard (#10475)."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"headers": {}}).encode()
+
+        with (
+            patch("auth.urllib.request.Request"),
+            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+        ):
+            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
+
+        mock_resp.close.assert_called_once()  # urllib external boundary (#9991)
+
+    def test_closes_http_error_response(self):
+        """HTTPError path must close the underlying socket — FD leak guard (#10475)."""
+        error_body = json.dumps(
+            {"error": {"message": "Bad request", "code": "BAD_REQUEST"}}
+        ).encode()
+        http_error = urllib.error.HTTPError(
+            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
+            400,
+            "Bad Request",
+            {},
+            io.BytesIO(error_body),
+        )
+        http_error.close = MagicMock()
+
+        with (
+            patch("auth.urllib.request.Request"),
+            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+            pytest.raises(urllib.error.HTTPError),
+        ):
+            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
+
+        http_error.close.assert_called_once()  # urllib external boundary (#9991)
+
     async def test_async_wrapper_passes_api_url_from_ctx(self, headers):
         """fetch_firewall_headers reads api_url on the event loop and passes it to the sync fn."""
         mock_resp = MagicMock()


### PR DESCRIPTION
## Summary

- `_fetch_firewall_headers_sync` (auth.py:164) now closes the `urlopen` response on success and the `HTTPError` socket on failure. Each cache-miss previously leaked one FD.
- Under sustained firewall-auth load the leaked sockets exhaust the mitmproxy FD limit; `handle_firewall_request` fail-opens on the resulting `OSError`, so the VM sees `502 auth_failed` with `firewall_action=ALLOW` — indistinguishable from an upstream outage.
- Fix extends the existing `usage._post_webhook` pattern: success path uses explicit `try/finally: resp.close()`, HTTPError arm wraps the full translation block in `with e:` so `close()` runs on every exit (body-parse error, `CONNECTOR_NOT_CONFIGURED` translation, or bare re-raise).

Closes #10475.

Scope note: the sibling leak in `_forward_request_sync` (#10476) is intentionally out of scope for this PR.

## Test plan

- [x] `pytest tests/test_connectors.py::TestFetchFirewallHeaders` — 9/9 pass (2 new)
- [x] `pytest tests/test_connectors.py tests/test_handlers.py` — 445/445 pass (no regression)
- [x] New tests mirror the pattern in `test_handlers.py:2569 test_closes_http_error_response`:
  - `test_closes_response_on_success` — asserts `mock_resp.close.assert_called_once()` on 2xx
  - `test_closes_http_error_response` — asserts `http_error.close.assert_called_once()` on 4xx (the `with e:` form routes through `addinfourl.__exit__` which calls `self.close()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)