### PR TITLE
docs(runner): fix misleading comments in resolve_ambiguous test

### DIFF
--- a/crates/runner/src/cmd/local/cancel.rs
+++ b/crates/runner/src/cmd/local/cancel.rs
@@ -133,14 +133,12 @@ mod tests {
     #[test]
     fn resolve_ambiguous() {
         let dir = tempfile::tempdir().unwrap();
-        // Create two claim files with the same prefix (first char).
         let id1 = RunId::new_v4();
         let id2 = RunId::new_v4();
         std::fs::write(dir.path().join(format!("{id1}.claim")), b"").unwrap();
         std::fs::write(dir.path().join(format!("{id2}.claim")), b"").unwrap();
 
-        // Single-char prefix — likely matches both.
-        // Use empty prefix to guarantee ambiguity.
+        // Empty prefix matches every `.claim` file, so two files guarantee ambiguity.
         let err = resolve_run_id(dir.path(), "").unwrap_err();
         assert!(err.to_string().contains("ambiguous"), "got: {err}");
     }


### PR DESCRIPTION
## Summary

- The comments in `resolve_ambiguous` test were self-contradictory and factually wrong:
  - "Create two claim files with the same prefix (first char)" — two random v4 UUIDs share a first char with probability ~1/16, not reliably
  - "Single-char prefix — likely matches both" — described a strategy the code never used (the call site uses empty prefix)
  - Only "Use empty prefix to guarantee ambiguity" matched the actual code
- Collapse all three into a single accurate comment explaining why empty prefix forces ambiguity.

Closes #10637.

## Test plan

- [x] `cargo test -p runner cmd::local::cancel` — all 5 tests pass