### PR TITLE
chore(deps): bump vuln deps and patch aws-sdk xml-builder for fxp 5.7

### DIFF
--- a/turbo/package.json
+++ b/turbo/package.json
@@ -48,7 +48,8 @@
       ]
     },
     "overrides": {
-      "fast-xml-parser": ">=5.5.7",
+      "fast-xml-parser": ">=5.7.0",
+      "uuid": ">=14.0.0",
       "glob": ">=10.5.0",
       "tar": ">=7.5.7",
       "@isaacs/brace-expansion": ">=5.0.1",

--- a/turbo/package.json
+++ b/turbo/package.json
@@ -69,6 +69,9 @@
       "smol-toml": ">=1.6.1",
       "@opentelemetry/instrumentation": ">=0.213.0",
       "zod": "4.3.6"
+    },
+    "patchedDependencies": {
+      "@aws-sdk/xml-builder@3.972.18": "patches/@aws-sdk__xml-builder@3.972.18.patch"
     }
   },
   "packageManager": "pnpm@10.15.0",

--- a/turbo/patches/@aws-sdk__xml-builder@3.972.18.patch
+++ b/turbo/patches/@aws-sdk__xml-builder@3.972.18.patch
@@ -1,0 +1,26 @@
+diff --git a/dist-cjs/xml-parser.js b/dist-cjs/xml-parser.js
+index 31499ae6d0d8319b58891fa870744493503c805b..d21356d4b862b461c6d82c9e154161974c23d56c 100644
+--- a/dist-cjs/xml-parser.js
++++ b/dist-cjs/xml-parser.js
+@@ -16,8 +16,6 @@ const parser = new fast_xml_parser_1.XMLParser({
+     tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+     maxNestedTags: Infinity,
+ });
+-parser.addEntity("#xD", "\r");
+-parser.addEntity("#10", "\n");
+ function parseXML(xmlString) {
+     return parser.parse(xmlString, true);
+ }
+diff --git a/dist-es/xml-parser.js b/dist-es/xml-parser.js
+index 9bd0f4ba572f221544c4c692092bd128bb57f9f0..9bb8d52f29bc921a05174561e861044218bf8ec1 100644
+--- a/dist-es/xml-parser.js
++++ b/dist-es/xml-parser.js
+@@ -13,8 +13,6 @@ const parser = new XMLParser({
+     tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+     maxNestedTags: Infinity,
+ });
+-parser.addEntity("#xD", "\r");
+-parser.addEntity("#10", "\n");
+ export function parseXML(xmlString) {
+     return parser.parse(xmlString, true);
+ }

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-xml-parser: '>=5.5.7'
+  fast-xml-parser: '>=5.7.0'
+  uuid: '>=14.0.0'
   glob: '>=10.5.0'
   tar: '>=7.5.7'
   '@isaacs/brace-expansion': '>=5.0.1'
@@ -2008,6 +2009,9 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -5694,11 +5698,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
-  fast-xml-parser@5.5.11:
-    resolution: {integrity: sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==}
+  fast-xml-parser@5.7.1:
+    resolution: {integrity: sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -8038,12 +8042,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vfile-location@5.0.3:
@@ -8802,7 +8802,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.18':
     dependencies:
       '@smithy/types': 4.14.1
-      fast-xml-parser: 5.5.11
+      fast-xml-parser: 5.7.1
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -9845,6 +9845,8 @@ snapshots:
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@1.8.0': {}
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -11223,7 +11225,7 @@ snapshots:
   '@sentry/webpack-plugin@5.1.1':
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13671,13 +13673,14 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.1.5:
     dependencies:
       path-expression-matcher: 1.5.0
 
-  fast-xml-parser@5.5.11:
+  fast-xml-parser@5.7.1:
     dependencies:
-      fast-xml-builder: 1.1.4
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
@@ -16220,12 +16223,12 @@ snapshots:
   svix@1.86.0:
     dependencies:
       standardwebhooks: 1.0.0
-      uuid: 10.0.0
+      uuid: 14.0.0
 
   svix@1.89.0:
     dependencies:
       standardwebhooks: 1.0.0
-      uuid: 10.0.0
+      uuid: 14.0.0
 
   swr@2.3.4(react@19.2.4):
     dependencies:
@@ -16554,9 +16557,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@10.0.0: {}
-
-  uuid@9.0.1: {}
+  uuid@14.0.0: {}
 
   vfile-location@5.0.3:
     dependencies:

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -27,6 +27,11 @@ overrides:
   '@opentelemetry/instrumentation': '>=0.213.0'
   zod: 4.3.6
 
+patchedDependencies:
+  '@aws-sdk/xml-builder@3.972.18':
+    hash: 273499ccbf268caa52ebd2d8790281a14c417dc772ddcf7bd85d721ec8d80386
+    path: patches/@aws-sdk__xml-builder@3.972.18.patch
+
 importers:
 
   .:
@@ -8455,7 +8460,7 @@ snapshots:
   '@aws-sdk/core@3.974.1':
     dependencies:
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/xml-builder': 3.972.18
+      '@aws-sdk/xml-builder': 3.972.18(patch_hash=273499ccbf268caa52ebd2d8790281a14c417dc772ddcf7bd85d721ec8d80386)
       '@smithy/core': 3.23.15
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
@@ -8799,7 +8804,7 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.18':
+  '@aws-sdk/xml-builder@3.972.18(patch_hash=273499ccbf268caa52ebd2d8790281a14c417dc772ddcf7bd85d721ec8d80386)':
     dependencies:
       '@smithy/types': 4.14.1
       fast-xml-parser: 5.7.1


### PR DESCRIPTION
## Summary

Two-part fix for moderate pnpm audit findings + the regression our own override introduces in AWS SDK.

### 1. Bump vulnerable transitive deps via `pnpm.overrides`

Resolve two moderate findings reported by `pnpm audit`:
- **fast-xml-parser <5.7.0** — [GHSA-gh4j-gqv2-49f6](https://github.com/advisories/GHSA-gh4j-gqv2-49f6) (XML comment/CDATA injection via unescaped delimiters)
- **uuid <14.0.0** — [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (missing buffer bounds check in v3/v5/v6 when `buf` is provided)

Both come in transitively (`@aws-sdk/client-s3` → `fast-xml-parser`; `@sentry/webpack-plugin` + `svix` → `uuid`), so they're fixed via `pnpm.overrides` in `turbo/package.json`. `fast-xml-parser` override was already present at `>=5.5.7` — the floor just wasn't high enough; raising to `>=5.7.0`.

Installed versions after the bump:
- `fast-xml-parser` 5.5.11 → 5.7.1
- `uuid` 9.0.1 / 10.0.0 → 14.0.0

### 2. Patch `@aws-sdk/xml-builder` for fast-xml-parser 5.7 incompatibility

Simply raising fxp to 5.7.x makes every S3 / STS call throw during XML deserialization:

```
[S3DownloadError]: Failed to list objects in s3://.../...
  [cause]: Error: [EntityReplacer] Invalid character '#' in entity name: "#xD"
```

Surfaced locally as a 500 from `zero agent delete` (see `e2e/tests/01-serial/ser-t05-zero-agent.bats:97`).

**Root cause** (not our code — upstream incompatibility triggered by our override):
- `@aws-sdk/xml-builder@3.972.18` (latest) calls `parser.addEntity("#xD", "\r")` and `addEntity("#10", "\n")` as a legacy fallback for `&#xD;` / `&#10;` character references in S3/STS responses.
- fast-xml-parser 5.7.0 made that a hard error — [CHANGELOG](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CHANGELOG.md#570--2026-04-17): *"you cant add numeric external entity"* (switched entity handling to `@nodable/entities`, which rejects `#`-prefixed names).
- AWS SDK pins fxp to `5.5.8`; our override forces it to 5.7.1 → collision.

**Fix**: pnpm `patchedDependencies` drops both `addEntity` lines from `@aws-sdk/xml-builder`. fxp 5.7.x already decodes `&#xD;` / `&#10;` internally ([CHANGELOG 5.6.0](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CHANGELOG.md#560--2026-04-15): *"fix: entity replacement for numeric entities"*), so the fallback is functionally redundant.

### Why not just accept the CVE?

Three points of evidence this is a known upstream incompatibility, not a local misstep:

- [aws-sdk-js-v3#7949](https://github.com/aws/aws-sdk-js-v3/issues/7949) (2026-04-22) — another user reporting the same fxp 5.7 override need vs aws-sdk-xml-builder@3.972.18
- [aws-amplify/amplify-backend#3172](https://github.com/aws-amplify/amplify-backend/issues/3172) (2026-04-17, fxp 5.7.0 release day) — same `[EntityReplacer] Invalid character '#' in entity name: "#xD"` from STS GetCallerIdentity
- [aws-sdk-js-v3#7863](https://github.com/aws/aws-sdk-js-v3/pull/7863) — AWS's long-term fix (replacing fxp with an internal parser) has been open ~5 weeks and is not yet merged

## Test plan
- [x] `pnpm install` succeeds; patch applied to `@aws-sdk/xml-builder@3.972.18`
- [x] `pnpm audit` reports no known vulnerabilities
- [x] `pnpm check-types` passes (after clearing stale `.next` typegen cache)
- [ ] Local smoke: S3 `ListObjectsV2` / agent delete path returns without `EntityReplacer` error
- [ ] CI lint + test + deploy + cli-e2e