### PR TITLE
feat: remove Vm0GlmModel feature flag, fully enable GLM-5.1

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
@@ -7,7 +7,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@vm0/ui/components/ui/select";
-import { useLastResolved } from "ccstate-react";
 import {
   MODEL_PROVIDER_TYPES,
   getAuthMethodsForType,
@@ -27,7 +26,6 @@ import {
   getUIAuthMethodLabel,
 } from "./provider-ui-config.ts";
 import { ClaudeCodeSetupPrompt } from "./setup-prompt.tsx";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 
 export function OAuthFields({
   secret,
@@ -289,14 +287,12 @@ function ModelSelector({
   onUseDefaultModelChange: (value: boolean) => void;
 }) {
   const type = providerType as keyof typeof MODEL_PROVIDER_TYPES;
-  const features = useLastResolved(featureSwitch$);
-
   if (!hasModelSelection(type)) {
     return null;
   }
 
   const models = (
-    type === "vm0" ? getVm0VisibleModels(features) : (getModels(type) ?? [])
+    type === "vm0" ? getVm0VisibleModels() : (getModels(type) ?? [])
   ).filter((m) => {
     return m !== "";
   });

--- a/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
@@ -10,7 +10,6 @@ import {
   MODEL_PROVIDER_FIREWALL_CONFIGS,
   type ModelProviderType,
 } from "../model-providers";
-import { FeatureSwitchKey } from "../../feature-switch-key";
 
 describe("getProviderBaseUrl", () => {
   it.each([
@@ -136,21 +135,10 @@ describe("model selection for Anthropic-native providers", () => {
 });
 
 describe("getVm0VisibleModels", () => {
-  it("kimi and minimax are always visible (no feature flag required)", () => {
+  it("all models are always visible (no feature flags)", () => {
     const models = getVm0VisibleModels();
     expect(models).toContain("kimi-k2.5");
     expect(models).toContain("MiniMax-M2.7");
-  });
-
-  it("glm-5.1 is excluded when Vm0GlmModel flag is absent", () => {
-    const models = getVm0VisibleModels();
-    expect(models).not.toContain("glm-5.1");
-  });
-
-  it("glm-5.1 is included when Vm0GlmModel flag is enabled", () => {
-    const models = getVm0VisibleModels({
-      [FeatureSwitchKey.Vm0GlmModel]: true,
-    });
     expect(models).toContain("glm-5.1");
   });
 });

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ExpandedFirewallConfig } from "./firewalls";
 
 /**
@@ -42,7 +41,6 @@ interface Vm0ModelConfig {
   // different identifier than what we show to users (e.g. OpenRouter uses
   // "z-ai/glm-5.1" while our UI shows "glm-5.1").
   apiModel?: string;
-  featureFlag?: FeatureSwitchKey;
 }
 
 // Key order is load-bearing: `Object.keys()` preserves insertion order and
@@ -65,7 +63,6 @@ export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
     concreteType: "openrouter-api-key",
     vendor: "openrouter",
     apiModel: "z-ai/glm-5.1",
-    featureFlag: FeatureSwitchKey.Vm0GlmModel,
   },
   "claude-haiku-4-5": {
     concreteType: "anthropic-api-key",
@@ -86,21 +83,10 @@ export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
 };
 
 /**
- * Return the VM0 managed models visible to the caller, filtered by feature
- * switches. Models without a featureFlag are always visible; models with a
- * flag require the flag to be enabled in the supplied feature map.
+ * Return all VM0 managed models visible to the caller.
  */
-export function getVm0VisibleModels(
-  features?: Partial<Record<FeatureSwitchKey, boolean>>,
-): string[] {
-  return Object.entries(VM0_MODEL_TO_PROVIDER)
-    .filter(([, { featureFlag }]) => {
-      if (!featureFlag) return true;
-      return features?.[featureFlag] === true;
-    })
-    .map(([model]) => {
-      return model;
-    });
+export function getVm0VisibleModels(): string[] {
+  return Object.keys(VM0_MODEL_TO_PROVIDER);
 }
 
 /**

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -56,5 +56,4 @@ export enum FeatureSwitchKey {
   ModelProviderSelection = "modelProviderSelection",
   NanoBananaConnector = "nanoBananaConnector",
   UnifyChatThreads = "unifyChatThreads",
-  Vm0GlmModel = "vm0GlmModel",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -279,12 +279,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the Zoom connector (OAuth 2.0) for meetings, past participants, and cloud recordings access",
     enabled: false,
   },
-  [FeatureSwitchKey.Vm0GlmModel]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Expose Z.AI GLM-5.1 as a selectable model under the VM0 managed provider",
-    enabled: false,
-  },
+
   [FeatureSwitchKey.ApiKeys]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Remove the `Vm0GlmModel` feature flag that gates GLM-5.1 visibility in the VM0 managed provider
- GLM-5.1 has been routing through OpenRouter since #10321 (merged Apr 20); the flag is no longer needed
- All users can now see and select GLM-5.1 without feature flag opt-in

## Changes

- **`feature-switch-key.ts`**: Remove `Vm0GlmModel` from `FeatureSwitchKey` enum
- **`feature-switch.ts`**: Remove `Vm0GlmModel` from `FEATURE_SWITCHES` registry
- **`model-providers.ts`**: Remove `featureFlag` field from `Vm0ModelConfig` interface and GLM-5.1 entry; simplify `getVm0VisibleModels()` to return all models unconditionally
- **`model-providers.test.ts`**: Update `getVm0VisibleModels` tests to reflect flagless behavior

## Test plan

- [ ] Verify GLM-5.1 appears in the Built-in model dropdown for non-staff users
- [ ] Verify existing GLM-5.1 agents (David, Iris) continue to work
- [ ] CI passes (unit tests + type check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)