### PR TITLE
feat: preview rich attachment content inline in chat

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -27,7 +27,7 @@ function mockChatAPI() {
 // ---------------------------------------------------------------------------
 
 describe("chat-d-056: file type icon renders based on getFileTypeIcon", () => {
-  it("renders img icon for pdf attachment in chat message", async () => {
+  it("renders a pdf preview card for pdf attachment in chat message", async () => {
     mockChatLifecycle({
       chatMessages: [
         {
@@ -45,13 +45,9 @@ describe("chat-d-056: file type icon renders based on getFileTypeIcon", () => {
     });
 
     await waitFor(() => {
+      expect(screen.getByTestId("attachment-preview-pdf")).toBeInTheDocument();
       expect(
-        document.querySelector('a[download="document.pdf"]'),
-      ).toBeInTheDocument();
-      expect(
-        document.querySelector(
-          'a[download="document.pdf"] img[aria-hidden="true"]',
-        ),
+        screen.getByRole("button", { name: "Load preview" }),
       ).toBeInTheDocument();
     });
   });
@@ -399,7 +395,7 @@ describe("chat-d-063: download link renders for file attachment", () => {
         `a[download="${filename}"]`,
       );
       expect(link).toBeInTheDocument();
-      expect(link?.getAttribute("href")).toBe(fileUrl);
+      expect(link?.getAttribute("href")).toBe(`${fileUrl}?download=1`);
     });
   });
 
@@ -436,7 +432,7 @@ describe("chat-d-063: download link renders for file attachment", () => {
         `a[download="${filename}"]`,
       );
       expect(link).toBeInTheDocument();
-      expect(link?.getAttribute("href")).toBe(fileUrl);
+      expect(link?.getAttribute("href")).toBe(`${fileUrl}?download=1`);
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
@@ -10,6 +12,16 @@ import {
 } from "./chat-test-helpers.ts";
 
 const context = testContext();
+
+beforeEach(() => {
+  server.use(
+    http.get("https://example.com/avatar.png", () => {
+      return new HttpResponse("avatar", {
+        headers: { "Content-Type": "image/png" },
+      });
+    }),
+  );
+});
 
 // CHAT-D-033: Pin pill renders conditionally in ChatThreadHeader
 describe("zero chat thread page display - pin pill conditional rendering", () => {
@@ -62,15 +74,21 @@ describe("zero chat thread page display - attachment image preview", () => {
   });
 });
 
-// CHAT-D-037: Attachment file previews render in ChatMessageRow
-describe("zero chat thread page display - attachment file preview", () => {
-  it("renders file attachment chip with a download link for non-image files", async () => {
+// CHAT-D-037: Attachment document previews render in ChatMessageRow
+describe("zero chat thread page display - attachment document preview", () => {
+  it("renders markdown attachment content inline instead of only a file chip", async () => {
+    const docUrl = "https://example.com/notes.md";
+    server.use(
+      http.get(docUrl, () => {
+        return HttpResponse.text("# PRD\n\nPreview body");
+      }),
+    );
+
     mockChatLifecycle({
       chatMessages: [
         {
           role: "user",
-          content:
-            "[Attached file: document.pdf](https://example.com/document.pdf)\nDownload with: curl https://example.com/document.pdf\n",
+          content: `[Attached file: notes.md](${docUrl})\nDownload with: curl ${docUrl}\n`,
           createdAt: "2026-03-10T00:00:00Z",
         },
       ],
@@ -79,7 +97,11 @@ describe("zero chat thread page display - attachment file preview", () => {
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
     await waitFor(() => {
-      expect(screen.getByTitle("document.pdf")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("attachment-preview-markdown"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("PRD")).toBeInTheDocument();
+      expect(screen.getByText("Preview body")).toBeInTheDocument();
     });
   });
 });
@@ -117,6 +139,78 @@ describe("zero chat thread page display - attachment video preview", () => {
     expect(
       document.querySelector('a[download="clip.mp4"]'),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("zero chat thread page display - attachment html preview", () => {
+  it("renders html attachment through a dedicated controlled preview card", async () => {
+    const htmlUrl = "https://example.com/report.html";
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: `[Attached file: report.html](${htmlUrl})\nDownload with: curl ${htmlUrl}\n`,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-preview-html")).toBeInTheDocument();
+      expect(screen.getByText("Load preview")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero chat thread page display - attachment json preview", () => {
+  it("renders json attachment in a structured preview block", async () => {
+    const jsonUrl = "https://example.com/data.json";
+    server.use(
+      http.get(jsonUrl, () => {
+        return HttpResponse.text('{"status":"ok","count":2}');
+      }),
+    );
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: `[Attached file: data.json](${jsonUrl})\nDownload with: curl ${jsonUrl}\n`,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-preview-json")).toBeInTheDocument();
+      expect(screen.getByText('{"status":"ok","count":2}')).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero chat thread page display - attachment pdf preview", () => {
+  it("renders pdf attachment as a previewable document card", async () => {
+    const pdfUrl = "https://example.com/document.pdf";
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: `[Attached file: document.pdf](${pdfUrl})\nDownload with: curl ${pdfUrl}\n`,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-preview-pdf")).toBeInTheDocument();
+      expect(screen.getByText("Load preview")).toBeInTheDocument();
+    });
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -1,6 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import { hasSubscription } from "../../../mocks/ably.ts";
@@ -17,6 +19,16 @@ import {
 const context = testContext();
 
 const THREAD_ID = "thread-test-1";
+
+beforeEach(() => {
+  server.use(
+    http.get("https://example.com/avatar.png", () => {
+      return new HttpResponse("avatar", {
+        headers: { "Content-Type": "image/png" },
+      });
+    }),
+  );
+});
 
 // CHAT-S-044: Sending state affects ChatThreadComposer button display
 describe("zero chat thread page - sending state affects composer button display", () => {
@@ -215,6 +227,13 @@ describe("zero chat thread page - view activity logs link", () => {
 // CHAT-I-055: Attachment download links do not navigate away from the page
 describe("zero chat thread page - file attachment download does not navigate away", () => {
   it("clicking the download link does not change the pathname (CHAT-I-055)", async () => {
+    server.use(
+      http.get("https://example.com/document.pdf", () => {
+        return new HttpResponse("%PDF-test", {
+          headers: { "Content-Type": "application/pdf" },
+        });
+      }),
+    );
     mockChatLifecycle({
       chatMessages: [
         {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -99,6 +99,76 @@ describe("directed connect page", () => {
     expect(screen.queryByText("Connect")).not.toBeInTheDocument();
   });
 
+  it("shows Reconnect button alongside Connected pill when already connected", async () => {
+    mockConnectors([{ type: "github" }]);
+
+    detachedSetupPage({ context, path: "/connectors/github/connect" });
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub connected")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    const reconnectBtn = screen.getAllByRole("button").find((el) => {
+      return el.textContent?.trim() === "Reconnect";
+    });
+    expect(reconnectBtn).toBeDefined();
+  });
+
+  it("reconnect button reopens OAuth flow for an already-connected OAuth connector", async () => {
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue({ closed: true } as Window);
+    mockConnectors([{ type: "github" }]);
+
+    detachedSetupPage({ context, path: "/connectors/github/connect" });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button").find((el) => {
+          return el.textContent?.trim() === "Reconnect";
+        }),
+      ).toBeDefined();
+    });
+
+    const reconnectBtn = screen.getAllByRole("button").find((el) => {
+      return el.textContent?.trim() === "Reconnect";
+    });
+    expect(reconnectBtn).toBeDefined();
+    click(reconnectBtn!);
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/api/zero/connectors/github/authorize"),
+      "_blank",
+      expect.any(String),
+    );
+  });
+
+  it("reconnect button opens api-token dialog for an already-connected api-token connector", async () => {
+    mockConnectors([{ type: "axiom" }]);
+
+    detachedSetupPage({ context, path: "/connectors/axiom/connect" });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button").find((el) => {
+          return el.textContent?.trim() === "Reconnect";
+        }),
+      ).toBeDefined();
+    });
+
+    const reconnectBtn = screen.getAllByRole("button").find((el) => {
+      return el.textContent?.trim() === "Reconnect";
+    });
+    expect(reconnectBtn).toBeDefined();
+    click(reconnectBtn!);
+
+    // api-token connectors route the reconnect click through the token dialog
+    // rather than an OAuth popup.
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("xaat-...")).toBeInTheDocument();
+    });
+  });
+
   it("normalizes uppercase type in URL to match connector key", async () => {
     detachedSetupPage({ context, path: "/connectors/Gmail/connect" });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -99,21 +99,6 @@ describe("directed connect page", () => {
     expect(screen.queryByText("Connect")).not.toBeInTheDocument();
   });
 
-  it("shows Reconnect button alongside Connected pill when already connected", async () => {
-    mockConnectors([{ type: "github" }]);
-
-    detachedSetupPage({ context, path: "/connectors/github/connect" });
-
-    await waitFor(() => {
-      expect(screen.getByText("GitHub connected")).toBeInTheDocument();
-    });
-    expect(screen.getByText("Connected")).toBeInTheDocument();
-    const reconnectBtn = screen.getAllByRole("button").find((el) => {
-      return el.textContent?.trim() === "Reconnect";
-    });
-    expect(reconnectBtn).toBeDefined();
-  });
-
   it("reconnect button reopens OAuth flow for an already-connected OAuth connector", async () => {
     const openSpy = vi
       .spyOn(window, "open")

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -57,6 +57,13 @@ function filenameFromUrl(url: string): string {
   return last && last.length > 0 ? last : "image";
 }
 
+function toDownloadUrl(url: string): string {
+  if (url.includes("download=1")) {
+    return url;
+  }
+  return `${url}${url.includes("?") ? "&" : "?"}download=1`;
+}
+
 function triggerBlobDownload(blob: Blob, filename: string): void {
   const blobUrl = URL.createObjectURL(blob);
   const a = document.createElement("a");
@@ -164,7 +171,7 @@ export function FileAttachmentChip({
   const iconSrc = getFileTypeIcon(filename);
   return (
     <a
-      href={url}
+      href={toDownloadUrl(url)}
       download={filename}
       title={filename}
       className="inline-flex items-center justify-center rounded-lg hover:bg-foreground/10 transition-colors p-0.5"

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -152,7 +152,7 @@ function PreviewShell({
 }
 
 class TextPreview extends Component<TextPreviewProps, TextPreviewState> {
-  state = {
+  state: TextPreviewState = {
     status: "loading" as const,
     text: "",
   };
@@ -239,7 +239,7 @@ class IframePreview extends Component<
   IframePreviewProps,
   { showPreview: boolean }
 > {
-  state = { showPreview: false };
+  state: { showPreview: boolean } = { showPreview: false };
 
   render() {
     const { filename, url, kind } = this.props;

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { Component, type ReactNode } from "react";
 import {
   IconDownload,
   IconExternalLink,
@@ -21,6 +21,23 @@ interface ChatAttachmentDescriptor {
   url: string;
   contentType?: string;
 }
+
+type TextPreviewProps = {
+  filename: string;
+  url: string;
+  kind: "markdown" | "text" | "json";
+};
+
+type TextPreviewState = {
+  status: "loading" | "loaded" | "error";
+  text: string;
+};
+
+type IframePreviewProps = {
+  filename: string;
+  url: string;
+  kind: "pdf" | "html";
+};
 
 function fileExt(filename: string): string {
   return filename.split(".").pop()?.toLowerCase() ?? "";
@@ -134,120 +151,122 @@ function PreviewShell({
   );
 }
 
-function useTextAttachment(url: string) {
-  const [state, setState] = useState<{
-    status: "loading" | "loaded" | "error";
-    text: string;
-  }>({ status: "loading", text: "" });
+class TextPreview extends Component<TextPreviewProps, TextPreviewState> {
+  state = {
+    status: "loading" as const,
+    text: "",
+  };
 
-  useEffect(() => {
-    let active = true;
-    setState({ status: "loading", text: "" });
+  #active = false;
 
-    fetch(url)
-      .then(async (res) => {
-        if (!res.ok) {
-          throw new Error(`HTTP ${String(res.status)}`);
-        }
-        return await res.text();
-      })
-      .then((text) => {
-        if (active) {
-          setState({ status: "loaded", text });
-        }
-      })
-      .catch(() => {
-        if (active) {
-          setState({ status: "error", text: "" });
-        }
-      });
+  componentDidMount() {
+    this.#active = true;
+    this.#loadText();
+  }
 
-    return () => {
-      active = false;
-    };
-  }, [url]);
-
-  return state;
-}
-
-function TextPreview({
-  filename,
-  url,
-  kind,
-}: {
-  filename: string;
-  url: string;
-  kind: "markdown" | "text" | "json";
-}) {
-  const { status, text } = useTextAttachment(url);
-
-  let content: React.ReactNode = (
-    <p className="text-xs text-muted-foreground">Loading preview…</p>
-  );
-
-  if (status === "error") {
-    content = (
-      <p className="text-xs text-muted-foreground">
-        Preview unavailable. Use open or download instead.
-      </p>
-    );
-  } else if (status === "loaded") {
-    const trimmed = text.length > 8000 ? `${text.slice(0, 8000)}\n\n…` : text;
-    if (kind === "markdown") {
-      content = (
-        <div className="max-h-72 overflow-auto pr-1">
-          <Markdown source={trimmed} />
-        </div>
-      );
-    } else {
-      content = (
-        <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-muted/50 p-3 text-xs text-foreground">
-          {trimmed}
-        </pre>
-      );
+  componentDidUpdate(previousProps: Readonly<TextPreviewProps>) {
+    if (previousProps.url !== this.props.url) {
+      this.#loadText();
     }
   }
 
-  return (
-    <PreviewShell filename={filename} url={url} badge={kind}>
-      {content}
-    </PreviewShell>
-  );
+  componentWillUnmount() {
+    this.#active = false;
+  }
+
+  #loadText() {
+    this.setState({ status: "loading", text: "" });
+
+    fetch(this.props.url)
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP ${String(response.status)}`);
+        }
+        return await response.text();
+      })
+      .then((text) => {
+        if (this.#active) {
+          this.setState({ status: "loaded", text });
+        }
+      })
+      .catch(() => {
+        if (this.#active) {
+          this.setState({ status: "error", text: "" });
+        }
+      });
+  }
+
+  render() {
+    const { filename, url, kind } = this.props;
+    const { status, text } = this.state;
+
+    let content: ReactNode = (
+      <p className="text-xs text-muted-foreground">Loading preview…</p>
+    );
+
+    if (status === "error") {
+      content = (
+        <p className="text-xs text-muted-foreground">
+          Preview unavailable. Use open or download instead.
+        </p>
+      );
+    } else if (status === "loaded") {
+      const trimmed = text.length > 8000 ? `${text.slice(0, 8000)}\n\n…` : text;
+      if (kind === "markdown") {
+        content = (
+          <div className="max-h-72 overflow-auto pr-1">
+            <Markdown source={trimmed} />
+          </div>
+        );
+      } else {
+        content = (
+          <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-muted/50 p-3 text-xs text-foreground">
+            {trimmed}
+          </pre>
+        );
+      }
+    }
+
+    return (
+      <PreviewShell filename={filename} url={url} badge={kind}>
+        {content}
+      </PreviewShell>
+    );
+  }
 }
 
-function IframePreview({
-  filename,
-  url,
-  kind,
-}: {
-  filename: string;
-  url: string;
-  kind: "pdf" | "html";
-}) {
-  const [showPreview, setShowPreview] = useState(false);
+class IframePreview extends Component<
+  IframePreviewProps,
+  { showPreview: boolean }
+> {
+  state = { showPreview: false };
 
-  return (
-    <PreviewShell filename={filename} url={url} badge={kind}>
-      {!showPreview ? (
-        <button
-          type="button"
-          onClick={() => {
-            setShowPreview(true);
-          }}
-          className="inline-flex items-center gap-2 rounded-lg border border-foreground/10 bg-muted/40 px-3 py-2 text-xs font-medium text-foreground hover:bg-muted/60"
-        >
-          Load preview
-        </button>
-      ) : (
-        <iframe
-          src={url}
-          title={`${filename} preview`}
-          sandbox={kind === "html" ? "" : undefined}
-          className="h-72 w-full rounded-lg border border-foreground/10 bg-background"
-        />
-      )}
-    </PreviewShell>
-  );
+  render() {
+    const { filename, url, kind } = this.props;
+
+    return (
+      <PreviewShell filename={filename} url={url} badge={kind}>
+        {!this.state.showPreview ? (
+          <button
+            type="button"
+            onClick={() => {
+              this.setState({ showPreview: true });
+            }}
+            className="inline-flex items-center gap-2 rounded-lg border border-foreground/10 bg-muted/40 px-3 py-2 text-xs font-medium text-foreground hover:bg-muted/60"
+          >
+            Load preview
+          </button>
+        ) : (
+          <iframe
+            src={url}
+            title={`${filename} preview`}
+            sandbox={kind === "html" ? "" : undefined}
+            className="h-72 w-full rounded-lg border border-foreground/10 bg-background"
+          />
+        )}
+      </PreviewShell>
+    );
+  }
 }
 
 export function AttachmentPreview({
@@ -258,7 +277,7 @@ export function AttachmentPreview({
   const kind = classifyChatAttachment(attachment);
 
   switch (kind) {
-    case "markdown":
+    case "markdown": {
       return (
         <TextPreview
           filename={attachment.filename}
@@ -266,7 +285,8 @@ export function AttachmentPreview({
           kind="markdown"
         />
       );
-    case "text":
+    }
+    case "text": {
       return (
         <TextPreview
           filename={attachment.filename}
@@ -274,7 +294,8 @@ export function AttachmentPreview({
           kind="text"
         />
       );
-    case "json":
+    }
+    case "json": {
       return (
         <TextPreview
           filename={attachment.filename}
@@ -282,7 +303,8 @@ export function AttachmentPreview({
           kind="json"
         />
       );
-    case "pdf":
+    }
+    case "pdf": {
       return (
         <IframePreview
           filename={attachment.filename}
@@ -290,7 +312,8 @@ export function AttachmentPreview({
           kind="pdf"
         />
       );
-    case "html":
+    }
+    case "html": {
       return (
         <IframePreview
           filename={attachment.filename}
@@ -298,7 +321,9 @@ export function AttachmentPreview({
           kind="html"
         />
       );
-    default:
+    }
+    default: {
       return null;
+    }
   }
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -1,0 +1,304 @@
+import { useEffect, useState, type ReactNode } from "react";
+import {
+  IconDownload,
+  IconExternalLink,
+  IconFileText,
+} from "@tabler/icons-react";
+import { Markdown } from "../components/markdown.tsx";
+
+type ChatAttachmentKind =
+  | "image"
+  | "video"
+  | "markdown"
+  | "text"
+  | "json"
+  | "pdf"
+  | "html"
+  | "file";
+
+interface ChatAttachmentDescriptor {
+  filename: string;
+  url: string;
+  contentType?: string;
+}
+
+function fileExt(filename: string): string {
+  return filename.split(".").pop()?.toLowerCase() ?? "";
+}
+
+function normalizeType(contentType?: string): string {
+  return (contentType ?? "").split(";")[0]?.trim().toLowerCase();
+}
+
+export function classifyChatAttachment(
+  attachment: ChatAttachmentDescriptor,
+): ChatAttachmentKind {
+  const type = normalizeType(attachment.contentType);
+  const ext = fileExt(attachment.filename);
+
+  if (type.startsWith("image/")) {
+    return "image";
+  }
+  if (type.startsWith("video/")) {
+    return "video";
+  }
+
+  if (type === "text/markdown" || ext === "md") {
+    return "markdown";
+  }
+  if (type === "text/plain" || ext === "txt") {
+    return "text";
+  }
+  if (type === "application/json" || ext === "json") {
+    return "json";
+  }
+  if (type === "application/pdf" || ext === "pdf") {
+    return "pdf";
+  }
+  if (type === "text/html" || ext === "html" || ext === "htm") {
+    return "html";
+  }
+
+  if (
+    ["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "avif"].includes(ext)
+  ) {
+    return "image";
+  }
+  if (["mp4", "webm", "mov", "ogv"].includes(ext)) {
+    return "video";
+  }
+
+  return "file";
+}
+
+function toDownloadUrl(url: string): string {
+  if (url.includes("download=1")) {
+    return url;
+  }
+  return `${url}${url.includes("?") ? "&" : "?"}download=1`;
+}
+
+function PreviewActions({ filename, url }: { filename: string; url: string }) {
+  return (
+    <div className="flex items-center gap-2 pt-2">
+      <a
+        href={toDownloadUrl(url)}
+        download={filename}
+        title={filename}
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <IconDownload size={14} />
+        Download
+      </a>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <IconExternalLink size={14} />
+        Open
+      </a>
+    </div>
+  );
+}
+
+function PreviewShell({
+  filename,
+  url,
+  badge,
+  children,
+}: {
+  filename: string;
+  url: string;
+  badge: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className="rounded-xl border border-foreground/10 bg-background/60 p-3"
+      data-testid={`attachment-preview-${badge}`}
+    >
+      <div className="flex items-center gap-2 pb-2">
+        <IconFileText size={16} className="text-muted-foreground" />
+        <span className="min-w-0 truncate text-sm font-medium text-foreground">
+          {filename}
+        </span>
+        <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          {badge}
+        </span>
+      </div>
+      {children}
+      <PreviewActions filename={filename} url={url} />
+    </div>
+  );
+}
+
+function useTextAttachment(url: string) {
+  const [state, setState] = useState<{
+    status: "loading" | "loaded" | "error";
+    text: string;
+  }>({ status: "loading", text: "" });
+
+  useEffect(() => {
+    let active = true;
+    setState({ status: "loading", text: "" });
+
+    fetch(url)
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP ${String(res.status)}`);
+        }
+        return await res.text();
+      })
+      .then((text) => {
+        if (active) {
+          setState({ status: "loaded", text });
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setState({ status: "error", text: "" });
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [url]);
+
+  return state;
+}
+
+function TextPreview({
+  filename,
+  url,
+  kind,
+}: {
+  filename: string;
+  url: string;
+  kind: "markdown" | "text" | "json";
+}) {
+  const { status, text } = useTextAttachment(url);
+
+  let content: React.ReactNode = (
+    <p className="text-xs text-muted-foreground">Loading preview…</p>
+  );
+
+  if (status === "error") {
+    content = (
+      <p className="text-xs text-muted-foreground">
+        Preview unavailable. Use open or download instead.
+      </p>
+    );
+  } else if (status === "loaded") {
+    const trimmed = text.length > 8000 ? `${text.slice(0, 8000)}\n\n…` : text;
+    if (kind === "markdown") {
+      content = (
+        <div className="max-h-72 overflow-auto pr-1">
+          <Markdown source={trimmed} />
+        </div>
+      );
+    } else {
+      content = (
+        <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-muted/50 p-3 text-xs text-foreground">
+          {trimmed}
+        </pre>
+      );
+    }
+  }
+
+  return (
+    <PreviewShell filename={filename} url={url} badge={kind}>
+      {content}
+    </PreviewShell>
+  );
+}
+
+function IframePreview({
+  filename,
+  url,
+  kind,
+}: {
+  filename: string;
+  url: string;
+  kind: "pdf" | "html";
+}) {
+  const [showPreview, setShowPreview] = useState(false);
+
+  return (
+    <PreviewShell filename={filename} url={url} badge={kind}>
+      {!showPreview ? (
+        <button
+          type="button"
+          onClick={() => {
+            setShowPreview(true);
+          }}
+          className="inline-flex items-center gap-2 rounded-lg border border-foreground/10 bg-muted/40 px-3 py-2 text-xs font-medium text-foreground hover:bg-muted/60"
+        >
+          Load preview
+        </button>
+      ) : (
+        <iframe
+          src={url}
+          title={`${filename} preview`}
+          sandbox={kind === "html" ? "" : undefined}
+          className="h-72 w-full rounded-lg border border-foreground/10 bg-background"
+        />
+      )}
+    </PreviewShell>
+  );
+}
+
+export function AttachmentPreview({
+  attachment,
+}: {
+  attachment: ChatAttachmentDescriptor;
+}) {
+  const kind = classifyChatAttachment(attachment);
+
+  switch (kind) {
+    case "markdown":
+      return (
+        <TextPreview
+          filename={attachment.filename}
+          url={attachment.url}
+          kind="markdown"
+        />
+      );
+    case "text":
+      return (
+        <TextPreview
+          filename={attachment.filename}
+          url={attachment.url}
+          kind="text"
+        />
+      );
+    case "json":
+      return (
+        <TextPreview
+          filename={attachment.filename}
+          url={attachment.url}
+          kind="json"
+        />
+      );
+    case "pdf":
+      return (
+        <IframePreview
+          filename={attachment.filename}
+          url={attachment.url}
+          kind="pdf"
+        />
+      );
+    case "html":
+      return (
+        <IframePreview
+          filename={attachment.filename}
+          url={attachment.url}
+          kind="html"
+        />
+      );
+    default:
+      return null;
+  }
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -886,7 +886,7 @@ export function ZeroChatComposer({
         ref={setFileInputEl}
         type="file"
         className="hidden"
-        accept="image/*,video/mp4,video/webm,video/quicktime,.pdf,.txt,.csv,.md,.json"
+        accept="image/*,video/mp4,video/webm,video/quicktime,.pdf,.txt,.csv,.md,.json,.html"
         multiple
         onChange={handleFileChange}
       />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -805,6 +805,80 @@ function resolveAttachments(
   });
 }
 
+function UserMessageAttachments({
+  attachments,
+  onImageClick,
+}: {
+  attachments: ReturnType<typeof resolveAttachments>;
+  onImageClick: (url: string) => void;
+}) {
+  if (attachments.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="border-t border-foreground/10 px-3 py-2.5 flex flex-wrap gap-2">
+      {attachments.map((a) => {
+        if (a.isImage) {
+          return (
+            <button
+              key={a.url}
+              type="button"
+              onClick={() => {
+                onImageClick(a.url);
+              }}
+              className="group relative rounded-lg overflow-hidden border border-foreground/10 hover:border-foreground/25 transition-colors"
+            >
+              <img
+                src={a.url}
+                alt={a.filename}
+                className="h-9 max-w-[72px] object-cover"
+              />
+              <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/30 transition-colors">
+                <IconPhoto
+                  size={18}
+                  className="text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow"
+                />
+              </span>
+            </button>
+          );
+        }
+        if (a.isVideo) {
+          return (
+            <video
+              key={a.url}
+              src={a.url}
+              controls
+              className="max-h-48 max-w-full rounded-lg border border-foreground/10"
+            />
+          );
+        }
+        if (
+          a.kind === "markdown" ||
+          a.kind === "text" ||
+          a.kind === "json" ||
+          a.kind === "pdf" ||
+          a.kind === "html"
+        ) {
+          return (
+            <AttachmentPreview
+              key={a.url}
+              attachment={{
+                filename: a.filename,
+                url: a.url,
+                contentType: a.contentType,
+              }}
+            />
+          );
+        }
+        return (
+          <FileAttachmentChip key={a.url} filename={a.filename} url={a.url} />
+        );
+      })}
+    </div>
+  );
+}
+
 function PagedUserMessage({
   message,
   thread,
@@ -864,71 +938,10 @@ function PagedUserMessage({
                 />
               </div>
             )}
-            {allAttachments.length > 0 && (
-              <div className="border-t border-foreground/10 px-3 py-2.5 flex flex-wrap gap-2">
-                {allAttachments.map((a) => {
-                  if (a.isImage) {
-                    return (
-                      <button
-                        key={a.url}
-                        type="button"
-                        onClick={() => {
-                          return setLightboxUrl(a.url);
-                        }}
-                        className="group relative rounded-lg overflow-hidden border border-foreground/10 hover:border-foreground/25 transition-colors"
-                      >
-                        <img
-                          src={a.url}
-                          alt={a.filename}
-                          className="h-9 max-w-[72px] object-cover"
-                        />
-                        <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/30 transition-colors">
-                          <IconPhoto
-                            size={18}
-                            className="text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow"
-                          />
-                        </span>
-                      </button>
-                    );
-                  }
-                  if (a.isVideo) {
-                    return (
-                      <video
-                        key={a.url}
-                        src={a.url}
-                        controls
-                        className="max-h-48 max-w-full rounded-lg border border-foreground/10"
-                      />
-                    );
-                  }
-                  if (
-                    a.kind === "markdown" ||
-                    a.kind === "text" ||
-                    a.kind === "json" ||
-                    a.kind === "pdf" ||
-                    a.kind === "html"
-                  ) {
-                    return (
-                      <AttachmentPreview
-                        key={a.url}
-                        attachment={{
-                          filename: a.filename,
-                          url: a.url,
-                          contentType: a.contentType,
-                        }}
-                      />
-                    );
-                  }
-                  return (
-                    <FileAttachmentChip
-                      key={a.url}
-                      filename={a.filename}
-                      url={a.url}
-                    />
-                  );
-                })}
-              </div>
-            )}
+            <UserMessageAttachments
+              attachments={allAttachments}
+              onImageClick={openLightbox}
+            />
           </div>
           {cleanContent && (
             <div className="flex justify-end mt-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -785,15 +785,19 @@ function resolveAttachments(
       ? message.attachFiles
       : parsed;
   return source.map((f) => {
+    const contentType =
+      "contentType" in f && typeof f.contentType === "string"
+        ? f.contentType
+        : undefined;
     const kind = classifyChatAttachment({
       filename: f.filename,
       url: f.url,
-      contentType: "contentType" in f ? f.contentType : undefined,
+      contentType,
     });
     return {
       filename: f.filename,
       url: f.url,
-      contentType: "contentType" in f ? f.contentType : undefined,
+      contentType,
       isImage: kind === "image" || isImageFilename(f.filename),
       isVideo: kind === "video" || isVideoFilename(f.filename),
       kind,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -41,6 +41,10 @@ import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 import { FileAttachmentChip, ImageLightbox } from "./zero-attachment-chips.tsx";
 import {
+  AttachmentPreview,
+  classifyChatAttachment,
+} from "./zero-attachment-preview.tsx";
+import {
   lightboxUrl$ as attachmentLightboxUrl$,
   setLightboxUrl$ as setAttachmentLightboxUrl$,
 } from "../../signals/zero-page/zero-attachment-chips.ts";
@@ -781,11 +785,18 @@ function resolveAttachments(
       ? message.attachFiles
       : parsed;
   return source.map((f) => {
+    const kind = classifyChatAttachment({
+      filename: f.filename,
+      url: f.url,
+      contentType: "contentType" in f ? f.contentType : undefined,
+    });
     return {
       filename: f.filename,
       url: f.url,
-      isImage: isImageFilename(f.filename),
-      isVideo: isVideoFilename(f.filename),
+      contentType: "contentType" in f ? f.contentType : undefined,
+      isImage: kind === "image" || isImageFilename(f.filename),
+      isVideo: kind === "video" || isVideoFilename(f.filename),
+      kind,
     };
   });
 }
@@ -883,6 +894,24 @@ function PagedUserMessage({
                         src={a.url}
                         controls
                         className="max-h-48 max-w-full rounded-lg border border-foreground/10"
+                      />
+                    );
+                  }
+                  if (
+                    a.kind === "markdown" ||
+                    a.kind === "text" ||
+                    a.kind === "json" ||
+                    a.kind === "pdf" ||
+                    a.kind === "html"
+                  ) {
+                    return (
+                      <AttachmentPreview
+                        key={a.url}
+                        attachment={{
+                          filename: a.filename,
+                          url: a.url,
+                          contentType: a.contentType,
+                        }}
                       />
                     );
                   }

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -225,6 +225,47 @@ function ApiTokenDialog({
   );
 }
 
+function ConnectActions({
+  isConnected,
+  isConnecting,
+  onConnect,
+}: {
+  isConnected: boolean;
+  isConnecting: boolean;
+  onConnect: () => void;
+}) {
+  if (isConnected) {
+    return (
+      <>
+        <div className="inline-flex h-9 w-[100px] items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
+          <IconCheck size={16} />
+          Connected
+        </div>
+        <button
+          type="button"
+          disabled={isConnecting}
+          onClick={onConnect}
+          className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-60 inline-flex items-center gap-1.5"
+        >
+          {isConnecting && <IconLoader2 size={12} className="animate-spin" />}
+          {isConnecting ? "Reconnecting..." : "Reconnect"}
+        </button>
+      </>
+    );
+  }
+  return (
+    <button
+      type="button"
+      disabled={isConnecting}
+      onClick={onConnect}
+      className="inline-flex h-9 w-[100px] items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] text-sm font-medium text-white transition-colors hover:bg-[#d35400] disabled:opacity-60"
+    >
+      {isConnecting && <IconLoader2 size={14} className="animate-spin" />}
+      {isConnecting ? "Connecting..." : "Connect"}
+    </button>
+  );
+}
+
 function DirectedConnectCard() {
   const type = useGet(directedConnectType$);
   const agentId = useGet(directedConnectAgentId$);
@@ -308,37 +349,11 @@ function DirectedConnectCard() {
             </div>
             {!isLoading && (
               <div className="flex flex-col items-center justify-center gap-2">
-                {isConnected ? (
-                  <>
-                    <div className="inline-flex h-9 w-[100px] items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
-                      <IconCheck size={16} />
-                      Connected
-                    </div>
-                    <button
-                      type="button"
-                      disabled={isConnecting}
-                      onClick={handleConnect}
-                      className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-60 inline-flex items-center gap-1.5"
-                    >
-                      {isConnecting && (
-                        <IconLoader2 size={12} className="animate-spin" />
-                      )}
-                      {isConnecting ? "Reconnecting..." : "Reconnect"}
-                    </button>
-                  </>
-                ) : (
-                  <button
-                    type="button"
-                    disabled={isConnecting}
-                    onClick={handleConnect}
-                    className="inline-flex h-9 w-[100px] items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] text-sm font-medium text-white transition-colors hover:bg-[#d35400] disabled:opacity-60"
-                  >
-                    {isConnecting && (
-                      <IconLoader2 size={14} className="animate-spin" />
-                    )}
-                    {isConnecting ? "Connecting..." : "Connect"}
-                  </button>
-                )}
+                <ConnectActions
+                  isConnected={isConnected}
+                  isConnecting={isConnecting}
+                  onConnect={handleConnect}
+                />
               </div>
             )}
           </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -307,12 +307,25 @@ function DirectedConnectCard() {
               )}
             </div>
             {!isLoading && (
-              <div className="flex items-center justify-center">
+              <div className="flex flex-col items-center justify-center gap-2">
                 {isConnected ? (
-                  <div className="inline-flex h-9 w-[100px] items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
-                    <IconCheck size={16} />
-                    Connected
-                  </div>
+                  <>
+                    <div className="inline-flex h-9 w-[100px] items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
+                      <IconCheck size={16} />
+                      Connected
+                    </div>
+                    <button
+                      type="button"
+                      disabled={isConnecting}
+                      onClick={handleConnect}
+                      className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-60 inline-flex items-center gap-1.5"
+                    >
+                      {isConnecting && (
+                        <IconLoader2 size={12} className="animate-spin" />
+                      )}
+                      {isConnecting ? "Reconnecting..." : "Reconnect"}
+                    </button>
+                  </>
                 ) : (
                   <button
                     type="button"

--- a/turbo/apps/web/app/api/zero/uploads/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/uploads/prepare/__tests__/route.test.ts
@@ -139,6 +139,22 @@ describe("POST /api/zero/uploads/prepare", () => {
       });
     });
 
+    it("accepts html uploads for controlled chat preview flows", async () => {
+      const response = await POST(
+        createPrepareRequest({
+          filename: "report.html",
+          contentType: "text/html",
+          size: 2048,
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toMatchObject({
+        filename: "report.html",
+        contentType: "text/html",
+      });
+    });
+
     it("sanitizes filenames when building the S3 key", async () => {
       const response = await POST(
         createPrepareRequest({

--- a/turbo/apps/web/src/lib/shared/mimetype.ts
+++ b/turbo/apps/web/src/lib/shared/mimetype.ts
@@ -17,6 +17,8 @@ export const EXT_MIMETYPE_MAP: Readonly<Record<string, string>> = {
   txt: "text/plain",
   csv: "text/csv",
   md: "text/markdown",
+  html: "text/html",
+  htm: "text/html",
   json: "application/json",
 };
 

--- a/turbo/apps/web/src/lib/zero/uploads/constants.ts
+++ b/turbo/apps/web/src/lib/zero/uploads/constants.ts
@@ -23,5 +23,6 @@ export const ALLOWED_UPLOAD_TYPES: ReadonlySet<string> = new Set([
   "text/plain",
   "text/csv",
   "text/markdown",
+  "text/html",
   "application/json",
 ]);


### PR DESCRIPTION
## Summary
- add type-based attachment previews for markdown, text, json, pdf, and html in chat threads
- keep image/video behavior as-is and preserve generic file-chip fallback for unsupported types
- allow html uploads and infer html MIME types so controlled html previews can participate in the same attachment flow

## Testing
- `cd turbo/apps/platform && pnpm exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx`
- `cd turbo/apps/web && pnpm exec vitest run app/api/zero/uploads/prepare/__tests__/route.test.ts`
- `cd turbo/apps/platform && pnpm exec eslint src/views/zero-page/zero-attachment-preview.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx`
- `cd turbo/apps/web && pnpm exec eslint src/lib/shared/mimetype.ts src/lib/zero/uploads/constants.ts app/api/zero/uploads/prepare/__tests__/route.test.ts`

Closes #10830
