### PR TITLE
chore(rust): update dependencies (2026-04-23)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.130.0"
+version = "1.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221e06508938be90c370333cb61978b7bd9526473b7fb9b9ac2e33507fc09d85"
+checksum = "fe1b8c5282bf859170836045296b3cd710b7573aceb909498366bb508a41058e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -2581,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "log",


### PR DESCRIPTION
## Summary

Weekly Rust dependency refresh for the `crates/` workspace via `cargo update`.

### Updated dependencies (2)

| Package | From | To |
|---------|------|----|
| `aws-sdk-s3` | 1.130.0 | 1.131.0 |
| `rustls` | 0.23.38 | 0.23.39 |

### Dependencies that could NOT be updated (3)

These are **transitive** deps pinned by their parent crates — the required bump must come from upstream, not our `Cargo.toml`.

| Package | Current | Latest | Reason |
|---------|---------|--------|--------|
| `crc` | 3.3.0 | 3.4.0 | Pinned by `crc-fast` 1.9.0 (→ `aws-smithy-checksums`) |
| `crc-fast` | 1.9.0 | 1.10.0 | Pinned by `aws-smithy-checksums` 0.64.7 |
| `generic-array` | 0.14.7 | 0.14.9 | Pinned by `digest` 0.10.7 / `block-buffer` / `crypto-common` |

### Manual version bumps in `Cargo.toml`

None. No direct workspace dependencies required a manual version-specifier bump — all direct deps resolved to their latest compatible versions via semver constraints already declared in `crates/Cargo.toml`.

### Test status

`cargo test --workspace` — **all passing**.

No test fixes required; the two updates are patch/minor bumps with no API changes affecting this workspace.

## Test plan

- [x] `cargo test --workspace` passes locally
- [ ] CI green
