### PR TITLE
feat(guest-download): support file:// urls for host-staged tarballs

### DIFF
--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -8,6 +8,7 @@
 use guest_common::{log_error, log_info, log_warn, telemetry::record_sandbox_op};
 use serde::Deserialize;
 use std::fs;
+use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::sync::LazyLock;
 use std::thread;
@@ -431,22 +432,38 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
         status_code: None,
     })?;
 
-    // Make HTTP request using global agent
-    let response = HTTP_AGENT.get(url).call().map_err(|e| {
-        let (retriable, status_code) = match &e {
-            // Retry on server errors (5xx) and rate limiting (429)
-            ureq::Error::StatusCode(code) => (*code >= 500 || *code == 429, Some(*code)),
-            _ => (true, None), // network/timeout errors are retriable
-        };
-        DownloadError {
-            message: format!("HTTP {e} url={url}"),
-            retriable,
-            status_code,
-        }
-    })?;
+    // Obtain a reader for the archive bytes. HTTP is the production path today;
+    // file:// is used by the runner-side storage cache (epic #10800) to feed
+    // host-staged tarballs that were pushed into the guest over vsock.
+    let local_path: Option<PathBuf>;
+    let reader: Box<dyn Read> = if let Some(path) = url.strip_prefix("file://") {
+        let path_buf = PathBuf::from(path);
+        log_info!(LOG_TAG, "Reading local archive from {path}");
+        let file = fs::File::open(&path_buf).map_err(|e| DownloadError {
+            message: format!("Failed to open local archive {path}: {e}"),
+            retriable: false,
+            status_code: None,
+        })?;
+        local_path = Some(path_buf);
+        Box::new(file)
+    } else {
+        local_path = None;
+        let response = HTTP_AGENT.get(url).call().map_err(|e| {
+            let (retriable, status_code) = match &e {
+                // Retry on server errors (5xx) and rate limiting (429)
+                ureq::Error::StatusCode(code) => (*code >= 500 || *code == 429, Some(*code)),
+                _ => (true, None), // network/timeout errors are retriable
+            };
+            DownloadError {
+                message: format!("HTTP {e} url={url}"),
+                retriable,
+                status_code,
+            }
+        })?;
+        Box::new(response.into_body().into_reader())
+    };
 
-    // Stream: HTTP response -> GzDecoder -> tar::Archive
-    let reader = response.into_body().into_reader();
+    // Stream: reader -> GzDecoder -> tar::Archive
     let decoder = flate2::read::GzDecoder::new(reader);
     let mut archive = tar::Archive::new(decoder);
 
@@ -566,6 +583,19 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
             retriable: false,
             status_code: None,
         })?;
+    }
+
+    // For file:// URLs, drop the staged tarball now that extraction succeeded so it
+    // doesn't pin COW space for the lifetime of the sandbox. Failure is not fatal —
+    // the runner stages these under /tmp, which is wiped on VM teardown anyway.
+    if let Some(path) = local_path
+        && let Err(e) = fs::remove_file(&path)
+    {
+        log_warn!(
+            LOG_TAG,
+            "Failed to remove staged archive {}: {e}",
+            path.display()
+        );
     }
 
     Ok(())
@@ -706,6 +736,13 @@ mod tests {
     fn is_valid_url_valid() {
         assert!(is_valid_url(&Some(
             "https://example.com/archive.tar.gz".to_string()
+        )));
+    }
+
+    #[test]
+    fn is_valid_url_file_scheme() {
+        assert!(is_valid_url(&Some(
+            "file:///tmp/vm0-storage-cache/abc.tar.gz".to_string()
         )));
     }
 

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -1102,3 +1102,67 @@ fn symlink_missing_link_target_skipped() {
     // Malformed symlink should NOT be created
     assert!(mount.join("bad_symlink").symlink_metadata().is_err());
 }
+
+// ---------------------------------------------------------------------------
+// file:// scheme — host-staged tarballs (epic #10800)
+// ---------------------------------------------------------------------------
+
+// Successful file:// extraction: the local tarball is read, its contents are
+// extracted into the mount path, and the tarball is deleted.
+#[test]
+fn file_scheme_extraction_success() {
+    let tar_gz = create_tar_gz(&[("hello.txt", b"hello from file")]).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let staged = dir.path().join("staged.tar.gz");
+    std::fs::write(&staged, &tar_gz).unwrap();
+
+    let mount = dir.path().join("mount");
+    let url = format!("file://{}", staged.display());
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    assert_eq!(
+        std::fs::read_to_string(mount.join("hello.txt")).unwrap(),
+        "hello from file"
+    );
+    // Staged tarball is cleaned up after successful extraction
+    assert!(!staged.exists());
+}
+
+// Storage with a missing file:// target fails the run. The runner only rewrites
+// archive_url to file:// after vsock-staging succeeds, so a missing file means a
+// broken runner contract — fatal, no retry (status_code is None, retriable false).
+#[test]
+fn file_scheme_missing_storage_fatal() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("never-existed.tar.gz");
+    assert!(!missing.exists());
+
+    let mount = dir.path().join("mount");
+    let url = format!("file://{}", missing.display());
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+    assert!(!result);
+}
+
+// Artifacts treat HTTP 404 as non-fatal ("may not exist on first run"), but the
+// file:// path has no status_code, so a missing local file is fatal for artifacts
+// too. Same reasoning as storages: the runner only stages + rewrites after the
+// file lands, so a missing file signals a broken contract, not an absent artifact.
+#[test]
+fn file_scheme_missing_artifact_fatal() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("never-existed.tar.gz");
+    assert!(!missing.exists());
+
+    let mount = dir.path().join("artifact_mount");
+    let url = format!("file://{}", missing.display());
+    let manifest = write_manifest(&dir, &[], Some((mount.to_str().unwrap(), Some(&url)))).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+    assert!(!result);
+}


### PR DESCRIPTION
## Summary

- Add a `file://` branch to `download_and_extract` in `crates/guest-download/src/lib.rs`: when `archive_url` starts with `file://`, strip the prefix, open the local file, and feed it through the existing `GzDecoder` → `tar::Archive` pipeline. HTTP(S) behavior is unchanged.
- Delete the staged tarball with `fs::remove_file` after successful extraction. Delete failure is `log_warn!`-logged, not fatal.
- Local-file errors (missing, permission denied) return `DownloadError { retriable: false, status_code: None }` so they break out of the retry loop immediately and fail the run consistently for both storages and artifacts.

## Context

Part of epic #10800 (runner-side cache for storage archive downloads). The runner will push cached tarballs over vsock into the guest at `/tmp/vm0-storage-cache/<vasVersionId>.tar.gz` and rewrite `archive_url` to `file:///tmp/vm0-storage-cache/<vasVersionId>.tar.gz`. `guest-download` needs to accept those URLs.

**This PR is a production no-op until the runner cache module lands** — no current code path produces `file://` URLs. The HTTP path is byte-for-byte unchanged; the new branch is only reachable when `archive_url.starts_with("file://")`.

## Notes

- Per-entry security validation (`is_within`, symlink/hardlink target checks, `ancestors_within_target`) is reused as-is — it operates on decoded tar entries, not the transport.
- Missing-file-is-fatal for artifacts (not treated like HTTP 404): the runner only rewrites `archive_url` to `file://` after vsock-staging succeeds, so a missing file means a broken runner contract, not an optional absent artifact.
- No new dependencies.

## Test plan

- [x] `cargo fmt -p guest-download` clean
- [x] `cargo clippy -p guest-download --all-targets -- -D warnings` passes
- [x] `cargo test -p guest-download` passes — 25 unit + 29 integration tests (3 new `file_scheme_*` cases: success + deletion, missing storage fatal, missing artifact fatal; plus `is_valid_url_file_scheme` unit test)
- [x] Existing HTTP-path tests all pass unchanged (no regressions on the production-reachable path)
- [ ] Full turbo.yml CI on PR

Closes #10805