### PR TITLE
perf(chat): fuse org credit-check queries into a single cte

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -14,6 +14,7 @@ import {
   insertOrgMembersEntry,
   insertTestZeroRun,
   deleteOrgRow,
+  insertCreditExpiresRecord,
 } from "../../../__tests__/api-test-helpers";
 import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
 import { reloadEnv } from "../../../env";
@@ -24,6 +25,8 @@ import {
   enqueueRun,
   dispatchQueuedZeroRun,
 } from "../zero-run-queue-service";
+import { checkOrgCredits } from "../zero-run-policy";
+import { isInsufficientCredits } from "../../shared/errors";
 import { seedTestRun } from "../../../__tests__/db-test-seeders/runs";
 
 const context = testContext();
@@ -327,5 +330,85 @@ describe("model provider check (queue dispatch path)", () => {
     const run = await findTestRunRecord(queued.runId);
     expect(run!.status).toBe("failed");
     expect(run!.error).toContain("No model provider configured");
+  });
+});
+
+describe("checkOrgCredits (fused CTE branches)", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  async function expectInsufficientCredits(fn: () => Promise<void>) {
+    try {
+      await fn();
+    } catch (err) {
+      expect(isInsufficientCredits(err)).toBe(true);
+      return;
+    }
+    throw new Error("expected checkOrgCredits to throw insufficientCredits");
+  }
+
+  it("returns OK when modelProvider is non-vm0 (fast exit, no DB call)", async () => {
+    await setOrgCredits(user.orgId, 0);
+    await expect(
+      checkOrgCredits(user.orgId, user.userId, "anthropic"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns OK when default provider is vm0 and credits are available", async () => {
+    await insertOrgDefaultModelProvider(user.orgId, "vm0");
+    await setOrgCredits(user.orgId, 10000);
+    await expect(
+      checkOrgCredits(user.orgId, user.userId, undefined),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws when default provider is vm0 and member creditEnabled is false", async () => {
+    await insertOrgDefaultModelProvider(user.orgId, "vm0");
+    await setOrgCredits(user.orgId, 10000);
+    await insertOrgMembersEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      creditEnabled: false,
+    });
+
+    await expectInsufficientCredits(() => {
+      return checkOrgCredits(user.orgId, user.userId, undefined);
+    });
+  });
+
+  it("throws when default provider is vm0 and spendable balance (credits − unsettledExpired) is zero", async () => {
+    await insertOrgDefaultModelProvider(user.orgId, "vm0");
+    await setOrgCredits(user.orgId, 5000);
+    // Seed an already-expired record with remaining=5000 so spendable = 0.
+    await insertCreditExpiresRecord({
+      orgId: user.orgId,
+      source: "subscription_renewal",
+      amount: 5000,
+      remaining: 5000,
+      expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+
+    await expectInsufficientCredits(() => {
+      return checkOrgCredits(user.orgId, user.userId, undefined);
+    });
+  });
+
+  it("returns OK when default provider is non-vm0 even when credits are depleted", async () => {
+    await insertOrgDefaultModelProvider(user.orgId, "anthropic");
+    await setOrgCredits(user.orgId, 0);
+    await expect(
+      checkOrgCredits(user.orgId, user.userId, undefined),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws when explicit modelProvider is vm0 and org_metadata row is missing", async () => {
+    await deleteOrgRow(user.orgId);
+    await expectInsufficientCredits(() => {
+      return checkOrgCredits(user.orgId, user.userId, "vm0");
+    });
   });
 });

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -1,4 +1,4 @@
-import { eq, and, count, gt, or } from "drizzle-orm";
+import { eq, and, count, gt, or, sql } from "drizzle-orm";
 import { env } from "../../env";
 import { agentRuns } from "../../db/schema/agent-run";
 import {
@@ -10,9 +10,6 @@ import {
 import { canAccessCompose } from "../infra/agent/compose-access";
 import { logger } from "../shared/logger";
 import { modelProviders } from "../../db/schema/model-provider";
-import { orgMetadata } from "../../db/schema/org-metadata";
-import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
-import { getUnsettledExpiredAmount } from "./credit/credit-expires-service";
 import { ORG_SENTINEL_USER_ID } from "./org/org-sentinel";
 import { MODEL_PROVIDER_ENV_VARS } from "./context/resolve-model-provider";
 import type { Database } from "../../types/global";
@@ -153,55 +150,65 @@ export async function checkOrgCredits(
     return;
   }
 
-  let isVm0 = modelProvider === "vm0";
+  // One round-trip to collapse: default provider, member cap, org credits,
+  // unsettled-expired sum. Each subquery hits an index and each scalar
+  // subselect returns NULL when the underlying row is missing.
+  const { rows } = await db.execute<{
+    default_type: string | null;
+    credit_enabled: boolean | null;
+    credits: string | null;
+    unsettled_expired: string | null;
+  }>(sql`
+    WITH default_provider AS (
+      SELECT type FROM model_providers
+      WHERE org_id = ${orgId}
+        AND user_id = ${ORG_SENTINEL_USER_ID}
+        AND is_default = true
+      LIMIT 1
+    ),
+    member AS (
+      SELECT credit_enabled FROM org_members_metadata
+      WHERE org_id = ${orgId} AND user_id = ${userId}
+      LIMIT 1
+    ),
+    org AS (
+      SELECT credits FROM org_metadata
+      WHERE org_id = ${orgId}
+      LIMIT 1
+    ),
+    expired AS (
+      SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+      FROM credit_expires_record
+      WHERE org_id = ${orgId}
+        AND expires_at <= now()
+        AND remaining > 0
+    )
+    SELECT
+      (SELECT type FROM default_provider) AS default_type,
+      (SELECT credit_enabled FROM member) AS credit_enabled,
+      (SELECT credits FROM org) AS credits,
+      (SELECT total FROM expired) AS unsettled_expired
+  `);
 
-  if (!isVm0 && !modelProvider) {
-    const [defaultProvider] = await db
-      .select({ type: modelProviders.type })
-      .from(modelProviders)
-      .where(
-        and(
-          eq(modelProviders.orgId, orgId),
-          eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
-          eq(modelProviders.isDefault, true),
-        ),
-      )
-      .limit(1);
-    isVm0 = defaultProvider?.type === "vm0";
+  const row = rows[0];
+  if (!row) return;
+
+  const isVm0 = modelProvider === "vm0" || row.default_type === "vm0";
+
+  if (isVm0 && row.credit_enabled === false) {
+    throw insufficientCredits();
   }
 
-  if (isVm0) {
-    const [memberRow] = await db
-      .select({ creditEnabled: orgMembersMetadata.creditEnabled })
-      .from(orgMembersMetadata)
-      .where(
-        and(
-          eq(orgMembersMetadata.orgId, orgId),
-          eq(orgMembersMetadata.userId, userId),
-        ),
-      )
-      .limit(1);
-
-    if (memberRow?.creditEnabled === false) {
-      throw insufficientCredits();
-    }
-  }
-
-  const [orgRow] = await db
-    .select({ credits: orgMetadata.credits })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
-
-  if (!orgRow) {
+  if (row.credits == null) {
     if (isVm0) {
       throw insufficientCredits();
     }
     return;
   }
 
-  const unsettledExpired = await getUnsettledExpiredAmount(orgId, db);
-  if (orgRow.credits - unsettledExpired > 0) {
+  const credits = Number(row.credits);
+  const unsettledExpired = Number(row.unsettled_expired ?? 0);
+  if (credits - unsettledExpired > 0) {
     return;
   }
 


### PR DESCRIPTION
## Summary

- Collapse four serial DB round-trips inside `checkOrgCredits()` into one `WITH ... SELECT` statement (default-provider lookup, member `credit_enabled`, org `credits`, unsettled-expired sum).
- Preserve the zero-DB-call BYOK fast exit for non-vm0 `modelProvider` values; preserve every throwing condition (`credit_enabled === false`, missing `org_metadata` row for vm0, `credits − unsettled_expired ≤ 0`).
- Extend `credit-check.test.ts` with six integration tests covering every branch enumerated in #10874's DoD.

Expected impact on the Axiom panel `api_chat_send_create_run_round3_credits`: **P50 263ms → ~70ms** (−193ms), from eliminating 3× Neon us-west ↔ Vercel us-east RTT on the hot chat-send path.

Closes #10874
Refs #10796

## Test plan

- [x] `pnpm turbo run lint --filter=web` — 0 warnings/errors
- [x] `pnpm check-types` — all packages pass
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no issues
- [x] `pnpm -F web exec vitest run src/lib/zero/__tests__/credit-check.test.ts` — **14 passed** (8 existing queue-path + 6 new direct-CTE branches)
- [x] `pnpm -F web exec vitest run src/lib/zero/` — **672 passed**
- [x] `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/` — **39 passed**
- [ ] Post-deploy: verify P50 ≤ 80ms on `api_chat_send_create_run_round3_credits` in Axiom