### PR TITLE
refactor(webhooks): tighten fk-race error helper and test its contract

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
@@ -44,9 +44,26 @@ const router = tsr.router(webhookCheckpointsContract, {
     // tracked in #10763), PG raises SQLSTATE 23503; we surface it as
     // 404 instead of 500 to keep the same "run not found" contract
     // the caller already handles.
-    let result;
     try {
-      result = await createCheckpoint(body, userId);
+      const result = await createCheckpoint(body, userId);
+
+      log.debug(
+        `Checkpoint created: ${result.checkpointId}, session: ${result.agentSessionId}, conversation: ${result.conversationId}`,
+      );
+
+      // Note: vm0_result event is now sent by the complete API
+      // This endpoint only handles checkpoint data persistence
+
+      return {
+        status: 200 as const,
+        body: {
+          checkpointId: result.checkpointId,
+          agentSessionId: result.agentSessionId,
+          conversationId: result.conversationId,
+          artifacts: result.artifacts,
+          volumes: result.volumes,
+        },
+      };
     } catch (err) {
       if (isForeignKeyViolation(err)) {
         log.info("Run deleted concurrent with checkpoint, dropping", {
@@ -61,24 +78,6 @@ const router = tsr.router(webhookCheckpointsContract, {
       }
       throw err;
     }
-
-    log.debug(
-      `Checkpoint created: ${result.checkpointId}, session: ${result.agentSessionId}, conversation: ${result.conversationId}`,
-    );
-
-    // Note: vm0_result event is now sent by the complete API
-    // This endpoint only handles checkpoint data persistence
-
-    return {
-      status: 200 as const,
-      body: {
-        checkpointId: result.checkpointId,
-        agentSessionId: result.agentSessionId,
-        conversationId: result.conversationId,
-        artifacts: result.artifacts,
-        volumes: result.volumes,
-      },
-    };
   },
 });
 

--- a/turbo/apps/web/src/lib/shared/__tests__/pg-errors.test.ts
+++ b/turbo/apps/web/src/lib/shared/__tests__/pg-errors.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { isForeignKeyViolation } from "../pg-errors";
+
+describe("isForeignKeyViolation", () => {
+  it("returns true for drizzle-wrapped PG error with cause.code 23503", () => {
+    // Shape drizzle actually produces at runtime — DrizzleQueryError wraps
+    // the underlying postgres driver error as `.cause`, which exposes
+    // SQLSTATE on `.code`. This is the shape observed in production
+    // Sentry reports for #10725.
+    const pgError = Object.assign(new Error("foreign_key_violation"), {
+      code: "23503",
+    });
+    const wrapped = new Error("Failed query: insert into ...", {
+      cause: pgError,
+    });
+    expect(isForeignKeyViolation(wrapped)).toBe(true);
+  });
+
+  it("returns true for a plain Error whose cause is an object with code 23503", () => {
+    const err = new Error("wrapped", { cause: { code: "23503" } });
+    expect(isForeignKeyViolation(err)).toBe(true);
+  });
+
+  it("returns false when cause.code is a different SQLSTATE", () => {
+    // 23505 = unique_violation. Common sibling of 23503; must not be
+    // conflated — unique violations shouldn't 404 the caller.
+    const err = new Error("wrapped", { cause: { code: "23505" } });
+    expect(isForeignKeyViolation(err)).toBe(false);
+  });
+
+  it("returns false when cause is missing", () => {
+    expect(isForeignKeyViolation(new Error("no cause"))).toBe(false);
+  });
+
+  it("returns false when cause is not an object", () => {
+    const err = new Error("string cause", { cause: "23503" });
+    expect(isForeignKeyViolation(err)).toBe(false);
+  });
+
+  it("returns false when cause is null", () => {
+    const err = new Error("null cause", { cause: null });
+    expect(isForeignKeyViolation(err)).toBe(false);
+  });
+
+  it("returns false when cause.code is missing", () => {
+    const err = new Error("no code", { cause: { detail: "something" } });
+    expect(isForeignKeyViolation(err)).toBe(false);
+  });
+
+  it("returns false for non-Error inputs", () => {
+    expect(isForeignKeyViolation(null)).toBe(false);
+    expect(isForeignKeyViolation(undefined)).toBe(false);
+    expect(isForeignKeyViolation("23503")).toBe(false);
+    expect(isForeignKeyViolation({ code: "23503" })).toBe(false);
+  });
+});

--- a/turbo/apps/web/src/lib/shared/pg-errors.ts
+++ b/turbo/apps/web/src/lib/shared/pg-errors.ts
@@ -14,9 +14,9 @@ export function isForeignKeyViolation(err: unknown): boolean {
   if (!(err instanceof Error)) {
     return false;
   }
-  const cause = (err as Error & { cause?: unknown }).cause;
-  if (cause && typeof cause === "object" && "code" in cause) {
-    return (cause as { code: unknown }).code === PG_FOREIGN_KEY_VIOLATION;
+  const { cause } = err;
+  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
+    return false;
   }
-  return false;
+  return cause.code === PG_FOREIGN_KEY_VIOLATION;
 }


### PR DESCRIPTION
## Summary

Follow-up to the review on #10785. Three small changes, no behavior change:

- **P2**: Drop two redundant `as` casts in `isForeignKeyViolation` by using ES2022's `Error.cause: unknown` typing + `in`-narrowing. Per CLAUDE.md "Avoid \`as\` casting unless absolutely necessary".
- **P2**: Cover the 23503 branch on the \`checkpoints\` handler. The existing handler-level integration test hits \`createCheckpoint\`'s internal SELECT first and throws \`notFound\` before any INSERT runs, so the 23503 catch path was effectively dead from a coverage standpoint. Added a direct unit test for \`isForeignKeyViolation\` that pins the contract against every error shape the helper must recognise or reject.
- **P3**: Restructure the \`checkpoints\` handler to return inside the \`try\` block rather than the \`let result; try { result = ... }\` shape that reads awkwardly and splits success/failure across two statements.

## Test plan

- [x] \`pnpm -F web exec vitest run src/lib/shared/__tests__/pg-errors.test.ts app/api/webhooks/agent\` — 182/182 pass (includes the 8 new \`isForeignKeyViolation\` contract cases)
- [x] \`pnpm -F web exec tsc --noEmit\` — 0 errors

## Notes

- The 8 cases for \`isForeignKeyViolation\` each test one shape the helper must classify: drizzle-wrapped (\`.cause.code = "23503"\`), plain \`{ code }\` cause, sibling SQLSTATEs (23505 unique_violation), missing cause, non-object cause, null cause, missing code, and non-Error inputs. That's the pragmatic alternative to simulating a mid-\`createCheckpoint\` run deletion via test-time hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)