### PR TITLE
chore: drop stale memory/artifact references from test fixtures

### DIFF
--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -377,7 +377,6 @@ mod tests {
             "debugNoMockClaude": true,
             "apiStartTime": 1700000000000.0,
             "userTimezone": "America/New_York",
-            "memoryName": "project-mem",
             "firewalls": [{
                 "name": "github",
                 "apis": [{"base": "https://api.github.com", "auth": {"headers": {}}}]

--- a/turbo/apps/web/src/__tests__/db-test-assertions/storage.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/storage.ts
@@ -40,7 +40,7 @@ export async function findTestStorageByName(
 export async function findTestStorage(
   orgId: string,
   name: string,
-  type: "volume" | "artifact" | "memory",
+  type: "volume" | "artifact",
 ): Promise<
   { id: string; name: string; userId: string; s3Prefix: string } | undefined
 > {

--- a/turbo/apps/web/src/__tests__/db-test-seeders/storage.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/storage.ts
@@ -157,7 +157,7 @@ export async function insertTestStorage(params: {
   userId: string;
   orgId: string;
   name: string;
-  type?: string;
+  type?: "volume" | "artifact";
 }): Promise<{ id: string }> {
   initServices();
   const [row] = await globalThis.services.db

--- a/turbo/apps/web/src/lib/zero/user/__tests__/user-s3-cleanup.test.ts
+++ b/turbo/apps/web/src/lib/zero/user/__tests__/user-s3-cleanup.test.ts
@@ -31,7 +31,7 @@ describe("deleteUserS3Data", () => {
     const name2 = uniqueId("storage");
 
     await insertTestStorage({ userId, orgId, name: name1, type: "artifact" });
-    await insertTestStorage({ userId, orgId, name: name2, type: "memory" });
+    await insertTestStorage({ userId, orgId, name: name2, type: "artifact" });
 
     const prefix1 = `storages/${orgId}/${name1}/`;
     const prefix2 = `storages/${orgId}/${name2}/`;
@@ -155,7 +155,7 @@ describe("deleteUserS3Data", () => {
     const exportKey = `exports/${userId}/${uniqueId("job")}.zip`;
 
     await insertTestStorage({ userId, orgId, name: name1, type: "artifact" });
-    await insertTestStorage({ userId, orgId, name: name2, type: "memory" });
+    await insertTestStorage({ userId, orgId, name: name2, type: "artifact" });
     await insertTestExportJob(orgId, {
       userId,
       status: "completed",


### PR DESCRIPTION
## Summary

- Drop `type: "memory"` test fixtures from storage assertions/seeders and `user-s3-cleanup.test.ts`; flip to `"artifact"` (the production pathway since Epic #10577).
- Remove `memoryName?: string` from the `createTestRun` helper; inline the 3 call sites in `app/api/agent/runs/__tests__/route.test.ts` via `createTestRequest` so they continue to exercise the still-live legacy HTTP shim until sibling PR #10742 retires it.
- Drop the stale `"memoryName": "project-mem"` key from the Rust `ExecutionContext` round-trip JSON fixture — the field is not declared on the struct and was silently discarded by serde.

Parent Epic: #10740. Closes #10741.

## Scope Note

Issue body's item #4 claimed the helper's `memoryName?` had no real consumers, but three tests in `app/api/agent/runs/__tests__/route.test.ts` (outside the scope glob `turbo/apps/web/src/**/*.test.ts`) passed `memoryName` through it. Removing the field without updating those callers would fail `pnpm check-types`. The extension was approved in the planning round; callers are inlined via `createTestRequest` to preserve legacy HTTP coverage until #10742 lands.

## Verification

Issue-body checklist:

- [x] `grep -rn '"memory"' turbo/apps/web/src/__tests__/` — zero hits
- [x] `grep -rn "memoryName" turbo/apps/web/src/__tests__/` — two hits remain (`db-test-assertions/agents.ts:116, 135`). **These are legitimate reads of the preserved `agent_sessions.memory_name` DB column** (kept per Epic #10577 DoD). The issue's grep is slightly over-strict; all *stale fixture* references are cleared.
- [x] `grep -n "memoryName" crates/runner/src/types.rs` — zero hits
- [x] `pnpm -F web exec vitest` — 363 test files / 3785 tests pass
- [x] `cargo test -p runner execution_context` — 4 tests pass
- [x] `pnpm check-types` — pass
- [x] `pnpm turbo run lint` — pass

## Test plan

- [ ] CI `test` green
- [ ] CI `lint` green
- [ ] CI `cli-e2e` green
- [ ] CI `deploy` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)