### PR TITLE
feat: add deepseek-chat to vm0 managed models with feature flag

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
@@ -7,6 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@vm0/ui/components/ui/select";
+import { useLastResolved } from "ccstate-react";
 import {
   MODEL_PROVIDER_TYPES,
   getAuthMethodsForType,
@@ -26,6 +27,7 @@ import {
   getUIAuthMethodLabel,
 } from "./provider-ui-config.ts";
 import { ClaudeCodeSetupPrompt } from "./setup-prompt.tsx";
+import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 
 export function OAuthFields({
   secret,
@@ -287,12 +289,14 @@ function ModelSelector({
   onUseDefaultModelChange: (value: boolean) => void;
 }) {
   const type = providerType as keyof typeof MODEL_PROVIDER_TYPES;
+  const features = useLastResolved(featureSwitch$);
+
   if (!hasModelSelection(type)) {
     return null;
   }
 
   const models = (
-    type === "vm0" ? getVm0VisibleModels() : (getModels(type) ?? [])
+    type === "vm0" ? getVm0VisibleModels(features) : (getModels(type) ?? [])
   ).filter((m) => {
     return m !== "";
   });

--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -92,6 +92,14 @@ const MODEL_PRICING: (typeof creditPricing.$inferInsert)[] = [
     cacheReadTokenPrice: usd(0.06),
     cacheCreationTokenPrice: usd(0.375),
   },
+  {
+    model: "deepseek-chat",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(0.28),
+    outputTokenPrice: usd(0.42),
+    cacheReadTokenPrice: usd(0.028),
+    cacheCreationTokenPrice: 0,
+  },
 ];
 
 /**

--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -171,11 +171,17 @@ describe("VM0 managed model provider", () => {
     });
 
     it("should have all VM0 provider models mapped", () => {
-      const vm0Models = Object.keys(VM0_MODEL_TO_PROVIDER);
-      expect(vm0Models.length).toBeGreaterThan(0);
-      for (const model of vm0Models) {
-        expect(VM0_MODEL_TO_PROVIDER[model]).toBeDefined();
-      }
+      expect(Object.keys(VM0_MODEL_TO_PROVIDER)).toEqual([
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "glm-5.1",
+        "claude-haiku-4-5",
+        "kimi-k2.6",
+        "kimi-k2.5",
+        "MiniMax-M2.7",
+        "deepseek-chat",
+      ]);
     });
   });
 

--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -171,21 +171,11 @@ describe("VM0 managed model provider", () => {
     });
 
     it("should have all VM0 provider models mapped", () => {
-      const vm0Models = [
-        "claude-opus-4-7",
-        "claude-opus-4-6",
-        "claude-sonnet-4-6",
-        "claude-haiku-4-5",
-        "glm-5.1",
-        "kimi-k2.6",
-        "kimi-k2.5",
-        "MiniMax-M2.7",
-        "deepseek-chat",
-      ];
+      const vm0Models = Object.keys(VM0_MODEL_TO_PROVIDER);
+      expect(vm0Models.length).toBeGreaterThan(0);
       for (const model of vm0Models) {
         expect(VM0_MODEL_TO_PROVIDER[model]).toBeDefined();
       }
-      expect(Object.keys(VM0_MODEL_TO_PROVIDER)).toHaveLength(vm0Models.length);
     });
   });
 

--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -180,6 +180,7 @@ describe("VM0 managed model provider", () => {
         "kimi-k2.6",
         "kimi-k2.5",
         "MiniMax-M2.7",
+        "deepseek-chat",
       ];
       for (const model of vm0Models) {
         expect(VM0_MODEL_TO_PROVIDER[model]).toBeDefined();

--- a/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
@@ -8,6 +8,7 @@ import {
   getDefaultModel,
   getEnvironmentMapping,
   getVm0VisibleModels,
+  VM0_MODEL_TO_PROVIDER,
   MODEL_PROVIDER_FIREWALL_CONFIGS,
   type ModelProviderType,
 } from "../model-providers";
@@ -141,7 +142,17 @@ describe("getVm0VisibleModels", () => {
     expect(models).toContain("kimi-k2.5");
     expect(models).toContain("MiniMax-M2.7");
     expect(models).toContain("glm-5.1");
-    expect(models).not.toContain("deepseek-chat");
+    // All feature-flagged models must be hidden when no features are provided
+    const featureFlaggedModels = Object.entries(VM0_MODEL_TO_PROVIDER)
+      .filter(([, config]) => {
+        return config.featureFlag !== undefined;
+      })
+      .map(([model]) => {
+        return model;
+      });
+    for (const model of featureFlaggedModels) {
+      expect(models).not.toContain(model);
+    }
   });
 
   it("hides deepseek-chat when Vm0DeepseekModel flag is disabled", () => {

--- a/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { FeatureSwitchKey } from "../../feature-switch-key";
 import {
   getProviderBaseUrl,
   areProvidersCompatible,
@@ -135,11 +136,26 @@ describe("model selection for Anthropic-native providers", () => {
 });
 
 describe("getVm0VisibleModels", () => {
-  it("all models are always visible (no feature flags)", () => {
+  it("returns all models when no features are provided", () => {
     const models = getVm0VisibleModels();
     expect(models).toContain("kimi-k2.5");
     expect(models).toContain("MiniMax-M2.7");
     expect(models).toContain("glm-5.1");
+    expect(models).not.toContain("deepseek-chat");
+  });
+
+  it("hides deepseek-chat when Vm0DeepseekModel flag is disabled", () => {
+    const models = getVm0VisibleModels({
+      [FeatureSwitchKey.Vm0DeepseekModel]: false,
+    });
+    expect(models).not.toContain("deepseek-chat");
+  });
+
+  it("shows deepseek-chat when Vm0DeepseekModel flag is enabled", () => {
+    const models = getVm0VisibleModels({
+      [FeatureSwitchKey.Vm0DeepseekModel]: true,
+    });
+    expect(models).toContain("deepseek-chat");
   });
 });
 

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ExpandedFirewallConfig } from "./firewalls";
 
 /**
@@ -41,6 +42,7 @@ interface Vm0ModelConfig {
   // different identifier than what we show to users (e.g. OpenRouter uses
   // "z-ai/glm-5.1" while our UI shows "glm-5.1").
   apiModel?: string;
+  featureFlag?: FeatureSwitchKey;
 }
 
 // Key order is load-bearing: `Object.keys()` preserves insertion order and
@@ -80,13 +82,29 @@ export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
     concreteType: "minimax-api-key",
     vendor: "minimax",
   },
+  "deepseek-chat": {
+    concreteType: "deepseek-api-key",
+    vendor: "deepseek",
+    featureFlag: FeatureSwitchKey.Vm0DeepseekModel,
+  },
 };
 
 /**
- * Return all VM0 managed models visible to the caller.
+ * Return the VM0 managed models visible to the caller, filtered by feature
+ * switches. Models without a featureFlag are always visible; models with a
+ * flag require the flag to be enabled in the supplied feature map.
  */
-export function getVm0VisibleModels(): string[] {
-  return Object.keys(VM0_MODEL_TO_PROVIDER);
+export function getVm0VisibleModels(
+  features?: Partial<Record<FeatureSwitchKey, boolean>>,
+): string[] {
+  return Object.entries(VM0_MODEL_TO_PROVIDER)
+    .filter(([, { featureFlag }]) => {
+      if (!featureFlag) return true;
+      return features?.[featureFlag] === true;
+    })
+    .map(([model]) => {
+      return model;
+    });
 }
 
 /**

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -56,4 +56,5 @@ export enum FeatureSwitchKey {
   ModelProviderSelection = "modelProviderSelection",
   NanoBananaConnector = "nanoBananaConnector",
   UnifyChatThreads = "unifyChatThreads",
+  Vm0DeepseekModel = "vm0DeepseekModel",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -330,6 +330,11 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "still uses the current-agent fallback.",
     enabled: false,
   },
+  [FeatureSwitchKey.Vm0DeepseekModel]: {
+    maintainer: "ethan@vm0.ai",
+    description: "Enable the DeepSeek-V3.2 (deepseek-chat) VM0 managed model",
+    enabled: false,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary

Add DeepSeek-V3.2 (`deepseek-chat`) to the VM0 managed model list, gated behind the `Vm0DeepseekModel` feature flag (default disabled).

## Changes

- **model-providers.ts**: Restore feature flag filtering in `getVm0VisibleModels`; add `deepseek-chat` mapped to `deepseek-api-key` vendor with `Vm0DeepseekModel` flag
- **feature-switch-key.ts**: Add `Vm0DeepseekModel` enum value
- **feature-switch.ts**: Register `Vm0DeepseekModel` in feature switch registry (default `enabled: false`)
- **provider-dialog-fields.tsx**: Restore `useLastResolved(featureSwitch$)` hook and pass resolved features into `getVm0VisibleModels`
- **dev-seed.ts**: Add credit pricing seed for `deepseek-chat` (input $0.28/M, output $0.42/M, cache read $0.028/M, cache creation $0)
- **model-providers.test.ts**: Update tests to verify flag-based visibility for `deepseek-chat`

## Pricing

| Token Type | Price (per 1M) | Credits |
|---|---|---|
| Input | $0.28 | 280 |
| Output | $0.42 | 420 |
| Cache read | $0.028 | 28 |
| Cache creation | $0.00 | 0 |

## Notes

- Uses DeepSeek overseas direct connection (`https://api.deepseek.com/anthropic`)
- `cacheCreationTokenPrice` is set to 0 because DeepSeek's Anthropic-compatible endpoint ignores `anthropic-beta` prompt-caching headers and does not return `cache_creation_input_tokens`
- Feature flag allows gradual rollout before full enablement

🤖 Generated with [Claude Code](https://claude.com/code)