### PR TITLE
feat: add tooltip to attachment upload button

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -935,14 +935,23 @@ export function ZeroChatComposer({
             />
             <div className="flex items-center justify-between gap-2 px-4 pb-3 pt-1">
               <div className="flex items-center gap-1 text-muted-foreground">
-                <button
-                  type="button"
-                  className="p-[9px] rounded-lg hover:bg-accent hover:text-foreground transition-colors duration-200"
-                  aria-label="Attach"
-                  onClick={handleFileSelect}
-                >
-                  <IconPaperclip size={18} stroke={1.5} />
-                </button>
+                <TooltipProvider delayDuration={300}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="p-[9px] rounded-lg hover:bg-accent hover:text-foreground transition-colors duration-200"
+                        aria-label="Attach"
+                        onClick={handleFileSelect}
+                      >
+                        <IconPaperclip size={18} stroke={1.5} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="text-xs">
+                      Attach
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
                 <ConnectorsPopoverButton
                   agentConnectors={agentConnectors}
                   connectorsLoading={connectorsLoading}


### PR DESCRIPTION
## Summary
- Add tooltip ("Attach") to the paperclip file upload button in the chat composer
- Matches existing tooltip pattern used by mic button and connectors button (TooltipProvider with 300ms delay, top placement)

## Test plan
- [ ] Hover over the paperclip button in the chat composer — tooltip "Attach" appears after 300ms
- [ ] Verify tooltip does not interfere with click-to-upload functionality
- [ ] Confirm tooltip styling matches mic and connectors button tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)