### PR TITLE
feat(voice-chat): add right-column active tasks panel

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-tasks.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-tasks.test.ts
@@ -1,0 +1,525 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import {
+  zeroVoiceChatContextContract,
+  zeroVoiceChatSessionsContract,
+  zeroVoiceChatTasksContract,
+  type ContextEvent,
+  type VoiceChatTask,
+} from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { triggerAblyEvent } from "../../../mocks/ably.ts";
+import { detach, Reason } from "../../utils.ts";
+import {
+  startVoiceChat$,
+  endVoiceChat$,
+  vcStatus$,
+  vcTasksById$,
+  vcActiveTasks$,
+  vcAllTasksSorted$,
+} from "../voice-chat-session.ts";
+
+const context = testContext();
+
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+const TASK_ID_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const TASK_ID_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function sessionCreatedPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SESSION_ID,
+    status: "preparing",
+    runId: "99999999-9999-4999-8999-999999999999",
+    createdAt: "2026-04-20T00:00:00Z",
+    prepared: false,
+    ...overrides,
+  };
+}
+
+function taskPayload(overrides: Partial<VoiceChatTask> = {}): VoiceChatTask {
+  return {
+    id: TASK_ID_A,
+    sessionId: SESSION_ID,
+    runId: null,
+    prompt: "do the thing",
+    status: "running",
+    result: null,
+    error: null,
+    assistantMessages: [],
+    createdAt: "2026-04-20T00:00:00Z",
+    startedAt: null,
+    finishedAt: null,
+    ...overrides,
+  };
+}
+
+function prepReadyEvent(seq = 1): ContextEvent {
+  return {
+    id: `evt-${seq}`,
+    seq,
+    source: "system",
+    type: "preparation-ready",
+    content: null,
+    createdAt: "2026-04-20T00:00:00Z",
+  };
+}
+
+type OpenAIRealtimeEvent = { type: string; [key: string]: unknown };
+
+interface FakeDC {
+  readyState: "open" | "closed";
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  addEventListener: (event: string, cb: (ev?: unknown) => void) => void;
+  emitOpen: () => void;
+  emitMessage: (event: OpenAIRealtimeEvent) => void;
+  emitClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Mock endpoint helpers
+// ---------------------------------------------------------------------------
+
+function mockCreateSessionOk() {
+  server.use(
+    mockApi(zeroVoiceChatSessionsContract.create, ({ respond }) => {
+      return respond(200, { session: sessionCreatedPayload() });
+    }),
+  );
+}
+
+function mockActivateOk() {
+  server.use(
+    mockApi(zeroVoiceChatSessionsContract.activate, ({ respond }) => {
+      return respond(200, {
+        session: { id: SESSION_ID, status: "active" },
+      });
+    }),
+  );
+}
+
+function mockTokenOk() {
+  server.use(
+    mockApi(zeroVoiceChatSessionsContract.token, ({ respond }) => {
+      return respond(200, {
+        client_secret: { value: "ek_test", expires_at: 9_999_999_999 },
+      });
+    }),
+  );
+}
+
+function mockHeartbeatOk() {
+  server.use(
+    mockApi(zeroVoiceChatSessionsContract.heartbeat, ({ respond }) => {
+      return respond(200, { ok: true as const });
+    }),
+  );
+}
+
+function mockEndSessionOk() {
+  server.use(
+    mockApi(zeroVoiceChatSessionsContract.end, ({ respond }) => {
+      return respond(200, { ok: true as const });
+    }),
+  );
+}
+
+function mockGetEventsPreparationReady() {
+  let delivered = false;
+  server.use(
+    mockApi(zeroVoiceChatContextContract.getEvents, ({ respond }) => {
+      if (delivered) {
+        return respond(200, { events: [] });
+      }
+      delivered = true;
+      return respond(200, { events: [prepReadyEvent()] });
+    }),
+  );
+}
+
+function mockAppendEventOk() {
+  server.use(
+    mockApi(zeroVoiceChatContextContract.appendEvent, ({ body, respond }) => {
+      return respond(200, {
+        event: {
+          id: "evt-append",
+          seq: 9999,
+          source: body.source,
+          type: body.type,
+          content: body.content ?? null,
+          createdAt: "2026-04-20T00:00:00Z",
+        },
+      });
+    }),
+  );
+}
+
+interface TasksMockHandle {
+  setTasks(tasks: VoiceChatTask[]): void;
+  callCount: () => number;
+}
+
+function mockListTasksStateful(initial: VoiceChatTask[] = []): TasksMockHandle {
+  let current = initial;
+  let calls = 0;
+  server.use(
+    mockApi(zeroVoiceChatTasksContract.listTasks, ({ respond }) => {
+      calls++;
+      return respond(200, { tasks: current });
+    }),
+  );
+  return {
+    setTasks(tasks: VoiceChatTask[]) {
+      current = tasks;
+    },
+    callCount() {
+      return calls;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// WebRTC stub (mirrors voice-chat-candidate pattern)
+// ---------------------------------------------------------------------------
+
+async function setup() {
+  await setupPage({
+    context,
+    path: "/voice-chat",
+    withoutRender: true,
+    featureSwitches: { voiceChat: true },
+  });
+}
+
+describe("voice-chat session tasks signals", () => {
+  const dcRef: { current: FakeDC | null } = { current: null };
+
+  function stubWebRTC() {
+    const mediaStreamStub = {
+      getAudioTracks() {
+        return [{ enabled: true }];
+      },
+      getTracks() {
+        return [{ stop: vi.fn() }];
+      },
+    } as unknown as MediaStream;
+
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia: vi.fn().mockResolvedValue(mediaStreamStub) },
+      writable: true,
+      configurable: true,
+    });
+
+    class FakeRTCPeerConnection {
+      iceConnectionState = "new";
+      private trackListeners: ((ev: unknown) => void)[] = [];
+      private iceListeners: (() => void)[] = [];
+      addTrack = vi.fn();
+      close = vi.fn();
+      createOffer = vi.fn().mockResolvedValue({ sdp: "offer-sdp" });
+      setLocalDescription = vi.fn().mockResolvedValue(undefined);
+      setRemoteDescription = vi.fn().mockResolvedValue(undefined);
+
+      createDataChannel(): FakeDC {
+        const openListeners: (() => void)[] = [];
+        const messageListeners: ((ev: MessageEvent) => void)[] = [];
+        const closeListeners: (() => void)[] = [];
+
+        const dc: FakeDC = {
+          readyState: "open",
+          send: vi.fn(),
+          close: vi.fn(() => {
+            dc.readyState = "closed";
+            for (const l of closeListeners) {
+              l();
+            }
+          }),
+          addEventListener: (event, cb) => {
+            if (event === "open") {
+              openListeners.push(cb as () => void);
+            }
+            if (event === "message") {
+              messageListeners.push(cb as (ev: MessageEvent) => void);
+            }
+            if (event === "close") {
+              closeListeners.push(cb as () => void);
+            }
+          },
+          emitOpen: () => {
+            for (const l of openListeners) {
+              l();
+            }
+          },
+          emitMessage: (event: OpenAIRealtimeEvent) => {
+            for (const l of messageListeners) {
+              l({ data: JSON.stringify(event) } as MessageEvent);
+            }
+          },
+          emitClose: () => {
+            dc.readyState = "closed";
+            for (const l of closeListeners) {
+              l();
+            }
+          },
+        };
+
+        dcRef.current = dc;
+        return dc;
+      }
+
+      addEventListener(event: string, cb: (ev?: unknown) => void) {
+        if (event === "track") {
+          this.trackListeners.push(cb);
+        }
+        if (event === "iceconnectionstatechange") {
+          this.iceListeners.push(cb as () => void);
+        }
+      }
+    }
+
+    vi.stubGlobal("RTCPeerConnection", FakeRTCPeerConnection);
+
+    class FakeAudio {
+      autoplay = false;
+      srcObject: unknown = null;
+      pause = vi.fn();
+    }
+    vi.stubGlobal("Audio", FakeAudio);
+
+    server.use(
+      http.post("https://api.openai.com/v1/realtime", () => {
+        return new HttpResponse("answer-sdp", { status: 200 });
+      }),
+    );
+  }
+
+  function clearWebRTC() {
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    dcRef.current = null;
+    vi.unstubAllGlobals();
+  }
+
+  async function driveToConnected(tasksMock: TasksMockHandle) {
+    mockCreateSessionOk();
+    mockGetEventsPreparationReady();
+    mockActivateOk();
+    mockTokenOk();
+    mockHeartbeatOk();
+    mockEndSessionOk();
+    mockAppendEventOk();
+    // tasksMock is already registered by caller via mockListTasksStateful
+    void tasksMock;
+
+    detach(
+      context.store.set(startVoiceChat$, context.signal),
+      Reason.DomCallback,
+    );
+
+    await vi.waitFor(() => {
+      expect(dcRef.current).not.toBeNull();
+    });
+    dcRef.current?.emitOpen();
+
+    await vi.waitFor(() => {
+      expect(context.store.get(vcStatus$)).toBe("connected");
+    });
+  }
+
+  beforeEach(() => {
+    stubWebRTC();
+  });
+
+  afterEach(() => {
+    clearWebRTC();
+  });
+
+  describe("empty", () => {
+    it("leaves task signals empty when listTasks returns []", async () => {
+      await setup();
+      const tasksMock = mockListTasksStateful([]);
+      await driveToConnected(tasksMock);
+
+      await vi.waitFor(() => {
+        expect(tasksMock.callCount()).toBeGreaterThan(0);
+      });
+
+      expect(context.store.get(vcTasksById$)).toStrictEqual({});
+      expect(context.store.get(vcAllTasksSorted$)).toStrictEqual([]);
+      expect(context.store.get(vcActiveTasks$)).toStrictEqual([]);
+    });
+  });
+
+  describe("running task visible after dispatch", () => {
+    it("upserts running task into all three signals after ably poke", async () => {
+      await setup();
+      const tasksMock = mockListTasksStateful([]);
+      await driveToConnected(tasksMock);
+
+      await vi.waitFor(() => {
+        expect(context.store.get(vcTasksById$)).toStrictEqual({});
+      });
+
+      const running = taskPayload({
+        id: TASK_ID_A,
+        status: "running",
+        prompt: "deploy the staging env",
+        createdAt: "2026-04-21T10:00:00Z",
+      });
+      tasksMock.setTasks([running]);
+      triggerAblyEvent(`voice:${SESSION_ID}`);
+
+      await vi.waitFor(() => {
+        expect(context.store.get(vcTasksById$)[TASK_ID_A]).toBeDefined();
+      });
+
+      expect(context.store.get(vcTasksById$)[TASK_ID_A]?.status).toBe(
+        "running",
+      );
+      expect(context.store.get(vcAllTasksSorted$)).toHaveLength(1);
+      expect(context.store.get(vcActiveTasks$)).toHaveLength(1);
+      expect(context.store.get(vcActiveTasks$)[0]?.id).toBe(TASK_ID_A);
+    });
+  });
+
+  describe("running → done transition", () => {
+    it("removes task from active list and preserves result", async () => {
+      await setup();
+      const running = taskPayload({
+        id: TASK_ID_A,
+        status: "running",
+        prompt: "fetch latest logs",
+      });
+      const tasksMock = mockListTasksStateful([running]);
+      await driveToConnected(tasksMock);
+
+      await vi.waitFor(() => {
+        expect(context.store.get(vcTasksById$)[TASK_ID_A]?.status).toBe(
+          "running",
+        );
+      });
+
+      const done = taskPayload({
+        id: TASK_ID_A,
+        status: "done",
+        prompt: "fetch latest logs",
+        result: "Here are the logs you asked for.",
+        finishedAt: "2026-04-21T10:05:00Z",
+      });
+      tasksMock.setTasks([done]);
+      triggerAblyEvent(`voice:${SESSION_ID}`);
+
+      await vi.waitFor(() => {
+        expect(context.store.get(vcTasksById$)[TASK_ID_A]?.status).toBe("done");
+      });
+
+      expect(context.store.get(vcActiveTasks$)).toHaveLength(0);
+      expect(context.store.get(vcAllTasksSorted$)).toHaveLength(1);
+      expect(context.store.get(vcTasksById$)[TASK_ID_A]?.result).toBe(
+        "Here are the logs you asked for.",
+      );
+    });
+  });
+
+  describe("running → failed transition", () => {
+    it("surfaces error message on failure", async () => {
+      await setup();
+      const running = taskPayload({
+        id: TASK_ID_A,
+        status: "running",
+        prompt: "run flaky script",
+      });
+      const tasksMock = mockListTasksStateful([running]);
+      await driveToConnected(tasksMock);
+
+      await vi.waitFor(() => {
+        expect(context.store.get(vcTasksById$)[TASK_ID_A]?.status).toBe(
+          "running",
+        );
+      });
+
+      const failed = taskPayload({
+        id: TASK_ID_A,
+        status: "failed",
+        prompt: "run flaky script",
+        error: "Exit code 127",
+        finishedAt: "2026-04-21T10:06:00Z",
+      });
+      tasksMock.setTasks([failed]);
+      triggerAblyEvent(`voice:${SESSION_ID}`);
+
+      await vi.waitFor(() => {
+        expect(context.store.get(vcTasksById$)[TASK_ID_A]?.status).toBe(
+          "failed",
+        );
+      });
+
+      expect(context.store.get(vcActiveTasks$)).toHaveLength(0);
+      expect(context.store.get(vcTasksById$)[TASK_ID_A]?.error).toBe(
+        "Exit code 127",
+      );
+    });
+  });
+
+  describe("newest-first ordering", () => {
+    it("sorts vcAllTasksSorted by createdAt descending", async () => {
+      await setup();
+      const older = taskPayload({
+        id: TASK_ID_A,
+        prompt: "older task",
+        createdAt: "2026-04-21T09:00:00Z",
+        status: "done",
+      });
+      const newer = taskPayload({
+        id: TASK_ID_B,
+        prompt: "newer task",
+        createdAt: "2026-04-21T11:00:00Z",
+        status: "done",
+      });
+      // Register intentionally out of chronological order.
+      const tasksMock = mockListTasksStateful([older, newer]);
+      await driveToConnected(tasksMock);
+
+      await vi.waitFor(() => {
+        expect(context.store.get(vcAllTasksSorted$)).toHaveLength(2);
+      });
+
+      const sorted = context.store.get(vcAllTasksSorted$);
+      expect(sorted[0]?.id).toBe(TASK_ID_B);
+      expect(sorted[1]?.id).toBe(TASK_ID_A);
+    });
+  });
+
+  describe("end session clears tasks", () => {
+    it("resets vcTasksById$ on endVoiceChat$", async () => {
+      await setup();
+      const running = taskPayload({
+        id: TASK_ID_A,
+        status: "running",
+        prompt: "ongoing work",
+      });
+      const tasksMock = mockListTasksStateful([running]);
+      await driveToConnected(tasksMock);
+
+      await vi.waitFor(() => {
+        expect(context.store.get(vcTasksById$)[TASK_ID_A]).toBeDefined();
+      });
+
+      context.store.set(endVoiceChat$);
+
+      await vi.waitFor(() => {
+        expect(context.store.get(vcStatus$)).toBe("idle");
+      });
+
+      expect(context.store.get(vcTasksById$)).toStrictEqual({});
+      expect(context.store.get(vcAllTasksSorted$)).toStrictEqual([]);
+      expect(context.store.get(vcActiveTasks$)).toStrictEqual([]);
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -3,7 +3,9 @@ import {
   FeatureSwitchKey,
   zeroVoiceChatSessionsContract,
   zeroVoiceChatContextContract,
+  zeroVoiceChatTasksContract,
   type ContextEvent,
+  type VoiceChatTask,
 } from "@vm0/core";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { defaultAgentId$ } from "../agent.ts";
@@ -151,6 +153,7 @@ function formatInjectionMessage(event: ContextEvent): string {
 const internalStatus$ = state<ConnectionStatus>("idle");
 const internalTranscript$ = state<TranscriptEntry[]>([]);
 const internalEvents$ = state<ContextEvent[]>([]);
+const internalTasksById$ = state<Record<string, VoiceChatTask>>({});
 const internalMuted$ = state(false);
 const internalError$ = state<string | null>(null);
 const internalSessionId$ = state<string | null>(null);
@@ -253,6 +256,26 @@ export const vcModel$ = computed((get) => {
 });
 export const setVcModel$ = command(({ set }, model: RealtimeModel) => {
   set(internalModel$, model);
+});
+
+export const vcTasksById$ = computed((get) => {
+  return get(internalTasksById$);
+});
+
+export const vcActiveTasks$ = computed((get) => {
+  return Object.values(get(internalTasksById$))
+    .filter((t) => {
+      return t.status === "queued" || t.status === "running";
+    })
+    .sort((a, b) => {
+      return b.createdAt.localeCompare(a.createdAt);
+    });
+});
+
+export const vcAllTasksSorted$ = computed((get) => {
+  return Object.values(get(internalTasksById$)).sort((a, b) => {
+    return b.createdAt.localeCompare(a.createdAt);
+  });
 });
 
 // --- Internal commands ---
@@ -696,6 +719,22 @@ const startPoll$ = command(async ({ get, set }, signal: AbortSignal) => {
       }
       set(injectSlowBrainEvents$, res.body.events);
     }
+
+    const tasksClient = createClient(zeroVoiceChatTasksContract);
+    const tasksRes = await accept(
+      tasksClient.listTasks({ params: { id: innerSid } }),
+      [200, 401, 404],
+      { toast: false },
+    );
+    loopSignal.throwIfAborted();
+    if (tasksRes.status === 200) {
+      const next: Record<string, VoiceChatTask> = {};
+      for (const task of tasksRes.body.tasks) {
+        next[task.id] = task;
+      }
+      set(internalTasksById$, next);
+    }
+
     return false;
   });
 
@@ -1148,6 +1187,7 @@ export const startVoiceChat$ = command(
     set(internalError$, null);
     set(internalTranscript$, []);
     set(internalEvents$, []);
+    set(internalTasksById$, {});
     set(internalMuted$, false);
     set(internalSessionId$, null);
     set(internalLastSeq$, 0);
@@ -1250,6 +1290,7 @@ export const endVoiceChat$ = command(({ get, set }) => {
   }
 
   set(internalSessionId$, null);
+  set(internalTasksById$, {});
   set(internalPrepStartTime$, null);
   set(internalPrepElapsedMs$, 0);
   set(internalReconnectAttempt$, 0);

--- a/turbo/apps/platform/src/views/voice-chat/__tests__/tasks-panel.test.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/__tests__/tasks-panel.test.tsx
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { screen, waitFor } from "@testing-library/react";
+import {
+  zeroVoiceChatContextContract,
+  zeroVoiceChatSessionsContract,
+  zeroVoiceChatTasksContract,
+  type ContextEvent,
+  type VoiceChatTask,
+} from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { detach, Reason } from "../../../signals/utils.ts";
+import {
+  startVoiceChat$,
+  vcStatus$,
+  vcTasksById$,
+} from "../../../signals/voice-chat/voice-chat-session.ts";
+
+const context = testContext();
+
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+const TASK_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+function sessionCreatedPayload() {
+  return {
+    id: SESSION_ID,
+    status: "preparing",
+    runId: "99999999-9999-4999-8999-999999999999",
+    createdAt: "2026-04-20T00:00:00Z",
+    prepared: false,
+  };
+}
+
+function taskPayload(overrides: Partial<VoiceChatTask> = {}): VoiceChatTask {
+  return {
+    id: TASK_ID,
+    sessionId: SESSION_ID,
+    runId: null,
+    prompt: "do the thing",
+    status: "running",
+    result: null,
+    error: null,
+    assistantMessages: [],
+    createdAt: "2026-04-20T00:00:00Z",
+    startedAt: null,
+    finishedAt: null,
+    ...overrides,
+  };
+}
+
+function prepReadyEvent(): ContextEvent {
+  return {
+    id: "evt-1",
+    seq: 1,
+    source: "system",
+    type: "preparation-ready",
+    content: null,
+    createdAt: "2026-04-20T00:00:00Z",
+  };
+}
+
+type OpenAIRealtimeEvent = { type: string; [key: string]: unknown };
+
+interface FakeDC {
+  readyState: "open" | "closed";
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  addEventListener: (event: string, cb: (ev?: unknown) => void) => void;
+  emitOpen: () => void;
+  emitMessage: (event: OpenAIRealtimeEvent) => void;
+  emitClose: () => void;
+}
+
+function mockAllOk(initialTasks: VoiceChatTask[] = []) {
+  let eventDelivered = false;
+
+  server.use(
+    mockApi(zeroVoiceChatSessionsContract.create, ({ respond }) => {
+      return respond(200, { session: sessionCreatedPayload() });
+    }),
+    mockApi(zeroVoiceChatContextContract.getEvents, ({ respond }) => {
+      if (eventDelivered) {
+        return respond(200, { events: [] });
+      }
+      eventDelivered = true;
+      return respond(200, { events: [prepReadyEvent()] });
+    }),
+    mockApi(zeroVoiceChatSessionsContract.activate, ({ respond }) => {
+      return respond(200, {
+        session: { id: SESSION_ID, status: "active" },
+      });
+    }),
+    mockApi(zeroVoiceChatSessionsContract.token, ({ respond }) => {
+      return respond(200, {
+        client_secret: { value: "ek_test", expires_at: 9_999_999_999 },
+      });
+    }),
+    mockApi(zeroVoiceChatSessionsContract.heartbeat, ({ respond }) => {
+      return respond(200, { ok: true as const });
+    }),
+    mockApi(zeroVoiceChatSessionsContract.end, ({ respond }) => {
+      return respond(200, { ok: true as const });
+    }),
+    mockApi(zeroVoiceChatContextContract.appendEvent, ({ body, respond }) => {
+      return respond(200, {
+        event: {
+          id: "evt-append",
+          seq: 9999,
+          source: body.source,
+          type: body.type,
+          content: body.content ?? null,
+          createdAt: "2026-04-20T00:00:00Z",
+        },
+      });
+    }),
+    mockApi(zeroVoiceChatTasksContract.listTasks, ({ respond }) => {
+      return respond(200, { tasks: initialTasks });
+    }),
+  );
+}
+
+describe("tasks panel component", () => {
+  const dcRef: { current: FakeDC | null } = { current: null };
+
+  function stubWebRTC() {
+    const mediaStreamStub = {
+      getAudioTracks() {
+        return [{ enabled: true }];
+      },
+      getTracks() {
+        return [{ stop: vi.fn() }];
+      },
+    } as unknown as MediaStream;
+
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia: vi.fn().mockResolvedValue(mediaStreamStub) },
+      writable: true,
+      configurable: true,
+    });
+
+    class FakeRTCPeerConnection {
+      iceConnectionState = "new";
+      addTrack = vi.fn();
+      close = vi.fn();
+      createOffer = vi.fn().mockResolvedValue({ sdp: "offer-sdp" });
+      setLocalDescription = vi.fn().mockResolvedValue(undefined);
+      setRemoteDescription = vi.fn().mockResolvedValue(undefined);
+
+      createDataChannel(): FakeDC {
+        const openListeners: (() => void)[] = [];
+        const messageListeners: ((ev: MessageEvent) => void)[] = [];
+        const closeListeners: (() => void)[] = [];
+
+        const dc: FakeDC = {
+          readyState: "open",
+          send: vi.fn(),
+          close: vi.fn(() => {
+            dc.readyState = "closed";
+            for (const l of closeListeners) {
+              l();
+            }
+          }),
+          addEventListener: (event, cb) => {
+            if (event === "open") {
+              openListeners.push(cb as () => void);
+            }
+            if (event === "message") {
+              messageListeners.push(cb as (ev: MessageEvent) => void);
+            }
+            if (event === "close") {
+              closeListeners.push(cb as () => void);
+            }
+          },
+          emitOpen: () => {
+            for (const l of openListeners) {
+              l();
+            }
+          },
+          emitMessage: (event: OpenAIRealtimeEvent) => {
+            for (const l of messageListeners) {
+              l({ data: JSON.stringify(event) } as MessageEvent);
+            }
+          },
+          emitClose: () => {
+            dc.readyState = "closed";
+            for (const l of closeListeners) {
+              l();
+            }
+          },
+        };
+
+        dcRef.current = dc;
+        return dc;
+      }
+
+      addEventListener() {
+        // no-op for tests
+      }
+    }
+
+    vi.stubGlobal("RTCPeerConnection", FakeRTCPeerConnection);
+
+    class FakeAudio {
+      autoplay = false;
+      srcObject: unknown = null;
+      pause = vi.fn();
+    }
+    vi.stubGlobal("Audio", FakeAudio);
+
+    server.use(
+      http.post("https://api.openai.com/v1/realtime", () => {
+        return new HttpResponse("answer-sdp", { status: 200 });
+      }),
+    );
+  }
+
+  function clearWebRTC() {
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    dcRef.current = null;
+    vi.unstubAllGlobals();
+  }
+
+  async function startSession() {
+    detachedSetupPage({
+      context,
+      path: "/voice-chat",
+      featureSwitches: { voiceChat: true },
+    });
+
+    await waitFor(() => {
+      const btn = screen.getAllByRole("button").find((b) => {
+        return /start voice chat/i.test(b.textContent ?? "");
+      });
+      expect(btn).toBeDefined();
+      expect(btn).not.toBeDisabled();
+    });
+
+    detach(
+      context.store.set(startVoiceChat$, context.signal),
+      Reason.DomCallback,
+    );
+
+    await waitFor(() => {
+      expect(dcRef.current).not.toBeNull();
+    });
+    dcRef.current?.emitOpen();
+
+    await waitFor(() => {
+      expect(context.store.get(vcStatus$)).toBe("connected");
+    });
+  }
+
+  beforeEach(() => {
+    stubWebRTC();
+  });
+
+  afterEach(() => {
+    clearWebRTC();
+  });
+
+  it("renders empty state when there are no tasks", async () => {
+    mockAllOk([]);
+    await startSession();
+
+    await waitFor(() => {
+      expect(screen.getByText(/no tasks yet/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/active tasks/i)).toBeInTheDocument();
+  });
+
+  it("renders a running task card with spinner and prompt", async () => {
+    const running = taskPayload({
+      status: "running",
+      prompt: "deploy the staging environment",
+    });
+    mockAllOk([running]);
+    await startSession();
+
+    await waitFor(() => {
+      expect(context.store.get(vcTasksById$)[TASK_ID]).toBeDefined();
+    });
+
+    await expect(
+      screen.findByText(/deploy the staging environment/),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText("running")).toBeInTheDocument();
+    const panel = screen.getByText(/active tasks/i).closest("aside");
+    expect(panel?.querySelector(".animate-spin")).not.toBeNull();
+  });
+
+  it("renders a done task card with its result body", async () => {
+    const done = taskPayload({
+      status: "done",
+      prompt: "fetch latest logs",
+      result: "Here are the logs you asked for.",
+      finishedAt: "2026-04-21T10:05:00Z",
+    });
+    mockAllOk([done]);
+    await startSession();
+
+    await waitFor(() => {
+      expect(context.store.get(vcTasksById$)[TASK_ID]?.status).toBe("done");
+    });
+
+    await expect(
+      screen.findByText(/fetch latest logs/),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText("done")).toBeInTheDocument();
+    expect(
+      screen.getByText(/here are the logs you asked for/i),
+    ).toBeInTheDocument();
+    const panel = screen.getByText(/active tasks/i).closest("aside");
+    expect(panel?.querySelector(".animate-spin")).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/views/voice-chat/tasks-panel.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/tasks-panel.tsx
@@ -1,0 +1,78 @@
+import { useGet } from "ccstate-react";
+import { cn } from "@vm0/ui";
+import { IconLoader2 } from "@tabler/icons-react";
+import type { VoiceChatTaskStatus } from "@vm0/core";
+import { vcAllTasksSorted$ } from "../../signals/voice-chat/voice-chat-session.ts";
+
+function TaskStatusBadge({ status }: { status: VoiceChatTaskStatus }) {
+  const color: Record<VoiceChatTaskStatus, string> = {
+    pending: "bg-muted text-muted-foreground",
+    queued: "bg-muted text-muted-foreground",
+    running:
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    done: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    failed: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+  };
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+        color[status],
+      )}
+    >
+      {status === "running" && (
+        <IconLoader2 size={10} className="animate-spin mr-1" />
+      )}
+      {status}
+    </span>
+  );
+}
+
+export function TasksPanel() {
+  const tasks = useGet(vcAllTasksSorted$);
+
+  return (
+    <aside className="flex flex-col min-h-0 overflow-hidden text-xs border-l">
+      <div className="shrink-0 px-4 py-2 flex items-center gap-3 text-muted-foreground border-b">
+        <span className="font-medium">Active tasks</span>
+        <span className="font-mono">{tasks.length}</span>
+      </div>
+      <div className="flex-1 min-h-0 overflow-y-auto px-3 py-3 flex flex-col gap-3">
+        {tasks.length === 0 ? (
+          <p className="text-muted-foreground italic text-center py-4">
+            No tasks yet.
+          </p>
+        ) : (
+          tasks.map((task) => {
+            return (
+              <div
+                key={task.id}
+                className="rounded-lg border border-border bg-muted/30 px-3 py-2 flex flex-col gap-2"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <TaskStatusBadge status={task.status} />
+                  <span className="text-[10px] text-muted-foreground font-mono">
+                    {new Date(task.createdAt).toLocaleTimeString()}
+                  </span>
+                </div>
+                <p className="text-xs text-foreground break-words line-clamp-3">
+                  {task.prompt}
+                </p>
+                {task.result && (
+                  <p className="text-xs text-foreground/80 whitespace-pre-wrap break-words border-t border-border/60 pt-2">
+                    {task.result}
+                  </p>
+                )}
+                {task.error && (
+                  <p className="text-xs text-destructive break-words border-t border-border/60 pt-2">
+                    {task.error}
+                  </p>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -34,6 +34,7 @@ import {
   VoiceAssistantBubble,
   SlowBrainIndicator,
 } from "./voice-chat-bubbles.tsx";
+import { TasksPanel } from "./tasks-panel.tsx";
 
 type ConnectionStatus =
   | "idle"
@@ -292,39 +293,44 @@ export function VoiceChatPage() {
         </div>
       )}
 
-      {/* Main content: unified conversation view */}
-      <div ref={setScrollContainer} className="flex-1 min-h-0 overflow-y-auto">
-        <div className="mx-auto w-full max-w-[900px] px-4 pt-4 pb-8">
-          <div className="flex flex-col gap-4">
-            {conversationItems.length === 0 && (
-              <p className="text-sm text-muted-foreground text-center py-8">
-                {status === "preparing"
-                  ? "Waiting for preparation to begin..."
-                  : status === "connecting"
-                    ? "Connecting..."
-                    : "Speak to start the conversation."}
-              </p>
-            )}
-            {conversationItems.map((item) => {
-              if (item.kind === "transcript") {
-                return item.entry.role === "user" ? (
-                  <VoiceUserBubble key={item.key} content={item.entry.text} />
-                ) : (
-                  <VoiceAssistantBubble
+      {/* Main content: conversation + tasks side panel on md+ */}
+      <div className="grid grid-cols-1 md:grid-cols-[1fr_320px] flex-1 min-h-0">
+        <div ref={setScrollContainer} className="min-h-0 overflow-y-auto">
+          <div className="mx-auto w-full max-w-[900px] px-4 pt-4 pb-8">
+            <div className="flex flex-col gap-4">
+              {conversationItems.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-8">
+                  {status === "preparing"
+                    ? "Waiting for preparation to begin..."
+                    : status === "connecting"
+                      ? "Connecting..."
+                      : "Speak to start the conversation."}
+                </p>
+              )}
+              {conversationItems.map((item) => {
+                if (item.kind === "transcript") {
+                  return item.entry.role === "user" ? (
+                    <VoiceUserBubble key={item.key} content={item.entry.text} />
+                  ) : (
+                    <VoiceAssistantBubble
+                      key={item.key}
+                      content={item.entry.text}
+                    />
+                  );
+                }
+                return (
+                  <SlowBrainIndicator
                     key={item.key}
-                    content={item.entry.text}
+                    type={item.event.type}
+                    content={item.event.content}
                   />
                 );
-              }
-              return (
-                <SlowBrainIndicator
-                  key={item.key}
-                  type={item.event.type}
-                  content={item.event.content}
-                />
-              );
-            })}
+              })}
+            </div>
           </div>
+        </div>
+        <div className="hidden md:block min-h-0">
+          <TasksPanel />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Adds `vcTasksById$`, `vcActiveTasks$`, and `vcAllTasksSorted$` computed signals, fed from a new `listTasks` call piggy-backed on the existing Ably poll loop inside `startPoll$`
- Adds `TasksPanel` component that renders queued/running/done/failed task cards (prompt, status badge, optional result/error, newest-first)
- Swaps the active-session layout on `voice-chat-page.tsx` to `grid-cols-1 md:grid-cols-[1fr_320px]`, mounting the panel in the right column (hidden below `md:`, conversation column keeps `max-w-[900px]`)
- Adds signal integration tests (6 cases: empty, dispatched → running, running → done, running → failed, newest-first ordering, end-session reset) and component tests (empty / running / done)

Closes #10665 — sub-issue of epic #10661.

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run src/signals/voice-chat src/views/voice-chat` — 6 files / 42 tests passing
- [x] `pnpm turbo run lint --filter=@vm0/app` — 0 warnings, 0 errors
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — all unchanged
- [x] `pnpm knip --workspace apps/platform` — no issues
- [ ] Manual desktop: idle → start session → task dispatched by slow-brain appears as `running` card → transitions to `done` with result body
- [ ] Manual mobile (<md): verify right panel is hidden and layout stays single-column

🤖 Generated with [Claude Code](https://claude.com/claude-code)