### PR TITLE
chore: remove dead voicechat feature switch key

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
@@ -234,7 +234,6 @@ async function setup() {
     context,
     path: "/voice-chat-candidate",
     withoutRender: true,
-    featureSwitches: { voiceChat: true },
   });
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/agent-chat-voice-mode.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/agent-chat-voice-mode.test.ts
@@ -254,7 +254,7 @@ async function driveSession(
     context,
     path: `/agents/${AGENT_ID}/chat`,
     withoutRender: true,
-    featureSwitches: { voiceChat: true, trinity: true },
+    featureSwitches: { trinity: true },
   });
   mockCandidateEndpoints({ items, tasks });
   const dcRef: { current: FakeDC | null } = { current: null };

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -30,7 +30,6 @@ describe("lab page", () => {
   it("should show feature switches sorted alphabetically", async () => {
     setMockFeatureSwitches({
       [FeatureSwitchKey.UsageAnalytics]: true,
-      [FeatureSwitchKey.VoiceChat]: false,
     });
 
     detachedSetupPage({ context, path: "/_/lab" });

--- a/turbo/apps/web/src/lib/zero/user/__tests__/load-feature-switch-overrides.test.ts
+++ b/turbo/apps/web/src/lib/zero/user/__tests__/load-feature-switch-overrides.test.ts
@@ -42,14 +42,12 @@ describe("loadFeatureSwitchOverrides", () => {
     const { userId, orgId } = await context.setupUser();
 
     await updateUserFeatureSwitches(orgId, userId, {
-      [FeatureSwitchKey.VoiceChat]: false,
       [FeatureSwitchKey.ComputerUse]: true,
     });
 
     const result = await loadFeatureSwitchOverrides(orgId, userId);
 
     expect(result).toEqual({
-      [FeatureSwitchKey.VoiceChat]: false,
       [FeatureSwitchKey.ComputerUse]: true,
     });
   });

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -37,7 +37,6 @@ export enum FeatureSwitchKey {
   Lab = "lab",
   AuditLink = "auditLink",
   PhoneIntegration = "phoneIntegration",
-  VoiceChat = "voiceChat",
   AudioInput = "audioInput",
   AudioOutput = "audioOutput",
   MissionControlSidebar = "missionControlSidebar",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -200,11 +200,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Show the Phone page for voice call integration",
     enabled: false,
   },
-  [FeatureSwitchKey.VoiceChat]: {
-    maintainer: "lancy@vm0.ai",
-    description: "Enable the Voice Chat feature and API endpoints",
-    enabled: false,
-  },
   [FeatureSwitchKey.AudioInput]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Removes the now-dead `FeatureSwitchKey.VoiceChat` enum entry and its registry metadata (`packages/core/src/feature-switch-key.ts`, `packages/core/src/feature-switch.ts`).
- Removes all test-fixture references to `voiceChat` across 4 test files.
- `FeatureSwitchKey.Trinity` (which gates `voice-chat-candidate`) is untouched.

Part of epic #10749. Prerequisite PR #10764 stripped the backend routes and `voice-chat:write` capability — no runtime code reads this flag anymore.

## Scope note

The approved plan listed 5 line removals across 4 files. During implementation, `pnpm check-types` surfaced 2 additional `voiceChat: true` entries inside the `setupPage({ featureSwitches })` param, whose type is `Partial<Record<FeatureSwitchKey, boolean>>`:

- `apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts:237`
- `apps/platform/src/signals/zero-page/__tests__/agent-chat-voice-mode.test.ts:257`

Both were vestigial — the tests are gated by `Trinity` (voice-chat-candidate), not `VoiceChat`. Applied plain deletion (aligned with the approved invariant "no substitute keys"). The second test already had `trinity: true`; the first uses `withoutRender: true` so it doesn't need any flag.

## Verification

From `/turbo`:

```
pnpm turbo run lint         # ✓ green
pnpm check-types            # ✓ green
pnpm format                 # ✓ unchanged
pnpm knip                   # ✓ no issues
pnpm -F @vm0/core exec vitest run    # ✓ 22 files / 770 tests
pnpm -F @vm0/cli  exec vitest run    # ✓ 107 files / 1066 tests
pnpm -F @vm0/app  exec vitest run    # ✓ 232 files / 1989 tests
pnpm -F web       exec vitest run    # ✓ 353 files / 3681 tests
```

Also verified:

```
rg 'FeatureSwitchKey\.VoiceChat' turbo/   # 0 hits
rg '"voiceChat"'                turbo/    # 0 hits
rg 'FeatureSwitchKey\.Trinity'  turbo/    # 4 hits (unchanged — voice-chat-candidate keeps its gate)
```

## Test plan

- [x] Lint, check-types, format, knip all green from `turbo/`.
- [x] `@vm0/core`, `@vm0/cli`, `@vm0/app`, `web` vitest suites all pass.
- [x] `FeatureSwitchKey.VoiceChat` and `"voiceChat"` absent from the repo.
- [x] `FeatureSwitchKey.Trinity` untouched; 4 references preserved.
- [ ] CI green on all checks (lint, test, deploy, cli-e2e).

Closes #10773
Part of #10749

🤖 Generated with [Claude Code](https://claude.com/claude-code)