### PR TITLE
feat: gate Zapier use case behind ZapierConnector feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -1,6 +1,7 @@
 import { command, computed, state } from "ccstate";
 import { talkDraft$ } from "./chat-draft.ts";
 import { getRandomPrompts } from "../../views/zero-page/zero-ideation-data.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { orgModelProviders$ } from "../external/org-model-providers.ts";
 import { currentChatAgent$ } from "../agent-chat.ts";
@@ -26,12 +27,12 @@ export const chatPageTaglineIndex$ = computed((get) => {
 });
 
 // ---------------------------------------------------------------------------
-// Suggested prompts — initialized once at module load, never modified
+// Suggested prompts — filtered by active feature switches
 // ---------------------------------------------------------------------------
 
-const internalSuggestedPrompts$ = state(getRandomPrompts(2));
-export const suggestedPrompts$ = computed((get) => {
-  return get(internalSuggestedPrompts$);
+export const suggestedPrompts$ = computed(async (get) => {
+  const features = await get(featureSwitch$);
+  return getRandomPrompts(2, features);
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page-display.test.tsx
@@ -33,7 +33,7 @@ describe("zero chat page display - tagline with userName via TypewriterText", ()
 // CHAT-D-008: suggested prompt connector icons render with the correct count
 describe("zero chat page display - suggested prompt connector icons", () => {
   it("renders the correct number of connector icon images for prompt cards that have connectors", async () => {
-    const allUseCases = getCategories().flatMap((c) => {
+    const allUseCases = getCategories(undefined).flatMap((c) => {
       return c.cases;
     });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -27,7 +27,7 @@ function renderChatPage() {
 }
 
 describe("zero chat page - suggested prompts", () => {
-  const allUseCases = getCategories().flatMap((c) => {
+  const allUseCases = getCategories(undefined).flatMap((c) => {
     return c.cases;
   });
   const allTitles = new Set(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -8,6 +8,7 @@ import {
   click,
 } from "../../../__tests__/page-helper.ts";
 import { getCategories } from "../zero-ideation-data.ts";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { pathname } from "../../../signals/location.ts";
 import {
   setMockComposesList,
@@ -66,7 +67,7 @@ describe("ideation page - direct route rendering", () => {
 });
 
 describe("ideation page - category tabs", () => {
-  const categories = getCategories().slice(0, 5);
+  const categories = getCategories(undefined).slice(0, 5);
 
   it("should render All tab and each category tab", async () => {
     await renderIdeationPage();
@@ -342,6 +343,36 @@ describe("ideation page - navigation", () => {
 
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${customAgentId}/chat`);
+    });
+  });
+});
+
+describe("ideation page - ZapierConnector feature switch", () => {
+  it("should hide the Zapier use case card when ZapierConnector switch is off (default)", async () => {
+    mockChatAPI();
+    detachedSetupPage({ context, path: IDEAS_PATH });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Ideas & Use Cases" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("Zapier → VM0 migration"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show the Zapier use case card when ZapierConnector switch is on", async () => {
+    mockChatAPI();
+    detachedSetupPage({
+      context,
+      path: IDEAS_PATH,
+      featureSwitches: { [FeatureSwitchKey.ZapierConnector]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Zapier → VM0 migration")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -439,7 +439,7 @@ export function AgentChatPage() {
         )
       : "";
 
-  const suggestedPrompts = useGet(suggestedPrompts$);
+  const suggestedPrompts = useLastResolved(suggestedPrompts$) ?? [];
   const navigate = useSet(detachedNavigateTo$);
   const pageSignal = useGet(pageSignal$);
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -356,12 +356,9 @@ function ChatThreadComposer({
 }) {
   const groups = useLastResolved(thread.groupedChatMessages$) ?? [];
   const hasMessages = groups.length > 0;
-<<<<<<< HEAD
-=======
   const hasUserMessages = groups.some((g) => {
     return g.role === "user";
   });
->>>>>>> origin/main
   const displayName = useLastResolved(thread.agentDisplayName$) ?? "Zero";
   const allFinishedLoadable = useLastLoadable(thread.allFinished$);
   const allFinished =
@@ -451,18 +448,10 @@ function ChatThreadComposer({
                   onChange: setModelSelection,
                   sessionProviderType:
                     threadData?.latestSessionProviderType ?? null,
-<<<<<<< HEAD
-                  // Lock once the thread has stored values — mirrors the
-                  // backend guard in rejectIfThreadModelLocked.
-                  disabled: Boolean(
-                    threadData?.modelProviderId && threadData?.selectedModel,
-                  ),
-=======
                   // Lock as soon as the thread has a user message — provider
                   // must stay consistent within a session to maintain
                   // continuity.
                   disabled: hasUserMessages,
->>>>>>> origin/main
                   agentDefault: agentModelDefault,
                 }
               : undefined

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -1,10 +1,12 @@
 import type { ConnectorType } from "@vm0/core/contracts/connectors";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 interface UseCase {
   readonly title: string;
   readonly description: string;
   readonly prompt: string;
   readonly connectors?: readonly ConnectorType[];
+  readonly featureFlag?: FeatureSwitchKey;
 }
 
 interface Category {
@@ -586,6 +588,7 @@ const categories: readonly Category[] = [
         prompt:
           "Help me migrate my Zapier workflows to VM0. I have zaps for: new Slack message → Notion, Gmail → Google Sheets, and GitHub PR → Slack",
         connectors: ["zapier", "slack", "notion"],
+        featureFlag: FeatureSwitchKey.ZapierConnector,
       },
       {
         title: "Make scenario builder",
@@ -626,14 +629,31 @@ const categories: readonly Category[] = [
   },
 ];
 
-export function getCategories(): readonly Category[] {
-  return categories;
+function isEnabled(
+  useCase: UseCase,
+  features?: Partial<Record<FeatureSwitchKey, boolean>>,
+): boolean {
+  if (!useCase.featureFlag) return true;
+  return !!features?.[useCase.featureFlag];
 }
 
-export function getRandomPrompts(count: number): UseCase[] {
+export function getCategories(
+  features?: Partial<Record<FeatureSwitchKey, boolean>>,
+): readonly Category[] {
+  return categories
+    .map((c) => {
+      return { ...c, cases: c.cases.filter((u) => isEnabled(u, features)) };
+    })
+    .filter((c) => c.cases.length > 0);
+}
+
+export function getRandomPrompts(
+  count: number,
+  features?: Partial<Record<FeatureSwitchKey, boolean>>,
+): UseCase[] {
   const all = categories.flatMap((c) => {
     return c.cases.filter((u) => {
-      return u.connectors && u.connectors.length > 0;
+      return u.connectors && u.connectors.length > 0 && isEnabled(u, features);
     });
   });
   const shuffled = [...all].sort(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -643,11 +643,17 @@ export function getCategories(
   features?: Partial<Record<FeatureSwitchKey, boolean>>,
 ): readonly Category[] {
   return categories
-    .map((c) => ({
-      ...c,
-      cases: c.cases.filter((u) => isEnabled(u, features)),
-    }))
-    .filter((c) => c.cases.length > 0);
+    .map((c) => {
+      return {
+        ...c,
+        cases: c.cases.filter((u) => {
+          return isEnabled(u, features);
+        }),
+      };
+    })
+    .filter((c) => {
+      return c.cases.length > 0;
+    });
 }
 
 export function getRandomPrompts(

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -633,7 +633,9 @@ function isEnabled(
   useCase: UseCase,
   features?: Partial<Record<FeatureSwitchKey, boolean>>,
 ): boolean {
-  if (!useCase.featureFlag) return true;
+  if (!useCase.featureFlag) {
+    return true;
+  }
   return !!features?.[useCase.featureFlag];
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -644,9 +644,9 @@ export function getCategories(
 ): readonly Category[] {
   return categories
     .map((c) => {
-      return { ...c, cases: c.cases.filter((u) => isEnabled(u, features)) };
+      return { ...c, cases: c.cases.filter((u) => { return isEnabled(u, features); }) };
     })
-    .filter((c) => c.cases.length > 0);
+    .filter((c) => { return c.cases.length > 0; });
 }
 
 export function getRandomPrompts(

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -643,10 +643,11 @@ export function getCategories(
   features?: Partial<Record<FeatureSwitchKey, boolean>>,
 ): readonly Category[] {
   return categories
-    .map((c) => {
-      return { ...c, cases: c.cases.filter((u) => { return isEnabled(u, features); }) };
-    })
-    .filter((c) => { return c.cases.length > 0; });
+    .map((c) => ({
+      ...c,
+      cases: c.cases.filter((u) => isEnabled(u, features)),
+    }))
+    .filter((c) => c.cases.length > 0);
 }
 
 export function getRandomPrompts(

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -1,6 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
-import { useGet, useSet } from "ccstate-react";
+import { useGet, useLastResolved, useSet } from "ccstate-react";
 import {
   IconArrowUpRight,
   IconMessageCircle,
@@ -9,6 +9,7 @@ import {
 import { Card, CardContent, cn, Input } from "@vm0/ui";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { getCategories } from "./zero-ideation-data.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { currentAgentId$ } from "../../signals/agent.ts";
 import {
@@ -18,7 +19,8 @@ import {
   setIdeationSearchQuery$,
 } from "../../signals/zero-page/zero-ideation.ts";
 export function ZeroIdeationPage() {
-  const categories = getCategories().slice(0, 5);
+  const features = useLastResolved(featureSwitch$);
+  const categories = getCategories(features).slice(0, 5);
   const activeTab = useGet(ideationActiveTab$);
   const setActiveTab = useSet(setIdeationActiveTab$);
   const searchQuery = useGet(ideationSearchQuery$);


### PR DESCRIPTION
## Summary

- Removes the "Zapier → VM0 migration" use case from the ideation page and suggested prompts when `ZapierConnector` feature switch is disabled (the default)
- Adds `featureFlag?: FeatureSwitchKey` field to the `UseCase` interface so future use cases can be gated similarly
- `getCategories()` and `getRandomPrompts()` now accept a `features` param and filter out flagged use cases accordingly
- `suggestedPrompts$` converted from static `state` to async `computed` that reads `featureSwitch$` at runtime
- Consumers updated: `ZeroIdeationPage` uses `useLastResolved(featureSwitch$)`, `AgentChatPage` switches from `useGet` to `useLastResolved` for suggested prompts

## Test plan

- [ ] With `ZapierConnector` disabled (default): "Zapier → VM0 migration" card should not appear in Ideas & Use Cases, nor in chat page suggested prompts
- [ ] With `ZapierConnector` enabled via feature switch: card appears as expected
- [ ] All other use cases unaffected
- [ ] Existing ideation page tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)