### PR TITLE
feat(voice-chat): render fast-brain request-slow-brain events in ui

### DIFF
--- a/turbo/apps/platform/src/views/voice-chat/__tests__/voice-chat-bubbles.test.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/__tests__/voice-chat-bubbles.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Tests for VoiceChatEventItem rendering of fast-brain/request-slow-brain
+ * events and the system-event hidden invariant.
+ *
+ * See: turbo/apps/platform/src/views/voice-chat/voice-chat-bubbles.tsx
+ */
+
+import type { ContextEvent } from "@vm0/core";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { VoiceChatEventItem } from "../voice-chat-bubbles.tsx";
+
+function makeEvent(partial: Partial<ContextEvent>): ContextEvent {
+  return {
+    id: "evt-1",
+    seq: 1,
+    source: "system",
+    type: "session-start",
+    content: null,
+    createdAt: new Date().toISOString(),
+    ...partial,
+  };
+}
+
+describe("voice-chat event item - fast-brain request-slow-brain", () => {
+  it("renders a Delegated to slow-brain indicator with task content", () => {
+    const event = makeEvent({
+      source: "fast-brain",
+      type: "request-slow-brain",
+      content: "check PR #123",
+    });
+
+    render(<VoiceChatEventItem event={event} />);
+
+    expect(screen.getByText("Delegated to slow-brain")).toBeInTheDocument();
+    expect(screen.getByText("check PR #123")).toBeInTheDocument();
+  });
+
+  it("renders the label without content details when content is null", () => {
+    const event = makeEvent({
+      source: "fast-brain",
+      type: "request-slow-brain",
+      content: null,
+    });
+
+    const { container } = render(<VoiceChatEventItem event={event} />);
+
+    expect(screen.getByText("Delegated to slow-brain")).toBeInTheDocument();
+    expect(container.querySelector("details")).toBeNull();
+  });
+});
+
+describe("voice-chat event item - system events stay hidden", () => {
+  it("renders nothing for a session-start event", () => {
+    const event = makeEvent({
+      source: "system",
+      type: "session-start",
+      content: null,
+    });
+
+    const { container } = render(<VoiceChatEventItem event={event} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for task-dispatched and task-completed events", () => {
+    for (const type of ["task-dispatched", "task-completed"] as const) {
+      const event = makeEvent({
+        source: "system",
+        type,
+        content: "irrelevant",
+      });
+      const { container, unmount } = render(
+        <VoiceChatEventItem event={event} />,
+      );
+      expect(container).toBeEmptyDOMElement();
+      unmount();
+    }
+  });
+});

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-bubbles.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-bubbles.tsx
@@ -1,4 +1,4 @@
-import { IconBrain } from "@tabler/icons-react";
+import { IconArrowRight, IconBrain } from "@tabler/icons-react";
 import type { ContextEvent } from "@vm0/core";
 import { Markdown } from "../components/markdown.tsx";
 
@@ -6,7 +6,12 @@ import { Markdown } from "../components/markdown.tsx";
 // Event classification
 // ---------------------------------------------------------------------------
 
-type EventCategory = "user" | "assistant" | "slow-brain" | "system";
+type EventCategory =
+  | "user"
+  | "assistant"
+  | "fast-brain-request"
+  | "slow-brain"
+  | "system";
 
 function categorizeEvent(event: ContextEvent): EventCategory {
   if (event.source === "user" && event.type === "speech") {
@@ -14,6 +19,9 @@ function categorizeEvent(event: ContextEvent): EventCategory {
   }
   if (event.source === "fast-brain" && event.type === "response") {
     return "assistant";
+  }
+  if (event.source === "fast-brain" && event.type === "request-slow-brain") {
+    return "fast-brain-request";
   }
   if (event.source === "slow-brain") {
     return "slow-brain";
@@ -94,6 +102,26 @@ export function SlowBrainIndicator({
   );
 }
 
+function FastBrainRequestIndicator({ content }: { content: string | null }) {
+  return (
+    <div className="flex items-start gap-2 px-2 py-1.5 text-xs text-muted-foreground">
+      <IconArrowRight size={14} className="shrink-0 mt-0.5" />
+      <div className="min-w-0">
+        <span className="font-medium">Delegated to slow-brain</span>
+        {content?.trim() && (
+          <details className="group mt-0.5 cursor-pointer">
+            <summary className="list-none">
+              <p className="text-muted-foreground/80 line-clamp-3 group-open:line-clamp-none break-words">
+                {content}
+              </p>
+            </summary>
+          </details>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Event renderer
 // ---------------------------------------------------------------------------
@@ -106,6 +134,9 @@ export function VoiceChatEventItem({ event }: { event: ContextEvent }) {
     }
     case "assistant": {
       return <VoiceAssistantBubble content={event.content ?? ""} />;
+    }
+    case "fast-brain-request": {
+      return <FastBrainRequestIndicator content={event.content} />;
     }
     case "slow-brain": {
       return <SlowBrainIndicator type={event.type} content={event.content} />;


### PR DESCRIPTION
## Summary
- Extend `categorizeEvent` in `voice-chat-bubbles.tsx` to recognise `fast-brain/request-slow-brain`
- Add `FastBrainRequestIndicator` inline muted row mirroring `SlowBrainIndicator`, using `IconArrowRight` + "Delegated to slow-brain" label
- Wire the new category into `VoiceChatEventItem`'s switch
- Add render-path tests covering the new branch and the system-event hidden invariant

Refs #10671. Sub-issue of #10661.

## Scope note

This change updates `VoiceChatEventItem`, which is consumed by `mission-control-page/voice-chat-panel-content.tsx` — where the indicator will now render. The main `/voice-chat` page (`voice-chat-page.tsx`) uses `vcConversationItems$` (in `voice-chat-session.ts`) which currently filters events to `source === "slow-brain"` only, so fast-brain request events never reach its render pipeline. Following the issue's scope fence (no touches to `voice-chat-page.tsx` or `voice-chat-session.ts`), that signal-layer extension is left for a follow-up / sibling issue. The bubbles file is ready the moment upstream starts including these events.

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run voice-chat-bubbles` — 4/4 pass
- [x] `pnpm turbo run lint --filter=@vm0/app` — clean
- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm knip` — no issues
- [ ] Manual: after upstream signal extension, voice chat shows "Delegated to slow-brain" row between user bubble and first slow-brain bubble when fast-brain calls `request_slow_brain`
- [x] System events (`session-start`, `task-dispatched`, `task-completed`) still render null — covered by new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)