### PR TITLE
refactor(mitm-addon): surface one-shot warnings for best-effort failures

### DIFF
--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -9,10 +9,21 @@ delivered).  File format: ``"<flows>:<reports>"`` written atomically
 import threading
 from pathlib import Path
 
+from mitmproxy import ctx
+
 _counter_lock = threading.Lock()
 _in_flight_flows = 0
 _pending_reports = 0
 _pending_path = ""
+# One-shot guard: the symptom of sustained ``_write_pending`` failure is
+# the runner always hitting its 15s SIGKILL on graceful shutdown without
+# any local signal pointing at FS trouble.  Emit one warn per addon
+# process on first failure — enough to seed the operator investigation
+# without spamming logs under persistent FS pressure.  Deliberately goes
+# through mitmproxy's own stderr logger (not ``log_proxy_entry``) because
+# the per-job proxy log shares the same filesystem we just failed to
+# write and is likely affected by the same root cause.
+_pending_write_error_logged = False
 
 
 def set_pending_path(path: str) -> None:
@@ -24,6 +35,7 @@ def set_pending_path(path: str) -> None:
 
 def _write_pending() -> None:
     """Atomically write current counters to file."""
+    global _pending_write_error_logged
     if not _pending_path:
         return
     tmp = Path(_pending_path + ".tmp")
@@ -31,14 +43,20 @@ def _write_pending() -> None:
         with tmp.open("w") as f:
             f.write(f"{_in_flight_flows}:{_pending_reports}")
         tmp.replace(_pending_path)
-    except OSError:
+    except OSError as exc:
         # Best-effort: this file is observability (runner polls it to
         # wait for in-flight flows + pending reports to drain before
         # SIGTERM).  Transient write failures are upper-bounded by the
         # runner's 15s SIGKILL hard stop — in the worst case the runner
         # proceeds to SIGKILL with possible in-flight webhooks lost,
         # which is the same outcome as a genuinely stalled flow.
-        pass
+        if not _pending_write_error_logged:
+            _pending_write_error_logged = True
+            ctx.log.warn(
+                f"Failed to write pending count to {_pending_path!r}: {exc}.  "
+                "Subsequent failures in this process will be silent; runner "
+                "shutdown may hit the 15s SIGKILL hard stop."
+            )
 
 
 def increment_flows() -> None:

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -16,6 +16,8 @@ from collections.abc import Callable
 
 from mitmproxy import http
 
+from logging_utils import log_proxy_entry
+
 from . import x
 
 # Map firewall_name → per-connector report_usage handler.  A handler is only
@@ -27,6 +29,13 @@ from . import x
 _HANDLERS: dict[str, Callable[[http.HTTPFlow, str], None]] = {
     "x": x.report_usage,
 }
+
+# One-shot guard: first time we see a billable firewall_name with no
+# registered handler, warn once per name per addon process.  Catches the
+# deployment-desync case where ``@vm0/core``'s ``BILLABLE_CONNECTORS`` has
+# grown but the runner is on an older addon image — without this, billing
+# records silently drop with no local signal.
+_unregistered_handler_warned: set[str] = set()
 
 
 def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
@@ -51,5 +60,16 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
     firewall_name = flow.metadata.get("firewall_name", "")
     handler = _HANDLERS.get(firewall_name)
     if handler is None:
+        if firewall_name and firewall_name not in _unregistered_handler_warned:
+            _unregistered_handler_warned.add(firewall_name)
+            log_proxy_entry(
+                flow.metadata.get("vm_proxy_log_path", ""),
+                "warn",
+                f"Billable firewall {firewall_name!r} has no registered handler — "
+                "billing records for this firewall will be dropped.  Check that "
+                "BILLABLE_CONNECTORS in @vm0/core and _HANDLERS here are in sync.",
+                type="connector_billing",
+                firewall_name=firewall_name,
+            )
         return
     handler(flow, run_id)

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -27,6 +27,7 @@ from mitmproxy.test import tflow, tutils
 import auth
 import mitm_addon
 import usage
+from usage.providers import connectors as _usage_connectors
 
 
 @pytest.fixture(autouse=True)
@@ -48,6 +49,8 @@ def _reset_module_state() -> None:
     auth._cache_locks.clear()
     auth._force_refresh_markers.clear()
     auth._last_force_refresh_at.clear()
+    _usage_connectors._unregistered_handler_warned.clear()
+    usage.counters._pending_write_error_logged = False
 
 
 def _headers(*pairs: tuple[str, str]) -> http.Headers:

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -2482,6 +2482,54 @@ class TestReportConnectorUsage:
         flow.metadata["firewall_name"] = "github"
         assert self._call_and_get_billing(flow) == []
 
+    # ---- unregistered-handler one-shot warn (issue #10483) ----
+
+    def test_warns_once_per_unregistered_firewall_name(self, tmp_path, real_flow):
+        """First billable flow for an unregistered firewall_name emits a warn;
+        subsequent flows for the same name stay silent (one-shot guard)."""
+        proxy_log = tmp_path / "proxy.jsonl"
+        for _ in range(3):
+            flow = self._make_x_flow(real_flow, tmp_path)
+            flow.metadata["firewall_name"] = "github"
+            assert self._call_and_get_billing(flow) == []
+
+        lines = [
+            json.loads(line)
+            for line in proxy_log.read_text().splitlines()
+            if "no registered handler" in line
+        ]
+        assert len(lines) == 1
+        assert lines[0]["level"] == "warn"
+        assert lines[0]["firewall_name"] == "github"
+        assert lines[0]["type"] == "connector_billing"
+
+    def test_warns_separately_per_firewall_name(self, tmp_path, real_flow):
+        """One-shot guard is per-firewall-name, not global — a new desynced
+        connector name still surfaces even after an earlier one warned."""
+        proxy_log = tmp_path / "proxy.jsonl"
+        for name in ("github", "slack", "github"):  # github repeats; slack new
+            flow = self._make_x_flow(real_flow, tmp_path)
+            flow.metadata["firewall_name"] = name
+            assert self._call_and_get_billing(flow) == []
+
+        warned_names = [
+            json.loads(line)["firewall_name"]
+            for line in proxy_log.read_text().splitlines()
+            if "no registered handler" in line
+        ]
+        assert warned_names == ["github", "slack"]
+
+    def test_does_not_warn_on_empty_firewall_name(self, tmp_path, real_flow):
+        """Empty firewall_name is a different bug class (web-layer contract
+        violation) already logged elsewhere — don't double-warn here."""
+        proxy_log = tmp_path / "proxy.jsonl"
+        flow = self._make_x_flow(real_flow, tmp_path)
+        flow.metadata["firewall_name"] = ""
+        assert self._call_and_get_billing(flow) == []
+
+        if proxy_log.exists():
+            assert "no registered handler" not in proxy_log.read_text()
+
     def test_skips_when_not_billable(self, tmp_path, real_flow):
         """Firewalls with firewall_billable=False are not reported."""
         flow = self._make_x_flow(real_flow, tmp_path)
@@ -3070,6 +3118,38 @@ class TestUsagePendingCounter:
         # Should not raise — just no file written.
         assert usage.counters._in_flight_flows == 0
         assert usage.counters._pending_reports == 0
+
+    # ---- one-shot warn on write failure (issue #10483) ----
+
+    def test_write_failure_warns_once_per_process(self, tmp_path):
+        """Repeated OSErrors from ``_write_pending`` emit exactly one
+        ``ctx.log.warn`` per addon process — enough to seed FS-trouble
+        investigation without spamming logs on sustained failure."""
+        usage.set_pending_path(str(tmp_path / "usage-pending"))
+
+        mock_log = MagicMock()
+        with (
+            patch.object(usage.counters.ctx, "log", mock_log, create=True),
+            patch.object(usage.counters.Path, "open", side_effect=OSError("disk full")),
+        ):
+            for _ in range(3):
+                usage.increment_flows()
+
+        assert mock_log.warn.call_count == 1
+        assert "Failed to write pending count" in mock_log.warn.call_args[0][0]
+        assert "disk full" in mock_log.warn.call_args[0][0]
+
+    def test_write_failure_does_not_raise(self, tmp_path):
+        """Write failures stay best-effort after the one-shot warn — callers
+        (hot-path increment/decrement) must never observe the OSError."""
+        usage.set_pending_path(str(tmp_path / "usage-pending"))
+
+        with (
+            patch.object(usage.counters.ctx, "log", MagicMock(), create=True),
+            patch.object(usage.counters.Path, "open", side_effect=OSError("disk full")),
+        ):
+            usage.increment_flows()  # should not raise
+            usage.decrement_flows()  # should not raise
 
     def test_report_decrements_after_completion(self, tmp_path, real_flow, fresh_usage_executor):
         """Retry exhaustion still runs the decrement finally-block."""


### PR DESCRIPTION
## Summary

Two silent-drop paths in the usage reporting package now emit exactly one warn per addon process on first occurrence, so operators have a local signal when the failure mode engages.

- **Case 1** — dispatcher handler miss in `providers/connectors/__init__.py`: when a flow is flagged `firewall_billable=True` but `firewall_name` has no `_HANDLERS` entry (deployment desync — `@vm0/core`'s `BILLABLE_CONNECTORS` grew but the runner is on an older addon image), the first flow per `firewall_name` writes a warn to the per-job proxy log. Subsequent flows for the same name stay silent.
- **Case 2** — `counters.py::_write_pending` OSError: a failing pending-count write (disk full, permissions) would make every runner shutdown hit the 15s SIGKILL hard stop with no local signal. The first failure now emits `ctx.log.warn` to mitmproxy's stderr and sets a module-level bool guard.

## Design note — Case 2 routing

The issue's original sketch proposed a callback form (`set_pending_path(path, on_error=...)`) to preserve `counters.py`'s "no external addon deps" property, or an import of `logging_utils`.

This PR goes a third way: inline `ctx.log.warn` (mitmproxy's own logger). Rationale:

- **Catch-22 avoidance**: `log_proxy_entry` writes to `proxy_log_path` on the same filesystem we just failed to write. The failure mode most likely to need this warn (FS exhaustion, permission denial) is also the one most likely to silently swallow a `log_proxy_entry` call. `ctx.log.warn` goes to mitmproxy's stderr, which runner owns via pipe — no shared FS.
- **Minimal wiring**: no callback plumbing through `set_pending_path`, no new path parameter.
- **`ctx` is ambient in addon context**: `logging_utils.py` already uses `ctx.log.warn` as its own fallback (line 45), so this keeps the pattern.

See discussion in issue [#10483 comment](https://github.com/vm0-ai/vm0/issues/10483#issuecomment-4293216640).

## Test plan

- [x] `pytest tests/ -q` — all 902 tests pass (5 new)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] New tests cover: one-shot per `firewall_name` (Case 1), per-name guard is not global (Case 1), empty `firewall_name` does not warn (Case 1), one-shot per process (Case 2), write failure does not raise (Case 2)
- [x] `conftest.py` autouse reset clears both module-level guards so no state leaks between tests

Closes #10483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)