### PR TITLE
feat(ui): add vm0 managed badge to platform-auth connector cards

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
@@ -132,6 +132,35 @@ describe("connectors page - connector status indicators", () => {
       expect(screen.getByText("@octocat")).toBeInTheDocument();
     });
   });
+
+  it("platform-auth connector renders the VM0 Managed badge", async () => {
+    mockConnectors([{ type: "openai", authMethod: "platform" }]);
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await waitFor(() => {
+      expect(screen.getByText("VM0 Managed")).toBeInTheDocument();
+    });
+  });
+
+  it("oauth-auth connector does not render the VM0 Managed badge", async () => {
+    mockConnectors([
+      {
+        type: "github",
+        authMethod: "oauth",
+        oauthScopes: ["repo", "project", "workflow"],
+      },
+    ]);
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    // Wait for the connector card to render — "Connected" pills onto the
+    // card once mockConnectors resolves.
+    await waitFor(() => {
+      expect(screen.getByText("Connected")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("VM0 Managed")).not.toBeInTheDocument();
+  });
 });
 
 describe("connectors page - loading state", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-test-helpers.ts
@@ -4,6 +4,7 @@ import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 export function mockConnectors(
   connectors: {
     type: ConnectorType;
+    authMethod?: "oauth" | "api-token" | "platform";
     externalUsername?: string;
     needsReconnect?: boolean;
     oauthScopes?: string[];
@@ -14,7 +15,7 @@ export function mockConnectors(
       return {
         id: crypto.randomUUID(),
         type: c.type,
-        authMethod: "oauth",
+        authMethod: c.authMethod ?? "oauth",
         externalId: null,
         externalUsername: c.externalUsername ?? null,
         externalEmail: null,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../../../signals/zero-page/settings/connectors.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ConnectorIcon } from "./connector-icons.tsx";
+import { Vm0ManagedBadge } from "./vm0-managed-badge.tsx";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { GoogleOAuthNotice } from "../../zero-directed-shared.tsx";
 
@@ -375,11 +376,7 @@ export function ConnectModal({
         {item.connected && (
           <p className="flex items-center gap-2 text-sm text-muted-foreground">
             <span>{connectedStatusText(item)}</span>
-            {item.connector?.authMethod === "platform" && (
-              <span className="shrink-0 rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
-                VM0 Managed
-              </span>
-            )}
+            {item.connector?.authMethod === "platform" && <Vm0ManagedBadge />}
           </p>
         )}
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -373,8 +373,13 @@ export function ConnectModal({
         </DialogHeader>
 
         {item.connected && (
-          <p className="text-sm text-muted-foreground">
-            {connectedStatusText(item)}
+          <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span>{connectedStatusText(item)}</span>
+            {item.connector?.authMethod === "platform" && (
+              <span className="shrink-0 rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                VM0 Managed
+              </span>
+            )}
           </p>
         )}
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/vm0-managed-badge.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/vm0-managed-badge.tsx
@@ -1,0 +1,12 @@
+/**
+ * Small metadata pill rendered next to a connector's "Connected" status
+ * when the connection is provided by VM0's hosted key (usage is billed to
+ * org credits) rather than a user-supplied credential.
+ */
+export function Vm0ManagedBadge() {
+  return (
+    <span className="shrink-0 rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+      VM0 Managed
+    </span>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -123,12 +123,20 @@ function GlobalConnectorCard({
       );
     }
     if (connector.connected) {
+      const isPlatform = connector.connector?.authMethod === "platform";
       return (
         <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
           <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
-          {connector.connector?.externalUsername
-            ? `@${connector.connector.externalUsername}`
-            : "Connected"}
+          <span className="truncate">
+            {connector.connector?.externalUsername
+              ? `@${connector.connector.externalUsername}`
+              : "Connected"}
+          </span>
+          {isPlatform && (
+            <span className="shrink-0 rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+              VM0 Managed
+            </span>
+          )}
         </span>
       );
     }

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -27,6 +27,7 @@ import {
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { CustomConnectorsPanel } from "./components/settings/custom-connectors-panel.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import { Vm0ManagedBadge } from "./components/settings/vm0-managed-badge.tsx";
 import {
   allConnectorTypes$,
   connectConnector$,
@@ -123,7 +124,7 @@ function GlobalConnectorCard({
       );
     }
     if (connector.connected) {
-      const isPlatform = connector.connector?.authMethod === "platform";
+      const isPlatformAuth = connector.connector?.authMethod === "platform";
       return (
         <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
           <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
@@ -132,11 +133,7 @@ function GlobalConnectorCard({
               ? `@${connector.connector.externalUsername}`
               : "Connected"}
           </span>
-          {isPlatform && (
-            <span className="shrink-0 rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
-              VM0 Managed
-            </span>
-          )}
+          {isPlatformAuth && <Vm0ManagedBadge />}
         </span>
       );
     }


### PR DESCRIPTION
## Summary

Follow-up polish on #10580 (OpenAI platform auth skeleton). After Part A shipped, a user with a `platform` auth connector saw the same generic "Connected" status as an api-token connector — no way to tell whether their usage was going against their own API key or against VM0's hosted key (billed to org credits).

Add a small gray pill labelled **VM0 Managed** next to the status text when `authMethod === "platform"`:

- `zero-connectors-page.tsx` — badge appears on the connector card below the green dot / status line.
- `add-connection-dialog.tsx` — badge appears in the connect modal header next to the existing status text, for consistency.

The badge uses muted / border styles so it reads as metadata rather than a call-to-action.

## Test plan

- [x] `pnpm turbo run lint --filter=@vm0/app` — clean
- [x] `pnpm check-types --filter=@vm0/app` — clean
- [x] Manual smoke on `/connectors` — card shows the pill only when connected via platform auth (tested with a staff-org OpenAI `platform` row); api-token connectors (axiom etc.) continue to show the plain "Connected" text.

## References

- Part A: #10580
- Follow-up work (Part B, firewall key injection): #10586

🤖 Generated with [Claude Code](https://claude.com/claude-code)