### PR TITLE
feat(platform): require unsaved-bar confirmation for auto-recharge edits

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -250,14 +250,13 @@ export const saveAutoRecharge$ = command(
     // last-resolved config (useLastLoadable returns the pre-save value):
     // toggling ON and saving would blink to OFF for ~one network RTT, and
     // the unsaved-bar briefly disappears because `autoRechargeDirty$` goes
-    // false when all overrides are null against the stale config.
-    try {
-      await get(autoRechargeConfig$);
-    } finally {
-      set(internalPendingEnabled$, null);
-      set(internalFormThresholdOverride$, null);
-      set(internalFormAmountOverride$, null);
-    }
+    // false when all overrides are null against the stale config. If the
+    // refetch fails, `accept()` inside billingStatusAsync$ already surfaces
+    // the error; leaving overrides in place lets the user retry or discard.
+    await get(autoRechargeConfig$);
+    set(internalPendingEnabled$, null);
+    set(internalFormThresholdOverride$, null);
+    set(internalFormAmountOverride$, null);
     toast.success("Auto-recharge updated");
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -197,6 +197,34 @@ export const setFormAmount$ = command(({ set }, value: string) => {
   set(internalFormAmountOverride$, value);
 });
 
+/**
+ * Auto-recharge has unsaved changes when the user has toggled the switch
+ * (pendingEnabled is non-null and differs from saved) or when threshold/amount
+ * overrides differ from the saved values.
+ */
+export const autoRechargeDirty$ = computed(async (get) => {
+  const config = await get(autoRechargeConfig$);
+  const pendingEnabled = get(internalPendingEnabled$);
+  if (pendingEnabled !== null && pendingEnabled !== config.enabled) {
+    return true;
+  }
+  const thresholdOverride = get(internalFormThresholdOverride$);
+  if (thresholdOverride !== null && thresholdOverride !== config.threshold) {
+    return true;
+  }
+  const amountOverride = get(internalFormAmountOverride$);
+  if (amountOverride !== null && amountOverride !== config.amount) {
+    return true;
+  }
+  return false;
+});
+
+export const discardAutoRecharge$ = command(({ set }) => {
+  set(internalPendingEnabled$, null);
+  set(internalFormThresholdOverride$, null);
+  set(internalFormAmountOverride$, null);
+});
+
 // ---------------------------------------------------------------------------
 // Auto-recharge save
 // ---------------------------------------------------------------------------
@@ -210,7 +238,8 @@ export const saveAutoRecharge$ = command(
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingAutoRechargeContract);
     await accept(client.update({ body: config }), [200]);
-    // Clear form overrides so fields fall back to fresh server values
+    // Clear pending overrides so fields fall back to fresh server values
+    set(internalPendingEnabled$, null);
     set(internalFormThresholdOverride$, null);
     set(internalFormAmountOverride$, null);
     // Reload billing status — autoRechargeConfig$ re-derives automatically

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -7,6 +7,7 @@ import {
   zeroBillingInvoicesContract,
   zeroBillingDowngradeContract,
 } from "@vm0/core";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 
@@ -238,14 +239,26 @@ export const saveAutoRecharge$ = command(
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingAutoRechargeContract);
     await accept(client.update({ body: config }), [200]);
-    // Clear pending overrides so fields fall back to fresh server values
-    set(internalPendingEnabled$, null);
-    set(internalFormThresholdOverride$, null);
-    set(internalFormAmountOverride$, null);
-    // Reload billing status — autoRechargeConfig$ re-derives automatically
+    // Kick off a refetch first so autoRechargeConfig$ has a new in-flight
+    // promise carrying the just-saved values.
     set(billingReload$, (x) => {
       return x + 1;
     });
+    // Keep the optimistic overrides in place until the refetch resolves.
+    // Otherwise there's a visible flash between the override-clear and the
+    // refetch-complete where `displayEnabled` falls back to the stale
+    // last-resolved config (useLastLoadable returns the pre-save value):
+    // toggling ON and saving would blink to OFF for ~one network RTT, and
+    // the unsaved-bar briefly disappears because `autoRechargeDirty$` goes
+    // false when all overrides are null against the stale config.
+    try {
+      await get(autoRechargeConfig$);
+    } finally {
+      set(internalPendingEnabled$, null);
+      set(internalFormThresholdOverride$, null);
+      set(internalFormAmountOverride$, null);
+    }
+    toast.success("Auto-recharge updated");
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -444,10 +444,16 @@ describe("org billing tab - auto-recharge section", () => {
 
     // First fetch returns the pre-save state (enabled=false). Subsequent
     // fetches are held open so the window between override-clear and
-    // refetch-complete is long enough to observe.
+    // refetch-complete is long enough to observe. Entering the gated branch
+    // signals that the PATCH has resolved and the reload has been kicked off
+    // — i.e. we are inside the bug's danger window.
     let releaseRefetch = (): void => {};
     const refetchStarted = new Promise<void>((resolve) => {
       releaseRefetch = resolve;
+    });
+    let markRefetchEntered = (): void => {};
+    const refetchEntered = new Promise<void>((resolve) => {
+      markRefetchEntered = resolve;
     });
     let refetchCount = 0;
     server.use(
@@ -455,6 +461,7 @@ describe("org billing tab - auto-recharge section", () => {
         refetchCount++;
         const enabled = refetchCount > 1;
         if (refetchCount > 1) {
+          markRefetchEntered();
           await refetchStarted;
         }
         return respond(200, {
@@ -486,12 +493,17 @@ describe("org billing tab - auto-recharge section", () => {
     const bar = await screen.findByTestId("auto-recharge-unsaved-bar");
     const savePromise = user.click(within(bar).getByTestId("save-button"));
 
-    // While the refetch is blocked, the toggle must stay ON (no flash).
-    // Poll for a beat then assert state hasn't regressed.
-    await new Promise((r) => {
-      return setTimeout(r, 50);
+    // Wait until the refetch has entered the gated branch — at this point the
+    // PATCH has resolved and billingReload$ has been bumped, so we are inside
+    // the exact window where the regression would have cleared the optimistic
+    // overrides. Flush microtasks so any regressed state update propagates.
+    await refetchEntered;
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+      expect(
+        screen.getByTestId("auto-recharge-unsaved-bar"),
+      ).toBeInTheDocument();
     });
-    expect(toggle).toHaveAttribute("aria-checked", "true");
 
     // Release the refetch and let the save finish.
     releaseRefetch();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -214,12 +214,12 @@ describe("org billing tab - auto-recharge section", () => {
     const thresholdInput = screen.getByLabelText(
       /credit threshold for auto-recharge/i,
     );
-    expect(thresholdInput).toHaveValue(5000);
+    expect(thresholdInput).toHaveValue("5000");
 
     const amountInput = screen.getByLabelText(
       /auto-recharge credit amount in credits/i,
     );
-    expect(amountInput).toHaveValue(50_000);
+    expect(amountInput).toHaveValue("50000");
   });
 
   it("should show toggle off when server auto-recharge is disabled", async () => {
@@ -332,7 +332,9 @@ describe("org billing tab - auto-recharge section", () => {
 
     await fill(thresholdInput, "2000");
     await fill(amountInput, "10000");
-    amountInput.blur();
+
+    const unsavedBar = await screen.findByTestId("auto-recharge-unsaved-bar");
+    await user.click(within(unsavedBar).getByTestId("save-button"));
 
     await waitFor(() => {
       expect(capturedBody).toStrictEqual({
@@ -344,6 +346,7 @@ describe("org billing tab - auto-recharge section", () => {
   });
 
   it("should send correct data when saving auto-recharge config", async () => {
+    const user = userEvent.setup();
     let capturedBody: unknown = null;
     server.use(
       mockApi(zeroBillingAutoRechargeContract.update, ({ body, respond }) => {
@@ -375,13 +378,15 @@ describe("org billing tab - auto-recharge section", () => {
       const input = screen.getByLabelText(
         /credit threshold for auto-recharge/i,
       );
-      expect(input).toHaveValue(2000);
+      expect(input).toHaveValue("2000");
       return input;
     });
 
-    // Change threshold and blur to trigger save
+    // Change threshold and click Save from UnsavedBar
     await fill(thresholdInput, "3000");
-    thresholdInput.blur();
+
+    const unsavedBar = await screen.findByTestId("auto-recharge-unsaved-bar");
+    await user.click(within(unsavedBar).getByTestId("save-button"));
 
     await waitFor(() => {
       expect(capturedBody).toStrictEqual({
@@ -390,6 +395,68 @@ describe("org billing tab - auto-recharge section", () => {
         amount: 10_000,
       });
     });
+  });
+
+  it("should reject negative and decimal input in threshold/amount fields", async () => {
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: true, threshold: 2000, amount: 10_000 },
+    });
+
+    await openBillingTab();
+
+    const thresholdInput = await waitFor(() => {
+      const input = screen.getByLabelText(
+        /credit threshold for auto-recharge/i,
+      );
+      expect(input).toHaveValue("2000");
+      return input;
+    });
+
+    await fill(thresholdInput, "-5");
+    expect(thresholdInput).toHaveValue("2000");
+
+    await fill(thresholdInput, "12.5");
+    expect(thresholdInput).toHaveValue("2000");
+
+    await fill(thresholdInput, "3000");
+    expect(thresholdInput).toHaveValue("3000");
+  });
+
+  it("should discard unsaved auto-recharge changes when Discard is clicked", async () => {
+    const user = userEvent.setup();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: true, threshold: 2000, amount: 10_000 },
+    });
+
+    await openBillingTab();
+
+    const thresholdInput = await waitFor(() => {
+      const input = screen.getByLabelText(
+        /credit threshold for auto-recharge/i,
+      );
+      expect(input).toHaveValue("2000");
+      return input;
+    });
+
+    await fill(thresholdInput, "9999");
+
+    const unsavedBar = await screen.findByTestId("auto-recharge-unsaved-bar");
+    await user.click(within(unsavedBar).getByTestId("discard-button"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("auto-recharge-unsaved-bar"),
+      ).not.toBeInTheDocument();
+    });
+    expect(thresholdInput).toHaveValue("2000");
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -426,6 +426,85 @@ describe("org billing tab - auto-recharge section", () => {
     expect(thresholdInput).toHaveValue("3000");
   });
 
+  it("should not flash the toggle state between save-resolve and refetch-complete", async () => {
+    // Regression: saveAutoRecharge$ used to clear optimistic overrides before
+    // waiting for billingReload$ to produce a fresh config, so useLastLoadable
+    // (keepLastResolved=true) handed back the stale pre-save config for one
+    // network RTT. On a toggle-ON save the user briefly saw the switch blink
+    // back to OFF and the threshold/amount section collapse; dirty also
+    // flipped false, briefly hiding UnsavedBar.
+    const user = userEvent.setup();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: false, threshold: 2000, amount: 10_000 },
+    });
+
+    // First fetch returns the pre-save state (enabled=false). Subsequent
+    // fetches are held open so the window between override-clear and
+    // refetch-complete is long enough to observe.
+    let releaseRefetch = (): void => {};
+    const refetchStarted = new Promise<void>((resolve) => {
+      releaseRefetch = resolve;
+    });
+    let refetchCount = 0;
+    server.use(
+      mockApi(zeroBillingStatusContract.get, async ({ respond }) => {
+        refetchCount++;
+        const enabled = refetchCount > 1;
+        if (refetchCount > 1) {
+          await refetchStarted;
+        }
+        return respond(200, {
+          tier: "pro",
+          credits: 20_000,
+          subscriptionStatus: "active",
+          currentPeriodEnd: null,
+          cancelAtPeriodEnd: false,
+          hasSubscription: true,
+          autoRecharge: { enabled, threshold: 2000, amount: 10_000 },
+          creditExpiry: { expiringNextCycle: 0, nextExpiryDate: null },
+        });
+      }),
+    );
+
+    await openBillingTab();
+
+    const toggle = await waitFor(() => {
+      const t = screen.getByRole("switch", { name: /enable auto-recharge/i });
+      expect(t).toHaveAttribute("aria-checked", "false");
+      return t;
+    });
+
+    await user.click(toggle);
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+    });
+
+    const bar = await screen.findByTestId("auto-recharge-unsaved-bar");
+    const savePromise = user.click(within(bar).getByTestId("save-button"));
+
+    // While the refetch is blocked, the toggle must stay ON (no flash).
+    // Poll for a beat then assert state hasn't regressed.
+    await new Promise((r) => {
+      return setTimeout(r, 50);
+    });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+
+    // Release the refetch and let the save finish.
+    releaseRefetch();
+    await savePromise;
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("auto-recharge-unsaved-bar"),
+      ).not.toBeInTheDocument();
+    });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
   it("should discard unsaved auto-recharge changes when Discard is clicked", async () => {
     const user = userEvent.setup();
     setMockBillingStatus({

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -6,6 +6,7 @@ import {
   useLastLoadable,
   useLastResolved,
 } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
@@ -26,6 +27,8 @@ import {
   openDowngradeDialog$,
   saveAutoRecharge$,
   autoRechargeConfig$,
+  autoRechargeDirty$,
+  discardAutoRecharge$,
   pendingEnabled$,
   setPendingEnabled$,
   formThreshold$,
@@ -39,6 +42,7 @@ import {
 } from "../../signals/zero-page/billing-dialog-state.ts";
 import { SaveAutoRechargeButton } from "./save-auto-recharge-button.tsx";
 import { CheckoutButton } from "./checkout-button.tsx";
+import { UnsavedBar } from "./components/org-manage/unsaved-bar.tsx";
 
 const PLANS = [
   {
@@ -164,6 +168,11 @@ export function AutoRechargeSection({
   const setThreshold = useSet(setFormThreshold$);
   const setAmount = useSet(setFormAmount$);
 
+  const dirty = useLastResolved(autoRechargeDirty$) ?? false;
+  const discard = useSet(discardAutoRecharge$);
+  const [saveLoadable, doSave] = useLoadableSet(saveAutoRecharge$);
+  const saving = saveLoadable.state === "loading";
+
   if (currentTier === "free") {
     return null;
   }
@@ -212,9 +221,6 @@ export function AutoRechargeSection({
   } | null => {
     const { threshold: t, amount: a } = parseFormNumbers();
     if (!loading && (!displayEnabled || (t > 0 && a >= CREDITS_PER_DOLLAR))) {
-      if (displayEnabled) {
-        setPendingEnabled(null);
-      }
       return {
         enabled: displayEnabled,
         ...(displayEnabled ? { threshold: t, amount: a } : {}),
@@ -223,123 +229,121 @@ export function AutoRechargeSection({
     return null;
   };
 
-  const persistIfValid = () => {
+  const handleSave = () => {
     const values = getFormValues();
-    if (values) {
-      saveCurrent({
-        enabled: values.enabled,
-        threshold: values.threshold,
-        amount: values.amount,
-      });
+    if (!values) {
+      return;
     }
+    detach(doSave(values, pageSignal), Reason.DomCallback);
   };
 
   const inputRowClass = "h-9 w-[200px] shrink-0";
 
   if (variant === "settings") {
     return (
-      <section className="flex flex-col gap-3">
-        <h3 className="text-sm font-medium text-foreground">Auto-recharge</h3>
-        <div
-          className="overflow-hidden rounded-xl bg-card"
-          style={settingsCardBorder}
-        >
-          <div className="flex items-center justify-between gap-4 px-5 py-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">
-                Automatic top-ups
-              </p>
-              <p className="text-[13px] text-muted-foreground mt-0.5">
-                Purchase credits when your balance falls below a threshold.
-              </p>
+      <>
+        <section className="flex flex-col gap-3">
+          <h3 className="text-sm font-medium text-foreground">Auto-recharge</h3>
+          <div
+            className="overflow-hidden rounded-xl bg-card"
+            style={settingsCardBorder}
+          >
+            <div className="flex items-center justify-between gap-4 px-5 py-4">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-foreground">
+                  Automatic top-ups
+                </p>
+                <p className="text-[13px] text-muted-foreground mt-0.5">
+                  Purchase credits when your balance falls below a threshold.
+                </p>
+              </div>
+              <Switch
+                checked={displayEnabled}
+                onCheckedChange={(v) => {
+                  setPendingEnabled(v === enabled ? null : v);
+                }}
+                disabled={loading || saving}
+                className="shrink-0"
+                aria-label="Enable auto-recharge"
+              />
             </div>
-            <Switch
-              checked={displayEnabled}
-              onCheckedChange={(v) => {
-                if (!v) {
-                  setPendingEnabled(null);
-                  saveCurrent({ enabled: false });
-                  return;
-                }
-                const t = Number(config.threshold);
-                const a = Number(config.amount);
-                if (!loading && t > 0 && a >= CREDITS_PER_DOLLAR) {
-                  saveCurrent({ enabled: true, threshold: t, amount: a });
-                } else {
-                  setPendingEnabled(true);
-                }
-              }}
-              disabled={loading}
-              className="shrink-0"
-              aria-label="Enable auto-recharge"
-            />
-          </div>
-          {displayEnabled && (
-            <>
-              <div className="h-0 zero-border-t mx-5" />
-              <div className="flex items-center justify-between gap-4 px-5 py-4">
-                <div className="min-w-0">
-                  <p className="text-sm font-medium text-foreground">
-                    When credits drop below
-                  </p>
-                  <p className="text-[13px] text-muted-foreground mt-0.5">
-                    Trigger a purchase when your credit balance goes under this
-                    number.
-                  </p>
-                </div>
-                <Input
-                  type="number"
-                  min={1}
-                  value={thresholdValue}
-                  onChange={(e) => {
-                    setThreshold(e.target.value);
-                  }}
-                  onBlur={() => {
-                    return persistIfValid();
-                  }}
-                  placeholder="e.g. 2000"
-                  className={inputRowClass}
-                  aria-label="Credit threshold for auto-recharge"
-                />
-              </div>
-              <div className="h-0 zero-border-t mx-5" />
-              <div className="flex items-center justify-between gap-4 px-5 py-4">
-                <div className="min-w-0 flex flex-col gap-1">
-                  <span className="text-xl font-semibold tabular-nums tracking-tight text-foreground">
-                    ${dollarAmount}
-                  </span>
-                  <p className="text-[13px] font-normal text-muted-foreground">
-                    Recharge amount
-                  </p>
-                </div>
-                <div className="relative w-[200px] shrink-0">
+            {displayEnabled && (
+              <>
+                <div className="h-0 zero-border-t mx-5" />
+                <div className="flex items-center justify-between gap-4 px-5 py-4">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-foreground">
+                      When credits drop below
+                    </p>
+                    <p className="text-[13px] text-muted-foreground mt-0.5">
+                      Trigger a purchase when your credit balance goes under
+                      this number.
+                    </p>
+                  </div>
                   <Input
-                    type="number"
-                    min={CREDITS_PER_DOLLAR}
-                    step={CREDITS_PER_DOLLAR}
-                    value={amountValue}
+                    type="text"
+                    inputMode="numeric"
+                    value={thresholdValue}
                     onChange={(e) => {
-                      setAmount(e.target.value);
+                      const v = e.target.value;
+                      if (v !== "" && !/^\d+$/.test(v)) {
+                        return;
+                      }
+                      setThreshold(v);
                     }}
-                    onBlur={() => {
-                      return persistIfValid();
-                    }}
-                    placeholder="100000"
-                    className={`${inputRowClass} pr-[4.25rem] tabular-nums`}
-                    aria-label="Auto-recharge credit amount in credits"
+                    placeholder="e.g. 2000"
+                    className={inputRowClass}
+                    aria-label="Credit threshold for auto-recharge"
                   />
-                  <span
-                    className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[13px] text-muted-foreground"
-                    aria-hidden
-                  >
-                    credits
-                  </span>
                 </div>
-              </div>
-            </>
-          )}
-        </div>
-      </section>
+                <div className="h-0 zero-border-t mx-5" />
+                <div className="flex items-center justify-between gap-4 px-5 py-4">
+                  <div className="min-w-0 flex flex-col gap-1">
+                    <span className="text-xl font-semibold tabular-nums tracking-tight text-foreground">
+                      ${dollarAmount}
+                    </span>
+                    <p className="text-[13px] font-normal text-muted-foreground">
+                      Recharge amount
+                    </p>
+                  </div>
+                  <div className="relative w-[200px] shrink-0">
+                    <Input
+                      type="text"
+                      inputMode="numeric"
+                      value={amountValue}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        if (v !== "" && !/^\d+$/.test(v)) {
+                          return;
+                        }
+                        setAmount(v);
+                      }}
+                      placeholder="100000"
+                      className={`${inputRowClass} pr-[4.25rem] tabular-nums`}
+                      aria-label="Auto-recharge credit amount in credits"
+                    />
+                    <span
+                      className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[13px] text-muted-foreground"
+                      aria-hidden
+                    >
+                      credits
+                    </span>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </section>
+        {dirty && (
+          <UnsavedBar
+            onDiscard={discard}
+            onSave={handleSave}
+            saving={saving}
+            saveDisabled={getFormValues() === null}
+            testId="auto-recharge-unsaved-bar"
+          />
+        )}
+      </>
     );
   }
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -1,10 +1,10 @@
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { createPortal } from "react-dom";
 import type { OrgMember, MemberUsage } from "@vm0/core";
-import { IconUsers, IconPencil, IconLoader2 } from "@tabler/icons-react";
-import { Button, Input } from "@vm0/ui";
+import { IconUsers } from "@tabler/icons-react";
+import { Input } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
+import { UnsavedBar } from "./unsaved-bar.tsx";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { usageMembersAsync$ } from "../../../../signals/usage-page/usage-signals.ts";
 import { orgMembers$ } from "../../../../signals/external/org-members.ts";
@@ -84,67 +84,6 @@ function InlineCapInput({ member }: { member: MemberUsage }) {
       }}
       className="h-8 w-full text-[13px] tabular-nums placeholder:text-xs"
     />
-  );
-}
-
-function UnsavedBar({
-  onDiscard,
-  onSave,
-  saving,
-}: {
-  onDiscard: () => void;
-  onSave: () => void;
-  saving: boolean;
-}) {
-  const container = document.getElementById("org-manage-content");
-  if (!container) {
-    return null;
-  }
-  return createPortal(
-    <div className="absolute bottom-6 left-0 right-0 z-10 flex justify-center px-4">
-      <div
-        data-testid="unsaved-bar"
-        className="zero-card flex max-w-md items-center justify-between gap-4 px-5 py-4 shadow-lg"
-      >
-        <div className="flex items-center gap-2 text-sm text-foreground">
-          <IconPencil
-            size={18}
-            stroke={1.5}
-            className="shrink-0 text-muted-foreground"
-          />
-          <span>You have unsaved changes</span>
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
-          <Button
-            data-testid="discard-button"
-            variant="ghost"
-            size="sm"
-            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-            onClick={onDiscard}
-            disabled={saving}
-          >
-            Discard
-          </Button>
-          <Button
-            data-testid="save-button"
-            size="sm"
-            className="h-9 rounded-lg px-4 bg-primary text-primary-foreground hover:bg-primary/90"
-            onClick={onSave}
-            disabled={saving}
-          >
-            {saving ? (
-              <IconLoader2
-                size={14}
-                stroke={1.5}
-                className="animate-spin mr-1.5"
-              />
-            ) : null}
-            Save
-          </Button>
-        </div>
-      </div>
-    </div>,
-    container,
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/unsaved-bar.tsx
@@ -1,0 +1,68 @@
+import { createPortal } from "react-dom";
+import { IconPencil, IconLoader2 } from "@tabler/icons-react";
+import { Button } from "@vm0/ui";
+
+export function UnsavedBar({
+  onDiscard,
+  onSave,
+  saving,
+  testId = "unsaved-bar",
+  saveDisabled = false,
+}: {
+  onDiscard: () => void;
+  onSave: () => void;
+  saving: boolean;
+  testId?: string;
+  saveDisabled?: boolean;
+}) {
+  const container = document.getElementById("org-manage-content");
+  if (!container) {
+    return null;
+  }
+  return createPortal(
+    <div className="absolute bottom-6 left-0 right-0 z-10 flex justify-center px-4">
+      <div
+        data-testid={testId}
+        className="zero-card flex max-w-md items-center justify-between gap-4 px-5 py-4 shadow-lg"
+      >
+        <div className="flex items-center gap-2 text-sm text-foreground">
+          <IconPencil
+            size={18}
+            stroke={1.5}
+            className="shrink-0 text-muted-foreground"
+          />
+          <span>You have unsaved changes</span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            data-testid="discard-button"
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            onClick={onDiscard}
+            disabled={saving}
+          >
+            Discard
+          </Button>
+          <Button
+            data-testid="save-button"
+            size="sm"
+            className="h-9 rounded-lg px-4 bg-primary text-primary-foreground hover:bg-primary/90"
+            onClick={onSave}
+            disabled={saving || saveDisabled}
+          >
+            {saving ? (
+              <IconLoader2
+                size={14}
+                stroke={1.5}
+                className="animate-spin mr-1.5"
+              />
+            ) : null}
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>,
+    container,
+  );
+}


### PR DESCRIPTION
## Summary
- Auto-recharge edits in the org-manage billing tab now stage a pending change and only commit on explicit Save, matching the unsaved-bar pattern already used for member credit caps on the usage tab.
- Threshold and amount inputs switched from `type="number"` to `type="text"` + `inputMode="numeric"` with a `/^\d+$/` guard, so negatives, decimals, and `-`/`e` keystrokes are rejected at entry (same treatment as `InlineCapInput`).
- Extracted a shared `UnsavedBar` component (portalled into `#org-manage-content`) so the billing tab and usage tab reuse it with distinct `testId`s.
- `saveAutoRecharge$` now also clears `pendingEnabled` on success; added `autoRechargeDirty$` computed + `discardAutoRecharge$` command to drive the bar.
- The billing-dialog modal variant (still reached from the zero-page upgrade flow) is unchanged — it already had an explicit Save button.

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx` — 35/35 pass (includes two new tests: rejects negative/decimal input, Discard reverts pending changes).
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx src/views/zero-page/__tests__/billing-dialog-display.test.tsx src/views/zero-page/components/org-manage` — 22/22 pass.
- [x] `pnpm -F @vm0/app exec vitest run org-usage-tab` — 13/13 pass (shared UnsavedBar refactor).
- [x] Typecheck (`tsc --noEmit`) and ESLint on touched files clean.
- [ ] Manual: org-manage → Billing → toggle auto-recharge / edit threshold / edit amount → confirm unsaved-bar appears, Save commits, Discard reverts.
- [ ] Manual: attempt to enter `-5`, `12.5`, or `1e3` in threshold/amount and confirm the input ignores the keystroke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)