### PR TITLE
fix(mitm-addon): stop load_registry log spam on sustained failure

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -103,6 +103,12 @@ def get_registry_path() -> str:
 # Cache for proxy registry (invalidated by file stat change)
 _registry_cache: dict = {}
 _registry_cache_key: tuple[int, int] = (0, 0)
+# One-shot guard for stat-path failures: no cache key is available in that
+# branch, so we fall back to a flag (mirrors counters.py:_pending_write_error_logged).
+# Parse-path failures use the cache key itself — recording the bad file's
+# (mtime_ns, size) as already-processed prevents re-parsing the same bytes
+# on every request and re-warning about them.
+_registry_load_error_logged = False
 
 # Track request start times for latency calculation
 _request_start_times: dict = {}
@@ -110,14 +116,22 @@ _request_start_times: dict = {}
 
 def load_registry() -> dict:
     """Load the proxy registry from file, with stat-based cache invalidation."""
-    global _registry_cache, _registry_cache_key
+    global _registry_cache, _registry_cache_key, _registry_load_error_logged
 
     try:
         registry_path = Path(get_registry_path())
         st = registry_path.stat()
-        key = (st.st_mtime_ns, st.st_size)
-        if key == _registry_cache_key:
-            return _registry_cache
+    except OSError as e:
+        if not _registry_load_error_logged:
+            _registry_load_error_logged = True
+            ctx.log.warn(f"Failed to stat proxy registry: {e}")
+        return _registry_cache
+
+    key = (st.st_mtime_ns, st.st_size)
+    if key == _registry_cache_key:
+        return _registry_cache
+
+    try:
         with registry_path.open() as f:
             new_registry = json.load(f).get("vms", {})
 
@@ -126,10 +140,15 @@ def load_registry() -> dict:
         evict_stale_cache_keys(active_run_ids)
 
         _registry_cache = new_registry
-        _registry_cache_key = key
+        _registry_load_error_logged = False
     except Exception as e:
-        ctx.log.warn(f"Failed to load proxy registry: {e}")
+        if not _registry_load_error_logged:
+            _registry_load_error_logged = True
+            ctx.log.warn(f"Failed to parse proxy registry: {e}")
 
+    # Record this file state as already processed — success or parse failure —
+    # so subsequent requests on the same bytes short-circuit at the key check.
+    _registry_cache_key = key
     return _registry_cache
 
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -45,6 +45,7 @@ def _reset_module_state() -> None:
     mitm_addon._request_start_times.clear()
     mitm_addon._registry_cache = {}
     mitm_addon._registry_cache_key = (0, 0)
+    mitm_addon._registry_load_error_logged = False
     auth._firewall_header_cache.clear()
     auth._cache_locks.clear()
     auth._force_refresh_markers.clear()

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -13,6 +13,7 @@ def _reset_cache():
     """Reset the module-level registry cache between tests."""
     mitm_addon._registry_cache = {}
     mitm_addon._registry_cache_key = (0, 0)
+    mitm_addon._registry_load_error_logged = False
     auth._firewall_header_cache.clear()
     auth._cache_locks.clear()
 
@@ -57,6 +58,60 @@ class TestLoadRegistry:
             result2 = mitm_addon.load_registry()
             assert "10.200.0.99" in result2
             assert "10.200.0.1" not in result2
+
+    def test_missing_file_logs_once_across_calls(self, tmp_path):
+        """Stat-path failures repeated across requests emit at most one warn."""
+        missing = str(tmp_path / "nonexistent.json")
+        log = MagicMock()
+        with (
+            patch.object(mitm_addon, "get_registry_path", return_value=missing),
+            patch.object(mitm_addon.ctx, "log", log, create=True),
+        ):
+            for _ in range(5):
+                assert mitm_addon.load_registry() == {}
+
+        assert log.warn.call_count == 1
+        assert "Failed to stat" in log.warn.call_args_list[0].args[0]
+
+    def test_parse_failure_logs_once_and_does_not_reparse(self, tmp_path):
+        """Parse failure on a fixed file: key match short-circuits re-parse."""
+        bad = tmp_path / "bad.json"
+        bad.write_text("{ not valid json")
+        log = MagicMock()
+        with (
+            patch.object(mitm_addon, "get_registry_path", return_value=str(bad)),
+            patch.object(mitm_addon.ctx, "log", log, create=True),
+            patch.object(mitm_addon.json, "load", wraps=mitm_addon.json.load) as spy,
+        ):
+            for _ in range(5):
+                assert mitm_addon.load_registry() == {}
+
+        assert spy.call_count == 1
+        assert log.warn.call_count == 1
+        assert "Failed to parse" in log.warn.call_args_list[0].args[0]
+
+    def test_recovery_after_parse_failure_rewarns_on_next_failure(self, tmp_path):
+        """Successful load clears the flag so a later failure re-warns once."""
+        path = tmp_path / "registry.json"
+        path.write_text("{ broken")
+        log = MagicMock()
+        with (
+            patch.object(mitm_addon, "get_registry_path", return_value=str(path)),
+            patch.object(mitm_addon.ctx, "log", log, create=True),
+        ):
+            mitm_addon.load_registry()  # parse fails → warn #1
+            assert log.warn.call_count == 1
+
+            # File becomes valid → successful load clears the flag.
+            path.write_text(json.dumps({"vms": {"10.0.0.1": {"runId": "r1"}}}))
+            result = mitm_addon.load_registry()
+            assert "10.0.0.1" in result
+            assert log.warn.call_count == 1  # no new warn on success
+
+            # File breaks again with a different mtime/size → warn #2.
+            path.write_text("{ broken again, longer")
+            mitm_addon.load_registry()
+            assert log.warn.call_count == 2
 
     def test_evicts_header_cache_on_run_removal(self, registry_file):
         """When a run disappears from registry, its header cache entries are evicted."""

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -108,8 +108,10 @@ class TestLoadRegistry:
             assert "10.0.0.1" in result
             assert log.warn.call_count == 1  # no new warn on success
 
-            # File breaks again with a different mtime/size → warn #2.
-            path.write_text("{ broken again, longer")
+            # File breaks again. Different size than the good content above
+            # busts the cache key so the parse re-runs; the successful load
+            # reset the flag, so this failure warns again.
+            path.write_text("{ broken again, different size")
             mitm_addon.load_registry()
             assert log.warn.call_count == 2
 


### PR DESCRIPTION
Closes #10562.

## Summary

- `load_registry()` was called on every MITM request. On failure it warn-logged without updating `_registry_cache_key`, so every subsequent request re-ran the failing I/O + JSON parse and re-warned — 100 req/s during an incident produced 100 warn lines/s and 100 redundant parses/s.
- Split the function into a stat phase and a parse phase. The stat failure branch uses a one-shot flag (mirrors `counters.py:_pending_write_error_logged`); the parse failure branch relies on `_registry_cache_key = key` being moved out of the try block, so the bad file's `(mtime_ns, size)` is recorded as already-processed and subsequent requests short-circuit at the existing key check — no re-open, no re-parse, no re-warn.
- Successful load clears the flag so a fresh failure after recovery re-warns once, preserving the operator signal.

## Test plan

- [x] `python3 -m pytest` in `crates/runner/mitm-addon` — 915 passed (13 in `test_registry.py`, three new)
- [x] `ruff check` + `ruff format --check` clean on edited files
- [x] New tests:
  - `test_missing_file_logs_once_across_calls` — stat-failure dedup across 5 calls
  - `test_parse_failure_logs_once_and_does_not_reparse` — asserts `json.load` called once across 5 calls
  - `test_recovery_after_parse_failure_rewarns_on_next_failure` — bad → good → bad re-warns

🤖 Generated with [Claude Code](https://claude.com/claude-code)