### PR TITLE
docs: document nbd request and reply fields

### DIFF
--- a/crates/nbd-cow/src/protocol.rs
+++ b/crates/nbd-cow/src/protocol.rs
@@ -44,17 +44,30 @@ impl Command {
 /// NBD request header (28 bytes, client -> server).
 #[derive(Debug, Clone)]
 pub struct NbdRequest {
+    /// Per-command flags bitmask (e.g. `NBD_CMD_FLAG_FUA = 0x0001`).
     pub flags: u16,
+    /// Decoded command type. The wire encoding is `u16`; see [`Command`].
     pub command: Command,
+    /// Opaque request identifier echoed back in [`NbdReply::handle`]. The
+    /// dispatcher uses this to correlate replies with in-flight requests;
+    /// the server does not interpret the value.
     pub handle: u64,
+    /// Byte offset into the device where the operation applies (Read /
+    /// Write / Trim). Ignored for Flush and Disconnect.
     pub offset: u64,
+    /// Payload length in bytes. Requests exceeding the server's
+    /// `MAX_REQUEST_LENGTH` (see `server.rs`) are rejected with `EIO`.
     pub length: u32,
 }
 
 /// NBD reply header (16 bytes, server -> client).
 #[derive(Debug, Clone)]
 pub struct NbdReply {
+    /// NBD error code: `0` means success; a non-zero value is an errno
+    /// the kernel maps back to the originating I/O (e.g. `libc::EIO`).
     pub error: u32,
+    /// Echoes [`NbdRequest::handle`] from the originating request so the
+    /// client can match this reply to the pending operation.
     pub handle: u64,
 }
 


### PR DESCRIPTION
## Summary
- Add field-level docs to the two wire-protocol structs in `crates/nbd-cow/src/protocol.rs` (`NbdRequest` and `NbdReply`)
- `handle`, `flags`, and `error` have semantics that aren't obvious from names alone — `handle` is the opaque request/reply correlation id the kernel uses to match in-flight operations, `flags` is the NBD per-command bitmask, and `error` uses errno conventions
- Doc-only; no code changes

Closes #10645.

## Test plan
- [x] `cargo build -p nbd-cow` — clean
- [x] `cargo clippy -p nbd-cow --all-targets` — clean
- [x] `cargo test -p nbd-cow --lib protocol::` — 13 pass
- [x] `RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links -D rustdoc::private-intra-doc-links" cargo doc -p nbd-cow --no-deps` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)