### PR TITLE
feat(cli): add --avatar option to agent create and edit commands

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -21,27 +21,24 @@ const mockAgent = {
   displayName: "New Agent",
   description: null,
   sound: null,
+  avatarUrl: null,
 };
 
 describe("zero agent create command", () => {
-  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
-    throw new Error("process.exit called");
-  }) as never);
-  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
-  const mockConsoleError = vi
-    .spyOn(console, "error")
-    .mockImplementation(() => {});
+  let mockExit: ReturnType<typeof vi.spyOn>;
+  let mockConsoleLog: ReturnType<typeof vi.spyOn>;
+  let mockConsoleError: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+    mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockConsoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
-  });
-
-  afterEach(() => {
-    mockExit.mockClear();
-    mockConsoleLog.mockClear();
-    mockConsoleError.mockClear();
   });
 
   describe("successful create", () => {

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -124,7 +124,7 @@ describe("zero agent create command", () => {
       expect(capturedBody?.avatarUrl).toBe("preset:2");
     });
 
-    it("should send custom svg avatar in request body", async () => {
+    it("should compose svg avatar from descriptive flags", async () => {
       let capturedBody: Record<string, unknown> | undefined;
       server.use(
         http.post(
@@ -141,11 +141,15 @@ describe("zero agent create command", () => {
         "cli",
         "--display-name",
         "New Agent",
-        "--avatar",
-        "svg:r3s1h2c2f4h",
+        "--avatar-skin",
+        "dark",
+        "--avatar-hair-color",
+        "teal",
+        "--avatar-intensity",
+        "hyped",
       ]);
 
-      expect(capturedBody?.avatarUrl).toBe("svg:r3s1h2c2f4h");
+      expect(capturedBody?.avatarUrl).toBe("svg:r3s4h1c2f1h");
     });
 
     describe("with instructions file", () => {
@@ -194,7 +198,7 @@ describe("zero agent create command", () => {
   });
 
   describe("error handling", () => {
-    it("should reject invalid avatar format", async () => {
+    it("should reject invalid avatar preset", async () => {
       await expect(async () => {
         await createCommand.parseAsync([
           "node",
@@ -202,12 +206,50 @@ describe("zero agent create command", () => {
           "--display-name",
           "New Agent",
           "--avatar",
-          "bad-avatar",
+          "preset:9",
         ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Invalid avatar"),
+        expect.stringContaining("Invalid --avatar"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject invalid avatar skin value", async () => {
+      await expect(async () => {
+        await createCommand.parseAsync([
+          "node",
+          "cli",
+          "--display-name",
+          "New Agent",
+          "--avatar-skin",
+          "purple",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid --avatar-skin"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject combining --avatar preset with --avatar-* flags", async () => {
+      await expect(async () => {
+        await createCommand.parseAsync([
+          "node",
+          "cli",
+          "--display-name",
+          "New Agent",
+          "--avatar",
+          "preset:1",
+          "--avatar-skin",
+          "dark",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("cannot be combined"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -100,6 +100,54 @@ describe("zero agent create command", () => {
       expect(logCalls).toContain("other-skill");
     });
 
+    it("should send preset avatar in request body", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/agents",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(mockAgent, { status: 201 });
+          },
+        ),
+      );
+
+      await createCommand.parseAsync([
+        "node",
+        "cli",
+        "--display-name",
+        "New Agent",
+        "--avatar",
+        "preset:2",
+      ]);
+
+      expect(capturedBody?.avatarUrl).toBe("preset:2");
+    });
+
+    it("should send custom svg avatar in request body", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/agents",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(mockAgent, { status: 201 });
+          },
+        ),
+      );
+
+      await createCommand.parseAsync([
+        "node",
+        "cli",
+        "--display-name",
+        "New Agent",
+        "--avatar",
+        "svg:r3s1h2c2f4h",
+      ]);
+
+      expect(capturedBody?.avatarUrl).toBe("svg:r3s1h2c2f4h");
+    });
+
     describe("with instructions file", () => {
       let instructionsPath: string;
 
@@ -146,6 +194,24 @@ describe("zero agent create command", () => {
   });
 
   describe("error handling", () => {
+    it("should reject invalid avatar format", async () => {
+      await expect(async () => {
+        await createCommand.parseAsync([
+          "node",
+          "cli",
+          "--display-name",
+          "New Agent",
+          "--avatar",
+          "bad-avatar",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid avatar"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should handle authentication error", async () => {
       server.use(
         http.post("http://localhost:3000/api/zero/agents", () => {

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
@@ -144,6 +144,35 @@ describe("zero agent edit command", () => {
     });
   });
 
+    it("should update avatar and include it in request body", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.put(
+          "http://localhost:3000/api/zero/agents/my-agent",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(mockAgent);
+          },
+        ),
+      );
+
+      await editCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--avatar",
+        "preset:3",
+      ]);
+
+      expect(capturedBody?.avatarUrl).toBe("preset:3");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("updated");
+    });
+  });
+
   describe("validation", () => {
     it("should fail when no options provided", async () => {
       await expect(async () => {
@@ -152,6 +181,23 @@ describe("zero agent edit command", () => {
 
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("At least one option is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject invalid avatar format", async () => {
+      await expect(async () => {
+        await editCommand.parseAsync([
+          "node",
+          "cli",
+          "my-agent",
+          "--avatar",
+          "invalid",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid avatar"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
@@ -21,6 +21,7 @@ const mockAgent = {
   displayName: "My Agent",
   description: null,
   sound: null,
+  avatarUrl: null,
 };
 
 describe("zero agent edit command", () => {
@@ -101,6 +102,93 @@ describe("zero agent edit command", () => {
       expect(logCalls).toContain("updated");
     });
 
+    it("should update avatar with preset and include it in request body", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.put(
+          "http://localhost:3000/api/zero/agents/my-agent",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(mockAgent);
+          },
+        ),
+      );
+
+      await editCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--avatar",
+        "preset:3",
+      ]);
+
+      expect(capturedBody?.avatarUrl).toBe("preset:3");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("updated");
+    });
+
+    it("should compose svg avatar from descriptive flags", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.put(
+          "http://localhost:3000/api/zero/agents/my-agent",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(mockAgent);
+          },
+        ),
+      );
+
+      await editCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--avatar-hair-color",
+        "teal",
+        "--avatar-expression",
+        "excited",
+        "--avatar-intensity",
+        "hyped",
+      ]);
+
+      expect(capturedBody?.avatarUrl).toBe("svg:r3s2h1c2f5h");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("updated");
+    });
+
+    it("should preserve existing avatar when no avatar flags given", async () => {
+      const agentWithAvatar = { ...mockAgent, avatarUrl: "svg:r2s1h3c3f1m" };
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(agentWithAvatar);
+        }),
+        http.put(
+          "http://localhost:3000/api/zero/agents/my-agent",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(agentWithAvatar);
+          },
+        ),
+      );
+
+      await editCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--display-name",
+        "Updated",
+      ]);
+
+      expect(capturedBody?.avatarUrl).toBe("svg:r2s1h3c3f1m");
+    });
+
     describe("with instructions file", () => {
       let instructionsPath: string;
 
@@ -144,35 +232,6 @@ describe("zero agent edit command", () => {
     });
   });
 
-    it("should update avatar and include it in request body", async () => {
-      let capturedBody: Record<string, unknown> | undefined;
-      server.use(
-        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
-          return HttpResponse.json(mockAgent);
-        }),
-        http.put(
-          "http://localhost:3000/api/zero/agents/my-agent",
-          async ({ request }) => {
-            capturedBody = (await request.json()) as Record<string, unknown>;
-            return HttpResponse.json(mockAgent);
-          },
-        ),
-      );
-
-      await editCommand.parseAsync([
-        "node",
-        "cli",
-        "my-agent",
-        "--avatar",
-        "preset:3",
-      ]);
-
-      expect(capturedBody?.avatarUrl).toBe("preset:3");
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("updated");
-    });
-  });
-
   describe("validation", () => {
     it("should fail when no options provided", async () => {
       await expect(async () => {
@@ -185,19 +244,38 @@ describe("zero agent edit command", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it("should reject invalid avatar format", async () => {
+    it("should reject invalid avatar hair color", async () => {
+      await expect(async () => {
+        await editCommand.parseAsync([
+          "node",
+          "cli",
+          "my-agent",
+          "--avatar-hair-color",
+          "purple",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid --avatar-hair-color"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject combining --avatar preset with --avatar-* flags", async () => {
       await expect(async () => {
         await editCommand.parseAsync([
           "node",
           "cli",
           "my-agent",
           "--avatar",
-          "invalid",
+          "preset:0",
+          "--avatar-skin",
+          "dark",
         ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Invalid avatar"),
+        expect.stringContaining("cannot be combined"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
@@ -25,24 +25,20 @@ const mockAgent = {
 };
 
 describe("zero agent edit command", () => {
-  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
-    throw new Error("process.exit called");
-  }) as never);
-  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
-  const mockConsoleError = vi
-    .spyOn(console, "error")
-    .mockImplementation(() => {});
+  let mockExit: ReturnType<typeof vi.spyOn>;
+  let mockConsoleLog: ReturnType<typeof vi.spyOn>;
+  let mockConsoleError: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+    mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockConsoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
-  });
-
-  afterEach(() => {
-    mockExit.mockClear();
-    mockConsoleLog.mockClear();
-    mockConsoleError.mockClear();
   });
 
   describe("successful edit", () => {

--- a/turbo/apps/cli/src/commands/zero/agent/avatar.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/avatar.ts
@@ -1,0 +1,135 @@
+const SKIN_MAP: Record<string, number> = {
+  light: 0,
+  "light-medium": 1,
+  medium: 2,
+  "medium-dark": 3,
+  dark: 4,
+};
+
+const HAIR_COLOR_MAP: Record<string, number> = {
+  blonde: 1,
+  teal: 2,
+  grey: 3,
+  pink: 4,
+  brown: 5,
+};
+
+const EXPRESSION_MAP: Record<string, number> = {
+  calm: 1,
+  content: 2,
+  neutral: 3,
+  pleasant: 4,
+  excited: 5,
+};
+
+const INTENSITY_MAP: Record<string, "d" | "m" | "h"> = {
+  chill: "d",
+  normal: "m",
+  hyped: "h",
+};
+
+function lookupRequired<T>(
+  value: string,
+  map: Readonly<Record<string, T>>,
+  flag: string,
+): T {
+  if (!(value in map)) {
+    throw new Error(
+      `Invalid ${flag} "${value}". Must be one of: ${Object.keys(map).join(", ")}`,
+    );
+  }
+  return map[value]!;
+}
+
+function parseIntRange(
+  value: string,
+  flag: string,
+  min: number,
+  max: number,
+): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < min || n > max) {
+    throw new Error(`Invalid ${flag} "${value}". Must be ${min}–${max}`);
+  }
+  return n;
+}
+
+function buildCustomSvgAvatar(opts: AvatarOptions): string {
+  const r =
+    opts.avatarRotation !== undefined
+      ? parseIntRange(opts.avatarRotation, "--avatar-rotation", 1, 5)
+      : 3;
+  const h =
+    opts.avatarHairStyle !== undefined
+      ? parseIntRange(opts.avatarHairStyle, "--avatar-hair-style", 1, 5)
+      : 1;
+  const s =
+    opts.avatarSkin !== undefined
+      ? lookupRequired(opts.avatarSkin, SKIN_MAP, "--avatar-skin")
+      : 2;
+  const c =
+    opts.avatarHairColor !== undefined
+      ? lookupRequired(
+          opts.avatarHairColor,
+          HAIR_COLOR_MAP,
+          "--avatar-hair-color",
+        )
+      : 5;
+  const f =
+    opts.avatarExpression !== undefined
+      ? lookupRequired(
+          opts.avatarExpression,
+          EXPRESSION_MAP,
+          "--avatar-expression",
+        )
+      : 1;
+  const i =
+    opts.avatarIntensity !== undefined
+      ? lookupRequired(
+          opts.avatarIntensity,
+          INTENSITY_MAP,
+          "--avatar-intensity",
+        )
+      : "m";
+  return `svg:r${r}s${s}h${h}c${c}f${f}${i}`;
+}
+
+export interface AvatarOptions {
+  avatar?: string;
+  avatarRotation?: string;
+  avatarSkin?: string;
+  avatarHairStyle?: string;
+  avatarHairColor?: string;
+  avatarExpression?: string;
+  avatarIntensity?: string;
+}
+
+export function resolveAvatarUrl(opts: AvatarOptions): string | undefined {
+  const hasPreset = opts.avatar !== undefined;
+  const hasCustom =
+    opts.avatarRotation !== undefined ||
+    opts.avatarSkin !== undefined ||
+    opts.avatarHairStyle !== undefined ||
+    opts.avatarHairColor !== undefined ||
+    opts.avatarExpression !== undefined ||
+    opts.avatarIntensity !== undefined;
+
+  if (!hasPreset && !hasCustom) return undefined;
+
+  if (hasPreset && hasCustom) {
+    throw new Error(
+      "--avatar cannot be combined with --avatar-* attribute options",
+    );
+  }
+
+  if (hasPreset) {
+    if (!/^preset:[0-4]$/.test(opts.avatar!)) {
+      throw new Error(
+        `Invalid --avatar "${opts.avatar}". Use preset:0 through preset:4`,
+      );
+    }
+    return opts.avatar;
+  }
+
+  return buildCustomSvgAvatar(opts);
+}

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -5,12 +5,126 @@ import { zeroAgentCustomSkillNameSchema } from "@vm0/core";
 import { createZeroAgent, updateZeroAgentInstructions } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 
-function validateAvatar(value: string): void {
-  if (/^preset:[0-4]$/.test(value)) return;
-  if (/^svg:r[1-5]s[0-4]h[1-5]c[1-5]f[1-5][dmh]$/.test(value)) return;
-  throw new Error(
-    `Invalid avatar "${value}". Use preset:0–4 or svg:r{1-5}s{0-4}h{1-5}c{1-5}f{1-5}{d|m|h} (e.g. svg:r3s1h2c2f4h)`,
-  );
+const SKIN_MAP: Record<string, number> = {
+  light: 0,
+  "light-medium": 1,
+  medium: 2,
+  "medium-dark": 3,
+  dark: 4,
+};
+
+const HAIR_COLOR_MAP: Record<string, number> = {
+  blonde: 1,
+  teal: 2,
+  grey: 3,
+  pink: 4,
+  brown: 5,
+};
+
+const EXPRESSION_MAP: Record<string, number> = {
+  calm: 1,
+  content: 2,
+  neutral: 3,
+  pleasant: 4,
+  excited: 5,
+};
+
+const INTENSITY_MAP: Record<string, "d" | "m" | "h"> = {
+  chill: "d",
+  normal: "m",
+  hyped: "h",
+};
+
+function lookupRequired<T>(
+  value: string,
+  map: Readonly<Record<string, T>>,
+  flag: string,
+): T {
+  if (!(value in map)) {
+    throw new Error(
+      `Invalid ${flag} "${value}". Must be one of: ${Object.keys(map).join(", ")}`,
+    );
+  }
+  return map[value]!;
+}
+
+interface AvatarOptions {
+  avatar?: string;
+  avatarRotation?: string;
+  avatarSkin?: string;
+  avatarHairStyle?: string;
+  avatarHairColor?: string;
+  avatarExpression?: string;
+  avatarIntensity?: string;
+}
+
+function resolveAvatarUrl(opts: AvatarOptions): string | undefined {
+  const hasPreset = opts.avatar !== undefined;
+  const hasCustom =
+    opts.avatarRotation !== undefined ||
+    opts.avatarSkin !== undefined ||
+    opts.avatarHairStyle !== undefined ||
+    opts.avatarHairColor !== undefined ||
+    opts.avatarExpression !== undefined ||
+    opts.avatarIntensity !== undefined;
+
+  if (!hasPreset && !hasCustom) return undefined;
+
+  if (hasPreset && hasCustom) {
+    throw new Error(
+      "--avatar cannot be combined with --avatar-* attribute options",
+    );
+  }
+
+  if (hasPreset) {
+    if (!/^preset:[0-4]$/.test(opts.avatar!)) {
+      throw new Error(
+        `Invalid --avatar "${opts.avatar}". Use preset:0 through preset:4`,
+      );
+    }
+    return opts.avatar;
+  }
+
+  let r = 3;
+  if (opts.avatarRotation !== undefined) {
+    const n = Number(opts.avatarRotation);
+    if (!Number.isInteger(n) || n < 1 || n > 5) {
+      throw new Error(
+        `Invalid --avatar-rotation "${opts.avatarRotation}". Must be 1–5`,
+      );
+    }
+    r = n;
+  }
+
+  let h = 1;
+  if (opts.avatarHairStyle !== undefined) {
+    const n = Number(opts.avatarHairStyle);
+    if (!Number.isInteger(n) || n < 1 || n > 5) {
+      throw new Error(
+        `Invalid --avatar-hair-style "${opts.avatarHairStyle}". Must be 1–5`,
+      );
+    }
+    h = n;
+  }
+
+  const s =
+    opts.avatarSkin !== undefined
+      ? lookupRequired(opts.avatarSkin, SKIN_MAP, "--avatar-skin")
+      : 2;
+  const c =
+    opts.avatarHairColor !== undefined
+      ? lookupRequired(opts.avatarHairColor, HAIR_COLOR_MAP, "--avatar-hair-color")
+      : 5;
+  const f =
+    opts.avatarExpression !== undefined
+      ? lookupRequired(opts.avatarExpression, EXPRESSION_MAP, "--avatar-expression")
+      : 1;
+  const i =
+    opts.avatarIntensity !== undefined
+      ? lookupRequired(opts.avatarIntensity, INTENSITY_MAP, "--avatar-intensity")
+      : "m";
+
+  return `svg:r${r}s${s}h${h}c${c}f${f}${i}`;
 }
 
 export const createCommand = new Command()
@@ -26,30 +140,48 @@ export const createCommand = new Command()
     "--sound <tone>",
     "Agent tone: professional, friendly, direct, supportive",
   )
-  .option("--avatar <config>", "Agent avatar (preset:0–4 or custom svg: string)")
+  .option("--avatar <preset>", "Avatar preset: preset:0 through preset:4")
+  .option("--avatar-rotation <1-5>", "Head angle: 1=far-left  3=center  5=far-right")
+  .option(
+    "--avatar-skin <tone>",
+    "Skin tone: light | light-medium | medium | medium-dark | dark",
+  )
+  .option("--avatar-hair-style <1-5>", "Hair style: 1–5")
+  .option(
+    "--avatar-hair-color <color>",
+    "Hair color: blonde | teal | grey | pink | brown",
+  )
+  .option(
+    "--avatar-expression <expr>",
+    "Expression: calm | content | neutral | pleasant | excited",
+  )
+  .option("--avatar-intensity <level>", "Intensity: chill | normal | hyped")
   .option("--instructions-file <path>", "Path to instructions file")
   .addHelpText(
     "after",
     `
-Avatar format:
-  Presets:
+Avatar:
+  Quick presets (--avatar):
     preset:0  light skin, brown hair, calm, hyped
     preset:1  light-medium skin, grey hair, calm, normal
     preset:2  medium skin, pink hair, neutral, chill
     preset:3  medium-dark skin, blonde hair, pleasant, hyped
     preset:4  dark skin, teal hair, excited, normal
-  Custom: svg:r{R}s{S}h{H}c{C}f{F}{I}
-    R  head angle   1=far-left  3=center  5=far-right
-    S  skin tone    0=lightest  2=medium  4=darkest
-    H  hair style   1–5
-    C  hair color   1=blonde  2=teal  3=grey  4=pink  5=brown
-    F  expression   1=calm  3=neutral  5=excited
-    I  intensity    d=chill  m=normal  h=hyped
+
+  Custom attributes (--avatar-* flags, omitted fields use defaults):
+    --avatar-rotation   1=far-left  3=center(default)  5=far-right
+    --avatar-skin       light / light-medium / medium(default) / medium-dark / dark
+    --avatar-hair-style 1–5 (default: 1)
+    --avatar-hair-color blonde / teal / grey / pink / brown(default)
+    --avatar-expression calm(default) / content / neutral / pleasant / excited
+    --avatar-intensity  chill / normal(default) / hyped
+
+  Note: --avatar and --avatar-* cannot be used together.
 
 Examples:
   Minimal:               zero agent create --display-name "My Agent"
-  With avatar:           zero agent create --display-name "My Agent" --avatar preset:2
-  Custom avatar:         zero agent create --display-name "My Agent" --avatar svg:r3s1h2c2f4h
+  Quick preset:          zero agent create --display-name "My Agent" --avatar preset:2
+  Custom avatar:         zero agent create --display-name "My Agent" --avatar-skin dark --avatar-hair-color teal --avatar-intensity hyped
   With skills:           zero agent create --skills my-skill,other-skill --display-name "My Agent"
   With instructions:     zero agent create --display-name "My Agent" --instructions-file ./instructions.md`,
   )
@@ -61,6 +193,12 @@ Examples:
         description?: string;
         sound?: string;
         avatar?: string;
+        avatarRotation?: string;
+        avatarSkin?: string;
+        avatarHairStyle?: string;
+        avatarHairColor?: string;
+        avatarExpression?: string;
+        avatarIntensity?: string;
         instructionsFile?: string;
       }) => {
         const customSkills = options.skills
@@ -80,15 +218,13 @@ Examples:
           }
         }
 
-        if (options.avatar !== undefined) {
-          validateAvatar(options.avatar);
-        }
+        const avatarUrl = resolveAvatarUrl(options);
 
         const agent = await createZeroAgent({
           displayName: options.displayName,
           description: options.description,
           sound: options.sound,
-          avatarUrl: options.avatar,
+          avatarUrl,
           customSkills,
         });
 

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -4,128 +4,7 @@ import chalk from "chalk";
 import { zeroAgentCustomSkillNameSchema } from "@vm0/core";
 import { createZeroAgent, updateZeroAgentInstructions } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
-
-const SKIN_MAP: Record<string, number> = {
-  light: 0,
-  "light-medium": 1,
-  medium: 2,
-  "medium-dark": 3,
-  dark: 4,
-};
-
-const HAIR_COLOR_MAP: Record<string, number> = {
-  blonde: 1,
-  teal: 2,
-  grey: 3,
-  pink: 4,
-  brown: 5,
-};
-
-const EXPRESSION_MAP: Record<string, number> = {
-  calm: 1,
-  content: 2,
-  neutral: 3,
-  pleasant: 4,
-  excited: 5,
-};
-
-const INTENSITY_MAP: Record<string, "d" | "m" | "h"> = {
-  chill: "d",
-  normal: "m",
-  hyped: "h",
-};
-
-function lookupRequired<T>(
-  value: string,
-  map: Readonly<Record<string, T>>,
-  flag: string,
-): T {
-  if (!(value in map)) {
-    throw new Error(
-      `Invalid ${flag} "${value}". Must be one of: ${Object.keys(map).join(", ")}`,
-    );
-  }
-  return map[value]!;
-}
-
-interface AvatarOptions {
-  avatar?: string;
-  avatarRotation?: string;
-  avatarSkin?: string;
-  avatarHairStyle?: string;
-  avatarHairColor?: string;
-  avatarExpression?: string;
-  avatarIntensity?: string;
-}
-
-function resolveAvatarUrl(opts: AvatarOptions): string | undefined {
-  const hasPreset = opts.avatar !== undefined;
-  const hasCustom =
-    opts.avatarRotation !== undefined ||
-    opts.avatarSkin !== undefined ||
-    opts.avatarHairStyle !== undefined ||
-    opts.avatarHairColor !== undefined ||
-    opts.avatarExpression !== undefined ||
-    opts.avatarIntensity !== undefined;
-
-  if (!hasPreset && !hasCustom) return undefined;
-
-  if (hasPreset && hasCustom) {
-    throw new Error(
-      "--avatar cannot be combined with --avatar-* attribute options",
-    );
-  }
-
-  if (hasPreset) {
-    if (!/^preset:[0-4]$/.test(opts.avatar!)) {
-      throw new Error(
-        `Invalid --avatar "${opts.avatar}". Use preset:0 through preset:4`,
-      );
-    }
-    return opts.avatar;
-  }
-
-  let r = 3;
-  if (opts.avatarRotation !== undefined) {
-    const n = Number(opts.avatarRotation);
-    if (!Number.isInteger(n) || n < 1 || n > 5) {
-      throw new Error(
-        `Invalid --avatar-rotation "${opts.avatarRotation}". Must be 1–5`,
-      );
-    }
-    r = n;
-  }
-
-  let h = 1;
-  if (opts.avatarHairStyle !== undefined) {
-    const n = Number(opts.avatarHairStyle);
-    if (!Number.isInteger(n) || n < 1 || n > 5) {
-      throw new Error(
-        `Invalid --avatar-hair-style "${opts.avatarHairStyle}". Must be 1–5`,
-      );
-    }
-    h = n;
-  }
-
-  const s =
-    opts.avatarSkin !== undefined
-      ? lookupRequired(opts.avatarSkin, SKIN_MAP, "--avatar-skin")
-      : 2;
-  const c =
-    opts.avatarHairColor !== undefined
-      ? lookupRequired(opts.avatarHairColor, HAIR_COLOR_MAP, "--avatar-hair-color")
-      : 5;
-  const f =
-    opts.avatarExpression !== undefined
-      ? lookupRequired(opts.avatarExpression, EXPRESSION_MAP, "--avatar-expression")
-      : 1;
-  const i =
-    opts.avatarIntensity !== undefined
-      ? lookupRequired(opts.avatarIntensity, INTENSITY_MAP, "--avatar-intensity")
-      : "m";
-
-  return `svg:r${r}s${s}h${h}c${c}f${f}${i}`;
-}
+import { resolveAvatarUrl } from "./avatar";
 
 export const createCommand = new Command()
   .name("create")
@@ -141,7 +20,10 @@ export const createCommand = new Command()
     "Agent tone: professional, friendly, direct, supportive",
   )
   .option("--avatar <preset>", "Avatar preset: preset:0 through preset:4")
-  .option("--avatar-rotation <1-5>", "Head angle: 1=far-left  3=center  5=far-right")
+  .option(
+    "--avatar-rotation <1-5>",
+    "Head angle: 1=far-left  3=center  5=far-right",
+  )
   .option(
     "--avatar-skin <tone>",
     "Skin tone: light | light-medium | medium | medium-dark | dark",

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -5,6 +5,14 @@ import { zeroAgentCustomSkillNameSchema } from "@vm0/core";
 import { createZeroAgent, updateZeroAgentInstructions } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 
+function validateAvatar(value: string): void {
+  if (/^preset:[0-4]$/.test(value)) return;
+  if (/^svg:r[1-5]s[0-4]h[1-5]c[1-5]f[1-5][dmh]$/.test(value)) return;
+  throw new Error(
+    `Invalid avatar "${value}". Use preset:0–4 or svg:r{1-5}s{0-4}h{1-5}c{1-5}f{1-5}{d|m|h} (e.g. svg:r3s1h2c2f4h)`,
+  );
+}
+
 export const createCommand = new Command()
   .name("create")
   .description("Create a new zero agent")
@@ -18,12 +26,30 @@ export const createCommand = new Command()
     "--sound <tone>",
     "Agent tone: professional, friendly, direct, supportive",
   )
+  .option("--avatar <config>", "Agent avatar (preset:0–4 or custom svg: string)")
   .option("--instructions-file <path>", "Path to instructions file")
   .addHelpText(
     "after",
     `
+Avatar format:
+  Presets:
+    preset:0  light skin, brown hair, calm, hyped
+    preset:1  light-medium skin, grey hair, calm, normal
+    preset:2  medium skin, pink hair, neutral, chill
+    preset:3  medium-dark skin, blonde hair, pleasant, hyped
+    preset:4  dark skin, teal hair, excited, normal
+  Custom: svg:r{R}s{S}h{H}c{C}f{F}{I}
+    R  head angle   1=far-left  3=center  5=far-right
+    S  skin tone    0=lightest  2=medium  4=darkest
+    H  hair style   1–5
+    C  hair color   1=blonde  2=teal  3=grey  4=pink  5=brown
+    F  expression   1=calm  3=neutral  5=excited
+    I  intensity    d=chill  m=normal  h=hyped
+
 Examples:
   Minimal:               zero agent create --display-name "My Agent"
+  With avatar:           zero agent create --display-name "My Agent" --avatar preset:2
+  Custom avatar:         zero agent create --display-name "My Agent" --avatar svg:r3s1h2c2f4h
   With skills:           zero agent create --skills my-skill,other-skill --display-name "My Agent"
   With instructions:     zero agent create --display-name "My Agent" --instructions-file ./instructions.md`,
   )
@@ -34,6 +60,7 @@ Examples:
         displayName?: string;
         description?: string;
         sound?: string;
+        avatar?: string;
         instructionsFile?: string;
       }) => {
         const customSkills = options.skills
@@ -53,10 +80,15 @@ Examples:
           }
         }
 
+        if (options.avatar !== undefined) {
+          validateAvatar(options.avatar);
+        }
+
         const agent = await createZeroAgent({
           displayName: options.displayName,
           description: options.description,
           sound: options.sound,
+          avatarUrl: options.avatar,
           customSkills,
         });
 

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -169,12 +169,12 @@ Avatar:
     preset:4  dark skin, teal hair, excited, normal
 
   Custom attributes (--avatar-* flags, omitted fields use defaults):
-    --avatar-rotation   1=far-left  3=center(default)  5=far-right
-    --avatar-skin       light / light-medium / medium(default) / medium-dark / dark
-    --avatar-hair-style 1–5 (default: 1)
-    --avatar-hair-color blonde / teal / grey / pink / brown(default)
-    --avatar-expression calm(default) / content / neutral / pleasant / excited
-    --avatar-intensity  chill / normal(default) / hyped
+    --avatar-rotation    1=far-left  3=center(default)  5=far-right
+    --avatar-skin        light / light-medium / medium(default) / medium-dark / dark
+    --avatar-hair-style  1–5 (default: 1)
+    --avatar-hair-color  blonde / teal / grey / pink / brown(default)
+    --avatar-expression  calm(default) / content / neutral / pleasant / excited
+    --avatar-intensity   chill / normal(default) / hyped
 
   Note: --avatar and --avatar-* cannot be used together.
 

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -14,6 +14,7 @@ interface AgentEditOptions {
   displayName?: string;
   description?: string;
   sound?: string;
+  avatar?: string;
   skills?: string;
   addSkill?: string;
   removeSkill?: string;
@@ -22,11 +23,20 @@ interface AgentEditOptions {
   model?: string;
 }
 
+function validateAvatar(value: string): void {
+  if (/^preset:[0-4]$/.test(value)) return;
+  if (/^svg:r[1-5]s[0-4]h[1-5]c[1-5]f[1-5][dmh]$/.test(value)) return;
+  throw new Error(
+    `Invalid avatar "${value}". Use preset:0–4 or svg:r{1-5}s{0-4}h{1-5}c{1-5}f{1-5}{d|m|h} (e.g. svg:r3s1h2c2f4h)`,
+  );
+}
+
 function hasAgentFieldUpdate(options: AgentEditOptions): boolean {
   return (
     options.displayName !== undefined ||
     options.description !== undefined ||
     options.sound !== undefined ||
+    options.avatar !== undefined ||
     options.skills !== undefined ||
     options.addSkill !== undefined ||
     options.removeSkill !== undefined ||
@@ -64,6 +74,10 @@ async function applyAgentUpdate(
       options.sound !== undefined
         ? options.sound
         : (current.sound ?? undefined),
+    avatarUrl:
+      options.avatar !== undefined
+        ? options.avatar
+        : (current.avatarUrl ?? undefined),
     customSkills,
     modelProviderId,
     selectedModel,
@@ -131,6 +145,7 @@ export const editCommand = new Command()
     "--sound <tone>",
     "New tone: professional, friendly, direct, supportive",
   )
+  .option("--avatar <config>", "Agent avatar (preset:0–4 or custom svg: string)")
   .option(
     "--skills <items>",
     "Comma-separated custom skill names to attach (replaces existing)",
@@ -149,9 +164,26 @@ export const editCommand = new Command()
   .addHelpText(
     "after",
     `
+Avatar format:
+  Presets:
+    preset:0  light skin, brown hair, calm, hyped
+    preset:1  light-medium skin, grey hair, calm, normal
+    preset:2  medium skin, pink hair, neutral, chill
+    preset:3  medium-dark skin, blonde hair, pleasant, hyped
+    preset:4  dark skin, teal hair, excited, normal
+  Custom: svg:r{R}s{S}h{H}c{C}f{F}{I}
+    R  head angle   1=far-left  3=center  5=far-right
+    S  skin tone    0=lightest  2=medium  4=darkest
+    H  hair style   1–5
+    C  hair color   1=blonde  2=teal  3=grey  4=pink  5=brown
+    F  expression   1=calm  3=neutral  5=excited
+    I  intensity    d=chill  m=normal  h=hyped
+
 Examples:
   Update description:      zero agent edit <agent-id> --description "new role"
   Update tone:             zero agent edit <agent-id> --sound friendly
+  Set avatar:              zero agent edit <agent-id> --avatar preset:2
+  Custom avatar:           zero agent edit <agent-id> --avatar svg:r3s1h2c2f4h
   Replace all skills:      zero agent edit <agent-id> --skills my-skill,other-skill
   Add a skill:             zero agent edit <agent-id> --add-skill my-skill
   Remove a skill:          zero agent edit <agent-id> --remove-skill my-skill
@@ -174,8 +206,12 @@ Notes:
 
       if (!hasAgentUpdate && !options.instructionsFile) {
         throw new Error(
-          "At least one option is required (--display-name, --description, --sound, --skills, --add-skill, --remove-skill, --model-provider, --model, --instructions-file)",
+          "At least one option is required (--display-name, --description, --sound, --avatar, --skills, --add-skill, --remove-skill, --model-provider, --model, --instructions-file)",
         );
+      }
+
+      if (options.avatar !== undefined) {
+        validateAvatar(options.avatar);
       }
 
       if (hasAgentUpdate) {

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -314,12 +314,12 @@ Avatar:
     preset:4  dark skin, teal hair, excited, normal
 
   Custom attributes (--avatar-* flags, replace the entire avatar):
-    --avatar-rotation   1=far-left  3=center(default)  5=far-right
-    --avatar-skin       light / light-medium / medium(default) / medium-dark / dark
-    --avatar-hair-style 1–5 (default: 1)
-    --avatar-hair-color blonde / teal / grey / pink / brown(default)
-    --avatar-expression calm(default) / content / neutral / pleasant / excited
-    --avatar-intensity  chill / normal(default) / hyped
+    --avatar-rotation    1=far-left  3=center(default)  5=far-right
+    --avatar-skin        light / light-medium / medium(default) / medium-dark / dark
+    --avatar-hair-style  1–5 (default: 1)
+    --avatar-hair-color  blonde / teal / grey / pink / brown(default)
+    --avatar-expression  calm(default) / content / neutral / pleasant / excited
+    --avatar-intensity   chill / normal(default) / hyped
 
   Note: --avatar and --avatar-* cannot be used together.
 

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -10,11 +10,132 @@ import {
 import { withErrorHandler } from "../../../lib/command";
 import { parseModelFlag } from "../../../lib/domain/model-provider/shared";
 
-interface AgentEditOptions {
+const SKIN_MAP: Record<string, number> = {
+  light: 0,
+  "light-medium": 1,
+  medium: 2,
+  "medium-dark": 3,
+  dark: 4,
+};
+
+const HAIR_COLOR_MAP: Record<string, number> = {
+  blonde: 1,
+  teal: 2,
+  grey: 3,
+  pink: 4,
+  brown: 5,
+};
+
+const EXPRESSION_MAP: Record<string, number> = {
+  calm: 1,
+  content: 2,
+  neutral: 3,
+  pleasant: 4,
+  excited: 5,
+};
+
+const INTENSITY_MAP: Record<string, "d" | "m" | "h"> = {
+  chill: "d",
+  normal: "m",
+  hyped: "h",
+};
+
+function lookupRequired<T>(
+  value: string,
+  map: Readonly<Record<string, T>>,
+  flag: string,
+): T {
+  if (!(value in map)) {
+    throw new Error(
+      `Invalid ${flag} "${value}". Must be one of: ${Object.keys(map).join(", ")}`,
+    );
+  }
+  return map[value]!;
+}
+
+interface AvatarOptions {
+  avatar?: string;
+  avatarRotation?: string;
+  avatarSkin?: string;
+  avatarHairStyle?: string;
+  avatarHairColor?: string;
+  avatarExpression?: string;
+  avatarIntensity?: string;
+}
+
+function resolveAvatarUrl(opts: AvatarOptions): string | undefined {
+  const hasPreset = opts.avatar !== undefined;
+  const hasCustom =
+    opts.avatarRotation !== undefined ||
+    opts.avatarSkin !== undefined ||
+    opts.avatarHairStyle !== undefined ||
+    opts.avatarHairColor !== undefined ||
+    opts.avatarExpression !== undefined ||
+    opts.avatarIntensity !== undefined;
+
+  if (!hasPreset && !hasCustom) return undefined;
+
+  if (hasPreset && hasCustom) {
+    throw new Error(
+      "--avatar cannot be combined with --avatar-* attribute options",
+    );
+  }
+
+  if (hasPreset) {
+    if (!/^preset:[0-4]$/.test(opts.avatar!)) {
+      throw new Error(
+        `Invalid --avatar "${opts.avatar}". Use preset:0 through preset:4`,
+      );
+    }
+    return opts.avatar;
+  }
+
+  let r = 3;
+  if (opts.avatarRotation !== undefined) {
+    const n = Number(opts.avatarRotation);
+    if (!Number.isInteger(n) || n < 1 || n > 5) {
+      throw new Error(
+        `Invalid --avatar-rotation "${opts.avatarRotation}". Must be 1–5`,
+      );
+    }
+    r = n;
+  }
+
+  let h = 1;
+  if (opts.avatarHairStyle !== undefined) {
+    const n = Number(opts.avatarHairStyle);
+    if (!Number.isInteger(n) || n < 1 || n > 5) {
+      throw new Error(
+        `Invalid --avatar-hair-style "${opts.avatarHairStyle}". Must be 1–5`,
+      );
+    }
+    h = n;
+  }
+
+  const s =
+    opts.avatarSkin !== undefined
+      ? lookupRequired(opts.avatarSkin, SKIN_MAP, "--avatar-skin")
+      : 2;
+  const c =
+    opts.avatarHairColor !== undefined
+      ? lookupRequired(opts.avatarHairColor, HAIR_COLOR_MAP, "--avatar-hair-color")
+      : 5;
+  const f =
+    opts.avatarExpression !== undefined
+      ? lookupRequired(opts.avatarExpression, EXPRESSION_MAP, "--avatar-expression")
+      : 1;
+  const i =
+    opts.avatarIntensity !== undefined
+      ? lookupRequired(opts.avatarIntensity, INTENSITY_MAP, "--avatar-intensity")
+      : "m";
+
+  return `svg:r${r}s${s}h${h}c${c}f${f}${i}`;
+}
+
+interface AgentEditOptions extends AvatarOptions {
   displayName?: string;
   description?: string;
   sound?: string;
-  avatar?: string;
   skills?: string;
   addSkill?: string;
   removeSkill?: string;
@@ -23,11 +144,15 @@ interface AgentEditOptions {
   model?: string;
 }
 
-function validateAvatar(value: string): void {
-  if (/^preset:[0-4]$/.test(value)) return;
-  if (/^svg:r[1-5]s[0-4]h[1-5]c[1-5]f[1-5][dmh]$/.test(value)) return;
-  throw new Error(
-    `Invalid avatar "${value}". Use preset:0–4 or svg:r{1-5}s{0-4}h{1-5}c{1-5}f{1-5}{d|m|h} (e.g. svg:r3s1h2c2f4h)`,
+function hasAvatarUpdate(options: AvatarOptions): boolean {
+  return (
+    options.avatar !== undefined ||
+    options.avatarRotation !== undefined ||
+    options.avatarSkin !== undefined ||
+    options.avatarHairStyle !== undefined ||
+    options.avatarHairColor !== undefined ||
+    options.avatarExpression !== undefined ||
+    options.avatarIntensity !== undefined
   );
 }
 
@@ -36,7 +161,7 @@ function hasAgentFieldUpdate(options: AgentEditOptions): boolean {
     options.displayName !== undefined ||
     options.description !== undefined ||
     options.sound !== undefined ||
-    options.avatar !== undefined ||
+    hasAvatarUpdate(options) ||
     options.skills !== undefined ||
     options.addSkill !== undefined ||
     options.removeSkill !== undefined ||
@@ -61,6 +186,10 @@ async function applyAgentUpdate(
       ? parseModelFlag(options.model)
       : current.selectedModel;
 
+  const avatarUrl = hasAvatarUpdate(options)
+    ? resolveAvatarUrl(options)
+    : (current.avatarUrl ?? undefined);
+
   await updateZeroAgent(agentId, {
     displayName:
       options.displayName !== undefined
@@ -74,10 +203,7 @@ async function applyAgentUpdate(
       options.sound !== undefined
         ? options.sound
         : (current.sound ?? undefined),
-    avatarUrl:
-      options.avatar !== undefined
-        ? options.avatar
-        : (current.avatarUrl ?? undefined),
+    avatarUrl,
     customSkills,
     modelProviderId,
     selectedModel,
@@ -145,7 +271,22 @@ export const editCommand = new Command()
     "--sound <tone>",
     "New tone: professional, friendly, direct, supportive",
   )
-  .option("--avatar <config>", "Agent avatar (preset:0–4 or custom svg: string)")
+  .option("--avatar <preset>", "Avatar preset: preset:0 through preset:4")
+  .option("--avatar-rotation <1-5>", "Head angle: 1=far-left  3=center  5=far-right")
+  .option(
+    "--avatar-skin <tone>",
+    "Skin tone: light | light-medium | medium | medium-dark | dark",
+  )
+  .option("--avatar-hair-style <1-5>", "Hair style: 1–5")
+  .option(
+    "--avatar-hair-color <color>",
+    "Hair color: blonde | teal | grey | pink | brown",
+  )
+  .option(
+    "--avatar-expression <expr>",
+    "Expression: calm | content | neutral | pleasant | excited",
+  )
+  .option("--avatar-intensity <level>", "Intensity: chill | normal | hyped")
   .option(
     "--skills <items>",
     "Comma-separated custom skill names to attach (replaces existing)",
@@ -164,26 +305,29 @@ export const editCommand = new Command()
   .addHelpText(
     "after",
     `
-Avatar format:
-  Presets:
+Avatar:
+  Quick presets (--avatar):
     preset:0  light skin, brown hair, calm, hyped
     preset:1  light-medium skin, grey hair, calm, normal
     preset:2  medium skin, pink hair, neutral, chill
     preset:3  medium-dark skin, blonde hair, pleasant, hyped
     preset:4  dark skin, teal hair, excited, normal
-  Custom: svg:r{R}s{S}h{H}c{C}f{F}{I}
-    R  head angle   1=far-left  3=center  5=far-right
-    S  skin tone    0=lightest  2=medium  4=darkest
-    H  hair style   1–5
-    C  hair color   1=blonde  2=teal  3=grey  4=pink  5=brown
-    F  expression   1=calm  3=neutral  5=excited
-    I  intensity    d=chill  m=normal  h=hyped
+
+  Custom attributes (--avatar-* flags, replace the entire avatar):
+    --avatar-rotation   1=far-left  3=center(default)  5=far-right
+    --avatar-skin       light / light-medium / medium(default) / medium-dark / dark
+    --avatar-hair-style 1–5 (default: 1)
+    --avatar-hair-color blonde / teal / grey / pink / brown(default)
+    --avatar-expression calm(default) / content / neutral / pleasant / excited
+    --avatar-intensity  chill / normal(default) / hyped
+
+  Note: --avatar and --avatar-* cannot be used together.
 
 Examples:
   Update description:      zero agent edit <agent-id> --description "new role"
   Update tone:             zero agent edit <agent-id> --sound friendly
-  Set avatar:              zero agent edit <agent-id> --avatar preset:2
-  Custom avatar:           zero agent edit <agent-id> --avatar svg:r3s1h2c2f4h
+  Quick preset avatar:     zero agent edit <agent-id> --avatar preset:2
+  Custom avatar:           zero agent edit <agent-id> --avatar-skin dark --avatar-hair-color teal --avatar-intensity hyped
   Replace all skills:      zero agent edit <agent-id> --skills my-skill,other-skill
   Add a skill:             zero agent edit <agent-id> --add-skill my-skill
   Remove a skill:          zero agent edit <agent-id> --remove-skill my-skill
@@ -206,12 +350,8 @@ Notes:
 
       if (!hasAgentUpdate && !options.instructionsFile) {
         throw new Error(
-          "At least one option is required (--display-name, --description, --sound, --avatar, --skills, --add-skill, --remove-skill, --model-provider, --model, --instructions-file)",
+          "At least one option is required (--display-name, --description, --sound, --avatar, --avatar-*, --skills, --add-skill, --remove-skill, --model-provider, --model, --instructions-file)",
         );
-      }
-
-      if (options.avatar !== undefined) {
-        validateAvatar(options.avatar);
       }
 
       if (hasAgentUpdate) {

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -53,9 +53,8 @@ async function applyAgentUpdate(
   agentId: string,
   options: AgentEditOptions,
 ): Promise<void> {
-  const resolvedAvatarUrl = hasAvatarUpdate(options)
-    ? resolveAvatarUrl(options)
-    : undefined;
+  const hasAvatar = hasAvatarUpdate(options);
+  const resolvedAvatarUrl = hasAvatar ? resolveAvatarUrl(options) : undefined;
 
   const current = await getZeroAgent(agentId);
   const customSkills = resolveCustomSkills(options, current.customSkills ?? []);
@@ -69,7 +68,7 @@ async function applyAgentUpdate(
       ? parseModelFlag(options.model)
       : current.selectedModel;
 
-  const avatarUrl = hasAvatarUpdate(options)
+  const avatarUrl = hasAvatar
     ? resolvedAvatarUrl
     : (current.avatarUrl ?? undefined);
 

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -9,128 +9,7 @@ import {
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import { parseModelFlag } from "../../../lib/domain/model-provider/shared";
-
-const SKIN_MAP: Record<string, number> = {
-  light: 0,
-  "light-medium": 1,
-  medium: 2,
-  "medium-dark": 3,
-  dark: 4,
-};
-
-const HAIR_COLOR_MAP: Record<string, number> = {
-  blonde: 1,
-  teal: 2,
-  grey: 3,
-  pink: 4,
-  brown: 5,
-};
-
-const EXPRESSION_MAP: Record<string, number> = {
-  calm: 1,
-  content: 2,
-  neutral: 3,
-  pleasant: 4,
-  excited: 5,
-};
-
-const INTENSITY_MAP: Record<string, "d" | "m" | "h"> = {
-  chill: "d",
-  normal: "m",
-  hyped: "h",
-};
-
-function lookupRequired<T>(
-  value: string,
-  map: Readonly<Record<string, T>>,
-  flag: string,
-): T {
-  if (!(value in map)) {
-    throw new Error(
-      `Invalid ${flag} "${value}". Must be one of: ${Object.keys(map).join(", ")}`,
-    );
-  }
-  return map[value]!;
-}
-
-interface AvatarOptions {
-  avatar?: string;
-  avatarRotation?: string;
-  avatarSkin?: string;
-  avatarHairStyle?: string;
-  avatarHairColor?: string;
-  avatarExpression?: string;
-  avatarIntensity?: string;
-}
-
-function resolveAvatarUrl(opts: AvatarOptions): string | undefined {
-  const hasPreset = opts.avatar !== undefined;
-  const hasCustom =
-    opts.avatarRotation !== undefined ||
-    opts.avatarSkin !== undefined ||
-    opts.avatarHairStyle !== undefined ||
-    opts.avatarHairColor !== undefined ||
-    opts.avatarExpression !== undefined ||
-    opts.avatarIntensity !== undefined;
-
-  if (!hasPreset && !hasCustom) return undefined;
-
-  if (hasPreset && hasCustom) {
-    throw new Error(
-      "--avatar cannot be combined with --avatar-* attribute options",
-    );
-  }
-
-  if (hasPreset) {
-    if (!/^preset:[0-4]$/.test(opts.avatar!)) {
-      throw new Error(
-        `Invalid --avatar "${opts.avatar}". Use preset:0 through preset:4`,
-      );
-    }
-    return opts.avatar;
-  }
-
-  let r = 3;
-  if (opts.avatarRotation !== undefined) {
-    const n = Number(opts.avatarRotation);
-    if (!Number.isInteger(n) || n < 1 || n > 5) {
-      throw new Error(
-        `Invalid --avatar-rotation "${opts.avatarRotation}". Must be 1–5`,
-      );
-    }
-    r = n;
-  }
-
-  let h = 1;
-  if (opts.avatarHairStyle !== undefined) {
-    const n = Number(opts.avatarHairStyle);
-    if (!Number.isInteger(n) || n < 1 || n > 5) {
-      throw new Error(
-        `Invalid --avatar-hair-style "${opts.avatarHairStyle}". Must be 1–5`,
-      );
-    }
-    h = n;
-  }
-
-  const s =
-    opts.avatarSkin !== undefined
-      ? lookupRequired(opts.avatarSkin, SKIN_MAP, "--avatar-skin")
-      : 2;
-  const c =
-    opts.avatarHairColor !== undefined
-      ? lookupRequired(opts.avatarHairColor, HAIR_COLOR_MAP, "--avatar-hair-color")
-      : 5;
-  const f =
-    opts.avatarExpression !== undefined
-      ? lookupRequired(opts.avatarExpression, EXPRESSION_MAP, "--avatar-expression")
-      : 1;
-  const i =
-    opts.avatarIntensity !== undefined
-      ? lookupRequired(opts.avatarIntensity, INTENSITY_MAP, "--avatar-intensity")
-      : "m";
-
-  return `svg:r${r}s${s}h${h}c${c}f${f}${i}`;
-}
+import { type AvatarOptions, resolveAvatarUrl } from "./avatar";
 
 interface AgentEditOptions extends AvatarOptions {
   displayName?: string;
@@ -174,6 +53,10 @@ async function applyAgentUpdate(
   agentId: string,
   options: AgentEditOptions,
 ): Promise<void> {
+  const resolvedAvatarUrl = hasAvatarUpdate(options)
+    ? resolveAvatarUrl(options)
+    : undefined;
+
   const current = await getZeroAgent(agentId);
   const customSkills = resolveCustomSkills(options, current.customSkills ?? []);
 
@@ -187,7 +70,7 @@ async function applyAgentUpdate(
       : current.selectedModel;
 
   const avatarUrl = hasAvatarUpdate(options)
-    ? resolveAvatarUrl(options)
+    ? resolvedAvatarUrl
     : (current.avatarUrl ?? undefined);
 
   await updateZeroAgent(agentId, {
@@ -272,7 +155,10 @@ export const editCommand = new Command()
     "New tone: professional, friendly, direct, supportive",
   )
   .option("--avatar <preset>", "Avatar preset: preset:0 through preset:4")
-  .option("--avatar-rotation <1-5>", "Head angle: 1=far-left  3=center  5=far-right")
+  .option(
+    "--avatar-rotation <1-5>",
+    "Head angle: 1=far-left  3=center  5=far-right",
+  )
   .option(
     "--avatar-skin <tone>",
     "Skin tone: light | light-medium | medium | medium-dark | dark",


### PR DESCRIPTION
## Summary

Adds avatar support to `zero agent create` and `zero agent edit`. The `svg:` serialization format is an internal detail — agents and users never construct it manually.

**Two ways to set an avatar:**

1. **Quick preset** — `--avatar preset:0` through `preset:4`
2. **Descriptive attribute flags** — pick named values, CLI composes the svg string:

| Flag | Values | Default |
|------|--------|---------|
| `--avatar-rotation` | 1 (far-left) – 5 (far-right) | 3 (center) |
| `--avatar-skin` | light / light-medium / medium / medium-dark / dark | medium |
| `--avatar-hair-style` | 1–5 | 1 |
| `--avatar-hair-color` | blonde / teal / grey / pink / brown | brown |
| `--avatar-expression` | calm / content / neutral / pleasant / excited | calm |
| `--avatar-intensity` | chill / normal / hyped | normal |

`--avatar` and `--avatar-*` flags are mutually exclusive. For `edit`, omitting all avatar flags preserves the existing avatar.

**Preset reference** (shown in `--help`):
- `preset:0` light skin, brown hair, calm, hyped
- `preset:1` light-medium skin, grey hair, calm, normal
- `preset:2` medium skin, pink hair, neutral, chill
- `preset:3` medium-dark skin, blonde hair, pleasant, hyped
- `preset:4` dark skin, teal hair, excited, normal

## Test plan

- [ ] `--avatar preset:2` sends `avatarUrl: "preset:2"`
- [ ] `--avatar-skin dark --avatar-hair-color teal --avatar-intensity hyped` composes to correct `svg:` string
- [ ] `--avatar preset:1 --avatar-skin dark` exits with "cannot be combined" error
- [ ] `--avatar-hair-color purple` exits with "Invalid --avatar-hair-color" error
- [ ] `zero agent edit <id> --display-name x` (no avatar flags) preserves existing `avatarUrl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)