### PR TITLE
feat: enable DeepSeek models for all users

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -221,6 +221,8 @@ const VM0_MODEL_CREDIT_MULTIPLIER = Object.freeze<Record<string, number>>({
   "kimi-k2.6": 0.3,
   "kimi-k2.5": 0.2,
   "MiniMax-M2.7": 0.1,
+  "deepseek-chat": 0.1,
+  "deepseek-reasoner": 0.1,
 });
 
 export function getVm0ModelMultiplier(model: string): number | undefined {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -332,8 +332,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.Vm0DeepseekModel]: {
     maintainer: "ethan@vm0.ai",
-    description: "Enable the DeepSeek-V3.2 (deepseek-chat) VM0 managed model",
-    enabled: false,
+    description: "Enable DeepSeek (deepseek-chat, deepseek-reasoner) VM0 managed models",
+    enabled: true,
   },
 };
 


### PR DESCRIPTION
## Summary
- Flip `Vm0DeepseekModel` feature flag from `enabled: false` to `enabled: true`, making `deepseek-chat` and `deepseek-reasoner` visible in the Built-in model picker for **all users**
- Add credit multipliers for both DeepSeek models (0.1x each) in `provider-ui-config.ts`

### Credit multiplier calculation
Using the blended formula `(input + 5×output) / 78` normalized against Sonnet 4.6 ($3/$15 per M):

| Model | Input/M | Output/M | Blended | Multiplier |
|-------|---------|----------|---------|------------|
| deepseek-chat (V3) | $0.27 | $1.10 | $5.77 | 0.1x |
| deepseek-reasoner (R1) | $0.55 | $2.19 | $11.50 | 0.1x |

### Checklist before merge
- [ ] Ensure `vm0_api_keys` table has a DeepSeek vendor key in the pool
- [ ] Ensure `credit_pricing` table has entries for `deepseek-chat` and `deepseek-reasoner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)