### PR TITLE
fix(auth): hide clerk create-organization buttons in sign-in ui

### DIFF
--- a/turbo/apps/web/app/components/auth/clerk-appearance.ts
+++ b/turbo/apps/web/app/components/auth/clerk-appearance.ts
@@ -39,6 +39,8 @@ export function getClerkAppearance(theme: "light" | "dark"): ClerkAppearance {
         "h-9 w-9 bg-input border border-border rounded-lg text-center text-base font-medium uppercase text-foreground focus:border-primary focus:ring-[3px] focus:ring-primary/10",
       formResendCodeLink: "text-primary",
       footer: "hidden",
+      organizationListCreateOrganizationActionButton: "hidden",
+      taskChooseOrganizationCreateOrganizationActionButton: "hidden",
     },
   };
 }

--- a/turbo/apps/web/app/components/auth/clerk-appearance.ts
+++ b/turbo/apps/web/app/components/auth/clerk-appearance.ts
@@ -39,8 +39,8 @@ export function getClerkAppearance(theme: "light" | "dark"): ClerkAppearance {
         "h-9 w-9 bg-input border border-border rounded-lg text-center text-base font-medium uppercase text-foreground focus:border-primary focus:ring-[3px] focus:ring-primary/10",
       formResendCodeLink: "text-primary",
       footer: "hidden",
-      organizationListCreateOrganizationActionButton: "hidden",
-      taskChooseOrganizationCreateOrganizationActionButton: "hidden",
+      organizationListCreateOrganizationActionButton: "!hidden",
+      taskChooseOrganizationCreateOrganizationActionButton: "!hidden",
     },
   };
 }


### PR DESCRIPTION
## Summary
- Hides the "Create organization" action button on Clerk's `<SignIn>` choose-organization task page and on the shared `<OrganizationList>` surface by adding `hidden` to the corresponding `appearance.elements` keys (`taskChooseOrganizationCreateOrganizationActionButton`, `organizationListCreateOrganizationActionButton`).
- This closes the last user-facing path to `clerk.createOrganization()` in the `<SignIn>` flow, so users who have already hit the org-creation limit can no longer trigger Clerk's `_baseFetch` failure from the UI.
- Addresses Sentry PLATFORM-2Z surfaced in #10506.

## Test plan
- [ ] Verify `/sign-in/tasks/choose-organization` no longer shows the "Create organization" button for a user forced into org selection.
- [ ] Verify existing sign-in / sign-up flows still render normally (no style regressions from the added appearance keys).
- [ ] Confirm no new Sentry events of the same shape appear in production after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)