### PR TITLE
fix: skip chat composer auto-focus on iOS

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -111,6 +111,16 @@ import { setBillingDialogOpen$ } from "../../signals/zero-page/billing.ts";
 
 const MAX_FILE_SIZE = 1024 * 1024 * 1024; // 1 GB — keep in sync with web constants
 
+// iOS auto-focus pops the on-screen keyboard and scrolls the viewport, which is
+// jarring when landing on a chat page. Desktop/Android behavior is unchanged.
+function isIOSDevice(): boolean {
+  const ua = navigator.userAgent;
+  return (
+    /iPad|iPhone|iPod/.test(ua) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
@@ -872,7 +882,7 @@ export function ZeroChatComposer({
             )}
             <textarea
               ref={(el) => {
-                if (el && autoFocus) {
+                if (el && autoFocus && !isIOSDevice()) {
                   el.focus();
                 }
                 setInputRef?.(el);


### PR DESCRIPTION
## Summary
- `ZeroChatComposer` called `textarea.focus()` unconditionally when `autoFocus` was set, which on iOS pops the on-screen keyboard and scrolls the viewport as soon as the user lands on `/agents/chat` or a thread page.
- Add an inline `isIOSDevice()` check (covers iPhone/iPad/iPod UAs and iPadOS pretending to be MacIntel with touch) and skip the programmatic focus on iOS only. Desktop and Android are unchanged.

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run` for `zero-chat-composer-*` (interaction/display/mic-button), `sidebar-navigation`, `chat-default-model-resolution`, `zero-chat-thread-page-interaction` — all green (default jsdom UA is non-iOS, so existing autoFocus assertions still pass)
- [x] `pnpm -F @vm0/app check-types`
- [x] `pnpm -F @vm0/app lint`
- [ ] Manual: open `/agents/chat` on iOS Safari — composer no longer steals focus; opening on desktop still auto-focuses