### PR TITLE
fix: disable reasoner task backfill in voice chat

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts
@@ -586,7 +586,7 @@ describe("voice-chat-candidate session", () => {
         type: "input_audio_buffer.speech_started",
       });
 
-      expect(audioRef.current.pause).toHaveBeenCalledTimes(1);
+      expect(audioRef.current.pause).not.toHaveBeenCalled();
       expect(dcRef.current?.send).toHaveBeenCalledTimes(1);
       expect(
         JSON.parse(dcRef.current?.send.mock.calls[0]?.[0] as string),
@@ -658,7 +658,7 @@ describe("voice-chat-candidate session", () => {
         transcript: "hello",
       });
 
-      expect(audioRef.current.pause).toHaveBeenCalledTimes(1);
+      expect(audioRef.current.pause).not.toHaveBeenCalled();
       expect(dcRef.current?.send).toHaveBeenCalledTimes(1);
       expect(
         JSON.parse(dcRef.current?.send.mock.calls[0]?.[0] as string),

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -60,7 +60,6 @@ const internalLastAssistantMessage$ = state<string>("");
 // to refetch server-side state depend on this counter.
 const vccReload$ = state<number>(0);
 
-const internalMuted$ = state<boolean>(false);
 const internalBargeInMode$ = state<BargeInMode>("speech_started");
 
 const internalPc$ = state<RTCPeerConnection | null>(null);
@@ -344,7 +343,6 @@ const truncateCurrentAssistantAudio$ = command(
       currentAudioPositionMs(audioEl) - current.startedAtMs,
     );
 
-    audioEl.pause();
     dc.send(
       JSON.stringify({
         type: "conversation.item.truncate",
@@ -755,7 +753,6 @@ export const startVoiceChatCandidate$ = command(
     set(internalError$, null);
     set(internalLastUserMessage$, "");
     set(internalLastAssistantMessage$, "");
-    set(internalMuted$, false);
     set(internalBargeInMode$, "speech_started");
     set(internalCurrentAssistantAudioItem$, null);
     set(internalSessionId$, null);

--- a/turbo/apps/web/src/__tests__/db-test-assertions/voice-chat-candidate.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/voice-chat-candidate.ts
@@ -146,26 +146,6 @@ export async function getTestVoiceChatCandidateTask(id: string): Promise<
 }
 
 /**
- * List all task rows for a session for integration test assertions.
- * @why-db-direct The missingTasks Step 5c integration test needs to assert that
- * a task row was created; no public read API exposes individual task rows.
- */
-export async function listTestVoiceChatCandidateTasks(
-  sessionId: string,
-): Promise<{ id: string; prompt: string; status: string; callId: string }[]> {
-  initServices();
-  return globalThis.services.db
-    .select({
-      id: voiceChatTasks.id,
-      prompt: voiceChatTasks.prompt,
-      status: voiceChatTasks.status,
-      callId: voiceChatTasks.callId,
-    })
-    .from(voiceChatTasks)
-    .where(eq(voiceChatTasks.sessionId, sessionId));
-}
-
-/**
  * Read all items for a session for callback side-effect assertions.
  * @why-db-direct Callback tests need to assert task_result and system_note
  * items written by the callback handler; there is no public list-items API

--- a/turbo/apps/web/src/__tests__/db-test-seeders/voice-chat-candidate.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/voice-chat-candidate.ts
@@ -31,6 +31,7 @@ export async function appendTestVoiceChatCandidateItem(params: {
 export async function insertTestVoiceChatCandidateTask(
   sessionId: string,
   overrides: {
+    prompt?: string;
     result?: string;
     resultUpdatedAt?: Date;
     finishedAt?: Date;
@@ -46,7 +47,7 @@ export async function insertTestVoiceChatCandidateTask(
     .values({
       sessionId,
       callId: uniqueId("call"),
-      prompt: "Summarize the situation",
+      prompt: overrides.prompt ?? "Summarize the situation",
       status,
       result: overrides.result ?? "A".repeat(500) + " important data",
       resultUpdatedAt: overrides.resultUpdatedAt ?? twoMinutesAgo,

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/trigger-reasoning.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/trigger-reasoning.test.ts
@@ -5,16 +5,16 @@ import { seedTestCompose } from "../../../../__tests__/db-test-seeders/agents";
 import {
   appendTestVoiceChatCandidateItem,
   insertTestVoiceChatCandidateSession,
+  insertTestVoiceChatCandidateTask,
   seedTestVoiceChatCandidateSession,
   simulateConcurrentVoiceChatCandidateSessionWrite,
 } from "../../../../__tests__/db-test-seeders/voice-chat-candidate";
 import {
   getTestVoiceChatCandidateSessionReasoningState,
+  getTestVoiceChatCandidateTask,
   readTestVoiceChatCandidateItems,
 } from "../../../../__tests__/db-test-assertions/voice-chat-candidate";
 import { createTestCompose } from "../../../../__tests__/api-test-helpers";
-import { getTestVoiceChatCandidateTask } from "../../../../__tests__/db-test-assertions/voice-chat-candidate";
-import { insertTestVoiceChatCandidateTask } from "../../../../__tests__/db-test-seeders/voice-chat-candidate";
 import { server } from "../../../../mocks/server";
 import { http } from "../../../../__tests__/msw";
 import { mockAblyPublish } from "../../../../__tests__/ably-mock";

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/trigger-reasoning.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/__tests__/trigger-reasoning.test.ts
@@ -2,20 +2,19 @@ import { describe, it, expect, vi } from "vitest";
 import { HttpResponse } from "msw";
 import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
 import { seedTestCompose } from "../../../../__tests__/db-test-seeders/agents";
-import { createTestCompose } from "../../../../__tests__/api-test-helpers";
 import {
   appendTestVoiceChatCandidateItem,
-  insertTestVoiceChatCandidateTask,
   insertTestVoiceChatCandidateSession,
   seedTestVoiceChatCandidateSession,
   simulateConcurrentVoiceChatCandidateSessionWrite,
 } from "../../../../__tests__/db-test-seeders/voice-chat-candidate";
 import {
-  getTestVoiceChatCandidateTask,
   getTestVoiceChatCandidateSessionReasoningState,
-  listTestVoiceChatCandidateTasks,
   readTestVoiceChatCandidateItems,
 } from "../../../../__tests__/db-test-assertions/voice-chat-candidate";
+import { createTestCompose } from "../../../../__tests__/api-test-helpers";
+import { getTestVoiceChatCandidateTask } from "../../../../__tests__/db-test-assertions/voice-chat-candidate";
+import { insertTestVoiceChatCandidateTask } from "../../../../__tests__/db-test-seeders/voice-chat-candidate";
 import { server } from "../../../../mocks/server";
 import { http } from "../../../../__tests__/msw";
 import { mockAblyPublish } from "../../../../__tests__/ably-mock";
@@ -278,16 +277,14 @@ describe("triggerReasoning", () => {
     expect(body.messages[1]!.content).toContain("Agent system prompt:\n(none)");
   });
 
-  it("H7 — creates task rows and system_notes for each missing task the reasoner detects", async () => {
+  it("H7 — missing task hints do not auto-create tasks", async () => {
     context.setupMocks();
     vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     reloadEnv();
 
-    // createZeroRun requires a compose with a published version that has a
-    // model provider key. createTestCompose creates a version with ANTHROPIC_API_KEY.
     const { userId, orgId } = await context.setupUser();
     const { composeId } = await createTestCompose(
-      uniqueId("vcc-reasoner-tasks"),
+      uniqueId("vcc-reasoner-dedupe"),
     );
     const sessionId = await seedTestVoiceChatCandidateSession({
       userId,
@@ -321,29 +318,17 @@ describe("triggerReasoning", () => {
 
     await triggerReasoning(sessionId);
 
-    // The reasoner summary write should succeed
     const row = await getTestVoiceChatCandidateSessionReasoningState(sessionId);
     expect(row?.conversationSummary).toBe("Focus: flight research");
     expect(row?.summaryVersion).toBe(1);
     expect(row?.reasoningStatus).toBe("idle");
 
-    // A task row must have been created for the missing task
-    const tasks = await listTestVoiceChatCandidateTasks(sessionId);
-    expect(tasks).toHaveLength(1);
-    expect(tasks[0]!.prompt).toBe("Look up flight prices to Tokyo");
-    expect(tasks[0]!.callId).toMatch(/^reasoner-auto-/u);
-
-    // A system_note must have been appended for the auto-created task
     const items = await readTestVoiceChatCandidateItems(sessionId);
     const systemNotes = items.filter((i) => {
       return i.role === "system_note";
     });
-    expect(systemNotes).toHaveLength(1);
-    expect(systemNotes[0]!.content).toBe(
-      "Reasoner auto-created task: Look up flight prices to Tokyo",
-    );
+    expect(systemNotes).toHaveLength(0);
 
-    // Ably signal published (for both the summary write and the missing-tasks step)
     expect(mockAblyPublish).toHaveBeenCalledWith(
       `voice-chat-candidate:${sessionId}`,
       null,
@@ -377,7 +362,7 @@ describe("triggerReasoning", () => {
     expect(mockAblyPublish).not.toHaveBeenCalled();
   });
 
-  it("H7 — uses only the heard portion of an interrupted assistant turn", async () => {
+  it("H8 — uses only the heard portion of an interrupted assistant turn", async () => {
     context.setupMocks();
     vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     reloadEnv();

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/trigger-reasoning.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/trigger-reasoning.ts
@@ -10,12 +10,9 @@ import {
   appendVoiceChatCandidateItem,
   readVoiceChatCandidateItems,
 } from "./item-service";
-import { createVoiceChatCandidateTask, listSessionTasks } from "./task-service";
+import { listSessionTasks } from "./task-service";
 import { callReasoner } from "./reasoner";
 import { compactVoiceChatCandidateTaskResults } from "./compact-task-results";
-import { buildSlowBrainAppendSystemPrompt } from "./build-slow-brain-prompt";
-import { adaptVoiceChatCandidateTaskTrigger } from "./adapt-task-trigger";
-import { createZeroRun } from "../zero-run-service";
 import { publishUserSignal } from "../../infra/realtime/client";
 import { isBadRequest } from "../../shared/errors";
 import { logger } from "../../shared/logger";
@@ -239,55 +236,6 @@ export async function triggerReasoning(sessionId: string): Promise<void> {
       .where(eq(voiceChatSessions.id, sessionId));
   }
 
-  // Step 5c — if the Reasoner detected tasks the Talker promised but never
-  // dispatched, create them now. This runs after the lock is released so
-  // slow spawnRun calls do not block concurrent ticks.
-  if (
-    result !== null &&
-    result.missingTasks.length > 0 &&
-    currentSession.agentId
-  ) {
-    const agentId = currentSession.agentId;
-    const apiStartTime = Date.now();
-    const appendSystemPrompt = buildSlowBrainAppendSystemPrompt({
-      agentSystemPrompt,
-      items: transcript,
-      sessionTasks: tasks,
-    });
-
-    for (let i = 0; i < result.missingTasks.length; i++) {
-      const prompt = result.missingTasks[i];
-      if (!prompt) continue;
-      await createVoiceChatCandidateTask({
-        sessionId,
-        callId: `reasoner-auto-${apiStartTime}-${String(i)}`,
-        prompt,
-        spawnRun: (taskId) => {
-          const runParams = adaptVoiceChatCandidateTaskTrigger({
-            userId: currentSession.userId,
-            agentId,
-            taskId,
-            prompt,
-            appendSystemPrompt,
-            apiStartTime,
-          });
-          return createZeroRun(runParams);
-        },
-      });
-      await appendVoiceChatCandidateItem({
-        sessionId,
-        role: "system_note",
-        content: `Reasoner auto-created task: ${prompt}`,
-        realtimeItemId: null,
-      });
-    }
-
-    await publishUserSignal(
-      [currentSession.userId],
-      `voice-chat-candidate:${sessionId}`,
-    );
-  }
-
   // Step 6 — compact old finished-task results along the exponential
   // schedule. Cheap no-op when nothing is due. The compactor itself fans
   // out an Ably signal when it actually shrinks a row, so the browser
@@ -389,7 +337,6 @@ function parseAssistantInterruptedNote(
   try {
     parsed = JSON.parse(content);
   } catch {
-    log.warn(`failed to parse assistant interrupted note: ${content}`);
     return null;
   }
   if (!parsed || typeof parsed !== "object") {


### PR DESCRIPTION
## Summary
- remove reasoner-driven missing-task backfill from voice chat candidate
- keep the reasoner focused on summary updates and task result compaction
- stop pausing the shared voice-chat audio element on truncate so playback continues after barge-in

## Testing
- pnpm exec vitest run src/lib/zero/voice-chat-candidate/__tests__/trigger-reasoning.test.ts
- pnpm exec vitest run src/signals/voice-chat-candidate/__tests__/voice-chat-candidate-session.test.ts