### PR TITLE
refactor: remove ArtifactSnapshot singleton type and checkpoint legacy branch

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -64,9 +64,8 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentSessionId: "test-session",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshot: {
-              artifactName: "test-artifact",
-              artifactVersion: "version-123",
+            artifactSnapshots: {
+              "test-artifact": "version-123",
             },
           }),
         },
@@ -97,9 +96,8 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentSessionId: "test-session",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshot: {
-              artifactName: "test-artifact",
-              artifactVersion: "version-123",
+            artifactSnapshots: {
+              "test-artifact": "version-123",
             },
           }),
         },
@@ -127,9 +125,8 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             // cliAgentSessionId: missing
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshot: {
-              artifactName: "test-artifact",
-              artifactVersion: "version-123",
+            artifactSnapshots: {
+              "test-artifact": "version-123",
             },
           }),
         },
@@ -156,9 +153,8 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentType: "claude-code",
             cliAgentSessionId: "test-session",
             // cliAgentSessionHistoryHash: missing
-            artifactSnapshot: {
-              artifactName: "test-artifact",
-              artifactVersion: "version-123",
+            artifactSnapshots: {
+              "test-artifact": "version-123",
             },
           }),
         },
@@ -171,7 +167,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       expect(data.error.message).toContain("cliAgentSessionHistoryHash");
     });
 
-    it("should accept checkpoint without artifactSnapshot (optional artifact)", async () => {
+    it("should accept checkpoint without artifactSnapshots (optional artifact)", async () => {
       const request = createTestRequest(
         "http://localhost:3000/api/webhooks/agent/checkpoints",
         {
@@ -185,7 +181,6 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentType: "claude-code",
             cliAgentSessionId: "test-session-no-artifact",
             cliAgentSessionHistoryHash: sha256("test-session-history"),
-            // artifactSnapshot: optional - runs without artifact don't have one
           }),
         },
       );
@@ -197,7 +192,36 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       expect(data.checkpointId).toBeDefined();
       expect(data.agentSessionId).toBeDefined();
       expect(data.conversationId).toBeDefined();
-      expect(data.artifact).toBeUndefined();
+      expect(data.artifacts).toBeUndefined();
+    });
+
+    it("should reject checkpoint containing the removed artifactSnapshot field", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "test-session-strict",
+            cliAgentSessionHistoryHash: sha256("strict-history"),
+            artifactSnapshot: {
+              artifactName: "test-artifact",
+              artifactVersion: "v1",
+            },
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("artifactSnapshot");
     });
   });
 
@@ -223,9 +247,8 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentSessionId: "test-session",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshot: {
-              artifactName: "test-artifact",
-              artifactVersion: "version-123",
+            artifactSnapshots: {
+              "test-artifact": "version-123",
             },
           }),
         },
@@ -272,9 +295,8 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentSessionId: "test-session",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshot: {
-              artifactName: "test-artifact",
-              artifactVersion: "version-123",
+            artifactSnapshots: {
+              "test-artifact": "version-123",
             },
           }),
         },
@@ -289,10 +311,9 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
   });
 
   describe("Success", () => {
-    it("should create checkpoint with artifact snapshot", async () => {
-      const artifactSnapshot = {
-        artifactName: "test-artifact",
-        artifactVersion: "version-123-456",
+    it("should create checkpoint with single artifact", async () => {
+      const artifactSnapshots = {
+        "test-artifact": "version-123-456",
       };
 
       const request = createTestRequest(
@@ -308,7 +329,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentType: "claude-code",
             cliAgentSessionId: "test-session-456",
             cliAgentSessionHistoryHash: sha256("test-session-456-history"),
-            artifactSnapshot,
+            artifactSnapshots,
           }),
         },
       );
@@ -320,10 +341,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       expect(data.checkpointId).toBeDefined();
       expect(data.agentSessionId).toBeDefined();
       expect(data.conversationId).toBeDefined();
-      // Legacy singleton body gets folded into the artifacts map by the server.
-      expect(data.artifacts).toEqual({
-        [artifactSnapshot.artifactName]: artifactSnapshot.artifactVersion,
-      });
+      expect(data.artifacts).toEqual(artifactSnapshots);
     });
 
     it("should persist artifactSnapshots map", async () => {
@@ -360,48 +378,12 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       expect(checkpoint).toBeDefined();
       expect(checkpoint!.artifactSnapshots).toEqual(artifactSnapshots);
     });
-
-    it("should prefer artifactSnapshots map when both legacy and map are sent", async () => {
-      const legacy = {
-        artifactName: "legacy-name",
-        artifactVersion: "legacy-version",
-      };
-      const artifactSnapshots = {
-        "canonical-artifact": "canonical-version",
-      };
-
-      const request = createTestRequest(
-        "http://localhost:3000/api/webhooks/agent/checkpoints",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${testToken}`,
-          },
-          body: JSON.stringify({
-            runId: testRunId,
-            cliAgentType: "claude-code",
-            cliAgentSessionId: "dual-send-session",
-            cliAgentSessionHistoryHash: sha256("dual-send-history"),
-            artifactSnapshot: legacy,
-            artifactSnapshots,
-          }),
-        },
-      );
-
-      const response = await POST(request);
-
-      expect(response.status).toBe(200);
-      const checkpoint = await findTestCheckpoint(testRunId);
-      expect(checkpoint!.artifactSnapshots).toEqual(artifactSnapshots);
-    });
   });
 
   describe("Session independence", () => {
     it("should create independent sessions for separate artifact runs", async () => {
-      const artifactSnapshot = {
-        artifactName: "my-app",
-        artifactVersion: "v1",
+      const artifactSnapshots = {
+        "my-app": "v1",
       };
 
       // Allow multiple concurrent runs and re-enable Clerk auth for API route calls
@@ -429,7 +411,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentSessionId: "session-run-1",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshot,
+            artifactSnapshots,
           }),
         },
       );
@@ -452,7 +434,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentSessionId: "session-run-2",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshot,
+            artifactSnapshots,
           }),
         },
       );
@@ -539,9 +521,8 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         cliAgentType: "claude-code",
         cliAgentSessionId: "test-session-unique",
         cliAgentSessionHistoryHash: sha256("test-session-unique-history"),
-        artifactSnapshot: {
-          artifactName: "test-artifact",
-          artifactVersion: "version-123",
+        artifactSnapshots: {
+          "test-artifact": "version-123",
         },
       };
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
@@ -72,7 +72,6 @@ const router = tsr.router(webhookCheckpointsContract, {
         checkpointId: result.checkpointId,
         agentSessionId: result.agentSessionId,
         conversationId: result.conversationId,
-        artifact: result.artifact,
         artifacts: result.artifacts,
         volumes: result.volumes,
       },

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -223,9 +223,8 @@ describe("POST /api/webhooks/agent/complete", () => {
             cliAgentSessionId: "test-session",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshot: {
-              artifactName: "test-artifact",
-              artifactVersion: "v1",
+            artifactSnapshots: {
+              "test-artifact": "v1",
             },
           }),
         },
@@ -1014,9 +1013,8 @@ describe("POST /api/webhooks/agent/complete", () => {
               cliAgentSessionId: "recovery-session",
               cliAgentSessionHistoryHash:
                 "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-              artifactSnapshot: {
-                artifactName: "recovery-artifact",
-                artifactVersion: "v1",
+              artifactSnapshots: {
+                "recovery-artifact": "v1",
               },
             }),
           },

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -17,32 +17,6 @@ import type {
 const log = logger("checkpoint");
 
 /**
- * Resolve the artifact snapshot map from a checkpoint request. During the
- * deployment window the guest-agent may still send the legacy singleton
- * `artifactSnapshot`; fold it into the map when the map is missing/empty so
- * no data is lost in mixed old-guest/new-server states.
- */
-function resolveArtifactSnapshots(request: CheckpointRequest): {
-  map: Record<string, string> | null;
-  primaryArtifactName: string | undefined;
-} {
-  const rawMap = request.artifactSnapshots ?? null;
-  const hasMap = rawMap !== null && Object.keys(rawMap).length > 0;
-  if (hasMap) {
-    const primaryArtifactName = Object.keys(rawMap)[0];
-    return { map: rawMap, primaryArtifactName };
-  }
-  const legacy = request.artifactSnapshot;
-  if (legacy) {
-    return {
-      map: { [legacy.artifactName]: legacy.artifactVersion },
-      primaryArtifactName: legacy.artifactName,
-    };
-  }
-  return { map: null, primaryArtifactName: undefined };
-}
-
-/**
  * Create a checkpoint for an agent run
  *
  * @param request Checkpoint request data from webhook
@@ -160,11 +134,10 @@ export async function createCheckpoint(
       }
     : null;
 
-  // Consolidate artifact snapshots. The guest-agent's authoritative payload
-  // is artifactSnapshots (name -> version map); during rollout a legacy
-  // singleton artifactSnapshot is folded into the map if present.
-  const { map: artifactSnapshotsMap, primaryArtifactName } =
-    resolveArtifactSnapshots(request);
+  const rawMap = request.artifactSnapshots ?? null;
+  const hasMap = rawMap !== null && Object.keys(rawMap).length > 0;
+  const artifactSnapshotsMap = hasMap ? rawMap : null;
+  const primaryArtifactName = hasMap ? Object.keys(rawMap)[0] : undefined;
 
   const snapshotFields = {
     conversationId: conversation.id,

--- a/turbo/apps/web/src/lib/infra/checkpoint/types.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/types.ts
@@ -15,15 +15,6 @@ export interface AgentComposeSnapshot {
 }
 
 /**
- * Artifact snapshot for VAS managed artifacts
- * Fields align with CLI parameters --artifact-name and --artifact-version
- */
-export interface ArtifactSnapshot {
-  artifactName: string;
-  artifactVersion: string;
-}
-
-/**
  * Volume versions snapshot for checkpoint
  * Stores resolved volume versions at checkpoint time for exact reproducibility
  */
@@ -46,10 +37,9 @@ export interface CheckpointRequest {
   cliAgentType: string;
   cliAgentSessionId: string;
   cliAgentSessionHistoryHash: string;
-  artifactSnapshot?: ArtifactSnapshot;
   // Multi-artifact snapshot map: artifactName -> versionId. Emitted
-  // unconditionally by the guest-agent during the multi-mount rollout;
-  // may be empty or missing when the guest snapshotted nothing.
+  // unconditionally by the guest-agent; may be empty or missing when the
+  // guest snapshotted nothing.
   artifactSnapshots?: Record<string, string>;
   volumeVersionsSnapshot?: VolumeVersionsSnapshot;
 }
@@ -61,7 +51,6 @@ export interface CheckpointResponse {
   checkpointId: string;
   agentSessionId: string;
   conversationId: string;
-  artifact?: ArtifactSnapshot;
   artifacts?: Record<string, string>;
   volumes?: Record<string, string>;
 }

--- a/turbo/apps/web/src/lib/infra/run/context/build-context.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/build-context.ts
@@ -1,6 +1,9 @@
 import { expandEnvironmentFromCompose } from "../environment/expand-environment";
-import type { ExecutionContext, ResumeSession } from "../types";
-import type { ArtifactSnapshot } from "../../checkpoint/types";
+import type {
+  ExecutionContext,
+  ResumeSession,
+  ArtifactSnapshot,
+} from "../types";
 import type { AdditionalArtifact, AdditionalVolume } from "../../storage/types";
 import type { Firewalls, NetworkPolicies } from "@vm0/core";
 

--- a/turbo/apps/web/src/lib/infra/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/types.ts
@@ -1,6 +1,5 @@
 import type { StorageManifest } from "../../../infra/storage/types";
-import type { ResumeSession } from "../types";
-import type { ArtifactSnapshot } from "../../checkpoint/types";
+import type { ResumeSession, ArtifactSnapshot } from "../types";
 import type { Firewalls, NetworkPolicies } from "@vm0/core";
 
 /**

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -1,6 +1,14 @@
-import type { ArtifactSnapshot } from "../checkpoint/types";
 import type { AdditionalArtifact, AdditionalVolume } from "../storage/types";
 import type { Firewalls, NetworkPolicies } from "@vm0/core";
+
+/**
+ * Single-artifact reference used by resume flows.
+ * Fields align with CLI parameters --artifact-name and --artifact-version.
+ */
+export interface ArtifactSnapshot {
+  artifactName: string;
+  artifactVersion: string;
+}
 
 /**
  * Run status values

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -14,8 +14,11 @@ import {
 import { zeroRuns } from "../../db/schema/zero-run";
 import { badRequest, notFound } from "../shared/errors";
 import { logger } from "../shared/logger";
-import type { ExecutionContext, ResumeSession } from "../infra/run/types";
-import type { ArtifactSnapshot } from "../infra/checkpoint/types";
+import type {
+  ExecutionContext,
+  ResumeSession,
+  ArtifactSnapshot,
+} from "../infra/run/types";
 import type {
   AdditionalArtifact,
   AdditionalVolume,

--- a/turbo/apps/web/src/lib/zero/context/resolve-source.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-source.ts
@@ -17,8 +17,7 @@ import {
   providerIncompatible,
 } from "../../shared/errors";
 import { logger } from "../../shared/logger";
-import type { ResumeSession } from "../../infra/run/types";
-import type { ArtifactSnapshot } from "../../infra/checkpoint/types";
+import type { ResumeSession, ArtifactSnapshot } from "../../infra/run/types";
 import type { AdditionalVolume } from "../../infra/storage/types";
 import {
   resolveCheckpoint,

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -41,14 +41,6 @@ const agentEventSchema = z
   .passthrough();
 
 /**
- * Artifact snapshot schema
- */
-const artifactSnapshotSchema = z.object({
-  artifactName: z.string(),
-  artifactVersion: z.string(),
-});
-
-/**
  * Volume versions snapshot schema
  */
 const volumeVersionsSnapshotSchema = z.object({
@@ -138,25 +130,23 @@ export const webhookCheckpointsContract = c.router({
     method: "POST",
     path: "/api/webhooks/agent/checkpoints",
     headers: authHeadersSchema,
-    body: z.object({
-      runId: z.string().min(1, "runId is required"),
-      cliAgentType: z.string().min(1, "cliAgentType is required"),
-      cliAgentSessionId: z.string().min(1, "cliAgentSessionId is required"),
-      cliAgentSessionHistoryHash: z
-        .string()
-        .length(
-          64,
-          "cliAgentSessionHistoryHash must be a 64-character SHA-256 hex string",
-        ),
-      // Legacy singleton artifact snapshot. The guest-agent may still emit
-      // this when exactly one artifact is snapshotted during rollout; the
-      // server folds it into artifactSnapshots before persisting.
-      artifactSnapshot: artifactSnapshotSchema.optional(),
-      // Multi-artifact snapshot map: artifact name → version id. Authoritative
-      // payload persisted to checkpoints.artifact_snapshots.
-      artifactSnapshots: z.record(z.string(), z.string()).optional(),
-      volumeVersionsSnapshot: volumeVersionsSnapshotSchema.optional(),
-    }),
+    body: z
+      .object({
+        runId: z.string().min(1, "runId is required"),
+        cliAgentType: z.string().min(1, "cliAgentType is required"),
+        cliAgentSessionId: z.string().min(1, "cliAgentSessionId is required"),
+        cliAgentSessionHistoryHash: z
+          .string()
+          .length(
+            64,
+            "cliAgentSessionHistoryHash must be a 64-character SHA-256 hex string",
+          ),
+        // Multi-artifact snapshot map: artifact name → version id.
+        // Authoritative payload persisted to checkpoints.artifact_snapshots.
+        artifactSnapshots: z.record(z.string(), z.string()).optional(),
+        volumeVersionsSnapshot: volumeVersionsSnapshotSchema.optional(),
+      })
+      .strict(),
     responses: {
       200: z.object({
         checkpointId: z.string(),


### PR DESCRIPTION
## Summary

- Move the `ArtifactSnapshot` interface from `infra/checkpoint/types.ts` to `infra/run/types.ts` (its only real consumers are resume flows, not the HTTP contract)
- Drop the singular `artifactSnapshot` field from the checkpoint webhook request body and response body — all guest-agents now emit the plural `artifactSnapshots` map
- Inline the dead legacy fallback branch in `resolveArtifactSnapshots` / `createCheckpoint`, and add `.strict()` to the zod body schema so any future typo or stale client fails fast at the boundary

## Pre-flight

`grep -r "artifactSnapshot\b" crates/guest-agent/src/` returns zero hits — safe to drop the singular HTTP field.

## Test plan

- [x] `pnpm turbo run lint --filter=@vm0/core --filter=web` — green
- [x] `pnpm check-types` (web) — green
- [x] `pnpm -F web exec vitest run src/lib/infra/checkpoint` — green
- [x] `pnpm -F web exec vitest run app/api/webhooks/agent/checkpoints` — green
- [x] `cargo test -p guest-agent` (repo root `crates/`) — green
- [x] Added negative test: payload carrying the removed `artifactSnapshot` field is rejected at the zod boundary

Refs #10743
Parent epic #10740

🤖 Generated with [Claude Code](https://claude.com/claude-code)