### PR TITLE
fix(platform): add iOS safe-area padding to chat composer footer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -408,6 +408,7 @@ function ChatThreadComposer({
     <footer
       data-chat-composer
       className="relative shrink-0 overflow-y-auto [scrollbar-gutter:stable] px-4 sm:px-6 pt-3 pb-2 bg-[hsl(var(--background))]"
+      style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
     >
       <div className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-t from-[hsl(var(--background))] to-transparent" />
       <div className="mx-auto max-w-[900px]">


### PR DESCRIPTION
## Summary
Add `env(safe-area-inset-bottom)` padding to the chat composer footer on `/chats/:id` so the input area is not obscured by the iOS Home Indicator on devices with rounded corners (e.g. iPhone X+).

## Change
- `turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx`
- Added `style={{ paddingBottom: \"max(0.5rem, env(safe-area-inset-bottom))\" }}` to the `<footer>` wrapping `ChatThreadComposer`

## Behavior
- Desktop: unchanged (`pb-2` = 0.5rem)
- iOS with safe-area: bottom padding expands to match the device’s safe-area inset (~34px on most modern iPhones)

## Test plan
- [ ] Open `/chats/:id` on an iPhone with a Home Indicator and confirm the input box is fully visible
- [ ] Verify desktop layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)