### PR TITLE
fix(web): enable Ably queryTime to prevent clock skew auth failures

### DIFF
--- a/turbo/apps/web/src/lib/infra/realtime/client.ts
+++ b/turbo/apps/web/src/lib/infra/realtime/client.ts
@@ -9,7 +9,7 @@ let ablyClient: Ably.Rest | null = null;
 
 function getAblyClient(): Ably.Rest {
   if (!ablyClient) {
-    ablyClient = new Ably.Rest({ key: env().ABLY_API_KEY });
+    ablyClient = new Ably.Rest({ key: env().ABLY_API_KEY, queryTime: true });
     log.debug("Ably client initialized");
   }
 


### PR DESCRIPTION
## Summary
- Enable `queryTime: true` on the server-side `Ably.Rest` singleton so TokenRequests are signed using Ably's reference time instead of the local Vercel Lambda clock.
- Fixes `Timestamp not current` auth rejections that cascade into `Connection closed` / `Connection to server unavailable` errors on the platform frontend.

## Context
Issue #10520 consolidates ~25 production Sentry reports tracing back to a single root cause: Ably rejecting TokenRequests whose `timestamp` has drifted too far from its reference time. Today the `Ably.Rest` client in `apps/web/src/lib/infra/realtime/client.ts` is constructed with only `key`, so `createTokenRequest` falls back to `Date.now() + serverTimeOffset` (offset = 0), meaning the Vercel Lambda local clock is trusted directly.

With `queryTime: true`, the first `createTokenRequest` per client instance calls Ably's `time()` endpoint once, caches `serverTimeOffset`, and applies it to every subsequent signing. One extra REST roundtrip per Vercel Lambda cold start; no impact on the hot publish path or per-message cost.

The same singleton backs `generateRunnerGroupToken`, so runner token signing is fixed in the same change. Runner-side impact was raised in #dev with @liangyou.

## Test plan
- [ ] CI green
- [ ] After deploy, watch Sentry for a drop in `Timestamp not current`, `Client configured authentication provider request failed`, `Connection closed`, and `Connection to server unavailable` occurrences grouped under #10520.

Fixes #10520

🤖 Generated with [Claude Code](https://claude.com/claude-code)