### PR TITLE
fix(ci): ignore non-exploitable pnpm audit advisories

### DIFF
--- a/turbo/package.json
+++ b/turbo/package.json
@@ -68,6 +68,12 @@
       "smol-toml": ">=1.6.1",
       "@opentelemetry/instrumentation": ">=0.213.0",
       "zod": "4.3.6"
+    },
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-gh4j-gqv2-49f6",
+        "GHSA-w5hq-g745-h8pq"
+      ]
     }
   },
   "packageManager": "pnpm@10.15.0",


### PR DESCRIPTION
## Summary

The Security Scanning workflow's `pnpm audit (SCA)` job has been failing on `main` (e.g. [run 24813422319](https://github.com/vm0-ai/vm0/actions/runs/24813422319/job/72622779855)) due to three transitive findings that cannot be resolved by upgrading without breaking other workloads. Add both advisory IDs to `pnpm.auditConfig.ignoreGhsas` with rationale.

### Why not upgrade?

**`GHSA-gh4j-gqv2-49f6` (fast-xml-parser <5.7.0, XMLBuilder CDATA/comment injection)**
- Only exploitable when attacker-controlled content is passed to XMLBuilder as CDATA/comments. Our only consumer is AWS SDK `@aws-sdk/xml-builder` for S3/R2, which serializes application-generated identifiers, not user input.
- Bumping the override to `>=5.7.0` pulls breaking changes (fast-xml-builder CDATA/comment sanitization + a new single-entity scan rule in 5.7.0) that break `@aws-sdk/xml-builder` (pins `fast-xml-parser: 5.5.8`). This was already demonstrated on #10716: `zero agent delete removes agent` returned 500 from `listS3Objects`/`deleteS3Objects` when cleaning up the instructions volume.

**`GHSA-w5hq-g745-h8pq` (uuid <14.0.0, missing buffer bounds check in v3/v5/v6 when `buf` is provided)**
- Exploitable only when callers pass a `buf` argument to v3/v5/v6. Transitive consumers `@sentry/webpack-plugin` and `svix` only generate v4 UUIDs and never pass `buf`.
- `uuid@14` is ESM-only (`type: "module"`, `dist-node/*.js` all use `export` syntax). `@sentry/webpack-plugin@5.1.1` still uses `require("uuid")` in its CJS entry, so overriding to `>=14` breaks the Next.js build.

### Change

Add `auditConfig.ignoreGhsas` under `pnpm` in `turbo/package.json`. Six-line additive edit. **No dependency resolutions change; `pnpm-lock.yaml` is untouched.**

## Test plan

- [x] `pnpm audit --prod --ignore-registry-errors` exits 0 locally (`3 vulnerabilities found, Severity: 3 moderate (2 ignored)` — unique advisories ignored = 2)
- [x] `pnpm install --frozen-lockfile` succeeds (lockfile unchanged)
- [ ] CI `Security Scanning / pnpm audit (SCA)` job turns green
- [ ] Rest of CI stays green (no dep resolution impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)