### PR TITLE
fix(mitm-addon): close urllib response and error in _forward_request_sync

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -277,10 +277,14 @@ def _forward_request_sync(
             continue
         req.add_header(k, v)
     try:
-        resp = _opener.open(req, timeout=30)
-        return resp.status, resp.read(), _filter_response_headers(dict(resp.headers))
+        with _opener.open(req, timeout=30) as resp:
+            return resp.status, resp.read(), _filter_response_headers(dict(resp.headers))
     except urllib.error.HTTPError as e:
-        return e.code, e.read(), _filter_response_headers(dict(e.headers))
+        # HTTPError wraps an open socket; context-manage it or the fd leaks
+        # (sustained auth.base URL-rewrite traffic would eventually exhaust
+        # the mitmproxy process FD limit).
+        with e:
+            return e.code, e.read(), _filter_response_headers(dict(e.headers))
 
 
 async def forward_request(

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1861,6 +1861,49 @@ class TestForwardRequestSecurity:
         assert result is None
 
 
+class TestForwardRequestResourceCleanup:
+    """Regression tests for #10476: urllib response/HTTPError must be closed
+    or sustained auth.base URL-rewrite traffic will leak sockets and
+    eventually exhaust the mitmproxy process FD limit.
+    """
+
+    def test_closes_response_on_success(self):
+        resp = MagicMock()
+        resp.__enter__.return_value = resp
+        resp.status = 200
+        resp.read.return_value = b"ok"
+        resp.headers = {"Content-Type": "application/json"}
+        with patch.object(auth._opener, "open", return_value=resp):
+            status, body, _ = auth._forward_request_sync("https://example.com", "GET", {}, None)
+        assert status == 200
+        assert body == b"ok"
+        resp.__exit__.assert_called_once()
+
+    def test_closes_httperror_on_error(self):
+        err = urllib.error.HTTPError(
+            "https://example.com", 500, "Server Error", {}, io.BytesIO(b"oops")
+        )
+        err.close = MagicMock(wraps=err.close)
+        with patch.object(auth._opener, "open", side_effect=err):
+            status, body, _ = auth._forward_request_sync("https://example.com", "GET", {}, None)
+        assert status == 500
+        assert body == b"oops"
+        err.close.assert_called_once()
+
+    def test_closes_response_when_read_raises(self):
+        resp = MagicMock()
+        resp.__enter__.return_value = resp
+        resp.status = 200
+        resp.read.side_effect = OSError("socket closed")
+        resp.headers = {}
+        with (
+            patch.object(auth._opener, "open", return_value=resp),
+            pytest.raises(OSError, match="socket closed"),
+        ):
+            auth._forward_request_sync("https://example.com", "GET", {}, None)
+        resp.__exit__.assert_called_once()
+
+
 # =========================================================================
 # auth.base URL rewriting
 # =========================================================================


### PR DESCRIPTION
## Summary

- `_forward_request_sync` (auth.py) never closed the returned `HTTPResponse` on success or the `HTTPError` on failure — each auth.base URL-rewrite forward leaked one socket.
- Wrap both paths in `with` context managers. `HTTPError` inherits `HTTPResponse`'s context-manager protocol, so the same idiom works for both.
- Add 3 regression tests: success closes, HTTPError closes, close still fires when `.read()` raises.

## Why it matters

Connectors configured with `auth.base` cause the addon to forward every matched request itself. Under sustained traffic, the leaked sockets accumulate and the mitmproxy process eventually exhausts its file-descriptor limit. Once the limit is hit, all URL-rewrite forwards fail with `OSError: [Errno 24]`, the broad `except Exception` in `handle_firewall_request` swallows the error, and the VM receives opaque `502 url_rewrite_forward_failed` responses that look indistinguishable from real upstream outages.

Mirrors the close() pattern already used in `usage/webhook.py:_post_webhook`.

Fixes #10476

## Test plan

- [x] `python3 -m pytest` — 895 pass (3 new)
- [x] `ruff check` / `ruff format --check`
- [x] `cargo check -p runner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)