### PR TITLE
fix: lock model provider picker once thread has messages

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -174,7 +174,12 @@ function mockOrgProviders(options: {
 function mockThread(options: {
   modelProviderId: string | null;
   selectedModel: string | null;
-  messages?: { id: string; role: "user" | "assistant"; content: string; createdAt: string }[];
+  messages?: {
+    id: string;
+    role: "user" | "assistant";
+    content: string;
+    createdAt: string;
+  }[];
 }) {
   server.use(
     mockApi(chatThreadByIdContract.get, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -174,7 +174,7 @@ function mockOrgProviders(options: {
 function mockThread(options: {
   modelProviderId: string | null;
   selectedModel: string | null;
-  messages?: Array<{ id: string; role: "user" | "assistant"; content: string; createdAt: string }>;
+  messages?: { id: string; role: "user" | "assistant"; content: string; createdAt: string }[];
 }) {
   server.use(
     mockApi(chatThreadByIdContract.get, ({ respond }) => {
@@ -363,6 +363,14 @@ describe("chat composer — default model resolution", () => {
     mockThread({
       modelProviderId: ZAI_PROVIDER_ID,
       selectedModel: "glm-5.1",
+      messages: [
+        {
+          id: "msg-user-1",
+          role: "user" as const,
+          content: "Use GLM",
+          createdAt: "2026-03-10T00:01:00Z",
+        },
+      ],
     });
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
@@ -370,10 +378,11 @@ describe("chat composer — default model resolution", () => {
     await expectThreadComposerShowsModel("GLM-5.1");
   });
 
-  // CHAT-DM-007: When the thread has no stored model but already has a user
-  // message, the composer shows the agent default as a locked SPAN — the
-  // thread is already mid-session so the picker cannot be reopened.
-  it("thread without override but with messages shows agent default as locked (CHAT-DM-007)", async () => {
+  // CHAT-DM-007: When the thread has no override, the composer on the
+  // thread page falls back to the agent default (same rule as on the
+  // landing page) — ensuring the override chain is consistent across both
+  // entry points.
+  it("thread without override falls back to the agent default (CHAT-DM-007)", async () => {
     mockOrgProviders({
       defaultProviderId: MOONSHOT_PROVIDER_ID,
       defaultSelectedModel: "kimi-k2.5",
@@ -382,22 +391,11 @@ describe("chat composer — default model resolution", () => {
       modelProviderId: ANTHROPIC_PROVIDER_ID,
       selectedModel: "claude-opus-4-7",
     });
-    mockThread({
-      modelProviderId: null,
-      selectedModel: null,
-      messages: [
-        {
-          id: "msg-user-1",
-          role: "user" as const,
-          content: "Hello",
-          createdAt: "2026-03-10T00:01:00Z",
-        },
-      ],
-    });
+    mockThread({ modelProviderId: null, selectedModel: null });
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    // Thread has a user message — picker is locked to agent default.
-    await expectThreadComposerShowsModel("Claude Opus 4.7");
+    // Thread has no stored values yet — picker remains interactive.
+    await expectComposerShowsModel("Claude Opus 4.7");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -174,6 +174,7 @@ function mockOrgProviders(options: {
 function mockThread(options: {
   modelProviderId: string | null;
   selectedModel: string | null;
+  messages?: Array<{ id: string; role: "user" | "assistant"; content: string; createdAt: string }>;
 }) {
   server.use(
     mockApi(chatThreadByIdContract.get, ({ respond }) => {
@@ -194,7 +195,7 @@ function mockThread(options: {
       });
     }),
     mockApi(chatThreadMessagesContract.list, ({ respond }) => {
-      return respond(200, { messages: [] });
+      return respond(200, { messages: options.messages ?? [] });
     }),
     mockApi(chatMessagesContract.send, ({ respond }) => {
       return respond(201, {
@@ -369,11 +370,10 @@ describe("chat composer — default model resolution", () => {
     await expectThreadComposerShowsModel("GLM-5.1");
   });
 
-  // CHAT-DM-007: When the thread has no override, the composer on the
-  // thread page falls back to the agent default (same rule as on the
-  // landing page) — ensuring the override chain is consistent across both
-  // entry points.
-  it("thread without override falls back to the agent default (CHAT-DM-007)", async () => {
+  // CHAT-DM-007: When the thread has no stored model but already has a user
+  // message, the composer shows the agent default as a locked SPAN — the
+  // thread is already mid-session so the picker cannot be reopened.
+  it("thread without override but with messages shows agent default as locked (CHAT-DM-007)", async () => {
     mockOrgProviders({
       defaultProviderId: MOONSHOT_PROVIDER_ID,
       defaultSelectedModel: "kimi-k2.5",
@@ -382,11 +382,22 @@ describe("chat composer — default model resolution", () => {
       modelProviderId: ANTHROPIC_PROVIDER_ID,
       selectedModel: "claude-opus-4-7",
     });
-    mockThread({ modelProviderId: null, selectedModel: null });
+    mockThread({
+      modelProviderId: null,
+      selectedModel: null,
+      messages: [
+        {
+          id: "msg-user-1",
+          role: "user" as const,
+          content: "Hello",
+          createdAt: "2026-03-10T00:01:00Z",
+        },
+      ],
+    });
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    // Thread has no stored values yet — picker remains interactive.
-    await expectComposerShowsModel("Claude Opus 4.7");
+    // Thread has a user message — picker is locked to agent default.
+    await expectThreadComposerShowsModel("Claude Opus 4.7");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
@@ -121,15 +121,13 @@ describe("chat thread page — model picker read-only", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const label = await waitFor(() => {
-      return screen.getByLabelText("Claude Sonnet 4.6");
-    });
+    const label = await waitFor(() =>
+      screen.getByLabelText("Claude Sonnet 4.6"),
+    );
     expect(label.tagName).toBe("SPAN");
-    await waitFor(() => {
-      return expect(
-        screen.queryByRole("combobox", { name: "Claude Sonnet 4.6" }),
-      ).toBeNull();
-    });
+    expect(
+      screen.queryByRole("combobox", { name: "Claude Sonnet 4.6" }),
+    ).toBeNull();
   });
 
   // CHAT-LOCK-002: thread with only assistant messages keeps the picker
@@ -154,9 +152,9 @@ describe("chat thread page — model picker read-only", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    await waitFor(() => {
-      return screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i });
-    });
+    await waitFor(() =>
+      screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
+    );
   });
 
   // CHAT-LOCK-003: empty thread keeps the picker interactive.
@@ -180,8 +178,8 @@ describe("chat thread page — model picker read-only", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    await waitFor(() => {
-      return screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i });
-    });
+    await waitFor(() =>
+      screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
+    );
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
@@ -41,7 +41,6 @@ const context = testContext();
 const mockApi = createMockApi(context);
 
 const PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
-const STORED_MODEL = "claude-opus-4-7";
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const THREAD_ID = "thread-readonly-1";
 
@@ -122,13 +121,15 @@ describe("chat thread page — model picker read-only", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const label = await waitFor(() =>
-      screen.getByLabelText("Claude Sonnet 4.6"),
-    );
+    const label = await waitFor(() => {
+      return screen.getByLabelText("Claude Sonnet 4.6");
+    });
     expect(label.tagName).toBe("SPAN");
-    expect(
-      screen.queryByRole("combobox", { name: "Claude Sonnet 4.6" }),
-    ).toBeNull();
+    await waitFor(() => {
+      return expect(
+        screen.queryByRole("combobox", { name: "Claude Sonnet 4.6" }),
+      ).toBeNull();
+    });
   });
 
   // CHAT-LOCK-002: thread with only assistant messages keeps the picker
@@ -153,9 +154,9 @@ describe("chat thread page — model picker read-only", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    await waitFor(() =>
-      screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
-    );
+    await waitFor(() => {
+      return screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i });
+    });
   });
 
   // CHAT-LOCK-003: empty thread keeps the picker interactive.
@@ -179,8 +180,8 @@ describe("chat thread page — model picker read-only", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    await waitFor(() =>
-      screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
-    );
+    await waitFor(() => {
+      return screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i });
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
@@ -1,20 +1,15 @@
 /**
- * Thread-page model picker is read-only.
+ * Thread-page model picker read-only behaviour.
  *
- * Rule: once a chat thread has been sent (modelProviderId + selectedModel
- * persisted on the row), the composer's model picker becomes read-only. The
- * user cannot change the thread's model — the backend also enforces this,
- * see route.test.ts.
+ * Rule: once a chat thread has at least one user message the composer's model
+ * picker becomes read-only. The provider must remain consistent within a
+ * session. Threads with only assistant messages (e.g. system-generated
+ * preambles) or no messages at all keep the picker interactive.
  *
  * Entry point: /chats/:threadId thread page.
  * Mock (external): Web API via MSW (feature switch + org providers + thread
- *   row with stored overrides).
+ *   messages via paginated endpoint).
  * Real (internal): routing, chat-thread-page signals, composer, picker.
- *
- * The parallel "picker is enabled on /agents/:id/chat" case is covered by
- * chat-default-model-resolution.test.tsx and chat-composer-model-selection-send.test.tsx
- * (both mount the landing page and interact with the picker), so we only
- * need to prove the lock is applied on the thread page here.
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
@@ -50,7 +45,37 @@ const STORED_MODEL = "claude-opus-4-7";
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const THREAD_ID = "thread-readonly-1";
 
-describe("chat thread page — model picker is read-only on existing threads", () => {
+const BASE_THREAD = {
+  id: THREAD_ID,
+  title: "My thread",
+  agentId: AGENT_ID,
+  chatMessages: [],
+  latestSessionId: null,
+  latestSessionProviderType: null,
+  activeRunIds: [],
+  createdAt: "2026-03-10T00:00:00Z",
+  updatedAt: "2026-03-10T00:00:00Z",
+  draftContent: null,
+  draftAttachments: null,
+  modelProviderId: null,
+  selectedModel: null,
+};
+
+const USER_MESSAGE = {
+  id: "msg-user-1",
+  role: "user" as const,
+  content: "Hello",
+  createdAt: "2026-03-10T00:01:00Z",
+};
+
+const ASSISTANT_MESSAGE = {
+  id: "msg-assistant-1",
+  role: "assistant" as const,
+  content: "Hi there",
+  createdAt: "2026-03-10T00:02:00Z",
+};
+
+describe("chat thread page — model picker read-only", () => {
   beforeEach(() => {
     resetMockOrgModelProviders();
     resetMockFeatureSwitches();
@@ -75,49 +100,87 @@ describe("chat thread page — model picker is read-only on existing threads", (
     ]);
   });
 
-  // CHAT-LOCK-001: picker on an existing thread renders as plain text — no
-  // combobox/button — so the user cannot switch models mid-thread.
-  it("renders the picker as plain text on /chats/:threadId when the thread has stored values (CHAT-LOCK-001)", async () => {
+  // CHAT-LOCK-001: picker on a thread with a user message renders as plain
+  // text — no combobox/button — so the provider cannot be switched mid-session.
+  it("renders picker as plain text when thread has a user message (CHAT-LOCK-001)", async () => {
     server.use(
-      mockApi(chatThreadByIdContract.get, ({ respond }) => {
-        return respond(200, {
-          id: THREAD_ID,
-          title: "My thread",
-          agentId: AGENT_ID,
-          chatMessages: [],
-          latestSessionId: null,
-          latestSessionProviderType: null,
-          activeRunIds: [],
-          createdAt: "2026-03-10T00:00:00Z",
-          updatedAt: "2026-03-10T00:00:00Z",
-          draftContent: null,
-          draftAttachments: null,
-          modelProviderId: PROVIDER_ID,
-          selectedModel: STORED_MODEL,
-        });
-      }),
-      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
-        return respond(200, { messages: [] });
-      }),
-      mockApi(chatMessagesContract.send, ({ respond }) => {
-        return respond(201, {
+      mockApi(chatThreadByIdContract.get, ({ respond }) =>
+        respond(200, { ...BASE_THREAD }),
+      ),
+      mockApi(chatThreadMessagesContract.list, ({ respond }) =>
+        respond(200, { messages: [USER_MESSAGE] }),
+      ),
+      mockApi(chatMessagesContract.send, ({ respond }) =>
+        respond(201, {
           runId: "run-test-1",
           threadId: THREAD_ID,
           status: "pending",
           createdAt: "2026-03-10T00:00:00Z",
-        });
-      }),
+        }),
+      ),
     );
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const label = await waitFor(() => {
-      return screen.getByLabelText("Claude Opus 4.7");
-    });
-    // Plain-text span, not a combobox/button — no dropdown affordance.
+    const label = await waitFor(() =>
+      screen.getByLabelText("Claude Sonnet 4.6"),
+    );
     expect(label.tagName).toBe("SPAN");
     expect(
-      screen.queryByRole("combobox", { name: "Claude Opus 4.7" }),
+      screen.queryByRole("combobox", { name: "Claude Sonnet 4.6" }),
     ).toBeNull();
+  });
+
+  // CHAT-LOCK-002: thread with only assistant messages keeps the picker
+  // interactive — no user turn has started a session yet.
+  it("keeps picker interactive when thread has only assistant messages (CHAT-LOCK-002)", async () => {
+    server.use(
+      mockApi(chatThreadByIdContract.get, ({ respond }) =>
+        respond(200, { ...BASE_THREAD }),
+      ),
+      mockApi(chatThreadMessagesContract.list, ({ respond }) =>
+        respond(200, { messages: [ASSISTANT_MESSAGE] }),
+      ),
+      mockApi(chatMessagesContract.send, ({ respond }) =>
+        respond(201, {
+          runId: "run-test-2",
+          threadId: THREAD_ID,
+          status: "pending",
+          createdAt: "2026-03-10T00:00:00Z",
+        }),
+      ),
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await waitFor(() =>
+      screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
+    );
+  });
+
+  // CHAT-LOCK-003: empty thread keeps the picker interactive.
+  it("keeps picker interactive on empty thread (CHAT-LOCK-003)", async () => {
+    server.use(
+      mockApi(chatThreadByIdContract.get, ({ respond }) =>
+        respond(200, { ...BASE_THREAD }),
+      ),
+      mockApi(chatThreadMessagesContract.list, ({ respond }) =>
+        respond(200, { messages: [] }),
+      ),
+      mockApi(chatMessagesContract.send, ({ respond }) =>
+        respond(201, {
+          runId: "run-test-3",
+          threadId: THREAD_ID,
+          status: "pending",
+          createdAt: "2026-03-10T00:00:00Z",
+        }),
+      ),
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await waitFor(() =>
+      screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
+    );
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
@@ -19,8 +19,8 @@ import {
   chatMessagesContract,
   chatThreadByIdContract,
   chatThreadMessagesContract,
+  type PagedChatMessage,
 } from "@vm0/core/contracts/chat-threads";
-import type { PagedChatMessage } from "@vm0/core/contracts/chat-threads";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
@@ -20,6 +20,7 @@ import {
   chatThreadByIdContract,
   chatThreadMessagesContract,
 } from "@vm0/core/contracts/chat-threads";
+import type { PagedChatMessage } from "@vm0/core/contracts/chat-threads";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -44,35 +45,60 @@ const PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const THREAD_ID = "thread-readonly-1";
 
-const BASE_THREAD = {
-  id: THREAD_ID,
-  title: "My thread",
-  agentId: AGENT_ID,
-  chatMessages: [],
-  latestSessionId: null,
-  latestSessionProviderType: null,
-  activeRunIds: [],
-  createdAt: "2026-03-10T00:00:00Z",
-  updatedAt: "2026-03-10T00:00:00Z",
-  draftContent: null,
-  draftAttachments: null,
-  modelProviderId: null,
-  selectedModel: null,
-};
+function makeThreadDetail() {
+  return {
+    id: THREAD_ID,
+    title: "My thread",
+    agentId: AGENT_ID,
+    chatMessages: [],
+    latestSessionId: null,
+    latestSessionProviderType: null,
+    activeRunIds: [],
+    createdAt: "2026-03-10T00:00:00Z",
+    updatedAt: "2026-03-10T00:00:00Z",
+    draftContent: null,
+    draftAttachments: null,
+    modelProviderId: null,
+    selectedModel: null,
+  };
+}
 
-const USER_MESSAGE = {
-  id: "msg-user-1",
-  role: "user" as const,
-  content: "Hello",
-  createdAt: "2026-03-10T00:01:00Z",
-};
+function makeUserMessage(): PagedChatMessage {
+  return {
+    id: "msg-user-1",
+    role: "user",
+    content: "Hello",
+    createdAt: "2026-03-10T00:01:00Z",
+  };
+}
 
-const ASSISTANT_MESSAGE = {
-  id: "msg-assistant-1",
-  role: "assistant" as const,
-  content: "Hi there",
-  createdAt: "2026-03-10T00:02:00Z",
-};
+function makeAssistantMessage(): PagedChatMessage {
+  return {
+    id: "msg-assistant-1",
+    role: "assistant",
+    content: "Hi there",
+    createdAt: "2026-03-10T00:02:00Z",
+  };
+}
+
+function setupMocks(messages: PagedChatMessage[]) {
+  server.use(
+    mockApi(chatThreadByIdContract.get, ({ respond }) => {
+      return respond(200, makeThreadDetail());
+    }),
+    mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+      return respond(200, { messages });
+    }),
+    mockApi(chatMessagesContract.send, ({ respond }) => {
+      return respond(201, {
+        runId: "run-test-1",
+        threadId: THREAD_ID,
+        status: "pending",
+        createdAt: "2026-03-10T00:00:00Z",
+      });
+    }),
+  );
+}
 
 describe("chat thread page — model picker read-only", () => {
   beforeEach(() => {
@@ -102,28 +128,13 @@ describe("chat thread page — model picker read-only", () => {
   // CHAT-LOCK-001: picker on a thread with a user message renders as plain
   // text — no combobox/button — so the provider cannot be switched mid-session.
   it("renders picker as plain text when thread has a user message (CHAT-LOCK-001)", async () => {
-    server.use(
-      mockApi(chatThreadByIdContract.get, ({ respond }) =>
-        respond(200, { ...BASE_THREAD }),
-      ),
-      mockApi(chatThreadMessagesContract.list, ({ respond }) =>
-        respond(200, { messages: [USER_MESSAGE] }),
-      ),
-      mockApi(chatMessagesContract.send, ({ respond }) =>
-        respond(201, {
-          runId: "run-test-1",
-          threadId: THREAD_ID,
-          status: "pending",
-          createdAt: "2026-03-10T00:00:00Z",
-        }),
-      ),
-    );
+    setupMocks([makeUserMessage()]);
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const label = await waitFor(() =>
-      screen.getByLabelText("Claude Sonnet 4.6"),
-    );
+    const label = await waitFor(() => {
+      return screen.getByLabelText("Claude Sonnet 4.6");
+    });
     expect(label.tagName).toBe("SPAN");
     expect(
       screen.queryByRole("combobox", { name: "Claude Sonnet 4.6" }),
@@ -133,53 +144,23 @@ describe("chat thread page — model picker read-only", () => {
   // CHAT-LOCK-002: thread with only assistant messages keeps the picker
   // interactive — no user turn has started a session yet.
   it("keeps picker interactive when thread has only assistant messages (CHAT-LOCK-002)", async () => {
-    server.use(
-      mockApi(chatThreadByIdContract.get, ({ respond }) =>
-        respond(200, { ...BASE_THREAD }),
-      ),
-      mockApi(chatThreadMessagesContract.list, ({ respond }) =>
-        respond(200, { messages: [ASSISTANT_MESSAGE] }),
-      ),
-      mockApi(chatMessagesContract.send, ({ respond }) =>
-        respond(201, {
-          runId: "run-test-2",
-          threadId: THREAD_ID,
-          status: "pending",
-          createdAt: "2026-03-10T00:00:00Z",
-        }),
-      ),
-    );
+    setupMocks([makeAssistantMessage()]);
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    await waitFor(() =>
-      screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
-    );
+    await waitFor(() => {
+      return screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i });
+    });
   });
 
   // CHAT-LOCK-003: empty thread keeps the picker interactive.
   it("keeps picker interactive on empty thread (CHAT-LOCK-003)", async () => {
-    server.use(
-      mockApi(chatThreadByIdContract.get, ({ respond }) =>
-        respond(200, { ...BASE_THREAD }),
-      ),
-      mockApi(chatThreadMessagesContract.list, ({ respond }) =>
-        respond(200, { messages: [] }),
-      ),
-      mockApi(chatMessagesContract.send, ({ respond }) =>
-        respond(201, {
-          runId: "run-test-3",
-          threadId: THREAD_ID,
-          status: "pending",
-          createdAt: "2026-03-10T00:00:00Z",
-        }),
-      ),
-    );
+    setupMocks([]);
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    await waitFor(() =>
-      screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
-    );
+    await waitFor(() => {
+      return screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i });
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -356,6 +356,7 @@ function ChatThreadComposer({
 }) {
   const groups = useLastResolved(thread.groupedChatMessages$) ?? [];
   const hasMessages = groups.length > 0;
+  const hasUserMessages = groups.some((g) => g.role === "user");
   const displayName = useLastResolved(thread.agentDisplayName$) ?? "Zero";
   const allFinishedLoadable = useLastLoadable(thread.allFinished$);
   const allFinished =
@@ -445,10 +446,10 @@ function ChatThreadComposer({
                   onChange: setModelSelection,
                   sessionProviderType:
                     threadData?.latestSessionProviderType ?? null,
-                  // Lock as soon as the thread has any messages — provider
+                  // Lock as soon as the thread has a user message — provider
                   // must stay consistent within a session to maintain
                   // continuity.
-                  disabled: hasMessages,
+                  disabled: hasUserMessages,
                   agentDefault: agentModelDefault,
                 }
               : undefined

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -445,11 +445,10 @@ function ChatThreadComposer({
                   onChange: setModelSelection,
                   sessionProviderType:
                     threadData?.latestSessionProviderType ?? null,
-                  // Lock once the thread has stored values — mirrors the
-                  // backend guard in rejectIfThreadModelLocked.
-                  disabled: Boolean(
-                    threadData?.modelProviderId && threadData?.selectedModel,
-                  ),
+                  // Lock as soon as the thread has any messages — provider
+                  // must stay consistent within a session to maintain
+                  // continuity.
+                  disabled: hasMessages,
                   agentDefault: agentModelDefault,
                 }
               : undefined

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -356,7 +356,9 @@ function ChatThreadComposer({
 }) {
   const groups = useLastResolved(thread.groupedChatMessages$) ?? [];
   const hasMessages = groups.length > 0;
-  const hasUserMessages = groups.some((g) => g.role === "user");
+  const hasUserMessages = groups.some((g) => {
+    return g.role === "user";
+  });
   const displayName = useLastResolved(thread.agentDisplayName$) ?? "Zero";
   const allFinishedLoadable = useLastLoadable(thread.allFinished$);
   const allFinished =


### PR DESCRIPTION
## Summary

- The model provider picker was previously only disabled when `modelProviderId` **and** `selectedModel` were both persisted in the DB — meaning threads using the default model remained unlocked indefinitely.
- Changed the disable condition to `hasUserMessages` so the picker locks as soon as the thread has at least one user message.
- Threads with only assistant messages (e.g. system-generated preambles) or empty threads keep the picker interactive.
- Prevents mid-conversation provider switches that would break session continuity.

## Root cause

\`\`\`ts
// Before — only locked if user had previously selected a custom model
disabled: Boolean(threadData?.modelProviderId && threadData?.selectedModel)

// After — locked whenever there is at least one user message
disabled: hasUserMessages
\`\`\`

## Test plan

- [x] New thread (no messages): model provider picker is enabled (CHAT-LOCK-003)
- [x] Thread with at least one user message: picker is disabled (CHAT-LOCK-001)
- [x] Thread with only assistant messages (e.g. system preamble): picker stays enabled (CHAT-LOCK-002)
- [x] Thread created with default agent model (no explicit picker selection): picker is disabled after first user message