### PR TITLE
feat: add openai platform auth skeleton behind PlatformConnectors flag

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -3,6 +3,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import {
   CONNECTOR_TYPES,
+  FeatureSwitchKey,
   hasRequiredScopes,
   zeroConnectorScopeDiffContract,
   zeroConnectorsMainContract,
@@ -102,38 +103,46 @@ export const allConnectorTypes$ = computed(async (get) => {
   );
   const features = await get(featureSwitch$);
 
+  const platformGloballyEnabled =
+    !!features?.[FeatureSwitchKey.PlatformConnectors];
+
   const items = (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
     .filter((type) => {
       const flag = CONNECTOR_TYPES[type].featureFlag;
       const flagEnabled = !flag || !!features?.[flag];
       const methods = CONNECTOR_TYPES[type].authMethods;
-      const hasOauth = "oauth" in methods;
-      const hasApiToken = "api-token" in methods;
-      const hasPlatform = "platform" in methods;
-      // Connector visible if:
-      //  - the feature flag (if any) allows it AND an OAuth or platform method exists, or
-      //  - it has an api-token method (api-token is always available regardless of flag).
-      return (flagEnabled && (hasOauth || hasPlatform)) || hasApiToken;
+      // Connector visible if any auth method should be shown. api-token is
+      // always available regardless of flag; oauth requires the per-connector
+      // flag; platform requires both the per-connector flag and the global
+      // PlatformConnectors flag.
+      const showOauth = flagEnabled && "oauth" in methods;
+      const showApiToken = "api-token" in methods;
+      const showPlatform =
+        flagEnabled && platformGloballyEnabled && "platform" in methods;
+      return showOauth || showApiToken || showPlatform;
     })
     .map((type) => {
       const config = CONNECTOR_TYPES[type];
       const connector = connectorMap.get(type) ?? null;
       const flag = CONNECTOR_TYPES[type].featureFlag;
       const flagEnabled = !flag || !!features?.[flag];
-      const hasOauth = "oauth" in config.authMethods;
-      const hasApiToken = "api-token" in config.authMethods;
-      const hasPlatform = "platform" in config.authMethods;
+      const showOauth = flagEnabled && "oauth" in config.authMethods;
+      const showApiToken = "api-token" in config.authMethods;
+      const showPlatform =
+        flagEnabled &&
+        platformGloballyEnabled &&
+        "platform" in config.authMethods;
       const availableAuthMethods: string[] = [];
-      if (flagEnabled && hasOauth) {
+      if (showOauth) {
         availableAuthMethods.push("oauth");
       }
-      if (hasApiToken) {
+      if (showApiToken) {
         availableAuthMethods.push("api-token");
       }
-      if (flagEnabled && hasPlatform) {
+      if (showPlatform) {
         availableAuthMethods.push("platform");
       }
-      const isExperimental = !!flag && !hasApiToken;
+      const isExperimental = !!flag && !showApiToken;
       return {
         type,
         label: isExperimental ? `[Experimental] ${config.label}` : config.label,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -313,6 +313,17 @@ function ConnectModalContent({
         <ApiTokenForm type={item.type} item={item} onSuccess={onSuccess} />
       )}
 
+      {hasApiToken && hasPlatform && (
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full zero-border-t" />
+          </div>
+          <div className="relative flex justify-center text-xs">
+            <span className="bg-background px-2 text-muted-foreground">or</span>
+          </div>
+        </div>
+      )}
+
       {hasPlatform && (
         <PlatformConfirmationForm type={item.type} onSuccess={onSuccess} />
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -321,10 +321,12 @@ export function ZeroConnectorsPage() {
     const ct = allConnectors.find((c) => {
       return c.type === type;
     });
+    // Any connector without OAuth opens the ConnectModal — the modal handles
+    // api-token and platform (and both simultaneously) via its dual-form
+    // render. Only pure-OAuth connectors skip the modal and jump straight
+    // to the popup flow.
     if (
-      (ct &&
-        ct.availableAuthMethods.length === 1 &&
-        ct.availableAuthMethods[0] !== "oauth") ||
+      (ct && !ct.availableAuthMethods.includes("oauth")) ||
       isGoogleOAuthConnector(type)
     ) {
       setSelected(type);

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -69,6 +69,9 @@ function runDirectedConnect(params: {
     params.openTokenDialog();
     return;
   }
+  // Defensive fallback for the degenerate empty-authMethods case — the
+  // contract disallows it today, so in practice this is unreachable after
+  // the api-token branch above.
   if (!hasOAuth && !hasPlatform) {
     params.openTokenDialog();
     return;

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -57,7 +57,18 @@ function runDirectedConnect(params: {
   openTokenDialog: () => void;
 }): void {
   const hasOAuth = params.authMethods.includes("oauth");
+  const hasApiToken = params.authMethods.includes("api-token");
   const hasPlatform = params.authMethods.includes("platform");
+
+  // Priority: OAuth launches the external popup; api-token (with or without
+  // platform) opens the modal so the user picks explicitly; platform-only
+  // falls through to silent enable. The api-token + platform combo MUST go
+  // through the modal — auto-enabling platform would bypass the api-token
+  // form entirely for a directed-connect link.
+  if (!hasOAuth && hasApiToken) {
+    params.openTokenDialog();
+    return;
+  }
   if (!hasOAuth && !hasPlatform) {
     params.openTokenDialog();
     return;

--- a/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import { GET, DELETE } from "../route";
 import {
   createTestRequest,
   createTestOrg,
+  createTestSecret,
   insertTestPlatformConnector,
   countPlatformConnectorRows,
 } from "../../../../../../src/__tests__/api-test-helpers";
@@ -141,6 +142,27 @@ describe("DELETE /api/zero/connectors/:type", () => {
 
     expect(await countPlatformConnectorRows(orgId, userId, "github")).toBe(0);
     const after = await GET(createTestRequest(connectorUrl("github")));
+    expect(after.status).toBe(404);
+  });
+
+  it("clears api-token secret alongside platform row for openai", async () => {
+    // openai is the first connector that legitimately supports both
+    // api-token and platform auth methods. If a user sets the API key AND
+    // clicks Enable, DELETE must wipe both — otherwise the secret lingers
+    // and the connector still shows as connected via api-token derivation.
+    const userId = uniqueId("zcdel-openai-dual");
+    const { orgId } = await setupOrg(userId);
+    await createTestSecret("OPENAI_TOKEN", "sk-test-key");
+    await insertTestPlatformConnector(orgId, userId, "openai");
+    expect(await countPlatformConnectorRows(orgId, userId, "openai")).toBe(1);
+
+    const response = await DELETE(
+      createTestRequest(connectorUrl("openai"), { method: "DELETE" }),
+    );
+    expect(response.status).toBe(204);
+
+    expect(await countPlatformConnectorRows(orgId, userId, "openai")).toBe(0);
+    const after = await GET(createTestRequest(connectorUrl("openai")));
     expect(after.status).toBe(404);
   });
 });

--- a/turbo/apps/web/app/api/zero/connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/__tests__/route.test.ts
@@ -103,4 +103,19 @@ describe("GET /api/zero/connectors", () => {
     });
     expect(orphan).toBeUndefined();
   });
+
+  it("surfaces a platform row for openai with authMethod=platform", async () => {
+    const userId = uniqueId("zcon-openai-pl");
+    const { orgId } = await setupOrg(userId);
+    await insertTestPlatformConnector(orgId, userId, "openai");
+
+    const response = await GET(createTestRequest(connectorsUrl()));
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const openai = data.connectors.find((c: { type: string }) => {
+      return c.type === "openai";
+    });
+    expect(openai).toBeDefined();
+    expect(openai.authMethod).toBe("platform");
+  });
 });

--- a/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
@@ -158,4 +158,41 @@ describe("GET /api/zero/connectors/search", () => {
       expect(found).toBeDefined();
     }
   });
+
+  it("exposes openai platform auth method for staff orgs", async () => {
+    // Staff orgId hash is in STAFF_ORG_ID_HASHES, so the PlatformConnectors
+    // feature switch fires automatically and `platform` surfaces alongside
+    // `api-token` in the response.
+    mockClerk({
+      userId: "staff-user-openai-platform",
+      orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+    });
+    const response = await searchConnectors();
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const openai = data.connectors.find((c: { id: string }) => {
+      return c.id === "openai";
+    });
+    expect(openai).toBeDefined();
+    expect(openai.authMethods).toEqual(
+      expect.arrayContaining(["api-token", "platform"]),
+    );
+  });
+
+  it("hides openai platform auth method for non-staff orgs", async () => {
+    // Non-staff default: the PlatformConnectors gate is off, so `platform`
+    // is filtered out and the connector looks identical to pre-skeleton.
+    mockClerk({
+      userId: "non-staff-user-openai-platform",
+      orgId: "org_non_staff_openai",
+    });
+    const response = await searchConnectors();
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const openai = data.connectors.find((c: { id: string }) => {
+      return c.id === "openai";
+    });
+    expect(openai).toBeDefined();
+    expect(openai.authMethods).toEqual(["api-token"]);
+  });
 });

--- a/turbo/apps/web/app/api/zero/connectors/search/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/route.ts
@@ -5,6 +5,7 @@ import {
   CONNECTOR_TYPES,
   ConnectorType,
   ConnectorSearchAuthMethod,
+  FeatureSwitchKey,
   getAllFeatureStates,
 } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
@@ -31,28 +32,36 @@ const router = tsr.router(zeroConnectorsSearchContract, {
     });
     const keyword = query.keyword?.toLowerCase();
 
+    const platformGloballyEnabled =
+      !!featureStates[FeatureSwitchKey.PlatformConnectors];
+
     const connectors = (
       Object.keys(CONNECTOR_TYPES) as ConnectorType[]
     ).flatMap((type) => {
       const config = CONNECTOR_TYPES[type];
       const flag = config.featureFlag;
       const flagEnabled = !flag || !!featureStates[flag];
-      const hasOauth = "oauth" in config.authMethods;
-      const hasApiToken = "api-token" in config.authMethods;
-      const hasPlatform = "platform" in config.authMethods;
+      // api-token is always available; oauth requires the per-connector
+      // flag; platform requires both the per-connector flag and the global
+      // PlatformConnectors flag.
+      const showOauth = flagEnabled && "oauth" in config.authMethods;
+      const showApiToken = "api-token" in config.authMethods;
+      const showPlatform =
+        flagEnabled &&
+        platformGloballyEnabled &&
+        "platform" in config.authMethods;
 
-      // Hidden unless the flag allows an OAuth/platform method or an api-token
-      // method exists (api-token is always available regardless of flag).
-      if (!flagEnabled && !hasApiToken) return [];
+      // Hidden unless at least one auth method shows.
+      if (!showOauth && !showApiToken && !showPlatform) return [];
 
       const availableAuthMethods: ConnectorSearchAuthMethod[] = [];
-      if (flagEnabled && hasOauth) {
+      if (showOauth) {
         availableAuthMethods.push("oauth");
       }
-      if (hasApiToken) {
+      if (showApiToken) {
         availableAuthMethods.push("api-token");
       }
-      if (flagEnabled && hasPlatform) {
+      if (showPlatform) {
         availableAuthMethods.push("platform");
       }
 

--- a/turbo/apps/web/app/api/zero/platform-connectors/[type]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/platform-connectors/[type]/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { POST } from "../route";
 import {
   createTestRequest,
   createTestOrg,
+  countPlatformConnectorRows,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -24,11 +25,16 @@ function enableUrl(type: string): string {
   return `http://localhost:3000/api/zero/platform-connectors/${type}`;
 }
 
-// With no connector currently declaring `platform` auth the success path is
-// unreachable (validated upstream by `connectorTypeSchema`). These tests
-// cover the two branches that stay exercisable: auth rejection and the
-// "type doesn't support platform enable" rejection. Expand to cover 200
-// again when the next platform connector lands.
+function enablePost(type: string) {
+  return POST(
+    createTestRequest(enableUrl(type), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    }),
+  );
+}
+
 describe("POST /api/zero/platform-connectors/:type", () => {
   beforeEach(() => {
     context.setupMocks();
@@ -37,13 +43,7 @@ describe("POST /api/zero/platform-connectors/:type", () => {
   it("returns 401 when not authenticated", async () => {
     mockClerk({ userId: null });
 
-    const response = await POST(
-      createTestRequest(enableUrl("test-oauth"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      }),
-    );
+    const response = await enablePost("openai");
     expect(response.status).toBe(401);
   });
 
@@ -55,13 +55,33 @@ describe("POST /api/zero/platform-connectors/:type", () => {
     const userId = uniqueId("zpl-np");
     await setupOrg(userId);
 
-    const response = await POST(
-      createTestRequest(enableUrl("test-oauth"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      }),
-    );
+    const response = await enablePost("test-oauth");
     expect(response.status).toBe(400);
+  });
+
+  it("enables openai and persists a platform row", async () => {
+    const userId = uniqueId("zpl-ok");
+    const { orgId } = await setupOrg(userId);
+
+    const response = await enablePost("openai");
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.type).toBe("openai");
+    expect(body.authMethod).toBe("platform");
+
+    expect(await countPlatformConnectorRows(orgId, userId, "openai")).toBe(1);
+  });
+
+  it("is idempotent — repeat POSTs yield one row", async () => {
+    const userId = uniqueId("zpl-idem");
+    const { orgId } = await setupOrg(userId);
+
+    const first = await enablePost("openai");
+    expect(first.status).toBe(200);
+    const second = await enablePost("openai");
+    expect(second.status).toBe(200);
+
+    expect(await countPlatformConnectorRows(orgId, userId, "openai")).toBe(1);
   });
 });

--- a/turbo/apps/web/app/api/zero/platform-connectors/[type]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/platform-connectors/[type]/__tests__/route.test.ts
@@ -13,12 +13,24 @@ import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 
 const context = testContext();
 
-async function setupOrg(userId: string) {
+// `STAFF_ORG_ID_HASHES` contains the hash of this orgId (see
+// `packages/core/src/identity-hash.ts`), so a user mocked into this org
+// satisfies the `PlatformConnectors` feature switch without any override.
+const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+
+async function setupNonStaffOrg(userId: string) {
   const slug = uniqueId("zpl");
   const orgId = `org_mock_${userId}`;
   mockClerk({ userId, orgId, orgRole: "org:admin" });
   await createTestOrg(slug);
   return { slug, orgId };
+}
+
+async function setupStaffOrg(userId: string) {
+  const slug = uniqueId("zpl-staff");
+  mockClerk({ userId, orgId: STAFF_ORG_ID, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId: STAFF_ORG_ID };
 }
 
 function enableUrl(type: string): string {
@@ -47,21 +59,31 @@ describe("POST /api/zero/platform-connectors/:type", () => {
     expect(response.status).toBe(401);
   });
 
-  it("rejects types that don't declare a platform auth method", async () => {
+  it("returns 404 when PlatformConnectors flag is off for this org", async () => {
+    // Non-staff org → flag is off → endpoint 404s as if it doesn't exist.
+    // Matches the UI, which also hides the Enable button for these users.
+    const userId = uniqueId("zpl-nostaff");
+    await setupNonStaffOrg(userId);
+
+    const response = await enablePost("openai");
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects types that don't declare a platform auth method (staff)", async () => {
     // `test-oauth` is the internal synthetic OAuth connector — it passes
     // `connectorTypeSchema` (so the request reaches the handler) and will
     // never grow a `platform` auth method by contract, so the 400 branch
     // is stable under future contract changes.
     const userId = uniqueId("zpl-np");
-    await setupOrg(userId);
+    await setupStaffOrg(userId);
 
     const response = await enablePost("test-oauth");
     expect(response.status).toBe(400);
   });
 
-  it("enables openai and persists a platform row", async () => {
+  it("enables openai for a staff user and persists a platform row", async () => {
     const userId = uniqueId("zpl-ok");
-    const { orgId } = await setupOrg(userId);
+    const { orgId } = await setupStaffOrg(userId);
 
     const response = await enablePost("openai");
     expect(response.status).toBe(200);
@@ -75,7 +97,7 @@ describe("POST /api/zero/platform-connectors/:type", () => {
 
   it("is idempotent — repeat POSTs yield one row", async () => {
     const userId = uniqueId("zpl-idem");
-    const { orgId } = await setupOrg(userId);
+    const { orgId } = await setupStaffOrg(userId);
 
     const first = await enablePost("openai");
     expect(first.status).toBe(200);

--- a/turbo/apps/web/app/api/zero/platform-connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/platform-connectors/[type]/route.ts
@@ -3,6 +3,8 @@ import {
   zeroPlatformConnectorContract,
   createErrorResponse,
   CONNECTOR_TYPES,
+  FeatureSwitchKey,
+  isFeatureEnabled,
 } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -11,6 +13,7 @@ import {
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { createPlatformConnector } from "../../../../../src/lib/zero/connector/connector-service";
+import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 
 const router = tsr.router(zeroPlatformConnectorContract, {
   create: async ({ params, headers }) => {
@@ -19,6 +22,20 @@ const router = tsr.router(zeroPlatformConnectorContract, {
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
+
+    const { org } = await resolveOrg(authCtx);
+
+    const overrides = await loadFeatureSwitchOverrides(org.orgId, userId);
+    const platformConnectorsEnabled = isFeatureEnabled(
+      FeatureSwitchKey.PlatformConnectors,
+      { userId, orgId: org.orgId, overrides },
+    );
+    if (!platformConnectorsEnabled) {
+      return createErrorResponse(
+        "NOT_FOUND",
+        `Connector "${params.type}" not found`,
+      );
+    }
 
     // Only connector types that declare a `platform` auth method can be
     // enabled via this endpoint. Anything else is a client bug — OAuth /
@@ -31,7 +48,6 @@ const router = tsr.router(zeroPlatformConnectorContract, {
       );
     }
 
-    const { org } = await resolveOrg(authCtx);
     const connector = await createPlatformConnector(
       org.orgId,
       userId,

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -642,15 +642,14 @@ export async function deleteConnector(
     deleted = true;
   }
 
-  if (deleted) {
-    await publishUserSignal([userId], "connector:changed");
-    return;
-  }
-
-  // No DB record — check if type supports api-token and delete secrets + variables
+  // Always clean up api-token secrets/variables, even if an OAuth or
+  // platform record was already deleted above. A connector can legitimately
+  // hold both credential forms simultaneously (e.g. openai: user sets an
+  // API key AND clicks Enable for platform access), so a DELETE must
+  // remove every trace or the UI will still treat the connector as
+  // connected via the leftover secret.
   const fields = getApiTokenFieldsByType(type);
-  if (fields && (fields.secrets.length > 0 || fields.variables.length > 0)) {
-    let deletedAny = false;
+  if (fields) {
     for (const name of fields.secrets) {
       const result = await db
         .delete(secrets)
@@ -663,7 +662,7 @@ export async function deleteConnector(
           ),
         )
         .returning({ id: secrets.id });
-      if (result.length > 0) deletedAny = true;
+      if (result.length > 0) deleted = true;
     }
     for (const name of fields.variables) {
       const result = await db
@@ -676,19 +675,15 @@ export async function deleteConnector(
           ),
         )
         .returning({ id: variables.id });
-      if (result.length > 0) deletedAny = true;
-    }
-    if (deletedAny) {
-      log.debug("api-token connector deleted via user secrets/variables", {
-        orgId,
-        type,
-      });
-      await publishUserSignal([userId], "connector:changed");
-      return;
+      if (result.length > 0) deleted = true;
     }
   }
 
-  throw notFound("Connector not found");
+  if (!deleted) {
+    throw notFound("Connector not found");
+  }
+
+  await publishUserSignal([userId], "connector:changed");
 }
 
 /**

--- a/turbo/packages/core/src/contracts/connectors/openai.ts
+++ b/turbo/packages/core/src/contracts/connectors/openai.ts
@@ -22,6 +22,11 @@ export const openai = {
           },
         },
       },
+      platform: {
+        label: "Enable",
+        helpText: "No credentials needed. Usage is billed to your org credits.",
+        secrets: {},
+      },
     },
     defaultAuthMethod: "api-token",
   },

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -56,4 +56,5 @@ export enum FeatureSwitchKey {
   ModelProviderSelection = "modelProviderSelection",
   UnifyChatThreads = "unifyChatThreads",
   Vm0DeepseekModel = "vm0DeepseekModel",
+  PlatformConnectors = "platformConnectors",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -328,6 +328,16 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the DeepSeek-V3.2 (deepseek-chat) VM0 managed model",
     enabled: false,
   },
+  [FeatureSwitchKey.PlatformConnectors]: {
+    maintainer: "liangyou@vm0.ai",
+    description:
+      "Gate the entire platform-managed connector UI (Enable button and " +
+      "POST /api/zero/platform-connectors/:type). When off, only api-token " +
+      "and OAuth methods surface in connectors list/search, and the enable " +
+      "endpoint 404s. Staff-only during rollout.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary

Part A of #10569. Skeleton only — OpenAI gains an Enable button (staff-gated) that records a platform enablement row in `user_platform_connectors`. The row is inert until Part B wires firewall key injection + billing; agent calls to OpenAI still use the user's own API key for now.

- Register `FeatureSwitchKey.PlatformConnectors` (staff-only via `STAFF_ORG_ID_HASHES`). Both the server search route and the client settings signals layer this global flag on top of each connector's per-type `featureFlag`.
- Add a `platform` entry to `openai` in the contract. `defaultAuthMethod` stays `api-token` so the API key form renders above the Enable button in ConnectModal; an \`or\` divider sits between them for visual parity with the OAuth/api-token divider above.
- Fix two UI bugs that were never exercised when the only platform connector was platform-only (nano-banana): `zero-connectors-page.tsx` opens ConnectModal for any non-OAuth connector regardless of method count; `zero-directed-connect-page.tsx` routes dual-method (api-token + platform) connectors through the token dialog so a directed-connect link can't silently auto-enroll on platform.
- Fix a latent bug in `deleteConnector` exposed by OpenAI being the first dual-method connector: the function used to early-return after clearing the OAuth or platform row, leaving user-scoped api-token secrets behind. Now always runs all three cleanup branches.

## Security note — deferred to Part B

The POST /api/zero/platform-connectors/:type handler has no staff gate in this PR. Since the row is inert, a user who self-overrides the `PlatformConnectors` flag (via POST /api/zero/feature-switches) and POSTs here gains nothing — just a DB row with no effect. Before Part B hooks the firewall to grant real platform-key access, that handler MUST add \`isStaffOrg(org.orgId)\` (feature-switch-based gates are bypassable per feature-switch.ts:7-12). Part B issue will track this.

## Test plan

- [x] \`pnpm -F @vm0/core exec vitest run\` — 842/842
- [x] \`pnpm -F web exec vitest run\` — 3711/3711 (2 pre-existing failures: gpt-tokenizer import in voice-chat-candidate, unrelated)
- [x] \`pnpm turbo run lint\` — clean
- [x] \`pnpm check-types\` — clean (except pre-existing gpt-tokenizer)
- [x] \`pnpm format\` — applied
- [x] \`pnpm knip\` — no new unused/unresolved
- [x] Manual smoke on \`/connectors\` as a staff user — OpenAI modal shows API Key form + divider + Enable button; clicking Enable creates a row; GET /connectors surfaces it with \`authMethod: "platform"\`; Disconnect wipes both the row and any previously-set OPENAI_TOKEN secret.

Closes #10569 (Part A; Part B issue to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)