### PR TITLE
feat(zero): dual-read memory storage (artifact→memory fallback)

### DIFF
--- a/turbo/apps/web/src/lib/infra/storage/__tests__/memory-dual-read.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/memory-dual-read.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach } from "vitest";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Internal infrastructure: no API route
+import { prepareStorageManifest } from "../storage-service";
+import {
+  createTestArtifact,
+  createTestMemory,
+} from "../../../../__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../__tests__/test-helpers";
+
+const context = testContext();
+
+describe("Memory dual-read (artifact → memory fallback)", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("resolves memory from type='memory' row (pre-flip state)", async () => {
+    const memoryName = uniqueId("mem");
+    const { versionId } = await createTestMemory(memoryName);
+
+    const manifest = await prepareStorageManifest(
+      undefined,
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      memoryName,
+    );
+
+    expect(manifest.memory).not.toBeNull();
+    expect(manifest.memory!.vasStorageName).toBe(memoryName);
+    expect(manifest.memory!.vasVersionId).toBe(versionId);
+  });
+
+  it("resolves memory from type='artifact' row (post-flip state)", async () => {
+    const memoryName = uniqueId("mem");
+    const { versionId } = await createTestArtifact(memoryName);
+
+    const manifest = await prepareStorageManifest(
+      undefined,
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      memoryName,
+    );
+
+    expect(manifest.memory).not.toBeNull();
+    expect(manifest.memory!.vasStorageName).toBe(memoryName);
+    expect(manifest.memory!.vasVersionId).toBe(versionId);
+  });
+
+  it("prefers type='artifact' when both rows exist for same name", async () => {
+    const memoryName = uniqueId("mem");
+    const { versionId: memoryVersionId } = await createTestMemory(memoryName, {
+      files: [
+        {
+          path: "memory.txt",
+          hash: "a".repeat(64),
+          size: 10,
+        },
+      ],
+    });
+    const { versionId: artifactVersionId } = await createTestArtifact(
+      memoryName,
+      {
+        files: [
+          {
+            path: "artifact.txt",
+            hash: "b".repeat(64),
+            size: 20,
+          },
+        ],
+      },
+    );
+    expect(artifactVersionId).not.toBe(memoryVersionId);
+
+    const manifest = await prepareStorageManifest(
+      undefined,
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      memoryName,
+    );
+
+    expect(manifest.memory).not.toBeNull();
+    expect(manifest.memory!.vasVersionId).toBe(artifactVersionId);
+    expect(manifest.memory!.vasVersionId).not.toBe(memoryVersionId);
+  });
+});

--- a/turbo/apps/web/src/lib/infra/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/infra/storage/storage-service.ts
@@ -817,6 +817,15 @@ async function executeBatchResolution(
   }
 
   if (memoryName) {
+    // Dual-read compat for epic #10577 Phase 2 type flip (#10601):
+    // check type='artifact' first (post-flip state), fall back to
+    // type='memory' (pre-flip state). Removed in #10603.
+    remainingLookups.push({
+      orgId: runtimeClerkOrgId,
+      userId,
+      name: memoryName,
+      type: "artifact",
+    });
     remainingLookups.push({
       orgId: runtimeClerkOrgId,
       userId,
@@ -1093,10 +1102,30 @@ async function buildManifestFromResults(
   // Build memory
   let memory: ManifestArtifact | null = null;
   if (memoryName) {
-    const key = lookupKey(runtimeClerkOrgId, userId, memoryName, "memory");
-    const resolved = allResults.get(key);
+    // Dual-read compat for epic #10577 Phase 2 type flip (#10601):
+    // prefer type='artifact' row, fall back to type='memory'. Removed in #10603.
+    const artifactKey = lookupKey(
+      runtimeClerkOrgId,
+      userId,
+      memoryName,
+      "artifact",
+    );
+    const memoryKey = lookupKey(
+      runtimeClerkOrgId,
+      userId,
+      memoryName,
+      "memory",
+    );
+    const resolved = lookupWithFallback(allResults, artifactKey, memoryKey);
     if (!resolved) {
       throw new Error(`Storage "${memoryName}" not found in database`);
+    }
+    if (!allResults.has(artifactKey)) {
+      log.info("memory dual-read fallback hit", {
+        memoryName,
+        orgId: runtimeClerkOrgId,
+        userId,
+      });
     }
     const archiveKey = `${resolved.s3Key}/archive.tar.gz`;
     const archiveUrl = await generatePresignedUrl(bucketName, archiveKey);


### PR DESCRIPTION
## Summary

Sub-issue #10600 of epic #10577, Phase 2 step 1 of 5.

Makes `prepareStorageManifest` tolerate either `type='memory'` or `type='artifact'` rows when resolving `agent_sessions.memoryName`, so the DB type-flip migration (#10601) can ship with zero downtime and zero data loss.

- In `executeBatchResolution`: for each `memoryName`, register **both** a `type='artifact'` lookup (post-flip primary) and a `type='memory'` lookup (pre-flip fallback) on the existing batched SQL `IN` query — no extra round trip.
- In `buildManifestFromResults`: reuse the existing `lookupWithFallback(artifactKey, memoryKey)` helper (already used for system-vs-runtime volume fallback four lines away). When both rows exist, the artifact row wins — matching the interrupted-migration edge case in the spec.
- Telemetry: `log.info("memory dual-read fallback hit", { memoryName, orgId, userId })` when the primary artifact key misses and memory key hits. Scheduled for deletion in #10603.
- Write path unchanged: `ensureStorageExists(..., "memory")` still creates rows with `type='memory'`.

## Touch points

- `turbo/apps/web/src/lib/infra/storage/storage-service.ts` — the two call sites above; ~30 lines net.
- `turbo/apps/web/src/lib/infra/storage/__tests__/memory-dual-read.test.ts` — new integration test file (3 cases).

## Test plan

New file `memory-dual-read.test.ts`, driven via the real DB with the existing `createTestMemory` / `createTestArtifact` helpers. Follows the same pattern as `system-volume-resolution.test.ts` and `additional-volumes.test.ts`.

- [x] Pre-flip state: only `type='memory'` row exists → resolves to memory row (regression guard).
- [x] Post-flip state: only `type='artifact'` row exists → resolves via primary artifact key, no error.
- [x] Interrupted-migration edge case: both rows exist with distinct versions → primary `type='artifact'` wins.
- [x] `pnpm -F web exec vitest run src/lib/infra/` — 96 tests passed.
- [x] `pnpm turbo run lint` — clean.
- [x] `pnpm check-types` — clean.
- [x] `pnpm format` — clean.
- [x] `pnpm knip` — no issues.

## Rollback

Plain revert. No DB changes, no contract changes, no external API shape change. Because #10601 (the actual type flip) hasn't shipped yet, the DB is still all-`type='memory'` and the reverted code resolves memory normally.

## Closes

Closes #10600

🤖 Generated with [Claude Code](https://claude.com/claude-code)