### PR TITLE
fix(connector): skip orphan oauth rows in list endpoint

### DIFF
--- a/turbo/apps/web/app/api/zero/connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/__tests__/route.test.ts
@@ -69,14 +69,31 @@ describe("GET /api/zero/connectors", () => {
     expect(response.status).toBe(401);
   });
 
+  // Regression: when a connector is removed from CONNECTOR_TYPES, rows in
+  // `connectors` (OAuth) and `user_platform_connectors` (platform) with that
+  // stale type become orphaned. The list endpoint must stay usable — silently
+  // drop the orphan instead of failing the whole response.
   it("skips platform rows whose type no longer exists in the contract", async () => {
-    // Regression: when a platform-managed connector is removed from
-    // CONNECTOR_TYPES, any previously-enabled row in user_platform_connectors
-    // becomes orphaned. The list endpoint must stay usable — silently drop
-    // the orphan instead of failing the whole response.
-    const userId = uniqueId("zcon-orphan");
+    const userId = uniqueId("zcon-orphan-pl");
     const { orgId } = await setupOrg(userId);
     await insertTestPlatformConnector(orgId, userId, "__removed_connector__");
+
+    const response = await GET(createTestRequest(connectorsUrl()));
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const orphan = data.connectors.find((c: { type: string }) => {
+      return c.type === "__removed_connector__";
+    });
+    expect(orphan).toBeUndefined();
+  });
+
+  it("skips oauth rows whose type no longer exists in the contract", async () => {
+    const userId = uniqueId("zcon-orphan-oa");
+    const { orgId } = await setupOrg(userId);
+    await context.createConnector(orgId, {
+      userId,
+      type: "__removed_connector__",
+    });
 
     const response = await GET(createTestRequest(connectorsUrl()));
     expect(response.status).toBe(200);

--- a/turbo/apps/web/app/api/zero/platform-connectors/[type]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/platform-connectors/[type]/__tests__/route.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zpl");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function enableUrl(type: string): string {
+  return `http://localhost:3000/api/zero/platform-connectors/${type}`;
+}
+
+// With no connector currently declaring `platform` auth the success path is
+// unreachable (validated upstream by `connectorTypeSchema`). These tests
+// cover the two branches that stay exercisable: auth rejection and the
+// "type doesn't support platform enable" rejection. Expand to cover 200
+// again when the next platform connector lands.
+describe("POST /api/zero/platform-connectors/:type", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(
+      createTestRequest(enableUrl("github"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects types that don't declare a platform auth method", async () => {
+    const userId = uniqueId("zpl-np");
+    await setupOrg(userId);
+
+    const response = await POST(
+      createTestRequest(enableUrl("github"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(response.status).toBe(400);
+  });
+});

--- a/turbo/apps/web/app/api/zero/platform-connectors/[type]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/platform-connectors/[type]/__tests__/route.test.ts
@@ -38,7 +38,7 @@ describe("POST /api/zero/platform-connectors/:type", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest(enableUrl("github"), {
+      createTestRequest(enableUrl("test-oauth"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
@@ -48,11 +48,15 @@ describe("POST /api/zero/platform-connectors/:type", () => {
   });
 
   it("rejects types that don't declare a platform auth method", async () => {
+    // `test-oauth` is the internal synthetic OAuth connector — it passes
+    // `connectorTypeSchema` (so the request reaches the handler) and will
+    // never grow a `platform` auth method by contract, so the 400 branch
+    // is stable under future contract changes.
     const userId = uniqueId("zpl-np");
     await setupOrg(userId);
 
     const response = await POST(
-      createTestRequest(enableUrl("github"), {
+      createTestRequest(enableUrl("test-oauth"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -155,26 +155,29 @@ export async function listConnectors(
     getApiTokenConnectorTypes(orgId, userId),
   ]);
 
+  // Both tables store `type` as varchar, so either can outlive a connector's
+  // removal from the contract (a type dropped from `CONNECTOR_TYPES` while
+  // stale rows remain). Skip unknown types instead of throwing, so the list
+  // endpoint stays usable while ops cleans up orphans.
   const dbConnectors: ConnectorResponse[] = [
-    ...oauthRows.map((row) => {
-      return {
-        id: row.id,
-        type: parseConnectorType(row.type),
-        authMethod: row.authMethod,
-        externalId: row.externalId,
-        externalUsername: row.externalUsername,
-        externalEmail: row.externalEmail,
-        oauthScopes: row.oauthScopes ? JSON.parse(row.oauthScopes) : null,
-        needsReconnect: row.needsReconnect,
-        createdAt: row.createdAt.toISOString(),
-        updatedAt: row.updatedAt.toISOString(),
-      };
+    ...oauthRows.flatMap((row) => {
+      const parsed = connectorTypeSchema.safeParse(row.type);
+      if (!parsed.success) return [];
+      return [
+        {
+          id: row.id,
+          type: parsed.data,
+          authMethod: row.authMethod,
+          externalId: row.externalId,
+          externalUsername: row.externalUsername,
+          externalEmail: row.externalEmail,
+          oauthScopes: row.oauthScopes ? JSON.parse(row.oauthScopes) : null,
+          needsReconnect: row.needsReconnect,
+          createdAt: row.createdAt.toISOString(),
+          updatedAt: row.updatedAt.toISOString(),
+        },
+      ];
     }),
-    // Platform rows are indexed by varchar, so the table can outlive a
-    // connector's removal from the contract (e.g. a type dropped from
-    // `CONNECTOR_TYPES` while stale rows remain). Silently skip unknown
-    // types instead of throwing, so the list endpoint stays usable while
-    // ops/back-office cleans up the orphan rows.
     ...platformRows.flatMap((row) => {
       const parsed = connectorTypeSchema.safeParse(row.type);
       return parsed.success ? [platformRowToResponse(row, parsed.data)] : [];


### PR DESCRIPTION
## Summary

Follow-up to #10552. That PR fixed the orphan-row crash for the platform table (`user_platform_connectors`) — but the same class of bug still exists on the OAuth side:

- `connector-service.ts:162` runs `parseConnectorType(row.type)` for every OAuth row in `listConnectors`. That function throws on any type not in the zod enum, so **any** connector removed from `CONNECTOR_TYPES` would have 400-ed the list for orgs that still had a matching OAuth row — not just nano-banana, and not just platform connectors.

This PR applies the same `flatMap` + `safeParse` pattern to `oauthRows`, adds a parallel regression test, and restores the 401 / 400 branches of `POST /api/zero/platform-connectors/:type` that were deleted alongside the nano-banana-specific suite in #10552 (addressing the P2 comment on that review).

## Changes

- `connector-service.ts`: unified orphan-skip comment and applied `flatMap` + `safeParse` to both `oauthRows` and `platformRows`.
- `connectors/__tests__/route.test.ts`: added "skips oauth rows whose type no longer exists in the contract" alongside the existing platform case.
- `platform-connectors/[type]/__tests__/route.test.ts`: minimal coverage for 401 (unauthenticated) and 400 (type without `platform` auth, using `github` as fixture). Success path returns once a platform connector lands again.

## Test plan

- [x] `pnpm -F web exec vitest run app/api/zero/connectors app/api/zero/platform-connectors` — 43/43
- [x] `pnpm turbo run lint --filter=web` — 0 warnings / 0 errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)