### PR TITLE
feat(cli): add zero voice-chat task commands

### DIFF
--- a/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/task-create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/task-create.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for zero voice-chat task create command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { voiceChatTaskCreateCommand } from "../task/create";
+
+const TASKS_URL = "http://localhost:3000/api/zero/voice-chat/:id/tasks";
+
+describe("zero voice-chat task create command", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful create", () => {
+    it("should POST prompt and print the created task", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      const createdTask = {
+        id: "00000000-0000-0000-0000-000000000001",
+        sessionId: "00000000-0000-0000-0000-00000000aaaa",
+        runId: null,
+        prompt: "Summarize the PR",
+        status: "pending",
+        result: null,
+        error: null,
+        assistantMessages: [],
+        createdAt: "2026-04-22T00:00:00Z",
+        startedAt: null,
+        finishedAt: null,
+      };
+
+      server.use(
+        http.post(TASKS_URL, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ task: createdTask }, { status: 200 });
+        }),
+      );
+
+      await voiceChatTaskCreateCommand.parseAsync([
+        "node",
+        "cli",
+        "00000000-0000-0000-0000-00000000aaaa",
+        "--prompt",
+        "Summarize the PR",
+      ]);
+
+      expect(capturedBody).toEqual({ prompt: "Summarize the PR" });
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        JSON.stringify(createdTask, null, 2),
+      );
+    });
+  });
+
+  describe("missing --prompt", () => {
+    it("should exit non-zero when --prompt is not provided", async () => {
+      await expect(async () => {
+        await voiceChatTaskCreateCommand.parseAsync([
+          "node",
+          "cli",
+          "00000000-0000-0000-0000-00000000aaaa",
+        ]);
+      }).rejects.toThrow("process.exit called");
+    });
+  });
+
+  describe("API errors", () => {
+    it("should handle 404 session not found", async () => {
+      server.use(
+        http.post(TASKS_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Voice-chat session not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await voiceChatTaskCreateCommand.parseAsync([
+          "node",
+          "cli",
+          "00000000-0000-0000-0000-00000000aaaa",
+          "--prompt",
+          "Summarize the PR",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Voice-chat session not found"),
+      );
+    });
+
+    it("should handle 401 unauthorized", async () => {
+      server.use(
+        http.post(TASKS_URL, () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await voiceChatTaskCreateCommand.parseAsync([
+          "node",
+          "cli",
+          "00000000-0000-0000-0000-00000000aaaa",
+          "--prompt",
+          "Summarize the PR",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/task-get.test.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/task-get.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for zero voice-chat task get command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { voiceChatTaskGetCommand } from "../task/get";
+
+const TASK_URL = "http://localhost:3000/api/zero/voice-chat/:id/tasks/:taskId";
+
+describe("zero voice-chat task get command", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful get", () => {
+    it("should fetch and print the task as JSON", async () => {
+      const task = {
+        id: "00000000-0000-0000-0000-000000000001",
+        sessionId: "00000000-0000-0000-0000-00000000aaaa",
+        runId: "00000000-0000-0000-0000-00000000bbbb",
+        prompt: "Summarize the PR",
+        status: "done",
+        result: "PR summary here",
+        error: null,
+        assistantMessages: [
+          {
+            type: "assistant",
+            content: "PR summary here",
+            at: "2026-04-22T00:05:00Z",
+          },
+        ],
+        createdAt: "2026-04-22T00:00:00Z",
+        startedAt: "2026-04-22T00:01:00Z",
+        finishedAt: "2026-04-22T00:05:00Z",
+      };
+
+      server.use(
+        http.get(TASK_URL, () => {
+          return HttpResponse.json({ task }, { status: 200 });
+        }),
+      );
+
+      await voiceChatTaskGetCommand.parseAsync([
+        "node",
+        "cli",
+        "00000000-0000-0000-0000-00000000aaaa",
+        "00000000-0000-0000-0000-000000000001",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        JSON.stringify(task, null, 2),
+      );
+    });
+  });
+
+  describe("API errors", () => {
+    it("should handle 404 task not found", async () => {
+      server.use(
+        http.get(TASK_URL, () => {
+          return HttpResponse.json(
+            { error: { message: "Task not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await voiceChatTaskGetCommand.parseAsync([
+          "node",
+          "cli",
+          "00000000-0000-0000-0000-00000000aaaa",
+          "00000000-0000-0000-0000-000000000001",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Task not found"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/task-list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/task-list.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for zero voice-chat task list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { voiceChatTaskListCommand } from "../task/list";
+
+const TASKS_URL = "http://localhost:3000/api/zero/voice-chat/:id/tasks";
+
+describe("zero voice-chat task list command", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful list", () => {
+    it("should print a slim array of {id, status, createdAt}", async () => {
+      const tasks = [
+        {
+          id: "00000000-0000-0000-0000-000000000001",
+          sessionId: "00000000-0000-0000-0000-00000000aaaa",
+          runId: null,
+          prompt: "Summarize the PR",
+          status: "pending",
+          result: null,
+          error: null,
+          assistantMessages: [],
+          createdAt: "2026-04-22T00:00:00Z",
+          startedAt: null,
+          finishedAt: null,
+        },
+        {
+          id: "00000000-0000-0000-0000-000000000002",
+          sessionId: "00000000-0000-0000-0000-00000000aaaa",
+          runId: "00000000-0000-0000-0000-00000000cccc",
+          prompt: "Another prompt",
+          status: "done",
+          result: "Full result string that should be pruned out",
+          error: null,
+          assistantMessages: [
+            {
+              type: "assistant",
+              content: "Answer",
+              at: "2026-04-22T00:10:00Z",
+            },
+          ],
+          createdAt: "2026-04-22T00:05:00Z",
+          startedAt: "2026-04-22T00:06:00Z",
+          finishedAt: "2026-04-22T00:10:00Z",
+        },
+      ];
+
+      server.use(
+        http.get(TASKS_URL, () => {
+          return HttpResponse.json({ tasks }, { status: 200 });
+        }),
+      );
+
+      await voiceChatTaskListCommand.parseAsync([
+        "node",
+        "cli",
+        "00000000-0000-0000-0000-00000000aaaa",
+      ]);
+
+      const expected = [
+        {
+          id: "00000000-0000-0000-0000-000000000001",
+          status: "pending",
+          createdAt: "2026-04-22T00:00:00Z",
+        },
+        {
+          id: "00000000-0000-0000-0000-000000000002",
+          status: "done",
+          createdAt: "2026-04-22T00:05:00Z",
+        },
+      ];
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        JSON.stringify(expected, null, 2),
+      );
+    });
+
+    it("should print an empty array when there are no tasks", async () => {
+      server.use(
+        http.get(TASKS_URL, () => {
+          return HttpResponse.json({ tasks: [] }, { status: 200 });
+        }),
+      );
+
+      await voiceChatTaskListCommand.parseAsync([
+        "node",
+        "cli",
+        "00000000-0000-0000-0000-00000000aaaa",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(JSON.stringify([], null, 2));
+    });
+  });
+
+  describe("API errors", () => {
+    it("should handle 401 unauthorized", async () => {
+      server.use(
+        http.get(TASKS_URL, () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await voiceChatTaskListCommand.parseAsync([
+          "node",
+          "cli",
+          "00000000-0000-0000-0000-00000000aaaa",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/voice-chat/index.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/index.ts
@@ -1,15 +1,20 @@
 import { Command } from "commander";
 import { voiceChatContextCommand } from "./context";
+import { voiceChatTaskCommand } from "./task";
 
 export const zeroVoiceChatCommand = new Command()
   .name("voice-chat")
-  .description("Read and write voice-chat shared context events")
+  .description("Read and write voice-chat shared context and tasks")
   .addCommand(voiceChatContextCommand)
+  .addCommand(voiceChatTaskCommand)
   .addHelpText(
     "after",
     `
 Examples:
   Read all events:       zero voice-chat context get <session-id>
   Read new events:       zero voice-chat context get <session-id> --after 5
-  Append an event:       zero voice-chat context append <session-id> --source slow-brain --type directive --content "Done"`,
+  Append an event:       zero voice-chat context append <session-id> --source slow-brain --type directive --content "Done"
+  Create a task:         zero voice-chat task create <session-id> --prompt "Summarize the latest PR"
+  List tasks:            zero voice-chat task list <session-id>
+  Get a task:            zero voice-chat task get <session-id> <task-id>`,
   );

--- a/turbo/apps/cli/src/commands/zero/voice-chat/task/create.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/task/create.ts
@@ -1,0 +1,17 @@
+import { Command } from "commander";
+import { withErrorHandler } from "../../../../lib/command";
+import { createVoiceChatTask } from "../../../../lib/api";
+
+export const voiceChatTaskCreateCommand = new Command()
+  .name("create")
+  .description("Dispatch a new task to a fresh Zero sandbox run")
+  .argument("<session-id>", "Voice-chat session ID")
+  .requiredOption("--prompt <prompt>", "Task prompt for the Tasker")
+  .action(
+    withErrorHandler(async (sessionId: string, options: { prompt: string }) => {
+      const task = await createVoiceChatTask(sessionId, {
+        prompt: options.prompt,
+      });
+      console.log(JSON.stringify(task, null, 2));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/voice-chat/task/get.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/task/get.ts
@@ -1,0 +1,15 @@
+import { Command } from "commander";
+import { withErrorHandler } from "../../../../lib/command";
+import { getVoiceChatTask } from "../../../../lib/api";
+
+export const voiceChatTaskGetCommand = new Command()
+  .name("get")
+  .description("Get a single voice-chat task")
+  .argument("<session-id>", "Voice-chat session ID")
+  .argument("<task-id>", "Task ID")
+  .action(
+    withErrorHandler(async (sessionId: string, taskId: string) => {
+      const task = await getVoiceChatTask(sessionId, taskId);
+      console.log(JSON.stringify(task, null, 2));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/voice-chat/task/index.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/task/index.ts
@@ -1,0 +1,11 @@
+import { Command } from "commander";
+import { voiceChatTaskCreateCommand } from "./create";
+import { voiceChatTaskGetCommand } from "./get";
+import { voiceChatTaskListCommand } from "./list";
+
+export const voiceChatTaskCommand = new Command()
+  .name("task")
+  .description("Dispatch and inspect voice-chat Tasker runs")
+  .addCommand(voiceChatTaskCreateCommand)
+  .addCommand(voiceChatTaskGetCommand)
+  .addCommand(voiceChatTaskListCommand);

--- a/turbo/apps/cli/src/commands/zero/voice-chat/task/list.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/task/list.ts
@@ -1,0 +1,21 @@
+import { Command } from "commander";
+import { withErrorHandler } from "../../../../lib/command";
+import { listVoiceChatTasks } from "../../../../lib/api";
+
+export const voiceChatTaskListCommand = new Command()
+  .name("list")
+  .description("List voice-chat tasks for a session")
+  .argument("<session-id>", "Voice-chat session ID")
+  .action(
+    withErrorHandler(async (sessionId: string) => {
+      const tasks = await listVoiceChatTasks(sessionId);
+      const slim = tasks.map((t) => {
+        return {
+          id: t.id,
+          status: t.status,
+          createdAt: t.createdAt,
+        };
+      });
+      console.log(JSON.stringify(slim, null, 2));
+    }),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-voice-chat-tasks.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-voice-chat-tasks.ts
@@ -1,0 +1,64 @@
+import { initClient } from "@ts-rest/core";
+import {
+  zeroVoiceChatTasksContract,
+  type VoiceChatTask,
+  type CreateVoiceChatTaskBody,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+export async function createVoiceChatTask(
+  sessionId: string,
+  body: CreateVoiceChatTaskBody,
+): Promise<VoiceChatTask> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVoiceChatTasksContract, config);
+
+  const result = await client.createTask({
+    params: { id: sessionId },
+    body,
+    headers: {},
+  });
+
+  if (result.status === 200) {
+    return result.body.task;
+  }
+
+  handleError(result, "Failed to create voice-chat task");
+}
+
+export async function getVoiceChatTask(
+  sessionId: string,
+  taskId: string,
+): Promise<VoiceChatTask> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVoiceChatTasksContract, config);
+
+  const result = await client.getTask({
+    params: { id: sessionId, taskId },
+    headers: {},
+  });
+
+  if (result.status === 200) {
+    return result.body.task;
+  }
+
+  handleError(result, "Failed to get voice-chat task");
+}
+
+export async function listVoiceChatTasks(
+  sessionId: string,
+): Promise<VoiceChatTask[]> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVoiceChatTasksContract, config);
+
+  const result = await client.listTasks({
+    params: { id: sessionId },
+    headers: {},
+  });
+
+  if (result.status === 200) {
+    return result.body.tasks;
+  }
+
+  handleError(result, "Failed to list voice-chat tasks");
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -193,5 +193,12 @@ export {
   appendVoiceChatContextEvent,
 } from "./domains/zero-voice-chat-context";
 
+// Domain modules - Zero Voice Chat Tasks
+export {
+  createVoiceChatTask,
+  getVoiceChatTask,
+  listVoiceChatTasks,
+} from "./domains/zero-voice-chat-tasks";
+
 // Domain modules - Web
 export { downloadWebFile, uploadWebFile } from "./domains/web";


### PR DESCRIPTION
## Summary

- Adds three CLI subcommands under `zero voice-chat task` — `create`, `get`, `list` — plus a new API-client domain file. These are the interface slow-brain uses from its Zero sandbox to dispatch and inspect Tasker runs.
- Binds to the Wave 1 ts-rest contracts from #10546 (`zeroVoiceChatTasksContract`).
- `list` prunes to `{id, status, createdAt}` so slow-brain's context stays small. Domain functions unwrap `{task}`/`{tasks}` envelopes at the API boundary.
- Merges independently of #10547 (backend) — tests use MSW.

Refs: #10548, epic #10545

## Test plan

- [x] `pnpm -F @vm0/cli exec vitest run` — 118 files, 1122 tests pass (9 new)
- [x] `pnpm turbo run lint --filter=@vm0/cli --filter=@vm0/core`
- [x] `pnpm check-types` (all 6 packages)
- [x] `pnpm knip`
- [x] `pnpm format`
- [ ] Manual `zero voice-chat task --help` sanity check (deferred — dev-server tunnel not available in isolated container; slow-brain e2e covered in sub-issue #4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)