### PR TITLE
fix(billing): prevent double-grant on duplicate invoice.paid webhook delivery

### DIFF
--- a/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -678,6 +678,55 @@ describe("POST /api/webhooks/stripe", () => {
       expect(oldRecord?.remaining).toBe(0);
     });
 
+    it("concurrent duplicate invoice.paid grants credits only once", async () => {
+      // Two webhook deliveries racing in parallel both read the old
+      // `lastProcessedInvoiceId` (null) and pass the fast-path check. Without
+      // the inner `createExpiresRecord` idempotency gate both would call
+      // `grantOrgCredits` and double the balance; the unique index ensures
+      // only one transaction successfully inserts the expires record, and
+      // the other bails before granting.
+      const cusId = uniqueId("cus-race");
+      const subId = uniqueId("sub-race");
+      const invId = uniqueId("inv-race");
+      const periodEnd = Math.floor(Date.now() / 1000) + 30 * 86400;
+
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+        stripeSubscriptionId: subId,
+      });
+
+      stripeMocks.subscriptionsRetrieve.mockResolvedValue({
+        id: subId,
+        items: { data: [{ price: { id: TEST_PRICE_PRO } }] },
+      });
+
+      const creditsBefore = await getOrgCredits(user.orgId);
+
+      const payload = {
+        id: invId,
+        customer: cusId,
+        lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
+        parent: { subscription_details: { subscription: subId } },
+      };
+
+      const [r1, r2] = await Promise.all([
+        sendWebhookEvent("invoice.paid", payload),
+        sendWebhookEvent("invoice.paid", payload),
+      ]);
+
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(200);
+
+      const creditsAfter = await getOrgCredits(user.orgId);
+      expect(creditsAfter! - creditsBefore!).toBe(20_000);
+
+      const records = await findCreditExpiresRecords(user.orgId);
+      const renewalRecords = records.filter((r) => {
+        return r.stripeInvoiceId === invId;
+      });
+      expect(renewalRecords).toHaveLength(1);
+    });
+
     it("duplicate invoice.paid is idempotent for expires records", async () => {
       const cusId = uniqueId("cus-exp-idem");
       const subId = uniqueId("sub-exp-idem");
@@ -803,8 +852,14 @@ describe("POST /api/webhooks/stripe", () => {
       );
     });
 
-    it("auto-recharge does NOT create expires record", async () => {
+    it("auto-recharge writes a sentinel expires record with far-future expires_at", async () => {
+      // The record is the idempotency marker for the auto-recharge invoice;
+      // `expires_at` is set past any realistic date so `expireCredits` never
+      // settles it — preserving the "PAYG credits never expire" contract
+      // while letting the unique `(org_id, stripe_invoice_id)` index block
+      // double-delivery from double-granting.
       const cusId = uniqueId("cus-exp-auto");
+      const invId = uniqueId("inv-auto-exp");
 
       await updateOrgStripeFields(user.orgId, {
         stripeCustomerId: cusId,
@@ -814,7 +869,7 @@ describe("POST /api/webhooks/stripe", () => {
       });
 
       const response = await sendWebhookEvent("invoice.paid", {
-        id: uniqueId("inv-auto-exp"),
+        id: invId,
         customer: cusId,
         metadata: {
           type: "auto_recharge",
@@ -827,7 +882,59 @@ describe("POST /api/webhooks/stripe", () => {
       expect(response.status).toBe(200);
 
       const records = await findCreditExpiresRecords(user.orgId);
-      expect(records).toHaveLength(0);
+      const autoRecharge = records.filter((r) => {
+        return r.source === "auto_recharge";
+      });
+      expect(autoRecharge).toHaveLength(1);
+      expect(autoRecharge[0]?.stripeInvoiceId).toBe(invId);
+      expect(autoRecharge[0]?.amount).toBe(5000);
+      expect(
+        autoRecharge[0]?.expiresAt.getUTCFullYear(),
+      ).toBeGreaterThanOrEqual(2999);
+    });
+
+    it("concurrent duplicate auto-recharge grants credits only once", async () => {
+      // Without the expires-record idempotency gate, two racing deliveries
+      // both pass the metadata check and both call grantOrgCredits.
+      const cusId = uniqueId("cus-auto-race");
+      const invId = uniqueId("inv-auto-race");
+
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargePendingAt: new Date(),
+      });
+
+      const creditsBefore = await getOrgCredits(user.orgId);
+
+      const payload = {
+        id: invId,
+        customer: cusId,
+        metadata: {
+          type: "auto_recharge",
+          orgId: user.orgId,
+          creditsAmount: "5000",
+        },
+        parent: null,
+      };
+
+      const [r1, r2] = await Promise.all([
+        sendWebhookEvent("invoice.paid", payload),
+        sendWebhookEvent("invoice.paid", payload),
+      ]);
+
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(200);
+
+      const creditsAfter = await getOrgCredits(user.orgId);
+      expect(creditsAfter! - creditsBefore!).toBe(5000);
+
+      const records = await findCreditExpiresRecords(user.orgId);
+      const autoRecharge = records.filter((r) => {
+        return r.stripeInvoiceId === invId;
+      });
+      expect(autoRecharge).toHaveLength(1);
     });
   });
 

--- a/turbo/apps/web/src/lib/zero/billing/auto-recharge-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/auto-recharge-service.ts
@@ -2,6 +2,7 @@ import { eq, sql } from "drizzle-orm";
 import type Stripe from "stripe";
 import { orgMetadata } from "../../../db/schema/org-metadata";
 import { grantOrgCredits } from "../org/org-service";
+import { createExpiresRecord } from "../credit/credit-expires-service";
 import { getStripe } from "../stripe";
 import { logger } from "../../shared/logger";
 
@@ -12,6 +13,16 @@ const CREDITS_PER_DOLLAR = 1000;
 
 /** Pending recharge older than this is considered stale and can be retried. */
 const STALE_THRESHOLD_MINUTES = 10;
+
+/**
+ * Sentinel "never expires" timestamp for auto-recharge credits. Writing a
+ * real (far-future) value lets us reuse the `(org_id, stripe_invoice_id)`
+ * unique index on `credit_expires_record` as the idempotency guard for
+ * auto-recharge invoices, while keeping the promised PAYG semantics: the
+ * row is never selected by `expireCredits` (which only touches records
+ * with `expires_at <= NOW()`).
+ */
+const AUTO_RECHARGE_NEVER_EXPIRES_AT = new Date("2999-12-31T00:00:00Z");
 
 interface OrgRechargeState {
   credits: number;
@@ -190,7 +201,16 @@ export async function triggerAutoRecharge(orgId: string): Promise<void> {
  * Handle an auto-recharge invoice.paid webhook event.
  * Grants credits to the org and clears the pending flag.
  *
- * @returns true if the invoice was an auto-recharge invoice and was handled
+ * Idempotent: the `(org_id, stripe_invoice_id)` unique index on
+ * `credit_expires_record` gates `grantOrgCredits`. A duplicate delivery
+ * (Stripe retry, dual-listener, etc.) inserts with ON CONFLICT DO NOTHING,
+ * sees `inserted=false`, and bails before re-granting. `expires_at` is set
+ * far in the future so `expireCredits` never settles these records — the
+ * row exists only as the idempotency marker, the PAYG "never expires"
+ * contract is preserved.
+ *
+ * @returns true if the invoice was an auto-recharge invoice (regardless of
+ *   whether credits were freshly granted or the delivery was a duplicate)
  */
 export async function handleAutoRechargeInvoicePaid(invoice: {
   id: string;
@@ -214,19 +234,37 @@ export async function handleAutoRechargeInvoicePaid(invoice: {
 
   const db = globalThis.services.db;
 
-  await db.transaction(async (tx) => {
+  const granted = await db.transaction(async (tx) => {
+    const inserted = await createExpiresRecord(tx, orgId, {
+      source: "auto_recharge",
+      stripeInvoiceId: invoice.id,
+      amount: creditsAmount,
+      expiresAt: AUTO_RECHARGE_NEVER_EXPIRES_AT,
+    });
+    if (!inserted) {
+      log.info(
+        "Auto-recharge invoice already processed — skipping (duplicate delivery)",
+        { orgId, invoiceId: invoice.id },
+      );
+      return false;
+    }
+
     await grantOrgCredits(tx, orgId, creditsAmount);
     await tx
       .update(orgMetadata)
       .set({ autoRechargePendingAt: null, updatedAt: new Date() })
       .where(eq(orgMetadata.orgId, orgId));
+
+    return true;
   });
 
-  log.info("Auto-recharge credits granted", {
-    orgId,
-    creditsAmount,
-    invoiceId: invoice.id,
-  });
+  if (granted) {
+    log.info("Auto-recharge credits granted", {
+      orgId,
+      creditsAmount,
+      invoiceId: invoice.id,
+    });
+  }
 
   return true;
 }

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -443,39 +443,56 @@ export async function handleInvoicePaid(invoice: InvoiceInput): Promise<void> {
     return;
   }
 
-  // Grant credits and mark invoice as processed in a transaction
-  await db.transaction(async (tx) => {
-    // Settle expired credits before granting new ones
+  // The subscription line item's period.end is the actual subscription
+  // billing-cycle end — i.e. the time the customer is paying through.
+  // (The top-level invoice.period_end is the "period over which billables
+  // accrued" and for a renewal invoice collapses to the invoice creation
+  // moment, not the next renewal date — do NOT use it here.)
+  const subscriptionLine = invoice.lines.data.find((line) => {
+    return line.parent?.type === "subscription_item_details";
+  });
+  const periodEndUnix = subscriptionLine?.period.end;
+  if (!periodEndUnix) {
+    throw new Error(
+      `invoice.paid has no subscription line item with period.end — cannot create expiry record (invoiceId=${invoice.id}, orgId=${org.orgId})`,
+    );
+  }
+  const periodEndDate = new Date(periodEndUnix * 1000);
+  const expiresAt = new Date(periodEndDate);
+  expiresAt.setMonth(expiresAt.getMonth() + 1);
+
+  // Grant credits and mark invoice as processed in a transaction.
+  //
+  // The `lastProcessedInvoiceId` fast path above catches sequential retries
+  // (first delivery commits, later retry sees the updated value). It fails
+  // open when two deliveries race: both reads see the old value, both pass,
+  // and both would grant credits. The durable guard is `createExpiresRecord`
+  // — it inserts with ON CONFLICT DO NOTHING on the
+  // `(org_id, stripe_invoice_id)` unique index, and a losing concurrent tx
+  // blocks until the winner commits then observes the conflict, so only one
+  // caller sees `inserted=true`. Gate `grantOrgCredits` on that flag.
+  const granted = await db.transaction(async (tx) => {
+    // Settle expired credits before granting new ones. Safe to run in the
+    // losing tx too: `expireCredits` takes SELECT FOR UPDATE on expired
+    // rows, so the loser sees `remaining = 0` once the winner commits and
+    // no-ops.
     await expireCredits(tx, org.orgId);
 
-    await grantOrgCredits(tx, org.orgId, credits);
-
-    // The subscription line item's period.end is the actual subscription
-    // billing-cycle end — i.e. the time the customer is paying through.
-    // (The top-level invoice.period_end is the "period over which billables
-    // accrued" and for a renewal invoice collapses to the invoice creation
-    // moment, not the next renewal date — do NOT use it here.)
-    const subscriptionLine = invoice.lines.data.find((line) => {
-      return line.parent?.type === "subscription_item_details";
-    });
-    const periodEndUnix = subscriptionLine?.period.end;
-    if (!periodEndUnix) {
-      throw new Error(
-        `invoice.paid has no subscription line item with period.end — cannot create expiry record (invoiceId=${invoice.id}, orgId=${org.orgId})`,
-      );
-    }
-
-    // Calculate expires_at: currentPeriodEnd + 1 month
-    const periodEndDate = new Date(periodEndUnix * 1000);
-    const expiresAt = new Date(periodEndDate);
-    expiresAt.setMonth(expiresAt.getMonth() + 1);
-
-    await createExpiresRecord(tx, org.orgId, {
+    const inserted = await createExpiresRecord(tx, org.orgId, {
       source: "subscription_renewal",
       stripeInvoiceId: invoice.id,
       amount: credits,
       expiresAt,
     });
+    if (!inserted) {
+      log.info(
+        "invoice.paid already processed — skipping (concurrent delivery)",
+        { invoiceId: invoice.id, orgId: org.orgId },
+      );
+      return false;
+    }
+
+    await grantOrgCredits(tx, org.orgId, credits);
 
     await tx
       .update(orgMetadata)
@@ -485,7 +502,11 @@ export async function handleInvoicePaid(invoice: InvoiceInput): Promise<void> {
         updatedAt: new Date(),
       })
       .where(eq(orgMetadata.orgId, org.orgId));
+
+    return true;
   });
+
+  if (!granted) return;
 
   // Reset member credit cap flags for the new billing period
   await resetMemberCreditFlags(org.orgId);


### PR DESCRIPTION
## Summary

Both \`handleInvoicePaid\` and \`handleAutoRechargeInvoicePaid\` could double-grant credits when Stripe delivered the same \`invoice.paid\` event twice. Reproduced locally via dual \`stripe listen\` dev setup — same \`evt_…\` id delivered twice, both log \`credits granted via invoice.paid\`, \`org_metadata.credits\` goes up 2× while only one \`credit_expires_record\` is inserted.

## Root cause

- **Subscription** (\`handleInvoicePaid\`, \`billing-service.ts\`): the \`lastProcessedInvoiceId === invoice.id\` gate is read **before** the transaction. Two concurrent deliveries both see the old value, both pass, both call \`grantOrgCredits\`, and the losing \`createExpiresRecord\` silently \`onConflictDoNothing\`s — the tx still commits.
- **Auto-recharge** (\`handleAutoRechargeInvoicePaid\`, \`auto-recharge-service.ts\`): no fast-path gate at all, no \`credit_expires_record\` insert. Even a sequential retry double-grants.

\`handleOneTimePurchaseCompleted\` and \`ensureStarterCreditGrant\` already get this right: insert the expires record first, only \`grantOrgCredits\` when \`inserted === true\`. The UNIQUE \`(org_id, stripe_invoice_id)\` index is the durable guard — a losing concurrent tx blocks on the index, then observes the conflict after the winner commits.

## Changes

- **\`billing-service.ts\`** — Pull expires_at computation out of the tx, reorder so \`createExpiresRecord\` runs before \`grantOrgCredits\`, short-circuit on \`inserted === false\`. Retain the outer \`lastProcessedInvoiceId\` gate as a fast path for sequential retries (skips the Stripe API call).
- **\`auto-recharge-service.ts\`** — Same pattern; write a sentinel record with \`source: "auto_recharge"\` and \`expires_at: "2999-12-31"\` so \`expireCredits\` never touches it. The PAYG "never expires" contract is preserved — the row exists only as the idempotency marker.
- **Tests** — Added concurrent-duplicate tests (parallel \`Promise.all\` deliveries of same invoice id) for both handlers; refreshed the auto-recharge expires test to reflect the sentinel record.

## Notes for reviewer

- **Coordination with #10585**: that PR's credit-breakdown chart classifies records by \`source\`. The new \`auto_recharge\` source falls through its switch, so on that PR \`auto_recharge\` records would be invisible in the chart. Add \`else if (r.source === "auto_recharge") addSegment("payAsYouGo", "Pay as you go", r.remaining);\` in \`billing-service.ts\` \`getBillingStatus\` before merging #10585. Not blocking this PR (main doesn't have that breakdown code yet).
- **Post-deploy migration**: any Stripe invoice retry that arrives AFTER deploy for an invoice processed BEFORE deploy (pre-existing orgs with no expires record) would hit \`inserted=true\` and double-grant. Mitigation: the subscription path still has the \`lastProcessedInvoiceId\` fast path, so only auto-recharge is exposed during the narrow retry window, and Stripe retry backoff is long enough that this is vanishingly rare in practice.

## Test plan

- [x] \`pnpm -F web exec vitest run app/api/webhooks/stripe/__tests__/route.test.ts\` — 27/27 passing (2 new: concurrent subscription duplicate, concurrent auto-recharge duplicate)
- [x] \`pnpm -F web exec vitest run src/lib/zero/billing/__tests__/\` — 19/19 passing
- [x] \`pnpm check-types\` — clean
- [x] \`pnpm turbo run lint --filter=web\` — clean
- [ ] Manual: trigger a Pro subscription via Stripe CLI test mode, verify exactly one \`credits granted via invoice.paid\` log line and one \`subscription_renewal\` record

🤖 Generated with [Claude Code](https://claude.com/claude-code)