### PR TITLE
fix(voice-chat): resolve preparation timeout from task dispatch pollution

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -58,7 +58,7 @@ function upsertUserTranscript(
 }
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
-const PREP_TIMEOUT_CHAT_MS = 60_000;
+const PREP_TIMEOUT_CHAT_MS = 120_000;
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 1000;
 export type RealtimeModel = "gpt-realtime" | "gpt-realtime-mini";

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -58,6 +58,9 @@ function upsertUserTranscript(
 }
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
+// 120s absorbs runner VM cold-start variance. Prep normally finishes in well
+// under 30s; the buffer guards against occasional cold sandboxes without
+// failing the UI too eagerly. Revisit (tighten) once cold-start p95 stabilises.
 const PREP_TIMEOUT_CHAT_MS = 120_000;
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 1000;

--- a/turbo/apps/web/app/api/zero/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/route.ts
@@ -66,7 +66,7 @@ export async function POST(request: Request) {
   try {
     const session = await createSession(org.orgId, userId, agentId);
 
-    const run = await dispatchSlowBrain(session, org.orgId, userId, agentId, {
+    const run = await dispatchSlowBrain(session, userId, agentId, {
       apiStartTime,
     });
 

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -103,7 +103,6 @@ You will see events like:
 - **fast-brain/response** — what your fast-brain says back
 - **fast-brain/request-slow-brain** — an explicit ask from fast-brain (see Explicit Requests)
 - **system/session-start** and **system/session-end** — session lifecycle
-- **system/task-dispatched** and **system/task-completed** — tasks you dispatched (see Dispatching Tasks)
 
 Based on what you observe, proactively decide what to do. Do not wait to be asked.
 
@@ -135,50 +134,6 @@ When you see a \`fast-brain/request-slow-brain\` event, it is a direct task from
 - **directive**: High-level instructions for your fast-brain. Include what to tell the user, relevant data, and why. Do not script exact words — your fast-brain controls phrasing.
 - **thinking**: Progress updates and intermediate results while you work.
 - **observation**: Proactive insights the user did not ask for but might find valuable.
-
-### Dispatching Tasks
-
-Some work is too heavy to do inline: code changes, file operations, external API calls (GitHub, Slack, Linear), database queries, multi-step research. For these, dispatch a task to a fresh sandbox so your polling loop stays responsive.
-
-Dispatch a task:
-
-\`zero voice-chat task create <SESSION_ID> --prompt "<self-sufficient task prompt>"\`
-
-The command returns a JSON object with \`id\` and \`status\` immediately. **Write down the id and return to the poll loop.** Never block, wait, or sleep for the task to finish.
-
-The task prompt must be self-sufficient. The Tasker runs in a fresh sandbox with no conversation history — include repo paths, user intent, and any data it needs. Write the prompt as if briefing a smart colleague who just walked in.
-
-Fetch a result once completed:
-
-\`zero voice-chat task get <SESSION_ID> <TASK_ID>\` → JSON with \`status\`, \`result\`, \`error\`.
-
-List your tasks:
-
-\`zero voice-chat task list <SESSION_ID>\` → array of \`{ id, status, createdAt }\`.
-
-#### When to dispatch vs. handle inline
-
-- **Dispatch** when the work requires tool use you don't already have the answer to: reading files, running commands, calling APIs, querying DBs, doing long research.
-- **Handle inline** (directive only) when you can answer from the prompt, context, or memory: knowledge answers, opinions, summarizing the conversation so far, simple context lookups.
-- **Stay quiet** for casual chat, greetings, and small talk — same as before.
-
-Spinning a Tasker has cold-start cost. Don't use it for "what's 2+2".
-
-#### Every directive carries task context in natural language
-
-Fast-brain knows nothing about tasks, ids, or the Tasker subsystem. Your directives are the only channel it learns from. Never mention "task", "taskId", or ids in directive content — fast-brain reads directives aloud.
-
-- **On dispatch**, write a directive telling fast-brain to acknowledge work is happening.
-  - OK: "I'm checking the PR — tell the user you're looking into it."
-  - NOT OK: "Dispatched task T1 to check PR status."
-- **On completion**, write a directive describing what to say.
-  - OK: "The PR was merged yesterday by Alice — tell the user naturally."
-  - NOT OK: "Task abc-123 returned: PR merged by Alice on 2026-04-20."
-- **On failure**, write a directive describing the failure plainly and recovering.
-  - OK: "Couldn't reach GitHub right now — tell the user there's a hiccup and we'll try again in a moment."
-  - NOT OK: "Task failed with error: GITHUB_API_TIMEOUT."
-
-Without the on-dispatch directive, fast-brain has nothing to say while the task runs and the user hears dead air. Always emit that first directive before returning to the poll loop.
 
 ### Polling and Lifecycle
 

--- a/turbo/apps/web/src/lib/zero/voice-chat/__tests__/session-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/__tests__/session-service.test.ts
@@ -4,11 +4,7 @@ import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
 import { seedTestCompose } from "../../../../__tests__/db-test-seeders/agents";
 import { seedTestRun } from "../../../../__tests__/db-test-seeders/runs";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route covers these services yet
-import {
-  createSession,
-  endSession,
-  getPriorVoiceChatAgentSessionId,
-} from "../session-service";
+import { createSession, endSession } from "../session-service";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: seed tasks on the stale/ended session to assert cancel hook
 import {
   attachTaskRun,
@@ -46,14 +42,12 @@ async function seedSessionWithRun(options: {
   userId: string;
   agentId: string;
   runStatus?: string;
-  runResult?: Record<string, unknown>;
   sessionStatus?: "active" | "preparing" | "ended" | "timeout";
   createdAt?: Date;
 }) {
   const { runId } = await seedTestRun(options.userId, options.agentId, {
     orgId: options.orgId,
     status: options.runStatus ?? "running",
-    result: options.runResult,
     triggerSource: "voice-chat",
   });
 
@@ -143,147 +137,13 @@ describe("endSession — graceful slow-brain exit", () => {
     expect(sessionAfter!.endedAt).not.toBeNull();
 
     // The critical invariant: agent_runs.status MUST NOT be mutated.
-    // Prior behaviour flipped it to 'cancelled' which prevented the
-    // agent-complete webhook from populating result.agentSessionId —
-    // and consequently blocked session continuation.
+    // Slow-brain sees session-end on its next poll and self-exits cleanly;
+    // hard-cancelling would abort mid-step and drop the event trail.
     const [runAfter] = await db
       .select({ status: agentRuns.status })
       .from(agentRuns)
       .where(eq(agentRuns.id, runId));
     expect(runAfter!.status).toBe("running");
-  });
-});
-
-describe("getPriorVoiceChatAgentSessionId", () => {
-  it("returns the agentSessionId from the most recent ended session", async () => {
-    context.setupMocks();
-    const { userId, orgId, agentId } = await seedAgent();
-
-    await seedSessionWithRun({
-      orgId,
-      userId,
-      agentId,
-      sessionStatus: "ended",
-      runResult: { agentSessionId: "older-cc-session" },
-      createdAt: new Date(Date.now() - 2 * 60_000),
-    });
-    await seedSessionWithRun({
-      orgId,
-      userId,
-      agentId,
-      sessionStatus: "ended",
-      runResult: { agentSessionId: "newer-cc-session" },
-      createdAt: new Date(Date.now() - 30_000),
-    });
-
-    const result = await getPriorVoiceChatAgentSessionId(orgId, userId);
-    expect(result).toBe("newer-cc-session");
-  });
-
-  it("skips recent sessions whose run did not write an agentSessionId", async () => {
-    context.setupMocks();
-    const { userId, orgId, agentId } = await seedAgent();
-
-    // Earlier session has a valid id.
-    await seedSessionWithRun({
-      orgId,
-      userId,
-      agentId,
-      sessionStatus: "ended",
-      runResult: { agentSessionId: "earlier-cc-session" },
-      createdAt: new Date(Date.now() - 2 * 60_000),
-    });
-    // More recent session's run never populated result.agentSessionId
-    // (e.g. crashed before the agent-complete webhook fired). The 5-row
-    // scan should fall through past it.
-    await seedSessionWithRun({
-      orgId,
-      userId,
-      agentId,
-      sessionStatus: "ended",
-      runResult: { other: "noise" },
-      createdAt: new Date(Date.now() - 30_000),
-    });
-
-    const result = await getPriorVoiceChatAgentSessionId(orgId, userId);
-    expect(result).toBe("earlier-cc-session");
-  });
-
-  it("returns null when no prior sessions exist for the user", async () => {
-    context.setupMocks();
-    const { userId, orgId } = await seedAgent();
-
-    const result = await getPriorVoiceChatAgentSessionId(orgId, userId);
-    expect(result).toBeNull();
-  });
-
-  it("returns null when every prior session's run lacks an agentSessionId", async () => {
-    context.setupMocks();
-    const { userId, orgId, agentId } = await seedAgent();
-
-    await seedSessionWithRun({
-      orgId,
-      userId,
-      agentId,
-      sessionStatus: "ended",
-      runResult: { other: "noise" },
-    });
-
-    const result = await getPriorVoiceChatAgentSessionId(orgId, userId);
-    expect(result).toBeNull();
-  });
-
-  it("matches both 'ended' and 'timeout' status values", async () => {
-    context.setupMocks();
-    const { userId, orgId, agentId } = await seedAgent();
-
-    await seedSessionWithRun({
-      orgId,
-      userId,
-      agentId,
-      sessionStatus: "timeout",
-      runResult: { agentSessionId: "cron-timeout-cc-session" },
-    });
-
-    const result = await getPriorVoiceChatAgentSessionId(orgId, userId);
-    expect(result).toBe("cron-timeout-cc-session");
-  });
-
-  it("ignores active and preparing sessions", async () => {
-    context.setupMocks();
-    const { userId, orgId, agentId } = await seedAgent();
-
-    // Active session should be ignored even if its run already has a session id
-    // — the session is still in flight, not a valid continuation source yet.
-    await seedSessionWithRun({
-      orgId,
-      userId,
-      agentId,
-      sessionStatus: "active",
-      runResult: { agentSessionId: "still-running-cc-session" },
-    });
-
-    const result = await getPriorVoiceChatAgentSessionId(orgId, userId);
-    expect(result).toBeNull();
-  });
-
-  it("is scoped by (orgId, userId) — does not leak across users", async () => {
-    context.setupMocks();
-    const { userId, orgId, agentId } = await seedAgent();
-
-    // Seed a prior session owned by a different user. setupUser() caches the
-    // default user — passing a distinct prefix forces a fresh (userId, orgId).
-    const other = await context.setupUser({ prefix: "other-user" });
-    await seedSessionWithRun({
-      orgId: other.orgId,
-      userId: other.userId,
-      agentId,
-      sessionStatus: "ended",
-      runResult: { agentSessionId: "other-user-cc-session" },
-    });
-
-    const result = await getPriorVoiceChatAgentSessionId(orgId, userId);
-    expect(result).toBeNull();
   });
 });
 
@@ -369,24 +229,6 @@ describe("createSession — auto-end stale rows", () => {
       .from(agentRuns)
       .where(eq(agentRuns.id, runId));
     expect(run!.status).toBe("running");
-  });
-
-  it("hands the stale run's agentSessionId to getPriorVoiceChatAgentSessionId for continuation", async () => {
-    context.setupMocks();
-    const { userId, orgId, agentId } = await seedAgent();
-
-    await seedSessionWithRun({
-      orgId,
-      userId,
-      agentId,
-      sessionStatus: "active",
-      runResult: { agentSessionId: "prior-cc-session" },
-    });
-
-    await createSession(orgId, userId, agentId);
-
-    const prior = await getPriorVoiceChatAgentSessionId(orgId, userId);
-    expect(prior).toBe("prior-cc-session");
   });
 
   it("cancels in-flight tasks on the stale session it force-ends", async () => {

--- a/turbo/apps/web/src/lib/zero/voice-chat/__tests__/tasker-round-trip.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/__tests__/tasker-round-trip.test.ts
@@ -12,7 +12,6 @@ import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
 import { mockClerk } from "../../../../__tests__/clerk-mock";
 import { insertOrgDefaultModelProvider } from "../../../../__tests__/db-test-seeders/org";
 import { mockAblyPublish } from "../../../../__tests__/ably-mock";
-import { buildVoiceChatQuickPrepPrompt } from "../../integration-prompt";
 /* eslint-disable web/no-direct-db-in-tests -- Service-level exception: no user-facing API appends slow-brain/fast-brain-sourced events or reads a task without auth; exercising the round trip requires simulating both sides. */
 import { appendEvent } from "../context-service";
 import { getVoiceChatTask } from "../task-service";
@@ -36,22 +35,6 @@ const { POST: postCallbackRoute } =
 
 const TASKS_BASE_URL = "http://localhost:3000/api/zero/voice-chat";
 const CALLBACK_URL = "http://localhost/api/internal/callbacks/voice-chat-task";
-
-describe("voice-chat slow-brain prompt includes tasker guidance", () => {
-  const prompt = buildVoiceChatQuickPrepPrompt("test-session-id");
-
-  it.each([
-    ["task create command", "zero voice-chat task create"],
-    ["task get command", "zero voice-chat task get"],
-    ["task list command", "zero voice-chat task list"],
-    ["task-dispatched event", "task-dispatched"],
-    ["task-completed event", "task-completed"],
-    ["never-block rule", "Never block"],
-    ["natural language rule", "natural language"],
-  ])("includes %s", (_name, substring) => {
-    expect(prompt).toContain(substring);
-  });
-});
 
 describe("tasker round trip through the blackboard", () => {
   const context = testContext();

--- a/turbo/apps/web/src/lib/zero/voice-chat/adapt-voice-chat-session-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/adapt-voice-chat-session-trigger.ts
@@ -9,13 +9,6 @@ interface VoiceChatSessionTriggerContext {
   appendSystemPrompt: string;
   /** voice_chat_sessions.id — used only as the callback payload key. */
   sessionId: string;
-  /**
-   * Prior voice-chat's agent (CC) session id, if any. Passed through as
-   * CreateZeroRunParams.sessionId so the new run restores that CC session
-   * and prefers the cached runner VM. Distinct from the voice-chat session
-   * id above — these are two different UUIDs.
-   */
-  continueFromAgentSessionId?: string;
   apiStartTime: number;
 }
 
@@ -32,7 +25,6 @@ export function adaptVoiceChatSessionTrigger(
     appendSystemPrompt: ctx.appendSystemPrompt,
     triggerSource: "voice-chat",
     apiStartTime: ctx.apiStartTime,
-    sessionId: ctx.continueFromAgentSessionId,
     callbacks: [
       {
         url: `${getApiUrl()}/api/internal/callbacks/voice-chat`,

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -1,13 +1,11 @@
-import { eq, and, inArray, desc, isNotNull } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import {
   voiceChatSessions,
   voiceChatEvents,
 } from "../../../db/schema/voice-chat";
-import { agentRuns } from "../../../db/schema/agent-run";
 import { createZeroRun, type CreateZeroRunResult } from "../zero-run-service";
 import { buildVoiceChatQuickPrepPrompt } from "../integration-prompt";
 import { notFound, badRequest, forbidden } from "../../shared/errors";
-import { hasAgentSessionId } from "../run-result";
 import { adaptVoiceChatSessionTrigger } from "./adapt-voice-chat-session-trigger";
 import { cancelSessionPendingRuns } from "./task-service";
 
@@ -23,9 +21,9 @@ export async function createSession(
   const db = globalThis.services.db;
 
   const { session, staleIds } = await db.transaction(async (tx) => {
-    // Graceful auto-end: slow-brain sees session-end within 5s and self-exits,
-    // populating result.agentSessionId so the new run can resume via
-    // getPriorVoiceChatAgentSessionId. Do NOT cancelRun — that skips the webhook.
+    // Graceful auto-end: emit session-end and flip status, letting the stale
+    // slow-brain run self-exit on its next 5s poll. Do NOT cancelRun — that
+    // would abort the run mid-step and lose the session-end event trail.
     const stale = await tx
       .select({ id: voiceChatSessions.id })
       .from(voiceChatSessions)
@@ -86,47 +84,6 @@ async function getSession(sessionId: string) {
   return session ?? null;
 }
 
-/**
- * Find the most recent agentSessionId for a user's prior voice chats.
- *
- * Joins voice_chat_sessions with agent_runs via runId and scans the last 5
- * terminated sessions (status IN ('ended', 'timeout')) for this (orgId,
- * userId) — both graceful-exit paths populate result.agentSessionId via the
- * agent-complete webhook. Returns the first populated agentSessionId found,
- * or null when no suitable prior session exists.
- *
- * The 5-row scan (same as chat-thread's getLatestSessionIdForThread) tolerates
- * the race where a just-ended session's run hasn't yet written its result.
- */
-export async function getPriorVoiceChatAgentSessionId(
-  orgId: string,
-  userId: string,
-): Promise<string | null> {
-  const db = globalThis.services.db;
-
-  const rows = await db
-    .select({ result: agentRuns.result })
-    .from(voiceChatSessions)
-    .innerJoin(agentRuns, eq(voiceChatSessions.runId, agentRuns.id))
-    .where(
-      and(
-        eq(voiceChatSessions.userId, userId),
-        eq(voiceChatSessions.orgId, orgId),
-        inArray(voiceChatSessions.status, ["ended", "timeout"]),
-        isNotNull(voiceChatSessions.runId),
-      ),
-    )
-    .orderBy(desc(voiceChatSessions.createdAt))
-    .limit(5);
-
-  for (const row of rows) {
-    if (hasAgentSessionId(row.result)) {
-      return row.result.agentSessionId;
-    }
-  }
-  return null;
-}
-
 export async function heartbeat(
   sessionId: string,
   orgId: string,
@@ -167,10 +124,8 @@ export async function endSession(
   }
 
   // Write session-end event and update status atomically. Slow-brain sees the
-  // event within its 5s poll window and self-exits via the agent-complete
-  // webhook path — which is what populates `agent_runs.result.agentSessionId`
-  // so the next voice chat can resume this CC session. Hard-cancelling here
-  // would skip that webhook and lose the session id.
+  // event within its 5s poll window and self-exits gracefully. Hard-cancelling
+  // here would abort the run mid-step and drop the event trail.
   await db.transaction(async (tx) => {
     await tx.insert(voiceChatEvents).values({
       sessionId,
@@ -194,7 +149,6 @@ export async function endSession(
 
 export async function dispatchSlowBrain(
   session: { id: string },
-  orgId: string,
   userId: string,
   agentId: string,
   options: { apiStartTime: number },
@@ -203,9 +157,6 @@ export async function dispatchSlowBrain(
   const appendSystemPrompt = buildVoiceChatQuickPrepPrompt(session.id);
   const prompt = `You are Zero's slow-brain for voice-chat session ${session.id}. Review the agent configuration and user context, then prepare an initial directive before the conversation begins.`;
 
-  const continueFromAgentSessionId =
-    (await getPriorVoiceChatAgentSessionId(orgId, userId)) ?? undefined;
-
   const result = await createZeroRun(
     adaptVoiceChatSessionTrigger({
       userId,
@@ -213,7 +164,6 @@ export async function dispatchSlowBrain(
       prompt,
       appendSystemPrompt,
       sessionId: session.id,
-      continueFromAgentSessionId,
       apiStartTime: options.apiStartTime,
     }),
   );


### PR DESCRIPTION
## Summary

Fixes the **"Preparation timed out"** error users hit when starting voice chat in production after PR #10570 rolled out.

- Drop the `Dispatching Tasks` section from `SHARED_OBSERVATION_PROMPT` so Phase 1 quick-prep is no longer instructed to consider tasker tools while reading the agent's system prompt. Tasker guidance still lives in the run-time prompt where it belongs.
- Bump `PREP_TIMEOUT_CHAT_MS` from 60s → 120s to absorb cold-start variance on the runner VM without failing UI state too eagerly.
- Remove the prior-session continuation path (`getPriorVoiceChatAgentSessionId` + `continueFromAgentSessionId`). Resume via CC `sessionId` added cross-run coupling and wasn't pulling its weight — revisit once prep is stable.

## Root cause

PR #10570 appended a rich "Dispatching Tasks" section to `SHARED_OBSERVATION_PROMPT`, which is also injected into the Phase 1 **quick-prep** prompt. Slow-brain read the new guidance (e.g. *"Dispatch when the work requires tool use you don't already have the answer to"*) during prep and fired off tasker dispatches instead of finishing prep quickly. That pushed the prep run past the 60s client-side deadline and surfaced as a timeout.

## Test plan

- [ ] Start a voice chat on staging — Phase 1 prep completes well under 120s
- [ ] Verify slow-brain does not emit `task-dispatched` events during the prep phase (check `voice_chat_events`)
- [ ] Confirm a second voice chat after the first does NOT attempt to restore a prior CC sessionId (runId on the new session should be a fresh run)
- [ ] Existing tasker round-trip test still passes (`tasker-round-trip.test.ts`)
- [ ] Existing session-service tests still pass (`session-service.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)