### PR TITLE
fix: harden billing webhook credit grants

### DIFF
--- a/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -14,6 +14,7 @@ import {
   insertOrgMembersEntry,
   getOrgMembersEntry,
   findCreditExpiresRecords,
+  findCreditExpiresRecordByStripeInvoiceId,
   insertCreditExpiresRecord,
   setOrgCredits,
 } from "../../../../../src/__tests__/api-test-helpers";
@@ -70,6 +71,12 @@ const TEST_PRICE_TEAM_LEGACY = "price_test_team_legacy";
 const TEST_ZERO_PRICE = JSON.stringify({
   pro: [TEST_PRICE_PRO],
   team: [TEST_PRICE_TEAM, TEST_PRICE_TEAM_LEGACY],
+});
+const TEST_ONE_TIME_CAMPAIGN = JSON.stringify({
+  ZERO100: {
+    priceId: "price_test_campaign",
+    couponId: "ZERO100",
+  },
 });
 
 /**
@@ -138,6 +145,7 @@ describe("POST /api/webhooks/stripe", () => {
     vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake");
     vi.stubEnv("STRIPE_WEBHOOK_SECRET", TEST_WEBHOOK_SECRET);
     vi.stubEnv("ZERO_PRICE", TEST_ZERO_PRICE);
+    vi.stubEnv("ZERO_ONE_TIME_CAMPAIGN", TEST_ONE_TIME_CAMPAIGN);
     reloadEnv();
 
     stripeMocks.constructEvent.mockReset();
@@ -256,6 +264,55 @@ describe("POST /api/webhooks/stripe", () => {
 
       const billing = await getOrgBillingFields(user.orgId);
       expect(billing?.tier).toBe("pro");
+    });
+
+    it("does not grant one-time credits before checkout payment settles", async () => {
+      const sessionId = uniqueId("cs-unpaid");
+      const creditsBefore = await getOrgCredits(user.orgId);
+
+      const response = await sendWebhookEvent("checkout.session.completed", {
+        id: sessionId,
+        subscription: null,
+        customer: "cus_one_time",
+        payment_status: "unpaid",
+        metadata: {
+          purpose: "one_time_purchase",
+          orgId: user.orgId,
+          campaignKey: "ZERO100",
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(await getOrgCredits(user.orgId)).toBe(creditsBefore);
+      expect(
+        await findCreditExpiresRecordByStripeInvoiceId(user.orgId, sessionId),
+      ).toBeUndefined();
+    });
+
+    it("grants one-time credits on async payment success", async () => {
+      const sessionId = uniqueId("cs-async-paid");
+      const creditsBefore = await getOrgCredits(user.orgId);
+
+      const response = await sendWebhookEvent(
+        "checkout.session.async_payment_succeeded",
+        {
+          id: sessionId,
+          subscription: null,
+          customer: "cus_one_time",
+          payment_status: "paid",
+          metadata: {
+            purpose: "one_time_purchase",
+            orgId: user.orgId,
+            campaignKey: "ZERO100",
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(await getOrgCredits(user.orgId)).toBe(creditsBefore! + 100_000);
+      expect(
+        await findCreditExpiresRecordByStripeInvoiceId(user.orgId, sessionId),
+      ).toBeDefined();
     });
   });
 

--- a/turbo/apps/web/app/api/webhooks/stripe/route.ts
+++ b/turbo/apps/web/app/api/webhooks/stripe/route.ts
@@ -20,6 +20,7 @@ const log = logger("webhook:stripe");
  *
  * Handles incoming Stripe webhook events:
  * - checkout.session.completed — subscription activated
+ * - checkout.session.async_payment_succeeded — delayed one-time payment settled
  * - invoice.paid — grant monthly credits
  * - customer.subscription.updated — sync status/tier changes
  * - customer.subscription.deleted — downgrade to free
@@ -70,6 +71,9 @@ export async function POST(request: Request) {
   // correct `data.object` type without explicit casts.
   switch (event.type) {
     case "checkout.session.completed":
+      await handleCheckoutCompleted(event.data.object);
+      break;
+    case "checkout.session.async_payment_succeeded":
       await handleCheckoutCompleted(event.data.object);
       break;
     case "invoice.paid":

--- a/turbo/apps/web/src/__tests__/api-test-helpers/org.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/org.ts
@@ -9,6 +9,7 @@ export {
   insertOrgMembersEntry,
   insertOrgDefaultModelProvider,
   setOrgCredits,
+  lockOrgAndSetCredits,
 } from "../db-test-seeders/org";
 
 // Re-exports: read-only assertions

--- a/turbo/apps/web/src/__tests__/db-test-seeders/org.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/org.ts
@@ -241,3 +241,48 @@ export async function setOrgCredits(
       set: { credits, updatedAt: new Date() },
     });
 }
+
+/**
+ * Hold a row lock on org_metadata, update credits, and keep the transaction
+ * open until the returned release function is called.
+ *
+ * @why-db-direct Exercises lock-ordering race conditions in service tests;
+ * no API route can hold a row lock open for coordinated concurrency.
+ */
+export async function lockOrgAndSetCredits(
+  orgId: string,
+  credits: number,
+): Promise<{
+  release: () => void;
+  ready: Promise<void>;
+  done: Promise<void>;
+}> {
+  initServices();
+
+  let release!: () => void;
+  const releaseSignal = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let markReady!: () => void;
+  const ready = new Promise<void>((resolve) => {
+    markReady = resolve;
+  });
+
+  const done = globalThis.services.db.transaction(async (tx) => {
+    await tx
+      .select({ orgId: orgMetadata.orgId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId))
+      .for("update");
+
+    await tx
+      .update(orgMetadata)
+      .set({ credits, updatedAt: new Date() })
+      .where(eq(orgMetadata.orgId, orgId));
+
+    markReady();
+    await releaseSignal;
+  });
+
+  return { release, ready, done };
+}

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/auto-recharge-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/auto-recharge-service.test.ts
@@ -5,6 +5,7 @@ import {
   uniqueId,
   type UserContext,
 } from "../../../../__tests__/test-helpers";
+import { orgMetadata } from "../../../../db/schema/org-metadata";
 import {
   getOrgCredits,
   updateOrgTier,
@@ -50,8 +51,6 @@ vi.mock("stripe", () => {
 });
 
 import { reloadEnv } from "../../../../env";
-// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: deterministic row-lock race coverage
-import { orgMetadata } from "../../../../db/schema/org-metadata";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
 import {
   triggerAutoRecharge,
@@ -283,21 +282,25 @@ describe("auto-recharge-service", () => {
         releaseLock = resolve;
       });
       const blockerReady = new Promise<void>((resolve) => {
-        void globalThis.services.db.transaction(async (tx) => {
-          await tx
-            .select({ orgId: orgMetadata.orgId })
-            .from(orgMetadata)
-            .where(eq(orgMetadata.orgId, user.orgId))
-            .for("update");
+        globalThis.services.db
+          .transaction(async (tx) => {
+            await tx
+              .select({ orgId: orgMetadata.orgId })
+              .from(orgMetadata)
+              .where(eq(orgMetadata.orgId, user.orgId))
+              .for("update");
 
-          await tx
-            .update(orgMetadata)
-            .set({ credits: 250_000, updatedAt: new Date() })
-            .where(eq(orgMetadata.orgId, user.orgId));
+            await tx
+              .update(orgMetadata)
+              .set({ credits: 250_000, updatedAt: new Date() })
+              .where(eq(orgMetadata.orgId, user.orgId));
 
-          resolve();
-          await rowUpdated;
-        });
+            resolve();
+            await rowUpdated;
+          })
+          .catch((error: unknown) => {
+            throw error;
+          });
       });
 
       await blockerReady;

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/auto-recharge-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/auto-recharge-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
 import {
   testContext,
   uniqueId,
@@ -49,6 +50,8 @@ vi.mock("stripe", () => {
 });
 
 import { reloadEnv } from "../../../../env";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: deterministic row-lock race coverage
+import { orgMetadata } from "../../../../db/schema/org-metadata";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
 import {
   triggerAutoRecharge,
@@ -261,6 +264,51 @@ describe("auto-recharge-service", () => {
 
       // Only one should have created an invoice
       expect(stripeMocks.invoicesCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("rechecks the latest balance before claiming a recharge slot", async () => {
+      const cusId = uniqueId("cus");
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 110_000,
+        autoRechargeAmount: 5000,
+      });
+
+      let releaseLock!: () => void;
+      const rowUpdated = new Promise<void>((resolve) => {
+        releaseLock = resolve;
+      });
+      const blockerReady = new Promise<void>((resolve) => {
+        void globalThis.services.db.transaction(async (tx) => {
+          await tx
+            .select({ orgId: orgMetadata.orgId })
+            .from(orgMetadata)
+            .where(eq(orgMetadata.orgId, user.orgId))
+            .for("update");
+
+          await tx
+            .update(orgMetadata)
+            .set({ credits: 250_000, updatedAt: new Date() })
+            .where(eq(orgMetadata.orgId, user.orgId));
+
+          resolve();
+          await rowUpdated;
+        });
+      });
+
+      await blockerReady;
+
+      const triggerPromise = triggerAutoRecharge(user.orgId);
+      releaseLock();
+      await triggerPromise;
+
+      expect(stripeMocks.invoicesCreate).not.toHaveBeenCalled();
+      const fields = await getOrgAutoRechargeFields(user.orgId);
+      expect(fields?.autoRechargePendingAt).toBeNull();
     });
 
     it("skips when Stripe customer is deleted", async () => {

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/auto-recharge-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/auto-recharge-service.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { eq } from "drizzle-orm";
 import {
   testContext,
   uniqueId,
   type UserContext,
 } from "../../../../__tests__/test-helpers";
-import { orgMetadata } from "../../../../db/schema/org-metadata";
 import {
   getOrgCredits,
   updateOrgTier,
@@ -13,6 +11,7 @@ import {
   updateOrgAutoRecharge,
   getOrgAutoRechargeFields,
   setOrgCredits,
+  lockOrgAndSetCredits,
 } from "../../../../__tests__/api-test-helpers";
 
 // Stripe mock — must be defined before importing the service
@@ -277,37 +276,13 @@ describe("auto-recharge-service", () => {
         autoRechargeAmount: 5000,
       });
 
-      let releaseLock!: () => void;
-      const rowUpdated = new Promise<void>((resolve) => {
-        releaseLock = resolve;
-      });
-      const blockerReady = new Promise<void>((resolve) => {
-        globalThis.services.db
-          .transaction(async (tx) => {
-            await tx
-              .select({ orgId: orgMetadata.orgId })
-              .from(orgMetadata)
-              .where(eq(orgMetadata.orgId, user.orgId))
-              .for("update");
-
-            await tx
-              .update(orgMetadata)
-              .set({ credits: 250_000, updatedAt: new Date() })
-              .where(eq(orgMetadata.orgId, user.orgId));
-
-            resolve();
-            await rowUpdated;
-          })
-          .catch((error: unknown) => {
-            throw error;
-          });
-      });
-
-      await blockerReady;
+      const blocker = await lockOrgAndSetCredits(user.orgId, 250_000);
+      await blocker.ready;
 
       const triggerPromise = triggerAutoRecharge(user.orgId);
-      releaseLock();
+      blocker.release();
       await triggerPromise;
+      await blocker.done;
 
       expect(stripeMocks.invoicesCreate).not.toHaveBeenCalled();
       const fields = await getOrgAutoRechargeFields(user.orgId);

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../__tests__/test-helpers";
+import { getOrgBillingFields } from "../../../../__tests__/api-test-helpers";
+
+const stripeMocks = vi.hoisted(() => {
+  return {
+    customersCreate: vi.fn(),
+    checkoutSessionsCreate: vi.fn(),
+    subscriptionsRetrieve: vi.fn(),
+    billingPortalSessionsCreate: vi.fn(),
+    invoicesList: vi.fn(),
+  };
+});
+
+vi.mock("stripe", () => {
+  return {
+    default: function MockStripe() {
+      return {
+        customers: { create: stripeMocks.customersCreate },
+        checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
+        subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+        billingPortal: {
+          sessions: { create: stripeMocks.billingPortalSessionsCreate },
+        },
+        invoices: { list: stripeMocks.invoicesList },
+        webhooks: { constructEvent: vi.fn() },
+      };
+    },
+  };
+});
+
+import { createCheckoutSession } from "../billing-service";
+
+const context = testContext();
+
+describe("billing-service", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    stripeMocks.customersCreate.mockReset();
+    stripeMocks.checkoutSessionsCreate.mockReset();
+    stripeMocks.subscriptionsRetrieve.mockReset();
+    stripeMocks.billingPortalSessionsCreate.mockReset();
+    stripeMocks.invoicesList.mockReset();
+
+    stripeMocks.checkoutSessionsCreate.mockImplementation(async (params) => {
+      return {
+        url: `https://checkout.stripe.test/${params.customer}`,
+      };
+    });
+  });
+
+  it("serializes Stripe customer creation across concurrent checkout requests", async () => {
+    const firstCustomerId = uniqueId("cus");
+
+    stripeMocks.customersCreate.mockImplementationOnce(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      return { id: firstCustomerId };
+    });
+
+    const checkout1 = createCheckoutSession(
+      user.orgId,
+      "price_test_pro",
+      "https://app.vm0.test/success",
+      "https://app.vm0.test/cancel",
+    );
+
+    const checkout2 = createCheckoutSession(
+      user.orgId,
+      "price_test_pro",
+      "https://app.vm0.test/success",
+      "https://app.vm0.test/cancel",
+    );
+
+    const [url1, url2] = await Promise.all([checkout1, checkout2]);
+
+    expect(stripeMocks.customersCreate).toHaveBeenCalledTimes(1);
+    expect(stripeMocks.checkoutSessionsCreate).toHaveBeenCalledTimes(2);
+
+    const sessionCustomers = stripeMocks.checkoutSessionsCreate.mock.calls.map(
+      ([params]) => {
+        return params.customer;
+      },
+    );
+    expect(sessionCustomers).toEqual([firstCustomerId, firstCustomerId]);
+    expect(url1).toBe(`https://checkout.stripe.test/${firstCustomerId}`);
+    expect(url2).toBe(`https://checkout.stripe.test/${firstCustomerId}`);
+
+    const billing = await getOrgBillingFields(user.orgId);
+    expect(billing?.stripeCustomerId).toBe(firstCustomerId);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
@@ -33,8 +33,6 @@ vi.mock("stripe", () => {
   };
 });
 
-import { createCheckoutSession } from "../billing-service";
-
 const context = testContext();
 
 describe("billing-service", () => {
@@ -58,6 +56,7 @@ describe("billing-service", () => {
   });
 
   it("serializes Stripe customer creation across concurrent checkout requests", async () => {
+    const { createCheckoutSession } = await import("../billing-service");
     const firstCustomerId = uniqueId("cus");
 
     stripeMocks.customersCreate.mockImplementationOnce(async () => {

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/one-time-purchase-webhook.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/one-time-purchase-webhook.test.ts
@@ -56,6 +56,7 @@ interface CheckoutInput {
   subscription: string | { id: string } | null;
   customer: string | { id: string } | null;
   metadata: Record<string, string> | null;
+  payment_status?: string | null;
 }
 
 function oneTimeSession(
@@ -67,6 +68,7 @@ function oneTimeSession(
     subscription: null,
     customer: "cus_one_time",
     metadata,
+    payment_status: "paid",
   };
 }
 
@@ -112,6 +114,37 @@ describe("handleCheckoutCompleted — one-time purchase dispatch", () => {
     const expiresMs = row!.expiresAt.getTime() - now;
     expect(expiresMs).toBeGreaterThan(29 * 24 * 60 * 60 * 1000);
     expect(expiresMs).toBeLessThan(31 * 24 * 60 * 60 * 1000);
+  });
+
+  it("does not grant credits until a one-time checkout is actually paid", async () => {
+    const sessionId = `cs_test_${user.userId}_awaiting_payment`;
+    await handleCheckoutCompleted(
+      oneTimeSession(sessionId, {
+        purpose: "one_time_purchase",
+        orgId: user.orgId,
+        campaignKey: KNOWN_CAMPAIGN,
+      }),
+    );
+
+    expect(await getOrgCredits(user.orgId)).toBe(baseCredits + KNOWN_CREDITS);
+
+    const unpaidSessionId = `cs_test_${user.userId}_unpaid`;
+    await handleCheckoutCompleted({
+      ...oneTimeSession(unpaidSessionId, {
+        purpose: "one_time_purchase",
+        orgId: user.orgId,
+        campaignKey: KNOWN_CAMPAIGN,
+      }),
+      payment_status: "unpaid",
+    });
+
+    expect(await getOrgCredits(user.orgId)).toBe(baseCredits + KNOWN_CREDITS);
+
+    const unpaidRow = await findCreditExpiresRecordByStripeInvoiceId(
+      user.orgId,
+      unpaidSessionId,
+    );
+    expect(unpaidRow).toBeUndefined();
   });
 
   it("is idempotent when the same session id is delivered twice", async () => {

--- a/turbo/apps/web/src/lib/zero/billing/auto-recharge-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/auto-recharge-service.ts
@@ -35,22 +35,11 @@ interface OrgRechargeState {
   autoRechargePendingAt: Date | null;
 }
 
-function isEligibleForRecharge(
-  org: OrgRechargeState,
-): org is OrgRechargeState & {
+type ClaimedRechargeState = OrgRechargeState & {
   stripeCustomerId: string;
   autoRechargeThreshold: number;
   autoRechargeAmount: number;
-} {
-  return (
-    org.autoRechargeEnabled &&
-    org.tier !== "free" &&
-    org.stripeCustomerId !== null &&
-    org.autoRechargeThreshold !== null &&
-    org.autoRechargeAmount !== null &&
-    org.credits <= org.autoRechargeThreshold
-  );
-}
+};
 
 async function clearPendingFlag(orgId: string): Promise<void> {
   const db = globalThis.services.db;
@@ -110,9 +99,25 @@ async function resolvePaymentMethod(
 export async function triggerAutoRecharge(orgId: string): Promise<void> {
   const db = globalThis.services.db;
 
-  // Read org state
-  const [org] = await db
-    .select({
+  // Atomically claim the recharge slot against fresh org state. This prevents
+  // using an outdated balance/config snapshot after a manual top-up, renewal,
+  // or settings change that lands between "should recharge?" and invoice
+  // creation.
+  const claimed = await db
+    .update(orgMetadata)
+    .set({ autoRechargePendingAt: new Date(), updatedAt: new Date() })
+    .where(
+      sql`${orgMetadata.orgId} = ${orgId}
+          AND ${orgMetadata.autoRechargeEnabled} = true
+          AND ${orgMetadata.tier} != 'free'
+          AND ${orgMetadata.stripeCustomerId} IS NOT NULL
+          AND ${orgMetadata.autoRechargeThreshold} IS NOT NULL
+          AND ${orgMetadata.autoRechargeAmount} IS NOT NULL
+          AND ${orgMetadata.credits} <= ${orgMetadata.autoRechargeThreshold}
+          AND (${orgMetadata.autoRechargePendingAt} IS NULL
+               OR ${orgMetadata.autoRechargePendingAt} < now() - interval '${sql.raw(String(STALE_THRESHOLD_MINUTES))} minutes')`,
+    )
+    .returning({
       credits: orgMetadata.credits,
       tier: orgMetadata.tier,
       stripeCustomerId: orgMetadata.stripeCustomerId,
@@ -121,27 +126,10 @@ export async function triggerAutoRecharge(orgId: string): Promise<void> {
       autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
       autoRechargeAmount: orgMetadata.autoRechargeAmount,
       autoRechargePendingAt: orgMetadata.autoRechargePendingAt,
-    })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
+    });
 
-  if (!org || !isEligibleForRecharge(org)) return;
-
-  // Atomically claim the recharge slot — only one writer wins.
-  // Allows retry if the previous pending is stale (> 10 min).
-  const claimed = await db
-    .update(orgMetadata)
-    .set({ autoRechargePendingAt: new Date(), updatedAt: new Date() })
-    .where(
-      sql`${orgMetadata.orgId} = ${orgId}
-          AND ${orgMetadata.autoRechargeEnabled} = true
-          AND (${orgMetadata.autoRechargePendingAt} IS NULL
-               OR ${orgMetadata.autoRechargePendingAt} < now() - interval '${sql.raw(String(STALE_THRESHOLD_MINUTES))} minutes')`,
-    )
-    .returning({ orgId: orgMetadata.orgId });
-
-  if (claimed.length === 0) {
+  const org = claimed[0] as ClaimedRechargeState | undefined;
+  if (!org) {
     log.debug("Auto-recharge already pending, skipping", { orgId });
     return;
   }

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import type { OrgTier } from "@vm0/core";
 import { getStripe } from "../stripe";
 import { env } from "../../../env";
@@ -30,6 +30,7 @@ interface CheckoutSessionInput {
   subscription: string | { id: string } | null;
   customer: string | { id: string } | null;
   metadata: Record<string, string> | null;
+  payment_status?: string | null;
 }
 
 /** Fields read by {@link handleInvoicePaid}. */
@@ -92,24 +93,30 @@ export function activePriceId(tier: "pro" | "team"): string | undefined {
  */
 async function getOrCreateStripeCustomer(orgId: string): Promise<string> {
   const db = globalThis.services.db;
-  const [row] = await db
-    .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
+  return db.transaction(async (tx) => {
+    // Serialize customer materialization per org so concurrent checkout / redeem
+    // requests cannot mint multiple Stripe customers and orphan webhook events.
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext('stripe_customer_' || ${orgId}))`,
+    );
 
-  if (row?.stripeCustomerId) {
-    return row.stripeCustomerId;
-  }
+    const [row] = await tx
+      .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId))
+      .limit(1);
 
-  const stripe = getStripe();
-  const customer = await stripe.customers.create({
-    metadata: { orgId },
-  });
+    if (row?.stripeCustomerId) {
+      return row.stripeCustomerId;
+    }
 
-  // Guarantee the starter grant at first org_metadata materialisation — a
-  // free user may skip onboarding and first hit billing (pricing → upgrade).
-  await db.transaction(async (tx) => {
+    const stripe = getStripe();
+    const customer = await stripe.customers.create({
+      metadata: { orgId },
+    });
+
+    // Guarantee the starter grant at first org_metadata materialisation — a
+    // free user may skip onboarding and first hit billing (pricing → upgrade).
     await ensureStarterCreditGrant(tx, orgId);
     await tx
       .insert(orgMetadata)
@@ -118,9 +125,9 @@ async function getOrCreateStripeCustomer(orgId: string): Promise<string> {
         target: orgMetadata.orgId,
         set: { stripeCustomerId: customer.id, updatedAt: new Date() },
       });
-  });
 
-  return customer.id;
+    return customer.id;
+  });
 }
 
 /**
@@ -167,6 +174,13 @@ export async function handleCheckoutCompleted(
   session: CheckoutSessionInput,
 ): Promise<void> {
   if (session.metadata?.purpose === "one_time_purchase") {
+    if (session.payment_status !== "paid") {
+      log.info("one_time_purchase checkout completed before payment settled", {
+        sessionId: session.id,
+        paymentStatus: session.payment_status ?? null,
+      });
+      return;
+    }
     await handleOneTimePurchaseCompleted(session);
     return;
   }


### PR DESCRIPTION
## Summary
- gate one-time credit grants on settled Stripe payments and handle `checkout.session.async_payment_succeeded`
- serialize Stripe customer creation per org to avoid duplicate customers and orphaned billing webhooks
- re-check auto-recharge eligibility inside the atomic claim query so stale balances/config changes cannot trigger unwanted recharges
- add regression coverage for unpaid one-time checkouts, async payment success, concurrent checkout customer creation, and stale-state auto-recharge races

## Testing
- `timeout 120s pnpm --dir /workspaces/vm6/turbo/apps/web exec vitest run /workspaces/vm6/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts`
- `timeout 120s pnpm --dir /workspaces/vm6/turbo/apps/web exec vitest run /workspaces/vm6/turbo/apps/web/src/lib/zero/billing/__tests__/one-time-purchase-webhook.test.ts`
- `timeout 120s pnpm --dir /workspaces/vm6/turbo/apps/web exec vitest run /workspaces/vm6/turbo/apps/web/src/lib/zero/billing/__tests__/auto-recharge-service.test.ts`
- `timeout 120s pnpm --dir /workspaces/vm6/turbo/apps/web exec vitest run /workspaces/vm6/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts`
