### PR TITLE
fix: use bg-muted for connector permission dialog icon container

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-permission-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-permission-dialog.tsx
@@ -78,7 +78,7 @@ export function ConnectorPermissionDialog({
         aria-describedby={undefined}
       >
         <DialogHeader className="mt-5 items-center gap-2.5 text-center">
-          <div className="flex items-center justify-center rounded-[10px] bg-[#f3f5f8] p-2.5">
+          <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
             <ConnectorIcon type={connectorType} size={20} />
           </div>
           <DialogTitle className="text-base font-medium">


### PR DESCRIPTION
## Summary
Fixes #10579.

In dark mode, the OpenAI connector icon was invisible in the permission dialog because the icon container had a hardcoded light background (`bg-[#f3f5f8]`), while `ConnectorIcon` inverts monochrome icons to white in dark mode.

## Change
- Changed the icon container background from `bg-[#f3f5f8]` to `bg-muted` in `connector-permission-dialog.tsx:81`
- `bg-muted` adapts automatically to the current theme (light in light mode, dark in dark mode)

## Test plan
- [ ] Verify OpenAI icon is visible in the connector success modal in dark mode
- [ ] Verify the modal still looks correct in light mode
- [ ] Run `pnpm -F @vm0/platform exec vitest run src/views/zero-page/__tests__/connector-permission-dialog.test.tsx`
- [ ] Run `pnpm turbo run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)