### PR TITLE
feat(auth): carry org id in sandbox jwt

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
@@ -212,7 +212,11 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
 
     it("should accept sandbox token with any capability", async () => {
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-1");
+      const token = await generateSandboxToken(
+        user.userId,
+        "run-1",
+        "org-test",
+      );
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${randomUUID()}`,

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -339,7 +339,11 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
     it("should accept sandbox token with agent-run:write", async () => {
       const run = await createTestRun(testComposeId, "Run to cancel");
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, run.runId);
+      const token = await generateSandboxToken(
+        user.userId,
+        run.runId,
+        "org-test",
+      );
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${run.runId}/cancel`,
@@ -355,7 +359,11 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
 
     it("should accept sandbox token with any capability", async () => {
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-1");
+      const token = await generateSandboxToken(
+        user.userId,
+        "run-1",
+        "org-test",
+      );
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${randomUUID()}/cancel`,

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1121,7 +1121,11 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       // Bind a claude-code conversation (matches compose default framework)
       // and mark the run complete so continuation validation passes and the
       // concurrency limit does not block the follow-up run.
-      const sandboxToken = await generateSandboxToken(user.userId, first.runId);
+      const sandboxToken = await generateSandboxToken(
+        user.userId,
+        first.runId,
+        "org-test",
+      );
       const checkpointResponse = await checkpointWebhook(
         createTestRequest(
           "http://localhost:3000/api/webhooks/agent/checkpoints",
@@ -1543,7 +1547,11 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
     it("should accept sandbox token with agent-run:write for create", async () => {
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-1");
+      const token = await generateSandboxToken(
+        user.userId,
+        "run-1",
+        "org-test",
+      );
 
       const request = createTestRequest(
         "http://localhost:3000/api/agent/runs",
@@ -1567,7 +1575,11 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
     it("should accept sandbox token with any capability for create", async () => {
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-1");
+      const token = await generateSandboxToken(
+        user.userId,
+        "run-1",
+        "org-test",
+      );
 
       const request = createTestRequest(
         "http://localhost:3000/api/agent/runs",

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -418,7 +418,11 @@ const router = tsr.router(runsMainContract, {
       const transactionTime = Date.now();
 
       // 8. Generate sandbox token
-      const sandboxToken = await generateSandboxToken(userId, run.id);
+      const sandboxToken = await generateSandboxToken(
+        userId,
+        run.id,
+        org.orgId,
+      );
       const tokenTime = Date.now();
 
       try {

--- a/turbo/apps/web/app/api/auth/me/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/auth/me/__tests__/route.test.ts
@@ -44,7 +44,11 @@ describe("GET /api/auth/me", () => {
   describe("sandbox token support", () => {
     it("sandbox token with any capability returns user info", async () => {
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-123");
+      const token = await generateSandboxToken(
+        user.userId,
+        "run-123",
+        "org-test",
+      );
 
       const response = await GET(
         createTestRequest("http://localhost:3000/api/auth/me", {
@@ -59,7 +63,11 @@ describe("GET /api/auth/me", () => {
 
     it("sandbox token with storage:write returns user info", async () => {
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-456");
+      const token = await generateSandboxToken(
+        user.userId,
+        "run-456",
+        "org-test",
+      );
 
       const response = await GET(
         createTestRequest("http://localhost:3000/api/auth/me", {
@@ -74,7 +82,11 @@ describe("GET /api/auth/me", () => {
 
     it("sandbox token with no capabilities is accepted (acceptAnySandboxCapability)", async () => {
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-789");
+      const token = await generateSandboxToken(
+        user.userId,
+        "run-789",
+        "org-test",
+      );
 
       const response = await GET(
         createTestRequest("http://localhost:3000/api/auth/me", {

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -138,7 +138,11 @@ const router = tsr.router(runnersJobClaimContract, {
     }
 
     // Generate sandbox token for the run
-    const sandboxToken = await generateSandboxToken(run.userId, run.id);
+    const sandboxToken = await generateSandboxToken(
+      run.userId,
+      run.id,
+      run.orgId,
+    );
 
     // Record api_to_claim metric
     if (storedContext.apiStartTime) {

--- a/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
@@ -43,7 +43,7 @@ describe("Storage capability enforcement", () => {
   describe("sandbox token access for list", () => {
     it("should accept sandbox token with agent:read for volume list", async () => {
       await createTestVolume("test-vol");
-      const token = await generateSandboxToken(userId, runId);
+      const token = await generateSandboxToken(userId, runId, "org-test");
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -61,7 +61,7 @@ describe("Storage capability enforcement", () => {
 
     it("should accept sandbox token with agent:read for artifact list", async () => {
       await createTestArtifact("test-art");
-      const token = await generateSandboxToken(userId, runId);
+      const token = await generateSandboxToken(userId, runId, "org-test");
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -79,7 +79,7 @@ describe("Storage capability enforcement", () => {
 
     it("should accept sandbox token regardless of specific capability", async () => {
       await createTestVolume("test-vol");
-      const token = await generateSandboxToken(userId, runId);
+      const token = await generateSandboxToken(userId, runId, "org-test");
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -94,7 +94,7 @@ describe("Storage capability enforcement", () => {
 
     it("should accept sandbox token with no capabilities (acceptAnySandboxCapability)", async () => {
       await createTestVolume("test-vol-nocap");
-      const token = await generateSandboxToken(userId, runId);
+      const token = await generateSandboxToken(userId, runId, "org-test");
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -110,7 +110,7 @@ describe("Storage capability enforcement", () => {
 
   describe("sandbox token access for prepare", () => {
     it("should accept sandbox token with agent:write for volume prepare", async () => {
-      const token = await generateSandboxToken(userId, runId);
+      const token = await generateSandboxToken(userId, runId, "org-test");
       mockClerk({ userId: null });
 
       const response = await prepareRoute(
@@ -132,7 +132,7 @@ describe("Storage capability enforcement", () => {
     });
 
     it("should accept sandbox token regardless of specific capability for prepare", async () => {
-      const token = await generateSandboxToken(userId, runId);
+      const token = await generateSandboxToken(userId, runId, "org-test");
       mockClerk({ userId: null });
 
       const response = await prepareRoute(
@@ -157,7 +157,7 @@ describe("Storage capability enforcement", () => {
   describe("sandbox token access for download", () => {
     it("should accept agent:read token for volume download", async () => {
       await createTestVolume("test-vol");
-      const token = await generateSandboxToken(userId, runId);
+      const token = await generateSandboxToken(userId, runId, "org-test");
       mockClerk({ userId: null });
 
       const response = await downloadRoute(
@@ -173,7 +173,7 @@ describe("Storage capability enforcement", () => {
 
     it("should accept sandbox token for artifact download regardless of capability", async () => {
       await createTestArtifact("test-art");
-      const token = await generateSandboxToken(userId, runId);
+      const token = await generateSandboxToken(userId, runId, "org-test");
       mockClerk({ userId: null });
 
       const response = await downloadRoute(
@@ -219,7 +219,7 @@ describe("Storage capability enforcement", () => {
       await createTestVolume("org-vol");
 
       // Sandbox token should resolve to the same org via run record
-      const token = await generateSandboxToken(userId, runId);
+      const token = await generateSandboxToken(userId, runId, "org-test");
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -237,7 +237,7 @@ describe("Storage capability enforcement", () => {
 
     it("should return 404 when sandbox token run not found", async () => {
       const fakeRunId = randomUUID();
-      const token = await generateSandboxToken(userId, fakeRunId);
+      const token = await generateSandboxToken(userId, fakeRunId, "org-test");
       mockClerk({ userId: null });
 
       const response = await listRoute(

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -65,7 +65,7 @@ describe("POST /api/zero/chat/messages", () => {
 
   it("should return 403 for sandbox token without agent-run:write capability", async () => {
     mockClerk({ userId: null });
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const response = await POST(
       createTestRequest(URL, {

--- a/turbo/apps/web/app/api/zero/chat/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/search/__tests__/route.test.ts
@@ -42,7 +42,7 @@ describe("GET /api/zero/chat/search", () => {
 
   it("returns 403 when token lacks chat-message:read capability", async () => {
     const user = await context.setupUser();
-    const token = await generateSandboxToken(user.userId, "run-1");
+    const token = await generateSandboxToken(user.userId, "run-1", "org-test");
     mockClerk({ userId: null });
 
     const response = await GET(

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
@@ -45,7 +45,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
     const { composeId } = await createTestCompose(uniqueId("agent"));
     const { runId } = await seedTestRun(user.userId, composeId);
     mockClerk({ userId: null });
-    const token = await generateSandboxToken(user.userId, runId);
+    const token = await generateSandboxToken(user.userId, runId, "org-test");
     return { token, runId };
   }
 

--- a/turbo/apps/web/app/api/zero/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/[id]/__tests__/route.test.ts
@@ -299,7 +299,7 @@ describe("GET /api/zero/logs/[id]", () => {
 
     it("should return 403 for sandbox token without agent-run:read", async () => {
       const { runId } = await createTestRun(testComposeId, "Test prompt");
-      const token = await generateSandboxToken(user.userId, runId);
+      const token = await generateSandboxToken(user.userId, runId, "org-test");
       mockClerk({ userId: null });
 
       const request = createTestRequest(

--- a/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
@@ -866,7 +866,7 @@ describe("GET /api/zero/logs", () => {
         `zero-auth-${randomUUID().slice(0, 8)}`,
       );
       const { runId } = await createTestRun(composeId, "test");
-      const token = await generateSandboxToken(user.userId, runId);
+      const token = await generateSandboxToken(user.userId, runId, "org-test");
       mockClerk({ userId: null });
 
       const request = createTestRequest("http://localhost:3000/api/zero/logs", {

--- a/turbo/apps/web/app/api/zero/logs/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/search/__tests__/route.test.ts
@@ -84,7 +84,11 @@ describe("GET /api/zero/logs/search", () => {
   });
 
   it("should return 403 for sandbox token without agent-run:read", async () => {
-    const token = await generateSandboxToken(user.userId, testRunId);
+    const token = await generateSandboxToken(
+      user.userId,
+      testRunId,
+      "org-test",
+    );
 
     const request = createTestRequest(
       "http://localhost:3000/api/zero/logs/search?keyword=test",

--- a/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
@@ -70,7 +70,7 @@ describe("GET /api/zero/runs/:id", () => {
 
   it("should return 403 for sandbox token without agent-run:read capability", async () => {
     mockClerk({ userId: null });
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const response = await GET(
       createTestRequest("http://localhost:3000/api/zero/runs/some-id", {

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
@@ -114,7 +114,7 @@ describe("POST /api/zero/runs/:id/cancel", () => {
 
   it("should return 403 for sandbox token without agent-run:write capability", async () => {
     mockClerk({ userId: null });
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const response = await POST(
       createTestRequest("http://localhost:3000/api/zero/runs/some-id/cancel", {

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -73,7 +73,7 @@ describe("GET /api/zero/runs/:id/telemetry/agent", () => {
 
   it("should return 403 for sandbox token without agent-run:read capability", async () => {
     mockClerk({ userId: null });
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const response = await GET(
       createTestRequest(

--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -63,7 +63,7 @@ describe("POST /api/zero/runs", () => {
 
   it("should return 403 for sandbox token without agent-run:write capability", async () => {
     mockClerk({ userId: null });
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const response = await POST(
       createTestRequest(URL, {

--- a/turbo/apps/web/app/api/zero/runs/queue/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/__tests__/route.test.ts
@@ -77,7 +77,7 @@ describe("GET /api/zero/runs/queue", () => {
 
   it("should return 403 for sandbox token without agent-run:read capability", async () => {
     mockClerk({ userId: null });
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const response = await GET(
       createTestRequest("http://localhost:3000/api/zero/runs/queue", {

--- a/turbo/apps/web/app/api/zero/web/download-file/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/web/download-file/__tests__/route.test.ts
@@ -43,7 +43,7 @@ describe("GET /api/zero/web/download-file", () => {
 
   it("returns 401 for sandbox token without file:read capability", async () => {
     mockClerk({ userId: null });
-    const token = await generateSandboxToken(user.userId, "run-1");
+    const token = await generateSandboxToken(user.userId, "run-1", "org-test");
 
     const request = createTestRequest(`${URL}?file_id=abc`, {
       method: "GET",

--- a/turbo/apps/web/src/__tests__/api-test-helpers/core.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/core.ts
@@ -88,7 +88,7 @@ export async function createTestSandboxToken(
   userId: string,
   runId: string,
 ): Promise<string> {
-  return generateSandboxToken(userId, runId);
+  return generateSandboxToken(userId, runId, "org-test");
 }
 
 /**

--- a/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
@@ -117,7 +117,7 @@ export async function createTestCheckpoint(
   agentSessionId: string;
   conversationId: string;
 }> {
-  const sandboxToken = await generateSandboxToken(userId, runId);
+  const sandboxToken = await generateSandboxToken(userId, runId, "org-test");
   const request = createTestRequest(
     "http://localhost:3000/api/webhooks/agent/checkpoints",
     {
@@ -174,7 +174,7 @@ export async function completeTestRun(
   );
 
   // Then complete the run
-  const sandboxToken = await generateSandboxToken(userId, runId);
+  const sandboxToken = await generateSandboxToken(userId, runId, "org-test");
   const request = createTestRequest(
     "http://localhost:3000/api/webhooks/agent/complete",
     {
@@ -210,7 +210,7 @@ export async function failTestRun(
   runId: string,
   error?: string,
 ): Promise<void> {
-  const sandboxToken = await generateSandboxToken(userId, runId);
+  const sandboxToken = await generateSandboxToken(userId, runId, "org-test");
   const request = createTestRequest(
     "http://localhost:3000/api/webhooks/agent/complete",
     {

--- a/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
@@ -64,14 +64,14 @@ describe("getAuthContext with requiredCapability", () => {
   });
 
   it("should reject sandbox token without requiredCapability (backward compat)", async () => {
-    const token = await generateSandboxToken("user-123", "run-456");
+    const token = await generateSandboxToken("user-123", "run-456", "org-test");
     const result = await getAuthContext(`Bearer ${token}`);
 
     expect(result).toBeNull();
   });
 
   it("should reject sandbox token with requiredCapability (sandbox tokens have no capabilities)", async () => {
-    const token = await generateSandboxToken("user-123", "run-456");
+    const token = await generateSandboxToken("user-123", "run-456", "org-test");
     const result = await getAuthContext(`Bearer ${token}`, {
       requiredCapability: "agent:read",
     });
@@ -80,7 +80,7 @@ describe("getAuthContext with requiredCapability", () => {
   });
 
   it("should reject sandbox token without matching capability", async () => {
-    const token = await generateSandboxToken("user-123", "run-456");
+    const token = await generateSandboxToken("user-123", "run-456", "org-test");
     const result = await getAuthContext(`Bearer ${token}`, {
       requiredCapability: "agent:write",
     });
@@ -89,7 +89,7 @@ describe("getAuthContext with requiredCapability", () => {
   });
 
   it("should reject sandbox token with no capabilities", async () => {
-    const token = await generateSandboxToken("user-123", "run-456");
+    const token = await generateSandboxToken("user-123", "run-456", "org-test");
     const result = await getAuthContext(`Bearer ${token}`, {
       requiredCapability: "agent:read",
     });
@@ -122,7 +122,7 @@ describe("getAuthContext with acceptAnySandboxCapability", () => {
   });
 
   it("should accept sandbox token with acceptAnySandboxCapability", async () => {
-    const token = await generateSandboxToken("user-123", "run-456");
+    const token = await generateSandboxToken("user-123", "run-456", "org-test");
     const result = await getAuthContext(`Bearer ${token}`, {
       acceptAnySandboxCapability: true,
     });
@@ -133,7 +133,7 @@ describe("getAuthContext with acceptAnySandboxCapability", () => {
   });
 
   it("should accept sandbox token without capabilities via acceptAnySandboxCapability", async () => {
-    const token = await generateSandboxToken("user-123", "run-456");
+    const token = await generateSandboxToken("user-123", "run-456", "org-test");
     const result = await getAuthContext(`Bearer ${token}`, {
       acceptAnySandboxCapability: true,
     });
@@ -143,7 +143,7 @@ describe("getAuthContext with acceptAnySandboxCapability", () => {
   });
 
   it("should accept sandbox token with no capabilities when acceptAnySandboxCapability is true", async () => {
-    const token = await generateSandboxToken("user-123", "run-456");
+    const token = await generateSandboxToken("user-123", "run-456", "org-test");
     const result = await getAuthContext(`Bearer ${token}`, {
       acceptAnySandboxCapability: true,
     });
@@ -218,7 +218,7 @@ describe("getAuthContext org fields from Clerk session", () => {
   });
 
   it("should not populate org fields for sandbox tokens", async () => {
-    const token = await generateSandboxToken("user-123", "run-456");
+    const token = await generateSandboxToken("user-123", "run-456", "org-test");
     const result = await getAuthContext(`Bearer ${token}`, {
       acceptAnySandboxCapability: true,
     });
@@ -241,7 +241,7 @@ describe("getAuthContext auth() call optimization", () => {
   });
 
   it("should not call auth() when sandbox token is provided", async () => {
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
     await getAuthContext(`Bearer ${token}`, {
       requiredCapability: "agent:read",
     });
@@ -249,7 +249,7 @@ describe("getAuthContext auth() call optimization", () => {
   });
 
   it("should not call auth() when sandbox token is rejected", async () => {
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
     await getAuthContext(`Bearer ${token}`);
     expect(mockAuth).not.toHaveBeenCalled();
   });

--- a/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
@@ -33,7 +33,7 @@ describe("requireAuth", () => {
   });
 
   it("should return 403 for sandbox token with requiredCapability (sandbox tokens have no capabilities)", async () => {
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const result = await requireAuth(`Bearer ${token}`, {
       requiredCapability: "agent:read",
@@ -47,7 +47,7 @@ describe("requireAuth", () => {
   });
 
   it("should return 403 for sandbox token missing required capability", async () => {
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const result = await requireAuth(`Bearer ${token}`, {
       requiredCapability: "agent:write",
@@ -64,7 +64,7 @@ describe("requireAuth", () => {
   });
 
   it("should return 403 for sandbox token with no capabilities", async () => {
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const result = await requireAuth(`Bearer ${token}`, {
       requiredCapability: "agent:read",
@@ -81,7 +81,7 @@ describe("requireAuth", () => {
   });
 
   it("should return 403 for sandbox token on uncovered endpoint", async () => {
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     // No requiredCapability = uncovered endpoint
     const result = await requireAuth(`Bearer ${token}`);
@@ -97,7 +97,7 @@ describe("requireAuth", () => {
   });
 
   it("should return AuthContext for acceptAnySandboxCapability (sandbox tokens always accepted)", async () => {
-    const token = await generateSandboxToken("user-1", "run-1");
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const result = await requireAuth(`Bearer ${token}`, {
       acceptAnySandboxCapability: true,

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -31,7 +31,11 @@ vi.mock("@vm0/core", async (importOriginal) => {
 describe("sandbox-token", () => {
   describe("generateSandboxToken", () => {
     it("should generate a prefixed token", async () => {
-      const token = await generateSandboxToken("user-123", "run-456");
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
 
       expect(token).toBeDefined();
       expect(typeof token).toBe("string");
@@ -42,15 +46,31 @@ describe("sandbox-token", () => {
     });
 
     it("should generate different tokens for different runs", async () => {
-      const token1 = await generateSandboxToken("user-123", "run-456");
-      const token2 = await generateSandboxToken("user-123", "run-789");
+      const token1 = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
+      const token2 = await generateSandboxToken(
+        "user-123",
+        "run-789",
+        "org-test",
+      );
 
       expect(token1).not.toBe(token2);
     });
 
     it("should generate different tokens for different users", async () => {
-      const token1 = await generateSandboxToken("user-123", "run-456");
-      const token2 = await generateSandboxToken("user-789", "run-456");
+      const token1 = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
+      const token2 = await generateSandboxToken(
+        "user-789",
+        "run-456",
+        "org-test",
+      );
 
       expect(token1).not.toBe(token2);
     });
@@ -58,12 +78,17 @@ describe("sandbox-token", () => {
 
   describe("verifySandboxToken", () => {
     it("should verify a valid token and return auth info", async () => {
-      const token = await generateSandboxToken("user-123", "run-456");
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
       const auth = verifySandboxToken(token);
 
       expect(auth).not.toBeNull();
       expect(auth?.userId).toBe("user-123");
       expect(auth?.runId).toBe("run-456");
+      expect(auth?.orgId).toBe("org-test");
     });
 
     it("should return null for token without prefix", () => {
@@ -80,7 +105,11 @@ describe("sandbox-token", () => {
     });
 
     it("should return null for tampered token", async () => {
-      const token = await generateSandboxToken("user-123", "run-456");
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
       // Tamper with the JWT portion after the prefix
       const jwt = token.slice(SANDBOX_TOKEN_PREFIX.length);
       const parts = jwt.split(".");
@@ -93,7 +122,11 @@ describe("sandbox-token", () => {
     });
 
     it("should return null for token with invalid signature", async () => {
-      const token = await generateSandboxToken("user-123", "run-456");
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
       const jwt = token.slice(SANDBOX_TOKEN_PREFIX.length);
       const parts = jwt.split(".");
       parts[2] = "invalid-signature";
@@ -105,7 +138,11 @@ describe("sandbox-token", () => {
     });
 
     it("should return null for expired token", async () => {
-      const token = await generateSandboxToken("user-123", "run-456");
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
 
       // Mock time to be 3 hours in the future (beyond 2 hour expiration)
       const realDateNow = Date.now;
@@ -122,7 +159,11 @@ describe("sandbox-token", () => {
     });
 
     it("should verify token that is still within expiration", async () => {
-      const token = await generateSandboxToken("user-123", "run-456");
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
 
       // Mock time to be 1 hour in the future (within 2 hour expiration)
       const realDateNow = Date.now;
@@ -158,23 +199,29 @@ describe("sandbox-token", () => {
   });
 
   describe("roundtrip", () => {
-    it("should correctly roundtrip userId and runId", async () => {
+    it("should correctly roundtrip userId, runId and orgId", async () => {
       const testCases = [
-        { userId: "user_123", runId: "run_456" },
-        { userId: "user-with-dashes", runId: "run-with-dashes" },
+        { userId: "user_123", runId: "run_456", orgId: "org_abc" },
+        {
+          userId: "user-with-dashes",
+          runId: "run-with-dashes",
+          orgId: "org-with-dashes",
+        },
         {
           userId: "very-long-user-id-that-is-quite-lengthy",
           runId: "very-long-run-id-that-is-quite-lengthy",
+          orgId: "very-long-org-id-that-is-quite-lengthy",
         },
       ];
 
-      for (const { userId, runId } of testCases) {
-        const token = await generateSandboxToken(userId, runId);
+      for (const { userId, runId, orgId } of testCases) {
+        const token = await generateSandboxToken(userId, runId, orgId);
         const auth = verifySandboxToken(token);
 
         expect(auth).not.toBeNull();
         expect(auth?.userId).toBe(userId);
         expect(auth?.runId).toBe(runId);
+        expect(auth?.orgId).toBe(orgId);
       }
     });
   });
@@ -376,7 +423,11 @@ describe("sandbox-token", () => {
 
   describe("cross-scope rejection", () => {
     it("should reject sandbox token with verifyComposeJobToken", async () => {
-      const token = await generateSandboxToken("user-123", "run-456");
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
       const auth = verifyComposeJobToken(token);
 
       expect(auth).toBeNull();
@@ -397,7 +448,11 @@ describe("sandbox-token", () => {
     });
 
     it("should reject sandbox token with verifyZeroToken", async () => {
-      const token = await generateSandboxToken("user-123", "run-456");
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
       const auth = verifyZeroToken(token);
 
       expect(auth).toBeNull();
@@ -411,7 +466,11 @@ describe("sandbox-token", () => {
     });
 
     it("should identify sandbox/compose/zero token types with isSandboxToken", async () => {
-      const sandboxToken = await generateSandboxToken("user-123", "run-456");
+      const sandboxToken = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
       const composeToken = await generateComposeJobToken("user-123", "job-456");
       const zeroToken = await generateZeroToken(
         "user-123",
@@ -437,7 +496,11 @@ describe("sandbox-token", () => {
         "org-789",
         "token-id-1",
       );
-      const sandboxToken = await generateSandboxToken("user-123", "run-456");
+      const sandboxToken = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
 
       expect(isPatToken(cliToken)).toBe(true);
       expect(isPatToken(sandboxToken)).toBe(false);
@@ -459,7 +522,11 @@ describe("sandbox-token", () => {
     });
 
     it("should reject sandbox token with verifyCliToken", async () => {
-      const token = await generateSandboxToken("user-123", "run-456");
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        "org-test",
+      );
       expect(verifyCliToken(token)).toBeNull();
     });
 

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -52,6 +52,7 @@ export const PAT_TOKEN_PREFIX = "vm0_pat_";
 interface SandboxTokenPayload {
   userId: string;
   runId: string;
+  orgId: string;
   scope: "sandbox";
   iat: number;
   exp: number;
@@ -99,6 +100,7 @@ interface CliTokenPayload {
 export interface SandboxAuth {
   userId: string;
   runId: string;
+  orgId: string;
 }
 
 /**
@@ -258,6 +260,7 @@ function verifyJwtPayload(rawJwt: string): JwtPayload | null {
 export async function generateSandboxToken(
   userId: string,
   runId: string,
+  orgId: string,
 ): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const expiresIn = 2 * 60 * 60; // 2 hours in seconds
@@ -265,6 +268,7 @@ export async function generateSandboxToken(
   const payload: SandboxTokenPayload = {
     userId,
     runId,
+    orgId,
     scope: "sandbox",
     iat: now,
     exp: now + expiresIn,
@@ -292,17 +296,26 @@ export function verifySandboxToken(token: string): SandboxAuth | null {
     return null;
   }
 
-  // Validate scope and required fields
+  // Validate scope and required fields. Tokens minted before orgId was added
+  // to the payload (2-hour expiry) fail this check and force a re-auth instead
+  // of leaking a partial claim.
   if (payload.scope !== "sandbox") {
     return null;
   }
-  if (!("runId" in payload) || !payload.userId || !payload.runId) {
+  if (
+    !("runId" in payload) ||
+    !("orgId" in payload) ||
+    !payload.userId ||
+    !payload.runId ||
+    !payload.orgId
+  ) {
     return null;
   }
 
   return {
     userId: payload.userId,
     runId: payload.runId,
+    orgId: payload.orgId,
   };
 }
 

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -533,7 +533,11 @@ export async function dispatchQueuedZeroRun(
   }
 
   // Generate sandbox token + build zero context
-  const sandboxToken = await generateSandboxToken(params.userId, runId);
+  const sandboxToken = await generateSandboxToken(
+    params.userId,
+    runId,
+    params.orgId,
+  );
   const tokenTime = Date.now();
   const contextResult = await buildZeroExecutionContext({
     ...params,

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -684,7 +684,7 @@ async function dispatchZeroRun(
     const overrides = result.featureSwitchOverrides;
     const [zeroToken, sandboxToken] = await Promise.all([
       generateZeroToken(zeroParams.userId, record.run.id, orgId, overrides),
-      generateSandboxToken(zeroParams.userId, record.run.id),
+      generateSandboxToken(zeroParams.userId, record.run.id, orgId),
     ]);
     const tokenTime = Date.now();
 


### PR DESCRIPTION
## Summary

- Add `orgId` to `SandboxTokenPayload` / `SandboxAuth` and require it in `generateSandboxToken`.
- `verifySandboxToken` now rejects payloads missing `orgId` (fail-closed, no fallback) — tokens minted before this deploy will fail verification, but sandbox tokens only live 2h so the migration window is short.
- All four production callers already had `orgId` in scope; no upstream plumbing needed.

Enables the #10725 handler refactor: once this lands, `/api/webhooks/agent/usage-event` and `/api/webhooks/agent/checkpoints` can drop their `SELECT agent_runs` round-trip and read `orgId` directly from the JWT, eliminating the FK race window and halving per-webhook DB traffic on Neon serverless.

Closes #10767

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/auth/__tests__` — 99/99 pass, including new `orgId` roundtrip + verify-returns-orgId assertions
- [x] `pnpm -F web exec tsc --noEmit` — 0 errors
- [x] All four production callers confirmed to have `orgId` in scope:
  - `api/agent/runs/route.ts:421` — uses `org.orgId` (already referenced at line 429)
  - `api/runners/jobs/[id]/claim/route.ts:141` — uses `run.orgId` from RETURNING clause
  - `src/lib/zero/zero-run-queue-service.ts:536` — uses `params.orgId`
  - `src/lib/zero/zero-run-service.ts:687` — uses `orgId` already in closure
- [ ] Full `pnpm vitest` run — blocked locally by an unrelated DB schema drift (`checkpoints.artifact_snapshots` column missing in local test DB). CI will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)