### PR TITLE
feat(billing): add credit balance breakdown with stacked bar chart

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-billing.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-billing.ts
@@ -42,6 +42,9 @@ function defaultBillingStatus(): BillingStatusResponse {
       expiringNextCycle: 10_000,
       nextExpiryDate: MOCK_STARTER_GRANT_EXPIRY,
     },
+    creditBreakdown: [
+      { category: "free", label: "Free plan", credits: 10_000 },
+    ],
   };
 }
 

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -25,6 +25,13 @@
   --color-sidebar-active: hsl(var(--primary) / 0.95);
   --color-sidebar-primary: hsl(var(--white));
   --color-sidebar-accent: hsl(var(--gray-100));
+
+  /* Credit balance breakdown segment colors (usage bar chart) */
+  --color-credit-free: #3eb7b8;
+  --color-credit-promotional: #e88033;
+  --color-credit-pay-as-you-go: #97918a;
+  --color-credit-plan-pro: #edc43e;
+  --color-credit-plan-team: #6b8de3;
 }
 
 /* Landing tagline carousel: smooth vertical fade-in */

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -473,6 +473,7 @@ describe("org billing tab - auto-recharge section", () => {
           hasSubscription: true,
           autoRecharge: { enabled, threshold: 2000, amount: 10_000 },
           creditExpiry: { expiringNextCycle: 0, nextExpiryDate: null },
+          creditBreakdown: [],
         });
       }),
     );

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -45,24 +45,27 @@ function displayName(m: OrgMember): string {
 
 type CreditSegment = BillingStatusResponse["creditBreakdown"][number];
 
+// Segment swatches map to theme tokens defined in
+// `turbo/apps/platform/src/views/css/index.css` under `@theme`. Keep the
+// mapping here purely symbolic so branding/dark-mode tweaks happen in CSS.
 const CATEGORY_COLORS: Readonly<
   Record<Exclude<CreditSegment["category"], "plan">, string>
 > = {
-  free: "bg-[#3EB7B8]",
-  promotional: "bg-[#E88033]",
-  payAsYouGo: "bg-[#97918A]",
+  free: "bg-credit-free",
+  promotional: "bg-credit-promotional",
+  payAsYouGo: "bg-credit-pay-as-you-go",
 };
 
 const PLAN_COLORS: Readonly<
   Record<NonNullable<CreditSegment["tier"]>, string>
 > = {
-  pro: "bg-[#EDC43E]",
-  team: "bg-[#6B8DE3]",
+  pro: "bg-credit-plan-pro",
+  team: "bg-credit-plan-team",
 };
 
 function colorForSegment(seg: CreditSegment): string {
   if (seg.category === "plan") {
-    return seg.tier ? PLAN_COLORS[seg.tier] : "bg-[#EDC43E]";
+    return seg.tier ? PLAN_COLORS[seg.tier] : "bg-credit-plan-pro";
   }
   return CATEGORY_COLORS[seg.category];
 }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -1,8 +1,14 @@
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import type { OrgMember, MemberUsage } from "@vm0/core";
+import type { OrgMember, MemberUsage, BillingStatusResponse } from "@vm0/core";
 import { IconUsers } from "@tabler/icons-react";
 import { Input } from "@vm0/ui";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui/components/ui/tooltip";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { UnsavedBar } from "./unsaved-bar.tsx";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
@@ -31,6 +37,119 @@ import {
 function displayName(m: OrgMember): string {
   const parts = [m.firstName, m.lastName].filter(Boolean);
   return parts.length > 0 ? parts.join(" ") : "";
+}
+
+// ---------------------------------------------------------------------------
+// Credit breakdown bar chart
+// ---------------------------------------------------------------------------
+
+const CATEGORY_COLORS: Record<string, string> = {
+  free: "bg-[#3EB7B8]",
+  promotional: "bg-[#E88033]",
+  payAsYouGo: "bg-[#97918A]",
+};
+
+const PLAN_COLORS: Record<string, string> = {
+  "Pro plan": "bg-[#EDC43E]",
+  "Team plan": "bg-[#6B8DE3]",
+};
+
+function colorForSegment(seg: { category: string; label: string }): string {
+  if (seg.category === "plan") {
+    return PLAN_COLORS[seg.label] ?? "bg-[#EDC43E]";
+  }
+  return CATEGORY_COLORS[seg.category] ?? "bg-[#97918A]";
+}
+
+const CATEGORY_DESCRIPTIONS: Record<string, string> = {
+  free: "Starter credits, use until depleted",
+  promotional: "Campaign credits, expires after a set period",
+  payAsYouGo: "Auto-recharge credits, never expire",
+};
+
+function descriptionForSegment(
+  seg: { category: string; label: string },
+  currentTier: string,
+): string {
+  if (seg.category !== "plan") {
+    return CATEGORY_DESCRIPTIONS[seg.category] ?? "";
+  }
+  const segTier = seg.label.replace(" plan", "").toLowerCase();
+  if (segTier === currentTier) {
+    return "Monthly plan credits, resets each billing cycle";
+  }
+  return "Leftover credits from previous plan";
+}
+
+function CreditBalanceChart({ billing }: { billing: BillingStatusResponse }) {
+  const segments = billing.creditBreakdown.filter((s) => s.credits > 0);
+  const total = billing.credits;
+
+  return (
+    <div className="px-5 py-4" data-testid="credit-balance-info">
+      <p className="text-sm font-medium tabular-nums text-foreground">
+        {total.toLocaleString()}
+      </p>
+
+      {total > 0 && segments.length > 0 && (
+        <div className="mt-3 flex flex-col gap-2">
+          {/* Bar */}
+          <TooltipProvider delayDuration={100}>
+            <div className="flex h-2.5 w-full rounded-full bg-muted/40">
+              {segments.map((s, i) => {
+                const color = colorForSegment(s);
+                const desc = descriptionForSegment(s, billing.tier);
+                return (
+                  <Tooltip key={`${s.category}-${i}`}>
+                    <TooltipTrigger asChild>
+                      <div
+                        className={`h-2.5 ${color} cursor-default first:rounded-l-full last:rounded-r-full ring-0 hover:ring-2 hover:ring-foreground/30 hover:z-10 transition-shadow`}
+                        style={{
+                          width: `${(s.credits / total) * 100}%`,
+                        }}
+                      />
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="top"
+                      sideOffset={8}
+                      style={{ backgroundColor: "white", color: "inherit" }}
+                      className="border shadow-md"
+                    >
+                      <div className="font-medium text-foreground">
+                        {s.label} — {s.credits.toLocaleString()}
+                      </div>
+                      <div className="text-muted-foreground mt-0.5">{desc}</div>
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+          </TooltipProvider>
+
+          {/* Legend */}
+          <div className="flex flex-wrap gap-x-4 gap-y-1">
+            {segments.map((s, i) => {
+              const color = colorForSegment(s);
+              return (
+                <div
+                  key={`${s.category}-${i}`}
+                  className="flex items-center gap-1.5 text-xs text-muted-foreground"
+                >
+                  <span
+                    className={`inline-block h-2 w-2 shrink-0 rounded-full ${color}`}
+                  />
+                  <span>{s.label}</span>
+                  <span className="tabular-nums">
+                    {s.credits.toLocaleString()}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -170,11 +289,7 @@ function OverviewSection() {
               <div className="h-1.5 w-full rounded-full bg-muted/40 animate-pulse" />
             </div>
           ) : billing ? (
-            <div className="px-5 py-4" data-testid="credit-balance-info">
-              <p className="text-sm font-medium tabular-nums text-foreground">
-                {billing.credits.toLocaleString()}
-              </p>
-            </div>
+            <CreditBalanceChart billing={billing} />
           ) : (
             <div className="px-5 py-4">
               <p className="text-sm text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -43,46 +43,61 @@ function displayName(m: OrgMember): string {
 // Credit breakdown bar chart
 // ---------------------------------------------------------------------------
 
-const CATEGORY_COLORS: Record<string, string> = {
+type CreditSegment = BillingStatusResponse["creditBreakdown"][number];
+
+const CATEGORY_COLORS: Readonly<
+  Record<Exclude<CreditSegment["category"], "plan">, string>
+> = {
   free: "bg-[#3EB7B8]",
   promotional: "bg-[#E88033]",
   payAsYouGo: "bg-[#97918A]",
 };
 
-const PLAN_COLORS: Record<string, string> = {
-  "Pro plan": "bg-[#EDC43E]",
-  "Team plan": "bg-[#6B8DE3]",
+const PLAN_COLORS: Readonly<
+  Record<NonNullable<CreditSegment["tier"]>, string>
+> = {
+  pro: "bg-[#EDC43E]",
+  team: "bg-[#6B8DE3]",
 };
 
-function colorForSegment(seg: { category: string; label: string }): string {
+function colorForSegment(seg: CreditSegment): string {
   if (seg.category === "plan") {
-    return PLAN_COLORS[seg.label] ?? "bg-[#EDC43E]";
+    return seg.tier ? PLAN_COLORS[seg.tier] : "bg-[#EDC43E]";
   }
-  return CATEGORY_COLORS[seg.category] ?? "bg-[#97918A]";
+  return CATEGORY_COLORS[seg.category];
 }
 
-const CATEGORY_DESCRIPTIONS: Record<string, string> = {
+const CATEGORY_DESCRIPTIONS: Readonly<
+  Record<Exclude<CreditSegment["category"], "plan">, string>
+> = {
   free: "Starter credits, use until depleted",
   promotional: "Campaign credits, expires after a set period",
   payAsYouGo: "Auto-recharge credits, never expire",
 };
 
+function segmentKey(seg: CreditSegment): string {
+  // `buildCreditBreakdown` keys segments by `category:tier`, so the same
+  // composite is stable and unique across the array.
+  return seg.tier ? `${seg.category}:${seg.tier}` : seg.category;
+}
+
 function descriptionForSegment(
-  seg: { category: string; label: string },
+  seg: CreditSegment,
   currentTier: string,
 ): string {
   if (seg.category !== "plan") {
-    return CATEGORY_DESCRIPTIONS[seg.category] ?? "";
+    return CATEGORY_DESCRIPTIONS[seg.category];
   }
-  const segTier = seg.label.replace(" plan", "").toLowerCase();
-  if (segTier === currentTier) {
+  if (seg.tier === currentTier) {
     return "Monthly plan credits, resets each billing cycle";
   }
   return "Leftover credits from previous plan";
 }
 
 function CreditBalanceChart({ billing }: { billing: BillingStatusResponse }) {
-  const segments = billing.creditBreakdown.filter((s) => s.credits > 0);
+  const segments = billing.creditBreakdown.filter((s) => {
+    return s.credits > 0;
+  });
   const total = billing.credits;
 
   return (
@@ -96,11 +111,11 @@ function CreditBalanceChart({ billing }: { billing: BillingStatusResponse }) {
           {/* Bar */}
           <TooltipProvider delayDuration={100}>
             <div className="flex h-2.5 w-full rounded-full bg-muted/40">
-              {segments.map((s, i) => {
+              {segments.map((s) => {
                 const color = colorForSegment(s);
                 const desc = descriptionForSegment(s, billing.tier);
                 return (
-                  <Tooltip key={`${s.category}-${i}`}>
+                  <Tooltip key={segmentKey(s)}>
                     <TooltipTrigger asChild>
                       <div
                         className={`h-2.5 ${color} cursor-default first:rounded-l-full last:rounded-r-full ring-0 hover:ring-2 hover:ring-foreground/30 hover:z-10 transition-shadow`}
@@ -128,11 +143,11 @@ function CreditBalanceChart({ billing }: { billing: BillingStatusResponse }) {
 
           {/* Legend */}
           <div className="flex flex-wrap gap-x-4 gap-y-1">
-            {segments.map((s, i) => {
+            {segments.map((s) => {
               const color = colorForSegment(s);
               return (
                 <div
-                  key={`${s.category}-${i}`}
+                  key={segmentKey(s)}
                   className="flex items-center gap-1.5 text-xs text-muted-foreground"
                 >
                   <span

--- a/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
@@ -231,6 +231,58 @@ describe("GET /api/zero/billing/status", () => {
     expect(data.credits).toBe(100_000);
   });
 
+  it("maps auto_recharge expires records to Pay as you go segment", async () => {
+    const { orgId } = await context.setupUser({ prefix: "payg-user" });
+    await setOrgCredits(orgId, 40_000);
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus-payg"),
+      stripeSubscriptionId: uniqueId("sub-payg"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: new Date("2026-05-20T00:00:00Z"),
+      tier: "pro",
+    });
+
+    // Pro monthly grant
+    await insertCreditExpiresRecord({
+      orgId,
+      source: "subscription_renewal",
+      amount: 20_000,
+      expiresAt: new Date("2026-06-20T00:00:00Z"),
+      stripeInvoiceId: uniqueId("inv-sub"),
+    });
+    // Two separate auto-recharge top-ups — must merge into a single segment
+    await insertCreditExpiresRecord({
+      orgId,
+      source: "auto_recharge",
+      amount: 10_000,
+      expiresAt: new Date("2999-12-31T00:00:00Z"),
+      stripeInvoiceId: uniqueId("inv-ar1"),
+    });
+    await insertCreditExpiresRecord({
+      orgId,
+      source: "auto_recharge",
+      amount: 10_000,
+      expiresAt: new Date("2999-12-31T00:00:00Z"),
+      stripeInvoiceId: uniqueId("inv-ar2"),
+    });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/billing/status"),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const payg = data.creditBreakdown.find((s: { category: string }) => {
+      return s.category === "payAsYouGo";
+    });
+    expect(payg).toEqual({
+      category: "payAsYouGo",
+      label: "Pay as you go",
+      credits: 20_000,
+    });
+  });
+
   it("returns defaults when org row does not exist", async () => {
     const newOrgId = uniqueId("org-norow");
     const newSlug = `billing-norow-${Date.now()}`;

--- a/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
@@ -283,6 +283,268 @@ describe("GET /api/zero/billing/status", () => {
     });
   });
 
+  it("maps subscription_renewal at Pro amount to Pro plan segment", async () => {
+    const { orgId } = await context.setupUser({ prefix: "pro-renewal" });
+    await setOrgCredits(orgId, 20_000);
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus-pro"),
+      stripeSubscriptionId: uniqueId("sub-pro"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: new Date("2026-05-20T00:00:00Z"),
+      tier: "pro",
+    });
+
+    await insertCreditExpiresRecord({
+      orgId,
+      source: "subscription_renewal",
+      amount: 20_000,
+      expiresAt: new Date("2026-06-20T00:00:00Z"),
+      stripeInvoiceId: uniqueId("inv-pro"),
+    });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/billing/status"),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.creditBreakdown).toEqual([
+      {
+        category: "plan",
+        label: "Pro plan",
+        credits: 20_000,
+        tier: "pro",
+      },
+    ]);
+  });
+
+  it("maps subscription_renewal at Team amount to Team plan segment", async () => {
+    const { orgId } = await context.setupUser({ prefix: "team-renewal" });
+    await setOrgCredits(orgId, 120_000);
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus-team"),
+      stripeSubscriptionId: uniqueId("sub-team"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: new Date("2026-05-20T00:00:00Z"),
+      tier: "team",
+    });
+
+    await insertCreditExpiresRecord({
+      orgId,
+      source: "subscription_renewal",
+      amount: 120_000,
+      expiresAt: new Date("2026-06-20T00:00:00Z"),
+      stripeInvoiceId: uniqueId("inv-team"),
+    });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/billing/status"),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.creditBreakdown).toEqual([
+      {
+        category: "plan",
+        label: "Team plan",
+        credits: 120_000,
+        tier: "team",
+      },
+    ]);
+  });
+
+  it("shows Team plan leftover alongside current Pro plan for a downgraded org", async () => {
+    // Pro-tier org that still has unused credits from a prior Team renewal.
+    const { orgId } = await context.setupUser({ prefix: "leftover-team" });
+    await setOrgCredits(orgId, 20_000 + 40_000);
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus-leftover"),
+      stripeSubscriptionId: uniqueId("sub-leftover"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: new Date("2026-05-20T00:00:00Z"),
+      tier: "pro",
+    });
+
+    // Current Pro monthly grant
+    await insertCreditExpiresRecord({
+      orgId,
+      source: "subscription_renewal",
+      amount: 20_000,
+      expiresAt: new Date("2026-06-20T00:00:00Z"),
+      stripeInvoiceId: uniqueId("inv-pro-leftover"),
+    });
+    // Leftover Team renewal from previous cycle
+    await insertCreditExpiresRecord({
+      orgId,
+      source: "subscription_renewal",
+      amount: 120_000,
+      remaining: 40_000,
+      expiresAt: new Date("2026-07-20T00:00:00Z"),
+      stripeInvoiceId: uniqueId("inv-team-leftover"),
+    });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/billing/status"),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.creditBreakdown).toEqual([
+      {
+        category: "plan",
+        label: "Pro plan",
+        credits: 20_000,
+        tier: "pro",
+      },
+      {
+        category: "plan",
+        label: "Team plan",
+        credits: 40_000,
+        tier: "team",
+      },
+    ]);
+  });
+
+  it("maps starter_grant records to Free plan segment", async () => {
+    const { orgId } = await context.setupUser({ prefix: "starter" });
+    await setOrgCredits(orgId, 10_000);
+
+    await insertCreditExpiresRecord({
+      orgId,
+      source: "starter_grant",
+      amount: 10_000,
+      expiresAt: new Date("2099-12-31T00:00:00Z"),
+      stripeInvoiceId: uniqueId("inv-starter"),
+    });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/billing/status"),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const free = data.creditBreakdown.find((s: { category: string }) => {
+      return s.category === "free";
+    });
+    expect(free).toEqual({
+      category: "free",
+      label: "Free plan",
+      credits: 10_000,
+    });
+  });
+
+  it("maps one_time_purchase records to Promotional segment", async () => {
+    const { orgId } = await context.setupUser({ prefix: "promo-user" });
+    await setOrgCredits(orgId, 5_000);
+
+    await insertCreditExpiresRecord({
+      orgId,
+      source: "one_time_purchase",
+      amount: 5_000,
+      expiresAt: new Date("2099-12-31T00:00:00Z"),
+      stripeInvoiceId: uniqueId("inv-promo"),
+    });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/billing/status"),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const promo = data.creditBreakdown.find((s: { category: string }) => {
+      return s.category === "promotional";
+    });
+    expect(promo).toEqual({
+      category: "promotional",
+      label: "Promotional",
+      credits: 5_000,
+    });
+  });
+
+  it("surfaces untracked paid-tier balance as Pay as you go fallback", async () => {
+    // Paid-tier org whose ledger shows more credits than any active expires
+    // record accounts for (pre-sentinel top-up / historical drift).
+    const { orgId } = await context.setupUser({ prefix: "untracked-pro" });
+    await setOrgCredits(orgId, 25_000);
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus-untracked"),
+      stripeSubscriptionId: uniqueId("sub-untracked"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: new Date("2026-05-20T00:00:00Z"),
+      tier: "pro",
+    });
+
+    // Only 20k is tracked via the Pro renewal record
+    await insertCreditExpiresRecord({
+      orgId,
+      source: "subscription_renewal",
+      amount: 20_000,
+      expiresAt: new Date("2026-06-20T00:00:00Z"),
+      stripeInvoiceId: uniqueId("inv-untracked-sub"),
+    });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/billing/status"),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.creditBreakdown).toEqual([
+      {
+        category: "plan",
+        label: "Pro plan",
+        credits: 20_000,
+        tier: "pro",
+      },
+      {
+        category: "payAsYouGo",
+        label: "Pay as you go",
+        credits: 5_000,
+      },
+    ]);
+  });
+
+  it("merges untracked balance on free tier into Free plan segment", async () => {
+    // Free-tier org where `org_metadata.credits` exceeds the starter_grant
+    // record's remaining. The delta should render under "Free plan", not
+    // "Pay as you go".
+    const { orgId } = await context.setupUser({ prefix: "untracked-free" });
+    await setOrgCredits(orgId, 12_000);
+
+    await insertCreditExpiresRecord({
+      orgId,
+      source: "starter_grant",
+      amount: 10_000,
+      expiresAt: new Date("2099-12-31T00:00:00Z"),
+      stripeInvoiceId: uniqueId("inv-free-starter"),
+    });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/billing/status"),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const free = data.creditBreakdown.find((s: { category: string }) => {
+      return s.category === "free";
+    });
+    expect(free).toEqual({
+      category: "free",
+      label: "Free plan",
+      credits: 12_000,
+    });
+    // No "Pay as you go" segment should be emitted on free tier.
+    expect(
+      data.creditBreakdown.find((s: { category: string }) => {
+        return s.category === "payAsYouGo";
+      }),
+    ).toBeUndefined();
+  });
+
   it("returns defaults when org row does not exist", async () => {
     const newOrgId = uniqueId("org-norow");
     const newSlug = `billing-norow-${Date.now()}`;

--- a/turbo/apps/web/proxy.layers.ts
+++ b/turbo/apps/web/proxy.layers.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import createIntlMiddleware from "next-intl/middleware";
-import { handleCors } from "./proxy.cors";
 import { locales, defaultLocale } from "./i18n";
 
 // ---------------------------------------------------------------------------
@@ -152,14 +151,6 @@ export const legalRedirectLayer: ProxyLayer = (ctx) => {
     const target = new URL(ctx.request.nextUrl);
     target.pathname = `/${match[2]}${match[3] ?? ""}`;
     return NextResponse.redirect(target, 308);
-  }
-  return null;
-};
-
-/** Handle CORS for API routes. Always short-circuits for "api" routes. */
-export const corsLayer: ProxyLayer = (ctx) => {
-  if (ctx.routeKind === "api") {
-    return handleCors(ctx.request);
   }
   return null;
 };

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import type { NextFetchEvent } from "next/server";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import {
   runLayers,
   authRedirectLayer,

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -3,7 +3,6 @@ import type { NextFetchEvent } from "next/server";
 import { NextRequest, NextResponse } from "next/server";
 import {
   runLayers,
-  corsLayer,
   authRedirectLayer,
   legalRedirectLayer,
   localeGuardLayer,
@@ -81,8 +80,9 @@ const clerk = clerkMiddleware(async (auth, request: NextRequest) => {
     }
   }
 
+  // CORS for API routes is handled in the outer middleware (before Clerk),
+  // so we skip corsLayer here. Only non-API layers remain.
   return runLayers(request, [
-    corsLayer,
     authRedirectLayer,
     legalRedirectLayer,
     localeGuardLayer,
@@ -108,13 +108,12 @@ export default async function middleware(
   request: NextRequest,
   event: NextFetchEvent,
 ) {
+  const isApiRoute = request.nextUrl.pathname.startsWith("/api/");
+
   // Handle CORS preflight before Clerk — OPTIONS requests carry no credentials,
   // and Clerk may add x-middleware-next to the response which prevents Next.js
   // from returning our 200 directly.
-  if (
-    request.method === "OPTIONS" &&
-    request.nextUrl.pathname.startsWith("/api/")
-  ) {
+  if (isApiRoute && request.method === "OPTIONS") {
     return handleCors(request);
   }
 
@@ -127,7 +126,7 @@ export default async function middleware(
   // (verified server-side). Bypass Clerk middleware entirely so its session
   // detection never touches the opaque Bearer tokens it cannot parse.
   if (request.nextUrl.pathname.startsWith("/api/v1/")) {
-    return NextResponse.next();
+    return handleCors(request);
   }
 
   // Self-signed tokens (sandbox, PAT) are only consumed by /api/* endpoints.
@@ -136,8 +135,8 @@ export default async function middleware(
   // calling Clerk so auth() in server components resolves to an anonymous
   // session instead of throwing "clerkMiddleware not detected".
   if (hasSelfSignedToken) {
-    if (request.nextUrl.pathname.startsWith("/api/")) {
-      return NextResponse.next();
+    if (isApiRoute) {
+      return handleCors(request);
     }
     const scrubbedHeaders = new Headers(request.headers);
     scrubbedHeaders.delete("authorization");
@@ -147,7 +146,20 @@ export default async function middleware(
     return clerk(scrubbedRequest, event);
   }
 
-  return clerk(request, event);
+  const response = await clerk(request, event);
+
+  // Ensure CORS headers are present on all API responses, even if Clerk
+  // or an inner layer failed to set them (e.g. Clerk error, layer bypass).
+  if (isApiRoute && response) {
+    const corsResponse = handleCors(request);
+    const allowOrigin = corsResponse.headers.get("Access-Control-Allow-Origin");
+    if (allowOrigin && !response.headers.get("Access-Control-Allow-Origin")) {
+      response.headers.set("Access-Control-Allow-Origin", allowOrigin);
+      response.headers.set("Access-Control-Allow-Credentials", "true");
+    }
+  }
+
+  return response;
 }
 
 export const config = {

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -148,12 +148,17 @@ export default async function middleware(
 
   const response = await clerk(request, event);
 
-  // Ensure CORS headers are present on all API responses, even if Clerk
-  // or an inner layer failed to set them (e.g. Clerk error, layer bypass).
+  // API responses from Clerk carry no CORS headers — the inner `corsLayer`
+  // was removed so Clerk's auth.protect() redirects aren't shadowed by a
+  // CORS early-return. Apply response-side CORS headers here so browsers can
+  // read cross-origin authenticated responses. Preflight is handled above,
+  // so only Allow-Origin and Allow-Credentials are needed for actual
+  // requests. `handleCors` performs origin-allowlist validation.
   if (isApiRoute && response) {
-    const corsResponse = handleCors(request);
-    const allowOrigin = corsResponse.headers.get("Access-Control-Allow-Origin");
-    if (allowOrigin && !response.headers.get("Access-Control-Allow-Origin")) {
+    const allowOrigin = handleCors(request).headers.get(
+      "Access-Control-Allow-Origin",
+    );
+    if (allowOrigin) {
       response.headers.set("Access-Control-Allow-Origin", allowOrigin);
       response.headers.set("Access-Control-Allow-Credentials", "true");
     }

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -1002,12 +1002,7 @@ export async function getBillingStatus(orgId: string): Promise<{
     expiringNextCycle: number;
     nextExpiryDate: Date | null;
   };
-  creditBreakdown: Array<{
-    category: CreditBreakdownCategory;
-    label: string;
-    credits: number;
-    tier?: "pro" | "team";
-  }>;
+  creditBreakdown: CreditBreakdownSegment[];
 }> {
   const db = globalThis.services.db;
   const [org] = await db

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -842,6 +842,82 @@ export async function getOrgInvoices(orgId: string): Promise<{
   return { invoices };
 }
 
+interface CreditBreakdownSegment {
+  category: string;
+  label: string;
+  credits: number;
+}
+
+/**
+ * Build the Usage-tab credit breakdown from active expires records.
+ *
+ * - `subscription_renewal` → "<Tier> plan" under category `plan`, tier derived
+ *   from the record's amount so leftover credits from a previous tier (e.g. a
+ *   Team user that dropped to Pro) render under their original tier label.
+ * - `starter_grant` → "Free plan".
+ * - `one_time_purchase` → "Promotional".
+ * - `auto_recharge` → "Pay as you go" (sentinel record from #10668).
+ *
+ * Legacy balance not backed by any active record (pre-sentinel top-ups,
+ * ledger drift) is surfaced as "Pay as you go" for paid tiers or "Free plan"
+ * for free, so the segments always sum to `displayedCredits`.
+ */
+function buildCreditBreakdown(args: {
+  tier: string;
+  displayedCredits: number;
+  records: Array<{ source: string; amount: number; remaining: number }>;
+}): CreditBreakdownSegment[] {
+  const { tier, displayedCredits, records } = args;
+
+  const planTierFromAmount = (amount: number): string => {
+    if (amount === TIER_MONTHLY_CREDITS.team) return "Team";
+    if (amount === TIER_MONTHLY_CREDITS.pro) return "Pro";
+    return tier.charAt(0).toUpperCase() + tier.slice(1);
+  };
+
+  const labelCredits = new Map<string, CreditBreakdownSegment>();
+  const addSegment = (category: string, label: string, credits: number) => {
+    const existing = labelCredits.get(label);
+    if (existing) {
+      existing.credits += credits;
+    } else {
+      labelCredits.set(label, { category, label, credits });
+    }
+  };
+
+  let trackedTotal = 0;
+  for (const r of records) {
+    trackedTotal += r.remaining;
+    if (r.source === "subscription_renewal") {
+      addSegment("plan", `${planTierFromAmount(r.amount)} plan`, r.remaining);
+    } else if (r.source === "starter_grant") {
+      addSegment("free", "Free plan", r.remaining);
+    } else if (r.source === "one_time_purchase") {
+      addSegment("promotional", "Promotional", r.remaining);
+    } else if (r.source === "auto_recharge") {
+      addSegment("payAsYouGo", "Pay as you go", r.remaining);
+    }
+  }
+
+  const untracked = Math.max(displayedCredits - trackedTotal, 0);
+  if (untracked > 0) {
+    if (tier === "free") {
+      addSegment("free", "Free plan", untracked);
+    } else {
+      addSegment("payAsYouGo", "Pay as you go", untracked);
+    }
+  }
+
+  const categoryOrder = ["plan", "free", "promotional", "payAsYouGo"];
+  const segments = Array.from(labelCredits.values());
+  segments.sort((a, b) => {
+    return (
+      categoryOrder.indexOf(a.category) - categoryOrder.indexOf(b.category)
+    );
+  });
+  return segments;
+}
+
 /**
  * Get billing status for an org.
  */
@@ -890,66 +966,7 @@ export async function getBillingStatus(orgId: string): Promise<{
   const displayedCredits = Math.max(rawCredits - unsettledExpired, 0);
   const tier = org?.tier ?? "free";
 
-  // Build breakdown segments from individual credit records.
-  // subscription_renewal records are matched to tier by amount.
-  const breakdown: Array<{
-    category: string;
-    label: string;
-    credits: number;
-  }> = [];
-  const planTierFromAmount = (amount: number): string => {
-    if (amount === TIER_MONTHLY_CREDITS.team) return "Team";
-    if (amount === TIER_MONTHLY_CREDITS.pro) return "Pro";
-    const name = tier.charAt(0).toUpperCase() + tier.slice(1);
-    return name;
-  };
-
-  // Accumulate by label to merge records with the same label
-  const labelCredits = new Map<
-    string,
-    { category: string; label: string; credits: number }
-  >();
-  const addSegment = (category: string, label: string, credits: number) => {
-    const existing = labelCredits.get(label);
-    if (existing) {
-      existing.credits += credits;
-    } else {
-      labelCredits.set(label, { category, label, credits });
-    }
-  };
-
-  for (const r of records) {
-    if (r.source === "subscription_renewal") {
-      const tierName = planTierFromAmount(r.amount);
-      addSegment("plan", `${tierName} plan`, r.remaining);
-    } else if (r.source === "starter_grant") {
-      addSegment("free", "Free plan", r.remaining);
-    } else if (r.source === "one_time_purchase") {
-      addSegment("promotional", "Promotional", r.remaining);
-    }
-  }
-
-  // Untracked credits (auto-recharge or legacy data)
-  const trackedTotal = records.reduce((sum, r) => sum + r.remaining, 0);
-  const untracked = Math.max(displayedCredits - trackedTotal, 0);
-  if (untracked > 0) {
-    if (tier === "free") {
-      addSegment("free", "Free plan", untracked);
-    } else {
-      addSegment("payAsYouGo", "Pay as you go", untracked);
-    }
-  }
-
-  // Order: plan entries first, then free, promotional, payAsYouGo
-  const categoryOrder = ["plan", "free", "promotional", "payAsYouGo"];
-  for (const [, seg] of labelCredits) {
-    breakdown.push(seg);
-  }
-  breakdown.sort((a, b) => {
-    return (
-      categoryOrder.indexOf(a.category) - categoryOrder.indexOf(b.category)
-    );
-  });
+  const breakdown = buildCreditBreakdown({ tier, displayedCredits, records });
 
   return {
     tier,

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -842,10 +842,14 @@ export async function getOrgInvoices(orgId: string): Promise<{
   return { invoices };
 }
 
+type CreditBreakdownCategory = "plan" | "free" | "promotional" | "payAsYouGo";
+
 interface CreditBreakdownSegment {
-  category: string;
+  category: CreditBreakdownCategory;
   label: string;
   credits: number;
+  /** Only set on `plan` segments. */
+  tier?: "pro" | "team";
 }
 
 /**
@@ -854,34 +858,45 @@ interface CreditBreakdownSegment {
  * - `subscription_renewal` → "<Tier> plan" under category `plan`, tier derived
  *   from the record's amount so leftover credits from a previous tier (e.g. a
  *   Team user that dropped to Pro) render under their original tier label.
+ *   The raw `tier` (`"pro" | "team"`) is also emitted on each plan segment so
+ *   UI callers don't have to round-trip through the display label.
  * - `starter_grant` → "Free plan".
  * - `one_time_purchase` → "Promotional".
  * - `auto_recharge` → "Pay as you go" (sentinel record from #10668).
  *
  * Legacy balance not backed by any active record (pre-sentinel top-ups,
  * ledger drift) is surfaced as "Pay as you go" for paid tiers or "Free plan"
- * for free, so the segments always sum to `displayedCredits`.
+ * for free, so the segments always sum to `displayedCredits`. When a non-zero
+ * untracked delta is observed we emit a `logger.warn` so ops can track drift.
  */
 function buildCreditBreakdown(args: {
+  orgId: string;
   tier: string;
   displayedCredits: number;
   records: Array<{ source: string; amount: number; remaining: number }>;
 }): CreditBreakdownSegment[] {
-  const { tier, displayedCredits, records } = args;
+  const { orgId, tier, displayedCredits, records } = args;
 
-  const planTierFromAmount = (amount: number): string => {
-    if (amount === TIER_MONTHLY_CREDITS.team) return "Team";
-    if (amount === TIER_MONTHLY_CREDITS.pro) return "Pro";
-    return tier.charAt(0).toUpperCase() + tier.slice(1);
+  // Returns `null` when the amount doesn't match any known tier — caller will
+  // skip emitting a plan segment for such a record, avoiding a fabricated tier.
+  const planTierFromAmount = (amount: number): "pro" | "team" | null => {
+    if (amount === TIER_MONTHLY_CREDITS.team) return "team";
+    if (amount === TIER_MONTHLY_CREDITS.pro) return "pro";
+    return null;
   };
 
-  const labelCredits = new Map<string, CreditBreakdownSegment>();
-  const addSegment = (category: string, label: string, credits: number) => {
-    const existing = labelCredits.get(label);
+  const segmentKey = (category: CreditBreakdownCategory, tierKey?: string) => {
+    return tierKey ? `${category}:${tierKey}` : category;
+  };
+
+  const byKey = new Map<string, CreditBreakdownSegment>();
+  const addSegment = (segment: CreditBreakdownSegment) => {
+    const key = segmentKey(segment.category, segment.tier);
+    const existing = byKey.get(key);
     if (existing) {
-      existing.credits += credits;
+      existing.credits += segment.credits;
     } else {
-      labelCredits.set(label, { category, label, credits });
+      byKey.set(key, { ...segment });
     }
   };
 
@@ -889,27 +904,77 @@ function buildCreditBreakdown(args: {
   for (const r of records) {
     trackedTotal += r.remaining;
     if (r.source === "subscription_renewal") {
-      addSegment("plan", `${planTierFromAmount(r.amount)} plan`, r.remaining);
+      const planTier = planTierFromAmount(r.amount);
+      if (!planTier) {
+        log.warn("subscription_renewal amount does not match any tier", {
+          orgId,
+          amount: r.amount,
+          remaining: r.remaining,
+        });
+        // Fall through: surface the remaining as untracked so the bar still
+        // sums to `displayedCredits`.
+        trackedTotal -= r.remaining;
+        continue;
+      }
+      const label = planTier === "team" ? "Team plan" : "Pro plan";
+      addSegment({
+        category: "plan",
+        label,
+        credits: r.remaining,
+        tier: planTier,
+      });
     } else if (r.source === "starter_grant") {
-      addSegment("free", "Free plan", r.remaining);
+      addSegment({
+        category: "free",
+        label: "Free plan",
+        credits: r.remaining,
+      });
     } else if (r.source === "one_time_purchase") {
-      addSegment("promotional", "Promotional", r.remaining);
+      addSegment({
+        category: "promotional",
+        label: "Promotional",
+        credits: r.remaining,
+      });
     } else if (r.source === "auto_recharge") {
-      addSegment("payAsYouGo", "Pay as you go", r.remaining);
+      addSegment({
+        category: "payAsYouGo",
+        label: "Pay as you go",
+        credits: r.remaining,
+      });
     }
   }
 
   const untracked = Math.max(displayedCredits - trackedTotal, 0);
   if (untracked > 0) {
+    log.warn("credit breakdown has untracked balance", {
+      orgId,
+      tier,
+      displayedCredits,
+      trackedTotal,
+      untracked,
+    });
     if (tier === "free") {
-      addSegment("free", "Free plan", untracked);
+      addSegment({
+        category: "free",
+        label: "Free plan",
+        credits: untracked,
+      });
     } else {
-      addSegment("payAsYouGo", "Pay as you go", untracked);
+      addSegment({
+        category: "payAsYouGo",
+        label: "Pay as you go",
+        credits: untracked,
+      });
     }
   }
 
-  const categoryOrder = ["plan", "free", "promotional", "payAsYouGo"];
-  const segments = Array.from(labelCredits.values());
+  const categoryOrder: CreditBreakdownCategory[] = [
+    "plan",
+    "free",
+    "promotional",
+    "payAsYouGo",
+  ];
+  const segments = Array.from(byKey.values());
   segments.sort((a, b) => {
     return (
       categoryOrder.indexOf(a.category) - categoryOrder.indexOf(b.category)
@@ -937,7 +1002,12 @@ export async function getBillingStatus(orgId: string): Promise<{
     expiringNextCycle: number;
     nextExpiryDate: Date | null;
   };
-  creditBreakdown: Array<{ category: string; label: string; credits: number }>;
+  creditBreakdown: Array<{
+    category: CreditBreakdownCategory;
+    label: string;
+    credits: number;
+    tier?: "pro" | "team";
+  }>;
 }> {
   const db = globalThis.services.db;
   const [org] = await db
@@ -966,7 +1036,12 @@ export async function getBillingStatus(orgId: string): Promise<{
   const displayedCredits = Math.max(rawCredits - unsettledExpired, 0);
   const tier = org?.tier ?? "free";
 
-  const breakdown = buildCreditBreakdown({ tier, displayedCredits, records });
+  const breakdown = buildCreditBreakdown({
+    orgId,
+    tier,
+    displayedCredits,
+    records,
+  });
 
   return {
     tier,

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -11,6 +11,7 @@ import {
   expireCredits,
   getExpiresRecordsSummary,
   getUnsettledExpiredAmount,
+  getCreditBreakdownRecords,
 } from "../credit/credit-expires-service";
 import { getCampaign } from "./one-time-products";
 import { ensureStarterCreditGrant } from "../credit/starter-grant-service";
@@ -860,6 +861,7 @@ export async function getBillingStatus(orgId: string): Promise<{
     expiringNextCycle: number;
     nextExpiryDate: Date | null;
   };
+  creditBreakdown: Array<{ category: string; label: string; credits: number }>;
 }> {
   const db = globalThis.services.db;
   const [org] = await db
@@ -878,18 +880,79 @@ export async function getBillingStatus(orgId: string): Promise<{
     .where(eq(orgMetadata.orgId, orgId))
     .limit(1);
 
-  const expirySummary = await getExpiresRecordsSummary(orgId);
+  const [expirySummary, unsettledExpired, records] = await Promise.all([
+    getExpiresRecordsSummary(orgId),
+    getUnsettledExpiredAmount(orgId),
+    getCreditBreakdownRecords(orgId),
+  ]);
 
-  // Subtract not-yet-settled expired credits so the displayed balance matches
-  // what the user can actually spend. Dormant non-subscription orgs never hit
-  // `expireCredits` until their next run, so the raw `credits` column can be
-  // inflated until then — this keeps the UI honest in the meantime.
-  const unsettledExpired = await getUnsettledExpiredAmount(orgId);
   const rawCredits = org?.credits ?? 0;
   const displayedCredits = Math.max(rawCredits - unsettledExpired, 0);
+  const tier = org?.tier ?? "free";
+
+  // Build breakdown segments from individual credit records.
+  // subscription_renewal records are matched to tier by amount.
+  const breakdown: Array<{
+    category: string;
+    label: string;
+    credits: number;
+  }> = [];
+  const planTierFromAmount = (amount: number): string => {
+    if (amount === TIER_MONTHLY_CREDITS.team) return "Team";
+    if (amount === TIER_MONTHLY_CREDITS.pro) return "Pro";
+    const name = tier.charAt(0).toUpperCase() + tier.slice(1);
+    return name;
+  };
+
+  // Accumulate by label to merge records with the same label
+  const labelCredits = new Map<
+    string,
+    { category: string; label: string; credits: number }
+  >();
+  const addSegment = (category: string, label: string, credits: number) => {
+    const existing = labelCredits.get(label);
+    if (existing) {
+      existing.credits += credits;
+    } else {
+      labelCredits.set(label, { category, label, credits });
+    }
+  };
+
+  for (const r of records) {
+    if (r.source === "subscription_renewal") {
+      const tierName = planTierFromAmount(r.amount);
+      addSegment("plan", `${tierName} plan`, r.remaining);
+    } else if (r.source === "starter_grant") {
+      addSegment("free", "Free plan", r.remaining);
+    } else if (r.source === "one_time_purchase") {
+      addSegment("promotional", "Promotional", r.remaining);
+    }
+  }
+
+  // Untracked credits (auto-recharge or legacy data)
+  const trackedTotal = records.reduce((sum, r) => sum + r.remaining, 0);
+  const untracked = Math.max(displayedCredits - trackedTotal, 0);
+  if (untracked > 0) {
+    if (tier === "free") {
+      addSegment("free", "Free plan", untracked);
+    } else {
+      addSegment("payAsYouGo", "Pay as you go", untracked);
+    }
+  }
+
+  // Order: plan entries first, then free, promotional, payAsYouGo
+  const categoryOrder = ["plan", "free", "promotional", "payAsYouGo"];
+  for (const [, seg] of labelCredits) {
+    breakdown.push(seg);
+  }
+  breakdown.sort((a, b) => {
+    return (
+      categoryOrder.indexOf(a.category) - categoryOrder.indexOf(b.category)
+    );
+  });
 
   return {
-    tier: org?.tier ?? "free",
+    tier,
     credits: displayedCredits,
     subscriptionStatus: org?.subscriptionStatus ?? null,
     currentPeriodEnd: org?.currentPeriodEnd ?? null,
@@ -901,5 +964,6 @@ export async function getBillingStatus(orgId: string): Promise<{
       amount: org?.autoRechargeAmount ?? null,
     },
     creditExpiry: expirySummary,
+    creditBreakdown: breakdown,
   };
 }

--- a/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
@@ -1,4 +1,4 @@
-import { eq, and, gt, lte, asc, sql, sum } from "drizzle-orm";
+import { eq, and, gt, lte, asc, sql } from "drizzle-orm";
 import { creditExpiresRecord } from "../../../db/schema/credit-expires-record";
 import { orgMetadata } from "../../../db/schema/org-metadata";
 import { logger } from "../../shared/logger";

--- a/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
@@ -1,4 +1,4 @@
-import { eq, and, gt, lte, asc, sql } from "drizzle-orm";
+import { eq, and, gt, lte, asc, sql, sum } from "drizzle-orm";
 import { creditExpiresRecord } from "../../../db/schema/credit-expires-record";
 import { orgMetadata } from "../../../db/schema/org-metadata";
 import { logger } from "../../shared/logger";
@@ -218,4 +218,30 @@ export async function getExpiresRecordsSummary(orgId: string): Promise<{
     }, 0);
 
   return { expiringNextCycle, nextExpiryDate };
+}
+
+/**
+ * Remaining credits for active (non-expired) records, returned as individual
+ * rows so callers can distinguish subscription_renewal records from different
+ * tiers (e.g. pro=20k vs team=120k).
+ */
+export async function getCreditBreakdownRecords(
+  orgId: string,
+): Promise<Array<{ source: string; amount: number; remaining: number }>> {
+  const db = globalThis.services.db;
+
+  return db
+    .select({
+      source: creditExpiresRecord.source,
+      amount: creditExpiresRecord.amount,
+      remaining: creditExpiresRecord.remaining,
+    })
+    .from(creditExpiresRecord)
+    .where(
+      and(
+        eq(creditExpiresRecord.orgId, orgId),
+        gt(creditExpiresRecord.remaining, 0),
+        gt(creditExpiresRecord.expiresAt, new Date()),
+      ),
+    );
 }

--- a/turbo/packages/core/src/contracts/zero-billing.ts
+++ b/turbo/packages/core/src/contracts/zero-billing.ts
@@ -20,9 +20,13 @@ const creditExpirySchema = z.object({
 });
 
 const creditBreakdownSegmentSchema = z.object({
-  category: z.string(),
+  category: z.enum(["plan", "free", "promotional", "payAsYouGo"]),
   label: z.string(),
   credits: z.number(),
+  // Only set on `plan` segments. Lets the UI decide whether a segment
+  // represents the current plan or leftover credits from a previous plan
+  // without round-tripping through the `label` string.
+  tier: z.enum(["pro", "team"]).optional(),
 });
 
 const billingStatusResponseSchema = z.object({

--- a/turbo/packages/core/src/contracts/zero-billing.ts
+++ b/turbo/packages/core/src/contracts/zero-billing.ts
@@ -19,6 +19,12 @@ const creditExpirySchema = z.object({
   nextExpiryDate: z.string().nullable(),
 });
 
+const creditBreakdownSegmentSchema = z.object({
+  category: z.string(),
+  label: z.string(),
+  credits: z.number(),
+});
+
 const billingStatusResponseSchema = z.object({
   tier: z.string(),
   credits: z.number(),
@@ -28,6 +34,7 @@ const billingStatusResponseSchema = z.object({
   hasSubscription: z.boolean(),
   autoRecharge: autoRechargeSchema,
   creditExpiry: creditExpirySchema,
+  creditBreakdown: z.array(creditBreakdownSegmentSchema),
 });
 
 const checkoutResponseSchema = z.object({


### PR DESCRIPTION
## Summary
- Add credit balance breakdown in the Usage tab as a horizontal stacked bar chart with hover tooltips
- Credits are broken down by source: plan (Pro/Team), free, promotional, and pay-as-you-go
- Each plan tier gets its own color and label; leftover credits from a previous tier are described as such
- Fix CORS handling: bypass paths (`/api/v1/`, self-signed tokens) now apply CORS headers; fallback ensures headers survive Clerk failures

## Changes
- **`billing-service.ts`** — `getBillingStatus` returns `creditBreakdown` array with per-record segments, distinguishing Pro vs Team subscription credits by amount
- **`credit-expires-service.ts`** — New `getCreditBreakdownRecords` returning individual active records (replaces grouped query)
- **`zero-billing.ts`** (contract) — Add `creditBreakdown` array schema to billing status response
- **`org-usage-tab.tsx`** — `CreditBalanceChart` component with stacked bar, Radix Tooltip popovers, and avatar-palette colors
- **`proxy.ts` / `proxy.layers.ts`** — Consolidate CORS handling in outer middleware; remove `corsLayer` from `runLayers`

## Test plan
- [ ] Open Usage tab on free, pro, and team tier orgs — verify correct breakdown
- [ ] Hover bar chart segments — tooltip shows label, amount, and description
- [ ] Upgrade from Pro to Team — Pro segment shows "Leftover credits from previous plan"
- [ ] Verify CORS works for cross-origin API requests (platform → web)
- [ ] Existing billing and CORS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)