### PR TITLE
refactor(web): consolidate api-error factories and document sentry filter chain

### DIFF
--- a/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/ts-rest-handler.test.ts
@@ -49,7 +49,12 @@ import {
   tsr,
   TsRestResponse,
 } from "../ts-rest-handler";
-import { badRequest, notFound, forbidden } from "../shared/errors";
+import {
+  badRequest,
+  notFound,
+  forbidden,
+  providerIncompatible,
+} from "../shared/errors";
 
 describe("createSafeErrorHandler", () => {
   const handler = createSafeErrorHandler("test-route");
@@ -83,6 +88,15 @@ describe("createSafeErrorHandler", () => {
     const body = await response!.json();
     expect(body.error.code).toBe("FORBIDDEN");
     expect(body.error.message).toBe("Access denied");
+  });
+
+  it("should return correct status for ProviderIncompatibleError (required-message factory)", async () => {
+    const response = handler(providerIncompatible("Provider mismatch"));
+    expect(response).toBeDefined();
+    expect(response!.status).toBe(400);
+    const body = await response!.json();
+    expect(body.error.code).toBe("PROVIDER_INCOMPATIBLE");
+    expect(body.error.message).toBe("Provider mismatch");
   });
 
   it("should return 500 with generic message for unknown errors", async () => {

--- a/turbo/apps/web/src/lib/shared/errors.ts
+++ b/turbo/apps/web/src/lib/shared/errors.ts
@@ -1,223 +1,178 @@
 /**
- * Custom API errors using factory functions and type guards
+ * Custom API errors using factory functions and type guards.
+ *
+ * The factory+type-guard pattern (rather than `class ApiError extends Error`)
+ * is intentional — errors thrown here cross serverless function boundaries
+ * and must round-trip cleanly through JSON. Inheriting from a project-local
+ * class would lose `instanceof` semantics after serialization, so factories
+ * mint plain `Error` instances carrying a literal `name`, `code`, and
+ * `statusCode`; type guards then narrow via the string `name`.
  */
-
-// ============================================================================
-// Type Definitions
-// ============================================================================
 
 interface ApiErrorBase extends Error {
   readonly statusCode: number;
   readonly code: string;
 }
 
-interface UnauthorizedError extends ApiErrorBase {
-  readonly name: "UnauthorizedError";
-  readonly statusCode: 401;
-  readonly code: "UNAUTHORIZED";
-}
-
-interface NotFoundError extends ApiErrorBase {
-  readonly name: "NotFoundError";
-  readonly statusCode: 404;
-  readonly code: "NOT_FOUND";
-}
-
-interface BadRequestError extends ApiErrorBase {
-  readonly name: "BadRequestError";
-  readonly statusCode: 400;
-  readonly code: "BAD_REQUEST";
-}
-
-interface ForbiddenError extends ApiErrorBase {
-  readonly name: "ForbiddenError";
-  readonly statusCode: 403;
-  readonly code: "FORBIDDEN";
-}
-
-interface ConflictError extends ApiErrorBase {
-  readonly name: "ConflictError";
-  readonly statusCode: 409;
-  readonly code: "CONFLICT";
-}
-
-interface SchedulePastError extends ApiErrorBase {
-  readonly name: "SchedulePastError";
-  readonly statusCode: 400;
-  readonly code: "SCHEDULE_PAST";
-}
-
-interface ConcurrentRunLimitError extends ApiErrorBase {
-  readonly name: "ConcurrentRunLimitError";
-  readonly statusCode: 429;
-  readonly code: "TOO_MANY_REQUESTS";
-}
-
-interface InsufficientCreditsError extends ApiErrorBase {
-  readonly name: "InsufficientCreditsError";
-  readonly statusCode: 402;
-  readonly code: "INSUFFICIENT_CREDITS";
-}
-
-interface ProviderIncompatibleError extends ApiErrorBase {
-  readonly name: "ProviderIncompatibleError";
-  readonly statusCode: 400;
-  readonly code: "PROVIDER_INCOMPATIBLE";
-}
-
-interface RunNotCancellableError extends ApiErrorBase {
-  readonly name: "RunNotCancellableError";
-  readonly statusCode: 400;
-  readonly code: "RUN_NOT_CANCELLABLE";
-}
-
-interface NoModelProviderError extends ApiErrorBase {
-  readonly name: "NoModelProviderError";
-  readonly statusCode: 422;
-  readonly code: "NO_MODEL_PROVIDER";
+/**
+ * Build a typed factory that mints an `ApiErrorBase` carrying a literal
+ * `name`, `code`, and `statusCode`.
+ *
+ * Two overloads preserve the required-vs-optional message contract of
+ * individual factories:
+ * - With `defaultMessage` → resulting factory takes `message?: string`
+ * - Without `defaultMessage` → resulting factory takes `message: string`
+ */
+function makeApiError<N extends string, C extends string, S extends number>(
+  name: N,
+  code: C,
+  statusCode: S,
+  defaultMessage: string,
+): (message?: string) => ApiErrorBase & { name: N; code: C; statusCode: S };
+function makeApiError<N extends string, C extends string, S extends number>(
+  name: N,
+  code: C,
+  statusCode: S,
+): (message: string) => ApiErrorBase & { name: N; code: C; statusCode: S };
+function makeApiError<N extends string, C extends string, S extends number>(
+  name: N,
+  code: C,
+  statusCode: S,
+  defaultMessage?: string,
+): (message?: string) => ApiErrorBase & { name: N; code: C; statusCode: S } {
+  return (message?: string) => {
+    const err = new Error(message ?? defaultMessage);
+    Object.assign(err, { name, code, statusCode });
+    return err as ApiErrorBase & { name: N; code: C; statusCode: S };
+  };
 }
 
 // ============================================================================
 // Factory Functions
 // ============================================================================
 
-export function unauthorized(message = "Unauthorized"): UnauthorizedError {
-  const error = new Error(message) as UnauthorizedError;
-  (error as { name: string }).name = "UnauthorizedError";
-  (error as { statusCode: number }).statusCode = 401;
-  (error as { code: string }).code = "UNAUTHORIZED";
-  return error;
-}
+export const unauthorized = makeApiError(
+  "UnauthorizedError",
+  "UNAUTHORIZED",
+  401,
+  "Unauthorized",
+);
 
-export function notFound(message = "Resource not found"): NotFoundError {
-  const error = new Error(message) as NotFoundError;
-  (error as { name: string }).name = "NotFoundError";
-  (error as { statusCode: number }).statusCode = 404;
-  (error as { code: string }).code = "NOT_FOUND";
-  return error;
-}
+export const notFound = makeApiError(
+  "NotFoundError",
+  "NOT_FOUND",
+  404,
+  "Resource not found",
+);
 
-export function badRequest(message = "Bad request"): BadRequestError {
-  const error = new Error(message) as BadRequestError;
-  (error as { name: string }).name = "BadRequestError";
-  (error as { statusCode: number }).statusCode = 400;
-  (error as { code: string }).code = "BAD_REQUEST";
-  return error;
-}
+export const badRequest = makeApiError(
+  "BadRequestError",
+  "BAD_REQUEST",
+  400,
+  "Bad request",
+);
 
-export function conflict(message = "Resource already exists"): ConflictError {
-  const error = new Error(message) as ConflictError;
-  (error as { name: string }).name = "ConflictError";
-  (error as { statusCode: number }).statusCode = 409;
-  (error as { code: string }).code = "CONFLICT";
-  return error;
-}
+export const forbidden = makeApiError(
+  "ForbiddenError",
+  "FORBIDDEN",
+  403,
+  "Forbidden",
+);
 
-export function forbidden(message = "Forbidden"): ForbiddenError {
-  const error = new Error(message) as ForbiddenError;
-  (error as { name: string }).name = "ForbiddenError";
-  (error as { statusCode: number }).statusCode = 403;
-  (error as { code: string }).code = "FORBIDDEN";
-  return error;
-}
+export const conflict = makeApiError(
+  "ConflictError",
+  "CONFLICT",
+  409,
+  "Resource already exists",
+);
 
-export function schedulePast(
-  message = "Schedule time has already passed",
-): SchedulePastError {
-  const error = new Error(message) as SchedulePastError;
-  (error as { name: string }).name = "SchedulePastError";
-  (error as { statusCode: number }).statusCode = 400;
-  (error as { code: string }).code = "SCHEDULE_PAST";
-  return error;
-}
+export const schedulePast = makeApiError(
+  "SchedulePastError",
+  "SCHEDULE_PAST",
+  400,
+  "Schedule time has already passed",
+);
 
-export function concurrentRunLimit(
-  message = "You have reached the concurrent agent run limit. Please wait for your current run to complete before starting a new one.",
-): ConcurrentRunLimitError {
-  const error = new Error(message) as ConcurrentRunLimitError;
-  (error as { name: string }).name = "ConcurrentRunLimitError";
-  (error as { statusCode: number }).statusCode = 429;
-  (error as { code: string }).code = "TOO_MANY_REQUESTS";
-  return error;
-}
+export const concurrentRunLimit = makeApiError(
+  "ConcurrentRunLimitError",
+  "TOO_MANY_REQUESTS",
+  429,
+  "You have reached the concurrent agent run limit. Please wait for your current run to complete before starting a new one.",
+);
 
-export function insufficientCredits(): InsufficientCreditsError {
-  const message =
-    "Insufficient credits. Add credits or configure your own API key to continue.";
-  const error = new Error(message) as InsufficientCreditsError;
-  (error as { name: string }).name = "InsufficientCreditsError";
-  (error as { statusCode: number }).statusCode = 402;
-  (error as { code: string }).code = "INSUFFICIENT_CREDITS";
-  return error;
-}
+export const insufficientCredits = makeApiError(
+  "InsufficientCreditsError",
+  "INSUFFICIENT_CREDITS",
+  402,
+  "Insufficient credits. Add credits or configure your own API key to continue.",
+);
 
-export function providerIncompatible(
-  message: string,
-): ProviderIncompatibleError {
-  const error = new Error(message) as ProviderIncompatibleError;
-  (error as { name: string }).name = "ProviderIncompatibleError";
-  (error as { statusCode: number }).statusCode = 400;
-  (error as { code: string }).code = "PROVIDER_INCOMPATIBLE";
-  return error;
-}
+export const providerIncompatible = makeApiError(
+  "ProviderIncompatibleError",
+  "PROVIDER_INCOMPATIBLE",
+  400,
+);
 
-export function runNotCancellable(message: string): RunNotCancellableError {
-  const error = new Error(message) as RunNotCancellableError;
-  (error as { name: string }).name = "RunNotCancellableError";
-  (error as { statusCode: number }).statusCode = 400;
-  (error as { code: string }).code = "RUN_NOT_CANCELLABLE";
-  return error;
-}
+export const runNotCancellable = makeApiError(
+  "RunNotCancellableError",
+  "RUN_NOT_CANCELLABLE",
+  400,
+);
 
-export function noModelProvider(
-  message = "No model provider configured. Run 'zero org model-provider setup' to configure one, or add environment variables to your vm0.yaml.",
-): NoModelProviderError {
-  const error = new Error(message) as NoModelProviderError;
-  (error as { name: string }).name = "NoModelProviderError";
-  (error as { statusCode: number }).statusCode = 422;
-  (error as { code: string }).code = "NO_MODEL_PROVIDER";
-  return error;
-}
+export const noModelProvider = makeApiError(
+  "NoModelProviderError",
+  "NO_MODEL_PROVIDER",
+  422,
+  "No model provider configured. Run 'zero org model-provider setup' to configure one, or add environment variables to your vm0.yaml.",
+);
 
 // ============================================================================
 // Type Guards
 // ============================================================================
 
-export function isNotFound(e: unknown): e is NotFoundError {
+export function isNotFound(e: unknown): e is ReturnType<typeof notFound> {
   return e instanceof Error && e.name === "NotFoundError";
 }
 
-export function isBadRequest(e: unknown): e is BadRequestError {
+export function isBadRequest(e: unknown): e is ReturnType<typeof badRequest> {
   return e instanceof Error && e.name === "BadRequestError";
 }
 
-export function isConflict(e: unknown): e is ConflictError {
+export function isConflict(e: unknown): e is ReturnType<typeof conflict> {
   return e instanceof Error && e.name === "ConflictError";
 }
 
-export function isForbidden(e: unknown): e is ForbiddenError {
+export function isForbidden(e: unknown): e is ReturnType<typeof forbidden> {
   return e instanceof Error && e.name === "ForbiddenError";
 }
 
-export function isSchedulePast(e: unknown): e is SchedulePastError {
+export function isSchedulePast(
+  e: unknown,
+): e is ReturnType<typeof schedulePast> {
   return e instanceof Error && e.name === "SchedulePastError";
 }
 
-export function isConcurrentRunLimit(e: unknown): e is ConcurrentRunLimitError {
+export function isConcurrentRunLimit(
+  e: unknown,
+): e is ReturnType<typeof concurrentRunLimit> {
   return e instanceof Error && e.name === "ConcurrentRunLimitError";
 }
 
 export function isInsufficientCredits(
   e: unknown,
-): e is InsufficientCreditsError {
+): e is ReturnType<typeof insufficientCredits> {
   return e instanceof Error && e.name === "InsufficientCreditsError";
 }
 
-export function isNoModelProvider(e: unknown): e is NoModelProviderError {
+export function isNoModelProvider(
+  e: unknown,
+): e is ReturnType<typeof noModelProvider> {
   return e instanceof Error && e.name === "NoModelProviderError";
 }
 
-export function isRunNotCancellable(e: unknown): e is RunNotCancellableError {
+export function isRunNotCancellable(
+  e: unknown,
+): e is ReturnType<typeof runNotCancellable> {
   return e instanceof Error && e.name === "RunNotCancellableError";
 }
 

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -1,15 +1,42 @@
 /**
  * Unified ts-rest handler configuration with automatic log flushing.
  *
- * This module wraps createNextHandler to ensure all logs are flushed
- * to Axiom before the serverless function terminates.
+ * Wraps createNextHandler to ensure logs flush to Axiom before the
+ * serverless function terminates.
  *
  * Usage:
  *   import { createHandler, tsr } from "@/lib/ts-rest-handler";
- *
  *   const router = tsr.router(contract, { ... });
  *   const handler = createHandler(contract, router);
  *   export { handler as GET, handler as POST };
+ *
+ * ## Sentry capture rules
+ *
+ * Errors are filtered at three independent points: this handler's
+ * `createSafeErrorHandler`, Next.js's `instrumentation.onRequestError`
+ * (for non-ts-rest routes), and the browser SDK's `beforeSend` hook
+ * in `instrumentation-client.ts`. What reaches Sentry:
+ *
+ * | Origin                                    | Status / Class          | Reaches Sentry?       |
+ * |-------------------------------------------|-------------------------|-----------------------|
+ * | ts-rest, `createSafeErrorHandler`         | 4xx `ApiError`          | No (warn-log)         |
+ * | ts-rest, `createSafeErrorHandler`         | 4xx zod validation      | No (warn-log)         |
+ * | ts-rest, `createSafeErrorHandler`         | 400 malformed JSON body | No (warn-log)         |
+ * | ts-rest, `createSafeErrorHandler`         | unknown 5xx throw       | Yes (†)               |
+ * | ts-rest, `createSilentErrorHandler`       | any                     | No (‡)                |
+ * | non-ts-rest route (any thrown error)      | any                     | Yes (onRequestError)  |
+ * | Client, 4xx fetch/XHR response            | —                       | No (beforeSend drops) |
+ * | Client, 5xx response or JS error          | —                       | Yes                   |
+ *
+ * † Captured with `mechanism.type = "ts-rest-handler"` and
+ *   `tags.route = <routeName>`. 5xx `ApiError` instances (uncommon —
+ *   current factories top out at 422) are `log.error`'d but NOT
+ *   Sentry-captured; capture fires only for the final "unknown throw"
+ *   branch of `makeErrorHandler`.
+ *
+ * ‡ `createSilentErrorHandler` is used only by `/api/zero/report-error`
+ *   so the client-error sink does not feed its own failures back into
+ *   Sentry as fresh issues.
  */
 import "server-only";
 import { createNextHandler, tsr } from "@ts-rest/serverless/next";


### PR DESCRIPTION
## Summary

Bundles the remaining two sub-tasks from #10565 into a single PR:

- **P2 — consolidate `ApiError` factories.** Replace the 11 hand-written factories in `turbo/apps/web/src/lib/shared/errors.ts` with a typed `makeApiError` helper. Two overloads preserve each factory's required-vs-optional message contract exactly. Drop the 11 module-private error interfaces (never exported) and use `ReturnType` in the type guards so narrowing still picks up literal `name` / `code` / `statusCode` types. No call-site in `apps/web` needed updating — the public API (factory names, signatures, default messages, return-type shape) is preserved.
- **P3 — document the Sentry filter chain.** Add a JSDoc block at the top of `turbo/apps/web/src/lib/ts-rest-handler.ts` mapping which errors reach Sentry across the three filter points (`createSafeErrorHandler`, `instrumentation.onRequestError`, `instrumentation-client.ts` `beforeSend`). Table verified against the current code and includes two footnotes clarifying 5xx `ApiError` (not captured) and why `createSilentErrorHandler` is used only by `/api/zero/report-error`.

Parent issue #10565 context:
- P0 (silent 500 in custom error handlers) landed in #10608.
- P1 (non-ts-rest unified error schema wrapper) deferred as YAGNI — none of the callers parse the JSON shape.

## Test plan

- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean across all workspaces
- [x] `pnpm format` — no diff
- [x] `pnpm -F web exec vitest run src/lib/__tests__/ts-rest-handler.test.ts` — all 15 tests pass (existing 14 + 1 new `providerIncompatible` case covering the required-message overload path)
- [x] `pnpm knip` — no new issues
- [x] Full `pnpm -F web exec vitest run` — only pre-existing flakes in `cron/aggregate-insights` and `cron/voice-chat-cleanup` (reproduce on `main` unchanged; caused by stale DB rows from prior test runs, unrelated to this PR)

Closes #10666