### PR TITLE
test(runner): cover extract_field duplicate-key first-wins

### DIFF
--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -340,6 +340,14 @@ mod tests {
     }
 
     #[test]
+    fn extract_field_returns_first_match_for_duplicate_key() {
+        // dmesg iptables lines emit LEN= twice for UDP (outer packet then
+        // inner UDP payload). We rely on first-wins to pick the outer length.
+        let fields = "LEN=63 TOS=0x00 LEN=43";
+        assert_eq!(extract_field(fields, "LEN="), Some("63"));
+    }
+
+    #[test]
     fn parse_malformed_len_defaults_to_zero() {
         let msg = "VM0:10.200.0.2:IN=vm0-ve-00-00 OUT=ens5 SRC=10.200.0.2 DST=8.8.8.8 LEN=abc PROTO=UDP SPT=1234 DPT=53";
         let entry = parse_log_message(msg).unwrap();


### PR DESCRIPTION
## Summary

Add a direct `extract_field` test for the duplicate-key first-wins invariant.

Follow-up to #10682 — addresses the optional P2 nit from /pr-review.

## Why

dmesg iptables log lines for UDP emit `LEN=` twice:

```
... DST=8.8.8.8 LEN=63 TOS=0x00 ... PROTO=UDP SPT=44793 DPT=53 LEN=43
```

The first `LEN=` is the outer IP packet length (what we want); the second is the inner UDP payload length. `parse_log_message` relies on `extract_field` returning the first occurrence.

This invariant was previously covered only transitively by `parse_dmesg_format_with_timestamp_prefix`. Adding a direct single-line assertion makes it grep-able, so a future refactor of `extract_field` (e.g. swapping the iterator chain back to a manual scan) can't silently flip the semantics without a test failure.

## Test plan

- [x] `cargo test -p runner kmsg_log::tests::extract_field` — 7/7 pass
- [x] No production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)