### PR TITLE
fix(voice-chat): auto-end stale session on double-start and unstick preparing UI

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -1153,40 +1153,50 @@ export const startVoiceChat$ = command(
 
     const sessionSignal = set(resetSessionSignal$, signal);
 
-    const agentId = await get(defaultAgentId$);
-    signal.throwIfAborted();
+    // eslint-disable-next-line no-restricted-syntax -- safety net: any non-abort rejection after setting "preparing" must transition to "error" or VoiceBanner sticks on "Enabling…"
+    try {
+      const agentId = await get(defaultAgentId$);
+      signal.throwIfAborted();
 
-    if (!agentId) {
-      set(internalError$, "No agent selected");
+      if (!agentId) {
+        set(internalError$, "No agent selected");
+        set(internalStatus$, "error");
+        return;
+      }
+
+      const createClient = get(zeroClient$);
+      const sessionsClient = createClient(zeroVoiceChatSessionsContract);
+      const sessionRes = await accept(
+        sessionsClient.create({ body: { agentId } }),
+        [200, 400, 401, 403],
+        { toast: false },
+      );
+      signal.throwIfAborted();
+
+      if (sessionRes.status !== 200) {
+        set(internalError$, sessionRes.body.error.message);
+        set(internalStatus$, "error");
+        return;
+      }
+
+      const { session } = sessionRes.body;
+      set(internalSessionId$, session.id);
+
+      await set(
+        prepareActivateConnect$,
+        { sessionId: session.id, timeoutMs: PREP_TIMEOUT_CHAT_MS },
+        sessionSignal,
+        signal,
+        signal,
+      );
+    } catch (error) {
+      throwIfAbort(error);
+      set(
+        internalError$,
+        error instanceof Error ? error.message : "Failed to start voice chat",
+      );
       set(internalStatus$, "error");
-      return;
     }
-
-    const createClient = get(zeroClient$);
-    const sessionsClient = createClient(zeroVoiceChatSessionsContract);
-    const sessionRes = await accept(
-      sessionsClient.create({ body: { agentId } }),
-      [200, 400, 401, 403],
-      { toast: false },
-    );
-    signal.throwIfAborted();
-
-    if (sessionRes.status !== 200) {
-      set(internalError$, sessionRes.body.error.message);
-      set(internalStatus$, "error");
-      return;
-    }
-
-    const { session } = sessionRes.body;
-    set(internalSessionId$, session.id);
-
-    await set(
-      prepareActivateConnect$,
-      { sessionId: session.id, timeoutMs: PREP_TIMEOUT_CHAT_MS },
-      sessionSignal,
-      signal,
-      signal,
-    );
   },
 );
 

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/voice-banner.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/voice-banner.test.tsx
@@ -167,6 +167,45 @@ describe("voiceBanner — error on session creation (MC-VC-004)", () => {
   });
 });
 
+describe("voiceBanner — unexpected server error (MC-VC-006)", () => {
+  it("shows 'Voice error' instead of sticking on 'Enabling...' when POST returns 500", async () => {
+    setMockFeatureSwitches({ voiceChat: true });
+
+    server.use(
+      mockApi(zeroVoiceChatSessionsContract.create, ({ respond }) => {
+        return respond(500, {
+          error: { message: "Internal error", code: "INTERNAL" },
+        });
+      }),
+      mockApi(zeroVoiceChatSessionsContract.end, ({ respond }) => {
+        return respond(200, { ok: true });
+      }),
+    );
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button").find((el) => {
+          return /Voice On/i.test(el.textContent ?? "");
+        }),
+      ).toBeDefined();
+    });
+
+    await user.click(
+      screen.getAllByRole("button").find((el) => {
+        return /Voice On/i.test(el.textContent ?? "");
+      })!,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Voice error")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Enabling...")).toBeNull();
+  });
+});
+
 describe("voiceBanner — dismiss error restores idle (MC-VC-005)", () => {
   it("hides error banner and shows Voice On again when Dismiss is clicked", async () => {
     setMockFeatureSwitches({ voiceChat: true });

--- a/turbo/apps/web/app/api/zero/voice-chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/__tests__/route.test.ts
@@ -117,20 +117,27 @@ describe("POST /api/zero/voice-chat (create session)", () => {
     expect(body.error.code).toBe("BAD_REQUEST");
   });
 
-  it("should return 409 when user already has an active session", async () => {
-    await createTestVoiceChatSession(orgId, userId);
-    const response = await POST(createRequest({ agentId: "any-agent-id" }));
+  it("should auto-end stale 'active' session and succeed instead of returning 409", async () => {
+    const { agentId } = await createTestCompose(uniqueId("vc-agent"));
+    const stale = await createTestVoiceChatSession(orgId, userId);
+
+    const response = await POST(createRequest({ agentId }));
     const body = await response.json();
-    expect(response.status).toBe(409);
-    expect(body.error.code).toBe("CONFLICT");
+
+    expect(response.status).toBe(200);
+    expect(body.session.id).not.toBe(stale.id);
+    expect(body.session.status).toBe("preparing");
   });
 
-  it("should return 409 when user has a preparing session", async () => {
-    await createTestVoiceChatSession(orgId, userId, "preparing");
-    const response = await POST(createRequest({ agentId: "any-agent-id" }));
+  it("should auto-end stale 'preparing' session and succeed instead of returning 409", async () => {
+    const { agentId } = await createTestCompose(uniqueId("vc-agent"));
+    const stale = await createTestVoiceChatSession(orgId, userId, "preparing");
+
+    const response = await POST(createRequest({ agentId }));
     const body = await response.json();
-    expect(response.status).toBe(409);
-    expect(body.error.code).toBe("CONFLICT");
+
+    expect(response.status).toBe(200);
+    expect(body.session.id).not.toBe(stale.id);
   });
 
   it("should create session and dispatch slow-brain on success", async () => {

--- a/turbo/apps/web/src/lib/zero/voice-chat/__tests__/session-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/__tests__/session-service.test.ts
@@ -10,7 +10,10 @@ import {
   getPriorVoiceChatAgentSessionId,
 } from "../session-service";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: verify DB side-effects directly
-import { voiceChatSessions } from "../../../../db/schema/voice-chat";
+import {
+  voiceChatSessions,
+  voiceChatEvents,
+} from "../../../../db/schema/voice-chat";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: verify agent_runs is not mutated by endSession
 import { agentRuns } from "../../../../db/schema/agent-run";
 
@@ -234,5 +237,147 @@ describe("getPriorVoiceChatAgentSessionId", () => {
 
     const result = await getPriorVoiceChatAgentSessionId(orgId, userId);
     expect(result).toBeNull();
+  });
+});
+
+describe("createSession — auto-end stale rows", () => {
+  it("transitions an existing 'active' row to 'ended' and creates a new row", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+
+    const { sessionId: staleId } = await seedSessionWithRun({
+      orgId,
+      userId,
+      agentId,
+      sessionStatus: "active",
+    });
+
+    const fresh = await createSession(orgId, userId, agentId);
+
+    expect(fresh.id).not.toBe(staleId);
+    expect(fresh.status).toBe("preparing");
+
+    // eslint-disable-next-line web/no-direct-db-in-tests -- verify DB side effects directly
+    const db = globalThis.services.db;
+    const [stale] = await db
+      .select()
+      .from(voiceChatSessions)
+      .where(eq(voiceChatSessions.id, staleId));
+    expect(stale!.status).toBe("ended");
+    expect(stale!.endedAt).not.toBeNull();
+
+    const events = await db
+      .select()
+      .from(voiceChatEvents)
+      .where(eq(voiceChatEvents.sessionId, staleId));
+    const endEvents = events.filter((e) => {
+      return e.type === "session-end";
+    });
+    expect(endEvents).toHaveLength(1);
+    expect(endEvents[0]!.source).toBe("system");
+  });
+
+  it("transitions an existing 'preparing' row to 'ended' and creates a new row", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+
+    const { sessionId: staleId } = await seedSessionWithRun({
+      orgId,
+      userId,
+      agentId,
+      sessionStatus: "preparing",
+    });
+
+    const fresh = await createSession(orgId, userId, agentId);
+
+    expect(fresh.id).not.toBe(staleId);
+
+    // eslint-disable-next-line web/no-direct-db-in-tests -- verify DB side effects directly
+    const db = globalThis.services.db;
+    const [stale] = await db
+      .select()
+      .from(voiceChatSessions)
+      .where(eq(voiceChatSessions.id, staleId));
+    expect(stale!.status).toBe("ended");
+  });
+
+  it("leaves stale run's agent_runs.status untouched (graceful-exit invariant)", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+
+    const { runId } = await seedSessionWithRun({
+      orgId,
+      userId,
+      agentId,
+      sessionStatus: "active",
+      runStatus: "running",
+    });
+
+    await createSession(orgId, userId, agentId);
+
+    // eslint-disable-next-line web/no-direct-db-in-tests -- invariant check from #10429
+    const db = globalThis.services.db;
+    const [run] = await db
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId));
+    expect(run!.status).toBe("running");
+  });
+
+  it("hands the stale run's agentSessionId to getPriorVoiceChatAgentSessionId for continuation", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+
+    await seedSessionWithRun({
+      orgId,
+      userId,
+      agentId,
+      sessionStatus: "active",
+      runResult: { agentSessionId: "prior-cc-session" },
+    });
+
+    await createSession(orgId, userId, agentId);
+
+    const prior = await getPriorVoiceChatAgentSessionId(orgId, userId);
+    expect(prior).toBe("prior-cc-session");
+  });
+
+  it("does not touch other users' active rows", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+    const other = await context.setupUser({ prefix: "other-user" });
+
+    const { sessionId: otherStaleId } = await seedSessionWithRun({
+      orgId: other.orgId,
+      userId: other.userId,
+      agentId,
+      sessionStatus: "active",
+    });
+
+    await createSession(orgId, userId, agentId);
+
+    // eslint-disable-next-line web/no-direct-db-in-tests -- cross-user isolation check
+    const db = globalThis.services.db;
+    const [untouched] = await db
+      .select()
+      .from(voiceChatSessions)
+      .where(eq(voiceChatSessions.id, otherStaleId));
+    expect(untouched!.status).toBe("active");
+    expect(untouched!.endedAt).toBeNull();
+  });
+
+  it("creates the row without emitting a session-end event when no stale row exists", async () => {
+    context.setupMocks();
+    const { userId, orgId, agentId } = await seedAgent();
+
+    const fresh = await createSession(orgId, userId, agentId);
+
+    // eslint-disable-next-line web/no-direct-db-in-tests -- verify no stray events
+    const db = globalThis.services.db;
+    const events = await db
+      .select()
+      .from(voiceChatEvents)
+      .where(eq(voiceChatEvents.sessionId, fresh.id));
+    expect(events).toHaveLength(0);
   });
 });

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -6,7 +6,7 @@ import {
 import { agentRuns } from "../../../db/schema/agent-run";
 import { createZeroRun, type CreateZeroRunResult } from "../zero-run-service";
 import { buildVoiceChatQuickPrepPrompt } from "../integration-prompt";
-import { conflict, notFound, badRequest, forbidden } from "../../shared/errors";
+import { notFound, badRequest, forbidden } from "../../shared/errors";
 import { hasAgentSessionId } from "../run-result";
 import { adaptVoiceChatSessionTrigger } from "./adapt-voice-chat-session-trigger";
 
@@ -21,34 +21,45 @@ export async function createSession(
 ) {
   const db = globalThis.services.db;
 
-  const [existing] = await db
-    .select({ id: voiceChatSessions.id })
-    .from(voiceChatSessions)
-    .where(
-      and(
-        eq(voiceChatSessions.userId, userId),
-        eq(voiceChatSessions.orgId, orgId),
-        inArray(voiceChatSessions.status, ["active", "preparing"]),
-      ),
-    )
-    .limit(1);
+  return await db.transaction(async (tx) => {
+    // Graceful auto-end: slow-brain sees session-end within 5s and self-exits,
+    // populating result.agentSessionId so the new run can resume via
+    // getPriorVoiceChatAgentSessionId. Do NOT cancelRun — that skips the webhook.
+    const stale = await tx
+      .select({ id: voiceChatSessions.id })
+      .from(voiceChatSessions)
+      .where(
+        and(
+          eq(voiceChatSessions.userId, userId),
+          eq(voiceChatSessions.orgId, orgId),
+          inArray(voiceChatSessions.status, ["active", "preparing"]),
+        ),
+      );
 
-  if (existing) {
-    throw conflict("User already has an active voice-chat session");
-  }
+    for (const row of stale) {
+      await tx.insert(voiceChatEvents).values({
+        sessionId: row.id,
+        source: "system",
+        type: "session-end",
+      });
+      await tx
+        .update(voiceChatSessions)
+        .set({ status: "ended", endedAt: new Date() })
+        .where(eq(voiceChatSessions.id, row.id));
+    }
 
-  const [session] = await db
-    .insert(voiceChatSessions)
-    .values({
-      orgId,
-      userId,
-      agentId,
-      status: "preparing",
-    })
-    .returning();
+    const [session] = await tx
+      .insert(voiceChatSessions)
+      .values({
+        orgId,
+        userId,
+        agentId,
+        status: "preparing",
+      })
+      .returning();
 
-  // Insert always returns the inserted row
-  return session!;
+    return session!;
+  });
 }
 
 async function getSession(sessionId: string) {

--- a/turbo/packages/core/src/contracts/zero-voice-chat-sessions.ts
+++ b/turbo/packages/core/src/contracts/zero-voice-chat-sessions.ts
@@ -43,6 +43,7 @@ export const zeroVoiceChatSessionsContract = c.router({
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
+      500: apiErrorSchema,
     },
     summary: "Create a new voice-chat session",
   },


### PR DESCRIPTION
## Summary

- **Server**: `createSession()` no longer throws 409 when a stale `active`/`preparing` row exists. It transactionally writes `session-end` + flips the stale row to `ended` + inserts the new row. Slow-brain observes the event within ~5s and self-exits via the agent-complete webhook, preserving the #10429 invariant that `agent_runs.result.agentSessionId` is populated — so the new run resumes the prior CC session via `getPriorVoiceChatAgentSessionId()`.
- **Client**: `startVoiceChat$` now wraps its body in a try/catch that transitions `internalStatus$` to `"error"` on any non-Abort rejection. Previously, any unexpected server response (500, network failure, etc.) left VoiceBanner stuck on "Enabling…".

Closes #10369.

## Test plan

- [x] `session-service.test.ts` — new `describe` block covers: active auto-end, preparing auto-end, graceful-exit invariant (agent_runs.status untouched), continuation wiring via `getPriorVoiceChatAgentSessionId`, cross-user isolation, and no-op fresh-user path.
- [x] `route.test.ts` — previous 409 tests rewritten to assert the new 200 behavior (auto-end + fresh session id).
- [x] `voice-banner.test.tsx` — new MC-VC-006 test verifies that a 500 from POST /voice-chat transitions the banner to "Voice error" instead of sticking on "Enabling…".
- [x] All pre-commit checks pass: lint, check-types, format, knip.
- [x] Full voice-chat test suites pass: 157 tests in web, 46 tests in platform mission-control + signals.

## Manual verification

1. Open voice chat. Close the tab without clicking end. Reopen and start voice chat again — it connects without the 409, and continues the prior CC session.
2. Simulate a 500 from the create endpoint — banner shows "Voice error" + Dismiss, not stuck on "Enabling…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)