### PR TITLE
chore: ignore agents workspace dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,4 @@ tmp/
 junit.xml
 e2e/results/
 .codex/
+.agents/


### PR DESCRIPTION
## Summary
- ignore the local .agents workspace directory
- keep generated local agent artifacts out of git status
