### PR TITLE
chore(runner): forward axiom env vars to production deploy

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1435,6 +1435,7 @@ jobs:
           AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           SENTRY_DSN_RUNNER: ${{ secrets.SENTRY_DSN_RUNNER }}
+          AXIOM_TOKEN_TELEMETRY: ${{ secrets.AXIOM_TOKEN_TELEMETRY }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
           R2_ACCOUNT_ID: ${{ needs.resolve-image-cache.outputs.r2-account-id }}
           R2_USER_STORAGES_BUCKET_NAME: ${{ needs.resolve-image-cache.outputs.r2-bucket }}
@@ -1445,6 +1446,8 @@ jobs:
             playbooks/promote-runner.yml \
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
             -e "sentry_dsn=${SENTRY_DSN_RUNNER}" \
+            -e "axiom_token_telemetry=${AXIOM_TOKEN_TELEMETRY}" \
+            -e "axiom_dataset_suffix=prod" \
             -e "runner_version=${RUNNER_VERSION}" \
             -e "r2_account_id=${R2_ACCOUNT_ID:-}" \
             -e "r2_access_key_id=${R2_ACCESS_KEY_ID:-}" \

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -19,6 +19,9 @@
 #
 # Optional Variables:
 #   - sentry_dsn: Forwarded to the systemd unit as SENTRY_DSN
+#   - axiom_token_telemetry / axiom_dataset_suffix:
+#       Forwarded to the systemd unit as AXIOM_TOKEN_TELEMETRY /
+#       AXIOM_DATASET_SUFFIX. Both must be set for Axiom telemetry to activate.
 #   - r2_account_id / r2_access_key_id / r2_secret_access_key / r2_bucket:
 #       Passed to `runner gc` so R2-side cache cleanup runs.
 
@@ -43,6 +46,12 @@
         --config {{ runner_dir }}/runner.yaml
         {% if sentry_dsn is defined and sentry_dsn %}
         --env SENTRY_DSN={{ sentry_dsn }}
+        {% endif %}
+        {% if axiom_token_telemetry is defined and axiom_token_telemetry %}
+        --env AXIOM_TOKEN_TELEMETRY={{ axiom_token_telemetry }}
+        {% endif %}
+        {% if axiom_dataset_suffix is defined and axiom_dataset_suffix %}
+        --env AXIOM_DATASET_SUFFIX={{ axiom_dataset_suffix }}
         {% endif %}
 
     # ========================================


### PR DESCRIPTION
## Summary
- Closes #10739
- Runner's Axiom telemetry layer (`crates/runner/src/axiom_layer.rs`) already reads `AXIOM_TOKEN_TELEMETRY` / `AXIOM_DATASET_SUFFIX` and disables itself when either is unset. The production promote path never passed them, so telemetry was silently off on all prod runner hosts.
- Mirror the existing `sentry_dsn` plumbing: surface `AXIOM_TOKEN_TELEMETRY` in the workflow env, forward it + a fixed `axiom_dataset_suffix=prod` to `promote-runner.yml`, and conditionally append `--env` flags on `runner service install` so the systemd unit gets them.
- No code changes — runner activates telemetry automatically once the vars land on the host.

## Test plan
- [ ] Release-please green; production promote job reaches the `runner service install` step (existing integration path)
- [ ] After deploy, verify `AXIOM_TOKEN_TELEMETRY` / `AXIOM_DATASET_SUFFIX` present in the unit (`systemctl show vm0-runner-v<ver> -p Environment`)
- [ ] Logs show up in the `vm0-web-logs-prod` Axiom dataset from runner hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)