### PR TITLE
fix(platform): remember last used agent on web home

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/agent.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/agent.test.ts
@@ -1,16 +1,22 @@
 import { describe, expect, it } from "vitest";
+import { waitFor } from "@testing-library/react";
 import { onboardingCompleteContract } from "@vm0/core/contracts/onboarding";
 import { zeroAgentsByIdContract } from "@vm0/core/contracts/zero-agents";
 import { server } from "../../mocks/server.ts";
 import { createMockApi } from "../../mocks/msw-contract.ts";
 import { setMockOnboardingStatus } from "../../mocks/handlers/api-onboarding.ts";
+import { setMockTeam } from "../../mocks/handlers/api-agents.ts";
 import { detachedSetupPage } from "../../__tests__/page-helper.ts";
+import { pathname } from "../location.ts";
 import { testContext } from "./test-helpers.ts";
 import {
   agentById,
   defaultAgentName$,
+  homeAgentId$,
+  lastUsedAgentId$,
   leadAgentAvatarUrl$,
   reloadAgentById$,
+  rememberLastUsedAgentId$,
 } from "../agent.ts";
 import { zeroJobUpdateSettings$ } from "../zero-page/job-detail/settings.ts";
 import { deleteZeroJobAgent$ } from "../zero-page/job-detail/delete.ts";
@@ -23,6 +29,7 @@ import { completeOnboarding$ } from "../zero-page/zero-onboarding-actions.ts";
 const context = testContext();
 const mockApi = createMockApi(context);
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const OTHER_AGENT_ID = "c0000000-0000-4000-a000-000000000002";
 
 interface AgentOverrides {
   displayName?: string | null;
@@ -234,5 +241,86 @@ describe("agent mutations trigger reloadAgentById$", () => {
     const after = await context.store.get(agentById(AGENT_ID));
     expect(after.displayName).toBe("After");
     expect(counter.getCalls).toBeGreaterThan(callsBeforeMutation);
+  });
+});
+
+describe("last used agent persistence", () => {
+  it("prefers the last used agent on home when it still exists", async () => {
+    setMockOnboardingStatus({ defaultAgentId: AGENT_ID });
+    setMockTeam([
+      {
+        id: AGENT_ID,
+        displayName: null,
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: OTHER_AGENT_ID,
+        displayName: "Other Agent",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_2",
+        updatedAt: "2024-01-02T00:00:00Z",
+      },
+    ]);
+
+    context.store.set(rememberLastUsedAgentId$, OTHER_AGENT_ID);
+
+    expect(context.store.get(lastUsedAgentId$)).toBe(OTHER_AGENT_ID);
+    await expect(context.store.get(homeAgentId$)).resolves.toBe(OTHER_AGENT_ID);
+  });
+
+  it("falls back to the default agent when the last used agent no longer exists", async () => {
+    setMockOnboardingStatus({ defaultAgentId: AGENT_ID });
+    setMockTeam([
+      {
+        id: AGENT_ID,
+        displayName: null,
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+
+    context.store.set(rememberLastUsedAgentId$, OTHER_AGENT_ID);
+
+    await expect(context.store.get(homeAgentId$)).resolves.toBe(AGENT_ID);
+  });
+
+  it("redirects / to the last used agent chat page", async () => {
+    setMockOnboardingStatus({ defaultAgentId: AGENT_ID });
+    setMockTeam([
+      {
+        id: AGENT_ID,
+        displayName: null,
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: OTHER_AGENT_ID,
+        displayName: "Other Agent",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_2",
+        updatedAt: "2024-01-02T00:00:00Z",
+      },
+    ]);
+
+    context.store.set(rememberLastUsedAgentId$, OTHER_AGENT_ID);
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${OTHER_AGENT_ID}/chat`);
+    });
   });
 });

--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -16,6 +16,12 @@ import { activeRoute$ } from "./active-route.ts";
 import { zeroOnboardingStatus$ } from "./zero-page/zero-onboarding.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
+import { localStorageSignals } from "./external/local-storage.ts";
+
+const LAST_USED_AGENT_STORAGE_KEY = "zero.lastUsedAgentId";
+
+const { get$: lastUsedAgentIdRaw$, set$: setLastUsedAgentIdRaw$ } =
+  localStorageSignals(LAST_USED_AGENT_STORAGE_KEY);
 
 export const defaultAgentId$ = computed(async (get) => {
   const status = await get(zeroOnboardingStatus$);
@@ -90,6 +96,15 @@ export const currentAgent$ = computed((get) => {
   return get(agentById(agentId));
 });
 
+export const lastUsedAgentId$ = computed((get) => {
+  const value = get(lastUsedAgentIdRaw$);
+  return typeof value === "string" && value.length > 0 ? value : null;
+});
+
+export const rememberLastUsedAgentId$ = command(({ set }, agentId: string) => {
+  set(setLastUsedAgentIdRaw$, agentId);
+});
+
 const internalReloadAgents$ = state(0);
 
 /** All agents in the user's org (from /api/zero/team). */
@@ -98,6 +113,24 @@ export const agents$ = computed(async (get) => {
   const zeroClient = get(zeroClient$)(zeroTeamContract);
   const result = await accept(zeroClient.list(), [200]);
   return result.body;
+});
+
+export const homeAgentId$ = computed(async (get) => {
+  const lastUsedAgentId = get(lastUsedAgentId$);
+  if (!lastUsedAgentId) {
+    return await get(defaultAgentId$);
+  }
+
+  const agents = await get(agents$);
+  if (
+    agents.some((agent) => {
+      return agent.id === lastUsedAgentId;
+    })
+  ) {
+    return lastUsedAgentId;
+  }
+
+  return await get(defaultAgentId$);
 });
 
 export const sortedAgents$ = computed(async (get) => {

--- a/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
@@ -1,9 +1,14 @@
 import { command } from "ccstate";
+import type { TeamComposeItem } from "@vm0/core";
 import { createElement } from "react";
 import { AgentDetailPage } from "../../views/team-page/zero-team-detail-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { currentAgentId$, agents$ } from "../agent.ts";
+import {
+  currentAgentId$,
+  agents$,
+  rememberLastUsedAgentId$,
+} from "../agent.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { setActiveAgent$ } from "../zero-page/zero-job-detail.ts";
@@ -23,12 +28,13 @@ export const setupAgentDetailPage$ = command(
     // Activate the agent to trigger dependent signals (detail, schedule, etc.)
     set(setActiveAgent$, agentId);
     set(setChatAgentId$, agentId);
+    set(rememberLastUsedAgentId$, agentId);
 
     // Update title with agent display name
     const agents = await get(agents$);
     signal.throwIfAborted();
 
-    const agent = agents.find((a) => {
+    const agent = agents.find((a: TeamComposeItem) => {
       return a.id === agentId;
     });
     const displayName = agent?.displayName ?? "Agent";

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
@@ -3,6 +3,7 @@ import { createElement } from "react";
 import { PermissionAllowPage } from "../../views/permission-allow/permission-allow-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
+import { currentAgentId$, rememberLastUsedAgentId$ } from "../agent.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import { isOrgAdmin$ } from "../org.ts";
@@ -25,6 +26,11 @@ export const setupPermissionAllowPage$ = command(
     set(updateDocumentTitle$, "Permissions");
     set(resetFocusedState$);
 
+    const agentId = get(currentAgentId$);
+    if (agentId) {
+      set(rememberLastUsedAgentId$, agentId);
+    }
+
     await set(hideAppSkeleton$, signal);
 
     if (await set(onboardGuard$, signal)) {
@@ -40,11 +46,11 @@ export const setupPermissionAllowPage$ = command(
     }
 
     // Auto-redirect: member in doctor mode with existing request → request mode
-    const agentId = get(permissionAllowAgentId$);
+    const permissionAgentId = get(permissionAllowAgentId$);
     const ref = get(permissionAllowRef$);
     const requestId = get(permissionAllowRequestId$);
     const permission = get(permissionAllowPermission$);
-    if (!requestId && permission && agentId && ref) {
+    if (!requestId && permission && permissionAgentId && ref) {
       const isAdmin = await get(isOrgAdmin$);
       signal.throwIfAborted();
       if (!isAdmin) {

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -9,7 +9,11 @@ import {
   detachedNavigateTo$,
 } from "../route.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
-import { currentAgentId$, defaultAgentId$ } from "../agent.ts";
+import {
+  currentAgentId$,
+  defaultAgentId$,
+  rememberLastUsedAgentId$,
+} from "../agent.ts";
 import { setChatAgentId$, currentChatAgent$ } from "../agent-chat.ts";
 import { talkDraft$ } from "./chat-draft.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
@@ -32,6 +36,7 @@ export const setupAgentChatPage$ = command(
     const agentId = get(currentAgentId$);
     if (agentId) {
       set(setChatAgentId$, agentId);
+      set(rememberLastUsedAgentId$, agentId);
     }
 
     await set(hideAppSkeleton$, signal);

--- a/turbo/apps/platform/src/signals/zero-page/agent-talk-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-talk-page-setup.ts
@@ -5,7 +5,11 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
-import { currentAgentId$, defaultAgentId$ } from "../agent.ts";
+import {
+  currentAgentId$,
+  defaultAgentId$,
+  rememberLastUsedAgentId$,
+} from "../agent.ts";
 import { setChatAgentId$, currentChatAgent$ } from "../agent-chat.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import {
@@ -28,6 +32,7 @@ export const setupAgentTalkPage$ = command(
     const agentId = get(currentAgentId$);
     if (agentId) {
       set(setChatAgentId$, agentId);
+      set(rememberLastUsedAgentId$, agentId);
     }
 
     await set(hideAppSkeleton$, signal);

--- a/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
@@ -1,7 +1,7 @@
 import { command } from "ccstate";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { checkSettingsParam$ } from "./settings/org-manage-dialog.ts";
-import { defaultAgentId$ } from "../agent.ts";
+import { homeAgentId$ } from "../agent.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 
 export const setupHomePage$ = command(
@@ -13,9 +13,9 @@ export const setupHomePage$ = command(
     await set(checkSettingsParam$, signal);
 
     // Redirect bare / to /agents/:id/chat, forwarding ?prompt= and ?queue= if present
-    const defaultAgentId = await get(defaultAgentId$);
+    const homeAgentId = await get(homeAgentId$);
     signal.throwIfAborted();
-    if (defaultAgentId) {
+    if (homeAgentId) {
       const params = get(searchParams$);
       const forwardParams = new URLSearchParams();
       const prompt = params.get("prompt");
@@ -27,7 +27,7 @@ export const setupHomePage$ = command(
         forwardParams.set("queue", queue);
       }
       set(detachedNavigateTo$, "/agents/:agentId/chat", {
-        pathParams: { agentId: defaultAgentId },
+        pathParams: { agentId: homeAgentId },
         searchParams: forwardParams.size > 0 ? forwardParams : undefined,
         replace: true,
       });

--- a/turbo/apps/platform/src/signals/zero-page/ideation-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/ideation-page-setup.ts
@@ -5,11 +5,17 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { currentAgentId$, rememberLastUsedAgentId$ } from "../agent.ts";
 
 export const setupIdeationPage$ = command(
-  async ({ set }, signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroIdeationPage), "sidebar");
     set(updateDocumentTitle$, "Ideas & Use Cases");
+
+    const agentId = get(currentAgentId$);
+    if (agentId) {
+      set(rememberLastUsedAgentId$, agentId);
+    }
 
     if (await set(onboardGuard$, signal)) {
       return;


### PR DESCRIPTION
## Summary
- remember the last agent visited in the platform web app
- redirect `/` to the remembered agent chat instead of always using the default agent
- fall back to the default agent when the stored agent no longer exists

## Testing
- pre-commit hooks passed during commit (`prettier`, `knip`, commitlint)
- added regression coverage in `turbo/apps/platform/src/signals/__tests__/agent.test.ts`
- `pnpm exec vitest run src/signals/__tests__/agent.test.ts` is currently blocked by an existing repo issue: `turbo/packages/core/src/firewalls/index.ts` imports missing generated modules such as `etsy.generated`
- `pnpm exec tsc --noEmit` is also currently blocked by pre-existing repo errors unrelated to this change