### PR TITLE
fix: add auto-recharge threshold/amount bounds and loop prevention

### DIFF
--- a/turbo/apps/web/app/api/zero/billing/auto-recharge/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/auto-recharge/__tests__/route.test.ts
@@ -181,6 +181,84 @@ describe("/api/zero/billing/auto-recharge", () => {
       expect(response.status).toBe(400);
     });
 
+    it("returns 400 when amount exceeds the maximum", async () => {
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 1000,
+          amount: 10_000_001,
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when threshold exceeds the maximum", async () => {
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 10_000_001,
+          amount: 20_000_000,
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when threshold equals amount", async () => {
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 5000,
+          amount: 5000,
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: {
+          message: "threshold must be less than amount to avoid recharge loops",
+        },
+      });
+    });
+
+    it("returns 400 when threshold is greater than amount", async () => {
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 6000,
+          amount: 5000,
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: {
+          message: "threshold must be less than amount to avoid recharge loops",
+        },
+      });
+    });
+
     it("returns 403 for non-admin member", async () => {
       mockClerk({
         userId: user.userId,

--- a/turbo/apps/web/app/api/zero/billing/portal/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/portal/__tests__/route.test.ts
@@ -114,6 +114,20 @@ describe("POST /api/zero/billing/portal", () => {
     expect(response.status).toBe(400);
   });
 
+  it("returns 400 when returnUrl is not a valid URL", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/portal",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ returnUrl: "not-a-url" }),
+      },
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+  });
+
   it("returns 403 for non-admin member", async () => {
     mockClerk({
       userId: user.userId,

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -772,6 +772,12 @@ export async function updateAutoRechargeConfig(
         error: "threshold and amount are required when enabling auto-recharge",
       };
     }
+    if (threshold >= amount) {
+      return {
+        ok: false,
+        error: "threshold must be less than amount to avoid recharge loops",
+      };
+    }
   }
 
   const db = globalThis.services.db;

--- a/turbo/packages/core/src/contracts/zero-billing.ts
+++ b/turbo/packages/core/src/contracts/zero-billing.ts
@@ -80,11 +80,14 @@ const autoRechargeUpdateRequestSchema = z
     amount: z.number().int().min(1000).max(10_000_000).optional(),
   })
   .refine(
-    (data) =>
-      !data.enabled ||
-      data.threshold === undefined ||
-      data.amount === undefined ||
-      data.threshold < data.amount,
+    (data) => {
+      return (
+        !data.enabled ||
+        data.threshold === undefined ||
+        data.amount === undefined ||
+        data.threshold < data.amount
+      );
+    },
     { message: "threshold must be less than amount to avoid recharge loops" },
   );
 

--- a/turbo/packages/core/src/contracts/zero-billing.ts
+++ b/turbo/packages/core/src/contracts/zero-billing.ts
@@ -70,14 +70,23 @@ const checkoutRequestSchema = z.object({
 });
 
 const portalRequestSchema = z.object({
-  returnUrl: z.string().min(1),
+  returnUrl: z.string().url(),
 });
 
-const autoRechargeUpdateRequestSchema = z.object({
-  enabled: z.boolean(),
-  threshold: z.number().int().positive().optional(),
-  amount: z.number().int().min(1000).optional(),
-});
+const autoRechargeUpdateRequestSchema = z
+  .object({
+    enabled: z.boolean(),
+    threshold: z.number().int().positive().max(10_000_000).optional(),
+    amount: z.number().int().min(1000).max(10_000_000).optional(),
+  })
+  .refine(
+    (data) =>
+      !data.enabled ||
+      data.threshold === undefined ||
+      data.amount === undefined ||
+      data.threshold < data.amount,
+    { message: "threshold must be less than amount to avoid recharge loops" },
+  );
 
 const redeemRequestSchema = z.object({
   successUrl: z.string().url(),


### PR DESCRIPTION
## Problem

Two gaps in auto-recharge config validation:

**1. No upper bound on `amount`**
The contract only enforced `min(1000)`. An arbitrarily large value (e.g. 1,000,000,000) would generate a Stripe invoice for ~$1M, which Stripe would reject. After the rejection, `autoRechargePendingAt` is cleared and the next run retriggers the attempt — a tight loop of failing Stripe API calls until the org's balance rises above threshold.

**2. `threshold >= amount` creates a recharge loop**
If threshold ≥ amount, every recharge leaves the balance still below the threshold, triggering another recharge 10 minutes later. Example: `threshold=10000, amount=1000` → charges the user $1 every 10 minutes indefinitely. The 10-minute cooldown limits blast radius but doesn't prevent it.

## Fix

**Contract (`zero-billing.ts`)**
- `threshold`: add `.max(10_000_000)`
- `amount`: add `.max(10_000_000)`
- `.refine()`: when `enabled`, enforce `threshold < amount`
- `returnUrl` on portal schema: tighten from `z.string().min(1)` → `z.string().url()`

**Service (`billing-service.ts`)**
- `updateAutoRechargeConfig`: add server-side guard `if (threshold >= amount) return error` (defence-in-depth; contract validation runs first but service layer is the source of truth)

## Test plan
- [ ] `amount=10_000_001` → 400 validation error
- [ ] `threshold=5000, amount=5000` (equal) → error "threshold must be less than amount"
- [ ] `threshold=6000, amount=5000` (threshold > amount) → same error
- [ ] `threshold=4999, amount=5000` → accepted