### PR TITLE
feat: classify built-in connectors with ai-first grouping

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
@@ -29,6 +29,217 @@ const CONNECTOR_CATEGORY_ORDER: readonly ConnectorDisplayCategory[] = [
   "data-automation-infrastructure",
 ];
 
+const COMMUNICATION_COLLABORATION_TYPES = [
+  "agentmail",
+  "agentphone",
+  "brevo",
+  "chatwoot",
+  "customer-io",
+  "discord",
+  "discord-webhook",
+  "freshdesk",
+  "gmail",
+  "instantly",
+  "intercom",
+  "lark",
+  "line",
+  "loops",
+  "mailchimp",
+  "mailsac",
+  "msg9",
+  "outlook-mail",
+  "plain",
+  "pushinator",
+  "resend",
+  "slack",
+  "slack-webhook",
+  "zendesk",
+  "zeptomail",
+] as const satisfies readonly ConnectorType[];
+
+const MEETINGS_SCHEDULING_TYPES = [
+  "cal-com",
+  "calendly",
+  "fireflies",
+  "google-calendar",
+  "google-meet",
+  "granola",
+  "intervals-icu",
+  "outlook-calendar",
+  "tldv",
+  "zoom",
+] as const satisfies readonly ConnectorType[];
+
+const DOCS_FILES_KNOWLEDGE_TYPES = [
+  "airtable",
+  "canva",
+  "coda",
+  "drive9",
+  "dropbox",
+  "figma",
+  "google-docs",
+  "google-drive",
+  "google-sheets",
+  "minio",
+  "miro",
+  "notion",
+  "onyx",
+  "strapi",
+] as const satisfies readonly ConnectorType[];
+
+const ENGINEERING_TEAM_EXECUTION_TYPES = [
+  "asana",
+  "atlassian",
+  "clickup",
+  "cloudflare",
+  "computer",
+  "doppler",
+  "github",
+  "gitlab",
+  "infisical",
+  "jam",
+  "jira",
+  "linear",
+  "monday",
+  "sentry",
+  "todoist",
+  "vercel",
+  "workos",
+  "wrike",
+] as const satisfies readonly ConnectorType[];
+
+const SALES_CRM_BUSINESS_OPERATIONS_TYPES = [
+  "apollo",
+  "attio",
+  "bitrix",
+  "close",
+  "deel",
+  "explorium",
+  "greenhouse",
+  "hubspot",
+  "kommo",
+  "mercury",
+  "pipedrive",
+  "productlane",
+  "salesforce",
+  "streak",
+  "twenty",
+] as const satisfies readonly ConnectorType[];
+
+const MARKETING_CONTENT_GROWTH_TYPES = [
+  "ahrefs",
+  "buffer",
+  "cloudinary",
+  "devto",
+  "gamma",
+  "heygen",
+  "htmlcsstoimage",
+  "imgur",
+  "instagram",
+  "klaviyo",
+  "meta-ads",
+  "qiita",
+  "reportei",
+  "shortio",
+  "similarweb",
+  "webflow",
+  "wix",
+  "x",
+  "youtube",
+] as const satisfies readonly ConnectorType[];
+
+const AI_GENERAL_MODEL_TYPES = [
+  "openai",
+  "deepseek",
+  "groq",
+  "hugging-face",
+  "minimax",
+  "together",
+] as const satisfies readonly ConnectorType[];
+
+const AI_IMAGE_VIDEO_TYPES = [
+  "fal",
+  "luma",
+  "pika",
+  "replicate",
+  "runway",
+  "stability-ai",
+] as const satisfies readonly ConnectorType[];
+
+const AI_VOICE_AUDIO_TYPES = [
+  "elevenlabs",
+  "hume",
+] as const satisfies readonly ConnectorType[];
+
+const AI_AGENT_APPS_TYPES = [
+  "anthropic-managed-agents",
+  "dify",
+  "manus",
+  "v0",
+] as const satisfies readonly ConnectorType[];
+
+const AI_MEMORY_TRACING_EVAL_TYPES = [
+  "helicone",
+  "langfuse",
+  "langsmith",
+  "mem0",
+  "wandb",
+  "zep",
+] as const satisfies readonly ConnectorType[];
+
+const DATA_AUTOMATION_INFRASTRUCTURE_TYPES = [
+  "amplitude",
+  "apify",
+  "axiom",
+  "brave-search",
+  "bright-data",
+  "browserbase",
+  "browserless",
+  "cronlytic",
+  "db9",
+  "docusign",
+  "dropbox-sign",
+  "duffel",
+  "e2b",
+  "etsy",
+  "exa",
+  "firecrawl",
+  "garmin-connect",
+  "jotform",
+  "make",
+  "metabase",
+  "mixpanel",
+  "n8n",
+  "neon",
+  "pandadoc",
+  "pdf4me",
+  "pdfco",
+  "pdforge",
+  "perplexity",
+  "pinecone",
+  "plausible",
+  "podchaser",
+  "posthog",
+  "prisma-postgres",
+  "qdrant",
+  "reddit",
+  "revenuecat",
+  "scrapeninja",
+  "serpapi",
+  "shopify",
+  "spotify",
+  "strava",
+  "stripe",
+  "supabase",
+  "supadata",
+  "tavily",
+  "test-oauth",
+  "typeform",
+  "xero",
+  "zapier",
+  "zapsign",
+] as const satisfies readonly ConnectorType[];
+
 interface ConnectorCategorySection<T> {
   category: ConnectorDisplayCategory;
   label: string;
@@ -37,225 +248,92 @@ interface ConnectorCategorySection<T> {
 
 function getConnectorCategoryLabel(category: ConnectorDisplayCategory): string {
   switch (category) {
-    case "ai-general-models":
+    case "ai-general-models": {
       return "AI: General Models and Reasoning";
-    case "ai-image-video":
+    }
+    case "ai-image-video": {
       return "AI: Image / Video Generation";
-    case "ai-voice-audio":
+    }
+    case "ai-voice-audio": {
       return "AI: Voice / Audio";
-    case "ai-agent-apps":
+    }
+    case "ai-agent-apps": {
       return "AI: Agent Platforms and AI Apps";
-    case "ai-memory-tracing-eval":
+    }
+    case "ai-memory-tracing-eval": {
       return "AI: Memory / Tracing / Evaluation";
-    case "communication-collaboration":
+    }
+    case "communication-collaboration": {
       return "Communication and Collaboration";
-    case "meetings-scheduling":
+    }
+    case "meetings-scheduling": {
       return "Meetings and Scheduling";
-    case "docs-files-knowledge":
+    }
+    case "docs-files-knowledge": {
       return "Docs, Files, and Knowledge";
-    case "engineering-team-execution":
+    }
+    case "engineering-team-execution": {
       return "Engineering and Team Execution";
-    case "sales-crm-business-operations":
+    }
+    case "sales-crm-business-operations": {
       return "Sales, CRM, and Business Operations";
-    case "marketing-content-growth":
+    }
+    case "marketing-content-growth": {
       return "Marketing, Content, and Growth";
-    case "data-automation-infrastructure":
+    }
+    case "data-automation-infrastructure": {
       return "Data, Automation, and Infrastructure";
+    }
   }
+}
+
+function includesConnectorType(
+  types: readonly ConnectorType[],
+  type: ConnectorType,
+): boolean {
+  return types.includes(type);
 }
 
 export function getConnectorDisplayCategory(
   type: ConnectorType,
 ): ConnectorDisplayCategory {
-  switch (type) {
-    case "agentmail":
-    case "agentphone":
-    case "brevo":
-    case "chatwoot":
-    case "customer-io":
-    case "discord":
-    case "discord-webhook":
-    case "freshdesk":
-    case "gmail":
-    case "instantly":
-    case "intercom":
-    case "lark":
-    case "line":
-    case "loops":
-    case "mailchimp":
-    case "mailsac":
-    case "msg9":
-    case "outlook-mail":
-    case "plain":
-    case "pushinator":
-    case "resend":
-    case "slack":
-    case "slack-webhook":
-    case "zendesk":
-    case "zeptomail":
-      return "communication-collaboration";
-    case "cal-com":
-    case "calendly":
-    case "fireflies":
-    case "google-calendar":
-    case "google-meet":
-    case "granola":
-    case "intervals-icu":
-    case "outlook-calendar":
-    case "tldv":
-    case "zoom":
-      return "meetings-scheduling";
-    case "airtable":
-    case "canva":
-    case "coda":
-    case "drive9":
-    case "dropbox":
-    case "figma":
-    case "google-docs":
-    case "google-drive":
-    case "google-sheets":
-    case "minio":
-    case "miro":
-    case "notion":
-    case "onyx":
-    case "strapi":
-      return "docs-files-knowledge";
-    case "asana":
-    case "atlassian":
-    case "clickup":
-    case "cloudflare":
-    case "computer":
-    case "doppler":
-    case "github":
-    case "gitlab":
-    case "infisical":
-    case "jam":
-    case "jira":
-    case "linear":
-    case "monday":
-    case "sentry":
-    case "todoist":
-    case "vercel":
-    case "workos":
-    case "wrike":
-      return "engineering-team-execution";
-    case "apollo":
-    case "attio":
-    case "bitrix":
-    case "close":
-    case "deel":
-    case "explorium":
-    case "greenhouse":
-    case "hubspot":
-    case "kommo":
-    case "mercury":
-    case "pipedrive":
-    case "productlane":
-    case "salesforce":
-    case "streak":
-    case "twenty":
-      return "sales-crm-business-operations";
-    case "ahrefs":
-    case "buffer":
-    case "cloudinary":
-    case "devto":
-    case "gamma":
-    case "heygen":
-    case "htmlcsstoimage":
-    case "imgur":
-    case "instagram":
-    case "klaviyo":
-    case "meta-ads":
-    case "qiita":
-    case "reportei":
-    case "shortio":
-    case "similarweb":
-    case "webflow":
-    case "wix":
-    case "x":
-    case "youtube":
-      return "marketing-content-growth";
-    case "openai":
-    case "deepseek":
-    case "groq":
-    case "hugging-face":
-    case "minimax":
-    case "together":
-      return "ai-general-models";
-    case "fal":
-    case "luma":
-    case "pika":
-    case "replicate":
-    case "runway":
-    case "stability-ai":
-      return "ai-image-video";
-    case "elevenlabs":
-    case "hume":
-      return "ai-voice-audio";
-    case "anthropic-managed-agents":
-    case "dify":
-    case "manus":
-    case "v0":
-      return "ai-agent-apps";
-    case "helicone":
-    case "langfuse":
-    case "langsmith":
-    case "mem0":
-    case "wandb":
-    case "zep":
-      return "ai-memory-tracing-eval";
-    case "amplitude":
-    case "apify":
-    case "axiom":
-    case "brave-search":
-    case "bright-data":
-    case "browserbase":
-    case "browserless":
-    case "cronlytic":
-    case "db9":
-    case "docusign":
-    case "dropbox-sign":
-    case "duffel":
-    case "e2b":
-    case "etsy":
-    case "exa":
-    case "firecrawl":
-    case "garmin-connect":
-    case "jotform":
-    case "make":
-    case "metabase":
-    case "mixpanel":
-    case "n8n":
-    case "neon":
-    case "pandadoc":
-    case "pdf4me":
-    case "pdfco":
-    case "pdforge":
-    case "perplexity":
-    case "pinecone":
-    case "plausible":
-    case "podchaser":
-    case "posthog":
-    case "prisma-postgres":
-    case "qdrant":
-    case "reddit":
-    case "revenuecat":
-    case "scrapeninja":
-    case "serpapi":
-    case "shopify":
-    case "spotify":
-    case "strava":
-    case "stripe":
-    case "supabase":
-    case "supadata":
-    case "tavily":
-    case "test-oauth":
-    case "typeform":
-    case "xero":
-    case "zapier":
-    case "zapsign":
-      return "data-automation-infrastructure";
+  if (includesConnectorType(COMMUNICATION_COLLABORATION_TYPES, type)) {
+    return "communication-collaboration";
   }
+  if (includesConnectorType(MEETINGS_SCHEDULING_TYPES, type)) {
+    return "meetings-scheduling";
+  }
+  if (includesConnectorType(DOCS_FILES_KNOWLEDGE_TYPES, type)) {
+    return "docs-files-knowledge";
+  }
+  if (includesConnectorType(ENGINEERING_TEAM_EXECUTION_TYPES, type)) {
+    return "engineering-team-execution";
+  }
+  if (includesConnectorType(SALES_CRM_BUSINESS_OPERATIONS_TYPES, type)) {
+    return "sales-crm-business-operations";
+  }
+  if (includesConnectorType(MARKETING_CONTENT_GROWTH_TYPES, type)) {
+    return "marketing-content-growth";
+  }
+  if (includesConnectorType(AI_GENERAL_MODEL_TYPES, type)) {
+    return "ai-general-models";
+  }
+  if (includesConnectorType(AI_IMAGE_VIDEO_TYPES, type)) {
+    return "ai-image-video";
+  }
+  if (includesConnectorType(AI_VOICE_AUDIO_TYPES, type)) {
+    return "ai-voice-audio";
+  }
+  if (includesConnectorType(AI_AGENT_APPS_TYPES, type)) {
+    return "ai-agent-apps";
+  }
+  if (includesConnectorType(AI_MEMORY_TRACING_EVAL_TYPES, type)) {
+    return "ai-memory-tracing-eval";
+  }
+  if (includesConnectorType(DATA_AUTOMATION_INFRASTRUCTURE_TYPES, type)) {
+    return "data-automation-infrastructure";
+  }
+  return "data-automation-infrastructure";
 }
 
 export function groupConnectorsByCategory<

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
@@ -1,0 +1,274 @@
+import type { ConnectorType } from "@vm0/core";
+
+type ConnectorDisplayCategory =
+  | "ai-general-models"
+  | "ai-image-video"
+  | "ai-voice-audio"
+  | "ai-agent-apps"
+  | "ai-memory-tracing-eval"
+  | "communication-collaboration"
+  | "meetings-scheduling"
+  | "docs-files-knowledge"
+  | "engineering-team-execution"
+  | "sales-crm-business-operations"
+  | "marketing-content-growth"
+  | "data-automation-infrastructure";
+
+const CONNECTOR_CATEGORY_ORDER: readonly ConnectorDisplayCategory[] = [
+  "ai-general-models",
+  "ai-image-video",
+  "ai-voice-audio",
+  "ai-agent-apps",
+  "ai-memory-tracing-eval",
+  "communication-collaboration",
+  "meetings-scheduling",
+  "docs-files-knowledge",
+  "engineering-team-execution",
+  "sales-crm-business-operations",
+  "marketing-content-growth",
+  "data-automation-infrastructure",
+];
+
+const CONNECTOR_CATEGORY_LABELS: Record<ConnectorDisplayCategory, string> = {
+  "ai-general-models": "AI: General Models and Reasoning",
+  "ai-image-video": "AI: Image / Video Generation",
+  "ai-voice-audio": "AI: Voice / Audio",
+  "ai-agent-apps": "AI: Agent Platforms and AI Apps",
+  "ai-memory-tracing-eval": "AI: Memory / Tracing / Evaluation",
+  "communication-collaboration": "Communication and Collaboration",
+  "meetings-scheduling": "Meetings and Scheduling",
+  "docs-files-knowledge": "Docs, Files, and Knowledge",
+  "engineering-team-execution": "Engineering and Team Execution",
+  "sales-crm-business-operations": "Sales, CRM, and Business Operations",
+  "marketing-content-growth": "Marketing, Content, and Growth",
+  "data-automation-infrastructure": "Data, Automation, and Infrastructure",
+};
+
+const CONNECTOR_CATEGORY_BY_TYPE = {
+  agentmail: "communication-collaboration",
+  agentphone: "communication-collaboration",
+  ahrefs: "marketing-content-growth",
+  airtable: "docs-files-knowledge",
+  amplitude: "data-automation-infrastructure",
+  "anthropic-managed-agents": "ai-agent-apps",
+  apify: "data-automation-infrastructure",
+  apollo: "sales-crm-business-operations",
+  asana: "engineering-team-execution",
+  atlassian: "engineering-team-execution",
+  attio: "sales-crm-business-operations",
+  axiom: "data-automation-infrastructure",
+  bitrix: "sales-crm-business-operations",
+  "brave-search": "data-automation-infrastructure",
+  brevo: "communication-collaboration",
+  "bright-data": "data-automation-infrastructure",
+  browserbase: "data-automation-infrastructure",
+  browserless: "data-automation-infrastructure",
+  buffer: "marketing-content-growth",
+  "cal-com": "meetings-scheduling",
+  calendly: "meetings-scheduling",
+  canva: "docs-files-knowledge",
+  chatwoot: "communication-collaboration",
+  clickup: "engineering-team-execution",
+  close: "sales-crm-business-operations",
+  cloudflare: "engineering-team-execution",
+  cloudinary: "marketing-content-growth",
+  coda: "docs-files-knowledge",
+  computer: "engineering-team-execution",
+  cronlytic: "data-automation-infrastructure",
+  "customer-io": "communication-collaboration",
+  db9: "data-automation-infrastructure",
+  deel: "sales-crm-business-operations",
+  deepseek: "ai-general-models",
+  devto: "marketing-content-growth",
+  dify: "ai-agent-apps",
+  discord: "communication-collaboration",
+  "discord-webhook": "communication-collaboration",
+  docusign: "data-automation-infrastructure",
+  doppler: "engineering-team-execution",
+  drive9: "docs-files-knowledge",
+  dropbox: "docs-files-knowledge",
+  "dropbox-sign": "data-automation-infrastructure",
+  duffel: "data-automation-infrastructure",
+  e2b: "data-automation-infrastructure",
+  elevenlabs: "ai-voice-audio",
+  etsy: "data-automation-infrastructure",
+  exa: "data-automation-infrastructure",
+  explorium: "sales-crm-business-operations",
+  fal: "ai-image-video",
+  figma: "docs-files-knowledge",
+  firecrawl: "data-automation-infrastructure",
+  fireflies: "meetings-scheduling",
+  freshdesk: "communication-collaboration",
+  gamma: "marketing-content-growth",
+  "garmin-connect": "data-automation-infrastructure",
+  github: "engineering-team-execution",
+  gitlab: "engineering-team-execution",
+  gmail: "communication-collaboration",
+  "google-calendar": "meetings-scheduling",
+  "google-docs": "docs-files-knowledge",
+  "google-drive": "docs-files-knowledge",
+  "google-meet": "meetings-scheduling",
+  "google-sheets": "docs-files-knowledge",
+  granola: "meetings-scheduling",
+  greenhouse: "sales-crm-business-operations",
+  groq: "ai-general-models",
+  helicone: "ai-memory-tracing-eval",
+  heygen: "marketing-content-growth",
+  htmlcsstoimage: "marketing-content-growth",
+  hubspot: "sales-crm-business-operations",
+  "hugging-face": "ai-general-models",
+  hume: "ai-voice-audio",
+  imgur: "marketing-content-growth",
+  infisical: "engineering-team-execution",
+  instagram: "marketing-content-growth",
+  instantly: "communication-collaboration",
+  intercom: "communication-collaboration",
+  "intervals-icu": "meetings-scheduling",
+  jam: "engineering-team-execution",
+  jira: "engineering-team-execution",
+  jotform: "data-automation-infrastructure",
+  klaviyo: "marketing-content-growth",
+  kommo: "sales-crm-business-operations",
+  langfuse: "ai-memory-tracing-eval",
+  langsmith: "ai-memory-tracing-eval",
+  lark: "communication-collaboration",
+  line: "communication-collaboration",
+  linear: "engineering-team-execution",
+  loops: "communication-collaboration",
+  luma: "ai-image-video",
+  mailchimp: "communication-collaboration",
+  mailsac: "communication-collaboration",
+  make: "data-automation-infrastructure",
+  manus: "ai-agent-apps",
+  mem0: "ai-memory-tracing-eval",
+  mercury: "sales-crm-business-operations",
+  "meta-ads": "marketing-content-growth",
+  metabase: "data-automation-infrastructure",
+  minimax: "ai-general-models",
+  minio: "docs-files-knowledge",
+  miro: "docs-files-knowledge",
+  mixpanel: "data-automation-infrastructure",
+  monday: "engineering-team-execution",
+  msg9: "communication-collaboration",
+  n8n: "data-automation-infrastructure",
+  neon: "data-automation-infrastructure",
+  notion: "docs-files-knowledge",
+  onyx: "docs-files-knowledge",
+  openai: "ai-general-models",
+  "outlook-calendar": "meetings-scheduling",
+  "outlook-mail": "communication-collaboration",
+  pandadoc: "data-automation-infrastructure",
+  pdf4me: "data-automation-infrastructure",
+  pdfco: "data-automation-infrastructure",
+  pdforge: "data-automation-infrastructure",
+  perplexity: "data-automation-infrastructure",
+  pika: "ai-image-video",
+  pinecone: "data-automation-infrastructure",
+  pipedrive: "sales-crm-business-operations",
+  plain: "communication-collaboration",
+  plausible: "data-automation-infrastructure",
+  podchaser: "data-automation-infrastructure",
+  posthog: "data-automation-infrastructure",
+  "prisma-postgres": "data-automation-infrastructure",
+  productlane: "sales-crm-business-operations",
+  pushinator: "communication-collaboration",
+  qdrant: "data-automation-infrastructure",
+  qiita: "marketing-content-growth",
+  reddit: "data-automation-infrastructure",
+  replicate: "ai-image-video",
+  reportei: "marketing-content-growth",
+  resend: "communication-collaboration",
+  revenuecat: "data-automation-infrastructure",
+  runway: "ai-image-video",
+  salesforce: "sales-crm-business-operations",
+  scrapeninja: "data-automation-infrastructure",
+  sentry: "engineering-team-execution",
+  serpapi: "data-automation-infrastructure",
+  shopify: "data-automation-infrastructure",
+  shortio: "marketing-content-growth",
+  similarweb: "marketing-content-growth",
+  slack: "communication-collaboration",
+  "slack-webhook": "communication-collaboration",
+  spotify: "data-automation-infrastructure",
+  "stability-ai": "ai-image-video",
+  strapi: "docs-files-knowledge",
+  strava: "data-automation-infrastructure",
+  streak: "sales-crm-business-operations",
+  stripe: "data-automation-infrastructure",
+  supabase: "data-automation-infrastructure",
+  supadata: "data-automation-infrastructure",
+  tavily: "data-automation-infrastructure",
+  "test-oauth": "data-automation-infrastructure",
+  tldv: "meetings-scheduling",
+  todoist: "engineering-team-execution",
+  together: "ai-general-models",
+  twenty: "sales-crm-business-operations",
+  typeform: "data-automation-infrastructure",
+  v0: "ai-agent-apps",
+  vercel: "engineering-team-execution",
+  wandb: "ai-memory-tracing-eval",
+  webflow: "marketing-content-growth",
+  wix: "marketing-content-growth",
+  workos: "engineering-team-execution",
+  wrike: "engineering-team-execution",
+  x: "marketing-content-growth",
+  xero: "data-automation-infrastructure",
+  youtube: "marketing-content-growth",
+  zapier: "data-automation-infrastructure",
+  zapsign: "data-automation-infrastructure",
+  zendesk: "communication-collaboration",
+  zep: "ai-memory-tracing-eval",
+  zeptomail: "communication-collaboration",
+  zoom: "meetings-scheduling",
+} as const satisfies Record<ConnectorType, ConnectorDisplayCategory>;
+
+interface ConnectorCategorySection<T> {
+  category: ConnectorDisplayCategory;
+  label: string;
+  connectors: T[];
+}
+
+export function getConnectorDisplayCategory(
+  type: ConnectorType,
+): ConnectorDisplayCategory {
+  return CONNECTOR_CATEGORY_BY_TYPE[type];
+}
+
+export function groupConnectorsByCategory<
+  T extends {
+    category: ConnectorDisplayCategory;
+    connected: boolean;
+    label: string;
+  },
+>(connectors: readonly T[]): ConnectorCategorySection<T>[] {
+  const grouped = new Map<ConnectorDisplayCategory, T[]>();
+
+  for (const connector of connectors) {
+    const items = grouped.get(connector.category);
+    if (items) {
+      items.push(connector);
+    } else {
+      grouped.set(connector.category, [connector]);
+    }
+  }
+
+  return CONNECTOR_CATEGORY_ORDER.flatMap((category) => {
+    const items = grouped.get(category);
+    if (!items || items.length === 0) {
+      return [];
+    }
+    const sorted = [...items].sort((a, b) => {
+      if (a.connected !== b.connected) {
+        return a.connected ? -1 : 1;
+      }
+      return a.label.localeCompare(b.label);
+    });
+    return [
+      {
+        category,
+        label: CONNECTOR_CATEGORY_LABELS[category],
+        connectors: sorted,
+      },
+    ];
+  });
+}

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
@@ -1,339 +1,24 @@
-import type { ConnectorType } from "@vm0/core";
+import {
+  CONNECTOR_DISPLAY_CATEGORY_GROUPS,
+  CONNECTOR_DISPLAY_CATEGORY_META,
+  CONNECTOR_DISPLAY_CATEGORY_ORDER,
+  type ConnectorDisplayCategory,
+  type ConnectorDisplayCategoryGroup,
+} from "@vm0/core";
 
-type ConnectorDisplayCategory =
-  | "ai-general-models"
-  | "ai-image-video"
-  | "ai-voice-audio"
-  | "ai-agent-apps"
-  | "ai-memory-tracing-eval"
-  | "communication-collaboration"
-  | "meetings-scheduling"
-  | "docs-files-knowledge"
-  | "engineering-team-execution"
-  | "sales-crm-business-operations"
-  | "marketing-content-growth"
-  | "data-automation-infrastructure";
-
-const CONNECTOR_CATEGORY_ORDER: readonly ConnectorDisplayCategory[] = [
-  "ai-general-models",
-  "ai-image-video",
-  "ai-voice-audio",
-  "ai-agent-apps",
-  "ai-memory-tracing-eval",
-  "communication-collaboration",
-  "meetings-scheduling",
-  "docs-files-knowledge",
-  "engineering-team-execution",
-  "sales-crm-business-operations",
-  "marketing-content-growth",
-  "data-automation-infrastructure",
-];
-
-const COMMUNICATION_COLLABORATION_TYPES = [
-  "agentmail",
-  "agentphone",
-  "brevo",
-  "chatwoot",
-  "customer-io",
-  "discord",
-  "discord-webhook",
-  "freshdesk",
-  "gmail",
-  "instantly",
-  "intercom",
-  "lark",
-  "line",
-  "loops",
-  "mailchimp",
-  "mailsac",
-  "msg9",
-  "outlook-mail",
-  "plain",
-  "pushinator",
-  "resend",
-  "slack",
-  "slack-webhook",
-  "zendesk",
-  "zeptomail",
-] as const satisfies readonly ConnectorType[];
-
-const MEETINGS_SCHEDULING_TYPES = [
-  "cal-com",
-  "calendly",
-  "fireflies",
-  "google-calendar",
-  "google-meet",
-  "granola",
-  "intervals-icu",
-  "outlook-calendar",
-  "tldv",
-  "zoom",
-] as const satisfies readonly ConnectorType[];
-
-const DOCS_FILES_KNOWLEDGE_TYPES = [
-  "airtable",
-  "canva",
-  "coda",
-  "drive9",
-  "dropbox",
-  "figma",
-  "google-docs",
-  "google-drive",
-  "google-sheets",
-  "minio",
-  "miro",
-  "notion",
-  "onyx",
-  "strapi",
-] as const satisfies readonly ConnectorType[];
-
-const ENGINEERING_TEAM_EXECUTION_TYPES = [
-  "asana",
-  "atlassian",
-  "clickup",
-  "cloudflare",
-  "computer",
-  "doppler",
-  "github",
-  "gitlab",
-  "infisical",
-  "jam",
-  "jira",
-  "linear",
-  "monday",
-  "sentry",
-  "todoist",
-  "vercel",
-  "workos",
-  "wrike",
-] as const satisfies readonly ConnectorType[];
-
-const SALES_CRM_BUSINESS_OPERATIONS_TYPES = [
-  "apollo",
-  "attio",
-  "bitrix",
-  "close",
-  "deel",
-  "explorium",
-  "greenhouse",
-  "hubspot",
-  "kommo",
-  "mercury",
-  "pipedrive",
-  "productlane",
-  "salesforce",
-  "streak",
-  "twenty",
-] as const satisfies readonly ConnectorType[];
-
-const MARKETING_CONTENT_GROWTH_TYPES = [
-  "ahrefs",
-  "buffer",
-  "cloudinary",
-  "devto",
-  "gamma",
-  "heygen",
-  "htmlcsstoimage",
-  "imgur",
-  "instagram",
-  "klaviyo",
-  "meta-ads",
-  "qiita",
-  "reportei",
-  "shortio",
-  "similarweb",
-  "webflow",
-  "wix",
-  "x",
-  "youtube",
-] as const satisfies readonly ConnectorType[];
-
-const AI_GENERAL_MODEL_TYPES = [
-  "openai",
-  "deepseek",
-  "groq",
-  "hugging-face",
-  "minimax",
-  "together",
-] as const satisfies readonly ConnectorType[];
-
-const AI_IMAGE_VIDEO_TYPES = [
-  "fal",
-  "luma",
-  "pika",
-  "replicate",
-  "runway",
-  "stability-ai",
-] as const satisfies readonly ConnectorType[];
-
-const AI_VOICE_AUDIO_TYPES = [
-  "elevenlabs",
-  "hume",
-] as const satisfies readonly ConnectorType[];
-
-const AI_AGENT_APPS_TYPES = [
-  "anthropic-managed-agents",
-  "dify",
-  "manus",
-  "v0",
-] as const satisfies readonly ConnectorType[];
-
-const AI_MEMORY_TRACING_EVAL_TYPES = [
-  "helicone",
-  "langfuse",
-  "langsmith",
-  "mem0",
-  "wandb",
-  "zep",
-] as const satisfies readonly ConnectorType[];
-
-const DATA_AUTOMATION_INFRASTRUCTURE_TYPES = [
-  "amplitude",
-  "apify",
-  "axiom",
-  "brave-search",
-  "bright-data",
-  "browserbase",
-  "browserless",
-  "cronlytic",
-  "db9",
-  "docusign",
-  "dropbox-sign",
-  "duffel",
-  "e2b",
-  "etsy",
-  "exa",
-  "firecrawl",
-  "garmin-connect",
-  "jotform",
-  "make",
-  "metabase",
-  "mixpanel",
-  "n8n",
-  "neon",
-  "pandadoc",
-  "pdf4me",
-  "pdfco",
-  "pdforge",
-  "perplexity",
-  "pinecone",
-  "plausible",
-  "podchaser",
-  "posthog",
-  "prisma-postgres",
-  "qdrant",
-  "reddit",
-  "revenuecat",
-  "scrapeninja",
-  "serpapi",
-  "shopify",
-  "spotify",
-  "strava",
-  "stripe",
-  "supabase",
-  "supadata",
-  "tavily",
-  "test-oauth",
-  "typeform",
-  "xero",
-  "zapier",
-  "zapsign",
-] as const satisfies readonly ConnectorType[];
-
-interface ConnectorCategorySection<T> {
+export interface ConnectorCategorySection<T> {
   category: ConnectorDisplayCategory;
   label: string;
+  menuLabel: string;
   connectors: T[];
 }
 
-function getConnectorCategoryLabel(category: ConnectorDisplayCategory): string {
-  switch (category) {
-    case "ai-general-models": {
-      return "AI: General Models and Reasoning";
-    }
-    case "ai-image-video": {
-      return "AI: Image / Video Generation";
-    }
-    case "ai-voice-audio": {
-      return "AI: Voice / Audio";
-    }
-    case "ai-agent-apps": {
-      return "AI: Agent Platforms and AI Apps";
-    }
-    case "ai-memory-tracing-eval": {
-      return "AI: Memory / Tracing / Evaluation";
-    }
-    case "communication-collaboration": {
-      return "Communication and Collaboration";
-    }
-    case "meetings-scheduling": {
-      return "Meetings and Scheduling";
-    }
-    case "docs-files-knowledge": {
-      return "Docs, Files, and Knowledge";
-    }
-    case "engineering-team-execution": {
-      return "Engineering and Team Execution";
-    }
-    case "sales-crm-business-operations": {
-      return "Sales, CRM, and Business Operations";
-    }
-    case "marketing-content-growth": {
-      return "Marketing, Content, and Growth";
-    }
-    case "data-automation-infrastructure": {
-      return "Data, Automation, and Infrastructure";
-    }
-  }
-}
-
-function includesConnectorType(
-  types: readonly ConnectorType[],
-  type: ConnectorType,
-): boolean {
-  return types.includes(type);
-}
-
-export function getConnectorDisplayCategory(
-  type: ConnectorType,
-): ConnectorDisplayCategory {
-  if (includesConnectorType(COMMUNICATION_COLLABORATION_TYPES, type)) {
-    return "communication-collaboration";
-  }
-  if (includesConnectorType(MEETINGS_SCHEDULING_TYPES, type)) {
-    return "meetings-scheduling";
-  }
-  if (includesConnectorType(DOCS_FILES_KNOWLEDGE_TYPES, type)) {
-    return "docs-files-knowledge";
-  }
-  if (includesConnectorType(ENGINEERING_TEAM_EXECUTION_TYPES, type)) {
-    return "engineering-team-execution";
-  }
-  if (includesConnectorType(SALES_CRM_BUSINESS_OPERATIONS_TYPES, type)) {
-    return "sales-crm-business-operations";
-  }
-  if (includesConnectorType(MARKETING_CONTENT_GROWTH_TYPES, type)) {
-    return "marketing-content-growth";
-  }
-  if (includesConnectorType(AI_GENERAL_MODEL_TYPES, type)) {
-    return "ai-general-models";
-  }
-  if (includesConnectorType(AI_IMAGE_VIDEO_TYPES, type)) {
-    return "ai-image-video";
-  }
-  if (includesConnectorType(AI_VOICE_AUDIO_TYPES, type)) {
-    return "ai-voice-audio";
-  }
-  if (includesConnectorType(AI_AGENT_APPS_TYPES, type)) {
-    return "ai-agent-apps";
-  }
-  if (includesConnectorType(AI_MEMORY_TRACING_EVAL_TYPES, type)) {
-    return "ai-memory-tracing-eval";
-  }
-  if (includesConnectorType(DATA_AUTOMATION_INFRASTRUCTURE_TYPES, type)) {
-    return "data-automation-infrastructure";
-  }
-  return "data-automation-infrastructure";
+export interface ConnectorCategoryGroup<T> {
+  id: ConnectorDisplayCategory | ConnectorDisplayCategoryGroup;
+  kind: "category" | "group";
+  label: string;
+  menuLabel: string;
+  sections: [ConnectorCategorySection<T>, ...ConnectorCategorySection<T>[]];
 }
 
 export function groupConnectorsByCategory<
@@ -342,7 +27,7 @@ export function groupConnectorsByCategory<
     connected: boolean;
     label: string;
   },
->(connectors: readonly T[]): ConnectorCategorySection<T>[] {
+>(connectors: readonly T[]): ConnectorCategoryGroup<T>[] {
   const grouped = new Map<ConnectorDisplayCategory, T[]>();
 
   for (const connector of connectors) {
@@ -354,23 +39,60 @@ export function groupConnectorsByCategory<
     }
   }
 
-  return CONNECTOR_CATEGORY_ORDER.flatMap((category) => {
-    const items = grouped.get(category);
-    if (!items || items.length === 0) {
-      return [];
-    }
-    const sorted = [...items].sort((a, b) => {
-      if (a.connected !== b.connected) {
-        return a.connected ? -1 : 1;
+  const categorySections = CONNECTOR_DISPLAY_CATEGORY_ORDER.flatMap(
+    (category) => {
+      const items = grouped.get(category);
+      if (!items || items.length === 0) {
+        return [];
       }
-      return a.label.localeCompare(b.label);
+      const sorted = [...items].sort((a, b) => {
+        if (a.connected !== b.connected) {
+          return a.connected ? -1 : 1;
+        }
+        return a.label.localeCompare(b.label);
+      });
+      return [
+        {
+          category,
+          label: CONNECTOR_DISPLAY_CATEGORY_META[category].label,
+          menuLabel: CONNECTOR_DISPLAY_CATEGORY_META[category].menuLabel,
+          connectors: sorted,
+        },
+      ];
+    },
+  );
+
+  const groups: ConnectorCategoryGroup<T>[] = [];
+
+  for (const section of categorySections) {
+    const meta = CONNECTOR_DISPLAY_CATEGORY_META[section.category];
+    if (!meta.group) {
+      groups.push({
+        id: section.category,
+        kind: "category",
+        label: section.label,
+        menuLabel: section.menuLabel,
+        sections: [section],
+      });
+      continue;
+    }
+
+    const existingGroup = groups.find((group) => {
+      return group.kind === "group" && group.id === meta.group;
     });
-    return [
-      {
-        category,
-        label: getConnectorCategoryLabel(category),
-        connectors: sorted,
-      },
-    ];
-  });
+    if (existingGroup) {
+      existingGroup.sections.push(section);
+      continue;
+    }
+
+    groups.push({
+      id: meta.group,
+      kind: "group",
+      label: CONNECTOR_DISPLAY_CATEGORY_GROUPS[meta.group].label,
+      menuLabel: CONNECTOR_DISPLAY_CATEGORY_GROUPS[meta.group].menuLabel,
+      sections: [section],
+    });
+  }
+
+  return groups;
 }

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
@@ -29,209 +29,233 @@ const CONNECTOR_CATEGORY_ORDER: readonly ConnectorDisplayCategory[] = [
   "data-automation-infrastructure",
 ];
 
-const CONNECTOR_CATEGORY_LABELS: Record<ConnectorDisplayCategory, string> = {
-  "ai-general-models": "AI: General Models and Reasoning",
-  "ai-image-video": "AI: Image / Video Generation",
-  "ai-voice-audio": "AI: Voice / Audio",
-  "ai-agent-apps": "AI: Agent Platforms and AI Apps",
-  "ai-memory-tracing-eval": "AI: Memory / Tracing / Evaluation",
-  "communication-collaboration": "Communication and Collaboration",
-  "meetings-scheduling": "Meetings and Scheduling",
-  "docs-files-knowledge": "Docs, Files, and Knowledge",
-  "engineering-team-execution": "Engineering and Team Execution",
-  "sales-crm-business-operations": "Sales, CRM, and Business Operations",
-  "marketing-content-growth": "Marketing, Content, and Growth",
-  "data-automation-infrastructure": "Data, Automation, and Infrastructure",
-};
-
-const CONNECTOR_CATEGORY_BY_TYPE = {
-  agentmail: "communication-collaboration",
-  agentphone: "communication-collaboration",
-  ahrefs: "marketing-content-growth",
-  airtable: "docs-files-knowledge",
-  amplitude: "data-automation-infrastructure",
-  "anthropic-managed-agents": "ai-agent-apps",
-  apify: "data-automation-infrastructure",
-  apollo: "sales-crm-business-operations",
-  asana: "engineering-team-execution",
-  atlassian: "engineering-team-execution",
-  attio: "sales-crm-business-operations",
-  axiom: "data-automation-infrastructure",
-  bitrix: "sales-crm-business-operations",
-  "brave-search": "data-automation-infrastructure",
-  brevo: "communication-collaboration",
-  "bright-data": "data-automation-infrastructure",
-  browserbase: "data-automation-infrastructure",
-  browserless: "data-automation-infrastructure",
-  buffer: "marketing-content-growth",
-  "cal-com": "meetings-scheduling",
-  calendly: "meetings-scheduling",
-  canva: "docs-files-knowledge",
-  chatwoot: "communication-collaboration",
-  clickup: "engineering-team-execution",
-  close: "sales-crm-business-operations",
-  cloudflare: "engineering-team-execution",
-  cloudinary: "marketing-content-growth",
-  coda: "docs-files-knowledge",
-  computer: "engineering-team-execution",
-  cronlytic: "data-automation-infrastructure",
-  "customer-io": "communication-collaboration",
-  db9: "data-automation-infrastructure",
-  deel: "sales-crm-business-operations",
-  deepseek: "ai-general-models",
-  devto: "marketing-content-growth",
-  dify: "ai-agent-apps",
-  discord: "communication-collaboration",
-  "discord-webhook": "communication-collaboration",
-  docusign: "data-automation-infrastructure",
-  doppler: "engineering-team-execution",
-  drive9: "docs-files-knowledge",
-  dropbox: "docs-files-knowledge",
-  "dropbox-sign": "data-automation-infrastructure",
-  duffel: "data-automation-infrastructure",
-  e2b: "data-automation-infrastructure",
-  elevenlabs: "ai-voice-audio",
-  etsy: "data-automation-infrastructure",
-  exa: "data-automation-infrastructure",
-  explorium: "sales-crm-business-operations",
-  fal: "ai-image-video",
-  figma: "docs-files-knowledge",
-  firecrawl: "data-automation-infrastructure",
-  fireflies: "meetings-scheduling",
-  freshdesk: "communication-collaboration",
-  gamma: "marketing-content-growth",
-  "garmin-connect": "data-automation-infrastructure",
-  github: "engineering-team-execution",
-  gitlab: "engineering-team-execution",
-  gmail: "communication-collaboration",
-  "google-calendar": "meetings-scheduling",
-  "google-docs": "docs-files-knowledge",
-  "google-drive": "docs-files-knowledge",
-  "google-meet": "meetings-scheduling",
-  "google-sheets": "docs-files-knowledge",
-  granola: "meetings-scheduling",
-  greenhouse: "sales-crm-business-operations",
-  groq: "ai-general-models",
-  helicone: "ai-memory-tracing-eval",
-  heygen: "marketing-content-growth",
-  htmlcsstoimage: "marketing-content-growth",
-  hubspot: "sales-crm-business-operations",
-  "hugging-face": "ai-general-models",
-  hume: "ai-voice-audio",
-  imgur: "marketing-content-growth",
-  infisical: "engineering-team-execution",
-  instagram: "marketing-content-growth",
-  instantly: "communication-collaboration",
-  intercom: "communication-collaboration",
-  "intervals-icu": "meetings-scheduling",
-  jam: "engineering-team-execution",
-  jira: "engineering-team-execution",
-  jotform: "data-automation-infrastructure",
-  klaviyo: "marketing-content-growth",
-  kommo: "sales-crm-business-operations",
-  langfuse: "ai-memory-tracing-eval",
-  langsmith: "ai-memory-tracing-eval",
-  lark: "communication-collaboration",
-  line: "communication-collaboration",
-  linear: "engineering-team-execution",
-  loops: "communication-collaboration",
-  luma: "ai-image-video",
-  mailchimp: "communication-collaboration",
-  mailsac: "communication-collaboration",
-  make: "data-automation-infrastructure",
-  manus: "ai-agent-apps",
-  mem0: "ai-memory-tracing-eval",
-  mercury: "sales-crm-business-operations",
-  "meta-ads": "marketing-content-growth",
-  metabase: "data-automation-infrastructure",
-  minimax: "ai-general-models",
-  minio: "docs-files-knowledge",
-  miro: "docs-files-knowledge",
-  mixpanel: "data-automation-infrastructure",
-  monday: "engineering-team-execution",
-  msg9: "communication-collaboration",
-  n8n: "data-automation-infrastructure",
-  neon: "data-automation-infrastructure",
-  notion: "docs-files-knowledge",
-  onyx: "docs-files-knowledge",
-  openai: "ai-general-models",
-  "outlook-calendar": "meetings-scheduling",
-  "outlook-mail": "communication-collaboration",
-  pandadoc: "data-automation-infrastructure",
-  pdf4me: "data-automation-infrastructure",
-  pdfco: "data-automation-infrastructure",
-  pdforge: "data-automation-infrastructure",
-  perplexity: "data-automation-infrastructure",
-  pika: "ai-image-video",
-  pinecone: "data-automation-infrastructure",
-  pipedrive: "sales-crm-business-operations",
-  plain: "communication-collaboration",
-  plausible: "data-automation-infrastructure",
-  podchaser: "data-automation-infrastructure",
-  posthog: "data-automation-infrastructure",
-  "prisma-postgres": "data-automation-infrastructure",
-  productlane: "sales-crm-business-operations",
-  pushinator: "communication-collaboration",
-  qdrant: "data-automation-infrastructure",
-  qiita: "marketing-content-growth",
-  reddit: "data-automation-infrastructure",
-  replicate: "ai-image-video",
-  reportei: "marketing-content-growth",
-  resend: "communication-collaboration",
-  revenuecat: "data-automation-infrastructure",
-  runway: "ai-image-video",
-  salesforce: "sales-crm-business-operations",
-  scrapeninja: "data-automation-infrastructure",
-  sentry: "engineering-team-execution",
-  serpapi: "data-automation-infrastructure",
-  shopify: "data-automation-infrastructure",
-  shortio: "marketing-content-growth",
-  similarweb: "marketing-content-growth",
-  slack: "communication-collaboration",
-  "slack-webhook": "communication-collaboration",
-  spotify: "data-automation-infrastructure",
-  "stability-ai": "ai-image-video",
-  strapi: "docs-files-knowledge",
-  strava: "data-automation-infrastructure",
-  streak: "sales-crm-business-operations",
-  stripe: "data-automation-infrastructure",
-  supabase: "data-automation-infrastructure",
-  supadata: "data-automation-infrastructure",
-  tavily: "data-automation-infrastructure",
-  "test-oauth": "data-automation-infrastructure",
-  tldv: "meetings-scheduling",
-  todoist: "engineering-team-execution",
-  together: "ai-general-models",
-  twenty: "sales-crm-business-operations",
-  typeform: "data-automation-infrastructure",
-  v0: "ai-agent-apps",
-  vercel: "engineering-team-execution",
-  wandb: "ai-memory-tracing-eval",
-  webflow: "marketing-content-growth",
-  wix: "marketing-content-growth",
-  workos: "engineering-team-execution",
-  wrike: "engineering-team-execution",
-  x: "marketing-content-growth",
-  xero: "data-automation-infrastructure",
-  youtube: "marketing-content-growth",
-  zapier: "data-automation-infrastructure",
-  zapsign: "data-automation-infrastructure",
-  zendesk: "communication-collaboration",
-  zep: "ai-memory-tracing-eval",
-  zeptomail: "communication-collaboration",
-  zoom: "meetings-scheduling",
-} as const satisfies Record<ConnectorType, ConnectorDisplayCategory>;
-
 interface ConnectorCategorySection<T> {
   category: ConnectorDisplayCategory;
   label: string;
   connectors: T[];
 }
 
+function getConnectorCategoryLabel(category: ConnectorDisplayCategory): string {
+  switch (category) {
+    case "ai-general-models":
+      return "AI: General Models and Reasoning";
+    case "ai-image-video":
+      return "AI: Image / Video Generation";
+    case "ai-voice-audio":
+      return "AI: Voice / Audio";
+    case "ai-agent-apps":
+      return "AI: Agent Platforms and AI Apps";
+    case "ai-memory-tracing-eval":
+      return "AI: Memory / Tracing / Evaluation";
+    case "communication-collaboration":
+      return "Communication and Collaboration";
+    case "meetings-scheduling":
+      return "Meetings and Scheduling";
+    case "docs-files-knowledge":
+      return "Docs, Files, and Knowledge";
+    case "engineering-team-execution":
+      return "Engineering and Team Execution";
+    case "sales-crm-business-operations":
+      return "Sales, CRM, and Business Operations";
+    case "marketing-content-growth":
+      return "Marketing, Content, and Growth";
+    case "data-automation-infrastructure":
+      return "Data, Automation, and Infrastructure";
+  }
+}
+
 export function getConnectorDisplayCategory(
   type: ConnectorType,
 ): ConnectorDisplayCategory {
-  return CONNECTOR_CATEGORY_BY_TYPE[type];
+  switch (type) {
+    case "agentmail":
+    case "agentphone":
+    case "brevo":
+    case "chatwoot":
+    case "customer-io":
+    case "discord":
+    case "discord-webhook":
+    case "freshdesk":
+    case "gmail":
+    case "instantly":
+    case "intercom":
+    case "lark":
+    case "line":
+    case "loops":
+    case "mailchimp":
+    case "mailsac":
+    case "msg9":
+    case "outlook-mail":
+    case "plain":
+    case "pushinator":
+    case "resend":
+    case "slack":
+    case "slack-webhook":
+    case "zendesk":
+    case "zeptomail":
+      return "communication-collaboration";
+    case "cal-com":
+    case "calendly":
+    case "fireflies":
+    case "google-calendar":
+    case "google-meet":
+    case "granola":
+    case "intervals-icu":
+    case "outlook-calendar":
+    case "tldv":
+    case "zoom":
+      return "meetings-scheduling";
+    case "airtable":
+    case "canva":
+    case "coda":
+    case "drive9":
+    case "dropbox":
+    case "figma":
+    case "google-docs":
+    case "google-drive":
+    case "google-sheets":
+    case "minio":
+    case "miro":
+    case "notion":
+    case "onyx":
+    case "strapi":
+      return "docs-files-knowledge";
+    case "asana":
+    case "atlassian":
+    case "clickup":
+    case "cloudflare":
+    case "computer":
+    case "doppler":
+    case "github":
+    case "gitlab":
+    case "infisical":
+    case "jam":
+    case "jira":
+    case "linear":
+    case "monday":
+    case "sentry":
+    case "todoist":
+    case "vercel":
+    case "workos":
+    case "wrike":
+      return "engineering-team-execution";
+    case "apollo":
+    case "attio":
+    case "bitrix":
+    case "close":
+    case "deel":
+    case "explorium":
+    case "greenhouse":
+    case "hubspot":
+    case "kommo":
+    case "mercury":
+    case "pipedrive":
+    case "productlane":
+    case "salesforce":
+    case "streak":
+    case "twenty":
+      return "sales-crm-business-operations";
+    case "ahrefs":
+    case "buffer":
+    case "cloudinary":
+    case "devto":
+    case "gamma":
+    case "heygen":
+    case "htmlcsstoimage":
+    case "imgur":
+    case "instagram":
+    case "klaviyo":
+    case "meta-ads":
+    case "qiita":
+    case "reportei":
+    case "shortio":
+    case "similarweb":
+    case "webflow":
+    case "wix":
+    case "x":
+    case "youtube":
+      return "marketing-content-growth";
+    case "openai":
+    case "deepseek":
+    case "groq":
+    case "hugging-face":
+    case "minimax":
+    case "together":
+      return "ai-general-models";
+    case "fal":
+    case "luma":
+    case "pika":
+    case "replicate":
+    case "runway":
+    case "stability-ai":
+      return "ai-image-video";
+    case "elevenlabs":
+    case "hume":
+      return "ai-voice-audio";
+    case "anthropic-managed-agents":
+    case "dify":
+    case "manus":
+    case "v0":
+      return "ai-agent-apps";
+    case "helicone":
+    case "langfuse":
+    case "langsmith":
+    case "mem0":
+    case "wandb":
+    case "zep":
+      return "ai-memory-tracing-eval";
+    case "amplitude":
+    case "apify":
+    case "axiom":
+    case "brave-search":
+    case "bright-data":
+    case "browserbase":
+    case "browserless":
+    case "cronlytic":
+    case "db9":
+    case "docusign":
+    case "dropbox-sign":
+    case "duffel":
+    case "e2b":
+    case "etsy":
+    case "exa":
+    case "firecrawl":
+    case "garmin-connect":
+    case "jotform":
+    case "make":
+    case "metabase":
+    case "mixpanel":
+    case "n8n":
+    case "neon":
+    case "pandadoc":
+    case "pdf4me":
+    case "pdfco":
+    case "pdforge":
+    case "perplexity":
+    case "pinecone":
+    case "plausible":
+    case "podchaser":
+    case "posthog":
+    case "prisma-postgres":
+    case "qdrant":
+    case "reddit":
+    case "revenuecat":
+    case "scrapeninja":
+    case "serpapi":
+    case "shopify":
+    case "spotify":
+    case "strava":
+    case "stripe":
+    case "supabase":
+    case "supadata":
+    case "tavily":
+    case "test-oauth":
+    case "typeform":
+    case "xero":
+    case "zapier":
+    case "zapsign":
+      return "data-automation-infrastructure";
+  }
 }
 
 export function groupConnectorsByCategory<
@@ -266,7 +290,7 @@ export function groupConnectorsByCategory<
     return [
       {
         category,
-        label: CONNECTOR_CATEGORY_LABELS[category],
+        label: getConnectorCategoryLabel(category),
         connectors: sorted,
       },
     ];

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
@@ -1,10 +1,11 @@
+import { command, computed, state } from "ccstate";
 import {
   CONNECTOR_DISPLAY_CATEGORY_GROUPS,
   CONNECTOR_DISPLAY_CATEGORY_META,
   CONNECTOR_DISPLAY_CATEGORY_ORDER,
   type ConnectorDisplayCategory,
   type ConnectorDisplayCategoryGroup,
-} from "@vm0/core";
+} from "@vm0/core/contracts/connectors";
 
 export interface ConnectorCategorySection<T> {
   category: ConnectorDisplayCategory;
@@ -96,3 +97,89 @@ export function groupConnectorsByCategory<
 
   return groups;
 }
+
+export function getConnectorCategorySectionId(category: string): string {
+  return `connector-category-${category}`;
+}
+
+export function scrollToConnectorCategory(category: string): void {
+  document
+    .getElementById(getConnectorCategorySectionId(category))
+    ?.scrollIntoView({ block: "start", behavior: "smooth" });
+}
+
+const SECTION_ID_PREFIX = "connector-category-";
+
+function getActiveConnectorCategoryId(
+  scrollContainer: HTMLElement,
+): string | null {
+  const sections = Array.from(
+    document.querySelectorAll<HTMLElement>(`[id^="${SECTION_ID_PREFIX}"]`),
+  ).filter((element) => {
+    return scrollContainer.contains(element);
+  });
+  if (sections.length === 0) {
+    return null;
+  }
+  let activeId: string | null =
+    sections[0]?.id.slice(SECTION_ID_PREFIX.length) ?? null;
+  const anchorY = scrollContainer.getBoundingClientRect().top + 120;
+
+  for (const section of sections) {
+    if (section.getBoundingClientRect().top <= anchorY) {
+      activeId = section.id.slice(SECTION_ID_PREFIX.length);
+      continue;
+    }
+    break;
+  }
+
+  return activeId;
+}
+
+// ---------------------------------------------------------------------------
+// Scroll-driven active category tracking
+// ---------------------------------------------------------------------------
+
+const internalActiveConnectorCategoryId$ = state<string | null>(null);
+
+export const activeConnectorCategoryId$ = computed((get) => {
+  return get(internalActiveConnectorCategoryId$);
+});
+
+const setActiveConnectorCategoryId$ = command(
+  ({ get, set }, nextActiveId: string | null) => {
+    const previous = get(internalActiveConnectorCategoryId$);
+    if (previous !== nextActiveId) {
+      set(internalActiveConnectorCategoryId$, nextActiveId);
+    }
+  },
+);
+
+export const resetActiveConnectorCategory$ = command(({ set }) => {
+  set(internalActiveConnectorCategoryId$, null);
+});
+
+/**
+ * Attach scroll/resize listeners to update the active category indicator.
+ * Returns a cleanup function that removes the listeners. Call from a React
+ * callback ref inside an effect-equivalent lifecycle (e.g. component mount).
+ */
+export const attachConnectorCategoryScrollTracking$ = command(
+  ({ set }, scrollContainer: HTMLElement): (() => void) => {
+    const updateActiveCategory = () => {
+      const nextActiveId = getActiveConnectorCategoryId(scrollContainer);
+      set(setActiveConnectorCategoryId$, nextActiveId);
+    };
+
+    updateActiveCategory();
+    scrollContainer.addEventListener("scroll", updateActiveCategory, {
+      passive: true,
+    });
+    window.addEventListener("resize", updateActiveCategory);
+
+    return () => {
+      scrollContainer.removeEventListener("scroll", updateActiveCategory);
+      window.removeEventListener("resize", updateActiveCategory);
+    };
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -33,6 +33,7 @@ import { jsonParseOr, raceUnderSignal } from "../../utils.ts";
 import { awaitRealtimeReady$, setAblyLoop$ } from "../../realtime.ts";
 import { localStorageSignals } from "../../external/local-storage.ts";
 import { resetPermissionDialog$ } from "./permission-dialog.ts";
+import { getConnectorDisplayCategory } from "./connector-categories.ts";
 
 const HIDDEN_CONNECTIONS_STORAGE_KEY = "vm0.connections.hiddenTypes";
 const { get$: hiddenConnectorTypesRaw$, set$: setHiddenConnectorTypes$ } =
@@ -50,6 +51,7 @@ export interface ConnectorTypeWithStatus {
   type: ConnectorType;
   label: string;
   helpText: string;
+  category: ReturnType<typeof getConnectorDisplayCategory>;
   /** Lowercase aliases/keywords used by connector search (from CONNECTOR_TYPES). */
   tags: readonly string[];
   connected: boolean;
@@ -157,6 +159,7 @@ export const allConnectorTypes$ = computed(async (get) => {
         type,
         label: isExperimental ? `[Experimental] ${config.label}` : config.label,
         helpText: config.helpText,
+        category: getConnectorDisplayCategory(type),
         tags: config.tags ?? [],
         connected: connector !== null,
         connector,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -4,6 +4,7 @@ import { accept } from "../../../lib/accept.ts";
 import {
   CONNECTOR_TYPES,
   type ConnectorType,
+  type ConnectorDisplayCategory,
 } from "@vm0/core/contracts/connectors";
 import { hasRequiredScopes } from "@vm0/core/contracts/connector-utils";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -33,7 +34,6 @@ import { jsonParseOr, raceUnderSignal } from "../../utils.ts";
 import { awaitRealtimeReady$, setAblyLoop$ } from "../../realtime.ts";
 import { localStorageSignals } from "../../external/local-storage.ts";
 import { resetPermissionDialog$ } from "./permission-dialog.ts";
-import { getConnectorDisplayCategory } from "./connector-categories.ts";
 
 const HIDDEN_CONNECTIONS_STORAGE_KEY = "vm0.connections.hiddenTypes";
 const { get$: hiddenConnectorTypesRaw$, set$: setHiddenConnectorTypes$ } =
@@ -51,7 +51,7 @@ export interface ConnectorTypeWithStatus {
   type: ConnectorType;
   label: string;
   helpText: string;
-  category: ReturnType<typeof getConnectorDisplayCategory>;
+  category: ConnectorDisplayCategory;
   /** Lowercase aliases/keywords used by connector search (from CONNECTOR_TYPES). */
   tags: readonly string[];
   connected: boolean;
@@ -159,7 +159,7 @@ export const allConnectorTypes$ = computed(async (get) => {
         type,
         label: isExperimental ? `[Experimental] ${config.label}` : config.label,
         helpText: config.helpText,
-        category: getConnectorDisplayCategory(type),
+        category: config.category,
         tags: config.tags ?? [],
         connected: connector !== null,
         connector,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-disconnect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-disconnect.test.tsx
@@ -19,7 +19,7 @@ import { mockConnectors } from "./zero-connectors-page-test-helpers.ts";
 
 const context = testContext();
 
-test("disconnect moves a just-connected connector out of Connected (regression #10272)", async () => {
+test("disconnect moves a just-connected connector back to an available card (regression #10272)", async () => {
   // Start with Ahrefs already connected — mirrors the screenshot in #10272.
   mockConnectors([{ type: "ahrefs" }]);
 
@@ -37,17 +37,19 @@ test("disconnect moves a just-connected connector out of Connected (regression #
   detachedSetupPage({ context, path: "/connectors" });
 
   await waitFor(() => {
-    expect(screen.getByText("Connected (1)")).toBeInTheDocument();
+    expect(
+      screen.getByText("Marketing, Content, and Growth"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("More options")).toBeInTheDocument();
   });
 
   click(screen.getByLabelText("More options"));
   click(screen.getByText("Disconnect"));
 
-  // After a successful disconnect the card must leave the Connected section
-  // regardless of whether a search filter is active.
+  // After a successful disconnect the connector must render as an available
+  // card again, even if it was marked as just connected earlier in the session.
   await waitFor(() => {
-    expect(screen.queryByText("Connected (1)")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("More options")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Connect Ahrefs")).toBeInTheDocument();
   });
-
-  expect(screen.getByLabelText("Connect Ahrefs")).toBeInTheDocument();
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-disconnect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-disconnect.test.tsx
@@ -37,9 +37,6 @@ test("disconnect moves a just-connected connector back to an available card (reg
   detachedSetupPage({ context, path: "/connectors" });
 
   await waitFor(() => {
-    expect(
-      screen.getByText("Marketing, Content, and Growth"),
-    ).toBeInTheDocument();
     expect(screen.getByLabelText("More options")).toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
@@ -20,14 +20,9 @@ import { createMockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
-const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
 
 afterEach(() => {
   vi.restoreAllMocks();
-  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
-    configurable: true,
-    value: originalScrollIntoView,
-  });
 });
 
 describe("connectors page - count display", () => {
@@ -44,26 +39,20 @@ describe("connectors page - count display", () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("heading", {
-          level: 2,
-          name: "AI",
-        }),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("connector-category-ai")).toBeInTheDocument();
     });
     expect(
-      screen.getByRole("heading", {
-        level: 3,
-        name: "General Models and Reasoning",
-      }),
+      screen.getByTestId("connector-category-ai-general-models"),
     ).toBeInTheDocument();
-    const headings = screen.getAllByRole("heading", { level: 2 });
-    const labels = headings.map((heading) => {
-      return heading.textContent;
-    });
-    expect(labels.indexOf("AI")).toBeLessThan(
-      labels.indexOf("Engineering and Team Execution"),
+
+    const aiGroup = screen.getByTestId("connector-category-ai");
+    const engineeringGroup = screen.getByTestId(
+      "connector-category-engineering-team-execution",
     );
+    expect(
+      aiGroup.compareDocumentPosition(engineeringGroup) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("only matching categories are shown for search-filtered results (CONN-D-002)", async () => {
@@ -76,18 +65,10 @@ describe("connectors page - count display", () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("heading", {
-          level: 2,
-          name: "AI",
-        }),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("connector-category-ai")).toBeInTheDocument();
     });
     expect(
-      screen.getByRole("heading", {
-        level: 3,
-        name: "General Models and Reasoning",
-      }),
+      screen.getByTestId("connector-category-ai-general-models"),
     ).toBeInTheDocument();
 
     await userEvent.type(
@@ -97,23 +78,14 @@ describe("connectors page - count display", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", {
-          level: 2,
-          name: "Engineering and Team Execution",
-        }),
+        screen.getByTestId("connector-category-engineering-team-execution"),
       ).toBeInTheDocument();
     });
     expect(
-      screen.queryByRole("heading", {
-        level: 2,
-        name: "AI",
-      }),
+      screen.queryByTestId("connector-category-ai"),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("heading", {
-        level: 2,
-        name: "Communication and Collaboration",
-      }),
+      screen.queryByTestId("connector-category-communication-collaboration"),
     ).not.toBeInTheDocument();
   });
 });
@@ -132,16 +104,10 @@ describe("connectors page - grouped display", () => {
     });
 
     expect(
-      screen.queryByRole("heading", {
-        level: 2,
-        name: "AI",
-      }),
+      screen.queryByTestId("connector-category-ai"),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("heading", {
-        level: 2,
-        name: "Engineering and Team Execution",
-      }),
+      screen.queryByTestId("connector-category-engineering-team-execution"),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("navigation", {
@@ -151,11 +117,10 @@ describe("connectors page - grouped display", () => {
   });
 
   it("renders a category menu that scrolls to grouped sections", async () => {
-    const scrollIntoView = vi.fn();
-    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
-      configurable: true,
-      value: scrollIntoView,
-    });
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => {});
+
     mockConnectors([
       { type: "github" },
       { type: "openai", authMethod: "platform" },
@@ -167,20 +132,25 @@ describe("connectors page - grouped display", () => {
       featureSwitches: { [FeatureSwitchKey.ConnectorCategories]: true },
     });
 
-    const menu = await screen.findByRole("navigation", {
+    await screen.findByRole("navigation", {
       name: "Connector categories",
     });
 
     await userEvent.click(
-      within(menu).getByRole("button", {
-        name: "Engineering and Team Execution",
-      }),
+      screen.getByTestId("connector-category-menu-engineering-team-execution"),
     );
 
-    expect(scrollIntoView).toHaveBeenCalledWith({
-      block: "start",
-      behavior: "smooth",
+    // Assert the correct section was targeted (user-observable: the scrolled
+    // element is the engineering section). Do not assert on the options
+    // object — that couples the test to implementation detail.
+    const engineeringSection = screen.getByTestId(
+      "connector-category-engineering-team-execution",
+    );
+    expect(scrollIntoView).toHaveBeenCalled();
+    const scrolledInto = scrollIntoView.mock.instances.some((instance) => {
+      return instance === engineeringSection;
     });
+    expect(scrolledInto).toBe(true);
   });
 
   it("connected connectors are shown before available ones within a category", async () => {
@@ -194,23 +164,18 @@ describe("connectors page - grouped display", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", {
-          level: 2,
-          name: "Engineering and Team Execution",
-        }),
+        screen.getByTestId("connector-category-engineering-team-execution"),
       ).toBeInTheDocument();
     });
 
     const engineeringSection = screen.getByTestId(
       "connector-category-engineering-team-execution",
     );
-    const labels = Array.from(
-      engineeringSection.querySelectorAll(
-        "span.text-sm.font-medium.text-foreground.truncate",
-      ),
-    ).map((element) => {
-      return element.textContent;
-    });
+    const labels = within(engineeringSection)
+      .getAllByTestId("connector-card-label")
+      .map((element) => {
+        return element.textContent;
+      });
     expect(labels[0]).toBe("GitHub");
     expect(labels).toContain("Asana");
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
@@ -7,18 +7,28 @@
  * - Real (internal): All signals, components, rendering
  */
 
-import { describe, expect, it, vi } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { mockConnectors } from "./zero-connectors-page-test-helpers.ts";
 import { zeroConnectorsMainContract } from "@vm0/core/contracts/zero-connectors";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: originalScrollIntoView,
+  });
+});
 
 describe("connectors page - count display", () => {
   it("ai categories render before non-ai categories (CONN-D-001)", async () => {
@@ -27,18 +37,31 @@ describe("connectors page - count display", () => {
       { type: "openai", authMethod: "platform" },
     ]);
 
-    detachedSetupPage({ context, path: "/connectors" });
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorCategories]: true },
+    });
 
     await waitFor(() => {
       expect(
-        screen.getByText("AI: General Models and Reasoning"),
+        screen.getByRole("heading", {
+          level: 2,
+          name: "AI",
+        }),
       ).toBeInTheDocument();
     });
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "General Models and Reasoning",
+      }),
+    ).toBeInTheDocument();
     const headings = screen.getAllByRole("heading", { level: 2 });
     const labels = headings.map((heading) => {
       return heading.textContent;
     });
-    expect(labels.indexOf("AI: General Models and Reasoning")).toBeLessThan(
+    expect(labels.indexOf("AI")).toBeLessThan(
       labels.indexOf("Engineering and Team Execution"),
     );
   });
@@ -46,13 +69,26 @@ describe("connectors page - count display", () => {
   it("only matching categories are shown for search-filtered results (CONN-D-002)", async () => {
     mockConnectors([{ type: "github" }]);
 
-    detachedSetupPage({ context, path: "/connectors" });
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorCategories]: true },
+    });
 
     await waitFor(() => {
       expect(
-        screen.getByText("AI: General Models and Reasoning"),
+        screen.getByRole("heading", {
+          level: 2,
+          name: "AI",
+        }),
       ).toBeInTheDocument();
     });
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "General Models and Reasoning",
+      }),
+    ).toBeInTheDocument();
 
     await userEvent.type(
       screen.getByPlaceholderText("Find connectors"),
@@ -61,27 +97,107 @@ describe("connectors page - count display", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Engineering and Team Execution"),
+        screen.getByRole("heading", {
+          level: 2,
+          name: "Engineering and Team Execution",
+        }),
       ).toBeInTheDocument();
     });
     expect(
-      screen.queryByText("AI: General Models and Reasoning"),
+      screen.queryByRole("heading", {
+        level: 2,
+        name: "AI",
+      }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText("Communication and Collaboration"),
+      screen.queryByRole("heading", {
+        level: 2,
+        name: "Communication and Collaboration",
+      }),
     ).not.toBeInTheDocument();
   });
 });
 
 describe("connectors page - grouped display", () => {
-  it("connected connectors are shown before available ones within a category", async () => {
-    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+  it("does not render categories or the category menu when the feature switch is off", async () => {
+    mockConnectors([
+      { type: "github" },
+      { type: "openai", authMethod: "platform" },
+    ]);
 
     detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("heading", {
+        level: 2,
+        name: "AI",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", {
+        level: 2,
+        name: "Engineering and Team Execution",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("navigation", {
+        name: "Connector categories",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a category menu that scrolls to grouped sections", async () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    mockConnectors([
+      { type: "github" },
+      { type: "openai", authMethod: "platform" },
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorCategories]: true },
+    });
+
+    const menu = await screen.findByRole("navigation", {
+      name: "Connector categories",
+    });
+
+    await userEvent.click(
+      within(menu).getByRole("button", {
+        name: "Engineering and Team Execution",
+      }),
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: "start",
+      behavior: "smooth",
+    });
+  });
+
+  it("connected connectors are shown before available ones within a category", async () => {
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorCategories]: true },
+    });
+
+    await waitFor(() => {
       expect(
-        screen.getByText("Engineering and Team Execution"),
+        screen.getByRole("heading", {
+          level: 2,
+          name: "Engineering and Team Execution",
+        }),
       ).toBeInTheDocument();
     });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
@@ -146,11 +146,10 @@ describe("connectors page - grouped display", () => {
     const engineeringSection = screen.getByTestId(
       "connector-category-engineering-team-execution",
     );
-    expect(scrollIntoView).toHaveBeenCalled();
     const scrolledInto = scrollIntoView.mock.instances.some((instance) => {
       return instance === engineeringSection;
     });
-    expect(scrolledInto).toBe(true);
+    expect(scrolledInto).toBeTruthy();
   });
 
   it("connected connectors are shown before available ones within a category", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
@@ -21,29 +21,82 @@ const context = testContext();
 const mockApi = createMockApi(context);
 
 describe("connectors page - count display", () => {
-  it("connected connectors count is displayed (CONN-D-001)", async () => {
-    mockConnectors([{ type: "github" }, { type: "linear" }]);
+  it("ai categories render before non-ai categories (CONN-D-001)", async () => {
+    mockConnectors([
+      { type: "github" },
+      { type: "openai", authMethod: "platform" },
+    ]);
 
     detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
-      expect(screen.getByText("Connected (2)")).toBeInTheDocument();
+      expect(
+        screen.getByText("AI: General Models and Reasoning"),
+      ).toBeInTheDocument();
     });
+    const headings = screen.getAllByRole("heading", { level: 2 });
+    const labels = headings.map((heading) => {
+      return heading.textContent;
+    });
+    expect(labels.indexOf("AI: General Models and Reasoning")).toBeLessThan(
+      labels.indexOf("Engineering and Team Execution"),
+    );
   });
 
-  it("available connectors count is displayed (CONN-D-002)", async () => {
+  it("only matching categories are shown for search-filtered results (CONN-D-002)", async () => {
     mockConnectors([{ type: "github" }]);
 
     detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
-      const availableHeading = screen.getByText(/^Available \(\d+\)$/);
-      expect(availableHeading).toBeInTheDocument();
-      const count = Number.parseInt(
-        availableHeading.textContent?.match(/\d+/)?.[0] ?? "0",
-      );
-      expect(count).toBeGreaterThan(0);
+      expect(
+        screen.getByText("AI: General Models and Reasoning"),
+      ).toBeInTheDocument();
     });
+
+    await userEvent.type(
+      screen.getByPlaceholderText("Find connectors"),
+      "github",
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Engineering and Team Execution"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("AI: General Models and Reasoning"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Communication and Collaboration"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("connectors page - grouped display", () => {
+  it("connected connectors are shown before available ones within a category", async () => {
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Engineering and Team Execution"),
+      ).toBeInTheDocument();
+    });
+
+    const engineeringSection = screen.getByTestId(
+      "connector-category-engineering-team-execution",
+    );
+    const labels = Array.from(
+      engineeringSection.querySelectorAll(
+        "span.text-sm.font-medium.text-foreground.truncate",
+      ),
+    ).map((element) => {
+      return element.textContent;
+    });
+    expect(labels[0]).toBe("GitHub");
+    expect(labels).toContain("Asana");
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -39,26 +39,29 @@ describe("connectors page", () => {
   it("shows available connectors when none are connected", async () => {
     detachedSetupPage({ context, path: "/connectors" });
 
-    // Default mock returns no connected connectors, so all should be in "Available"
     await waitFor(() => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
-    expect(screen.getByText(/Available/)).toBeInTheDocument();
-    // "Connected" section should not appear
-    expect(screen.queryByText(/Connected \(/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText("AI: General Models and Reasoning"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Engineering and Team Execution"),
+    ).toBeInTheDocument();
   });
 
-  it("shows connected and available sections when some connectors are connected", async () => {
+  it("shows connected connectors within their category sections", async () => {
     mockConnectors([{ type: "github", externalUsername: "testuser" }]);
 
     detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
-      expect(screen.getByText(/Connected \(/)).toBeInTheDocument();
+      expect(
+        screen.getByText("Engineering and Team Execution"),
+      ).toBeInTheDocument();
     });
-    // The connected connector should show the GitHub label
     expect(screen.getByText("GitHub")).toBeInTheDocument();
-    expect(screen.getByText(/Available/)).toBeInTheDocument();
+    expect(screen.getByLabelText("More options")).toBeInTheDocument();
   });
 
   it("filters connectors by search term", async () => {
@@ -149,7 +152,7 @@ describe("connectors page", () => {
 
     // Wait for the connected GitHub card to appear
     await waitFor(() => {
-      expect(screen.getByText(/Connected \(/)).toBeInTheDocument();
+      expect(screen.getByLabelText("More options")).toBeInTheDocument();
     });
 
     // Radix DropdownMenu opens on click
@@ -189,7 +192,7 @@ describe("connectors page", () => {
     detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
-      expect(screen.getByText(/Connected \(/)).toBeInTheDocument();
+      expect(screen.getByLabelText("More options")).toBeInTheDocument();
     });
 
     // Radix DropdownMenu opens on click

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -43,22 +43,13 @@ describe("connectors page", () => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
     expect(
-      screen.queryByRole("heading", {
-        level: 2,
-        name: "AI",
-      }),
+      screen.queryByTestId("connector-category-ai"),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("heading", {
-        level: 3,
-        name: "General Models and Reasoning",
-      }),
+      screen.queryByTestId("connector-category-ai-general-models"),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("heading", {
-        level: 2,
-        name: "Engineering and Team Execution",
-      }),
+      screen.queryByTestId("connector-category-engineering-team-execution"),
     ).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -43,22 +43,32 @@ describe("connectors page", () => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
     expect(
-      screen.getByText("AI: General Models and Reasoning"),
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", {
+        level: 2,
+        name: "AI",
+      }),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText("Engineering and Team Execution"),
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", {
+        level: 3,
+        name: "General Models and Reasoning",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", {
+        level: 2,
+        name: "Engineering and Team Execution",
+      }),
+    ).not.toBeInTheDocument();
   });
 
-  it("shows connected connectors within their category sections", async () => {
+  it("shows connected connectors", async () => {
     mockConnectors([{ type: "github", externalUsername: "testuser" }]);
 
     detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Engineering and Team Execution"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
     expect(screen.getByText("GitHub")).toBeInTheDocument();
     expect(screen.getByLabelText("More options")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -1,5 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
+import { Fragment, useEffect, useRef, useState, type ReactNode } from "react";
 import {
   useGet,
   useSet,
@@ -15,6 +16,7 @@ import {
 } from "@tabler/icons-react";
 import {
   CONNECTOR_TYPES,
+  FeatureSwitchKey,
   type ConnectorType,
 } from "@vm0/core/contracts/connectors";
 import { isGoogleOAuthConnector } from "@vm0/core/contracts/connector-utils";
@@ -46,8 +48,12 @@ import {
   matchesConnectorSearch,
   type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
-import { groupConnectorsByCategory } from "../../signals/zero-page/settings/connector-categories.ts";
+import {
+  groupConnectorsByCategory,
+  type ConnectorCategoryGroup,
+} from "../../signals/zero-page/settings/connector-categories.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { ScopeReviewModal } from "./components/settings/scope-review-modal.tsx";
 import { ConnectorPermissionDialog } from "./components/settings/connector-permission-dialog.tsx";
@@ -64,6 +70,248 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@vm0/ui";
+
+function getConnectorCategorySectionId(category: string): string {
+  return `connector-category-${category}`;
+}
+
+function scrollToConnectorCategory(category: string): void {
+  document
+    .getElementById(getConnectorCategorySectionId(category))
+    ?.scrollIntoView({ block: "start", behavior: "smooth" });
+}
+
+function getConnectorCategoryTargetIds(
+  groups: readonly ConnectorCategoryGroup<ConnectorTypeWithStatus>[],
+): string[] {
+  return groups.flatMap((group) => {
+    if (group.kind === "group") {
+      return [
+        group.id,
+        ...group.sections.map((section) => {
+          return section.category;
+        }),
+      ];
+    }
+    return [group.sections[0].category];
+  });
+}
+
+function getActiveConnectorCategoryId(
+  categoryIds: readonly string[],
+  scrollContainer: HTMLElement,
+): string | null {
+  let activeId = categoryIds[0] ?? null;
+  const anchorY = scrollContainer.getBoundingClientRect().top + 120;
+
+  for (const categoryId of categoryIds) {
+    const element = document.getElementById(
+      getConnectorCategorySectionId(categoryId),
+    );
+    if (!element) {
+      continue;
+    }
+    if (element.getBoundingClientRect().top <= anchorY) {
+      activeId = categoryId;
+      continue;
+    }
+    break;
+  }
+
+  return activeId;
+}
+
+function ConnectorCategoryMenu({
+  activeCategoryId,
+  groups,
+}: {
+  activeCategoryId: string | null;
+  groups: readonly ConnectorCategoryGroup<ConnectorTypeWithStatus>[];
+}) {
+  if (groups.length <= 1) {
+    return null;
+  }
+
+  return (
+    <aside className="pointer-events-none absolute bottom-0 left-full top-[60px] ml-16 hidden w-44 xl:block">
+      <nav
+        aria-label="Connector categories"
+        className="group pointer-events-auto sticky top-[28vh] flex flex-col gap-3 pb-3 pl-5"
+      >
+        {groups.map((group) => {
+          if (group.kind === "group") {
+            const isActiveChild = group.sections.some((section) => {
+              return activeCategoryId === section.category;
+            });
+            return (
+              <Fragment key={group.id}>
+                <ConnectorCategoryMenuItem
+                  activeState={
+                    activeCategoryId === group.id
+                      ? "current"
+                      : isActiveChild
+                        ? "ancestor"
+                        : null
+                  }
+                  depth="parent"
+                  label={group.label}
+                  menuLabel={group.menuLabel}
+                  onClick={() => {
+                    scrollToConnectorCategory(group.id);
+                  }}
+                />
+                {group.sections.map((section) => {
+                  return (
+                    <ConnectorCategoryMenuItem
+                      key={section.category}
+                      activeState={
+                        activeCategoryId === section.category ? "current" : null
+                      }
+                      depth="child"
+                      label={section.label}
+                      menuLabel={section.menuLabel}
+                      onClick={() => {
+                        scrollToConnectorCategory(section.category);
+                      }}
+                    />
+                  );
+                })}
+              </Fragment>
+            );
+          }
+
+          const section = group.sections[0];
+          return (
+            <ConnectorCategoryMenuItem
+              key={section.category}
+              activeState={
+                activeCategoryId === section.category ? "current" : null
+              }
+              depth="parent"
+              label={section.label}
+              menuLabel={section.menuLabel}
+              onClick={() => {
+                scrollToConnectorCategory(section.category);
+              }}
+            />
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}
+
+function ConnectorCategoryMenuItem({
+  activeState,
+  depth,
+  label,
+  menuLabel,
+  onClick,
+}: {
+  activeState: "current" | "ancestor" | null;
+  depth: "parent" | "child";
+  label: string;
+  menuLabel: string;
+  onClick: () => void;
+}) {
+  const isChild = depth === "child";
+  const lineClass =
+    activeState === "current"
+      ? isChild
+        ? "ml-1 w-3 bg-foreground/70 group-hover/item:bg-foreground/80"
+        : "w-4 bg-foreground/70 group-hover/item:bg-foreground/80"
+      : activeState === "ancestor"
+        ? "w-4 bg-muted-foreground/55 group-hover/item:bg-foreground/60"
+        : isChild
+          ? "ml-1 w-3 bg-muted-foreground/20 group-hover:bg-muted-foreground/35 group-hover/item:bg-foreground/50"
+          : "w-4 bg-muted-foreground/20 group-hover:bg-muted-foreground/35 group-hover/item:bg-foreground/50";
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-current={activeState === "current" ? "true" : undefined}
+      title={label}
+      className={`group/item relative flex h-3 w-full items-center text-left leading-snug transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 ${
+        activeState === "current"
+          ? isChild
+            ? "text-[11px] text-foreground hover:text-foreground"
+            : "text-xs font-medium text-foreground hover:text-foreground"
+          : isChild
+            ? "text-[11px] text-muted-foreground/70 hover:text-foreground"
+            : "text-xs font-medium text-muted-foreground hover:text-foreground"
+      }`}
+      onClick={onClick}
+    >
+      <span
+        aria-hidden="true"
+        className={`block h-0.5 rounded-sm transition-colors ${lineClass}`}
+      />
+      <span className="absolute left-7 top-1/2 block -translate-y-1/2 translate-x-1 whitespace-nowrap opacity-0 transition duration-150 group-hover:translate-x-0 group-hover:opacity-100 group-focus-within:translate-x-0 group-focus-within:opacity-100">
+        {menuLabel}
+      </span>
+    </button>
+  );
+}
+
+function ConnectorCategoryGroupSection({
+  group,
+  renderCard,
+}: {
+  group: ConnectorCategoryGroup<ConnectorTypeWithStatus>;
+  renderCard: (connector: ConnectorTypeWithStatus) => ReactNode;
+}) {
+  if (group.kind === "group") {
+    return (
+      <section
+        key={group.id}
+        id={getConnectorCategorySectionId(group.id)}
+        className="scroll-mt-6 flex flex-col gap-4"
+        data-testid={`connector-category-${group.id}`}
+      >
+        <h2 className="text-sm font-medium text-muted-foreground">
+          {group.label}
+        </h2>
+        <div className="flex flex-col gap-5">
+          {group.sections.map((section) => {
+            return (
+              <div
+                key={section.category}
+                id={getConnectorCategorySectionId(section.category)}
+                className="scroll-mt-6 flex flex-col gap-3"
+                data-testid={`connector-category-${section.category}`}
+              >
+                <h3 className="text-xs font-medium text-muted-foreground/80">
+                  {section.label}
+                </h3>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                  {section.connectors.map(renderCard)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    );
+  }
+
+  const section = group.sections[0];
+  return (
+    <section
+      key={section.category}
+      id={getConnectorCategorySectionId(section.category)}
+      className="scroll-mt-6 flex flex-col gap-3"
+      data-testid={`connector-category-${section.category}`}
+    >
+      <h2 className="text-sm font-medium text-muted-foreground">
+        {section.label}
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {section.connectors.map(renderCard)}
+      </div>
+    </section>
+  );
+}
 
 function GlobalConnectorCard({
   connector,
@@ -283,6 +531,7 @@ function AvailableConnectorCard({
 }
 
 export function ZeroConnectorsPage() {
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
   const pollingType = useGet(pollingConnectorType$);
   const connect = useSet(connectConnector$);
@@ -299,6 +548,10 @@ export function ZeroConnectorsPage() {
   const setActiveTab = useSet(setConnectorsPageTab$);
   const isAdmin = useLastResolved(isOrgAdmin$) ?? false;
   const openCreateCustom = useSet(openCustomConnectorCreateDialog$);
+  const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
+  const features = useLastResolved(featureSwitch$);
+  const showConnectorCategories =
+    features?.[FeatureSwitchKey.ConnectorCategories] ?? false;
 
   const search = useGet(connectorsSearch$);
   const setSearch = useSet(setConnectorsSearch$);
@@ -386,12 +639,57 @@ export function ZeroConnectorsPage() {
     );
   };
 
-  const grouped = groupConnectorsByCategory(filtered.map(getEffective));
+  const grouped = showConnectorCategories
+    ? groupConnectorsByCategory(filtered.map(getEffective))
+    : [];
+
+  useEffect(() => {
+    if (
+      activeTab !== "builtin" ||
+      allTypesLoadable.state !== "hasData" ||
+      !showConnectorCategories
+    ) {
+      setActiveCategoryId(null);
+      return;
+    }
+
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) {
+      return;
+    }
+
+    const categoryIds = getConnectorCategoryTargetIds(grouped);
+    const updateActiveCategory = () => {
+      const nextActiveId = getActiveConnectorCategoryId(
+        categoryIds,
+        scrollContainer,
+      );
+      setActiveCategoryId((previousActiveId) => {
+        return previousActiveId === nextActiveId
+          ? previousActiveId
+          : nextActiveId;
+      });
+    };
+
+    updateActiveCategory();
+    scrollContainer.addEventListener("scroll", updateActiveCategory, {
+      passive: true,
+    });
+    window.addEventListener("resize", updateActiveCategory);
+
+    return () => {
+      scrollContainer.removeEventListener("scroll", updateActiveCategory);
+      window.removeEventListener("resize", updateActiveCategory);
+    };
+  }, [activeTab, allTypesLoadable.state, grouped, showConnectorCategories]);
 
   return (
-    <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
+    <div
+      ref={scrollContainerRef}
+      className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]"
+    >
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-3 md:pt-10 pb-0 md:pb-3">
-        <div className="mx-auto max-w-[900px]">
+        <div className="mx-auto max-w-[960px]">
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div className="min-w-0 hidden md:block">
               <h1 className="text-lg font-semibold tracking-tight text-foreground">
@@ -422,84 +720,95 @@ export function ZeroConnectorsPage() {
       </header>
 
       <main className="flex-1 px-4 sm:px-6 pt-3 pb-16">
-        <div className="mx-auto max-w-[900px] flex flex-col gap-6">
-          <div className="flex items-center justify-between">
-            <Tabs
-              value={activeTab}
-              onValueChange={(v) => {
-                return setActiveTab(v === "custom" ? "custom" : "builtin");
-              }}
-            >
-              <TabsList>
-                <TabsTrigger value="builtin">Built-in</TabsTrigger>
-                <TabsTrigger value="custom">Custom</TabsTrigger>
-              </TabsList>
-            </Tabs>
-            {activeTab === "custom" && isAdmin && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="zero-btn-morandi h-9 gap-2 shrink-0 rounded-lg border"
-                onClick={openCreateCustom}
-              >
-                <IconPlus size={14} stroke={2} />
-                New connector
-              </Button>
+        <div className="relative mx-auto w-full max-w-[960px]">
+          {activeTab === "builtin" &&
+            allTypesLoadable.state === "hasData" &&
+            showConnectorCategories && (
+              <ConnectorCategoryMenu
+                activeCategoryId={activeCategoryId}
+                groups={grouped}
+              />
             )}
-          </div>
 
-          {activeTab === "builtin" && (
-            <>
-              {grouped.map((section) => {
-                return (
-                  <section
-                    key={section.category}
-                    className="flex flex-col gap-3"
-                    data-testid={`connector-category-${section.category}`}
-                  >
-                    <h2 className="text-sm font-medium text-muted-foreground">
-                      {section.label}
-                    </h2>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                      {section.connectors.map(renderCard)}
-                    </div>
-                  </section>
-                );
-              })}
-
-              {allTypesLoadable.state !== "hasData" && (
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                  {Array.from({ length: 6 }, (_, i) => {
-                    return (
-                      <div
-                        key={i}
-                        data-testid="connector-skeleton"
-                        className="zero-card flex flex-col animate-pulse"
-                      >
-                        <div className="flex h-14 items-center gap-2.5 px-5">
-                          <span className="h-5 w-5 shrink-0 rounded-lg bg-muted/50" />
-                          <span className="h-4 w-24 rounded bg-muted/50" />
-                        </div>
-                        <div className="flex h-11 items-center border-t border-border/30 px-5">
-                          <span className="h-3 w-16 rounded bg-muted/30" />
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
+          <div className="min-w-0 flex flex-col gap-6">
+            <div className="flex items-center justify-between">
+              <Tabs
+                value={activeTab}
+                onValueChange={(v) => {
+                  return setActiveTab(v === "custom" ? "custom" : "builtin");
+                }}
+              >
+                <TabsList>
+                  <TabsTrigger value="builtin">Built-in</TabsTrigger>
+                  <TabsTrigger value="custom">Custom</TabsTrigger>
+                </TabsList>
+              </Tabs>
+              {activeTab === "custom" && isAdmin && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="zero-btn-morandi h-9 gap-2 shrink-0 rounded-lg border"
+                  onClick={openCreateCustom}
+                >
+                  <IconPlus size={14} stroke={2} />
+                  New connector
+                </Button>
               )}
+            </div>
 
-              {allTypesLoadable.state === "hasData" &&
-                filtered.length === 0 &&
-                search && (
-                  <p className="py-12 text-center text-sm text-muted-foreground">
-                    No connectors matching &ldquo;{search}&rdquo;
-                  </p>
+            {activeTab === "builtin" && (
+              <>
+                {allTypesLoadable.state === "hasData" &&
+                  (showConnectorCategories ? (
+                    grouped.map((group) => {
+                      return (
+                        <ConnectorCategoryGroupSection
+                          key={group.id}
+                          group={group}
+                          renderCard={renderCard}
+                        />
+                      );
+                    })
+                  ) : (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                      {filtered.map(renderCard)}
+                    </div>
+                  ))}
+
+                {allTypesLoadable.state !== "hasData" && (
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                    {Array.from({ length: 6 }, (_, i) => {
+                      return (
+                        <div
+                          key={i}
+                          data-testid="connector-skeleton"
+                          className="zero-card flex flex-col animate-pulse"
+                        >
+                          <div className="flex h-14 items-center gap-2.5 px-5">
+                            <span className="h-5 w-5 shrink-0 rounded-lg bg-muted/50" />
+                            <span className="h-4 w-24 rounded bg-muted/50" />
+                          </div>
+                          <div className="flex h-11 items-center border-t border-border/30 px-5">
+                            <span className="h-3 w-16 rounded bg-muted/30" />
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
                 )}
-            </>
-          )}
 
-          {activeTab === "custom" && <CustomConnectorsPanel />}
+                {allTypesLoadable.state === "hasData" &&
+                  filtered.length === 0 &&
+                  search && (
+                    <p className="py-12 text-center text-sm text-muted-foreground">
+                      No connectors matching &ldquo;{search}&rdquo;
+                    </p>
+                  )}
+              </>
+            )}
+
+            {activeTab === "custom" && <CustomConnectorsPanel />}
+          </div>
         </div>
       </main>
 

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -156,6 +156,7 @@ function ConnectorCategoryMenu({
                   depth="parent"
                   label={group.label}
                   menuLabel={group.menuLabel}
+                  targetId={group.id}
                   onClick={() => {
                     scrollToConnectorCategory(group.id);
                   }}
@@ -170,6 +171,7 @@ function ConnectorCategoryMenu({
                       depth="child"
                       label={section.label}
                       menuLabel={section.menuLabel}
+                      targetId={section.category}
                       onClick={() => {
                         scrollToConnectorCategory(section.category);
                       }}
@@ -190,6 +192,7 @@ function ConnectorCategoryMenu({
               depth="parent"
               label={section.label}
               menuLabel={section.menuLabel}
+              targetId={section.category}
               onClick={() => {
                 scrollToConnectorCategory(section.category);
               }}
@@ -206,12 +209,14 @@ function ConnectorCategoryMenuItem({
   depth,
   label,
   menuLabel,
+  targetId,
   onClick,
 }: {
   activeState: "current" | "ancestor" | null;
   depth: "parent" | "child";
   label: string;
   menuLabel: string;
+  targetId: string;
   onClick: () => void;
 }) {
   const isChild = depth === "child";
@@ -231,6 +236,7 @@ function ConnectorCategoryMenuItem({
       type="button"
       aria-label={label}
       aria-current={activeState === "current" ? "true" : undefined}
+      data-testid={`connector-category-menu-${targetId}`}
       title={label}
       className={`group/item relative flex h-3 w-full items-center text-left leading-snug transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 ${
         activeState === "current"
@@ -411,7 +417,10 @@ function GlobalConnectorCard({
             />
           )}
         </span>
-        <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
+        <span
+          data-testid="connector-card-label"
+          className="min-w-0 flex-1 text-sm font-medium text-foreground truncate"
+        >
           {connector.label}
         </span>
       </div>
@@ -476,7 +485,10 @@ function AvailableConnectorCard({
             />
           )}
         </span>
-        <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
+        <span
+          data-testid="connector-card-label"
+          className="min-w-0 flex-1 text-sm font-medium text-foreground truncate"
+        >
           {connector.label}
         </span>
         {isPolling ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -46,6 +46,7 @@ import {
   matchesConnectorSearch,
   type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
+import { groupConnectorsByCategory } from "../../signals/zero-page/settings/connector-categories.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { ScopeReviewModal } from "./components/settings/scope-review-modal.tsx";
@@ -309,19 +310,6 @@ export function ZeroConnectorsPage() {
     return matchesConnectorSearch(search, c);
   });
 
-  const connected = filtered.filter((c) => {
-    if (optimisticConnected.has(c.type)) {
-      return true;
-    }
-    return c.connected;
-  });
-  const notConnected = filtered.filter((c) => {
-    if (optimisticConnected.has(c.type)) {
-      return false;
-    }
-    return !c.connected;
-  });
-
   const connectHandler = (type: ConnectorType) => {
     const ct = allConnectors.find((c) => {
       return c.type === type;
@@ -367,10 +355,23 @@ export function ZeroConnectorsPage() {
   };
 
   const renderCard = (c: ConnectorTypeWithStatus) => {
+    const effectiveConnector = getEffective(c);
+    if (!effectiveConnector.connected) {
+      return (
+        <AvailableConnectorCard
+          key={c.type}
+          connector={effectiveConnector}
+          isPolling={pollingType === c.type}
+          onConnect={() => {
+            return connectHandler(c.type);
+          }}
+        />
+      );
+    }
     return (
       <GlobalConnectorCard
         key={c.type}
-        connector={getEffective(c)}
+        connector={effectiveConnector}
         isPolling={pollingType === c.type}
         onConnect={() => {
           return connectHandler(c.type);
@@ -384,6 +385,8 @@ export function ZeroConnectorsPage() {
       />
     );
   };
+
+  const grouped = groupConnectorsByCategory(filtered.map(getEffective));
 
   return (
     <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
@@ -447,38 +450,22 @@ export function ZeroConnectorsPage() {
 
           {activeTab === "builtin" && (
             <>
-              {connected.length > 0 && (
-                <section className="flex flex-col gap-3">
-                  <h2 className="text-sm font-medium text-muted-foreground">
-                    Connected ({connected.length})
-                  </h2>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                    {connected.map(renderCard)}
-                  </div>
-                </section>
-              )}
-
-              {notConnected.length > 0 && (
-                <section className="flex flex-col gap-3">
-                  <h2 className="text-sm font-medium text-muted-foreground">
-                    Available ({notConnected.length})
-                  </h2>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                    {notConnected.map((c) => {
-                      return (
-                        <AvailableConnectorCard
-                          key={c.type}
-                          connector={c}
-                          isPolling={pollingType === c.type}
-                          onConnect={() => {
-                            return connectHandler(c.type);
-                          }}
-                        />
-                      );
-                    })}
-                  </div>
-                </section>
-              )}
+              {grouped.map((section) => {
+                return (
+                  <section
+                    key={section.category}
+                    className="flex flex-col gap-3"
+                    data-testid={`connector-category-${section.category}`}
+                  >
+                    <h2 className="text-sm font-medium text-muted-foreground">
+                      {section.label}
+                    </h2>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                      {section.connectors.map(renderCard)}
+                    </div>
+                  </section>
+                );
+              })}
 
               {allTypesLoadable.state !== "hasData" && (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -1,6 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
-import { Fragment, useEffect, useRef, useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import {
   useGet,
   useSet,
@@ -16,9 +16,9 @@ import {
 } from "@tabler/icons-react";
 import {
   CONNECTOR_TYPES,
-  FeatureSwitchKey,
   type ConnectorType,
 } from "@vm0/core/contracts/connectors";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { isGoogleOAuthConnector } from "@vm0/core/contracts/connector-utils";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
@@ -49,7 +49,12 @@ import {
   type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
 import {
+  activeConnectorCategoryId$,
+  attachConnectorCategoryScrollTracking$,
+  getConnectorCategorySectionId,
   groupConnectorsByCategory,
+  resetActiveConnectorCategory$,
+  scrollToConnectorCategory,
   type ConnectorCategoryGroup,
 } from "../../signals/zero-page/settings/connector-categories.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -71,54 +76,26 @@ import {
   TooltipTrigger,
 } from "@vm0/ui";
 
-function getConnectorCategorySectionId(category: string): string {
-  return `connector-category-${category}`;
-}
-
-function scrollToConnectorCategory(category: string): void {
-  document
-    .getElementById(getConnectorCategorySectionId(category))
-    ?.scrollIntoView({ block: "start", behavior: "smooth" });
-}
-
-function getConnectorCategoryTargetIds(
-  groups: readonly ConnectorCategoryGroup<ConnectorTypeWithStatus>[],
-): string[] {
-  return groups.flatMap((group) => {
-    if (group.kind === "group") {
-      return [
-        group.id,
-        ...group.sections.map((section) => {
-          return section.category;
-        }),
-      ];
+// Callback ref that attaches scroll tracking while enabled. Each call returns
+// a fresh ref callback; React only invokes it when the underlying element
+// changes, so listeners are registered on mount and cleaned up on unmount.
+function useScrollTrackingRef(
+  enabled: boolean,
+  attach: (el: HTMLElement) => () => void,
+  resetActive: () => void,
+) {
+  let cleanup: (() => void) | null = null;
+  return (el: HTMLDivElement | null) => {
+    if (cleanup) {
+      cleanup();
+      cleanup = null;
     }
-    return [group.sections[0].category];
-  });
-}
-
-function getActiveConnectorCategoryId(
-  categoryIds: readonly string[],
-  scrollContainer: HTMLElement,
-): string | null {
-  let activeId = categoryIds[0] ?? null;
-  const anchorY = scrollContainer.getBoundingClientRect().top + 120;
-
-  for (const categoryId of categoryIds) {
-    const element = document.getElementById(
-      getConnectorCategorySectionId(categoryId),
-    );
-    if (!element) {
-      continue;
+    if (el && enabled) {
+      cleanup = attach(el);
+    } else {
+      resetActive();
     }
-    if (element.getBoundingClientRect().top <= anchorY) {
-      activeId = categoryId;
-      continue;
-    }
-    break;
-  }
-
-  return activeId;
+  };
 }
 
 function ConnectorCategoryMenu({
@@ -138,52 +115,51 @@ function ConnectorCategoryMenu({
         aria-label="Connector categories"
         className="group pointer-events-auto sticky top-[28vh] flex flex-col gap-3 pb-3 pl-5"
       >
-        {groups.map((group) => {
+        {groups.flatMap((group) => {
           if (group.kind === "group") {
             const isActiveChild = group.sections.some((section) => {
               return activeCategoryId === section.category;
             });
-            return (
-              <Fragment key={group.id}>
-                <ConnectorCategoryMenuItem
-                  activeState={
-                    activeCategoryId === group.id
-                      ? "current"
-                      : isActiveChild
-                        ? "ancestor"
-                        : null
-                  }
-                  depth="parent"
-                  label={group.label}
-                  menuLabel={group.menuLabel}
-                  targetId={group.id}
-                  onClick={() => {
-                    scrollToConnectorCategory(group.id);
-                  }}
-                />
-                {group.sections.map((section) => {
-                  return (
-                    <ConnectorCategoryMenuItem
-                      key={section.category}
-                      activeState={
-                        activeCategoryId === section.category ? "current" : null
-                      }
-                      depth="child"
-                      label={section.label}
-                      menuLabel={section.menuLabel}
-                      targetId={section.category}
-                      onClick={() => {
-                        scrollToConnectorCategory(section.category);
-                      }}
-                    />
-                  );
-                })}
-              </Fragment>
-            );
+            return [
+              <ConnectorCategoryMenuItem
+                key={group.id}
+                activeState={
+                  activeCategoryId === group.id
+                    ? "current"
+                    : isActiveChild
+                      ? "ancestor"
+                      : null
+                }
+                depth="parent"
+                label={group.label}
+                menuLabel={group.menuLabel}
+                targetId={group.id}
+                onClick={() => {
+                  scrollToConnectorCategory(group.id);
+                }}
+              />,
+              ...group.sections.map((section) => {
+                return (
+                  <ConnectorCategoryMenuItem
+                    key={section.category}
+                    activeState={
+                      activeCategoryId === section.category ? "current" : null
+                    }
+                    depth="child"
+                    label={section.label}
+                    menuLabel={section.menuLabel}
+                    targetId={section.category}
+                    onClick={() => {
+                      scrollToConnectorCategory(section.category);
+                    }}
+                  />
+                );
+              }),
+            ];
           }
 
           const section = group.sections[0];
-          return (
+          return [
             <ConnectorCategoryMenuItem
               key={section.category}
               activeState={
@@ -196,8 +172,8 @@ function ConnectorCategoryMenu({
               onClick={() => {
                 scrollToConnectorCategory(section.category);
               }}
-            />
-          );
+            />,
+          ];
         })}
       </nav>
     </aside>
@@ -542,8 +518,73 @@ function AvailableConnectorCard({
   );
 }
 
+function renderBuiltinList({
+  loadingState,
+  showConnectorCategories,
+  grouped,
+  filtered,
+  renderCard,
+  search,
+}: {
+  loadingState: "loading" | "hasData" | "hasError";
+  showConnectorCategories: boolean;
+  grouped: ConnectorCategoryGroup<ConnectorTypeWithStatus>[];
+  filtered: ConnectorTypeWithStatus[];
+  renderCard: (connector: ConnectorTypeWithStatus) => ReactNode;
+  search: string;
+}): ReactNode {
+  if (loadingState !== "hasData") {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {Array.from({ length: 6 }, (_, i) => {
+          return (
+            <div
+              key={i}
+              data-testid="connector-skeleton"
+              className="zero-card flex flex-col animate-pulse"
+            >
+              <div className="flex h-14 items-center gap-2.5 px-5">
+                <span className="h-5 w-5 shrink-0 rounded-lg bg-muted/50" />
+                <span className="h-4 w-24 rounded bg-muted/50" />
+              </div>
+              <div className="flex h-11 items-center border-t border-border/30 px-5">
+                <span className="h-3 w-16 rounded bg-muted/30" />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (filtered.length === 0 && search) {
+    return (
+      <p className="py-12 text-center text-sm text-muted-foreground">
+        No connectors matching &ldquo;{search}&rdquo;
+      </p>
+    );
+  }
+
+  if (showConnectorCategories) {
+    return grouped.map((group) => {
+      return (
+        <ConnectorCategoryGroupSection
+          key={group.id}
+          group={group}
+          renderCard={renderCard}
+        />
+      );
+    });
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {filtered.map(renderCard)}
+    </div>
+  );
+}
+
 export function ZeroConnectorsPage() {
-  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
   const pollingType = useGet(pollingConnectorType$);
   const connect = useSet(connectConnector$);
@@ -560,10 +601,21 @@ export function ZeroConnectorsPage() {
   const setActiveTab = useSet(setConnectorsPageTab$);
   const isAdmin = useLastResolved(isOrgAdmin$) ?? false;
   const openCreateCustom = useSet(openCustomConnectorCreateDialog$);
-  const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
+  const activeCategoryId = useGet(activeConnectorCategoryId$);
+  const attachScrollTracking = useSet(attachConnectorCategoryScrollTracking$);
+  const resetActiveCategory = useSet(resetActiveConnectorCategory$);
   const features = useLastResolved(featureSwitch$);
   const showConnectorCategories =
     features?.[FeatureSwitchKey.ConnectorCategories] ?? false;
+  const categoryTrackingEnabled =
+    activeTab === "builtin" &&
+    allTypesLoadable.state === "hasData" &&
+    showConnectorCategories;
+  const scrollContainerRef = useScrollTrackingRef(
+    categoryTrackingEnabled,
+    attachScrollTracking,
+    resetActiveCategory,
+  );
 
   const search = useGet(connectorsSearch$);
   const setSearch = useSet(setConnectorsSearch$);
@@ -655,45 +707,14 @@ export function ZeroConnectorsPage() {
     ? groupConnectorsByCategory(filtered.map(getEffective))
     : [];
 
-  useEffect(() => {
-    if (
-      activeTab !== "builtin" ||
-      allTypesLoadable.state !== "hasData" ||
-      !showConnectorCategories
-    ) {
-      setActiveCategoryId(null);
-      return;
-    }
-
-    const scrollContainer = scrollContainerRef.current;
-    if (!scrollContainer) {
-      return;
-    }
-
-    const categoryIds = getConnectorCategoryTargetIds(grouped);
-    const updateActiveCategory = () => {
-      const nextActiveId = getActiveConnectorCategoryId(
-        categoryIds,
-        scrollContainer,
-      );
-      setActiveCategoryId((previousActiveId) => {
-        return previousActiveId === nextActiveId
-          ? previousActiveId
-          : nextActiveId;
-      });
-    };
-
-    updateActiveCategory();
-    scrollContainer.addEventListener("scroll", updateActiveCategory, {
-      passive: true,
-    });
-    window.addEventListener("resize", updateActiveCategory);
-
-    return () => {
-      scrollContainer.removeEventListener("scroll", updateActiveCategory);
-      window.removeEventListener("resize", updateActiveCategory);
-    };
-  }, [activeTab, allTypesLoadable.state, grouped, showConnectorCategories]);
+  const builtinList = renderBuiltinList({
+    loadingState: allTypesLoadable.state,
+    showConnectorCategories,
+    grouped,
+    filtered,
+    renderCard,
+    search,
+  });
 
   return (
     <div
@@ -768,56 +789,7 @@ export function ZeroConnectorsPage() {
               )}
             </div>
 
-            {activeTab === "builtin" && (
-              <>
-                {allTypesLoadable.state === "hasData" &&
-                  (showConnectorCategories ? (
-                    grouped.map((group) => {
-                      return (
-                        <ConnectorCategoryGroupSection
-                          key={group.id}
-                          group={group}
-                          renderCard={renderCard}
-                        />
-                      );
-                    })
-                  ) : (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                      {filtered.map(renderCard)}
-                    </div>
-                  ))}
-
-                {allTypesLoadable.state !== "hasData" && (
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                    {Array.from({ length: 6 }, (_, i) => {
-                      return (
-                        <div
-                          key={i}
-                          data-testid="connector-skeleton"
-                          className="zero-card flex flex-col animate-pulse"
-                        >
-                          <div className="flex h-14 items-center gap-2.5 px-5">
-                            <span className="h-5 w-5 shrink-0 rounded-lg bg-muted/50" />
-                            <span className="h-4 w-24 rounded bg-muted/50" />
-                          </div>
-                          <div className="flex h-11 items-center border-t border-border/30 px-5">
-                            <span className="h-3 w-16 rounded bg-muted/30" />
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-
-                {allTypesLoadable.state === "hasData" &&
-                  filtered.length === 0 &&
-                  search && (
-                    <p className="py-12 text-center text-sm text-muted-foreground">
-                      No connectors matching &ldquo;{search}&rdquo;
-                    </p>
-                  )}
-              </>
-            )}
+            {activeTab === "builtin" && builtinList}
 
             {activeTab === "custom" && <CustomConnectorsPanel />}
           </div>

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -73,6 +73,7 @@ describe("getAllFeatureStates", () => {
     });
     // PlatformConnectors has STAFF_ORG_ID_HASHES and should be true
     expect(states[FeatureSwitchKey.PlatformConnectors]).toBe(true);
+    expect(states[FeatureSwitchKey.ConnectorCategories]).toBe(true);
     // Globally enabled should still be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
     // Switches without org hashes should remain false
@@ -84,6 +85,7 @@ describe("getAllFeatureStates", () => {
       orgId: "org_nonexistent",
     });
     expect(states[FeatureSwitchKey.PlatformConnectors]).toBe(false);
+    expect(states[FeatureSwitchKey.ConnectorCategories]).toBe(false);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -225,12 +225,111 @@ export type ConnectorAuthMethodType =
   | "api"
   | "platform";
 
+export type ConnectorDisplayCategory =
+  | "ai-general-models"
+  | "ai-image-video"
+  | "ai-voice-audio"
+  | "ai-agent-apps"
+  | "ai-memory-tracing-eval"
+  | "communication-collaboration"
+  | "meetings-scheduling"
+  | "docs-files-knowledge"
+  | "engineering-team-execution"
+  | "sales-crm-business-operations"
+  | "marketing-content-growth"
+  | "data-automation-infrastructure";
+
+export type ConnectorDisplayCategoryGroup = "ai";
+
+export const CONNECTOR_DISPLAY_CATEGORY_GROUPS: Record<
+  ConnectorDisplayCategoryGroup,
+  { label: string; menuLabel: string }
+> = {
+  ai: { label: "AI", menuLabel: "AI" },
+};
+
+export const CONNECTOR_DISPLAY_CATEGORY_META: Record<
+  ConnectorDisplayCategory,
+  { label: string; menuLabel: string; group?: ConnectorDisplayCategoryGroup }
+> = {
+  "ai-general-models": {
+    label: "General Models and Reasoning",
+    menuLabel: "General Models",
+    group: "ai",
+  },
+  "ai-image-video": {
+    label: "Image / Video Generation",
+    menuLabel: "Image and Video",
+    group: "ai",
+  },
+  "ai-voice-audio": {
+    label: "Voice / Audio",
+    menuLabel: "Voice and Audio",
+    group: "ai",
+  },
+  "ai-agent-apps": {
+    label: "Agent Platforms and AI Apps",
+    menuLabel: "Agent Platforms",
+    group: "ai",
+  },
+  "ai-memory-tracing-eval": {
+    label: "Memory / Tracing / Evaluation",
+    menuLabel: "Memory and Evaluation",
+    group: "ai",
+  },
+  "communication-collaboration": {
+    label: "Communication and Collaboration",
+    menuLabel: "Communication",
+  },
+  "meetings-scheduling": {
+    label: "Meetings and Scheduling",
+    menuLabel: "Meetings",
+  },
+  "docs-files-knowledge": {
+    label: "Docs, Files, and Knowledge",
+    menuLabel: "Documents",
+  },
+  "engineering-team-execution": {
+    label: "Engineering and Team Execution",
+    menuLabel: "Engineering",
+  },
+  "sales-crm-business-operations": {
+    label: "Sales, CRM, and Business Operations",
+    menuLabel: "Sales and Business",
+  },
+  "marketing-content-growth": {
+    label: "Marketing, Content, and Growth",
+    menuLabel: "Marketing",
+  },
+  "data-automation-infrastructure": {
+    label: "Data, Automation, and Infrastructure",
+    menuLabel: "Data and Automation",
+  },
+};
+
+export const CONNECTOR_DISPLAY_CATEGORY_ORDER: readonly ConnectorDisplayCategory[] =
+  [
+    "ai-general-models",
+    "ai-image-video",
+    "ai-voice-audio",
+    "ai-agent-apps",
+    "ai-memory-tracing-eval",
+    "communication-collaboration",
+    "meetings-scheduling",
+    "docs-files-knowledge",
+    "engineering-team-execution",
+    "sales-crm-business-operations",
+    "marketing-content-growth",
+    "data-automation-infrastructure",
+  ];
+
 /**
  * Base configuration shape for all connector types.
  */
 export interface ConnectorConfig {
   readonly label: string;
   readonly helpText: string;
+  readonly category: ConnectorDisplayCategory;
   readonly featureFlag?: FeatureSwitchKey;
   /**
    * When true, the featureFlag gates this connector even when it has api-token

--- a/turbo/packages/core/src/contracts/connectors/agentmail.ts
+++ b/turbo/packages/core/src/contracts/connectors/agentmail.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const agentmail = {
   agentmail: {
     label: "AgentMail",
+    category: "communication-collaboration",
     environmentMapping: {
       AGENTMAIL_TOKEN: "$secrets.AGENTMAIL_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/ahrefs.ts
+++ b/turbo/packages/core/src/contracts/connectors/ahrefs.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const ahrefs = {
   ahrefs: {
     label: "Ahrefs",
+    category: "marketing-content-growth",
     environmentMapping: {
       AHREFS_TOKEN: "$secrets.AHREFS_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/airtable.ts
+++ b/turbo/packages/core/src/contracts/connectors/airtable.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const airtable = {
   airtable: {
     label: "Airtable",
+    category: "docs-files-knowledge",
     environmentMapping: {
       AIRTABLE_TOKEN: "$secrets.AIRTABLE_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/amplitude.ts
+++ b/turbo/packages/core/src/contracts/connectors/amplitude.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const amplitude = {
   amplitude: {
     label: "Amplitude",
+    category: "data-automation-infrastructure",
     tags: ["analytics", "product-analytics", "events", "funnels"],
     environmentMapping: {
       AMPLITUDE_API_KEY: "$secrets.AMPLITUDE_API_KEY",

--- a/turbo/packages/core/src/contracts/connectors/anthropic-managed-agents.ts
+++ b/turbo/packages/core/src/contracts/connectors/anthropic-managed-agents.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const anthropicManagedAgents = {
   "anthropic-managed-agents": {
     label: "Anthropic Managed Agents",
+    category: "ai-agent-apps",
     environmentMapping: {
       ANTHROPIC_MANAGED_AGENTS_TOKEN: "$secrets.ANTHROPIC_MANAGED_AGENTS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/apify.ts
+++ b/turbo/packages/core/src/contracts/connectors/apify.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const apify = {
   apify: {
     label: "Apify",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       APIFY_TOKEN: "$secrets.APIFY_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/apollo.ts
+++ b/turbo/packages/core/src/contracts/connectors/apollo.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const apollo = {
   apollo: {
     label: "Apollo",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       APOLLO_TOKEN: "$secrets.APOLLO_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/asana.ts
+++ b/turbo/packages/core/src/contracts/connectors/asana.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const asana = {
   asana: {
     label: "Asana",
+    category: "engineering-team-execution",
     environmentMapping: {
       ASANA_TOKEN: "$secrets.ASANA_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/atlassian.ts
+++ b/turbo/packages/core/src/contracts/connectors/atlassian.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const atlassian = {
   atlassian: {
     label: "Atlassian (Jira/Confluence)",
+    category: "engineering-team-execution",
     environmentMapping: {
       ATLASSIAN_TOKEN: "$secrets.ATLASSIAN_TOKEN",
       ATLASSIAN_EMAIL: "$vars.ATLASSIAN_EMAIL",

--- a/turbo/packages/core/src/contracts/connectors/attio.ts
+++ b/turbo/packages/core/src/contracts/connectors/attio.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const attio = {
   attio: {
     label: "Attio",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       ATTIO_TOKEN: "$secrets.ATTIO_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/axiom.ts
+++ b/turbo/packages/core/src/contracts/connectors/axiom.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const axiom = {
   axiom: {
     label: "Axiom",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       AXIOM_TOKEN: "$secrets.AXIOM_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/bitrix.ts
+++ b/turbo/packages/core/src/contracts/connectors/bitrix.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const bitrix = {
   bitrix: {
     label: "Bitrix24",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       BITRIX_WEBHOOK_URL: "$secrets.BITRIX_WEBHOOK_URL",
     },

--- a/turbo/packages/core/src/contracts/connectors/brave-search.ts
+++ b/turbo/packages/core/src/contracts/connectors/brave-search.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const braveSearch = {
   "brave-search": {
     label: "Brave Search",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       BRAVE_API_KEY: "$secrets.BRAVE_API_KEY",
     },

--- a/turbo/packages/core/src/contracts/connectors/brevo.ts
+++ b/turbo/packages/core/src/contracts/connectors/brevo.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const brevo = {
   brevo: {
     label: "Brevo",
+    category: "communication-collaboration",
     environmentMapping: {
       BREVO_TOKEN: "$secrets.BREVO_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/bright-data.ts
+++ b/turbo/packages/core/src/contracts/connectors/bright-data.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const brightData = {
   "bright-data": {
     label: "Bright Data",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       BRIGHTDATA_TOKEN: "$secrets.BRIGHTDATA_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/browser-use.ts
+++ b/turbo/packages/core/src/contracts/connectors/browser-use.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const browserUse = {
   "browser-use": {
     label: "Browser Use",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       BROWSER_USE_TOKEN: "$secrets.BROWSER_USE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/browserbase.ts
+++ b/turbo/packages/core/src/contracts/connectors/browserbase.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const browserbase = {
   browserbase: {
     label: "Browserbase",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       BROWSERBASE_TOKEN: "$secrets.BROWSERBASE_TOKEN",
       BROWSERBASE_PROJECT_ID: "$vars.BROWSERBASE_PROJECT_ID",

--- a/turbo/packages/core/src/contracts/connectors/browserless.ts
+++ b/turbo/packages/core/src/contracts/connectors/browserless.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const browserless = {
   browserless: {
     label: "Browserless",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       BROWSERLESS_TOKEN: "$secrets.BROWSERLESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/buffer.ts
+++ b/turbo/packages/core/src/contracts/connectors/buffer.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const buffer = {
   buffer: {
     label: "Buffer",
+    category: "marketing-content-growth",
     environmentMapping: {
       BUFFER_TOKEN: "$secrets.BUFFER_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/cal-com.ts
+++ b/turbo/packages/core/src/contracts/connectors/cal-com.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const calCom = {
   "cal-com": {
     label: "Cal.com",
+    category: "meetings-scheduling",
     environmentMapping: {
       CALCOM_TOKEN: "$secrets.CALCOM_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/calendly.ts
+++ b/turbo/packages/core/src/contracts/connectors/calendly.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const calendly = {
   calendly: {
     label: "Calendly",
+    category: "meetings-scheduling",
     environmentMapping: {
       CALENDLY_TOKEN: "$secrets.CALENDLY_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/canva.ts
+++ b/turbo/packages/core/src/contracts/connectors/canva.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const canva = {
   canva: {
     label: "Canva",
+    category: "docs-files-knowledge",
     environmentMapping: {
       CANVA_TOKEN: "$secrets.CANVA_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/chatwoot.ts
+++ b/turbo/packages/core/src/contracts/connectors/chatwoot.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const chatwoot = {
   chatwoot: {
     label: "Chatwoot",
+    category: "communication-collaboration",
     environmentMapping: {
       CHATWOOT_TOKEN: "$secrets.CHATWOOT_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/clickup.ts
+++ b/turbo/packages/core/src/contracts/connectors/clickup.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const clickup = {
   clickup: {
     label: "ClickUp",
+    category: "engineering-team-execution",
     environmentMapping: {
       CLICKUP_TOKEN: "$secrets.CLICKUP_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/close.ts
+++ b/turbo/packages/core/src/contracts/connectors/close.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const close = {
   close: {
     label: "Close",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       CLOSE_TOKEN: "$secrets.CLOSE_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/cloudflare.ts
+++ b/turbo/packages/core/src/contracts/connectors/cloudflare.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const cloudflare = {
   cloudflare: {
     label: "Cloudflare",
+    category: "engineering-team-execution",
     environmentMapping: {
       CLOUDFLARE_TOKEN: "$secrets.CLOUDFLARE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/cloudinary.ts
+++ b/turbo/packages/core/src/contracts/connectors/cloudinary.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const cloudinary = {
   cloudinary: {
     label: "Cloudinary",
+    category: "marketing-content-growth",
     environmentMapping: {
       CLOUDINARY_TOKEN: "$secrets.CLOUDINARY_TOKEN",
       CLOUDINARY_API_SECRET: "$secrets.CLOUDINARY_API_SECRET",

--- a/turbo/packages/core/src/contracts/connectors/coda.ts
+++ b/turbo/packages/core/src/contracts/connectors/coda.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const coda = {
   coda: {
     label: "Coda",
+    category: "docs-files-knowledge",
     environmentMapping: {
       CODA_TOKEN: "$secrets.CODA_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/computer.ts
+++ b/turbo/packages/core/src/contracts/connectors/computer.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const computer = {
   computer: {
     label: "Computer",
+    category: "engineering-team-execution",
     environmentMapping: {
       COMPUTER_CONNECTOR_BRIDGE_TOKEN:
         "$secrets.COMPUTER_CONNECTOR_BRIDGE_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/cronlytic.ts
+++ b/turbo/packages/core/src/contracts/connectors/cronlytic.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const cronlytic = {
   cronlytic: {
     label: "Cronlytic",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       CRONLYTIC_API_KEY: "$secrets.CRONLYTIC_API_KEY",
       CRONLYTIC_USER_ID: "$vars.CRONLYTIC_USER_ID",

--- a/turbo/packages/core/src/contracts/connectors/customer-io.ts
+++ b/turbo/packages/core/src/contracts/connectors/customer-io.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const customerIo = {
   "customer-io": {
     label: "Customer.io",
+    category: "communication-collaboration",
     environmentMapping: {
       CUSTOMERIO_APP_TOKEN: "$secrets.CUSTOMERIO_APP_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/db9.ts
+++ b/turbo/packages/core/src/contracts/connectors/db9.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const db9 = {
   db9: {
     label: "db9",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       DB9_API_KEY: "$secrets.DB9_API_KEY",
     },

--- a/turbo/packages/core/src/contracts/connectors/deel.ts
+++ b/turbo/packages/core/src/contracts/connectors/deel.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const deel = {
   deel: {
     label: "Deel",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       DEEL_TOKEN: "$secrets.DEEL_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/deepseek.ts
+++ b/turbo/packages/core/src/contracts/connectors/deepseek.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const deepseek = {
   deepseek: {
     label: "DeepSeek",
+    category: "ai-general-models",
     environmentMapping: {
       DEEPSEEK_TOKEN: "$secrets.DEEPSEEK_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/devto.ts
+++ b/turbo/packages/core/src/contracts/connectors/devto.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const devto = {
   devto: {
     label: "Dev.to",
+    category: "marketing-content-growth",
     environmentMapping: {
       DEVTO_TOKEN: "$secrets.DEVTO_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/dify.ts
+++ b/turbo/packages/core/src/contracts/connectors/dify.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const dify = {
   dify: {
     label: "Dify",
+    category: "ai-agent-apps",
     environmentMapping: {
       DIFY_TOKEN: "$secrets.DIFY_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/discord-webhook.ts
+++ b/turbo/packages/core/src/contracts/connectors/discord-webhook.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const discordWebhook = {
   "discord-webhook": {
     label: "Discord Webhook",
+    category: "communication-collaboration",
     environmentMapping: {
       DISCORD_WEBHOOK_URL: "$secrets.DISCORD_WEBHOOK_URL",
     },

--- a/turbo/packages/core/src/contracts/connectors/discord.ts
+++ b/turbo/packages/core/src/contracts/connectors/discord.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const discord = {
   discord: {
     label: "Discord",
+    category: "communication-collaboration",
     environmentMapping: {
       DISCORD_BOT_TOKEN: "$secrets.DISCORD_BOT_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/docusign.ts
+++ b/turbo/packages/core/src/contracts/connectors/docusign.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const docusign = {
   docusign: {
     label: "DocuSign",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       DOCUSIGN_TOKEN: "$secrets.DOCUSIGN_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/doppler.ts
+++ b/turbo/packages/core/src/contracts/connectors/doppler.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const doppler = {
   doppler: {
     label: "Doppler",
+    category: "engineering-team-execution",
     environmentMapping: {
       DOPPLER_TOKEN: "$secrets.DOPPLER_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/drive9.ts
+++ b/turbo/packages/core/src/contracts/connectors/drive9.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const drive9 = {
   drive9: {
     label: "drive9",
+    category: "docs-files-knowledge",
     environmentMapping: {
       DRIVE9_TOKEN: "$secrets.DRIVE9_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/dropbox-sign.ts
+++ b/turbo/packages/core/src/contracts/connectors/dropbox-sign.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const dropboxSign = {
   "dropbox-sign": {
     label: "Dropbox Sign",
+    category: "data-automation-infrastructure",
     tags: ["hellosign", "e-signature", "signature", "sign", "document"],
     environmentMapping: {
       DROPBOX_SIGN_TOKEN: "$secrets.DROPBOX_SIGN_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/dropbox.ts
+++ b/turbo/packages/core/src/contracts/connectors/dropbox.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const dropbox = {
   dropbox: {
     label: "Dropbox",
+    category: "docs-files-knowledge",
     environmentMapping: {
       DROPBOX_TOKEN: "$secrets.DROPBOX_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/duffel.ts
+++ b/turbo/packages/core/src/contracts/connectors/duffel.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const duffel = {
   duffel: {
     label: "Duffel",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       DUFFEL_TOKEN: "$secrets.DUFFEL_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/e2b.ts
+++ b/turbo/packages/core/src/contracts/connectors/e2b.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const e2b = {
   e2b: {
     label: "E2B",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       E2B_TOKEN: "$secrets.E2B_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/elevenlabs.ts
+++ b/turbo/packages/core/src/contracts/connectors/elevenlabs.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const elevenlabs = {
   elevenlabs: {
     label: "ElevenLabs",
+    category: "ai-voice-audio",
     environmentMapping: {
       ELEVENLABS_TOKEN: "$secrets.ELEVENLABS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/etsy.ts
+++ b/turbo/packages/core/src/contracts/connectors/etsy.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const etsy = {
   etsy: {
     label: "Etsy",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       ETSY_TOKEN: "$secrets.ETSY_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/exa.ts
+++ b/turbo/packages/core/src/contracts/connectors/exa.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const exa = {
   exa: {
     label: "Exa",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       EXA_TOKEN: "$secrets.EXA_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/explorium.ts
+++ b/turbo/packages/core/src/contracts/connectors/explorium.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const explorium = {
   explorium: {
     label: "Explorium",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       EXPLORIUM_TOKEN: "$secrets.EXPLORIUM_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/fal.ts
+++ b/turbo/packages/core/src/contracts/connectors/fal.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const fal = {
   fal: {
     label: "fal.ai",
+    category: "ai-image-video",
     environmentMapping: {
       FAL_TOKEN: "$secrets.FAL_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/figma.ts
+++ b/turbo/packages/core/src/contracts/connectors/figma.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const figma = {
   figma: {
     label: "Figma",
+    category: "docs-files-knowledge",
     environmentMapping: {
       FIGMA_TOKEN: "$secrets.FIGMA_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/firecrawl.ts
+++ b/turbo/packages/core/src/contracts/connectors/firecrawl.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const firecrawl = {
   firecrawl: {
     label: "Firecrawl",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       FIRECRAWL_TOKEN: "$secrets.FIRECRAWL_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/fireflies.ts
+++ b/turbo/packages/core/src/contracts/connectors/fireflies.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const fireflies = {
   fireflies: {
     label: "Fireflies",
+    category: "meetings-scheduling",
     environmentMapping: {
       FIREFLIES_TOKEN: "$secrets.FIREFLIES_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/freshdesk.ts
+++ b/turbo/packages/core/src/contracts/connectors/freshdesk.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const freshdesk = {
   freshdesk: {
     label: "Freshdesk",
+    category: "communication-collaboration",
     tags: ["helpdesk", "tickets", "customer-support"],
     environmentMapping: {
       FRESHDESK_TOKEN: "$secrets.FRESHDESK_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/gamma.ts
+++ b/turbo/packages/core/src/contracts/connectors/gamma.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const gamma = {
   gamma: {
     label: "Gamma",
+    category: "marketing-content-growth",
     environmentMapping: {
       GAMMA_TOKEN: "$secrets.GAMMA_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/garmin-connect.ts
+++ b/turbo/packages/core/src/contracts/connectors/garmin-connect.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const garminConnect = {
   "garmin-connect": {
     label: "Garmin Connect",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       GARMIN_CONNECT_TOKEN: "$secrets.GARMIN_CONNECT_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/github.ts
+++ b/turbo/packages/core/src/contracts/connectors/github.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const github = {
   github: {
     label: "GitHub",
+    category: "engineering-team-execution",
     tags: ["gh", "gh_api_key", "git", "vcs", "scm", "repos"],
     environmentMapping: {
       GH_TOKEN: "$secrets.GITHUB_ACCESS_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/gitlab.ts
+++ b/turbo/packages/core/src/contracts/connectors/gitlab.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const gitlab = {
   gitlab: {
     label: "GitLab",
+    category: "engineering-team-execution",
     tags: ["git", "vcs", "scm", "repos"],
     environmentMapping: {
       GITLAB_TOKEN: "$secrets.GITLAB_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/gmail.ts
+++ b/turbo/packages/core/src/contracts/connectors/gmail.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const gmail = {
   gmail: {
     label: "Gmail",
+    category: "communication-collaboration",
     tags: ["email", "mail"],
     environmentMapping: {
       GMAIL_TOKEN: "$secrets.GMAIL_ACCESS_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/google-calendar.ts
+++ b/turbo/packages/core/src/contracts/connectors/google-calendar.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const googleCalendar = {
   "google-calendar": {
     label: "Google Calendar",
+    category: "meetings-scheduling",
     tags: ["calendar", "scheduling", "gcal"],
     environmentMapping: {
       GOOGLE_CALENDAR_TOKEN: "$secrets.GOOGLE_CALENDAR_ACCESS_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/google-docs.ts
+++ b/turbo/packages/core/src/contracts/connectors/google-docs.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const googleDocs = {
   "google-docs": {
     label: "Google Docs",
+    category: "docs-files-knowledge",
     environmentMapping: {
       GOOGLE_DOCS_TOKEN: "$secrets.GOOGLE_DOCS_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/google-drive.ts
+++ b/turbo/packages/core/src/contracts/connectors/google-drive.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const googleDrive = {
   "google-drive": {
     label: "Google Drive",
+    category: "docs-files-knowledge",
     environmentMapping: {
       GOOGLE_DRIVE_TOKEN: "$secrets.GOOGLE_DRIVE_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/google-meet.ts
+++ b/turbo/packages/core/src/contracts/connectors/google-meet.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const googleMeet = {
   "google-meet": {
     label: "Google Meet",
+    category: "meetings-scheduling",
     environmentMapping: {
       GOOGLE_MEET_TOKEN: "$secrets.GOOGLE_MEET_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/google-sheets.ts
+++ b/turbo/packages/core/src/contracts/connectors/google-sheets.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const googleSheets = {
   "google-sheets": {
     label: "Google Sheets",
+    category: "docs-files-knowledge",
     environmentMapping: {
       GOOGLE_SHEETS_TOKEN: "$secrets.GOOGLE_SHEETS_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/granola.ts
+++ b/turbo/packages/core/src/contracts/connectors/granola.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const granola = {
   granola: {
     label: "Granola",
+    category: "meetings-scheduling",
     environmentMapping: {
       GRANOLA_TOKEN: "$secrets.GRANOLA_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/greenhouse.ts
+++ b/turbo/packages/core/src/contracts/connectors/greenhouse.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const greenhouse = {
   greenhouse: {
     label: "Greenhouse",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       GREENHOUSE_TOKEN: "$secrets.GREENHOUSE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/groq.ts
+++ b/turbo/packages/core/src/contracts/connectors/groq.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const groq = {
   groq: {
     label: "Groq",
+    category: "ai-general-models",
     tags: ["llm", "ai", "llama", "inference"],
     environmentMapping: {
       GROQ_TOKEN: "$secrets.GROQ_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/helicone.ts
+++ b/turbo/packages/core/src/contracts/connectors/helicone.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const helicone = {
   helicone: {
     label: "Helicone",
+    category: "ai-memory-tracing-eval",
     helpText:
       "Connect to Helicone for LLM cost tracking, request logging, and performance analytics.",
     environmentMapping: {

--- a/turbo/packages/core/src/contracts/connectors/heygen.ts
+++ b/turbo/packages/core/src/contracts/connectors/heygen.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const heygen = {
   heygen: {
     label: "HeyGen",
+    category: "marketing-content-growth",
     environmentMapping: {
       HEYGEN_TOKEN: "$secrets.HEYGEN_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/htmlcsstoimage.ts
+++ b/turbo/packages/core/src/contracts/connectors/htmlcsstoimage.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const htmlcsstoimage = {
   htmlcsstoimage: {
     label: "HTML/CSS to Image",
+    category: "marketing-content-growth",
     environmentMapping: {
       HCTI_API_KEY: "$secrets.HCTI_API_KEY",
       HCTI_USER_ID: "$vars.HCTI_USER_ID",

--- a/turbo/packages/core/src/contracts/connectors/hubspot.ts
+++ b/turbo/packages/core/src/contracts/connectors/hubspot.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const hubspot = {
   hubspot: {
     label: "HubSpot",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       HUBSPOT_TOKEN: "$secrets.HUBSPOT_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/hugging-face.ts
+++ b/turbo/packages/core/src/contracts/connectors/hugging-face.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const huggingFace = {
   "hugging-face": {
     label: "Hugging Face",
+    category: "ai-general-models",
     environmentMapping: {
       HUGGING_FACE_TOKEN: "$secrets.HUGGING_FACE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/hume.ts
+++ b/turbo/packages/core/src/contracts/connectors/hume.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const hume = {
   hume: {
     label: "Hume",
+    category: "ai-voice-audio",
     environmentMapping: {
       HUME_TOKEN: "$secrets.HUME_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/imgur.ts
+++ b/turbo/packages/core/src/contracts/connectors/imgur.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const imgur = {
   imgur: {
     label: "Imgur",
+    category: "marketing-content-growth",
     environmentMapping: {
       IMGUR_CLIENT_ID: "$secrets.IMGUR_CLIENT_ID",
     },

--- a/turbo/packages/core/src/contracts/connectors/infisical.ts
+++ b/turbo/packages/core/src/contracts/connectors/infisical.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const infisical = {
   infisical: {
     label: "Infisical",
+    category: "engineering-team-execution",
     environmentMapping: {
       INFISICAL_CLIENT_ID: "$secrets.INFISICAL_CLIENT_ID",
       INFISICAL_CLIENT_SECRET: "$secrets.INFISICAL_CLIENT_SECRET",

--- a/turbo/packages/core/src/contracts/connectors/instagram.ts
+++ b/turbo/packages/core/src/contracts/connectors/instagram.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const instagram = {
   instagram: {
     label: "Instagram",
+    category: "marketing-content-growth",
     environmentMapping: {
       INSTAGRAM_TOKEN: "$secrets.INSTAGRAM_TOKEN",
       INSTAGRAM_BUSINESS_ACCOUNT_ID: "$vars.INSTAGRAM_BUSINESS_ACCOUNT_ID",

--- a/turbo/packages/core/src/contracts/connectors/instantly.ts
+++ b/turbo/packages/core/src/contracts/connectors/instantly.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const instantly = {
   instantly: {
     label: "Instantly",
+    category: "communication-collaboration",
     environmentMapping: {
       INSTANTLY_API_KEY: "$secrets.INSTANTLY_API_KEY",
     },

--- a/turbo/packages/core/src/contracts/connectors/intercom.ts
+++ b/turbo/packages/core/src/contracts/connectors/intercom.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const intercom = {
   intercom: {
     label: "Intercom",
+    category: "communication-collaboration",
     environmentMapping: {
       INTERCOM_TOKEN: "$secrets.INTERCOM_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/intervals-icu.ts
+++ b/turbo/packages/core/src/contracts/connectors/intervals-icu.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const intervalsIcu = {
   "intervals-icu": {
     label: "Intervals.icu",
+    category: "meetings-scheduling",
     environmentMapping: {
       INTERVALS_ICU_TOKEN: "$secrets.INTERVALS_ICU_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/jam.ts
+++ b/turbo/packages/core/src/contracts/connectors/jam.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const jam = {
   jam: {
     label: "Jam",
+    category: "engineering-team-execution",
     environmentMapping: {
       JAM_TOKEN: "$secrets.JAM_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/jira.ts
+++ b/turbo/packages/core/src/contracts/connectors/jira.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const jira = {
   jira: {
     label: "Jira",
+    category: "engineering-team-execution",
     tags: ["issues", "tickets", "project-management"],
     environmentMapping: {
       JIRA_API_TOKEN: "$secrets.JIRA_API_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/jotform.ts
+++ b/turbo/packages/core/src/contracts/connectors/jotform.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const jotform = {
   jotform: {
     label: "Jotform",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       JOTFORM_TOKEN: "$secrets.JOTFORM_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/klaviyo.ts
+++ b/turbo/packages/core/src/contracts/connectors/klaviyo.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const klaviyo = {
   klaviyo: {
     label: "Klaviyo",
+    category: "marketing-content-growth",
     environmentMapping: {
       KLAVIYO_TOKEN: "$secrets.KLAVIYO_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/kommo.ts
+++ b/turbo/packages/core/src/contracts/connectors/kommo.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const kommo = {
   kommo: {
     label: "Kommo",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       KOMMO_API_KEY: "$secrets.KOMMO_API_KEY",
       KOMMO_SUBDOMAIN: "$vars.KOMMO_SUBDOMAIN",

--- a/turbo/packages/core/src/contracts/connectors/langfuse.ts
+++ b/turbo/packages/core/src/contracts/connectors/langfuse.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const langfuse = {
   langfuse: {
     label: "Langfuse",
+    category: "ai-memory-tracing-eval",
     tags: ["observability", "tracing", "llm", "analytics"],
     environmentMapping: {
       LANGFUSE_PUBLIC_KEY: "$secrets.LANGFUSE_PUBLIC_KEY",

--- a/turbo/packages/core/src/contracts/connectors/langsmith.ts
+++ b/turbo/packages/core/src/contracts/connectors/langsmith.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const langsmith = {
   langsmith: {
     label: "LangSmith",
+    category: "ai-memory-tracing-eval",
     helpText:
       "Connect to LangSmith for LLM tracing, evaluation, and dataset management.",
     environmentMapping: {

--- a/turbo/packages/core/src/contracts/connectors/lark.ts
+++ b/turbo/packages/core/src/contracts/connectors/lark.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const lark = {
   lark: {
     label: "Lark",
+    category: "communication-collaboration",
     environmentMapping: {
       LARK_TOKEN: "$secrets.LARK_TOKEN",
       LARK_APP_ID: "$vars.LARK_APP_ID",

--- a/turbo/packages/core/src/contracts/connectors/line.ts
+++ b/turbo/packages/core/src/contracts/connectors/line.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const line = {
   line: {
     label: "LINE",
+    category: "communication-collaboration",
     environmentMapping: {
       LINE_TOKEN: "$secrets.LINE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/linear.ts
+++ b/turbo/packages/core/src/contracts/connectors/linear.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const linear = {
   linear: {
     label: "Linear",
+    category: "engineering-team-execution",
     tags: ["issues", "tickets", "project-management"],
     environmentMapping: {
       LINEAR_TOKEN: "$secrets.LINEAR_ACCESS_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/loops.ts
+++ b/turbo/packages/core/src/contracts/connectors/loops.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const loops = {
   loops: {
     label: "Loops",
+    category: "communication-collaboration",
     environmentMapping: {
       LOOPS_TOKEN: "$secrets.LOOPS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/luma.ts
+++ b/turbo/packages/core/src/contracts/connectors/luma.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const luma = {
   luma: {
     label: "Luma AI",
+    category: "ai-image-video",
     environmentMapping: {
       LUMA_TOKEN: "$secrets.LUMA_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/mailchimp.ts
+++ b/turbo/packages/core/src/contracts/connectors/mailchimp.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const mailchimp = {
   mailchimp: {
     label: "Mailchimp",
+    category: "communication-collaboration",
     environmentMapping: {
       MAILCHIMP_TOKEN: "$secrets.MAILCHIMP_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/mailsac.ts
+++ b/turbo/packages/core/src/contracts/connectors/mailsac.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const mailsac = {
   mailsac: {
     label: "Mailsac",
+    category: "communication-collaboration",
     environmentMapping: {
       MAILSAC_TOKEN: "$secrets.MAILSAC_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/make.ts
+++ b/turbo/packages/core/src/contracts/connectors/make.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const make = {
   make: {
     label: "Make",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       MAKE_TOKEN: "$secrets.MAKE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/manus.ts
+++ b/turbo/packages/core/src/contracts/connectors/manus.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const manus = {
   manus: {
     label: "Manus",
+    category: "ai-agent-apps",
     environmentMapping: {
       MANUS_TOKEN: "$secrets.MANUS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/mem0.ts
+++ b/turbo/packages/core/src/contracts/connectors/mem0.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const mem0 = {
   mem0: {
     label: "Mem0",
+    category: "ai-memory-tracing-eval",
     helpText:
       "Connect to Mem0 for persistent AI memory across conversations and sessions.",
     environmentMapping: { MEM0_TOKEN: "$secrets.MEM0_TOKEN" },

--- a/turbo/packages/core/src/contracts/connectors/mercury.ts
+++ b/turbo/packages/core/src/contracts/connectors/mercury.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const mercury = {
   mercury: {
     label: "Mercury",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       MERCURY_TOKEN: "$secrets.MERCURY_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/meta-ads.ts
+++ b/turbo/packages/core/src/contracts/connectors/meta-ads.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const metaAds = {
   "meta-ads": {
     label: "Meta Ads",
+    category: "marketing-content-growth",
     environmentMapping: {
       META_ADS_TOKEN: "$secrets.META_ADS_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/metabase.ts
+++ b/turbo/packages/core/src/contracts/connectors/metabase.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const metabase = {
   metabase: {
     label: "Metabase",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       METABASE_TOKEN: "$secrets.METABASE_TOKEN",
       METABASE_BASE_URL: "$vars.METABASE_BASE_URL",

--- a/turbo/packages/core/src/contracts/connectors/minimax.ts
+++ b/turbo/packages/core/src/contracts/connectors/minimax.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const minimax = {
   minimax: {
     label: "MiniMax",
+    category: "ai-general-models",
     environmentMapping: {
       MINIMAX_TOKEN: "$secrets.MINIMAX_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/minio.ts
+++ b/turbo/packages/core/src/contracts/connectors/minio.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const minio = {
   minio: {
     label: "MinIO",
+    category: "docs-files-knowledge",
     environmentMapping: {
       MINIO_TOKEN: "$secrets.MINIO_TOKEN",
       MINIO_SECRET_TOKEN: "$secrets.MINIO_SECRET_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/miro.ts
+++ b/turbo/packages/core/src/contracts/connectors/miro.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const miro = {
   miro: {
     label: "Miro",
+    category: "docs-files-knowledge",
     environmentMapping: {
       MIRO_TOKEN: "$secrets.MIRO_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/mixpanel.ts
+++ b/turbo/packages/core/src/contracts/connectors/mixpanel.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const mixpanel = {
   mixpanel: {
     label: "Mixpanel",
+    category: "data-automation-infrastructure",
     tags: ["analytics", "product-analytics", "events"],
     environmentMapping: {
       MIXPANEL_SERVICE_ACCOUNT_USERNAME:

--- a/turbo/packages/core/src/contracts/connectors/monday.ts
+++ b/turbo/packages/core/src/contracts/connectors/monday.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const monday = {
   monday: {
     label: "Monday.com",
+    category: "engineering-team-execution",
     environmentMapping: {
       MONDAY_TOKEN: "$secrets.MONDAY_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/msg9.ts
+++ b/turbo/packages/core/src/contracts/connectors/msg9.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const msg9 = {
   msg9: {
     label: "msg9",
+    category: "communication-collaboration",
     environmentMapping: {
       MSG9_TOKEN: "$secrets.MSG9_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/n8n.ts
+++ b/turbo/packages/core/src/contracts/connectors/n8n.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const n8n = {
   n8n: {
     label: "n8n",
+    category: "data-automation-infrastructure",
     helpText:
       "Connect your n8n instance to manage workflows, trigger executions, and automate processes",
     environmentMapping: {

--- a/turbo/packages/core/src/contracts/connectors/neon.ts
+++ b/turbo/packages/core/src/contracts/connectors/neon.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const neon = {
   neon: {
     label: "Neon",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       NEON_TOKEN: "$secrets.NEON_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/notion.ts
+++ b/turbo/packages/core/src/contracts/connectors/notion.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const notion = {
   notion: {
     label: "Notion",
+    category: "docs-files-knowledge",
     tags: ["docs", "wiki", "workspace"],
     environmentMapping: {
       NOTION_TOKEN: "$secrets.NOTION_ACCESS_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/onyx.ts
+++ b/turbo/packages/core/src/contracts/connectors/onyx.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const onyx = {
   onyx: {
     label: "Onyx",
+    category: "docs-files-knowledge",
     helpText:
       "Connect your Onyx account to search internal knowledge bases, chat with AI agents, and index documents",
     environmentMapping: {

--- a/turbo/packages/core/src/contracts/connectors/openai.ts
+++ b/turbo/packages/core/src/contracts/connectors/openai.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const openai = {
   openai: {
     label: "OpenAI",
+    category: "ai-general-models",
     tags: ["llm", "ai", "gpt", "chatgpt"],
     environmentMapping: {
       OPENAI_TOKEN: "$secrets.OPENAI_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/outlook-calendar.ts
+++ b/turbo/packages/core/src/contracts/connectors/outlook-calendar.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const outlookCalendar = {
   "outlook-calendar": {
     label: "Outlook Calendar",
+    category: "meetings-scheduling",
     environmentMapping: {
       OUTLOOK_CALENDAR_TOKEN: "$secrets.OUTLOOK_CALENDAR_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/outlook-mail.ts
+++ b/turbo/packages/core/src/contracts/connectors/outlook-mail.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const outlookMail = {
   "outlook-mail": {
     label: "Outlook Mail",
+    category: "communication-collaboration",
     environmentMapping: {
       OUTLOOK_MAIL_TOKEN: "$secrets.OUTLOOK_MAIL_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/pandadoc.ts
+++ b/turbo/packages/core/src/contracts/connectors/pandadoc.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const pandadoc = {
   pandadoc: {
     label: "PandaDoc",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       PANDADOC_TOKEN: "$secrets.PANDADOC_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/pdf4me.ts
+++ b/turbo/packages/core/src/contracts/connectors/pdf4me.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const pdf4me = {
   pdf4me: {
     label: "PDF4me",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       PDF4ME_TOKEN: "$secrets.PDF4ME_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/pdfco.ts
+++ b/turbo/packages/core/src/contracts/connectors/pdfco.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const pdfco = {
   pdfco: {
     label: "PDF.co",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       PDFCO_TOKEN: "$secrets.PDFCO_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/pdforge.ts
+++ b/turbo/packages/core/src/contracts/connectors/pdforge.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const pdforge = {
   pdforge: {
     label: "PDForge",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       PDFORGE_API_KEY: "$secrets.PDFORGE_API_KEY",
     },

--- a/turbo/packages/core/src/contracts/connectors/perplexity.ts
+++ b/turbo/packages/core/src/contracts/connectors/perplexity.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const perplexity = {
   perplexity: {
     label: "Perplexity",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       PERPLEXITY_TOKEN: "$secrets.PERPLEXITY_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/pika.ts
+++ b/turbo/packages/core/src/contracts/connectors/pika.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const pika = {
   pika: {
     label: "Pika",
+    category: "ai-image-video",
     environmentMapping: {
       PIKA_TOKEN: "$secrets.PIKA_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/pinecone.ts
+++ b/turbo/packages/core/src/contracts/connectors/pinecone.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const pinecone = {
   pinecone: {
     label: "Pinecone",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       PINECONE_TOKEN: "$secrets.PINECONE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/pipedrive.ts
+++ b/turbo/packages/core/src/contracts/connectors/pipedrive.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const pipedrive = {
   pipedrive: {
     label: "Pipedrive",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       PIPEDRIVE_TOKEN: "$secrets.PIPEDRIVE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/plain.ts
+++ b/turbo/packages/core/src/contracts/connectors/plain.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const plain = {
   plain: {
     label: "Plain",
+    category: "communication-collaboration",
     environmentMapping: {
       PLAIN_TOKEN: "$secrets.PLAIN_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/plausible.ts
+++ b/turbo/packages/core/src/contracts/connectors/plausible.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const plausible = {
   plausible: {
     label: "Plausible",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       PLAUSIBLE_TOKEN: "$secrets.PLAUSIBLE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/podchaser.ts
+++ b/turbo/packages/core/src/contracts/connectors/podchaser.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const podchaser = {
   podchaser: {
     label: "Podchaser",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       PODCHASER_TOKEN: "$secrets.PODCHASER_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/posthog.ts
+++ b/turbo/packages/core/src/contracts/connectors/posthog.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const posthog = {
   posthog: {
     label: "PostHog",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       POSTHOG_TOKEN: "$secrets.POSTHOG_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/prisma-postgres.ts
+++ b/turbo/packages/core/src/contracts/connectors/prisma-postgres.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const prismaPostgres = {
   "prisma-postgres": {
     label: "Prisma Postgres",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       PRISMA_POSTGRES_TOKEN: "$secrets.PRISMA_POSTGRES_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/productlane.ts
+++ b/turbo/packages/core/src/contracts/connectors/productlane.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const productlane = {
   productlane: {
     label: "Productlane",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       PRODUCTLANE_TOKEN: "$secrets.PRODUCTLANE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/pushinator.ts
+++ b/turbo/packages/core/src/contracts/connectors/pushinator.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const pushinator = {
   pushinator: {
     label: "Pushinator",
+    category: "communication-collaboration",
     environmentMapping: {
       PUSHINATOR_TOKEN: "$secrets.PUSHINATOR_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/qdrant.ts
+++ b/turbo/packages/core/src/contracts/connectors/qdrant.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const qdrant = {
   qdrant: {
     label: "Qdrant",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       QDRANT_TOKEN: "$secrets.QDRANT_TOKEN",
       QDRANT_BASE_URL: "$vars.QDRANT_BASE_URL",

--- a/turbo/packages/core/src/contracts/connectors/qiita.ts
+++ b/turbo/packages/core/src/contracts/connectors/qiita.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const qiita = {
   qiita: {
     label: "Qiita",
+    category: "marketing-content-growth",
     environmentMapping: {
       QIITA_TOKEN: "$secrets.QIITA_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/reddit.ts
+++ b/turbo/packages/core/src/contracts/connectors/reddit.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const reddit = {
   reddit: {
     label: "Reddit",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       REDDIT_TOKEN: "$secrets.REDDIT_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/replicate.ts
+++ b/turbo/packages/core/src/contracts/connectors/replicate.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const replicate = {
   replicate: {
     label: "Replicate",
+    category: "ai-image-video",
     environmentMapping: {
       REPLICATE_TOKEN: "$secrets.REPLICATE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/reportei.ts
+++ b/turbo/packages/core/src/contracts/connectors/reportei.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const reportei = {
   reportei: {
     label: "Reportei",
+    category: "marketing-content-growth",
     environmentMapping: {
       REPORTEI_TOKEN: "$secrets.REPORTEI_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/resend.ts
+++ b/turbo/packages/core/src/contracts/connectors/resend.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const resend = {
   resend: {
     label: "Resend",
+    category: "communication-collaboration",
     environmentMapping: {
       RESEND_TOKEN: "$secrets.RESEND_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/revenuecat.ts
+++ b/turbo/packages/core/src/contracts/connectors/revenuecat.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const revenuecat = {
   revenuecat: {
     label: "RevenueCat",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       REVENUECAT_TOKEN: "$secrets.REVENUECAT_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/runway.ts
+++ b/turbo/packages/core/src/contracts/connectors/runway.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const runway = {
   runway: {
     label: "Runway",
+    category: "ai-image-video",
     environmentMapping: {
       RUNWAY_TOKEN: "$secrets.RUNWAY_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/salesforce.ts
+++ b/turbo/packages/core/src/contracts/connectors/salesforce.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const salesforce = {
   salesforce: {
     label: "Salesforce",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       SALESFORCE_TOKEN: "$secrets.SALESFORCE_TOKEN",
       SALESFORCE_INSTANCE: "$vars.SALESFORCE_INSTANCE",

--- a/turbo/packages/core/src/contracts/connectors/scrapeninja.ts
+++ b/turbo/packages/core/src/contracts/connectors/scrapeninja.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const scrapeninja = {
   scrapeninja: {
     label: "ScrapeNinja",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       SCRAPENINJA_TOKEN: "$secrets.SCRAPENINJA_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/sentry.ts
+++ b/turbo/packages/core/src/contracts/connectors/sentry.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const sentry = {
   sentry: {
     label: "Sentry",
+    category: "engineering-team-execution",
     environmentMapping: {
       SENTRY_TOKEN: "$secrets.SENTRY_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/serpapi.ts
+++ b/turbo/packages/core/src/contracts/connectors/serpapi.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const serpapi = {
   serpapi: {
     label: "SerpApi",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       SERPAPI_TOKEN: "$secrets.SERPAPI_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/shopify.ts
+++ b/turbo/packages/core/src/contracts/connectors/shopify.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const shopify = {
   shopify: {
     label: "Shopify",
+    category: "data-automation-infrastructure",
     tags: ["ecommerce", "store", "products", "orders"],
     environmentMapping: {
       SHOPIFY_TOKEN: "$secrets.SHOPIFY_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/shortio.ts
+++ b/turbo/packages/core/src/contracts/connectors/shortio.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const shortio = {
   shortio: {
     label: "Short.io",
+    category: "marketing-content-growth",
     environmentMapping: {
       SHORTIO_TOKEN: "$secrets.SHORTIO_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/similarweb.ts
+++ b/turbo/packages/core/src/contracts/connectors/similarweb.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const similarweb = {
   similarweb: {
     label: "SimilarWeb",
+    category: "marketing-content-growth",
     environmentMapping: {
       SIMILARWEB_TOKEN: "$secrets.SIMILARWEB_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/slack-webhook.ts
+++ b/turbo/packages/core/src/contracts/connectors/slack-webhook.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const slackWebhook = {
   "slack-webhook": {
     label: "Slack Webhook",
+    category: "communication-collaboration",
     environmentMapping: {
       SLACK_WEBHOOK_URL: "$secrets.SLACK_WEBHOOK_URL",
     },

--- a/turbo/packages/core/src/contracts/connectors/slack.ts
+++ b/turbo/packages/core/src/contracts/connectors/slack.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const slack = {
   slack: {
     label: "Slack",
+    category: "communication-collaboration",
     tags: ["chat", "messaging", "im"],
     environmentMapping: {
       SLACK_TOKEN: "$secrets.SLACK_ACCESS_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/spotify.ts
+++ b/turbo/packages/core/src/contracts/connectors/spotify.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const spotify = {
   spotify: {
     label: "Spotify",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       SPOTIFY_TOKEN: "$secrets.SPOTIFY_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/stability-ai.ts
+++ b/turbo/packages/core/src/contracts/connectors/stability-ai.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const stabilityAi = {
   "stability-ai": {
     label: "Stability AI",
+    category: "ai-image-video",
     environmentMapping: {
       STABILITY_TOKEN: "$secrets.STABILITY_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/strapi.ts
+++ b/turbo/packages/core/src/contracts/connectors/strapi.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const strapi = {
   strapi: {
     label: "Strapi",
+    category: "docs-files-knowledge",
     environmentMapping: {
       STRAPI_TOKEN: "$secrets.STRAPI_TOKEN",
       STRAPI_BASE_URL: "$vars.STRAPI_BASE_URL",

--- a/turbo/packages/core/src/contracts/connectors/strava.ts
+++ b/turbo/packages/core/src/contracts/connectors/strava.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const strava = {
   strava: {
     label: "Strava",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       STRAVA_TOKEN: "$secrets.STRAVA_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/streak.ts
+++ b/turbo/packages/core/src/contracts/connectors/streak.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const streak = {
   streak: {
     label: "Streak",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       STREAK_TOKEN: "$secrets.STREAK_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/stripe.ts
+++ b/turbo/packages/core/src/contracts/connectors/stripe.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const stripe = {
   stripe: {
     label: "Stripe",
+    category: "data-automation-infrastructure",
     tags: ["payments", "billing", "checkout"],
     environmentMapping: {
       STRIPE_TOKEN: "$secrets.STRIPE_ACCESS_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/supabase.ts
+++ b/turbo/packages/core/src/contracts/connectors/supabase.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const supabase = {
   supabase: {
     label: "Supabase",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       SUPABASE_TOKEN: "$secrets.SUPABASE_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/supadata.ts
+++ b/turbo/packages/core/src/contracts/connectors/supadata.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const supadata = {
   supadata: {
     label: "Supadata",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       SUPADATA_TOKEN: "$secrets.SUPADATA_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/tavily.ts
+++ b/turbo/packages/core/src/contracts/connectors/tavily.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const tavily = {
   tavily: {
     label: "Tavily",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       TAVILY_TOKEN: "$secrets.TAVILY_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/test-oauth.ts
+++ b/turbo/packages/core/src/contracts/connectors/test-oauth.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const testOauth = {
   "test-oauth": {
     label: "Test OAuth (internal)",
+    category: "data-automation-infrastructure",
     featureFlag: FeatureSwitchKey.TestOauthConnector,
     environmentMapping: {
       TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_ACCESS_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors/tldv.ts
+++ b/turbo/packages/core/src/contracts/connectors/tldv.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const tldv = {
   tldv: {
     label: "tl;dv",
+    category: "meetings-scheduling",
     environmentMapping: {
       TLDV_TOKEN: "$secrets.TLDV_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/todoist.ts
+++ b/turbo/packages/core/src/contracts/connectors/todoist.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const todoist = {
   todoist: {
     label: "Todoist",
+    category: "engineering-team-execution",
     environmentMapping: {
       TODOIST_TOKEN: "$secrets.TODOIST_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/together.ts
+++ b/turbo/packages/core/src/contracts/connectors/together.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const together = {
   together: {
     label: "Together AI",
+    category: "ai-general-models",
     environmentMapping: {
       TOGETHER_TOKEN: "$secrets.TOGETHER_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/twenty.ts
+++ b/turbo/packages/core/src/contracts/connectors/twenty.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const twenty = {
   twenty: {
     label: "Twenty",
+    category: "sales-crm-business-operations",
     environmentMapping: {
       TWENTY_TOKEN: "$secrets.TWENTY_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/typeform.ts
+++ b/turbo/packages/core/src/contracts/connectors/typeform.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const typeform = {
   typeform: {
     label: "Typeform",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       TYPEFORM_TOKEN: "$secrets.TYPEFORM_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/v0.ts
+++ b/turbo/packages/core/src/contracts/connectors/v0.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const v0 = {
   v0: {
     label: "v0",
+    category: "ai-agent-apps",
     environmentMapping: {
       V0_TOKEN: "$secrets.V0_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/vercel.ts
+++ b/turbo/packages/core/src/contracts/connectors/vercel.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const vercel = {
   vercel: {
     label: "Vercel",
+    category: "engineering-team-execution",
     environmentMapping: {
       VERCEL_TOKEN: "$secrets.VERCEL_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/wandb.ts
+++ b/turbo/packages/core/src/contracts/connectors/wandb.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const wandb = {
   wandb: {
     label: "Weights & Biases",
+    category: "ai-memory-tracing-eval",
     helpText:
       "Connect to Weights & Biases for ML experiment tracking and LLM observability.",
     environmentMapping: { WANDB_TOKEN: "$secrets.WANDB_TOKEN" },

--- a/turbo/packages/core/src/contracts/connectors/webflow.ts
+++ b/turbo/packages/core/src/contracts/connectors/webflow.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const webflow = {
   webflow: {
     label: "Webflow",
+    category: "marketing-content-growth",
     environmentMapping: {
       WEBFLOW_TOKEN: "$secrets.WEBFLOW_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/wix.ts
+++ b/turbo/packages/core/src/contracts/connectors/wix.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const wix = {
   wix: {
     label: "Wix",
+    category: "marketing-content-growth",
     environmentMapping: {
       WIX_TOKEN: "$secrets.WIX_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/workos.ts
+++ b/turbo/packages/core/src/contracts/connectors/workos.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const workos = {
   workos: {
     label: "WorkOS",
+    category: "engineering-team-execution",
     helpText:
       "Connect to WorkOS for enterprise SSO, SCIM directory sync, RBAC fine-grained authorization, and audit log management.",
     environmentMapping: { WORKOS_TOKEN: "$secrets.WORKOS_TOKEN" },

--- a/turbo/packages/core/src/contracts/connectors/wrike.ts
+++ b/turbo/packages/core/src/contracts/connectors/wrike.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const wrike = {
   wrike: {
     label: "Wrike",
+    category: "engineering-team-execution",
     environmentMapping: {
       WRIKE_TOKEN: "$secrets.WRIKE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/x.ts
+++ b/turbo/packages/core/src/contracts/connectors/x.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const x = {
   x: {
     label: "X",
+    category: "marketing-content-growth",
     environmentMapping: {
       X_TOKEN: "$secrets.X_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/xero.ts
+++ b/turbo/packages/core/src/contracts/connectors/xero.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const xero = {
   xero: {
     label: "Xero",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       XERO_TOKEN: "$secrets.XERO_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/youtube.ts
+++ b/turbo/packages/core/src/contracts/connectors/youtube.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const youtube = {
   youtube: {
     label: "YouTube",
+    category: "marketing-content-growth",
     environmentMapping: {
       YOUTUBE_TOKEN: "$secrets.YOUTUBE_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/zapier.ts
+++ b/turbo/packages/core/src/contracts/connectors/zapier.ts
@@ -6,6 +6,7 @@ export const zapier = {
     label: "Zapier",
     featureFlag: FeatureSwitchKey.ZapierConnector,
     strictFeatureFlag: true,
+    category: "data-automation-infrastructure",
     environmentMapping: {
       ZAPIER_TOKEN: "$secrets.ZAPIER_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/zapsign.ts
+++ b/turbo/packages/core/src/contracts/connectors/zapsign.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const zapsign = {
   zapsign: {
     label: "ZapSign",
+    category: "data-automation-infrastructure",
     environmentMapping: {
       ZAPSIGN_TOKEN: "$secrets.ZAPSIGN_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/zendesk.ts
+++ b/turbo/packages/core/src/contracts/connectors/zendesk.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const zendesk = {
   zendesk: {
     label: "Zendesk",
+    category: "communication-collaboration",
     environmentMapping: {
       ZENDESK_API_TOKEN: "$secrets.ZENDESK_API_TOKEN",
       ZENDESK_EMAIL: "$vars.ZENDESK_EMAIL",

--- a/turbo/packages/core/src/contracts/connectors/zep.ts
+++ b/turbo/packages/core/src/contracts/connectors/zep.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const zep = {
   zep: {
     label: "Zep",
+    category: "ai-memory-tracing-eval",
     helpText:
       "Connect to Zep for long-term memory and conversation history management in AI agents.",
     environmentMapping: { ZEP_TOKEN: "$secrets.ZEP_TOKEN" },

--- a/turbo/packages/core/src/contracts/connectors/zeptomail.ts
+++ b/turbo/packages/core/src/contracts/connectors/zeptomail.ts
@@ -3,6 +3,7 @@ import type { ConnectorConfig } from "../connectors";
 export const zeptomail = {
   zeptomail: {
     label: "ZeptoMail",
+    category: "communication-collaboration",
     environmentMapping: {
       ZEPTOMAIL_TOKEN: "$secrets.ZEPTOMAIL_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/connectors/zoom.ts
+++ b/turbo/packages/core/src/contracts/connectors/zoom.ts
@@ -4,6 +4,7 @@ import type { ConnectorConfig } from "../connectors";
 export const zoom = {
   zoom: {
     label: "Zoom",
+    category: "meetings-scheduling",
     environmentMapping: {
       ZOOM_TOKEN: "$secrets.ZOOM_ACCESS_TOKEN",
     },

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -392,8 +392,13 @@ export {
 export {
   connectorTypeSchema,
   CONNECTOR_TYPES,
+  CONNECTOR_DISPLAY_CATEGORY_GROUPS,
+  CONNECTOR_DISPLAY_CATEGORY_META,
+  CONNECTOR_DISPLAY_CATEGORY_ORDER,
   type ConnectorType,
   type ConnectorConfig,
+  type ConnectorDisplayCategory,
+  type ConnectorDisplayCategoryGroup,
   type ConnectorSecretConfig,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodType,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -50,6 +50,7 @@ export enum FeatureSwitchKey {
   ApiKeys = "apiKeys",
   ModelProviderSelection = "modelProviderSelection",
   UnifyChatThreads = "unifyChatThreads",
+  ConnectorCategories = "connectorCategories",
   Vm0DeepseekModel = "vm0DeepseekModel",
   PlatformConnectors = "platformConnectors",
   Trinity = "trinity",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -284,6 +284,14 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "still uses the current-agent fallback.",
     enabled: false,
   },
+  [FeatureSwitchKey.ConnectorCategories]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Show category sections and the hover-reveal outline menu on the Connectors settings page. " +
+      "Staff-only during rollout.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.Vm0DeepseekModel]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the DeepSeek-V3.2 (deepseek-chat) VM0 managed model",


### PR DESCRIPTION
## Summary
- add an explicit built-in connector taxonomy with AI-first categories and broader non-AI groupings
- render the built-in connectors page in grouped sections while preserving existing card actions and statuses
- update connectors page tests to cover grouped rendering, search filtering, and AI-first ordering

## Testing
- pnpm --dir turbo/apps/platform exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx src/views/zero-page/__tests__/zero-connectors-page-interaction.test.tsx
- pnpm --dir turbo/apps/platform lint

## Notes
- pnpm --dir turbo/apps/platform check-types currently fails due unrelated existing repo-wide TypeScript errors in apps/platform.

Closes #10835