### PR TITLE
perf(chat-messages): fold compose content into round 1 to drop round 2 load arm

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -13,7 +13,11 @@ import {
   findTestRunCallbacks,
   createTestSessionWithConversation,
 } from "../../../__tests__/api-test-helpers";
-import { createTestZeroAgent } from "../../../__tests__/db-test-seeders/agents";
+import {
+  clearComposeHeadVersion,
+  createTestZeroAgent,
+  deleteTestCompose,
+} from "../../../__tests__/db-test-seeders/agents";
 import { bindCustomSkillToAgent } from "../../../__tests__/db-test-seeders/skills";
 import { createTestUserConnector } from "../../../__tests__/db-test-seeders/connectors";
 import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
@@ -443,6 +447,46 @@ describe("createZeroRun() — service-only parameters", () => {
       // After flushing, dispatch has run and the runner job is visible.
       const jobAfterFlush = await findTestRunnerJobEntry(result.runId);
       expect(jobAfterFlush).toBeDefined();
+    });
+  });
+
+  describe("compose resolution error paths (Round 1 JOIN)", () => {
+    it("throws notFound when composeId does not match any compose", async () => {
+      const missingComposeId = "00000000-0000-0000-0000-000000000000";
+
+      await expect(
+        createZeroRun(baseParams({ agentId: missingComposeId })),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining("Agent compose not found"),
+      });
+    });
+
+    it("throws badRequest when compose has no head version", async () => {
+      const agentName = uniqueId("headless-agent");
+      const compose = await createTestCompose(agentName);
+      const headlessAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      await clearComposeHeadVersion(compose.composeId);
+
+      await expect(
+        createZeroRun(baseParams({ agentId: headlessAgentId })),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining(
+          "Agent compose has no versions. Run 'vm0 build' first.",
+        ),
+      });
+    });
+
+    it("throws notFound after compose row is deleted", async () => {
+      const agentName = uniqueId("deleted-agent");
+      const compose = await createTestCompose(agentName);
+      const deletedAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      await deleteTestCompose(compose.composeId);
+
+      await expect(
+        createZeroRun(baseParams({ agentId: deletedAgentId })),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining("Agent compose not found"),
+      });
     });
   });
 });

--- a/turbo/apps/web/src/lib/zero/chat-thread/request-span-ops.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/request-span-ops.ts
@@ -26,6 +26,8 @@ export const CHAT_REQUEST_OPS = {
   create_run_round2_org_meta: "api_chat_send_create_run_round2_org_meta",
   create_run_round2_user_prefs: "api_chat_send_create_run_round2_user_prefs",
   create_run_round2_feature_sw: "api_chat_send_create_run_round2_feature_sw",
+  // Retained for back-compat of Axiom dashboards reading historical series;
+  // no longer emitted — compose content is now fetched in Round 1.
   create_run_round2_load_compose:
     "api_chat_send_create_run_round2_load_compose",
   create_run_round3_credits: "api_chat_send_create_run_round3_credits",

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -46,7 +46,7 @@ import { generateZeroToken, generateSandboxToken } from "../auth/sandbox-token";
 import { loadFeatureSwitchOverrides } from "./user/feature-switches-service";
 import { buildZeroExecutionContext } from "./build-zero-context";
 import { getOrgMetadata, type OrgMetadata } from "./org/org-metadata-service";
-import { isConcurrentRunLimit, notFound } from "../shared/errors";
+import { isConcurrentRunLimit } from "../shared/errors";
 import {
   DISALLOWED_TOOLS,
   buildAgentPrompt,
@@ -516,12 +516,6 @@ async function createZeroRunRecord(
 
   // ── Round 3: Pre-flight checks (need compose content) ───────────────
   const apiStartTime = params.apiStartTime;
-  // resolved.composeId is always populated on zero-run-service callers
-  // (resolveByComposeId always sets it; lookupComposeByVersion rejects via
-  // the orgId guard before here). Narrow it for the rest of the function.
-  if (!resolved.composeId) {
-    throw notFound("Agent compose not found");
-  }
   const composeId = resolved.composeId;
   authorizeCompose(params.userId, resolved.orgId, {
     id: composeId,

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -24,7 +24,6 @@ import type { RunStatus } from "@vm0/core/contracts/runs";
 import {
   insertRunRecord,
   buildAndDispatchRun,
-  loadCompose,
   markRunFailed,
   registerCallbacks,
   type CreateRunParams,
@@ -47,7 +46,7 @@ import { generateZeroToken, generateSandboxToken } from "../auth/sandbox-token";
 import { loadFeatureSwitchOverrides } from "./user/feature-switches-service";
 import { buildZeroExecutionContext } from "./build-zero-context";
 import { getOrgMetadata, type OrgMetadata } from "./org/org-metadata-service";
-import { isConcurrentRunLimit } from "../shared/errors";
+import { isConcurrentRunLimit, notFound } from "../shared/errors";
 import {
   DISALLOWED_TOOLS,
   buildAgentPrompt,
@@ -398,9 +397,6 @@ async function createZeroRunRecord(
   const round2FeatureSw = timed(async () => {
     return loadFeatureSwitchOverrides(resolved.orgId, params.userId);
   });
-  const round2LoadCompose = timed(async () => {
-    return loadCompose(resolved.agentComposeVersionId, resolved.composeId);
-  });
 
   const [
     connectorRowsT,
@@ -408,21 +404,18 @@ async function createZeroRunRecord(
     orgMetaT,
     userPrefsT,
     featureOverridesT,
-    preloadedComposeT,
   ] = await Promise.all([
     round2Connectors,
     round2CustomConnectors,
     round2OrgMeta,
     round2UserPrefs,
     round2FeatureSw,
-    round2LoadCompose,
   ]);
   const connectorRows = connectorRowsT.result;
   const customConnectorRows = customConnectorRowsT.result;
   const orgMeta = orgMetaT.result;
   const userPrefs = userPrefsT.result;
   const featureOverrides = featureOverridesT.result;
-  const preloadedCompose = preloadedComposeT.result;
 
   emit(CHAT_REQUEST_OPS.create_run_round2_connectors, connectorRowsT.ms);
   emit(
@@ -432,7 +425,6 @@ async function createZeroRunRecord(
   emit(CHAT_REQUEST_OPS.create_run_round2_org_meta, orgMetaT.ms);
   emit(CHAT_REQUEST_OPS.create_run_round2_user_prefs, userPrefsT.ms);
   emit(CHAT_REQUEST_OPS.create_run_round2_feature_sw, featureOverridesT.ms);
-  emit(CHAT_REQUEST_OPS.create_run_round2_load_compose, preloadedComposeT.ms);
 
   const orgTier = orgTierSchema.parse(orgMeta.tier);
 
@@ -503,7 +495,7 @@ async function createZeroRunRecord(
     userId: params.userId,
     agentComposeVersionId: resolved.agentComposeVersionId,
     prompt: params.prompt,
-    composeId: preloadedCompose.compose.id,
+    composeId: resolved.composeId,
     sessionId: params.sessionId,
     appendSystemPrompt,
     modelProvider: params.modelProvider,
@@ -524,11 +516,22 @@ async function createZeroRunRecord(
 
   // ── Round 3: Pre-flight checks (need compose content) ───────────────
   const apiStartTime = params.apiStartTime;
-  authorizeCompose(params.userId, resolved.orgId, preloadedCompose.compose);
+  // resolved.composeId is always populated on zero-run-service callers
+  // (resolveByComposeId always sets it; lookupComposeByVersion rejects via
+  // the orgId guard before here). Narrow it for the rest of the function.
+  if (!resolved.composeId) {
+    throw notFound("Agent compose not found");
+  }
+  const composeId = resolved.composeId;
+  authorizeCompose(params.userId, resolved.orgId, {
+    id: composeId,
+    userId: resolved.composeUserId,
+    orgId: resolved.orgId,
+  });
   const authorizeTime = Date.now();
 
   if (!params.sessionId) {
-    await validateComposeRequirements(preloadedCompose.composeContent);
+    await validateComposeRequirements(resolved.composeContent);
   }
 
   const round3Credits = timed(async () => {
@@ -538,7 +541,7 @@ async function createZeroRunRecord(
     return checkModelProviderConfigured(
       resolved.orgId,
       params.modelProvider,
-      preloadedCompose.composeContent,
+      resolved.composeContent,
     );
   });
   const round3Capture = timed(async () => {
@@ -579,7 +582,7 @@ async function createZeroRunRecord(
         return insertRunRecord(tx, {
           userId: runParams.userId,
           orgId: resolved.orgId,
-          agentComposeId: preloadedCompose.compose.id,
+          agentComposeId: composeId,
           agentComposeVersionId: runParams.agentComposeVersionId,
           prompt: runParams.prompt,
           appendSystemPrompt: runParams.appendSystemPrompt,
@@ -636,7 +639,7 @@ async function createZeroRunRecord(
 
   const record: CreateRunRecordResult = {
     run: { id: run.id, createdAt: run.createdAt },
-    composeContent: preloadedCompose.composeContent,
+    composeContent: resolved.composeContent,
     orgId: resolved.orgId,
     apiStartTime,
     authorizeTime,

--- a/turbo/apps/web/src/lib/zero/zero-run-validation.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-validation.ts
@@ -18,10 +18,13 @@ const log = logger("service:zero-run-validation");
  *
  * Includes version content and compose owner so the chat-send path can
  * authorize and build the run without a second DB round-trip.
+ *
+ * `composeId` is always populated — every resolution path either finds an
+ * existing compose (and throws `notFound` otherwise).
  */
 interface ResolvedStartRunCompose {
   agentComposeVersionId: string;
-  composeId?: string;
+  composeId: string;
   composeUserId: string;
   agentName?: string;
   orgId: string;
@@ -146,15 +149,11 @@ export async function validateAgentSession(
 
 /**
  * Look up compose metadata + version content from a version ID (shared by
- * checkpoint + versionId paths). Single LEFT JOIN; the caller checks
- * `orgId` to distinguish "version exists, compose missing" from the
- * happy path.
+ * checkpoint + versionId paths). Single LEFT JOIN. Throws `notFound` if
+ * the version row is missing or its parent compose row has been deleted.
  */
-async function lookupComposeByVersion(
-  versionId: string,
-  fallbackComposeId?: string,
-): Promise<{
-  composeId?: string;
+async function lookupComposeByVersion(versionId: string): Promise<{
+  composeId: string;
   composeUserId: string;
   agentName?: string;
   orgId: string;
@@ -176,12 +175,16 @@ async function lookupComposeByVersion(
     .where(eq(agentComposeVersions.id, versionId))
     .limit(1);
 
+  if (!row || !row.composeId || !row.composeOrgId) {
+    throw notFound("Agent compose version not found");
+  }
+
   return {
-    composeId: row?.composeId ?? fallbackComposeId,
-    composeUserId: row?.composeUserId ?? "",
-    agentName: row?.composeName ?? undefined,
-    orgId: row?.composeOrgId ?? "",
-    composeContent: (row?.versionContent ?? null) as AgentComposeYaml,
+    composeId: row.composeId,
+    composeUserId: row.composeUserId ?? "",
+    agentName: row.composeName ?? undefined,
+    orgId: row.composeOrgId,
+    composeContent: row.versionContent as AgentComposeYaml,
   };
 }
 
@@ -261,9 +264,6 @@ export async function resolveStartRunCompose(params: {
     const meta = await lookupComposeByVersion(
       checkpointData.agentComposeVersionId,
     );
-    if (!meta.orgId) {
-      throw notFound("Agent compose version not found");
-    }
     return {
       agentComposeVersionId: checkpointData.agentComposeVersionId,
       ...meta,
@@ -279,13 +279,7 @@ export async function resolveStartRunCompose(params: {
   }
 
   if (params.agentComposeVersionId) {
-    const meta = await lookupComposeByVersion(
-      params.agentComposeVersionId,
-      params.composeId,
-    );
-    if (!meta.orgId) {
-      throw notFound("Agent compose version not found");
-    }
+    const meta = await lookupComposeByVersion(params.agentComposeVersionId);
     return { agentComposeVersionId: params.agentComposeVersionId, ...meta };
   }
 

--- a/turbo/apps/web/src/lib/zero/zero-run-validation.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-validation.ts
@@ -8,18 +8,24 @@ import {
 import { notFound, unauthorized, badRequest } from "../shared/errors";
 import { logger } from "../shared/logger";
 import type { AgentComposeSnapshot } from "../infra/checkpoint/types";
+import type { AgentComposeYaml } from "../infra/agent-compose/types";
 import { getAgentSessionWithConversation } from "../infra/agent-session";
 
 const log = logger("service:zero-run-validation");
 
 /**
  * Resolved compose metadata from one of the 4 resolution modes.
+ *
+ * Includes version content and compose owner so the chat-send path can
+ * authorize and build the run without a second DB round-trip.
  */
 interface ResolvedStartRunCompose {
   agentComposeVersionId: string;
   composeId?: string;
+  composeUserId: string;
   agentName?: string;
   orgId: string;
+  composeContent: AgentComposeYaml;
 }
 
 /**
@@ -139,17 +145,28 @@ export async function validateAgentSession(
 }
 
 /**
- * Look up compose metadata from a version ID (shared by checkpoint + versionId paths).
+ * Look up compose metadata + version content from a version ID (shared by
+ * checkpoint + versionId paths). Single LEFT JOIN; the caller checks
+ * `orgId` to distinguish "version exists, compose missing" from the
+ * happy path.
  */
 async function lookupComposeByVersion(
   versionId: string,
   fallbackComposeId?: string,
-): Promise<{ composeId?: string; agentName?: string; orgId: string }> {
+): Promise<{
+  composeId?: string;
+  composeUserId: string;
+  agentName?: string;
+  orgId: string;
+  composeContent: AgentComposeYaml;
+}> {
   const [row] = await globalThis.services.db
     .select({
+      versionContent: agentComposeVersions.content,
       composeName: agentComposes.name,
       composeOrgId: agentComposes.orgId,
       composeId: agentComposes.id,
+      composeUserId: agentComposes.userId,
     })
     .from(agentComposeVersions)
     .leftJoin(
@@ -161,40 +178,54 @@ async function lookupComposeByVersion(
 
   return {
     composeId: row?.composeId ?? fallbackComposeId,
+    composeUserId: row?.composeUserId ?? "",
     agentName: row?.composeName ?? undefined,
     orgId: row?.composeOrgId ?? "",
+    composeContent: (row?.versionContent ?? null) as AgentComposeYaml,
   };
 }
 
 /**
- * Resolve compose by composeId → headVersionId.
+ * Resolve compose by composeId → headVersionId + content in a single JOIN.
+ *
+ * LEFT JOIN on head_version_id so we can distinguish "compose missing"
+ * (notFound) from "compose has no head version" (badRequest).
  */
 async function resolveByComposeId(
   composeId: string,
 ): Promise<ResolvedStartRunCompose> {
-  const [compose] = await globalThis.services.db
+  const [row] = await globalThis.services.db
     .select({
-      id: agentComposes.id,
-      name: agentComposes.name,
-      orgId: agentComposes.orgId,
+      composeId: agentComposes.id,
+      composeName: agentComposes.name,
+      composeOrgId: agentComposes.orgId,
+      composeUserId: agentComposes.userId,
       headVersionId: agentComposes.headVersionId,
+      versionId: agentComposeVersions.id,
+      versionContent: agentComposeVersions.content,
     })
     .from(agentComposes)
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentComposeVersions.id, agentComposes.headVersionId),
+    )
     .where(eq(agentComposes.id, composeId))
     .limit(1);
 
-  if (!compose) {
+  if (!row) {
     throw notFound("Agent compose not found");
   }
-  if (!compose.headVersionId) {
+  if (!row.headVersionId || !row.versionId) {
     throw badRequest("Agent compose has no versions. Run 'vm0 build' first.");
   }
 
   return {
-    agentComposeVersionId: compose.headVersionId,
-    composeId: compose.id,
-    agentName: compose.name ?? undefined,
-    orgId: compose.orgId,
+    agentComposeVersionId: row.versionId,
+    composeId: row.composeId,
+    composeUserId: row.composeUserId,
+    agentName: row.composeName || undefined,
+    orgId: row.composeOrgId,
+    composeContent: row.versionContent as AgentComposeYaml,
   };
 }
 


### PR DESCRIPTION
## Summary

- Widens `ResolvedStartRunCompose` to include `composeContent` and `composeUserId`; `resolveByComposeId` now returns both via a single LEFT JOIN (`agent_composes → agent_compose_versions on head_version_id`). `lookupComposeByVersion` extends its existing LEFT JOIN projection to the same shape.
- Removes the `round2LoadCompose` arm from `zero-run-service.ts`: Round 2 `Promise.all` drops from 6 arms to 5, and the `api_chat_send_create_run_round2_load_compose` span is no longer emitted (the constant is kept for Axiom back-compat).
- Leaves `loadCompose()` in `infra/run/run-service.ts` untouched so `zero-run-queue-service.ts` (the other caller) keeps its existing shape.

Closes #10875. Parent tracking: #10796.

## Test plan

- [x] Existing `src/lib/zero/__tests__/zero-run-service.test.ts` — all 24 prior tests pass (composeId happy path, sessionId resume with custom skills, all 7 trigger sources, deferred dispatch).
- [x] New error-path integration tests in the same file:
  - missing compose → `notFound("Agent compose not found")`
  - `head_version_id = NULL` → `badRequest("Agent compose has no versions. Run 'vm0 build' first.")`
  - compose row deleted after agent creation → `notFound`
- [x] `src/lib/zero/__tests__/run-queue-service.test.ts` — 17 tests pass (queue-service `loadCompose` path intact).
- [x] `app/api/zero/runs/__tests__/route.test.ts` — 49 tests pass (session inference, trigger source, skill volume injection, credit check).
- [x] `app/api/zero/chat/messages/__tests__/route.test.ts` + `route.incomplete-context.test.ts` — chat-send route path passes (this is the targeted hot path).
- [x] Full suite over `src/lib/zero`, `src/lib/infra/run`, `app/api/zero`, `app/api/agent`: **2257 tests pass**.
- [x] Pre-commit: `pnpm format`, `pnpm turbo run lint --filter=web`, `pnpm check-types`, `pnpm knip` all clean.

## Expected impact

- `api_chat_send_create_run_round2_load_compose` span disappears.
- Round 2 fan-out 6 → 5 arms (less connection-pool contention).
- `POST /api/zero/chat/messages` route P50: expected −50 to −100 ms.
- `api_chat_send_create_run_round1_compose` P50: slight rise (~6 ms) accepting JSONB in JOIN.

## Non-goals

- `loadCompose` in `run-service.ts` is untouched.
- `zero-run-queue-service.ts` is untouched.
- No caching, no feature flags.
- Sibling perf PR #10874 (credits CTE fuse) is independent — either order merge is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)