### PR TITLE
refactor(runner): simplify extract_field to single-line iterator chain

### DIFF
--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -225,21 +225,11 @@ fn parse_log_message(message: &str) -> Option<LogEntry> {
 
 /// Extract a value for a `KEY=value` field from an iptables log line.
 ///
-/// Matches `KEY=` only at the start of the string or after a space,
-/// preventing false matches on suffixes (e.g. `DSCP=` matching `SCP=`).
+/// Matches `KEY=` only at a whitespace-delimited token boundary, preventing
+/// false matches on suffixes (e.g. `DSCP=` matching `SCP=`).
 fn extract_field<'a>(line: &'a str, key: &str) -> Option<&'a str> {
-    let start = if line.starts_with(key) {
-        key.len()
-    } else {
-        let needle = format!(" {key}");
-        let pos = line.find(&needle)?;
-        pos + needle.len()
-    };
-    let end = line
-        .get(start..)?
-        .find(' ')
-        .map_or(line.len(), |i| start + i);
-    line.get(start..end)
+    line.split_whitespace()
+        .find_map(|tok| tok.strip_prefix(key))
 }
 
 /// Append a JSON line to the network log file.


### PR DESCRIPTION
## Summary

Replace 16 lines of offset arithmetic + `.get()?` boundary handling in `kmsg_log::extract_field` with a 1-line `split_whitespace().find_map(strip_prefix)` chain that reads as its own spec.

Closes #10656

## Not a perf change

The original issue framed this as "avoid heap allocation in a hot path". That framing is misleading:

- The path is iptables-rate-limited at 10 pps/VM (`crates/sandbox-fc/src/network/pool.rs:402-443`, `-m limit --limit 10/sec --limit-burst 50`), so a busy host at 100 VMs saturates at ~5000 short-string allocations/sec. Sub-microsecond of CPU on any modern allocator.
- The new iterator-chain still does the same O(L) token scanning under the hood — it trades one small `format!` allocation for tokenization work. Net perf delta is effectively zero.

The real value is code clarity: 16 lines → 1 line, no `.get(start..)?` boundary dance, no offset arithmetic, and the signature now reads directly as what the function does.

## Equivalence

Verified against every input case the `iptables -j LOG` target produces and every existing test case:

- Duplicate `LEN=` in dmesg lines (outer packet LEN vs inner UDP LEN) still returns the first occurrence.
- `XSRC=foo` still doesn't match `SRC=` (token-boundary protection replaces the explicit `" SRC="` needle).
- Empty value (`KEY= NEXT=val`) still returns `Some("")`.
- End-of-line without trailing space still works.
- `MAC=00:00:...` with embedded colons is unaffected.

The only theoretical divergences (tab as separator, embedded NBSP in values, trailing whitespace on last token) cannot occur in the caller's input — `iptables -j LOG` emits pure ASCII with literal 0x20 space separators, and `BufReader::lines()` strips line endings before `extract_field` sees the string.

## Test plan

- [x] `cargo test -p runner kmsg_log::` — 21/21 pass
- [x] `cargo clippy -p runner --tests` — clean
- [x] All 8 existing `extract_field_*` tests cover the behavior axes that matter (substring protection, empty value, end-of-line, missing key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)