### PR TITLE
fix(billing): error on missing credit_pricing for vm0-managed runs

### DIFF
--- a/turbo/apps/web/app/api/cron/process-credits/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/process-credits/__tests__/route.test.ts
@@ -217,10 +217,11 @@ describe("GET /api/cron/process-credits", () => {
       expect(credits).toBe(100_000);
     });
 
-    it("marks records with no matching pricing as processed with zero charge", async () => {
+    it("marks records with no matching pricing as processed with zero charge (user-key path)", async () => {
       const usageId = await insertTestCreditUsage(user.orgId, {
         userId: user.userId,
         model: "unknown-model",
+        modelProvider: "anthropic-api-key",
       });
 
       const response = await GET(cronRequest("test-cron-secret"));
@@ -230,6 +231,25 @@ describe("GET /api/cron/process-credits", () => {
       expect(record!.status).toBe("processed");
       expect(record!.creditsCharged).toBe(0);
       expect(record!.processedAt).toBeInstanceOf(Date);
+    });
+
+    it("leaves vm0 records with no matching pricing pending (misconfiguration, not free charge)", async () => {
+      const usageId = await insertTestCreditUsage(user.orgId, {
+        userId: user.userId,
+        model: "unseeded-vm0-model",
+        modelProvider: "vm0",
+      });
+
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
+
+      const record = await findTestCreditUsage(usageId);
+      expect(record!.status).toBe("pending");
+      expect(record!.creditsCharged).toBeNull();
+      expect(record!.processedAt).toBeNull();
+
+      const credits = await getOrgCredits(user.orgId);
+      expect(credits).toBe(100_000);
     });
 
     it("includes cache tokens in credit calculation", async () => {

--- a/turbo/apps/web/src/lib/zero/credit/credit-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-service.ts
@@ -62,8 +62,23 @@ export async function processOrgCredits(orgId: string): Promise<void> {
         `${record.model}|${record.modelProvider}`,
       );
       if (!pricing) {
-        // No matching pricing for this model+provider combo — no charge
-        // (user's own provider or unconfigured provider)
+        // For vm0-managed runs, missing pricing is a misconfiguration — we
+        // must not silently give away credits. Leave the record pending so
+        // the cron retries next tick once pricing is seeded.
+        if (record.modelProvider === "vm0") {
+          log.error(
+            "vm0 model has no credit_pricing row — skipping charge, record remains pending",
+            {
+              recordId: record.id,
+              model: record.model,
+              modelProvider: record.modelProvider,
+            },
+          );
+          continue;
+        }
+
+        // User-provided key (or untracked legacy path) — zero charge is
+        // correct because vm0 is not the billing party for this token spend.
         await tx
           .update(creditUsage)
           .set({
@@ -75,7 +90,7 @@ export async function processOrgCredits(orgId: string): Promise<void> {
 
         processedCount++;
 
-        log.debug("No matching pricing — zero charge", {
+        log.debug("No matching pricing — zero charge (user-key path)", {
           recordId: record.id,
           model: record.model,
           modelProvider: record.modelProvider,


### PR DESCRIPTION
## Summary

`processOrgCredits` silently marked vm0-managed `credit_usage` rows as processed with `creditsCharged=0` when no matching `credit_pricing` row existed. That zero-charge path is meant for user-provided keys (`modelProvider != "vm0"`), not vm0-billable spend — a missing pricing row for a vm0 model is a misconfiguration that was giving away credits.

## Change

- If `modelProvider === "vm0"` and no pricing match → `log.error` and **leave the record pending**. The per-minute cron will retry once pricing is seeded (self-healing).
- User-key path (modelProvider != "vm0") keeps existing zero-charge semantics.

## Test plan

- [x] New integration test: vm0 run with no pricing stays pending, org balance untouched
- [x] Updated existing "no matching pricing" test to assert the user-key (zero-charge) path explicitly
- [x] `pnpm -F web check-types`, `pnpm -F web lint`, `pnpm format`, `pnpm knip` pass
- [x] 16 process-credits tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)