### PR TITLE
ci(crates): add runner-cancel to ci-gate-crates needs

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1538,6 +1538,7 @@ jobs:
       - runner-build
       - runner-benchmark
       - runner-exec
+      - runner-cancel
       - runner-drain-resume
       - runner-balloon
       - runner-upgrade-local
@@ -1585,6 +1586,7 @@ jobs:
           check_result "runner-build" "${{ needs.runner-build.result }}" "true"
           check_result "runner-benchmark" "${{ needs.runner-benchmark.result }}" "true"
           check_result "runner-exec" "${{ needs.runner-exec.result }}" "true"
+          check_result "runner-cancel" "${{ needs.runner-cancel.result }}" "true"
           check_result "runner-drain-resume" "${{ needs.runner-drain-resume.result }}" "true"
           check_result "runner-balloon" "${{ needs.runner-balloon.result }}" "true"
           check_result "runner-upgrade-local" "${{ needs.runner-upgrade-local.result }}" "true"


### PR DESCRIPTION
## Summary

- `runner-cancel` was the only `runner-*` job not listed in `ci-gate-crates.needs` or validated by `check_result`. If it started failing, the PR would merge anyway because the gate never looked at its result.
- Adds `runner-cancel` to both places, alongside the other `runner-*` jobs. `allow_skip="true"` matches the rest — `runner-cancel` transitively skips when `runner-build` skips (PR-state preflight, gate, no changes, etc.).

Closes #10620.

## Context

Pre-existing gap, surfaced during review of #10614 ([comment](https://github.com/vm0-ai/vm0/pull/10614#issuecomment-4295115885)). Latent — only matters if/when `runner-cancel` starts failing.

## Test plan

- [ ] CI runs on this PR; `ci-gate-crates` now aggregates `runner-cancel.result`.
- [ ] When metal hosts are unavailable / changes don't touch runner code, `runner-cancel` skips together with the rest of `runner-*`; gate still passes because `allow_skip="true"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)