### PR TITLE
fix(runner): exempt vm0-runner services from needrestart auto-restart

### DIFF
--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -61,7 +61,12 @@
           # Managed by ansible/playbooks/provision-runner.yml — do not edit.
           # Prefix match (no `.service` anchor) so this fires regardless of
           # whether needrestart's code path hands us the short or full name.
+          # Belt-and-braces: override_rc is consulted at the per-service
+          # restart-decision layer; blacklist_rc short-circuits earlier in
+          # the scan path. Setting both means any future refactor of
+          # needrestart that drops one layer still leaves the other intact.
           $nrconf{override_rc}->{qr(^vm0-runner-)} = 0;
+          push(@{$nrconf{blacklist_rc}}, qr(^vm0-runner-));
         mode: '0644'
       become: true
 

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -39,6 +39,23 @@
         state: stopped
       become: true
 
+    # unattended-upgrades + needrestart (default on Ubuntu 22.04+) would
+    # `systemctl restart` our runner when a depended-on library (libc,
+    # libssl, systemd, ...) is patched. That sends SIGTERM, which the
+    # runner handles as a hard shutdown and cancels every in-flight job
+    # with exit 137. Graceful drain requires SIGUSR1 via `runner service
+    # drain`, which only the release-please promote path knows to send.
+    # Tell needrestart to leave vm0-runner units alone; the next promote
+    # picks up whatever library updates matter.
+    - name: Exempt vm0-runner services from needrestart auto-restart
+      copy:
+        dest: /etc/needrestart/conf.d/vm0-runner.conf
+        content: |
+          # Managed by ansible/playbooks/provision-runner.yml — do not edit.
+          $nrconf{override_rc}->{qr(^vm0-runner-.*\.service$)} = 0;
+        mode: '0644'
+      become: true
+
     - name: Add user to kvm group
       user:
         name: "{{ ansible_user }}"

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -47,12 +47,21 @@
     # drain`, which only the release-please promote path knows to send.
     # Tell needrestart to leave vm0-runner units alone; the next promote
     # picks up whatever library updates matter.
+    - name: Ensure needrestart conf.d exists
+      file:
+        path: /etc/needrestart/conf.d
+        state: directory
+        mode: '0755'
+      become: true
+
     - name: Exempt vm0-runner services from needrestart auto-restart
       copy:
         dest: /etc/needrestart/conf.d/vm0-runner.conf
         content: |
           # Managed by ansible/playbooks/provision-runner.yml — do not edit.
-          $nrconf{override_rc}->{qr(^vm0-runner-.*\.service$)} = 0;
+          # Prefix match (no `.service` anchor) so this fires regardless of
+          # whether needrestart's code path hands us the short or full name.
+          $nrconf{override_rc}->{qr(^vm0-runner-)} = 0;
         mode: '0644'
       become: true
 


### PR DESCRIPTION
## Summary

- Drop a `needrestart` override in `/etc/needrestart/conf.d/vm0-runner.conf` via `provision-runner.yml` so Ubuntu's unattended-upgrades / `needrestart -r a` leaves `vm0-runner-*.service` alone.

## Why

On Ubuntu 22.04+, unattended-upgrades runs daily around 06:00 UTC (with jitter). When it patches a library the runner is linked against (libc, libssl, systemd, ...), `needrestart` fires `systemctl restart` on every affected service. That path sends **SIGTERM**, which the runner handles as a **hard shutdown** and cancels every in-flight job with exit 137.

Prod-4 hit this at **2026-04-22 06:59:26 UTC** — 22 active jobs were killed, including run_id `fe5d91bd-f7cd-4aa3-a5d0-af1482336d0a`. The trigger chain:

```
06:58:55  apt-daily-upgrade.service starts
06:59:03  unattended-upgrade running
06:59:25  systemd[1]: Reexecuting (new systemd installed)
06:59:26  systemd[1]: Stopping vm0-runner-v0.90.0.service
06:59:26  runner: initiating hard shutdown signal="SIGTERM"
06:59:26  runner: dispatched per-job cancellations active_jobs=22
06:59:31  systemd[1]: Started vm0-runner-v0.90.0.service
```

Our release-please / rollback paths correctly use SIGUSR1 (`runner service drain`) for graceful drain — this issue only affects the OS-level patch window, which bypasses that protocol.

## How

`$nrconf{override_rc}->{qr(^vm0-runner-.*\.service$)} = 0` tells `needrestart` to never auto-restart units matching that regex. Library updates get picked up on the next natural release-please promote (which does a clean restart after the old version's drain completes).

## Rollout

`actions/provision` is hash-gated on the `ansible/` tree — this diff bumps the hash, so the next runner-rs release will re-run `provision-runner.yml` on every metal host and drop the file.

## Test plan

- [ ] CI passes
- [ ] Next runner-rs release re-provisions all prod hosts (check `~/.vm0-provision-hash` changes)
- [ ] `/etc/needrestart/conf.d/vm0-runner.conf` present on all prod hosts after that promote
- [ ] Next unattended-upgrades cycle that patches a runner-linked library does NOT trigger `systemctl restart` on `vm0-runner-*.service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)