### PR TITLE
docs: document sandbox trait surface

### DIFF
--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -1,3 +1,34 @@
+//! The [`Sandbox`] trait — the core backend abstraction of this crate.
+//!
+//! A sandbox is a process-isolation environment (a Firecracker VM in
+//! production, a mock harness in tests) that runs guest workloads on
+//! behalf of the runner. Implementations are created by a
+//! [`SandboxFactory`](crate::SandboxFactory) and handed to callers as
+//! `Box<dyn Sandbox>`.
+//!
+//! # Lifecycle
+//! ```text
+//!   created  ──start()──▶  running  ──stop()/kill()──▶  stopped
+//!                             │  ▲
+//!                             └──┤ park()/unpark()
+//! ```
+//! - [`start`](Sandbox::start) boots the guest and must be called before
+//!   any operation; subsequent `start` calls on the same instance fail.
+//! - [`stop`](Sandbox::stop) asks the guest to shut down gracefully, then
+//!   kills the backing process. [`kill`](Sandbox::kill) skips the graceful
+//!   step. Both are idempotent and both end in the stopped state.
+//! - [`park`](Sandbox::park) / [`unpark`](Sandbox::unpark) reclaim guest
+//!   resources while the sandbox is idle; a parked sandbox must be
+//!   unparked before further operations.
+//!
+//! # Operations
+//! Once running, callers invoke [`exec`](Sandbox::exec) /
+//! [`write_file`](Sandbox::write_file) / [`spawn_watch`](Sandbox::spawn_watch) /
+//! [`wait_exit`](Sandbox::wait_exit) via the host-to-guest IPC channel
+//! (vsock, in the Firecracker backend). Operations race against a crash
+//! notifier so that a dying backend process surfaces as a specific
+//! "backend crashed" error rather than an opaque IPC timeout.
+
 use std::any::Any;
 use std::time::Duration;
 
@@ -6,11 +37,45 @@ use async_trait::async_trait;
 use crate::error::Result;
 use crate::types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};
 
-/// The `Any` bound allows `SandboxFactory::destroy()` to downcast
-/// `Box<dyn Sandbox>` back to the concrete type for backend-specific cleanup.
+/// A process-isolation environment that runs guest workloads for the runner.
+///
+/// Implementations are created by a [`SandboxFactory`](crate::SandboxFactory)
+/// and consumed as `Box<dyn Sandbox>`.
+///
+/// # Lifecycle
+/// ```text
+///   created  ──start()──▶  running  ──stop()/kill()──▶  stopped
+///                             │  ▲
+///                             └──┤ park()/unpark()
+/// ```
+/// - [`start`](Self::start) boots the guest; it must be called exactly
+///   once and must precede any operation.
+/// - [`stop`](Self::stop) asks the guest to shut down gracefully, then
+///   kills the backing process. [`kill`](Self::kill) skips the graceful
+///   step. Both are idempotent and both end in the stopped state.
+/// - [`park`](Self::park) / [`unpark`](Self::unpark) reclaim guest
+///   resources while idle; a parked sandbox must be unparked before
+///   further operations.
+///
+/// # Operations
+/// Once running, callers invoke [`exec`](Self::exec) /
+/// [`write_file`](Self::write_file) / [`spawn_watch`](Self::spawn_watch) /
+/// [`wait_exit`](Self::wait_exit) via the host-to-guest IPC channel
+/// (vsock, in the Firecracker backend). Operations race against a crash
+/// notifier so that a dying backend process surfaces as a specific
+/// error rather than an opaque IPC timeout.
+///
+/// # Thread-safety and trait objects
+/// Implementations are consumed as `Box<dyn Sandbox>` and shared across
+/// tasks, hence `Send + Sync`. The `Any` bound allows
+/// [`SandboxFactory::destroy()`](crate::SandboxFactory::destroy) to
+/// downcast back to the concrete type for backend-specific cleanup.
 #[async_trait]
 pub trait Sandbox: Send + Sync + Any {
     // -- identity --
+
+    /// Stable identifier for this sandbox, unique within the runner
+    /// process. Used in logs, metrics, and socket/path derivation.
     fn id(&self) -> &str;
     /// The network-visible source IP address for this sandbox.
     /// Used as the key for proxy VM registration.
@@ -22,8 +87,34 @@ pub trait Sandbox: Send + Sync + Any {
     }
 
     // -- lifecycle --
+
+    /// Boot the guest and make the sandbox ready to serve operations.
+    ///
+    /// Must only be called once per instance. Implementations must leave
+    /// no leaked processes, sockets, or mounts on failure — a failed
+    /// `start` is equivalent to a sandbox that was never started, and
+    /// the caller may drop the instance without calling `stop`/`kill`.
     async fn start(&mut self) -> Result<()>;
+    /// Shut the guest down gracefully, then terminate the backing process.
+    ///
+    /// The guest is first notified via the IPC channel (with an
+    /// implementation-defined timeout) so user workloads can clean up;
+    /// the backing process is killed regardless of whether the guest
+    /// acknowledged. For a parked sandbox the graceful step is skipped
+    /// (vCPUs are paused and cannot process the message) and the
+    /// sandbox goes straight to force-kill — no user workload is lost
+    /// because a parked sandbox is idle by definition.
+    ///
+    /// Idempotent: calling `stop` on an already-stopped (or concurrently
+    /// stopping) sandbox returns `Ok(())` without side effects.
     async fn stop(&mut self) -> Result<()>;
+    /// Terminate the backing process immediately, without a graceful
+    /// guest shutdown. Prefer [`stop`](Self::stop) for normal teardown;
+    /// reach for `kill` when the guest is unresponsive or the caller is
+    /// already abandoning any in-flight work.
+    ///
+    /// Idempotent: calling `kill` on an already-stopped (or concurrently
+    /// stopping) sandbox returns `Ok(())` without side effects.
     async fn kill(&mut self) -> Result<()>;
 
     // -- idle transitions --
@@ -71,12 +162,40 @@ pub trait Sandbox: Send + Sync + Any {
     }
 
     // -- operations --
+    //
+    // Operations require the sandbox to be running (post-`start`,
+    // pre-`stop`/`kill`) and, if it was previously parked, unparked.
+    // They race the guest IPC call against a crash notifier so a dying
+    // backend process surfaces as a specific error rather than an
+    // opaque IPC timeout.
+
+    /// Run `request.cmd` in the guest, block until it exits or the
+    /// request timeout expires, and return the captured output.
+    ///
+    /// Returns an error if the sandbox is not running or if the backing
+    /// process crashes during execution.
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult>;
+    /// Write `content` to `path` inside the guest, creating or
+    /// truncating as needed. Returns an error if the sandbox is not
+    /// running or if the backing process crashes.
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;
+    /// Spawn `request.cmd` in the guest and return a handle for later
+    /// supervision via [`wait_exit`](Self::wait_exit).
+    ///
+    /// If `stdout_log_path` is `Some`, guest stdout is also mirrored
+    /// into that file on the guest side; the returned handle's
+    /// `stdout_rx` receives the same stream in real time when the
+    /// backend supports streaming (see
+    /// [`SpawnHandle::stdout_rx`](crate::SpawnHandle::stdout_rx)).
     async fn spawn_watch(
         &self,
         request: &ExecRequest<'_>,
         stdout_log_path: Option<&str>,
     ) -> Result<SpawnHandle>;
+    /// Wait for the process behind `handle` to exit, up to `timeout`.
+    ///
+    /// Consumes the handle. Returns an error if the sandbox is not
+    /// running, if the backing process crashes, or if the timeout
+    /// elapses before the guest process exits.
     async fn wait_exit(&self, handle: SpawnHandle, timeout: Duration) -> Result<ProcessExit>;
 }


### PR DESCRIPTION
## Summary
- Add module-level overview and trait-level docs to `crates/sandbox/src/sandbox.rs` — the primary public trait of the crate
- Document every previously undocumented method (`id`, `start`, `stop`, `kill`, `exec`, `write_file`, `spawn_watch`, `wait_exit`) with its contract, error conditions, and caller invariants
- Brings parity with the existing `park`/`unpark` docs, which already covered idempotency and partial-failure semantics
- Doc-only; no code changes

Closes #10774.

## Test plan
- [x] `cargo build -p sandbox` — clean
- [x] `cargo clippy -p sandbox --all-targets` — clean
- [x] `cargo clippy -p sandbox-fc -p sandbox-mock -p runner --all-targets` — downstream consumers clean
- [x] `cargo test -p sandbox` — 7 pass
- [x] `RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links -D rustdoc::private-intra-doc-links" cargo doc -p sandbox --no-deps` — all intra-doc links resolve
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)