### PR TITLE
fix(uploads): allow image/avif in zero upload allow-list

### DIFF
--- a/turbo/apps/web/app/api/zero/uploads/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/uploads/prepare/__tests__/route.test.ts
@@ -123,6 +123,22 @@ describe("POST /api/zero/uploads/prepare", () => {
       expect(body.id).toMatch(/^[0-9a-f-]{36}$/);
     });
 
+    it("accepts image/avif uploads", async () => {
+      const response = await POST(
+        createPrepareRequest({
+          filename: "screenshot.avif",
+          contentType: "image/avif",
+          size: 4096,
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toMatchObject({
+        filename: "screenshot.avif",
+        contentType: "image/avif",
+      });
+    });
+
     it("sanitizes filenames when building the S3 key", async () => {
       const response = await POST(
         createPrepareRequest({

--- a/turbo/apps/web/src/lib/shared/mimetype.ts
+++ b/turbo/apps/web/src/lib/shared/mimetype.ts
@@ -8,6 +8,7 @@ export const EXT_MIMETYPE_MAP: Readonly<Record<string, string>> = {
   jpeg: "image/jpeg",
   gif: "image/gif",
   webp: "image/webp",
+  avif: "image/avif",
   svg: "image/svg+xml",
   mp4: "video/mp4",
   webm: "video/webm",

--- a/turbo/apps/web/src/lib/zero/uploads/constants.ts
+++ b/turbo/apps/web/src/lib/zero/uploads/constants.ts
@@ -14,6 +14,7 @@ export const ALLOWED_UPLOAD_TYPES: ReadonlySet<string> = new Set([
   "image/jpeg",
   "image/gif",
   "image/webp",
+  "image/avif",
   "image/svg+xml",
   "video/mp4",
   "video/webm",


### PR DESCRIPTION
## Summary

- Adds `image/avif` to `ALLOWED_UPLOAD_TYPES` so the zero-page prepare endpoint stops returning 400 for AVIF attachments.
- Mirrors the `.avif` → `image/avif` entry in `EXT_MIMETYPE_MAP` so stored AVIF objects re-serve with the correct content-type instead of `application/octet-stream`.
- Extends the prepare-route test to cover the new positive case; the existing negative case (`application/x-msdownload` → 400) is preserved.

Resolves Sentry `PLATFORM-1S` (`Error: Unsupported file type: image/avif` from `src/signals/zero-page/chat-draft.ts`). The composer's file input already advertises `image/*`, and Next.js itself emits AVIF, so the rejection was an artifact of an incomplete allow-list — not a deliberate policy.

Closes #10511

## Test plan

- [x] `pnpm -F web exec vitest run app/api/zero/uploads/prepare` — 8 tests pass (7 prior + 1 new AVIF case).
- [x] `pnpm turbo run lint --filter=web` — clean.
- [x] `pnpm check-types` — clean across web, app, cli, core, ui.
- [x] `pnpm knip` — no issues.
- [x] `pnpm format` — no changes required.
- [ ] Manual: on production, attach a `.avif` image in the zero-page composer and confirm the upload completes (no 400, no Sentry entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)