### PR TITLE
fix(guest-download): don't delete staged tarball after extraction

### DIFF
--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -435,19 +435,15 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
     // Obtain a reader for the archive bytes. HTTP is the production path today;
     // file:// is used by the runner-side storage cache (epic #10800) to feed
     // host-staged tarballs that were pushed into the guest over vsock.
-    let local_path: Option<PathBuf>;
     let reader: Box<dyn Read> = if let Some(path) = url.strip_prefix("file://") {
-        let path_buf = PathBuf::from(path);
         log_info!(LOG_TAG, "Reading local archive from {path}");
-        let file = fs::File::open(&path_buf).map_err(|e| DownloadError {
+        let file = fs::File::open(path).map_err(|e| DownloadError {
             message: format!("Failed to open local archive {path}: {e}"),
             retriable: false,
             status_code: None,
         })?;
-        local_path = Some(path_buf);
         Box::new(file)
     } else {
-        local_path = None;
         let response = HTTP_AGENT.get(url).call().map_err(|e| {
             let (retriable, status_code) = match &e {
                 // Retry on server errors (5xx) and rate limiting (429)
@@ -583,19 +579,6 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
             retriable: false,
             status_code: None,
         })?;
-    }
-
-    // For file:// URLs, drop the staged tarball now that extraction succeeded so it
-    // doesn't pin COW space for the lifetime of the sandbox. Failure is not fatal —
-    // the runner stages these under /tmp, which is wiped on VM teardown anyway.
-    if let Some(path) = local_path
-        && let Err(e) = fs::remove_file(&path)
-    {
-        log_warn!(
-            LOG_TAG,
-            "Failed to remove staged archive {}: {e}",
-            path.display()
-        );
     }
 
     Ok(())

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -1107,8 +1107,10 @@ fn symlink_missing_link_target_skipped() {
 // file:// scheme — host-staged tarballs (epic #10800)
 // ---------------------------------------------------------------------------
 
-// Successful file:// extraction: the local tarball is read, its contents are
-// extracted into the mount path, and the tarball is deleted.
+// Successful file:// extraction: the local tarball is read and its contents are
+// extracted into the mount path. The staged tarball is intentionally left in
+// place — /tmp is wiped on VM teardown, and deleting it early breaks runs where
+// two manifest entries share the same staged path.
 #[test]
 fn file_scheme_extraction_success() {
     let tar_gz = create_tar_gz(&[("hello.txt", b"hello from file")]).unwrap();
@@ -1128,8 +1130,8 @@ fn file_scheme_extraction_success() {
         std::fs::read_to_string(mount.join("hello.txt")).unwrap(),
         "hello from file"
     );
-    // Staged tarball is cleaned up after successful extraction
-    assert!(!staged.exists());
+    // Staged tarball is preserved — runner cleans /tmp on VM teardown.
+    assert!(staged.exists());
 }
 
 // Storage with a missing file:// target fails the run. The runner only rewrites


### PR DESCRIPTION
## Summary

Removes the `fs::remove_file` call introduced in #10812 (`crates/guest-download/src/lib.rs:591-599`).

**Root cause of the bug:** Two manifest entries can share the same `file://` guest path when they resolve to the same `(vasStorageName, vasVersionId)` pair — e.g. a user artifact named `"memory"` collides with the auto-synthesized memory additional artifact (both resolve to the same storage row in the DB). `storage_cache.rs` stages one tarball and rewrites both entries to the same `file://` URL. `guest-download` then spawns two parallel `DownloadTask` threads for that URL. The first thread to finish extraction calls `remove_file`; the second thread's `File::open` returns `ENOENT` → `DownloadError { retriable: false }` → run fails.

**Why the deletion is safe to remove:** The comment on the deleted block already says:
> "the runner stages these under /tmp, which is wiped on VM teardown anyway"

The deletion was a pure COW-space optimisation with no correctness value. Removing it makes the `file://` path safe regardless of how many manifest entries share a staged tarball.

## Changes

- `crates/guest-download/src/lib.rs` — remove the 12-line `remove_file` block and the now-unused `local_path` variable / `path_buf` binding
- `crates/guest-download/tests/integration.rs` — update `file_scheme_extraction_success` to assert the staged tarball is **preserved** (was asserting deletion)

## Test plan

- [x] Existing `cargo test -p guest-download` suite passes (25 unit + 29 integration, including the 3 `file_scheme_*` tests)
- [x] No new tests needed — the correctness property (shared `file://` path succeeds) is exercised by any two-artifact run with a `(name, version)` collision; the unit behaviour change is captured by the updated `file_scheme_extraction_success` assertion

Fixes the production runner crash observed after #10812 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)