### PR TITLE
perf(chat): move thread-history fetch off the chat-send critical path

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -31,6 +31,7 @@ import {
   getLatestSessionIdForThread,
   getLatestMessagesByThreadId,
   getIncompleteRoundsSinceLastSuccess,
+  hasAnyRunsForThread,
   publishThreadListChanged,
   PREVIOUS_CONTEXT_MESSAGES,
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
@@ -98,9 +99,9 @@ function buildFullPrompt(
 interface ResolvedThread {
   threadId: string;
   sessionId: string | undefined;
-  previousContext: { role: "user" | "assistant"; content: string }[];
   continueFromSchedulePrompt: string | undefined;
   incompleteContext: string;
+  isNewThread: boolean;
 }
 
 /**
@@ -190,7 +191,7 @@ async function rejectIfThreadModelLocked(
  * Returns thread metadata needed for run creation and title generation.
  *
  * When `dims` is provided, each sub-stage (create-thread, get-thread,
- * session-id lookup, messages, incomplete-rounds, continue-from resolution)
+ * session-id lookup, has-any-run, incomplete-rounds, continue-from resolution)
  * emits a span to the `sandbox-op-log` Axiom dataset with
  * `source: "web-chat"`. Each parallel arm is wrapped in `timed()` so the
  * per-query duration is still captured alongside the parallel execution.
@@ -214,23 +215,24 @@ async function resolveThread(
     if (dims) {
       dims.thread_id = thread.id;
       dims.thread_is_new = true;
-      dims.thread_length = 0;
     }
     return {
       threadId: thread.id,
       sessionId: undefined,
-      previousContext: [],
       continueFromSchedulePrompt: undefined,
       incompleteContext: "",
+      isNewThread: true,
     };
   }
 
-  // All four reads key off `(existingThreadId, userId)` and have no data
-  // dependency on each other. Running them in parallel drops the happy-path
-  // wall time to the slowest of the four, not their sum. Each arm is wrapped
-  // in `timed()` so we still emit per-query spans alongside the parallel
-  // execution.
-  const [threadT, sessionIdT, messagesT, incompleteT] = await Promise.all([
+  // Four independent reads keyed off `(existingThreadId, userId)`. Running
+  // them in parallel caps wall time at the slowest arm. The prior 4th arm
+  // (`getLatestMessagesByThreadId`) was a ~275ms P50 read used only by the
+  // fire-and-forget title generator — now lifted off this critical path. It
+  // is replaced by the cheap `hasAnyRunsForThread` EXISTS probe so the
+  // continue-from-schedule gate keeps its first-run semantics without a
+  // 10-row scan on every send.
+  const [threadT, sessionIdT, hasAnyRunT, incompleteT] = await Promise.all([
     timed(async () => {
       return getChatThread(existingThreadId, userId);
     }),
@@ -238,10 +240,7 @@ async function resolveThread(
       return getLatestSessionIdForThread(existingThreadId);
     }),
     timed(async () => {
-      return getLatestMessagesByThreadId(
-        existingThreadId,
-        PREVIOUS_CONTEXT_MESSAGES,
-      );
+      return hasAnyRunsForThread(existingThreadId);
     }),
     timed(async () => {
       return getIncompleteRoundsSinceLastSuccess(existingThreadId);
@@ -249,25 +248,16 @@ async function resolveThread(
   ]);
   emit(CHAT_REQUEST_OPS.resolve_thread_get_thread, threadT.ms);
   emit(CHAT_REQUEST_OPS.resolve_thread_session_id, sessionIdT.ms);
-  emit(CHAT_REQUEST_OPS.resolve_thread_get_messages, messagesT.ms);
+  emit(CHAT_REQUEST_OPS.resolve_thread_has_any_run, hasAnyRunT.ms);
   emit(CHAT_REQUEST_OPS.resolve_thread_incomplete, incompleteT.ms);
 
   const thread = threadT.result;
   const sessionId = sessionIdT.result;
-  const messages = messagesT.result;
 
   if (dims) {
     dims.thread_id = thread.id;
     dims.thread_is_new = false;
-    dims.thread_length = messages.length;
   }
-
-  // `messages` already satisfies `content IS NOT NULL` and role IN
-  // ('user','assistant') in SQL; the service narrows the row shape so no
-  // per-caller casts are needed.
-  const previousContext = messages.map((m) => {
-    return { role: m.role, content: m.content };
-  });
 
   const incompleteContext = buildWebChatIncompleteContext(
     groupIncompleteRoundsByRunId(incompleteT.result),
@@ -275,7 +265,7 @@ async function resolveThread(
 
   let continueFromSchedulePrompt: string | undefined;
   const sourceScheduleRunId = thread.sourceScheduleRunId;
-  if (sourceScheduleRunId && messages.length === 0) {
+  if (sourceScheduleRunId && !hasAnyRunT.result) {
     const continueFromT = await timed(async () => {
       return globalThis.services.db
         .select({ name: zeroAgentSchedules.name })
@@ -298,9 +288,9 @@ async function resolveThread(
   return {
     threadId: thread.id,
     sessionId,
-    previousContext,
     continueFromSchedulePrompt,
     incompleteContext,
+    isNewThread: false,
   };
 }
 
@@ -442,9 +432,9 @@ const router = tsr.router(chatMessagesContract, {
       const {
         threadId,
         sessionId,
-        previousContext,
         continueFromSchedulePrompt,
         incompleteContext,
+        isNewThread,
       } = await resolveThread(
         authCtx.userId,
         body.agentId,
@@ -469,19 +459,43 @@ const router = tsr.router(chatMessagesContract, {
       // assistant reply is not yet available at send time — the chat
       // callback regenerates the title with the full current exchange
       // once the run completes.
+      //
+      // Title context fetch lives in this fire-and-forget IIFE so the
+      // ~275ms `chat_messages` read is not on the POST response path. For
+      // brand-new threads the fetch is skipped (no prior rounds exist), so
+      // we only pay the round trip on follow-up sends.
       if (body.hasTextContent !== false) {
-        void generateChatTitle({
-          currentUserMessage: body.prompt,
-          priorRounds: previousContext.length > 0 ? previousContext : undefined,
-        })
-          .then((title) => {
-            if (title) {
-              return updateChatThreadTitle(threadId, authCtx.userId, title);
-            }
-          })
-          .catch((err: unknown) => {
-            log.warn("Chat title generation failed", { threadId, err });
+        void (async () => {
+          let priorRounds:
+            | { role: "user" | "assistant"; content: string }[]
+            | undefined;
+          if (!isNewThread) {
+            const fetchT = await timed(async () => {
+              return getLatestMessagesByThreadId(
+                threadId,
+                PREVIOUS_CONTEXT_MESSAGES,
+              );
+            });
+            recordChatSpan(
+              CHAT_REQUEST_OPS.title_context_fetch,
+              fetchT.ms,
+              dims,
+            );
+            const mapped = fetchT.result.map((m) => {
+              return { role: m.role, content: m.content };
+            });
+            priorRounds = mapped.length > 0 ? mapped : undefined;
+          }
+          const title = await generateChatTitle({
+            currentUserMessage: body.prompt,
+            priorRounds,
           });
+          if (title) {
+            await updateChatThreadTitle(threadId, authCtx.userId, title);
+          }
+        })().catch((err: unknown) => {
+          log.warn("Chat title generation failed", { threadId, err });
+        });
       }
 
       // Build callback for session persistence

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
@@ -407,6 +407,27 @@ export async function getLatestSessionIdForThread(
 }
 
 /**
+ * Cheap existence probe used by `resolveThread()` to decide whether the
+ * continue-from-schedule system prompt should still be seeded on this send.
+ * Replaces the prior `messages.length === 0` signal now that the
+ * `getLatestMessagesByThreadId` read has moved off the POST critical path.
+ *
+ * Backed by `idx_zero_runs_chat_thread_id` (issue #10757): `LIMIT 1` turns
+ * this into an EXISTS probe, so the query returns in single-digit
+ * milliseconds even on long threads.
+ */
+export async function hasAnyRunsForThread(
+  chatThreadId: string,
+): Promise<boolean> {
+  const [row] = await globalThis.services.db
+    .select({ id: zeroRuns.id })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.chatThreadId, chatThreadId))
+    .limit(1);
+  return row !== undefined;
+}
+
+/**
  * Provider type of the most recent run in a thread, or null when the thread
  * has no runs yet. The composer uses this to disable picker options whose
  * base URL differs from the current session — `areProvidersCompatible`

--- a/turbo/apps/web/src/lib/zero/chat-thread/request-span-ops.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/request-span-ops.ts
@@ -13,6 +13,7 @@ export const CHAT_REQUEST_OPS = {
   resolve_thread_get_thread: "api_chat_send_resolve_thread_get_thread",
   resolve_thread_session_id: "api_chat_send_resolve_thread_session_id",
   resolve_thread_get_messages: "api_chat_send_resolve_thread_get_messages",
+  resolve_thread_has_any_run: "api_chat_send_resolve_thread_has_any_run",
   resolve_thread_incomplete: "api_chat_send_resolve_thread_incomplete",
   resolve_thread_continue_from: "api_chat_send_resolve_thread_continue_from",
   resolve_model_override: "api_chat_send_resolve_model_override",
@@ -40,6 +41,7 @@ export const CHAT_REQUEST_OPS = {
     "api_chat_send_insert_chat_message_publish_signal",
   insert_chat_message_publish_list:
     "api_chat_send_insert_chat_message_publish_list",
+  title_context_fetch: "api_chat_send_title_context_fetch",
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Lifts the `getLatestMessagesByThreadId(threadId, 10)` read out of `resolveThread()` on `POST /api/zero/chat/messages`. The title-generation context fetch is the only caller of that query on the request path, so it has been moved into the existing fire-and-forget title-generation IIFE — saving ~275ms P50 / ~362ms P95 with zero user-visible behavior change.

Closes #10756.

## What changed

- **Route (`app/api/zero/chat/messages/route.ts`)**
  - `resolveThread()` no longer reads prior messages; it now returns `isNewThread: boolean` instead of `previousContext`.
  - The `Promise.all` in `resolveThread()` swaps the old `getLatestMessagesByThreadId` arm for a cheap `hasAnyRunsForThread` probe.
  - The source-schedule prompt-injection gate — previously `messages.length === 0` — is replaced with `!hasAnyRunsForThread`, preserving exact semantics.
  - Title-generation is rewritten as `void (async () => { ... })().catch(...)`. Context fetch (`getLatestMessagesByThreadId`) only runs inside the IIFE, and is skipped entirely when `isNewThread === true`.
- **Service (`src/lib/zero/chat-thread/chat-message-service.ts`)** — adds `hasAnyRunsForThread(chatThreadId)` helper (`SELECT id FROM zero_runs WHERE chat_thread_id = $1 LIMIT 1`).
- **Spans (`src/lib/zero/chat-thread/request-span-ops.ts`)**
  - New `api_chat_send_resolve_thread_has_any_run` — covers the new probe.
  - New `api_chat_send_title_context_fetch` — covers the moved-off-path fetch so we retain visibility.
  - Existing `api_chat_send_resolve_thread_get_messages` constant is retained for Axiom dashboard backward-compat (the code stops emitting it naturally).

## ⚠️ Merge / deploy ordering

**This PR depends on #10757 being merged and deployed first.** The new `hasAnyRunsForThread` probe does `SELECT id FROM zero_runs WHERE chat_thread_id = $1 LIMIT 1`, which requires the `zero_runs.chat_thread_id` partial index shipped by #10757. Without that index the LIMIT 1 EXISTS probe seq-scans `zero_runs` when there are zero matching rows (the source-schedule first-chat-send path), which would be worse than the status quo for that specific case. Please do not merge this PR before #10757 has been merged AND deployed.

## Test plan

- [x] `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/route.test.ts` — 26/26 pass, including the per-request read-dedup contract tests for `zero_agents` / `org_metadata`.
- [x] `pnpm turbo run lint --filter=web` — clean.
- [x] `pnpm check-types` — clean.
- [x] `pnpm knip` — clean (configuration hints only, no unused code).
- [ ] Follow-up verification post-deploy: Axiom dashboards
  - `api_chat_send_resolve_thread_get_messages` timer-slot goes to zero.
  - `api_chat_send_title_context_fetch` appears with off-path latency distribution similar to the old slot.
  - `api_chat_send_resolve_thread_has_any_run` appears with sub-1ms P95 (index-only lookup).
- [ ] Follow-up verification post-deploy: `/api/zero/chat/messages` server-timing P50/P95 drop by ~250ms on follow-up sends.

Note: two existing `route.incomplete-context.test.ts` tests fail locally with `Failed to create checkpoint: An internal error occurred` — these also fail on `main` (verified via `git stash`) and are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)