### PR TITLE
fix(uploads): build attachment urls from public api host and bypass i18n

### DIFF
--- a/turbo/apps/cli/src/commands/zero/web/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/web/upload-file.ts
@@ -4,7 +4,7 @@ import { withErrorHandler } from "../../../lib/command";
 
 export const uploadFileCommand = new Command()
   .name("upload-file")
-  .description("Upload a local file and print a 7-day presigned URL")
+  .description("Upload a local file and print a permanent URL")
   .requiredOption("-f, --file <path>", "Local file path to upload")
   .option("--content-type <mime>", "Override inferred content type")
   .addHelpText(
@@ -20,7 +20,8 @@ Output:
 
 Notes:
   - Authenticates via ZERO_TOKEN (requires file:write capability)
-  - Returned URL is a presigned GET valid for 7 days
+  - Returned URL is permanent (serves a short-lived signed redirect on access)
+  - Safe to persist in chat messages or share over external channels
   - Max file size: 1 GB
   - Allowed types: png / jpeg / gif / webp / svg / mp4 / webm / mov / pdf / txt / csv / md / json`,
   )

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
@@ -259,7 +259,7 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     expect(data.messages[0].role).toBe("user");
   });
 
-  it("should resolve attach files with presigned URLs in paged messages", async () => {
+  it("should resolve attach files to permanent /f/ URLs in paged messages", async () => {
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {
         method: "POST",
@@ -290,9 +290,6 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
         return [];
       },
     );
-    context.mocks.s3.generatePresignedUrl.mockResolvedValue(
-      "https://presigned-url/data.csv",
-    );
 
     const response = await GET(
       createTestRequest(
@@ -309,7 +306,9 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     expect(userMsg.attachFiles).toHaveLength(1);
     expect(userMsg.attachFiles[0].id).toBe("paged-resolve-uuid");
     expect(userMsg.attachFiles[0].filename).toBe("data.csv");
-    expect(userMsg.attachFiles[0].url).toBe("https://presigned-url/data.csv");
+    expect(userMsg.attachFiles[0].url).toBe(
+      `http://localhost:3000/f/${encodeURIComponent(testUserId)}/paged-resolve-uuid/data.csv`,
+    );
   });
 
   it("should not expose run-level error on event-backed assistant rows", async () => {

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -497,7 +497,7 @@ describe("POST /api/zero/chat/messages", () => {
       expect(run.appendSystemPrompt).not.toContain("Web Attached Files");
     });
 
-    it("should resolve attach files with presigned URLs in thread detail", async () => {
+    it("should resolve attach files to permanent /f/ URLs in thread detail", async () => {
       // Create a thread with a message containing attach files via the API
       const attachFiles = [
         {
@@ -536,9 +536,6 @@ describe("POST /api/zero/chat/messages", () => {
           return [];
         },
       );
-      context.mocks.s3.generatePresignedUrl.mockResolvedValue(
-        "https://presigned-url/data.csv",
-      );
 
       // Fetch thread detail which resolves attach files
       const threadResponse = await getChatThreadById(
@@ -558,7 +555,9 @@ describe("POST /api/zero/chat/messages", () => {
       expect(userMsg.attachFiles).toHaveLength(1);
       expect(userMsg.attachFiles[0].id).toBe("resolve-uuid-1");
       expect(userMsg.attachFiles[0].filename).toBe("data.csv");
-      expect(userMsg.attachFiles[0].url).toBe("https://presigned-url/data.csv");
+      expect(userMsg.attachFiles[0].url).toBe(
+        `http://localhost:3000/f/${encodeURIComponent(user.userId)}/resolve-uuid-1/data.csv`,
+      );
     });
 
     describe("per-run model selection (composer picker)", () => {

--- a/turbo/apps/web/app/api/zero/uploads/prepare/route.ts
+++ b/turbo/apps/web/app/api/zero/uploads/prepare/route.ts
@@ -2,10 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
-import {
-  generatePresignedPutUrl,
-  generatePresignedUrl,
-} from "../../../../../src/lib/infra/s3/s3-client";
+import { generatePresignedPutUrl } from "../../../../../src/lib/infra/s3/s3-client";
 import { env } from "../../../../../src/env";
 import { logger } from "../../../../../src/lib/shared/logger";
 import {
@@ -13,6 +10,7 @@ import {
   MAX_UPLOAD_SIZE_BYTES,
   MAX_UPLOAD_SIZE_LABEL,
 } from "../../../../../src/lib/zero/uploads/constants";
+import { buildFileUrl } from "../../../../../src/lib/zero/uploads/file-url";
 
 const log = logger("api:zero:uploads:prepare");
 
@@ -22,10 +20,15 @@ const log = logger("api:zero:uploads:prepare");
  * Returns a presigned PUT URL so the browser (or CLI) uploads the file body
  * directly to R2. Because the body never passes through the Next.js runtime,
  * this path is not constrained by Vercel's ~4.5 MB serverless body cap.
+ *
+ * The GET-side URL returned to the caller is a permanent
+ * `/f/{userId}/{id}/{filename}` redirect served by the app — callers may
+ * persist it in messages, drafts, or external channels. The short-lived
+ * presigned signature is materialized per-request inside that route, on
+ * each individual access.
  */
 
 const PUT_URL_TTL_SECONDS = 3600; // 1 hour to finish the upload
-const GET_URL_TTL_SECONDS = 604800; // 7 days — max SigV4 TTL
 
 const prepareSchema = z.object({
   filename: z.string().min(1).max(255),
@@ -90,16 +93,14 @@ export async function POST(request: NextRequest) {
   const s3Key = `uploads/${userId}/${id}/${sanitizedName}`;
   const bucket = env().R2_USER_STORAGES_BUCKET_NAME;
 
-  const [uploadUrl, url] = await Promise.all([
-    generatePresignedPutUrl(
-      bucket,
-      s3Key,
-      contentType,
-      PUT_URL_TTL_SECONDS,
-      true,
-    ),
-    generatePresignedUrl(bucket, s3Key, GET_URL_TTL_SECONDS, sanitizedName),
-  ]);
+  const uploadUrl = await generatePresignedPutUrl(
+    bucket,
+    s3Key,
+    contentType,
+    PUT_URL_TTL_SECONDS,
+    true,
+  );
+  const url = buildFileUrl(userId, id, sanitizedName);
 
   log.debug(
     `Prepared presigned upload for ${sanitizedName} (${size} bytes) user=${userId}`,

--- a/turbo/apps/web/app/f/[userId]/[id]/[filename]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/f/[userId]/[id]/[filename]/__tests__/route.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { testContext } from "../../../../../../src/__tests__/test-helpers";
+
+const context = testContext();
+
+async function invoke(
+  userId: string,
+  id: string,
+  filename: string,
+  searchParams = "",
+) {
+  const url = `http://localhost:3000/f/${userId}/${id}/${filename}${searchParams}`;
+  return GET(new NextRequest(url), {
+    params: Promise.resolve({ userId, id, filename }),
+  });
+}
+
+describe("GET /f/[userId]/[id]/[filename]", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+  });
+
+  it("302-redirects to a short-lived presigned URL built from the S3 key convention", async () => {
+    context.mocks.s3.generatePresignedUrl.mockResolvedValue(
+      "https://signed.example.com/doc.pdf?sig=abc",
+    );
+
+    const res = await invoke("user_alice", "file-id", "doc.pdf");
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      "https://signed.example.com/doc.pdf?sig=abc",
+    );
+    expect(res.headers.get("Cache-Control")).toContain("private");
+
+    const [, key, ttlSeconds, contentDisposition] =
+      context.mocks.s3.generatePresignedUrl.mock.calls[0] ?? [];
+    // The key must be derived from the path segments, so any URL the user can
+    // hold (past or future) resolves to the correct R2 object without lookup.
+    expect(key).toBe("uploads/user_alice/file-id/doc.pdf");
+    // Short TTL keeps stale redirects from outliving the browser cache window.
+    expect(ttlSeconds).toBe(300);
+    expect(contentDisposition).toBeUndefined();
+  });
+
+  it("forces attachment download when ?download=1 is present", async () => {
+    context.mocks.s3.generatePresignedUrl.mockResolvedValue(
+      "https://signed.example.com/report.pdf",
+    );
+
+    await invoke("user_alice", "file-id", "report.pdf", "?download=1");
+
+    const call = context.mocks.s3.generatePresignedUrl.mock.calls[0];
+    expect(call?.[3]).toBe("report.pdf");
+  });
+});

--- a/turbo/apps/web/app/f/[userId]/[id]/[filename]/route.ts
+++ b/turbo/apps/web/app/f/[userId]/[id]/[filename]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { initServices } from "../../../../../src/lib/init-services";
+import { generatePresignedUrl } from "../../../../../src/lib/infra/s3/s3-client";
+import { env } from "../../../../../src/env";
+
+/**
+ * Permanent file URL resolver.
+ *
+ * Callers (chat messages, drafts, Slack unfurls, external share links) hold
+ * a stable `/f/{userId}/{id}/{filename}` URL returned by
+ * /api/zero/uploads/prepare. The three path segments rebuild the full S3
+ * key (`uploads/{userId}/{id}/{filename}`) — the same convention the
+ * prepare route uses — so this route needs no database or S3 listing to
+ * resolve the object. It mints a short-lived presigned URL per request and
+ * 302-redirects the browser.
+ *
+ * Access model: share-by-link. The path itself is the capability — any
+ * caller that knows it may fetch the file, matching the semantics of the
+ * previous 7-day presigned URLs. The 60-second Cache-Control lets the
+ * browser reuse the redirect across immediate re-renders (image lazy-load,
+ * scroll back into view) without re-hitting this route, while still forcing
+ * a refresh well before the underlying presigned URL expires.
+ *
+ * Pass `?download=1` to force the browser to save instead of render inline.
+ */
+
+const SIGNED_TTL_SECONDS = 300;
+
+export async function GET(
+  request: NextRequest,
+  {
+    params,
+  }: { params: Promise<{ userId: string; id: string; filename: string }> },
+) {
+  initServices();
+  const { userId, id, filename } = await params;
+
+  const bucket = env().R2_USER_STORAGES_BUCKET_NAME;
+  const s3Key = `uploads/${userId}/${id}/${filename}`;
+
+  const wantDownload = request.nextUrl.searchParams.get("download") === "1";
+  const signed = await generatePresignedUrl(
+    bucket,
+    s3Key,
+    SIGNED_TTL_SECONDS,
+    wantDownload ? filename : undefined,
+    true,
+  );
+
+  return new NextResponse(null, {
+    status: 302,
+    headers: {
+      Location: signed,
+      "Cache-Control": "private, max-age=60, must-revalidate",
+    },
+  });
+}

--- a/turbo/apps/web/proxy.layers.ts
+++ b/turbo/apps/web/proxy.layers.ts
@@ -24,6 +24,7 @@ const SKIP_I18N_PREFIXES = [
   "/terms-of-use",
   "/support",
   "/export",
+  "/f/",
 ] as const;
 
 const STATIC_FILE_RE = /\.(ico|png|jpg|jpeg|svg|gif|webp|woff|woff2|ttf|eot)$/i;

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -15,9 +15,10 @@ import {
   type ResolvedAttachFile,
   persistedAttachmentSchema,
 } from "@vm0/core";
-import { generatePresignedUrl, listS3Objects } from "../../infra/s3/s3-client";
+import { listS3Objects } from "../../infra/s3/s3-client";
 import { env } from "../../../env";
 import { EXT_MIMETYPE_MAP } from "../../shared/mimetype";
+import { buildFileUrl } from "../uploads/file-url";
 
 /**
  * Create a new chat thread.
@@ -301,8 +302,13 @@ type ChatMessage = {
 };
 
 /**
- * Resolve file IDs to presigned S3 URLs with metadata for the frontend.
- * Lists S3 objects at each file's prefix to discover filename and size.
+ * Resolve file IDs to permanent file URLs with metadata for the frontend.
+ *
+ * Lists S3 objects at each file's prefix to recover filename and size, then
+ * constructs the permanent `${APP_URL}/f/{userId}/{id}/{filename}` URL. The
+ * short-lived presigned signature is materialized per-request inside the /f
+ * route, not here — the value returned to the frontend is stable and safe
+ * to persist in markdown or share over external channels.
  */
 export async function resolveAttachFileUrls(
   userId: string,
@@ -321,7 +327,7 @@ export async function resolveAttachFileUrls(
       const ext = filename.split(".").pop()?.toLowerCase();
       const contentType =
         (ext ? EXT_MIMETYPE_MAP[ext] : undefined) ?? "application/octet-stream";
-      const url = await generatePresignedUrl(bucket, obj.key, 86400, filename);
+      const url = buildFileUrl(userId, fileId, filename);
       return { id: fileId, filename, contentType, size: obj.size, url };
     }),
   );

--- a/turbo/apps/web/src/lib/zero/uploads/file-url.ts
+++ b/turbo/apps/web/src/lib/zero/uploads/file-url.ts
@@ -1,0 +1,25 @@
+import { getApiUrl } from "../../infra/callback/dispatcher";
+
+/**
+ * Build the permanent URL for an uploaded attachment.
+ *
+ * The three path segments together reconstruct the S3 key
+ * `uploads/{userId}/{id}/{filename}`, so the /f route can generate a
+ * presigned GET without any database or listing lookup. Because the URL
+ * embeds only stable identifiers (no signature, no expiry), callers may
+ * persist it in chat message content, draft rows, Slack unfurls, or CLI
+ * output — the short-lived signature is materialized per-request inside
+ * the /f route on each access.
+ *
+ * Uses VM0_API_URL (public host) rather than NEXT_PUBLIC_APP_URL so the
+ * URL is reachable by anonymous share-by-link consumers (Slack unfurl
+ * bots, email clients, external viewers) that never sign in to the app
+ * domain.
+ */
+export function buildFileUrl(
+  userId: string,
+  id: string,
+  filename: string,
+): string {
+  return `${getApiUrl()}/f/${encodeURIComponent(userId)}/${id}/${encodeURIComponent(filename)}`;
+}

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -8,7 +8,7 @@ const c = initContract();
 
 /**
  * File attachment metadata stored alongside user messages.
- * The `id` is the S3 file key — URLs are resolved at query time.
+ * The `id` is the attachment id — URLs are resolved at query time.
  */
 const attachFileSchema = z.object({
   id: z.string(),
@@ -17,11 +17,24 @@ const attachFileSchema = z.object({
   size: z.number(),
 });
 
-/** Attach file with a resolved presigned URL, returned to the frontend. */
+/**
+ * Attach file returned to the frontend with a resolved URL.
+ * `url` is the permanent `${APP_URL}/f/{userId}/{id}/{filename}` redirect
+ * served by the app — consumers may render, cache, or share it freely; the
+ * underlying short-lived presigned signature is materialized per-request
+ * inside the /f route.
+ */
 const resolvedAttachFileSchema = attachFileSchema.extend({
   url: z.string(),
 });
 
+/**
+ * Attachment metadata persisted in chat_threads.draft_attachments.
+ *
+ * `url` is the permanent `/f/{userId}/{id}/{filename}` form. Historically
+ * this stored a 7-day presigned URL that could silently expire while
+ * drafts sat in the DB; the permanent redirect removes that footgun.
+ */
 const persistedAttachmentSchema = z.object({
   id: z.string(),
   url: z.string(),


### PR DESCRIPTION
## Summary

Re-lands #10460 on top of its revert (#10523, now merged as `a7f99f40a`), with two fixes that make the permanent `/f/{userId}/{id}/{filename}` redirect actually work for anonymous share-by-link consumers.

Background (from #10460): `/api/zero/uploads/prepare` returns a stable URL that rebuilds the S3 key `uploads/{userId}/{id}/{filename}` from its three path segments. The `/f` route mints a short-lived R2 presigned URL per request and 302-redirects the browser, so callers (chat messages, drafts, Slack unfurls, CLI output) can persist the URL without the 7-day signature window expiring out from under them.

## Fixes over #10460

- `buildFileUrl()` uses `getApiUrl()` (`VM0_API_URL` → `www.vm0.ai` in prod, Vercel preview URL in CI, tunnel/localhost in dev) instead of `getAppUrl()` (`NEXT_PUBLIC_APP_URL` → `app.vm0.ai`). `app.vm0.ai` is the auth-protected app domain — every unfurl bot, email client, or external viewer hit the Clerk sign-in redirect instead of the file. Matches the pattern already used by `/api/email/unsubscribe` (`email/handlers/shared.ts:282`).
- `/f/` is added to `SKIP_I18N_PREFIXES` in `proxy.layers.ts`. Without it the page-route branch runs next-intl on `/f/...` and redirects to `/en/f/...`, which doesn't match the Next.js route file and 404s. Classifying the route as `"skip"` also means Clerk's `auth.protect()` isn't invoked (only `PROTECTED_SKIP_PREFIXES` like `/cli-auth` trigger it), so anonymous share-by-link consumers work.

Test fixtures expect `VM0_API_URL = http://localhost:3000` (from `src/__tests__/setup.ts:59`) rather than the old `NEXT_PUBLIC_APP_URL = http://localhost:3001`.

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/zero/uploads app/f app/api/zero/uploads/prepare app/api/zero/chat-threads app/api/zero/chat/messages __tests__/proxy` — 170/170 pass
- [x] `oxlint` on changed files — clean
- [ ] CI lint / type / test / knip
- [ ] Manual smoke: upload a file via CLI → verify returned URL is `www.vm0.ai/f/...`, fetch anonymously (no Clerk session) follows the 302 to the R2 presigned URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)