### PR TITLE
fix(schedule): toast pre-api save errors and mark agent read-only

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
@@ -416,6 +416,35 @@ describe("zero-schedule signals", () => {
       );
     });
 
+    it("should not toast when save is aborted mid-flight", async () => {
+      // Aborts on DomCallback paths (e.g. navigation, unmount) are silent by
+      // design — detach() swallows AbortError. The error-toast helper must
+      // not surface these as user-visible toasts.
+      const errorSpy = vi.spyOn(toast, "error").mockImplementation(() => {
+        return "" as unknown as ReturnType<typeof toast.error>;
+      });
+
+      await setup();
+
+      await expect(
+        context.store.set(
+          saveZeroSchedule$,
+          {
+            prompt: "Aborted save",
+            freq: "every_day",
+            date: "2030-01-01",
+            hour: 9,
+            minute: 0,
+            timezone: "UTC",
+            intervalSeconds: 0,
+          },
+          AbortSignal.abort(),
+        ),
+      ).rejects.toThrow();
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
     it("should throw on API error during save", async () => {
       server.use(
         mockApi(zeroSchedulesMainContract.deploy, ({ respond }) => {

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import {
@@ -32,6 +33,10 @@ import {
 } from "../zero-schedule.ts";
 
 const context = testContext();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function mockScheduleResponse(): ScheduleResponse {
   return createMockScheduleResponse({
@@ -382,6 +387,33 @@ describe("zero-schedule signals", () => {
 
       expect(captured.body).not.toBeNull();
       expect(captured.body?.description).toBe("Custom description here");
+    });
+
+    it("should toast on pre-API validation error (past atTime)", async () => {
+      const errorSpy = vi.spyOn(toast, "error").mockImplementation(() => {
+        return "" as unknown as ReturnType<typeof toast.error>;
+      });
+
+      await setup();
+      await expect(
+        context.store.set(
+          saveZeroSchedule$,
+          {
+            prompt: "One-time task in the past",
+            freq: "once",
+            date: "2000-01-01",
+            hour: 9,
+            minute: 0,
+            timezone: "UTC",
+            intervalSeconds: 0,
+          },
+          context.signal,
+        ),
+      ).rejects.toThrow("Scheduled time must be in the future");
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Scheduled time must be in the future",
+      );
     });
 
     it("should throw on API error during save", async () => {
@@ -815,6 +847,38 @@ describe("org schedule signals", () => {
       expect(captured.body).not.toBeNull();
       expect(captured.body?.timezone).toBe("Asia/Shanghai");
       expect(captured.body?.name).toBe("existing-schedule");
+    });
+
+    // A validation error thrown inside saveOrgSchedule$ (before the API call)
+    // must surface as a toast. These errors propagate out of ccstate commands
+    // and are silently swallowed by detach(Reason.DomCallback) in the views,
+    // so without an explicit toast the user sees no feedback on save failure.
+    it("should toast on pre-API validation error (past atTime)", async () => {
+      const errorSpy = vi.spyOn(toast, "error").mockImplementation(() => {
+        return "" as unknown as ReturnType<typeof toast.error>;
+      });
+
+      await setup();
+      await expect(
+        context.store.set(
+          saveOrgSchedule$,
+          {
+            prompt: "One-time task in the past",
+            freq: "once",
+            date: "2000-01-01",
+            hour: 9,
+            minute: 0,
+            timezone: "UTC",
+            intervalSeconds: 0,
+            agentId: "e0000000-0000-4000-a000-000000000010",
+          },
+          context.signal,
+        ),
+      ).rejects.toThrow("Scheduled time must be in the future");
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Scheduled time must be in the future",
+      );
     });
   });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -19,6 +19,7 @@ import {
   type CronTimeOption,
 } from "./cron.ts";
 import { accept, ApiError } from "../../lib/accept.ts";
+import { throwIfAbort } from "../utils.ts";
 
 // ---------------------------------------------------------------------------
 // State
@@ -256,9 +257,11 @@ export interface ZeroScheduleSaveParams {
 
 // Non-API errors (e.g. validation from buildScheduleBody) would otherwise be
 // silently swallowed by detach(Reason.DomCallback). ApiError is skipped
-// because accept() already toasts it.
+// because accept() already toasts it. AbortError is skipped because aborts
+// on DomCallback paths are intentionally silent (component unmount, navigation).
 function runWithErrorToast<T>(fn: () => Promise<T>): Promise<T> {
   return fn().catch((error: unknown) => {
+    throwIfAbort(error);
     if (!(error instanceof ApiError)) {
       const message = error instanceof Error ? error.message : "Save failed";
       toast.error(message);

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -18,7 +18,7 @@ import {
   type ScheduleBody,
   type CronTimeOption,
 } from "./cron.ts";
-import { accept } from "../../lib/accept.ts";
+import { accept, ApiError } from "../../lib/accept.ts";
 
 // ---------------------------------------------------------------------------
 // State
@@ -254,19 +254,35 @@ export interface ZeroScheduleSaveParams {
   selectedModel?: string | null;
 }
 
+// Non-API errors (e.g. validation from buildScheduleBody) would otherwise be
+// silently swallowed by detach(Reason.DomCallback). ApiError is skipped
+// because accept() already toasts it.
+function runWithErrorToast<T>(fn: () => Promise<T>): Promise<T> {
+  return fn().catch((error: unknown) => {
+    if (!(error instanceof ApiError)) {
+      const message = error instanceof Error ? error.message : "Save failed";
+      toast.error(message);
+    }
+    throw error;
+  });
+}
+
 export const saveZeroSchedule$ = command(
   async ({ get, set }, params: ZeroScheduleSaveParams, signal: AbortSignal) => {
-    const status = await get(zeroOnboardingStatus$);
-    signal.throwIfAborted();
-    const composeId = status.defaultAgentId;
-    if (!composeId) {
-      throw new Error("No default agent configured");
-    }
+    await runWithErrorToast(async () => {
+      const status = await get(zeroOnboardingStatus$);
+      signal.throwIfAborted();
+      const composeId = status.defaultAgentId;
+      if (!composeId) {
+        throw new Error("No default agent configured");
+      }
 
-    const body = buildScheduleBody(composeId, params);
+      const body = buildScheduleBody(composeId, params);
 
-    const client = get(zeroClient$)(zeroSchedulesMainContract);
-    await accept(client.deploy({ body }), [200, 201]);
+      const client = get(zeroClient$)(zeroSchedulesMainContract);
+      await accept(client.deploy({ body }), [200, 201]);
+      signal.throwIfAborted();
+    });
     signal.throwIfAborted();
 
     toast.success(params.editName ? "Schedule updated" : "Schedule created");
@@ -415,13 +431,16 @@ export const saveOrgSchedule$ = command(
     params: ZeroScheduleSaveParams & { agentId: string },
     signal: AbortSignal,
   ) => {
-    const body = buildScheduleBody(params.agentId, params);
+    const scheduleId = await runWithErrorToast(async () => {
+      const body = buildScheduleBody(params.agentId, params);
 
-    const client = get(zeroClient$)(zeroSchedulesMainContract);
-    const result = await accept(client.deploy({ body }), [200, 201]);
+      const client = get(zeroClient$)(zeroSchedulesMainContract);
+      const result = await accept(client.deploy({ body }), [200, 201]);
+      signal.throwIfAborted();
+
+      return result.body.schedule.id;
+    });
     signal.throwIfAborted();
-
-    const scheduleId = result.body.schedule.id;
 
     toast.success(params.editName ? "Schedule updated" : "Schedule created");
     await set(fetchAllOrgSchedules$, signal);

--- a/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
@@ -173,10 +173,10 @@ describe("inline settings row - conditional (ORG-C-109)", () => {
       context,
       path: `/schedules/${TEST_SCHEDULE_ID}`,
     });
-    // The "Agent" InlineSettingsRow has description "Which agent runs when this schedule fires."
+    // The "Agent" InlineSettingsRow has a description explaining the field is read-only.
     await waitFor(() => {
       expect(
-        screen.getByText("Which agent runs when this schedule fires."),
+        screen.getByText(/The agent is fixed once a schedule is created/i),
       ).toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page-interaction.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -512,6 +512,29 @@ describe("zero schedule detail page - run now button triggers immediate run (SCH
     await waitFor(() => {
       expect(screen.getByText(/Run started/i)).toBeInTheDocument();
     });
+  });
+});
+
+// The Agent field is shown on the detail page but must be read-only: changing
+// it would create a duplicate schedule on the new agent rather than moving the
+// existing one (the backend keys schedule lookup on agentId + name). Keep the
+// control visible for context and disable it to match actual behavior.
+describe("zero schedule detail page - agent field is read-only", () => {
+  it("should render the agent select as disabled", async () => {
+    mockAPIs();
+    detachedSetupPage({ context, path: `/schedules/${SCHEDULE_ID}` });
+    await waitForPageLoad();
+
+    const agentDescription = await screen.findByText(
+      /The agent is fixed once a schedule is created/i,
+    );
+    // Row structure is <row><leftCol><p label /><p description /></leftCol>
+    // <rightCol>{Select}</rightCol></row>; walk up two parents to the row.
+    const row = agentDescription.parentElement?.parentElement;
+    expect(row).not.toBeNull();
+
+    const agentCombobox = within(row!).getByRole("combobox");
+    expect(agentCombobox).toBeDisabled();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -391,16 +391,10 @@ function ScheduleSettingsForm({
         <CardContent className="p-4 sm:p-5">
           <InlineSettingsRow
             label="Agent"
-            description="Which agent runs when this schedule fires."
+            description="The agent is fixed once a schedule is created. Delete and recreate the schedule to run it on a different agent."
           >
             <div className={SCHEDULE_DETAIL_CONTROL_WIDTH}>
-              <Select
-                value={form.agentId}
-                onValueChange={(v) => {
-                  return updateForm({ agentId: v });
-                }}
-                disabled={saving || agents.length === 0}
-              >
+              <Select value={form.agentId} disabled>
                 <SelectTrigger className="h-9 w-full">
                   <SelectValue placeholder="Select agent" />
                 </SelectTrigger>


### PR DESCRIPTION
## Summary

Two related bugs on the schedules page:

- **No toast on save failure.** `saveZeroSchedule$` / `saveOrgSchedule$` throw validation errors (past `atTime`, invalid timezone, no default agent) *before* `accept()` is called. Those errors propagate out of the ccstate command and are silently swallowed by `detach(Reason.DomCallback)`, so the user saw nothing when save failed. Wrapped both saves with a helper that toasts any non-`ApiError` and rethrows. `ApiError` is skipped because `accept()` already toasts those.
- **Agent select on the detail page is misleading.** The field was editable, but the backend `deploySchedule` keys the upsert on `(agentId, name, orgId, userId)` — changing `agentId` falls through to the insert branch, creating a duplicate schedule on the new agent while leaving the original orphaned. Marked the control as `disabled` on the detail page and updated the description text to explain why. Creating a schedule still lets you pick the agent.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest` — 1965 platform tests pass
- [x] `pnpm turbo run lint --filter=@vm0/app` — clean
- [x] `pnpm knip` — clean
- [x] New test: `saveOrgSchedule$` / `saveZeroSchedule$` toast on past `atTime` (pre-API validation error)
- [x] New test: detail page renders Agent combobox as disabled
- [ ] Manual smoke: trigger a past-time schedule save, confirm toast appears
- [ ] Manual smoke: open an existing schedule's settings tab, confirm Agent row is disabled with the new description

🤖 Generated with [Claude Code](https://claude.com/claude-code)