### PR TITLE
refactor: remove sandbox-reuse feature flag and enable full rollout

### DIFF
--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -39,7 +39,7 @@ pub struct SubmitArgs {
     /// Session ID for sandbox reuse across conversation turns
     #[arg(long)]
     session_id: Option<String>,
-    /// Feature flags (repeatable, format: key=value, e.g. --feature-flag sandboxReuse=true)
+    /// Feature flags (repeatable, format: key=value, e.g. --feature-flag myFlag=true)
     #[arg(long = "feature-flag")]
     feature_flags: Vec<String>,
     /// Timeout in seconds waiting for a runner to complete the job
@@ -336,7 +336,7 @@ mod tests {
             cli_agent_type: "claude-code".into(),
             profile: None,
             session_id: None,
-            feature_flags: vec!["sandboxReuse".into()],
+            feature_flags: vec!["myFlag".into()],
             timeout: 1,
         };
         let err = run_submit(args).await.unwrap_err();
@@ -352,7 +352,7 @@ mod tests {
             cli_agent_type: "claude-code".into(),
             profile: None,
             session_id: None,
-            feature_flags: vec!["sandboxReuse=yes".into()],
+            feature_flags: vec!["myFlag=yes".into()],
             timeout: 1,
         };
         let err = run_submit(args).await.unwrap_err();

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -246,8 +246,6 @@ pub async fn run_start(
     );
 
     // Idle sandbox pool for VM reuse across conversation turns.
-    // Whether individual jobs use the pool is controlled by the per-job
-    // `sandboxReuse` feature flag; the pool itself is always available.
     let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
         default_timeout: Duration::from_secs(idle_timeout_secs),
         max_idle,
@@ -762,15 +760,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
 
                 // Check idle pool for a reusable VM (same session + same profile).
-                // Only attempt reuse when the per-job sandboxReuse flag is on.
                 // The `reuse_result` tag is paired with `reuse_entry` so every
                 // fresh-create path names the branch it came from — the server
                 // persists it on the agent_runs row for observability.
-                let reuse_enabled = context.feature_enabled(crate::types::feature_flags::SANDBOX_REUSE);
                 let (reuse_entry, reuse_result): (Option<IdleEntry>, SandboxReuseResult) =
-                    if !reuse_enabled {
-                        (None, SandboxReuseResult::FeatureDisabled)
-                    } else if let Some(session_id) = context.session_id() {
+                    if let Some(session_id) = context.session_id() {
                         // Take the entry under the pool lock, then drop the
                         // lock before any awaits — the unpark HTTP call below
                         // must not block other take/park operations.
@@ -1088,9 +1082,8 @@ struct SpawnContext {
 /// If `reuse_entry` is `Some`, the job reuses an existing idle sandbox.
 /// Otherwise it creates a new one via the factory.
 ///
-/// After execution, if the per-job `sandboxReuse` feature flag is enabled
-/// and the job succeeded, the sandbox is parked in the idle pool instead
-/// of being destroyed.
+/// After a successful execution with a session ID available, the sandbox
+/// is parked in the idle pool instead of being destroyed.
 fn spawn_job(
     context: ExecutionContext,
     sandbox_id: SandboxId,
@@ -1102,7 +1095,6 @@ fn spawn_job(
 ) {
     let run_id = context.run_id;
     let session_id = context.session_id().map(String::from);
-    let reuse_enabled = context.feature_enabled(crate::types::feature_flags::SANDBOX_REUSE);
     let vcpu = job_profile.vcpu;
     let memory_mb = job_profile.memory_mb;
     let profile_name = job_profile.profile_name;
@@ -1198,17 +1190,14 @@ fn spawn_job(
 
         // Decide: park sandbox for reuse, or stop + destroy.
         let parked = if let Some(mut sandbox) = sandbox {
-            let parkable_session = if reuse_enabled
-                && exit_code == 0
-                && !job_cancel.is_cancelled()
-                && mode == RunnerMode::Running
-            {
-                // Prefer context session_id (from resume_session), fall back to
-                // guest-reported session ID (first run — CLI generated it).
-                session_id.as_deref().or(guest_session_id.as_deref())
-            } else {
-                None
-            };
+            let parkable_session =
+                if exit_code == 0 && !job_cancel.is_cancelled() && mode == RunnerMode::Running {
+                    // Prefer context session_id (from resume_session), fall back to
+                    // guest-reported session ID (first run — CLI generated it).
+                    session_id.as_deref().or(guest_session_id.as_deref())
+                } else {
+                    None
+                };
 
             if let Some(session_id) = parkable_session {
                 // Inflate the guest balloon BEFORE acquiring the pool lock —
@@ -3273,24 +3262,17 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Test 9: sandboxReuse feature flag gates idle pool park/take
+    // Test 9: idle pool park/take is gated on session ID availability
     //
-    // With the flag ON and a session ID, the VM is parked after execution.
-    // With the flag OFF (default), the VM is destroyed.
+    // With a session ID, the VM is parked after execution; without one,
+    // the VM is destroyed (no key to re-find it under).
     // -----------------------------------------------------------------------
 
-    fn context_with_reuse(
+    fn context_with_session_opt(
         run_id: RunId,
-        reuse: bool,
         session_id: Option<&str>,
     ) -> crate::types::ExecutionContext {
         let mut ctx = minimal_context(run_id);
-        if reuse {
-            ctx.feature_flags = Some(HashMap::from([(
-                crate::types::feature_flags::SANDBOX_REUSE.to_string(),
-                true,
-            )]));
-        }
         if let Some(sid) = session_id {
             ctx.resume_session = Some(crate::types::ResumeSession {
                 session_id: sid.to_string(),
@@ -3301,12 +3283,12 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn sandbox_reuse_flag_on_parks_vm() {
+    async fn job_with_session_parks_vm() {
         let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
         let run_id = RunId::new_v4();
-        let ctx = context_with_reuse(run_id, true, Some("sess-1"));
+        let ctx = context_with_session_opt(run_id, Some("sess-1"));
         push_job(&env, run_id, "vm0/default", Some(ctx));
 
         let c = env
@@ -3317,7 +3299,7 @@ mod tests {
         assert_eq!(c.unwrap().exit_code, 0);
 
         let pool = env.idle_pool.lock().await;
-        assert_eq!(pool.len(), 1, "VM should be parked when sandboxReuse is on");
+        assert_eq!(pool.len(), 1, "VM should be parked when session is present");
         assert!(pool.held_sessions().contains(&"sess-1".to_string()));
         drop(pool);
 
@@ -3325,41 +3307,13 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn sandbox_reuse_flag_off_destroys_vm() {
+    async fn job_without_session_does_not_park() {
         let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
         let run_id = RunId::new_v4();
-        // Flag OFF (default) — even with a session ID, VM should not be parked.
-        let ctx = context_with_reuse(run_id, false, Some("sess-1"));
-        push_job(&env, run_id, "vm0/default", Some(ctx));
-
-        let c = env
-            .handle
-            .wait_completion(run_id, Duration::from_secs(5))
-            .await;
-        assert!(c.is_some(), "job should complete");
-        assert_eq!(c.unwrap().exit_code, 0);
-
-        let pool = env.idle_pool.lock().await;
-        assert_eq!(
-            pool.len(),
-            0,
-            "VM should NOT be parked when sandboxReuse is off"
-        );
-        drop(pool);
-
-        shutdown(&env, run_handle).await;
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn sandbox_reuse_flag_on_without_session_does_not_park() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-        let run_handle = tokio::spawn(run(config));
-
-        let run_id = RunId::new_v4();
-        // Flag ON but no session — parking requires a session ID.
-        let ctx = context_with_reuse(run_id, true, None);
+        // No session — parking requires a session ID.
+        let ctx = context_with_session_opt(run_id, None);
         push_job(&env, run_id, "vm0/default", Some(ctx));
 
         let c = env
@@ -3436,13 +3390,9 @@ mod tests {
     // (eviction), shutdown drain, and edge cases (pool-full, reuse cycle).
     // =======================================================================
 
-    /// ExecutionContext with a resume_session and sandboxReuse flag for idle pool testing.
+    /// ExecutionContext with a resume_session for idle pool testing.
     fn context_with_session(run_id: RunId, session_id: &str) -> crate::types::ExecutionContext {
         let mut ctx = minimal_context(run_id);
-        ctx.feature_flags = Some(HashMap::from([(
-            crate::types::feature_flags::SANDBOX_REUSE.to_string(),
-            true,
-        )]));
         ctx.resume_session = Some(crate::types::ResumeSession {
             session_id: session_id.into(),
             session_history: String::new(),
@@ -3749,23 +3699,18 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Test 13b: Reuse-enabled job with no session reports NoSessionId
+    // Test 13b: Job with no session reports NoSessionId
     // -----------------------------------------------------------------------
 
     #[tokio::test(start_paused = true)]
-    async fn reuse_enabled_without_session_reports_no_session_id() {
+    async fn job_without_session_reports_no_session_id() {
         let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
 
         let run_handle = tokio::spawn(run(config));
 
-        // Feature on but no resume_session → NoSessionId branch.
+        // No resume_session → NoSessionId branch.
         let run_id = RunId::new_v4();
-        let mut ctx = minimal_context(run_id);
-        ctx.feature_flags = Some(HashMap::from([(
-            crate::types::feature_flags::SANDBOX_REUSE.to_string(),
-            true,
-        )]));
-        push_job(&env, run_id, "vm0/default", Some(ctx));
+        push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
         let completion = env
             .handle
@@ -3781,33 +3726,6 @@ mod tests {
         assert!(
             completion.sandbox_id.is_some(),
             "fresh create still allocates a sandbox id",
-        );
-
-        shutdown(&env, run_handle).await;
-    }
-
-    // -----------------------------------------------------------------------
-    // Test 13c: Feature-disabled job reports FeatureDisabled
-    // -----------------------------------------------------------------------
-
-    #[tokio::test(start_paused = true)]
-    async fn reuse_disabled_job_reports_feature_disabled() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-
-        let run_handle = tokio::spawn(run(config));
-
-        // minimal_context has feature_flags = None → SANDBOX_REUSE evaluates false.
-        let run_id = RunId::new_v4();
-        push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
-
-        let completion = env
-            .handle
-            .wait_completion(run_id, Duration::from_secs(5))
-            .await;
-        let completion = completion.expect("job should complete");
-        assert_eq!(
-            completion.reuse_result,
-            Some(SandboxReuseResult::FeatureDisabled),
         );
 
         shutdown(&env, run_handle).await;
@@ -4103,37 +4021,6 @@ mod tests {
             post_len, 0,
             "status.json idle_vms must be cleared after shutdown: {post}",
         );
-    }
-
-    // -----------------------------------------------------------------------
-    // Test 18: sandboxReuse flag OFF → VM destroyed, budget released
-    //
-    // When the feature flag is off, park is skipped even with a session.
-    // The sandbox must be destroyed and the budget released (not leaked).
-    // -----------------------------------------------------------------------
-
-    #[tokio::test(start_paused = true)]
-    async fn reuse_flag_off_destroys_and_releases_budget() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-        let budget = Arc::clone(&config.budget);
-        let run_handle = tokio::spawn(run(config));
-
-        let run_id = RunId::new_v4();
-        // Job has a session but flag is OFF — parking is skipped.
-        let ctx = context_with_reuse(run_id, false, Some("sess-rejected"));
-        push_job(&env, run_id, "vm0/default", Some(ctx));
-
-        let completion = env
-            .handle
-            .wait_completion(run_id, Duration::from_secs(5))
-            .await;
-        assert!(completion.is_some(), "job should complete");
-        assert_eq!(completion.unwrap().exit_code, 0);
-
-        // Flag OFF: sandbox destroyed, budget must be released.
-        wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
-
-        shutdown(&env, run_handle).await;
     }
 
     // -----------------------------------------------------------------------

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -152,8 +152,8 @@ pub async fn execute_job_reuse(
 }
 
 /// Emit a single telemetry event capturing the outcome of the reuse decision.
-/// `Reused` emits `sandbox_reuse_hit`; every miss variant (including
-/// `FeatureDisabled`) emits `sandbox_reuse_miss`. Firing on every job makes
+/// `Reused` emits `sandbox_reuse_hit`; every miss variant emits
+/// `sandbox_reuse_miss`. Firing on every job makes
 /// the reuse success rate queryable in Axiom as
 /// `countif(op_type == "sandbox_reuse_hit") / countif(op_type startswith "sandbox_reuse_")`.
 /// Miss-reason breakdown lives on the `agent_runs.sandbox_reuse_result`

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -162,8 +162,7 @@ pub async fn execute_job_reuse(
 fn record_reuse_result(telemetry: &mut JobTelemetry, result: SandboxReuseResult) {
     let action_type = match result {
         SandboxReuseResult::Reused => "sandbox_reuse_hit",
-        SandboxReuseResult::FeatureDisabled
-        | SandboxReuseResult::NoSessionId
+        SandboxReuseResult::NoSessionId
         | SandboxReuseResult::PoolMiss
         | SandboxReuseResult::ProfileMismatch
         | SandboxReuseResult::UnparkFailed => "sandbox_reuse_miss",
@@ -3274,7 +3273,6 @@ mod tests {
     #[test]
     fn record_reuse_result_emits_miss_for_every_miss_variant() {
         let variants = [
-            SandboxReuseResult::FeatureDisabled,
             SandboxReuseResult::NoSessionId,
             SandboxReuseResult::PoolMiss,
             SandboxReuseResult::ProfileMismatch,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -204,11 +204,6 @@ pub struct ResumeSession {
     pub session_history: String,
 }
 
-/// Feature flag keys (must match TypeScript `FeatureSwitchKey` values).
-pub mod feature_flags {
-    pub const SANDBOX_REUSE: &str = "sandboxReuse";
-}
-
 impl ExecutionContext {
     /// Extract the session ID from `resume_session` for sandbox reuse.
     ///
@@ -217,14 +212,6 @@ impl ExecutionContext {
     /// guest filesystem post-execution (see `read_guest_session_id`).
     pub fn session_id(&self) -> Option<&str> {
         self.resume_session.as_ref().map(|r| r.session_id.as_str())
-    }
-
-    /// Check whether a feature flag is enabled for this job.
-    pub fn feature_enabled(&self, flag: &str) -> bool {
-        self.feature_flags
-            .as_ref()
-            .and_then(|f| f.get(flag).copied())
-            .unwrap_or(false)
     }
 }
 
@@ -280,7 +267,6 @@ pub struct CompleteRequest {
 #[serde(rename_all = "camelCase")]
 pub enum SandboxReuseResult {
     Reused,
-    FeatureDisabled,
     NoSessionId,
     PoolMiss,
     ProfileMismatch,
@@ -507,10 +493,6 @@ mod tests {
 
     #[test]
     fn sandbox_reuse_result_serializes_camel_case() {
-        assert_eq!(
-            serde_json::to_value(SandboxReuseResult::FeatureDisabled).unwrap(),
-            serde_json::json!("featureDisabled"),
-        );
         assert_eq!(
             serde_json::to_value(SandboxReuseResult::NoSessionId).unwrap(),
             serde_json::json!("noSessionId"),

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -30,9 +30,9 @@ describe("isFeatureEnabled", () => {
   });
 
   it("should return true when orgId hash matches enabledOrgIdHashes", () => {
-    // SandboxReuse has enabledOrgIdHashes: STAFF_ORG_ID_HASHES
+    // SlackAgentSwitch has enabledOrgIdHashes: STAFF_ORG_ID_HASHES
     expect(
-      isFeatureEnabled(FeatureSwitchKey.SandboxReuse, {
+      isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch, {
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
     ).toBe(true);
@@ -40,19 +40,19 @@ describe("isFeatureEnabled", () => {
 
   it("should return false when orgId does not match enabledOrgIdHashes", () => {
     expect(
-      isFeatureEnabled(FeatureSwitchKey.SandboxReuse, {
+      isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch, {
         orgId: "org_nonexistent",
       }),
     ).toBe(false);
   });
 
   it("should return false when no orgId provided but switch has enabledOrgIdHashes", () => {
-    expect(isFeatureEnabled(FeatureSwitchKey.SandboxReuse)).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch)).toBe(false);
   });
 
   it("should return true when orgId matches even if userId does not", () => {
     expect(
-      isFeatureEnabled(FeatureSwitchKey.SandboxReuse, {
+      isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch, {
         userId: "non-matching-user",
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
@@ -71,8 +71,8 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates({
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
-    // SandboxReuse has STAFF_ORG_ID_HASHES and should be true
-    expect(states[FeatureSwitchKey.SandboxReuse]).toBe(true);
+    // SlackAgentSwitch has STAFF_ORG_ID_HASHES and should be true
+    expect(states[FeatureSwitchKey.SlackAgentSwitch]).toBe(true);
     // Globally enabled should still be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
     // Switches without org hashes should remain false
@@ -83,7 +83,7 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates({
       orgId: "org_nonexistent",
     });
-    expect(states[FeatureSwitchKey.SandboxReuse]).toBe(false);
+    expect(states[FeatureSwitchKey.SlackAgentSwitch]).toBe(false);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -15,6 +15,11 @@ const c = initContract();
  * Sandbox reuse outcome. One enum value per code branch in the runner's
  * reuse-decision block. `reused` means the sandbox was unparked from the idle
  * pool; the remaining variants describe why reuse did not happen.
+ *
+ * `featureDisabled` is legacy: written by older runners while reuse was gated
+ * by the `sandboxReuse` feature flag (removed when reuse went to full rollout
+ * in #10744). Retained here so historical `agent_runs.sandbox_reuse_result`
+ * rows still parse on read. The runner no longer emits it.
  */
 export const sandboxReuseResultSchema = z.enum([
   "reused",

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -40,7 +40,6 @@ export enum FeatureSwitchKey {
   AudioInput = "audioInput",
   AudioOutput = "audioOutput",
   AutoSkill = "autoSkill",
-  SandboxReuse = "sandboxReuse",
   ScheduleRunHistory = "scheduleRunHistory",
   SlackAgentSwitch = "slackAgentSwitch",
   TestOauthConnector = "testOauthConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -217,12 +217,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable automatic skill creation in agent prompts",
     enabled: false,
   },
-  [FeatureSwitchKey.SandboxReuse]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Enable sandbox reuse (keep-alive) across conversation turns",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ScheduleRunHistory]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

Sandbox reuse has been validated on staff orgs and is ready to ship unconditionally. This PR removes the per-job `sandboxReuse` feature flag so reuse is always attempted; the only remaining gate on park/take is having a session ID to key the idle pool under.

## Changes

### Rust (runner)
- Drop the `feature_flags` constant module and `ExecutionContext::feature_enabled` helper — only `SANDBOX_REUSE` used them (YAGNI). The serde `feature_flags` payload field on `ExecutionContext` stays as a cross-service contract.
- Inline `reuse_enabled = true` at both call sites in `cmd/start.rs` (take branch and post-execution park decision). Refresh the surrounding comments and the `spawn_job` docstring.
- Delete `SandboxReuseResult::FeatureDisabled` variant — the runner never emits it now, and since the enum only derives `Serialize` (Rust is a pure producer, not consumer of this value), the variant was dead code that clippy caught.
- Drop the three flag-off tests (`sandbox_reuse_flag_off_destroys_vm`, `reuse_disabled_job_reports_feature_disabled`, `reuse_flag_off_destroys_and_releases_budget`) and rename the remaining flag-on tests to describe the new gating condition (session presence).
- Generalise the `--feature-flag` CLI doc example in `local/submit` away from `sandboxReuse=true`.

### TypeScript (core)
- Remove `SandboxReuse` from `FeatureSwitchKey` and from the `FEATURE_SWITCHES` registry.
- Repoint `feature-switch.test.ts` STAFF_ORG cases onto another staff-gated flag (`SlackAgentSwitch`) so the test continues to exercise the `enabledOrgIdHashes` path.
- Keep `featureDisabled` in `sandboxReuseResultSchema` (zod) with a comment marking it as legacy — historical `agent_runs.sandbox_reuse_result` rows still need to parse on read. The runner no longer emits this value.

### Preserved on purpose
- `sandboxReuseResultSchema` (zod) `featureDisabled` string and the matching `SANDBOX_REUSE_LABELS` UI entry — read-path compatibility for historical rows.
- `agent_runs.sandbox_reuse_result` DB column.

## Acceptance criteria

- [x] Remove the sandbox reuse feature flag/configuration option
- [x] Ensure sandbox reuse is unconditionally enabled in all environments
- [x] Clean up any conditional branches or dead code guarded by the old toggle
- [x] No related configuration documentation or env var references found

## Test plan

- [x] `cargo clippy --all-targets --all-features` — clean (lefthook pre-commit also green)
- [x] `cargo test -p runner --bin runner` for `types::`, `cmd::start::tests::`, `cmd::local::`, `executor::` — all passing, including the renamed `job_with_session_parks_vm` / `job_without_session_does_not_park` / `job_without_session_reports_no_session_id`
- [x] `pnpm -F @vm0/core exec vitest run` — 770/770 pass (feature-switch.test.ts now exercises `SlackAgentSwitch`)
- [x] `pnpm turbo run lint` + `pnpm check-types` — clean
- [x] `pnpm knip` — no new dead code
- [ ] Post-merge: eyeball a staff-org run to confirm `sandboxReuseResult` still populates (`reused` / `poolMiss` / etc.) and historical `featureDisabled` rows still render correctly in the activity detail page

Fixes #10744

🤖 Generated with [Claude Code](https://claude.com/claude-code)