### PR TITLE
fix(web): dark mode contrast on Choose an Organization screen

### DIFF
--- a/turbo/apps/web/app/components/auth/clerk-appearance.ts
+++ b/turbo/apps/web/app/components/auth/clerk-appearance.ts
@@ -47,7 +47,12 @@ export function getClerkAppearance(theme: "light" | "dark"): ClerkAppearance {
       footerActionLink: "text-primary hover:text-primary/90",
       identityPreviewText: "text-foreground",
       identityPreviewEditButton: "text-muted-foreground",
-      formFieldInputShowPasswordButton: "text-muted-foreground",
+      formFieldInputShowPasswordButton: {
+        color: "hsl(var(--muted-foreground))",
+        border: "none",
+        boxShadow: "none",
+        background: "transparent",
+      },
       otpCodeFieldInput:
         "h-9 w-9 bg-input border border-border rounded-lg text-center text-base font-medium uppercase text-foreground focus:border-primary focus:ring-[3px] focus:ring-primary/10",
       formResendCodeLink: "text-primary",

--- a/turbo/apps/web/app/components/auth/clerk-appearance.ts
+++ b/turbo/apps/web/app/components/auth/clerk-appearance.ts
@@ -12,6 +12,19 @@ export function getClerkAppearance(theme: "light" | "dark"): ClerkAppearance {
         theme === "dark" ? "/assets/vm0-logo.svg" : "/assets/vm0-logo-dark.svg",
       logoPlacement: "inside",
     },
+    variables: {
+      colorBackground: "hsl(var(--card))",
+      colorForeground: "hsl(var(--card-foreground))",
+      colorNeutral: "hsl(var(--foreground))",
+      colorPrimary: "hsl(var(--primary))",
+      colorPrimaryForeground: "hsl(var(--primary-foreground))",
+      colorMuted: "hsl(var(--muted))",
+      colorMutedForeground: "hsl(var(--muted-foreground))",
+      colorInput: "hsl(var(--input))",
+      colorInputForeground: "hsl(var(--foreground))",
+      colorDanger: "hsl(var(--destructive))",
+      colorRing: "hsl(var(--ring))",
+    },
     elements: {
       rootBox: {
         margin: "0 auto",


### PR DESCRIPTION
## Summary
- Map Clerk's color tokens to vm0's theme CSS variables so all Clerk-rendered UI inherits the proper foreground colors in dark mode
- Fixes invisible org names and the low-contrast "Join" button on the `sign-in/tasks/choose-organization` task screen

## Root Cause
`getClerkAppearance` overrode the card background to `hsl(var(--card))` (dark in dark mode) but only set per-element text classes for the elements it knew about. Elements on the "Choose an Organization" task screen (org name labels, Join button) have no explicit override, so they rendered with Clerk's default dark text on vm0's dark card.

## Fix
Add a `variables` block mapping `colorBackground`, `colorForeground`, `colorNeutral`, `colorPrimary`, `colorMuted`, `colorMutedForeground`, `colorInput`, `colorDanger`, `colorRing`, etc. to the corresponding `hsl(var(--...))` theme variables. This mirrors the approach used by `@clerk/themes`'s shadcn theme and works across light/dark because vm0's variables already switch via `data-theme="dark"`.

Fixes #9038

## Test plan
- [ ] Enable dark mode, navigate to `/sign-in/tasks/choose-organization` (user with pending invitations) — org names next to icons are legible
- [ ] "Join" button label is clearly readable in dark mode
- [ ] Switch back to light mode — sign-in, sign-up, and org-chooser screens still render correctly
- [ ] Regression check: existing sign-in/sign-up flows (OTP, social buttons, password fields) render with correct colors in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)