### PR TITLE
perf(chat): parallelize thread resolution and bound message scans

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -9,7 +9,8 @@ import {
   insertChatMessage,
   insertAssistantEventMessages,
   publishChatThreadRunUpdated,
-  getMessagesByThreadId,
+  getLatestMessagesByThreadId,
+  PREVIOUS_CONTEXT_MESSAGES,
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
 import {
   generateChatTitle,
@@ -94,20 +95,22 @@ async function queryAssistantEvents(
  * Load the prior conversation turns to feed into title generation, excluding
  * the current exchange (this run's user message and assistant events).
  * Returns up to the last 10 messages (~5 rounds), oldest → newest.
+ *
+ * All filters (content not null, role user/assistant, exclude current run)
+ * run in SQL so the scan is bounded by `LIMIT N` even on long threads.
  */
 async function loadPriorTitleContext(
   threadId: string,
   currentRunId: string,
 ): Promise<TitleContextMessage[]> {
-  const messages = await getMessagesByThreadId(threadId);
-  const prior: TitleContextMessage[] = [];
-  for (const m of messages) {
-    if (m.runId === currentRunId) continue;
-    if (m.content === null) continue;
-    if (m.role !== "user" && m.role !== "assistant") continue;
-    prior.push({ role: m.role, content: m.content });
-  }
-  return prior.slice(-10);
+  const messages = await getLatestMessagesByThreadId(
+    threadId,
+    PREVIOUS_CONTEXT_MESSAGES,
+    { excludeRunId: currentRunId },
+  );
+  return messages.map((m) => {
+    return { role: m.role as "user" | "assistant", content: m.content! };
+  });
 }
 
 /**

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -109,7 +109,7 @@ async function loadPriorTitleContext(
     { excludeRunId: currentRunId },
   );
   return messages.map((m) => {
-    return { role: m.role as "user" | "assistant", content: m.content! };
+    return { role: m.role, content: m.content };
   });
 }
 

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.incomplete-context.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.incomplete-context.test.ts
@@ -272,4 +272,86 @@ describe("POST /api/zero/chat/messages — incomplete rounds context", () => {
     expect(prompt).toContain("…[truncated]");
     expect(prompt).not.toContain("x".repeat(5000));
   });
+
+  it("handles a long thread (≥100 messages) without scanning all of history", async () => {
+    // Seed 50 successive rounds (~100 chat_messages rows — one user + one
+    // placeholder assistant per round) so the thread is well past the
+    // PREVIOUS_CONTEXT_MESSAGES bound and past the incomplete-rounds 20-cap.
+    // The old `getMessagesByThreadId` scan + JS filter would read every row
+    // on every send; under the bounded rewrite this send must still succeed
+    // in reasonable time.
+    const first = await sendMessage({ agentId, prompt: "round 0" });
+    for (let i = 1; i < 50; i++) {
+      await sendMessage({
+        agentId,
+        prompt: `round ${i}`,
+        threadId: first.threadId,
+      });
+    }
+
+    const final = await sendMessage({
+      agentId,
+      prompt: "final",
+      threadId: first.threadId,
+    });
+
+    const run = await getTestRun(final.runId);
+    // None of the old rounds were cancelled, so the incomplete-rounds block
+    // must not appear — this also confirms the anchor subquery correctly
+    // returns no candidates when every run in the thread is healthy.
+    expect(run.appendSystemPrompt ?? "").not.toContain(
+      "# Incomplete Rounds Context",
+    );
+  });
+
+  it("anchors incomplete rounds correctly on a long thread with a mid-thread success", async () => {
+    // Pre-success tail: 30+ cancelled rounds the anchor must exclude.
+    const first = await sendMessage({ agentId, prompt: "early fail" });
+    await setTestRunStatus(first.runId, "cancelled");
+
+    for (let i = 0; i < 30; i++) {
+      const sent = await sendMessage({
+        agentId,
+        prompt: `pre-success ${i}`,
+        threadId: first.threadId,
+      });
+      await setTestRunStatus(sent.runId, "cancelled");
+    }
+
+    // Mid-thread success — stamps `agentSessionId` onto agent_runs.result,
+    // which is what the SQL anchor subquery keys off.
+    const success = await sendMessage({
+      agentId,
+      prompt: "success run",
+      threadId: first.threadId,
+    });
+    const { agentSessionId } = await completeTestRun(
+      user.userId,
+      success.runId,
+    );
+    await setTestRunResult(success.runId, { agentSessionId });
+
+    // Post-success incomplete round — must appear in incompleteContext.
+    const afterSuccess = await sendMessage({
+      agentId,
+      prompt: "post-success cancel",
+      threadId: first.threadId,
+    });
+    await setTestRunStatus(afterSuccess.runId, "cancelled");
+
+    const next = await sendMessage({
+      agentId,
+      prompt: "final",
+      threadId: first.threadId,
+    });
+
+    const run = await getTestRun(next.runId);
+    const prompt = run.appendSystemPrompt ?? "";
+    // Rounds after the anchor survive; rounds before it are dropped even
+    // though the thread has 30+ of them just upstream of the success.
+    expect(prompt).toContain("User: post-success cancel");
+    expect(prompt).not.toContain("User: pre-success 0");
+    expect(prompt).not.toContain("User: pre-success 29");
+    expect(prompt).not.toContain("User: early fail");
+  });
 });

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -26,9 +26,10 @@ import {
 import {
   insertChatMessage,
   getLatestSessionIdForThread,
-  getMessagesByThreadId,
+  getLatestMessagesByThreadId,
   getIncompleteRoundsSinceLastSuccess,
   publishThreadListChanged,
+  PREVIOUS_CONTEXT_MESSAGES,
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
 import { generateChatTitle } from "../../../../../src/lib/zero/ai/lightweight-model";
 import { zeroAgents } from "../../../../../src/db/schema/zero-agent";
@@ -194,22 +195,25 @@ async function resolveThread(
     };
   }
 
-  const thread = await getChatThread(existingThreadId, userId);
-  const sessionId = await getLatestSessionIdForThread(thread.id);
-  const messages = await getMessagesByThreadId(thread.id);
-  const previousContext = messages
-    .filter((m) => {
-      return m.content !== null;
-    })
-    .slice(-10)
-    .map((m) => {
-      return {
-        role: m.role as "user" | "assistant",
-        content: m.content as string,
-      };
-    });
+  // All four reads key off `(existingThreadId, userId)` and have no data
+  // dependency on each other. Running them in parallel drops the happy-path
+  // wall time to the slowest of the four, not their sum.
+  const [thread, sessionId, messages, incompleteRows] = await Promise.all([
+    getChatThread(existingThreadId, userId),
+    getLatestSessionIdForThread(existingThreadId),
+    getLatestMessagesByThreadId(existingThreadId, PREVIOUS_CONTEXT_MESSAGES),
+    getIncompleteRoundsSinceLastSuccess(existingThreadId),
+  ]);
 
-  const incompleteRows = await getIncompleteRoundsSinceLastSuccess(thread.id);
+  // `messages` already satisfies `content IS NOT NULL` and role IN
+  // ('user','assistant') in SQL — no further filtering needed.
+  const previousContext = messages.map((m) => {
+    return {
+      role: m.role as "user" | "assistant",
+      content: m.content as string,
+    };
+  });
+
   const incompleteContext = buildWebChatIncompleteContext(
     groupIncompleteRoundsByRunId(incompleteRows),
   );

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -206,12 +206,10 @@ async function resolveThread(
   ]);
 
   // `messages` already satisfies `content IS NOT NULL` and role IN
-  // ('user','assistant') in SQL — no further filtering needed.
+  // ('user','assistant') in SQL; the service narrows the row shape so no
+  // per-caller casts are needed.
   const previousContext = messages.map((m) => {
-    return {
-      role: m.role as "user" | "assistant",
-      content: m.content as string,
-    };
+    return { role: m.role, content: m.content };
   });
 
   const incompleteContext = buildWebChatIncompleteContext(

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
@@ -1,15 +1,4 @@
-import {
-  eq,
-  asc,
-  desc,
-  and,
-  or,
-  ne,
-  sql,
-  inArray,
-  isNull,
-  isNotNull,
-} from "drizzle-orm";
+import { eq, asc, desc, and, sql, inArray, isNotNull } from "drizzle-orm";
 import {
   chatMessages,
   type ChatMessageAttachFiles,
@@ -53,6 +42,17 @@ type MessageRow = {
   runStatus: string | null;
   runError: string | null;
   attachFiles: ChatMessageAttachFiles | null;
+};
+
+/**
+ * Narrower row shape returned by `getLatestMessagesByThreadId`. The SQL
+ * query enforces `role IN ('user','assistant')` and `content IS NOT NULL`,
+ * so callers can treat those fields as already narrowed without reaching
+ * for `as` casts.
+ */
+type PromptContextMessageRow = Omit<MessageRow, "role" | "content"> & {
+  role: "user" | "assistant";
+  content: string;
 };
 
 /**
@@ -246,20 +246,16 @@ export async function getLatestMessagesByThreadId(
   chatThreadId: string,
   limit: number,
   options?: { excludeRunId?: string },
-): Promise<MessageRow[]> {
+): Promise<PromptContextMessageRow[]> {
   const conditions = [
     eq(chatMessages.chatThreadId, chatThreadId),
     isNotNull(chatMessages.content),
     inArray(chatMessages.role, ["user", "assistant"]),
   ];
   if (options?.excludeRunId !== undefined) {
-    const excludeClause = or(
-      isNull(chatMessages.runId),
-      ne(chatMessages.runId, options.excludeRunId),
+    conditions.push(
+      sql`(${chatMessages.runId} IS NULL OR ${chatMessages.runId} != ${options.excludeRunId})`,
     );
-    if (excludeClause !== undefined) {
-      conditions.push(excludeClause);
-    }
   }
 
   const rows = await globalThis.services.db
@@ -269,7 +265,15 @@ export async function getLatestMessagesByThreadId(
     .where(and(...conditions))
     .orderBy(desc(chatMessages.createdAt), desc(chatMessages.sequenceNumber))
     .limit(limit);
-  return rows.reverse();
+  // SQL guarantees role ∈ {'user','assistant'} and content IS NOT NULL, so
+  // narrow once here instead of pushing the cast out to every caller.
+  return rows.reverse().map((row) => {
+    return {
+      ...row,
+      role: row.role as "user" | "assistant",
+      content: row.content as string,
+    };
+  });
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
@@ -1,4 +1,15 @@
-import { eq, asc, desc, and, sql } from "drizzle-orm";
+import {
+  eq,
+  asc,
+  desc,
+  and,
+  or,
+  ne,
+  sql,
+  inArray,
+  isNull,
+  isNotNull,
+} from "drizzle-orm";
 import {
   chatMessages,
   type ChatMessageAttachFiles,
@@ -8,6 +19,41 @@ import { agentRuns } from "../../../db/schema/agent-run";
 import { zeroRuns } from "../../../db/schema/zero-run";
 import { publishUserSignal } from "../../infra/realtime/client";
 import { hasAgentSessionId } from "../run-result";
+
+/**
+ * Number of most-recent prior-context messages consumed by prompt builders
+ * (chat send's `previousContext` and chat callback's title context). Rows
+ * returned by `getLatestMessagesByThreadId` are already filtered by
+ * `content IS NOT NULL` and role IN ('user','assistant') in SQL, so this
+ * bound is the exact count of usable rows — not a raw scan size.
+ */
+export const PREVIOUS_CONTEXT_MESSAGES = 10;
+
+const messageRowProjection = {
+  id: chatMessages.id,
+  role: chatMessages.role,
+  content: chatMessages.content,
+  runId: chatMessages.runId,
+  error: chatMessages.error,
+  sequenceNumber: chatMessages.sequenceNumber,
+  createdAt: chatMessages.createdAt,
+  runStatus: agentRuns.status,
+  runError: agentRuns.error,
+  attachFiles: chatMessages.attachFiles,
+} as const;
+
+type MessageRow = {
+  id: string;
+  role: string;
+  content: string | null;
+  runId: string | null;
+  error: string | null;
+  sequenceNumber: number | null;
+  createdAt: Date;
+  runStatus: string | null;
+  runError: string | null;
+  attachFiles: ChatMessageAttachFiles | null;
+};
 
 /**
  * Insert a chat message (user row on send, or assistant row on terminal
@@ -163,38 +209,67 @@ export async function publishThreadListChanged(userId: string): Promise<void> {
 
 /**
  * Get all messages for a thread with run status, ordered by createdAt ASC.
+ *
+ * Unbounded — only callers that truly need the full thread (e.g., the SPA's
+ * thread-bootstrap endpoint) should use this. Prompt-context builders must
+ * use `getLatestMessagesByThreadId`, which bounds the scan to `LIMIT N` and
+ * pushes usability filters into SQL so thread length does not compound
+ * latency on every send.
  */
-export async function getMessagesByThreadId(chatThreadId: string): Promise<
-  Array<{
-    id: string;
-    role: string;
-    content: string | null;
-    runId: string | null;
-    error: string | null;
-    sequenceNumber: number | null;
-    createdAt: Date;
-    runStatus: string | null;
-    runError: string | null;
-    attachFiles: ChatMessageAttachFiles | null;
-  }>
-> {
+export async function getMessagesByThreadId(
+  chatThreadId: string,
+): Promise<MessageRow[]> {
   return globalThis.services.db
-    .select({
-      id: chatMessages.id,
-      role: chatMessages.role,
-      content: chatMessages.content,
-      runId: chatMessages.runId,
-      error: chatMessages.error,
-      sequenceNumber: chatMessages.sequenceNumber,
-      createdAt: chatMessages.createdAt,
-      runStatus: agentRuns.status,
-      runError: agentRuns.error,
-      attachFiles: chatMessages.attachFiles,
-    })
+    .select(messageRowProjection)
     .from(chatMessages)
     .leftJoin(agentRuns, eq(chatMessages.runId, agentRuns.id))
     .where(eq(chatMessages.chatThreadId, chatThreadId))
     .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));
+}
+
+/**
+ * Fetch the latest `limit` messages for a thread that are eligible for
+ * prompt-context inclusion, returned in chronological order.
+ *
+ * Filters applied in SQL (so `limit` bounds the usable output, not the raw
+ * scan):
+ *  - `content IS NOT NULL` — placeholder assistant rows are excluded
+ *  - `role IN ('user','assistant')` — defensive; matches the downstream cast
+ *  - optional `excludeRunId` — chat callback excludes the current run's own
+ *    rows so the title-context window only contains prior rounds
+ *
+ * Using `ORDER BY createdAt DESC LIMIT N` then `reverse()` in memory keeps
+ * the query driven by `idx_chat_messages_thread_created` (thread_id,
+ * created_at).
+ */
+export async function getLatestMessagesByThreadId(
+  chatThreadId: string,
+  limit: number,
+  options?: { excludeRunId?: string },
+): Promise<MessageRow[]> {
+  const conditions = [
+    eq(chatMessages.chatThreadId, chatThreadId),
+    isNotNull(chatMessages.content),
+    inArray(chatMessages.role, ["user", "assistant"]),
+  ];
+  if (options?.excludeRunId !== undefined) {
+    const excludeClause = or(
+      isNull(chatMessages.runId),
+      ne(chatMessages.runId, options.excludeRunId),
+    );
+    if (excludeClause !== undefined) {
+      conditions.push(excludeClause);
+    }
+  }
+
+  const rows = await globalThis.services.db
+    .select(messageRowProjection)
+    .from(chatMessages)
+    .leftJoin(agentRuns, eq(chatMessages.runId, agentRuns.id))
+    .where(and(...conditions))
+    .orderBy(desc(chatMessages.createdAt), desc(chatMessages.sequenceNumber))
+    .limit(limit);
+  return rows.reverse();
 }
 
 /**
@@ -356,6 +431,17 @@ export async function getIncompleteRoundsSinceLastSuccess(
 ): Promise<IncompleteRoundRow[]> {
   const maxRounds = options?.maxRounds ?? 20;
 
+  // Single query with a session-anchor subquery:
+  //  - anchor: MAX(created_at) among this thread's rows whose run persisted
+  //    a string-typed agentSessionId — matches `hasAgentSessionId` exactly.
+  //  - outer scan: only rows strictly after that anchor with an incomplete
+  //    run status and a valid role, already sorted for the caller.
+  //
+  // INNER JOIN is equivalent to the old LEFT JOIN + `isIncompleteRunStatus(
+  // null) === false` discard, because the status filter only matches when
+  // a matching `agent_runs` row exists. Pushing the status/role filters
+  // into SQL lets Postgres skip the full-thread scan of `agent_runs.result`
+  // JSONB that the old "load every row + JS scan" pattern required.
   const rows = await globalThis.services.db
     .select({
       runId: chatMessages.runId,
@@ -366,23 +452,31 @@ export async function getIncompleteRoundsSinceLastSuccess(
       createdAt: chatMessages.createdAt,
       sequenceNumber: chatMessages.sequenceNumber,
       runStatus: agentRuns.status,
-      runResult: agentRuns.result,
     })
     .from(chatMessages)
-    .leftJoin(agentRuns, eq(chatMessages.runId, agentRuns.id))
-    .where(eq(chatMessages.chatThreadId, chatThreadId))
+    .innerJoin(agentRuns, eq(chatMessages.runId, agentRuns.id))
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, chatThreadId),
+        inArray(agentRuns.status, ["cancelled", "failed", "timeout"]),
+        inArray(chatMessages.role, ["user", "assistant"]),
+        sql`${chatMessages.createdAt} > COALESCE(
+          (
+            SELECT MAX(cm2.created_at)
+            FROM chat_messages cm2
+            INNER JOIN agent_runs ar2 ON cm2.run_id = ar2.id
+            WHERE cm2.chat_thread_id = ${chatThreadId}
+              AND ar2.result ? 'agentSessionId'
+              AND jsonb_typeof(ar2.result->'agentSessionId') = 'string'
+          ),
+          '-infinity'::timestamptz
+        )`,
+      ),
+    )
     .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));
 
-  let anchorIndex = -1;
-  for (let i = 0; i < rows.length; i++) {
-    if (hasAgentSessionId(rows[i]!.runResult)) {
-      anchorIndex = i;
-    }
-  }
-
   const candidates: IncompleteRoundRow[] = [];
-  for (let i = anchorIndex + 1; i < rows.length; i++) {
-    const row = rows[i]!;
+  for (const row of rows) {
     if (row.runId === null) continue;
     if (!isIncompleteRunStatus(row.runStatus)) continue;
     if (row.role !== "user" && row.role !== "assistant") continue;


### PR DESCRIPTION
## Summary

Closes #10593. Pure performance optimization for `POST /api/zero/chat/messages` (resolveThread) and the chat callback handler. **Zero behavior change** — all existing integration tests pass unchanged.

### Zero-behavior-change declaration

The revised plan elected option (A): push content/role/runId filters into SQL with `LIMIT 10` directly, so `previousContext` is now returned in the same form as before without relying on a JS-side `slice(-10)` over a larger pre-fetch. This avoids the subtle correctness risk of a larger fetch + JS filter silently shrinking `previousContext` when the tail has many null-content rows (e.g., placeholder assistant messages or error rows).

Key differences versus prior behavior:

- `previousContext` still contains user+assistant rows with non-null content, still newest-last, still capped at 10 — but the cap + filters are now enforced in SQL. On a healthy thread, output is byte-identical.
- `getIncompleteRoundsSinceLastSuccess` uses an INNER JOIN + SQL anchor subquery keyed off `jsonb_typeof(result->'agentSessionId') = 'string'`. Semantics match the old JS-side `hasAgentSessionId` type guard (string-valued `agentSessionId` anchors; everything else falls through). Orphan `chat_messages` rows with `runId = NULL` were already filtered out by the old JS filter (`isIncompleteRunStatus(null) === false`) so the INNER JOIN is a no-op semantically.
- `getMessagesByThreadId` (used only by the UI bootstrap `getChatThreadMessages`) is **unchanged behaviorally** — refactored to share the projection helper, but still unbounded for full-thread UI load.

### Key diffs

**Handler parallelization** (`app/api/zero/chat/messages/route.ts`):
```ts
const [thread, sessionId, messages, incompleteRows] = await Promise.all([
  getChatThread(existingThreadId, userId),
  getLatestSessionIdForThread(existingThreadId),
  getLatestMessagesByThreadId(existingThreadId, PREVIOUS_CONTEXT_MESSAGES),
  getIncompleteRoundsSinceLastSuccess(existingThreadId),
]);
```

**Bounded read** (`src/lib/zero/chat-thread/chat-message-service.ts`):
```ts
export async function getLatestMessagesByThreadId(
  chatThreadId: string,
  limit: number,
  options?: { excludeRunId?: string },
): Promise<MessageRow[]>
```
Filters `chat_thread_id`, `content IS NOT NULL`, `role IN ('user','assistant')`, optional `run_id != excludeRunId OR IS NULL`, ordered by `(created_at DESC, sequence_number DESC)` with `LIMIT N`, then reversed to oldest→newest.

**SQL anchor** (`getIncompleteRoundsSinceLastSuccess`):
```sql
AND chat_messages.created_at > COALESCE(
  (SELECT MAX(cm2.created_at) FROM chat_messages cm2
   INNER JOIN agent_runs ar2 ON cm2.run_id = ar2.id
   WHERE cm2.chat_thread_id = $1
     AND ar2.result ? 'agentSessionId'
     AND jsonb_typeof(ar2.result->'agentSessionId') = 'string'),
  '-infinity'::timestamptz
)
AND agent_runs.status IN ('cancelled','failed','timeout')
```
JS post-processing is now limited to applying the `maxRounds = 20` cap.

**Callback** (`app/api/internal/callbacks/chat/route.ts`):
`loadPriorTitleContext` now uses `getLatestMessagesByThreadId(threadId, PREVIOUS_CONTEXT_MESSAGES, { excludeRunId: currentRunId })` instead of unbounded `getMessagesByThreadId` + JS filter chain.

### Callers switched — diff summary

| Caller | Before | After |
|---|---|---|
| `app/api/zero/chat/messages/route.ts` (`resolveThread`) | `getMessagesByThreadId(id)` → JS slice(-10) (sequential await) | `getLatestMessagesByThreadId(id, 10)` (parallel in `Promise.all`) |
| `app/api/internal/callbacks/chat/route.ts` (`loadPriorTitleContext`) | `getMessagesByThreadId(id)` → JS filter + slice(-10) | `getLatestMessagesByThreadId(id, 10, { excludeRunId })` |
| `app/api/zero/chat/threads/[id]/messages/route.ts` (UI bootstrap) | `getMessagesByThreadId(id)` | unchanged (still unbounded full-thread read for UI load) |

### Local benchmark (100 POSTs after seeding 100 rounds, 5 runs each)

Seeded thread: 100 rounds (every other round cancelled) ≈ 200 chat_messages rows, ≈ 100 agent_runs. Each iteration issues a new POST against the same thread and measures end-to-end latency.

**Before (main @ 4dd4b9a2c):**
| Run | p50 (ms) | p95 (ms) |
|---|---|---|
| 1 | 13.6 | 21.1 |
| 2 | 33.8 | 75.7 |
| 3 | 29.9 | 61.5 |
| 4 | 27.3 | 43.0 |
| 5 | 9.0 | 13.4 |
| **median** | **27.3** | **43.0** |

**After (this branch):**
| Run | p50 (ms) | p95 (ms) |
|---|---|---|
| 1 | 7.9 | 12.0 |
| 2 | 8.1 | 11.4 |
| 3 | 9.3 | 13.3 |
| 4 | 8.7 | 12.3 |
| 5 | 8.8 | 16.5 |
| **median** | **8.7** | **12.3** |

Observations:
- p50 improvement ~3x (27.3ms → 8.7ms median of medians).
- p95 improvement ~3.5x (43.0ms → 12.3ms median of medians).
- Much lower variance — before runs spanned 9-34ms p50; after runs stayed in a tight 7.9-9.3ms band. This matches the prediction: unbounded scans scale with thread length, and cache warmth dominates variance.

Caveat: local Docker Postgres with ~200-row tables is an optimistic floor; production thread tails are much longer so the bounded scan win is expected to widen, not narrow.

## Test plan

- [x] All 10 existing `route.incomplete-context.test.ts` tests pass unchanged (zero behavior change gate).
- [x] Two new integration tests:
  - `handles a long thread (≥100 messages) without scanning all of history` — seeds 50 rounds, asserts send succeeds and incomplete-rounds block is absent.
  - `anchors incomplete rounds correctly on a long thread with a mid-thread success` — 30+ pre-success cancels + mid-thread success + post-success cancel; asserts only the post-success cancel surfaces.
- [x] Broader chat route + callback + service suites (139 tests) green.
- [x] Pre-commit: lint / typecheck / format / knip / vitest — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)