### PR TITLE
ci: move migrate-production to run after builds-complete

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,9 +66,10 @@ jobs:
             echo "✅ Created $gate check run on $PR_HEAD"
           done
 
-  # Run database migrations in production (always runs as a gate for all deploy jobs)
+  # Run database migrations in production (runs after builds-complete to reduce
+  # downtime: builds stage first, then migrate, then promote traffic.)
   migrate-production:
-    needs: release-please
+    needs: [release-please, builds-complete]
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
@@ -397,7 +398,6 @@ jobs:
   builds-complete:
     needs:
       - release-please
-      - migrate-production
       - build-web-production
       - build-app-production
       - build-runner-production
@@ -432,7 +432,7 @@ jobs:
           echo "✅ All build-phase jobs succeeded or were skipped."
 
   promote-web-production:
-    needs: [release-please, builds-complete, build-web-production]
+    needs: [release-please, builds-complete, build-web-production, migrate-production]
     if: >-
       !failure() && !cancelled() &&
       needs.release-please.outputs.web_release_created == 'true'
@@ -654,7 +654,7 @@ jobs:
 
   # Promote app staged deployment to production (traffic switch)
   promote-app-production:
-    needs: [release-please, builds-complete, build-app-production, promote-web-production]
+    needs: [release-please, builds-complete, build-app-production, promote-web-production, migrate-production]
     if: >-
       !failure() && !cancelled() &&
       needs.release-please.outputs.app_release_created == 'true'
@@ -1008,7 +1008,7 @@ jobs:
           echo "Updated rollback dashboard issue #${ISSUE_NUMBER}"
 
   publish-npm:
-    needs: [release-please, builds-complete]
+    needs: [release-please, builds-complete, migrate-production]
     if: >-
       !failure() && !cancelled() &&
       needs.release-please.outputs.cli_release_created == 'true'
@@ -1369,7 +1369,7 @@ jobs:
   # the schema and API it targets are live. Host-level prep
   # (provision-runner, provision-monitoring) already ran in build.
   promote-runner-production:
-    needs: [release-please, builds-complete, promote-web-production, resolve-image-cache, build-runner-production]
+    needs: [release-please, builds-complete, promote-web-production, resolve-image-cache, build-runner-production, migrate-production]
     if: >-
       !failure() && !cancelled() &&
       needs.release-please.outputs.runner_rs_release_created == 'true'
@@ -1534,7 +1534,7 @@ jobs:
   # Build E2B templates to production account
   # Uses production environment E2B_API_KEY secret
   build-e2b-template-production:
-    needs: [release-please, migrate-production]
+    needs: [release-please]
     # Build when any release is created
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
@@ -1559,7 +1559,7 @@ jobs:
 
   # Generate Software Bill of Materials (SBOM) for CASA compliance (CASA-DEP-003)
   sbom:
-    needs: [release-please, migrate-production]
+    needs: [release-please]
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
## Problem

Previously `migrate-production` ran in parallel with build jobs. If migration finished before builds completed, the production DB would sit on the new schema while old code was still serving traffic — widening the window for schema/code mismatch outages.

## Change

Reorder the pipeline:

1. **release-please** → triggers release
2. **build-\*** + **sbom** + **resolve-image-cache** → run in parallel
3. **builds-complete** → fan-in gate confirming all builds succeeded
4. **migrate-production** → runs only after `builds-complete`
5. **promote-\*** + **publish-npm** → run only after `migrate-production`

## Impact

- If a build fails, migration is skipped entirely.
- If migration fails, no promote jobs run.
- Downtime window between "new schema" and "new code serving traffic" is minimized.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)