### PR TITLE
Security: Proxy/network logs are created world-readable and may expose sensitive metadata

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -16,7 +16,7 @@ def log_network_entry(log_path: str, entry: dict) -> None:
     if not log_path:
         return
     try:
-        fd = os.open(log_path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
+        fd = os.open(log_path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
         try:
             os.write(fd, (json.dumps(entry) + "\n").encode())
         finally:
@@ -36,7 +36,7 @@ def log_proxy_entry(proxy_log_path: str, level: str, message: str, **extra: obje
     }
     entry.update(extra)
     try:
-        fd = os.open(proxy_log_path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
+        fd = os.open(proxy_log_path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
         try:
             os.write(fd, (json.dumps(entry) + "\n").encode())
         finally:
@@ -58,12 +58,16 @@ def add_firewall_metadata(flow: http.HTTPFlow, log_entry: dict) -> None:
     for key in (
         "firewall_params",
         "firewall_error",
-        "auth_resolved_secrets",
-        "auth_refreshed_connectors",
-        "auth_refreshed_secrets",
         "auth_cache_hit",
         "auth_url_rewrite",
     ):
         value = meta.get(key)
         if value is not None:
             log_entry[key] = value
+    for key in (
+        "auth_resolved_secrets",
+        "auth_refreshed_connectors",
+        "auth_refreshed_secrets",
+    ):
+        if meta.get(key) is not None:
+            log_entry[key] = "[REDACTED]"


### PR DESCRIPTION
## Summary

Security: Proxy/network logs are created world-readable and may expose sensitive metadata

## Problem

**Severity**: `High` | **File**: `crates/runner/mitm-addon/src/logging_utils.py:L19`

The addon writes JSONL logs using mode `0o644`, which allows any local user on the host to read them. `add_firewall_metadata` copies potentially sensitive fields (e.g., `auth_resolved_secrets`, auth refresh metadata) into log entries. If these fields contain credentials/tokens, they become readable by non-privileged local users.

## Solution

Create log files with restrictive permissions (e.g., `0o600`) and avoid logging raw secret material. Redact or hash sensitive fields before writing. Consider centralizing a safe logger that enforces both redaction and secure file mode.

## Changes

- `crates/runner/mitm-addon/src/logging_utils.py` (modified)