### PR TITLE
feat(runner): ship error logs to axiom via tracing layer

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -1,0 +1,246 @@
+//! Tracing layer that ships WARN+ events to Axiom.
+//!
+//! Disabled at construction when `AXIOM_TOKEN_TELEMETRY` or
+//! `AXIOM_DATASET_SUFFIX` is unset. Dual-write: the existing fmt subscriber
+//! keeps writing to stderr + file; this layer adds Axiom as an extra sink.
+//!
+//! Uses the workspace reqwest client directly (no axiom-rs) so we don't pull
+//! a second reqwest major into the musl binary. Ingest endpoint:
+//! `POST /v1/datasets/{name}/ingest` with Bearer auth and a JSON-array body —
+//! see <https://axiom.co/docs/restapi/ingest>.
+
+use std::fmt::Write as _;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use reqwest::Client;
+use serde_json::{Map, Value};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Metadata, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::registry::LookupSpan;
+
+const CHANNEL_CAP: usize = 1024;
+const BATCH_SIZE: usize = 50;
+const BATCH_INTERVAL: Duration = Duration::from_secs(5);
+const FLUSH_DEADLINE: Duration = Duration::from_secs(5);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
+const SERVICE_NAME: &str = "runner";
+
+/// Holds the dispatcher task. `shutdown().await` drains the queue; dropping
+/// without calling `shutdown` leaves the tokio runtime to abort the task.
+pub struct AxiomGuard {
+    tx: mpsc::Sender<Msg>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl AxiomGuard {
+    pub async fn shutdown(mut self) {
+        let _ = self.tx.send(Msg::Close).await;
+        if let Some(h) = self.handle.take() {
+            let _ = tokio::time::timeout(FLUSH_DEADLINE, h).await;
+        }
+    }
+}
+
+/// Initialize the Axiom layer. Returns `None` when required env is missing —
+/// caller should install a `None` layer in that case (no-op).
+pub fn init() -> Option<(AxiomLayer, AxiomGuard)> {
+    let token = std::env::var("AXIOM_TOKEN_TELEMETRY")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    let suffix = std::env::var("AXIOM_DATASET_SUFFIX")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    // `AXIOM_URL` override exists mainly for tests (points at an httpmock server).
+    let base_url = std::env::var("AXIOM_URL")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_AXIOM_URL.into());
+    // Shared dataset with TS: turbo/apps/web/src/lib/shared/axiom/datasets.ts
+    // DATASETS.WEB_LOGS. APL queries filter by `service == "runner"`.
+    let dataset = format!("vm0-web-logs-{suffix}");
+    let ingest_url = format!(
+        "{}/v1/datasets/{}/ingest",
+        base_url.trim_end_matches('/'),
+        dataset,
+    );
+
+    let client = match Client::builder().timeout(HTTP_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("warn: axiom http client build failed: {e}");
+            return None;
+        }
+    };
+
+    let (tx, rx) = mpsc::channel(CHANNEL_CAP);
+    let handle = tokio::spawn(dispatcher(client, ingest_url, token, rx));
+
+    Some((
+        AxiomLayer {
+            tx: tx.clone(),
+            dropped: AtomicU64::new(0),
+        },
+        AxiomGuard {
+            tx,
+            handle: Some(handle),
+        },
+    ))
+}
+
+pub struct AxiomLayer {
+    tx: mpsc::Sender<Msg>,
+    dropped: AtomicU64,
+}
+
+enum Msg {
+    Event(Value),
+    Close,
+}
+
+impl<S> Layer<S> for AxiomLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn enabled(&self, metadata: &Metadata<'_>, _: Context<'_, S>) -> bool {
+        // Fixed WARN+ threshold. Errors and warnings only; INFO/DEBUG stay out
+        // of Axiom to keep ingest volume predictable.
+        *metadata.level() <= tracing::Level::WARN
+    }
+
+    fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
+        let value = serialize_event(event);
+        if self.tx.try_send(Msg::Event(value)).is_err() {
+            // Bounded-channel full or dispatcher gone. Surface periodically —
+            // never through `tracing` itself (feedback loop).
+            let prev = self.dropped.fetch_add(1, Ordering::Relaxed);
+            if prev.is_multiple_of(1000) {
+                eprintln!("warn: axiom channel full, dropped {} events", prev + 1);
+            }
+        }
+    }
+}
+
+async fn dispatcher(
+    client: Client,
+    ingest_url: String,
+    token: String,
+    mut rx: mpsc::Receiver<Msg>,
+) {
+    let mut batch: Vec<Value> = Vec::with_capacity(BATCH_SIZE);
+    let mut interval = tokio::time::interval(BATCH_INTERVAL);
+    loop {
+        tokio::select! {
+            msg = rx.recv() => match msg {
+                Some(Msg::Event(v)) => {
+                    batch.push(v);
+                    if batch.len() >= BATCH_SIZE {
+                        flush(&client, &ingest_url, &token, &mut batch).await;
+                    }
+                }
+                Some(Msg::Close) | None => {
+                    flush(&client, &ingest_url, &token, &mut batch).await;
+                    return;
+                }
+            },
+            _ = interval.tick() => {
+                if !batch.is_empty() {
+                    flush(&client, &ingest_url, &token, &mut batch).await;
+                }
+            }
+        }
+    }
+}
+
+async fn flush(client: &Client, ingest_url: &str, token: &str, batch: &mut Vec<Value>) {
+    if batch.is_empty() {
+        return;
+    }
+    let drained: Vec<Value> = std::mem::take(batch);
+    match client
+        .post(ingest_url)
+        .bearer_auth(token)
+        .json(&drained)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) => {
+            // Drop events on non-success. Retry-from-inside-tracing risks
+            // feedback loops; if 429s become routine, add a real backoff
+            // wrapper then.
+            eprintln!("warn: axiom ingest returned {}", resp.status());
+        }
+        Err(e) => {
+            eprintln!("warn: axiom ingest failed: {e}");
+        }
+    }
+}
+
+/// Serialize a tracing event to match the TS logger payload shape in
+/// `turbo/apps/web/src/lib/shared/logger.ts`: flat top-level `_time`, `level`
+/// (lowercase), `message`, `context`, plus any user-supplied fields —
+/// augmented with a Rust-only `service` discriminator.
+fn serialize_event(event: &Event<'_>) -> Value {
+    struct V(Map<String, Value>);
+    impl Visit for V {
+        fn record_str(&mut self, f: &Field, v: &str) {
+            self.0.insert(f.name().into(), Value::String(v.into()));
+        }
+        fn record_i64(&mut self, f: &Field, v: i64) {
+            self.0.insert(f.name().into(), v.into());
+        }
+        fn record_u64(&mut self, f: &Field, v: u64) {
+            self.0.insert(f.name().into(), v.into());
+        }
+        fn record_f64(&mut self, f: &Field, v: f64) {
+            self.0.insert(f.name().into(), v.into());
+        }
+        fn record_bool(&mut self, f: &Field, v: bool) {
+            self.0.insert(f.name().into(), v.into());
+        }
+        fn record_error(&mut self, f: &Field, err: &(dyn std::error::Error + 'static)) {
+            // Mirror TS `serializeError` shape: an object with `message` and a
+            // `chain`. Rust has no stable `.name` / `.stack`; `chain` walks
+            // `.source()`, the closest analog to JS `cause`.
+            let mut chain: Vec<Value> = Vec::new();
+            let mut cur = err.source();
+            while let Some(e) = cur {
+                chain.push(Value::String(e.to_string()));
+                cur = e.source();
+            }
+            let mut obj = Map::new();
+            obj.insert("message".into(), Value::String(err.to_string()));
+            if !chain.is_empty() {
+                obj.insert("chain".into(), Value::Array(chain));
+            }
+            self.0.insert(f.name().into(), Value::Object(obj));
+        }
+        fn record_debug(&mut self, f: &Field, v: &dyn std::fmt::Debug) {
+            let mut s = String::new();
+            let _ = write!(s, "{v:?}");
+            self.0.insert(f.name().into(), Value::String(s));
+        }
+    }
+
+    let meta = event.metadata();
+    let mut v = V(Map::new());
+    event.record(&mut v);
+
+    let mut out = v.0;
+    out.insert(
+        "_time".into(),
+        Value::String(chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
+    );
+    out.insert(
+        "level".into(),
+        Value::String(meta.level().to_string().to_ascii_lowercase()),
+    );
+    out.insert("context".into(), Value::String(meta.target().into()));
+    out.insert("service".into(), Value::String(SERVICE_NAME.into()));
+    Value::Object(out)
+}

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -42,6 +42,22 @@ const FLUSH_DEADLINE: Duration = Duration::from_secs(15);
 /// stuck ingest call can hold up the dispatcher's batch loop. Must stay
 /// `<= FLUSH_DEADLINE` (see above).
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+// Compile-time enforcement of the FLUSH_DEADLINE >= HTTP_TIMEOUT invariant —
+// without this, a slow flush gets aborted mid-request during shutdown and
+// the final batch (usually the most valuable one) never reaches Axiom.
+const _: () = assert!(
+    FLUSH_DEADLINE.as_secs() >= HTTP_TIMEOUT.as_secs(),
+    "FLUSH_DEADLINE must be >= HTTP_TIMEOUT; see FLUSH_DEADLINE doc comment",
+);
+/// Max bytes we'll serialize from a single `Debug`-formatted field.
+///
+/// Covers typical legit Debug output (errors, configs — nearly all under
+/// ~2 KiB) while flagging accidental huge-struct dumps: `tracing::warn!(v
+/// = ?gigantic, ...)` would otherwise embed megabytes into a single event
+/// and blow past Axiom's per-request body limit. Oversized values are
+/// truncated on a UTF-8 boundary with a `…[truncated]` marker so the
+/// condition is visible in the log.
+const DEBUG_FIELD_MAX_BYTES: usize = 4 * 1024;
 const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
 /// Target used for this layer's own diagnostics (channel-full warnings,
@@ -52,13 +68,20 @@ const INTERNAL_TARGET: &str = "runner::axiom_layer::internal";
 
 /// Holds the dispatcher task. `shutdown().await` drains the queue; dropping
 /// without calling `shutdown` leaves the tokio runtime to abort the task.
-pub struct AxiomGuard {
+///
+/// **Abnormal-exit caveat**: on `panic!`, `std::process::exit`, or
+/// `std::process::abort`, `shutdown` does not run — the tokio runtime tears
+/// down mid-flight and the events buffered at that moment (often the most
+/// valuable batch, since they include whatever triggered the exit) are lost.
+/// Sentry's panic integration still captures the panic itself; Axiom just
+/// does not receive the corresponding structured log.
+pub(crate) struct AxiomGuard {
     tx: mpsc::Sender<Msg>,
     handle: Option<JoinHandle<()>>,
 }
 
 impl AxiomGuard {
-    pub async fn shutdown(mut self) {
+    pub(crate) async fn shutdown(mut self) {
         // Single deadline covers both `send(Close)` (may wait for a slot if
         // the channel is full) and `handle.await` (may wait for in-flight
         // HTTP flushes). Without wrapping both, a full backlog could stall
@@ -76,7 +99,7 @@ impl AxiomGuard {
 /// Initialize the Axiom layer. Returns `None` when required env is missing —
 /// caller should install a `None` layer in that case (no-op). Production
 /// entry point; always targets `DEFAULT_AXIOM_URL`.
-pub fn init() -> Option<(AxiomLayer, AxiomGuard)> {
+pub(crate) fn init() -> Option<(AxiomLayer, AxiomGuard)> {
     let token = std::env::var("AXIOM_TOKEN_TELEMETRY")
         .ok()
         .filter(|s| !s.is_empty())?;
@@ -90,7 +113,7 @@ pub fn init() -> Option<(AxiomLayer, AxiomGuard)> {
 /// at an `httpmock` server without leaking an `AXIOM_URL` override into the
 /// runner's production env surface — production code should always call
 /// [`init`], which hard-codes [`DEFAULT_AXIOM_URL`].
-pub fn init_with_base_url(
+pub(crate) fn init_with_base_url(
     base_url: &str,
     token: &str,
     suffix: &str,
@@ -127,7 +150,7 @@ pub fn init_with_base_url(
     ))
 }
 
-pub struct AxiomLayer {
+pub(crate) struct AxiomLayer {
     tx: mpsc::Sender<Msg>,
     dropped: AtomicU64,
 }
@@ -278,8 +301,20 @@ fn serialize_event(event: &Event<'_>) -> Value {
             self.0.insert(f.name().into(), Value::Object(obj));
         }
         fn record_debug(&mut self, f: &Field, v: &dyn std::fmt::Debug) {
+            // Cap per-field size so a user who logs a huge struct via `?v`
+            // can't blow past Axiom's body limit or starve the dispatcher.
             let mut s = String::new();
             let _ = write!(s, "{v:?}");
+            if s.len() > DEBUG_FIELD_MAX_BYTES {
+                // Truncate on a char boundary so the resulting String is
+                // still valid UTF-8.
+                let mut cut = DEBUG_FIELD_MAX_BYTES;
+                while !s.is_char_boundary(cut) {
+                    cut -= 1;
+                }
+                s.truncate(cut);
+                s.push_str("…[truncated]");
+            }
             self.0.insert(f.name().into(), Value::String(s));
         }
     }

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -47,7 +47,8 @@ impl AxiomGuard {
 }
 
 /// Initialize the Axiom layer. Returns `None` when required env is missing —
-/// caller should install a `None` layer in that case (no-op).
+/// caller should install a `None` layer in that case (no-op). Production
+/// entry point; always targets `DEFAULT_AXIOM_URL`.
 pub fn init() -> Option<(AxiomLayer, AxiomGuard)> {
     let token = std::env::var("AXIOM_TOKEN_TELEMETRY")
         .ok()
@@ -55,11 +56,18 @@ pub fn init() -> Option<(AxiomLayer, AxiomGuard)> {
     let suffix = std::env::var("AXIOM_DATASET_SUFFIX")
         .ok()
         .filter(|s| !s.is_empty())?;
-    // `AXIOM_URL` override exists mainly for tests (points at an httpmock server).
-    let base_url = std::env::var("AXIOM_URL")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| DEFAULT_AXIOM_URL.into());
+    init_with_base_url(DEFAULT_AXIOM_URL, &token, &suffix)
+}
+
+/// Core init with an explicit base URL. Exists so integration tests can point
+/// at an `httpmock` server without leaking an `AXIOM_URL` override into the
+/// runner's production env surface — production code should always call
+/// [`init`], which hard-codes [`DEFAULT_AXIOM_URL`].
+pub fn init_with_base_url(
+    base_url: &str,
+    token: &str,
+    suffix: &str,
+) -> Option<(AxiomLayer, AxiomGuard)> {
     // Shared dataset with TS: turbo/apps/web/src/lib/shared/axiom/datasets.ts
     // DATASETS.WEB_LOGS. APL queries filter by `service == "runner"`.
     let dataset = format!("vm0-web-logs-{suffix}");
@@ -78,7 +86,7 @@ pub fn init() -> Option<(AxiomLayer, AxiomGuard)> {
     };
 
     let (tx, rx) = mpsc::channel(CHANNEL_CAP);
-    let handle = tokio::spawn(dispatcher(client, ingest_url, token, rx));
+    let handle = tokio::spawn(dispatcher(client, ingest_url, token.to_string(), rx));
 
     Some((
         AxiomLayer {

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -41,6 +41,11 @@ const FLUSH_DEADLINE: Duration = Duration::from_secs(5);
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
+/// Target used for this layer's own diagnostics (channel-full warnings,
+/// non-success ingest responses, HTTP errors). Filtered out in `enabled()`
+/// so diagnostics reach stderr + the rolling log file via the fmt layer
+/// without looping back into this layer and re-flooding the dispatcher.
+const INTERNAL_TARGET: &str = "runner::axiom_layer::internal";
 
 /// Holds the dispatcher task. `shutdown().await` drains the queue; dropping
 /// without calling `shutdown` leaves the tokio runtime to abort the task.
@@ -135,20 +140,24 @@ where
 {
     fn enabled(&self, metadata: &Metadata<'_>, _: Context<'_, S>) -> bool {
         // Fixed WARN+ threshold. Errors and warnings only; INFO/DEBUG stay out
-        // of Axiom to keep ingest volume predictable.
-        *metadata.level() <= tracing::Level::WARN
+        // of Axiom to keep ingest volume predictable. The internal-target
+        // check prevents our own diagnostics from feeding back into the
+        // layer (and re-hammering the full channel).
+        *metadata.level() <= tracing::Level::WARN && metadata.target() != INTERNAL_TARGET
     }
 
     fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
         let value = serialize_event(event);
         if self.tx.try_send(Msg::Event(value)).is_err() {
-            // Bounded-channel full or dispatcher gone. Surface periodically —
-            // never through `tracing` itself (feedback loop).
+            // Bounded-channel full or dispatcher gone. Surface periodically
+            // under `INTERNAL_TARGET` so the message hits stderr + rolling
+            // file via the fmt layer but `enabled()` filters it out here.
             let prev = self.dropped.fetch_add(1, Ordering::Relaxed);
             if prev.is_multiple_of(1000) {
-                eprintln!(
-                    "warn: axiom channel full, {} event(s) dropped so far",
-                    prev + 1
+                tracing::warn!(
+                    target: INTERNAL_TARGET,
+                    dropped = prev + 1,
+                    "axiom channel full",
                 );
             }
         }
@@ -202,11 +211,21 @@ async fn flush(client: &Client, ingest_url: &str, token: &str, batch: &mut Vec<V
         Ok(resp) => {
             // Drop events on non-success. Retry-from-inside-tracing risks
             // feedback loops; if 429s become routine, add a real backoff
-            // wrapper then.
-            eprintln!("warn: axiom ingest returned {}", resp.status());
+            // wrapper then. Diagnostics go under INTERNAL_TARGET so they
+            // reach stderr + the rolling file via the fmt layer but don't
+            // get re-ingested here.
+            tracing::warn!(
+                target: INTERNAL_TARGET,
+                status = %resp.status(),
+                "axiom ingest returned non-success",
+            );
         }
         Err(e) => {
-            eprintln!("warn: axiom ingest failed: {e}");
+            tracing::warn!(
+                target: INTERNAL_TARGET,
+                error = %e,
+                "axiom ingest failed",
+            );
         }
     }
 }

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -22,10 +22,22 @@ use tracing::{Event, Metadata, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 use tracing_subscriber::registry::LookupSpan;
 
+/// Bounded-channel capacity between tracing callers and the dispatcher task.
+/// WARN+ events are rare, so 1024 absorbs realistic bursts; overflow is
+/// counted + surfaced via stderr rather than blocking the tracing hot path.
 const CHANNEL_CAP: usize = 1024;
+/// Max events per ingest POST. Axiom accepts thousands per batch, but a small
+/// cap keeps POST body size and peak dispatcher memory predictable.
 const BATCH_SIZE: usize = 50;
+/// Time-based flush trigger for batches that stay below `BATCH_SIZE`. Keeps
+/// events from sitting in the buffer indefinitely when traffic is sparse.
 const BATCH_INTERVAL: Duration = Duration::from_secs(5);
+/// Upper bound on how long `AxiomGuard::shutdown` waits for the dispatcher
+/// to drain before returning — caps process-exit latency even if the
+/// channel is backed up or Axiom is slow/unresponsive.
 const FLUSH_DEADLINE: Duration = Duration::from_secs(5);
+/// Per-request HTTP timeout on the reqwest client — bounds the time a single
+/// stuck ingest call can hold up the dispatcher's batch loop.
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
@@ -39,10 +51,17 @@ pub struct AxiomGuard {
 
 impl AxiomGuard {
     pub async fn shutdown(mut self) {
-        let _ = self.tx.send(Msg::Close).await;
-        if let Some(h) = self.handle.take() {
-            let _ = tokio::time::timeout(FLUSH_DEADLINE, h).await;
-        }
+        // Single deadline covers both `send(Close)` (may wait for a slot if
+        // the channel is full) and `handle.await` (may wait for in-flight
+        // HTTP flushes). Without wrapping both, a full backlog could stall
+        // shutdown for many seconds before the handle timeout even started.
+        let _ = tokio::time::timeout(FLUSH_DEADLINE, async move {
+            let _ = self.tx.send(Msg::Close).await;
+            if let Some(h) = self.handle.take() {
+                let _ = h.await;
+            }
+        })
+        .await;
     }
 }
 
@@ -127,7 +146,10 @@ where
             // never through `tracing` itself (feedback loop).
             let prev = self.dropped.fetch_add(1, Ordering::Relaxed);
             if prev.is_multiple_of(1000) {
-                eprintln!("warn: axiom channel full, dropped {} events", prev + 1);
+                eprintln!(
+                    "warn: axiom channel full, {} event(s) dropped so far",
+                    prev + 1
+                );
             }
         }
     }

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -33,11 +33,14 @@ const BATCH_SIZE: usize = 50;
 /// events from sitting in the buffer indefinitely when traffic is sparse.
 const BATCH_INTERVAL: Duration = Duration::from_secs(5);
 /// Upper bound on how long `AxiomGuard::shutdown` waits for the dispatcher
-/// to drain before returning — caps process-exit latency even if the
-/// channel is backed up or Axiom is slow/unresponsive.
-const FLUSH_DEADLINE: Duration = Duration::from_secs(5);
+/// to drain before returning. Must stay `>= HTTP_TIMEOUT` with enough slack
+/// for queued events to reach the `Close` marker — otherwise the final
+/// in-flight flush gets aborted mid-request and the most valuable batch
+/// (errors emitted right before shutdown) never reaches Axiom.
+const FLUSH_DEADLINE: Duration = Duration::from_secs(15);
 /// Per-request HTTP timeout on the reqwest client — bounds the time a single
-/// stuck ingest call can hold up the dispatcher's batch loop.
+/// stuck ingest call can hold up the dispatcher's batch loop. Must stay
+/// `<= FLUSH_DEADLINE` (see above).
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
@@ -172,6 +175,11 @@ async fn dispatcher(
 ) {
     let mut batch: Vec<Value> = Vec::with_capacity(BATCH_SIZE);
     let mut interval = tokio::time::interval(BATCH_INTERVAL);
+    // `Delay` prevents the default `Burst` from firing a run of catch-up
+    // ticks after a slow flush — each tick is only useful if it wakes us
+    // up with a non-empty batch, and missed ticks during a flush would
+    // just re-fire as empty no-ops.
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
         tokio::select! {
             msg = rx.recv() => match msg {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1,3 +1,4 @@
+mod axiom_layer;
 mod ca;
 mod cmd;
 mod config;
@@ -33,6 +34,8 @@ use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 use tracing_subscriber::fmt::writer::MakeWriterExt;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 #[derive(Parser)]
 #[command(name = "runner", version)]
@@ -120,12 +123,14 @@ fn sanitize_name(raw: &str) -> String {
     }
 }
 
-/// Initialize tracing with a tee writer (stderr + rolling log file).
+/// Initialize tracing with a tee writer (stderr + rolling log file) plus an
+/// optional Axiom layer.
 ///
 /// Returns the [`tracing_appender::non_blocking::WorkerGuard`] that must be
 /// held alive until the process exits so buffered logs are flushed.
 fn init_tracing_with_file(
     config_path: &Path,
+    axiom_layer: Option<axiom_layer::AxiomLayer>,
 ) -> Result<tracing_appender::non_blocking::WorkerGuard, Box<dyn std::error::Error>> {
     let home = paths::HomePaths::new()?;
     let log_dir = home.logs_dir();
@@ -144,17 +149,25 @@ fn init_tracing_with_file(
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
     let writer = std::io::stderr.and(non_blocking);
 
-    tracing_subscriber::fmt()
+    let fmt_layer = tracing_subscriber::fmt::layer()
         .with_writer(writer)
-        .with_ansi(false)
+        .with_ansi(false);
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(axiom_layer)
         .init();
 
     Ok(guard)
 }
 
-/// Initialize tracing with stderr output only (no rolling log file on disk).
-fn init_tracing_stderr() {
-    tracing_subscriber::fmt().init();
+/// Initialize tracing with stderr output only (no rolling log file on disk),
+/// plus an optional Axiom layer.
+fn init_tracing_stderr(axiom_layer: Option<axiom_layer::AxiomLayer>) {
+    let fmt_layer = tracing_subscriber::fmt::layer();
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(axiom_layer)
+        .init();
 }
 
 #[tokio::main]
@@ -178,17 +191,27 @@ async fn main() -> ExitCode {
 
     let cli = Cli::parse();
 
+    // Axiom layer (dual-write with fmt). Returns None — zero overhead — when
+    // AXIOM_TOKEN_TELEMETRY / AXIOM_DATASET_SUFFIX are unset.
+    let (axiom_layer, axiom_guard) = match axiom_layer::init() {
+        Some((layer, guard)) => (Some(layer), Some(guard)),
+        None => (None, None),
+    };
+
     let _guard = match &cli.command {
-        Command::Start(args) => match init_tracing_with_file(&args.config) {
+        Command::Start(args) => match init_tracing_with_file(&args.config, axiom_layer) {
             Ok(guard) => Some(guard),
             Err(e) => {
-                init_tracing_stderr();
+                // The failed `init_tracing_with_file` already consumed `axiom_layer`,
+                // so the stderr fallback runs without Axiom — acceptable degraded
+                // mode (home/log-dir setup is already broken at this point).
+                init_tracing_stderr(None);
                 tracing::warn!("file logging unavailable, using stderr only: {e}");
                 None
             }
         },
         _ => {
-            init_tracing_stderr();
+            init_tracing_stderr(axiom_layer);
             None
         }
     };
@@ -213,13 +236,19 @@ async fn main() -> ExitCode {
         Command::Local(args) => cmd::run_local(args).await,
     };
 
-    match result {
+    let exit = match result {
         Ok(code) => code,
         Err(e) => {
             eprintln!("error: {e}");
             ExitCode::FAILURE
         }
+    };
+
+    if let Some(g) = axiom_guard {
+        g.shutdown().await;
     }
+
+    exit
 }
 
 #[cfg(test)]

--- a/crates/runner/tests/axiom_layer.rs
+++ b/crates/runner/tests/axiom_layer.rs
@@ -22,7 +22,6 @@ fn clear_axiom_env() {
     unsafe {
         std::env::remove_var("AXIOM_TOKEN_TELEMETRY");
         std::env::remove_var("AXIOM_DATASET_SUFFIX");
-        std::env::remove_var("AXIOM_URL");
     }
 }
 
@@ -77,14 +76,10 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
         })
         .await;
 
-    let (layer, guard) = with_env(|| {
-        unsafe {
-            std::env::set_var("AXIOM_URL", server.base_url());
-            std::env::set_var("AXIOM_TOKEN_TELEMETRY", "test-token");
-            std::env::set_var("AXIOM_DATASET_SUFFIX", "test");
-        }
-        axiom_layer::init().expect("init must succeed with env set")
-    });
+    // Use the test-only `init_with_base_url` to redirect at the mock server.
+    // `init()` always targets api.axiom.co and can't be pointed elsewhere.
+    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "test-token", "test")
+        .expect("init_with_base_url must succeed");
 
     let subscriber = tracing_subscriber::registry().with(layer);
     {

--- a/crates/runner/tests/axiom_layer.rs
+++ b/crates/runner/tests/axiom_layer.rs
@@ -1,0 +1,119 @@
+//! Integration tests for the Axiom tracing layer.
+//!
+//! The layer + its dispatcher run for real; only the network boundary is
+//! mocked (`httpmock` stands in for `https://api.axiom.co`). Tests verify
+//! that events flow through the layer → channel → dispatcher → POST
+//! endpoint with the TS-compatible payload shape.
+//!
+//! Env vars are process-global, so tests serialize on `ENV_LOCK`.
+
+#[path = "../src/axiom_layer.rs"]
+mod axiom_layer;
+
+use httpmock::Method::POST;
+use httpmock::MockServer;
+use tracing_subscriber::layer::SubscriberExt;
+
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn clear_axiom_env() {
+    // SAFETY: setenv is not thread-safe, but we hold ENV_LOCK for the
+    // duration of every test that touches these vars.
+    unsafe {
+        std::env::remove_var("AXIOM_TOKEN_TELEMETRY");
+        std::env::remove_var("AXIOM_DATASET_SUFFIX");
+        std::env::remove_var("AXIOM_URL");
+    }
+}
+
+/// Acquire `ENV_LOCK`, run `f` with env state captured, then drop the lock.
+/// `f` does the env setup and returns anything cheap (e.g. a layer + guard).
+/// The lock never spans an `.await` — `axiom_layer::init` owns its env reads
+/// synchronously, and the returned dispatcher holds owned strings.
+fn with_env<T>(f: impl FnOnce() -> T) -> T {
+    // `unwrap_or_else` handles poison by reusing the inner guard — poisoning
+    // only means a previous test panicked while holding it, which doesn't
+    // corrupt the `()` payload.
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    clear_axiom_env();
+    f()
+}
+
+#[tokio::test]
+async fn warn_and_error_events_are_ingested_with_ts_shape() {
+    let server = MockServer::start_async().await;
+
+    // `body_includes` checks substrings in the batched JSON array. If any
+    // substring is missing, the mock doesn't match and `assert_calls_async(1)`
+    // below will name the expected-but-not-hit mock in the failure message.
+    let content_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/v1/datasets/vm0-web-logs-test/ingest")
+                // Rust-only discriminator.
+                .body_includes(r#""service":"runner""#)
+                // Lowercase levels (matches TS @axiomhq/logging).
+                .body_includes(r#""level":"warn""#)
+                .body_includes(r#""level":"error""#)
+                // `message` flattened to top level.
+                .body_includes(r#""message":"a warning""#)
+                .body_includes(r#""message":"a failure""#)
+                // User fields flattened.
+                .body_includes(r#""foo":"bar""#)
+                .body_includes(r#""code":42"#)
+                // `context` present (value is the tracing target — the test
+                // module path, whatever it turns out to be).
+                .body_includes(r#""context":"#);
+            then.status(200).body("{}");
+        })
+        .await;
+
+    // Negative: INFO is below the layer's WARN threshold, so no payload
+    // should contain `"level":"info"`.
+    let info_mock = server
+        .mock_async(|when, then| {
+            when.method(POST).body_includes(r#""level":"info""#);
+            then.status(200).body("{}");
+        })
+        .await;
+
+    let (layer, guard) = with_env(|| {
+        unsafe {
+            std::env::set_var("AXIOM_URL", server.base_url());
+            std::env::set_var("AXIOM_TOKEN_TELEMETRY", "test-token");
+            std::env::set_var("AXIOM_DATASET_SUFFIX", "test");
+        }
+        axiom_layer::init().expect("init must succeed with env set")
+    });
+
+    let subscriber = tracing_subscriber::registry().with(layer);
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        tracing::warn!(foo = "bar", "a warning");
+        tracing::error!(code = 42, "a failure");
+        tracing::info!("info is below threshold, should not be ingested");
+    }
+
+    guard.shutdown().await;
+
+    content_mock.assert_calls_async(1).await;
+    info_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
+async fn init_returns_none_when_env_missing() {
+    let result = with_env(axiom_layer::init);
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn init_returns_none_when_token_empty() {
+    let result = with_env(|| {
+        unsafe {
+            std::env::set_var("AXIOM_TOKEN_TELEMETRY", "");
+            std::env::set_var("AXIOM_DATASET_SUFFIX", "dev");
+        }
+        axiom_layer::init()
+    });
+    assert!(result.is_none());
+}

--- a/crates/runner/tests/axiom_layer.rs
+++ b/crates/runner/tests/axiom_layer.rs
@@ -112,3 +112,94 @@ async fn init_returns_none_when_token_empty() {
     });
     assert!(result.is_none());
 }
+
+/// Error type with a walkable `source()` chain. Lets us exercise the
+/// `record_error` visitor without pulling in extra deps.
+#[derive(Debug)]
+struct ChainErr {
+    msg: &'static str,
+    src: Option<Box<ChainErr>>,
+}
+
+impl std::fmt::Display for ChainErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.msg)
+    }
+}
+
+impl std::error::Error for ChainErr {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.src.as_deref().map(|e| e as &dyn std::error::Error)
+    }
+}
+
+#[tokio::test]
+async fn error_field_serializes_with_message_and_source_chain() {
+    let server = MockServer::start_async().await;
+
+    // Match on the exact nested shape the `record_error` visitor emits.
+    // `serde_json::Map` preserves insertion order, and we insert `message`
+    // before `chain` — so the substring literal is stable.
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/v1/datasets/vm0-web-logs-test/ingest")
+                .body_includes(r#""error":{"message":"top","chain":["middle","root"]}"#)
+                .body_includes(r#""message":"explosion""#);
+            then.status(200).body("{}");
+        })
+        .await;
+
+    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
+        .expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(layer);
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        let err = ChainErr {
+            msg: "top",
+            src: Some(Box::new(ChainErr {
+                msg: "middle",
+                src: Some(Box::new(ChainErr {
+                    msg: "root",
+                    src: None,
+                })),
+            })),
+        };
+        tracing::error!(
+            error = &err as &(dyn std::error::Error + 'static),
+            "explosion",
+        );
+    }
+    guard.shutdown().await;
+
+    mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn non_success_ingest_response_does_not_hang_shutdown_or_panic() {
+    let server = MockServer::start_async().await;
+
+    // Return 500 for every ingest. The dispatcher should log via
+    // INTERNAL_TARGET and drop the batch without panicking; shutdown must
+    // still complete well within FLUSH_DEADLINE.
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/v1/datasets/vm0-web-logs-test/ingest");
+            then.status(500).body("boom");
+        })
+        .await;
+
+    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
+        .expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(layer);
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        tracing::error!("trigger ingest failure");
+    }
+
+    // If the failure path panics or leaks the task, this await never returns
+    // (the test harness enforces its own timeout, so we'd see a hang).
+    guard.shutdown().await;
+    mock.assert_calls_async(1).await;
+}


### PR DESCRIPTION
## Summary

- Add a `tracing_subscriber::Layer` in `runner` that captures WARN+ events, batches them (50 events or 5s), and POSTs to the shared `vm0-web-logs-{suffix}` Axiom dataset — the same dataset `turbo/apps/web/src/lib/shared/logger.ts` writes to.
- Payload shape mirrors the TS `@axiomhq/logging` output: flat `{_time, level (lowercase), message, context, ...user_fields}`, plus a Rust-only `service: "runner"` discriminator so APL queries can scope by producer (`| where service == "runner"`).
- Disabled at zero cost when `AXIOM_TOKEN_TELEMETRY` or `AXIOM_DATASET_SUFFIX` is unset (same gate pattern as the existing Sentry init in `runner/src/main.rs`).
- Runner still writes to stderr + the rolling log file; Axiom is additive.

Uses the workspace's existing `reqwest 0.13 + rustls` client directly — not `axiom-rs` — because that crate pins `reqwest` to `0.12` for every TLS feature variant, which would duplicate the HTTP+TLS stack in the musl binary. Spike output is in issue #10534's plan-adjustment comment.

Closes #10534.

## Test plan
- [x] `cargo test -p runner` — 724 unit tests + 3 new integration tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Integration test (`crates/runner/tests/axiom_layer.rs`) uses `httpmock` as the only mocked boundary and asserts:
  - WARN + ERROR events POSTed with correct payload shape (service, lowercase level, flat message/context/user-fields)
  - INFO filtered out (never reaches Axiom)
  - `init()` returns `None` when env is missing or token is empty
  - Flush-on-shutdown drains pending batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)