### PR TITLE
feat(voice-chat): restore slow-brain tasker dispatch guidance

### DIFF
--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -103,6 +103,7 @@ You will see events like:
 - **fast-brain/response** — what your fast-brain says back
 - **fast-brain/request-slow-brain** — an explicit ask from fast-brain (see Explicit Requests)
 - **system/session-start** and **system/session-end** — session lifecycle
+- **system/task-dispatched** and **system/task-completed** — tasks you dispatched (see Dispatching Tasks)
 
 Based on what you observe, proactively decide what to do. Do not wait to be asked.
 
@@ -135,6 +136,50 @@ When you see a \`fast-brain/request-slow-brain\` event, it is a direct task from
 - **thinking**: Progress updates and intermediate results while you work.
 - **observation**: Proactive insights the user did not ask for but might find valuable.
 
+### Dispatching Tasks
+
+Some work is too heavy to do inline: code changes, file operations, external API calls (GitHub, Slack, Linear), database queries, multi-step research. For these, dispatch a task to a fresh sandbox so your polling loop stays responsive.
+
+Dispatch a task:
+
+\`zero voice-chat task create <SESSION_ID> --prompt "<self-sufficient task prompt>"\`
+
+The command returns a JSON object with \`id\` and \`status\` immediately. **Write down the id and return to the poll loop.** Never block, wait, or sleep for the task to finish.
+
+The task prompt must be self-sufficient. The Tasker runs in a fresh sandbox with no conversation history — include repo paths, user intent, and any data it needs. Write the prompt as if briefing a smart colleague who just walked in.
+
+Fetch a result once completed:
+
+\`zero voice-chat task get <SESSION_ID> <TASK_ID>\` → JSON with \`status\`, \`result\`, \`error\`.
+
+List your tasks:
+
+\`zero voice-chat task list <SESSION_ID>\` → array of \`{ id, status, createdAt }\`.
+
+#### When to dispatch vs. handle inline
+
+- **Dispatch** when the work requires tool use you don't already have the answer to: reading files, running commands, calling APIs, querying DBs, doing long research.
+- **Handle inline** (directive only) when you can answer from the prompt, context, or memory: knowledge answers, opinions, summarizing the conversation so far, simple context lookups.
+- **Stay quiet** for casual chat, greetings, and small talk — same as before.
+
+Spinning a Tasker has cold-start cost. Don't use it for "what's 2+2".
+
+#### Every directive carries task context in natural language
+
+Fast-brain knows nothing about tasks, ids, or the Tasker subsystem. Your directives are the only channel it learns from. Never mention "task", "taskId", or ids in directive content — fast-brain reads directives aloud.
+
+- **On dispatch**, write a directive telling fast-brain to acknowledge work is happening.
+  - OK: "I'm checking the PR — tell the user you're looking into it."
+  - NOT OK: "Dispatched task T1 to check PR status."
+- **On completion**, write a directive describing what to say.
+  - OK: "The PR was merged yesterday by Alice — tell the user naturally."
+  - NOT OK: "Task abc-123 returned: PR merged by Alice on 2026-04-20."
+- **On failure**, write a directive describing the failure plainly and recovering.
+  - OK: "Couldn't reach GitHub right now — tell the user there's a hiccup and we'll try again in a moment."
+  - NOT OK: "Task failed with error: GITHUB_API_TIMEOUT."
+
+Without the on-dispatch directive, fast-brain has nothing to say while the task runs and the user hears dead air. Always emit that first directive before returning to the poll loop.
+
 ### Polling and Lifecycle
 
 1. Check for new events every 5 seconds.
@@ -158,6 +203,8 @@ You are Zero's slow-brain. The voice conversation has not started yet. Your job 
 ## Phase 1: Quick Preparation
 
 This should only take a few seconds. Do NOT do deep research — just review what you already know.
+
+**Do NOT dispatch tasks during preparation.** The Tasker is only for Phase 2 (Live Observation). During Phase 1 you review existing context and emit a \`preparation-ready\` event — no tool use, no task creation.
 
 ### Steps
 

--- a/turbo/apps/web/src/lib/zero/voice-chat/__tests__/tasker-round-trip.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/__tests__/tasker-round-trip.test.ts
@@ -12,6 +12,7 @@ import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
 import { mockClerk } from "../../../../__tests__/clerk-mock";
 import { insertOrgDefaultModelProvider } from "../../../../__tests__/db-test-seeders/org";
 import { mockAblyPublish } from "../../../../__tests__/ably-mock";
+import { buildVoiceChatQuickPrepPrompt } from "../../integration-prompt";
 /* eslint-disable web/no-direct-db-in-tests -- Service-level exception: no user-facing API appends slow-brain/fast-brain-sourced events or reads a task without auth; exercising the round trip requires simulating both sides. */
 import { appendEvent } from "../context-service";
 import { getVoiceChatTask } from "../task-service";
@@ -35,6 +36,23 @@ const { POST: postCallbackRoute } =
 
 const TASKS_BASE_URL = "http://localhost:3000/api/zero/voice-chat";
 const CALLBACK_URL = "http://localhost/api/internal/callbacks/voice-chat-task";
+
+describe("voice-chat slow-brain prompt includes tasker guidance", () => {
+  const prompt = buildVoiceChatQuickPrepPrompt("test-session-id");
+
+  it.each([
+    ["task create command", "zero voice-chat task create"],
+    ["task get command", "zero voice-chat task get"],
+    ["task list command", "zero voice-chat task list"],
+    ["task-dispatched event", "task-dispatched"],
+    ["task-completed event", "task-completed"],
+    ["never-block rule", "Never block"],
+    ["natural language rule", "natural language"],
+    ["phase 1 dispatch guard", "Do NOT dispatch tasks during preparation"],
+  ])("includes %s", (_name, substring) => {
+    expect(prompt).toContain(substring);
+  });
+});
 
 describe("tasker round trip through the blackboard", () => {
   const context = testContext();


### PR DESCRIPTION
## Summary

Restores the Tasker dispatch guidance that was deleted in PR #10582, scoped to Phase 2 (Live Observation) with an explicit Phase 1 (Quick Preparation) negative guard so the prep timeout does not regress. Fixes #10662.

- Re-add the `system/task-dispatched` / `system/task-completed` event-list bullet in `SHARED_OBSERVATION_PROMPT`.
- Re-insert the byte-identical `### Dispatching Tasks` subsection between `### Writing to Shared Context` and `### Polling and Lifecycle`.
- Add a declarative `**Do NOT dispatch tasks during preparation.**` guard in `VOICE_CHAT_QUICK_PREPARATION_PROMPT` so slow-brain does not interpret the Phase 2 guidance as a Phase 1 action.
- Restore the prompt-shape regression `describe` block in `tasker-round-trip.test.ts` with an added `phase 1 dispatch guard` row.

Tasker backend (routes, service, callback, CLI) was never removed by PR #10582 — only the prompt wiring. This PR is prompt-only (no schema, route, or client changes).

## Context

PR #10570 originally introduced Dispatching Tasks in `SHARED_OBSERVATION_PROMPT`. Because that shared string is also injected into the Phase 1 quick-prep prompt, slow-brain treated task creation as fair game during prep and blew past the then-60s client timeout. PR #10582 fixed the timeout by deleting the subsection outright and raising `PREP_TIMEOUT_CHAT_MS` to 120s.

Since then, the 120s budget gives 2× headroom for cold-start variance. A targeted Phase 1 prohibition closes the original prep-pollution loop without reverting the architectural gain of the Tasker feature.

Parent epic: #10661 (voice-chat tasker visibility).
Deep-dive: see issue #10662 comments (research / innovate / plan).

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/zero/voice-chat/__tests__/tasker-round-trip.test.ts` — 9 tests (8 prompt-shape it.each + 1 round-trip) passing.
- [x] `pnpm -F web exec vitest run src/lib/zero/__tests__/integration-prompt.test.ts src/lib/zero/voice-chat/__tests__/tasker-round-trip.test.ts src/lib/zero/email/handlers/__tests__/adapt-email-trigger.test.ts src/lib/zero/email/handlers/__tests__/adapt-email-reply.test.ts` — 48 tests passing across files touching `integration-prompt`.
- [x] `pnpm turbo run lint --filter=web` — clean.
- [x] `pnpm prettier --check` on touched files — clean.
- [x] `pnpm knip --workspace apps/web` — clean.
- [x] Verification greps all return one hit each inside the expected constants:
  - `grep "Dispatching Tasks" integration-prompt.ts`
  - `grep "zero voice-chat task create" integration-prompt.ts`
  - `grep "Do NOT dispatch tasks during preparation" integration-prompt.ts`
- [ ] Manual: start a voice chat on dev/staging, say "check PR #123 on github"; confirm `task-dispatched` event (source=system) appears in `voice_chat_events` within Phase 2 and prep completes well under 120s.

## Rollback

Revert this PR → behavior identical to PR #10582's state (slow-brain runs work inline; Tasker backend stays live but unused). No data or schema coupling.

## Non-goals (follow-ups)

- Splitting `SHARED_OBSERVATION_PROMPT` into phase-specific constants — tracked under epic #10661.
- Re-landing the `getPriorVoiceChatAgentSessionId` / `continueFromAgentSessionId` path PR #10582 also removed.
- Tuning `PREP_TIMEOUT_CHAT_MS` back down from 120s.

Closes #10662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)