### PR TITLE
feat(billing): voice input quota — 10/month for free & pro, unlimited for team

### DIFF
--- a/turbo/apps/web/app/[locale]/pricing/PricingPageClient.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/PricingPageClient.tsx
@@ -461,6 +461,13 @@ export function PricingPageClient() {
                     pro={true}
                     team={true}
                   />
+                  <TableRow
+                    feature={t("tableFeatures.voiceInput")}
+                    description={t("tableFeatures.voiceInputDesc")}
+                    free={t("tableValues.tenPerMonth")}
+                    pro={t("tableValues.tenPerMonth")}
+                    team={t("tableValues.unlimited")}
+                  />
 
                   <TableSection title={t("sections.securityAndCompliance")} />
                   <TableRow

--- a/turbo/apps/web/app/api/zero/voice-io/quota/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/quota/__tests__/route.test.ts
@@ -11,7 +11,7 @@ import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { seedBehaviorCount } from "../../../../../../src/__tests__/db-test-seeders/behavior";
 import {
   AUDIO_INPUT_BEHAVIOR_KEY,
-  AUDIO_INPUT_FREE_QUOTA,
+  AUDIO_INPUT_QUOTA,
 } from "../../../../../../src/lib/zero/voice-io/audio-input-policy";
 
 const { GET } = await import("../route");
@@ -54,7 +54,7 @@ describe("GET /api/zero/voice-io/quota", () => {
     expect(body).toEqual({
       allowed: true,
       count: 0,
-      limit: AUDIO_INPUT_FREE_QUOTA,
+      limit: AUDIO_INPUT_QUOTA,
     });
   });
 
@@ -68,7 +68,7 @@ describe("GET /api/zero/voice-io/quota", () => {
     expect(body).toEqual({
       allowed: true,
       count: 2,
-      limit: AUDIO_INPUT_FREE_QUOTA,
+      limit: AUDIO_INPUT_QUOTA,
     });
   });
 
@@ -79,30 +79,50 @@ describe("GET /api/zero/voice-io/quota", () => {
       orgId,
       userId,
       AUDIO_INPUT_BEHAVIOR_KEY,
-      AUDIO_INPUT_FREE_QUOTA,
+      AUDIO_INPUT_QUOTA,
     );
     const response = await GET(createQuotaRequest());
     const body = await response.json();
     expect(response.status).toBe(200);
     expect(body).toEqual({
       allowed: false,
-      count: AUDIO_INPUT_FREE_QUOTA,
-      limit: AUDIO_INPUT_FREE_QUOTA,
+      count: AUDIO_INPUT_QUOTA,
+      limit: AUDIO_INPUT_QUOTA,
     });
   });
 
-  it("should return allowed=true with limit=null for a pro org regardless of history", async () => {
+  it("should return allowed=true with quota limit for a pro org with partial usage", async () => {
     const userId = uniqueId("quota-pro");
     const { orgId } = await setupOrg(userId);
     await updateOrgTier(orgId, "pro");
-    await seedBehaviorCount(orgId, userId, AUDIO_INPUT_BEHAVIOR_KEY, 10);
+    await seedBehaviorCount(orgId, userId, AUDIO_INPUT_BEHAVIOR_KEY, 5);
     const response = await GET(createQuotaRequest());
     const body = await response.json();
     expect(response.status).toBe(200);
     expect(body).toEqual({
       allowed: true,
-      count: 0,
-      limit: null,
+      count: 5,
+      limit: AUDIO_INPUT_QUOTA,
+    });
+  });
+
+  it("should return allowed=false when a pro org has reached the quota", async () => {
+    const userId = uniqueId("quota-pro-full");
+    const { orgId } = await setupOrg(userId);
+    await updateOrgTier(orgId, "pro");
+    await seedBehaviorCount(
+      orgId,
+      userId,
+      AUDIO_INPUT_BEHAVIOR_KEY,
+      AUDIO_INPUT_QUOTA,
+    );
+    const response = await GET(createQuotaRequest());
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      allowed: false,
+      count: AUDIO_INPUT_QUOTA,
+      limit: AUDIO_INPUT_QUOTA,
     });
   });
 

--- a/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
@@ -14,7 +14,7 @@ import { reloadEnv } from "../../../../../../src/env";
 import { readBehaviorCount } from "../../../../../../src/__tests__/db-test-seeders/behavior";
 import {
   AUDIO_INPUT_BEHAVIOR_KEY,
-  AUDIO_INPUT_FREE_QUOTA,
+  AUDIO_INPUT_QUOTA,
 } from "../../../../../../src/lib/zero/voice-io/audio-input-policy";
 
 vi.mock("@vm0/core", async (importOriginal) => {
@@ -174,14 +174,14 @@ describe("POST /api/zero/voice-io/stt", () => {
   });
 
   describe("org tier quota gating", () => {
-    it("should not increment the counter for a pro org across multiple successes", async () => {
-      const userId = uniqueId("stt-pro");
+    it("should not increment the counter for a team org across multiple successes", async () => {
+      const userId = uniqueId("stt-team");
       const { orgId } = await setupOrg(userId);
-      await updateOrgTier(orgId, "pro");
+      await updateOrgTier(orgId, "team");
 
       server.use(
         http.post("https://api.openai.com/v1/audio/transcriptions", () => {
-          return HttpResponse.json({ text: "pro transcript" });
+          return HttpResponse.json({ text: "team transcript" });
         }),
       );
 
@@ -198,6 +198,29 @@ describe("POST /api/zero/voice-io/stt", () => {
       expect(count).toBe(0);
     });
 
+    it("should increment the counter on each successful pro-tier call up to the quota", async () => {
+      const userId = uniqueId("stt-pro");
+      const { orgId } = await setupOrg(userId);
+      await updateOrgTier(orgId, "pro");
+
+      server.use(
+        http.post("https://api.openai.com/v1/audio/transcriptions", () => {
+          return HttpResponse.json({ text: "pro transcript" });
+        }),
+      );
+
+      for (let i = 1; i <= AUDIO_INPUT_QUOTA; i++) {
+        const response = await POST(createSttRequest(createAudioFile()));
+        expect(response.status).toBe(200);
+        const count = await readBehaviorCount(
+          orgId,
+          userId,
+          AUDIO_INPUT_BEHAVIOR_KEY,
+        );
+        expect(count).toBe(i);
+      }
+    });
+
     it("should increment the counter on each successful free-tier call up to the quota", async () => {
       const userId = uniqueId("stt-free");
       const { orgId } = await setupOrg(userId);
@@ -208,7 +231,7 @@ describe("POST /api/zero/voice-io/stt", () => {
         }),
       );
 
-      for (let i = 1; i <= AUDIO_INPUT_FREE_QUOTA; i++) {
+      for (let i = 1; i <= AUDIO_INPUT_QUOTA; i++) {
         const response = await POST(createSttRequest(createAudioFile()));
         expect(response.status).toBe(200);
         const count = await readBehaviorCount(
@@ -230,8 +253,7 @@ describe("POST /api/zero/voice-io/stt", () => {
         }),
       );
 
-      // Exhaust the quota with AUDIO_INPUT_FREE_QUOTA successful calls
-      for (let i = 0; i < AUDIO_INPUT_FREE_QUOTA; i++) {
+      for (let i = 0; i < AUDIO_INPUT_QUOTA; i++) {
         const ok = await POST(createSttRequest(createAudioFile()));
         expect(ok.status).toBe(200);
       }
@@ -241,8 +263,8 @@ describe("POST /api/zero/voice-io/stt", () => {
       expect(response.status).toBe(402);
       expect(body.error.code).toBe("AUDIO_INPUT_QUOTA_EXCEEDED");
       expect(body.quota).toEqual({
-        count: AUDIO_INPUT_FREE_QUOTA,
-        limit: AUDIO_INPUT_FREE_QUOTA,
+        count: AUDIO_INPUT_QUOTA,
+        limit: AUDIO_INPUT_QUOTA,
       });
 
       const count = await readBehaviorCount(
@@ -250,7 +272,29 @@ describe("POST /api/zero/voice-io/stt", () => {
         userId,
         AUDIO_INPUT_BEHAVIOR_KEY,
       );
-      expect(count).toBe(AUDIO_INPUT_FREE_QUOTA);
+      expect(count).toBe(AUDIO_INPUT_QUOTA);
+    });
+
+    it("should return 402 once the pro-tier quota is exhausted", async () => {
+      const userId = uniqueId("stt-pro-exceed");
+      const { orgId } = await setupOrg(userId);
+      await updateOrgTier(orgId, "pro");
+
+      server.use(
+        http.post("https://api.openai.com/v1/audio/transcriptions", () => {
+          return HttpResponse.json({ text: "ok" });
+        }),
+      );
+
+      for (let i = 0; i < AUDIO_INPUT_QUOTA; i++) {
+        const ok = await POST(createSttRequest(createAudioFile()));
+        expect(ok.status).toBe(200);
+      }
+
+      const response = await POST(createSttRequest(createAudioFile()));
+      const body = await response.json();
+      expect(response.status).toBe(402);
+      expect(body.error.code).toBe("AUDIO_INPUT_QUOTA_EXCEEDED");
     });
 
     it("should not increment the counter when OpenAI fails on the first free-tier call", async () => {

--- a/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: Request): Promise<Response> {
       {
         error: {
           message:
-            "Audio input quota exceeded. Upgrade to Pro or Team for unlimited audio input.",
+            "Audio input quota exceeded. Upgrade to Team for unlimited voice input.",
           code: "AUDIO_INPUT_QUOTA_EXCEEDED",
         },
         quota: { count: quota.count, limit: quota.limit },
@@ -155,9 +155,10 @@ export async function POST(request: Request): Promise<Response> {
 
   const result = (await openaiResponse.json()) as { text: string };
 
-  // 8. Record the successful audio input for free-tier quota accounting.
-  // Skipped on failure so infra errors don't burn the user's free quota.
-  if (orgTier === "free") {
+  // 8. Record the successful audio input for quota accounting.
+  // Team tier is unlimited; free and pro share the same capped quota.
+  // Skipped on failure so infra errors don't burn the user's quota.
+  if (orgTier !== "team") {
     await recordBehavior(orgId, authCtx.userId, AUDIO_INPUT_BEHAVIOR_KEY);
   }
 

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -161,6 +161,8 @@
       "connectorsDesc": "Verbinden Sie Ihre Tools wie Slack, GitHub, Notion und mehr",
       "bringOwnLLM": "Eigenes LLM mitbringen",
       "bringOwnLLMDesc": "Verwenden Sie Ihre eigenen Modellanbieter-API-Schlüssel",
+      "voiceInput": "Spracheingabe",
+      "voiceInputDesc": "Sprache-zu-Text-Eingabe für freihändige Agenten-Interaktion",
       "sandboxedExecution": "Sandbox-Ausführung",
       "sandboxedExecutionDesc": "Firecracker-microVMs mit Hardware-Level-KVM-Isolation",
       "fullAuditTrail": "Vollständiger Audit-Trail",
@@ -184,7 +186,8 @@
       "120k": "120.000",
       "unlimited": "Unbegrenzt",
       "oneMonth": "1 Monat",
-      "allConnectors": "Alle Konnektoren"
+      "allConnectors": "Alle Konnektoren",
+      "tenPerMonth": "10 / Monat"
     },
     "faq": {
       "title": "Häufig gestellte Fragen",

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -161,6 +161,8 @@
       "connectorsDesc": "Connect your tools like Slack, GitHub, Notion, and more",
       "bringOwnLLM": "Bring your own LLM",
       "bringOwnLLMDesc": "Use your own model provider API keys",
+      "voiceInput": "Voice input",
+      "voiceInputDesc": "Speech-to-text input for hands-free agent interaction",
       "sandboxedExecution": "Sandboxed execution",
       "sandboxedExecutionDesc": "Firecracker microVMs with hardware-level KVM isolation",
       "fullAuditTrail": "Full audit trail",
@@ -184,7 +186,8 @@
       "120k": "120,000",
       "unlimited": "Unlimited",
       "oneMonth": "1 month",
-      "allConnectors": "All connectors"
+      "allConnectors": "All connectors",
+      "tenPerMonth": "10 / month"
     },
     "faq": {
       "title": "Frequently asked questions",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -161,6 +161,8 @@
       "connectorsDesc": "Conecta tus herramientas como Slack, GitHub, Notion y más",
       "bringOwnLLM": "Usa tu propio LLM",
       "bringOwnLLMDesc": "Usa las claves API de tu propio proveedor de modelos",
+      "voiceInput": "Entrada de voz",
+      "voiceInputDesc": "Entrada de voz a texto para interacción manos libres con el agente",
       "sandboxedExecution": "Ejecución aislada",
       "sandboxedExecutionDesc": "Firecracker microVMs con aislamiento KVM a nivel de hardware",
       "fullAuditTrail": "Registro de auditoría completo",
@@ -184,7 +186,8 @@
       "120k": "120.000",
       "unlimited": "Ilimitado",
       "oneMonth": "1 mes",
-      "allConnectors": "Todos los conectores"
+      "allConnectors": "Todos los conectores",
+      "tenPerMonth": "10 / mes"
     },
     "faq": {
       "title": "Preguntas frecuentes",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -161,6 +161,8 @@
       "connectorsDesc": "Slack、GitHub、Notionなどのツールを接続",
       "bringOwnLLM": "自分のLLMを持ち込み",
       "bringOwnLLMDesc": "自分のモデルプロバイダーAPIキーを使用",
+      "voiceInput": "音声入力",
+      "voiceInputDesc": "ハンズフリーでエージェントと対話するための音声テキスト変換入力",
       "sandboxedExecution": "サンドボックス実行",
       "sandboxedExecutionDesc": "ハードウェアレベルのKVM分離によるFirecracker microVM",
       "fullAuditTrail": "完全な監査証跡",
@@ -184,7 +186,8 @@
       "120k": "120,000",
       "unlimited": "無制限",
       "oneMonth": "1ヶ月",
-      "allConnectors": "すべてのコネクター"
+      "allConnectors": "すべてのコネクター",
+      "tenPerMonth": "10回 / 月"
     },
     "faq": {
       "title": "よくある質問",

--- a/turbo/apps/web/src/lib/zero/voice-io/audio-input-policy.ts
+++ b/turbo/apps/web/src/lib/zero/voice-io/audio-input-policy.ts
@@ -1,7 +1,7 @@
 import type { OrgTier } from "@vm0/core";
 import { getCount } from "../behavior/user-behavior-count-service";
 
-export const AUDIO_INPUT_FREE_QUOTA = 3;
+export const AUDIO_INPUT_QUOTA = 10;
 export const AUDIO_INPUT_BEHAVIOR_KEY = "audio_input";
 
 interface AudioInputQuotaStatus {
@@ -15,13 +15,13 @@ export async function checkAudioInputQuota(
   userId: string,
   orgTier: OrgTier,
 ): Promise<AudioInputQuotaStatus> {
-  if (orgTier !== "free") {
+  if (orgTier === "team") {
     return { allowed: true, count: 0, limit: null };
   }
   const count = await getCount(orgId, userId, AUDIO_INPUT_BEHAVIOR_KEY);
   return {
-    allowed: count < AUDIO_INPUT_FREE_QUOTA,
+    allowed: count < AUDIO_INPUT_QUOTA,
     count,
-    limit: AUDIO_INPUT_FREE_QUOTA,
+    limit: AUDIO_INPUT_QUOTA,
   };
 }


### PR DESCRIPTION
## Summary
- Apply a unified 10 voice inputs/month quota to **Free** and **Pro** tiers (previously only Free had a 3-input cap; Pro was unlimited)
- **Team** tier remains unlimited
- Add "Voice input" row to the pricing comparison table with i18n support (en/ja/de/es)
- Update STT route to record usage for Pro tier and adjust the quota-exceeded message

## Test plan
- [x] All 27 voice-io tests pass (quota + STT + TTS)
- [ ] Verify pricing page renders the new Voice input row correctly across all locales
- [ ] Confirm Pro users hit 402 after 10 voice inputs in a billing period
- [ ] Confirm Team users have no quota limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)