### PR TITLE
fix(ci): skip deploy-web in merge queue

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -582,8 +582,9 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     needs: [prepare]
-    # Deploy if job-ref is set (PR or main), not a release-please commit, and web, CLI, runner, or platform changed
+    # Deploy if job-ref is set (PR or main), not a release-please commit, not a merge queue run, and web, CLI, runner, or platform changed
     if: |
+      github.event_name != 'merge_group' &&
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||


### PR DESCRIPTION
## Summary

- `deploy-web` was running on every merge queue entry and failing immediately with `HttpError: No ref found for: refs/heads/gh-readonly-queue/...` — the `bobheadxi/deployments@v1` action can't resolve merge queue temporary branch refs via the GitHub Deployments API
- Preview deployments have no value in the merge queue (the PR already has a preview from its own CI run)
- Added `github.event_name != 'merge_group'` as the first condition on the `deploy-web` job so it is skipped during merge queue runs
- `ci-gate-turbo` already uses `allow_skip: true` for `deploy-web`, so a `skipped` result is fully accepted — no gate changes needed

## Test plan

- [ ] Verify next merge queue run shows `deploy-web` as skipped (not failed)
- [ ] Verify `ci-gate-turbo` passes with skipped `deploy-web`
- [ ] Verify PR CI still runs `deploy-web` as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)