### PR TITLE
perf(chat): dedupe zero_agents and org_metadata reads on message post

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -28,6 +28,7 @@ import { server } from "../../../../../../src/mocks/server";
 import { http } from "../../../../../../src/__tests__/msw";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import { mockAblyPublish } from "../../../../../../src/__tests__/ably-mock";
+import { createQueryCounter } from "../../../../../../src/__tests__/db-query-counter";
 import { GET as getChatThreadById } from "../../../chat-threads/[id]/route";
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
@@ -559,6 +560,69 @@ describe("POST /api/zero/chat/messages", () => {
       expect(userMsg.attachFiles[0].id).toBe("resolve-uuid-1");
       expect(userMsg.attachFiles[0].filename).toBe("data.csv");
       expect(userMsg.attachFiles[0].url).toBe("https://presigned-url/data.csv");
+    });
+
+    // Two `org_metadata` SELECTs remain per POST after this dedup (Round 2
+    // tier via getOrgMetadata + Round 3 credits via checkOrgCredits). Dedup
+    // target is the duplicate `resolveOrg ↔ Round 2` pair in the
+    // modelSelection branch (3→2) plus the `zero_agents` pair on every POST
+    // (2→1). The checkOrgCredits read is a separate credits-admission path
+    // tracked as a follow-up (out of scope for #10594).
+    describe("deduplicates per-request reads", () => {
+      it("reads zero_agents once and org_metadata twice without modelSelection", async () => {
+        const counter = createQueryCounter();
+        try {
+          const response = await POST(
+            createTestRequest(URL, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                agentId,
+                prompt: "dedup without modelSelection",
+              }),
+            }),
+          );
+
+          expect(response.status).toBe(201);
+          expect(counter.countMatching(/from\s+"?zero_agents"?/i)).toBe(1);
+          expect(counter.countMatching(/from\s+"?org_metadata"?/i)).toBe(2);
+        } finally {
+          counter.restore();
+        }
+      });
+
+      it("reads zero_agents once and org_metadata twice with modelSelection (duplicate pair eliminated)", async () => {
+        const providerId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+        const counter = createQueryCounter();
+        try {
+          const response = await POST(
+            createTestRequest(URL, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                agentId,
+                prompt: "dedup with modelSelection",
+                modelSelection: {
+                  modelProviderId: providerId,
+                  selectedModel: "claude-opus-4-7",
+                },
+              }),
+            }),
+          );
+
+          expect(response.status).toBe(201);
+          expect(counter.countMatching(/from\s+"?zero_agents"?/i)).toBe(1);
+          // 3→2: resolveOrg still reads org_metadata for tier+credits, Round 3
+          // checkOrgCredits reads credits; Round 2 now hits the preload path
+          // built from resolveOrg's already-fetched tier (the eliminated dup).
+          expect(counter.countMatching(/from\s+"?org_metadata"?/i)).toBe(2);
+        } finally {
+          counter.restore();
+        }
+      });
     });
 
     describe("per-run model selection (composer picker)", () => {

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -7,7 +7,10 @@ import {
   requireAuth,
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
-import { createZeroRun } from "../../../../../src/lib/zero/zero-run-service";
+import {
+  createZeroRun,
+  fetchZeroAgentForRun,
+} from "../../../../../src/lib/zero/zero-run-service";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { modelProviders } from "../../../../../src/db/schema/model-provider";
 import { chatThreads } from "../../../../../src/db/schema/chat-thread";
@@ -31,7 +34,6 @@ import {
   publishThreadListChanged,
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
 import { generateChatTitle } from "../../../../../src/lib/zero/ai/lightweight-model";
-import { zeroAgents } from "../../../../../src/db/schema/zero-agent";
 import { zeroRuns } from "../../../../../src/db/schema/zero-run";
 import { zeroAgentSchedules } from "../../../../../src/db/schema/zero-agent-schedule";
 import {
@@ -283,16 +285,10 @@ const router = tsr.router(chatMessagesContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    // Verify agent exists and fetch model provider override
-    const [agent] = await globalThis.services.db
-      .select({
-        id: zeroAgents.id,
-        modelProviderId: zeroAgents.modelProviderId,
-        selectedModel: zeroAgents.selectedModel,
-      })
-      .from(zeroAgents)
-      .where(eq(zeroAgents.id, body.agentId))
-      .limit(1);
+    // Verify agent exists and fetch the union projection (404 check + model
+    // override fields here; full row passed through to createZeroRun so the
+    // service's Round 1 skips its duplicate SELECT).
+    const agent = await fetchZeroAgentForRun(body.agentId);
 
     if (!agent) {
       return {
@@ -305,8 +301,12 @@ const router = tsr.router(chatMessagesContract, {
 
     // Validate per-run model selection belongs to the caller's org before
     // we trust it to write onto the thread or override the agent's default.
+    // resolveOrg already fetches org_metadata — capture the tier here so the
+    // service's Round 2 can skip its duplicate getOrgMetadata call.
+    let preloadedOrgTier: { orgId: string; tier: string } | undefined;
     if (body.modelSelection) {
       const { org } = await resolveOrg(authCtx);
+      preloadedOrgTier = { orgId: org.orgId, tier: org.tier };
       const [provider] = await globalThis.services.db
         .select({ id: modelProviders.id })
         .from(modelProviders)
@@ -420,6 +420,8 @@ const router = tsr.router(chatMessagesContract, {
         ),
         callbacks: [chatCallback],
         chatThreadId: threadId,
+        preloadedAgent: agent,
+        preloadedOrgTier,
       });
 
       // Persist user message to chat_messages.

--- a/turbo/apps/web/src/__tests__/db-query-counter.ts
+++ b/turbo/apps/web/src/__tests__/db-query-counter.ts
@@ -1,0 +1,50 @@
+import type { Pool } from "pg";
+
+interface QueryCounter {
+  countMatching(pattern: RegExp): number;
+  restore(): void;
+}
+
+/**
+ * Wrap `globalThis.services.pool.query` to count SQL statements issued during
+ * a test, so integration tests can assert that duplicate reads have been
+ * deduplicated at the pool level (independent of which code path issued the
+ * SELECT). Tests run against pg; Neon serverless is prod-only.
+ *
+ * Two `as` coercions live at the monkey-patch boundary because `pool.query`
+ * is an overloaded function and a plain variadic wrapper is only assignable
+ * to it via cast. The first-arg text extraction uses structural `typeof` +
+ * `in` narrowing rather than casts, so no `any` / `eslint-disable` is needed.
+ */
+export function createQueryCounter(): QueryCounter {
+  const pool: Pool = globalThis.services.pool;
+  const original = pool.query.bind(pool);
+  const calls: string[] = [];
+  const wrapped = ((...args: unknown[]): unknown => {
+    const first = args[0];
+    let text = "";
+    if (typeof first === "string") {
+      text = first;
+    } else if (
+      typeof first === "object" &&
+      first !== null &&
+      "text" in first &&
+      typeof first.text === "string"
+    ) {
+      text = first.text;
+    }
+    calls.push(text);
+    return (original as (...rest: unknown[]) => unknown)(...args);
+  }) as typeof pool.query;
+  pool.query = wrapped;
+  return {
+    countMatching: (p) => {
+      return calls.filter((c) => {
+        return p.test(c);
+      }).length;
+    },
+    restore: () => {
+      pool.query = original as typeof pool.query;
+    },
+  };
+}

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -14,6 +14,8 @@ import {
   type FirewallPolicies,
   type ConnectorType,
   type RunStatus,
+  type RawPermissionPolicies,
+  type FirewallPolicyValue,
   connectorTypeSchema,
 } from "@vm0/core";
 import {
@@ -41,7 +43,7 @@ import {
 import { generateZeroToken, generateSandboxToken } from "../auth/sandbox-token";
 import { loadFeatureSwitchOverrides } from "./user/feature-switches-service";
 import { buildZeroExecutionContext } from "./build-zero-context";
-import { getOrgMetadata } from "./org/org-metadata-service";
+import { getOrgMetadata, type OrgMetadata } from "./org/org-metadata-service";
 import { isConcurrentRunLimit } from "../shared/errors";
 import {
   DISALLOWED_TOOLS,
@@ -82,6 +84,52 @@ function toAllowedCustomConnectorIds(
 }
 
 /**
+ * Union projection of zero_agents columns consumed by a run — covers both the
+ * route handler's needs (id / modelProviderId / selectedModel) and the service
+ * Round 1 needs (identity + permission policies + customSkills + orgId).
+ */
+export interface ZeroAgentForRun {
+  id: string;
+  displayName: string | null;
+  description: string | null;
+  sound: string | null;
+  permissionPolicies: RawPermissionPolicies | null;
+  unknownPermissionPolicies: Record<string, FirewallPolicyValue> | null;
+  orgId: string;
+  customSkills: string[];
+  modelProviderId: string | null;
+  selectedModel: string | null;
+}
+
+/**
+ * Fetch the union projection of zero_agents needed to create a run. Shared by
+ * the web chat route (404 check + model override fields) and the service's
+ * Round 1 pre-flight — callers that pre-fetch pass the result through as
+ * `preloadedAgent` so the service skips this query.
+ */
+export async function fetchZeroAgentForRun(
+  agentId: string,
+): Promise<ZeroAgentForRun | undefined> {
+  const [row] = await globalThis.services.db
+    .select({
+      id: zeroAgents.id,
+      displayName: zeroAgents.displayName,
+      description: zeroAgents.description,
+      sound: zeroAgents.sound,
+      permissionPolicies: zeroAgents.permissionPolicies,
+      unknownPermissionPolicies: zeroAgents.unknownPermissionPolicies,
+      orgId: zeroAgents.orgId,
+      customSkills: zeroAgents.customSkills,
+      modelProviderId: zeroAgents.modelProviderId,
+      selectedModel: zeroAgents.selectedModel,
+    })
+    .from(zeroAgents)
+    .where(eq(zeroAgents.id, agentId))
+    .limit(1);
+  return row;
+}
+
+/**
  * Parameters accepted by createZeroRun().
  * All zero trigger paths (web, schedule, telegram, slack, email, github)
  * use this interface to create agent runs with consistent defaults.
@@ -114,6 +162,20 @@ export interface CreateZeroRunParams {
   userInfoExtras?: UserInfoOptions;
   /** Force real Claude in mock environments (internal debugging / e2e only). */
   debugNoMockClaude?: boolean;
+  /**
+   * Pre-fetched zero_agents row passed in by callers that have already read it
+   * (e.g. the web chat route's 404 check). When present, Round 1 skips its own
+   * duplicate SELECT. When absent, Round 1 falls back to fetchZeroAgentForRun.
+   */
+  preloadedAgent?: ZeroAgentForRun;
+  /**
+   * Pre-fetched org tier scoped to the caller's active org. Round 2 uses it
+   * only when resolved.orgId === preloadedOrgTier.orgId (cross-org composes
+   * still read fresh org_metadata). Typed as a structural Pick so that the
+   * caller cannot accidentally populate a fake .credits — and so future code
+   * cannot read .credits via this preload.
+   */
+  preloadedOrgTier?: Pick<OrgMetadata, "orgId" | "tier">;
 }
 
 /**
@@ -134,6 +196,23 @@ interface ZeroRunRecordResult {
   featureSwitchOverrides?: Partial<Record<FeatureSwitchKey, boolean>>;
   /** Pre-fetched user timezone in Phase 1 — passed to buildZeroExecutionContext */
   userTimezone?: string;
+}
+
+function loadZeroAgentForRun(
+  preloaded: ZeroAgentForRun | undefined,
+  agentId: string,
+): Promise<ZeroAgentForRun | undefined> {
+  return preloaded ? Promise.resolve(preloaded) : fetchZeroAgentForRun(agentId);
+}
+
+function loadOrgTier(
+  preloaded: Pick<OrgMetadata, "orgId" | "tier"> | undefined,
+  orgId: string,
+): Promise<Pick<OrgMetadata, "orgId" | "tier">> {
+  if (preloaded && preloaded.orgId === orgId) {
+    return Promise.resolve(preloaded);
+  }
+  return getOrgMetadata(orgId);
 }
 
 /**
@@ -178,23 +257,9 @@ async function createZeroRunRecord(
 
   // ── Round 1: Independent operations (need only params) ──────────────
   const [row, resolved, cachedUser] = await Promise.all([
-    // Fetch agent metadata (displayName, description, sound, permissionPolicies, orgId)
-    db
-      .select({
-        displayName: zeroAgents.displayName,
-        description: zeroAgents.description,
-        sound: zeroAgents.sound,
-        permissionPolicies: zeroAgents.permissionPolicies,
-        unknownPermissionPolicies: zeroAgents.unknownPermissionPolicies,
-        orgId: zeroAgents.orgId,
-        customSkills: zeroAgents.customSkills,
-      })
-      .from(zeroAgents)
-      .where(eq(zeroAgents.id, params.agentId))
-      .limit(1)
-      .then(([r]) => {
-        return r;
-      }),
+    // Agent metadata — reuse caller's pre-fetched row when available (web chat
+    // route reads it for the 404 check), otherwise fetch the union projection.
+    loadZeroAgentForRun(params.preloadedAgent, params.agentId),
     // Resolve compose version + org context
     resolveStartRunCompose({
       userId: params.userId,
@@ -269,8 +334,11 @@ async function createZeroRunRecord(
             ),
           )
       : Promise.resolve([]),
-    // Org metadata (needs resolved.orgId)
-    getOrgMetadata(resolved.orgId),
+    // Org metadata (needs resolved.orgId). Reuse caller's pre-fetched tier
+    // when the compose org matches the caller's active org — cross-org
+    // composes (rare; also caught by authorizeCompose below) fall through to
+    // a fresh SELECT because the preload's tier is scoped to authCtx.orgId.
+    loadOrgTier(params.preloadedOrgTier, resolved.orgId),
     // User preferences (needs resolved.orgId)
     getUserPreferences(resolved.orgId, params.userId),
     // Feature switch overrides (needs resolved.orgId)


### PR DESCRIPTION
## Summary

Eliminates two pairs of duplicate per-request reads in the chat message `POST` path by plumbing caller-fetched rows through to `createZeroRun`:

- **zero_agents: 2 → 1** — route already reads `zero_agents` for its 404 check (via `fetchZeroAgentForRun`), then `createZeroRunRecord` re-fetched a near-identical projection. The service now accepts `preloadedAgent` and reuses the route's row.
- **org_metadata: 3 → 2** — `modelSelection` branch did a bespoke tier lookup in `resolveOrg`, then `createZeroRunRecord` re-fetched the full metadata. The service now accepts `preloadedOrgTier` (scoped to `authCtx.orgId`) and reuses it when the compose org matches.

Behavior is identical: same rows, same advisory-lock flow, same ordering. Fallbacks in the service preserve every non-chat trigger (schedule, telegram, slack, email, github) — no other `createZeroRun` caller changed.

## Why not "exactly 1" org_metadata read?

`checkOrgCredits` (Round 3, `zero-run-policy.ts:190`) does a third `SELECT credits FROM org_metadata` unconditionally and is also called from the dequeue path. Folding that read into the preload requires a different mechanism (credits go stale between queue and dequeue) and is out of scope for this PR.

### Out of scope (follow-up in #10596)

- `checkOrgCredits` `org_metadata` SELECT (same row, third read per POST)

## Before / After

| Table         | Before (no modelSelection) | After (no modelSelection) | Before (with modelSelection) | After (with modelSelection) |
| ------------- | -------------------------- | ------------------------- | ---------------------------- | --------------------------- |
| zero_agents   | 2                          | **1**                     | 2                            | **1**                       |
| org_metadata  | 2                          | 2                         | 3                            | **2**                       |

## Acceptance criteria

- [x] `zero_agents` read exactly once per chat POST (both `modelSelection` branches)
- [x] Both duplicate pairs eliminated (`zero_agents` pair + `resolveOrg` ↔ Round 2 `org_metadata` pair)
- [x] `resolveOrg` source unchanged (invariant: 100+ callers)
- [x] All non-chat `createZeroRun` callers unchanged
- [x] `db-query-counter` test helper has zero `any` / zero `eslint-disable`; two `as` coercions sit at the `pool.query` monkey-patch boundary
- [x] Dedup tests cover both `modelSelection` branches
- [x] Lint, type-check, format, knip, vitest all green

## Test plan

- [x] `pnpm -F web exec vitest run app/api/zero/chat/messages` — 33 passed (2 new dedup tests + 31 existing)
- [x] `pnpm -F web exec eslint <changed files> --max-warnings 0` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm format` — no changes
- [ ] CI: full lint, test, deploy, cli-e2e

Closes #10594