### PR TITLE
test(mitm-addon): drop redundant get_api_url patch + mitm_ctx stacking

### DIFF
--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1506,10 +1506,7 @@ class TestResponseUsageReporting:
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(
-                usage.providers.model_provider, "get_api_url", return_value="https://api.vm0.ai"
-            ),
-            mitm_ctx(),
+            mitm_ctx(api_url="https://api.vm0.ai"),
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
@@ -1548,10 +1545,7 @@ class TestResponseUsageReporting:
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(
-                usage.providers.model_provider, "get_api_url", return_value="https://api.vm0.ai"
-            ),
-            mitm_ctx(),
+            mitm_ctx(api_url="https://api.vm0.ai"),
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
@@ -1594,10 +1588,7 @@ class TestResponseUsageReporting:
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(
-                usage.providers.model_provider, "get_api_url", return_value="https://api.vm0.ai"
-            ),
-            mitm_ctx(),
+            mitm_ctx(api_url="https://api.vm0.ai"),
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
@@ -1635,10 +1626,7 @@ class TestResponseUsageReporting:
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
-            patch.object(
-                usage.providers.model_provider, "get_api_url", return_value="https://api.vm0.ai"
-            ),
-            mitm_ctx(),
+            mitm_ctx(api_url="https://api.vm0.ai"),
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             mock_opener.open.return_value = MagicMock()
@@ -1743,7 +1731,7 @@ class TestErrorHandler:
         assert "slack.com" in content
 
     def test_error_logs_connector_usage_for_x_stream(
-        self, tmp_path, real_flow, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
     ):
         """Mid-flight stream crash: partial counts still reported (issue #9534)."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
@@ -1773,9 +1761,7 @@ class TestErrorHandler:
         flow.metadata["vm_sandbox_token"] = "test-token"
 
         with (
-            patch.object(
-                usage.providers.connectors.x, "get_api_url", return_value="https://app.test"
-            ),
+            mitm_ctx(api_url="https://app.test"),
             patch.object(
                 usage.webhook, "_opener"
             ) as mock_opener,  # urllib external boundary (#9991)
@@ -1792,7 +1778,7 @@ class TestErrorHandler:
         assert by_cat["users.read"] == 5
 
     def test_full_pipeline_stream_error_midflight(
-        self, tmp_path, real_flow, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
     ):
         """End-to-end: responseheaders → partial chunks → error() logs observed counts.
 
@@ -1831,9 +1817,7 @@ class TestErrorHandler:
         flow.metadata["vm_sandbox_token"] = "test-token"
 
         with (
-            patch.object(
-                usage.providers.connectors.x, "get_api_url", return_value="https://app.test"
-            ),
+            mitm_ctx(api_url="https://app.test"),
             patch.object(
                 usage.webhook, "_opener"
             ) as mock_opener,  # urllib external boundary (#9991)
@@ -2594,10 +2578,7 @@ class TestReportConnectorUsage:
 
         # 3. Simulated disconnect - response() fires and logs via webhook
         with (
-            mitm_ctx(),
-            patch.object(
-                usage.providers.connectors.x, "get_api_url", return_value="https://app.test"
-            ),
+            mitm_ctx(api_url="https://app.test"),
             patch.object(
                 usage.webhook, "_opener"
             ) as mock_opener,  # urllib external boundary (#9991)


### PR DESCRIPTION
## Summary

- Remove 5 sites where `patch.object(usage.providers.*, "get_api_url", ...)` and `mitm_ctx()` were stacked in the same `with` block. Both resolve to `ctx.options.vm0_api_url` (see `auth.py:102-104`), so exactly one mechanism suffices.
- Convert 2 `TestErrorHandler` connector-x tests that used `patch.object` alone to `mitm_ctx(api_url=...)`, so all handler-path tests now follow a single rule and a future copy-pasted test cannot reintroduce the stacking pattern.
- No product behavior change — `mitm_ctx` is a strict superset for these tests (it also stubs `ctx.log` and `vm0_proxy_registry_path`, both unread on the handler path).

Net: 9 insertions, 28 deletions in `tests/test_handlers.py`.

Convention after this PR:
- handler-path test (flows through `mitm_addon.response/error`) → `mitm_ctx(api_url=...)`
- direct-call test (calls `usage.report_*` without mitmproxy) → `patch.object(usage.providers.*, "get_api_url", ...)`

Closes #10484.

## Test plan

- [x] `pytest tests/test_handlers.py -q` — 167 passed locally (same count as main)
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [ ] CI `lint` + `test` workflows green

🤖 Generated with [Claude Code](https://claude.com/claude-code)