### PR TITLE
feat(x-billing): map connector usage to official x api pricing buckets

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -244,6 +244,22 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Needed for the classifier↔firewall consistency check in
+      # tests/test_x_billing.py: the check reads
+      # `turbo/packages/core/src/firewalls/x.generated.ts`, which is
+      # gitignored and materialized by the `postinstall` hook in
+      # `turbo/package.json` (runs `@vm0/firewalls-generator generate`).
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          cache-dependency-path: turbo/pnpm-lock.yaml
+      - name: Install turbo deps (triggers firewalls-generator postinstall)
+        run: cd turbo && pnpm install --frozen-lockfile
+
       - name: Lint and format check
         run: |
           cd crates/runner/mitm-addon

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -19,6 +19,11 @@ from logging_utils import log_proxy_entry
 
 from ...namespaces import USAGE_EVENT_NAMESPACE_CONNECTOR
 from ...webhook import _enqueue_webhook
+from .x_billing import (
+    classify_bucket,
+    classify_includes_bucket,
+    refine_bucket_with_body,
+)
 
 # HTTP 2xx success range (RFC 9110).  Also defined in ``mitm_addon.py``; kept
 # local to avoid introducing a constants module for two callers.  The upper
@@ -288,42 +293,22 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
     return result
 
 
-# Conservative upper bound for GET requests whose body we couldn't parse and
-# whose URL carried no count hints.  X v2 read endpoints cap max_results at
-# 100 for most collections (search, timelines, liking_users, ...); using 100
-# as the floor avoids silent undercount if X ever changes response schema
-# or returns unparseable JSON.  Higher-capacity endpoints (search/all=500,
-# followers=1000) are still over-counted relative to reality — acceptable
-# for a rare edge case that should also trigger server-side monitoring.
-_UNPARSEABLE_READ_FALLBACK = 100
+def _compute_billable_counts(
+    method: str,
+    req_meta: dict,
+    resp_meta: dict,
+    endpoint_bucket: str,
+    log_warn: Callable[[str, dict], None] = lambda *_: None,
+) -> dict:
+    """Derive per-bucket billable resource counts for an X request.
 
+    Returns a dict mapping X billing bucket name → resource count.  The
+    caller emits one ``usage_event`` row per key in that dict.  Bucket
+    names correspond to X's published pricing buckets (see
+    :mod:`.x_billing`).
 
-# Mapping from X v2 ``includes.<key>`` resource types to firewall
-# permission names.  Listed explicitly for reviewability; unknown future
-# keys fall back to ``<key>.read`` in :func:`_compute_billable_counts`.
-# The ``tweets`` → ``tweet.read`` entry is the one irregular case
-# (includes key is plural, firewall permission is singular) — without it
-# referenced tweets would land on a separate ``tweets.read`` key.
-_INCLUDES_TO_PERMISSION = {
-    "users": "users.read",
-    "tweets": "tweet.read",
-    "media": "media.read",
-    "polls": "polls.read",
-    "places": "places.read",
-    "topics": "topics.read",
-}
-
-
-def _compute_billable_counts(method: str, req_meta: dict, resp_meta: dict, endpoint: str) -> dict:
-    """Derive per-permission billable resource counts for an X request.
-
-    Returns a dict mapping firewall permission name → resource count.
-    Keys are always existing X firewall permissions so the server's
-    usage pricing table doesn't need separate entries for expansion
-    resources.
-
-    Writes (non-GET) always count as ``{endpoint: 1}`` regardless of
-    response shape — X write endpoints don't support expansions.
+    Writes (non-GET) always count as ``{endpoint_bucket: 1}`` regardless
+    of response shape — X write endpoints don't support expansions.
 
     Reads (GET):
 
@@ -333,22 +318,20 @@ def _compute_billable_counts(method: str, req_meta: dict, resp_meta: dict, endpo
 
     - **Body parsed**: ``max(data_count, result_count)`` — trust the
       actual response.  Soft errors (HTTP 200 + ``errors`` array, no
-      ``data``) and zero-result searches correctly yield 0.
+      ``data``) and zero-result searches yield primary 0, which is
+      skipped from the returned dict so no empty ``usage_event`` row
+      is created.
     - **Body NOT parsed**: fall back to request-side hints
-      ``max(ids_count, max_results, 1)``, or
-      :data:`_UNPARSEABLE_READ_FALLBACK` (100) when no hints exist,
-      to avoid silent undercount.
-    - **Includes**: each ``includes.<key>`` is mapped via
-      :data:`_INCLUDES_TO_PERMISSION` when that type has a dedicated
-      firewall permission (``users`` → ``users.read``, ``tweets`` →
-      ``tweet.read``).  Unknown types fall back to a synthetic
-      ``<key>.read`` permission (e.g. ``future_widget`` →
-      ``future_widget.read``) so the server can price (or ignore) new
-      expansion types without a proxy redeploy.  Counts at the same
-      permission are summed.
+      ``max(ids_count, max_results, 1)``.  When the URL also carries
+      no hints we emit no ``usage_event`` row; :func:`report_usage`
+      detects that state and writes an error log so ops can audit.
+    - **Includes**: each ``includes.<key>`` is mapped to a billing
+      bucket via :func:`classify_includes_bucket`.  Unknown keys emit
+      a synthetic ``includes.<key>`` category for server-side fallback
+      pricing.  Counts at the same bucket are summed.
     """
     if method != "GET":
-        return {endpoint: 1}
+        return {endpoint_bucket: 1}
 
     data = resp_meta.get("response_data_count") or 0
     result = resp_meta.get("response_result_count") or 0
@@ -359,26 +342,33 @@ def _compute_billable_counts(method: str, req_meta: dict, resp_meta: dict, endpo
         primary = max(data, result)
     else:
         # Body couldn't be parsed — fall back to request-side hints.
+        # With no hints at all we leave primary at 0 and let the caller
+        # log this loss of visibility; blind-guessing a quantity risks
+        # over-charging by a large factor on small real responses.
         ids = req_meta.get("request_ids_count") or 0
         max_r = req_meta.get("max_results") or 0
-        primary = max(ids, max_r, 1)
-        # No hints at all → conservative fallback to avoid silent undercount.
-        if not any((ids, data, result, max_r)):
-            primary = max(primary, _UNPARSEABLE_READ_FALLBACK)
+        primary = max(ids, max_r, 1) if any((ids, max_r)) else 0
 
-    counts: dict = {endpoint: primary}
+    counts: dict = {}
+    if primary > 0:
+        counts[endpoint_bucket] = primary
 
-    # Map each includes.<key> to a billing permission and accumulate.
-    # Known types use :data:`_INCLUDES_TO_PERMISSION`; unknown future
-    # types get a synthetic ``<key>.read`` key via the same convention so
-    # the server sees a consistent naming and can price (or ignore) them
-    # without a proxy redeploy.
     includes = resp_meta.get("response_includes") or {}
     for key, n in includes.items():
         if n <= 0:
             continue
-        permission = _INCLUDES_TO_PERMISSION.get(key, f"{key}.read")
-        counts[permission] = counts.get(permission, 0) + n
+        bucket = classify_includes_bucket(key)
+        if bucket is None:
+            # Emit a synthetic per-key category so the billing processor
+            # can apply its server-side fallback price and ops can track
+            # each unknown type independently in ``usage_event``.
+            bucket = f"includes.{key}"
+            log_warn(
+                "X includes key unrecognised — "
+                "emitting synthetic category for server-side fallback",
+                {"includes_key": key, "includes_count": n, "category": bucket},
+            )
+        counts[bucket] = counts.get(bucket, 0) + n
 
     return counts
 
@@ -402,24 +392,79 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
     - response status is outside 2xx (failures aren't billable)
     - ``firewall_permission`` is empty (unknown-endpoint-allow has no
       stable pricing key)
+    - ``firewall_permission`` is not mapped to an X billing bucket
+      (e.g. the ``"app-only"`` scope for BearerToken-only endpoints)
     """
     firewall_name = flow.metadata.get("firewall_name", "")
     if not flow.response or not (
         _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
     ):
         return
-    endpoint = flow.metadata.get("firewall_permission", "")
-    if not endpoint:
+    permission = flow.metadata.get("firewall_permission", "")
+    if not permission:
         return
+    # mitmproxy's ``flow.request.path`` is the raw request-target — it
+    # includes the query string.  Strip it via ``urlsplit`` so
+    # literal-suffix overrides (e.g. ``/2/tweets/{id}/retweeted_by``)
+    # still match requests that carry ``?max_results=10`` or similar.
+    request_path = urllib.parse.urlsplit(flow.request.path).path
+    endpoint_bucket = classify_bucket(permission, flow.request.method, request_path)
+    if endpoint_bucket is None:
+        return
+    endpoint_bucket = refine_bucket_with_body(
+        endpoint_bucket,
+        flow.request.method,
+        request_path,
+        flow.request.content,
+    )
 
     req_meta = _parse_request_metadata(flow)
     resp_meta = _parse_response_metadata(flow)
-    billable_counts = _compute_billable_counts(flow.request.method, req_meta, resp_meta, endpoint)
+    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+
+    # Structured context common to every billing-side proxy log entry
+    # for this flow — threaded into the helper so the log firing at the
+    # fallback site can still identify the request for ops auditing.
+    log_context = {
+        "type": "usage_event",
+        "run_id": run_id,
+        "firewall_name": firewall_name,
+        "permission": permission,
+        "method": flow.request.method,
+        "url": flow.request.url,
+    }
+
+    def _log_warn(message: str, extra: dict) -> None:
+        # Merge so extra keys win over log_context on collision.  Python
+        # would otherwise raise TypeError on duplicate kwargs, turning a
+        # logging path into a request-crashing one.
+        log_proxy_entry(proxy_log_path, "warn", message, **{**log_context, **extra})
+
+    billable_counts = _compute_billable_counts(
+        flow.request.method, req_meta, resp_meta, endpoint_bucket, log_warn=_log_warn
+    )
+
+    # Loud-but-zero billing path: GET with an unparseable response body
+    # AND no URL-side count hints.  We deliberately emit nothing rather
+    # than blind-guess a quantity — the error log carries enough context
+    # for ops to audit and, if needed, back-charge manually.
+    if (
+        flow.request.method == "GET"
+        and not resp_meta.get("body_parsed")
+        and not req_meta.get("request_ids_count")
+        and not req_meta.get("max_results")
+    ):
+        log_proxy_entry(
+            proxy_log_path,
+            "error",
+            "X response unparseable and request carries no count hints — skipping billing",
+            **log_context,
+            body_truncated=bool(resp_meta.get("body_truncated")),
+        )
 
     # Forward usage events to the platform for persistence.
     sandbox_token = flow.metadata.get("vm_sandbox_token", "")
     api_url = get_api_url()
-    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
     if not sandbox_token or not api_url:
         log_proxy_entry(
             proxy_log_path,

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -299,7 +299,7 @@ def _compute_billable_counts(
     resp_meta: dict,
     endpoint_bucket: str,
     log_warn: Callable[[str, dict], None] = lambda *_: None,
-) -> dict:
+) -> dict[str, int]:
     """Derive per-bucket billable resource counts for an X request.
 
     Returns a dict mapping X billing bucket name → resource count.  The
@@ -349,7 +349,7 @@ def _compute_billable_counts(
         max_r = req_meta.get("max_results") or 0
         primary = max(ids, max_r, 1) if any((ids, max_r)) else 0
 
-    counts: dict = {}
+    counts: dict[str, int] = {}
     if primary > 0:
         counts[endpoint_bucket] = primary
 
@@ -447,12 +447,14 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
     # Loud-but-zero billing path: GET with an unparseable response body
     # AND no URL-side count hints.  We deliberately emit nothing rather
     # than blind-guess a quantity — the error log carries enough context
-    # for ops to audit and, if needed, back-charge manually.
+    # for ops to audit and, if needed, back-charge manually.  Use
+    # ``is None`` so a legitimate ``?max_results=0`` (no-op query) is
+    # distinguished from the absent-field case.
     if (
         flow.request.method == "GET"
         and not resp_meta.get("body_parsed")
-        and not req_meta.get("request_ids_count")
-        and not req_meta.get("max_results")
+        and req_meta.get("request_ids_count") is None
+        and req_meta.get("max_results") is None
     ):
         log_proxy_entry(
             proxy_log_path,

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -1,0 +1,304 @@
+"""X billing bucket classification.
+
+Maps firewall permission + request method/path to one of X's official
+per-API pricing buckets (see https://docs.x.com/x-api/getting-started/pricing).
+The bucket name is written to ``usage_event.category`` and used by the
+server-side billing processor to look up ``unit_price`` in
+``usage_pricing``.
+
+Body-dependent refinement is applied on top via
+:func:`refine_bucket_with_body` — currently used to drop
+``content.create_with_url`` to ``content.create`` when the POST /2/tweets
+body contains no URL.
+
+Design:
+
+- ``_PERMISSION_TO_BUCKET`` gives each firewall scope a default bucket.
+  The default is chosen to match the MAJORITY of paths in that scope
+  so the category name stays semantically meaningful (a tweet-read
+  request lands in ``posts.read``, not ``user.read``).
+
+- ``_PATH_OVERRIDES`` holds per-path refinements when a specific path
+  within a scope belongs to a different X bucket than the scope default.
+  Overrides may raise OR lower the price — the goal is accuracy, not
+  one-sided safety.
+
+  **Important**: X's public pricing page lists bucket names and prices
+  but does NOT publish an endpoint → bucket mapping.  The overrides
+  here are semantic inferences from the bucket names (e.g. DELETE of
+  your own content → ``content.manage``).  A handful of overrides
+  lower price by 10–40× based on name semantics alone.  Validate
+  against Developer Console billing data or empirical live calls
+  before relying on the numbers; drift from X's actual classification
+  will cause under- or over-charging until an override is corrected.
+
+- ``_INCLUDES_TO_BUCKET`` maps X v2 ``includes.<key>`` resource types
+  to buckets.  Unknown keys return ``None`` and the caller emits a
+  synthetic ``includes.<key>`` category; the billing processor applies
+  a server-side fallback price for these.
+
+- Scopes that are not billable (e.g. the ``"app-only"`` group for
+  BearerToken-only endpoints) are intentionally absent; ``classify_bucket``
+  returns ``None`` and the caller skips emitting a ``usage_event`` row.
+  That matches current behaviour where ``BILLABLE_CONNECTORS`` only
+  covers user-authenticated X calls.
+
+New X endpoints appearing in a scope but not in overrides will be
+billed at the scope default.  If X's own pricing for that new endpoint
+is higher than the default bucket, we'd under-charge until an override
+is added — monitor the firewall generator output and the X pricing
+sheet for drift.
+"""
+
+import json
+import re
+
+from matching import match_path
+
+# Permission → default bucket.  The default matches the majority of
+# paths in the scope; outliers go in `_PATH_OVERRIDES`.  Prices are
+# defined in turbo/apps/web/scripts/dev-seed.ts.
+_PERMISSION_TO_BUCKET: dict[str, str] = {
+    # — Writes with an unambiguous single bucket —
+    "tweet.moderate.write": "content.manage",
+    "bookmark.write": "bookmark",
+    "dm.write": "dm_interaction.create",
+    # — Writes that span multiple X buckets — default to the more
+    # expensive variant so an unmapped path never under-charges —
+    # tweet.write: Content: Create vs Content: Create (with URL).
+    # Distinguished by request body inspection in refine_bucket_with_body.
+    # DELETE /2/tweets/{id} and DELETE /2/notes/{id} split off to
+    # content.manage; retweet create/undo split off to
+    # user_interaction.create / interaction.delete — see overrides.
+    "tweet.write": "content.create_with_url",
+    # media.write: public upload paths stay on Content: Create (with URL);
+    # GETs, metadata/subtitles, and chat (DM) media uploads split off
+    # via overrides.
+    "media.write": "content.create_with_url",
+    # User-interaction writes: POST creates are User Interaction: Create;
+    # DELETE undoes are Interaction: Delete (Mute: Delete for mute).
+    # Default = POST bucket; DELETE paths go in override.
+    "like.write": "user_interaction.create",
+    "follows.write": "user_interaction.create",
+    "mute.write": "user_interaction.create",
+    # list.write: POST /2/lists is List: Create; everything else is
+    # List: Manage — see override.
+    "list.write": "list.create",
+    # — Reads —
+    "bookmark.read": "posts.read",
+    "dm.read": "dm_event.read",
+    "follows.read": "following_followers.read",
+    "like.read": "posts.read",
+    "timeline.read": "posts.read",
+    "space.read": "space.read",
+    "list.read": "list.read",
+    # Scopes whose response is a list of users
+    "block.read": "user.read",
+    "mute.read": "user.read",
+    # tweet.read: majority of paths return tweets (Posts: Read).
+    # Outlier /2/tweets/{id}/retweeted_by returns users — see override.
+    "tweet.read": "posts.read",
+    # users.read: majority return user records (User: Read).
+    # Paths that return tweets (/mentions, /timelines, /tweets) and
+    # /communities/search go to cheaper buckets via override.
+    "users.read": "user.read",
+}
+
+# Per-path refinements when a specific path within a scope belongs to a
+# different X bucket than the scope default.  First-match wins.
+_PATH_OVERRIDES: list[tuple[str, str, str, str]] = [
+    # (scope, method, path pattern, bucket)
+    #
+    # — reads —
+    # tweet.read: retweeted_by returns users, priced as User: Read.
+    ("tweet.read", "GET", "/2/tweets/{id}/retweeted_by", "user.read"),
+    # tweet.read: analytics / media / note paths share the posts.read
+    # price but belong to semantically distinct X buckets.
+    ("tweet.read", "GET", "/2/insights/28hr", "analytics.read"),
+    ("tweet.read", "GET", "/2/insights/historical", "analytics.read"),
+    ("tweet.read", "GET", "/2/media/analytics", "analytics.read"),
+    ("tweet.read", "GET", "/2/tweets/analytics", "analytics.read"),
+    ("tweet.read", "GET", "/2/media", "media.read"),
+    ("tweet.read", "GET", "/2/media/{media_key}", "media.read"),
+    ("tweet.read", "GET", "/2/notes/search/notes_written", "note.read"),
+    ("tweet.read", "GET", "/2/notes/search/posts_eligible_for_notes", "note.read"),
+    # users.read: paths returning tweets are Posts: Read.
+    ("users.read", "GET", "/2/users/{id}/mentions", "posts.read"),
+    ("users.read", "GET", "/2/users/{id}/timelines/reverse_chronological", "posts.read"),
+    ("users.read", "GET", "/2/users/{id}/tweets", "posts.read"),
+    # users.read: community search is Community: Read.
+    ("users.read", "GET", "/2/communities/search", "community.read"),
+    #
+    # — writes: undo actions go to Interaction: Delete —
+    ("like.write", "DELETE", "/2/users/{id}/likes/{tweet_id}", "interaction.delete"),
+    (
+        "follows.write",
+        "DELETE",
+        "/2/users/{source_user_id}/following/{target_user_id}",
+        "interaction.delete",
+    ),
+    #
+    # — tweet.write: DELETE of your own content is Content: Manage;
+    # retweeting is a User Interaction (create/delete).  POST /2/notes
+    # stays on the default because a note can carry URLs; evaluating
+    # a community note is a user interaction, not content creation.
+    # (X does not publish endpoint-to-bucket mapping — these are
+    # semantic inferences from the bucket names in the pricing page.)
+    ("tweet.write", "DELETE", "/2/tweets/{id}", "content.manage"),
+    ("tweet.write", "DELETE", "/2/notes/{id}", "content.manage"),
+    ("tweet.write", "POST", "/2/users/{id}/retweets", "user_interaction.create"),
+    (
+        "tweet.write",
+        "DELETE",
+        "/2/users/{id}/retweets/{source_tweet_id}",
+        "interaction.delete",
+    ),
+    ("tweet.write", "POST", "/2/evaluate_note", "user_interaction.create"),
+    #
+    # — dm.write: deleting a DM you sent is managing your own content —
+    ("dm.write", "DELETE", "/2/dm_events/{event_id}", "content.manage"),
+    #
+    # — mute undo is its own Mute: Delete bucket, cheaper than
+    # Interaction: Delete —
+    (
+        "mute.write",
+        "DELETE",
+        "/2/users/{source_user_id}/muting/{target_user_id}",
+        "mute.delete",
+    ),
+    #
+    # — list.write: default is List: Create for POST /2/lists; every
+    # other path in the scope is List: Manage —
+    ("list.write", "PUT", "/2/lists/{id}", "list.manage"),
+    ("list.write", "DELETE", "/2/lists/{id}", "list.manage"),
+    ("list.write", "POST", "/2/lists/{id}/members", "list.manage"),
+    ("list.write", "DELETE", "/2/lists/{id}/members/{user_id}", "list.manage"),
+    ("list.write", "POST", "/2/users/{id}/followed_lists", "list.manage"),
+    ("list.write", "DELETE", "/2/users/{id}/followed_lists/{list_id}", "list.manage"),
+    ("list.write", "POST", "/2/users/{id}/pinned_lists", "list.manage"),
+    ("list.write", "DELETE", "/2/users/{id}/pinned_lists/{list_id}", "list.manage"),
+    #
+    # — bookmark removal is still Bookmark, not Interaction: Delete.
+    # (Default already covers POST; DELETE explicitly kept in the same
+    # bucket to document that we checked.) —
+    ("bookmark.write", "DELETE", "/2/users/{id}/bookmarks/{tweet_id}", "bookmark"),
+    #
+    # — media.write: default covers public upload paths; GETs, metadata,
+    # subtitles, and chat (DM) media uploads split off to cheaper
+    # buckets.  Chat media routes are in DM context, so we infer
+    # DM Interaction: Create (same inference confidence as the DM
+    # write overrides above — not docs-confirmed). —
+    ("media.write", "GET", "/2/media/upload", "media.read"),
+    ("media.write", "GET", "/2/chat/media/{id}/{media_hash_key}", "media.read"),
+    ("media.write", "POST", "/2/media/metadata", "media_metadata"),
+    ("media.write", "POST", "/2/media/subtitles", "media_metadata"),
+    ("media.write", "DELETE", "/2/media/subtitles", "media_metadata"),
+    ("media.write", "POST", "/2/chat/media/upload/initialize", "dm_interaction.create"),
+    ("media.write", "POST", "/2/chat/media/upload/{id}/append", "dm_interaction.create"),
+    ("media.write", "POST", "/2/chat/media/upload/{id}/finalize", "dm_interaction.create"),
+]
+
+
+def _build_override_index(
+    overrides: list[tuple[str, str, str, str]],
+) -> dict[tuple[str, str], list[tuple[str, str]]]:
+    """Group overrides by ``(scope, method)`` so :func:`classify_bucket`
+    only walks patterns under the matching scope/method instead of the
+    full list.  Insertion order is preserved inside each bucket, which
+    keeps first-match-wins semantics from the source list.
+    """
+    index: dict[tuple[str, str], list[tuple[str, str]]] = {}
+    for scope, method, pattern, bucket in overrides:
+        index.setdefault((scope, method), []).append((pattern, bucket))
+    return index
+
+
+_OVERRIDE_INDEX = _build_override_index(_PATH_OVERRIDES)
+
+
+def classify_bucket(permission: str, method: str, path: str) -> str | None:
+    """Return the X billing bucket for a matched firewall request.
+
+    ``permission`` is the firewall permission name set on
+    ``flow.metadata["firewall_permission"]``.  ``method`` and ``path``
+    come from ``flow.request``.
+
+    Returns ``None`` for permissions that are not billable (e.g. the
+    ``"app-only"`` scope).  The caller should skip emission in that
+    case.
+    """
+    for pattern, bucket in _OVERRIDE_INDEX.get((permission, method.upper()), ()):
+        if match_path(path, pattern) is not None:
+            return bucket
+    return _PERMISSION_TO_BUCKET.get(permission)
+
+
+# X v2 ``includes.<key>`` resource types → X billing bucket.
+# Irregular cases: includes key is plural while firewall permission is
+# singular (``tweets`` → Posts: Read, ``spaces`` → Space: Read).
+_INCLUDES_TO_BUCKET: dict[str, str] = {
+    "users": "user.read",
+    "tweets": "posts.read",
+    "media": "media.read",
+    "polls": "posts.read",
+    "places": "posts.read",
+    "topics": "posts.read",
+    "spaces": "space.read",
+}
+
+
+def classify_includes_bucket(key: str) -> str | None:
+    """Return the billing bucket for an ``includes.<key>`` resource
+    type, or ``None`` if the key is not recognized.  Caller is
+    responsible for substituting a safe over-charging fallback.
+    """
+    return _INCLUDES_TO_BUCKET.get(key)
+
+
+# URL detector for tweet body refinement.  Matches any http(s) scheme,
+# covering the common case; we stay on the expensive ``with_url`` bucket
+# when the text can't be inspected or when quote/media are attached
+# (both render as link previews and may be billed as "with URL" by X).
+_URL_RE = re.compile(r"https?://")
+
+
+def refine_bucket_with_body(bucket: str, method: str, path: str, body: bytes | None) -> str:
+    """Refine a bucket using the request body, when the body carries
+    billing-relevant signal.
+
+    Current behaviour: for ``POST /2/tweets`` classified as
+    ``content.create_with_url``, drop to ``content.create`` when the
+    tweet body is plain text with no URL, no quote reference and no
+    media attachment.  All parse failures or ambiguity → stay on the
+    more expensive bucket, matching the "never under-charge" rule.
+    """
+    if bucket != "content.create_with_url" or method != "POST" or path != "/2/tweets":
+        return bucket
+    if not body:
+        return bucket
+    try:
+        obj = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return bucket
+    if not isinstance(obj, dict):
+        return bucket
+    # Quote tweets embed a link to the quoted post; X likely bills
+    # these as "with URL" on the rendered tweet.  Stay conservative.
+    if obj.get("quote_tweet_id") is not None:
+        return bucket
+    # Attached media renders as a t.co preview URL in the published
+    # tweet.  Stay conservative.
+    media = obj.get("media")
+    if isinstance(media, dict) and media.get("media_ids"):
+        return bucket
+    # A `card_uri` attaches a link preview card to the tweet — the
+    # published post always renders a URL.  Treat as with-URL even
+    # when the text itself is plain.
+    if obj.get("card_uri"):
+        return bucket
+    text = obj.get("text")
+    if not isinstance(text, str):
+        return bucket
+    if _URL_RE.search(text):
+        return bucket
+    return "content.create"

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1774,8 +1774,8 @@ class TestErrorHandler:
         assert mock_opener.open.called
         payloads = [json.loads(call[0][0].data) for call in mock_opener.open.call_args_list]
         by_cat = {p["category"]: p["quantity"] for p in payloads}
-        assert by_cat["tweet.read"] == 23
-        assert by_cat["users.read"] == 5
+        assert by_cat["posts.read"] == 23
+        assert by_cat["user.read"] == 5
 
     def test_full_pipeline_stream_error_midflight(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
@@ -1829,8 +1829,8 @@ class TestErrorHandler:
         # 4. Billing must reflect the 2 complete tweets (partial 3rd is dropped)
         payloads = [json.loads(call[0][0].data) for call in mock_opener.open.call_args_list]
         by_cat = {p["category"]: p["quantity"] for p in payloads}
-        assert by_cat["tweet.read"] == 2  # not 3 — partial trailing dropped
-        assert by_cat["users.read"] == 1
+        assert by_cat["posts.read"] == 2  # not 3 — partial trailing dropped
+        assert by_cat["user.read"] == 1
 
 
 class TestReportModelProviderUsage:
@@ -2075,7 +2075,7 @@ class TestReportConnectorUsage:
             real_flow, tmp_path, path="/2/tweets/1", body=body, rule="GET /2/tweets/{id}"
         )
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
+        assert p["category"] == "posts.read"
         assert p["quantity"] == 1
 
     def test_logs_batch_ids(self, tmp_path, real_flow):
@@ -2083,7 +2083,7 @@ class TestReportConnectorUsage:
         body = json.dumps({"data": [{"id": "1"}, {"id": "2"}, {"id": "3"}]}).encode()
         flow = self._make_x_flow(real_flow, tmp_path, query="ids=1,2,3", body=body)
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
+        assert p["category"] == "posts.read"
         assert p["quantity"] == 3
 
     def test_logs_batch_ids_with_deletions(self, tmp_path, real_flow):
@@ -2091,7 +2091,7 @@ class TestReportConnectorUsage:
         body = json.dumps({"data": [{"id": "1"}, {"id": "3"}]}).encode()
         flow = self._make_x_flow(real_flow, tmp_path, query="ids=1,2,3", body=body)
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
+        assert p["category"] == "posts.read"
         assert p["quantity"] == 2
 
     def test_logs_expansions_includes(self, tmp_path, real_flow):
@@ -2113,10 +2113,10 @@ class TestReportConnectorUsage:
         )
         payloads = self._call_and_get_billing(flow)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
-        assert by_cat == {"tweet.read": 1, "users.read": 1, "media.read": 2}
+        assert by_cat == {"posts.read": 1, "user.read": 1, "media.read": 2}
 
-    def test_logs_empty_search_bills_zero(self, tmp_path, real_flow):
-        """Search returning zero results bills 0."""
+    def test_empty_search_emits_no_billing(self, tmp_path, real_flow):
+        """Search returning zero results emits no usage_event row."""
         body = json.dumps({"data": [], "meta": {"result_count": 0}}).encode()
         flow = self._make_x_flow(
             real_flow,
@@ -2126,12 +2126,12 @@ class TestReportConnectorUsage:
             body=body,
             rule="GET /2/tweets/search/recent",
         )
-        p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
-        assert p["quantity"] == 0
+        payloads = self._call_and_get_billing(flow)
+        assert payloads == []
 
-    def test_soft_error_bills_zero(self, tmp_path, real_flow):
-        """HTTP 200 + errors array + no data field -> bills 0 (issue #9620)."""
+    def test_soft_error_emits_no_billing(self, tmp_path, real_flow):
+        """HTTP 200 + errors array + no data field emits no usage_event
+        row (issue #9620)."""
         body = json.dumps(
             {
                 "errors": [
@@ -2153,12 +2153,12 @@ class TestReportConnectorUsage:
             body=body,
             rule="GET /2/tweets/{id}",
         )
-        p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
-        assert p["quantity"] == 0
+        payloads = self._call_and_get_billing(flow)
+        assert payloads == []
 
-    def test_zero_result_search_with_max_results_bills_zero(self, tmp_path, real_flow):
-        """Search with max_results=10 returning 0 results -> bills 0 (issue #9620)."""
+    def test_zero_result_search_with_max_results_emits_no_billing(self, tmp_path, real_flow):
+        """Search with max_results=10 returning 0 results emits no
+        usage_event row (issue #9620)."""
         body = json.dumps({"meta": {"result_count": 0, "newest_id": None}}).encode()
         flow = self._make_x_flow(
             real_flow,
@@ -2168,9 +2168,8 @@ class TestReportConnectorUsage:
             body=body,
             rule="GET /2/tweets/search/recent",
         )
-        p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
-        assert p["quantity"] == 0
+        payloads = self._call_and_get_billing(flow)
+        assert payloads == []
 
     def test_logs_expansions_users_and_referenced_tweets(self, tmp_path, real_flow):
         """includes.users and includes.tweets produce two billing payloads."""
@@ -2192,12 +2191,14 @@ class TestReportConnectorUsage:
         payloads = self._call_and_get_billing(flow)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat == {
-            "tweet.read": 3,  # 1 primary + 2 referenced tweets
-            "users.read": 2,
+            "posts.read": 3,  # 1 primary + 2 referenced tweets
+            "user.read": 2,
         }
 
     def test_handles_unknown_includes_key(self, tmp_path, real_flow):
-        """Unknown includes.<key> types get a synthetic <key>.read billing key."""
+        """Unknown includes.<key> types emit a synthetic ``includes.<key>``
+        category (the billing processor applies a server-side fallback
+        price) and emit a warn log at the decision point."""
         body = json.dumps(
             {
                 "data": [{"id": "1"}],
@@ -2210,11 +2211,19 @@ class TestReportConnectorUsage:
         flow = self._make_x_flow(real_flow, tmp_path, query="expansions=author_id", body=body)
         payloads = self._call_and_get_billing(flow)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
+        # 1 primary (posts.read) + 1 users include (mapped to user.read)
+        # + 3 unknown-widget includes (emitted as `includes.future_widget`).
         assert by_cat == {
-            "tweet.read": 1,
-            "users.read": 1,
-            "future_widget.read": 3,
+            "posts.read": 1,
+            "user.read": 1,
+            "includes.future_widget": 3,
         }
+        proxy_log = tmp_path / "proxy.jsonl"
+        assert proxy_log.exists()
+        content = proxy_log.read_text()
+        assert "future_widget" in content
+        assert "unrecognised" in content.lower()
+        assert '"level":"warn"' in content or '"level": "warn"' in content
 
     def test_logs_search_meta_result_count(self, tmp_path, real_flow):
         """Search response with meta.result_count -> quantity=20."""
@@ -2234,7 +2243,7 @@ class TestReportConnectorUsage:
             rule="GET /2/tweets/search/recent",
         )
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
+        assert p["category"] == "posts.read"
         assert p["quantity"] == 20
 
     def test_logs_users_by_usernames_batch(self, tmp_path, real_flow):
@@ -2252,7 +2261,7 @@ class TestReportConnectorUsage:
             rule="GET /2/users/by",
         )
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "users.read"
+        assert p["category"] == "user.read"
         assert p["quantity"] == 2
 
     def test_logs_tweet_counts_total_tweet_count(self, tmp_path, real_flow):
@@ -2275,7 +2284,7 @@ class TestReportConnectorUsage:
             rule="GET /2/tweets/counts/recent",
         )
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
+        assert p["category"] == "posts.read"
         assert p["quantity"] == 12567
 
     def test_handles_gzip_body(self, tmp_path, real_flow):
@@ -2284,11 +2293,12 @@ class TestReportConnectorUsage:
         body = gzip.compress(raw)
         flow = self._make_x_flow(real_flow, tmp_path, body=body, content_encoding="gzip")
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
+        assert p["category"] == "posts.read"
         assert p["quantity"] == 1
 
     def test_logs_write_operation_charges_one(self, tmp_path, real_flow):
-        """POST /2/tweets -> category=tweet.write, quantity=1."""
+        """POST /2/tweets (no request body parsed) -> stay on the expensive
+        with_url bucket, quantity=1."""
         body = json.dumps({"data": {"id": "99", "text": "new tweet"}}).encode()
         flow = self._make_x_flow(
             real_flow,
@@ -2301,11 +2311,113 @@ class TestReportConnectorUsage:
         )
         flow.request.method = "POST"
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.write"
+        assert p["category"] == "content.create_with_url"
         assert p["quantity"] == 1
 
+    def test_tweet_create_plain_text_downgrades_to_content_create(self, tmp_path, real_flow):
+        """POST /2/tweets with text only (no URL, no quote, no media)
+        downgrades to the cheaper Content: Create bucket."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets",
+            body=json.dumps({"data": {"id": "1"}}).encode(),
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+        )
+        flow.request.method = "POST"
+        flow.request.content = json.dumps({"text": "hello world"}).encode()
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "content.create"
+        assert p["quantity"] == 1
+
+    def test_tweet_create_with_url_stays_on_with_url_bucket(self, tmp_path, real_flow):
+        """POST /2/tweets whose text contains a URL stays on the
+        Content: Create (with URL) bucket."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets",
+            body=json.dumps({"data": {"id": "1"}}).encode(),
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+        )
+        flow.request.method = "POST"
+        flow.request.content = json.dumps({"text": "check https://example.com"}).encode()
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "content.create_with_url"
+        assert p["quantity"] == 1
+
+    def test_tweet_create_quote_or_media_stays_on_with_url_bucket(self, tmp_path, real_flow):
+        """Quote tweets and attached media both render as link previews;
+        we stay on the expensive bucket even when the text has no URL."""
+        for req_body in [
+            # quote tweet
+            json.dumps({"text": "nice", "quote_tweet_id": "abc"}).encode(),
+            # attached media
+            json.dumps({"text": "pic", "media": {"media_ids": ["42"]}}).encode(),
+        ]:
+            flow = self._make_x_flow(
+                real_flow,
+                tmp_path,
+                path="/2/tweets",
+                body=json.dumps({"data": {"id": "1"}}).encode(),
+                status=201,
+                permission="tweet.write",
+                rule="POST /2/tweets",
+            )
+            flow.request.method = "POST"
+            flow.request.content = req_body
+            p = self._call_and_get_single_billing(flow)
+            assert p["category"] == "content.create_with_url"
+
+    def test_tweet_create_unparseable_body_stays_conservative(self, tmp_path, real_flow):
+        """A malformed request body keeps billing on the max bucket so
+        we never under-charge on parse failure."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets",
+            body=json.dumps({"data": {"id": "1"}}).encode(),
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+        )
+        flow.request.method = "POST"
+        flow.request.content = b"not valid json at all"
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "content.create_with_url"
+
+    def test_query_string_does_not_break_literal_suffix_override(self, tmp_path, real_flow):
+        """``flow.request.path`` from mitmproxy includes the query string;
+        literal-suffix overrides (e.g. ``/2/tweets/{id}/retweeted_by``)
+        must still fire.  Regression guard for under-charging on
+        popular paginated read endpoints."""
+        body = json.dumps({"data": [{"id": "u1"}, {"id": "u2"}]}).encode()
+        # The helper sets flow.request.path = path (no query), so we
+        # craft the path-with-query explicitly to mirror what mitmproxy
+        # delivers in real traffic.
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/123/retweeted_by?max_results=10",
+            body=body,
+            permission="tweet.read",
+            rule="GET /2/tweets/{id}/retweeted_by",
+        )
+        # The ?max_results metadata goes into original_url for
+        # req-meta parsing to consume.
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/123/retweeted_by?max_results=10"
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "user.read"
+        assert p["quantity"] == 2
+
     def test_delete_method_charges_one(self, tmp_path, real_flow):
-        """DELETE /2/tweets/:id -> category=tweet.write, quantity=1."""
+        """DELETE /2/tweets/{id} routes to Content: Manage, not the
+        tweet.write scope default.  Writes always charge quantity=1
+        regardless of response shape."""
         flow = self._make_x_flow(
             real_flow,
             tmp_path,
@@ -2316,7 +2428,7 @@ class TestReportConnectorUsage:
         )
         flow.request.method = "DELETE"
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.write"
+        assert p["category"] == "content.manage"
         assert p["quantity"] == 1
 
     def test_expansion_with_empty_includes_array(self, tmp_path, real_flow):
@@ -2329,12 +2441,12 @@ class TestReportConnectorUsage:
         ).encode()
         flow = self._make_x_flow(real_flow, tmp_path, query="expansions=author_id", body=body)
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
+        assert p["category"] == "posts.read"
         assert p["quantity"] == 1
 
-    def test_empty_search_with_includes_sends_both(self, tmp_path, real_flow):
-        """Search returns 0 data but non-empty includes -> two billing records,
-        primary with quantity=0."""
+    def test_empty_search_with_includes_emits_only_includes(self, tmp_path, real_flow):
+        """Search returns 0 data but non-empty includes -> only the
+        includes row is emitted; the zero-primary row is skipped."""
         body = json.dumps(
             {
                 "data": [],
@@ -2350,10 +2462,9 @@ class TestReportConnectorUsage:
             body=body,
             rule="GET /2/tweets/search/recent",
         )
-        payloads = self._call_and_get_billing(flow)
-        by_cat = {p["category"]: p["quantity"] for p in payloads}
-        assert by_cat["tweet.read"] == 0
-        assert by_cat["users.read"] == 1
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "user.read"
+        assert p["quantity"] == 1
 
     # ---- streaming: x_ndjson_state feeds billing directly (issue #9534) ----
 
@@ -2375,11 +2486,12 @@ class TestReportConnectorUsage:
         payloads = self._call_and_get_billing(flow)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         # tweet.read primary 50 + 12 from includes.tweets = 62
-        assert by_cat["tweet.read"] == 62
-        assert by_cat["users.read"] == 47
+        assert by_cat["posts.read"] == 62
+        assert by_cat["user.read"] == 47
 
-    def test_logs_x_stream_empty_no_fallback(self, tmp_path, real_flow):
-        """Stream that delivered 0 tweets bills 0, NOT _X_UNPARSEABLE_READ_FALLBACK."""
+    def test_x_stream_empty_emits_no_billing(self, tmp_path, real_flow):
+        """Stream that delivered 0 tweets emits no usage_event row, and
+        in particular does NOT trigger _X_UNPARSEABLE_READ_FALLBACK."""
         flow = self._make_x_flow(
             real_flow,
             tmp_path,
@@ -2393,39 +2505,54 @@ class TestReportConnectorUsage:
             "lines_parsed": 0,
             "lines_failed": 0,
         }
-        p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
-        assert p["quantity"] == 0
+        payloads = self._call_and_get_billing(flow)
+        assert payloads == []
 
     # ---- fallback / unparseable cases ----
 
-    def test_handles_truncated_buffer(self, tmp_path, real_flow):
-        """Truncated buffer -> unparseable fallback quantity=100."""
+    def test_truncated_buffer_with_no_hints_skips_billing(self, tmp_path, real_flow):
+        """Unparseable body + no URL hints → skip emission and log an
+        error.  The previous blind fallback of 100 units was removed;
+        ops audits via the proxy error log instead."""
         flow = self._make_x_flow(real_flow, tmp_path, body=b"{")
         flow.metadata["stream_buffer_state"] = {"truncated": True}
-        p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
-        assert p["quantity"] == 100
+        assert self._call_and_get_billing(flow) == []
 
-    def test_handles_invalid_json(self, tmp_path, real_flow):
-        """Malformed body -> unparseable fallback quantity=100."""
+    def test_invalid_json_with_no_hints_skips_billing(self, tmp_path, real_flow):
+        """Malformed body + no URL hints → skip emission (see above)."""
         flow = self._make_x_flow(real_flow, tmp_path, body=b"not json")
-        p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
-        assert p["quantity"] == 100
+        assert self._call_and_get_billing(flow) == []
+
+    def test_unparseable_no_hints_writes_error_to_proxy_log(self, tmp_path, real_flow):
+        """Operators must be able to audit the lost-visibility case —
+        the proxy log receives a structured error entry."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/search/recent",
+            body=b"not json",
+            rule="GET /2/tweets/search/recent",
+        )
+        proxy_log = tmp_path / "proxy.jsonl"
+        assert self._call_and_get_billing(flow) == []
+        assert proxy_log.exists()
+        content = proxy_log.read_text()
+        assert "unparseable" in content.lower()
+        assert '"level":"error"' in content or '"level": "error"' in content
+        assert "tweet.read" in content  # permission is included for auditing
 
     def test_billable_counts_fallback_only_when_no_hints(self, tmp_path, real_flow):
         """body unparseable but ?ids= present -> uses ids_count, no fallback."""
         flow = self._make_x_flow(real_flow, tmp_path, query="ids=1,2,3", body=b"not json")
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
+        assert p["category"] == "posts.read"
         assert p["quantity"] == 3
 
     def test_billable_counts_fallback_only_when_no_max_results(self, tmp_path, real_flow):
         """body unparseable but ?max_results=50 present -> uses max_results."""
         flow = self._make_x_flow(real_flow, tmp_path, query="max_results=50", body=b"not json")
         p = self._call_and_get_single_billing(flow)
-        assert p["category"] == "tweet.read"
+        assert p["category"] == "posts.read"
         assert p["quantity"] == 50
 
     # ---- skip cases ----
@@ -2591,9 +2718,9 @@ class TestReportConnectorUsage:
         payloads = [json.loads(call[0][0].data) for call in mock_opener.open.call_args_list]
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         # 3 tweets primary + 0 from includes.tweets (none here) = 3
-        assert by_cat["tweet.read"] == 3
+        assert by_cat["posts.read"] == 3
         # 3 users from includes
-        assert by_cat["users.read"] == 3
+        assert by_cat["user.read"] == 3
 
 
 class TestUsageWebhookDelivery:

--- a/crates/runner/mitm-addon/tests/test_x_billing.py
+++ b/crates/runner/mitm-addon/tests/test_x_billing.py
@@ -1,8 +1,11 @@
-"""Unit tests for :mod:`usage.providers.connectors.x_billing`.
+"""Cross-file static invariants for :mod:`usage.providers.connectors.x_billing`.
 
-Each public function gets dedicated coverage so a regression in the
-classifier surface is caught without relying on the broader billing
-pipeline tests in ``test_handlers.py``.
+End-to-end classifier behaviour (defaults, overrides, body refinement)
+is covered by ``tests/test_handlers.py``.  This module only holds the
+consistency suites that can't be expressed at the integration level:
+every firewall scope must be classified or intentionally unmapped,
+every override must exist in the firewall generator output, every
+emitted bucket must have a dev-seed row, etc.
 """
 
 from __future__ import annotations
@@ -10,6 +13,7 @@ from __future__ import annotations
 import json
 import pathlib
 import re
+from typing import ClassVar
 
 import pytest
 
@@ -17,265 +21,8 @@ from usage.providers.connectors.x_billing import (
     _INCLUDES_TO_BUCKET,
     _PATH_OVERRIDES,
     _PERMISSION_TO_BUCKET,
-    classify_bucket,
-    classify_includes_bucket,
     refine_bucket_with_body,
 )
-
-
-class TestClassifyBucket:
-    """``classify_bucket(permission, method, path) -> bucket | None``."""
-
-    @pytest.mark.parametrize(
-        ("permission", "method", "path", "expected"),
-        [
-            # — clean 1:1 writes —
-            ("tweet.moderate.write", "PUT", "/2/tweets/1/hidden", "content.manage"),
-            ("bookmark.write", "POST", "/2/users/me/bookmarks", "bookmark"),
-            ("dm.write", "POST", "/2/dm_events", "dm_interaction.create"),
-            # — clean 1:1 reads —
-            ("dm.read", "GET", "/2/dm_events", "dm_event.read"),
-            ("follows.read", "GET", "/2/users/1/followers", "following_followers.read"),
-            ("like.read", "GET", "/2/tweets/1/liking_users", "posts.read"),
-            ("timeline.read", "GET", "/2/users/1/timelines/reverse_chronological", "posts.read"),
-            ("space.read", "GET", "/2/spaces/1", "space.read"),
-            ("list.read", "GET", "/2/lists/1", "list.read"),
-            ("block.read", "GET", "/2/users/me/blocking", "user.read"),
-            ("mute.read", "GET", "/2/users/me/muting", "user.read"),
-            ("bookmark.read", "GET", "/2/users/me/bookmarks", "posts.read"),
-            # — multi-bucket scopes default to the conservative bucket —
-            ("tweet.write", "POST", "/2/tweets", "content.create_with_url"),
-            ("media.write", "POST", "/2/media/upload", "content.create_with_url"),
-            ("like.write", "POST", "/2/users/me/likes", "user_interaction.create"),
-            ("follows.write", "POST", "/2/users/me/following", "user_interaction.create"),
-            ("mute.write", "POST", "/2/users/me/muting", "user_interaction.create"),
-            ("list.write", "POST", "/2/lists", "list.create"),
-            ("tweet.read", "GET", "/2/tweets", "posts.read"),
-            ("users.read", "GET", "/2/users/1", "user.read"),
-        ],
-    )
-    def test_defaults(self, permission, method, path, expected):
-        assert classify_bucket(permission, method, path) == expected
-
-    @pytest.mark.parametrize(
-        ("permission", "method", "path", "expected"),
-        [
-            # — tweet.read refinements —
-            ("tweet.read", "GET", "/2/tweets/1/retweeted_by", "user.read"),
-            ("tweet.read", "GET", "/2/insights/28hr", "analytics.read"),
-            ("tweet.read", "GET", "/2/insights/historical", "analytics.read"),
-            ("tweet.read", "GET", "/2/media/analytics", "analytics.read"),
-            ("tweet.read", "GET", "/2/tweets/analytics", "analytics.read"),
-            ("tweet.read", "GET", "/2/media", "media.read"),
-            ("tweet.read", "GET", "/2/media/abc", "media.read"),
-            ("tweet.read", "GET", "/2/notes/search/notes_written", "note.read"),
-            ("tweet.read", "GET", "/2/notes/search/posts_eligible_for_notes", "note.read"),
-            # — users.read refinements —
-            ("users.read", "GET", "/2/users/1/mentions", "posts.read"),
-            ("users.read", "GET", "/2/users/1/timelines/reverse_chronological", "posts.read"),
-            ("users.read", "GET", "/2/users/1/tweets", "posts.read"),
-            ("users.read", "GET", "/2/communities/search", "community.read"),
-            # — write DELETE → interaction.delete / mute.delete —
-            ("like.write", "DELETE", "/2/users/1/likes/2", "interaction.delete"),
-            ("follows.write", "DELETE", "/2/users/1/following/2", "interaction.delete"),
-            ("mute.write", "DELETE", "/2/users/1/muting/2", "mute.delete"),
-            # — list.write refinements: create stays, everything else is manage —
-            ("list.write", "PUT", "/2/lists/1", "list.manage"),
-            ("list.write", "DELETE", "/2/lists/1", "list.manage"),
-            ("list.write", "POST", "/2/lists/1/members", "list.manage"),
-            ("list.write", "DELETE", "/2/lists/1/members/2", "list.manage"),
-            ("list.write", "POST", "/2/users/1/followed_lists", "list.manage"),
-            ("list.write", "DELETE", "/2/users/1/followed_lists/2", "list.manage"),
-            ("list.write", "POST", "/2/users/1/pinned_lists", "list.manage"),
-            ("list.write", "DELETE", "/2/users/1/pinned_lists/2", "list.manage"),
-            # — bookmark DELETE stays on bookmark (not interaction.delete) —
-            ("bookmark.write", "DELETE", "/2/users/1/bookmarks/2", "bookmark"),
-            # — media.write refinements —
-            ("media.write", "GET", "/2/media/upload", "media.read"),
-            ("media.write", "GET", "/2/chat/media/abc/xyz", "media.read"),
-            ("media.write", "POST", "/2/media/metadata", "media_metadata"),
-            ("media.write", "POST", "/2/media/subtitles", "media_metadata"),
-            ("media.write", "DELETE", "/2/media/subtitles", "media_metadata"),
-            # — media.write: chat (DM) media uploads route to DM bucket —
-            (
-                "media.write",
-                "POST",
-                "/2/chat/media/upload/initialize",
-                "dm_interaction.create",
-            ),
-            (
-                "media.write",
-                "POST",
-                "/2/chat/media/upload/abc/append",
-                "dm_interaction.create",
-            ),
-            (
-                "media.write",
-                "POST",
-                "/2/chat/media/upload/abc/finalize",
-                "dm_interaction.create",
-            ),
-            # — tweet.write: DELETE of your own content → Content: Manage —
-            ("tweet.write", "DELETE", "/2/tweets/123", "content.manage"),
-            ("tweet.write", "DELETE", "/2/notes/abc", "content.manage"),
-            # — tweet.write: retweets are User Interaction (create/delete) —
-            ("tweet.write", "POST", "/2/users/1/retweets", "user_interaction.create"),
-            ("tweet.write", "DELETE", "/2/users/1/retweets/999", "interaction.delete"),
-            ("tweet.write", "POST", "/2/evaluate_note", "user_interaction.create"),
-            # — dm.write: deleting a DM → Content: Manage —
-            ("dm.write", "DELETE", "/2/dm_events/abc", "content.manage"),
-        ],
-    )
-    def test_path_overrides(self, permission, method, path, expected):
-        assert classify_bucket(permission, method, path) == expected
-
-    @pytest.mark.parametrize(
-        ("permission", "method", "path"),
-        [
-            # The "app-only" scope is in the firewall but intentionally
-            # unmapped here — BearerToken-only endpoints are not billed.
-            ("app-only", "GET", "/2/tweets/counts/all"),
-            # — any unknown scope falls through —
-            ("unknown.scope", "GET", "/anywhere"),
-            ("", "GET", "/2/tweets"),
-        ],
-    )
-    def test_returns_none_for_unmapped(self, permission, method, path):
-        assert classify_bucket(permission, method, path) is None
-
-    def test_method_is_case_insensitive(self):
-        # Override tables store methods uppercased; classifier must match
-        # regardless of what the caller passes in.
-        assert (
-            classify_bucket("like.write", "delete", "/2/users/me/likes/1") == "interaction.delete"
-        )
-        assert (
-            classify_bucket("like.write", "DELETE", "/2/users/me/likes/1") == "interaction.delete"
-        )
-
-
-class TestClassifyIncludesBucket:
-    @pytest.mark.parametrize(
-        ("key", "expected"),
-        [
-            ("users", "user.read"),
-            ("tweets", "posts.read"),
-            ("media", "media.read"),
-            ("polls", "posts.read"),
-            ("places", "posts.read"),
-            ("topics", "posts.read"),
-            ("spaces", "space.read"),
-        ],
-    )
-    def test_known_keys(self, key, expected):
-        assert classify_includes_bucket(key) == expected
-
-    @pytest.mark.parametrize("key", ["future_widget", "", "users_extended"])
-    def test_unknown_keys_return_none(self, key):
-        assert classify_includes_bucket(key) is None
-
-
-class TestRefineBucketWithBody:
-    """``refine_bucket_with_body`` only affects POST /2/tweets.
-    Everything else flows through unchanged.
-    """
-
-    def _body(self, obj: dict) -> bytes:
-        return json.dumps(obj).encode()
-
-    # — paths that bypass refinement —
-
-    @pytest.mark.parametrize(
-        ("bucket", "method", "path", "body"),
-        [
-            # Non-target bucket
-            ("posts.read", "POST", "/2/tweets", b'{"text": "no url"}'),
-            # Non-POST
-            ("content.create_with_url", "GET", "/2/tweets", b'{"text": "no url"}'),
-            # Non-target path
-            (
-                "content.create_with_url",
-                "POST",
-                "/2/tweets/1/hidden",
-                b'{"text": "no url"}',
-            ),
-        ],
-    )
-    def test_passthrough(self, bucket, method, path, body):
-        assert refine_bucket_with_body(bucket, method, path, body) == bucket
-
-    # — POST /2/tweets downgrade path —
-
-    def test_plain_text_downgrades(self):
-        body = self._body({"text": "hello world"})
-        assert (
-            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
-            == "content.create"
-        )
-
-    @pytest.mark.parametrize(
-        "text",
-        [
-            "check https://example.com out",
-            "http://legacy.example.com",
-            "prefix http://x.co suffix",
-        ],
-    )
-    def test_url_in_text_stays_on_with_url(self, text):
-        body = self._body({"text": text})
-        assert (
-            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
-            == "content.create_with_url"
-        )
-
-    def test_quote_tweet_stays_on_with_url(self):
-        body = self._body({"text": "nice", "quote_tweet_id": "abc"})
-        assert (
-            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
-            == "content.create_with_url"
-        )
-
-    def test_attached_media_stays_on_with_url(self):
-        body = self._body({"text": "pic", "media": {"media_ids": ["42"]}})
-        assert (
-            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
-            == "content.create_with_url"
-        )
-
-    def test_card_uri_stays_on_with_url(self):
-        # card_uri attaches a link preview card — the published tweet
-        # always renders a URL even if the text is plain.
-        body = self._body({"text": "plain", "card_uri": "card://12345"})
-        assert (
-            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
-            == "content.create_with_url"
-        )
-
-    def test_empty_media_ids_list_allows_downgrade(self):
-        body = self._body({"text": "no media", "media": {"media_ids": []}})
-        assert (
-            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
-            == "content.create"
-        )
-
-    @pytest.mark.parametrize(
-        "body",
-        [
-            None,
-            b"",
-            b"not json",
-            b'["unexpected array"]',
-            # Dict without `text`
-            b"{}",
-            # text is not a string
-            b'{"text": 42}',
-        ],
-    )
-    def test_defensive_cases_stay_on_with_url(self, body):
-        assert (
-            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
-            == "content.create_with_url"
-        )
 
 
 class TestFirewallConsistency:
@@ -413,6 +160,155 @@ class TestFirewallConsistency:
             "Either the firewall rule was renamed/removed upstream, or "
             "the override has a typo."
         )
+
+    # Firewall paths that deliberately take their scope's default bucket.
+    # Any firewall rule under a classified scope must either be in
+    # `_PATH_OVERRIDES` or listed here, forcing an explicit decision for
+    # every path instead of defaulting silently when a new endpoint is
+    # added upstream.  Review each entry: if the scope default is wrong
+    # for a path, move it into `_PATH_OVERRIDES` with the correct bucket.
+    _ACKNOWLEDGED_DEFAULT_PATHS: ClassVar[dict[str, set[tuple[str, str]]]] = {
+        "block.read": {("GET", "/2/users/{id}/blocking")},
+        "bookmark.read": {
+            ("GET", "/2/users/{id}/bookmarks"),
+            ("GET", "/2/users/{id}/bookmarks/folders"),
+            ("GET", "/2/users/{id}/bookmarks/folders/{folder_id}"),
+        },
+        "bookmark.write": {("POST", "/2/users/{id}/bookmarks")},
+        "dm.read": {
+            ("POST", "/2/activity/subscriptions"),
+            ("GET", "/2/chat/conversations"),
+            ("GET", "/2/chat/conversations/{id}"),
+            ("GET", "/2/dm_conversations/media/{dm_id}/{media_id}/{resource_id}"),
+            ("GET", "/2/dm_conversations/with/{participant_id}/dm_events"),
+            ("GET", "/2/dm_conversations/{id}/dm_events"),
+            ("GET", "/2/dm_events"),
+            ("GET", "/2/dm_events/{event_id}"),
+            ("GET", "/2/users/public_keys"),
+            ("GET", "/2/users/{id}/public_keys"),
+        },
+        "dm.write": {
+            ("GET", "/2/account_activity/webhooks/{webhook_id}/subscriptions/all"),
+            ("POST", "/2/account_activity/webhooks/{webhook_id}/subscriptions/all"),
+            ("POST", "/2/chat/conversations/group"),
+            ("POST", "/2/chat/conversations/group/initialize"),
+            ("POST", "/2/chat/conversations/{id}/keys"),
+            ("POST", "/2/chat/conversations/{id}/members"),
+            ("POST", "/2/chat/conversations/{id}/messages"),
+            ("POST", "/2/chat/conversations/{id}/read"),
+            ("POST", "/2/chat/conversations/{id}/typing"),
+            ("POST", "/2/dm_conversations"),
+            ("POST", "/2/dm_conversations/with/{participant_id}/messages"),
+            ("POST", "/2/dm_conversations/{dm_conversation_id}/messages"),
+            ("POST", "/2/users/{id}/dm/block"),
+            ("POST", "/2/users/{id}/dm/unblock"),
+            ("POST", "/2/users/{id}/public_keys"),
+        },
+        "follows.read": {
+            ("GET", "/2/users/{id}/followers"),
+            ("GET", "/2/users/{id}/following"),
+        },
+        "follows.write": {("POST", "/2/users/{id}/following")},
+        "like.read": {
+            ("GET", "/2/tweets/{id}/liking_users"),
+            ("GET", "/2/users/{id}/liked_tweets"),
+        },
+        "like.write": {("POST", "/2/users/{id}/likes")},
+        "list.read": {
+            ("GET", "/2/communities/{id}"),
+            ("GET", "/2/lists/{id}"),
+            ("GET", "/2/lists/{id}/followers"),
+            ("GET", "/2/lists/{id}/members"),
+            ("GET", "/2/lists/{id}/tweets"),
+            ("GET", "/2/users/{id}/followed_lists"),
+            ("GET", "/2/users/{id}/list_memberships"),
+            ("GET", "/2/users/{id}/owned_lists"),
+            ("GET", "/2/users/{id}/pinned_lists"),
+        },
+        "list.write": {("POST", "/2/lists")},
+        "media.write": {
+            ("POST", "/2/media/upload"),
+            ("POST", "/2/media/upload/initialize"),
+            ("POST", "/2/media/upload/{id}/append"),
+            ("POST", "/2/media/upload/{id}/finalize"),
+        },
+        "mute.read": {("GET", "/2/users/{id}/muting")},
+        "mute.write": {("POST", "/2/users/{id}/muting")},
+        "space.read": {
+            ("GET", "/2/spaces"),
+            ("GET", "/2/spaces/by/creator_ids"),
+            ("GET", "/2/spaces/search"),
+            ("GET", "/2/spaces/{id}"),
+            ("GET", "/2/spaces/{id}/buyers"),
+            ("GET", "/2/spaces/{id}/tweets"),
+        },
+        "timeline.read": {("GET", "/2/users/reposts_of_me")},
+        "tweet.moderate.write": {("PUT", "/2/tweets/{tweet_id}/hidden")},
+        "tweet.read": {
+            ("GET", "/2/tweets"),
+            ("GET", "/2/tweets/search/recent"),
+            ("GET", "/2/tweets/{id}"),
+            ("GET", "/2/tweets/{id}/quote_tweets"),
+            ("GET", "/2/tweets/{id}/retweets"),
+        },
+        "tweet.write": {
+            ("POST", "/2/notes"),
+            ("POST", "/2/tweets"),
+        },
+        "users.read": {
+            ("GET", "/2/news/search"),
+            ("GET", "/2/news/{id}"),
+            ("GET", "/2/users"),
+            ("GET", "/2/users/by"),
+            ("GET", "/2/users/by/username/{username}"),
+            ("GET", "/2/users/me"),
+            ("GET", "/2/users/personalized_trends"),
+            ("GET", "/2/users/search"),
+            ("GET", "/2/users/{id}"),
+            ("GET", "/2/users/{id}/affiliates"),
+        },
+    }
+
+    def test_every_firewall_path_has_an_explicit_decision(self):
+        """Every firewall rule under a classified scope must either be
+        in ``_PATH_OVERRIDES`` (explicitly routed to a non-default bucket)
+        or in ``_ACKNOWLEDGED_DEFAULT_PATHS`` (explicitly confirmed to
+        take the scope default).  This catches the case where X adds a
+        new endpoint under an existing scope whose correct bucket is
+        NOT the scope default — without this check, the new endpoint
+        would silently bill at the wrong rate (e.g. 10-40× off) until
+        someone noticed."""
+        firewall = self._load_firewall_rules()
+        override_paths: dict[str, set[tuple[str, str]]] = {}
+        for scope, method, pattern, _bucket in _PATH_OVERRIDES:
+            override_paths.setdefault(scope, set()).add((method, pattern))
+
+        unreviewed: list[tuple[str, str, str]] = []
+        obsolete: list[tuple[str, str, str]] = []
+        for scope, rules in firewall.items():
+            if scope in self._INTENTIONALLY_UNMAPPED:
+                continue
+            expected_defaults = self._ACKNOWLEDGED_DEFAULT_PATHS.get(scope, set())
+            actual_defaults = rules - override_paths.get(scope, set())
+            for method, pattern in sorted(actual_defaults - expected_defaults):
+                unreviewed.append((scope, method, pattern))
+            for method, pattern in sorted(expected_defaults - actual_defaults):
+                obsolete.append((scope, method, pattern))
+
+        drift_msg = (
+            "Firewall path coverage drifted.\n\n"
+            "Unreviewed (new firewall paths, confirm scope default or add override): "
+            f"{unreviewed}\n\n"
+            "Obsolete (in acknowledged list but no longer in firewall): "
+            f"{obsolete}\n\n"
+            "For each unreviewed path: inspect X's bucket pricing and EITHER add "
+            "an override in `_PATH_OVERRIDES` (if the scope default is wrong) OR "
+            "add the path to `_ACKNOWLEDGED_DEFAULT_PATHS` under the scope (if "
+            "the default is correct).  Do not silently let new endpoints take "
+            "the default — that is how billing drifts undetected."
+        )
+        assert not unreviewed, drift_msg
+        assert not obsolete, drift_msg
 
 
 class TestSeedConsistency:

--- a/crates/runner/mitm-addon/tests/test_x_billing.py
+++ b/crates/runner/mitm-addon/tests/test_x_billing.py
@@ -1,0 +1,490 @@
+"""Unit tests for :mod:`usage.providers.connectors.x_billing`.
+
+Each public function gets dedicated coverage so a regression in the
+classifier surface is caught without relying on the broader billing
+pipeline tests in ``test_handlers.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+import pytest
+
+from usage.providers.connectors.x_billing import (
+    _INCLUDES_TO_BUCKET,
+    _PATH_OVERRIDES,
+    _PERMISSION_TO_BUCKET,
+    classify_bucket,
+    classify_includes_bucket,
+    refine_bucket_with_body,
+)
+
+
+class TestClassifyBucket:
+    """``classify_bucket(permission, method, path) -> bucket | None``."""
+
+    @pytest.mark.parametrize(
+        ("permission", "method", "path", "expected"),
+        [
+            # — clean 1:1 writes —
+            ("tweet.moderate.write", "PUT", "/2/tweets/1/hidden", "content.manage"),
+            ("bookmark.write", "POST", "/2/users/me/bookmarks", "bookmark"),
+            ("dm.write", "POST", "/2/dm_events", "dm_interaction.create"),
+            # — clean 1:1 reads —
+            ("dm.read", "GET", "/2/dm_events", "dm_event.read"),
+            ("follows.read", "GET", "/2/users/1/followers", "following_followers.read"),
+            ("like.read", "GET", "/2/tweets/1/liking_users", "posts.read"),
+            ("timeline.read", "GET", "/2/users/1/timelines/reverse_chronological", "posts.read"),
+            ("space.read", "GET", "/2/spaces/1", "space.read"),
+            ("list.read", "GET", "/2/lists/1", "list.read"),
+            ("block.read", "GET", "/2/users/me/blocking", "user.read"),
+            ("mute.read", "GET", "/2/users/me/muting", "user.read"),
+            ("bookmark.read", "GET", "/2/users/me/bookmarks", "posts.read"),
+            # — multi-bucket scopes default to the conservative bucket —
+            ("tweet.write", "POST", "/2/tweets", "content.create_with_url"),
+            ("media.write", "POST", "/2/media/upload", "content.create_with_url"),
+            ("like.write", "POST", "/2/users/me/likes", "user_interaction.create"),
+            ("follows.write", "POST", "/2/users/me/following", "user_interaction.create"),
+            ("mute.write", "POST", "/2/users/me/muting", "user_interaction.create"),
+            ("list.write", "POST", "/2/lists", "list.create"),
+            ("tweet.read", "GET", "/2/tweets", "posts.read"),
+            ("users.read", "GET", "/2/users/1", "user.read"),
+        ],
+    )
+    def test_defaults(self, permission, method, path, expected):
+        assert classify_bucket(permission, method, path) == expected
+
+    @pytest.mark.parametrize(
+        ("permission", "method", "path", "expected"),
+        [
+            # — tweet.read refinements —
+            ("tweet.read", "GET", "/2/tweets/1/retweeted_by", "user.read"),
+            ("tweet.read", "GET", "/2/insights/28hr", "analytics.read"),
+            ("tweet.read", "GET", "/2/insights/historical", "analytics.read"),
+            ("tweet.read", "GET", "/2/media/analytics", "analytics.read"),
+            ("tweet.read", "GET", "/2/tweets/analytics", "analytics.read"),
+            ("tweet.read", "GET", "/2/media", "media.read"),
+            ("tweet.read", "GET", "/2/media/abc", "media.read"),
+            ("tweet.read", "GET", "/2/notes/search/notes_written", "note.read"),
+            ("tweet.read", "GET", "/2/notes/search/posts_eligible_for_notes", "note.read"),
+            # — users.read refinements —
+            ("users.read", "GET", "/2/users/1/mentions", "posts.read"),
+            ("users.read", "GET", "/2/users/1/timelines/reverse_chronological", "posts.read"),
+            ("users.read", "GET", "/2/users/1/tweets", "posts.read"),
+            ("users.read", "GET", "/2/communities/search", "community.read"),
+            # — write DELETE → interaction.delete / mute.delete —
+            ("like.write", "DELETE", "/2/users/1/likes/2", "interaction.delete"),
+            ("follows.write", "DELETE", "/2/users/1/following/2", "interaction.delete"),
+            ("mute.write", "DELETE", "/2/users/1/muting/2", "mute.delete"),
+            # — list.write refinements: create stays, everything else is manage —
+            ("list.write", "PUT", "/2/lists/1", "list.manage"),
+            ("list.write", "DELETE", "/2/lists/1", "list.manage"),
+            ("list.write", "POST", "/2/lists/1/members", "list.manage"),
+            ("list.write", "DELETE", "/2/lists/1/members/2", "list.manage"),
+            ("list.write", "POST", "/2/users/1/followed_lists", "list.manage"),
+            ("list.write", "DELETE", "/2/users/1/followed_lists/2", "list.manage"),
+            ("list.write", "POST", "/2/users/1/pinned_lists", "list.manage"),
+            ("list.write", "DELETE", "/2/users/1/pinned_lists/2", "list.manage"),
+            # — bookmark DELETE stays on bookmark (not interaction.delete) —
+            ("bookmark.write", "DELETE", "/2/users/1/bookmarks/2", "bookmark"),
+            # — media.write refinements —
+            ("media.write", "GET", "/2/media/upload", "media.read"),
+            ("media.write", "GET", "/2/chat/media/abc/xyz", "media.read"),
+            ("media.write", "POST", "/2/media/metadata", "media_metadata"),
+            ("media.write", "POST", "/2/media/subtitles", "media_metadata"),
+            ("media.write", "DELETE", "/2/media/subtitles", "media_metadata"),
+            # — media.write: chat (DM) media uploads route to DM bucket —
+            (
+                "media.write",
+                "POST",
+                "/2/chat/media/upload/initialize",
+                "dm_interaction.create",
+            ),
+            (
+                "media.write",
+                "POST",
+                "/2/chat/media/upload/abc/append",
+                "dm_interaction.create",
+            ),
+            (
+                "media.write",
+                "POST",
+                "/2/chat/media/upload/abc/finalize",
+                "dm_interaction.create",
+            ),
+            # — tweet.write: DELETE of your own content → Content: Manage —
+            ("tweet.write", "DELETE", "/2/tweets/123", "content.manage"),
+            ("tweet.write", "DELETE", "/2/notes/abc", "content.manage"),
+            # — tweet.write: retweets are User Interaction (create/delete) —
+            ("tweet.write", "POST", "/2/users/1/retweets", "user_interaction.create"),
+            ("tweet.write", "DELETE", "/2/users/1/retweets/999", "interaction.delete"),
+            ("tweet.write", "POST", "/2/evaluate_note", "user_interaction.create"),
+            # — dm.write: deleting a DM → Content: Manage —
+            ("dm.write", "DELETE", "/2/dm_events/abc", "content.manage"),
+        ],
+    )
+    def test_path_overrides(self, permission, method, path, expected):
+        assert classify_bucket(permission, method, path) == expected
+
+    @pytest.mark.parametrize(
+        ("permission", "method", "path"),
+        [
+            # The "app-only" scope is in the firewall but intentionally
+            # unmapped here — BearerToken-only endpoints are not billed.
+            ("app-only", "GET", "/2/tweets/counts/all"),
+            # — any unknown scope falls through —
+            ("unknown.scope", "GET", "/anywhere"),
+            ("", "GET", "/2/tweets"),
+        ],
+    )
+    def test_returns_none_for_unmapped(self, permission, method, path):
+        assert classify_bucket(permission, method, path) is None
+
+    def test_method_is_case_insensitive(self):
+        # Override tables store methods uppercased; classifier must match
+        # regardless of what the caller passes in.
+        assert (
+            classify_bucket("like.write", "delete", "/2/users/me/likes/1") == "interaction.delete"
+        )
+        assert (
+            classify_bucket("like.write", "DELETE", "/2/users/me/likes/1") == "interaction.delete"
+        )
+
+
+class TestClassifyIncludesBucket:
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            ("users", "user.read"),
+            ("tweets", "posts.read"),
+            ("media", "media.read"),
+            ("polls", "posts.read"),
+            ("places", "posts.read"),
+            ("topics", "posts.read"),
+            ("spaces", "space.read"),
+        ],
+    )
+    def test_known_keys(self, key, expected):
+        assert classify_includes_bucket(key) == expected
+
+    @pytest.mark.parametrize("key", ["future_widget", "", "users_extended"])
+    def test_unknown_keys_return_none(self, key):
+        assert classify_includes_bucket(key) is None
+
+
+class TestRefineBucketWithBody:
+    """``refine_bucket_with_body`` only affects POST /2/tweets.
+    Everything else flows through unchanged.
+    """
+
+    def _body(self, obj: dict) -> bytes:
+        return json.dumps(obj).encode()
+
+    # — paths that bypass refinement —
+
+    @pytest.mark.parametrize(
+        ("bucket", "method", "path", "body"),
+        [
+            # Non-target bucket
+            ("posts.read", "POST", "/2/tweets", b'{"text": "no url"}'),
+            # Non-POST
+            ("content.create_with_url", "GET", "/2/tweets", b'{"text": "no url"}'),
+            # Non-target path
+            (
+                "content.create_with_url",
+                "POST",
+                "/2/tweets/1/hidden",
+                b'{"text": "no url"}',
+            ),
+        ],
+    )
+    def test_passthrough(self, bucket, method, path, body):
+        assert refine_bucket_with_body(bucket, method, path, body) == bucket
+
+    # — POST /2/tweets downgrade path —
+
+    def test_plain_text_downgrades(self):
+        body = self._body({"text": "hello world"})
+        assert (
+            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
+            == "content.create"
+        )
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "check https://example.com out",
+            "http://legacy.example.com",
+            "prefix http://x.co suffix",
+        ],
+    )
+    def test_url_in_text_stays_on_with_url(self, text):
+        body = self._body({"text": text})
+        assert (
+            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
+            == "content.create_with_url"
+        )
+
+    def test_quote_tweet_stays_on_with_url(self):
+        body = self._body({"text": "nice", "quote_tweet_id": "abc"})
+        assert (
+            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
+            == "content.create_with_url"
+        )
+
+    def test_attached_media_stays_on_with_url(self):
+        body = self._body({"text": "pic", "media": {"media_ids": ["42"]}})
+        assert (
+            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
+            == "content.create_with_url"
+        )
+
+    def test_card_uri_stays_on_with_url(self):
+        # card_uri attaches a link preview card — the published tweet
+        # always renders a URL even if the text is plain.
+        body = self._body({"text": "plain", "card_uri": "card://12345"})
+        assert (
+            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
+            == "content.create_with_url"
+        )
+
+    def test_empty_media_ids_list_allows_downgrade(self):
+        body = self._body({"text": "no media", "media": {"media_ids": []}})
+        assert (
+            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
+            == "content.create"
+        )
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            None,
+            b"",
+            b"not json",
+            b'["unexpected array"]',
+            # Dict without `text`
+            b"{}",
+            # text is not a string
+            b'{"text": 42}',
+        ],
+    )
+    def test_defensive_cases_stay_on_with_url(self, body):
+        assert (
+            refine_bucket_with_body("content.create_with_url", "POST", "/2/tweets", body)
+            == "content.create_with_url"
+        )
+
+
+class TestFirewallConsistency:
+    """Every permission group produced by the X firewall generator must
+    either have a classifier mapping or appear in the intentionally
+    unmapped set.  Without this check, an OpenAPI-driven firewall
+    regeneration could introduce a new OAuth scope that silently skips
+    billing (``classify_bucket`` returns ``None`` → request not
+    recorded).
+    """
+
+    # Permission names that the classifier deliberately skips.  Requests
+    # matching these scopes do not emit ``usage_event`` rows.
+    _INTENTIONALLY_UNMAPPED: frozenset[str] = frozenset({"app-only"})
+
+    def _firewall_block(self) -> str:
+        fw_path = (
+            pathlib.Path(__file__).resolve().parent.parent.parent.parent.parent
+            / "turbo"
+            / "packages"
+            / "core"
+            / "src"
+            / "firewalls"
+            / "x.generated.ts"
+        )
+        if not fw_path.exists():
+            pytest.fail(
+                f"x.generated.ts not found at {fw_path}.\n"
+                "This file is generated by the firewall generator's postinstall "
+                "hook and is gitignored — run `cd turbo && pnpm install` to "
+                "produce it before running these tests.  If the file still "
+                "isn't created after install, the generator output path has "
+                "likely moved; update this test's path computation."
+            )
+        text = fw_path.read_text()
+        try:
+            start = text.index("permissions: [")
+        except ValueError:
+            pytest.fail(
+                "Could not locate the `permissions: [...]` block in "
+                f"{fw_path}.  The firewall generator's output shape changed "
+                "— update this test."
+            )
+        pos = start + len("permissions: [")
+        depth = 1
+        while pos < len(text) and depth > 0:
+            c = text[pos]
+            if c == "[":
+                depth += 1
+            elif c == "]":
+                depth -= 1
+            pos += 1
+        if depth != 0:
+            pytest.fail(f"Unbalanced `permissions: [...]` brackets in {fw_path}.")
+        return text[start:pos]
+
+    def _load_firewall_permissions(self) -> set[str]:
+        # Pick permission-level `name: "..."` entries, not the outer
+        # firewall name or any future sibling structures.
+        return set(re.findall(r'name:\s*"([^"]+)"', self._firewall_block()))
+
+    def _load_firewall_rules(self) -> dict[str, set[tuple[str, str]]]:
+        """Return ``{scope: {(method, pattern), ...}}`` from the generated
+        firewall.  Used to verify that every classifier path override
+        actually exists as a rule under its claimed scope."""
+        block = self._firewall_block()
+        group_re = re.compile(
+            r'name:\s*"(?P<name>[^"]+)"\s*,'
+            r'(?:\s*description:\s*"[^"]*"\s*,)?'
+            r"\s*rules:\s*\[(?P<rules>.*?)\]",
+            re.DOTALL,
+        )
+        rule_re = re.compile(r'"(?P<method>[A-Z]+)\s+(?P<pattern>[^"]+)"')
+        result: dict[str, set[tuple[str, str]]] = {}
+        for m in group_re.finditer(block):
+            rules = {
+                (r.group("method"), r.group("pattern")) for r in rule_re.finditer(m.group("rules"))
+            }
+            result[m.group("name")] = rules
+        return result
+
+    def test_every_firewall_scope_is_mapped_or_intentionally_skipped(self):
+        firewall_scopes = self._load_firewall_permissions()
+        classified = set(_PERMISSION_TO_BUCKET.keys())
+        accounted_for = classified | self._INTENTIONALLY_UNMAPPED
+        missing = firewall_scopes - accounted_for
+        assert not missing, (
+            "The X firewall generator produces permission names that the "
+            f"classifier does not handle: {sorted(missing)}.  Either add an "
+            f"entry to `_PERMISSION_TO_BUCKET` in x_billing.py or (if the "
+            "scope should stay unbilled) add it to "
+            "`TestFirewallConsistency._INTENTIONALLY_UNMAPPED`."
+        )
+
+    def test_no_classifier_entry_is_stale(self):
+        """Guard against typos: every key in `_PERMISSION_TO_BUCKET` must
+        correspond to an actual scope the firewall generator emits."""
+        firewall_scopes = self._load_firewall_permissions()
+        stale = set(_PERMISSION_TO_BUCKET.keys()) - firewall_scopes
+        assert not stale, (
+            "The classifier has entries for scopes that no longer appear "
+            f"in the firewall generator output: {sorted(stale)}.  Either "
+            "these scopes were renamed/removed upstream, or the keys are "
+            "typos."
+        )
+
+    def test_overrides_never_reference_intentionally_unmapped(self):
+        """`classify_bucket` consults ``_PATH_OVERRIDES`` before
+        ``_PERMISSION_TO_BUCKET``, so an override under an
+        intentionally-unmapped scope would silently enable billing for
+        a scope we've decided not to bill (e.g. ``app-only``)."""
+        override_scopes = {scope for scope, *_ in _PATH_OVERRIDES}
+        clashing = override_scopes & self._INTENTIONALLY_UNMAPPED
+        assert not clashing, (
+            "These scopes are in _INTENTIONALLY_UNMAPPED but also appear "
+            f"in _PATH_OVERRIDES: {sorted(clashing)}.  The override would "
+            "override the unmapped decision and start emitting usage_event "
+            "rows.  Either remove the override or drop the scope from "
+            "_INTENTIONALLY_UNMAPPED and add it to _PERMISSION_TO_BUCKET."
+        )
+
+    def test_every_override_path_exists_in_firewall(self):
+        """Each `_PATH_OVERRIDES` entry must point at a real rule in the
+        firewall generator output.  Catches typos in the method or path
+        pattern that would otherwise silently fail to match at runtime."""
+        firewall = self._load_firewall_rules()
+        missing: list[tuple[str, str, str]] = []
+        for scope, method, pattern, _bucket in _PATH_OVERRIDES:
+            rules = firewall.get(scope, set())
+            if (method, pattern) not in rules:
+                missing.append((scope, method, pattern))
+        assert not missing, (
+            "Classifier overrides reference (scope, method, path) tuples "
+            f"that are not in the firewall generator output: {missing}.  "
+            "Either the firewall rule was renamed/removed upstream, or "
+            "the override has a typo."
+        )
+
+
+class TestSeedConsistency:
+    """Every bucket the classifier can emit must have a pricing row in
+    ``turbo/apps/web/scripts/dev-seed.ts``.  Without that, the billing
+    processor would stamp ``billing_error = 'missing_pricing'`` and
+    charge $0 for legitimate requests.
+    """
+
+    def _load_seed_categories(self) -> set[str]:
+        seed_path = (
+            pathlib.Path(__file__).resolve().parent.parent.parent.parent.parent
+            / "turbo"
+            / "apps"
+            / "web"
+            / "scripts"
+            / "dev-seed.ts"
+        )
+        if not seed_path.exists():
+            pytest.fail(
+                f"dev-seed.ts not found at {seed_path}.  The X_CONNECTOR_PRICING "
+                "block has likely moved — update this test's path computation."
+            )
+        text = seed_path.read_text()
+        # Walk from the X_CONNECTOR_PRICING declaration to its closing
+        # bracket so we don't accidentally scoop up other category-like
+        # strings elsewhere in the file.
+        try:
+            start = text.index("const X_CONNECTOR_PRICING")
+            end = text.index("];", start)
+        except ValueError:
+            pytest.fail(
+                "Could not locate the `const X_CONNECTOR_PRICING = [...]` block "
+                f"in {seed_path}.  Either the variable was renamed or the array "
+                "syntax changed — update this test to match."
+            )
+        block = text[start:end]
+        return set(re.findall(r'category:\s*"([^"]+)"', block))
+
+    def _emitted_buckets(self) -> set[str]:
+        emitted = set(_PERMISSION_TO_BUCKET.values())
+        emitted.update(bucket for _, _, _, bucket in _PATH_OVERRIDES)
+        emitted.update(_INCLUDES_TO_BUCKET.values())
+        # refine_bucket_with_body may downgrade the with-url bucket —
+        # derive the target by invoking it on a no-URL body rather than
+        # hardcoding the bucket name.
+        downgraded = refine_bucket_with_body(
+            "content.create_with_url",
+            "POST",
+            "/2/tweets",
+            json.dumps({"text": "plain text without any link"}).encode(),
+        )
+        emitted.add(downgraded)
+        # Unknown ``includes.<key>`` categories are synthetic per-request
+        # strings; they intentionally have no seed row — the billing
+        # processor applies a server-side fallback price.  Not included
+        # in the check.
+        return emitted
+
+    def test_every_emitted_bucket_is_in_seed(self):
+        seed = self._load_seed_categories()
+        emitted = self._emitted_buckets()
+        missing = emitted - seed
+        assert not missing, f"classifier emits buckets not present in dev-seed: {sorted(missing)}"
+
+    def test_fallback_row_is_seeded(self):
+        """Unknown ``includes.<key>`` categories rely on the
+        ``__fallback__`` seed row for server-side pricing.  If that row
+        is deleted the billing processor silently charges $0 for any
+        unrecognised includes type."""
+        seed = self._load_seed_categories()
+        assert "__fallback__" in seed, (
+            "dev-seed.ts lost the `__fallback__` X_CONNECTOR_PRICING row.  "
+            "Unknown includes keys would bill at $0 — restore the row."
+        )

--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -143,8 +143,10 @@ const X_CONNECTOR_PRICING: Array<{
   { category: "mute.delete", unitPrice: usd(0.005) },
   { category: "counts.recent", unitPrice: usd(0.005) },
   { category: "counts.all", unitPrice: usd(0.01) },
-  // fallback
-  { category: "__fallback__", unitPrice: usd(0.01) },
+  // fallback — priced at the minimum bucket rate across the table
+  // above, so an unknown includes key can never be billed at more
+  // than X charges for the cheapest known bucket.
+  { category: "__fallback__", unitPrice: usd(0.005) },
 ];
 
 /**

--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -111,33 +111,40 @@ const MODEL_PRICING: (typeof creditPricing.$inferInsert)[] = [
   },
 ];
 
+// https://docs.x.com/x-api/getting-started/pricing
 const X_CONNECTOR_PRICING: Array<{
   category: string;
   unitPrice: number;
 }> = [
-  { category: "block.read", unitPrice: usd(0.01) },
-  { category: "bookmark.read", unitPrice: usd(0.01) },
-  { category: "bookmark.write", unitPrice: usd(0.005) },
-  { category: "dm.read", unitPrice: usd(0.01) },
-  { category: "dm.write", unitPrice: usd(0.015) },
-  { category: "follows.read", unitPrice: usd(0.01) },
-  { category: "follows.write", unitPrice: usd(0.015) },
-  { category: "like.read", unitPrice: usd(0.01) },
-  { category: "like.write", unitPrice: usd(0.015) },
+  // reads — $/resource
+  { category: "posts.read", unitPrice: usd(0.005) },
+  { category: "user.read", unitPrice: usd(0.01) },
+  { category: "dm_event.read", unitPrice: usd(0.01) },
+  { category: "following_followers.read", unitPrice: usd(0.01) },
   { category: "list.read", unitPrice: usd(0.005) },
-  { category: "list.write", unitPrice: usd(0.01) },
-  { category: "media.read", unitPrice: usd(0.005) },
-  { category: "media.write", unitPrice: usd(0.015) },
-  { category: "mute.read", unitPrice: usd(0.01) },
-  { category: "mute.write", unitPrice: usd(0.015) },
-  { category: "places.read", unitPrice: usd(0.01) },
-  { category: "polls.read", unitPrice: usd(0.01) },
   { category: "space.read", unitPrice: usd(0.005) },
-  { category: "timeline.read", unitPrice: usd(0.005) },
-  { category: "topics.read", unitPrice: usd(0.01) },
-  { category: "tweet.read", unitPrice: usd(0.01) },
-  { category: "tweet.write", unitPrice: usd(0.2) },
-  { category: "users.read", unitPrice: usd(0.01) },
+  { category: "community.read", unitPrice: usd(0.005) },
+  { category: "note.read", unitPrice: usd(0.005) },
+  { category: "media.read", unitPrice: usd(0.005) },
+  { category: "analytics.read", unitPrice: usd(0.005) },
+  { category: "trend.read", unitPrice: usd(0.01) },
+  // writes — $/request
+  { category: "content.create", unitPrice: usd(0.015) },
+  { category: "content.create_with_url", unitPrice: usd(0.2) },
+  { category: "dm_interaction.create", unitPrice: usd(0.015) },
+  { category: "user_interaction.create", unitPrice: usd(0.015) },
+  { category: "interaction.delete", unitPrice: usd(0.01) },
+  { category: "content.manage", unitPrice: usd(0.005) },
+  { category: "list.create", unitPrice: usd(0.01) },
+  { category: "list.manage", unitPrice: usd(0.005) },
+  { category: "bookmark", unitPrice: usd(0.005) },
+  { category: "media_metadata", unitPrice: usd(0.005) },
+  { category: "privacy.update", unitPrice: usd(0.01) },
+  { category: "mute.delete", unitPrice: usd(0.005) },
+  { category: "counts.recent", unitPrice: usd(0.005) },
+  { category: "counts.all", unitPrice: usd(0.01) },
+  // fallback
+  { category: "__fallback__", unitPrice: usd(0.01) },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Redesign `usage_event.category` from OAuth scope names to X's published pricing buckets (`posts.read`, `content.create`, `content.manage`, `interaction.delete`, …) so the server-side billing processor can read `unit_price` from `usage_pricing` directly.
- New `src/usage/providers/connectors/x_billing.py` centralizes the classifier: per-scope default bucket + per-path overrides + `includes.<key>` map + body refinement for `POST /2/tweets` (URL / quote / media / `card_uri` stay on `content.create_with_url`; plain text downgrades to `content.create`).
- `dev-seed.ts` seeds 25 X bucket prices and a `__fallback__` row for unknown `includes` keys.
- Crates CI job runs `pnpm install` so the firewall generator's gitignored `x.generated.ts` is present before pytest.

## Caveats (please review)
X's public pricing page lists buckets + prices but **does not publish an endpoint → bucket mapping**. Several overrides are semantic inferences from bucket names — notably `DELETE /2/tweets/{id}` → `content.manage`, `POST /2/users/{id}/retweets` → `user_interaction.create`, `DELETE /2/users/{id}/retweets/{source_tweet_id}` → `interaction.delete`, and chat media uploads → `dm_interaction.create`. These lower the bill 10–40× vs. the scope default. Validate against Developer Console billing data or empirical live calls before go-live; module docstring flags the risk.

Known gaps tracked for follow-up:
- Owned Reads detection (5–10× over-charge on self-endpoints until implemented)
- 24h dedup window (X dedups identical Post reads per day; we don't)
- Bare-domain URL detection in tweet body (`https?://` only; t.co may auto-link `example.com`)

## Test plan
- [x] `pytest tests/` — 588 passing
- [x] `ruff check` + `ruff format --check` clean
- [x] Consistency tests:
  - every firewall scope is classified or intentionally unmapped
  - no classifier entry is stale
  - every override path exists in the firewall generator output
  - no override references an intentionally-unmapped scope
  - every emitted bucket has a dev-seed row
  - `__fallback__` seed row is present
- [ ] Manual validation against Developer Console billing once a dev app is set up

🤖 Generated with [Claude Code](https://claude.com/claude-code)