### PR TITLE
fix(auth): rotate clerk jwt on org switch before navigating

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -177,3 +177,8 @@ export function fireClerkListeners() {
     cb();
   }
 }
+
+/** Number of currently registered Clerk listeners. */
+export function clerkListenerCount(): number {
+  return clerkListeners.length;
+}

--- a/turbo/apps/platform/src/signals/__tests__/auth.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { testContext } from "./test-helpers";
 import { detachedSetupPage } from "../../__tests__/page-helper";
-import { fireClerkListeners, mockUser } from "../../__tests__/mock-auth";
-import { setupClerk$, user$, resolveWebOrigin } from "../auth";
+import {
+  clearMockedAuth,
+  clerkListenerCount,
+  fireClerkListeners,
+  mockOrganization,
+  mockedClerk,
+  mockUser,
+} from "../../__tests__/mock-auth";
+import { setupClerk$, user$, resolveWebOrigin, watchOrgSwitch$ } from "../auth";
+import { detach, Reason } from "../utils";
 
 const context = testContext();
 
@@ -73,5 +81,86 @@ describe("setupClerk$ auth reload filtering", () => {
 
     const userAfter = await store.get(user$);
     expect(userAfter).toBeUndefined();
+  });
+});
+
+describe("watchOrgSwitch$", () => {
+  afterEach(() => {
+    if (window.location.pathname !== "/") {
+      window.location.href = "http://localhost/";
+    }
+    // These tests don't go through detachedSetupPage, which would hook
+    // this up via signal abort — do it manually so mock-call history and
+    // stub implementations don't leak across cases.
+    clearMockedAuth();
+  });
+
+  it("rotates the session JWT before reloading when the active org changes", async () => {
+    const { store, signal } = context;
+
+    mockUser(
+      { id: "test-user", fullName: "Test User" },
+      { token: "test-token" },
+    );
+    mockOrganization({
+      activeOrg: { id: "org_a", name: "Org A" },
+      memberships: [{ id: "org_a" }, { id: "org_b" }],
+    });
+    const listenersBefore = clerkListenerCount();
+    // watchOrgSwitch$ is a daemon that never resolves on its own.
+    detach(store.set(watchOrgSwitch$, signal), Reason.Daemon);
+
+    // Wait until the daemon has registered its listener — only then will
+    // fireClerkListeners reach it.
+    await vi.waitFor(() => {
+      expect(clerkListenerCount()).toBeGreaterThan(listenersBefore);
+    });
+
+    // Simulate an active-org change — either this tab's own setActive, or
+    // Clerk's cross-tab sync from a sibling tab. The watcher treats them
+    // the same.
+    mockOrganization({
+      activeOrg: { id: "org_b", name: "Org B" },
+      memberships: [{ id: "org_a" }, { id: "org_b" }],
+    });
+    fireClerkListeners();
+
+    // The shared .vm0.ai session cookie is rotated by Clerk only when a
+    // new JWT is minted — skipCache ensures the next request to www.vm0.ai
+    // sees the new orgId claim instead of a stale cached one.
+    await vi.waitFor(() => {
+      expect(mockedClerk.sessionGetToken).toHaveBeenCalledWith({
+        skipCache: true,
+      });
+    });
+  });
+
+  it("ignores listener fires that do not change the active org", async () => {
+    const { store, signal } = context;
+
+    mockUser(
+      { id: "test-user", fullName: "Test User" },
+      { token: "test-token" },
+    );
+    mockOrganization({
+      activeOrg: { id: "org_a", name: "Org A" },
+      memberships: [{ id: "org_a" }],
+    });
+    const listenersBefore = clerkListenerCount();
+    detach(store.set(watchOrgSwitch$, signal), Reason.Daemon);
+
+    await vi.waitFor(() => {
+      expect(clerkListenerCount()).toBeGreaterThan(listenersBefore);
+    });
+
+    // Token refresh without an org change fires the listener repeatedly —
+    // the watcher must not trigger a JWT refresh or navigation.
+    fireClerkListeners();
+    fireClerkListeners();
+    fireClerkListeners();
+
+    expect(mockedClerk.sessionGetToken).not.toHaveBeenCalledWith({
+      skipCache: true,
+    });
   });
 });

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -86,45 +86,55 @@ export const setupClerk$ = command(
 );
 
 /**
- * User signal that provides the current authenticated user from Clerk.
- * Returns undefined if no user is authenticated.
- */
-const ORG_ID_KEY = "clerk-active-org-id";
-
-function persistOrgId(orgId: string | undefined) {
-  if (orgId) {
-    sessionStorage.setItem(ORG_ID_KEY, orgId);
-  } else {
-    sessionStorage.removeItem(ORG_ID_KEY);
-  }
-}
-
-/**
- * Command that monitors the active Clerk organization and reloads
- * the page when it changes. Persists the active org ID to session storage.
+ * Daemon that listens for Clerk state changes and reloads the page on any
+ * active-organization switch. This runs in every tab on every origin, so:
+ *
+ * - The tab that initiated the switch (via `clerk.setActive`) reloads as
+ *   soon as Clerk's listener fires.
+ * - Sibling tabs reload too — Clerk v5 broadcasts `sessionUpdated` via
+ *   its internal BroadcastChannel, so their Clerk instances pick up the
+ *   change and fire listeners within milliseconds.
+ *
+ * Before reloading we force Clerk to mint a fresh session JWT with
+ * `skipCache: true`. The session cookie is shared across *.vm0.ai, so
+ * without this, the reload (or any in-flight request to www.vm0.ai) could
+ * land with a stale JWT whose orgId still reflects the previous org.
+ *
+ * Runs until its signal aborts — kick off via `detach()` from the views
+ * layer since it never resolves on its own.
  */
 export const watchOrgSwitch$ = command(async ({ get }, signal: AbortSignal) => {
   const clerk = await get(clerk$);
   signal.throwIfAborted();
 
-  let prevOrgId = sessionStorage.getItem(ORG_ID_KEY) ?? undefined;
-  const currentOrgId = clerk.organization?.id ?? undefined;
-  prevOrgId = currentOrgId;
-  persistOrgId(currentOrgId);
+  let prevOrgId = clerk.organization?.id ?? undefined;
 
-  const unsubscribe = clerk.addListener(() => {
+  while (!signal.aborted) {
+    await new Promise<void>((resolve) => {
+      const onAbort = () => {
+        unsubscribe();
+        resolve();
+      };
+      const unsubscribe = clerk.addListener(() => {
+        signal.removeEventListener("abort", onAbort);
+        unsubscribe();
+        resolve();
+      });
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+    if (signal.aborted) return;
+
     const newOrgId = clerk.organization?.id ?? undefined;
-    if (newOrgId !== prevOrgId) {
-      prevOrgId = newOrgId;
-      persistOrgId(newOrgId);
-      // Navigate to the Zero homepage on org switch. A full page load is
-      // required because server-side data (agents, jobs, secrets, etc.) is
-      // scoped to the active organization, and multiple signal trees depend
-      // on the org context established at bootstrap time.
-      location.href = "/";
-    }
-  });
-  signal.addEventListener("abort", unsubscribe);
+    if (newOrgId === prevOrgId) continue;
+    prevOrgId = newOrgId;
+
+    await clerk.session?.getToken({ skipCache: true }).catch(() => {
+      return null;
+    });
+    signal.throwIfAborted();
+    location.href = "/";
+    return;
+  }
 });
 
 export const user$ = computed(async (get) => {

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -111,21 +111,34 @@ export const watchOrgSwitch$ = command(async ({ get }, signal: AbortSignal) => {
 
   while (!signal.aborted) {
     await new Promise<void>((resolve) => {
+      let unsubscribe: () => void = () => {};
       const onAbort = () => {
         unsubscribe();
         resolve();
       };
-      const unsubscribe = clerk.addListener(() => {
+      // Clerk's addListener fires the callback synchronously once on
+      // registration with the current state — skip that initial call, we only
+      // care about subsequent state changes.
+      let initialized = false;
+      unsubscribe = clerk.addListener(() => {
+        if (!initialized) {
+          initialized = true;
+          return;
+        }
         signal.removeEventListener("abort", onAbort);
         unsubscribe();
         resolve();
       });
       signal.addEventListener("abort", onAbort, { once: true });
     });
-    if (signal.aborted) return;
+    if (signal.aborted) {
+      return;
+    }
 
     const newOrgId = clerk.organization?.id ?? undefined;
-    if (newOrgId === prevOrgId) continue;
+    if (newOrgId === prevOrgId) {
+      continue;
+    }
     prevOrgId = newOrgId;
 
     await clerk.session?.getToken({ skipCache: true }).catch(() => {

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { setupClerk$, watchOrgSwitch$ } from "./auth.ts";
+import { setupClerk$ } from "./auth.ts";
 import { initTheme$ } from "./theme.ts";
 import { setRootSignal$ } from "./root-signal.ts";
 import {
@@ -349,10 +349,7 @@ export const bootstrap$ = command(
       set(setupPwaEdgeSwipe$, signal),
       set(setupSidebarShortcut$, signal),
       set(startSkeletonCycling$, signal),
-      (async () => {
-        await set(setupClerk$, signal);
-        await set(watchOrgSwitch$, signal);
-      })(),
+      set(setupClerk$, signal),
       set(setupRoutes$, signal),
     ]);
 

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@vm0/ui/components/ui/sonner";
 import { ErrorBoundary } from "./error-boundary.tsx";
 import { Router } from "./router.tsx";
 import { subscribeThreadListChanged$ } from "../signals/chat-thread-list-reload.ts";
+import { watchOrgSwitch$ } from "../signals/auth.ts";
 import { rootSignal$ } from "../signals/root-signal.ts";
 import { detach, Reason } from "../signals/utils.ts";
 import "./css/index.css";
@@ -15,6 +16,7 @@ export const setupRouter = (
 ) => {
   const { signal } = store.get(rootSignal$);
   detach(store.set(subscribeThreadListChanged$, signal), Reason.Daemon);
+  detach(store.set(watchOrgSwitch$, signal), Reason.Daemon);
   render(
     <StrictMode>
       <StoreProvider value={store}>


### PR DESCRIPTION
## Summary

Switching org on app.vm0.ai did not always update the shared `.vm0.ai` session cookie before requests hit www.vm0.ai — the reload (or any parallel fetch) could land with a stale JWT and get the previous org back.

Reshaped `watchOrgSwitch$` into a daemon that listens to Clerk's own state changes and drives the reload for every tab:

- **Tab that initiated the switch** (via `clerk.setActive`): Clerk fires its listener locally → daemon wakes → forces a fresh session JWT via `getToken({ skipCache: true })` → navigates to `/`. The new `orgId` claim is in the shared cookie before any request to www.vm0.ai.
- **Sibling tabs**: Clerk v5 broadcasts `sessionUpdated` over its internal BroadcastChannel, so their Clerk instances fire listeners within milliseconds — the same daemon path runs and reloads. No custom cross-tab plumbing needed.

The daemon never resolves, so it is kicked off from the views layer with `Reason.Daemon` (same pattern as `subscribeThreadListChanged$`). Call sites that trigger `setActive` (switch, create, leave, delete) are untouched — the watcher is the single reload mechanism.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/signals/__tests__/auth.test.ts` — 9 tests, two new cases covering: JWT refresh + reload on org change, no side effects on listener fires without org change
- [x] `pnpm -F @vm0/app exec vitest run` — 1986 tests pass (one pre-existing happy-dom teardown flake in an unrelated chat-thread test)
- [x] `pnpm -F @vm0/app exec eslint <changed files>` clean
- [x] Typecheck clean for touched files
- [ ] Manual verification in dev: open two tabs on app.vm0.ai, switch org in one, confirm the other reloads within ms with the new org

🤖 Generated with [Claude Code](https://claude.com/claude-code)