### PR TITLE
refactor(infra): stop updating agent_sessions.artifact_name on checkpoint webhook

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
   findTestCheckpoint,
   findTestRunRecord,
   getTestAgentSessionWithConversation,
+  setTestAgentSessionArtifactName,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import {
@@ -740,6 +741,44 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       // run.sessionId unchanged
       const runAfter = await findTestRunRecord(testRunId);
       expect(runAfter?.sessionId).toBe(preCreatedSessionId);
+    });
+
+    it("should not mutate agent_sessions.artifact_name when checkpoint webhook fires", async () => {
+      // The API-based createTestRun helper does not exercise the artifact-name
+      // path, so pre-populate the field directly to simulate a session whose
+      // artifactName was set at run creation.
+      const runBefore = await findTestRunRecord(testRunId);
+      const sessionId = runBefore!.sessionId!;
+      const originalArtifactName = "user-specified-artifact";
+      await setTestAgentSessionArtifactName(sessionId, originalArtifactName);
+
+      // Fire a checkpoint webhook whose artifactSnapshots map first key
+      // differs from the session's artifactName.
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "artifact-name-preserve",
+            cliAgentSessionHistoryHash: sha256("artifact-name-preserve"),
+            artifactSnapshots: {
+              "different-artifact-name": "v1",
+              "another-name": "v2",
+            },
+          }),
+        },
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const sessionAfter = await getTestAgentSessionWithConversation(sessionId);
+      expect(sessionAfter?.artifactName).toBe(originalArtifactName);
     });
   });
 });

--- a/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
@@ -30,6 +30,7 @@ export {
   setTestChatMessageAttachFiles,
   setTestChatMessageContent,
   setTestChatThreadLastReadAt,
+  setTestAgentSessionArtifactName,
 } from "../db-test-seeders/agents";
 
 export {

--- a/turbo/apps/web/src/__tests__/db-test-assertions/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/agents.ts
@@ -114,6 +114,7 @@ export async function getTestAgentSessionWithConversation(
       agentComposeId: string;
       conversationId: string | null;
       memoryName: string | null;
+      artifactName: string | null;
     }
   | undefined
 > {
@@ -133,6 +134,7 @@ export async function getTestAgentSessionWithConversation(
     agentComposeId: session.agentComposeId,
     conversationId: session.conversationId ?? null,
     memoryName: session.memoryName ?? null,
+    artifactName: session.artifactName ?? null,
   };
 }
 

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -364,6 +364,24 @@ export async function createTestSessionWithConversation(
 }
 
 /**
+ * Set artifact_name on an agent session directly in the database.
+ *
+ * @why-db-direct The run-creation API resolves artifactName via storage
+ * lookup; tests that need a known artifactName on a pre-seeded session
+ * (e.g. to verify webhook invariants) must set it directly.
+ */
+export async function setTestAgentSessionArtifactName(
+  sessionId: string,
+  artifactName: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(agentSessions)
+    .set({ artifactName })
+    .where(eq(agentSessions.id, sessionId));
+}
+
+/**
  * Set last_read_at on a chat thread directly in the database.
  *
  * @why-db-direct The mark-read API sets last_read_at via a forward-only

--- a/turbo/apps/web/src/lib/infra/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/infra/agent-session/agent-session-service.ts
@@ -48,25 +48,18 @@ export async function getAgentSessionWithConversation(
 }
 
 /**
- * Update an existing agent session's conversation reference. Optional
- * artifactName lets the checkpoint webhook record the per-run artifact name
- * on sessions that were created eagerly at run insertion (when the name
- * was not yet known). memoryName is set at run creation, not here.
+ * Bind an agent session to its conversation. Called by the checkpoint
+ * webhook once the CLI-side session history is uploaded and the
+ * conversation row is upserted. Sessions are created eagerly at run
+ * insertion; artifactName/memoryName are populated then, not here.
  */
 export async function updateAgentSession(
   id: string,
   conversationId: string,
-  options?: { artifactName?: string },
 ): Promise<AgentSessionData> {
   const [session] = await globalThis.services.db
     .update(agentSessions)
-    .set({
-      conversationId,
-      updatedAt: new Date(),
-      ...(options?.artifactName !== undefined
-        ? { artifactName: options.artifactName }
-        : {}),
-    })
+    .set({ conversationId, updatedAt: new Date() })
     .where(eq(agentSessions.id, id))
     .returning();
 

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -143,10 +143,11 @@ export async function createCheckpoint(
       }
     : null;
 
-  const rawMap = request.artifactSnapshots ?? null;
-  const hasMap = rawMap !== null && Object.keys(rawMap).length > 0;
-  const artifactSnapshotsMap = hasMap ? rawMap : null;
-  const primaryArtifactName = hasMap ? Object.keys(rawMap)[0] : undefined;
+  const artifactSnapshotsMap =
+    request.artifactSnapshots &&
+    Object.keys(request.artifactSnapshots).length > 0
+      ? request.artifactSnapshots
+      : null;
 
   const snapshotFields = {
     conversationId: conversation.id,
@@ -191,13 +192,7 @@ export async function createCheckpoint(
   if (!run.sessionId) {
     throw notFound("Agent run has no session_id");
   }
-  const agentSession = await updateAgentSession(
-    run.sessionId,
-    conversation.id,
-    {
-      artifactName: primaryArtifactName,
-    },
-  );
+  const agentSession = await updateAgentSession(run.sessionId, conversation.id);
 
   log.debug(`Agent session updated/created: ${agentSession.id}`);
 


### PR DESCRIPTION
## Summary

Closes #10847 (parent epic #10843).

The checkpoint webhook was overwriting `agent_sessions.artifact_name` on every call with an arbitrary `Object.keys(request.artifactSnapshots)[0]` value. The "primary" designation had no semantic basis — it was just whichever key happened to come first in the runner-reported map. After this PR, `agent_sessions.artifact_name` is set once at run/session creation (from the user's run input) and never mutated by subsequent checkpoint webhooks.

- Remove the `updateAgentSession(..., { artifactName })` write and the now-unused `primaryArtifactName` local in `checkpoint-service.ts`. Response synthesis already uses the full `artifactSnapshotsMap`, so no consumer breaks.
- Drop the `options` parameter from the `updateAgentSession` helper — it had a single caller passing `artifactName`, which is now gone.
- Extend `getTestAgentSessionWithConversation` to surface `artifactName`, add a `setTestAgentSessionArtifactName` seeder, and wire them through the api-test-helpers barrel for the regression test.

## Test plan

- [x] New integration test in `app/api/webhooks/agent/checkpoints/__tests__/route.test.ts`: seeds `agent_sessions.artifact_name = "user-specified-artifact"`, fires the webhook with an `artifactSnapshots` map whose first key is `different-artifact-name`, and asserts the session's `artifact_name` is unchanged after the webhook.
- [x] Existing checkpoint webhook tests — 18 pass (17 existing + 1 new).
- [x] `src/lib/infra/run`, `src/lib/infra/agent-session`, `src/lib/infra/checkpoint` — 35 pass.
- [x] `app/api/agent/runs` — 202 pass.
- [x] `pnpm turbo run lint` — 0 warnings, 0 errors.
- [x] `pnpm check-types` — clean.
- [x] `pnpm format` — unchanged.
- [x] `pnpm knip` — no issues.

## Rollback

Pure code change, no schema migration. Revert the PR — the checkpoint webhook resumes overwriting `artifact_name`. No data loss.