### PR TITLE
docs(mitm-addon): clarify firewall_action vs firewall_error semantics

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -442,6 +442,15 @@ async def handle_firewall_request(
             type="firewall",
             firewall_base=firewall_base,
         )
+        # `firewall_action` records the firewall's permission decision
+        # (ALLOW/DENY/BLOCK); `firewall_error` records post-decision
+        # execution failures. They are orthogonal — the firewall granted
+        # the request, but we cannot fulfill it because auth is missing,
+        # so action=ALLOW + error=<reason> is the correct combination
+        # (applies to the two analogous 502 paths below as well).
+        # Permission-usage analytics should read `action`; execution error
+        # rates should aggregate independently on `firewall_error`.
+        # See #10493 for why this is not a miscategorization.
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_error"] = "auth_unavailable"
         flow.response = http.Response.make(


### PR DESCRIPTION
## Summary
- Adds a comment at the first 502 error path in `handle_firewall_request` explaining that `firewall_action` and `firewall_error` are orthogonal: `firewall_action` records the firewall's permission decision (ALLOW/DENY/BLOCK); `firewall_error` records post-decision execution failures.
- The 502 paths (missing `encryptedSecrets`, generic auth fetch exception, forward-request exception) correctly set `action=ALLOW` + `error=<reason>` — the firewall granted the request but fulfillment failed for reasons unrelated to the firewall decision.
- Closes #10493 (flagged as a security issue, but actually by-design — both `aggregate-insights` aggregation and `contracts/runs.ts` enum are consistent with this semantic).

## Test plan
- [x] Comment-only change, ruff-check and ruff-fmt pass via lefthook
- [x] No runtime/behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)