### PR TITLE
feat(cli): display avatar in agent view command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "vm0-repo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -95,6 +95,81 @@ describe("zero agent view command", () => {
       expect(logCalls).toContain("github (full access)");
     });
 
+    it("should display preset avatar", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json({
+            ...mockAgent,
+            avatarUrl: "preset:2",
+          });
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: [] });
+          },
+        ),
+        mockConnectorListHandler(),
+      );
+
+      await viewCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Avatar:");
+      expect(logCalls).toContain(
+        "preset:2 (medium skin, pink hair, neutral, chill)",
+      );
+    });
+
+    it("should display custom svg avatar", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json({
+            ...mockAgent,
+            avatarUrl: "svg:r3s4h1c2f5h",
+          });
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: [] });
+          },
+        ),
+        mockConnectorListHandler(),
+      );
+
+      await viewCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Avatar:");
+      expect(logCalls).toContain(
+        "custom (dark skin, teal hair, excited, hyped)",
+      );
+    });
+
+    it("should not display avatar when null", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json({
+            ...mockAgent,
+            avatarUrl: null,
+          });
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: [] });
+          },
+        ),
+        mockConnectorListHandler(),
+      );
+
+      await viewCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).not.toContain("Avatar:");
+    });
+
     it("should show permission summary with permission policies", async () => {
       server.use(
         http.get("http://localhost:3000/api/zero/agents/my-agent", () => {

--- a/turbo/apps/cli/src/commands/zero/agent/avatar.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/avatar.ts
@@ -133,3 +133,98 @@ export function resolveAvatarUrl(opts: AvatarOptions): string | undefined {
 
   return buildCustomSvgAvatar(opts);
 }
+
+const REVERSE_SKIN_MAP: Record<number, string> = {
+  0: "light",
+  1: "light-medium",
+  2: "medium",
+  3: "medium-dark",
+  4: "dark",
+};
+
+const REVERSE_HAIR_COLOR_MAP: Record<number, string> = {
+  1: "blonde",
+  2: "teal",
+  3: "grey",
+  4: "pink",
+  5: "brown",
+};
+
+const REVERSE_EXPRESSION_MAP: Record<number, string> = {
+  1: "calm",
+  2: "content",
+  3: "neutral",
+  4: "pleasant",
+  5: "excited",
+};
+
+const REVERSE_INTENSITY_MAP: Record<string, string> = {
+  d: "chill",
+  m: "normal",
+  h: "hyped",
+};
+
+const PRESET_DESCRIPTIONS: Record<string, string> = {
+  "preset:0": "light skin, brown hair, calm, hyped",
+  "preset:1": "light-medium skin, grey hair, calm, normal",
+  "preset:2": "medium skin, pink hair, neutral, chill",
+  "preset:3": "medium-dark skin, blonde hair, pleasant, hyped",
+  "preset:4": "dark skin, teal hair, excited, normal",
+};
+
+function parseSvgAvatar(svg: string): string | undefined {
+  const match = svg.match(/^svg:r(\d)s(\d)h(\d)c(\d)f(\d)([dmh])$/);
+  if (!match) return undefined;
+
+  const [, r, s, h, c, f, i] = match as RegExpExecArray;
+  const parts: string[] = [];
+
+  const skin = REVERSE_SKIN_MAP[Number(s)];
+  if (skin) parts.push(`${skin} skin`);
+
+  const hairColor = REVERSE_HAIR_COLOR_MAP[Number(c)];
+  if (hairColor) parts.push(`${hairColor} hair`);
+
+  const expression = REVERSE_EXPRESSION_MAP[Number(f)];
+  if (expression) parts.push(expression);
+
+  const intensity = REVERSE_INTENSITY_MAP[i!];
+  if (intensity) parts.push(intensity);
+
+  if (parts.length === 0) return undefined;
+
+  let desc = parts.join(", ");
+  if (r !== "3") {
+    const rotationLabels: Record<string, string> = {
+      "1": "far-left",
+      "2": "left",
+      "4": "right",
+      "5": "far-right",
+    };
+    const rot = rotationLabels[r!];
+    if (rot) desc += `, ${rot}`;
+  }
+  if (h !== "1") {
+    desc += `, hair style ${h}`;
+  }
+
+  return desc;
+}
+
+export function formatAvatar(
+  avatarUrl: string | null | undefined,
+): string | undefined {
+  if (!avatarUrl) return undefined;
+
+  if (avatarUrl.startsWith("preset:")) {
+    const desc = PRESET_DESCRIPTIONS[avatarUrl];
+    return desc ? `${avatarUrl} (${desc})` : avatarUrl;
+  }
+
+  if (avatarUrl.startsWith("svg:")) {
+    const desc = parseSvgAvatar(avatarUrl);
+    return desc ? `custom (${desc})` : avatarUrl;
+  }
+
+  return avatarUrl;
+}

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -16,6 +16,7 @@ import {
   type ConnectorResponse,
 } from "@vm0/core";
 import { policyIcon } from "../../../lib/utils/format-utils";
+import { formatAvatar } from "./avatar";
 
 interface ConnectorPermissionInfo {
   type: string;
@@ -200,6 +201,8 @@ Examples:
         if (agent.description)
           console.log(`Description:  ${agent.description}`);
         if (agent.sound) console.log(`Sound:        ${agent.sound}`);
+        const avatar = formatAvatar(agent.avatarUrl);
+        if (avatar) console.log(`Avatar:       ${avatar}`);
 
         if (options.permissions && connectorInfos.length > 0) {
           console.log();


### PR DESCRIPTION
## Summary

Adds avatar display to `zero agent view`, matching the `--avatar` / `--avatar-*` parameter format introduced in #10610.

**Changes:**
- Added `formatAvatar()` helper to `avatar.ts` that parses `avatarUrl` into human-readable descriptions
- `zero agent view` now shows an `Avatar:` line when the agent has an avatar set
- Supports both formats:
  - **Preset**: `preset:2 (medium skin, pink hair, neutral, chill)`
  - **Custom SVG**: `custom (dark skin, teal hair, excited, hyped)`
- Added tests for preset avatar, custom SVG avatar, and null avatar cases

## Test plan

- [x] `zero agent view` displays preset avatar with descriptive label
- [x] `zero agent view` parses and displays custom `svg:` avatars
- [x] `zero agent view` omits Avatar line when `avatarUrl` is null

🤖 Generated with [Claude Code](https://claude.com/claude-code)