### PR TITLE
fix(webhooks): 404 instead of 500 when run deleted mid-webhook

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
@@ -5,10 +5,9 @@ import {
 } from "../../../../../src/lib/ts-rest-handler";
 import { webhookCheckpointsContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { agentRuns } from "../../../../../src/db/schema/agent-run";
-import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
 import { createCheckpoint } from "../../../../../src/lib/infra/checkpoint";
+import { isForeignKeyViolation } from "../../../../../src/lib/shared/pg-errors";
 import { logger } from "../../../../../src/lib/shared/logger";
 
 const log = logger("webhook:checkpoints");
@@ -37,27 +36,31 @@ const router = tsr.router(webhookCheckpointsContract, {
       `Received checkpoint request for run ${body.runId} from user ${userId}`,
     );
 
-    // Verify run exists and belongs to the authenticated user
-    const [run] = await globalThis.services.db
-      .select()
-      .from(agentRuns)
-      .where(and(eq(agentRuns.id, body.runId), eq(agentRuns.userId, userId)))
-      .limit(1);
-
-    if (!run) {
-      return {
-        status: 404 as const,
-        body: {
-          error: { message: "Agent run not found", code: "NOT_FOUND" },
-        },
-      };
+    // `createCheckpoint` fetches `agent_runs` internally and throws
+    // `notFound` if the row is missing — no up-front SELECT here. If
+    // the run vanishes concurrent with a downstream INSERT
+    // (conversations / checkpoints, both FK-constrained on
+    // `agent_runs.id` — see #10725 and the aggregate-deletion paths
+    // tracked in #10763), PG raises SQLSTATE 23503; we surface it as
+    // 404 instead of 500 to keep the same "run not found" contract
+    // the caller already handles.
+    let result;
+    try {
+      result = await createCheckpoint(body, userId);
+    } catch (err) {
+      if (isForeignKeyViolation(err)) {
+        log.info("Run deleted concurrent with checkpoint, dropping", {
+          runId: body.runId,
+        });
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent run not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      throw err;
     }
-
-    // Note: We don't check run status here because the checkpoint is called from within
-    // the sandbox before the complete webhook updates the run status to "completed"
-
-    // Create checkpoint
-    const result = await createCheckpoint(body);
 
     log.debug(
       `Checkpoint created: ${result.checkpointId}, session: ${result.agentSessionId}, conversation: ${result.conversationId}`,

--- a/turbo/apps/web/app/api/webhooks/agent/usage-event/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/usage-event/__tests__/route.test.ts
@@ -72,7 +72,12 @@ describe("POST /api/webhooks/agent/usage-event", () => {
       expect(response.status).toBe(401);
     });
 
-    it("returns 404 for run that does not exist", async () => {
+    it("returns 404 for run that does not exist (covers #10725 FK race)", async () => {
+      // At the DB level this is indistinguishable from the #10725
+      // aggregate-deletion race: the token is valid but the run row
+      // referenced by `usage_event.runId` is not present, so the FK
+      // raises SQLSTATE 23503 on INSERT. The handler surfaces it as
+      // 404 rather than 500.
       const missingRunId = randomUUID();
       const token = await createTestSandboxToken(user.userId, missingRunId);
       const response = await POST(

--- a/turbo/apps/web/app/api/webhooks/agent/usage-event/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/usage-event/route.ts
@@ -5,10 +5,9 @@ import {
 } from "../../../../../src/lib/ts-rest-handler";
 import { webhookUsageEventContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { usageEvent } from "../../../../../src/db/schema/usage-event";
-import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
+import { isForeignKeyViolation } from "../../../../../src/lib/shared/pg-errors";
 import { logger } from "../../../../../src/lib/shared/logger";
 
 const log = logger("webhooks:usage-event");
@@ -30,42 +29,48 @@ const router = tsr.router(webhookUsageEventContract, {
       };
     }
 
-    const { userId } = auth;
+    const { userId, orgId } = auth;
 
-    const [run] = await globalThis.services.db
-      .select({
-        id: agentRuns.id,
-        orgId: agentRuns.orgId,
-      })
-      .from(agentRuns)
-      .where(and(eq(agentRuns.id, body.runId), eq(agentRuns.userId, userId)))
-      .limit(1);
-
-    if (!run) {
-      return {
-        status: 404 as const,
-        body: {
-          error: {
-            message: "Run not found",
-            code: "NOT_FOUND",
+    // No up-front `SELECT agent_runs` here: the sandbox JWT (#10770)
+    // already carries `orgId` and the runId is cross-checked in
+    // `getSandboxAuthForRun`. The FK on `usage_event.runId` protects
+    // the INSERT — if the run was never created (bad runId) or has
+    // been deleted between sandbox boot and this webhook arriving
+    // (aggregate-deletion paths, see #10763), PG raises SQLSTATE
+    // 23503 and we surface it as 404 instead of 500, preserving the
+    // "run not found" contract the handler had before this refactor.
+    try {
+      await globalThis.services.db
+        .insert(usageEvent)
+        .values({
+          runId: body.runId,
+          orgId,
+          userId,
+          kind: body.kind,
+          provider: body.provider,
+          category: body.category,
+          quantity: body.quantity,
+          idempotencyKey: body.idempotencyKey,
+        })
+        .onConflictDoNothing({ target: [usageEvent.idempotencyKey] });
+    } catch (err) {
+      if (isForeignKeyViolation(err)) {
+        log.info("Run not found for usage event, dropping", {
+          runId: body.runId,
+          idempotencyKey: body.idempotencyKey,
+        });
+        return {
+          status: 404 as const,
+          body: {
+            error: {
+              message: "Run not found",
+              code: "NOT_FOUND",
+            },
           },
-        },
-      };
+        };
+      }
+      throw err;
     }
-
-    await globalThis.services.db
-      .insert(usageEvent)
-      .values({
-        runId: body.runId,
-        orgId: run.orgId,
-        userId,
-        kind: body.kind,
-        provider: body.provider,
-        category: body.category,
-        quantity: body.quantity,
-        idempotencyKey: body.idempotencyKey,
-      })
-      .onConflictDoNothing({ target: [usageEvent.idempotencyKey] });
 
     log.debug("Usage event recorded", {
       runId: body.runId,

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { agentRuns } from "../../../db/schema/agent-run";
 import { agentComposeVersions } from "../../../db/schema/agent-compose";
 import { conversations } from "../../../db/schema/conversation";
@@ -17,14 +17,23 @@ import type {
 const log = logger("checkpoint");
 
 /**
- * Create a checkpoint for an agent run
+ * Create a checkpoint for an agent run.
+ *
+ * `userId` is checked against `agent_runs.user_id` as a defence-in-depth
+ * tripwire: sandbox tokens are HMAC-signed and bind `userId`/`runId`
+ * together at mint time, so a mismatch here shouldn't be reachable in
+ * production. The check is retained so a leaked signing key or a
+ * handler refactor regression would 404 rather than write to a foreign
+ * user's run.
  *
  * @param request Checkpoint request data from webhook
+ * @param userId  Authenticated userId from the sandbox token
  * @returns Checkpoint ID and artifact status
- * @throws NotFoundError if run doesn't exist
+ * @throws NotFoundError if run doesn't exist or doesn't belong to userId
  */
 export async function createCheckpoint(
   request: CheckpointRequest,
+  userId: string,
 ): Promise<CheckpointResponse> {
   log.debug(`Creating checkpoint for run ${request.runId}`);
 
@@ -32,7 +41,7 @@ export async function createCheckpoint(
   const [run] = await globalThis.services.db
     .select()
     .from(agentRuns)
-    .where(eq(agentRuns.id, request.runId))
+    .where(and(eq(agentRuns.id, request.runId), eq(agentRuns.userId, userId)))
     .limit(1);
 
   if (!run) {

--- a/turbo/apps/web/src/lib/shared/pg-errors.ts
+++ b/turbo/apps/web/src/lib/shared/pg-errors.ts
@@ -1,0 +1,22 @@
+// https://www.postgresql.org/docs/current/errcodes-appendix.html
+const PG_FOREIGN_KEY_VIOLATION = "23503";
+
+/**
+ * True iff `err` wraps a postgres driver error with SQLSTATE `23503`
+ * (foreign_key_violation). Drizzle wraps the underlying PG error on
+ * `.cause`; the postgres.js driver surfaces the SQLSTATE on `.code`.
+ *
+ * Webhook handlers use this to recognize "the `agent_runs` row vanished
+ * between auth and INSERT" races (see #10725) and silently drop the
+ * event rather than returning 500.
+ */
+export function isForeignKeyViolation(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const cause = (err as Error & { cause?: unknown }).cause;
+  if (cause && typeof cause === "object" && "code" in cause) {
+    return (cause as { code: unknown }).code === PG_FOREIGN_KEY_VIOLATION;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Fixes the FK-race 500 surfaced in #10725.

**Before**: usage-event / checkpoints webhooks return 500 when the `agent_runs` row they reference gets deleted between token issuance and the webhook arriving. Sandbox then retries into the same wall; Sentry fills with `foreign_key_violation` noise.

**After**: same scenario returns 404. The sandbox doesn't retry on 404, the 500 alert goes quiet, and the "run is gone" intent becomes explicit.

## What changed

- **`lib/shared/pg-errors.ts`**: small new helper, `isForeignKeyViolation(err)`, that recognises SQLSTATE 23503 on a drizzle-wrapped PG error.
- **`usage-event/route.ts`**: drops the redundant `SELECT agent_runs` (orgId now comes straight from the sandbox JWT thanks to #10770), wraps the INSERT in a `23503 → 404` catch. Net: **one DB round-trip instead of two**, no race window inside the handler itself.
- **`checkpoints/route.ts`**: drops the redundant handler-level `SELECT agent_runs` (the service does the same SELECT internally), wraps the `createCheckpoint(...)` call in the same `23503 → 404` catch to cover the service-internal INSERT path.
- **`checkpoint-service.ts`**: `createCheckpoint(request, userId)` — userId is now a required argument and filters `agent_runs` by owner. This restores the defence-in-depth ownership check the handler used to do, so the "rejects checkpoint for run owned by another user" test stays green.

## Why not add the same userId filter for usage-event?

The attack model for a forged token on `usage-event` is self-harming (billing lands on the attacker's own userId, not the victim's), so the defence-in-depth layer isn't worth a second query or a regressed race window. Keeping usage-event as a single INSERT is deliberate.

## Related

- **Prerequisite**: #10770 (sandbox JWT carries orgId) — merged, unblocks dropping the handler-level SELECT.
- **Upstream follow-up**: #10763 — aggregate-deletion paths still skip `cancelRun`, which is what surfaces this race in the first place. This PR is the downstream backstop; fixing #10763 would make the race structurally rare but not impossible (mitmproxy's thread-pool can still have webhooks queued when cancel fires).

## Test plan

- [x] `pnpm -F web exec vitest run app/api/webhooks/agent` — 174/174 pass, including:
  - Existing "returns 404 for run that does not exist" cases on both handlers — same SQLSTATE path as the race, exercises the new catch.
  - Restored "rejects checkpoint for run owned by different user" — now backed by the service-layer userId filter.
- [x] `pnpm -F web exec tsc --noEmit` — 0 errors
- [x] `pnpm knip` — no unused exports introduced
- [x] `pnpm -F web exec prettier --write` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)