### PR TITLE
feat(voice-chat): inject system task events into fast-brain

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from "msw";
 import {
   zeroVoiceChatSessionsContract,
   zeroVoiceChatContextContract,
+  zeroVoiceChatTasksContract,
   type ContextEvent,
 } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
@@ -87,6 +88,14 @@ function mockHeartbeat() {
   server.use(
     mockApi(zeroVoiceChatSessionsContract.heartbeat, ({ respond }) => {
       return respond(200, { ok: true as const });
+    }),
+  );
+}
+
+function mockListTasks() {
+  server.use(
+    mockApi(zeroVoiceChatTasksContract.listTasks, ({ respond }) => {
+      return respond(200, { tasks: [] });
     }),
   );
 }
@@ -238,6 +247,7 @@ describe("voice-chat fast-brain injection", () => {
     mockToken();
     mockActivate();
     mockHeartbeat();
+    mockListTasks();
 
     detach(
       context.store.set(startVoiceChat$, context.signal),

--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
@@ -1,0 +1,463 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import {
+  zeroVoiceChatSessionsContract,
+  zeroVoiceChatContextContract,
+  type ContextEvent,
+} from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { triggerAblyEvent } from "../../../mocks/ably.ts";
+import { detach, Reason } from "../../utils.ts";
+import { startVoiceChat$, vcStatus$ } from "../voice-chat-session.ts";
+
+const context = testContext();
+
+const SESSION_ID = "vc-inj-session";
+const TASK_ID = "task-abc";
+
+function eventRow(
+  overrides: Partial<ContextEvent> & { seq: number },
+): ContextEvent {
+  return {
+    id: `evt-${overrides.seq}`,
+    source: "system",
+    type: "preparation-ready",
+    content: null,
+    createdAt: "2026-04-22T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// WebRTC stubs
+// ---------------------------------------------------------------------------
+
+interface FakeDC {
+  readyState: "open" | "closed";
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  addEventListener: (event: string, cb: (ev?: unknown) => void) => void;
+  emitOpen: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Mock endpoint helpers
+// ---------------------------------------------------------------------------
+
+function mockCreateSession() {
+  server.use(
+    mockApi(zeroVoiceChatSessionsContract.create, ({ respond }) => {
+      return respond(200, {
+        session: {
+          id: SESSION_ID,
+          status: "preparing",
+          runId: "run-1",
+          createdAt: "2026-04-22T00:00:00Z",
+          prepared: false,
+        },
+      });
+    }),
+  );
+}
+
+function mockToken() {
+  server.use(
+    mockApi(zeroVoiceChatSessionsContract.token, ({ respond }) => {
+      return respond(200, {
+        client_secret: { value: "ek_test", expires_at: 9_999_999_999 },
+      });
+    }),
+  );
+}
+
+function mockActivate() {
+  server.use(
+    mockApi(zeroVoiceChatSessionsContract.activate, ({ params, respond }) => {
+      return respond(200, {
+        session: { id: params.id, status: "active" },
+      });
+    }),
+  );
+}
+
+function mockHeartbeat() {
+  server.use(
+    mockApi(zeroVoiceChatSessionsContract.heartbeat, ({ respond }) => {
+      return respond(200, { ok: true as const });
+    }),
+  );
+}
+
+/**
+ * Dynamic /context handler. Returns any events with `seq > after`. Tests push
+ * rows via the returned `add()` — the preparation-ready seed satisfies the
+ * preparation gate, later rows flow through startPoll$ and into
+ * injectSlowBrainEvents$. `afterValues` records every poll's `after` query
+ * param so tests can use `vi.waitFor` to detect that a triggered poll has
+ * been consumed (rather than relying on manual delays).
+ */
+function mockContextEvents(): {
+  add: (...events: ContextEvent[]) => void;
+  afterValues: number[];
+} {
+  const events: ContextEvent[] = [
+    eventRow({ seq: 1, type: "preparation-ready" }),
+  ];
+  const afterValues: number[] = [];
+  server.use(
+    mockApi(zeroVoiceChatContextContract.getEvents, ({ query, respond }) => {
+      const after = query.after ?? 0;
+      afterValues.push(after);
+      return respond(200, {
+        events: events.filter((e) => {
+          return e.seq > after;
+        }),
+      });
+    }),
+  );
+  return {
+    add: (...rows: ContextEvent[]) => {
+      events.push(...rows);
+    },
+    afterValues,
+  };
+}
+
+async function setup() {
+  await setupPage({
+    context,
+    path: "/voice-chat",
+    withoutRender: true,
+    featureSwitches: { voiceChat: true },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("voice-chat fast-brain injection", () => {
+  const dcRef: { current: FakeDC | null } = { current: null };
+
+  function stubWebRTC() {
+    const mediaStreamStub = {
+      getAudioTracks() {
+        return [{ enabled: true }];
+      },
+      getTracks() {
+        return [{ stop: vi.fn() }];
+      },
+    } as unknown as MediaStream;
+
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia: vi.fn().mockResolvedValue(mediaStreamStub) },
+      writable: true,
+      configurable: true,
+    });
+
+    class FakeRTCPeerConnection {
+      iceConnectionState = "new";
+      addTrack = vi.fn();
+      close = vi.fn();
+      createOffer = vi.fn().mockResolvedValue({ sdp: "offer-sdp" });
+      setLocalDescription = vi.fn().mockResolvedValue(undefined);
+      setRemoteDescription = vi.fn().mockResolvedValue(undefined);
+
+      createDataChannel(): FakeDC {
+        const openListeners: (() => void)[] = [];
+        const messageListeners: ((ev: MessageEvent) => void)[] = [];
+        const closeListeners: (() => void)[] = [];
+
+        const dc: FakeDC = {
+          readyState: "open",
+          send: vi.fn(),
+          close: vi.fn(() => {
+            dc.readyState = "closed";
+            for (const l of closeListeners) {
+              l();
+            }
+          }),
+          addEventListener: (event, cb) => {
+            if (event === "open") {
+              openListeners.push(cb as () => void);
+            }
+            if (event === "message") {
+              messageListeners.push(cb as (ev: MessageEvent) => void);
+            }
+            if (event === "close") {
+              closeListeners.push(cb as () => void);
+            }
+          },
+          emitOpen: () => {
+            for (const l of openListeners) {
+              l();
+            }
+          },
+        };
+
+        dcRef.current = dc;
+        return dc;
+      }
+
+      addEventListener() {
+        // no-op: tests don't drive track/ice events
+      }
+    }
+
+    vi.stubGlobal("RTCPeerConnection", FakeRTCPeerConnection);
+
+    class FakeAudio {
+      autoplay = false;
+      srcObject: unknown = null;
+      pause = vi.fn();
+    }
+    vi.stubGlobal("Audio", FakeAudio);
+
+    server.use(
+      http.post("https://api.openai.com/v1/realtime", () => {
+        return new HttpResponse("answer-sdp", { status: 200 });
+      }),
+    );
+  }
+
+  function clearWebRTC() {
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    dcRef.current = null;
+    vi.unstubAllGlobals();
+  }
+
+  async function startSuccessfully() {
+    mockCreateSession();
+    mockToken();
+    mockActivate();
+    mockHeartbeat();
+
+    detach(
+      context.store.set(startVoiceChat$, context.signal),
+      Reason.DomCallback,
+    );
+
+    await vi.waitFor(() => {
+      expect(dcRef.current).not.toBeNull();
+    });
+    dcRef.current?.emitOpen();
+    await vi.waitFor(() => {
+      expect(context.store.get(vcStatus$)).toBe("connected");
+    });
+    // Clear the initial session.update send so each test starts with a clean
+    // mock.calls ledger.
+    dcRef.current?.send.mockClear();
+  }
+
+  /** Read every DC send as a parsed JSON object. */
+  function decodedSends(): {
+    type: string;
+    item?: { content?: { text: string }[] };
+  }[] {
+    return (dcRef.current?.send.mock.calls ?? []).map((call) => {
+      return JSON.parse(call[0] as string);
+    });
+  }
+
+  function injectedTexts(): string[] {
+    return decodedSends()
+      .filter((m) => {
+        return m.type === "conversation.item.create";
+      })
+      .map((m) => {
+        return m.item?.content?.[0]?.text ?? "";
+      });
+  }
+
+  beforeEach(() => {
+    stubWebRTC();
+  });
+
+  afterEach(() => {
+    clearWebRTC();
+  });
+
+  it("injects a task-dispatched event as `[Task dispatched] <prompt>` user message", async () => {
+    await setup();
+    const ctx = mockContextEvents();
+    await startSuccessfully();
+
+    ctx.add(
+      eventRow({
+        seq: 2,
+        type: "task-dispatched",
+        content: JSON.stringify({
+          taskId: TASK_ID,
+          prompt: "check if PR #123 merged",
+        }),
+      }),
+    );
+    triggerAblyEvent(`voice:${SESSION_ID}`);
+
+    await vi.waitFor(() => {
+      expect(injectedTexts()).toContain(
+        "[Task dispatched] check if PR #123 merged",
+      );
+    });
+  });
+
+  it("does NOT send response.cancel or response.create for a task event alone", async () => {
+    await setup();
+    const ctx = mockContextEvents();
+    await startSuccessfully();
+
+    ctx.add(
+      eventRow({
+        seq: 2,
+        type: "task-dispatched",
+        content: JSON.stringify({ taskId: TASK_ID, prompt: "do thing" }),
+      }),
+    );
+    triggerAblyEvent(`voice:${SESSION_ID}`);
+
+    await vi.waitFor(() => {
+      expect(injectedTexts()).toContain("[Task dispatched] do thing");
+    });
+    const types = decodedSends().map((m) => {
+      return m.type;
+    });
+    expect(types).not.toContain("response.cancel");
+    expect(types).not.toContain("response.create");
+  });
+
+  it("mixed directive + task-dispatched sends both injections plus response.create", async () => {
+    await setup();
+    const ctx = mockContextEvents();
+    await startSuccessfully();
+
+    ctx.add(
+      eventRow({
+        seq: 2,
+        source: "slow-brain",
+        type: "directive",
+        content: "Tell the user you're on it.",
+      }),
+      eventRow({
+        seq: 3,
+        type: "task-dispatched",
+        content: JSON.stringify({ taskId: TASK_ID, prompt: "check PR" }),
+      }),
+    );
+    triggerAblyEvent(`voice:${SESSION_ID}`);
+
+    await vi.waitFor(() => {
+      const texts = injectedTexts();
+      expect(texts).toContain(
+        "[Slow-brain directive] Tell the user you're on it.",
+      );
+      expect(texts).toContain("[Task dispatched] check PR");
+    });
+    const types = decodedSends().map((m) => {
+      return m.type;
+    });
+    expect(types).toContain("response.create");
+  });
+
+  it("formats task-completed success as `[Task completed: done] <result>`", async () => {
+    await setup();
+    const ctx = mockContextEvents();
+    await startSuccessfully();
+
+    ctx.add(
+      eventRow({
+        seq: 2,
+        type: "task-completed",
+        content: JSON.stringify({
+          taskId: TASK_ID,
+          status: "done",
+          result: "PR #123 merged by @alice",
+          error: null,
+        }),
+      }),
+    );
+    triggerAblyEvent(`voice:${SESSION_ID}`);
+
+    await vi.waitFor(() => {
+      expect(injectedTexts()).toContain(
+        "[Task completed: done] PR #123 merged by @alice",
+      );
+    });
+  });
+
+  it("formats task-completed failure using the error field", async () => {
+    await setup();
+    const ctx = mockContextEvents();
+    await startSuccessfully();
+
+    ctx.add(
+      eventRow({
+        seq: 2,
+        type: "task-completed",
+        content: JSON.stringify({
+          taskId: TASK_ID,
+          status: "failed",
+          result: null,
+          error: "sandbox timeout",
+        }),
+      }),
+    );
+    triggerAblyEvent(`voice:${SESSION_ID}`);
+
+    await vi.waitFor(() => {
+      expect(injectedTexts()).toContain(
+        "[Task completed: failed] sandbox timeout",
+      );
+    });
+  });
+
+  it("does NOT inject other system events (e.g. session-start)", async () => {
+    await setup();
+    const ctx = mockContextEvents();
+    await startSuccessfully();
+
+    ctx.add(
+      eventRow({
+        seq: 2,
+        type: "session-start",
+        content: null,
+      }),
+    );
+    const baseline = ctx.afterValues.length;
+    triggerAblyEvent(`voice:${SESSION_ID}`);
+
+    // Wait for the poke to drive at least one poll past the baseline, then
+    // assert nothing was injected.
+    await vi.waitFor(() => {
+      expect(ctx.afterValues.length).toBeGreaterThan(baseline);
+    });
+    expect(injectedTexts()).toStrictEqual([]);
+  });
+
+  it("drops silently when task content is malformed JSON", async () => {
+    await setup();
+    const ctx = mockContextEvents();
+    await startSuccessfully();
+
+    ctx.add(
+      eventRow({
+        seq: 2,
+        type: "task-dispatched",
+        content: "{not json",
+      }),
+    );
+    const baseline = ctx.afterValues.length;
+    triggerAblyEvent(`voice:${SESSION_ID}`);
+
+    await vi.waitFor(() => {
+      expect(ctx.afterValues.length).toBeGreaterThan(baseline);
+    });
+    expect(injectedTexts()).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -131,6 +131,16 @@ Only after your slow-brain responds can you tell the user that something is not 
 
 When you receive a message starting with [Slow-brain...], it is from your slow-brain. Incorporate that information naturally into your response. Use your own voice — do not read it verbatim. The slow-brain message provides the substance; you provide the delivery.
 
+## Receiving task updates
+
+You may also receive messages starting with [Task dispatched] or [Task completed: ...]. These are background tasks your slow-brain has kicked off on your behalf. Use them purely for situational awareness:
+
+- If the user asks "what are you doing right now?" or similar, you can mention the subject naturally — "I'm looking up that PR for you" or "I was checking your calendar."
+- Do NOT read the task message verbatim. Do NOT announce dispatch or completion unless slow-brain explicitly directs you to via a directive.
+- Do NOT interrupt an ongoing utterance when you see these — they are background context, not commands.
+
+Directives from slow-brain remain the authoritative source for what to say next. Task messages just help you stay grounded when the user asks what is happening.
+
 ## Communication style
 
 - Keep responses concise and natural. You are speaking, not writing.
@@ -146,6 +156,49 @@ function formatInjectionMessage(event: ContextEvent): string {
   };
   const label = prefixes[event.type] ?? `[Slow-brain update - ${event.type}]`;
   return `${label} ${event.content ?? ""}`.trim();
+}
+
+const SYSTEM_TASK_INJECTION_MAX = 400;
+
+function truncateForInjection(s: string | null | undefined): string {
+  if (!s) {
+    return "";
+  }
+  return s.length > SYSTEM_TASK_INJECTION_MAX
+    ? `${s.slice(0, SYSTEM_TASK_INJECTION_MAX)}…`
+    : s;
+}
+
+function formatSystemTaskMessage(event: ContextEvent): string | null {
+  if (!event.content) {
+    return null;
+  }
+  let parsed: unknown;
+  // eslint-disable-next-line no-restricted-syntax -- defensive parse: content is backend JSON, drop silently on malformed input rather than crashing the realtime loop
+  try {
+    parsed = JSON.parse(event.content);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return null;
+  }
+  const p = parsed as Record<string, unknown>;
+
+  if (event.type === "task-dispatched") {
+    const prompt = typeof p.prompt === "string" ? p.prompt : "";
+    const body = truncateForInjection(prompt);
+    return body ? `[Task dispatched] ${body}` : "[Task dispatched]";
+  }
+  if (event.type === "task-completed") {
+    const status = typeof p.status === "string" ? p.status : "done";
+    const result = typeof p.result === "string" ? p.result : "";
+    const error = typeof p.error === "string" ? p.error : "";
+    const body = truncateForInjection(status === "failed" ? error : result);
+    const label = `[Task completed: ${status}]`;
+    return body ? `${label} ${body}` : label;
+  }
+  return null;
 }
 
 // --- Internal state ---
@@ -475,6 +528,10 @@ const handleDCMessage$ = command(
 
 const injectSlowBrainEvents$ = command(
   ({ get, set }, events: ContextEvent[]) => {
+    // Historical name kept — this command also injects system/task-dispatched
+    // and system/task-completed events as non-interrupting situational
+    // awareness for fast-brain. `needsResponse` stays tied to slow-brain
+    // directive/observation only, so task events never fire response.cancel.
     const dc = get(internalDc$);
     if (!dc || dc.readyState !== "open") {
       return;
@@ -483,7 +540,13 @@ const injectSlowBrainEvents$ = command(
     const slowBrainEvents = events.filter((e) => {
       return e.source === "slow-brain" && e.content;
     });
-    if (slowBrainEvents.length === 0) {
+    const systemTaskEvents = events.filter((e) => {
+      return (
+        e.source === "system" &&
+        (e.type === "task-dispatched" || e.type === "task-completed")
+      );
+    });
+    if (slowBrainEvents.length === 0 && systemTaskEvents.length === 0) {
       return;
     }
 
@@ -509,6 +572,24 @@ const injectSlowBrainEvents$ = command(
             content: [
               { type: "input_text", text: formatInjectionMessage(event) },
             ],
+          },
+        }),
+      );
+    }
+
+    // Inject task-dispatched / task-completed as non-interrupting context
+    for (const event of systemTaskEvents) {
+      const text = formatSystemTaskMessage(event);
+      if (!text) {
+        continue;
+      }
+      dc.send(
+        JSON.stringify({
+          type: "conversation.item.create",
+          item: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text }],
           },
         }),
       );

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-task/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-task/__tests__/route.test.ts
@@ -162,14 +162,21 @@ describe("POST /api/internal/callbacks/voice-chat-task", () => {
     });
     expect(completed).toBeTruthy();
     expect(completed!.source).toBe("system");
-    expect(completed!.content).toBe(JSON.stringify({ taskId }));
+    expect(completed!.content).toBe(
+      JSON.stringify({
+        taskId,
+        status: "done",
+        result: "final answer",
+        error: null,
+      }),
+    );
 
     await context.mocks.flushAfter();
     expect(mockAblyPublish).toHaveBeenCalledWith(`voice:${sessionId}`, null);
   });
 
   it("marks the task failed with the error text on failed", async () => {
-    const { runId, taskId, secret } = await setupTaskWithCallback();
+    const { runId, taskId, sessionId, secret } = await setupTaskWithCallback();
 
     const response = await POST(
       createSignedCallbackRequest(
@@ -189,10 +196,23 @@ describe("POST /api/internal/callbacks/voice-chat-task", () => {
     expect(row!.status).toBe("failed");
     expect(row!.error).toBe("runner crashed");
     expect(row!.result).toBeNull();
+
+    const events = await listEvents(sessionId);
+    const completed = events.find((e) => {
+      return e.type === "task-completed";
+    });
+    expect(completed!.content).toBe(
+      JSON.stringify({
+        taskId,
+        status: "failed",
+        result: null,
+        error: "runner crashed",
+      }),
+    );
   });
 
   it("maps cancelled to failed with 'Run cancelled' default error", async () => {
-    const { runId, taskId, secret } = await setupTaskWithCallback();
+    const { runId, taskId, sessionId, secret } = await setupTaskWithCallback();
 
     const response = await POST(
       createSignedCallbackRequest(
@@ -206,10 +226,23 @@ describe("POST /api/internal/callbacks/voice-chat-task", () => {
     const row = await readTask(taskId);
     expect(row!.status).toBe("failed");
     expect(row!.error).toBe("Run cancelled");
+
+    const events = await listEvents(sessionId);
+    const completed = events.find((e) => {
+      return e.type === "task-completed";
+    });
+    expect(completed!.content).toBe(
+      JSON.stringify({
+        taskId,
+        status: "failed",
+        result: null,
+        error: "Run cancelled",
+      }),
+    );
   });
 
   it("maps timeout to failed with 'Run timeout' default error", async () => {
-    const { runId, taskId, secret } = await setupTaskWithCallback();
+    const { runId, taskId, sessionId, secret } = await setupTaskWithCallback();
 
     const response = await POST(
       createSignedCallbackRequest(
@@ -223,6 +256,19 @@ describe("POST /api/internal/callbacks/voice-chat-task", () => {
     const row = await readTask(taskId);
     expect(row!.status).toBe("failed");
     expect(row!.error).toBe("Run timeout");
+
+    const events = await listEvents(sessionId);
+    const completed = events.find((e) => {
+      return e.type === "task-completed";
+    });
+    expect(completed!.content).toBe(
+      JSON.stringify({
+        taskId,
+        status: "failed",
+        result: null,
+        error: "Run timeout",
+      }),
+    );
   });
 
   it("writes the task-completed event even when the session has already ended", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-task/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-task/route.ts
@@ -97,7 +97,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: true });
   }
 
-  await appendTaskEvent(completed.sessionId, "task-completed", completed.id);
+  await appendTaskEvent(completed.sessionId, {
+    type: "task-completed",
+    taskId: completed.id,
+    status: taskStatus,
+    result: resultText ?? null,
+    error: errorText,
+  });
 
   const [session] = await globalThis.services.db
     .select({ userId: voiceChatSessions.userId })

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/tasks/__tests__/route.test.ts
@@ -175,7 +175,9 @@ describe("POST /api/zero/voice-chat/[id]/tasks (createTask)", () => {
     });
     expect(dispatched).toBeTruthy();
     expect(dispatched!.source).toBe("system");
-    expect(dispatched!.content).toBe(JSON.stringify({ taskId: body.task.id }));
+    expect(dispatched!.content).toBe(
+      JSON.stringify({ taskId: body.task.id, prompt: "summarize this" }),
+    );
   });
 });
 

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/tasks/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/tasks/route.ts
@@ -151,7 +151,11 @@ export async function POST(
     taskId: task.id,
     runId: run.runId,
   });
-  await appendTaskEvent(id, "task-dispatched", task.id);
+  await appendTaskEvent(id, {
+    type: "task-dispatched",
+    taskId: task.id,
+    prompt: parsed.data.prompt,
+  });
 
   after(() => {
     return publishUserSignal([session.userId], `voice:${id}`);

--- a/turbo/apps/web/src/lib/zero/voice-chat/__tests__/task-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/__tests__/task-service.test.ts
@@ -154,7 +154,30 @@ describe("getVoiceChatTask / listVoiceChatTasks", () => {
 });
 
 describe("appendTaskEvent", () => {
-  it("inserts a system-source event that bypasses the active-session gate", async () => {
+  it("writes a task-dispatched event with taskId + prompt in content", async () => {
+    context.setupMocks();
+    const { sessionId } = await seedActiveSession();
+
+    await appendTaskEvent(sessionId, {
+      type: "task-dispatched",
+      taskId: "task-abc",
+      prompt: "check PR #123",
+    });
+
+    const rows = await globalThis.services.db
+      .select()
+      .from(voiceChatEvents)
+      .where(eq(voiceChatEvents.sessionId, sessionId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.source).toBe("system");
+    expect(rows[0]!.type).toBe("task-dispatched");
+    expect(JSON.parse(rows[0]!.content!)).toStrictEqual({
+      taskId: "task-abc",
+      prompt: "check PR #123",
+    });
+  });
+
+  it("writes a task-completed event with status/result/error and bypasses the active-session gate", async () => {
     context.setupMocks();
     const { sessionId } = await seedActiveSession();
 
@@ -163,7 +186,13 @@ describe("appendTaskEvent", () => {
       .set({ status: "ended", endedAt: new Date() })
       .where(eq(voiceChatSessions.id, sessionId));
 
-    await appendTaskEvent(sessionId, "task-completed", "task-abc");
+    await appendTaskEvent(sessionId, {
+      type: "task-completed",
+      taskId: "task-abc",
+      status: "done",
+      result: "PR #123 merged by @alice",
+      error: null,
+    });
 
     const rows = await globalThis.services.db
       .select()
@@ -172,7 +201,32 @@ describe("appendTaskEvent", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]!.source).toBe("system");
     expect(rows[0]!.type).toBe("task-completed");
-    expect(rows[0]!.content).toBe(JSON.stringify({ taskId: "task-abc" }));
+    expect(JSON.parse(rows[0]!.content!)).toStrictEqual({
+      taskId: "task-abc",
+      status: "done",
+      result: "PR #123 merged by @alice",
+      error: null,
+    });
+  });
+
+  it("truncates overly long prompts at the 2000-char server cap", async () => {
+    context.setupMocks();
+    const { sessionId } = await seedActiveSession();
+    const huge = "x".repeat(2500);
+
+    await appendTaskEvent(sessionId, {
+      type: "task-dispatched",
+      taskId: "t",
+      prompt: huge,
+    });
+
+    const rows = await globalThis.services.db
+      .select()
+      .from(voiceChatEvents)
+      .where(eq(voiceChatEvents.sessionId, sessionId));
+    const parsed = JSON.parse(rows[0]!.content!);
+    expect(parsed.prompt.length).toBe(2001);
+    expect(parsed.prompt.endsWith("…")).toBe(true);
   });
 });
 

--- a/turbo/apps/web/src/lib/zero/voice-chat/__tests__/tasker-round-trip.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/__tests__/tasker-round-trip.test.ts
@@ -122,7 +122,9 @@ describe("tasker round trip through the blackboard", () => {
     });
     expect(dispatched).toBeTruthy();
     expect(dispatched!.source).toBe("system");
-    expect(dispatched!.content).toBe(JSON.stringify({ taskId: task.id }));
+    const dispatchedContent = JSON.parse(dispatched!.content!);
+    expect(dispatchedContent.taskId).toBe(task.id);
+    expect(dispatchedContent.prompt).toContain("PR #123");
 
     context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
       { eventData: { result: "PR #123 merged by @alice on 2026-04-21" } },
@@ -160,7 +162,10 @@ describe("tasker round trip through the blackboard", () => {
     });
     expect(completedEvent).toBeTruthy();
     expect(completedEvent!.source).toBe("system");
-    expect(completedEvent!.content).toBe(JSON.stringify({ taskId: task.id }));
+    const completedContent = JSON.parse(completedEvent!.content!);
+    expect(completedContent.taskId).toBe(task.id);
+    expect(completedContent.status).toBe("done");
+    expect(completedContent.result).toContain("merged by @alice");
 
     const fetched = await getVoiceChatTask(task.id);
     await appendEvent(

--- a/turbo/apps/web/src/lib/zero/voice-chat/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/task-service.ts
@@ -83,6 +83,29 @@ export async function listVoiceChatTasks(
     .orderBy(asc(voiceChatTasks.createdAt));
 }
 
+const TASK_EVENT_CONTENT_MAX = 2000;
+
+function truncateTaskEventField(s: string | null | undefined): string | null {
+  if (s == null) return null;
+  return s.length > TASK_EVENT_CONTENT_MAX
+    ? `${s.slice(0, TASK_EVENT_CONTENT_MAX)}…`
+    : s;
+}
+
+type TaskEventInput =
+  | {
+      type: "task-dispatched";
+      taskId: string;
+      prompt: string;
+    }
+  | {
+      type: "task-completed";
+      taskId: string;
+      status: VoiceChatTaskTerminalStatus;
+      result: string | null;
+      error: string | null;
+    };
+
 /**
  * Append a system-source task lifecycle event directly into the blackboard.
  *
@@ -91,17 +114,33 @@ export async function listVoiceChatTasks(
  * `endSession` has flipped the session to "ended" (the cancel step races with
  * runs that are already terminating), so system writes bypass that gate the
  * same way `endSession` itself does when emitting `session-end`.
+ *
+ * Content is JSON with the task subject (prompt on dispatch, status/result/error
+ * on completion) so fast-brain and the tasks-panel UI can render human-readable
+ * context without a secondary fetch. Fields are truncated at 2000 chars.
  */
 export async function appendTaskEvent(
   sessionId: string,
-  type: "task-dispatched" | "task-completed",
-  taskId: string,
+  input: TaskEventInput,
 ): Promise<void> {
+  const content =
+    input.type === "task-dispatched"
+      ? JSON.stringify({
+          taskId: input.taskId,
+          prompt: truncateTaskEventField(input.prompt),
+        })
+      : JSON.stringify({
+          taskId: input.taskId,
+          status: input.status,
+          result: truncateTaskEventField(input.result),
+          error: truncateTaskEventField(input.error),
+        });
+
   await globalThis.services.db.insert(voiceChatEvents).values({
     sessionId,
     source: "system",
-    type,
-    content: JSON.stringify({ taskId }),
+    type: input.type,
+    content,
   });
 }
 


### PR DESCRIPTION
## Summary

Teach fast-brain about in-flight Tasker runs so it can answer "what are you doing right now?" grounded in real task state.

- **Backend** (`task-service.ts`): `appendTaskEvent` now takes a tagged-union input and writes the dispatch prompt on `task-dispatched` and terminal status/result/error on `task-completed`. Each text field is truncated at 2000 chars so the event row stays bounded.
- **Client** (`voice-chat-session.ts`): `injectSlowBrainEvents\$` is broadened to also forward `system/task-dispatched` and `system/task-completed` events into the OpenAI realtime conversation as non-interrupting user messages (`[Task dispatched] <prompt>` / `[Task completed: <status>] <body>`). Body is truncated at 400 chars on the client. Task events deliberately do NOT fire `response.cancel` or `response.create` — they are situational awareness only, not a speak-now signal. Slow-brain directives remain the authoritative driver for what to say.
- **Instructions**: `FAST_BRAIN_INSTRUCTIONS` now has a "Receiving task updates" section telling the model to mention subjects naturally if asked, never read verbatim, and never interrupt mid-utterance when these arrive.

Resolves #10663 (part of epic #10661).

## Test plan

- [x] `task-service.test.ts` — task-dispatched shape, task-completed shape (including session-gate bypass), and 2000-char truncation
- [x] `tasker-round-trip.test.ts` — existing round-trip adjusted to parse the richer JSON content
- [x] `voice-chat-session.test.ts` (new, 7 cases) — dispatched injection, no response.cancel/create for task alone, mixed directive + dispatched, completed-success format, completed-failure format, non-task system events ignored, malformed JSON dropped silently
- [x] `pnpm -F web exec vitest run src/lib/zero/voice-chat src/app/api/zero/voice-chat` — 59 passed
- [x] `pnpm -F @vm0/app exec vitest run src/signals/voice-chat src/views/mission-control-page` — 53 passed
- [x] `pnpm turbo run lint` — green (platform + web)
- [x] `pnpm check-types` — green
- [x] `pnpm format` — applied
- [x] `pnpm knip` — no new unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)