### PR TITLE
fix(ts-rest-handler): fall through to default when custom error handler returns undefined

### DIFF
--- a/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
@@ -11,8 +11,15 @@ vi.mock("@sentry/nextjs", () => {
 });
 
 // Capture the errorHandler passed to createNextHandler so tests can invoke it
-// directly without spinning up a real Next.js server.
-type ResolvedErrorHandler = (err: unknown, req: TsRestRequest) => unknown;
+// directly without spinning up a real Next.js server. Return type mirrors the
+// real resolver so tests can access `.status` / `.json()` without casts.
+type ResolvedErrorHandler = (
+  err: unknown,
+  req: TsRestRequest,
+) =>
+  | InstanceType<typeof TsRestResponse>
+  | void
+  | Promise<InstanceType<typeof TsRestResponse> | void>;
 let capturedErrorHandler: ResolvedErrorHandler | undefined;
 
 vi.mock("@ts-rest/serverless/next", async (importOriginal) => {
@@ -36,7 +43,12 @@ vi.mock("@ts-rest/serverless/next", async (importOriginal) => {
 
 import { initContract } from "@ts-rest/core";
 import { z } from "zod";
-import { createSafeErrorHandler, createHandler, tsr } from "../ts-rest-handler";
+import {
+  createSafeErrorHandler,
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../ts-rest-handler";
 import { badRequest, notFound, forbidden } from "../shared/errors";
 
 describe("createSafeErrorHandler", () => {
@@ -191,8 +203,12 @@ describe("createHandler per-operation dispatch", () => {
     });
   });
 
-  it("uses custom errorHandler when provided, bypassing per-operation dispatch", async () => {
-    const customHandler = vi.fn().mockReturnValue(undefined);
+  it("uses custom errorHandler response as-is when it returns a response", async () => {
+    const fakeResponse = TsRestResponse.fromJson(
+      { error: { message: "custom", code: "CUSTOM" } },
+      { status: 418 },
+    );
+    const customHandler = vi.fn().mockReturnValue(fakeResponse);
     createHandler(twoOpContract, router, {
       routeName: "test",
       errorHandler: customHandler,
@@ -201,8 +217,120 @@ describe("createHandler per-operation dispatch", () => {
 
     const fakeReq = { method: "GET", route: "/api/test" } as TsRestRequest;
     const err = new Error("custom error");
-    await capturedErrorHandler!(err, fakeReq);
+    const response = await capturedErrorHandler!(err, fakeReq);
     expect(customHandler).toHaveBeenCalledWith(err);
+    expect(response).toBe(fakeResponse);
+    expect(vi.mocked(Sentry.captureException)).not.toHaveBeenCalled();
+  });
+});
+
+describe("createHandler custom errorHandler fall-through", () => {
+  const c2 = initContract();
+  const singleOpContract = c2.router({
+    show: {
+      method: "GET",
+      path: "/api/thing/:id",
+      pathParams: z.object({ id: z.string() }),
+      responses: { 200: z.object({ id: z.string() }) },
+    },
+  });
+
+  const singleOpRouter = tsr.router(singleOpContract, {
+    show: async ({ params }) => {
+      return { status: 200 as const, body: { id: params.id } };
+    },
+  });
+
+  // Simulates the pattern used in all 28 real routes: handle pathParamsError,
+  // otherwise return undefined (the "delegate to default" signal).
+  const validationOnlyHandler = (err: unknown): TsRestResponse | void => {
+    if (err && typeof err === "object" && "pathParamsError" in err) {
+      return TsRestResponse.fromJson(
+        { error: { message: "bad id", code: "BAD_REQUEST" } },
+        { status: 400 },
+      );
+    }
+    return undefined;
+  };
+
+  beforeEach(() => {
+    capturedErrorHandler = undefined;
+    vi.clearAllMocks();
+  });
+
+  it("delegates ApiError to defaultHandler (404 with proper code, no Sentry)", async () => {
+    createHandler(singleOpContract, singleOpRouter, {
+      routeName: "thing.show",
+      errorHandler: validationOnlyHandler,
+    });
+    expect(capturedErrorHandler).toBeDefined();
+
+    const fakeReq = {
+      method: "GET",
+      route: "/api/thing/:id",
+    } as TsRestRequest;
+    const err = notFound("Agent compose not found");
+
+    const response = await capturedErrorHandler!(err, fakeReq);
+
+    expect(response).toBeDefined();
+    expect(response!.status).toBe(404);
+    const body = await response!.json();
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(body.error.message).toBe("Agent compose not found");
+    expect(vi.mocked(Sentry.captureException)).not.toHaveBeenCalled();
+  });
+
+  it("delegates raw Error to defaultHandler (500 + Sentry capture)", async () => {
+    createHandler(singleOpContract, singleOpRouter, {
+      routeName: "thing.show",
+      errorHandler: validationOnlyHandler,
+    });
+    expect(capturedErrorHandler).toBeDefined();
+
+    const fakeReq = {
+      method: "GET",
+      route: "/api/thing/:id",
+    } as TsRestRequest;
+    const err = new Error("db connection lost");
+
+    const response = await capturedErrorHandler!(err, fakeReq);
+
+    expect(response).toBeDefined();
+    expect(response!.status).toBe(500);
+    const body = await response!.json();
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(err, {
+      mechanism: { type: "ts-rest-handler", handled: true },
+      captureContext: { tags: { route: "thing.show" } },
+    });
+  });
+
+  it("custom handler still wins when it returns a response (validation errors)", async () => {
+    createHandler(singleOpContract, singleOpRouter, {
+      routeName: "thing.show",
+      errorHandler: validationOnlyHandler,
+    });
+    expect(capturedErrorHandler).toBeDefined();
+
+    const fakeReq = {
+      method: "GET",
+      route: "/api/thing/:id",
+    } as TsRestRequest;
+    const validationErr = {
+      pathParamsError: {
+        issues: [{ path: ["id"], message: "required" }],
+      },
+    };
+
+    const response = await capturedErrorHandler!(validationErr, fakeReq);
+
+    expect(response).toBeDefined();
+    expect(response!.status).toBe(400);
+    const body = await response!.json();
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toBe("bad id");
     expect(vi.mocked(Sentry.captureException)).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -241,7 +241,13 @@ export function createHandler<T extends AppRouter>(
     err: unknown,
     req: TsRestRequest,
   ): TsRestResponse | void => {
-    if (options.errorHandler) return options.errorHandler(err);
+    if (options.errorHandler) {
+      const result = options.errorHandler(err);
+      if (result) return result;
+      // Custom handler declined this error (returned undefined) — delegate to
+      // the default chain so ApiError → correct status, raw errors → log +
+      // Sentry. ts-rest's own dispatcher uses the same truthy-check semantic.
+    }
     if (perOpHandlers && opMap) {
       const op = opMap.get(`${req.method}:${req.route}`);
       const h = op ? perOpHandlers.get(op) : undefined;


### PR DESCRIPTION
## Summary

- `createHandler` in `turbo/apps/web/src/lib/ts-rest-handler.ts` treated any value returned by a route's custom `errorHandler` as terminal — including `undefined`. Since ts-rest's framework-level fallback maps `undefined` to a generic `TsRestHttpError(500, "Server Error")`, every error the custom handler didn't explicitly match became an opaque 500 with **no `log.error`, no Sentry capture, no stack trace** (only the Axiom request-log entry).
- Fix: use a truthy check on the custom handler's return value — matching ts-rest's own dispatcher convention. When the custom handler returns `undefined`, fall through to the default chain so `ApiError` surfaces with its correct status code and raw errors reach `log.error` + `Sentry.captureException`.
- All 28 existing inline `errorHandler` functions already end in `return undefined`; their "delegate to default" intent is now honored without any per-route edit.
- Transitively closes #10376: `GET /api/agent/composes/:id` with a deleted compose id, where `getComposeOrgId(params.id)` throws `notFound(...)` outside the inline try/catch, now correctly returns 404 instead of silent 500.

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/__tests__/ts-rest-handler.test.ts` — 14 passed (3 new fall-through cases + updated "response as-is" assertion)
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — no issues (only config hints)
- [x] Full `pnpm -F web exec vitest run` in isolation: all 3770 tests pass (one flaky cross-test DB contamination in `voice-chat-cleanup/__tests__/route.test.ts` unrelated to this change — passes in isolation)

Closes #10597
Closes #10376

🤖 Generated with [Claude Code](https://claude.com/claude-code)