### PR TITLE
chore: remove root package-lock.json and add to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ web_modules/
 # Output of 'npm pack'
 *.tgz
 
+# npm lockfile (project uses pnpm)
+package-lock.json
+
 # Yarn Integrity file
 .yarn-integrity
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "vm0-repo",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary
- Remove the stray `package-lock.json` from the repo root (project uses pnpm)
- Add `package-lock.json` to `.gitignore` to prevent accidental re-commits

## Test plan
- [x] Confirmed `package-lock.json` is removed from the tree
- [x] Confirmed `.gitignore` now matches `package-lock.json`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)