### PR TITLE
fix: route voice input quota upsell to the Compare plans modal

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -7,7 +7,11 @@ import {
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { fetch$ } from "../fetch.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { setBillingDialogOpen$ } from "../zero-page/billing.ts";
+import {
+  setActiveOrgManageTab$,
+  setBillingSubPage$,
+} from "../zero-page/settings/org-manage-tabs-state.ts";
+import { setOrgManageDialogOpen$ } from "../zero-page/settings/org-manage-dialog.ts";
 import { logger } from "../log.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { stopTts$ } from "./voice-io-tts.ts";
@@ -218,7 +222,9 @@ export const stopAndTranscribe$ = command(
           } | null;
           if (body?.error?.code === "AUDIO_INPUT_QUOTA_EXCEEDED") {
             set(refreshAudioInputQuota$);
-            set(setBillingDialogOpen$, true);
+            set(setActiveOrgManageTab$, "billing");
+            set(setBillingSubPage$, true);
+            await set(setOrgManageDialogOpen$, true, signal);
             set(resetState$);
             return "";
           }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx
@@ -351,7 +351,7 @@ describe("chat-i-035: mic button gates on audio input quota", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
     });
-    expect(screen.queryByText("Choose your plan")).not.toBeInTheDocument();
+    expect(screen.queryByText("Compare plans")).not.toBeInTheDocument();
   });
 
   it("should open billing dialog without recording when quota is exhausted", async () => {
@@ -381,7 +381,7 @@ describe("chat-i-035: mic button gates on audio input quota", () => {
     click(micButton);
 
     await waitFor(() => {
-      expect(screen.getByText("Choose your plan")).toBeInTheDocument();
+      expect(screen.getByText("Compare plans")).toBeInTheDocument();
     });
 
     expect(screen.queryByLabelText("Stop recording")).not.toBeInTheDocument();
@@ -412,7 +412,7 @@ describe("chat-i-035: mic button gates on audio input quota", () => {
     click(stopButton);
 
     await waitFor(() => {
-      expect(screen.getByText("Choose your plan")).toBeInTheDocument();
+      expect(screen.getByText("Compare plans")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -110,7 +110,11 @@ import {
   startRecording$,
   stopAndTranscribe$,
 } from "../../signals/voice-io/voice-io-stt.ts";
-import { setBillingDialogOpen$ } from "../../signals/zero-page/billing.ts";
+import {
+  setActiveOrgManageTab$,
+  setBillingSubPage$,
+} from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
+import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
 
 const MAX_FILE_SIZE = 1024 * 1024 * 1024; // 1 GB — keep in sync with web constants
 
@@ -515,7 +519,9 @@ function MicButton({
   const transcribing = useGet(sttTranscribing$);
   const startRec = useSet(startRecording$);
   const stopAndTranscribe = useSet(stopAndTranscribe$);
-  const openBillingDialog = useSet(setBillingDialogOpen$);
+  const setTab = useSet(setActiveOrgManageTab$);
+  const setSubPage = useSet(setBillingSubPage$);
+  const openOrgManage = useSet(setOrgManageDialogOpen$);
   const signal = useGet(pageSignal$);
 
   if (!available) {
@@ -537,7 +543,9 @@ function MicButton({
       );
     } else {
       if (quota && !quota.allowed) {
-        openBillingDialog(true);
+        setTab("billing");
+        setSubPage(true);
+        detach(openOrgManage(true, signal), Reason.DomCallback);
         return;
       }
       detach(startRec(signal), Reason.DomCallback);


### PR DESCRIPTION
Closes #10807

## Summary

- Free-tier voice input (10-use cap) was opening `BillingDialog` ("Choose your plan" — the vibe-coding-styled modal). Per #10807 it should open the same Compare plans subpage that the bottom-left sidebar upgrade card already uses.
- Both trigger sites swapped to the existing `OrgManageDialog` with `billing` tab + `billingSubPage` flag: the preemptive quota check in `MicButton` (`zero-chat-composer.tsx`) and the 402 `AUDIO_INPUT_QUOTA_EXCEEDED` handler in `stopAndTranscribe$` (`voice-io-stt.ts`).
- Updated existing `chat-i-035` mic-button tests to assert on the new modal's "Compare plans" heading instead of "Choose your plan".

## Test plan

- [x] `pnpm exec vitest run src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx` — 9/9 pass
- [x] `pnpm exec vitest run org-billing-tab.test.tsx billing-dialog-display.test.tsx billing-dialog-interaction.test.tsx` — 58/58 pass
- [x] `pnpm run check-types` — clean
- [x] `pnpm run lint` — clean
- [ ] Manual: hit the free-tier voice input cap and confirm the modal matches the sidebar upgrade entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)