### PR TITLE
fix(credits): admission gate subtracts unsettled expired credits

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -12,6 +12,7 @@ import {
   insertOrgDefaultModelProvider,
   insertUserCacheEntry,
   setOrgCredits,
+  insertCreditExpiresRecord,
   deleteOrgRow,
   insertOrgMembersEntry,
   findTestRunsByUserAndPrompt,
@@ -989,6 +990,50 @@ describe("POST /api/zero/runs — credit check", () => {
       expect(response.status).toBe(402);
       const data = await response.json();
       expect(data.error.code).toBe("INSUFFICIENT_CREDITS");
+    });
+
+    it("should reject VM0 run when unsettled expired credits wipe out the balance", async () => {
+      // Dormant non-subscription org: credits column still inflated because
+      // expireCredits hasn't run (no renewal, no pending usage). The admission
+      // gate must subtract unsettled expired — otherwise the run is admitted
+      // on a stale inflated balance and burns real COGS.
+      await setOrgCredits(user.orgId, 1000);
+      await insertCreditExpiresRecord({
+        orgId: user.orgId,
+        amount: 1000,
+        remaining: 1000,
+        expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+        modelProvider: "vm0",
+      });
+
+      expect(response.status).toBe(402);
+      const data = await response.json();
+      expect(data.error.code).toBe("INSUFFICIENT_CREDITS");
+    });
+
+    it("should allow VM0 run when a future-expiring record does not exceed the balance", async () => {
+      // Sanity check: an expires record whose expiresAt is in the future is
+      // NOT unsettled, so it must not be subtracted from the admission balance.
+      await setOrgCredits(user.orgId, 1000);
+      await insertCreditExpiresRecord({
+        orgId: user.orgId,
+        amount: 1000,
+        remaining: 1000,
+        expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      });
+
+      const response = await postRun({
+        agentId,
+        prompt: "Credit check test",
+        modelProvider: "vm0",
+      });
+
+      expect(response.status).toBe(201);
     });
 
     it("should allow non-VM0 run when credits = 0", async () => {

--- a/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
@@ -151,11 +151,15 @@ export async function expireCredits(tx: Tx, orgId: string): Promise<number> {
  * `org_metadata.credits` aggregate still includes them until the next
  * `expireCredits` call. Use this to present the true spendable balance on
  * read paths that run outside the settlement transaction.
+ *
+ * Accepts an optional `db` so callers already running inside a transaction
+ * (e.g. the admission gate inside `dequeueNextAtomic`) can pass their tx
+ * handle and keep both reads under the same isolation boundary.
  */
 export async function getUnsettledExpiredAmount(
   orgId: string,
+  db: typeof globalThis.services.db = globalThis.services.db,
 ): Promise<number> {
-  const db = globalThis.services.db;
   const [row] = await db
     .select({
       total: sql<number>`COALESCE(SUM(${creditExpiresRecord.remaining}), 0)::int`,

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -12,6 +12,7 @@ import { logger } from "../shared/logger";
 import { modelProviders } from "../../db/schema/model-provider";
 import { orgMetadata } from "../../db/schema/org-metadata";
 import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
+import { getUnsettledExpiredAmount } from "./credit/credit-expires-service";
 import { ORG_SENTINEL_USER_ID } from "./org/org-sentinel";
 import { MODEL_PROVIDER_ENV_VARS } from "./context/resolve-model-provider";
 import type { Database } from "../../types/global";
@@ -132,6 +133,15 @@ export async function validateComposeRequirements(
  * Accepts an optional `db` parameter so callers running inside a transaction
  * (e.g. dequeueNextAtomic with pg_advisory_xact_lock) can pass the transaction
  * object and keep all reads within the same isolation boundary.
+ *
+ * The spendable balance used for admission is
+ *   org_metadata.credits − getUnsettledExpiredAmount(orgId)
+ * — the same form `getBillingStatus` presents in the UI. Without this
+ * subtraction a dormant non-subscription org whose credits have all expired
+ * but haven't been settled yet (nothing triggers `expireCredits` until the
+ * next `processOrgCredits` batch or subscription renewal) would be admitted
+ * on its stale inflated balance, the run would burn real COGS, and only the
+ * next settlement would notice.
  */
 export async function checkOrgCredits(
   orgId: string,
@@ -187,7 +197,8 @@ export async function checkOrgCredits(
     return;
   }
 
-  if (orgRow.credits > 0) {
+  const unsettledExpired = await getUnsettledExpiredAmount(orgId, db);
+  if (orgRow.credits - unsettledExpired > 0) {
     return;
   }
 


### PR DESCRIPTION
## Summary

Addresses item 3 of #10386.

`checkOrgCredits` (the run-admission gate) read the raw `org_metadata.credits` column and gated on `> 0`, while `getBillingStatus` (the display path) subtracted `getUnsettledExpiredAmount(orgId)` before showing the balance. For dormant non-subscription orgs the two reads disagreed — nothing triggers `expireCredits` on them until the next `processOrgCredits` batch, so the `credits` column stays inflated with already-expired-but-unsettled records. The UI correctly showed 0, but the admission gate admitted the run on the stale inflated balance, letting it burn real COGS before the next cron tick caught up.

## Change

`checkOrgCredits` now mirrors the display-path formula:

```ts
const unsettledExpired = await getUnsettledExpiredAmount(orgId, db);
if (orgRow.credits - unsettledExpired > 0) {
  return;
}
```

`getUnsettledExpiredAmount` gains an optional `db` parameter so the admission gate (which already threads a tx handle from `dequeueNextAtomic`) keeps both reads under the same isolation boundary.

## Test plan

- [x] New integration test: credits=1000 + expired record (remaining=1000, expiresAt in the past) → rejected with `INSUFFICIENT_CREDITS`
- [x] New integration test: credits=1000 + future-expiring record (expiresAt +30d) → admitted (future-expiring records are not "unsettled expired")
- [x] Existing "credit check" test block (15 cases) still passes
- [x] `src/lib/zero/credit` and `src/lib/zero/billing` test suites still pass
- [x] oxlint on changed files — clean

## Not in scope

- **#1** (`deductOrgCredits` negative-balance floor) is bookkeeping hygiene, not an exploit mitigation on its own — see issue discussion.
- **#2** (per-run spend cap / reservation) is the actual anti-freeload fix and needs architectural work; separate from this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)