### PR TITLE
fix: invalidate agentById cache after agent mutations

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/agent.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/agent.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { zeroAgentsByIdContract } from "@vm0/core";
+import { server } from "../../mocks/server.ts";
+import { mockApi } from "../../mocks/msw-contract.ts";
+import { setMockOnboardingStatus } from "../../mocks/handlers/api-onboarding.ts";
+import { detachedSetupPage } from "../../__tests__/page-helper.ts";
+import { testContext } from "./test-helpers.ts";
+import {
+  agentById,
+  defaultAgentName$,
+  leadAgentAvatarUrl$,
+  reloadAgentById$,
+} from "../agent.ts";
+import { zeroJobUpdateSettings$ } from "../zero-page/job-detail/settings.ts";
+import { deleteZeroJobAgent$ } from "../zero-page/job-detail/delete.ts";
+import {
+  setActiveAgent$,
+  zeroJobDetail$,
+} from "../zero-page/zero-job-detail.ts";
+
+const context = testContext();
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+interface AgentOverrides {
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  selectedModel?: string | null;
+}
+
+function mockAgentResponse(overrides: AgentOverrides = {}) {
+  return {
+    agentId: AGENT_ID,
+    ownerId: "test-owner-id",
+    description: null,
+    displayName: null,
+    sound: null,
+    avatarUrl: null,
+    permissionPolicies: null,
+    customSkills: [],
+    modelProviderId: null,
+    selectedModel: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Install a GET /api/zero/agents/:id handler that serves whatever the caller
+ * most recently placed in the mutable `state` box. Every invocation is counted
+ * so tests can assert how many times `agentById()` refetched.
+ */
+function serveAgent(state: { current: AgentOverrides }): { getCalls: number } {
+  const counter = { getCalls: 0 };
+  server.use(
+    mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+      counter.getCalls += 1;
+      return respond(200, mockAgentResponse(state.current));
+    }),
+  );
+  return counter;
+}
+
+describe("agentById$ cache invalidation", () => {
+  it("returns the fresh response after reloadAgentById$ is dispatched", async () => {
+    const state = { current: { displayName: "Old Name" } as AgentOverrides };
+    const counter = serveAgent(state);
+
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    // `agentById()` constructs a new `computed` per call — hold one instance
+    // so repeated reads exercise ccstate's cache rather than building fresh
+    // computeds that always refetch.
+    const agent$ = agentById(AGENT_ID);
+
+    const first = await context.store.get(agent$);
+    expect(first.displayName).toBe("Old Name");
+    expect(counter.getCalls).toBe(1);
+
+    // Re-reading the same computed must not refetch — this is the baseline
+    // the reload counter gates on.
+    await context.store.get(agent$);
+    expect(counter.getCalls).toBe(1);
+
+    // Simulate a server-side mutation (e.g. PATCH by some other tab/device)
+    // and then bump the counter to mirror what agent mutation commands do.
+    state.current = { displayName: "New Name" };
+    context.store.set(reloadAgentById$);
+
+    const third = await context.store.get(agent$);
+    expect(third.displayName).toBe("New Name");
+    expect(counter.getCalls).toBe(2);
+  });
+});
+
+describe("leadAgentAvatarUrl$", () => {
+  it("derives from the default agent so it invalidates with reloadAgentById$", async () => {
+    setMockOnboardingStatus({ defaultAgentId: AGENT_ID });
+    const state = {
+      current: { avatarUrl: "https://example.com/a.png" } as AgentOverrides,
+    };
+    const counter = serveAgent(state);
+
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    const first = await context.store.get(leadAgentAvatarUrl$);
+    expect(first).toBe("https://example.com/a.png");
+    const callsBeforeReload = counter.getCalls;
+
+    state.current = { avatarUrl: "https://example.com/b.png" };
+    context.store.set(reloadAgentById$);
+
+    const second = await context.store.get(leadAgentAvatarUrl$);
+    // Regression: previously `leadAgentAvatarUrl$` had its own direct API call
+    // with no invalidation and would have returned the stale value.
+    expect(second).toBe("https://example.com/b.png");
+    expect(counter.getCalls).toBeGreaterThan(callsBeforeReload);
+  });
+
+  it("returns null when there is no default agent", async () => {
+    setMockOnboardingStatus({ defaultAgentId: null });
+
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    const avatar = await context.store.get(leadAgentAvatarUrl$);
+    expect(avatar).toBeNull();
+  });
+
+  it("updates defaultAgentName$ after reloadAgentById$ because it shares agentById", async () => {
+    setMockOnboardingStatus({ defaultAgentId: AGENT_ID });
+    const state = {
+      current: { displayName: "Zero" } as AgentOverrides,
+    };
+    serveAgent(state);
+
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    await expect(context.store.get(defaultAgentName$)).resolves.toBe("Zero");
+
+    state.current = { displayName: "Renamed" };
+    context.store.set(reloadAgentById$);
+
+    await expect(context.store.get(defaultAgentName$)).resolves.toBe("Renamed");
+  });
+});
+
+describe("agent mutations trigger reloadAgentById$", () => {
+  it("zeroJobUpdateSettings$ invalidates agentById so a later read refetches", async () => {
+    const state = { current: { displayName: "Old" } as AgentOverrides };
+    const counter = serveAgent(state);
+    server.use(
+      mockApi(zeroAgentsByIdContract.updateMetadata, ({ respond }) => {
+        return respond(200, mockAgentResponse({ displayName: "Updated" }));
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+    context.store.set(setActiveAgent$, AGENT_ID);
+    await context.store.get(zeroJobDetail$);
+
+    // Prime the agentById cache before the mutation so we can observe the
+    // invalidation (rather than a first-read miss).
+    const before = await context.store.get(agentById(AGENT_ID));
+    expect(before.displayName).toBe("Old");
+    const callsBeforeMutation = counter.getCalls;
+
+    state.current = { displayName: "Updated" };
+    await context.store.set(
+      zeroJobUpdateSettings$,
+      { displayName: "Updated" },
+      context.signal,
+    );
+
+    const after = await context.store.get(agentById(AGENT_ID));
+    expect(after.displayName).toBe("Updated");
+    expect(counter.getCalls).toBeGreaterThan(callsBeforeMutation);
+  });
+
+  it("deleteZeroJobAgent$ invalidates agentById so a later read refetches", async () => {
+    const state = { current: { displayName: "Doomed" } as AgentOverrides };
+    const counter = serveAgent(state);
+    server.use(
+      mockApi(zeroAgentsByIdContract.delete, ({ respond }) => {
+        return respond(204);
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+    context.store.set(setActiveAgent$, AGENT_ID);
+    await context.store.get(zeroJobDetail$);
+
+    const before = await context.store.get(agentById(AGENT_ID));
+    expect(before.displayName).toBe("Doomed");
+    const callsBeforeMutation = counter.getCalls;
+
+    await context.store.set(deleteZeroJobAgent$, context.signal);
+
+    await context.store.get(agentById(AGENT_ID));
+    // The only guarantee we need from the fix: reloadAgentById$ was bumped so
+    // any consumer still subscribed to agentById(deletedId) re-reads and sees
+    // the server's post-delete state instead of the cached pre-delete body.
+    expect(counter.getCalls).toBeGreaterThan(callsBeforeMutation);
+  });
+});

--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -18,13 +18,20 @@ export const defaultAgentId$ = computed(async (get) => {
   return status.defaultAgentId;
 });
 
+const internalAgentByIdReload$ = state(0);
+
 export function agentById(id: string) {
   return computed(async (get) => {
+    get(internalAgentByIdReload$);
     const client = get(zeroClient$)(zeroAgentsByIdContract);
     const result = await accept(client.get({ params: { id } }), [200]);
     return result.body;
   });
 }
+
+export const reloadAgentById$ = command(({ set }) => {
+  set(internalAgentByIdReload$, (prev) => prev + 1);
+});
 
 const defaultAgent$ = computed(async (get) => {
   const defaultId = await get(defaultAgentId$);
@@ -112,11 +119,6 @@ export interface SubagentInfo {
 }
 
 export const leadAgentAvatarUrl$ = computed(async (get) => {
-  const agentId = await get(defaultAgentId$);
-  if (!agentId) {
-    return null;
-  }
-  const client = get(zeroClient$)(zeroAgentsByIdContract);
-  const result = await accept(client.get({ params: { id: agentId } }), [200]);
-  return result.body.avatarUrl ?? null;
+  const agent = await get(defaultAgent$);
+  return agent?.avatarUrl ?? null;
 });

--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -30,7 +30,9 @@ export function agentById(id: string) {
 }
 
 export const reloadAgentById$ = command(({ set }) => {
-  set(internalAgentByIdReload$, (prev) => prev + 1);
+  set(internalAgentByIdReload$, (prev) => {
+    return prev + 1;
+  });
 });
 
 const defaultAgent$ = computed(async (get) => {

--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -5,8 +5,12 @@
  * metadata, and avatar signals. Downstream code should import from here
  * instead of reaching into individual signal files.
  */
-import { command, computed, state } from "ccstate";
-import { zeroAgentsByIdContract, zeroTeamContract } from "@vm0/core";
+import { command, computed, type Computed, state } from "ccstate";
+import {
+  type ZeroAgentResponse,
+  zeroAgentsByIdContract,
+  zeroTeamContract,
+} from "@vm0/core";
 import { pathParams$ } from "./route.ts";
 import { activeRoute$ } from "./active-route.ts";
 import { zeroOnboardingStatus$ } from "./zero-page/zero-onboarding.ts";
@@ -20,14 +24,27 @@ export const defaultAgentId$ = computed(async (get) => {
 
 const internalAgentByIdReload$ = state(0);
 
-export function agentById(id: string) {
-  return computed(async (get) => {
-    get(internalAgentByIdReload$);
-    const client = get(zeroClient$)(zeroAgentsByIdContract);
-    const result = await accept(client.get({ params: { id } }), [200]);
-    return result.body;
-  });
+function createAgentByIdFactory(): (
+  id: string,
+) => Computed<Promise<ZeroAgentResponse>> {
+  const cache = new Map<string, Computed<Promise<ZeroAgentResponse>>>();
+  return (id: string) => {
+    const existing = cache.get(id);
+    if (existing) {
+      return existing;
+    }
+    const atom$ = computed(async (get) => {
+      get(internalAgentByIdReload$);
+      const client = get(zeroClient$)(zeroAgentsByIdContract);
+      const result = await accept(client.get({ params: { id } }), [200]);
+      return result.body;
+    });
+    cache.set(id, atom$);
+    return atom$;
+  };
 }
+
+export const agentById = createAgentByIdFactory();
 
 export const reloadAgentById$ = command(({ set }) => {
   set(internalAgentByIdReload$, (prev) => {

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/delete.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/delete.ts
@@ -4,7 +4,7 @@ import { zeroAgentsByIdContract } from "@vm0/core";
 import { zeroClient$ } from "../../api-client.ts";
 import { accept } from "../../../lib/accept.ts";
 import { zeroJobDetail$ } from "./detail.ts";
-import { reloadAgents$ } from "../../agent.ts";
+import { reloadAgentById$, reloadAgents$ } from "../../agent.ts";
 
 // ---------------------------------------------------------------------------
 // Delete agent
@@ -24,5 +24,6 @@ export const deleteZeroJobAgent$ = command(
 
     toast.success("Agent deleted");
     set(reloadAgents$);
+    set(reloadAgentById$);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/settings.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/settings.ts
@@ -3,7 +3,7 @@ import { zeroAgentsByIdContract } from "@vm0/core";
 import { zeroClient$ } from "../../api-client.ts";
 import { accept } from "../../../lib/accept.ts";
 import { zeroJobDetail$, reloadJobDetail$ } from "./detail.ts";
-import { reloadAgents$ } from "../../agent.ts";
+import { reloadAgentById$, reloadAgents$ } from "../../agent.ts";
 
 // ---------------------------------------------------------------------------
 // Settings: update agent metadata (displayName, sound)
@@ -38,5 +38,6 @@ export const zeroJobUpdateSettings$ = command(
 
     set(reloadJobDetail$);
     set(reloadAgents$);
+    set(reloadAgentById$);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -15,7 +15,7 @@ import { currentChatAgentDisplayName$ } from "../agent-chat.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { slackOrgData$ } from "./zero-slack.ts";
 import { reloadBillingStatus$ } from "./billing.ts";
-import { reloadAgents$ } from "../agent.ts";
+import { reloadAgentById$, reloadAgents$ } from "../agent.ts";
 import { reloadPinnedAgents$ } from "./zero-pinned-agents.ts";
 import { showAppSkeleton$, startSkeletonCycling$ } from "../app-skeleton.ts";
 import { logger } from "../log.ts";
@@ -233,6 +233,7 @@ const completeOnboarding$ = command(
       : await set(completeMemberOnboarding$, signal);
 
     set(reloadAgents$);
+    set(reloadAgentById$);
     set(reloadPinnedAgents$);
     return agentId;
   },


### PR DESCRIPTION
## Summary

- `agentById()` had no reload counter, so after updating agent metadata on the profile page, derived signals (`currentChatAgent$`, `currentAgent$`, `defaultAgent$`, `leadAgentAvatarUrl$`) returned stale cached data
- Added `internalAgentByIdReload$` counter following the same pattern as `internalReloadAgents$` and `internalDetailReload$`, with a `reloadAgentById$` command to bump it
- Wired `reloadAgentById$` into all three agent mutation commands: `zeroJobUpdateSettings$`, `deleteZeroJobAgent$`, and `completeOnboarding$`
- Refactored `leadAgentAvatarUrl$` to derive from `defaultAgent$` instead of making its own direct API call (which also had no invalidation)

### Before

After saving agent profile changes:
- Sidebar avatar/name stayed stale
- Chat page model picker showed old selection
- Profile page header showed stale data (because `useAgentFields` prefers `currentAgent$` over fresh `zeroJobDetail$`)
- Default agent name/avatar stayed stale across sidebar, agents page, phone page

### After

All `agentById`-dependent computeds recompute when any agent mutation bumps `reloadAgentById$`.

## Test plan

- [ ] Edit agent display name on profile page → verify sidebar, chat header, and breadcrumb update immediately
- [ ] Change agent avatar → verify avatar updates in sidebar and chat
- [ ] Change agent model selection → verify chat page model picker reflects the change
- [ ] Delete an agent → verify UI no longer shows stale data for the deleted agent
- [ ] Complete onboarding → verify default agent name/avatar appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)