### PR TITLE
feat: add 0.2x credit multiplier for deepseek-chat

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -221,6 +221,7 @@ const VM0_MODEL_CREDIT_MULTIPLIER = Object.freeze<Record<string, number>>({
   "kimi-k2.6": 0.3,
   "kimi-k2.5": 0.2,
   "MiniMax-M2.7": 0.1,
+  "deepseek-chat": 0.2,
 });
 
 export function getVm0ModelMultiplier(model: string): number | undefined {


### PR DESCRIPTION
## Summary
- Add `deepseek-chat` to `VM0_MODEL_CREDIT_MULTIPLIER` with 0.2x pricing label
- This will display "0.2x" badge in the model picker UI for DeepSeek Chat when using VM0 managed provider

## Test plan
- [ ] Verify the multiplier badge appears in the model picker for `deepseek-chat`
- [ ] Ensure credit calculations use the 0.2x multiplier appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)