### PR TITLE
refactor(infra): remove memoryName from infra layer

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -110,26 +110,6 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.status).toBe("pending");
     });
 
-    it("should reject legacy memoryName body field with 400", async () => {
-      const request = createTestRequest(
-        "http://localhost:3000/api/agent/runs",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentComposeId: testComposeId,
-            prompt: "Legacy memoryName should be rejected",
-            memoryName: "legacy-field",
-          }),
-        },
-      );
-      const response = await POST(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(400);
-      expect(data.error.code).toBe("BAD_REQUEST");
-    });
-
     it("should reject legacy artifactName body field with 400", async () => {
       const request = createTestRequest(
         "http://localhost:3000/api/agent/runs",

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -16,7 +16,6 @@ import {
 } from "../../../../src/db/schema/agent-compose";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
 import {
-  AUTO_MEMORY_MOUNT_PATH,
   type AdditionalArtifact,
   type AdditionalVolume,
 } from "../../../../src/lib/infra/storage/types";
@@ -378,21 +377,6 @@ const router = tsr.router(runsMainContract, {
         artifacts: effectiveArtifacts,
       } = consolidateArtifactInputs(body, resolved);
 
-      // 6b. Synthesize memory-as-artifact at the auto-memory mount path for
-      // session/checkpoint-resumed runs. Mirrors buildZeroExecutionContext's
-      // memoryArtifacts synthesis — the CLI path carries memory through the
-      // unified artifacts[] channel, not a dedicated memoryName field.
-      const effectiveArtifactsWithMemory: AdditionalArtifact[] | undefined =
-        resolved.memoryName
-          ? [
-              ...(effectiveArtifacts ?? []),
-              {
-                name: resolved.memoryName,
-                mountPath: AUTO_MEMORY_MOUNT_PATH,
-              },
-            ]
-          : effectiveArtifacts;
-
       // 7. Concurrency check + INSERT (transaction with advisory lock)
       const run = await globalThis.services.db.transaction(async (tx) => {
         await tx.execute(
@@ -412,7 +396,6 @@ const router = tsr.router(runsMainContract, {
           resumedFromCheckpointId: body.checkpointId,
           sessionId: body.sessionId,
           artifactName: effectiveArtifactName,
-          memoryName: resolved.memoryName,
         });
       });
       const transactionTime = Date.now();
@@ -441,7 +424,7 @@ const router = tsr.router(runsMainContract, {
           secretConnectorMap: resolved.secretConnectorMap,
           artifactName: effectiveArtifactName,
           artifactVersion: effectiveArtifactVersion,
-          artifacts: effectiveArtifactsWithMemory,
+          artifacts: effectiveArtifacts,
           volumeVersions: resolved.volumeVersions ?? body.volumeVersions,
           additionalVolumes: finalAdditionalVolumes,
           environment: resolved.environment,

--- a/turbo/apps/web/src/__tests__/db-test-assertions/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/agents.ts
@@ -113,7 +113,6 @@ export async function getTestAgentSessionWithConversation(
       orgId: string;
       agentComposeId: string;
       conversationId: string | null;
-      memoryName: string | null;
     }
   | undefined
 > {
@@ -132,7 +131,6 @@ export async function getTestAgentSessionWithConversation(
     orgId: session.orgId,
     agentComposeId: session.agentComposeId,
     conversationId: session.conversationId ?? null,
-    memoryName: session.memoryName ?? null,
   };
 }
 

--- a/turbo/apps/web/src/lib/infra/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/infra/agent-session/agent-session-service.ts
@@ -51,7 +51,7 @@ export async function getAgentSessionWithConversation(
  * Update an existing agent session's conversation reference. Optional
  * artifactName lets the checkpoint webhook record the per-run artifact name
  * on sessions that were created eagerly at run insertion (when the name
- * was not yet known). memoryName is set at run creation, not here.
+ * was not yet known).
  */
 export async function updateAgentSession(
   id: string,
@@ -87,7 +87,6 @@ function mapToAgentSessionData(
     agentComposeId: session.agentComposeId,
     conversationId: session.conversationId,
     artifactName: session.artifactName,
-    memoryName: session.memoryName,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
   };

--- a/turbo/apps/web/src/lib/infra/agent-session/types.ts
+++ b/turbo/apps/web/src/lib/infra/agent-session/types.ts
@@ -14,7 +14,6 @@ export interface AgentSessionData {
   agentComposeId: string;
   conversationId: string | null;
   artifactName: string | null;
-  memoryName: string | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -182,8 +182,7 @@ export async function createCheckpoint(
   // Bind the pre-created agent session (always populated since #10323 made
   // agent_runs.session_id NOT NULL) to this conversation and record per-run
   // snapshot fields that were not known when the session was created eagerly
-  // at run insertion. memoryName on agent_sessions is populated at run
-  // creation (see insertRunRecord); the complete webhook no longer updates it.
+  // at run insertion.
   const volumeSnapshot = request.volumeVersionsSnapshot as
     | VolumeVersionsSnapshot
     | undefined;

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
@@ -45,8 +45,7 @@ export async function resolveCheckpoint(
 
   // Extract snapshots. The primary artifact name is sourced from
   // agent_sessions.artifact_name (populated at run creation); the version is
-  // looked up in the artifactSnapshots map. memoryName is sourced from
-  // agent_sessions.memory_name, matching the resolveSession path.
+  // looked up in the artifactSnapshots map.
   const agentComposeSnapshot =
     checkpoint.agentComposeSnapshot as unknown as AgentComposeSnapshot;
   const artifactSnapshotsMap =
@@ -70,14 +69,13 @@ export async function resolveCheckpoint(
     throw badRequest("Invalid checkpoint: missing agentComposeVersionId");
   }
 
-  // Verify checkpoint belongs to user and fetch session artifact/memory names
-  // in one query. Both live on agent_sessions (set eagerly at run creation),
+  // Verify checkpoint belongs to user and fetch the session artifact name
+  // in one query. It lives on agent_sessions (set eagerly at run creation),
   // not on checkpoint snapshots.
   const [originalRun] = await globalThis.services.db
     .select({
       runId: agentRuns.id,
       sessionArtifactName: agentSessions.artifactName,
-      sessionMemoryName: agentSessions.memoryName,
     })
     .from(agentRuns)
     .innerJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
@@ -146,7 +144,6 @@ export async function resolveCheckpoint(
     },
     artifactName: primaryArtifactName,
     artifactVersion: primaryArtifactVersion,
-    memoryName: originalRun.sessionMemoryName ?? undefined,
     vars: agentComposeSnapshot.vars || {},
     volumeVersions: checkpointVolumeVersions?.versions,
     additionalVolumes: checkpointAdditionalVolumes,

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
@@ -132,7 +132,6 @@ export async function resolveSession(
     },
     artifactName: session.artifactName ?? undefined,
     artifactVersion: session.artifactName ? "latest" : undefined,
-    memoryName: session.memoryName ?? undefined,
     vars: lastRunVars,
     volumeVersions: undefined,
     buildResumeArtifact: !!session.artifactName,

--- a/turbo/apps/web/src/lib/infra/run/resolvers/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/types.ts
@@ -17,7 +17,6 @@ export interface ConversationResolution {
   };
   artifactName?: string;
   artifactVersion?: string;
-  memoryName?: string;
   vars?: Record<string, string>;
   volumeVersions?: Record<string, string>;
   additionalVolumes?: AdditionalVolume[];

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -103,7 +103,6 @@ export interface CreateRunParams {
   secrets?: Record<string, string>;
   artifactName?: string;
   artifactVersion?: string;
-  memoryName?: string;
   volumeVersions?: Record<string, string>;
   callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
   resumedFromCheckpointId?: string;
@@ -433,7 +432,6 @@ interface InsertRunParams {
   resumedFromCheckpointId?: string;
   sessionId?: string;
   artifactName?: string;
-  memoryName?: string;
 }
 
 /**
@@ -458,7 +456,6 @@ export async function insertRunRecord(
         orgId: params.orgId,
         agentComposeId: params.agentComposeId,
         artifactName: params.artifactName,
-        memoryName: params.memoryName,
         conversationId: null,
       })
       .returning({ id: agentSessions.id });

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -351,7 +351,6 @@ interface ResolvedCliContext {
   agentCompose?: unknown;
   artifactName?: string;
   artifactVersion?: string;
-  memoryName?: string;
   vars?: Record<string, string>;
   volumeVersions?: Record<string, string>;
   additionalVolumes?: AdditionalVolume[];
@@ -411,7 +410,6 @@ export async function resolveCliRunContext(
   let artifactName: string | undefined;
   let artifactVersion: string | undefined;
   let vars: Record<string, string> | undefined = params.vars;
-  let memoryName: string | undefined;
   let volumeVersions: Record<string, string> | undefined =
     params.volumeVersions;
   let additionalVolumes: AdditionalVolume[] | undefined;
@@ -430,7 +428,6 @@ export async function resolveCliRunContext(
     agentCompose = defaults.agentCompose;
     artifactName = defaults.artifactName;
     artifactVersion = defaults.artifactVersion;
-    memoryName = defaults.memoryName;
     vars = defaults.vars;
     volumeVersions = defaults.volumeVersions;
     additionalVolumes = defaults.additionalVolumes;
@@ -535,7 +532,6 @@ export async function resolveCliRunContext(
     agentCompose,
     artifactName,
     artifactVersion,
-    memoryName,
     vars: mergedVars ?? vars,
     volumeVersions,
     additionalVolumes,
@@ -582,7 +578,7 @@ export async function buildZeroExecutionContext(
   let artifactName: string | undefined = params.artifactName;
   let artifactVersion: string | undefined = params.artifactVersion;
   let vars: Record<string, string> | undefined = params.vars;
-  let memoryName: string | undefined = params.memoryName;
+  const memoryName: string | undefined = params.memoryName;
   let volumeVersions: Record<string, string> | undefined =
     params.volumeVersions;
   let additionalVolumes: AdditionalVolume[] | undefined =
@@ -603,7 +599,6 @@ export async function buildZeroExecutionContext(
     agentCompose = defaults.agentCompose;
     artifactName = defaults.artifactName;
     artifactVersion = defaults.artifactVersion;
-    memoryName = defaults.memoryName;
     vars = defaults.vars;
     volumeVersions = defaults.volumeVersions;
     additionalVolumes = params.additionalVolumes || defaults.additionalVolumes;

--- a/turbo/apps/web/src/lib/zero/context/resolve-source.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-source.ts
@@ -185,7 +185,6 @@ interface ApplyResolutionDefaultsParams {
   agentComposeVersionId?: string;
   artifactName?: string;
   artifactVersion?: string;
-  memoryName?: string;
   vars?: Record<string, string>;
   volumeVersions?: Record<string, string>;
   additionalVolumes?: AdditionalVolume[];
@@ -203,7 +202,6 @@ export function applyResolutionDefaults(
   agentCompose: unknown;
   artifactName: string | undefined;
   artifactVersion: string | undefined;
-  memoryName: string | undefined;
   vars: Record<string, string> | undefined;
   volumeVersions: Record<string, string> | undefined;
   additionalVolumes: AdditionalVolume[] | undefined;
@@ -228,7 +226,6 @@ export function applyResolutionDefaults(
     agentCompose: resolution.agentCompose,
     artifactName,
     artifactVersion,
-    memoryName: params.memoryName || resolution.memoryName,
     vars: params.vars || resolution.vars,
     volumeVersions: params.volumeVersions || resolution.volumeVersions,
     additionalVolumes: params.additionalVolumes || resolution.additionalVolumes,

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -119,7 +119,6 @@ export async function enqueueRun(
           orgId,
           agentComposeId,
           artifactName: params.artifactName,
-          memoryName: params.memoryName,
           conversationId: null,
         })
         .returning({ id: agentSessions.id });
@@ -552,6 +551,7 @@ export async function dispatchQueuedZeroRun(
   const tokenTime = Date.now();
   const contextResult = await buildZeroExecutionContext({
     ...params,
+    memoryName: "memory",
     secrets: { ...params.secrets, ZERO_TOKEN: zeroToken },
     sandboxToken,
     agentCompose: composeContent,

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -507,7 +507,6 @@ async function createZeroRunRecord(
     modelProviderId: params.modelProviderId,
     selectedModelOverride: params.selectedModelOverride,
     callbacks: params.callbacks,
-    memoryName: "memory",
     disallowedTools: [...DISALLOWED_TOOLS],
     vars: { ZERO_AGENT_ID: params.agentId },
     permissionPolicies: permissionPolicies ?? undefined,
@@ -587,7 +586,6 @@ async function createZeroRunRecord(
           resumedFromCheckpointId: runParams.resumedFromCheckpointId,
           sessionId: runParams.sessionId,
           artifactName: runParams.artifactName,
-          memoryName: runParams.memoryName,
         });
       });
       emit(CHAT_REQUEST_OPS.create_run_insert_run_record, insertT.ms);
@@ -695,6 +693,7 @@ async function dispatchZeroRun(
     };
     const contextResult = await buildZeroExecutionContext({
       ...paramsWithToken,
+      memoryName: "memory",
       sandboxToken,
       runId: record.run.id,
       agentCompose: record.composeContent,


### PR DESCRIPTION
## Summary

- Removes all `memoryName` references from the infra layer (`src/lib/infra/*`, `/api/agent/*`, `db-test-assertions`) as part of Epic #10843 cleanup after memory was migrated to the zero layer (Epic #10740).
- The `agent_sessions.memory_name` column is intentionally **kept** — a later Epic sub-issue bundles the schema drop with the migration. Writes to the column are removed (no readers remain).
- Zero-layer type adaptations: `zero-run-service` and `zero-run-queue-service` no longer route `memoryName` through infra's `CreateRunParams`/`InsertRunParams`. Instead they pass the hardcoded `"memory"` value directly to `buildZeroExecutionContext`, so memory-artifact synthesis still works for `/api/zero/runs`.

## Test plan

- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm -F web exec vitest run app/api/agent/runs/__tests__` — 88/88 pass
- [x] `pnpm -F web exec vitest run app/api/zero/runs src/lib/zero src/lib/infra/run src/lib/infra/agent-session src/lib/infra/checkpoint` — 779/779 pass
- [x] `pnpm knip` — clean (only pre-existing config hints)
- [x] Confirmed `agent_sessions.memory_name` is nullable before removing the insert
- [x] Confirmed no remaining `memoryName` in `src/lib/infra/**`, `app/api/agent/**`, `app/api/webhooks/**`, `db-test-assertions/`

Closes #10848

🤖 Generated with [Claude Code](https://claude.com/claude-code)