### PR TITLE
fix: harden speakerphone barge-in in voice chat candidate

### DIFF
--- a/turbo/apps/platform/src/lib/voice-io/audio-config.ts
+++ b/turbo/apps/platform/src/lib/voice-io/audio-config.ts
@@ -1,8 +1,10 @@
 type NoiseReduction = "near_field" | "far_field";
+type BargeInMode = "speech_started" | "transcript_confirmed";
 
 interface AudioConfig {
   constraints: MediaTrackConstraints;
   noiseReduction: NoiseReduction;
+  bargeInMode: BargeInMode;
 }
 
 /**
@@ -18,6 +20,9 @@ interface AudioConfig {
  * - OpenAI's `far_field` noise reduction is tuned for conference-style mic
  *   placements; `near_field` is better for phone-to-mouth speakerphone where
  *   the mic is close and echo dominates background noise.
+ * - In the same speakerphone case, treat `speech_started` as untrusted for
+ *   barge-in. Wait for a finalized transcript before truncating assistant
+ *   audio; otherwise the assistant's own playback can interrupt itself.
  *
  * Also flips `navigator.audioSession.type` to "play-and-record" when
  * supported (Chrome Android 116+, Safari iOS 17+), which routes audio through
@@ -48,5 +53,6 @@ export async function resolveAudioConfig(): Promise<AudioConfig> {
       autoGainControl: !speakerRisk,
     },
     noiseReduction: speakerRisk ? "near_field" : "far_field",
+    bargeInMode: speakerRisk ? "transcript_confirmed" : "speech_started",
   };
 }

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
@@ -598,6 +598,83 @@ describe("voice-chat-candidate session", () => {
         realtimeItemId: "truncate:rt-asst-live",
       });
     });
+
+    it("waits for a finalized user transcript before truncating on mobile speakerphone", async () => {
+      vi.spyOn(navigator, "maxTouchPoints", "get").mockReturnValue(5);
+      vi.spyOn(navigator, "userAgent", "get").mockReturnValue(
+        "Mozilla/5.0 (Linux; Android 13) Mobile Safari/537.36",
+      );
+      stubWebRTC([{ kind: "audiooutput", deviceId: "default" }]);
+
+      await setup();
+      const appendCalls = mockAppendItemOk();
+      await startSuccessfully();
+
+      dcRef.current?.send.mockClear();
+      if (!audioRef.current) {
+        throw new Error("audio not initialized");
+      }
+      audioRef.current.currentTime = 20;
+
+      dcRef.current?.emitMessage({
+        type: "conversation.item.created",
+        item: {
+          id: "rt-asst-speaker",
+          type: "message",
+          role: "assistant",
+        },
+      });
+
+      dcRef.current?.emitMessage({
+        type: "response.audio_transcript.delta",
+        delta: "speaker mode",
+      });
+
+      audioRef.current.currentTime = 20.8;
+      await dcRef.current?.emitMessage({
+        type: "input_audio_buffer.speech_started",
+      });
+
+      expect(audioRef.current.pause).not.toHaveBeenCalled();
+      expect(dcRef.current?.send).not.toHaveBeenCalled();
+      expect(appendCalls).toHaveLength(0);
+
+      audioRef.current.currentTime = 21.4;
+      await dcRef.current?.emitMessage({
+        type: "conversation.item.input_audio_transcription.completed",
+        item_id: "rt-user-speaker",
+        transcript: "hello",
+      });
+
+      expect(audioRef.current.pause).toHaveBeenCalledTimes(1);
+      expect(dcRef.current?.send).toHaveBeenCalledTimes(1);
+      expect(
+        JSON.parse(dcRef.current?.send.mock.calls[0]?.[0] as string),
+      ).toStrictEqual({
+        type: "conversation.item.truncate",
+        item_id: "rt-asst-speaker",
+        content_index: 0,
+        audio_end_ms: 1400,
+      });
+      await vi.waitFor(() => {
+        expect(appendCalls).toHaveLength(2);
+      });
+      expect(appendCalls[0]).toStrictEqual({
+        role: "system_note",
+        content: JSON.stringify({
+          type: "assistant_interrupted",
+          assistantRealtimeItemId: "rt-asst-speaker",
+          heardText: "speaker mode",
+          audioEndMs: 1400,
+        }),
+        realtimeItemId: "truncate:rt-asst-speaker",
+      });
+      expect(appendCalls[1]).toStrictEqual({
+        role: "user",
+        content: "hello",
+        realtimeItemId: "rt-user-speaker",
+      });
+    });
   });
 
   describe("talker tool calls", () => {

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -19,6 +19,7 @@ type ConnectionStatus =
   | "connected"
   | "disconnected"
   | "error";
+type BargeInMode = "speech_started" | "transcript_confirmed";
 
 // Model used for the SDP exchange URL. Session config (tools / VAD / etc.) is
 // preset server-side in createEphemeralToken — keep this file free of it.
@@ -60,6 +61,7 @@ const internalLastAssistantMessage$ = state<string>("");
 const vccReload$ = state<number>(0);
 
 const internalMuted$ = state<boolean>(false);
+const internalBargeInMode$ = state<BargeInMode>("speech_started");
 
 const internalPc$ = state<RTCPeerConnection | null>(null);
 const internalDc$ = state<RTCDataChannel | null>(null);
@@ -277,8 +279,14 @@ const handleAudioTranscriptDone$ = command(
 );
 
 const handleInputAudioTranscriptionCompleted$ = command(
-  async ({ set }, event: RealtimeDCEvent, signal: AbortSignal) => {
+  async ({ get, set }, event: RealtimeDCEvent, signal: AbortSignal) => {
     if (event.transcript && event.item_id) {
+      if (
+        get(internalBargeInMode$) === "transcript_confirmed" &&
+        event.transcript.trim()
+      ) {
+        await set(truncateCurrentAssistantAudio$, signal);
+      }
       await set(appendItem$, "user", event.transcript, event.item_id, signal);
     }
   },
@@ -363,7 +371,7 @@ const truncateCurrentAssistantAudio$ = command(
 );
 
 const handleDCMessage$ = command(
-  async ({ set }, data: string, signal: AbortSignal) => {
+  async ({ get, set }, data: string, signal: AbortSignal) => {
     const event = JSON.parse(data) as RealtimeDCEvent;
 
     switch (event.type) {
@@ -380,7 +388,9 @@ const handleDCMessage$ = command(
         break;
       }
       case "input_audio_buffer.speech_started": {
-        await set(truncateCurrentAssistantAudio$, signal);
+        if (get(internalBargeInMode$) === "speech_started") {
+          await set(truncateCurrentAssistantAudio$, signal);
+        }
         break;
       }
       case "response.audio_transcript.done": {
@@ -658,6 +668,7 @@ export const startVoiceChatCandidate$ = command(
     set(internalLastUserMessage$, "");
     set(internalLastAssistantMessage$, "");
     set(internalMuted$, false);
+    set(internalBargeInMode$, "speech_started");
     set(internalCurrentAssistantAudioItem$, null);
     set(internalSessionId$, null);
     set(vccReload$, (n) => {
@@ -694,6 +705,7 @@ export const startVoiceChatCandidate$ = command(
     // per connection so plugging in headphones between calls takes effect.
     const audioConfig = await resolveAudioConfig();
     signal.throwIfAborted();
+    set(internalBargeInMode$, audioConfig.bargeInMode);
 
     const tokenRes = await accept(
       client.token({
@@ -790,6 +802,7 @@ export const endVoiceChatCandidate$ = command(({ get, set }) => {
   set(internalSessionId$, null);
   set(internalLastUserMessage$, "");
   set(internalLastAssistantMessage$, "");
+  set(internalBargeInMode$, "speech_started");
   set(internalCurrentAssistantAudioItem$, null);
   set(internalStatus$, "idle");
   // Bump so vccTaskFeed$ re-resolves to [] after sessionId is cleared.

--- a/turbo/apps/web/app/api/zero/voice-chat-candidate/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat-candidate/token/__tests__/route.test.ts
@@ -132,6 +132,7 @@ describe("POST /api/zero/voice-chat-candidate/token", () => {
     expect(received?.turn_detection).toEqual({
       type: "semantic_vad",
       eagerness: "medium",
+      interrupt_response: false,
     });
     const toolNames =
       received?.tools?.map((t) => {

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/session-config.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/session-config.ts
@@ -62,6 +62,10 @@ export const SESSION_TOOLS = [
 export const TURN_DETECTION_CONFIG = {
   type: "semantic_vad",
   eagerness: "medium",
+  // Disable the server's automatic barge-in cancellation. The browser handles
+  // truncation itself so mobile speakerphone can apply a stricter policy than
+  // "any VAD start event immediately interrupts the assistant".
+  interrupt_response: false,
 } as const;
 
 export const INPUT_AUDIO_TRANSCRIPTION_CONFIG = {


### PR DESCRIPTION
## Summary
- disable server-side auto interrupt for voice-chat-candidate realtime sessions
- defer speakerphone barge-in until user transcript is confirmed on mobile speaker mode
- cover the new speakerphone interrupt behavior in platform and web tests

## Testing
- pnpm exec vitest run src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
- pnpm exec vitest run app/api/zero/voice-chat-candidate/token/__tests__/route.test.ts