### PR TITLE
refactor(platform): improve model picker trigger in composer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -480,7 +480,7 @@ function ModelSelectDropdown({
           />
         </SelectValue>
       </SelectTrigger>
-      <SelectContent className="max-h-64">
+      <SelectContent className="max-h-[280px]">
         {showUseDefault && (
           <InheritToggleRow
             effectiveDefault={effectiveDefault}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -970,8 +970,8 @@ export function ZeroChatComposer({
                         onChange={modelPicker.onChange}
                         placeholder="Default"
                         triggerClassName={cn(
-                          "h-8 w-auto max-w-[12rem] gap-1 border-transparent bg-transparent px-2 text-xs text-muted-foreground transition-colors",
-                          "hover:bg-accent hover:text-foreground focus:bg-accent focus:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
+                          "h-9 w-auto max-w-[12rem] gap-1 border-transparent bg-transparent px-2 text-sm text-muted-foreground transition-colors",
+                          "hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
                         )}
                         sessionProviderType={modelPicker.sessionProviderType}
                         compactTrigger


### PR DESCRIPTION
## Summary
- Align model picker trigger height to `h-9` to match mic and send buttons
- Increase font size from `text-xs` to `text-sm` for readability
- Remove `focus:bg-accent` to prevent sticky highlight after dropdown closes
- Increase dropdown max height from 256px to 280px

## Test plan
- [ ] Open chat composer with model picker visible
- [ ] Verify model picker, mic button, and send button are aligned at the same height
- [ ] Verify model name text is readable (14px, not 12px)
- [ ] Open and close the model dropdown — trigger should not stay highlighted after close
- [ ] Verify dropdown height is reasonable with many models

🤖 Generated with [Claude Code](https://claude.com/claude-code)