### PR TITLE
refactor(mitm-addon): unify urllib cleanup on `with` blocks

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -161,7 +161,8 @@ def _fetch_firewall_headers_sync(
     try:
         # S310 is satisfied by provenance: `req` always targets
         # ctx.options.vm0_api_url (operator-set at mitmdump launch).
-        resp = urllib.request.urlopen(req, timeout=10)  # noqa: S310
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         # HTTPError wraps an open socket; `with e` closes on every exit
         # path to avoid FD exhaustion under sustained cache-miss load (#10475).
@@ -176,10 +177,6 @@ def _fetch_firewall_headers_sync(
                     error_info.get("message", "Connector not configured"),
                 ) from None
             raise
-    try:
-        return json.loads(resp.read())
-    finally:
-        resp.close()
 
 
 async def fetch_firewall_headers(

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -22,11 +22,13 @@ def _post_webhook(url: str, sandbox_token: str, payload: dict) -> None:
     data = json.dumps(payload).encode()
     req = make_api_request(url, data, sandbox_token)
     try:
-        resp = _opener.open(req, timeout=10)
-        resp.close()
+        with _opener.open(req, timeout=10):
+            pass
     except urllib.error.HTTPError as exc:
-        exc.close()  # HTTPError holds an open socket
-        raise
+        # HTTPError wraps an open socket; context-manage it so the fd is
+        # released on every exit path (matches _forward_request_sync #10476).
+        with exc:
+            raise
 
 
 def _post_webhook_with_retry(

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1665,6 +1665,7 @@ class TestHandleFirewallRequest:
 class TestFetchFirewallHeaders:
     def test_builds_correct_request(self, headers):
         mock_resp = MagicMock()
+        mock_resp.__enter__.return_value = mock_resp
         mock_resp.read.return_value = json.dumps(
             {"headers": {"Authorization": "Bearer tok"}}
         ).encode()
@@ -1697,6 +1698,7 @@ class TestFetchFirewallHeaders:
 
     def test_includes_vercel_bypass_header(self, headers):
         mock_resp = MagicMock()
+        mock_resp.__enter__.return_value = mock_resp
         mock_resp.read.return_value = json.dumps({"headers": {}}).encode()
 
         mock_req_instance = MagicMock()
@@ -1715,6 +1717,7 @@ class TestFetchFirewallHeaders:
 
     def test_no_vercel_bypass_when_empty(self, headers):
         mock_resp = MagicMock()
+        mock_resp.__enter__.return_value = mock_resp
         mock_resp.read.return_value = json.dumps({"headers": {}}).encode()
 
         mock_req_instance = MagicMock()
@@ -1730,6 +1733,7 @@ class TestFetchFirewallHeaders:
 
     def test_includes_auth_base_in_request_body(self, headers):
         mock_resp = MagicMock()
+        mock_resp.__enter__.return_value = mock_resp
         mock_resp.read.return_value = json.dumps(
             {"headers": {}, "base": "https://discord.com/api/webhooks/123/abc"}
         ).encode()
@@ -1804,6 +1808,7 @@ class TestFetchFirewallHeaders:
     def test_closes_response_on_success(self):
         """Success path must close the urlopen response — FD leak guard (#10475)."""
         mock_resp = MagicMock()
+        mock_resp.__enter__.return_value = mock_resp
         mock_resp.read.return_value = json.dumps({"headers": {}}).encode()
 
         with (
@@ -1813,7 +1818,7 @@ class TestFetchFirewallHeaders:
         ):
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
 
-        mock_resp.close.assert_called_once()  # urllib external boundary (#9991)
+        mock_resp.__exit__.assert_called_once()  # urllib external boundary (#9991)
 
     def test_closes_http_error_response(self):
         """HTTPError path must close the underlying socket — FD leak guard (#10475)."""
@@ -1842,6 +1847,7 @@ class TestFetchFirewallHeaders:
     async def test_async_wrapper_passes_api_url_from_ctx(self, headers):
         """fetch_firewall_headers reads api_url on the event loop and passes it to the sync fn."""
         mock_resp = MagicMock()
+        mock_resp.__enter__.return_value = mock_resp
         mock_resp.read.return_value = json.dumps({"headers": {"Auth": "tok"}}).encode()
 
         with (


### PR DESCRIPTION
## Summary

- Migrate `_post_webhook` (`usage/webhook.py`) and `_fetch_firewall_headers_sync` (`auth.py` success path) to `with` blocks so all three urllib call sites in the addon use the same idiom introduced by `_forward_request_sync` (#10476).
- No behavior change — #10475 already closed the real FD leak in `auth.py`'s HTTPError arm. This is consistency + defense-in-depth so a future edit between `open()` and the matching `close()` can't silently regress.

## Test plan

- [x] `python3 -m pytest` in `crates/runner/mitm-addon` — 897/897 pass
- [x] Six existing `TestFetchFirewallHeaders` mocks updated to `__enter__.return_value = mock_resp` so `with urlopen(...) as resp:` binds to the test-configured mock
- [x] `test_closes_response_on_success` now asserts `mock_resp.__exit__` (parallels `TestForwardRequestResourceCleanup`)

Closes #10491. Related: #10475, #10476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)