### PR TITLE
fix: don't let sessions.expire failure permanently block campaign redemption

### DIFF
--- a/turbo/apps/web/app/api/zero/billing/redeem/[campaign]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/redeem/[campaign]/__tests__/route.test.ts
@@ -306,6 +306,52 @@ describe("POST /api/zero/billing/redeem/:campaign", () => {
     expect(row).toBeUndefined();
   });
 
+  it("still drops the cached session row when expiring it in Stripe fails", async () => {
+    await updateOrgStripeFields(user.orgId, {
+      stripeCustomerId: uniqueId("cus"),
+    });
+    await insertOrgPromoRedemption({
+      orgId: user.orgId,
+      campaignKey: CAMPAIGN,
+      stripeSessionId: "cs_open_expire_fails",
+    });
+    stripeMocks.checkoutSessionsRetrieve.mockResolvedValue({
+      id: "cs_open_expire_fails",
+      status: "open",
+      url: "https://stripe.test/checkout/cs_open_expire_fails",
+    });
+    stripeMocks.couponsRetrieve.mockRejectedValue(
+      new Stripe.errors.StripeInvalidRequestError({
+        type: "invalid_request_error",
+        message: `No such coupon: '${COUPON_ID}'`,
+        code: "resource_missing",
+      }),
+    );
+    stripeMocks.checkoutSessionsExpire.mockRejectedValue(
+      new Stripe.errors.StripeInvalidRequestError({
+        type: "invalid_request_error",
+        message: "Session can no longer be expired",
+        code: "session_expired",
+      }),
+    );
+
+    const response = await POST(makeRequest());
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toEqual({
+      status: "error",
+      reason: "campaign_misconfigured",
+    });
+    expect(stripeMocks.checkoutSessionsExpire).toHaveBeenCalledWith(
+      "cs_open_expire_fails",
+    );
+    const row = await findOrgPromoRedemption({
+      orgId: user.orgId,
+      campaignKey: CAMPAIGN,
+    });
+    expect(row).toBeUndefined();
+  });
+
   it("drops the cached session and returns campaign_misconfigured when the coupon is no longer valid", async () => {
     await updateOrgStripeFields(user.orgId, {
       stripeCustomerId: uniqueId("cus"),

--- a/turbo/apps/web/src/lib/zero/billing/one-time-purchase-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/one-time-purchase-service.ts
@@ -273,11 +273,14 @@ async function cleanupStaleRedemption(
   try {
     await stripe.checkout.sessions.expire(stripeSessionId);
   } catch {
-    log.info("one_time_purchase session already expired or un-expirable, continuing cleanup", {
-      orgId: params.orgId,
-      campaignKey: params.campaignKey,
-      stripeSessionId,
-    });
+    log.info(
+      "one_time_purchase session already expired or un-expirable, continuing cleanup",
+      {
+        orgId: params.orgId,
+        campaignKey: params.campaignKey,
+        stripeSessionId,
+      },
+    );
   }
   await db
     .delete(orgPromoRedemption)

--- a/turbo/apps/web/src/lib/zero/billing/one-time-purchase-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/one-time-purchase-service.ts
@@ -266,11 +266,19 @@ async function cleanupStaleRedemption(
   const db = globalThis.services.db;
   const stripe = getStripe();
   // Expire the Stripe session so it stops showing up in dashboard listings.
-  // If this throws, let it propagate — the original error (coupon gone, price
-  // archived, etc.) is lost but so is the need to surface it once we can no
-  // longer keep Stripe state in sync. Sessions auto-expire after 24h anyway,
-  // so the side effect of a failed expire is cosmetic.
-  await stripe.checkout.sessions.expire(stripeSessionId);
+  // Sessions auto-expire after 24h anyway so a failure here is cosmetic — but
+  // we must NOT let it block the DB row deletion below. A naturally-expired
+  // session causes Stripe to throw, which previously prevented cleanup and
+  // permanently locked the org out of the campaign.
+  try {
+    await stripe.checkout.sessions.expire(stripeSessionId);
+  } catch {
+    log.info("one_time_purchase session already expired or un-expirable, continuing cleanup", {
+      orgId: params.orgId,
+      campaignKey: params.campaignKey,
+      stripeSessionId,
+    });
+  }
   await db
     .delete(orgPromoRedemption)
     .where(


### PR DESCRIPTION
## Problem

`cleanupStaleRedemption()` in `one-time-purchase-service.ts` called `stripe.checkout.sessions.expire()` before deleting the `org_promo_redemption` row. When a session expires naturally (after 24 h without payment), calling `expire()` again throws a Stripe error — and because there was no try/catch, the DB delete never ran.

Result: the `org_promo_redemption` row was permanently stuck, and the org could never retry redeeming the ZERO100 campaign. Every subsequent visit to the redeem page hit the same broken session and returned `campaign_misconfigured`.

## Fix

Wrap `sessions.expire` in a try/catch. A failure just means the session is already gone from Stripe's perspective (cosmetic). The DB row deletion always proceeds:

```typescript
try {
  await stripe.checkout.sessions.expire(stripeSessionId);
} catch {
  log.info("session already expired or un-expirable, continuing cleanup", { ... });
}
await db.delete(orgPromoRedemption).where(...);
```

## Test plan
- [ ] Simulate an already-expired session ID → cleanup completes, DB row deleted, org can retry
- [ ] Simulate a valid open session → still expires correctly, DB row deleted