### PR TITLE
fix(platform): rotate clerk jwt before reload on org switch

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/auth.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { testContext } from "./test-helpers";
-import { detachedSetupPage } from "../../__tests__/page-helper";
-import { fireClerkListeners, mockUser } from "../../__tests__/mock-auth";
+import { detachedSetupPage, setupPage } from "../../__tests__/page-helper";
+import {
+  fireClerkListeners,
+  mockedClerk,
+  mockOrganization,
+  mockUser,
+} from "../../__tests__/mock-auth";
 import { setupClerk$, user$, resolveWebOrigin } from "../auth";
 
 const context = testContext();
@@ -73,5 +78,80 @@ describe("setupClerk$ auth reload filtering", () => {
 
     const userAfter = await store.get(user$);
     expect(userAfter).toBeUndefined();
+  });
+});
+
+describe("watchOrgSwitch$ JWT rotation on org change", () => {
+  afterEach(() => {
+    // Reset href between tests — the listener assigns it to "/"
+    if (window.location.pathname !== "/") {
+      window.location.href = "http://localhost/";
+    }
+  });
+
+  it("rotates the Clerk JWT with skipCache:true before navigating on org switch", async () => {
+    // Bootstrap with an initial active org so watchOrgSwitch$ captures
+    // it as prevOrgId. Use the awaited `setupPage` so the Clerk
+    // listener is registered before we simulate the org switch below.
+    await setupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_A", name: "Org A" },
+        memberships: [{ id: "org_A" }, { id: "org_B" }],
+      },
+      withoutRender: true,
+    });
+
+    // Simulate an org switch: flip the mocked active org, then fire
+    // the Clerk listeners (the production trigger path is
+    // `clerk.setActive({ organization })` which fires listeners under
+    // the hood — the mock exposes `fireClerkListeners` to simulate it).
+    mockOrganization({
+      activeOrg: { id: "org_B", name: "Org B" },
+      memberships: [{ id: "org_A" }, { id: "org_B" }],
+    });
+    fireClerkListeners();
+
+    // The listener awaits getToken({ skipCache: true }) before
+    // assigning location.href. Both should land once the microtask
+    // queue drains.
+    await vi.waitFor(() => {
+      expect(mockedClerk.sessionGetToken).toHaveBeenCalledWith({
+        skipCache: true,
+      });
+    });
+    await vi.waitFor(() => {
+      expect(window.location.pathname).toBe("/");
+    });
+  });
+
+  it("still reloads when getToken rejects (refresh failure is swallowed)", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_A", name: "Org A" },
+        memberships: [{ id: "org_A" }, { id: "org_B" }],
+      },
+      withoutRender: true,
+    });
+
+    // Arm the rejection AFTER bootstrap so it only fires on the
+    // listener's skipCache:true call (not on unrelated pre-bootstrap
+    // fetches that also call getToken()).
+    mockedClerk.sessionGetToken.mockRejectedValueOnce(
+      new Error("token endpoint down"),
+    );
+
+    mockOrganization({
+      activeOrg: { id: "org_B", name: "Org B" },
+      memberships: [{ id: "org_A" }, { id: "org_B" }],
+    });
+    fireClerkListeners();
+
+    await vi.waitFor(() => {
+      expect(window.location.pathname).toBe("/");
+    });
   });
 });

--- a/turbo/apps/platform/src/signals/__tests__/auth.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth.test.ts
@@ -84,18 +84,26 @@ describe("setupClerk$ auth reload filtering", () => {
 describe("watchOrgSwitch$ JWT rotation on org change", () => {
   afterEach(() => {
     // Reset href between tests — the listener assigns it to "/"
-    if (window.location.pathname !== "/") {
+    if (window.location.href !== "http://localhost/") {
       window.location.href = "http://localhost/";
     }
   });
 
   it("rotates the Clerk JWT with skipCache:true before navigating on org switch", async () => {
+    // Force `window.location` away from "/" so the production listener
+    // assignment `location.href = "/"` produces an observable change.
+    // happy-dom's default pathname is already "/", and the mocked
+    // `pushState` does not touch `window.location` — we must set the
+    // href directly.
+    window.location.href = "http://localhost/agents";
+    expect(window.location.pathname).toBe("/agents");
+
     // Bootstrap with an initial active org so watchOrgSwitch$ captures
     // it as prevOrgId. Use the awaited `setupPage` so the Clerk
     // listener is registered before we simulate the org switch below.
     await setupPage({
       context,
-      path: "/",
+      path: "/agents",
       org: {
         activeOrg: { id: "org_A", name: "Org A" },
         memberships: [{ id: "org_A" }, { id: "org_B" }],
@@ -113,9 +121,10 @@ describe("watchOrgSwitch$ JWT rotation on org change", () => {
     });
     fireClerkListeners();
 
-    // The listener awaits getToken({ skipCache: true }) before
-    // assigning location.href. Both should land once the microtask
-    // queue drains.
+    // The listener invokes getToken({ skipCache: true }) and then
+    // assigns location.href. Both should land once the microtask
+    // queue drains — the pathname change from "/agents" to "/" is the
+    // observable marker that the reload ran.
     await vi.waitFor(() => {
       expect(mockedClerk.sessionGetToken).toHaveBeenCalledWith({
         skipCache: true,
@@ -127,9 +136,14 @@ describe("watchOrgSwitch$ JWT rotation on org change", () => {
   });
 
   it("still reloads when getToken rejects (refresh failure is swallowed)", async () => {
+    // Force `window.location` away from "/" so the reload is
+    // observable (see explanation in the happy-path test above).
+    window.location.href = "http://localhost/agents";
+    expect(window.location.pathname).toBe("/agents");
+
     await setupPage({
       context,
-      path: "/",
+      path: "/agents",
       org: {
         activeOrg: { id: "org_A", name: "Org A" },
         memberships: [{ id: "org_A" }, { id: "org_B" }],

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -112,26 +112,38 @@ export const watchOrgSwitch$ = command(async ({ get }, signal: AbortSignal) => {
   prevOrgId = currentOrgId;
   persistOrgId(currentOrgId);
 
-  const unsubscribe = clerk.addListener(async () => {
+  // Listener stays `() => void`: Clerk's `ListenerCallback` signature
+  // is not awaited, and returning a promise from it would trip
+  // `typescript/no-misused-promises`. The promise chain below is
+  // terminated by `.catch(() => undefined)`, which satisfies
+  // `typescript/no-floating-promises` and ensures the reload still
+  // fires even if the token rotation rejects.
+  const unsubscribe = clerk.addListener(() => {
     const newOrgId = clerk.organization?.id ?? undefined;
-    if (newOrgId !== prevOrgId) {
-      prevOrgId = newOrgId;
-      persistOrgId(newOrgId);
-      // Force a JWT rotation so the __session cookie carries the new
-      // org_id claim before the reload — a brand-new tab opened in
-      // parallel would otherwise read the stale cookie JWT (which bakes
-      // org_id at mint time) and see the old org until the ~60s TTL
-      // expires. Swallow refresh failures so the reload still runs — the
-      // fresh page load will re-establish Clerk state regardless.
-      await clerk.session?.getToken({ skipCache: true }).catch(() => {
+    if (newOrgId === prevOrgId) {
+      return;
+    }
+    prevOrgId = newOrgId;
+    persistOrgId(newOrgId);
+    // Force a JWT rotation so the __session cookie carries the new
+    // org_id claim before the reload — a brand-new tab opened in
+    // parallel would otherwise read the stale cookie JWT (which bakes
+    // org_id at mint time) and see the old org until the ~60s TTL
+    // expires. The trailing `.catch(() => undefined)` swallows refresh
+    // failures so the reload still runs — the fresh page load will
+    // re-establish Clerk state regardless.
+    clerk.session
+      ?.getToken({ skipCache: true })
+      .then(() => {
+        // Full page load is required because server-side data (agents,
+        // jobs, secrets, etc.) is scoped to the active organization and
+        // multiple signal trees depend on the org context established
+        // at bootstrap time.
+        location.href = "/";
+      })
+      .catch(() => {
         return undefined;
       });
-      // Full page load is required because server-side data (agents,
-      // jobs, secrets, etc.) is scoped to the active organization and
-      // multiple signal trees depend on the org context established at
-      // bootstrap time.
-      location.href = "/";
-    }
   });
   signal.addEventListener("abort", unsubscribe);
 });

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -112,15 +112,24 @@ export const watchOrgSwitch$ = command(async ({ get }, signal: AbortSignal) => {
   prevOrgId = currentOrgId;
   persistOrgId(currentOrgId);
 
-  const unsubscribe = clerk.addListener(() => {
+  const unsubscribe = clerk.addListener(async () => {
     const newOrgId = clerk.organization?.id ?? undefined;
     if (newOrgId !== prevOrgId) {
       prevOrgId = newOrgId;
       persistOrgId(newOrgId);
-      // Navigate to the Zero homepage on org switch. A full page load is
-      // required because server-side data (agents, jobs, secrets, etc.) is
-      // scoped to the active organization, and multiple signal trees depend
-      // on the org context established at bootstrap time.
+      // Force a JWT rotation so the __session cookie carries the new
+      // org_id claim before the reload — a brand-new tab opened in
+      // parallel would otherwise read the stale cookie JWT (which bakes
+      // org_id at mint time) and see the old org until the ~60s TTL
+      // expires. Swallow refresh failures so the reload still runs — the
+      // fresh page load will re-establish Clerk state regardless.
+      await clerk.session?.getToken({ skipCache: true }).catch(() => {
+        return undefined;
+      });
+      // Full page load is required because server-side data (agents,
+      // jobs, secrets, etc.) is scoped to the active organization and
+      // multiple signal trees depend on the org context established at
+      // bootstrap time.
       location.href = "/";
     }
   });

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -114,10 +114,10 @@ export const watchOrgSwitch$ = command(async ({ get }, signal: AbortSignal) => {
 
   // Listener stays `() => void`: Clerk's `ListenerCallback` signature
   // is not awaited, and returning a promise from it would trip
-  // `typescript/no-misused-promises`. The promise chain below is
-  // terminated by `.catch(() => undefined)`, which satisfies
-  // `typescript/no-floating-promises` and ensures the reload still
-  // fires even if the token rotation rejects.
+  // `typescript/no-misused-promises`. The promise chain below handles
+  // both fulfillment and rejection in `.then(reload, reload)`, which
+  // satisfies `typescript/no-floating-promises` and ensures the
+  // reload still fires even if the token rotation rejects.
   const unsubscribe = clerk.addListener(() => {
     const newOrgId = clerk.organization?.id ?? undefined;
     if (newOrgId === prevOrgId) {
@@ -129,21 +129,21 @@ export const watchOrgSwitch$ = command(async ({ get }, signal: AbortSignal) => {
     // org_id claim before the reload — a brand-new tab opened in
     // parallel would otherwise read the stale cookie JWT (which bakes
     // org_id at mint time) and see the old org until the ~60s TTL
-    // expires. The trailing `.catch(() => undefined)` swallows refresh
-    // failures so the reload still runs — the fresh page load will
-    // re-establish Clerk state regardless.
-    clerk.session
-      ?.getToken({ skipCache: true })
-      .then(() => {
-        // Full page load is required because server-side data (agents,
-        // jobs, secrets, etc.) is scoped to the active organization and
-        // multiple signal trees depend on the org context established
-        // at bootstrap time.
-        location.href = "/";
-      })
-      .catch(() => {
-        return undefined;
-      });
+    // expires. Passing the same reload handler as both fulfilled and
+    // rejected callbacks to `.then` guarantees the reload runs in
+    // both cases: on success the fresh JWT is already in the cookie;
+    // on failure the full page load will re-establish Clerk state
+    // regardless. This form also satisfies
+    // `typescript/no-floating-promises`, which requires a rejection
+    // handler on the terminal call.
+    const reload = (): void => {
+      // Full page load is required because server-side data (agents,
+      // jobs, secrets, etc.) is scoped to the active organization and
+      // multiple signal trees depend on the org context established
+      // at bootstrap time.
+      location.href = "/";
+    };
+    clerk.session?.getToken({ skipCache: true }).then(reload, reload);
   });
   signal.addEventListener("abort", unsubscribe);
 });


### PR DESCRIPTION
## Summary

- Force a `clerk.session.getToken({ skipCache: true })` inside `watchOrgSwitch$` right before `location.href = "/"`, so the new `org_id` claim lands in the `__session` cookie before the full-page reload.
- Closes the race where switching org in tab A and immediately opening a brand-new tab B made B read the stale cookie JWT and see the old org until the ~60s JWT TTL expired. `org_id` is baked into the JWT at mint time, so without a forced rotation the cookie keeps the old claim and our backend `auth()` trusts it.
- `.catch(() => undefined)` swallows refresh failures — the reload that follows will re-establish Clerk state regardless, so nothing should block it.
- Already-open tabs keep refreshing on Clerk's own cadence (by design, not changed).

## Test plan

- [x] `pnpm -F @vm0/app exec eslint src/signals/auth.ts` — pass
- [x] `pnpm -F @vm0/app exec tsc --noEmit` — pass
- [x] `pnpm -F @vm0/app exec vitest run` — 229 files, 1918 tests, all pass
- [x] `pnpm format` — unchanged
- [x] knip via pre-commit hook — no issues
- [ ] Manual check: switch org in tab A, then immediately open a new tab B and hit an API — confirm backend `authCtx.orgId` is the new org (no 60s stale window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)