### PR TITLE
perf(runner): parallelize idle pool drain

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1336,7 +1336,7 @@ fn spawn_job(
 /// (e.g. "draining" vs "shutdown").
 async fn drain_idle_pool(
     idle_pool: &SharedIdlePool,
-    budget: &ResourceBudget,
+    budget: &Arc<ResourceBudget>,
     status: &StatusTracker,
     context: &'static str,
 ) {
@@ -1345,11 +1345,18 @@ async fn drain_idle_pool(
         return;
     }
     info!(count = entries.len(), context, "destroying idle VMs");
+    // Destroy in parallel — each `stop_and_destroy` is ~1–3s (FC shutdown +
+    // cgroup/NBD/netns teardown), and teardown-path callers sit between the
+    // last job finishing and the runner process exiting. Serial destroy
+    // blows past the CI `wait_for_exit` budget on multi-VM drains.
+    let mut set = tokio::task::JoinSet::new();
     for entry in entries {
-        let vcpu = entry.vcpu;
-        let memory_mb = entry.memory_mb;
-        entry.stop_and_destroy().await;
-        budget.release(vcpu, memory_mb);
+        set.spawn(destroy_idle_entry(entry, Arc::clone(budget)));
+    }
+    while let Some(result) = set.join_next().await {
+        if let Err(e) = result {
+            warn!(error = %e, "idle entry destroy task panicked");
+        }
     }
     status.set_idle_info(Vec::new()).await;
 }

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1326,11 +1326,11 @@ fn spawn_job(
     });
 }
 
-/// Drain the idle pool synchronously: destroy every entry and release each
-/// one's budget. Called from both the Draining arm (soft-drain entry) and
-/// teardown — both need the same sequence, and teardown also wants the
-/// `status.json` `idle_vms` list cleared so the final snapshot is
-/// consistent with the empty pool.
+/// Drain the idle pool: destroy every entry in parallel and wait for all
+/// destroys to complete before returning (budgets released, `status.json`
+/// `idle_vms` cleared). Called from both the Draining arm (soft-drain
+/// entry) and teardown — both need the final state consistent with an
+/// empty pool before proceeding.
 ///
 /// `context` is logged alongside the destroyed count for operator clarity
 /// (e.g. "draining" vs "shutdown").
@@ -1355,7 +1355,7 @@ async fn drain_idle_pool(
     }
     while let Some(result) = set.join_next().await {
         if let Err(e) = result {
-            warn!(error = %e, "idle entry destroy task panicked");
+            warn!(context, error = %e, "idle entry destroy task panicked");
         }
     }
     status.set_idle_info(Vec::new()).await;


### PR DESCRIPTION
## Summary

Destroy idle VMs in parallel during `drain_idle_pool` instead of serially, so teardown with N parked VMs costs `max(stop_and_destroy)` instead of `N × stop_and_destroy`.

## Context

Hypothesis prompted by `runner-upgrade-local` CI failure on [run 24828954009](https://github.com/vm0-ai/vm0/actions/runs/24828954009/job/72672789043). The test waits up to 5s for `vm0-runner-*-a` to exit after drain completes; A actually exited ~9s after its last job (at `10:02:40.738`). The post-jobs 5s gap (10:02:31.6 → 10:02:36.679 where the visible iptables cleanup begins) is **not directly observable** in the failure's journal dump (`--lines 50` truncated the earlier events), but the most plausible candidate is teardown's `drain_idle_pool` destroying parked VMs one-by-one — each `stop_and_destroy` is ~1–3s (FC stop + cgroup / NBD / netns).

Related: #10416, #10410 ("drain cadence too tight — 5s gives <1 heartbeat tick of headroom").

## Change

`drain_idle_pool` now spawns each `destroy_idle_entry` on a `JoinSet`. The helper already exists and is used at three other call sites (lines 806 / 821 / 901) — this just reuses it on the drain path.

## Honest assessment

- **Diagnosis partially unverified**: I can't see what happens in the 5s gap from the dump. This PR fixes the most likely suspect but may not be sufficient alone if other teardown steps are also slow.
- **iptables contention**: N parallel destroys still serialize on xtables lock for their `iptables -D` calls. Real speedup applies to FC stop / cgroup / NBD cleanup, not iptables.
- **Panic isolation**: Parallel version surfaces panics as `warn!` per-task (matching line 961's pattern) instead of aborting the whole drain; small improvement.
- **No tests added**: existing regressions (`late_park_during_draining_cleaned_by_teardown`, `shutdown_clears_idle_vms_in_status_json`, `shutdown_drains_idle_pool`) already assert pool empty + budget released + `idle_vms` cleared, which are order-independent. Added tests would mostly verify timing and be fragile.

## Plan

Ship this as a targeted optimization, observe whether `runner-upgrade-local` flake rate drops. If it still flakes, the next move is either raising the `wait_for_exit` budget (revive #10410) or adding profiling logs to the teardown path to identify the remaining slow step.

## Test plan

- [ ] `cargo test -p runner` passes (764 tests, all green locally)
- [ ] `runner-upgrade-local` passes in CI
- [ ] Observe flake rate on subsequent merges to confirm (or refute) the hypothesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)