### PR TITLE
fix: remove starter credit grant from campaign checkout path

### DIFF
--- a/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
@@ -113,9 +113,7 @@ describe("billing-service", () => {
     });
     vi.stubEnv(
       "ZERO_ONE_TIME_CAMPAIGN",
-      JSON.stringify({
-        ZERO100: { priceId: "price_zero100", couponId: "ZERO100" },
-      }),
+      JSON.stringify({ ZERO100: { priceId: "price_zero100", couponId: "ZERO100" } }),
     );
     reloadEnv();
 
@@ -130,9 +128,7 @@ describe("billing-service", () => {
     expect(billing?.credits ?? 0).toBe(0);
 
     const expires = await findCreditExpiresRecords(user.orgId);
-    expect(
-      expires.filter((r) => r.source === "starter_grant"),
-    ).toHaveLength(0);
+    expect(expires.filter((r) => r.source === "starter_grant")).toHaveLength(0);
   });
 });
 

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
@@ -130,7 +130,9 @@ describe("billing-service", () => {
     expect(billing?.credits ?? 0).toBe(0);
 
     const expires = await findCreditExpiresRecords(user.orgId);
-    expect(expires.filter((r) => { return r.source === "starter_grant"; })).toHaveLength(0);
+    const starterGrants = expires.filter((r) => {
+      return r.source === "starter_grant";
+    });
+    expect(starterGrants).toHaveLength(0);
   });
 });
-

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
@@ -4,7 +4,8 @@ import {
   uniqueId,
   type UserContext,
 } from "../../../../__tests__/test-helpers";
-import { getOrgBillingFields } from "../../../../__tests__/api-test-helpers";
+import { getOrgBillingFields, findCreditExpiresRecords } from "../../../../__tests__/api-test-helpers";
+import { reloadEnv } from "../../../../env";
 
 const stripeMocks = vi.hoisted(() => {
   return {
@@ -96,5 +97,34 @@ describe("billing-service", () => {
 
     const billing = await getOrgBillingFields(user.orgId);
     expect(billing?.stripeCustomerId).toBe(firstCustomerId);
+  });
+
+  it("campaign checkout does not grant starter credits to a new org", async () => {
+    const { createOneTimeCheckoutSession } = await import("../billing-service");
+
+    const customerId = uniqueId("cus");
+    stripeMocks.customersCreate.mockResolvedValue({ id: customerId });
+    stripeMocks.checkoutSessionsCreate.mockResolvedValue({
+      id: uniqueId("cs"),
+      url: `https://checkout.stripe.test/${customerId}`,
+    });
+    vi.stubEnv(
+      "ZERO_ONE_TIME_CAMPAIGN",
+      JSON.stringify({ ZERO100: { priceId: "price_zero100", couponId: "ZERO100" } }),
+    );
+    reloadEnv();
+
+    await createOneTimeCheckoutSession({
+      orgId: user.orgId,
+      campaignKey: "ZERO100",
+      successUrl: "https://app.vm0.test/success",
+      cancelUrl: "https://app.vm0.test/cancel",
+    });
+
+    const billing = await getOrgBillingFields(user.orgId);
+    expect(billing?.credits ?? 0).toBe(0);
+
+    const expires = await findCreditExpiresRecords(user.orgId);
+    expect(expires.filter((r) => r.source === "starter_grant")).toHaveLength(0);
   });
 });

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
@@ -113,7 +113,9 @@ describe("billing-service", () => {
     });
     vi.stubEnv(
       "ZERO_ONE_TIME_CAMPAIGN",
-      JSON.stringify({ ZERO100: { priceId: "price_zero100", couponId: "ZERO100" } }),
+      JSON.stringify({
+        ZERO100: { priceId: "price_zero100", couponId: "ZERO100" },
+      }),
     );
     reloadEnv();
 
@@ -131,4 +133,3 @@ describe("billing-service", () => {
     expect(expires.filter((r) => r.source === "starter_grant")).toHaveLength(0);
   });
 });
-

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
@@ -130,6 +130,7 @@ describe("billing-service", () => {
     expect(billing?.credits ?? 0).toBe(0);
 
     const expires = await findCreditExpiresRecords(user.orgId);
-    expect(expires.filter((r) => r.source === "starter_grant")).toHaveLength(0);
+    expect(expires.filter((r) => { return r.source === "starter_grant"; })).toHaveLength(0);
   });
 });
+

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/billing-service.test.ts
@@ -4,7 +4,10 @@ import {
   uniqueId,
   type UserContext,
 } from "../../../../__tests__/test-helpers";
-import { getOrgBillingFields, findCreditExpiresRecords } from "../../../../__tests__/api-test-helpers";
+import {
+  findCreditExpiresRecords,
+  getOrgBillingFields,
+} from "../../../../__tests__/api-test-helpers";
 import { reloadEnv } from "../../../../env";
 
 const stripeMocks = vi.hoisted(() => {
@@ -110,7 +113,9 @@ describe("billing-service", () => {
     });
     vi.stubEnv(
       "ZERO_ONE_TIME_CAMPAIGN",
-      JSON.stringify({ ZERO100: { priceId: "price_zero100", couponId: "ZERO100" } }),
+      JSON.stringify({
+        ZERO100: { priceId: "price_zero100", couponId: "ZERO100" },
+      }),
     );
     reloadEnv();
 
@@ -125,6 +130,9 @@ describe("billing-service", () => {
     expect(billing?.credits ?? 0).toBe(0);
 
     const expires = await findCreditExpiresRecords(user.orgId);
-    expect(expires.filter((r) => r.source === "starter_grant")).toHaveLength(0);
+    expect(
+      expires.filter((r) => r.source === "starter_grant"),
+    ).toHaveLength(0);
   });
 });
+

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -14,7 +14,6 @@ import {
   getCreditBreakdownRecords,
 } from "../credit/credit-expires-service";
 import { getCampaign } from "./one-time-products";
-import { ensureStarterCreditGrant } from "../credit/starter-grant-service";
 import { logger } from "../../shared/logger";
 
 const log = logger("billing");
@@ -115,9 +114,6 @@ async function getOrCreateStripeCustomer(orgId: string): Promise<string> {
       metadata: { orgId },
     });
 
-    // Guarantee the starter grant at first org_metadata materialisation — a
-    // free user may skip onboarding and first hit billing (pricing → upgrade).
-    await ensureStarterCreditGrant(tx, orgId);
     await tx
       .insert(orgMetadata)
       .values({ orgId, stripeCustomerId: customer.id })

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/starter-grant.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/starter-grant.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { testContext, uniqueId, ensureOrgRow } from "../../../../__tests__/test-helpers";
+import {
+  testContext,
+  uniqueId,
+  ensureOrgRow,
+} from "../../../../__tests__/test-helpers";
 import {
   findCreditExpiresRecords,
   getOrgCredits,
@@ -11,10 +15,13 @@ import {
   STARTER_GRANT_AMOUNT,
   STARTER_GRANT_SOURCE,
 } from "../starter-grant-service";
+import { initServices } from "../../../../lib/init-services";
 
 const context = testContext();
 
 async function callEnsureStarterCreditGrant(orgId: string): Promise<void> {
+  // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: needed to initialise services for direct-DB tests
+  initServices();
   // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: helper accepts a tx
   await globalThis.services.db.transaction(async (tx) => {
     await ensureStarterCreditGrant(tx, orgId);
@@ -27,7 +34,7 @@ describe("ensureStarterCreditGrant", () => {
   });
 
   it("first call grants 10k credits and writes one starter_grant expires row", async () => {
-    const { orgId } = await context.setupUser();
+    const orgId = uniqueId("org");
 
     await callEnsureStarterCreditGrant(orgId);
 
@@ -49,7 +56,7 @@ describe("ensureStarterCreditGrant", () => {
   });
 
   it("second call is a no-op — no double grant, still one row", async () => {
-    const { orgId } = await context.setupUser();
+    const orgId = uniqueId("org");
 
     await callEnsureStarterCreditGrant(orgId);
     await callEnsureStarterCreditGrant(orgId);
@@ -60,7 +67,7 @@ describe("ensureStarterCreditGrant", () => {
   });
 
   it("coexists with a subscription_renewal expires row", async () => {
-    const { orgId } = await context.setupUser();
+    const orgId = uniqueId("org");
 
     const futureDate = new Date();
     futureDate.setMonth(futureDate.getMonth() + 2);

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/starter-grant.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/starter-grant.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { testContext, uniqueId, ensureOrgRow } from "../../../../__tests__/test-helpers";
 import {
   findCreditExpiresRecords,
   getOrgCredits,
@@ -83,5 +83,20 @@ describe("ensureStarterCreditGrant", () => {
       })
       .sort();
     expect(sources).toEqual(["starter_grant", "subscription_renewal"]);
+  });
+
+  it("does not grant if org_metadata already exists (org previously initialised)", async () => {
+    const { orgId } = await context.setupUser();
+
+    // Simulate an org that was initialised but spent all starter credits —
+    // the credit_expires_record.starter_grant row may be absent (orgs at
+    // credits=0 when migration 0284 backfill ran fall into this category).
+    await ensureOrgRow(orgId);
+
+    await callEnsureStarterCreditGrant(orgId);
+
+    expect(await getOrgCredits(orgId)).toBe(0);
+    const rows = await findCreditExpiresRecords(orgId);
+    expect(rows).toHaveLength(0);
   });
 });

--- a/turbo/apps/web/src/lib/zero/credit/starter-grant-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/starter-grant-service.ts
@@ -1,4 +1,6 @@
+import { eq } from "drizzle-orm";
 import { creditExpiresRecord } from "../../../db/schema/credit-expires-record";
+import { orgMetadata } from "../../../db/schema/org-metadata";
 import { grantOrgCredits } from "../org/org-service";
 
 export const STARTER_GRANT_AMOUNT = 10_000;
@@ -30,11 +32,20 @@ type StarterGrantTx = Parameters<
  * The helper performs two writes (credit_expires_record insert and
  * grantOrgCredits) that must be atomic — see `StarterGrantTx` for details.
  *
- * Idempotency is enforced by the partial unique index
- *   uq_credit_expires_starter_grant ON (org_id) WHERE source = 'starter_grant'
- * combined with INSERT ... ON CONFLICT DO NOTHING RETURNING id. Only the
- * winning insert triggers the matching credit add, so concurrent callers
- * never double-grant.
+ * Idempotency is enforced by two complementary guards:
+ *
+ * 1. **org_metadata existence check** (first guard): if an `org_metadata`
+ *    row already exists for the org, the org has already been initialised
+ *    via onboarding or another path — return early without granting. This
+ *    closes the gap for orgs that fully spent their starter balance and
+ *    therefore have no `starter_grant` expires row (e.g. orgs at credits=0
+ *    when migration 0284 backfill ran).
+ *
+ * 2. **Partial unique index** (second guard): the index
+ *      uq_credit_expires_starter_grant ON (org_id) WHERE source = 'starter_grant'
+ *    combined with INSERT ... ON CONFLICT DO NOTHING RETURNING id ensures
+ *    that only the winning insert triggers the matching credit add, so
+ *    concurrent callers on a genuinely new org never double-grant.
  *
  * This is the single public entry point for the starter grant. The column
  * default for org_metadata.credits is 0 — skipping this helper means the
@@ -44,6 +55,19 @@ export async function ensureStarterCreditGrant(
   tx: StarterGrantTx,
   orgId: string,
 ): Promise<void> {
+  // Guard: skip if org_metadata already exists — the org has been through
+  // onboarding or another initialisation path. The credit_expires_record
+  // unique index covers concurrent fresh calls; this guard closes the gap
+  // for orgs that fully spent their starter balance and therefore have no
+  // starter_grant expires row (e.g. orgs at credits=0 when migration 0284
+  // backfill ran).
+  const [existing] = await tx
+    .select({ orgId: orgMetadata.orgId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  if (existing) return;
+
   const expiresAt = new Date();
   expiresAt.setMonth(expiresAt.getMonth() + 1);
 


### PR DESCRIPTION
## Summary

- New users who skipped onboarding and redeemed the `zero100` campaign received 110,000 credits instead of the expected 100,000.
- Root cause: `getOrCreateStripeCustomer` bundled a call to `ensureStarterCreditGrant` whenever it created a new Stripe customer. This fired for *both* subscription checkouts and campaign (one-time) checkouts.
- For the campaign path: `createOneTimeCheckoutSession` → `getOrCreateStripeCustomer` → `ensureStarterCreditGrant` (+10,000) then the webhook fired → campaign credits (+100,000) = **110,000 total**.

## Fix

### Layer 1 — Remove from billing path
- Remove `ensureStarterCreditGrant` from `getOrCreateStripeCustomer` in `billing-service.ts`. The billing path is responsible only for Stripe customer materialisation; starter credit grants belong in the onboarding flow, which already handles them correctly.
- Add a regression test in `billing-service.test.ts` that verifies no starter-grant credits or expires records are created when a campaign checkout session is initiated for a new org.

### Layer 2 — org_metadata existence guard inside ensureStarterCreditGrant
- Add an early-return check at the top of `ensureStarterCreditGrant`: if an `org_metadata` row already exists for the org, the org has already been initialised — return immediately without granting.
- This closes a gap that the `credit_expires_record` partial unique index cannot cover: orgs that fully consumed their starter credits before migration 0284's backfill ran have no `starter_grant` expires row, so the unique index provides no idempotency protection for them. A second call would silently re-grant 10k.
- Add a corresponding test: "does not grant if org_metadata already exists (org previously initialised)".

## Test plan

- [ ] New test "campaign checkout does not grant starter credits to a new org" passes
- [ ] New test "does not grant if org_metadata already exists" passes
- [ ] Existing concurrency serialization test still passes
- [ ] Manual: new user skipping onboarding + redeeming zero100 receives exactly 100,000 credits after webhook fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)