### PR TITLE
feat(voice-chat): enable tasker dispatch via slow-brain prompt

### DIFF
--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -101,7 +101,9 @@ Continuously read the shared context to follow the conversation:
 You will see events like:
 - **user/speech** — what the user says
 - **fast-brain/response** — what your fast-brain says back
+- **fast-brain/request-slow-brain** — an explicit ask from fast-brain (see Explicit Requests)
 - **system/session-start** and **system/session-end** — session lifecycle
+- **system/task-dispatched** and **system/task-completed** — tasks you dispatched (see Dispatching Tasks)
 
 Based on what you observe, proactively decide what to do. Do not wait to be asked.
 
@@ -133,6 +135,50 @@ When you see a \`fast-brain/request-slow-brain\` event, it is a direct task from
 - **directive**: High-level instructions for your fast-brain. Include what to tell the user, relevant data, and why. Do not script exact words — your fast-brain controls phrasing.
 - **thinking**: Progress updates and intermediate results while you work.
 - **observation**: Proactive insights the user did not ask for but might find valuable.
+
+### Dispatching Tasks
+
+Some work is too heavy to do inline: code changes, file operations, external API calls (GitHub, Slack, Linear), database queries, multi-step research. For these, dispatch a task to a fresh sandbox so your polling loop stays responsive.
+
+Dispatch a task:
+
+\`zero voice-chat task create <SESSION_ID> --prompt "<self-sufficient task prompt>"\`
+
+The command returns a JSON object with \`id\` and \`status\` immediately. **Write down the id and return to the poll loop.** Never block, wait, or sleep for the task to finish.
+
+The task prompt must be self-sufficient. The Tasker runs in a fresh sandbox with no conversation history — include repo paths, user intent, and any data it needs. Write the prompt as if briefing a smart colleague who just walked in.
+
+Fetch a result once completed:
+
+\`zero voice-chat task get <SESSION_ID> <TASK_ID>\` → JSON with \`status\`, \`result\`, \`error\`.
+
+List your tasks:
+
+\`zero voice-chat task list <SESSION_ID>\` → array of \`{ id, status, createdAt }\`.
+
+#### When to dispatch vs. handle inline
+
+- **Dispatch** when the work requires tool use you don't already have the answer to: reading files, running commands, calling APIs, querying DBs, doing long research.
+- **Handle inline** (directive only) when you can answer from the prompt, context, or memory: knowledge answers, opinions, summarizing the conversation so far, simple context lookups.
+- **Stay quiet** for casual chat, greetings, and small talk — same as before.
+
+Spinning a Tasker has cold-start cost. Don't use it for "what's 2+2".
+
+#### Every directive carries task context in natural language
+
+Fast-brain knows nothing about tasks, ids, or the Tasker subsystem. Your directives are the only channel it learns from. Never mention "task", "taskId", or ids in directive content — fast-brain reads directives aloud.
+
+- **On dispatch**, write a directive telling fast-brain to acknowledge work is happening.
+  - OK: "I'm checking the PR — tell the user you're looking into it."
+  - NOT OK: "Dispatched task T1 to check PR status."
+- **On completion**, write a directive describing what to say.
+  - OK: "The PR was merged yesterday by Alice — tell the user naturally."
+  - NOT OK: "Task abc-123 returned: PR merged by Alice on 2026-04-20."
+- **On failure**, write a directive describing the failure plainly and recovering.
+  - OK: "Couldn't reach GitHub right now — tell the user there's a hiccup and we'll try again in a moment."
+  - NOT OK: "Task failed with error: GITHUB_API_TIMEOUT."
+
+Without the on-dispatch directive, fast-brain has nothing to say while the task runs and the user hears dead air. Always emit that first directive before returning to the poll loop.
 
 ### Polling and Lifecycle
 

--- a/turbo/apps/web/src/lib/zero/voice-chat/__tests__/tasker-round-trip.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/__tests__/tasker-round-trip.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTestRequest,
+  createTestOrg,
+  createTestCompose,
+  insertTestVoiceChatSession,
+  getTestVoiceChatEvents,
+  createTestCallback,
+  createSignedCallbackRequest,
+} from "../../../../__tests__/api-test-helpers";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { mockClerk } from "../../../../__tests__/clerk-mock";
+import { insertOrgDefaultModelProvider } from "../../../../__tests__/db-test-seeders/org";
+import { mockAblyPublish } from "../../../../__tests__/ably-mock";
+import { buildVoiceChatQuickPrepPrompt } from "../../integration-prompt";
+/* eslint-disable web/no-direct-db-in-tests -- Service-level exception: no user-facing API appends slow-brain/fast-brain-sourced events or reads a task without auth; exercising the round trip requires simulating both sides. */
+import { appendEvent } from "../context-service";
+import { getVoiceChatTask } from "../task-service";
+/* eslint-enable web/no-direct-db-in-tests */
+
+vi.mock("@vm0/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vm0/core")>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn().mockReturnValue(true),
+  };
+});
+
+const { isFeatureEnabled } = await import("@vm0/core");
+const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
+
+const { POST: postTaskRoute } =
+  await import("../../../../../app/api/zero/voice-chat/[id]/tasks/route");
+const { POST: postCallbackRoute } =
+  await import("../../../../../app/api/internal/callbacks/voice-chat-task/route");
+
+const TASKS_BASE_URL = "http://localhost:3000/api/zero/voice-chat";
+const CALLBACK_URL = "http://localhost/api/internal/callbacks/voice-chat-task";
+
+describe("voice-chat slow-brain prompt includes tasker guidance", () => {
+  const prompt = buildVoiceChatQuickPrepPrompt("test-session-id");
+
+  it.each([
+    ["task create command", "zero voice-chat task create"],
+    ["task get command", "zero voice-chat task get"],
+    ["task list command", "zero voice-chat task list"],
+    ["task-dispatched event", "task-dispatched"],
+    ["task-completed event", "task-completed"],
+    ["never-block rule", "Never block"],
+    ["natural language rule", "natural language"],
+  ])("includes %s", (_name, substring) => {
+    expect(prompt).toContain(substring);
+  });
+});
+
+describe("tasker round trip through the blackboard", () => {
+  const context = testContext();
+
+  async function setupOrg(userId: string) {
+    const slug = uniqueId("zvc-tasker-rt");
+    const orgId = `org_mock_${userId}`;
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+    await createTestOrg(slug);
+    await insertOrgDefaultModelProvider(
+      orgId,
+      "anthropic",
+      "claude-3-5-sonnet-20241022",
+    );
+    return { orgId, slug };
+  }
+
+  beforeEach(async () => {
+    mockAblyPublish.mockClear();
+    context.setupMocks();
+    mockIsFeatureEnabled.mockReturnValue(true);
+  });
+
+  it("fast-brain request -> slow-brain dispatch -> tasker complete -> slow-brain directive", async () => {
+    const { userId } = await context.setupUser();
+    const { orgId } = await setupOrg(userId);
+    const agent = await createTestCompose(uniqueId("zvc-tasker-rt-agent"));
+    const sessionId = await insertTestVoiceChatSession({
+      orgId,
+      userId,
+      agentId: agent.composeId,
+    });
+
+    await appendEvent(
+      sessionId,
+      "fast-brain",
+      "request-slow-brain",
+      "check if PR #123 merged",
+    );
+
+    const dispatchResponse = await postTaskRoute(
+      createTestRequest(`${TASKS_BASE_URL}/${sessionId}/tasks`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          prompt:
+            "Check GitHub for PR #123 in vm0-ai/vm0 and return merged/open status with merger and date.",
+        }),
+      }),
+      { params: Promise.resolve({ id: sessionId }) },
+    );
+    expect(dispatchResponse.status).toBe(200);
+    const { task } = await dispatchResponse.json();
+    expect(task.status).toBe("queued");
+    expect(task.runId).toBeTruthy();
+
+    await appendEvent(
+      sessionId,
+      "slow-brain",
+      "directive",
+      "I'm checking the PR — tell the user you're looking into it.",
+    );
+
+    const eventsAfterDispatch = await getTestVoiceChatEvents(sessionId);
+    const dispatched = eventsAfterDispatch.find((e) => {
+      return e.type === "task-dispatched";
+    });
+    expect(dispatched).toBeTruthy();
+    expect(dispatched!.source).toBe("system");
+    expect(dispatched!.content).toBe(JSON.stringify({ taskId: task.id }));
+
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      { eventData: { result: "PR #123 merged by @alice on 2026-04-21" } },
+    ]);
+
+    const { secret } = await createTestCallback({
+      runId: task.runId,
+      url: CALLBACK_URL,
+      payload: { taskId: task.id },
+    });
+
+    const callbackResponse = await postCallbackRoute(
+      createSignedCallbackRequest(
+        CALLBACK_URL,
+        {
+          runId: task.runId,
+          status: "completed",
+          payload: { taskId: task.id },
+        },
+        secret,
+      ),
+    );
+    expect(callbackResponse.status).toBe(200);
+
+    const completedTask = await getVoiceChatTask(task.id);
+    expect(completedTask?.status).toBe("done");
+    expect(completedTask?.result).toContain("merged by @alice");
+
+    await context.mocks.flushAfter();
+    expect(mockAblyPublish).toHaveBeenCalledWith(`voice:${sessionId}`, null);
+
+    const eventsAfterComplete = await getTestVoiceChatEvents(sessionId);
+    const completedEvent = eventsAfterComplete.find((e) => {
+      return e.type === "task-completed";
+    });
+    expect(completedEvent).toBeTruthy();
+    expect(completedEvent!.source).toBe("system");
+    expect(completedEvent!.content).toBe(JSON.stringify({ taskId: task.id }));
+
+    const fetched = await getVoiceChatTask(task.id);
+    await appendEvent(
+      sessionId,
+      "slow-brain",
+      "directive",
+      `The PR was merged yesterday by Alice — tell the user naturally. ${fetched!.result}`,
+    );
+
+    const eventsFinal = await getTestVoiceChatEvents(sessionId);
+    const directives = eventsFinal.filter((e) => {
+      return e.source === "slow-brain" && e.type === "directive";
+    });
+    expect(directives).toHaveLength(2);
+
+    const completionDirective = directives[1]!.content!;
+    expect(completionDirective).not.toContain("taskId");
+    expect(completionDirective).not.toContain(task.id);
+    expect(completionDirective.toLowerCase()).not.toMatch(/\btask\b/);
+    expect(completionDirective).toContain("merged");
+  });
+});


### PR DESCRIPTION
## Summary

Wave 4 / activation of epic #10545. Closes #10549.

Flips the switch on voice-chat Tasker by extending `SHARED_OBSERVATION_PROMPT` in `turbo/apps/web/src/lib/zero/integration-prompt.ts`. Slow-brain now dispatches Tasker runs via `zero voice-chat task create` for tool-heavy work, watches for `task-completed` events in its 5s poll loop, fetches results via `zero voice-chat task get`, and always translates task state into natural-language directives for fast-brain.

### What changed

- **`### Dispatching Tasks` subsection** — new block inserted between `Writing to Shared Context` and `Polling and Lifecycle` inside `SHARED_OBSERVATION_PROMPT`. Covers: when to dispatch vs. handle inline, the CLI incantations, the never-block rule, the natural-language-directive contract with positive/negative examples for dispatch / completion / failure beats.
- **Event list** — `Observing the Conversation` now enumerates `system/task-dispatched`, `system/task-completed`, and `fast-brain/request-slow-brain` so slow-brain parses them as first-class types.
- **New test file** `turbo/apps/web/src/lib/zero/voice-chat/__tests__/tasker-round-trip.test.ts` — two describes:
  1. `prompt includes tasker guidance` — 7 substring checks over the rendered prompt (CLI commands, event names, canonical rules). Regression protection against accidental deletion.
  2. `tasker round trip through the blackboard` — exercises the full lifecycle at the service/route layer: fast-brain `request-slow-brain` event → POST `/api/zero/voice-chat/[id]/tasks` → `task-dispatched` event + backing Zero run → callback with Axiom-mocked result → task row `done` + `task-completed` event + `voice:<sessionId>` signal → slow-brain-style directive. Asserts the completion directive references the result (`merged`) and leaks no task jargon (no `taskId`, no id string, no `\btask\b` substring).

### Design decisions

- **No kill-switch sub-flag.** `FeatureSwitchKey.VoiceChat` already gates the tasks route; revert + the Wave-2 `cancelSessionPendingRuns` hook on session end give clean rollback without a new knob. Documented in the plan on #10549.
- **No README under `voice-chat/`.** The prompt IS the specification — duplicating it in markdown creates two sources of truth per YAGNI.
- **No LLM-in-the-loop test.** Stubbing `createZeroRun` back to nothing and simulating the agent's internal reasoning buys close to zero signal; the service-level round trip covers the same surfaces.
- **Fast-brain byte-identical.** Zero changes under `turbo/apps/platform/src/signals/voice-chat/`. Verified: `grep -rn "voice_chat_tasks\|task-dispatched\|task-completed" turbo/apps/platform/src/signals/voice-chat/` returns zero matches.

### Test plan

- [x] `pnpm -F web exec vitest run tasker-round-trip` — 8 tests pass (7 prompt-shape + 1 round-trip)
- [x] `pnpm -F web exec vitest run voice-chat-candidate` — 102 tests pass (sanity; prior-art candidate unaffected)
- [x] `pnpm turbo run lint --filter=web` — 0 warnings, 0 errors (service imports use the documented `no-direct-db-in-tests` service-level exception)
- [x] `pnpm -F web check-types` — clean
- [x] `pnpm format` — clean
- [x] `pnpm -F web exec knip` — diff against main is empty (pre-existing unused-exports noise is unchanged)
- [ ] Manual smoke test against dev server (deferred to post-merge): speak *"Can you check if PR #10545 was merged?"*, verify a `voice_chat_tasks` row appears and fast-brain voices the result a few seconds later.

### Rollback

Revert this PR → slow-brain prompt returns to prior state, stops dispatching Tasker runs. Wave 1–3 backend / CLI / schema remain but unused. In-flight Tasker runs at revert time are cancelled on next `endSession` call via `cancelSessionPendingRuns`. Single-commit, fully-reversible activation.

Refs #10549, part of epic #10545 (Wave 4 / final).

🤖 Generated with [Claude Code](https://claude.com/claude-code)