### PR TITLE
fix(platform): validate logo dimensions on upload and sync sidebar after save

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -41,6 +41,9 @@ let internalMockedSession: { token: string } | null = null;
 let internalMockedOrganization: {
   id: string;
   name: string;
+  slug?: string;
+  imageUrl?: string;
+  hasImage?: boolean;
   reload: () => Promise<void>;
 } | null = null;
 let internalMockedInvitations: MockedInvitation[] = [];
@@ -87,7 +90,13 @@ export function mockUser(
  * Configure organization-related mock state for testing org selection.
  */
 export function mockOrganization(options: {
-  activeOrg?: { id: string; name: string } | null;
+  activeOrg?: {
+    id: string;
+    name: string;
+    slug?: string;
+    imageUrl?: string;
+    hasImage?: boolean;
+  } | null;
   memberships?: MockedMembership[];
   pendingInvitations?: MockedInvitation[];
 }) {

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -37,7 +37,13 @@ export async function setupPage(options: {
   } | null;
   session?: { token: string } | null;
   org?: {
-    activeOrg?: { id: string; name: string } | null;
+    activeOrg?: {
+      id: string;
+      name: string;
+      slug?: string;
+      imageUrl?: string;
+      hasImage?: boolean;
+    } | null;
     memberships?: MockedMembership[];
     pendingInvitations?: MockedInvitation[];
   };

--- a/turbo/apps/platform/src/signals/__tests__/auth.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth.test.ts
@@ -7,7 +7,7 @@ import {
   mockOrganization,
   mockUser,
 } from "../../__tests__/mock-auth";
-import { setupClerk$, user$, resolveWebOrigin } from "../auth";
+import { setupClerk$, user$, currentOrgInfo$, resolveWebOrigin } from "../auth";
 
 const context = testContext();
 
@@ -78,6 +78,68 @@ describe("setupClerk$ auth reload filtering", () => {
 
     const userAfter = await store.get(user$);
     expect(userAfter).toBeUndefined();
+  });
+});
+
+describe("currentOrgInfo$ re-emits on Clerk listener events", () => {
+  it("picks up in-place mutations to the active org's imageUrl after fireClerkListeners", async () => {
+    const { store, signal } = context;
+
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: {
+          id: "org_A",
+          name: "Org A",
+          slug: "org-a",
+          imageUrl: "https://example.com/old-logo.png",
+          hasImage: true,
+        },
+        memberships: [{ id: "org_A" }],
+      },
+      withoutRender: true,
+    });
+    await store.set(setupClerk$, signal);
+
+    const before = await store.get(currentOrgInfo$);
+    expect(before?.imageUrl).toBe("https://example.com/old-logo.png");
+
+    // Simulate the Clerk SDK mutating imageUrl in place after a
+    // successful `clerk.organization.reload()` — the production bug
+    // this PR fixes is that subscribers never re-rendered because
+    // ccstate cannot see in-place mutations. Firing the listener is
+    // the production trigger that bumps clerkVersion$ and forces the
+    // computed to re-emit.
+    mockOrganization({
+      activeOrg: {
+        id: "org_A",
+        name: "Org A",
+        slug: "org-a",
+        imageUrl: "https://example.com/new-logo.png",
+        hasImage: true,
+      },
+      memberships: [{ id: "org_A" }],
+    });
+    fireClerkListeners();
+
+    const after = await store.get(currentOrgInfo$);
+    expect(after?.imageUrl).toBe("https://example.com/new-logo.png");
+  });
+
+  it("returns null when there is no active organization", async () => {
+    const { store, signal } = context;
+
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: { activeOrg: null, memberships: [] },
+      withoutRender: true,
+    });
+    await store.set(setupClerk$, signal);
+
+    const info = await store.get(currentOrgInfo$);
+    expect(info).toBeNull();
   });
 });
 

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -2,6 +2,7 @@ import { command, computed, state } from "ccstate";
 import { clearSentryUser, setSentryUser } from "../lib/sentry.ts";
 
 const reload$ = state(0);
+const clerkVersion$ = state(0);
 
 /**
  * Resolve the web app origin from the current app origin.
@@ -73,6 +74,12 @@ export const setupClerk$ = command(
       } else {
         clearSentryUser();
       }
+      // Bump on every clerk event so signals tracking mutable clerk state
+      // (e.g. current org's imageUrl after reload()) re-compute and their
+      // subscribers re-render.
+      set(clerkVersion$, (x) => {
+        return x + 1;
+      });
       const currentUserId = clerk.user?.id ?? null;
       if (currentUserId !== prevUserId) {
         prevUserId = currentUserId;
@@ -152,6 +159,28 @@ export const user$ = computed(async (get) => {
   get(reload$);
   const clerk = await get(clerk$);
   return clerk.user ?? undefined;
+});
+
+/**
+ * Snapshot of the Clerk active organization, re-emitted on every clerk
+ * event (via clerkVersion$). Read this instead of `clerk.organization.*`
+ * directly when you want the UI to react to in-place mutations such as
+ * `clerk.organization.reload()` after a logo or name update.
+ */
+export const currentOrgInfo$ = computed(async (get) => {
+  get(clerkVersion$);
+  const clerk = await get(clerk$);
+  const org = clerk.organization;
+  if (!org) {
+    return null;
+  }
+  return {
+    id: org.id,
+    name: org.name,
+    slug: org.slug,
+    imageUrl: org.imageUrl,
+    hasImage: org.hasImage,
+  };
 });
 
 /**

--- a/turbo/apps/platform/src/views/org/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-general-tab.test.tsx
@@ -120,6 +120,23 @@ describe("org general tab - display", () => {
   // ORG-D-013
   it("logo upload preview is shown after selecting a file", async () => {
     const user = userEvent.setup();
+    // Happy-dom does not decode image bytes, so `new Image()` never fires
+    // `load` with real dimensions. Stub Image so readImageDimensions resolves
+    // with an in-range size (100–4096 px) that the upload handler accepts.
+    class FakeImage {
+      naturalWidth = 512;
+      naturalHeight = 512;
+      private listeners: Record<string, () => void> = {};
+      addEventListener(event: string, cb: () => void) {
+        this.listeners[event] = cb;
+      }
+      set src(_value: string) {
+        queueMicrotask(() => {
+          this.listeners.load?.();
+        });
+      }
+    }
+    vi.stubGlobal("Image", FakeImage);
     vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-preview");
     vi.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
     setMockOrg({ slug: "test-org", name: "Test Org" });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
@@ -21,12 +22,51 @@ import {
 } from "@vm0/core";
 import { mockApi } from "../../../mocks/msw-contract.ts";
 
+vi.mock("@vm0/ui/components/ui/sonner", async (importOriginal) => {
+  const actual =
+    (await importOriginal()) as typeof import("@vm0/ui/components/ui/sonner");
+  return {
+    ...actual,
+    toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+  };
+});
+
 const context = testContext();
 
 beforeEach(() => {
   resetMockOrg();
   resetMockOrgLogo();
+  vi.mocked(toast.error).mockClear();
+  vi.mocked(toast.success).mockClear();
 });
+
+/**
+ * Happy-dom does not decode actual image bytes, so `new Image()` never
+ * fires `load` with real `naturalWidth`/`naturalHeight`. Stub the global
+ * `Image` constructor for the lifetime of a single test so the handler's
+ * dimension check has a deterministic answer.
+ */
+function stubImageDimensions(width: number, height: number): void {
+  class FakeImage {
+    naturalWidth = width;
+    naturalHeight = height;
+    private listeners: Record<string, () => void> = {};
+    addEventListener(event: string, cb: () => void) {
+      this.listeners[event] = cb;
+    }
+    set src(_value: string) {
+      queueMicrotask(() => {
+        this.listeners.load?.();
+      });
+    }
+  }
+  vi.stubGlobal("Image", FakeImage);
+  // Override only the two URL methods we care about — happy-dom's default
+  // revokeObjectURL throws on unknown blob URLs, and the real createObjectURL
+  // requires a live blob. Full URL stubbing would break MSW's URL parser.
+  vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+}
 
 async function openGeneralTab() {
   detachedSetupPage({ context, path: "/?settings=general" });
@@ -203,6 +243,68 @@ describe("org general tab - profile section", () => {
     click(screen.getByText("Discard"));
 
     expect(screen.queryByText("Slug is already taken")).not.toBeInTheDocument();
+  });
+
+  it("should reject a logo that is too small with a toast", async () => {
+    stubImageDimensions(50, 50);
+    setMockOrg({ name: "My Org", slug: "my-org", role: "admin" });
+    await openGeneralTab();
+
+    const fileInput = (await screen.findByLabelText(
+      "Upload logo",
+    )) as HTMLInputElement;
+    const file = new File(["x"], "tiny.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+        "Logo is too small (50×50px). Minimum size is 100×100px.",
+      );
+    });
+
+    // File must not have been staged — no Save button should appear
+    expect(screen.queryByText("Save changes")).not.toBeInTheDocument();
+  });
+
+  it("should reject a logo that is too large with a toast", async () => {
+    stubImageDimensions(5000, 5000);
+    setMockOrg({ name: "My Org", slug: "my-org", role: "admin" });
+    await openGeneralTab();
+
+    const fileInput = (await screen.findByLabelText(
+      "Upload logo",
+    )) as HTMLInputElement;
+    const file = new File(["x"], "huge.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+        "Logo is too large (5000×5000px). Maximum size is 4096×4096px.",
+      );
+    });
+
+    expect(screen.queryByText("Save changes")).not.toBeInTheDocument();
+  });
+
+  it("should accept a logo within bounds and stage it for save", async () => {
+    stubImageDimensions(512, 512);
+    setMockOrg({ name: "My Org", slug: "my-org", role: "admin" });
+    await openGeneralTab();
+
+    const fileInput = (await screen.findByLabelText(
+      "Upload logo",
+    )) as HTMLInputElement;
+    const file = new File(["x"], "good.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+    // Save button appears because a valid file was staged
+    await waitFor(() => {
+      expect(screen.getByText("Save changes")).toBeInTheDocument();
+    });
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
   });
 
   it("should load and display logo for non-admin members", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
@@ -391,6 +391,59 @@ describe("zero org switcher - pending invitations badge hidden when none (SIDEBA
   });
 });
 
+describe("zero org switcher - sidebar re-renders on Clerk listener event", () => {
+  it("updates the sidebar avatar and name when Clerk mutates the active org in place", async () => {
+    // Reproduces the bug fixed by this PR: Clerk's SDK mutates
+    // `clerk.organization.imageUrl` in place after `reload()`, and
+    // components reading the Clerk object directly never re-rendered.
+    // The fix routes reads through `currentOrgInfo$`, which re-emits a
+    // fresh snapshot on every Clerk listener event.
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: {
+          id: "org_1",
+          name: "Original Name",
+          imageUrl: "https://example.com/original.png",
+          hasImage: true,
+        },
+        memberships: [{ id: "org_1" }],
+      },
+    });
+
+    // Initial render uses the original name + avatar
+    const initialImg = await waitFor(() => {
+      const img = screen.getByAltText("Original Name") as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+      return img;
+    });
+    expect(initialImg.src).toBe("https://example.com/original.png");
+
+    // Simulate Clerk's in-place mutation after `organization.reload()`
+    mockOrganization({
+      activeOrg: {
+        id: "org_1",
+        name: "Renamed Workspace",
+        imageUrl: "https://example.com/updated.png",
+        hasImage: true,
+      },
+      memberships: [{ id: "org_1" }],
+    });
+    fireClerkListeners();
+
+    // Sidebar must reflect both the new name and the new logo without a page reload
+    await waitFor(() => {
+      const updatedImg = screen.getByAltText(
+        "Renamed Workspace",
+      ) as HTMLImageElement;
+      expect(updatedImg).toBeInTheDocument();
+      expect(updatedImg.src).toBe("https://example.com/updated.png");
+    });
+    expect(screen.getByText("Renamed Workspace")).toBeInTheDocument();
+  });
+});
+
 describe("zero org switcher - create workspace visibility based on createOrganizationEnabled", () => {
   it("hides create workspace when createOrganizationEnabled is false", async () => {
     detachedSetupPage({

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -57,12 +57,33 @@ const sectionCardStyle = {
   border: "0.7px solid hsl(var(--gray-400))",
 } as const;
 
+const MIN_LOGO_DIMENSION = 100;
+const MAX_LOGO_DIMENSION = 4096;
+
 function extractErrorMessage(
   result: { status: number; body: unknown },
   fallback: string,
 ): string {
   const body = result.body as { error?: { message?: string } } | undefined;
   return body?.error?.message ?? fallback;
+}
+
+function readImageDimensions(
+  file: File,
+): Promise<{ width: number; height: number } | null> {
+  const url = URL.createObjectURL(file);
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.addEventListener("load", () => {
+      URL.revokeObjectURL(url);
+      resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    });
+    img.addEventListener("error", () => {
+      URL.revokeObjectURL(url);
+      resolve(null);
+    });
+    img.src = url;
+  });
 }
 
 async function uploadLogo(
@@ -132,7 +153,25 @@ function ProfileSection({
   const hasSlugChange = slug !== (org.slug ?? "");
   const hasChanges = hasNameChange || hasSlugChange || !!pendingLogoFile;
 
-  const handleFileSelect = (file: File) => {
+  const handleFileSelect = async (file: File) => {
+    const dimensions = await readImageDimensions(file);
+    if (!dimensions) {
+      toast.error("Could not read image file");
+      return;
+    }
+    const { width, height } = dimensions;
+    if (width < MIN_LOGO_DIMENSION || height < MIN_LOGO_DIMENSION) {
+      toast.error(
+        `Logo is too small (${width}×${height}px). Minimum size is ${MIN_LOGO_DIMENSION}×${MIN_LOGO_DIMENSION}px.`,
+      );
+      return;
+    }
+    if (width > MAX_LOGO_DIMENSION || height > MAX_LOGO_DIMENSION) {
+      toast.error(
+        `Logo is too large (${width}×${height}px). Maximum size is ${MAX_LOGO_DIMENSION}×${MAX_LOGO_DIMENSION}px.`,
+      );
+      return;
+    }
     setPendingLogoFile(file);
     setPendingLogoPreview(URL.createObjectURL(file));
   };
@@ -246,7 +285,7 @@ function ProfileSection({
                 onChange={(e) => {
                   const file = e.target.files?.[0];
                   if (file) {
-                    handleFileSelect(file);
+                    detach(handleFileSelect(file), Reason.DomCallback);
                   }
                   e.target.value = "";
                 }}

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -17,7 +17,7 @@ import {
   IconPlus,
   IconMail,
 } from "@tabler/icons-react";
-import { clerk$ } from "../../signals/auth.ts";
+import { clerk$, currentOrgInfo$ } from "../../signals/auth.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -211,9 +211,9 @@ function OrgDropdownContent() {
   const clerkLoadable = useLastLoadable(clerk$);
   const orgData = useLastResolved(org$);
   const pendingInvitations = useLastResolved(userInvitations$);
+  const currentOrg = useLastResolved(currentOrgInfo$);
 
   const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
-  const currentOrg = clerk?.organization;
   const orgName = currentOrg?.name ?? "Organization";
   const orgSlug = orgData?.slug;
 
@@ -285,10 +285,7 @@ function PendingInvitationsBadge() {
 }
 
 export function ZeroOrgSwitcher() {
-  const clerkLoadable = useLastLoadable(clerk$);
-
-  const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
-  const currentOrg = clerk?.organization;
+  const currentOrg = useLastResolved(currentOrgInfo$);
   const orgName = currentOrg?.name ?? "Organization";
 
   return (


### PR DESCRIPTION
## Summary

- **Client-side logo dimension validation** — reject images outside 100×100 – 4096×4096 with a toast before they hit the upload endpoint, so users get instant feedback instead of Clerk rejecting the request after the round-trip.
- **Sidebar org avatar now updates immediately after save** — previously the avatar in `ZeroOrgSwitcher` / `OrgDropdownContent` kept showing the old logo until a full page refresh.

## Root cause (sidebar sync)

The sidebar read `clerk.organization.imageUrl` directly. Clerk's SDK mutates that field in place when `organization.reload()` runs, but ccstate has no visibility into those mutations, so subscribers never re-rendered.

## Fix

- `auth.ts` — new module-internal `clerkVersion$` state bumped from inside the global Clerk listener (`setupClerk$`) on every Clerk event; new `currentOrgInfo$` computed that snapshots `{ id, name, slug, imageUrl, hasImage }` so subscribers get a fresh object reference on each bump. `organization.reload()` fires the listener, which in turn bumps `clerkVersion$`, which recomputes `currentOrgInfo$`.
- `zero-org-switcher.tsx` — `ZeroOrgSwitcher` and `OrgDropdownContent` now read the org via `useLastResolved(currentOrgInfo$)`. `OtherMembershipsList` is unchanged since it reads from the membership list, not the live org.
- `org-general-tab.tsx`
  - `handleFileSelect` now reads `naturalWidth` / `naturalHeight` via a blob URL and toasts on out-of-range dimensions before staging the file.
  - `handleSave` awaits `clerk.organization.reload()` after the update succeeds; the global Clerk listener handles the version bump, so no additional call is needed.

## Test plan

- [ ] Upload a 50×50 PNG — toast reports "too small (50×50px). Minimum size is 100×100px." and no file is staged.
- [ ] Upload a 5000×5000 PNG — toast reports "too large (5000×5000px). Maximum size is 4096×4096px."
- [ ] Upload a 512×512 PNG → save → sidebar org avatar updates to the new logo without a page refresh.
- [ ] Rename or re-slug the workspace → save → sidebar reflects the new name without a page refresh.
- [ ] Existing `zero-org-switcher` tests still green (13 tests, verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
