### PR TITLE
fix(platform): apply thumbnail clamp to markdown image syntax

### DIFF
--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -166,6 +166,52 @@ describe("chat-d-067: markdown image URL renders inline", () => {
   });
 });
 
+describe("chat-d-069: markdown image syntax renders inline thumbnail", () => {
+  it("should render ![alt](url) image syntax through the thumbnail override so it matches the link-syntax sizing", async () => {
+    const src = "https://example.com/dog.png";
+    server.use(
+      mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
+        if (query.sinceId) {
+          return respond(200, { messages: [] });
+        }
+        return respond(200, {
+          messages: [
+            {
+              id: "msg-1",
+              role: "assistant",
+              content: `![dog](${src})`,
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+      mockApi(chatThreadByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          id: "thread-img-syntax",
+          ...makeThreadBase(),
+          chatMessages: [
+            {
+              role: "assistant",
+              content: `![dog](${src})`,
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-img-syntax" });
+
+    await waitFor(() => {
+      const img = document.querySelector(`img[src="${src}"]`);
+      expect(img).toBeInTheDocument();
+      // Must carry the thumbnail clamp so image-syntax URLs don't render at
+      // natural size (regression from PR #10254 which only overrode <a>).
+      expect(img?.className).toContain("max-h-32");
+    });
+  });
+});
+
 describe("chat-d-068: markdown video URL renders inline", () => {
   it("should render a <video controls> for video link", async () => {
     const src = "https://example.com/clip.mp4";

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -207,6 +207,28 @@ function PlainLink({ href, children, ...rest }: ComponentPropsWithoutRef<"a">) {
   );
 }
 
+function MediaImage({
+  src,
+  alt,
+  onImageClick,
+}: {
+  src: string;
+  alt: string;
+  onImageClick?: (url: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        onImageClick?.(src);
+      }}
+      className="block max-w-full my-1 rounded-lg overflow-hidden cursor-zoom-in border border-foreground/10"
+    >
+      <img src={src} alt={alt} className="max-h-32 max-w-full object-contain" />
+    </button>
+  );
+}
+
 function MediaLink({
   href,
   children,
@@ -225,21 +247,7 @@ function MediaLink({
 
   if (isImageUrl(href)) {
     const alt = typeof children === "string" ? children : "";
-    return (
-      <button
-        type="button"
-        onClick={() => {
-          onImageClick?.(href);
-        }}
-        className="block max-w-full my-1 rounded-lg overflow-hidden cursor-zoom-in border border-foreground/10"
-      >
-        <img
-          src={href}
-          alt={alt}
-          className="max-h-32 max-w-full object-contain"
-        />
-      </button>
-    );
+    return <MediaImage src={href} alt={alt} onImageClick={onImageClick} />;
   }
 
   if (isVideoUrl(href)) {
@@ -274,28 +282,6 @@ function MarkdownLinkRenderer(
     );
   }
   return <PlainLink {...rest}>{children}</PlainLink>;
-}
-
-function MediaImage({
-  src,
-  alt,
-  onImageClick,
-}: {
-  src: string;
-  alt: string;
-  onImageClick?: (url: string) => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => {
-        onImageClick?.(src);
-      }}
-      className="block max-w-full my-1 rounded-lg overflow-hidden cursor-zoom-in border border-foreground/10"
-    >
-      <img src={src} alt={alt} className="max-h-32 max-w-full object-contain" />
-    </button>
-  );
 }
 
 function MarkdownImageRenderer(

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -276,6 +276,42 @@ function MarkdownLinkRenderer(
   return <PlainLink {...rest}>{children}</PlainLink>;
 }
 
+function MediaImage({
+  src,
+  alt,
+  onImageClick,
+}: {
+  src: string;
+  alt: string;
+  onImageClick?: (url: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        onImageClick?.(src);
+      }}
+      className="block max-w-full my-1 rounded-lg overflow-hidden cursor-zoom-in border border-foreground/10"
+    >
+      <img src={src} alt={alt} className="max-h-32 max-w-full object-contain" />
+    </button>
+  );
+}
+
+function MarkdownImageRenderer(
+  props: ComponentPropsWithoutRef<"img"> & {
+    mediaPreview: boolean;
+    onImageClick: ((url: string) => void) | undefined;
+  },
+) {
+  const { mediaPreview, onImageClick, src, alt, ...rest } = props;
+  const hasSafeSrc = typeof src === "string" && isSafeMediaUrl(src);
+  if (mediaPreview && hasSafeSrc) {
+    return <MediaImage src={src} alt={alt ?? ""} onImageClick={onImageClick} />;
+  }
+  return <img {...rest} src={src} alt={alt} />;
+}
+
 export function Markdown({
   className,
   style,
@@ -298,6 +334,15 @@ export function Markdown({
       />
     );
   };
+  const renderImage = (props: ComponentPropsWithoutRef<"img">) => {
+    return (
+      <MarkdownImageRenderer
+        {...props}
+        mediaPreview={mediaPreview}
+        onImageClick={onImageClick}
+      />
+    );
+  };
   return (
     <MarkdownPreview
       className={`!bg-transparent !text-foreground text-sm ${className ?? ""}`}
@@ -313,6 +358,7 @@ export function Markdown({
       components={{
         table: ResponsiveTable,
         a: renderLink,
+        img: renderImage,
       }}
       {...rest}
     />


### PR DESCRIPTION
## Summary

Refs #10254. The media-preview pass from #10254 only overrode the `a` component, so `![alt](url)` image syntax (the standard markdown image form the assistant tends to produce, including for `/f/` upload URLs) fell through to react-markdown-preview's default `<img>` renderer and displayed at the image's natural size.

This PR adds a matching `img` override:

- When `mediaPreview` is on and the `src` is an `http(s)` URL, renders the same `MediaImage` thumbnail button (`max-h-32`, lightbox on click) used by the link-syntax branch in `MediaLink`.
- Otherwise falls through to a plain `<img>` so non-chat surfaces keep their current behaviour and unsafe schemes (`javascript:`, `data:`) stay blocked.

## Test plan

- [x] Added `chat-d-069` covering `![dog](https://example.com/dog.png)` → asserts the rendered `<img>` carries `max-h-32`, so this can't regress back to natural-size rendering.
- [x] `pnpm -F @vm0/app exec vitest run src/views/components/__tests__/markdown.test.tsx` — 6/6 pass.
- [x] `oxlint` on changed files — clean.
- [ ] Manual smoke in the chat UI: assistant reply containing `![x](/f/.../foo.png)` renders as a 128 px-tall thumbnail that opens the lightbox on click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)