### PR TITLE
ci: fail loudly when pr-state preflight cannot reach github api

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -138,9 +138,20 @@ jobs:
             # A late pull_request:synchronize run can reach here after
             # cleanup.yml has already stopped the runner — deploying again
             # would resurrect a stale service that no cleanup will ever reach.
-            STATE=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            #
+            # Retry transient API failures, then fail loudly if the state
+            # stays unknown. Silently skipping would let the PR merge without
+            # runner coverage; fail-open would risk deploying a zombie runner.
+            # A red check is the right middle ground — re-run the job once
+            # the API recovers.
+            STATE=$(curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+              -H "Authorization: Bearer $GH_TOKEN" \
               "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
               | jq -r .state)
+            if [ -z "$STATE" ]; then
+              echo "::error::Failed to query PR #${PR_NUMBER} state from GitHub API after retries"
+              exit 1
+            fi
             if [ "$STATE" != "open" ]; then
               echo "::warning::PR #${PR_NUMBER} is ${STATE}, skipping host/job-ref to prevent stale runner deployment"
               exit 0

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -202,9 +202,20 @@ jobs:
             # A late pull_request:synchronize run can reach here after
             # cleanup.yml has already stopped the runner — deploying again
             # would resurrect a stale service that no cleanup will ever reach.
-            STATE=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            #
+            # Retry transient API failures, then fail loudly if the state
+            # stays unknown. Silently skipping would let the PR merge without
+            # runner coverage; fail-open would risk deploying a zombie runner.
+            # A red check is the right middle ground — re-run the job once
+            # the API recovers.
+            STATE=$(curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+              -H "Authorization: Bearer $GH_TOKEN" \
               "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
               | jq -r .state)
+            if [ -z "$STATE" ]; then
+              echo "::error::Failed to query PR #${{ github.event.pull_request.number }} state from GitHub API after retries"
+              exit 1
+            fi
             if [ "$STATE" != "open" ]; then
               echo "::warning::PR #${{ github.event.pull_request.number }} is ${STATE}, skipping job-ref to prevent stale runner deployment"
               exit 0


### PR DESCRIPTION
## Summary

- Retry the `GET /pulls/{n}` call with curl's built-in `--retry 3 --retry-delay 2 --retry-all-errors` so transient 5xx/network errors don't short-circuit the preflight on the first hit.
- Change the empty-`STATE` branch from "silently skip" to `::error::` + `exit 1`: a red check is the right middle ground vs. silent skip (lets PR merge without runner coverage) or fail-open (risks a zombie runner).

Applied to both `.github/workflows/turbo.yml` (`Set job-ref`) and `.github/workflows/crates.yml` (`Select metal host`).

Closes #10619.

## Behavior matrix

| Outcome | Before | After |
|---|---|---|
| API returns `state: open` | proceed | proceed |
| API returns `state: closed`/`merged` | warn + skip | warn + skip (unchanged zombie guard) |
| API fails once (transient 5xx) | skip silently | retry → usually recovers |
| API fails after 3 retries | skip silently, gate still green | `::error::` + `exit 1`, gate red |

## Test plan

- [ ] Open this PR — both `turbo.yml` and `crates.yml` runner deployments should behave normally (API returns `state: open`).
- [ ] No structural change for `merge_group` or `push` events — those branches of the `if` were not touched.
- [ ] Verified shell logic locally: empty `STATE` takes the `exit 1` branch, non-empty/non-`open` takes the warn+skip branch, `open` falls through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)