### PR TITLE
feat: add mod+alt+. keyboard shortcut to open model picker

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -69,3 +69,13 @@ export const setPopoverSortOrder$ = command(
     set(internalPopoverSortOrder$, order);
   },
 );
+
+// -- Model picker open state ------------------------------------------------
+
+const internalModelPickerOpen$ = state(false);
+export const modelPickerOpen$ = computed((get) => {
+  return get(internalModelPickerOpen$);
+});
+export const setModelPickerOpen$ = command(({ set }, open: boolean) => {
+  set(internalModelPickerOpen$, open);
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Integration tests for the chat composer's mod+alt+. shortcut that opens
+ * the model picker dropdown.
+ *
+ * Entry point: /chats/:id thread page
+ * Mock (external): Web API via MSW — feature switch, org model providers,
+ *   chat thread row. Internal signals, composer, model-provider-picker,
+ *   Radix Select primitive are exercised for real.
+ *
+ * Behaviour covered:
+ * - mod+alt+. focused in the composer textarea opens the model picker's
+ *   Radix listbox (controlled open state wired through ModelProviderPicker).
+ * - The shortcut help dialog ("?" popup) lists "Switch model" under the
+ *   Composer section so users can discover the binding.
+ * - When the caller has not opted into a model picker (no modelPicker prop),
+ *   the shortcut is a no-op — it must not throw or surface a listbox.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FeatureSwitchKey } from "@vm0/core";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  setMockOrgModelProviders,
+  resetMockOrgModelProviders,
+} from "../../../mocks/handlers/api-org-model-providers.ts";
+import {
+  setMockFeatureSwitches,
+  resetMockFeatureSwitches,
+} from "../../../mocks/handlers/api-feature-switches.ts";
+import { setChatShortcutHelpOpen$ } from "../../../signals/chat-page/chat-shortcut-help.ts";
+import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
+
+const context = testContext();
+const THREAD_ID = "thread-test-shortcut";
+const PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+function enableModelPicker(): void {
+  setMockFeatureSwitches({
+    [FeatureSwitchKey.ModelProviderSelection]: true,
+  });
+  setMockOrgModelProviders([
+    {
+      id: PROVIDER_ID,
+      type: "anthropic-api-key",
+      framework: "claude-code",
+      secretName: "ANTHROPIC_API_KEY",
+      authMethod: null,
+      secretNames: null,
+      isDefault: true,
+      selectedModel: DEFAULT_MODEL,
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
+}
+
+async function openThreadWithPicker(): Promise<HTMLTextAreaElement> {
+  mockChatLifecycle({ threadId: THREAD_ID });
+  detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+  const textarea = await waitFor(() => {
+    return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+  });
+
+  // Wait until the picker trigger mounts — its existence is the signal that
+  // the modelPicker prop wiring has resolved (feature switch + providers).
+  await waitFor(() => {
+    expect(
+      screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+    ).toBeInTheDocument();
+  });
+
+  return textarea;
+}
+
+describe("chat composer — mod+alt+. opens the model picker", () => {
+  beforeEach(() => {
+    resetMockOrgModelProviders();
+    resetMockFeatureSwitches();
+  });
+
+  // CHAT-SHORT-MP-001
+  it("opens the model picker listbox when the user presses mod+alt+. in the textarea", async () => {
+    const user = userEvent.setup();
+    enableModelPicker();
+
+    const textarea = await openThreadWithPicker();
+
+    // No listbox yet — the picker is closed until the user invokes the shortcut.
+    expect(screen.queryByRole("listbox")).toBeNull();
+
+    await user.click(textarea);
+    await user.keyboard("{Control>}{Alt>}.{/Alt}{/Control}");
+
+    // Radix Select renders a role="listbox" when opened.
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    // Default model option is present inside the open listbox, confirming the
+    // picker wired its provider data into the dropdown body.
+    expect(screen.getAllByRole("option").length).toBeGreaterThan(0);
+  });
+
+  // CHAT-SHORT-MP-002
+  it("is a no-op in the textarea when the model picker is not rendered", async () => {
+    // Feature switch off → no picker rendered → shortcut should not crash and
+    // should not summon a listbox from elsewhere in the DOM.
+    resetMockFeatureSwitches();
+    resetMockOrgModelProviders();
+
+    const user = userEvent.setup();
+    mockChatLifecycle({ threadId: THREAD_ID });
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    // Picker trigger must not be present when the feature switch is off.
+    expect(screen.queryByRole("combobox", { name: /claude/i })).toBeNull();
+
+    await user.click(textarea);
+    await user.keyboard("{Control>}{Alt>}.{/Alt}{/Control}");
+
+    // Nothing opens — the binding guard (`if (modelPicker)`) must short-circuit.
+    expect(screen.queryByRole("listbox")).toBeNull();
+    // And the textarea text must not have captured the period as typed input —
+    // processShortcut always calls preventDefault() regardless of the guard.
+    expect(textarea.value).toBe("");
+  });
+});
+
+describe("chat composer — shortcut help lists the model picker binding", () => {
+  beforeEach(() => {
+    resetMockOrgModelProviders();
+    resetMockFeatureSwitches();
+  });
+
+  // CHAT-SHORT-MP-003
+  it("shows 'Switch model' under the Composer section of the help dialog", async () => {
+    enableModelPicker();
+    await openThreadWithPicker();
+
+    // Open the help dialog through the same signal that the shift+/ handler
+    // sets. Drives the dialog without depending on the document-level key
+    // listener (which this file's other tests exercise separately).
+    context.store.set(setChatShortcutHelpOpen$, true);
+
+    const dialog = await waitFor(() => {
+      return screen.getByRole("dialog", { name: /keyboard shortcuts/i });
+    });
+
+    // Locate the Composer section heading, then assert its sibling list
+    // contains the new Switch model entry alongside pre-existing composer
+    // bindings. This guards the discoverability fix so a future refactor
+    // can't drop the entry silently.
+    const composerHeading = Array.from(dialog.querySelectorAll("h3")).find(
+      (el) => {
+        return el.textContent === "Composer";
+      },
+    );
+    expect(composerHeading).toBeDefined();
+    const composerSection = composerHeading?.parentElement;
+    expect(composerSection).toBeDefined();
+    expect(composerSection?.textContent).toContain("Switch model");
+    expect(composerSection?.textContent).toContain("Send message");
+    expect(composerSection?.textContent).toContain("Blur composer");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -70,6 +70,10 @@ interface ModelProviderPickerProps {
    * space is tight and the full breakdown lives in the open dropdown.
    */
   compactTrigger?: boolean;
+  /** Controlled open state for programmatic toggle (e.g. keyboard shortcut). */
+  open?: boolean;
+  /** Callback when the open state changes. */
+  onOpenChange?: (open: boolean) => void;
 }
 
 // Radix Select reserves the empty string for "no value" and throws if a
@@ -179,6 +183,8 @@ export function ModelProviderPicker({
   triggerClassName,
   sessionProviderType,
   compactTrigger = false,
+  open,
+  onOpenChange,
 }: ModelProviderPickerProps) {
   const groups = providers
     .map((provider) => {
@@ -226,6 +232,8 @@ export function ModelProviderPicker({
       onValueChange={(raw) => {
         onChange(decodeValue(raw));
       }}
+      open={open}
+      onOpenChange={onOpenChange}
     >
       <SelectTrigger
         aria-label={triggerAriaLabel}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1,6 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import type React from "react";
+import { useState } from "react";
 import type { ChangeEvent, ClipboardEvent, DragEvent } from "react";
 import {
   useGet,
@@ -644,6 +645,7 @@ export function ZeroChatComposer({
 }: ZeroChatComposerProps) {
   const showAddDialog = useGet(showAddDialog$);
   const setShowAddDialog = useSet(setShowAddDialog$);
+  const [modelPickerOpen, setModelPickerOpen] = useState(false);
 
   const resolved = useResolvedComposerSignals(
     input,
@@ -824,6 +826,11 @@ export function ZeroChatComposer({
         "mod+b": () => {
           toggleSidebar();
         },
+        "mod+alt+.": () => {
+          if (modelPicker) {
+            setModelPickerOpen(true);
+          }
+        },
       },
       e,
     );
@@ -938,6 +945,8 @@ export function ZeroChatComposer({
                     )}
                     sessionProviderType={modelPicker.sessionProviderType}
                     compactTrigger
+                    open={modelPickerOpen}
+                    onOpenChange={setModelPickerOpen}
                   />
                 )}
                 <MicButton

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1,7 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import type React from "react";
-import { useState } from "react";
 import type { ChangeEvent, ClipboardEvent, DragEvent } from "react";
 import {
   useGet,
@@ -99,6 +98,8 @@ import {
   setPopoverSearch$,
   popoverSortOrder$,
   setPopoverSortOrder$,
+  modelPickerOpen$,
+  setModelPickerOpen$,
 } from "../../signals/zero-page/zero-chat-composer.ts";
 import {
   audioInputAvailable$,
@@ -645,7 +646,8 @@ export function ZeroChatComposer({
 }: ZeroChatComposerProps) {
   const showAddDialog = useGet(showAddDialog$);
   const setShowAddDialog = useSet(setShowAddDialog$);
-  const [modelPickerOpen, setModelPickerOpen] = useState(false);
+  const modelPickerOpen = useGet(modelPickerOpen$);
+  const setModelPickerOpen = useSet(setModelPickerOpen$);
 
   const resolved = useResolvedComposerSignals(
     input,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -92,6 +92,7 @@ const CHAT_SHORTCUT_SECTIONS = [
     shortcuts: [
       { key: "enter", label: "Send message" },
       { key: "escape", label: "Blur composer" },
+      { key: "mod+alt+.", label: "Switch model" },
     ],
   },
 ] as const;


### PR DESCRIPTION
## Summary
- Adds `mod+alt+.` (Cmd+Alt+. on Mac, Ctrl+Alt+. on Windows/Linux) keyboard shortcut to open the model picker from the chat composer input
- Adds controlled `open`/`onOpenChange` props to `ModelProviderPicker` for programmatic control via Radix Select
- Adds "Switch model" entry to the shortcut help dialog (? popup)

Matches the VS Code Copilot Chat convention where `Ctrl+Alt+.` opens the model picker.

## Changes
- **model-provider-picker.tsx** — Add `open` + `onOpenChange` props, pass through to Radix `<Select>`
- **zero-chat-composer.tsx** — Add `mod+alt+.` binding in `handleKeyDown`, controlled `modelPickerOpen` state, wire `open`/`onOpenChange` to picker
- **zero-chat-thread-page.tsx** — Add `{ key: "mod+alt+.", label: "Switch model" }` to Composer section of shortcut help

## Test coverage
Integration tests added in `apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx`, mounted at the `/chats/:id` entry point with real composer + real `ModelProviderPicker` + real Radix Select (only Web API mocked via MSW):

- **CHAT-SHORT-MP-001** — Focus composer, fire `Ctrl+Alt+.`, assert Radix listbox opens with model options (validates the new binding + controlled `open` wiring).
- **CHAT-SHORT-MP-002** — With model picker feature disabled, fire the same shortcut; assert no listbox appears and textarea stays empty (validates the `if (modelPicker)` guard + `preventDefault`).
- **CHAT-SHORT-MP-003** — Open shortcut help dialog; assert Composer section lists "Switch model" alongside existing entries (prevents silent regression of `CHAT_SHORTCUT_SECTIONS`).

Regression verified: reverting the three source edits fails tests 1 and 3 as expected; restoring passes 3/3. Full `src/views/zero-page/__tests__/` suite (111 files, 881 tests) green.

## Test plan
- [x] Focus chat composer, press Cmd+Alt+. (Mac) or Ctrl+Alt+. (Win/Linux) — model picker dropdown opens (covered by CHAT-SHORT-MP-001)
- [x] Shortcut does nothing when model picker is hidden (covered by CHAT-SHORT-MP-002)
- [x] Open shortcut help (Shift+/) — "Switch model" appears in Composer section (covered by CHAT-SHORT-MP-003)
- [ ] Select a model from the picker — selection applies correctly (manual)
- [ ] Press Escape or click outside — picker closes (manual)
- [ ] Existing shortcuts (Enter, Escape, Cmd+B) still work (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)