### PR TITLE
fix(platform): make chat image downloads work from lightbox

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
 import { chatMessagesContract } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -332,22 +333,17 @@ describe("chat-i-066: lightbox download fallback uses direct download", () => {
   it("appends download=1 and avoids opening a new tab", async () => {
     const user = userEvent.setup();
     const imageUrl = "http://localhost:3000/f/user-1/file-1/photo.png";
-    const originalFetch = window.fetch.bind(window);
-    const fetchSpy = vi
-      .spyOn(window, "fetch")
-      .mockImplementation((input, init) => {
-        const requestUrl =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.toString()
-              : input.url;
-        if (requestUrl === `${imageUrl}?download=1`) {
-          return Promise.reject(new TypeError("CORS"));
+    server.use(
+      http.get(imageUrl, ({ request }) => {
+        if (new URL(request.url).searchParams.get("download") === "1") {
+          return HttpResponse.error();
         }
-        return originalFetch(input as RequestInfo | URL, init);
-      });
-    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => {
+      return null;
+    });
 
     let clickedHref = "";
     let clickedDownload = "";
@@ -398,10 +394,6 @@ describe("chat-i-066: lightbox download fallback uses direct download", () => {
     click(downloadButton);
 
     await waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledWith(
-        `${imageUrl}?download=1`,
-        expect.objectContaining({ mode: "cors" }),
-      );
       expect(anchorClickSpy).toHaveBeenCalledOnce();
     });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { chatMessagesContract } from "@vm0/core";
@@ -325,6 +325,93 @@ describe("chat-i-061: backdrop click closes lightbox", () => {
 });
 
 // ---------------------------------------------------------------------------
+// CHAT-I-066: Lightbox download fallback stays in-page and forces attachment
+// ---------------------------------------------------------------------------
+
+describe("chat-i-066: lightbox download fallback uses direct download", () => {
+  it("appends download=1 and avoids opening a new tab", async () => {
+    const user = userEvent.setup();
+    const imageUrl = "http://localhost:3000/f/user-1/file-1/photo.png";
+    const originalFetch = window.fetch.bind(window);
+    const fetchSpy = vi
+      .spyOn(window, "fetch")
+      .mockImplementation((input, init) => {
+        const requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (requestUrl === `${imageUrl}?download=1`) {
+          return Promise.reject(new TypeError("CORS"));
+        }
+        return originalFetch(input as RequestInfo | URL, init);
+      });
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    let clickedHref = "";
+    let clickedDownload = "";
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        clickedHref = this.href;
+        clickedDownload = this.download;
+      });
+
+    server.use(
+      ...mockUploadSuccess({
+        id: "upload-1",
+        filename: "photo.png",
+        contentType: "image/png",
+        size: 2048,
+        url: imageUrl,
+      }),
+    );
+    mockChatAPI();
+
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+    });
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    await user.upload(
+      fileInput!,
+      new File(["img"], "photo.png", { type: "image/png" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(`img[src="${imageUrl}"]`),
+      ).toBeInTheDocument();
+    });
+
+    const chipDiv = document.querySelector<HTMLElement>('[title="photo.png"]');
+    const chipButton = chipDiv?.querySelector("button");
+    click(chipButton!);
+
+    const downloadButton = await waitFor(() => {
+      return screen.getByLabelText("Download");
+    });
+    click(downloadButton);
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${imageUrl}?download=1`,
+        expect.objectContaining({ mode: "cors" }),
+      );
+      expect(anchorClickSpy).toHaveBeenCalledOnce();
+    });
+
+    expect(clickedHref).toBe(`${imageUrl}?download=1`);
+    expect(clickedDownload).toBe("photo.png");
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // CHAT-I-062: Remove button on attachment chips calls onRemove
 // ---------------------------------------------------------------------------
 
@@ -404,7 +491,7 @@ describe("chat-d-063: download link renders for file attachment", () => {
   });
 
   it("renders a download anchor from the structured attachFiles field", async () => {
-    const fileUrl = "https://example.com/spec.pdf";
+    const fileUrl = "http://localhost:3000/f/user-1/file-1/spec.pdf";
     const filename = "spec.pdf";
 
     mockChatLifecycle({
@@ -436,7 +523,7 @@ describe("chat-d-063: download link renders for file attachment", () => {
         `a[download="${filename}"]`,
       );
       expect(link).toBeInTheDocument();
-      expect(link?.getAttribute("href")).toBe(fileUrl);
+      expect(link?.href).toBe(`${fileUrl}?download=1`);
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import { hasSubscription } from "../../../mocks/ably.ts";
@@ -135,25 +137,14 @@ describe("zero chat thread page - image attachment opens lightbox", () => {
 
   it("downloads a CDN image from the lightbox", async () => {
     const imageUrl = "https://cdn.example.com/photo.png";
-    const originalFetch = window.fetch.bind(window);
-    const fetchSpy = vi
-      .spyOn(window, "fetch")
-      .mockImplementation((input, init) => {
-        const requestUrl =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.toString()
-              : input.url;
-        if (requestUrl === imageUrl) {
-          return Promise.resolve(
-            new Response(new Blob(["img"], { type: "image/png" }), {
-              status: 200,
-            }),
-          );
-        }
-        return originalFetch(input as RequestInfo | URL, init);
-      });
+    server.use(
+      http.get(imageUrl, () => {
+        return new HttpResponse(new Blob(["img"], { type: "image/png" }), {
+          status: 200,
+          headers: { "Content-Type": "image/png" },
+        });
+      }),
+    );
     const createObjectURLSpy = vi
       .spyOn(URL, "createObjectURL")
       .mockReturnValue("blob:test");
@@ -185,7 +176,6 @@ describe("zero chat thread page - image attachment opens lightbox", () => {
     click(downloadButton);
 
     await waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledWith(imageUrl, { mode: "cors" });
       expect(createObjectURLSpy).toHaveBeenCalledOnce();
       expect(anchorClickSpy).toHaveBeenCalledWith();
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -187,7 +187,7 @@ describe("zero chat thread page - image attachment opens lightbox", () => {
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(imageUrl, { mode: "cors" });
       expect(createObjectURLSpy).toHaveBeenCalledOnce();
-      expect(anchorClickSpy).toHaveBeenCalled();
+      expect(anchorClickSpy).toHaveBeenCalledWith();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -132,6 +132,64 @@ describe("zero chat thread page - image attachment opens lightbox", () => {
       expect(lightboxImg).toBeInTheDocument();
     });
   });
+
+  it("downloads a CDN image from the lightbox", async () => {
+    const imageUrl = "https://cdn.example.com/photo.png";
+    const originalFetch = window.fetch.bind(window);
+    const fetchSpy = vi
+      .spyOn(window, "fetch")
+      .mockImplementation((input, init) => {
+        const requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (requestUrl === imageUrl) {
+          return Promise.resolve(
+            new Response(new Blob(["img"], { type: "image/png" }), {
+              status: 200,
+            }),
+          );
+        }
+        return originalFetch(input as RequestInfo | URL, init);
+      });
+    const createObjectURLSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:test");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: `[Attached file: photo.png](${imageUrl})\nDownload with: curl ${imageUrl}\n`,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    const imageButton = await waitFor(() => {
+      return screen.getByRole("img", { name: "photo.png" }).closest("button")!;
+    });
+    click(imageButton);
+
+    const downloadButton = await waitFor(() => {
+      return screen.getByLabelText("Download");
+    });
+    click(downloadButton);
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(imageUrl, { mode: "cors" });
+      expect(createObjectURLSpy).toHaveBeenCalledOnce();
+      expect(anchorClickSpy).toHaveBeenCalled();
+    });
+  });
 });
 
 // CHAT-I-052: Copy message button writes message content to clipboard

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -58,16 +58,15 @@ function filenameFromUrl(url: string): string {
 }
 
 function getAttachmentDownloadUrl(url: string): string {
-  try {
-    const parsed = new URL(url, window.location.origin);
-    const isFileRoute = /^\/f\/[^/]+\/[^/]+\/[^/]+$/.test(parsed.pathname);
-    if (isFileRoute) {
-      parsed.searchParams.set("download", "1");
-    }
-    return parsed.toString();
-  } catch {
+  if (!URL.canParse(url, window.location.origin)) {
     return url;
   }
+  const parsed = new URL(url, window.location.origin);
+  const isFileRoute = /^\/f\/[^/]+\/[^/]+\/[^/]+$/.test(parsed.pathname);
+  if (isFileRoute) {
+    parsed.searchParams.set("download", "1");
+  }
+  return parsed.toString();
 }
 
 function triggerDirectDownload(url: string, filename: string): void {

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -57,6 +57,28 @@ function filenameFromUrl(url: string): string {
   return last && last.length > 0 ? last : "image";
 }
 
+function getAttachmentDownloadUrl(url: string): string {
+  try {
+    const parsed = new URL(url, window.location.origin);
+    const isFileRoute = /^\/f\/[^/]+\/[^/]+\/[^/]+$/.test(parsed.pathname);
+    if (isFileRoute) {
+      parsed.searchParams.set("download", "1");
+    }
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+function triggerDirectDownload(url: string, filename: string): void {
+  const a = document.createElement("a");
+  a.href = getAttachmentDownloadUrl(url);
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
 function triggerBlobDownload(blob: Blob, filename: string): void {
   const blobUrl = URL.createObjectURL(blob);
   const a = document.createElement("a");
@@ -72,10 +94,10 @@ function triggerBlobDownload(blob: Blob, filename: string): void {
 // CORS failure. The `.catch` is intentionally scoped to the fetch branch so
 // only network failures fall back — any synchronous DOM / blob failure after
 // a successful fetch is a real bug and propagates to the caller. The
-// fallback logs the underlying error so unexpected failures surface in
-// Sentry instead of being silently mis-classified as "CORS".
+// fallback keeps the user on the same page and lets the app's `/f/...`
+// route force `Content-Disposition: attachment` via `?download=1`.
 function fetchBlobOrOpen(url: string): Promise<Blob | null> {
-  return fetch(url, { mode: "cors" })
+  return fetch(getAttachmentDownloadUrl(url), { mode: "cors" })
     .then((res) => {
       if (!res.ok) {
         throw new Error(`fetch failed: ${String(res.status)}`);
@@ -83,13 +105,16 @@ function fetchBlobOrOpen(url: string): Promise<Blob | null> {
       return res.blob();
     })
     .catch((error: unknown) => {
-      log.warn("downloadUrl: fetch failed, falling back to window.open", error);
-      window.open(url, "_blank", "noopener,noreferrer");
+      log.warn(
+        "downloadUrl: fetch failed, falling back to direct download",
+        error,
+      );
+      triggerDirectDownload(url, filenameFromUrl(url));
       return null;
     });
 }
 
-function downloadUrl(url: string): Promise<void> {
+function downloadAttachmentUrl(url: string): Promise<void> {
   const filename = filenameFromUrl(url);
   return fetchBlobOrOpen(url).then((blob) => {
     if (blob !== null) {
@@ -121,7 +146,7 @@ export function ImageLightbox({ url }: { url: string }) {
         <button
           type="button"
           onClick={() => {
-            downloadUrl(url).catch((error: unknown) => {
+            downloadAttachmentUrl(url).catch((error: unknown) => {
               log.error("downloadUrl: unexpected failure", error);
             });
           }}
@@ -164,7 +189,7 @@ export function FileAttachmentChip({
   const iconSrc = getFileTypeIcon(filename);
   return (
     <a
-      href={url}
+      href={getAttachmentDownloadUrl(url)}
       download={filename}
       title={filename}
       className="inline-flex items-center justify-center rounded-lg hover:bg-foreground/10 transition-colors p-0.5"


### PR DESCRIPTION
## Summary
- fix chat image downloads so the download action happens from the lightbox view
- make platform `/f/...` file links force attachment semantics with `?download=1`
- avoid opening a new tab when lightbox download fallback is triggered

## What changed
- added a shared attachment download URL normalizer in `zero-attachment-chips.tsx`
- updated lightbox download flow to prefer `fetch -> blob -> a.click()` and fall back to direct download instead of `window.open`
- kept chat image preview behavior as view-first: users open the image/lightbox first, then download from there
- added regression coverage for `/f/...` lightbox fallback and CDN image downloads from the chat lightbox

## Testing
- `pnpm exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx`
- `pnpm exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx`
