### PR TITLE
fix(voice-chat): recover microphone tracks after screen lock

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
@@ -942,5 +942,104 @@ describe("voice-chat-candidate session", () => {
       };
       expect(sender.replaceTrack).toHaveBeenCalledWith(freshTrack);
     });
+
+    it("does NOT trigger recovery when tracks are still live on screen resume", async () => {
+      await setup();
+      // Default stubWebRTC returns a stream whose tracks are "live".
+      // Capture the getUserMedia call count before firing visibilitychange so
+      // we can assert that no additional calls happen afterward.
+      await startSuccessfully();
+
+      const getUserMedia = navigator.mediaDevices.getUserMedia as ReturnType<
+        typeof vi.fn
+      >;
+      const callsBefore = getUserMedia.mock.calls.length;
+
+      // Simulate screen unlock with healthy tracks still live.
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      // Flush microtasks — recovery involves async calls, so a few ticks are
+      // enough to observe any spurious invocation.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(getUserMedia.mock.calls.length).toBe(callsBefore);
+      expect(context.store.get(vccStatus$)).toBe("connected");
+    });
+
+    it("sets vccError$ when getUserMedia is denied during recovery", async () => {
+      await setup();
+
+      const stoppedTrack = {
+        enabled: true,
+        readyState: "ended" as MediaStreamTrackState,
+        stop: vi.fn(),
+      };
+      const endedStream = {
+        getAudioTracks: () => {
+          return [stoppedTrack];
+        },
+        getTracks: () => {
+          return [stoppedTrack];
+        },
+      } as unknown as MediaStream;
+
+      Object.defineProperty(navigator, "mediaDevices", {
+        value: {
+          getUserMedia: vi
+            .fn()
+            .mockResolvedValueOnce(endedStream)
+            .mockRejectedValueOnce(
+              Object.assign(new Error("NotAllowedError"), {
+                name: "NotAllowedError",
+              }),
+            ),
+          enumerateDevices: vi.fn().mockResolvedValue([
+            { kind: "audiooutput", deviceId: "default" },
+            { kind: "audiooutput", deviceId: "bt-headset-1" },
+          ] as MediaDeviceInfo[]),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      mockCreateSessionOk();
+      mockTokenOk();
+      mockGetSessionOk();
+      mockListActiveTasksOk();
+      detach(
+        context.store.set(
+          startVoiceChatCandidate$,
+          DEFAULT_AGENT_ID,
+          context.signal,
+        ),
+        Reason.DomCallback,
+      );
+      await vi.waitFor(() => {
+        expect(dcRef.current).not.toBeNull();
+      });
+      dcRef.current?.emitOpen();
+      await vi.waitFor(() => {
+        expect(context.store.get(vccStatus$)).toBe("connected");
+      });
+
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      await vi.waitFor(() => {
+        expect(context.store.get(vccStatus$)).toBe("error");
+      });
+      expect(context.store.get(vccError$)).toBe(
+        "Microphone access lost. Please reconnect.",
+      );
+    });
   });
 });

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
@@ -285,14 +285,12 @@ describe("voice-chat-candidate session", () => {
       createOffer = vi.fn().mockResolvedValue({ sdp: "offer-sdp" });
       setLocalDescription = vi.fn().mockResolvedValue(undefined);
       setRemoteDescription = vi.fn().mockResolvedValue(undefined);
-      getSenders = vi
-        .fn()
-        .mockReturnValue([
-          {
-            track: { kind: "audio" },
-            replaceTrack: vi.fn().mockResolvedValue(undefined),
-          },
-        ]);
+      getSenders = vi.fn().mockReturnValue([
+        {
+          track: { kind: "audio" },
+          replaceTrack: vi.fn().mockResolvedValue(undefined),
+        },
+      ]);
 
       createDataChannel(): FakeDC {
         pcRef.current = this;

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
@@ -244,6 +244,12 @@ describe("voice-chat-candidate session", () => {
     current: { pause: ReturnType<typeof vi.fn>; currentTime: number } | null;
   } = { current: null };
 
+  // Ref to the RTCPeerConnection instance created during the session, so tests
+  // can inspect getSenders calls after startSuccessfully().
+  const pcRef: { current: { getSenders: ReturnType<typeof vi.fn> } | null } = {
+    current: null,
+  };
+
   function stubWebRTC(
     devices: Partial<MediaDeviceInfo>[] = [
       { kind: "audiooutput", deviceId: "default" },
@@ -252,7 +258,7 @@ describe("voice-chat-candidate session", () => {
   ) {
     const mediaStreamStub = {
       getAudioTracks() {
-        return [{ enabled: true }];
+        return [{ enabled: true, readyState: "live" as MediaStreamTrackState }];
       },
       getTracks() {
         return [{ stop: vi.fn() }];
@@ -279,8 +285,17 @@ describe("voice-chat-candidate session", () => {
       createOffer = vi.fn().mockResolvedValue({ sdp: "offer-sdp" });
       setLocalDescription = vi.fn().mockResolvedValue(undefined);
       setRemoteDescription = vi.fn().mockResolvedValue(undefined);
+      getSenders = vi
+        .fn()
+        .mockReturnValue([
+          {
+            track: { kind: "audio" },
+            replaceTrack: vi.fn().mockResolvedValue(undefined),
+          },
+        ]);
 
       createDataChannel(): FakeDC {
+        pcRef.current = this;
         const openListeners: (() => void)[] = [];
         const messageListeners: ((ev: MessageEvent) => void)[] = [];
         const closeListeners: (() => void)[] = [];
@@ -366,6 +381,7 @@ describe("voice-chat-candidate session", () => {
     });
     dcRef.current = null;
     audioRef.current = null;
+    pcRef.current = null;
     vi.unstubAllGlobals();
   }
 
@@ -833,6 +849,100 @@ describe("voice-chat-candidate session", () => {
         expect(context.store.get(vccStatus$)).toBe("idle");
       });
       expect(context.store.get(vccSessionId$)).toBeNull();
+    });
+  });
+
+  describe("microphone recovery", () => {
+    it("re-acquires getUserMedia and replaces the sender track when all audio tracks are ended on screen resume", async () => {
+      await setup();
+
+      // Simulate OS suspension: the initial stream has all tracks in "ended"
+      // state (what happens after screen lock on mobile/macOS).
+      const stoppedTrack = {
+        enabled: true,
+        readyState: "ended" as MediaStreamTrackState,
+        stop: vi.fn(),
+      };
+      const endedStream = {
+        getAudioTracks: () => {
+          return [stoppedTrack];
+        },
+        getTracks: () => {
+          return [stoppedTrack];
+        },
+      } as unknown as MediaStream;
+
+      // The fresh stream returned on recovery.
+      const freshTrack = {
+        kind: "audio",
+        enabled: true,
+        readyState: "live" as MediaStreamTrackState,
+        stop: vi.fn(),
+      };
+      const recoveredStream = {
+        getAudioTracks: () => {
+          return [freshTrack];
+        },
+        getTracks: () => {
+          return [freshTrack];
+        },
+      } as unknown as MediaStream;
+
+      // First getUserMedia call (initial connect) → ended stream so that
+      // visibilitychange sees all tracks dead and triggers recovery.
+      // Second call (inside recoverMicrophone$) → fresh stream.
+      Object.defineProperty(navigator, "mediaDevices", {
+        value: {
+          getUserMedia: vi
+            .fn()
+            .mockResolvedValueOnce(endedStream)
+            .mockResolvedValueOnce(recoveredStream),
+          enumerateDevices: vi.fn().mockResolvedValue([
+            { kind: "audiooutput", deviceId: "default" },
+            { kind: "audiooutput", deviceId: "bt-headset-1" },
+          ] as MediaDeviceInfo[]),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      mockCreateSessionOk();
+      mockTokenOk();
+      mockGetSessionOk();
+      mockListActiveTasksOk();
+      detach(
+        context.store.set(
+          startVoiceChatCandidate$,
+          DEFAULT_AGENT_ID,
+          context.signal,
+        ),
+        Reason.DomCallback,
+      );
+      await vi.waitFor(() => {
+        expect(dcRef.current).not.toBeNull();
+      });
+      dcRef.current?.emitOpen();
+      await vi.waitFor(() => {
+        expect(context.store.get(vccStatus$)).toBe("connected");
+      });
+
+      // Simulate screen unlock: document becomes visible again.
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      // recoverMicrophone$ should have called getUserMedia a second time and
+      // replaced the sender's audio track with the new one.
+      await vi.waitFor(() => {
+        expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(2);
+      });
+      expect(pcRef.current?.getSenders).toHaveBeenCalledWith();
+      const sender = pcRef.current?.getSenders.mock.results[0]?.value[0] as {
+        replaceTrack: ReturnType<typeof vi.fn>;
+      };
+      expect(sender.replaceTrack).toHaveBeenCalledWith(freshTrack);
     });
   });
 });

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
@@ -953,7 +953,7 @@ describe("voice-chat-candidate session", () => {
       const getUserMedia = navigator.mediaDevices.getUserMedia as ReturnType<
         typeof vi.fn
       >;
-      const callsBefore = getUserMedia.mock.calls.length;
+      getUserMedia.mockClear();
 
       // Simulate screen unlock with healthy tracks still live.
       Object.defineProperty(document, "visibilityState", {
@@ -968,7 +968,7 @@ describe("voice-chat-candidate session", () => {
       await Promise.resolve();
       await Promise.resolve();
 
-      expect(getUserMedia.mock.calls.length).toBe(callsBefore);
+      expect(getUserMedia.mock.calls).toHaveLength(0);
       expect(context.store.get(vccStatus$)).toBe("connected");
     });
 

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -668,9 +668,9 @@ const recoverMicrophone$ = command(
     signal.throwIfAborted();
     const newTrack = newStream.getAudioTracks()[0];
     if (!newTrack) {
-      newStream.getTracks().forEach((t) => {
+      for (const t of newStream.getTracks()) {
         t.stop();
-      });
+      }
       return;
     }
     const sender = pc.getSenders().find((s) => {
@@ -681,9 +681,9 @@ const recoverMicrophone$ = command(
         await sender.replaceTrack(newTrack);
       } catch (error) {
         throwIfAbort(error);
-        newStream.getTracks().forEach((t) => {
+        for (const t of newStream.getTracks()) {
           t.stop();
-        });
+        }
         set(internalError$, "Microphone access lost. Please reconnect.");
         set(internalStatus$, "error");
         return;
@@ -692,9 +692,9 @@ const recoverMicrophone$ = command(
     signal.throwIfAborted();
     const oldStream = get(internalStream$);
     if (oldStream) {
-      oldStream.getTracks().forEach((t) => {
+      for (const t of oldStream.getTracks()) {
         t.stop();
-      });
+      }
     }
     set(internalStream$, newStream);
     L.info("microphone recovered after screen resume");
@@ -712,11 +712,9 @@ const monitorMicrophoneRecovery$ = command(
         return;
       }
       const tracks = stream.getAudioTracks();
-      const isDead =
-        tracks.length === 0 ||
-        tracks.every((t) => {
-          return t.readyState === "ended";
-        });
+      const isDead = tracks.every((t) => {
+        return t.readyState === "ended";
+      });
       if (!isDead) {
         return;
       }

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -712,9 +712,11 @@ const monitorMicrophoneRecovery$ = command(
         return;
       }
       const tracks = stream.getAudioTracks();
-      const isDead = tracks.every((t) => {
-        return t.readyState === "ended";
-      });
+      const isDead =
+        tracks.length > 0 &&
+        tracks.every((t) => {
+          return t.readyState === "ended";
+        });
       if (!isDead) {
         return;
       }

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -703,7 +703,7 @@ const recoverMicrophone$ = command(
 
 const monitorMicrophoneRecovery$ = command(
   ({ get, set }, signal: AbortSignal): void => {
-    const onVisibilityChange = (): void => {
+    const onVisibilityChange = onDomEventFn(() => {
       if (document.visibilityState !== "visible" || signal.aborted) {
         return;
       }
@@ -718,10 +718,8 @@ const monitorMicrophoneRecovery$ = command(
       if (!isDead) {
         return;
       }
-      set(recoverMicrophone$, signal).catch(() => {
-        return undefined;
-      });
-    };
+      return set(recoverMicrophone$, signal);
+    });
     document.addEventListener("visibilitychange", onVisibilityChange);
     signal.addEventListener("abort", () => {
       document.removeEventListener("visibilitychange", onVisibilityChange);

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -643,6 +643,95 @@ const releaseWakeLock$ = command(({ get, set }) => {
 });
 
 // ---------------------------------------------------------------------------
+// Microphone recovery (re-acquire tracks after OS suspension on screen lock)
+// ---------------------------------------------------------------------------
+
+const recoverMicrophone$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const pc = get(internalPc$);
+    if (!pc || pc.connectionState === "closed") {
+      return;
+    }
+    let newStream: MediaStream;
+    try {
+      const audioConfig = await resolveAudioConfig();
+      signal.throwIfAborted();
+      newStream = await navigator.mediaDevices.getUserMedia({
+        audio: audioConfig.constraints,
+      });
+    } catch (error) {
+      throwIfAbort(error);
+      set(internalError$, "Microphone access lost. Please reconnect.");
+      set(internalStatus$, "error");
+      return;
+    }
+    signal.throwIfAborted();
+    const newTrack = newStream.getAudioTracks()[0];
+    if (!newTrack) {
+      newStream.getTracks().forEach((t) => {
+        t.stop();
+      });
+      return;
+    }
+    const sender = pc.getSenders().find((s) => {
+      return s.track?.kind === "audio";
+    });
+    if (sender) {
+      try {
+        await sender.replaceTrack(newTrack);
+      } catch (error) {
+        throwIfAbort(error);
+        newStream.getTracks().forEach((t) => {
+          t.stop();
+        });
+        set(internalError$, "Microphone access lost. Please reconnect.");
+        set(internalStatus$, "error");
+        return;
+      }
+    }
+    signal.throwIfAborted();
+    const oldStream = get(internalStream$);
+    if (oldStream) {
+      oldStream.getTracks().forEach((t) => {
+        t.stop();
+      });
+    }
+    set(internalStream$, newStream);
+    L.info("microphone recovered after screen resume");
+  },
+);
+
+const monitorMicrophoneRecovery$ = command(
+  ({ get, set }, signal: AbortSignal): void => {
+    const onVisibilityChange = (): void => {
+      if (document.visibilityState !== "visible" || signal.aborted) {
+        return;
+      }
+      const stream = get(internalStream$);
+      if (!stream) {
+        return;
+      }
+      const tracks = stream.getAudioTracks();
+      const isDead =
+        tracks.length === 0 ||
+        tracks.every((t) => {
+          return t.readyState === "ended";
+        });
+      if (!isDead) {
+        return;
+      }
+      set(recoverMicrophone$, signal).catch(() => {
+        return undefined;
+      });
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    signal.addEventListener("abort", () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Public commands
 // ---------------------------------------------------------------------------
 
@@ -745,6 +834,8 @@ export const startVoiceChatCandidate$ = command(
 
     await set(acquireWakeLock$, sessionSignal);
     signal.throwIfAborted();
+
+    set(monitorMicrophoneRecovery$, sessionSignal);
 
     await set(startAblyLoop$, session.id, sessionSignal);
   },


### PR DESCRIPTION
## Problem

On mobile (especially iOS PWA where `navigator.wakeLock` is not supported), locking the screen causes the OS to suspend audio tracks. When the user returns to the app, the microphone is silent — the WebRTC connection is still live but the audio sender is sending nothing.

## Fix

Add two new commands in `voice-chat-candidate-session.ts`:

- **`recoverMicrophone$`** — re-requests `getUserMedia` with the same adaptive audio config, then calls `RTCPeerConnection.getSenders().replaceTrack()` to hot-swap the dead track with a fresh one. The old stream is stopped cleanly. If recovery fails (e.g. permission denied), falls through to an error state with a user-visible message.

- **`monitorMicrophoneRecovery$`** — registers a `visibilitychange` listener for the duration of the session. On every foreground restore, checks if all audio tracks are `readyState === "ended"`. If so, fires `recoverMicrophone$`.

`monitorMicrophoneRecovery$` is started alongside `acquireWakeLock$` in `startVoiceChatCandidate$`, and is torn down automatically via the session `AbortSignal`.

## Test

1. Open Trinity voice chat on mobile
2. Lock screen for ~10s
3. Unlock — mic should auto-recover without reconnecting the session