### PR TITLE
test(web): randomize agent names in compose tests to avoid pkey collisions

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
@@ -56,7 +57,9 @@ describe("GET /api/agent/composes/:id/instructions", () => {
 
   it("should return null content when compose has no instructions", async () => {
     // Create compose without instructions field
-    const { composeId } = await createTestCompose("no-instructions-agent");
+    const { composeId } = await createTestCompose(
+      uniqueId("no-instructions-agent"),
+    );
 
     const request = createTestRequest(
       `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
@@ -74,9 +77,12 @@ describe("GET /api/agent/composes/:id/instructions", () => {
 
   it("should return null content when instructions volume does not exist", async () => {
     // Create compose WITH instructions field but no storage volume
-    const { composeId } = await createTestCompose("has-instructions-agent", {
-      overrides: { instructions: "AGENTS.md" },
-    });
+    const { composeId } = await createTestCompose(
+      uniqueId("has-instructions-agent"),
+      {
+        overrides: { instructions: "AGENTS.md" },
+      },
+    );
 
     const request = createTestRequest(
       `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
@@ -184,7 +190,7 @@ describe("GET /api/agent/composes/:id/instructions", () => {
   it("should return 404 for non-shared user", async () => {
     // Owner creates agent
     await context.setupUser({ prefix: "private-owner" });
-    const { composeId } = await createTestCompose("private-agent", {
+    const { composeId } = await createTestCompose(uniqueId("private-agent"), {
       overrides: { instructions: "AGENTS.md" },
     });
 

--- a/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
@@ -69,7 +69,7 @@ describe("/api/github/oauth/callback", () => {
     const userId = uniqueId("gh-user");
     mockClerk({ userId });
     await createTestOrg(uniqueId("gh-org"));
-    const { composeId } = await createTestCompose("gh-test-agent");
+    const { composeId } = await createTestCompose(uniqueId("gh-test-agent"));
 
     const state = buildSignedState(userId, composeId);
     const request = createTestRequest(
@@ -117,7 +117,7 @@ describe("/api/github/oauth/callback", () => {
     const userId = uniqueId("gh-user");
     mockClerk({ userId });
     await createTestOrg(uniqueId("gh-org"));
-    const { composeId } = await createTestCompose("gh-test-agent");
+    const { composeId } = await createTestCompose(uniqueId("gh-test-agent"));
 
     const installationId = uniqueNumericId();
     server.use(
@@ -146,7 +146,7 @@ describe("/api/github/oauth/callback", () => {
     const userId = uniqueId("gh-user");
     mockClerk({ userId });
     await createTestOrg(uniqueId("gh-org"));
-    const { composeId } = await createTestCompose("gh-test-agent");
+    const { composeId } = await createTestCompose(uniqueId("gh-test-agent"));
 
     const installationId = uniqueNumericId();
     setupGitHubMocks(installationId);
@@ -176,7 +176,7 @@ describe("/api/github/oauth/callback", () => {
     const userId = uniqueId("gh-user");
     mockClerk({ userId });
     await createTestOrg(uniqueId("gh-org"));
-    const { composeId } = await createTestCompose("gh-test-agent");
+    const { composeId } = await createTestCompose(uniqueId("gh-test-agent"));
 
     const state = buildSignedState(userId, composeId);
     const targetId = uniqueId("target");
@@ -219,7 +219,7 @@ describe("/api/github/oauth/callback", () => {
     const userId = uniqueId("gh-user");
     mockClerk({ userId });
     await createTestOrg(uniqueId("gh-org"));
-    const { composeId } = await createTestCompose("gh-test-agent");
+    const { composeId } = await createTestCompose(uniqueId("gh-test-agent"));
 
     const installationId = uniqueNumericId();
     setupGitHubMocks(installationId);

--- a/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
@@ -55,7 +55,8 @@ describe("/api/integrations/github", () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
       await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-agent");
+      const agentName = uniqueId("gh-agent");
+      const { composeId } = await createTestCompose(agentName);
 
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
@@ -70,14 +71,14 @@ describe("/api/integrations/github", () => {
       expect(data.installation).toBeDefined();
       expect(data.installation.installationId).toBeTruthy();
       expect(data.agent).toBeDefined();
-      expect(data.agent.name).toBe("gh-agent");
+      expect(data.agent.name).toBe(agentName);
     });
 
     it("should return environment data in response", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
       await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-agent");
+      const { composeId } = await createTestCompose(uniqueId("gh-agent"));
 
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
@@ -130,7 +131,7 @@ describe("/api/integrations/github", () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
       await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-agent");
+      const { composeId } = await createTestCompose(uniqueId("gh-agent"));
 
       const { installation } = await insertTestGitHubInstallationWithAdmin(
         composeId,
@@ -159,7 +160,7 @@ describe("/api/integrations/github", () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
       await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-agent");
+      const { composeId } = await createTestCompose(uniqueId("gh-agent"));
 
       const installation = await insertTestGitHubInstallation(composeId);
       // Link user but leave adminGithubUserId as null (default)
@@ -191,7 +192,7 @@ describe("/api/integrations/github", () => {
       const adminUserId = uniqueId("admin-user");
       mockClerk({ userId: adminUserId });
       await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-agent");
+      const { composeId } = await createTestCompose(uniqueId("gh-agent"));
       const { installation } = await insertTestGitHubInstallationWithAdmin(
         composeId,
         adminUserId,
@@ -246,7 +247,7 @@ describe("/api/integrations/github", () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
       await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-agent");
+      const { composeId } = await createTestCompose(uniqueId("gh-agent"));
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
       const request = createTestRequest(
@@ -291,7 +292,7 @@ describe("/api/integrations/github", () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
       await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-agent");
+      const { composeId } = await createTestCompose(uniqueId("gh-agent"));
 
       const installation = await insertTestGitHubInstallation(composeId);
       // Link user but leave adminGithubUserId as null (default)
@@ -323,7 +324,7 @@ describe("/api/integrations/github", () => {
       const adminUserId = uniqueId("admin-user");
       mockClerk({ userId: adminUserId });
       await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-agent");
+      const { composeId } = await createTestCompose(uniqueId("gh-agent"));
       const { installation } = await insertTestGitHubInstallationWithAdmin(
         composeId,
         adminUserId,
@@ -360,7 +361,7 @@ describe("/api/integrations/github", () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
       await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-agent");
+      const { composeId } = await createTestCompose(uniqueId("gh-agent"));
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
       const request = createTestRequest(
@@ -384,11 +385,12 @@ describe("/api/integrations/github", () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
       await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-agent");
+      const { composeId } = await createTestCompose(uniqueId("gh-agent"));
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
       // Create a new agent to switch to
-      await createTestCompose("new-agent");
+      const newAgentName = uniqueId("new-agent");
+      await createTestCompose(newAgentName);
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",
@@ -397,7 +399,7 @@ describe("/api/integrations/github", () => {
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ agentName: "new-agent" }),
+          body: JSON.stringify({ agentName: newAgentName }),
         },
       );
       const response = await PATCH(request);
@@ -412,7 +414,7 @@ describe("/api/integrations/github", () => {
       );
       const getData = await getResponse.json();
 
-      expect(getData.agent.name).toBe("new-agent");
+      expect(getData.agent.name).toBe(newAgentName);
     });
   });
 });

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
@@ -83,7 +83,7 @@ async function givenGitHubCallbackSetup(overrides?: {
   const userId = uniqueId("gh-cb-user");
   mockClerk({ userId });
   await createTestOrg(uniqueId("gh-cb-org"));
-  const { composeId } = await createTestCompose("gh-callback-agent");
+  const { composeId } = await createTestCompose(uniqueId("gh-callback-agent"));
 
   const { runId } = await seedTestRun(userId, composeId, {
     prompt: "Test GitHub prompt",
@@ -293,7 +293,9 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       const userId = uniqueId("gh-missing-user");
       mockClerk({ userId });
       await createTestOrg(uniqueId("gh-missing-org"));
-      const { composeId } = await createTestCompose("gh-missing-agent");
+      const { composeId } = await createTestCompose(
+        uniqueId("gh-missing-agent"),
+      );
 
       const { runId } = await seedTestRun(userId, composeId, {
         prompt: "Test prompt",

--- a/turbo/apps/web/app/api/internal/callbacks/imessage/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/imessage/__tests__/route.test.ts
@@ -36,7 +36,7 @@ async function setupIMessageCallback() {
   const userId = uniqueId("user");
   mockClerk({ userId });
 
-  const { composeId } = await createTestCompose("imessage-test-agent");
+  const { composeId } = await createTestCompose(uniqueId("imessage-agent"));
   const { runId } = await seedTestRun(userId, composeId, {
     prompt: "Hello from iMessage",
   });

--- a/turbo/apps/web/app/api/internal/callbacks/phone/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/phone/__tests__/route.test.ts
@@ -34,7 +34,7 @@ async function setupPhoneCallback() {
   mockClerk({ userId });
 
   await createTestOrg(uniqueId("org"));
-  const { composeId } = await createTestCompose("phone-test-agent");
+  const { composeId } = await createTestCompose(uniqueId("phone-agent"));
 
   const { runId } = await seedTestRun(userId, composeId, {
     prompt: "Phone call transcript",

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -86,7 +86,7 @@ async function setupTelegramCallback() {
 
   // Create org + compose (with version) through API
   await createTestOrg(uniqueId("org"));
-  const { composeId } = await createTestCompose("test-agent");
+  const { composeId } = await createTestCompose(uniqueId("telegram-agent"));
 
   // Create installation with encrypted bot token + user link via helper
   const { installationId, userLinkId } =

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { encryptSecretsMap } from "../../../../../../../src/lib/shared/crypto/secrets-encryption";
@@ -235,7 +236,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
   describe("Claim flow - Agent metadata", () => {
     it("should return appendSystemPrompt in claim response", async () => {
-      const { versionId } = await createTestCompose("test-asp");
+      const { versionId } = await createTestCompose(uniqueId("test-asp"));
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
@@ -265,7 +266,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
 
     it("should return null appendSystemPrompt when not set", async () => {
-      const { versionId } = await createTestCompose("test-asp-null");
+      const { versionId } = await createTestCompose(uniqueId("test-asp-null"));
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
@@ -295,7 +296,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
   describe("Claim flow - sandbox token generation", () => {
     it("should generate sandbox token without capabilities", async () => {
-      const { versionId } = await createTestCompose("test-no-caps");
+      const { versionId } = await createTestCompose(uniqueId("test-no-caps"));
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
@@ -327,7 +328,9 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
   describe("Claim flow - secretValues filtering", () => {
     it("should only include secret values present in environment", async () => {
-      const { versionId } = await createTestCompose("test-secret-filter");
+      const { versionId } = await createTestCompose(
+        uniqueId("test-secret-filter"),
+      );
 
       const encryptedSecrets = encryptSecretsMap(
         {
@@ -377,7 +380,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
 
     it("should return empty array when no secrets match environment", async () => {
-      const { versionId } = await createTestCompose("test-no-match");
+      const { versionId } = await createTestCompose(uniqueId("test-no-match"));
 
       const encryptedSecrets = encryptSecretsMap(
         { SECRET: "not-in-env" },
@@ -415,7 +418,9 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
 
     it("should return null when no encrypted secrets exist", async () => {
-      const { versionId } = await createTestCompose("test-no-secrets");
+      const { versionId } = await createTestCompose(
+        uniqueId("test-no-secrets"),
+      );
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
@@ -445,7 +450,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
   describe("Claim flow - execution context fields", () => {
     it("should return settings when present in stored context", async () => {
-      const { versionId } = await createTestCompose("test-settings");
+      const { versionId } = await createTestCompose(uniqueId("test-settings"));
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
@@ -474,7 +479,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
 
     it("should return tools when present in stored context", async () => {
-      const { versionId } = await createTestCompose("test-tools");
+      const { versionId } = await createTestCompose(uniqueId("test-tools"));
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
@@ -503,7 +508,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
 
     it("should omit fields when not in stored context", async () => {
-      const { versionId } = await createTestCompose("test-no-extras");
+      const { versionId } = await createTestCompose(uniqueId("test-no-extras"));
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,

--- a/turbo/apps/web/app/api/runners/poll/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/poll/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 
@@ -37,7 +38,7 @@ describe("POST /api/runners/poll — heldSessions affinity", () => {
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
-    const compose = await createTestCompose("poll-test");
+    const compose = await createTestCompose(uniqueId("poll-test"));
     versionId = compose.versionId;
     group = `vm0/poll-test-${randomUUID().slice(0, 8)}`;
   });

--- a/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
@@ -11,7 +11,7 @@ import {
   createTestCompose,
   createTestCliToken,
 } from "../../../../src/__tests__/api-test-helpers";
-import { testContext } from "../../../../src/__tests__/test-helpers";
+import { testContext, uniqueId } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
 import { generateSandboxToken } from "../../../../src/lib/auth/sandbox-token";
 import { seedTestRun } from "../../../../src/__tests__/db-test-seeders/runs";
@@ -36,7 +36,7 @@ describe("Storage capability enforcement", () => {
     userId = user.userId;
 
     // Create a compose and run so sandbox tokens can resolve org
-    const { composeId } = await createTestCompose("test-agent");
+    const { composeId } = await createTestCompose(uniqueId("storage-agent"));
     const result = await seedTestRun(userId, composeId);
     runId = result.runId;
   });

--- a/turbo/apps/web/app/api/user/export/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/user/export/__tests__/route.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { POST, GET } from "../route";
-import { testContext } from "../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import {
   createTestRequest,
@@ -42,7 +45,7 @@ describe("POST /api/user/export", () => {
       mockClerk({ userId: user.userId, orgId: user.orgId });
 
       // Create test compose with version
-      const { composeId } = await createTestCompose("test-agent", {
+      const { composeId } = await createTestCompose(uniqueId("export-agent"), {
         framework: "claude-code",
       });
 
@@ -183,7 +186,7 @@ describe("POST /api/user/export", () => {
       const userA = await context.setupUser();
       mockClerk({ userId: userA.userId, orgId: userA.orgId });
 
-      await createTestCompose("user-a-agent");
+      await createTestCompose(uniqueId("user-a-agent"));
 
       // User B triggers export
       const userB = await context.setupUser({ prefix: "other" });

--- a/turbo/apps/web/app/api/webhooks/clerk/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/clerk/__tests__/route.test.ts
@@ -252,7 +252,9 @@ describe("organization.deleted e2e cleanup", () => {
     // --- Populate org with data across all table types ---
 
     // Composes + sessions + runs
-    const { composeId, agentId } = await createTestCompose("e2e-org-test");
+    const { composeId, agentId } = await createTestCompose(
+      uniqueId("e2e-org-test"),
+    );
     const session = await createTestAgentSession(userId, composeId);
     await seedTestRun(userId, composeId, {
       status: "running",
@@ -288,8 +290,9 @@ describe("organization.deleted e2e cleanup", () => {
     });
 
     // Zero agent (need compose first since zero_agents.id = composeId)
-    await createTestCompose("e2e-zero-agent");
-    await createTestZeroAgent(orgId, "e2e-zero-agent", {
+    const zeroAgentName = uniqueId("e2e-zero-agent");
+    await createTestCompose(zeroAgentName);
+    await createTestZeroAgent(orgId, zeroAgentName, {
       displayName: "E2E",
     });
 
@@ -415,7 +418,9 @@ describe("user.deleted e2e cleanup", () => {
     // --- Populate user data across all table types ---
 
     // Composes + sessions + runs
-    const { composeId, agentId } = await createTestCompose("e2e-user-test");
+    const { composeId, agentId } = await createTestCompose(
+      uniqueId("e2e-user-test"),
+    );
     const session = await createTestAgentSession(userId, composeId);
     await seedTestRun(userId, composeId, {
       status: "running",

--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -560,7 +560,9 @@ describe("POST /api/webhooks/github", () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
       await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-webhook-agent");
+      const { composeId } = await createTestCompose(
+        uniqueId("gh-webhook-agent"),
+      );
 
       const targetId = String(Math.floor(Math.random() * 1_000_000_000));
       const ghInstallationId = Math.floor(Math.random() * 1_000_000_000);

--- a/turbo/apps/web/app/api/zero/default-agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/default-agent/__tests__/route.test.ts
@@ -7,7 +7,10 @@ import {
   getOrgDefaultAgent,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { deleteTestCompose } from "../../../../../src/__tests__/db-test-seeders/agents";
-import { testContext } from "../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 
 const context = testContext();
@@ -35,7 +38,7 @@ describe("PUT /api/zero/default-agent", () => {
 
   it("should allow admin to set default agent", async () => {
     await context.setupUser();
-    const compose = await createTestCompose("test-agent");
+    const compose = await createTestCompose(uniqueId("default-agent"));
 
     const response = await putDefaultAgent(compose.composeId);
     expect(response.status).toBe(200);
@@ -46,7 +49,7 @@ describe("PUT /api/zero/default-agent", () => {
 
   it("should return 409 when trying to unset an already-configured default agent", async () => {
     await context.setupUser();
-    const compose = await createTestCompose("test-agent");
+    const compose = await createTestCompose(uniqueId("default-agent"));
 
     // Set first
     await putDefaultAgent(compose.composeId);
@@ -61,7 +64,7 @@ describe("PUT /api/zero/default-agent", () => {
 
   it("should reject non-admin members", async () => {
     await context.setupUser();
-    const compose = await createTestCompose("test-agent");
+    const compose = await createTestCompose(uniqueId("default-agent"));
 
     // Create a second user (different prefix = different user, no org admin)
     await context.setupUser({ prefix: "member" });
@@ -84,7 +87,7 @@ describe("PUT /api/zero/default-agent", () => {
 
   it("should write default agent to org table", async () => {
     const { orgId } = await context.setupUser();
-    const compose = await createTestCompose("test-agent");
+    const compose = await createTestCompose(uniqueId("default-agent"));
 
     await putDefaultAgent(compose.composeId);
 
@@ -95,7 +98,7 @@ describe("PUT /api/zero/default-agent", () => {
 
   it("should not update org table when 409 conflict prevents unsetting", async () => {
     const { orgId } = await context.setupUser();
-    const compose = await createTestCompose("test-agent");
+    const compose = await createTestCompose(uniqueId("default-agent"));
 
     await putDefaultAgent(compose.composeId);
 
@@ -110,7 +113,7 @@ describe("PUT /api/zero/default-agent", () => {
 
   it("should return 409 when setting default agent twice", async () => {
     await context.setupUser();
-    const compose = await createTestCompose("test-agent");
+    const compose = await createTestCompose(uniqueId("default-agent"));
 
     // Set default
     const response1 = await putDefaultAgent(compose.composeId);
@@ -126,7 +129,7 @@ describe("PUT /api/zero/default-agent", () => {
 
   it("should allow re-setting default agent when previous compose was deleted", async () => {
     await context.setupUser();
-    const compose1 = await createTestCompose("agent-1");
+    const compose1 = await createTestCompose(uniqueId("agent-1"));
 
     // Set first default agent
     const response1 = await putDefaultAgent(compose1.composeId);
@@ -136,7 +139,7 @@ describe("PUT /api/zero/default-agent", () => {
     await deleteTestCompose(compose1.composeId);
 
     // Setting a new default should succeed since the old one no longer exists
-    const compose2 = await createTestCompose("agent-2");
+    const compose2 = await createTestCompose(uniqueId("agent-2"));
     const response2 = await putDefaultAgent(compose2.composeId);
     expect(response2.status).toBe(200);
 
@@ -146,7 +149,7 @@ describe("PUT /api/zero/default-agent", () => {
 
   it("should allow setting default agent when none is configured", async () => {
     await context.setupUser();
-    const compose = await createTestCompose("test-agent");
+    const compose = await createTestCompose(uniqueId("default-agent"));
 
     // No default agent configured yet — should succeed
     const response = await putDefaultAgent(compose.composeId);
@@ -158,7 +161,7 @@ describe("PUT /api/zero/default-agent", () => {
 
   it("should succeed when org row does not exist in org table", async () => {
     const { orgId } = await context.setupUser();
-    const compose = await createTestCompose("test-agent");
+    const compose = await createTestCompose(uniqueId("default-agent"));
 
     // Remove the org row to simulate a free-tier org that never triggered lazy migration
     await deleteOrgRow(orgId);

--- a/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
@@ -9,7 +9,10 @@ import {
   createTestZeroAgent,
   seedOrphanCompose,
 } from "../../../../../../src/__tests__/db-test-seeders/agents";
-import { testContext } from "../../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { PUT as setDefaultAgent } from "../../../default-agent/route";
 import { POST as completeOnboarding } from "../../complete/route";
@@ -74,7 +77,7 @@ describe("GET /api/zero/onboarding/status", () => {
     await context.setupUser();
 
     // Create a compose and set as default via API
-    const compose = await createTestCompose("test-agent");
+    const compose = await createTestCompose(uniqueId("onboarding-agent"));
 
     const setDefaultRequest = createTestRequest(
       "http://localhost:3000/api/zero/default-agent",
@@ -119,11 +122,12 @@ describe("GET /api/zero/onboarding/status", () => {
   it("should return defaultAgentMetadata when compose has metadata", async () => {
     const user = await context.setupUser();
 
-    // Create a compose
-    const compose = await createTestCompose("test-agent");
+    // Create a compose; zero_agents metadata must match the compose agent name
+    const agentName = uniqueId("onboarding-agent");
+    const compose = await createTestCompose(agentName);
 
     // Seed zero_agents with metadata (metadata now lives in this table)
-    await createTestZeroAgent(user.orgId, "test-agent", {
+    await createTestZeroAgent(user.orgId, agentName, {
       displayName: "My Agent",
       sound: "friendly",
     });
@@ -172,7 +176,7 @@ describe("GET /api/zero/onboarding/status", () => {
     await context.setupUser();
 
     // Create a compose and set as default via API (no model provider created)
-    const compose = await createTestCompose("test-agent");
+    const compose = await createTestCompose(uniqueId("onboarding-agent"));
 
     const setDefaultRequest = createTestRequest(
       "http://localhost:3000/api/zero/default-agent",

--- a/turbo/apps/web/src/__tests__/db-test-seeders/phone.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/phone.ts
@@ -58,8 +58,11 @@ export async function createPhoneOrg(orgId: string): Promise<{
   // Ensure org_metadata row exists for this org
   await ensureOrgRow(orgId);
 
-  // Create a compose with headVersionId via the API so it can be used in run creation
-  const { composeId } = await createTestCompose("phone-test-agent");
+  // Create a compose with headVersionId via the API so it can be used in run creation.
+  // Agent name is randomized per call so the content-addressed compose version id
+  // differs across concurrent tests — otherwise identical compose content hashes to
+  // the same primary key and racing inserts collide on agent_compose_versions_pkey.
+  const { composeId } = await createTestCompose(uniqueId("phone-agent"));
 
   // Configure org_metadata with agentphone agent ID and default agent
   await globalThis.services.db

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
@@ -53,7 +53,7 @@ describe("deleteOrgData", () => {
     context.setupMocks();
     const { userId, orgId } = await context.setupUser();
 
-    const { composeId } = await createTestCompose("cancel-test");
+    const { composeId } = await createTestCompose(uniqueId("cancel-test"));
     const { runId: queuedRunId } = await seedTestRun(userId, composeId, {
       status: "queued",
     });
@@ -83,7 +83,9 @@ describe("deleteOrgData", () => {
     context.setupMocks();
     const { userId, orgId } = await context.setupUser();
 
-    const { composeId } = await createTestCompose("cascade-compose-test");
+    const { composeId } = await createTestCompose(
+      uniqueId("cascade-compose-test"),
+    );
     await createTestAgentSession(userId, composeId);
 
     await deleteOrgData(orgId);
@@ -96,7 +98,7 @@ describe("deleteOrgData", () => {
     context.setupMocks();
     const { userId, orgId } = await context.setupUser();
 
-    const { composeId } = await createTestCompose("cascade-run-test");
+    const { composeId } = await createTestCompose(uniqueId("cascade-run-test"));
     const { runId } = await seedTestRun(userId, composeId, {
       status: "completed",
       completedAt: new Date(),
@@ -149,8 +151,9 @@ describe("deleteOrgData", () => {
     const { userId, orgId } = await context.setupUser();
 
     await createTestVariable("TEST_VAR", "test-value");
-    await createTestCompose("test-zero-agent");
-    await createTestZeroAgent(orgId, "test-zero-agent", {
+    const zeroAgentName = uniqueId("test-zero-agent");
+    await createTestCompose(zeroAgentName);
+    await createTestZeroAgent(orgId, zeroAgentName, {
       displayName: "Test",
     });
     await insertTestUsageDaily({ userId, orgId, date: "2026-01-01" });
@@ -183,7 +186,7 @@ describe("deleteOrgData", () => {
       vm0UserId: userId,
     });
 
-    const { composeId } = await createTestCompose("slack-test");
+    const { composeId } = await createTestCompose(uniqueId("slack-test"));
     await createTestAgentSession(userId, composeId);
 
     await insertTestSlackOrgThreadSession({ connectionId: connection.id });
@@ -214,7 +217,8 @@ describe("deleteOrgData", () => {
     const { userId, orgId } = await context.setupUser();
 
     // Composes, sessions, runs
-    const { composeId, agentId } = await createTestCompose("full-org-test");
+    const fullOrgAgentName = uniqueId("full-org-test");
+    const { composeId, agentId } = await createTestCompose(fullOrgAgentName);
     const session = await createTestAgentSession(userId, composeId);
     const { runId } = await seedTestRun(userId, composeId, {
       status: "running",
@@ -242,7 +246,7 @@ describe("deleteOrgData", () => {
 
     // Variables, zero agents, schedules, usage, exports
     await createTestVariable("FULL_TEST_VAR", "value");
-    await createTestZeroAgent(orgId, "full-org-test", {
+    await createTestZeroAgent(orgId, fullOrgAgentName, {
       displayName: "Full Test",
     });
     await createTestSchedule(composeId, "full-org-schedule");
@@ -339,7 +343,7 @@ describe("deleteOrgData", () => {
     context.setupMocks();
     const { userId, orgId } = await context.setupUser();
 
-    const { composeId } = await createTestCompose("idempotent-test");
+    const { composeId } = await createTestCompose(uniqueId("idempotent-test"));
     await seedTestRun(userId, composeId, {
       status: "running",
       startedAt: new Date(),

--- a/turbo/apps/web/src/lib/zero/user/__tests__/user-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/user/__tests__/user-deletion-service.test.ts
@@ -57,7 +57,7 @@ describe("deleteUserData", () => {
     context.setupMocks();
     const { userId } = await context.setupUser();
 
-    const { composeId } = await createTestCompose("cancel-test");
+    const { composeId } = await createTestCompose(uniqueId("cancel-test"));
     const { runId: queuedRunId } = await seedTestRun(userId, composeId, {
       status: "queued",
     });
@@ -87,7 +87,9 @@ describe("deleteUserData", () => {
     context.setupMocks();
     const { userId } = await context.setupUser();
 
-    const { composeId } = await createTestCompose("cascade-compose-test");
+    const { composeId } = await createTestCompose(
+      uniqueId("cascade-compose-test"),
+    );
     await createTestAgentSession(userId, composeId);
 
     await deleteUserData(userId);
@@ -99,7 +101,7 @@ describe("deleteUserData", () => {
     context.setupMocks();
     const { userId, orgId } = await context.setupUser();
 
-    const { composeId } = await createTestCompose("cascade-run-test");
+    const { composeId } = await createTestCompose(uniqueId("cascade-run-test"));
     const { runId } = await seedTestRun(userId, composeId, {
       status: "completed",
       completedAt: new Date(),
@@ -178,7 +180,7 @@ describe("deleteUserData", () => {
       vm0UserId: userId,
     });
 
-    const { composeId } = await createTestCompose("slack-test");
+    const { composeId } = await createTestCompose(uniqueId("slack-test"));
     await createTestAgentSession(userId, composeId);
 
     await insertTestSlackOrgThreadSession({ connectionId: connection.id });
@@ -192,7 +194,9 @@ describe("deleteUserData", () => {
     context.setupMocks();
     const { userId } = await context.setupUser();
 
-    const { composeId } = await createTestCompose("external-links-test");
+    const { composeId } = await createTestCompose(
+      uniqueId("external-links-test"),
+    );
 
     // GitHub: compose → installation → user link
     const ghInstallation = await insertTestGithubInstallation({ composeId });
@@ -266,7 +270,9 @@ describe("deleteUserData", () => {
     const { userId, orgId } = await context.setupUser();
 
     // Composes, sessions, runs
-    const { composeId, agentId } = await createTestCompose("full-user-test");
+    const { composeId, agentId } = await createTestCompose(
+      uniqueId("full-user-test"),
+    );
     const session = await createTestAgentSession(userId, composeId);
     const { runId } = await seedTestRun(userId, composeId, {
       status: "running",
@@ -379,7 +385,7 @@ describe("deleteUserData", () => {
     context.setupMocks();
     const { userId } = await context.setupUser();
 
-    const { composeId } = await createTestCompose("idempotent-test");
+    const { composeId } = await createTestCompose(uniqueId("idempotent-test"));
     await seedTestRun(userId, composeId, {
       status: "running",
       startedAt: new Date(),


### PR DESCRIPTION
## Summary

Replace hardcoded agent name literals (e.g. `"gh-agent"`, `"e2e-org-test"`, `"phone-test-agent"`) in integration tests with `uniqueId(...)` so each test case produces a distinct compose/agent. The compose version id is content-addressed, so two tests that pass the same literal name hash to the same `agent_compose_versions` primary key and race to insert it — causing intermittent `agent_compose_versions_pkey` duplicate-key failures under parallel execution.

## Changes

- Randomize `createTestCompose` / `createTestZeroAgent` name arguments across 17 integration test files
- Update the `createPhoneOrg` seeder (`phone.ts`) similarly, with a comment explaining the content-addressed id motivation
- Where the test asserted on the literal name (`integrations/github`), capture the generated id into a variable and assert against it

## Test plan

- [ ] `pnpm -F web exec vitest` locally passes
- [ ] CI lint / type / test checks stay green