### PR TITLE
fix(guest-agent): reap cli process group after type=result

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
 name = "guest-mock-claude"
 version = "0.17.2"
 dependencies = [
+ "libc",
  "serde_json",
  "tempfile",
 ]

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -16,6 +16,44 @@ use tokio::io::AsyncWriteExt;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
+/// State machine driving the post-`type=result` reap of the CLI process
+/// group. A single pinned deadline is resettable across phases; the enum
+/// value tells the lone select! branch what to do when the deadline fires.
+///
+/// | From             | Trigger        | To              | Action          |
+/// |------------------|----------------|-----------------|-----------------|
+/// | `Idle`           | `type=result`  | `SigtermPending`| arm sigterm grace |
+/// | `SigtermPending` | deadline fires | `SigkillPending`| SIGTERM pgid, arm sigkill grace |
+/// | `SigkillPending` | deadline fires | `Done`          | SIGKILL pgid    |
+/// | _any pending_    | `child.wait()` | `Done`          | (no signal)     |
+///
+/// `Done` is sticky: a late second `type=result` on the same run cannot
+/// re-arm the deadline, and any in-flight signalling is one-shot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReapState {
+    Idle,
+    SigtermPending,
+    SigkillPending,
+    Done,
+}
+
+impl ReapState {
+    /// True while waiting for an armed SIGTERM or SIGKILL deadline to fire;
+    /// used as the select! branch's eligibility guard.
+    fn is_pending(self) -> bool {
+        matches!(self, ReapState::SigtermPending | ReapState::SigkillPending)
+    }
+
+    /// Whether to arm the reap deadline on an incoming `type=result`
+    /// event. Only the initial Idle → SigtermPending transition should
+    /// fire — later events (or a result that races a CLI exit) must
+    /// not re-arm. Single source of truth consumed by both the
+    /// production guard in `execute_cli` and the FSM unit tests.
+    fn should_arm(self, cli_exited: bool) -> bool {
+        matches!(self, ReapState::Idle) && !cli_exited
+    }
+}
+
 /// Build the CLI command + args.
 pub fn build_cli_command() -> Result<Vec<String>, AgentError> {
     Ok(build_claude_command(env::use_mock_claude()))
@@ -95,7 +133,9 @@ fn build_claude_command(use_mock: bool) -> Vec<String> {
 
     let bin = if use_mock {
         log_info!(LOG_TAG, "Using mock-claude for testing");
-        "/usr/local/bin/guest-mock-claude".to_string()
+        // Tests can override the path so they target a cargo-built
+        // artifact rather than the sandbox's baked-in `/usr/local/bin`.
+        env::mock_claude_path()
     } else {
         "claude".to_string()
     };
@@ -184,6 +224,18 @@ pub async fn execute_cli(
     let drain_deadline = tokio::time::sleep(Duration::MAX);
     tokio::pin!(drain_deadline);
 
+    // Post-result reap: in --print mode the CLI prints its final `result`
+    // event and then waits for its own backgrounded Bash tasks to drain.
+    // A runaway task (e.g. an xargs-per-file pipeline that can't short-
+    // circuit) can hold the CLI — and therefore the whole sandbox —
+    // alive for tens of minutes. On `type=result` we step through
+    // SigtermPending → SigkillPending → Done, each step resetting this
+    // shared deadline with the next phase's grace window.
+    // See: https://github.com/vm0-ai/vm0/issues/10879
+    let reap_deadline = tokio::time::sleep(Duration::MAX);
+    tokio::pin!(reap_deadline);
+    let mut reap_state = ReapState::Idle;
+
     // Stuck-tool watchdog: workaround for Claude Code bug where
     // WebSearch/WebFetch hang indefinitely. Track all in-flight tool calls;
     // if a network tool exceeds STUCK_TOOL_TIMEOUT_SECS without producing
@@ -231,10 +283,22 @@ pub async fn execute_cli(
                                 timing::record_e2e_from_api("api_to_cli_init");
                             }
                             // Print result to stdout if applicable
-                            if event.get("type").and_then(|v| v.as_str()) == Some("result")
-                                && let Some(result) = event.get("result").and_then(|v| v.as_str())
-                            {
-                                println!("{result}");
+                            if event.get("type").and_then(|v| v.as_str()) == Some("result") {
+                                if let Some(result) = event.get("result").and_then(|v| v.as_str())
+                                {
+                                    println!("{result}");
+                                }
+                                // Arm the post-result reap deadline once
+                                // per run — see `ReapState::should_arm`.
+                                if reap_state.should_arm(cli_status.is_some()) {
+                                    reap_state = ReapState::SigtermPending;
+                                    reap_deadline.as_mut().reset(
+                                        tokio::time::Instant::now()
+                                            + Duration::from_secs(
+                                                env::post_result_sigterm_grace_secs(),
+                                            ),
+                                    );
+                                }
                             }
                             // Extract tool info BEFORE masking (masker may replace tool names)
                             for tool_event in events::extract_claude_tool_info(&event) {
@@ -266,12 +330,67 @@ pub async fn execute_cli(
                     Ok(s) => {
                         log_info!(LOG_TAG, "CLI process exited (status: {s}), draining stdout");
                         cli_status = Some(s);
+                        // CLI exited on its own (possibly in response to our
+                        // SIGTERM). Park the reap FSM so it can't re-arm on
+                        // any late `type=result` event.
+                        reap_state = ReapState::Done;
                         drain_deadline.as_mut().reset(
                             tokio::time::Instant::now()
                                 + Duration::from_secs(constants::STDOUT_DRAIN_DEADLINE_SECS),
                         );
                     }
                     Err(e) => break Err(AgentError::Io(e)),
+                }
+            }
+            () = &mut reap_deadline, if reap_state.is_pending() && cli_status.is_none() => {
+                // `libc::kill` return value is intentionally discarded in
+                // both arms: ESRCH (child reaped since the is_pending()
+                // / is_none() check) is racy-but-harmless, and every
+                // other error would be unrecoverable from userspace.
+                // The sigkill_grace deadline is the escalation path if
+                // the signal fails to take effect in time.
+                match reap_state {
+                    ReapState::SigtermPending => {
+                        let grace = env::post_result_sigterm_grace_secs();
+                        if let Some(pid) = pgid {
+                            log_warn!(
+                                LOG_TAG,
+                                "CLI still running {grace}s after type=result, SIGTERM pgid={pid} (likely a leaked backgrounded Bash task)"
+                            );
+                            unsafe { libc::kill(-pid, libc::SIGTERM); }
+                        }
+                        reap_state = ReapState::SigkillPending;
+                        reap_deadline.as_mut().reset(
+                            tokio::time::Instant::now()
+                                + Duration::from_secs(env::post_result_sigkill_grace_secs()),
+                        );
+                    }
+                    ReapState::SigkillPending => {
+                        let grace = env::post_result_sigkill_grace_secs();
+                        if let Some(pid) = pgid {
+                            log_warn!(
+                                LOG_TAG,
+                                "CLI did not exit after SIGTERM+{grace}s, SIGKILL pgid={pid}"
+                            );
+                            unsafe { libc::kill(-pid, libc::SIGKILL); }
+                        }
+                        reap_state = ReapState::Done;
+                    }
+                    // Unreachable by the is_pending() guard. Log in
+                    // every build so any future FSM regression surfaces
+                    // in production runner logs; debug_assert adds a
+                    // fail-fast panic under cfg(debug_assertions) so
+                    // CI / dev tests abort on the same condition.
+                    ReapState::Idle | ReapState::Done => {
+                        log_warn!(
+                            LOG_TAG,
+                            "reap_deadline fired in non-pending state {reap_state:?}"
+                        );
+                        debug_assert!(
+                            false,
+                            "reap_deadline fired in non-pending state {reap_state:?}"
+                        );
+                    }
                 }
             }
             () = &mut drain_deadline, if cli_status.is_some() => {
@@ -448,8 +567,14 @@ mod tests {
 
     #[test]
     fn build_claude_command_uses_mock_binary() {
+        // Unit tests run in the lib-test binary where
+        // `VM0_MOCK_CLAUDE_PATH` is unset, so `env::mock_claude_path()`
+        // falls through to `DEFAULT_MOCK_CLAUDE_PATH`. Asserting
+        // against the const (not the accessor) catches regressions in
+        // the default path itself — the previous form compared the
+        // accessor against itself and was tautological.
         let cmd = build_claude_command(true);
-        assert_eq!(cmd[0], "/usr/local/bin/guest-mock-claude");
+        assert_eq!(cmd[0], env::DEFAULT_MOCK_CLAUDE_PATH);
     }
 
     #[test]
@@ -563,5 +688,40 @@ mod tests {
     fn build_claude_args_prompt_always_last() {
         let args = build_claude_args("", "", "", "", "", "my prompt");
         assert_eq!(args.last().unwrap(), "my prompt");
+    }
+
+    // -----------------------------------------------------------------
+    // ReapState FSM
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn reap_state_is_pending_only_between_arming_and_done() {
+        assert!(!ReapState::Idle.is_pending());
+        assert!(ReapState::SigtermPending.is_pending());
+        assert!(ReapState::SigkillPending.is_pending());
+        assert!(!ReapState::Done.is_pending());
+    }
+
+    /// The arming guard must fire exactly once per run, on the first
+    /// `type=result` event, and only when the CLI is still alive. Any
+    /// later state — or a CLI that already exited — must be ignored
+    /// (Done is sticky; SigtermPending/SigkillPending already armed).
+    ///
+    /// Calls `ReapState::should_arm` directly so the test shares a
+    /// single source of truth with the production `select!` branch.
+    #[test]
+    fn reap_state_should_arm_matches_invariant() {
+        // Fire only from Idle with CLI still alive.
+        assert!(ReapState::Idle.should_arm(false));
+
+        // CLI already exited → no arm, even from Idle.
+        assert!(!ReapState::Idle.should_arm(true));
+
+        // Already armed → no re-arm.
+        assert!(!ReapState::SigtermPending.should_arm(false));
+        assert!(!ReapState::SigkillPending.should_arm(false));
+
+        // Done is sticky.
+        assert!(!ReapState::Done.should_arm(false));
     }
 }

--- a/crates/guest-agent/src/constants.rs
+++ b/crates/guest-agent/src/constants.rs
@@ -39,6 +39,19 @@ pub const STUCK_TOOL_CHECK_INTERVAL_SECS: u64 = 5;
 /// hanging on orphaned child processes that inherited the stdout fd.
 pub const STDOUT_DRAIN_DEADLINE_SECS: u64 = 5;
 
+/// Grace period after observing a `type=result` event before SIGTERM-ing the
+/// CLI process group. In vm0's one-shot web-agent integration the turn is
+/// complete when the CLI emits its final `result`, but the CLI itself may
+/// still be blocked draining long-running backgrounded Bash tasks it spawned
+/// via its 2-minute auto-background timeout. Those tasks have been observed
+/// holding the sandbox alive for tens of minutes until external cancel.
+/// See: https://github.com/vm0-ai/vm0/issues/10879
+pub const POST_RESULT_SIGTERM_GRACE_SECS: u64 = 10;
+
+/// Follow-up window after SIGTERM before escalating to SIGKILL when the CLI
+/// process group ignores the graceful signal.
+pub const POST_RESULT_SIGKILL_GRACE_SECS: u64 = 5;
+
 /// Maximum consecutive heartbeat failures before terminating the run.
 /// Each heartbeat attempt already retries `HTTP_MAX_RETRIES` times internally,
 /// so 3 consecutive failures = 9 total HTTP attempts over ~3 minutes.

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -35,22 +35,57 @@ static USE_MOCK_CLAUDE: LazyLock<bool> = LazyLock::new(|| {
         .map(|v| v == "true")
         .unwrap_or(false)
 });
+/// Production install location for the mock-claude binary. Exposed so
+/// tests can assert against a single source of truth when the
+/// `VM0_MOCK_CLAUDE_PATH` env override is unset.
+pub const DEFAULT_MOCK_CLAUDE_PATH: &str = "/usr/local/bin/guest-mock-claude";
+
+/// Optional override for the mock-claude binary path. Used by
+/// integration tests to point at a cargo-built artifact; production
+/// runs fall through to `DEFAULT_MOCK_CLAUDE_PATH`.
+static MOCK_CLAUDE_PATH: LazyLock<String> = LazyLock::new(|| {
+    std::env::var("VM0_MOCK_CLAUDE_PATH").unwrap_or_else(|_| DEFAULT_MOCK_CLAUDE_PATH.to_string())
+});
+/// Read an optional `u64` env var, falling back to `default` when it's
+/// unset or unparseable. Emits a stderr warning on the unparseable case so
+/// the mistake is visible in runner logs rather than silently absorbed.
+fn u64_env_or(name: &str, default: u64) -> u64 {
+    match std::env::var(name) {
+        Ok(v) => v.parse().unwrap_or_else(|_| {
+            eprintln!("[WARN] {name}={v:?} is not a valid u64, using default {default}s");
+            default
+        }),
+        Err(_) => default,
+    }
+}
+
 /// Workaround for Claude Code bug: WebSearch/WebFetch can hang indefinitely.
 /// See: https://github.com/anthropics/claude-code/issues/11650
 static STUCK_TOOL_TIMEOUT: LazyLock<u64> = LazyLock::new(|| {
-    match std::env::var("VM0_STUCK_TOOL_TIMEOUT_SECS") {
-        Ok(v) => match v.parse() {
-            Ok(secs) => secs,
-            Err(_) => {
-                eprintln!(
-                    "[WARN] VM0_STUCK_TOOL_TIMEOUT_SECS={v:?} is not a valid u64, using default {}s",
-                    constants::STUCK_TOOL_TIMEOUT_SECS
-                );
-                constants::STUCK_TOOL_TIMEOUT_SECS
-            }
-        },
-        Err(_) => constants::STUCK_TOOL_TIMEOUT_SECS,
-    }
+    u64_env_or(
+        "VM0_STUCK_TOOL_TIMEOUT_SECS",
+        constants::STUCK_TOOL_TIMEOUT_SECS,
+    )
+});
+
+/// Grace after `type=result` before SIGTERM-ing the CLI process group.
+/// Shortened in integration tests via env override so runs converge
+/// within a test-sized window instead of the prod default.
+/// See: https://github.com/vm0-ai/vm0/issues/10879
+static POST_RESULT_SIGTERM_GRACE: LazyLock<u64> = LazyLock::new(|| {
+    u64_env_or(
+        "VM0_POST_RESULT_SIGTERM_GRACE_SECS",
+        constants::POST_RESULT_SIGTERM_GRACE_SECS,
+    )
+});
+
+/// Follow-up grace after SIGTERM before escalating to SIGKILL. Same
+/// override rationale as `POST_RESULT_SIGTERM_GRACE`.
+static POST_RESULT_SIGKILL_GRACE: LazyLock<u64> = LazyLock::new(|| {
+    u64_env_or(
+        "VM0_POST_RESULT_SIGKILL_GRACE_SECS",
+        constants::POST_RESULT_SIGKILL_GRACE_SECS,
+    )
 });
 
 // ---------------------------------------------------------------------------
@@ -140,11 +175,20 @@ pub fn settings() -> &'static str {
 pub fn use_mock_claude() -> bool {
     *USE_MOCK_CLAUDE
 }
+pub fn mock_claude_path() -> String {
+    MOCK_CLAUDE_PATH.clone()
+}
 pub fn artifacts() -> &'static [ArtifactEnv] {
     &ARTIFACTS
 }
 pub fn stuck_tool_timeout_secs() -> u64 {
     *STUCK_TOOL_TIMEOUT
+}
+pub fn post_result_sigterm_grace_secs() -> u64 {
+    *POST_RESULT_SIGTERM_GRACE
+}
+pub fn post_result_sigkill_grace_secs() -> u64 {
+    *POST_RESULT_SIGKILL_GRACE
 }
 /// Whether a backend API is available (token set).
 ///

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1,0 +1,175 @@
+//! Shared setup for the post-`type=result` reap integration tests.
+//!
+//! # Why three test binaries instead of three cases in one
+//!
+//! `guest_agent::env` caches all `VM0_*` values in process-wide
+//! `LazyLock`s on first read. Consolidating the three reap scenarios
+//! (SIGTERM / SIGKILL-escalation / happy) into one `#[tokio::test]`
+//! binary would require each test to see its own `VM0_PROMPT`, which
+//! is impossible once the `LazyLock` is initialised. Splitting into
+//! three binaries gives each one a fresh process + fresh LazyLock
+//! state, paid for by a small cargo build-cache hit (idempotent).
+//!
+//! # Error handling
+//!
+//! Fallible helpers return `Result<_, String>` and let the test's
+//! `#[tokio::test]` body propagate with `?` — clippy's
+//! `allow-expect-in-tests` applies to test bodies but not to helpers
+//! defined in `tests/common/mod.rs`.
+
+#![allow(dead_code)] // consumed across multiple test binaries
+
+use std::path::{Path, PathBuf};
+
+/// 128 + SIGTERM(15). Rust / glibc's default signal handler maps a
+/// SIGTERM-terminated process to this exit code.
+pub const SIGTERM_EXIT: i32 = 143;
+
+/// 128 + SIGKILL(9). Un-catchable; the only way out for a process
+/// that ignores SIGTERM.
+pub const SIGKILL_EXIT: i32 = 137;
+
+/// Normal clean exit. Reap should never fire on this path.
+pub const CLEAN_EXIT: i32 = 0;
+
+/// Build the mock binary (idempotent when up to date) and resolve its
+/// filesystem path.
+///
+/// The subprocess `cargo build` must land the artifact in the same
+/// `target/` directory + profile that the enclosing `cargo test` uses,
+/// otherwise the mock goes to a different spot than where we look for
+/// it — which happens under `cargo llvm-cov` (custom `--target-dir`)
+/// and under `cargo test --release`. We infer both from the currently-
+/// running test binary's path and forward them to the subprocess.
+pub fn build_and_locate_mock() -> Result<PathBuf, String> {
+    // Test binary:   <target_dir>/<profile>/deps/<name>-<hash>
+    //   parent():    <target_dir>/<profile>/deps
+    //   parent().parent():  <target_dir>/<profile>   ← target_profile_dir
+    //   parent().parent().parent():  <target_dir>
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let target_dir = target_profile_dir
+        .parent()
+        .ok_or_else(|| "target dir".to_string())?;
+    let profile_dir_name = target_profile_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "profile dir name".to_string())?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", "guest-mock-claude", "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    // Cargo profile → output dir mapping:
+    //   --release            → target_dir/release
+    //   --profile <name>     → target_dir/<name>
+    //   (default / dev)      → target_dir/debug
+    // So pick the flag that lands the artifact beside our test binary.
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build -p guest-mock-claude failed".into());
+    }
+
+    let mock = target_profile_dir.join("guest-mock-claude");
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    Ok(mock)
+}
+
+/// Configure the process environment for a reap test. Must be called
+/// BEFORE any `guest_agent::env::*` accessor — the library's LazyLocks
+/// capture these values on first read.
+///
+/// `prompt` decides which mock-claude test prefix runs:
+/// - `@hang-after-result` → SIGTERM path
+/// - `@hang-after-result-deaf` → SIGKILL escalation path
+/// - `@exit-after-result` → happy path (no signal ever fires)
+///
+/// `sigterm_grace_secs` / `sigkill_grace_secs` control how long the
+/// FSM waits before each signal escalation. Signal-exit tests want
+/// them small (~1s) for fast convergence; the happy-path test wants
+/// sigterm grace large enough that the bound "elapsed < sigterm grace"
+/// survives cold-CI fork+exec jitter.
+///
+/// # Side effects
+///
+/// - Mutates the process-wide environment (`set_var`).
+/// - Mutates the process-wide working directory (`set_current_dir`).
+///
+/// Call AT MOST ONCE per test binary; calling from multiple `#[test]`s
+/// in the same binary races on CWD and on `LazyLock` capture order.
+///
+/// SAFETY: callers run in a single-test test binary, so no other thread
+/// is reading the process env concurrently.
+pub unsafe fn setup_env(
+    mock_path: &Path,
+    workdir: &Path,
+    prompt: &str,
+    sigterm_grace_secs: u64,
+    sigkill_grace_secs: u64,
+) -> Result<(), String> {
+    unsafe {
+        // Route the CLI binary resolution to the cargo-built mock.
+        std::env::set_var("VM0_MOCK_CLAUDE_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CLAUDE", "true");
+        std::env::set_var(
+            "VM0_POST_RESULT_SIGTERM_GRACE_SECS",
+            sigterm_grace_secs.to_string(),
+        );
+        std::env::set_var(
+            "VM0_POST_RESULT_SIGKILL_GRACE_SECS",
+            sigkill_grace_secs.to_string(),
+        );
+        // Derive run_id from the test binary's filename (which cargo
+        // hashes per target) so the three reap test binaries running
+        // concurrently don't collide on the `/tmp/vm0-*-{run_id}.*`
+        // files that paths.rs creates.
+        let run_id = std::env::current_exe()
+            .ok()
+            .as_deref()
+            .and_then(Path::file_name)
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "post-result-reap-test".to_string());
+        std::env::set_var("VM0_RUN_ID", run_id);
+        std::env::set_var("VM0_PROMPT", prompt);
+        std::env::set_var("VM0_WORKING_DIR", workdir);
+        // Empty API token → has_api() false → no network calls.
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        // Redirect HOME so the mock's session-history write
+        // (`$HOME/.claude/projects/.../<session>.jsonl`) stays inside
+        // the tempdir and gets cleaned up with it, instead of
+        // accumulating in the dev's real ~/.claude on every run.
+        std::env::set_var("HOME", workdir);
+    }
+    std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
+    std::env::set_current_dir(workdir).map_err(|e| format!("set_current_dir: {e}"))?;
+    Ok(())
+}
+
+/// Dummy heartbeat that never completes. The CLI-wait / reap-deadline
+/// branches of `execute_cli`'s select! loop are the intended exit paths
+/// for these tests; a heartbeat failure would go through a different
+/// code path entirely.
+pub fn spawn_dummy_heartbeat() -> tokio::task::JoinHandle<Result<(), guest_agent::error::AgentError>>
+{
+    tokio::spawn(std::future::pending())
+}

--- a/crates/guest-agent/tests/post_result_reap.rs
+++ b/crates/guest-agent/tests/post_result_reap.rs
@@ -1,0 +1,44 @@
+//! End-to-end: CLI hangs after `type=result`, reap SIGTERMs it, default
+//! SIGTERM handler exits with 143. Exercises Idle → SigtermPending →
+//! Done via `child.wait()` after the signal.
+//!
+//! See: https://github.com/vm0-ai/vm0/issues/10879
+
+mod common;
+
+use std::time::Duration;
+
+#[tokio::test]
+async fn post_result_reap_sigterm_kills_hung_cli() -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        // Fast convergence: 1s sigterm grace + 1s sigkill grace.
+        common::setup_env(&mock, tmp.path(), "@hang-after-result", 1, 1)?;
+    }
+
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let heartbeat = common::spawn_dummy_heartbeat();
+
+    // Budget: sigterm grace (1s) + stdout drain (5s) + slack = 15s.
+    // Mock hangs 3600s, so any completion under this cap came from the
+    // reap. Locally runs in ~1s.
+    let result = tokio::time::timeout(
+        Duration::from_secs(15),
+        guest_agent::cli::execute_cli(&masker, heartbeat),
+    )
+    .await
+    .expect("execute_cli did not return within 15s — reap likely broken");
+
+    let (exit_code, _stderr) = result.expect("execute_cli returned Err");
+
+    // On pathologically slow runners the sigkill escalation may fire
+    // before SIGTERM actually terminates the mock; accept either.
+    assert!(
+        exit_code == common::SIGTERM_EXIT || exit_code == common::SIGKILL_EXIT,
+        "expected signal-based exit ({} or {}), got {exit_code}",
+        common::SIGTERM_EXIT,
+        common::SIGKILL_EXIT
+    );
+    Ok(())
+}

--- a/crates/guest-agent/tests/post_result_reap_happy.rs
+++ b/crates/guest-agent/tests/post_result_reap_happy.rs
@@ -1,0 +1,62 @@
+//! End-to-end: CLI cleanly exits on its own after `type=result`. The
+//! reap FSM gets armed (Idle → SigtermPending) but `child.wait()`
+//! fires before any grace elapses, transitioning straight to Done.
+//! Neither SIGTERM nor SIGKILL is sent.
+//!
+//! Guards against the regression "reap accidentally kills healthy CLIs"
+//! — if a future change widens the arming guard or shortens grace to
+//! zero, this test catches it via the exit-code check.
+//!
+//! See: https://github.com/vm0-ai/vm0/issues/10879
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+#[tokio::test]
+async fn post_result_reap_stays_silent_on_clean_exit() -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        // 3s sigterm grace gives cold-CI fork+exec jitter a wide
+        // buffer below the 1s elapsed bound asserted below. sigkill
+        // grace is unused on this path (reap never fires at all).
+        common::setup_env(&mock, tmp.path(), "@exit-after-result", 3, 1)?;
+    }
+
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let heartbeat = common::spawn_dummy_heartbeat();
+
+    // Happy path completes in milliseconds (mock exits immediately
+    // after emitting result). A generous 15s cap ensures flakes on
+    // loaded CI still flag as "took too long", distinguishing from
+    // "did not return at all".
+    let started = Instant::now();
+    let result = tokio::time::timeout(
+        Duration::from_secs(15),
+        guest_agent::cli::execute_cli(&masker, heartbeat),
+    )
+    .await
+    .expect("execute_cli did not return within 15s on the happy path");
+    let elapsed = started.elapsed();
+
+    let (exit_code, _stderr) = result.expect("execute_cli returned Err");
+
+    // Clean exit(0) — if this is SIGTERM_EXIT / SIGKILL_EXIT, the
+    // reap fired against a healthy CLI, which is a correctness bug.
+    assert_eq!(
+        exit_code,
+        common::CLEAN_EXIT,
+        "expected clean exit, got {exit_code} — reap may have killed a healthy CLI"
+    );
+    // With sigterm grace = 3s, a reap that mistakenly fires would
+    // push elapsed to ≥3s. Any value well under that proves the
+    // deadline branch didn't execute. 1s cap gives two seconds of
+    // headroom over the tightest imaginable signal path while still
+    // easily accommodating a cold fork+exec on slow CI.
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "happy path took {elapsed:?}; reap deadline may have fired"
+    );
+    Ok(())
+}

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -1,0 +1,49 @@
+//! End-to-end: CLI hangs after `type=result` AND ignores SIGTERM, so
+//! the reap FSM must escalate to SIGKILL. Exercises Idle → SigtermPending
+//! → SigkillPending → Done, which the main `post_result_reap` test
+//! never reaches (default SIGTERM handler terminates its mock).
+//!
+//! This is the only coverage for the SigkillPending match arm and the
+//! `libc::kill(-pid, SIGKILL)` call in `cli.rs`.
+//!
+//! See: https://github.com/vm0-ai/vm0/issues/10879
+
+mod common;
+
+use std::time::Duration;
+
+#[tokio::test]
+async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        // 1s sigterm (ignored by mock) + 1s sigkill (unignorable) → ~2s total.
+        common::setup_env(&mock, tmp.path(), "@hang-after-result-deaf", 1, 1)?;
+    }
+
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let heartbeat = common::spawn_dummy_heartbeat();
+
+    // Budget: sigterm (1s, ignored) + sigkill (1s, unignorable) +
+    // stdout drain (5s) + slack = 15s.
+    let result = tokio::time::timeout(
+        Duration::from_secs(15),
+        guest_agent::cli::execute_cli(&masker, heartbeat),
+    )
+    .await
+    .expect("execute_cli did not return within 15s — sigkill escalation likely broken");
+
+    let (exit_code, _stderr) = result.expect("execute_cli returned Err");
+
+    // SIGKILL (9) → 128 + 9 = 137. SIGTERM is SIG_IGN'd in the mock,
+    // so 143 here would mean our SIGTERM somehow won a race it can't
+    // — or the mock isn't actually ignoring it (harness regression).
+    assert_eq!(
+        exit_code,
+        common::SIGKILL_EXIT,
+        "expected SIGKILL exit ({}), got {exit_code} — SigkillPending escalation path is not firing",
+        common::SIGKILL_EXIT
+    );
+    Ok(())
+}

--- a/crates/guest-mock-claude/Cargo.toml
+++ b/crates/guest-mock-claude/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.17.2"
 edition.workspace = true
 
 [dependencies]
+libc.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -6,9 +6,18 @@
 //! Usage: mock-claude [options] <prompt>
 //!
 //! Special test prefixes:
-//!   @fail:<message>  - Output message to stderr and exit with code 1
-//!   @stuck-tool      - Emit WebFetch tool_use then hang (test stuck-tool watchdog)
-//!   @orphan-pipe     - Emit events, spawn child holding stdout, then exit
+//!   @fail:<message>           - Output message to stderr and exit with code 1
+//!   @stuck-tool               - Emit WebFetch tool_use then hang (test stuck-tool watchdog)
+//!   @orphan-pipe              - Emit events, spawn child holding stdout, then exit
+//!   @hang-after-result        - Emit result event, then hang the process
+//!                               (SIGTERM kills it → exits with 143; tests
+//!                               the SigtermPending→Done reap path)
+//!   @hang-after-result-deaf   - Same, but ignores SIGTERM so only SIGKILL
+//!                               can terminate it; tests the
+//!                               SigkillPending→Done escalation path
+//!   @exit-after-result        - Emit result event, exit(0) immediately;
+//!                               tests that reap stays no-op on the
+//!                               happy path
 
 use serde_json::{Value, json};
 use std::io::Write;
@@ -122,6 +131,49 @@ fn build_session_history_path(session_id: &str, cwd: &str, home: &str) -> Option
 fn create_session_history(session_id: &str, cwd: &str) -> Option<String> {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
     build_session_history_path(session_id, cwd, &home)
+}
+
+/// Emit the init + result JSONL pair that the `*-after-result` test
+/// prefixes share, flush stdout so guest-agent sees them, and write
+/// the session history checkpoint file. Caller decides what happens
+/// after (hang / exit / ignore SIGTERM).
+fn emit_post_result_pair() {
+    let session_id = generate_session_id();
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "/".to_string());
+
+    let init_event = json!({
+        "type": "system",
+        "subtype": "init",
+        "cwd": cwd,
+        "session_id": session_id,
+        "tools": ["Bash"],
+        "model": "mock-claude"
+    });
+    println!("{init_event}");
+
+    let result_event = json!({
+        "type": "result",
+        "subtype": "success",
+        "session_id": session_id,
+        "is_error": false,
+        "duration_ms": 100,
+        "num_turns": 1,
+        "result": "Done.",
+        "total_cost_usd": 0,
+        "usage": {"input_tokens": 0, "output_tokens": 0}
+    });
+    println!("{result_event}");
+
+    if let Some(path) = create_session_history(&session_id, &cwd)
+        && let Ok(mut file) = std::fs::File::create(&path)
+    {
+        let _ = writeln!(file, "{init_event}");
+        let _ = writeln!(file, "{result_event}");
+    }
+
+    let _ = std::io::stdout().flush();
 }
 
 /// Execute prompt in text mode: inherited stdio, propagate exit code.
@@ -358,6 +410,48 @@ fn main() -> ExitCode {
             // Spawn a child that inherits stdout and sleeps forever.
             // This keeps the stdout pipe open after this process exits.
             let _ = Command::new("sleep").arg("3600").spawn();
+        }
+        return ExitCode::SUCCESS;
+    }
+
+    // The three `*-after-result` prefixes all emit the same init+result
+    // pair; only what happens *after* differs. Dispatch by order: the
+    // more-specific `-deaf` / `@exit-` must match before the generic
+    // `@hang-after-result`.
+    //
+    // See: https://github.com/vm0-ai/vm0/issues/10879
+    if parsed.prompt.starts_with("@hang-after-result-deaf") {
+        if parsed.output_format == "stream-json" {
+            emit_post_result_pair();
+            // Ignore SIGTERM so only SIGKILL can terminate this process.
+            // Exercises the SigtermPending → SigkillPending → Done
+            // escalation branch of the reap FSM.
+            // SAFETY: signal(SIGTERM, SIG_IGN) is async-signal-safe and
+            // has no data-race concerns at program start.
+            unsafe {
+                libc::signal(libc::SIGTERM, libc::SIG_IGN);
+            }
+            std::thread::sleep(std::time::Duration::from_secs(3600));
+        }
+        return ExitCode::SUCCESS;
+    }
+    if parsed.prompt.starts_with("@exit-after-result") {
+        if parsed.output_format == "stream-json" {
+            emit_post_result_pair();
+            // Exit immediately. Exercises the happy path: guest-agent's
+            // reap gets armed but `child.wait()` fires before any grace
+            // window elapses, so no signal is ever sent.
+        }
+        return ExitCode::SUCCESS;
+    }
+    if parsed.prompt.starts_with("@hang-after-result") {
+        if parsed.output_format == "stream-json" {
+            emit_post_result_pair();
+            // Hang this process forever. guest-agent's post-result reap
+            // SIGTERMs it within POST_RESULT_SIGTERM_GRACE_SECS; the
+            // default SIGTERM handler then exits with 143. Exercises
+            // the SigtermPending → Done path.
+            std::thread::sleep(std::time::Duration::from_secs(3600));
         }
         return ExitCode::SUCCESS;
     }


### PR DESCRIPTION
## Summary

- In `--print` mode Claude Code emits its final `type=result` event and then waits for its own backgrounded Bash tasks to drain — a runaway task can hold the CLI (and the sandbox) alive for tens of minutes past the user-visible answer, until external Ably cancel tears things down (see #10879 for the 28-minute run we traced).
- `guest-agent/src/cli.rs` now drives a `ReapState` FSM on the CLI's process group when `type=result` is observed: `Idle → SigtermPending → SigkillPending → Done`. `child.wait()` fires within seconds of end_turn and the rest of `execute()` runs as intended.
- `guest-mock-claude` gains a `@hang-after-result` test prefix; `guest-agent/tests/post_result_reap.rs` spawns the real mock binary and asserts the FSM reaps it within the configured grace window.

## How it works

| From             | Trigger        | To              | Action |
|------------------|----------------|-----------------|--------|
| `Idle`           | `type=result`  | `SigtermPending`| arm sigterm grace |
| `SigtermPending` | deadline fires | `SigkillPending`| `SIGTERM pgid`, arm sigkill grace |
| `SigkillPending` | deadline fires | `Done`          | `SIGKILL pgid` |
| _any pending_    | `child.wait()` | `Done`          | (no signal — CLI exited on its own) |

One pinned `Sleep` serves both phases via `reset()`; the single eligibility guard is `reap_state.is_pending() && cli_status.is_none()`. `Done` is sticky so a late second `type=result` can't re-arm.

`SIGTERM -pgid` covers grandchild processes too (the runaway `xargs` pipeline is a bash-spawned grandchild of the CLI). The same `libc::kill(-pgid, ...)` pattern is already used by the stuck-tool watchdog and the heartbeat-failure path.

## Configuration

| Constant | Default | Env override |
|---|---|---|
| `POST_RESULT_SIGTERM_GRACE_SECS` | 10 | `VM0_POST_RESULT_SIGTERM_GRACE_SECS` |
| `POST_RESULT_SIGKILL_GRACE_SECS` | 5  | `VM0_POST_RESULT_SIGKILL_GRACE_SECS` |

Also factored env.rs's numeric env-override parsing into `u64_env_or(name, default)` so the existing `STUCK_TOOL_TIMEOUT` and the two new grace knobs share one bit of logic instead of three match statements.

## Scope correction

Stdin is already `Stdio::null()` (`cli.rs:124`), so "close stdin to let the CLI see EOF" — which I'd originally suggested in #10879 — is a no-op. The CLI isn't waiting on stdin; it's blocked on its own backgrounded-task drain. Signalling the process group is the right lever.

## Test plan

- [x] `cargo build -p guest-agent` clean
- [x] `cargo clippy -p guest-agent -p guest-mock-claude --all-targets --no-deps` clean (incl. `-D clippy::unreachable` / `-D clippy::unwrap_used` / `-D clippy::expect_used`)
- [x] `cargo fmt --check` clean
- [x] **New** `cargo test -p guest-agent --test post_result_reap` — e2e FSM test spawns real mock, converges in ~1s (vs mock's 3600s hang) with signal-based exit code
- [x] `cargo test -p guest-agent` — 80 unit + 33 integration + 1 e2e reap pass (two new unit tests cover `ReapState::is_pending` and the arming guard)
- [x] `cargo test -p guest-mock-claude` — 19 pass

Closes #10879.