### PR TITLE
fix(dev): kill stale stripe and tunnel processes before starting

### DIFF
--- a/turbo/apps/web/scripts/dev.sh
+++ b/turbo/apps/web/scripts/dev.sh
@@ -16,18 +16,30 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 PORT=3000
 ENV_LOCAL_FILE="$WEB_APP_DIR/.env.local"
 
+# Kill stale background processes from prior runs that may have been orphaned
+# (e.g. previous run SIGKILLed, container stopped, or trap didn't fire).
+kill_stale() {
+  local pidfile="$1" pattern="$2"
+  local pid
+  pid=$(cat "$pidfile" 2>/dev/null || true)
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    sleep 1
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+  rm -f "$pidfile"
+  if [[ -n "$pattern" ]]; then
+    pkill -f "$pattern" 2>/dev/null || true
+  fi
+}
+
+kill_stale "/tmp/cloudflared-${PORT}.pid" "cloudflared tunnel .*localhost:${PORT}"
+kill_stale "/tmp/stripe-listen.pid" "stripe listen .*--forward-to localhost:${PORT}/api/webhooks/stripe"
+
 # Cleanup background processes on exit
 cleanup() {
-  TUNNEL_PID=$(cat "/tmp/cloudflared-${PORT}.pid" 2>/dev/null || true)
-  if [[ -n "$TUNNEL_PID" ]] && kill -0 "$TUNNEL_PID" 2>/dev/null; then
-    kill "$TUNNEL_PID" 2>/dev/null || true
-    sleep 1
-    kill -9 "$TUNNEL_PID" 2>/dev/null || true
-  fi
-  STRIPE_PID=$(cat "/tmp/stripe-listen.pid" 2>/dev/null || true)
-  if [[ -n "$STRIPE_PID" ]] && kill -0 "$STRIPE_PID" 2>/dev/null; then
-    kill "$STRIPE_PID" 2>/dev/null || true
-  fi
+  kill_stale "/tmp/cloudflared-${PORT}.pid" ""
+  kill_stale "/tmp/stripe-listen.pid" ""
 }
 trap cleanup EXIT INT TERM
 


### PR DESCRIPTION
## Summary
- `turbo/apps/web/scripts/dev.sh` only killed `stripe listen` / `cloudflared` via a trap on EXIT/INT/TERM. If the previous run was SIGKILLed, the container was stopped, or the shell session died, those processes survived and the next dev run would overwrite their PID files — orphaning the old processes and resulting in multiple stripe webhook forwarders (duplicate event delivery).
- Add a pre-start `kill_stale` pass that kills by PID file and, as a fallback, by command pattern. Reuse the same helper in the exit trap to remove duplicated logic.

## Test plan
- [ ] Run `pnpm dev` in `turbo/apps/web`, confirm one `stripe listen` and one `cloudflared` process
- [ ] `kill -9` the dev script mid-run, start `pnpm dev` again, confirm only one `stripe listen` / `cloudflared` after restart (no orphans)
- [ ] Graceful Ctrl+C still cleans up

🤖 Generated with [Claude Code](https://claude.com/claude-code)