### PR TITLE
feat(runner): content-addressed storage archive cache

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2513,6 +2513,7 @@ dependencies = [
  "chrono",
  "clap",
  "flate2",
+ "futures-util",
  "guest-agent",
  "guest-download",
  "guest-init",

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -26,6 +26,7 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 flate2 = { workspace = true }
+futures-util = { workspace = true }
 reqwest = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -319,6 +319,7 @@ pub async fn run_start(
         http,
         log_paths,
         ip_log_map,
+        home: home.clone(),
     });
 
     let config = RunConfig {
@@ -2247,7 +2248,7 @@ mod tests {
             group: "test-group".into(),
             profiles,
             runtime,
-            home,
+            home: home.clone(),
             budget: Arc::new(ResourceBudget::new(
                 budget_vcpu,
                 budget_memory_mb,
@@ -2270,6 +2271,7 @@ mod tests {
                 http: crate::http::HttpClient::new(api_url.to_string()).unwrap(),
                 log_paths: crate::paths::LogPaths::new(log_dir),
                 ip_log_map: kmsg_log::new_ip_log_map(),
+                home,
             }),
             firecracker: config::FirecrackerConfig {
                 binary: PathBuf::new(),

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -20,7 +20,7 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::idle_pool::IdleEntry;
 use crate::kmsg_log;
-use crate::paths::{LogPaths, guest};
+use crate::paths::{HomePaths, LogPaths, guest};
 use crate::proxy::{self, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
 use crate::types::{
@@ -35,6 +35,7 @@ pub struct ExecutorConfig {
     pub http: HttpClient,
     pub log_paths: LogPaths,
     pub ip_log_map: kmsg_log::IpLogMap,
+    pub home: HomePaths,
 }
 
 /// Per-job VM parameters resolved from the profile config.
@@ -410,13 +411,9 @@ async fn run_in_sandbox(
 
     // 3. Download storages (skipping entries unchanged since the previous turn)
     if let Some(manifest) = &context.storage_manifest {
-        let filtered;
-        let effective = match prev_storage {
-            Some(prev) => {
-                filtered = filter_unchanged_storages(manifest, prev);
-                &filtered
-            }
-            None => manifest,
+        let mut effective: StorageManifest = match prev_storage {
+            Some(prev) => filter_unchanged_storages(manifest, prev),
+            None => manifest.clone(),
         };
         // Short-circuit: skip the vsock exec if every entry was filtered out
         // and there are no paths to clean up.
@@ -428,7 +425,20 @@ async fn run_in_sandbox(
         }
         let t = Instant::now();
         let result = if has_work {
-            download_storages(sandbox, context, effective, &log_file).await
+            // Populate the runner-side cache first, rewriting eligible entries'
+            // `archive_url` to `file:///tmp/vm0-storage-cache/...` so the guest
+            // reads from its tmpfs instead of hitting R2 per turn.
+            match crate::storage_cache::populate_cache(
+                &mut effective,
+                sandbox,
+                &config.home,
+                telemetry,
+            )
+            .await
+            {
+                Ok(()) => download_storages(sandbox, context, &effective, &log_file).await,
+                Err(e) => Err(e),
+            }
         } else {
             Ok(())
         };
@@ -2331,6 +2341,7 @@ mod tests {
             http: crate::http::HttpClient::new("http://localhost:9999".into()).unwrap(),
             log_paths: LogPaths::new(log_dir),
             ip_log_map: kmsg_log::new_ip_log_map(),
+            home: HomePaths::with_root(dir.to_path_buf()),
         }
     }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -428,17 +428,17 @@ async fn run_in_sandbox(
             // Populate the runner-side cache first, rewriting eligible entries'
             // `archive_url` to `file:///tmp/vm0-storage-cache/...` so the guest
             // reads from its tmpfs instead of hitting R2 per turn.
-            match crate::storage_cache::populate_cache(
-                &mut effective,
-                sandbox,
-                &config.home,
-                telemetry,
-            )
-            .await
-            {
-                Ok(()) => download_storages(sandbox, context, &effective, &log_file).await,
-                Err(e) => Err(e),
+            async {
+                crate::storage_cache::populate_cache(
+                    &mut effective,
+                    sandbox,
+                    &config.home,
+                    telemetry,
+                )
+                .await?;
+                download_storages(sandbox, context, &effective, &log_file).await
             }
+            .await
         } else {
             Ok(())
         };

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -26,6 +26,7 @@ mod resource_budget;
 mod retry;
 mod runner_dirname;
 mod status;
+mod storage_cache;
 mod telemetry;
 mod types;
 

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -5,6 +5,25 @@ use sha2::{Digest, Sha256};
 use crate::error::RunnerResult;
 use crate::ids::RunId;
 
+/// Short hex digests (16 chars = 8 bytes) of a `(name, version)` pair, used
+/// when building filesystem paths from untrusted manifest fields.
+///
+/// Prefix-length of 16 is ample collision resistance for a runner-local
+/// cache (~10^10 pairs before birthday collision) while keeping directory
+/// names compact.
+fn storage_key_hashes(name: &str, version: &str) -> (String, String) {
+    (short_digest(name), short_digest(version))
+}
+
+/// Hex-encode the first 8 bytes of `SHA-256(s)` — 16 characters, collision
+/// resistant enough for runner-local bookkeeping and always a valid path
+/// segment.
+fn short_digest(s: &str) -> String {
+    let digest = Sha256::digest(s.as_bytes());
+    let prefix = digest.get(..8).unwrap_or(&digest);
+    hex::encode(prefix)
+}
+
 /// Update a directory's mtime to now, so `runner gc` treats it as recently used.
 pub fn touch_mtime(dir: &Path) {
     let Ok(f) = std::fs::File::open(dir) else {
@@ -53,6 +72,7 @@ impl RunnerPaths {
 }
 
 /// Paths rooted at /var/lib/vm0-runner/.
+#[derive(Clone)]
 pub struct HomePaths {
     root: PathBuf,
 }
@@ -147,10 +167,26 @@ impl HomePaths {
         self.root.join("storages")
     }
 
-    /// Per-version flock path guarding `<storages_dir>/<name>/<version>/`.
+    /// Cache directory for a specific storage (name, version) pair.
+    ///
+    /// `name` and `version` come from untrusted manifest fields
+    /// (`vas_storage_name` / `vas_version_id`) so they are hashed before use.
+    /// Hashing also makes the key pair injective — two distinct `(name,
+    /// version)` pairs cannot collide on a single directory regardless of
+    /// hyphen placement in either component.
+    pub fn storage_cache_dir(&self, name: &str, version: &str) -> PathBuf {
+        let (name_hash, version_hash) = storage_key_hashes(name, version);
+        self.storages_dir().join(name_hash).join(version_hash)
+    }
+
+    /// Per-version flock path guarding `storage_cache_dir(name, version)`.
+    ///
+    /// Same hashing rationale as `storage_cache_dir`: the lock filename must
+    /// be injective in `(name, version)` and safe to embed in a path segment.
     pub fn storage_lock(&self, name: &str, version: &str) -> PathBuf {
+        let (name_hash, version_hash) = storage_key_hashes(name, version);
         self.locks_dir()
-            .join(format!("storage-{name}-{version}.lock"))
+            .join(format!("storage-{name_hash}-{version_hash}.lock"))
     }
 }
 
@@ -397,10 +433,15 @@ mod tests {
     fn storages_paths_layout() {
         let home = HomePaths::with_root(PathBuf::from("/test"));
         assert_eq!(home.storages_dir(), PathBuf::from("/test/storages"));
-        assert_eq!(
-            home.storage_lock("system-bash", "v3"),
-            PathBuf::from("/test/locks/storage-system-bash-v3.lock"),
-        );
+        // `storage_lock` hashes its inputs: lockfile name is derived from
+        // `(short_digest(name), short_digest(version))` so the only stable
+        // invariants we can assert are the prefix, parent directory, and the
+        // `.lock` suffix.
+        let lock = home.storage_lock("system-bash", "v3");
+        assert_eq!(lock.parent(), Some(home.locks_dir().as_path()));
+        let file_name = lock.file_name().unwrap().to_str().unwrap();
+        assert!(file_name.starts_with("storage-"));
+        assert!(file_name.ends_with(".lock"));
     }
 
     #[test]
@@ -443,5 +484,61 @@ mod tests {
     #[test]
     fn touch_mtime_nonexistent_dir_does_not_panic() {
         touch_mtime(Path::new("/nonexistent/dir"));
+    }
+
+    #[test]
+    fn storage_cache_dir_stays_inside_root_for_traversal_names() {
+        // Regression guard: untrusted `vas_storage_name` / `vas_version_id`
+        // must be hashed before being embedded in the path, so that inputs
+        // like `../etc` or `foo/bar` cannot escape the cache root.
+        let home = HomePaths::with_root(PathBuf::from("/test"));
+        let storages = home.storages_dir();
+
+        for (name, version) in [
+            ("../etc", "v1"),
+            ("foo/bar", "v1"),
+            ("foo", "../../etc"),
+            ("foo", "v1/../../"),
+            ("normal", "v1"),
+        ] {
+            let dir = home.storage_cache_dir(name, version);
+            assert!(
+                dir.starts_with(&storages),
+                "cache dir {dir:?} escaped storages root for name={name:?} version={version:?}"
+            );
+            // Exactly two path components under `storages_dir()`:
+            // `<hashed-name>/<hashed-version>`.
+            let tail: Vec<_> = dir.strip_prefix(&storages).unwrap().components().collect();
+            assert_eq!(tail.len(), 2, "expected two hashed components in {dir:?}");
+        }
+    }
+
+    #[test]
+    fn storage_lock_is_injective_and_inside_locks_dir() {
+        // Distinct (name, version) pairs that would collide under naive
+        // `format!("storage-{name}-{version}.lock")` templating must produce
+        // distinct lock paths after hashing.
+        let home = HomePaths::with_root(PathBuf::from("/test"));
+        let locks = home.locks_dir();
+
+        let a = home.storage_lock("foo", "bar-v1");
+        let b = home.storage_lock("foo-bar", "v1");
+        assert_ne!(a, b, "hashed lock paths must not collide: {a:?} vs {b:?}");
+        assert!(a.starts_with(&locks));
+        assert!(b.starts_with(&locks));
+        assert!(a.to_string_lossy().ends_with(".lock"));
+    }
+
+    #[test]
+    fn storage_cache_dir_is_deterministic() {
+        let home = HomePaths::with_root(PathBuf::from("/test"));
+        assert_eq!(
+            home.storage_cache_dir("foo", "v1"),
+            home.storage_cache_dir("foo", "v1")
+        );
+        assert_ne!(
+            home.storage_cache_dir("foo", "v1"),
+            home.storage_cache_dir("foo", "v2")
+        );
     }
 }

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -18,7 +18,12 @@ fn storage_key_hashes(name: &str, version: &str) -> (String, String) {
 /// Hex-encode the first 8 bytes of `SHA-256(s)` — 16 characters, collision
 /// resistant enough for runner-local bookkeeping and always a valid path
 /// segment.
-fn short_digest(s: &str) -> String {
+///
+/// Exposed `pub(crate)` so the host-side cache dir (built here) and the
+/// guest-side `file://` URL (built in `storage_cache`) share one source of
+/// truth. A drift between two copies would silently route host writes and
+/// guest reads to different logical blobs.
+pub(crate) fn short_digest(s: &str) -> String {
     let digest = Sha256::digest(s.as_bytes());
     let prefix = digest.get(..8).unwrap_or(&digest);
     hex::encode(prefix)

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -5,8 +5,12 @@
 //! cache keyed by `(vasStorageName, vasVersionId)`. On hit, reads the cached
 //! tarball from disk and pushes it into the guest via vsock; on miss,
 //! downloads the archive from R2 into the cache first. Either way, the
-//! entry's `archive_url` is rewritten to `file:///tmp/vm0-storage-cache/<version>.tar.gz`
+//! entry's `archive_url` is rewritten to
+//! `file:///tmp/vm0-storage-cache/<hash(name)>-<hash(version)>.tar.gz`
 //! so `guest-download` reads from the local stage instead of re-fetching.
+//! Keying on both name and version keeps the guest file injective in the
+//! `(vasStorageName, vasVersionId)` pair — two entries that only differ in
+//! storage name cannot clobber each other on the guest tmpfs.
 //!
 //! Entries above [`CACHE_MAX_SIZE`], entries without a content key, and
 //! entries already marked `cached = true` (reuse-in-place from
@@ -24,6 +28,7 @@ use bytes::Bytes;
 use futures_util::stream::{self, StreamExt};
 use reqwest::Client;
 use sandbox::{ExecRequest, Sandbox};
+use sha2::{Digest, Sha256};
 use tokio::fs;
 use tracing::{debug, warn};
 
@@ -45,6 +50,25 @@ const GUEST_STAGE_DIR: &str = "/tmp/vm0-storage-cache";
 const HEAD_TIMEOUT: Duration = Duration::from_secs(10);
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
 const MKDIR_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Guest-side filename for a cached archive.
+///
+/// Must be injective in `(name, version)`: two manifest entries that differ
+/// only in `vas_storage_name` but share `vas_version_id` end up at distinct
+/// `file://` URLs so the second `sandbox.write_file` does not clobber the
+/// first. The 16-hex-char prefix of SHA-256 matches the host-side
+/// `HomePaths::storage_cache_dir` hashing.
+fn guest_archive_path(name: &str, version: &str) -> String {
+    let name_hash = short_hex(name);
+    let version_hash = short_hex(version);
+    format!("{GUEST_STAGE_DIR}/{name_hash}-{version_hash}.tar.gz")
+}
+
+fn short_hex(s: &str) -> String {
+    let digest = Sha256::digest(s.as_bytes());
+    let prefix = digest.get(..8).unwrap_or(&digest);
+    hex::encode(prefix)
+}
 
 /// One manifest entry that passed the eligibility filter.
 #[derive(Clone)]
@@ -147,6 +171,12 @@ fn collect_targets(manifest: &StorageManifest) -> Vec<CacheTarget> {
         let Some(version) = s.vas_version_id.as_deref() else {
             continue;
         };
+        // Empty components would hash to the same fixed digest as every
+        // other empty component, collapsing distinct manifest entries into
+        // a shared cache slot. Treat them like missing keys: passthrough.
+        if name.is_empty() || version.is_empty() {
+            continue;
+        }
         out.push(CacheTarget {
             kind: TargetKind::Storage,
             index: i,
@@ -162,6 +192,12 @@ fn collect_targets(manifest: &StorageManifest) -> Vec<CacheTarget> {
         let Some(url) = a.archive_url.as_deref() else {
             continue;
         };
+        // `ArtifactEntry` keys are non-optional `String`, so an empty value
+        // is representable and must be skipped for the same reason as the
+        // storage branch above.
+        if a.vas_storage_name.is_empty() || a.vas_version_id.is_empty() {
+            continue;
+        }
         out.push(CacheTarget {
             kind: TargetKind::Artifact,
             index: i,
@@ -213,7 +249,7 @@ async fn process_one(
             RunnerError::Internal(format!("read cached {}: {e}", archive_path.display()))
         })?;
         touch_mtime(&cache_dir);
-        let guest_path = format!("{GUEST_STAGE_DIR}/{}.tar.gz", target.version);
+        let guest_path = guest_archive_path(&target.name, &target.version);
         sandbox.write_file(&guest_path, &bytes).await?;
         return Ok(TargetOutcome::Hit);
     }
@@ -263,7 +299,7 @@ async fn process_one(
     let t = Instant::now();
     let bytes = download_tarball(http, &target.archive_url).await?;
     write_to_cache(&cache_dir, &bytes).await?;
-    let guest_path = format!("{GUEST_STAGE_DIR}/{}.tar.gz", target.version);
+    let guest_path = guest_archive_path(&target.name, &target.version);
     sandbox.write_file(&guest_path, &bytes).await?;
 
     Ok(TargetOutcome::Miss {
@@ -344,6 +380,10 @@ async fn write_to_cache(cache_dir: &Path, bytes: &[u8]) -> RunnerResult<()> {
             let _ = fs::remove_dir_all(&staging).await;
             return Ok(());
         }
+        // Non-race error: clean up the staging dir ourselves so EXDEV /
+        // ENOSPC / EACCES leftovers don't accumulate between retries. The
+        // cleanup is best-effort — we still surface the original error.
+        let _ = fs::remove_dir_all(&staging).await;
         return Err(RunnerError::Internal(format!(
             "rename {} -> {}: {e}",
             staging.display(),
@@ -415,7 +455,10 @@ fn apply_outcome(
 /// a hard error (the caller made the right conservative choice) but is
 /// logged so a regression that breaks the invariant is visible.
 fn rewrite_url(manifest: &mut StorageManifest, target: &CacheTarget) {
-    let new_url = format!("file://{GUEST_STAGE_DIR}/{}.tar.gz", target.version);
+    let new_url = format!(
+        "file://{}",
+        guest_archive_path(&target.name, &target.version)
+    );
     let mut applied = false;
     match target.kind {
         TargetKind::Storage => {
@@ -514,7 +557,7 @@ mod tests {
 
         assert_eq!(
             manifest.storages[0].archive_url.as_deref(),
-            Some(format!("file://{GUEST_STAGE_DIR}/{version}.tar.gz").as_str())
+            Some(format!("file://{}", guest_archive_path(name, version)).as_str())
         );
         let ops = telemetry.pending_ops_snapshot();
         assert!(
@@ -564,7 +607,7 @@ mod tests {
 
         assert_eq!(
             manifest.storages[0].archive_url.as_deref(),
-            Some(format!("file://{GUEST_STAGE_DIR}/{version}.tar.gz").as_str())
+            Some(format!("file://{}", guest_archive_path(name, version)).as_str())
         );
 
         let ops = telemetry.pending_ops_snapshot();
@@ -709,7 +752,7 @@ mod tests {
 
         assert_eq!(
             manifest.storages[0].archive_url.as_deref(),
-            Some(format!("file://{GUEST_STAGE_DIR}/v2.tar.gz").as_str())
+            Some(format!("file://{}", guest_archive_path(name, "v2")).as_str())
         );
         // v2 cache retained; v1 cache untouched (only a GC branch would evict it).
         assert!(v2_dir.join("archive.tar.gz").exists());
@@ -747,7 +790,7 @@ mod tests {
 
         assert_eq!(
             manifest.artifacts[0].archive_url.as_deref(),
-            Some(format!("file://{GUEST_STAGE_DIR}/{version}.tar.gz").as_str())
+            Some(format!("file://{}", guest_archive_path(name, version)).as_str())
         );
     }
 
@@ -794,5 +837,104 @@ mod tests {
         assert_eq!(s, PathBuf::from("/var/lib/vm0-runner/storages/foo/v1.tmp"));
         // Same parent → atomic rename.
         assert_eq!(s.parent(), d.parent());
+    }
+
+    #[tokio::test]
+    async fn shared_version_distinct_names_get_distinct_guest_paths() {
+        // Regression guard: two manifest entries that share `vasVersionId`
+        // but differ in `vasStorageName` must resolve to distinct guest
+        // `file://` URLs. Before the host/guest key symmetrization, both
+        // entries collided on `{GUEST_STAGE_DIR}/{version}.tar.gz` and the
+        // second `sandbox.write_file` clobbered the first.
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+
+        let version = "v1";
+        let name_a = "storage-a";
+        let name_b = "storage-b";
+        for name in [name_a, name_b] {
+            let cache_dir = home.storage_cache_dir(name, version);
+            std::fs::create_dir_all(&cache_dir).unwrap();
+            std::fs::write(cache_dir.join("archive.tar.gz"), tarball_bytes()).unwrap();
+        }
+
+        let mut manifest = StorageManifest {
+            storages: vec![
+                StorageEntry {
+                    mount_path: format!("/mnt/{name_a}"),
+                    archive_url: Some("https://r2.example.com/ignored.tar.gz".into()),
+                    cached: false,
+                    vas_storage_name: Some(name_a.to_string()),
+                    vas_version_id: Some(version.to_string()),
+                },
+                StorageEntry {
+                    mount_path: format!("/mnt/{name_b}"),
+                    archive_url: Some("https://r2.example.com/ignored.tar.gz".into()),
+                    cached: false,
+                    vas_storage_name: Some(name_b.to_string()),
+                    vas_version_id: Some(version.to_string()),
+                },
+            ],
+            artifacts: Vec::new(),
+            cleanup_paths: Vec::new(),
+        };
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        let url_a = manifest.storages[0].archive_url.clone().unwrap();
+        let url_b = manifest.storages[1].archive_url.clone().unwrap();
+        assert_ne!(
+            url_a, url_b,
+            "same-version entries must get distinct guest URLs"
+        );
+        assert_eq!(
+            url_a,
+            format!("file://{}", guest_archive_path(name_a, version))
+        );
+        assert_eq!(
+            url_b,
+            format!("file://{}", guest_archive_path(name_b, version))
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_key_components_are_passthrough() {
+        // Defensive guard: an artifact carries non-optional `String` keys,
+        // so an empty value is serde-representable. Hashing an empty string
+        // yields a fixed digest that every other empty-key entry would
+        // collide on, so we skip these rather than letting them share a
+        // cache slot.
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+
+        let original = "https://r2.example.com/nameless.tar.gz".to_string();
+        let mut manifest = StorageManifest {
+            storages: Vec::new(),
+            artifacts: vec![ArtifactEntry {
+                mount_path: "/mnt/nameless".into(),
+                archive_url: Some(original.clone()),
+                cached: false,
+                vas_storage_name: String::new(),
+                vas_version_id: String::new(),
+            }],
+            cleanup_paths: Vec::new(),
+        };
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        // archive_url untouched — the entry was skipped entirely.
+        assert_eq!(
+            manifest.artifacts[0].archive_url.as_deref(),
+            Some(original.as_str())
+        );
+        assert!(telemetry.pending_ops_snapshot().is_empty());
     }
 }

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -28,13 +28,12 @@ use bytes::Bytes;
 use futures_util::stream::{self, StreamExt};
 use reqwest::Client;
 use sandbox::{ExecRequest, Sandbox};
-use sha2::{Digest, Sha256};
 use tokio::fs;
 use tracing::{debug, warn};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
-use crate::paths::{HomePaths, touch_mtime};
+use crate::paths::{HomePaths, short_digest, touch_mtime};
 use crate::telemetry::JobTelemetry;
 use crate::types::StorageManifest;
 
@@ -56,18 +55,12 @@ const MKDIR_TIMEOUT: Duration = Duration::from_secs(5);
 /// Must be injective in `(name, version)`: two manifest entries that differ
 /// only in `vas_storage_name` but share `vas_version_id` end up at distinct
 /// `file://` URLs so the second `sandbox.write_file` does not clobber the
-/// first. The 16-hex-char prefix of SHA-256 matches the host-side
-/// `HomePaths::storage_cache_dir` hashing.
+/// first. Uses the same `short_digest` helper that `HomePaths` uses for
+/// the host cache dir, so the two keys always map 1:1.
 fn guest_archive_path(name: &str, version: &str) -> String {
-    let name_hash = short_hex(name);
-    let version_hash = short_hex(version);
+    let name_hash = short_digest(name);
+    let version_hash = short_digest(version);
     format!("{GUEST_STAGE_DIR}/{name_hash}-{version_hash}.tar.gz")
-}
-
-fn short_hex(s: &str) -> String {
-    let digest = Sha256::digest(s.as_bytes());
-    let prefix = digest.get(..8).unwrap_or(&digest);
-    hex::encode(prefix)
 }
 
 /// One manifest entry that passed the eligibility filter.
@@ -936,5 +929,94 @@ mod tests {
             Some(original.as_str())
         );
         assert!(telemetry.pending_ops_snapshot().is_empty());
+    }
+
+    #[tokio::test]
+    async fn concurrent_populate_for_same_key_downloads_once() {
+        // Two `populate_cache` invocations race for the same (name, version).
+        // The per-version flock must serialize them, so exactly one issues a
+        // GET to upstream and the second hits the just-warmed disk cache.
+        // `buffer_unordered(CONCURRENCY)` inside `populate_cache` means both
+        // tasks touch the flock acquire from separate spawn_blocking threads,
+        // so the test exercises real cross-thread flock semantics.
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox_a = MockSandbox::new("test-a");
+        let sandbox_b = MockSandbox::new("test-b");
+        let mut telemetry_a = new_telemetry();
+        let mut telemetry_b = new_telemetry();
+        let server = MockServer::start_async().await;
+        let body = tarball_bytes();
+
+        // `hits(1..)` expectations are checked after the race — the second
+        // caller must find the cache warm.
+        let head = server
+            .mock_async(|when, then| {
+                when.method(HEAD).path("/concurrent.tar.gz");
+                then.status(200)
+                    .header("content-length", body.len().to_string());
+            })
+            .await;
+        let get = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/concurrent.tar.gz");
+                then.status(200).body(body.clone());
+            })
+            .await;
+
+        let url = server.url("/concurrent.tar.gz");
+        let name = "race-skill";
+        let version = "v1";
+        let mut manifest_a = manifest_single_storage(url.clone(), name, version);
+        let mut manifest_b = manifest_single_storage(url.clone(), name, version);
+
+        let (res_a, res_b) = tokio::join!(
+            populate_cache(&mut manifest_a, &sandbox_a, &home, &mut telemetry_a),
+            populate_cache(&mut manifest_b, &sandbox_b, &home, &mut telemetry_b),
+        );
+        res_a.unwrap();
+        res_b.unwrap();
+
+        // Both manifests rewritten.
+        let expected = format!("file://{}", guest_archive_path(name, version));
+        assert_eq!(
+            manifest_a.storages[0].archive_url.as_deref(),
+            Some(expected.as_str())
+        );
+        assert_eq!(
+            manifest_b.storages[0].archive_url.as_deref(),
+            Some(expected.as_str())
+        );
+
+        // Exactly one download — the second caller saw the flock-serialized
+        // cache and took the hit path. HEAD may be issued 1-2 times depending
+        // on which task acquired the lock first; GET must be exactly once.
+        get.assert_calls_async(1).await;
+        assert!(head.calls_async().await >= 1);
+
+        // One miss telemetry across both tasks; the other records a hit.
+        let ops_a = telemetry_a.pending_ops_snapshot();
+        let ops_b = telemetry_b.pending_ops_snapshot();
+        let total_miss = ops_a
+            .iter()
+            .filter(|(k, _, _)| k == "storage_cache_miss")
+            .count()
+            + ops_b
+                .iter()
+                .filter(|(k, _, _)| k == "storage_cache_miss")
+                .count();
+        let total_hit = ops_a
+            .iter()
+            .filter(|(k, _, _)| k == "storage_cache_hit")
+            .count()
+            + ops_b
+                .iter()
+                .filter(|(k, _, _)| k == "storage_cache_hit")
+                .count();
+        assert_eq!(
+            total_miss, 1,
+            "exactly one miss across concurrent populates"
+        );
+        assert_eq!(total_hit, 1, "second populate must see the warmed cache");
     }
 }

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -16,9 +16,11 @@
 //! `guest-download` understands after #10805. The PR adding this module
 //! must not merge before #10805 is on `main`.
 
+use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use bytes::Bytes;
 use futures_util::stream::{self, StreamExt};
 use reqwest::Client;
 use sandbox::{ExecRequest, Sandbox};
@@ -62,9 +64,18 @@ enum TargetKind {
 
 enum TargetOutcome {
     Hit,
-    Miss { download_duration: Duration },
+    Miss {
+        download_duration: Duration,
+    },
     SkippedOverSize,
-    SkippedHeadFailed,
+    /// HEAD probe could not determine archive size, so the entry falls back
+    /// to the original R2 URL. `reason` carries either the upstream error
+    /// string or a short tag describing the missing-header case so ops can
+    /// separate transient network failures from permanent 4xx / missing
+    /// `Content-Length` headers in the telemetry feed.
+    SkippedHeadFailed {
+        reason: String,
+    },
 }
 
 /// Populate the runner-side cache for eligible entries in `manifest`.
@@ -209,7 +220,9 @@ async fn process_one(
 
     // 2. Miss path: probe size via HEAD. A HEAD failure is treated as
     //    passthrough — the entry keeps its original R2 URL and the guest
-    //    downloads it as today.
+    //    downloads it as today. The failure reason is threaded into the
+    //    outcome so telemetry can distinguish transient 5xx from missing
+    //    `Content-Length` headers.
     let size = match probe_size(http, &target.archive_url).await {
         Ok(Some(n)) => n,
         Ok(None) => {
@@ -218,16 +231,19 @@ async fn process_one(
                 version = %target.version,
                 "storage_cache: HEAD returned no Content-Length, passthrough"
             );
-            return Ok(TargetOutcome::SkippedHeadFailed);
+            return Ok(TargetOutcome::SkippedHeadFailed {
+                reason: "missing-content-length".to_string(),
+            });
         }
         Err(e) => {
+            let reason = e.to_string();
             warn!(
                 name = %target.name,
                 version = %target.version,
-                error = %e,
+                error = %reason,
                 "storage_cache: HEAD probe failed, passthrough"
             );
-            return Ok(TargetOutcome::SkippedHeadFailed);
+            return Ok(TargetOutcome::SkippedHeadFailed { reason });
         }
     };
     if size > CACHE_MAX_SIZE {
@@ -241,6 +257,9 @@ async fn process_one(
     }
 
     // 3. Download, stage, fsync, atomic rename, then push to guest.
+    //    `Bytes` is Arc-backed, so passing `&bytes[..]` to both the disk
+    //    writer and the sandbox `write_file` costs zero extra allocation
+    //    over the single response body.
     let t = Instant::now();
     let bytes = download_tarball(http, &target.archive_url).await?;
     write_to_cache(&cache_dir, &bytes).await?;
@@ -268,7 +287,7 @@ async fn probe_size(http: &Client, url: &str) -> RunnerResult<Option<u64>> {
         .and_then(|s| s.parse::<u64>().ok()))
 }
 
-async fn download_tarball(http: &Client, url: &str) -> RunnerResult<Vec<u8>> {
+async fn download_tarball(http: &Client, url: &str) -> RunnerResult<Bytes> {
     let resp = http
         .get(url)
         .timeout(DOWNLOAD_TIMEOUT)
@@ -277,11 +296,9 @@ async fn download_tarball(http: &Client, url: &str) -> RunnerResult<Vec<u8>> {
         .map_err(|e| RunnerError::Internal(format!("GET {url}: {e}")))?
         .error_for_status()
         .map_err(|e| RunnerError::Internal(format!("GET status {url}: {e}")))?;
-    let bytes = resp
-        .bytes()
+    resp.bytes()
         .await
-        .map_err(|e| RunnerError::Internal(format!("read body {url}: {e}")))?;
-    Ok(bytes.to_vec())
+        .map_err(|e| RunnerError::Internal(format!("read body {url}: {e}")))
 }
 
 async fn write_to_cache(cache_dir: &Path, bytes: &[u8]) -> RunnerResult<()> {
@@ -317,8 +334,13 @@ async fn write_to_cache(cache_dir: &Path, bytes: &[u8]) -> RunnerResult<()> {
 
     if let Err(e) = fs::rename(&staging, cache_dir).await {
         // A sibling runner may have populated the final dir while we were
-        // staging. If the final archive exists now, prefer it.
-        if fs::metadata(cache_dir.join("archive.tar.gz")).await.is_ok() {
+        // staging. Only swallow the error if (a) it looks like a "target
+        // already exists" kind (EEXIST / ENOTEMPTY on Linux — the kernel
+        // returns ENOTEMPTY for a non-empty target and EEXIST for some
+        // filesystems) and (b) the expected final artifact is actually
+        // there. Any other kernel error (EXDEV, ENOSPC, EACCES, ...) must
+        // propagate so callers can surface the real failure.
+        if is_rename_collision(&e) && fs::metadata(cache_dir.join("archive.tar.gz")).await.is_ok() {
             let _ = fs::remove_dir_all(&staging).await;
             return Ok(());
         }
@@ -329,6 +351,15 @@ async fn write_to_cache(cache_dir: &Path, bytes: &[u8]) -> RunnerResult<()> {
         )));
     }
     Ok(())
+}
+
+/// Whether a `fs::rename` error plausibly means "target already exists or is
+/// non-empty" — the race branch where a sibling runner beat us to it.
+fn is_rename_collision(e: &io::Error) -> bool {
+    matches!(
+        e.kind(),
+        io::ErrorKind::AlreadyExists | io::ErrorKind::DirectoryNotEmpty
+    )
 }
 
 /// `<dir>` -> `<dir>.tmp` sibling with the same parent (so rename is atomic).
@@ -365,12 +396,12 @@ fn apply_outcome(
                 None,
             );
         }
-        TargetOutcome::SkippedHeadFailed => {
+        TargetOutcome::SkippedHeadFailed { reason } => {
             telemetry.record(
                 "storage_cache_skipped_head_failed",
                 Duration::ZERO,
                 true,
-                None,
+                Some(reason.as_str()),
             );
         }
     }
@@ -380,9 +411,12 @@ fn apply_outcome(
 ///
 /// Verifies the entry at `target.index` still has the expected
 /// `(name, version)` before mutating — content-addressed safety against
-/// any future parallel mutation at this pipeline stage.
+/// any future parallel mutation at this pipeline stage. A mismatch is not
+/// a hard error (the caller made the right conservative choice) but is
+/// logged so a regression that breaks the invariant is visible.
 fn rewrite_url(manifest: &mut StorageManifest, target: &CacheTarget) {
     let new_url = format!("file://{GUEST_STAGE_DIR}/{}.tar.gz", target.version);
+    let mut applied = false;
     match target.kind {
         TargetKind::Storage => {
             if let Some(entry) = manifest.storages.get_mut(target.index)
@@ -390,6 +424,7 @@ fn rewrite_url(manifest: &mut StorageManifest, target: &CacheTarget) {
                 && entry.vas_version_id.as_deref() == Some(target.version.as_str())
             {
                 entry.archive_url = Some(new_url);
+                applied = true;
             }
         }
         TargetKind::Artifact => {
@@ -398,8 +433,17 @@ fn rewrite_url(manifest: &mut StorageManifest, target: &CacheTarget) {
                 && entry.vas_version_id == target.version
             {
                 entry.archive_url = Some(new_url);
+                applied = true;
             }
         }
+    }
+    if !applied {
+        warn!(
+            name = %target.name,
+            version = %target.version,
+            index = target.index,
+            "storage_cache: manifest identity mismatch at rewrite, skipping url swap"
+        );
     }
 }
 

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1,0 +1,754 @@
+//! Runner-side content-addressed cache for small storage archives.
+//!
+//! Sits between `filter_unchanged_storages` and `download_storages` in
+//! `run_in_sandbox`. For each eligible manifest entry, checks a host-local
+//! cache keyed by `(vasStorageName, vasVersionId)`. On hit, reads the cached
+//! tarball from disk and pushes it into the guest via vsock; on miss,
+//! downloads the archive from R2 into the cache first. Either way, the
+//! entry's `archive_url` is rewritten to `file:///tmp/vm0-storage-cache/<version>.tar.gz`
+//! so `guest-download` reads from the local stage instead of re-fetching.
+//!
+//! Entries above [`CACHE_MAX_SIZE`], entries without a content key, and
+//! entries already marked `cached = true` (reuse-in-place from
+//! `filter_unchanged_storages`) pass through untouched.
+//!
+//! Merge-order contract: this module produces `file://` URLs, which only
+//! `guest-download` understands after #10805. The PR adding this module
+//! must not merge before #10805 is on `main`.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use futures_util::stream::{self, StreamExt};
+use reqwest::Client;
+use sandbox::{ExecRequest, Sandbox};
+use tokio::fs;
+use tracing::{debug, warn};
+
+use crate::error::{RunnerError, RunnerResult};
+use crate::lock;
+use crate::paths::{HomePaths, touch_mtime};
+use crate::telemetry::JobTelemetry;
+use crate::types::StorageManifest;
+
+/// Archive sizes strictly larger than this are passthrough.
+const CACHE_MAX_SIZE: u64 = 8 * 1024 * 1024;
+
+/// Parallel (HEAD / GET / flock / vsock) operations per `populate_cache` call.
+const CONCURRENCY: usize = 4;
+
+/// Guest stage directory for `file://` archives.
+const GUEST_STAGE_DIR: &str = "/tmp/vm0-storage-cache";
+
+const HEAD_TIMEOUT: Duration = Duration::from_secs(10);
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
+const MKDIR_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One manifest entry that passed the eligibility filter.
+#[derive(Clone)]
+struct CacheTarget {
+    kind: TargetKind,
+    index: usize,
+    name: String,
+    version: String,
+    archive_url: String,
+}
+
+#[derive(Clone, Copy)]
+enum TargetKind {
+    Storage,
+    Artifact,
+}
+
+enum TargetOutcome {
+    Hit,
+    Miss { download_duration: Duration },
+    SkippedOverSize,
+    SkippedHeadFailed,
+}
+
+/// Populate the runner-side cache for eligible entries in `manifest`.
+///
+/// Mutates `manifest.storages[i].archive_url` / `manifest.artifacts[i].archive_url`
+/// in place, rewriting them to `file://` URLs pointing at host-staged tarballs
+/// pushed into the guest over vsock.
+///
+/// Invariant: only touches entries where `cached == false`, `archive_url.is_some()`,
+/// and both `vas_storage_name` and `vas_version_id` are set. Entries that
+/// `filter_unchanged_storages` marked as reuse-in-place (`archive_url = None`)
+/// are left untouched.
+pub async fn populate_cache(
+    manifest: &mut StorageManifest,
+    sandbox: &dyn Sandbox,
+    home: &HomePaths,
+    telemetry: &mut JobTelemetry,
+) -> RunnerResult<()> {
+    let targets = collect_targets(manifest);
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    // One-shot: ensure the guest stage directory exists so the first
+    // `sandbox.write_file` has a parent to write into. If #10805 takes on
+    // this responsibility in guest-download, this call becomes dead code and
+    // is removed in a follow-up commit.
+    ensure_guest_stage_dir(sandbox).await?;
+
+    let http = Client::builder()
+        .build()
+        .map_err(|e| RunnerError::Internal(format!("build http client: {e}")))?;
+
+    // `buffer_unordered` drives up to CONCURRENCY futures concurrently while
+    // keeping their borrows alive on the caller's stack. Unlike
+    // `tokio::task::JoinSet`, it does not require `'static` futures — which
+    // matters because our `sandbox: &dyn Sandbox` is a borrow, not an Arc.
+    let outcomes: Vec<(CacheTarget, RunnerResult<TargetOutcome>)> = stream::iter(targets)
+        .map(|target| {
+            let http = http.clone();
+            async move {
+                let res = process_one(&target, &http, home, sandbox).await;
+                (target, res)
+            }
+        })
+        .buffer_unordered(CONCURRENCY)
+        .collect()
+        .await;
+
+    for (target, outcome) in outcomes {
+        let outcome = outcome?;
+        apply_outcome(manifest, &target, &outcome, telemetry);
+    }
+    Ok(())
+}
+
+fn collect_targets(manifest: &StorageManifest) -> Vec<CacheTarget> {
+    let mut out = Vec::new();
+    for (i, s) in manifest.storages.iter().enumerate() {
+        if s.cached {
+            continue;
+        }
+        let Some(url) = s.archive_url.as_deref() else {
+            continue;
+        };
+        let Some(name) = s.vas_storage_name.as_deref() else {
+            continue;
+        };
+        let Some(version) = s.vas_version_id.as_deref() else {
+            continue;
+        };
+        out.push(CacheTarget {
+            kind: TargetKind::Storage,
+            index: i,
+            name: name.to_string(),
+            version: version.to_string(),
+            archive_url: url.to_string(),
+        });
+    }
+    for (i, a) in manifest.artifacts.iter().enumerate() {
+        if a.cached {
+            continue;
+        }
+        let Some(url) = a.archive_url.as_deref() else {
+            continue;
+        };
+        out.push(CacheTarget {
+            kind: TargetKind::Artifact,
+            index: i,
+            name: a.vas_storage_name.clone(),
+            version: a.vas_version_id.clone(),
+            archive_url: url.to_string(),
+        });
+    }
+    out
+}
+
+async fn ensure_guest_stage_dir(sandbox: &dyn Sandbox) -> RunnerResult<()> {
+    let cmd = format!("mkdir -p {GUEST_STAGE_DIR}");
+    let req = ExecRequest {
+        cmd: &cmd,
+        timeout: MKDIR_TIMEOUT,
+        env: &[],
+        sudo: false,
+    };
+    let res = sandbox.exec(&req).await?;
+    if res.exit_code != 0 {
+        return Err(RunnerError::Internal(format!(
+            "guest mkdir {GUEST_STAGE_DIR} exit={} stderr={}",
+            res.exit_code,
+            String::from_utf8_lossy(&res.stderr)
+        )));
+    }
+    Ok(())
+}
+
+async fn process_one(
+    target: &CacheTarget,
+    http: &Client,
+    home: &HomePaths,
+    sandbox: &dyn Sandbox,
+) -> RunnerResult<TargetOutcome> {
+    // Acquire the per-version flock (blocking, cross-process dedup).
+    // Disk-check happens under the lock so we never race with a writer.
+    let lock_path = home.storage_lock(&target.name, &target.version);
+    let _guard = lock::acquire(lock_path).await?;
+
+    let cache_dir = home.storage_cache_dir(&target.name, &target.version);
+    let archive_path = cache_dir.join("archive.tar.gz");
+
+    // 1. Fast path: disk hit. Read the bytes directly and skip the network.
+    //    This also makes the hit path resilient to transient HEAD failures.
+    if fs::metadata(&archive_path).await.is_ok() {
+        let bytes = fs::read(&archive_path).await.map_err(|e| {
+            RunnerError::Internal(format!("read cached {}: {e}", archive_path.display()))
+        })?;
+        touch_mtime(&cache_dir);
+        let guest_path = format!("{GUEST_STAGE_DIR}/{}.tar.gz", target.version);
+        sandbox.write_file(&guest_path, &bytes).await?;
+        return Ok(TargetOutcome::Hit);
+    }
+
+    // 2. Miss path: probe size via HEAD. A HEAD failure is treated as
+    //    passthrough — the entry keeps its original R2 URL and the guest
+    //    downloads it as today.
+    let size = match probe_size(http, &target.archive_url).await {
+        Ok(Some(n)) => n,
+        Ok(None) => {
+            warn!(
+                name = %target.name,
+                version = %target.version,
+                "storage_cache: HEAD returned no Content-Length, passthrough"
+            );
+            return Ok(TargetOutcome::SkippedHeadFailed);
+        }
+        Err(e) => {
+            warn!(
+                name = %target.name,
+                version = %target.version,
+                error = %e,
+                "storage_cache: HEAD probe failed, passthrough"
+            );
+            return Ok(TargetOutcome::SkippedHeadFailed);
+        }
+    };
+    if size > CACHE_MAX_SIZE {
+        debug!(
+            name = %target.name,
+            version = %target.version,
+            size,
+            "storage_cache: entry over size limit, passthrough"
+        );
+        return Ok(TargetOutcome::SkippedOverSize);
+    }
+
+    // 3. Download, stage, fsync, atomic rename, then push to guest.
+    let t = Instant::now();
+    let bytes = download_tarball(http, &target.archive_url).await?;
+    write_to_cache(&cache_dir, &bytes).await?;
+    let guest_path = format!("{GUEST_STAGE_DIR}/{}.tar.gz", target.version);
+    sandbox.write_file(&guest_path, &bytes).await?;
+
+    Ok(TargetOutcome::Miss {
+        download_duration: t.elapsed(),
+    })
+}
+
+async fn probe_size(http: &Client, url: &str) -> RunnerResult<Option<u64>> {
+    let resp = http
+        .head(url)
+        .timeout(HEAD_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("HEAD {url}: {e}")))?
+        .error_for_status()
+        .map_err(|e| RunnerError::Internal(format!("HEAD status {url}: {e}")))?;
+    Ok(resp
+        .headers()
+        .get(reqwest::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok()))
+}
+
+async fn download_tarball(http: &Client, url: &str) -> RunnerResult<Vec<u8>> {
+    let resp = http
+        .get(url)
+        .timeout(DOWNLOAD_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("GET {url}: {e}")))?
+        .error_for_status()
+        .map_err(|e| RunnerError::Internal(format!("GET status {url}: {e}")))?;
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("read body {url}: {e}")))?;
+    Ok(bytes.to_vec())
+}
+
+async fn write_to_cache(cache_dir: &Path, bytes: &[u8]) -> RunnerResult<()> {
+    let staging = staging_dir(cache_dir);
+
+    // Best-effort cleanup of stale staging from a prior crashed run.
+    let _ = fs::remove_dir_all(&staging).await;
+    fs::create_dir_all(&staging)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create staging {}: {e}", staging.display())))?;
+
+    let archive_staging = staging.join("archive.tar.gz");
+    fs::write(&archive_staging, bytes)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("write {}: {e}", archive_staging.display())))?;
+
+    // fsync the archive so a crash between rename and next sync cannot
+    // leave a zero-byte or torn file visible at the final path.
+    let f = fs::File::open(&archive_staging).await.map_err(|e| {
+        RunnerError::Internal(format!("open for fsync {}: {e}", archive_staging.display()))
+    })?;
+    f.sync_all()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("fsync {}: {e}", archive_staging.display())))?;
+    drop(f);
+
+    // Ensure the `<name>/` parent exists so the rename below has a target.
+    if let Some(parent) = cache_dir.parent() {
+        fs::create_dir_all(parent).await.map_err(|e| {
+            RunnerError::Internal(format!("create cache parent {}: {e}", parent.display()))
+        })?;
+    }
+
+    if let Err(e) = fs::rename(&staging, cache_dir).await {
+        // A sibling runner may have populated the final dir while we were
+        // staging. If the final archive exists now, prefer it.
+        if fs::metadata(cache_dir.join("archive.tar.gz")).await.is_ok() {
+            let _ = fs::remove_dir_all(&staging).await;
+            return Ok(());
+        }
+        return Err(RunnerError::Internal(format!(
+            "rename {} -> {}: {e}",
+            staging.display(),
+            cache_dir.display()
+        )));
+    }
+    Ok(())
+}
+
+/// `<dir>` -> `<dir>.tmp` sibling with the same parent (so rename is atomic).
+fn staging_dir(final_dir: &Path) -> PathBuf {
+    let mut name = final_dir
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    name.push(".tmp");
+    final_dir.with_file_name(name)
+}
+
+fn apply_outcome(
+    manifest: &mut StorageManifest,
+    target: &CacheTarget,
+    outcome: &TargetOutcome,
+    telemetry: &mut JobTelemetry,
+) {
+    match outcome {
+        TargetOutcome::Hit => {
+            rewrite_url(manifest, target);
+            telemetry.record("storage_cache_hit", Duration::ZERO, true, None);
+        }
+        TargetOutcome::Miss { download_duration } => {
+            rewrite_url(manifest, target);
+            telemetry.record("storage_cache_miss", Duration::ZERO, true, None);
+            telemetry.record("storage_cache_download", *download_duration, true, None);
+        }
+        TargetOutcome::SkippedOverSize => {
+            telemetry.record(
+                "storage_cache_skipped_over_size",
+                Duration::ZERO,
+                true,
+                None,
+            );
+        }
+        TargetOutcome::SkippedHeadFailed => {
+            telemetry.record(
+                "storage_cache_skipped_head_failed",
+                Duration::ZERO,
+                true,
+                None,
+            );
+        }
+    }
+}
+
+/// Rewrite `archive_url` to the guest `file://` stage path.
+///
+/// Verifies the entry at `target.index` still has the expected
+/// `(name, version)` before mutating — content-addressed safety against
+/// any future parallel mutation at this pipeline stage.
+fn rewrite_url(manifest: &mut StorageManifest, target: &CacheTarget) {
+    let new_url = format!("file://{GUEST_STAGE_DIR}/{}.tar.gz", target.version);
+    match target.kind {
+        TargetKind::Storage => {
+            if let Some(entry) = manifest.storages.get_mut(target.index)
+                && entry.vas_storage_name.as_deref() == Some(target.name.as_str())
+                && entry.vas_version_id.as_deref() == Some(target.version.as_str())
+            {
+                entry.archive_url = Some(new_url);
+            }
+        }
+        TargetKind::Artifact => {
+            if let Some(entry) = manifest.artifacts.get_mut(target.index)
+                && entry.vas_storage_name == target.name
+                && entry.vas_version_id == target.version
+            {
+                entry.archive_url = Some(new_url);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use httpmock::Method::{GET, HEAD};
+    use httpmock::prelude::*;
+    use sandbox_mock::MockSandbox;
+
+    use crate::http::HttpClient;
+    use crate::ids::RunId;
+    use crate::types::{ArtifactEntry, StorageEntry};
+
+    fn new_telemetry() -> JobTelemetry {
+        let http = HttpClient::new("http://localhost:0".to_string()).unwrap();
+        JobTelemetry::new(http, RunId::nil(), "test-token".to_string())
+    }
+
+    fn home_at(temp: &tempfile::TempDir) -> HomePaths {
+        HomePaths::with_root(temp.path().to_path_buf())
+    }
+
+    fn manifest_single_storage(url: String, name: &str, version: &str) -> StorageManifest {
+        StorageManifest {
+            storages: vec![StorageEntry {
+                mount_path: format!("/mnt/{name}"),
+                archive_url: Some(url),
+                cached: false,
+                vas_storage_name: Some(name.to_string()),
+                vas_version_id: Some(version.to_string()),
+            }],
+            artifacts: Vec::new(),
+            cleanup_paths: Vec::new(),
+        }
+    }
+
+    fn tarball_bytes() -> Vec<u8> {
+        // A small payload is enough — the cache treats it as opaque bytes.
+        b"pretend-tar-gz-bytes".to_vec()
+    }
+
+    #[tokio::test]
+    async fn hit_path_reads_from_disk_and_rewrites_url() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+
+        // Pre-populate the cache to simulate a hit.
+        let name = "seed-skill-foo";
+        let version = "v1";
+        let cache_dir = home.storage_cache_dir(name, version);
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join("archive.tar.gz"), tarball_bytes()).unwrap();
+
+        // Give populate_cache an R2-looking URL — it should never be called.
+        let mut manifest = manifest_single_storage(
+            "https://r2.example.com/never-called.tar.gz".to_string(),
+            name,
+            version,
+        );
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(format!("file://{GUEST_STAGE_DIR}/{version}.tar.gz").as_str())
+        );
+        let ops = telemetry.pending_ops_snapshot();
+        assert!(
+            ops.iter().any(|(k, _, _)| k == "storage_cache_hit"),
+            "expected storage_cache_hit in {ops:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn miss_path_downloads_and_populates_cache() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+        let server = MockServer::start_async().await;
+        let body = tarball_bytes();
+
+        let head = server
+            .mock_async(|when, then| {
+                when.method(HEAD).path("/archive.tar.gz");
+                then.status(200)
+                    .header("content-length", body.len().to_string());
+            })
+            .await;
+        let get = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/archive.tar.gz");
+                then.status(200).body(body.clone());
+            })
+            .await;
+
+        let url = server.url("/archive.tar.gz");
+        let name = "seed-skill-bar";
+        let version = "v2";
+        let mut manifest = manifest_single_storage(url, name, version);
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        head.assert_async().await;
+        get.assert_async().await;
+
+        let final_path = home.storage_cache_dir(name, version).join("archive.tar.gz");
+        assert!(final_path.exists(), "cache file must exist after miss");
+        assert_eq!(std::fs::read(&final_path).unwrap(), body);
+
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(format!("file://{GUEST_STAGE_DIR}/{version}.tar.gz").as_str())
+        );
+
+        let ops = telemetry.pending_ops_snapshot();
+        assert!(ops.iter().any(|(k, _, _)| k == "storage_cache_miss"));
+        assert!(ops.iter().any(|(k, _, _)| k == "storage_cache_download"));
+    }
+
+    #[tokio::test]
+    async fn over_size_entry_is_passthrough() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+        let server = MockServer::start_async().await;
+
+        let too_big = CACHE_MAX_SIZE + 1;
+        let head = server
+            .mock_async(|when, then| {
+                when.method(HEAD).path("/big.tar.gz");
+                then.status(200)
+                    .header("content-length", too_big.to_string());
+            })
+            .await;
+        // GET must NOT be called for passthrough — no mock registered.
+
+        let original = server.url("/big.tar.gz");
+        let name = "user-volume";
+        let version = "v9";
+        let mut manifest = manifest_single_storage(original.clone(), name, version);
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        head.assert_async().await;
+
+        // archive_url untouched.
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(original.as_str())
+        );
+        // Cache dir must not exist.
+        assert!(!home.storage_cache_dir(name, version).exists());
+
+        let ops = telemetry.pending_ops_snapshot();
+        assert!(
+            ops.iter()
+                .any(|(k, _, _)| k == "storage_cache_skipped_over_size")
+        );
+    }
+
+    #[tokio::test]
+    async fn cached_true_entry_is_not_touched() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+
+        // Entry the filter has already marked reuse-in-place: archive_url = None, cached = true.
+        let mut manifest = StorageManifest {
+            storages: vec![StorageEntry {
+                mount_path: "/mnt/foo".into(),
+                archive_url: None,
+                cached: true,
+                vas_storage_name: Some("foo".into()),
+                vas_version_id: Some("v1".into()),
+            }],
+            artifacts: Vec::new(),
+            cleanup_paths: Vec::new(),
+        };
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        // Unchanged.
+        assert!(manifest.storages[0].archive_url.is_none());
+        assert!(manifest.storages[0].cached);
+        // No telemetry emitted — no eligible targets.
+        assert!(telemetry.pending_ops_snapshot().is_empty());
+    }
+
+    #[tokio::test]
+    async fn missing_content_key_is_passthrough() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+
+        // Entry without vas_storage_name / vas_version_id — pre-epic schema.
+        let mut manifest = StorageManifest {
+            storages: vec![StorageEntry {
+                mount_path: "/mnt/legacy".into(),
+                archive_url: Some("https://r2.example.com/legacy.tar.gz".into()),
+                cached: false,
+                vas_storage_name: None,
+                vas_version_id: None,
+            }],
+            artifacts: Vec::new(),
+            cleanup_paths: Vec::new(),
+        };
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        // archive_url untouched.
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some("https://r2.example.com/legacy.tar.gz")
+        );
+    }
+
+    #[tokio::test]
+    async fn version_transition_cannot_serve_prev_bytes() {
+        // Correctness claim: (name, v1) and (name, v2) live in different
+        // directories. A warmed cache for v2 can never serve v1 bytes
+        // regardless of reused sandbox state.
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+
+        let name = "rolling-skill";
+        let v2_bytes = tarball_bytes();
+        let v2_dir = home.storage_cache_dir(name, "v2");
+        std::fs::create_dir_all(&v2_dir).unwrap();
+        std::fs::write(v2_dir.join("archive.tar.gz"), &v2_bytes).unwrap();
+
+        // If a stale v1 tarball exists, it's under a different cache key and
+        // is unreachable via (name, v2).
+        let v1_dir = home.storage_cache_dir(name, "v1");
+        std::fs::create_dir_all(&v1_dir).unwrap();
+        std::fs::write(v1_dir.join("archive.tar.gz"), b"STALE-V1-BYTES").unwrap();
+
+        let mut manifest =
+            manifest_single_storage("https://r2.example.com/ignored.tar.gz".into(), name, "v2");
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(format!("file://{GUEST_STAGE_DIR}/v2.tar.gz").as_str())
+        );
+        // v2 cache retained; v1 cache untouched (only a GC branch would evict it).
+        assert!(v2_dir.join("archive.tar.gz").exists());
+        assert!(v1_dir.join("archive.tar.gz").exists());
+    }
+
+    #[tokio::test]
+    async fn artifacts_are_cached_too() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+
+        let name = "build-artifact";
+        let version = "build-42";
+        let cache_dir = home.storage_cache_dir(name, version);
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join("archive.tar.gz"), tarball_bytes()).unwrap();
+
+        let mut manifest = StorageManifest {
+            storages: Vec::new(),
+            artifacts: vec![ArtifactEntry {
+                mount_path: "/mnt/artifact".into(),
+                archive_url: Some("https://r2.example.com/ignored.tar.gz".into()),
+                cached: false,
+                vas_storage_name: name.to_string(),
+                vas_version_id: version.to_string(),
+            }],
+            cleanup_paths: Vec::new(),
+        };
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            manifest.artifacts[0].archive_url.as_deref(),
+            Some(format!("file://{GUEST_STAGE_DIR}/{version}.tar.gz").as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn head_failure_is_passthrough() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+        let server = MockServer::start_async().await;
+
+        let head = server
+            .mock_async(|when, then| {
+                when.method(HEAD).path("/broken.tar.gz");
+                then.status(500);
+            })
+            .await;
+
+        let original = server.url("/broken.tar.gz");
+        let mut manifest = manifest_single_storage(original.clone(), "broken-skill", "v1");
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        head.assert_async().await;
+
+        // archive_url untouched — guest-download will retry via the original URL.
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(original.as_str())
+        );
+        let ops = telemetry.pending_ops_snapshot();
+        assert!(
+            ops.iter()
+                .any(|(k, _, _)| k == "storage_cache_skipped_head_failed")
+        );
+    }
+
+    #[test]
+    fn staging_dir_is_sibling() {
+        let d = PathBuf::from("/var/lib/vm0-runner/storages/foo/v1");
+        let s = staging_dir(&d);
+        assert_eq!(s, PathBuf::from("/var/lib/vm0-runner/storages/foo/v1.tmp"));
+        // Same parent → atomic rename.
+        assert_eq!(s.parent(), d.parent());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #10808 (part of epic #10800).

- Adds a runner-side content-addressed cache for storage archives ≤ 8 MB, keyed by `(vasStorageName, vasVersionId)`, with per-version flock-based cross-process dedup and atomic rename + fsync for crash-consistency.
- Inserts `storage_cache::populate_cache` between `filter_unchanged_storages` and `download_storages` in `run_in_sandbox`; rewrites eligible `archive_url` entries to `file:///tmp/vm0-storage-cache/<version>.tar.gz` after staging the tarball into the guest via vsock.
- Eligibility: `cached == false`, `archive_url.is_some()`, both content-key fields set. Over-size, missing-key, and HEAD-failure entries pass through untouched.
- Emits 4 telemetry action types: `storage_cache_hit`, `storage_cache_miss`, `storage_cache_download`, `storage_cache_skipped_over_size`, plus `storage_cache_skipped_head_failed` for the HEAD-failure passthrough (reflects a possible R2 edge case — if the rate is nontrivial we can fall back to GET+Range).
- Bounded concurrency (4) via `futures_util::StreamExt::buffer_unordered`, chosen over `JoinSet` because it tolerates borrowed `&dyn Sandbox` / `&HomePaths` handles without requiring `'static`.

## Merge order

⚠️ **Blocked on #10805.** The `file://` URLs this PR writes into the manifest are only meaningful once `guest-download` understands that scheme. Do not merge before #10805 is on `main`.

#10806 (GC for the storages cache directory) is independent — if it lands first, trivial rebase drops the path helpers from the first commit here.

## Test plan

- [x] `cargo check -p runner`
- [x] `cargo clippy -p runner --all-targets -- -D warnings`
- [x] `cargo fmt -p runner --check`
- [x] `cargo test -p runner` (746 passed, 0 failed, including 9 new `storage_cache::tests::*`)
- [x] Hit, miss, over-size, missing content key, cached-true, version-transition, artifact, HEAD-failure, and staging-sibling tests all pass
- [ ] CI green on `cli-e2e-*` jobs