### PR TITLE
fix(runner): prevent spurious mitmproxy restart loop from stopping flag race

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1581,8 +1581,12 @@ async fn maybe_spawn_mitm_restart(
         return;
     }
     retry.clear_timer();
-    // Drain any stale crash notifications from the previous process to prevent
-    // a spurious restart cycle after this one completes.
+    // Defensive drain: clears any crash notification already buffered
+    // from the very crash that armed this restart timer, so it can't
+    // re-trigger the select loop after we're done. `begin_restart` no
+    // longer produces post-call signals — each child owns its own
+    // `stopping` Arc, locked to `true` before kill — so this only
+    // sweeps pre-existing entries.
     while crash_rx.try_recv().is_ok() {}
     let params = mitm.begin_restart().await;
     retry.handle = Some(tokio::spawn(params.spawn()));

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1316,4 +1316,47 @@ mod tests {
         assert!(Arc::ptr_eq(&proxy.stopping, &params.stopping));
         assert!(!Arc::ptr_eq(&old_stopping, &params.stopping));
     }
+
+    /// `spawn_mitmdump` can fail (e.g. port still in use), leaving the
+    /// caller to retry without ever calling `complete_restart`. Each
+    /// `begin_restart` in that retry chain must still hand out a fresh
+    /// `Arc` and lock every previous one — otherwise a stale flag
+    /// could be reset on the next round, resurrecting the race.
+    #[tokio::test]
+    async fn repeated_begin_restart_produces_independent_flags() {
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+
+        let first = proxy.begin_restart().await;
+        let second = proxy.begin_restart().await;
+        let third = proxy.begin_restart().await;
+
+        // Every handed-out Arc is distinct.
+        assert!(!Arc::ptr_eq(&first.stopping, &second.stopping));
+        assert!(!Arc::ptr_eq(&second.stopping, &third.stopping));
+        assert!(!Arc::ptr_eq(&first.stopping, &third.stopping));
+
+        // Superseded flags are permanently locked; only the most
+        // recent one remains mutable.
+        assert!(first.stopping.load(Ordering::Acquire));
+        assert!(second.stopping.load(Ordering::Acquire));
+        assert!(!third.stopping.load(Ordering::Acquire));
+        assert!(Arc::ptr_eq(&proxy.stopping, &third.stopping));
+    }
+
+    /// `stop()` must set the *current* child's flag, not the one just
+    /// superseded by `begin_restart`. A regression here would make
+    /// `stop()` a silent no-op (the old Arc is already `true`), while
+    /// the new child's monitor — which is what `stop()` exists to
+    /// silence — would keep reading `false`.
+    #[tokio::test]
+    async fn stop_after_begin_restart_targets_current_flag() {
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+        let params = proxy.begin_restart().await;
+        let current = Arc::clone(&params.stopping);
+        assert!(!current.load(Ordering::Acquire));
+
+        proxy.stop().await.unwrap();
+
+        assert!(current.load(Ordering::Acquire));
+    }
 }

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -199,23 +199,39 @@ impl MitmProxy {
         self.registry_handle().unregister_vm(source_ip).await
     }
 
-    /// Prepare for restart: reset `stopping`, kill any lingering child, and
-    /// return the parameters needed for [`spawn_mitmdump`].
+    /// Prepare for restart: kill any lingering child, permanently silence
+    /// its stdout monitor, and return fresh parameters for
+    /// [`spawn_mitmdump`].
+    ///
+    /// `stopping` is scoped to a single child. The old flag is set to
+    /// `true` (so the old monitor task, which may observe the stdout
+    /// pipe close at some arbitrary point after this call returns,
+    /// reads "graceful shutdown" and never emits a spurious crash
+    /// notification) and the field is replaced with a fresh `Arc` for
+    /// the incoming process. The new child's monitor starts from a
+    /// clean slate and will detect real crashes.
     ///
     /// The caller should spawn the mitmdump process (potentially in a
     /// background task) and then call [`complete_restart`] with the result.
     pub async fn begin_restart(&mut self) -> MitmRestartParams {
-        self.stopping.store(false, Ordering::Release);
-        // Kill old child if somehow still running.
+        // Silence the old monitor permanently: after this call, no one
+        // else holds a handle that could reset its `Arc<AtomicBool>`
+        // back to `false`, so the monitor is guaranteed to read `true`
+        // regardless of scheduling order between `kill().await` and
+        // the stdout-pipe drain.
+        self.stopping.store(true, Ordering::Release);
         if let Some(ref mut child) = self.child {
             let _ = child.kill().await;
             self.child = None;
         }
+        // Fresh flag for the incoming process's monitor.
+        let new_stopping = Arc::new(AtomicBool::new(false));
+        self.stopping = Arc::clone(&new_stopping);
         MitmRestartParams {
             config: self.config.clone(),
             port: self.port,
             crash_tx: self.crash_tx.clone(),
-            stopping: Arc::clone(&self.stopping),
+            stopping: new_stopping,
         }
     }
 
@@ -1271,5 +1287,33 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("usage-pending"), "0").unwrap();
         assert!(wait_usage_flush(dir.path(), Duration::from_secs(1)).await);
+    }
+
+    /// Regression for #10624: `begin_restart` must lock the old
+    /// monitor's `stopping` at `true` and hand the caller a fresh
+    /// `Arc<AtomicBool>` for the next child. If the old flag were
+    /// shared across the restart boundary, the old stdout monitor
+    /// could race in after `kill().await` returned, read `stopping ==
+    /// false`, and emit a spurious crash notification.
+    #[tokio::test]
+    async fn begin_restart_isolates_stopping_flag_per_child() {
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+        let old_stopping = Arc::clone(&proxy.stopping);
+
+        let params = proxy.begin_restart().await;
+
+        // Old flag is now permanently `true`; any task still holding
+        // `old_stopping` (the old monitor) will observe graceful
+        // shutdown semantics regardless of when it wakes up.
+        assert!(old_stopping.load(Ordering::Acquire));
+
+        // The next child's monitor starts from a clean slate.
+        assert!(!params.stopping.load(Ordering::Acquire));
+
+        // And the proxy holds that same fresh `Arc` — so subsequent
+        // `stop()` / `Drop` calls operate on the new child, not the
+        // already-silenced old one.
+        assert!(Arc::ptr_eq(&proxy.stopping, &params.stopping));
+        assert!(!Arc::ptr_eq(&old_stopping, &params.stopping));
     }
 }


### PR DESCRIPTION
## Summary

- `begin_restart` reset `stopping` to `false` **before** killing the old mitmdump child. The old stdout-monitor task could observe the pipe close at some arbitrary point after `kill().await` returned — tokio does not synchronise the pipe drain with the kill syscall — read `stopping == false`, and emit a crash notification on `crash_tx`. The outer select loop in `start.rs` would then pick up this stale signal and trigger a second restart, occasionally cascading into a restart loop.
- Caller-side `while crash_rx.try_recv().is_ok() {}` only drains crash signals that existed **before** `begin_restart`; it can't block signals the old monitor emits **after** `begin_restart` returns.
- Fix: scope `stopping` to a single child. On restart, permanently set the old flag to `true` (the old monitor is the only remaining holder of that `Arc`, so nothing can reset it back to `false`) and install a fresh `Arc<AtomicBool>` for the incoming process. The new child's monitor starts from a clean slate and detects real crashes as before. No caller-visible API change; `complete_restart`, `stop()`, and `Drop` are untouched.

### Why per-child `Arc` instead of "reset later in `complete_restart`"

Keeping the flag shared across the restart boundary still requires the old monitor's `stopping.load(…)` to happen-before the `store(false, …)` that follows, which is impossible to guarantee without joining the monitor task. Giving each child its own `Arc` makes the old flag permanently observable as `true` by construction — the race is eliminated, not narrowed.

## Test plan

- [x] `cargo test -p runner --bin runner proxy::` — 20 passed, including new `begin_restart_isolates_stopping_flag_per_child` regression test that pins the new invariant (old `Arc` locked `true`, proxy holds fresh `Arc`, new flag starts `false`).
- [x] `cargo clippy -p runner --tests -- -D warnings` — clean.
- [ ] Stage/manual: leave a runner under load with repeated `begin_restart` triggers and confirm no extra crash notifications arrive on `crash_rx` after the scheduled restart.

Fixes #10624

🤖 Generated with [Claude Code](https://claude.com/claude-code)