### PR TITLE
refactor: drop voice-chat-candidate prefix in platform signals and rename ably topic

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -207,13 +207,13 @@ export default [
       "no-restricted-syntax": "off",
     },
   },
-  // voice-chat-candidate-session.ts wraps three browser APIs that are specified
+  // voice-chat-session.ts wraps three browser APIs that are specified
   // to throw: JSON.parse on untrusted Realtime DC event data, navigator.wakeLock.request
   // (OS deny or hidden document), and navigator.mediaDevices.getUserMedia (permission
   // denied or no hardware). Each try block has recovery logic that cannot use accept()
   // or useLoadableSet.
   {
-    files: ["src/signals/voice-chat-candidate/voice-chat-candidate-session.ts"],
+    files: ["src/signals/voice-chat/voice-chat-session.ts"],
     rules: {
       "no-restricted-syntax": "off",
     },

--- a/turbo/apps/platform/src/mocks/handlers/api-voice-chat.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-voice-chat.ts
@@ -1,7 +1,7 @@
 /**
  * Voice Chat API Handlers
  *
- * Mock handlers for /api/zero/voice-chat-candidate endpoints.
+ * Mock handlers for /api/zero/voice-chat endpoints.
  * Stateful: sessions, items, and tasks persist for the lifetime of a test
  * run; call resetMockVoiceChat() between cases for isolation.
  */

--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
@@ -893,7 +893,7 @@ describe("voice-chat session", () => {
           status: "running",
         }),
       ];
-      triggerAblyEvent(`voice-chat-candidate:${SESSION_ID}`);
+      triggerAblyEvent(`voice-chat:${SESSION_ID}`);
 
       await vi.waitFor(async () => {
         await expect(

--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
@@ -8,15 +8,15 @@ import { setupPage } from "../../../__tests__/page-helper.ts";
 import { triggerAblyEvent } from "../../../mocks/ably.ts";
 import { detach, Reason } from "../../utils.ts";
 import {
-  startVoiceChatCandidate$,
-  endVoiceChatCandidate$,
-  vccStatus$,
-  vccError$,
-  vccSessionId$,
-  vccLastAssistantMessage$,
-  vccLastUserMessage$,
-  vccTaskFeed$,
-} from "../voice-chat-candidate-session.ts";
+  startVoiceChat$,
+  endVoiceChat$,
+  voiceChatStatus$,
+  voiceChatError$,
+  voiceChatSessionId$,
+  voiceChatLastAssistantMessage$,
+  voiceChatLastUserMessage$,
+  voiceChatTaskFeed$,
+} from "../voice-chat-session.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -227,7 +227,7 @@ function mockCreateTaskError() {
 async function setup() {
   await setupPage({
     context,
-    path: "/voice-chat-candidate",
+    path: "/voice-chat",
     withoutRender: true,
   });
 }
@@ -236,7 +236,7 @@ async function setup() {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("voice-chat-candidate session", () => {
+describe("voice-chat session", () => {
   const dcRef: { current: FakeDC | null } = { current: null };
   const audioRef: {
     current: { pause: ReturnType<typeof vi.fn>; currentTime: number } | null;
@@ -387,11 +387,7 @@ describe("voice-chat-candidate session", () => {
     mockGetSessionOk();
     mockListActiveTasksOk();
     detach(
-      context.store.set(
-        startVoiceChatCandidate$,
-        DEFAULT_AGENT_ID,
-        context.signal,
-      ),
+      context.store.set(startVoiceChat$, DEFAULT_AGENT_ID, context.signal),
       Reason.DomCallback,
     );
     await vi.waitFor(() => {
@@ -399,7 +395,7 @@ describe("voice-chat-candidate session", () => {
     });
     dcRef.current?.emitOpen();
     await vi.waitFor(() => {
-      expect(context.store.get(vccStatus$)).toBe("connected");
+      expect(context.store.get(voiceChatStatus$)).toBe("connected");
     });
   }
 
@@ -411,13 +407,13 @@ describe("voice-chat-candidate session", () => {
     clearWebRTC();
   });
 
-  describe("startVoiceChatCandidate$", () => {
+  describe("startVoiceChat$", () => {
     it("transitions to connected on happy path", async () => {
       await setup();
       await startSuccessfully();
 
-      expect(context.store.get(vccSessionId$)).toBe(SESSION_ID);
-      expect(context.store.get(vccStatus$)).toBe("connected");
+      expect(context.store.get(voiceChatSessionId$)).toBe(SESSION_ID);
+      expect(context.store.get(voiceChatStatus$)).toBe("connected");
 
       // Session config (tools / VAD / modalities) is preset server-side when
       // minting the ephemeral token; dc.open no longer emits session.update.
@@ -435,33 +431,33 @@ describe("voice-chat-candidate session", () => {
       expect(parsed.session.instructions).toBe(TALKER_INSTRUCTIONS);
     });
 
-    it("surfaces create-session error in vccError$", async () => {
+    it("surfaces create-session error in voiceChatError$", async () => {
       await setup();
       mockCreateSessionError(400, "forbidden");
 
       await context.store.set(
-        startVoiceChatCandidate$,
+        startVoiceChat$,
         DEFAULT_AGENT_ID,
         context.signal,
       );
 
-      expect(context.store.get(vccStatus$)).toBe("error");
-      expect(context.store.get(vccError$)).toBe("forbidden");
+      expect(context.store.get(voiceChatStatus$)).toBe("error");
+      expect(context.store.get(voiceChatError$)).toBe("forbidden");
     });
 
-    it("surfaces token error in vccError$", async () => {
+    it("surfaces token error in voiceChatError$", async () => {
       await setup();
       mockCreateSessionOk();
       mockTokenError();
 
       await context.store.set(
-        startVoiceChatCandidate$,
+        startVoiceChat$,
         DEFAULT_AGENT_ID,
         context.signal,
       );
 
-      expect(context.store.get(vccStatus$)).toBe("error");
-      expect(context.store.get(vccError$)).toBe("token failed");
+      expect(context.store.get(voiceChatStatus$)).toBe("error");
+      expect(context.store.get(voiceChatError$)).toBe("token failed");
     });
 
     it("sends near_field noiseReduction when mobile speakerphone is detected", async () => {
@@ -481,11 +477,7 @@ describe("voice-chat-candidate session", () => {
       mockListActiveTasksOk();
 
       detach(
-        context.store.set(
-          startVoiceChatCandidate$,
-          DEFAULT_AGENT_ID,
-          context.signal,
-        ),
+        context.store.set(startVoiceChat$, DEFAULT_AGENT_ID, context.signal),
         Reason.DomCallback,
       );
       await vi.waitFor(() => {
@@ -801,13 +793,13 @@ describe("voice-chat-candidate session", () => {
   });
 
   describe("subtitle local state", () => {
-    it("populates vccLastUserMessage$ after a finalized user transcript (and leaves assistant untouched)", async () => {
+    it("populates voiceChatLastUserMessage$ after a finalized user transcript (and leaves assistant untouched)", async () => {
       await setup();
       mockAppendItemOk();
       await startSuccessfully();
 
-      expect(context.store.get(vccLastUserMessage$)).toBe("");
-      expect(context.store.get(vccLastAssistantMessage$)).toBe("");
+      expect(context.store.get(voiceChatLastUserMessage$)).toBe("");
+      expect(context.store.get(voiceChatLastAssistantMessage$)).toBe("");
 
       dcRef.current?.emitMessage({
         type: "conversation.item.input_audio_transcription.completed",
@@ -816,12 +808,12 @@ describe("voice-chat-candidate session", () => {
       });
 
       await vi.waitFor(() => {
-        expect(context.store.get(vccLastUserMessage$)).toBe("hi there");
+        expect(context.store.get(voiceChatLastUserMessage$)).toBe("hi there");
       });
-      expect(context.store.get(vccLastAssistantMessage$)).toBe("");
+      expect(context.store.get(voiceChatLastAssistantMessage$)).toBe("");
     });
 
-    it("populates vccLastAssistantMessage$ after a finalized assistant turn", async () => {
+    it("populates voiceChatLastAssistantMessage$ after a finalized assistant turn", async () => {
       await setup();
       mockAppendItemOk();
       await startSuccessfully();
@@ -834,11 +826,11 @@ describe("voice-chat-candidate session", () => {
       });
 
       await vi.waitFor(() => {
-        expect(context.store.get(vccLastAssistantMessage$)).toBe(
+        expect(context.store.get(voiceChatLastAssistantMessage$)).toBe(
           "hello from Talker",
         );
       });
-      expect(context.store.get(vccLastUserMessage$)).toBe("");
+      expect(context.store.get(voiceChatLastUserMessage$)).toBe("");
     });
 
     it("ignores whitespace-only transcripts (guards against mis-fires blanking the line)", async () => {
@@ -852,7 +844,7 @@ describe("voice-chat-candidate session", () => {
         transcript: "first",
       });
       await vi.waitFor(() => {
-        expect(context.store.get(vccLastUserMessage$)).toBe("first");
+        expect(context.store.get(voiceChatLastUserMessage$)).toBe("first");
       });
 
       dcRef.current?.emitMessage({
@@ -862,12 +854,12 @@ describe("voice-chat-candidate session", () => {
       });
       // Let any pending microtasks flush; the state should NOT be blanked.
       await Promise.resolve();
-      expect(context.store.get(vccLastUserMessage$)).toBe("first");
+      expect(context.store.get(voiceChatLastUserMessage$)).toBe("first");
     });
   });
 
   describe("ably poke refreshes task state", () => {
-    it("re-runs listTasks on ably event and updates vccTaskFeed$", async () => {
+    it("re-runs listTasks on ably event and updates voiceChatTaskFeed$", async () => {
       await setup();
       mockCreateSessionOk();
       mockTokenOk();
@@ -880,11 +872,7 @@ describe("voice-chat-candidate session", () => {
       );
 
       detach(
-        context.store.set(
-          startVoiceChatCandidate$,
-          DEFAULT_AGENT_ID,
-          context.signal,
-        ),
+        context.store.set(startVoiceChat$, DEFAULT_AGENT_ID, context.signal),
         Reason.DomCallback,
       );
       await vi.waitFor(() => {
@@ -892,9 +880,11 @@ describe("voice-chat-candidate session", () => {
       });
       dcRef.current?.emitOpen();
       await vi.waitFor(() => {
-        expect(context.store.get(vccStatus$)).toBe("connected");
+        expect(context.store.get(voiceChatStatus$)).toBe("connected");
       });
-      await expect(context.store.get(vccTaskFeed$)).resolves.toHaveLength(0);
+      await expect(context.store.get(voiceChatTaskFeed$)).resolves.toHaveLength(
+        0,
+      );
 
       activeTasks = [
         taskPayload({
@@ -906,22 +896,24 @@ describe("voice-chat-candidate session", () => {
       triggerAblyEvent(`voice-chat-candidate:${SESSION_ID}`);
 
       await vi.waitFor(async () => {
-        await expect(context.store.get(vccTaskFeed$)).resolves.toHaveLength(1);
+        await expect(
+          context.store.get(voiceChatTaskFeed$),
+        ).resolves.toHaveLength(1);
       });
     });
   });
 
-  describe("endVoiceChatCandidate$", () => {
+  describe("endVoiceChat$", () => {
     it("tears down WebRTC and resets state to idle without ending the session", async () => {
       await setup();
       await startSuccessfully();
 
-      context.store.set(endVoiceChatCandidate$);
+      context.store.set(endVoiceChat$);
 
       await vi.waitFor(() => {
-        expect(context.store.get(vccStatus$)).toBe("idle");
+        expect(context.store.get(voiceChatStatus$)).toBe("idle");
       });
-      expect(context.store.get(vccSessionId$)).toBeNull();
+      expect(context.store.get(voiceChatSessionId$)).toBeNull();
     });
   });
 
@@ -984,11 +976,7 @@ describe("voice-chat-candidate session", () => {
       mockGetSessionOk();
       mockListActiveTasksOk();
       detach(
-        context.store.set(
-          startVoiceChatCandidate$,
-          DEFAULT_AGENT_ID,
-          context.signal,
-        ),
+        context.store.set(startVoiceChat$, DEFAULT_AGENT_ID, context.signal),
         Reason.DomCallback,
       );
       await vi.waitFor(() => {
@@ -996,7 +984,7 @@ describe("voice-chat-candidate session", () => {
       });
       dcRef.current?.emitOpen();
       await vi.waitFor(() => {
-        expect(context.store.get(vccStatus$)).toBe("connected");
+        expect(context.store.get(voiceChatStatus$)).toBe("connected");
       });
 
       // Simulate screen unlock: document becomes visible again.
@@ -1044,10 +1032,10 @@ describe("voice-chat-candidate session", () => {
       await Promise.resolve();
 
       expect(getUserMedia.mock.calls).toHaveLength(0);
-      expect(context.store.get(vccStatus$)).toBe("connected");
+      expect(context.store.get(voiceChatStatus$)).toBe("connected");
     });
 
-    it("sets vccError$ when getUserMedia is denied during recovery", async () => {
+    it("sets voiceChatError$ when getUserMedia is denied during recovery", async () => {
       await setup();
 
       const stoppedTrack = {
@@ -1088,11 +1076,7 @@ describe("voice-chat-candidate session", () => {
       mockGetSessionOk();
       mockListActiveTasksOk();
       detach(
-        context.store.set(
-          startVoiceChatCandidate$,
-          DEFAULT_AGENT_ID,
-          context.signal,
-        ),
+        context.store.set(startVoiceChat$, DEFAULT_AGENT_ID, context.signal),
         Reason.DomCallback,
       );
       await vi.waitFor(() => {
@@ -1100,7 +1084,7 @@ describe("voice-chat-candidate session", () => {
       });
       dcRef.current?.emitOpen();
       await vi.waitFor(() => {
-        expect(context.store.get(vccStatus$)).toBe("connected");
+        expect(context.store.get(voiceChatStatus$)).toBe("connected");
       });
 
       Object.defineProperty(document, "visibilityState", {
@@ -1110,9 +1094,9 @@ describe("voice-chat-candidate session", () => {
       document.dispatchEvent(new Event("visibilitychange"));
 
       await vi.waitFor(() => {
-        expect(context.store.get(vccStatus$)).toBe("error");
+        expect(context.store.get(voiceChatStatus$)).toBe("error");
       });
-      expect(context.store.get(vccError$)).toBe(
+      expect(context.store.get(voiceChatError$)).toBe(
         "Microphone access lost. Please reconnect.",
       );
     });

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -11,7 +11,7 @@ import { accept } from "../../lib/accept.ts";
 import { resolveAudioConfig } from "../../lib/voice-io/audio-config.ts";
 import { logger } from "../log.ts";
 
-const L = logger("VoiceChatCandidate");
+const L = logger("VoiceChat");
 
 type ConnectionStatus =
   | "idle"
@@ -58,7 +58,7 @@ const internalLastAssistantMessage$ = state<string>("");
 
 // Bumped on every Ably tick (and manual refresh). Async computeds that need
 // to refetch server-side state depend on this counter.
-const vccReload$ = state<number>(0);
+const voiceChatReload$ = state<number>(0);
 
 const internalMuted$ = state<boolean>(false);
 const internalBargeInMode$ = state<BargeInMode>("speech_started");
@@ -80,46 +80,48 @@ const resetSessionSignal$ = resetSignal();
 // Exported computed getters
 // ---------------------------------------------------------------------------
 
-export const vccStatus$ = computed((get) => {
+export const voiceChatStatus$ = computed((get) => {
   return get(internalStatus$);
 });
 
-export const vccError$ = computed((get) => {
+export const voiceChatError$ = computed((get) => {
   return get(internalError$);
 });
 
-export const vccSessionId$ = computed((get) => {
+export const voiceChatSessionId$ = computed((get) => {
   return get(internalSessionId$);
 });
 
 /**
  * Active + recently-finished task feed for the Trinity sidebar. Refetches on
- * every Ably tick (via vccReload$). Returns [] until a session is live.
+ * every Ably tick (via voiceChatReload$). Returns [] until a session is live.
  */
-export const vccTaskFeed$ = computed(async (get): Promise<VoiceChatTask[]> => {
-  get(vccReload$);
-  const sid = get(internalSessionId$);
-  if (!sid) {
-    return [];
-  }
-  const createClient = get(zeroClient$);
-  const client = createClient(zeroVoiceChatContract);
-  const res = await accept(
-    client.listTasks({ params: { id: sid } }),
-    [200, 401, 404],
-    { toast: false },
-  );
-  if (res.status !== 200) {
-    return [];
-  }
-  return res.body.tasks;
-});
+export const voiceChatTaskFeed$ = computed(
+  async (get): Promise<VoiceChatTask[]> => {
+    get(voiceChatReload$);
+    const sid = get(internalSessionId$);
+    if (!sid) {
+      return [];
+    }
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroVoiceChatContract);
+    const res = await accept(
+      client.listTasks({ params: { id: sid } }),
+      [200, 401, 404],
+      { toast: false },
+    );
+    if (res.status !== 200) {
+      return [];
+    }
+    return res.body.tasks;
+  },
+);
 
-export const vccLastUserMessage$ = computed((get) => {
+export const voiceChatLastUserMessage$ = computed((get) => {
   return get(internalLastUserMessage$);
 });
 
-export const vccLastAssistantMessage$ = computed((get) => {
+export const voiceChatLastAssistantMessage$ = computed((get) => {
   return get(internalLastAssistantMessage$);
 });
 
@@ -562,9 +564,9 @@ const startAblyLoop$ = command(
         return true;
       }
       // One signal drives two things: bump the counter so async computeds
-      // (vccTaskFeed$) refetch, and push fresh instructions to the live DC
+      // (voiceChatTaskFeed$) refetch, and push fresh instructions to the live DC
       // session. Data is the server's truth — the browser caches nothing.
-      set(vccReload$, (n) => {
+      set(voiceChatReload$, (n) => {
         return n + 1;
       });
       await set(syncTalkerInstructions$, loopSignal);
@@ -576,7 +578,7 @@ const startAblyLoop$ = command(
 );
 
 // ---------------------------------------------------------------------------
-// Wake lock (parity with non-candidate voice-chat UX)
+// Wake lock
 // ---------------------------------------------------------------------------
 
 const MAX_WAKE_LOCK_REACQUIRE_ATTEMPTS = 3;
@@ -744,7 +746,7 @@ const monitorMicrophoneRecovery$ = command(
 // Public commands
 // ---------------------------------------------------------------------------
 
-export const startVoiceChatCandidate$ = command(
+export const startVoiceChat$ = command(
   async ({ get, set }, agentId: string, signal: AbortSignal) => {
     const status = get(internalStatus$);
     if (status === "connecting" || status === "connected") {
@@ -759,7 +761,7 @@ export const startVoiceChatCandidate$ = command(
     set(internalBargeInMode$, "speech_started");
     set(internalCurrentAssistantAudioItem$, null);
     set(internalSessionId$, null);
-    set(vccReload$, (n) => {
+    set(voiceChatReload$, (n) => {
       return n + 1;
     });
 
@@ -786,8 +788,8 @@ export const startVoiceChatCandidate$ = command(
     }
     const session = res.body.session;
     set(internalSessionId$, session.id);
-    // Bump so vccTaskFeed$ refetches with the new sessionId.
-    set(vccReload$, (n) => {
+    // Bump so voiceChatTaskFeed$ refetches with the new sessionId.
+    set(voiceChatReload$, (n) => {
       return n + 1;
     });
 
@@ -858,11 +860,11 @@ export const startVoiceChatCandidate$ = command(
 
 /**
  * Exit voice-chat mode: tear down the WebRTC / microphone / wake-lock /
- * Ably loop. The session row itself is left alone — voice-chat-candidate
- * sessions are stateless, so next time startVoiceChatCandidate$ runs with
- * the same (user, agent) it will resume this one via get-or-create.
+ * Ably loop. The session row itself is left alone — voice-chat sessions
+ * are stateless, so next time startVoiceChat$ runs with the same
+ * (user, agent) it will resume this one via get-or-create.
  */
-export const endVoiceChatCandidate$ = command(({ get, set }) => {
+export const endVoiceChat$ = command(({ get, set }) => {
   set(resetSessionSignal$);
   set(releaseWakeLock$);
 
@@ -899,8 +901,8 @@ export const endVoiceChatCandidate$ = command(({ get, set }) => {
   set(internalBargeInMode$, "speech_started");
   set(internalCurrentAssistantAudioItem$, null);
   set(internalStatus$, "idle");
-  // Bump so vccTaskFeed$ re-resolves to [] after sessionId is cleared.
-  set(vccReload$, (n) => {
+  // Bump so voiceChatTaskFeed$ re-resolves to [] after sessionId is cleared.
+  set(voiceChatReload$, (n) => {
     return n + 1;
   });
 });

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -46,7 +46,7 @@ function shortPrompt(prompt: string, max = 60): string {
 }
 
 function ablyTopic(sessionId: string): string {
-  return `voice-chat-candidate:${sessionId}`;
+  return `voice-chat:${sessionId}`;
 }
 
 const internalStatus$ = state<ConnectionStatus>("idle");

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/agent-chat-voice-mode.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/agent-chat-voice-mode.test.ts
@@ -10,9 +10,9 @@
  *
  * External mocks: feature-switch backend (via setMockFeatureSwitches) is not
  * needed here — these tests exercise only the page signals. The derived
- * conversation / task signals read from internal state in the voice-chat-
- * candidate module, which we drive through the real `startVoiceChatCandidate$`
- * happy path with MSW-stubbed endpoints + a stubbed WebRTC peer.
+ * conversation / task signals read from internal state in the voice-chat
+ * module, which we drive through the real `startVoiceChat$` happy path with
+ * MSW-stubbed endpoints + a stubbed WebRTC peer.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -24,9 +24,9 @@ import { testContext } from "../../__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { detach, Reason } from "../../utils.ts";
 import {
-  startVoiceChatCandidate$,
-  vccStatus$,
-} from "../../voice-chat-candidate/voice-chat-candidate-session.ts";
+  startVoiceChat$,
+  voiceChatStatus$,
+} from "../../voice-chat/voice-chat-session.ts";
 import { trinityEnabled$ } from "../../external/feature-switch.ts";
 import {
   agentChatVoiceMode$,
@@ -105,7 +105,7 @@ function taskPayload(overrides: {
   };
 }
 
-function mockCandidateEndpoints(options: {
+function mockVoiceChatEndpoints(options: {
   tasks: ReturnType<typeof taskPayload>[];
 }) {
   server.use(
@@ -233,11 +233,11 @@ async function driveSession(
     withoutRender: true,
     featureSwitches: { trinity: true },
   });
-  mockCandidateEndpoints({ tasks });
+  mockVoiceChatEndpoints({ tasks });
   const dcRef: { current: FakeDC | null } = { current: null };
   stubWebRTC(dcRef);
   detach(
-    context.store.set(startVoiceChatCandidate$, AGENT_ID, context.signal),
+    context.store.set(startVoiceChat$, AGENT_ID, context.signal),
     Reason.DomCallback,
   );
   await vi.waitFor(() => {
@@ -245,7 +245,7 @@ async function driveSession(
   });
   dcRef.current?.emitOpen();
   await vi.waitFor(() => {
-    expect(context.store.get(vccStatus$)).toBe("connected");
+    expect(context.store.get(voiceChatStatus$)).toBe("connected");
   });
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-voice-mode.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-voice-mode.ts
@@ -1,12 +1,12 @@
 import { command, computed, state } from "ccstate";
 import type { VoiceChatTask } from "@vm0/core";
 import {
-  startVoiceChatCandidate$,
-  endVoiceChatCandidate$,
-  vccLastUserMessage$,
-  vccLastAssistantMessage$,
-  vccTaskFeed$,
-} from "../voice-chat-candidate/voice-chat-candidate-session.ts";
+  startVoiceChat$,
+  endVoiceChat$,
+  voiceChatLastUserMessage$,
+  voiceChatLastAssistantMessage$,
+  voiceChatTaskFeed$,
+} from "../voice-chat/voice-chat-session.ts";
 
 type VoiceMode = "off" | "on";
 
@@ -18,14 +18,14 @@ export const agentChatVoiceMode$ = computed((get) => {
 
 /**
  * Flip voice mode on and begin the WebRTC / Ably handshake. The UI reflects
- * "connecting" via `vccStatus$` until `startVoiceChatCandidate$` resolves.
+ * "connecting" via `voiceChatStatus$` until `startVoiceChat$` resolves.
  * Callers in the views layer should detach this promise via `detach(...)` so
  * the click handler returns immediately.
  */
 export const enterAgentChatVoiceMode$ = command(
   async ({ set }, agentId: string, signal: AbortSignal) => {
     set(internalVoiceMode$, "on");
-    await set(startVoiceChatCandidate$, agentId, signal);
+    await set(startVoiceChat$, agentId, signal);
   },
 );
 
@@ -35,15 +35,15 @@ export const enterAgentChatVoiceMode$ = command(
  */
 export const exitAgentChatVoiceMode$ = command(({ set }) => {
   set(internalVoiceMode$, "off");
-  set(endVoiceChatCandidate$);
+  set(endVoiceChat$);
 });
 
 // Subtitle computeds mirror the per-role local state maintained by the
-// voice-chat-candidate signal module. Those states are set directly in
+// voice-chat signal module. Those states are set directly in
 // `appendItem$` after each successful DB write, so re-rendering is driven
 // purely by the user's and Talker's finalized turns — no server roundtrip.
-export const lastUserMessage$ = vccLastUserMessage$;
-export const lastAgentMessage$ = vccLastAssistantMessage$;
+export const lastUserMessage$ = voiceChatLastUserMessage$;
+export const lastAgentMessage$ = voiceChatLastAssistantMessage$;
 
 /**
  * Task cards shown in voice mode — only in-flight work. The server returns
@@ -52,7 +52,7 @@ export const lastAgentMessage$ = vccLastAssistantMessage$;
  */
 export const agentChatPendingTasks$ = computed(
   async (get): Promise<VoiceChatTask[]> => {
-    const tasks = await get(vccTaskFeed$);
+    const tasks = await get(voiceChatTaskFeed$);
     return tasks.filter((t) => {
       return t.status !== "done" && t.status !== "failed";
     });

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -71,7 +71,7 @@ import {
   startNewZeroSession$,
 } from "../../signals/chat-page/chat-message.ts";
 import { navigateToChat$ } from "../../signals/zero-page/zero-nav.ts";
-import { vccStatus$ } from "../../signals/voice-chat-candidate/voice-chat-candidate-session.ts";
+import { voiceChatStatus$ } from "../../signals/voice-chat/voice-chat-session.ts";
 
 function getTagline(
   agentName: string,
@@ -276,7 +276,7 @@ function PinPill() {
 
 export function VoiceChatLauncher() {
   const trinityEnabled = useLastResolved(trinityEnabled$) ?? false;
-  const vccStatus = useGet(vccStatus$);
+  const voiceChatStatus = useGet(voiceChatStatus$);
   const activeRoute = useGet(activeRoute$);
   const currentChatAgentId = useLastResolved(currentChatAgentId$);
   const navigate = useSet(detachedNavigateTo$);
@@ -296,8 +296,8 @@ export function VoiceChatLauncher() {
     });
   };
 
-  const isConnecting = onTalk && vccStatus === "connecting";
-  const isConnected = onTalk && vccStatus === "connected";
+  const isConnecting = onTalk && voiceChatStatus === "connecting";
+  const isConnected = onTalk && voiceChatStatus === "connected";
   const colorClass = isConnected
     ? "text-green-600 hover:text-green-700"
     : isConnecting

--- a/turbo/apps/platform/src/views/zero-page/agent-talk-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-talk-page.tsx
@@ -7,9 +7,9 @@ import {
 } from "../../signals/agent-chat.ts";
 import { Markdown } from "../components/markdown.tsx";
 import {
-  vccStatus$,
-  vccError$,
-} from "../../signals/voice-chat-candidate/voice-chat-candidate-session.ts";
+  voiceChatStatus$,
+  voiceChatError$,
+} from "../../signals/voice-chat/voice-chat-session.ts";
 import {
   lastUserMessage$,
   lastAgentMessage$,
@@ -105,13 +105,13 @@ export function AgentTalkPage() {
     currentChatAgentDisplayName$,
   );
   const pageSignal = useGet(pageSignal$);
-  const vccStatus = useGet(vccStatus$);
-  const vccError = useGet(vccError$);
+  const voiceChatStatus = useGet(voiceChatStatus$);
+  const voiceChatError = useGet(voiceChatError$);
 
   const statusText = voiceStatusText(
-    vccStatus,
+    voiceChatStatus,
     currentChatAgentDisplayName ?? "Agent",
-    vccError !== null,
+    voiceChatError !== null,
   );
 
   return (

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat/__tests__/route.test.ts
@@ -144,7 +144,7 @@ describe("POST /api/internal/callbacks/voice-chat", () => {
 
     await context.mocks.flushAfter();
     expect(mockAblyPublish).toHaveBeenCalledWith(
-      `voice-chat-candidate:${session.id}`,
+      `voice-chat:${session.id}`,
       null,
     );
     // userId is used via publishUserSignal — assert channel lookup indirectly

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat/route.ts
@@ -11,7 +11,7 @@ import { isNotFound } from "../../../../../src/lib/shared/errors";
 import type { VoiceChatCallbackPayload } from "../../../../../src/lib/infra/callback/callback-payloads";
 import { logger } from "../../../../../src/lib/shared/logger";
 
-const log = logger("callback:voice-chat-candidate");
+const log = logger("callback:voice-chat");
 
 export const maxDuration = 60;
 
@@ -110,7 +110,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // — without waiting for the reasoner LLM. The after() reasoner tick still
   // runs and will publish again once it has new conversation summary /
   // compacted results.
-  await publishUserSignal([userId], `voice-chat-candidate:${sessionId}`);
+  await publishUserSignal([userId], `voice-chat:${sessionId}`);
   after(() => {
     return triggerReasoning(sessionId);
   });

--- a/turbo/apps/web/app/api/internal/event-consumers/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/voice-chat/route.ts
@@ -11,7 +11,7 @@ import {
 import { publishUserSignal } from "../../../../../src/lib/infra/realtime/client";
 import { logger } from "../../../../../src/lib/shared/logger";
 
-const log = logger("event-consumer:voice-chat-candidate");
+const log = logger("event-consumer:voice-chat");
 
 /**
  * Concatenate all text blocks in a single assistant event into one string.
@@ -83,10 +83,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const touch = running ?? appended;
   if (touch) {
-    await publishUserSignal(
-      [touch.userId],
-      `voice-chat-candidate:${touch.sessionId}`,
-    );
+    await publishUserSignal([touch.userId], `voice-chat:${touch.sessionId}`);
   }
 
   log.debug("VCC assistant consumer processed", {

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/tasks/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/tasks/route.ts
@@ -103,7 +103,7 @@ export async function POST(
   // waiting for the reasoner LLM. The reasoner tick runs in after() and will
   // publish again when it completes (for the conversation summary + compact
   // side-effects).
-  await publishUserSignal([session.userId], `voice-chat-candidate:${id}`);
+  await publishUserSignal([session.userId], `voice-chat:${id}`);
   after(() => {
     return triggerReasoning(id);
   });

--- a/turbo/apps/web/app/api/zero/voice-chat/token/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/token/route.ts
@@ -17,7 +17,7 @@ import {
   voiceChatTokenBodySchema,
 } from "../_support";
 
-const log = logger("api:zero:voice-chat-candidate:token");
+const log = logger("api:zero:voice-chat:token");
 
 export async function POST(request: Request): Promise<Response> {
   initServices();

--- a/turbo/apps/web/src/lib/zero/voice-chat/__tests__/trigger-reasoning.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/__tests__/trigger-reasoning.test.ts
@@ -125,7 +125,7 @@ describe("triggerReasoning", () => {
     expect(handler.mocked).toHaveBeenCalledTimes(1);
 
     expect(mockAblyPublish).toHaveBeenCalledWith(
-      `voice-chat-candidate:${sessionId}`,
+      `voice-chat:${sessionId}`,
       null,
     );
   });
@@ -345,7 +345,7 @@ describe("triggerReasoning", () => {
 
     // Ably signal published (for both the summary write and the missing-tasks step)
     expect(mockAblyPublish).toHaveBeenCalledWith(
-      `voice-chat-candidate:${sessionId}`,
+      `voice-chat:${sessionId}`,
       null,
     );
   });
@@ -518,7 +518,7 @@ describe("triggerReasoning — task compaction", () => {
     expect(task?.resultUpdatedAt).not.toBeNull();
 
     expect(mockAblyPublish).toHaveBeenCalledWith(
-      `voice-chat-candidate:${sessionId}`,
+      `voice-chat:${sessionId}`,
       null,
     );
   });

--- a/turbo/apps/web/src/lib/zero/voice-chat/compact-task-results.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/compact-task-results.ts
@@ -35,7 +35,7 @@ const MODEL = "anthropic/claude-sonnet-4.5";
 const TIMEOUT_MS = 30_000;
 const TEMPERATURE = 0.2;
 
-const log = logger("zero:voice-chat-candidate:compact");
+const log = logger("zero:voice-chat:compact");
 
 interface OpenRouterResponse {
   choices: Array<{ message: { content: string } }>;
@@ -190,7 +190,7 @@ export async function compactVoiceChatTaskResults(
   }
 
   if (compactedCount > 0) {
-    await publishUserSignal([userId], `voice-chat-candidate:${sessionId}`);
+    await publishUserSignal([userId], `voice-chat:${sessionId}`);
     log.info(
       `compacted ${String(compactedCount)} task result(s) for session ${sessionId}`,
     );

--- a/turbo/apps/web/src/lib/zero/voice-chat/reasoner.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/reasoner.ts
@@ -14,7 +14,7 @@ const TIMEOUT_MS = 30_000;
 const MAX_TOKENS = 800;
 const TEMPERATURE = 0.2;
 
-const log = logger("zero:voice-chat-candidate:reasoner");
+const log = logger("zero:voice-chat:reasoner");
 
 interface OpenRouterResponse {
   choices: Array<{

--- a/turbo/apps/web/src/lib/zero/voice-chat/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/task-service.ts
@@ -10,7 +10,7 @@ import { cancelRun } from "../zero-run-cancel";
 import { isRunNotCancellable, notFound } from "../../shared/errors";
 import { logger } from "../../shared/logger";
 
-const log = logger("zero:voice-chat-candidate:task");
+const log = logger("zero:voice-chat:task");
 
 type SpawnRun = (taskId: string) => Promise<CreateZeroRunResult>;
 

--- a/turbo/apps/web/src/lib/zero/voice-chat/trigger-reasoning.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/trigger-reasoning.ts
@@ -17,7 +17,7 @@ import { publishUserSignal } from "../../infra/realtime/client";
 import { isBadRequest } from "../../shared/errors";
 import { logger } from "../../shared/logger";
 
-const log = logger("zero:voice-chat-candidate:trigger-reasoning");
+const log = logger("zero:voice-chat:trigger-reasoning");
 
 interface AssistantInterruptedNote {
   type: "assistant_interrupted";
@@ -195,7 +195,7 @@ export async function triggerReasoning(sessionId: string): Promise<void> {
     if (updated.length > 0) {
       await publishUserSignal(
         [currentSession.userId],
-        `voice-chat-candidate:${sessionId}`,
+        `voice-chat:${sessionId}`,
       );
     } else {
       log.info(`reasoner version contention for ${sessionId}, dropping tick`);
@@ -276,10 +276,7 @@ export async function triggerReasoning(sessionId: string): Promise<void> {
       });
     }
 
-    await publishUserSignal(
-      [currentSession.userId],
-      `voice-chat-candidate:${sessionId}`,
-    );
+    await publishUserSignal([currentSession.userId], `voice-chat:${sessionId}`);
   }
 
   // Step 6 — compact old finished-task results along the exponential


### PR DESCRIPTION
## Summary

Wave 2 frontend sibling of Epic #10853 (promote voice-chat to GA). Depends on #10855 (merged via PR #10863).

- Rename `turbo/apps/platform/src/signals/voice-chat-candidate/` → `voice-chat/` and drop all `vcc*`/`VCC*`/`VoiceChatCandidate*` exports in same-file context (scope extension approved by leader).
- Rename Ably topic `voice-chat-candidate:\${sessionId}` → `voice-chat:\${sessionId}` on **both** publisher (web) and subscriber (platform) atomically so no session straddles the transition.
- Rename backend logger channels `zero:voice-chat-candidate:*` → `zero:voice-chat:*` for consistency with frontend naming.
- Update MSW handler comment + ESLint \`no-restricted-syntax\` override path to reference the new \`src/signals/voice-chat/voice-chat-session.ts\` location.

Backend \`src/lib/zero/voice-chat-candidate/\` directory rename is **out of scope** — handled separately by S3 (#10877).

## Deployment note

Ably topic flip is not backward-compatible. Users with an active WebRTC session at deploy time will need to reconnect (their browser subscribes to the old topic until page refresh). This mirrors how ordinary app updates invalidate in-flight sessions — no runtime migration needed.

## Verification

- \`rg 'vcc[A-Z]|VCC[A-Z]' turbo/apps/platform/src\` → 0 hits
- \`rg 'voice-chat-candidate' turbo/apps/platform/src\` → 0 hits
- \`rg 'zero:voice-chat-candidate' turbo/apps/web/src\` → 0 hits
- Lint + type-check clean
- Platform vitest: 2013/2013 pass
- Web vitest (voice-chat-candidate dir): 21/21 pass

## Test plan

- [ ] CI lint + type-check green
- [ ] CI platform tests green
- [ ] CI web tests green
- [ ] Manual smoke: start a voice-chat session, verify reasoning/task events still stream through Ably

Closes #10878

🤖 Generated with [Claude Code](https://claude.com/claude-code)