### PR TITLE
refactor: remove http legacy run body shim and deprecated contract fields

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -30,6 +30,7 @@ import { POST as checkpointWebhook } from "../../../webhooks/agent/checkpoints/r
 import { POST as completeWebhook } from "../../../webhooks/agent/complete/route";
 import { POST as pollRoute } from "../../../runners/poll/route";
 import type { AgentComposeYaml } from "../../../../../src/lib/infra/agent-compose/types";
+import { AUTO_MEMORY_MOUNT_PATH } from "../../../../../src/lib/infra/storage/types";
 import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
 import { bindCustomSkillToAgent } from "../../../../../src/__tests__/db-test-seeders/skills";
 import {
@@ -85,13 +86,68 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(run.completedAt).toBeNull();
     });
 
-    it("should accept memoryName parameter", async () => {
-      const data = await createTestRun(testComposeId, "Test with memory", {
-        memoryName: "my-memory",
-      });
+    it("should accept memory as an artifact at the auto-memory mount path", async () => {
+      const memoryArtifact = uniqueId("my-memory");
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentComposeId: testComposeId,
+            prompt: "Test with memory",
+            artifacts: [
+              { name: memoryArtifact, mountPath: AUTO_MEMORY_MOUNT_PATH },
+            ],
+          }),
+        },
+      );
+      const response = await POST(request);
+      const data = await response.json();
 
+      expect(response.status).toBe(201);
       expect(data.runId).toBeDefined();
       expect(data.status).toBe("pending");
+    });
+
+    it("should reject legacy memoryName body field with 400", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentComposeId: testComposeId,
+            prompt: "Legacy memoryName should be rejected",
+            memoryName: "legacy-field",
+          }),
+        },
+      );
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("should reject legacy artifactName body field with 400", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentComposeId: testComposeId,
+            prompt: "Legacy artifactName should be rejected",
+            artifactName: "legacy-artifact",
+          }),
+        },
+      );
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("BAD_REQUEST");
     });
 
     it("should not inject agent identity (CLI path)", async () => {
@@ -1535,37 +1591,46 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
   });
 
   describe("Memory", () => {
-    it("should succeed when memory already exists (idempotent)", async () => {
+    it("should succeed when memory-as-artifact already exists (idempotent)", async () => {
       // Allow concurrent runs for this test
       vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "0");
       reloadEnv();
 
-      const memoryName = uniqueId("existing-mem");
-      // First run creates the memory
-      await createTestRun(testComposeId, "First run", { memoryName });
+      const memoryArtifact = uniqueId("existing-mem");
+      const memoryBody = {
+        agentComposeId: testComposeId,
+        artifacts: [
+          { name: memoryArtifact, mountPath: AUTO_MEMORY_MOUNT_PATH },
+        ],
+      };
+
+      // First run creates the memory artifact
+      const firstRequest = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...memoryBody, prompt: "First run" }),
+        },
+      );
+      const firstResponse = await POST(firstRequest);
+      expect(firstResponse.status).toBe(201);
 
       // Second run should also succeed (idempotent)
-      const data = await createTestRun(testComposeId, "Second run", {
-        memoryName,
-      });
+      const secondRequest = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...memoryBody, prompt: "Second run" }),
+        },
+      );
+      const secondResponse = await POST(secondRequest);
+      const data = await secondResponse.json();
+
+      expect(secondResponse.status).toBe(201);
       expect(data.runId).toBeDefined();
       expect(data.status).toBe("pending");
-    });
-
-    it("should persist memoryName on session row for continue flow resolution", async () => {
-      // Post-#10603: memoryName is stored on agent_sessions.memory_name by
-      // insertRunRecord, so a later continue-flow resolver can pull it back
-      // even when the continue request omits memoryName.
-      const initial = await createTestRun(testComposeId, "Initial run", {
-        memoryName: "restored-memory",
-      });
-      expect(initial.sessionId).toBeDefined();
-
-      const session = await getTestAgentSessionWithConversation(
-        initial.sessionId!,
-      );
-      expect(session).toBeDefined();
-      expect(session!.memoryName).toBe("restored-memory");
     });
   });
 
@@ -1580,7 +1645,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
           body: JSON.stringify({
             agentComposeId: testComposeId,
             prompt: "Test artifact auto-create",
-            artifactName,
+            artifacts: [{ name: artifactName, mountPath: "/mnt/work" }],
           }),
         },
       );
@@ -1603,7 +1668,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
           body: JSON.stringify({
             agentComposeId: testComposeId,
             prompt: "Test existing artifact",
-            artifactName,
+            artifacts: [{ name: artifactName, mountPath: "/mnt/work" }],
           }),
         },
       );
@@ -1658,43 +1723,6 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       });
       expect(names).toContain(artifactA);
       expect(names).toContain(artifactB);
-    });
-
-    it("should prefer body.artifacts over legacy artifactName when both are set", async () => {
-      const legacyName = uniqueId("legacy-art");
-      const newArtifact = uniqueId("new-art");
-      await createTestArtifact(legacyName);
-      await createTestArtifact(newArtifact);
-
-      const request = createTestRequest(
-        "http://localhost:3000/api/agent/runs",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentComposeId: testComposeId,
-            prompt: "Precedence test",
-            artifactName: legacyName,
-            artifacts: [{ name: newArtifact, mountPath: "/mnt/new" }],
-          }),
-        },
-      );
-      const response = await POST(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(201);
-      expect(data.status).toBe("pending");
-
-      const job = await findTestRunnerJobEntry(data.runId);
-      expect(job).toBeDefined();
-      const artifacts = job!.executionContext.storageManifest!.artifacts;
-      // Only the multi-mount entry should be present; the legacy singleton
-      // is dropped when body.artifacts is non-empty.
-      const names = artifacts.map((a) => {
-        return a.vasStorageName;
-      });
-      expect(names).toContain(newArtifact);
-      expect(names).not.toContain(legacyName);
     });
   });
 
@@ -2004,8 +2032,10 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
           body: JSON.stringify({
             agentComposeId: testComposeId,
             prompt: "Storage org test",
-            artifactName: "artifact",
-            memoryName: "memory",
+            artifacts: [
+              { name: "artifact", mountPath: "/mnt/work" },
+              { name: "memory", mountPath: AUTO_MEMORY_MOUNT_PATH },
+            ],
           }),
         },
       );
@@ -2019,7 +2049,8 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const run = await findTestRunRecord(data.runId);
       expect(run).toBeDefined();
 
-      // Verify artifact storage was created in the compose's org (user's default org)
+      // Both artifact entries (including the one mounted at the auto-memory
+      // path) auto-create storage in the compose's org (user's default org).
       const artifact = await findTestStorage(
         user.orgId,
         "artifact",
@@ -2028,10 +2059,6 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(artifact).toBeDefined();
       expect(artifact!.userId).toBe(user.userId);
 
-      // Verify memory storage was created in the compose's org. Post-#10602,
-      // memory flows through artifacts[] and is auto-created as type='artifact'
-      // (the legacy type='memory' branch was removed when infra folded memory
-      // into the artifacts pipeline).
       const memory = await findTestStorage(user.orgId, "memory", "artifact");
       expect(memory).toBeDefined();
       expect(memory!.userId).toBe(user.userId);

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -15,9 +15,10 @@ import {
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
-import type {
-  AdditionalArtifact,
-  AdditionalVolume,
+import {
+  AUTO_MEMORY_MOUNT_PATH,
+  type AdditionalArtifact,
+  type AdditionalVolume,
 } from "../../../../src/lib/infra/storage/types";
 import { and, eq, inArray, desc, gte, lte, sql } from "drizzle-orm";
 import {
@@ -50,15 +51,6 @@ import { generateSandboxToken } from "../../../../src/lib/auth/sandbox-token";
 import { buildInfraExecutionContext } from "../../../../src/lib/infra/run/context/build-context";
 import { getCachedUser } from "../../../../src/lib/auth/user-cache-service";
 import { env } from "../../../../src/env";
-import { z } from "zod";
-
-// Legacy compat: accept `memoryName` on the HTTP body even though the shared
-// contract no longer names it. Enabled by `.passthrough()` on the request
-// schema. Older CLIs pinned to pre-unification builds continue to work while
-// the field is dropped from docs and typed clients.
-const legacyRunBodyExtrasSchema = z
-  .object({ memoryName: z.string().optional() })
-  .passthrough();
 
 const log = logger("api:runs");
 
@@ -79,18 +71,14 @@ function resolveRunAdditionalVolumes(params: {
 }
 
 /**
- * Consolidate singleton + multi-mount artifact inputs into one shape.
+ * Consolidate body/resumed artifact inputs into one shape.
  *
- * body.artifacts (multi-mount) takes precedence — when non-empty, the legacy
- * singleton artifactName/Version fields are dropped so the infra layer only
- * speaks the new multi-mount contract.
+ * When body.artifacts is non-empty, the CLI path uses the multi-mount shape
+ * directly. Otherwise the route falls back to the session/checkpoint-resumed
+ * singleton artifactName/Version (Zero-layer resume bookkeeping).
  */
 function consolidateArtifactInputs(
-  body: {
-    artifactName?: string;
-    artifactVersion?: string;
-    artifacts?: AdditionalArtifact[];
-  },
+  body: { artifacts?: AdditionalArtifact[] },
   resolved: { artifactName?: string; artifactVersion?: string },
 ): {
   artifactName: string | undefined;
@@ -107,8 +95,8 @@ function consolidateArtifactInputs(
     };
   }
   return {
-    artifactName: resolved.artifactName ?? body.artifactName,
-    artifactVersion: resolved.artifactVersion ?? body.artifactVersion,
+    artifactName: resolved.artifactName,
+    artifactVersion: resolved.artifactVersion,
     artifacts: undefined,
   };
 }
@@ -325,9 +313,6 @@ const router = tsr.router(runsMainContract, {
     try {
       await enforceCaptureNetworkBodiesGate(userId, body.captureNetworkBodies);
 
-      const { memoryName: legacyMemoryName } =
-        legacyRunBodyExtrasSchema.parse(body);
-
       const resolved = await resolveCliRunContext({
         orgId: org.orgId,
         userId,
@@ -339,9 +324,6 @@ const router = tsr.router(runsMainContract, {
         vars: body.vars,
         secrets: body.secrets,
         permissionPolicies: body.permissionPolicies,
-        artifactName: body.artifactName,
-        artifactVersion: body.artifactVersion,
-        memoryName: legacyMemoryName,
         volumeVersions: body.volumeVersions,
       });
 
@@ -396,6 +378,21 @@ const router = tsr.router(runsMainContract, {
         artifacts: effectiveArtifacts,
       } = consolidateArtifactInputs(body, resolved);
 
+      // 6b. Synthesize memory-as-artifact at the auto-memory mount path for
+      // session/checkpoint-resumed runs. Mirrors buildZeroExecutionContext's
+      // memoryArtifacts synthesis — the CLI path carries memory through the
+      // unified artifacts[] channel, not a dedicated memoryName field.
+      const effectiveArtifactsWithMemory: AdditionalArtifact[] | undefined =
+        resolved.memoryName
+          ? [
+              ...(effectiveArtifacts ?? []),
+              {
+                name: resolved.memoryName,
+                mountPath: AUTO_MEMORY_MOUNT_PATH,
+              },
+            ]
+          : effectiveArtifacts;
+
       // 7. Concurrency check + INSERT (transaction with advisory lock)
       const run = await globalThis.services.db.transaction(async (tx) => {
         await tx.execute(
@@ -415,7 +412,7 @@ const router = tsr.router(runsMainContract, {
           resumedFromCheckpointId: body.checkpointId,
           sessionId: body.sessionId,
           artifactName: effectiveArtifactName,
-          memoryName: resolved.memoryName ?? legacyMemoryName,
+          memoryName: resolved.memoryName,
         });
       });
       const transactionTime = Date.now();
@@ -440,8 +437,7 @@ const router = tsr.router(runsMainContract, {
           secretConnectorMap: resolved.secretConnectorMap,
           artifactName: effectiveArtifactName,
           artifactVersion: effectiveArtifactVersion,
-          artifacts: effectiveArtifacts,
-          memoryName: resolved.memoryName ?? legacyMemoryName,
+          artifacts: effectiveArtifactsWithMemory,
           volumeVersions: resolved.volumeVersions ?? body.volumeVersions,
           additionalVolumes: finalAdditionalVolumes,
           environment: resolved.environment,

--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -73,7 +73,6 @@ describe("POST /api/zero/runs", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          agentComposeId: "some-compose-id",
           prompt: "test prompt",
         }),
       }),

--- a/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
@@ -45,7 +45,6 @@ export async function createTestRun(
     secrets?: Record<string, string>;
     sessionId?: string;
     checkpointId?: string;
-    memoryName?: string;
     appendSystemPrompt?: string;
     additionalVolumes?: Array<{
       name: string;

--- a/turbo/apps/web/src/lib/infra/run/context/build-context.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/build-context.ts
@@ -1,11 +1,7 @@
 import { expandEnvironmentFromCompose } from "../environment/expand-environment";
 import type { ExecutionContext, ResumeSession } from "../types";
 import type { ArtifactSnapshot } from "../../checkpoint/types";
-import {
-  AUTO_MEMORY_MOUNT_PATH,
-  type AdditionalArtifact,
-  type AdditionalVolume,
-} from "../../storage/types";
+import type { AdditionalArtifact, AdditionalVolume } from "../../storage/types";
 import type { Firewalls, NetworkPolicies } from "@vm0/core";
 
 interface BuildInfraContextParams {
@@ -23,7 +19,6 @@ interface BuildInfraContextParams {
   artifactName?: string;
   artifactVersion?: string;
   artifacts?: AdditionalArtifact[];
-  memoryName?: string;
   volumeVersions?: Record<string, string>;
   additionalVolumes?: AdditionalVolume[];
   environment?: Record<string, string>;
@@ -67,17 +62,6 @@ export function buildInfraExecutionContext(
       params.secrets,
     ).environment;
 
-  // Fold legacy memoryName into artifacts[] so the execution context only
-  // speaks the multi-mount shape. Session-row bookkeeping
-  // (agent_sessions.memory_name) happens separately in the route handler via
-  // insertRunRecord — the field is not propagated through the context.
-  const artifacts: AdditionalArtifact[] | undefined = params.memoryName
-    ? [
-        ...(params.artifacts ?? []),
-        { name: params.memoryName, mountPath: AUTO_MEMORY_MOUNT_PATH },
-      ]
-    : params.artifacts;
-
   const context: ExecutionContext = {
     runId: params.runId,
     userId: params.userId,
@@ -92,7 +76,7 @@ export function buildInfraExecutionContext(
     sandboxToken: params.sandboxToken,
     artifactName: params.artifactName,
     artifactVersion: params.artifactVersion,
-    artifacts,
+    artifacts: params.artifacts,
     volumeVersions: params.volumeVersions,
     additionalVolumes: params.additionalVolumes,
     environment,

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -332,10 +332,6 @@ interface ResolveCliRunContextParams {
   permissionPolicies?: FirewallPolicies;
   allowedConnectorTypes?: ConnectorType[];
   allowedCustomConnectorIds?: string[];
-  // Artifact/memory
-  artifactName?: string;
-  artifactVersion?: string;
-  memoryName?: string;
   volumeVersions?: Record<string, string>;
   // Model provider selection
   modelProviderId?: string;
@@ -409,10 +405,10 @@ export async function resolveCliRunContext(
   // Initialize context variables
   let agentComposeVersionId: string | undefined = params.agentComposeVersionId;
   let agentCompose: unknown;
-  let artifactName: string | undefined = params.artifactName;
-  let artifactVersion: string | undefined = params.artifactVersion;
+  let artifactName: string | undefined;
+  let artifactVersion: string | undefined;
   let vars: Record<string, string> | undefined = params.vars;
-  let memoryName: string | undefined = params.memoryName;
+  let memoryName: string | undefined;
   let volumeVersions: Record<string, string> | undefined =
     params.volumeVersions;
   let additionalVolumes: AdditionalVolume[] | undefined;

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -38,13 +38,7 @@ const unifiedRunRequestSchema = z
     agentComposeId: z.string().optional(),
     agentComposeVersionId: z.string().optional(),
     conversationId: z.string().optional(),
-    // @deprecated Legacy singleton artifact fields retained for a one-release
-    // compat window. The POST /api/agent/runs handler rewrites them into the
-    // new `artifacts` array before dispatch — prefer `artifacts` in new code.
-    artifactName: z.string().optional(),
-    artifactVersion: z.string().optional(),
-    // Multi-mount artifacts, each with its own mountPath. When provided, the
-    // server ignores artifactName/artifactVersion.
+    // Multi-mount artifacts, each with its own mountPath.
     artifacts: z
       .array(
         z.object({
@@ -96,9 +90,7 @@ const unifiedRunRequestSchema = z
     // Per-permission policies (e.g., { "github": { "actions:read": "allow" } })
     permissionPolicies: firewallPoliciesSchema.optional(),
   })
-  // Preserve unknown keys so route handlers can accept legacy compat fields
-  // at the HTTP boundary without naming them in the shared contract.
-  .passthrough();
+  .strict();
 
 /**
  * Create run response schema

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -24,8 +24,6 @@ import { sandboxReuseResultSchema } from "./webhooks";
 const zeroRunRequestSchema = unifiedRunRequestSchema
   .omit({
     triggerSource: true,
-    artifactName: true,
-    artifactVersion: true,
     artifacts: true,
     disallowedTools: true,
     volumeVersions: true,


### PR DESCRIPTION
## Summary

- Delete `legacyRunBodyExtrasSchema` + `.passthrough()` shim on `POST /api/agent/runs`; `unifiedRunRequestSchema` is now `.strict()` and no longer carries deprecated `artifactName` / `artifactVersion` fields.
- Drop `memoryName?`, `artifactName?`, `artifactVersion?` from `ResolveCliRunContextParams` and `memoryName?` from `BuildInfraContextParams` — these were inputs only, not return-type state.
- Route-level inline synthesis of memory-as-artifact at `AUTO_MEMORY_MOUNT_PATH` from `resolved.memoryName` (mirrors `buildZeroExecutionContext`); checkpoint/session-resume still populates `agent_sessions.memoryName` per Epic #10577 DoD (Option C in the deep-dive plan).
- Update route tests to validate strict-schema behavior: legacy `memoryName` / `artifactName` body fields now return 400; memory flows via `artifacts[]`.

Fixes #10742 — sub-issue of Epic #10740.

## Test plan

- [x] `pnpm -F web exec vitest run app/api/agent/runs/__tests__/route.test.ts` — 89 tests pass
- [x] `pnpm -F web exec vitest run app/api/zero` — 1344 tests pass
- [x] `pnpm check-types` — all packages type-clean
- [x] `pnpm turbo run lint` — 0 warnings / 0 errors
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no issues
- [ ] CI green