### PR TITLE
chore(platform): remove deleted voice-chat paths from oxlintrc no-restricted-imports

### DIFF
--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -118,8 +118,6 @@
       "files": [
         "src/signals/zero-page/zero-chat.ts",
         "src/signals/zero-page/chat-draft.ts",
-        "src/signals/voice-chat/voice-chat-session.ts",
-        "src/signals/mission-control-page/create-voice-chat-panel-signals.ts",
         "src/signals/voice-io/voice-io-tts.ts",
         "src/signals/voice-io/voice-io-stt.ts"
       ],


### PR DESCRIPTION
## Summary

- Remove two dead file-path entries from the `no-restricted-imports` override in `turbo/apps/platform/.oxlintrc.json`
- Both files were deleted in PR #10760 (epic sub-issue #10752 of #10749); the override entries are stale
- Pure config hygiene — zero runtime impact

Removed entries:
- `src/signals/voice-chat/voice-chat-session.ts`
- `src/signals/mission-control-page/create-voice-chat-panel-signals.ts`

Closes #10797

## Test plan

- [x] `rg 'voice-chat-session|create-voice-chat-panel-signals' turbo/apps/platform/.oxlintrc.json` → no matches
- [x] `pnpm turbo run lint --filter=@vm0/app` — green
- [x] `pnpm format` — file unchanged (already well-formatted)
- [x] `pnpm knip` — "Knip found no issues"
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)