### PR TITLE
perf(chat): skip user cache lookup when session claims carry identity

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { HttpResponse } from "msw";
+import { clerkClient } from "@clerk/nextjs/server";
 import { POST } from "../route";
 import {
   createTestRequest,
@@ -9,6 +10,7 @@ import {
   findTestRunRecord,
   getTestRun,
   getTestChatMessagesByThread,
+  countUserRows,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   getTestChatThreadModelOverride,
@@ -990,6 +992,100 @@ describe("POST /api/zero/chat/messages", () => {
           }),
         );
         expect(response.status).toBe(400);
+      });
+    });
+
+    describe("user info source", () => {
+      it("short-circuits getCachedUser when sessionClaims carry email + name", async () => {
+        const email = `${user.userId}@claims.example.com`;
+        mockClerk({
+          userId: user.userId,
+          email,
+          firstName: "Ada",
+          lastName: "Lovelace",
+          sessionClaims: {
+            email,
+            first_name: "Ada",
+            last_name: "Lovelace",
+          },
+        });
+        const client = await clerkClient();
+        vi.mocked(client.users.getUser).mockClear();
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ agentId, prompt: "claims fast path" }),
+          }),
+        );
+
+        expect(response.status).toBe(201);
+        const data = await response.json();
+
+        expect(client.users.getUser).not.toHaveBeenCalled();
+        expect(await countUserRows("user_cache", user.userId)).toBe(0);
+
+        const run = await getTestRun(data.runId);
+        expect(run.appendSystemPrompt).toContain("Name: Ada Lovelace");
+        expect(run.appendSystemPrompt).toContain(`Email: ${email}`);
+      });
+
+      it("falls back to getCachedUser when sessionClaims are empty", async () => {
+        const email = `${user.userId}@fallback.example.com`;
+        mockClerk({
+          userId: user.userId,
+          email,
+          firstName: "Ada",
+          lastName: null,
+        });
+        const client = await clerkClient();
+        vi.mocked(client.users.getUser).mockClear();
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ agentId, prompt: "cache fallback" }),
+          }),
+        );
+
+        expect(response.status).toBe(201);
+        const data = await response.json();
+
+        expect(client.users.getUser).toHaveBeenCalledWith(user.userId);
+
+        const run = await getTestRun(data.runId);
+        expect(run.appendSystemPrompt).toContain("Name: Ada");
+        expect(run.appendSystemPrompt).toContain(`Email: ${email}`);
+      });
+
+      it("falls back to getCachedUser when sessionClaims.email is empty", async () => {
+        const email = `${user.userId}@empty-claim.example.com`;
+        mockClerk({
+          userId: user.userId,
+          email,
+          firstName: "Ada",
+          lastName: "Lovelace",
+          sessionClaims: {
+            email: "",
+            first_name: "Ada",
+            last_name: "Lovelace",
+          },
+        });
+        const client = await clerkClient();
+        vi.mocked(client.users.getUser).mockClear();
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ agentId, prompt: "defensive fallback" }),
+          }),
+        );
+
+        expect(response.status).toBe(201);
+        expect(client.users.getUser).toHaveBeenCalledWith(user.userId);
       });
     });
   });

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -7,6 +7,7 @@ import {
   requireAuth,
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
+import { userProfileFromClaims } from "../../../../../src/lib/auth/user-profile-from-claims";
 import {
   createZeroRun,
   fetchZeroAgentForRun,
@@ -524,6 +525,7 @@ const router = tsr.router(chatMessagesContract, {
         preloadedAgent: agent,
         preloadedOrgTier,
         spanDims: dims,
+        userProfile: userProfileFromClaims(authCtx),
       });
 
       // Persist user message to chat_messages.

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -65,6 +65,7 @@ export function mockClerk(options: {
   orgSlug?: string | null;
   orgRole?: string | null;
   clerkOrgs?: Array<{ id: string; slug: string; name: string; role?: string }>;
+  sessionClaims?: Record<string, unknown>;
 }) {
   const email = options.email ?? "test@example.com";
 
@@ -113,7 +114,7 @@ export function mockClerk(options: {
     orgId: effectiveOrgId,
     orgSlug: options.orgSlug,
     orgRole: options.orgRole ?? (effectiveOrgId ? "org:admin" : undefined),
-    sessionClaims: {},
+    sessionClaims: options.sessionClaims ?? {},
   } as Awaited<ReturnType<typeof auth>>);
 
   // Also set up clerkClient mock to return user data with email
@@ -122,6 +123,8 @@ export function mockClerk(options: {
       getUser: vi.fn().mockResolvedValue({
         emailAddresses: [{ id: "email_1", emailAddress: email }],
         primaryEmailAddressId: "email_1",
+        firstName: options.firstName ?? null,
+        lastName: options.lastName ?? null,
       }),
       getUserList: vi
         .fn()

--- a/turbo/apps/web/src/lib/auth/__tests__/user-profile-from-claims.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/user-profile-from-claims.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import type { AuthContext } from "../get-auth-context";
+import { userProfileFromClaims } from "../user-profile-from-claims";
+
+function makeCtx(overrides: Partial<AuthContext>): AuthContext {
+  return {
+    userId: "user_123",
+    tokenType: "session",
+    sessionClaims: {},
+    ...overrides,
+  };
+}
+
+describe("userProfileFromClaims", () => {
+  it("returns { email, name } when all three claims are strings and email non-empty", () => {
+    const result = userProfileFromClaims(
+      makeCtx({
+        sessionClaims: {
+          email: "ada@example.com",
+          first_name: "Ada",
+          last_name: "Lovelace",
+        },
+      }),
+    );
+    expect(result).toEqual({ email: "ada@example.com", name: "Ada Lovelace" });
+  });
+
+  it("returns undefined when tokenType is not 'session'", () => {
+    const claims = {
+      email: "ada@example.com",
+      first_name: "Ada",
+      last_name: "Lovelace",
+    };
+    for (const tokenType of ["pat", "sandbox", "zero", undefined] as const) {
+      expect(
+        userProfileFromClaims(makeCtx({ tokenType, sessionClaims: claims })),
+      ).toBeUndefined();
+    }
+  });
+
+  it("returns undefined when sessionClaims is undefined", () => {
+    expect(
+      userProfileFromClaims(makeCtx({ sessionClaims: undefined })),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when email is empty, absent, or wrong type", () => {
+    expect(
+      userProfileFromClaims(makeCtx({ sessionClaims: { email: "" } })),
+    ).toBeUndefined();
+    expect(
+      userProfileFromClaims(makeCtx({ sessionClaims: {} })),
+    ).toBeUndefined();
+    expect(
+      userProfileFromClaims(
+        makeCtx({ sessionClaims: { email: 42 as unknown as string } }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns { email, name: null } when both first_name and last_name are absent", () => {
+    expect(
+      userProfileFromClaims(
+        makeCtx({ sessionClaims: { email: "ada@example.com" } }),
+      ),
+    ).toEqual({ email: "ada@example.com", name: null });
+  });
+
+  it("returns { email, name: 'Ada' } when only first_name is set", () => {
+    expect(
+      userProfileFromClaims(
+        makeCtx({
+          sessionClaims: { email: "ada@example.com", first_name: "Ada" },
+        }),
+      ),
+    ).toEqual({ email: "ada@example.com", name: "Ada" });
+  });
+
+  it("returns { email, name: 'Lovelace' } when only last_name is set", () => {
+    expect(
+      userProfileFromClaims(
+        makeCtx({
+          sessionClaims: { email: "ada@example.com", last_name: "Lovelace" },
+        }),
+      ),
+    ).toEqual({ email: "ada@example.com", name: "Lovelace" });
+  });
+
+  it("ignores non-string first_name / last_name (defensive type-narrowing)", () => {
+    expect(
+      userProfileFromClaims(
+        makeCtx({
+          sessionClaims: {
+            email: "ada@example.com",
+            first_name: 123 as unknown as string,
+            last_name: null as unknown as string,
+          },
+        }),
+      ),
+    ).toEqual({ email: "ada@example.com", name: null });
+  });
+});

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -17,13 +17,26 @@ const log = logger("auth:user");
 export type AuthTokenType = "session" | "pat" | "sandbox" | "zero";
 
 /**
+ * Clerk session JWT claims. Fields declared here are the ones we project into
+ * user info via `userProfileFromClaims`. The index signature preserves Clerk's
+ * built-in claims (`sub`, `org_id`, `org_role`, etc.) and any unknown custom
+ * claims without forcing us to enumerate them.
+ */
+export interface SessionClaims {
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  [key: string]: unknown;
+}
+
+/**
  * Authentication context returned by getAuthContext.
  */
 export type AuthContext = {
   userId: string;
   orgId?: string;
   orgRole?: OrgRole;
-  sessionClaims?: Record<string, unknown>;
+  sessionClaims?: SessionClaims;
   capabilities?: readonly ZeroCapability[];
   runId?: string;
   tokenType?: AuthTokenType;
@@ -282,9 +295,7 @@ async function getClerkSessionAuth(): Promise<AuthContext | null> {
         ? "admin"
         : "member"
       : undefined,
-    sessionClaims: authResult.sessionClaims as
-      | Record<string, unknown>
-      | undefined,
+    sessionClaims: authResult.sessionClaims as SessionClaims | undefined,
     tokenType: "session",
   };
 }

--- a/turbo/apps/web/src/lib/auth/user-profile-from-claims.ts
+++ b/turbo/apps/web/src/lib/auth/user-profile-from-claims.ts
@@ -1,0 +1,32 @@
+import type { AuthContext } from "./get-auth-context";
+
+interface UserProfile {
+  email: string;
+  name: string | null;
+}
+
+/**
+ * Project a Clerk session's claims into { email, name } for system-prompt
+ * seeding. Returns undefined when the caller is not a session token, when
+ * claims are absent, or when the email claim is missing/empty — callers must
+ * fall back to `getCachedUser(userId)` in those cases.
+ *
+ * `name` matches user-cache-service's derivation byte-for-byte:
+ *   [first, last].filter(Boolean).join(" ") || null
+ * so prompt output is stable regardless of which source produced the profile.
+ */
+export function userProfileFromClaims(
+  authCtx: AuthContext,
+): UserProfile | undefined {
+  if (authCtx.tokenType !== "session") return undefined;
+  const claims = authCtx.sessionClaims;
+  if (!claims) return undefined;
+  if (typeof claims.email !== "string" || claims.email.length === 0) {
+    return undefined;
+  }
+  const first =
+    typeof claims.first_name === "string" ? claims.first_name : null;
+  const last = typeof claims.last_name === "string" ? claims.last_name : null;
+  const name = [first, last].filter(Boolean).join(" ") || null;
+  return { email: claims.email, name };
+}

--- a/turbo/apps/web/src/lib/infra/metrics/instruments.ts
+++ b/turbo/apps/web/src/lib/infra/metrics/instruments.ts
@@ -42,6 +42,13 @@ export interface ChatSpanDimensions {
   model_selection_present?: boolean;
   thread_length?: number;
   thread_is_new?: boolean;
+  /**
+   * "claims" when Round 1 used Clerk session claims to build user info,
+   * "cache" when it fell back to `getCachedUser`. Lets Axiom split the
+   * `create_run_round1_cached_user` span by source to measure short-circuit
+   * hit rate after rollout.
+   */
+  user_info_source?: "claims" | "cache";
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -187,6 +187,15 @@ export interface CreateZeroRunParams {
    * slack, telegram, email, github, phone) omit it for zero behavior change.
    */
   spanDims?: ChatSpanDimensions;
+  /**
+   * Pre-projected { email, name } derived from Clerk session claims by the
+   * caller. When present, Round 1 skips `getCachedUser` for this request and
+   * feeds `buildUserInfo` directly. When absent (PAT/sandbox/zero/empty-claims
+   * session), Round 1 falls back to `getCachedUser` as before. Only the chat
+   * route passes this today; non-chat triggers (schedule, slack, telegram,
+   * email, github, voice-chat) have no session claims to project.
+   */
+  userProfile?: { email: string; name: string | null };
 }
 
 /**
@@ -289,7 +298,7 @@ async function createZeroRunRecord(
     });
   });
   const round1CachedUser = timed(async () => {
-    return getCachedUser(params.userId);
+    return params.userProfile ?? getCachedUser(params.userId);
   });
 
   const [agentTimed, composeTimed, cachedUserTimed] = await Promise.all([
@@ -300,6 +309,11 @@ async function createZeroRunRecord(
   const row = agentTimed.result;
   const resolved = composeTimed.result;
   const cachedUser = cachedUserTimed.result;
+
+  // user_info_source is determined purely by the caller's input — stamp it
+  // before emitting Round 1 spans so the `cached_user` span itself carries
+  // the dim and can be split by source in Axiom.
+  stamp({ user_info_source: params.userProfile ? "claims" : "cache" });
 
   emit(CHAT_REQUEST_OPS.create_run_round1_agent, agentTimed.ms);
   emit(CHAT_REQUEST_OPS.create_run_round1_compose, composeTimed.ms);


### PR DESCRIPTION
## Summary

- Session tokens already carry `email`, `first_name`, and `last_name` as custom claims. Projects those claims into the chat-send Round 1 user info so the `user_cache` SELECT + Clerk API round-trip is skipped for the common case.
- Falls back to `getCachedUser(userId)` for PAT / sandbox / zero tokens, and for sessions without the claims (defensive — empty / wrong-type email).
- Stamps `user_info_source=claims|cache` on the `cached_user` Phase-1 span so the optimization can be monitored in Axiom.

Expected impact (from #10746): Round-1 `cached_user` span P95 ~430ms → ~0–5ms, total chat-send P95 ~280ms lower for session-token users. No behavioral change for other token types.

Closes #10746

## Test plan

- [x] Unit: `userProfileFromClaims` covers all-claims-present, non-session tokenType, undefined/empty/wrong-type claims, name fallback, first/last-only
- [x] Integration: chat-send short-circuits `getCachedUser` when session claims are present (asserts `client.users.getUser` NOT called, `user_cache` row count is 0, prompt carries `Name: Ada Lovelace` and `Email: …`)
- [x] Integration: chat-send falls back to `getCachedUser` when session claims are empty or `email` is empty
- [x] `pnpm -F web check-types` passes
- [x] `pnpm -F web lint` passes
- [x] `pnpm format` clean
- [x] `pnpm knip` no unused exports added

🤖 Generated with [Claude Code](https://claude.com/claude-code)