### PR TITLE
chore(voice-chat): drop "candidate" wording from feature-switch description and contract summaries

### DIFF
--- a/turbo/packages/core/src/contracts/zero-voice-chat.ts
+++ b/turbo/packages/core/src/contracts/zero-voice-chat.ts
@@ -135,7 +135,7 @@ export const zeroVoiceChatContract = c.router({
       401: apiErrorSchema,
       403: apiErrorSchema,
     },
-    summary: "Create a new voice-chat-candidate session",
+    summary: "Create a new voice-chat session",
   },
 
   getSession: {
@@ -154,7 +154,7 @@ export const zeroVoiceChatContract = c.router({
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Get a voice-chat-candidate session with recent task logs",
+    summary: "Get a voice-chat session with recent task logs",
   },
 
   listSessions: {
@@ -168,7 +168,7 @@ export const zeroVoiceChatContract = c.router({
       401: apiErrorSchema,
       403: apiErrorSchema,
     },
-    summary: "List voice-chat-candidate sessions for the current user",
+    summary: "List voice-chat sessions for the current user",
   },
 
   triggerReasoning: {
@@ -183,7 +183,7 @@ export const zeroVoiceChatContract = c.router({
       404: apiErrorSchema,
     },
     summary:
-      "Queue a reasoner tick for a voice-chat-candidate session (respects CAS lock and debounce)",
+      "Queue a reasoner tick for a voice-chat session (respects CAS lock and debounce)",
   },
 
   appendItem: {
@@ -198,7 +198,7 @@ export const zeroVoiceChatContract = c.router({
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Append a conversation item to a voice-chat-candidate session",
+    summary: "Append a conversation item to a voice-chat session",
   },
 
   createTask: {
@@ -250,7 +250,7 @@ export const zeroVoiceChatContract = c.router({
       500: apiErrorSchema,
       503: apiErrorSchema,
     },
-    summary: "Mint an ephemeral OpenAI realtime token for voice-chat-candidate",
+    summary: "Mint an ephemeral OpenAI realtime token for voice-chat",
   },
 });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -325,7 +325,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.Trinity]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Embed the candidate voice-chat mic toggle + voice-mode layout into the agent chat page. Gates the mic launcher, composer swap, and status/subtitle/task-card UI.",
+      "Embed the voice-chat mic toggle + voice-mode layout into the agent chat page. Gates the mic launcher, composer swap, and status/subtitle/task-card UI.",
     enabled: false,
   },
   [FeatureSwitchKey.ZapierConnector]: {


### PR DESCRIPTION
## Summary

Final Wave 3 cleanup for Epic #10853 — drops residual "candidate" wording from
the Trinity feature-switch description and the 6 OpenAPI `summary` strings in
the zero-voice-chat contract module.

- `turbo/packages/core/src/feature-switch.ts:328` — `Trinity.description` no
  longer says "candidate voice-chat mic toggle".
- `turbo/packages/core/src/contracts/zero-voice-chat.ts` — all 6 `summary:`
  strings now read "voice-chat" (no "-candidate") on lines 138, 157, 171,
  185-186, 201, 253.

Key-not-value rule respected: `FeatureSwitchKey.Trinity = "trinity"` at
`feature-switch-key.ts:57` is unchanged, per Epic out-of-scope.

Metadata-only edits — zero runtime behavior change. No test additions per
project `/testing` conventions (no entry-point behavior is changing, and
existing contract tests assert on method/path/schema, not `summary` wording).

## Success-Criteria grep sweep

After this PR, the Epic's Success-Criteria grep:

```bash
rg "voice-chat-candidate|voiceChatCandidate|VoiceChatCandidate|featureCandidateVoiceChat|vcc[A-Z]" turbo -l
```

returns hits only inside `**/CHANGELOG.md` (historical release notes — frozen
per Epic out-of-scope):

- `turbo/packages/core/CHANGELOG.md`
- `turbo/apps/web/CHANGELOG.md`
- `turbo/apps/platform/CHANGELOG.md`
- `turbo/apps/cli/CHANGELOG.md`

Migration SQL and snapshot JSON files use snake_case (`voice_chat_candidate`)
and do not match the hyphen/camelCase grep patterns; they remain untouched as
frozen history.

## Test plan

- [x] `pnpm turbo run lint` — clean (5 successful, 0 warnings, 0 errors)
- [x] `pnpm -F @vm0/core exec tsc --noEmit` — clean (the package where edits live)
- [x] `pnpm -F @vm0/app exec vitest` — 236 files, 2016 tests passed
- [x] `pnpm -F @vm0/core exec vitest` — 22 files, 770 tests passed
- [x] `pnpm knip` — "no issues" (only pre-existing config hints in knip.json)
- [x] Epic Success-Criteria grep returns only the 4 CHANGELOG.md hits
- [x] `FeatureSwitchKey.Trinity === "trinity"` unchanged at `feature-switch-key.ts:57`

### Note on `pnpm check-types` (full monorepo)

The full `pnpm check-types` currently fails in `@vm0/cli` on unrelated files
(`apps/cli/src/lib/api/domains/zero-computer-use.ts:58`,
`apps/cli/src/lib/api/domains/zero-skills.ts:14`). These errors **reproduce on
`main` without this PR's changes** (verified by stashing the diff and
re-running). My edits are pure string-literal metadata changes and cannot
introduce missing-argument or arity errors in unrelated CLI API domain files.
This is a pre-existing environmental/main-state issue outside the scope of
this PR — leaving CI to make the final call.

Closes #10892.
Part of Epic #10853.