### PR TITLE
fix: flaky tests caused by midnight edge case and missing abort signal

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -162,7 +162,11 @@ export const fetchZeroSchedules$ = command(
     }
 
     const client = get(zeroClient$)(zeroSchedulesMainContract);
-    const result = await accept(client.list(), [200], { toast: false });
+    const result = await accept(
+      client.list({ fetchOptions: { signal } }),
+      [200],
+      { toast: false },
+    );
     signal.throwIfAborted();
 
     // Filter schedules for this agent's composeId
@@ -417,13 +421,16 @@ export const allOrgScheduleEntries$ = computed((get) => {
 });
 
 export const fetchAllOrgSchedules$ = command(
-  async ({ get, set }, _signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroSchedulesMainContract);
-    const result = await accept(client.list(), [200], { toast: false }).finally(
-      () => {
-        set(internalAllSchedulesLoaded$, true);
-      },
-    );
+    const result = await accept(
+      client.list({ fetchOptions: { signal } }),
+      [200],
+      { toast: false },
+    ).finally(() => {
+      set(internalAllSchedulesLoaded$, true);
+    });
+    signal.throwIfAborted();
     set(internalAllSchedules$, result.body.schedules);
   },
 );

--- a/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
@@ -199,6 +199,9 @@ describe("GET /api/zero/usage/insight", () => {
   });
 
   it("today produces hourly bucket strings", async () => {
+    // Fix time so seeded 09:00/12:00 data is always inside the [todayStart, now) window
+    context.mocks.date.setSystemTime(new Date("2026-04-23T15:00:00Z"));
+
     const { userId, orgId } = await context.user;
     const { composeId } = await seedTestCompose({
       userId,


### PR DESCRIPTION
## Summary

- Fixes `today produces hourly bucket strings` test failing at midnight UTC by pinning system time to 15:00 UTC so seeded 09:00/12:00 data always falls inside the `[todayStart, now)` query window
- Passes `AbortSignal` to `client.list()` in `fetchZeroSchedules$` and `fetchAllOrgSchedules$` so detached promises can be cancelled during test teardown, preventing `clearAllDetached()` from hanging until vitest timeout

## Changes

- `turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts`: add `context.mocks.date.setSystemTime()` before the flaky test
- `turbo/apps/platform/src/signals/zero-page/zero-schedule.ts`: wire `signal` into `client.list({ signal })` in both schedule fetch commands

## Test plan

- [ ] Run `pnpm vitest -- app/api/zero/usage/insight/__tests__/route.test.ts` and verify it passes
- [ ] Run `pnpm vitest -- schedule-default-model-resolution` and verify no 60s timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)