### PR TITLE
refactor(infra): unify artifact model with tolerant resolvers

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1675,7 +1675,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
   describe("Multi-Mount Artifacts (body.artifacts)", () => {
     it("should pipe body.artifacts through storage manifest", async () => {
-      // Pre-seed two artifacts so resolveAdditionalArtifact finds real storages.
+      // Pre-seed two artifacts so the unified resolver finds real storages.
       const artifactA = uniqueId("multi-art-a");
       const artifactB = uniqueId("multi-art-b");
       await createTestArtifact(artifactA);
@@ -1704,14 +1704,19 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();
+      // Zero also auto-injects "memory" at its well-known mount, so the
+      // manifest carries three entries: the two body artifacts plus memory.
       const artifacts = job!.executionContext.storageManifest!.artifacts;
-      expect(artifacts).toHaveLength(2);
-      const mountPaths = artifacts.map((a) => {
+      const userArtifacts = artifacts.filter((a) => {
+        return a.vasStorageName !== "memory";
+      });
+      expect(userArtifacts).toHaveLength(2);
+      const mountPaths = userArtifacts.map((a) => {
         return a.mountPath;
       });
       expect(mountPaths).toContain("/mnt/a");
       expect(mountPaths).toContain("/mnt/b");
-      const names = artifacts.map((a) => {
+      const names = userArtifacts.map((a) => {
         return a.vasStorageName;
       });
       expect(names).toContain(artifactA);

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -15,7 +15,10 @@ import {
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
-import { type AdditionalVolume } from "../../../../src/lib/infra/storage/types";
+import {
+  type AdditionalVolume,
+  AUTO_MEMORY_ARTIFACT_NAME,
+} from "../../../../src/lib/infra/storage/types";
 import { and, eq, inArray, desc, gte, lte, sql } from "drizzle-orm";
 import {
   loadCompose,
@@ -24,6 +27,7 @@ import {
   markRunFailed,
   type RunDispatchError,
 } from "../../../../src/lib/infra/run";
+import type { ContextArtifact } from "../../../../src/lib/infra/run/types";
 import {
   requireAuth,
   isAuthError,
@@ -335,7 +339,15 @@ const router = tsr.router(runsMainContract, {
         resolvedAdditionalVolumes: resolved.additionalVolumes,
       });
 
-      // 7. Concurrency check + INSERT (transaction with advisory lock)
+      // 7. Merge artifacts: resolved (checkpoint/session snapshot) first,
+      //    body.artifacts (CLI --artifact flag) second so per-run overrides
+      //    win dedup-by-name in prepareStorageManifest.
+      const mergedArtifacts: ContextArtifact[] = [
+        ...resolved.artifacts,
+        ...(body.artifacts ?? []),
+      ];
+
+      // 8. Concurrency check + INSERT (transaction with advisory lock)
       const run = await globalThis.services.db.transaction(async (tx) => {
         await tx.execute(
           sql`SELECT pg_advisory_xact_lock(hashtext(${org.orgId}))`,
@@ -353,17 +365,18 @@ const router = tsr.router(runsMainContract, {
           additionalVolumes: finalAdditionalVolumes,
           resumedFromCheckpointId: body.checkpointId,
           sessionId: body.sessionId,
-          // For new runs, populate agent_sessions.artifact_names from body.artifacts
-          // (CLI --artifact flag) so future continues can resolve the mount set.
+          // For new runs, seed agent_sessions.artifact_names from the merged
+          // list so future continues can resolve the mount set. Skip the
+          // auto-injected memory entry: it is re-appended on every run by the
+          // zero layer and should not be recorded as a user-declared artifact.
           // For resumes, this is unused since the existing session row is reused.
-          artifacts:
-            body.artifacts && body.artifacts.length > 0
-              ? Object.fromEntries(
-                  body.artifacts.map((a) => {
-                    return [a.name, a.version ?? "latest"];
-                  }),
-                )
-              : resolved.artifacts,
+          artifactNames: mergedArtifacts
+            .filter((a) => {
+              return a.name !== AUTO_MEMORY_ARTIFACT_NAME;
+            })
+            .map((a) => {
+              return a.name;
+            }),
         });
       });
       const transactionTime = Date.now();
@@ -390,8 +403,7 @@ const router = tsr.router(runsMainContract, {
           vars: resolved.vars ?? body.vars,
           secrets: resolved.secrets ?? body.secrets,
           secretConnectorMap: resolved.secretConnectorMap,
-          artifacts: resolved.artifacts,
-          additionalArtifacts: body.artifacts,
+          artifacts: mergedArtifacts,
           volumeVersions: resolved.volumeVersions ?? body.volumeVersions,
           additionalVolumes: finalAdditionalVolumes,
           environment: resolved.environment,

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -501,6 +501,53 @@ export async function setTestChatMessageAttachFiles(
 }
 
 /**
+ * Overwrite `agent_sessions.artifact_names` for a session.
+ *
+ * @why-db-direct `agent_sessions.artifact_names` is written by the run
+ * pipeline from the resolved artifact list. Resolver tests need to seed
+ * arbitrary name lists (including the auto-memory name) to exercise the
+ * mountPath heuristic expansion.
+ */
+export async function setTestSessionArtifactNames(
+  sessionId: string,
+  artifactNames: string[],
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(agentSessions)
+    .set({ artifactNames })
+    .where(eq(agentSessions.id, sessionId));
+}
+
+/**
+ * Update the cliAgentType on the conversation linked to a session.
+ *
+ * @why-db-direct Test checkpoint helpers seed conversations with
+ * cliAgentType "test-agent" while composes default to framework
+ * "claude-code". Resolver compatibility checks compare these, so
+ * resolveSession tests need to align the conversation framework before
+ * invoking the resolver.
+ */
+export async function setTestSessionFramework(
+  sessionId: string,
+  framework: string,
+): Promise<void> {
+  initServices();
+  const [session] = await globalThis.services.db
+    .select({ conversationId: agentSessions.conversationId })
+    .from(agentSessions)
+    .where(eq(agentSessions.id, sessionId))
+    .limit(1);
+  if (!session?.conversationId) {
+    throw new Error(`Session ${sessionId} has no conversation`);
+  }
+  await globalThis.services.db
+    .update(conversations)
+    .set({ cliAgentType: framework })
+    .where(eq(conversations.id, session.conversationId));
+}
+
+/**
  * Overwrite `chat_messages.content` for every row belonging to a run.
  *
  * @why-db-direct Simulates an overlong user body without exercising the

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -9,6 +9,7 @@ import {
 } from "../../db/schema/agent-compose";
 import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
 import { agentRunQueue } from "../../db/schema/agent-run-queue";
+import { checkpoints } from "../../db/schema/checkpoint";
 import { conversations } from "../../db/schema/conversation";
 import { sandboxTelemetry } from "../../db/schema/sandbox-telemetry";
 import { usageDaily } from "../../db/schema/usage-daily";
@@ -697,4 +698,22 @@ export async function insertTestUsageDaily(params: {
     date: params.date,
     runCount: 5,
   });
+}
+
+/**
+ * Overwrite `checkpoints.artifact_snapshots` JSONB for a checkpoint.
+ *
+ * @why-db-direct `checkpoints.artifact_snapshots` is written by the
+ * checkpoint webhook during run completion. Resolver tests need to seed
+ * arbitrary legacy and new-shape payloads to exercise shape tolerance.
+ */
+export async function setTestCheckpointArtifactSnapshots(
+  checkpointId: string,
+  snapshots: unknown,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(checkpoints)
+    .set({ artifactSnapshots: snapshots })
+    .where(eq(checkpoints.id, checkpointId));
 }

--- a/turbo/apps/web/src/lib/infra/run/context/build-context.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/build-context.ts
@@ -1,6 +1,10 @@
 import { expandEnvironmentFromCompose } from "../environment/expand-environment";
-import type { ExecutionContext, ResumeSession } from "../types";
-import type { AdditionalArtifact, AdditionalVolume } from "../../storage/types";
+import type {
+  ContextArtifact,
+  ExecutionContext,
+  ResumeSession,
+} from "../types";
+import type { AdditionalVolume } from "../../storage/types";
 import type { Firewalls, NetworkPolicies } from "@vm0/core/contracts/firewalls";
 
 interface BuildInfraContextParams {
@@ -15,8 +19,7 @@ interface BuildInfraContextParams {
   vars?: Record<string, string>;
   secrets?: Record<string, string>;
   secretConnectorMap?: Record<string, string>;
-  artifacts?: Record<string, string>;
-  additionalArtifacts?: AdditionalArtifact[];
+  artifacts?: ContextArtifact[];
   volumeVersions?: Record<string, string>;
   additionalVolumes?: AdditionalVolume[];
   environment?: Record<string, string>;
@@ -72,7 +75,6 @@ export function buildInfraExecutionContext(
     secretConnectorMap: params.secretConnectorMap,
     sandboxToken: params.sandboxToken,
     artifacts: params.artifacts,
-    additionalArtifacts: params.additionalArtifacts,
     volumeVersions: params.volumeVersions,
     additionalVolumes: params.additionalVolumes,
     environment,

--- a/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
@@ -115,22 +115,16 @@ export async function prepareForExecution(
 
   const agentOrgId = agentComposeInfo.orgId;
 
-  // Auto-create artifact storages if they don't exist yet. Primary artifacts
-  // come from context.artifacts (name → version map); additional artifacts
-  // (with explicit mount paths) come from context.additionalArtifacts. Memory
-  // rides in additionalArtifacts (zero synthesizes it). Infra no longer
-  // creates type='memory' rows — #10601 flipped existing rows to
-  // type='artifact'.
-  const primaryArtifacts = context.artifacts ?? {};
+  // Auto-create artifact storages if they don't exist yet. Every entry in the
+  // unified artifact list already carries its own mountPath (zero synthesizes
+  // the memory entry); infra creates one storage row per entry.
+  const artifacts = context.artifacts ?? [];
   const ensureStart = Date.now();
-  await Promise.all([
-    ...Object.keys(primaryArtifacts).map((name) => {
-      return ensureStorageExists(orgId, userId, name, "artifact");
-    }),
-    ...(context.additionalArtifacts ?? []).map((entry) => {
+  await Promise.all(
+    artifacts.map((entry) => {
       return ensureStorageExists(orgId, userId, entry.name, "artifact");
     }),
-  ]);
+  );
   const ensureEnd = Date.now();
 
   // Prepare storage manifest with dual orgs (see docs/resource-model.md)
@@ -143,11 +137,9 @@ export async function prepareForExecution(
     agentOrgId,
     orgId,
     userId,
-    primaryArtifacts,
-    workingDir,
+    artifacts,
     context.volumeVersions,
     context.additionalVolumes,
-    context.additionalArtifacts,
   );
   const storageEnd = Date.now();
 
@@ -231,9 +223,6 @@ function buildPreparedContext(
     secretConnectorMap: context.secretConnectorMap || null,
     // Resume support
     resumeSession: context.resumeSession || null,
-
-    // Primary artifacts (name → version)
-    artifacts: context.artifacts ?? {},
 
     // Firewall for proxy-side token replacement
     firewalls: toNullable(context.firewalls),

--- a/turbo/apps/web/src/lib/infra/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/types.ts
@@ -34,9 +34,6 @@ export interface PreparedContext {
   // Resume support
   resumeSession: ResumeSession | null;
 
-  // Primary artifacts (name → version). Empty record when the run has none.
-  artifacts: Record<string, string>;
-
   // Firewall for proxy-side token replacement (complete config, all permissions)
   firewalls: Firewalls | null;
 

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-checkpoint.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-checkpoint.test.ts
@@ -87,4 +87,33 @@ describe("resolveCheckpoint — artifactSnapshots shape tolerance", () => {
 
     expect(resolution.artifacts).toEqual([]);
   });
+
+  it("rejects malformed array entries with a descriptive error", async () => {
+    const { runId } = await createTestRun(composeId, "malformed array run");
+    const { checkpointId } = await createTestCheckpoint(user.userId, runId);
+
+    // Array-shape snapshot with a malformed entry (missing mountPath).
+    // Bypass the ContextArtifact type so we can stuff a bad payload into jsonb.
+    await setTestCheckpointArtifactSnapshots(checkpointId, [
+      { name: "bad" },
+    ] as unknown as ContextArtifact[]);
+
+    await expect(resolveCheckpoint(checkpointId, user.userId)).rejects.toThrow(
+      /artifactSnapshots\[0\]/,
+    );
+  });
+
+  it("rejects legacy Record entries with non-string versions", async () => {
+    const { runId } = await createTestRun(composeId, "malformed record run");
+    const { checkpointId } = await createTestCheckpoint(user.userId, runId);
+
+    // Legacy Record shape where a version is not a string.
+    await setTestCheckpointArtifactSnapshots(checkpointId, {
+      bad: 42,
+    } as unknown as Record<string, string>);
+
+    await expect(resolveCheckpoint(checkpointId, user.userId)).rejects.toThrow(
+      /"bad"/,
+    );
+  });
 });

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-checkpoint.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-checkpoint.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { resolveCheckpoint } from "../resolve-checkpoint";
+import {
+  createTestCheckpoint,
+  createTestCompose,
+  createTestRun,
+} from "../../../../../__tests__/api-test-helpers";
+import { setTestCheckpointArtifactSnapshots } from "../../../../../__tests__/db-test-seeders/runs";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../__tests__/test-helpers";
+import {
+  AUTO_MEMORY_ARTIFACT_NAME,
+  AUTO_MEMORY_MOUNT_PATH,
+} from "../../../storage/types";
+import type { ContextArtifact } from "../../types";
+
+const context = testContext();
+
+const WORKING_DIR = "/home/user/workspace";
+
+describe("resolveCheckpoint — artifactSnapshots shape tolerance", () => {
+  let user: UserContext;
+  let composeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    const compose = await createTestCompose(uniqueId("cp-resolver"));
+    composeId = compose.composeId;
+  });
+
+  it("decodes legacy Record<name, version> via mountPath heuristic", async () => {
+    const { runId } = await createTestRun(composeId, "legacy shape run");
+    const { checkpointId } = await createTestCheckpoint(user.userId, runId);
+
+    await setTestCheckpointArtifactSnapshots(checkpointId, {
+      [AUTO_MEMORY_ARTIFACT_NAME]: "v-mem",
+      "my-artifact": "v-art",
+    });
+
+    const resolution = await resolveCheckpoint(checkpointId, user.userId);
+
+    expect(resolution.artifacts).toHaveLength(2);
+    const byName = Object.fromEntries(
+      resolution.artifacts.map((a) => {
+        return [a.name, a];
+      }),
+    );
+    expect(byName[AUTO_MEMORY_ARTIFACT_NAME]).toEqual({
+      name: AUTO_MEMORY_ARTIFACT_NAME,
+      version: "v-mem",
+      mountPath: AUTO_MEMORY_MOUNT_PATH,
+    });
+    expect(byName["my-artifact"]).toEqual({
+      name: "my-artifact",
+      version: "v-art",
+      mountPath: WORKING_DIR,
+    });
+  });
+
+  it("passes new-shape ContextArtifact[] through unchanged", async () => {
+    const { runId } = await createTestRun(composeId, "new shape run");
+    const { checkpointId } = await createTestCheckpoint(user.userId, runId);
+
+    const newShape: ContextArtifact[] = [
+      { name: "m", version: "v", mountPath: "/custom/mount" },
+      { name: "n", version: "w", mountPath: "/another" },
+    ];
+
+    await setTestCheckpointArtifactSnapshots(checkpointId, newShape);
+
+    const resolution = await resolveCheckpoint(checkpointId, user.userId);
+
+    expect(resolution.artifacts).toEqual(newShape);
+  });
+
+  it("returns empty artifact list when artifactSnapshots is null", async () => {
+    const { runId } = await createTestRun(composeId, "null snapshot run");
+    const { checkpointId } = await createTestCheckpoint(user.userId, runId);
+
+    await setTestCheckpointArtifactSnapshots(checkpointId, null);
+
+    const resolution = await resolveCheckpoint(checkpointId, user.userId);
+
+    expect(resolution.artifacts).toEqual([]);
+  });
+});

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { resolveSession } from "../resolve-session";
+import {
+  completeTestRun,
+  createTestCompose,
+  createTestRun,
+} from "../../../../../__tests__/api-test-helpers";
+import {
+  setTestSessionArtifactNames,
+  setTestSessionFramework,
+} from "../../../../../__tests__/db-test-seeders/agents";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../__tests__/test-helpers";
+import {
+  AUTO_MEMORY_ARTIFACT_NAME,
+  AUTO_MEMORY_MOUNT_PATH,
+} from "../../../storage/types";
+
+const context = testContext();
+
+const WORKING_DIR = "/home/user/workspace";
+
+describe("resolveSession — artifactNames expansion", () => {
+  let user: UserContext;
+  let composeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    const compose = await createTestCompose(uniqueId("sess-resolver"));
+    composeId = compose.composeId;
+  });
+
+  it("expands session.artifactNames via mountPath heuristic with version 'latest'", async () => {
+    const { runId } = await createTestRun(composeId, "session expansion run");
+    const { agentSessionId } = await completeTestRun(user.userId, runId);
+    await setTestSessionFramework(agentSessionId, "claude-code");
+    await setTestSessionArtifactNames(agentSessionId, [
+      AUTO_MEMORY_ARTIFACT_NAME,
+      "ctx",
+    ]);
+
+    const resolution = await resolveSession(agentSessionId, user.userId);
+
+    expect(resolution.artifacts).toHaveLength(2);
+    const byName = Object.fromEntries(
+      resolution.artifacts.map((a) => {
+        return [a.name, a];
+      }),
+    );
+    expect(byName[AUTO_MEMORY_ARTIFACT_NAME]).toEqual({
+      name: AUTO_MEMORY_ARTIFACT_NAME,
+      version: "latest",
+      mountPath: AUTO_MEMORY_MOUNT_PATH,
+    });
+    expect(byName["ctx"]).toEqual({
+      name: "ctx",
+      version: "latest",
+      mountPath: WORKING_DIR,
+    });
+  });
+
+  it("returns empty artifact list when session has no artifactNames", async () => {
+    const { runId } = await createTestRun(composeId, "empty session run");
+    const { agentSessionId } = await completeTestRun(user.userId, runId);
+    await setTestSessionFramework(agentSessionId, "claude-code");
+    await setTestSessionArtifactNames(agentSessionId, []);
+
+    const resolution = await resolveSession(agentSessionId, user.userId);
+
+    expect(resolution.artifacts).toEqual([]);
+  });
+});

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
@@ -11,6 +11,11 @@ import type {
 } from "../../checkpoint/types";
 import type { AgentComposeYaml } from "../../agent-compose/types";
 import type { ConversationResolution } from "./types";
+import type { ContextArtifact } from "../types";
+import {
+  AUTO_MEMORY_ARTIFACT_NAME,
+  AUTO_MEMORY_MOUNT_PATH,
+} from "../../storage/types";
 import { extractWorkingDir } from "../utils";
 import { resolveSessionHistory } from "./resolve-session-history";
 
@@ -42,12 +47,14 @@ export async function resolveCheckpoint(
     throw notFound("Checkpoint not found");
   }
 
-  // Extract snapshots. Artifact name/version pairs are stored directly in
+  // Extract snapshots. Artifact entries are stored directly in
   // checkpoint.artifactSnapshots — no join to agent_sessions required.
   const agentComposeSnapshot =
     checkpoint.agentComposeSnapshot as unknown as AgentComposeSnapshot;
-  const artifacts =
-    (checkpoint.artifactSnapshots as Record<string, string> | null) ?? {};
+  const rawArtifacts = checkpoint.artifactSnapshots as
+    | Record<string, string>
+    | ContextArtifact[]
+    | null;
   const checkpointVolumeVersions =
     checkpoint.volumeVersionsSnapshot as VolumeVersionsSnapshot | null;
 
@@ -118,12 +125,14 @@ export async function resolveCheckpoint(
     throw notFound(`Agent compose version ${agentComposeVersionId} not found`);
   }
   const agentCompose = version.content as AgentComposeYaml;
+  const workingDir = extractWorkingDir(agentCompose);
+  const artifacts = decodeCheckpointArtifacts(rawArtifacts, workingDir);
 
   return {
     conversationId: checkpoint.conversationId,
     agentComposeVersionId,
     agentCompose,
-    workingDir: extractWorkingDir(agentCompose),
+    workingDir,
     conversationData: {
       cliAgentSessionId: conversation.cliAgentSessionId,
       cliAgentSessionHistory: sessionHistory,
@@ -133,4 +142,30 @@ export async function resolveCheckpoint(
     volumeVersions: checkpointVolumeVersions?.versions,
     additionalVolumes: checkpointAdditionalVolumes,
   };
+}
+
+/**
+ * Decode checkpoint.artifactSnapshots into the unified ContextArtifact[] form.
+ *
+ * Accepts both shapes:
+ * - Legacy: `Record<name, version>` — stamped with a mountPath via the name
+ *   heuristic ("memory" → AUTO_MEMORY_MOUNT_PATH, anything else → workingDir).
+ * - New: `Array<{name, version, mountPath}>` — passed through unchanged.
+ */
+function decodeCheckpointArtifacts(
+  raw: Record<string, string> | ContextArtifact[] | null,
+  workingDir: string,
+): ContextArtifact[] {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw;
+  return Object.entries(raw).map(([name, version]) => {
+    return {
+      name,
+      version,
+      mountPath:
+        name === AUTO_MEMORY_ARTIFACT_NAME
+          ? AUTO_MEMORY_MOUNT_PATH
+          : workingDir,
+    };
+  });
 }

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
@@ -51,10 +51,9 @@ export async function resolveCheckpoint(
   // checkpoint.artifactSnapshots — no join to agent_sessions required.
   const agentComposeSnapshot =
     checkpoint.agentComposeSnapshot as unknown as AgentComposeSnapshot;
-  const rawArtifacts = checkpoint.artifactSnapshots as
-    | Record<string, string>
-    | ContextArtifact[]
-    | null;
+  // artifactSnapshots is a Drizzle jsonb column (runtime type `unknown`).
+  // decodeCheckpointArtifacts does the runtime shape check; never cast here.
+  const rawArtifacts: unknown = checkpoint.artifactSnapshots;
   const checkpointVolumeVersions =
     checkpoint.volumeVersionsSnapshot as VolumeVersionsSnapshot | null;
 
@@ -147,25 +146,65 @@ export async function resolveCheckpoint(
 /**
  * Decode checkpoint.artifactSnapshots into the unified ContextArtifact[] form.
  *
+ * Input is a Drizzle `jsonb` column (runtime type `unknown`), so every branch
+ * must validate the shape at runtime — a malformed historical row should fail
+ * fast here with a descriptive error rather than surface much later as an
+ * opaque mount failure.
+ *
  * Accepts both shapes:
  * - Legacy: `Record<name, version>` — stamped with a mountPath via the name
  *   heuristic ("memory" → AUTO_MEMORY_MOUNT_PATH, anything else → workingDir).
- * - New: `Array<{name, version, mountPath}>` — passed through unchanged.
+ * - New: `Array<{name, version?, mountPath}>` — validated and passed through.
  */
 function decodeCheckpointArtifacts(
-  raw: Record<string, string> | ContextArtifact[] | null,
+  raw: unknown,
   workingDir: string,
 ): ContextArtifact[] {
-  if (!raw) return [];
-  if (Array.isArray(raw)) return raw;
-  return Object.entries(raw).map(([name, version]) => {
-    return {
-      name,
-      version,
-      mountPath:
-        name === AUTO_MEMORY_ARTIFACT_NAME
-          ? AUTO_MEMORY_MOUNT_PATH
-          : workingDir,
-    };
-  });
+  if (raw === null || raw === undefined) return [];
+
+  if (Array.isArray(raw)) {
+    return raw.map((entry, i) => {
+      if (!isContextArtifact(entry)) {
+        throw badRequest(
+          `Invalid checkpoint: artifactSnapshots[${i}] is not a valid ContextArtifact`,
+        );
+      }
+      return entry;
+    });
+  }
+
+  if (typeof raw !== "object") {
+    throw badRequest(
+      "Invalid checkpoint: artifactSnapshots must be an array or object",
+    );
+  }
+
+  return Object.entries(raw as Record<string, unknown>).map(
+    ([name, version]) => {
+      if (typeof version !== "string") {
+        throw badRequest(
+          `Invalid checkpoint: artifactSnapshots["${name}"] must be a string version`,
+        );
+      }
+      return {
+        name,
+        version,
+        mountPath:
+          name === AUTO_MEMORY_ARTIFACT_NAME
+            ? AUTO_MEMORY_MOUNT_PATH
+            : workingDir,
+      };
+    },
+  );
+}
+
+function isContextArtifact(value: unknown): value is ContextArtifact {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  if (typeof entry.name !== "string") return false;
+  if (typeof entry.mountPath !== "string") return false;
+  if (entry.version !== undefined && typeof entry.version !== "string") {
+    return false;
+  }
+  return true;
 }

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-conversation.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-conversation.ts
@@ -78,6 +78,6 @@ export async function resolveDirectConversation(
       cliAgentSessionHistory: sessionHistory,
     },
     // No defaults for artifact/vars/secrets/volumeVersions - use params directly
-    artifacts: {},
+    artifacts: [],
   };
 }

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
@@ -8,6 +8,11 @@ import { notFound, unauthorized, badRequest } from "../../../shared/errors";
 import { logger } from "../../../shared/logger";
 import { getAgentSessionWithConversation } from "../../agent-session";
 import type { ConversationResolution } from "./types";
+import type { ContextArtifact } from "../types";
+import {
+  AUTO_MEMORY_ARTIFACT_NAME,
+  AUTO_MEMORY_MOUNT_PATH,
+} from "../../storage/types";
 import { extractWorkingDir, extractCliAgentType } from "../utils";
 import { resolveSessionHistory } from "./resolve-session-history";
 
@@ -120,21 +125,28 @@ export async function resolveSession(
   const [lastRun] = lastRunResult;
   const lastRunVars =
     (lastRun?.vars as Record<string, string> | null) ?? undefined;
+  const workingDir = extractWorkingDir(version.content);
+  const artifacts: ContextArtifact[] = session.artifactNames.map((name) => {
+    return {
+      name,
+      version: "latest",
+      mountPath:
+        name === AUTO_MEMORY_ARTIFACT_NAME
+          ? AUTO_MEMORY_MOUNT_PATH
+          : workingDir,
+    };
+  });
 
   return {
     conversationId: session.conversationId,
     agentComposeVersionId: versionId,
     agentCompose: version.content,
-    workingDir: extractWorkingDir(version.content),
+    workingDir,
     conversationData: {
       cliAgentSessionId: conversation.cliAgentSessionId,
       cliAgentSessionHistory: sessionHistory,
     },
-    artifacts: Object.fromEntries(
-      session.artifactNames.map((name) => {
-        return [name, "latest"];
-      }),
-    ),
+    artifacts,
     vars: lastRunVars,
     volumeVersions: undefined,
     previousRunId: conversation.runId,

--- a/turbo/apps/web/src/lib/infra/run/resolvers/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/types.ts
@@ -1,4 +1,5 @@
 import type { AdditionalVolume } from "../../storage/types";
+import type { ContextArtifact } from "../types";
 
 /**
  * Intermediate resolution result from checkpoint/session/conversation expansion
@@ -16,11 +17,11 @@ export interface ConversationResolution {
     cliAgentSessionHistory: string;
   };
   /**
-   * Primary artifact map: name → version.
-   * Resume-from-session emits "latest" sentinels; resume-from-checkpoint emits
-   * concrete version IDs from checkpoints.artifactSnapshots.
+   * Unified artifact list with explicit mountPath per entry.
+   * Resume-from-session emits entries with version "latest"; resume-from-checkpoint
+   * emits concrete version IDs from checkpoints.artifactSnapshots.
    */
-  artifacts: Record<string, string>;
+  artifacts: ContextArtifact[];
   vars?: Record<string, string>;
   volumeVersions?: Record<string, string>;
   additionalVolumes?: AdditionalVolume[];

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -98,7 +98,6 @@ export interface CreateRunParams {
   conversationId?: string;
   vars?: Record<string, string>;
   secrets?: Record<string, string>;
-  artifacts?: Record<string, string>;
   volumeVersions?: Record<string, string>;
   callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
   resumedFromCheckpointId?: string;
@@ -427,7 +426,11 @@ interface InsertRunParams {
   }>;
   resumedFromCheckpointId?: string;
   sessionId?: string;
-  artifacts?: Record<string, string>;
+  /**
+   * Seed for agent_sessions.artifactNames on new runs. Unused when sessionId
+   * is provided (existing session row is reused).
+   */
+  artifactNames?: string[];
 }
 
 /**
@@ -451,7 +454,7 @@ export async function insertRunRecord(
         userId: params.userId,
         orgId: params.orgId,
         agentComposeId: params.agentComposeId,
-        artifactNames: params.artifacts ? Object.keys(params.artifacts) : [],
+        artifactNames: params.artifactNames ?? [],
         conversationId: null,
       })
       .returning({ id: agentSessions.id });

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -1,5 +1,17 @@
-import type { AdditionalArtifact, AdditionalVolume } from "../storage/types";
+import type { AdditionalVolume } from "../storage/types";
 import type { Firewalls, NetworkPolicies } from "@vm0/core/contracts/firewalls";
+
+/**
+ * Artifact entry on an ExecutionContext: a name, optional version ("latest"
+ * when undefined), and an explicit mount path. Replaces the old split between
+ * "primary" (name→version map, mount forced to working_dir) and "additional"
+ * (list with explicit mount paths). Every entry now carries its own mount.
+ */
+export interface ContextArtifact {
+  name: string;
+  version?: string;
+  mountPath: string;
+}
 
 /**
  * Run status values
@@ -60,14 +72,10 @@ export interface ExecutionContext {
   secretConnectorMap?: Record<string, string>; // Secret name → connector type for OAuth refresh
   sandboxToken: string;
 
-  // Primary artifacts: name → version map.
-  // New runs: "latest" sentinels. Resume from session: "latest". Resume from
-  // checkpoint: concrete version IDs from checkpoints.artifactSnapshots.
-  artifacts?: Record<string, string>;
-
-  // Additional artifacts passed at run time (beyond the primary artifact
-  // derived from compose working_dir). Each entry carries its own mountPath.
-  additionalArtifacts?: AdditionalArtifact[];
+  // Artifacts: unified list where every entry carries its own mountPath.
+  // Version is optional — undefined means "latest". New runs use undefined or
+  // "latest"; resume paths inject concrete version IDs from snapshots.
+  artifacts?: ContextArtifact[];
 
   // Volume version overrides (volume name -> version)
   volumeVersions?: Record<string, string>;

--- a/turbo/apps/web/src/lib/infra/storage/__tests__/additional-volumes.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/additional-volumes.test.ts
@@ -58,8 +58,7 @@ describe("Additional Volumes", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
-      undefined,
+      [],
       undefined,
       additional,
     );
@@ -90,8 +89,7 @@ describe("Additional Volumes", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
-      undefined,
+      [],
       undefined,
       additional,
     );
@@ -113,8 +111,7 @@ describe("Additional Volumes", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
-      undefined,
+      [],
       undefined,
       additional,
     );
@@ -136,8 +133,7 @@ describe("Additional Volumes", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
-      undefined,
+      [],
       undefined,
       additional,
     );
@@ -160,8 +156,7 @@ describe("Additional Volumes", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
-      undefined,
+      [],
       undefined,
       additional,
     );
@@ -188,8 +183,7 @@ describe("Additional Volumes", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
-      undefined,
+      [],
       undefined,
       additional,
     );
@@ -221,8 +215,7 @@ describe("Additional Volumes", () => {
       fakeAgentOrgId,
       user.orgId,
       user.userId,
-      {},
-      undefined,
+      [],
       undefined,
       additional,
     );
@@ -250,8 +243,7 @@ describe("Additional Volumes", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
-      undefined,
+      [],
       undefined,
       additional,
     );
@@ -282,8 +274,7 @@ describe("Additional Volumes", () => {
         user.orgId,
         user.orgId,
         user.userId,
-        {},
-        undefined,
+        [],
         undefined,
         additional,
       );
@@ -307,8 +298,7 @@ describe("Additional Volumes", () => {
         user.orgId,
         user.orgId,
         user.userId,
-        {},
-        undefined,
+        [],
         undefined,
         additional,
       );
@@ -337,8 +327,7 @@ describe("Additional Volumes", () => {
         user.orgId,
         user.orgId,
         user.userId,
-        {},
-        undefined,
+        [],
         undefined,
         additional,
       );
@@ -363,8 +352,7 @@ describe("Additional Volumes", () => {
         user.orgId,
         user.orgId,
         user.userId,
-        {},
-        undefined,
+        [],
         undefined,
         additional,
       );
@@ -386,8 +374,7 @@ describe("Additional Volumes", () => {
         user.orgId,
         user.orgId,
         user.userId,
-        {},
-        undefined,
+        [],
         undefined,
         additional,
       );

--- a/turbo/apps/web/src/lib/infra/storage/__tests__/primary-artifacts.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/primary-artifacts.test.ts
@@ -10,20 +10,16 @@ import {
   uniqueId,
   type UserContext,
 } from "../../../../__tests__/test-helpers";
-import type {
-  AdditionalArtifact,
-  AdditionalVolume,
-  AgentVolumeConfig,
-} from "../types";
+import type { AdditionalVolume, AgentVolumeConfig } from "../types";
+import type { ContextArtifact } from "../../run/types";
 
 const context = testContext();
 
 const WORKING_DIR = "/home/user/workspace";
 
 /**
- * Minimal agent config with no volumes — primary artifacts flow through
- * resolveVolumes via the `artifacts` map regardless of compose volume decls,
- * but an agentConfig object is required to trigger resolution at all.
+ * Minimal agent config with no volumes. Required to trigger volume resolution
+ * even when only artifacts are being resolved.
  */
 function emptyAgentConfig(): AgentVolumeConfig {
   return {
@@ -53,7 +49,7 @@ function composeVolumeConfig(
   };
 }
 
-describe("Primary Artifacts (artifacts record map)", () => {
+describe("Unified artifact list (ContextArtifact[])", () => {
   let user: UserContext;
 
   beforeEach(async () => {
@@ -61,9 +57,13 @@ describe("Primary Artifacts (artifacts record map)", () => {
     user = await context.setupUser();
   });
 
-  it("resolves a single primary artifact at compose working_dir", async () => {
+  it("resolves a single artifact at its explicit mount path", async () => {
     const artifactName = uniqueId("primary-one");
     const { versionId } = await createTestArtifact(artifactName);
+
+    const artifacts: ContextArtifact[] = [
+      { name: artifactName, mountPath: WORKING_DIR },
+    ];
 
     const manifest = await prepareStorageManifest(
       emptyAgentConfig(),
@@ -71,8 +71,7 @@ describe("Primary Artifacts (artifacts record map)", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      { [artifactName]: "latest" },
-      WORKING_DIR,
+      artifacts,
     );
 
     expect(manifest.artifacts).toHaveLength(1);
@@ -83,11 +82,16 @@ describe("Primary Artifacts (artifacts record map)", () => {
     expect(manifest.storages).toHaveLength(0);
   });
 
-  it("resolves multiple primary artifacts at the same working_dir mount", async () => {
+  it("resolves multiple artifacts with independent mount paths", async () => {
     const nameA = uniqueId("primary-a");
     const nameB = uniqueId("primary-b");
     const { versionId: vA } = await createTestArtifact(nameA);
     const { versionId: vB } = await createTestArtifact(nameB);
+
+    const artifacts: ContextArtifact[] = [
+      { name: nameA, mountPath: WORKING_DIR },
+      { name: nameB, mountPath: "/mnt/other" },
+    ];
 
     const manifest = await prepareStorageManifest(
       emptyAgentConfig(),
@@ -95,8 +99,7 @@ describe("Primary Artifacts (artifacts record map)", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      { [nameA]: "latest", [nameB]: "latest" },
-      WORKING_DIR,
+      artifacts,
     );
 
     expect(manifest.artifacts).toHaveLength(2);
@@ -106,14 +109,18 @@ describe("Primary Artifacts (artifacts record map)", () => {
       }),
     );
     expect(byName[nameA]!.vasVersionId).toBe(vA);
-    expect(byName[nameB]!.vasVersionId).toBe(vB);
     expect(byName[nameA]!.mountPath).toBe(WORKING_DIR);
-    expect(byName[nameB]!.mountPath).toBe(WORKING_DIR);
+    expect(byName[nameB]!.vasVersionId).toBe(vB);
+    expect(byName[nameB]!.mountPath).toBe("/mnt/other");
   });
 
-  it("resolves primary artifact with an explicit version (not latest)", async () => {
+  it("resolves artifact with an explicit pinned version", async () => {
     const artifactName = uniqueId("primary-pinned");
     const { versionId } = await createTestArtifact(artifactName);
+
+    const artifacts: ContextArtifact[] = [
+      { name: artifactName, version: versionId, mountPath: WORKING_DIR },
+    ];
 
     const manifest = await prepareStorageManifest(
       emptyAgentConfig(),
@@ -121,8 +128,7 @@ describe("Primary Artifacts (artifacts record map)", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      { [artifactName]: versionId },
-      WORKING_DIR,
+      artifacts,
     );
 
     expect(manifest.artifacts).toHaveLength(1);
@@ -130,25 +136,20 @@ describe("Primary Artifacts (artifacts record map)", () => {
     expect(manifest.artifacts[0]!.mountPath).toBe(WORKING_DIR);
   });
 
-  it("mixes primary artifact, compose volume, and additional artifact", async () => {
-    const artifactName = uniqueId("primary-mix");
-    const additionalArtifactName = uniqueId("additional-mix");
+  it("mixes artifact, compose volume, and per-entry mount path", async () => {
+    const artifactA = uniqueId("primary-mix");
+    const artifactB = uniqueId("additional-mix");
     const volumeStorageName = uniqueId("vol-mix");
     const volumeKey = uniqueId("vol");
 
-    const { versionId: primaryVersion } =
-      await createTestArtifact(artifactName);
-    const { versionId: additionalVersion } = await createTestArtifact(
-      additionalArtifactName,
-    );
+    const { versionId: versionA } = await createTestArtifact(artifactA);
+    const { versionId: versionB } = await createTestArtifact(artifactB);
     const { versionId: volumeVersion } =
       await createTestVolume(volumeStorageName);
 
-    const additionalArtifacts: AdditionalArtifact[] = [
-      {
-        name: additionalArtifactName,
-        mountPath: "/mnt/extra-artifact",
-      },
+    const artifacts: ContextArtifact[] = [
+      { name: artifactA, mountPath: WORKING_DIR },
+      { name: artifactB, mountPath: "/mnt/extra-artifact" },
     ];
 
     const manifest = await prepareStorageManifest(
@@ -157,60 +158,50 @@ describe("Primary Artifacts (artifacts record map)", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      { [artifactName]: "latest" },
-      WORKING_DIR,
-      undefined,
-      undefined,
-      additionalArtifacts,
+      artifacts,
     );
 
-    // Primary artifact at working_dir + additional artifact at its explicit path
     expect(manifest.artifacts).toHaveLength(2);
     const artifactByName = Object.fromEntries(
       manifest.artifacts.map((a) => {
         return [a.vasStorageName, a];
       }),
     );
-    expect(artifactByName[artifactName]!.vasVersionId).toBe(primaryVersion);
-    expect(artifactByName[artifactName]!.mountPath).toBe(WORKING_DIR);
-    expect(artifactByName[additionalArtifactName]!.vasVersionId).toBe(
-      additionalVersion,
-    );
-    expect(artifactByName[additionalArtifactName]!.mountPath).toBe(
-      "/mnt/extra-artifact",
-    );
+    expect(artifactByName[artifactA]!.vasVersionId).toBe(versionA);
+    expect(artifactByName[artifactA]!.mountPath).toBe(WORKING_DIR);
+    expect(artifactByName[artifactB]!.vasVersionId).toBe(versionB);
+    expect(artifactByName[artifactB]!.mountPath).toBe("/mnt/extra-artifact");
 
-    // Compose volume resolved alongside
     expect(manifest.storages).toHaveLength(1);
     expect(manifest.storages[0]!.vasStorageName).toBe(volumeStorageName);
     expect(manifest.storages[0]!.vasVersionId).toBe(volumeVersion);
     expect(manifest.storages[0]!.mountPath).toBe("/data");
   });
 
-  it("returns empty artifacts array when artifacts map is empty", async () => {
+  it("returns empty artifacts array when list is empty", async () => {
     const manifest = await prepareStorageManifest(
       emptyAgentConfig(),
       {},
       user.orgId,
       user.orgId,
       user.userId,
-      {},
-      WORKING_DIR,
+      [],
     );
 
     expect(manifest.artifacts).toHaveLength(0);
     expect(manifest.storages).toHaveLength(0);
   });
 
-  it("additional artifact overrides primary artifact at same mount path", async () => {
-    const primaryName = uniqueId("primary-override");
-    const overrideName = uniqueId("override-at-workingdir");
-    const { versionId: primaryVersion } = await createTestArtifact(primaryName);
-    const { versionId: overrideVersion } =
-      await createTestArtifact(overrideName);
+  it("later entry overrides earlier entry with the same name (dedup by name, last wins)", async () => {
+    // Same-name collision is the basis for memory injection: a checkpoint
+    // snapshot may already carry a "memory" entry, and Zero appends a fresh
+    // one. The later append must win.
+    const name = uniqueId("dedup-name");
+    const { versionId: firstVersion } = await createTestArtifact(name);
 
-    const additionalArtifacts: AdditionalArtifact[] = [
-      { name: overrideName, mountPath: WORKING_DIR },
+    const artifacts: ContextArtifact[] = [
+      { name, version: firstVersion, mountPath: "/old-path" },
+      { name, mountPath: "/new-path" },
     ];
 
     const manifest = await prepareStorageManifest(
@@ -219,23 +210,16 @@ describe("Primary Artifacts (artifacts record map)", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      { [primaryName]: "latest" },
-      WORKING_DIR,
-      undefined,
-      undefined,
-      additionalArtifacts,
+      artifacts,
     );
 
-    // Primary artifact at WORKING_DIR is filtered out; override remains.
     expect(manifest.artifacts).toHaveLength(1);
-    expect(manifest.artifacts[0]!.vasStorageName).toBe(overrideName);
-    expect(manifest.artifacts[0]!.vasVersionId).toBe(overrideVersion);
-    expect(manifest.artifacts[0]!.mountPath).toBe(WORKING_DIR);
-    // Primary is gone — its version is not in the output.
-    expect(manifest.artifacts[0]!.vasVersionId).not.toBe(primaryVersion);
+    expect(manifest.artifacts[0]!.vasStorageName).toBe(name);
+    // Last entry had no version → "latest" → resolves to the HEAD version
+    expect(manifest.artifacts[0]!.mountPath).toBe("/new-path");
   });
 
-  it("primary artifacts coexist with additional volumes at different paths", async () => {
+  it("artifacts coexist with additional volumes at different mount paths", async () => {
     const artifactName = uniqueId("primary-with-vol");
     const volumeName = uniqueId("addvol-with-artifact");
     const { versionId: artifactVersion } =
@@ -246,14 +230,17 @@ describe("Primary Artifacts (artifacts record map)", () => {
       { name: volumeName, mountPath: "/mnt/data" },
     ];
 
+    const artifacts: ContextArtifact[] = [
+      { name: artifactName, mountPath: WORKING_DIR },
+    ];
+
     const manifest = await prepareStorageManifest(
       emptyAgentConfig(),
       {},
       user.orgId,
       user.orgId,
       user.userId,
-      { [artifactName]: "latest" },
-      WORKING_DIR,
+      artifacts,
       undefined,
       additionalVolumes,
     );

--- a/turbo/apps/web/src/lib/infra/storage/__tests__/system-volume-resolution.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/system-volume-resolution.test.ts
@@ -59,7 +59,7 @@ describe("System Volume Resolution (VolumeConfig.system)", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
+      [],
     );
 
     expect(manifest.storages).toHaveLength(1);
@@ -78,7 +78,7 @@ describe("System Volume Resolution (VolumeConfig.system)", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
+      [],
     );
 
     expect(manifest.storages).toHaveLength(1);
@@ -101,7 +101,7 @@ describe("System Volume Resolution (VolumeConfig.system)", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
+      [],
     );
 
     expect(manifest.storages).toHaveLength(1);
@@ -121,7 +121,7 @@ describe("System Volume Resolution (VolumeConfig.system)", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
+      [],
     );
 
     expect(manifest.storages).toHaveLength(0);
@@ -138,7 +138,7 @@ describe("System Volume Resolution (VolumeConfig.system)", () => {
       user.orgId,
       user.orgId,
       user.userId,
-      {},
+      [],
     );
 
     expect(manifest.storages).toHaveLength(1);

--- a/turbo/apps/web/src/lib/infra/storage/storage-resolver.ts
+++ b/turbo/apps/web/src/lib/infra/storage/storage-resolver.ts
@@ -2,7 +2,6 @@ import type {
   AgentVolumeConfig,
   VolumeConfig,
   ResolvedVolume,
-  ResolvedArtifact,
   VolumeResolutionResult,
   VolumeError,
   StorageDriver,
@@ -124,28 +123,6 @@ function resolveVasVolume(
 }
 
 /**
- * Resolve primary artifacts from a name→version map.
- * All entries mount at the compose's working_dir (the "primary" mount); the
- * caller is responsible for any per-entry mount paths via additionalArtifacts.
- */
-function resolveArtifacts(
-  workingDir: string,
-  artifacts: Record<string, string>,
-): { artifacts: ResolvedArtifact[]; errors: VolumeError[] } {
-  const resolved: ResolvedArtifact[] = Object.entries(artifacts).map(
-    ([name, version]) => {
-      return {
-        driver: "vas" as StorageDriver,
-        mountPath: workingDir,
-        vasStorageName: name,
-        vasVersion: version || "latest",
-      };
-    },
-  );
-  return { artifacts: resolved, errors: [] };
-}
-
-/**
  * Process volume declarations from agent config into resolved volumes.
  */
 function processVolumeDeclarations(
@@ -246,24 +223,20 @@ function resolveInstructions(
 }
 
 /**
- * Resolve volumes from agent configuration
+ * Resolve volumes from agent configuration.
+ *
  * @param config - Agent configuration with volume definitions
  * @param vars - Template variables for placeholder replacement
- * @param artifacts - Primary artifacts map (name → version). Empty map = no artifacts.
  * @param volumeVersionOverrides - Optional volume version overrides (volume name -> version)
- * @param workingDir - Working directory for primary artifact mount path
- * @returns Resolution result with resolved volumes, artifacts, and errors
+ * @returns Resolution result with resolved volumes and errors
  */
 export function resolveVolumes(
   config: AgentVolumeConfig,
   vars: Record<string, string> = {},
-  artifacts: Record<string, string> = {},
   volumeVersionOverrides?: Record<string, string>,
-  workingDir?: string,
 ): VolumeResolutionResult {
   const volumes: ResolvedVolume[] = [];
   const errors: VolumeError[] = [];
-  let resolvedArtifacts: ResolvedArtifact[] = [];
 
   // Get first agent (currently only support one agent)
   const agentValues = config.agents ? Object.values(config.agents) : [];
@@ -287,16 +260,5 @@ export function resolveVolumes(
     volumes.push(...resolveInstructions(config, agent));
   }
 
-  // Process primary artifacts. Empty map = no artifacts (e.g. compose has no
-  // working_dir artifact declared or caller explicitly passes {}).
-  if (workingDir && Object.keys(artifacts).length > 0) {
-    const { artifacts: resolved, errors: artifactErrors } = resolveArtifacts(
-      workingDir,
-      artifacts,
-    );
-    resolvedArtifacts = resolved;
-    errors.push(...artifactErrors);
-  }
-
-  return { volumes, artifacts: resolvedArtifacts, errors };
+  return { volumes, errors };
 }

--- a/turbo/apps/web/src/lib/infra/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/infra/storage/storage-service.ts
@@ -3,15 +3,16 @@ import { resolveVolumes } from "./storage-resolver";
 import { generatePresignedUrl, putS3Object } from "../s3/s3-client";
 import { logger } from "../../shared/logger";
 import {
-  type AdditionalArtifact,
   type AdditionalVolume,
   type AgentVolumeConfig,
   type ResolvedArtifact,
   type ResolvedVolume,
+  type StorageDriver,
   type StorageManifest,
   type ManifestStorage,
   type ManifestArtifact,
 } from "./types";
+import type { ContextArtifact } from "../run/types";
 import { storages, storageVersions } from "../../../db/schema/storage";
 import { eq, and, isNull, sql } from "drizzle-orm";
 import { env } from "../../../env";
@@ -381,11 +382,11 @@ async function resolveAdditionalVolume(
 }
 
 /**
- * Resolve a single primary artifact to a ManifestArtifact.
+ * Resolve a single artifact entry to a ManifestArtifact.
  * Uses the batched latest lookup when possible and falls back to an
  * individual resolveVersion call for pinned versions.
  */
-async function resolvePrimaryArtifact(
+async function resolveArtifactEntry(
   artifactSource: ResolvedArtifact,
   allResults: Map<string, { versionId: string; s3Key: string }>,
   runtimeClerkOrgId: string,
@@ -442,38 +443,25 @@ async function resolvePrimaryArtifact(
 }
 
 /**
- * Resolve a single additional artifact by name/version against the runtime
- * org, returning a ManifestArtifact with presigned URLs. Missing storages
- * bubble up — additional artifacts are treated as required (unlike additional
- * volumes) because the caller explicitly opted them in by name.
+ * Dedup by name, last wins. Callers build artifact lists from multiple
+ * sources (snapshot, CLI --artifact flag, auto-memory injection) and may
+ * introduce duplicate names; collapsing here lets the auto-injected memory
+ * entry override a matching checkpoint snapshot without any upstream awareness.
  */
-async function resolveAdditionalArtifact(
-  entry: AdditionalArtifact,
-  runtimeClerkOrgId: string,
-  userId: string,
-  bucketName: string,
-): Promise<ManifestArtifact> {
-  const version = entry.version || "latest";
-  const resolved = await resolveVersion(
-    runtimeClerkOrgId,
-    entry.name,
-    "artifact",
-    version,
-    userId,
-  );
-  const { versionId, s3Key } = resolved;
-  const archiveKey = `${s3Key}/archive.tar.gz`;
-  const manifestKey = `${s3Key}/manifest.json`;
-  const [archiveUrl, manifestUrl] = await Promise.all([
-    generatePresignedUrl(bucketName, archiveKey),
-    generatePresignedUrl(bucketName, manifestKey),
-  ]);
+function dedupArtifactsByName(artifacts: ContextArtifact[]): ContextArtifact[] {
+  const byName = new Map<string, ContextArtifact>();
+  for (const entry of artifacts) {
+    byName.set(entry.name, entry);
+  }
+  return Array.from(byName.values());
+}
+
+function toResolvedArtifact(entry: ContextArtifact): ResolvedArtifact {
   return {
+    driver: "vas" as StorageDriver,
     mountPath: entry.mountPath,
     vasStorageName: entry.name,
-    vasVersionId: versionId,
-    archiveUrl,
-    manifestUrl,
+    vasVersion: entry.version || "latest",
   };
 }
 
@@ -486,11 +474,10 @@ async function resolveAdditionalArtifact(
  * @param agentClerkOrgId - Agent Clerk org ID for volume resolution (where the agent is defined)
  * @param runtimeClerkOrgId - Runtime Clerk org ID for artifact resolution (where the agent is executed)
  * @param userId - User ID within the runtime org (for artifact ownership)
- * @param artifacts - Primary artifacts map (name → version). All mount at compose working_dir.
- * @param workingDir - Working directory for primary artifact mount path
+ * @param artifacts - Unified artifact list; each entry carries its own mountPath.
+ *   Dedup-by-name (last wins) lets callers append auto-memory to checkpoint snapshots.
  * @param volumeVersionOverrides - Optional volume version overrides
  * @param additionalVolumes - Additional volumes with explicit mount paths
- * @param additionalArtifacts - Additional artifacts with explicit mount paths
  * @returns Storage manifest with presigned URLs
  */
 export async function prepareStorageManifest(
@@ -499,37 +486,32 @@ export async function prepareStorageManifest(
   agentClerkOrgId: string,
   runtimeClerkOrgId: string,
   userId: string,
-  artifacts: Record<string, string>,
-  workingDir?: string,
+  artifacts: ContextArtifact[],
   volumeVersionOverrides?: Record<string, string>,
   additionalVolumes?: AdditionalVolume[],
-  additionalArtifacts?: AdditionalArtifact[],
 ): Promise<StorageManifest> {
   log.debug("Preparing storage manifest with presigned URLs...");
 
   const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
 
+  const dedupedArtifacts = dedupArtifactsByName(artifacts);
+  const resolvedArtifacts: ResolvedArtifact[] =
+    dedupedArtifacts.map(toResolvedArtifact);
+
   // Shortcut: nothing to resolve at all.
   if (
     !agentConfig &&
-    Object.keys(artifacts).length === 0 &&
-    (!additionalVolumes || additionalVolumes.length === 0) &&
-    (!additionalArtifacts || additionalArtifacts.length === 0)
+    resolvedArtifacts.length === 0 &&
+    (!additionalVolumes || additionalVolumes.length === 0)
   ) {
     return { storages: [], artifacts: [] };
   }
 
-  // Resolve volumes + primary artifacts from agent config. Primary artifacts
-  // all mount at workingDir.
+  // Resolve volumes from agent config. Artifacts are resolved separately from
+  // the unified caller-provided list (mounts come from ContextArtifact.mountPath).
   const volumeResult = agentConfig
-    ? resolveVolumes(
-        agentConfig,
-        vars,
-        artifacts,
-        volumeVersionOverrides,
-        workingDir,
-      )
-    : { volumes: [], artifacts: [], errors: [] };
+    ? resolveVolumes(agentConfig, vars, volumeVersionOverrides)
+    : { volumes: [], errors: [] };
 
   if (volumeResult.errors.length > 0) {
     const messages = volumeResult.errors
@@ -539,8 +521,6 @@ export async function prepareStorageManifest(
       .join("; ");
     throw new Error(`Volume resolution failed: ${messages}`);
   }
-
-  const primaryArtifacts = volumeResult.artifacts;
 
   // Partition volumes into batch-eligible and individual-resolve groups
   const partitioned = partitionVolumes(
@@ -555,7 +535,7 @@ export async function prepareStorageManifest(
     agentClerkOrgId,
     runtimeClerkOrgId,
     userId,
-    primaryArtifacts,
+    resolvedArtifacts,
   );
 
   // Resolve non-latest volumes individually (rare: explicit version overrides)
@@ -571,50 +551,17 @@ export async function prepareStorageManifest(
     }),
   );
 
-  // Resolve additional artifacts in parallel. These are always resolved
-  // individually (no batching) because the list is typically small and each
-  // entry carries an explicit mountPath, so there's no shared agent/system
-  // fallback path to optimize.
-  const resolvedAdditionalArtifacts = await Promise.all(
-    (additionalArtifacts ?? []).map((entry) => {
-      return resolveAdditionalArtifact(
-        entry,
-        runtimeClerkOrgId,
-        userId,
-        bucketName,
-      );
-    }),
-  );
-
-  // Map batch results to manifest entries
-  const manifest = await buildManifestFromResults(
+  return buildManifestFromResults(
     allResults,
     partitioned,
     agentClerkOrgId,
     runtimeClerkOrgId,
     userId,
     bucketName,
-    primaryArtifacts,
+    resolvedArtifacts,
     nonLatestResolved,
     nonLatestAdditionalResolved,
   );
-
-  if (resolvedAdditionalArtifacts.length === 0) return manifest;
-
-  // Merge additional artifacts, deduplicating by mount path. Additional
-  // artifacts override any primary artifact mounted at the same path.
-  const additionalMountPaths = new Set(
-    resolvedAdditionalArtifacts.map((a) => {
-      return a.mountPath;
-    }),
-  );
-  const filteredArtifacts = manifest.artifacts.filter((a) => {
-    return !additionalMountPaths.has(a.mountPath);
-  });
-  return {
-    ...manifest,
-    artifacts: [...filteredArtifacts, ...resolvedAdditionalArtifacts],
-  };
 }
 
 /** Partitioned volumes for batch vs individual resolution */
@@ -707,7 +654,7 @@ async function executeBatchResolution(
   agentClerkOrgId: string,
   runtimeClerkOrgId: string,
   userId: string,
-  primaryArtifacts: ResolvedArtifact[],
+  resolvedArtifacts: ResolvedArtifact[],
 ): Promise<Map<string, { versionId: string; s3Key: string }>> {
   // Phase 1: System org batch (system compose volumes + system additional volumes)
   const systemLookups: StorageLookup[] = [
@@ -758,7 +705,7 @@ async function executeBatchResolution(
     }),
   ];
 
-  for (const artifact of primaryArtifacts) {
+  for (const artifact of resolvedArtifacts) {
     if (artifact.vasVersion !== "latest") continue;
     remainingLookups.push({
       orgId: runtimeClerkOrgId,
@@ -881,7 +828,7 @@ async function buildManifestFromResults(
   runtimeClerkOrgId: string,
   userId: string,
   bucketName: string,
-  primaryArtifacts: ResolvedArtifact[],
+  resolvedArtifacts: ResolvedArtifact[],
   nonLatestResolved: (ManifestStorage | null)[],
   nonLatestAdditionalResolved: (ManifestStorage | null)[],
 ): Promise<StorageManifest> {
@@ -1024,9 +971,9 @@ async function buildManifestFromResults(
     }),
   ];
 
-  const resolvedPrimaryArtifacts = await Promise.all(
-    primaryArtifacts.map((artifact) => {
-      return resolvePrimaryArtifact(
+  const resolvedArtifactManifests = await Promise.all(
+    resolvedArtifacts.map((artifact) => {
+      return resolveArtifactEntry(
         artifact,
         allResults,
         runtimeClerkOrgId,
@@ -1050,11 +997,11 @@ async function buildManifestFromResults(
   const filteredStorages = [...filteredCompose, ...resolvedAdditional];
 
   log.debug(
-    `Storage manifest prepared: ${filteredStorages.length} storages (${filteredCompose.length} compose + ${resolvedAdditional.length} additional), ${resolvedPrimaryArtifacts.length} artifacts`,
+    `Storage manifest prepared: ${filteredStorages.length} storages (${filteredCompose.length} compose + ${resolvedAdditional.length} additional), ${resolvedArtifactManifests.length} artifacts`,
   );
 
   return {
     storages: filteredStorages,
-    artifacts: resolvedPrimaryArtifacts,
+    artifacts: resolvedArtifactManifests,
   };
 }

--- a/turbo/apps/web/src/lib/infra/storage/types.ts
+++ b/turbo/apps/web/src/lib/infra/storage/types.ts
@@ -23,7 +23,7 @@ export const AUTO_MEMORY_MOUNT_PATH =
 
 /**
  * Storage name used for the auto-synthesized memory artifact. Zero-layer runs
- * always include an AdditionalArtifact with this name mounted at
+ * always include a ContextArtifact entry with this name mounted at
  * AUTO_MEMORY_MOUNT_PATH so Claude Code finds persistent memory without any
  * in-sandbox symlink bootstrap.
  */
@@ -49,7 +49,7 @@ export interface ResolvedVolume {
  */
 export interface ResolvedArtifact {
   driver: StorageDriver;
-  mountPath: string; // Resolved from framework config
+  mountPath: string; // Explicit mount path from ContextArtifact
   vasStorageName: string;
   vasVersion: string; // Version hash or "latest"
 }
@@ -59,7 +59,6 @@ export interface ResolvedArtifact {
  */
 export interface VolumeResolutionResult {
   volumes: ResolvedVolume[];
-  artifacts: ResolvedArtifact[];
   errors: VolumeError[];
 }
 
@@ -69,11 +68,7 @@ export interface VolumeResolutionResult {
 export interface VolumeError {
   volumeName: string;
   message: string;
-  type:
-    | "missing_definition"
-    | "missing_variable"
-    | "invalid_config"
-    | "missing_artifact_name";
+  type: "missing_definition" | "missing_variable" | "invalid_config";
 }
 
 /**
@@ -101,17 +96,6 @@ export interface AdditionalVolume {
   version?: string; // Version hash or "latest" (defaults to "latest")
   mountPath: string; // Absolute path in sandbox
   system?: boolean; // When true, resolve against SYSTEM_ORG first, fallback to runtime org
-}
-
-/**
- * Additional artifact passed directly at run time, each with an explicit
- * mountPath. Extras beyond the primary artifact (whose mount path is derived
- * from compose's working_dir). Resolved against the runtime org.
- */
-export interface AdditionalArtifact {
-  name: string; // Artifact storage name
-  version?: string; // Version hash or "latest" (defaults to "latest")
-  mountPath: string; // Absolute path in sandbox
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -64,6 +64,24 @@ export {
 const log = logger("zero:build-context");
 
 /**
+ * Append the auto-memory artifact to the unified artifact list.
+ *
+ * Dedup-by-name in prepareStorageManifest collapses the clash when a checkpoint
+ * snapshot also carries "memory". Resume-path gating is handled in a follow-up
+ * sub-issue (#10910) — today we always append on every Zero path, which is why
+ * this helper is shared by both resolveCliRunContext and
+ * buildZeroExecutionContext.
+ */
+function appendAutoMemoryArtifact(
+  artifacts: ContextArtifact[],
+): ContextArtifact[] {
+  return [
+    ...artifacts,
+    { name: AUTO_MEMORY_ARTIFACT_NAME, mountPath: AUTO_MEMORY_MOUNT_PATH },
+  ];
+}
+
+/**
  * Parameters for building Zero execution context.
  * Contains all fields needed to resolve secrets, model providers, connectors,
  * and build the final ExecutionContext for sandbox dispatch.
@@ -438,14 +456,8 @@ export async function resolveCliRunContext(
     );
   }
 
-  // Memory injection: append to the unified artifact list. Dedup-by-name in
-  // prepareStorageManifest collapses the clash when a checkpoint snapshot
-  // also carries "memory". Resume-path gating is handled in a follow-up
-  // sub-issue (#10910) — today we always append on every Zero path.
-  artifacts = [
-    ...artifacts,
-    { name: AUTO_MEMORY_ARTIFACT_NAME, mountPath: AUTO_MEMORY_MOUNT_PATH },
-  ];
+  // Memory injection — see appendAutoMemoryArtifact().
+  artifacts = appendAutoMemoryArtifact(artifacts);
 
   // Load compose content if we have a version ID
   if (!agentCompose && agentComposeVersionId) {
@@ -613,14 +625,8 @@ export async function buildZeroExecutionContext(
       (await loadAgentComposeForNewRun(agentComposeVersionId));
   }
 
-  // Memory injection: append to the unified artifact list. Dedup-by-name in
-  // prepareStorageManifest collapses the clash when a checkpoint snapshot
-  // also carries "memory". Resume-path gating is handled in a follow-up
-  // sub-issue (#10910) — today we always append on every path.
-  artifacts = [
-    ...artifacts,
-    { name: AUTO_MEMORY_ARTIFACT_NAME, mountPath: AUTO_MEMORY_MOUNT_PATH },
-  ];
+  // Memory injection — see appendAutoMemoryArtifact().
+  artifacts = appendAutoMemoryArtifact(artifacts);
 
   // Validate required fields
   if (!agentComposeVersionId) {

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -18,11 +18,12 @@ import {
 import { zeroRuns } from "../../db/schema/zero-run";
 import { badRequest, notFound } from "../shared/errors";
 import { logger } from "../shared/logger";
-import type { ExecutionContext, ResumeSession } from "../infra/run/types";
 import type {
-  AdditionalArtifact,
-  AdditionalVolume,
-} from "../infra/storage/types";
+  ContextArtifact,
+  ExecutionContext,
+  ResumeSession,
+} from "../infra/run/types";
+import type { AdditionalVolume } from "../infra/storage/types";
 import {
   AUTO_MEMORY_ARTIFACT_NAME,
   AUTO_MEMORY_MOUNT_PATH,
@@ -74,7 +75,7 @@ interface BuildZeroContextParams {
   // Base parameters
   agentComposeVersionId?: string;
   conversationId?: string;
-  artifacts?: Record<string, string>;
+  artifacts?: ContextArtifact[];
   vars?: Record<string, string>;
   secrets?: Record<string, string>;
   volumeVersions?: Record<string, string>;
@@ -350,7 +351,7 @@ interface ResolvedCliContext {
   // Session/checkpoint resolution
   agentComposeVersionId?: string;
   agentCompose?: unknown;
-  artifacts: Record<string, string>;
+  artifacts: ContextArtifact[];
   vars?: Record<string, string>;
   volumeVersions?: Record<string, string>;
   additionalVolumes?: AdditionalVolume[];
@@ -406,7 +407,7 @@ export async function resolveCliRunContext(
   // Initialize context variables
   let agentComposeVersionId: string | undefined = params.agentComposeVersionId;
   let agentCompose: unknown;
-  let artifacts: Record<string, string> = {};
+  let artifacts: ContextArtifact[] = [];
   let vars: Record<string, string> | undefined = params.vars;
   let volumeVersions: Record<string, string> | undefined =
     params.volumeVersions;
@@ -436,6 +437,15 @@ export async function resolveCliRunContext(
       params.orgId,
     );
   }
+
+  // Memory injection: append to the unified artifact list. Dedup-by-name in
+  // prepareStorageManifest collapses the clash when a checkpoint snapshot
+  // also carries "memory". Resume-path gating is handled in a follow-up
+  // sub-issue (#10910) — today we always append on every Zero path.
+  artifacts = [
+    ...artifacts,
+    { name: AUTO_MEMORY_ARTIFACT_NAME, mountPath: AUTO_MEMORY_MOUNT_PATH },
+  ];
 
   // Load compose content if we have a version ID
   if (!agentCompose && agentComposeVersionId) {
@@ -569,7 +579,7 @@ export async function buildZeroExecutionContext(
   // Initialize context variables
   let agentComposeVersionId: string | undefined = params.agentComposeVersionId;
   let agentCompose: unknown;
-  let artifacts: Record<string, string> = params.artifacts ?? {};
+  let artifacts: ContextArtifact[] = params.artifacts ?? [];
   let vars: Record<string, string> | undefined = params.vars;
   let volumeVersions: Record<string, string> | undefined =
     params.volumeVersions;
@@ -602,6 +612,15 @@ export async function buildZeroExecutionContext(
       params.agentCompose ??
       (await loadAgentComposeForNewRun(agentComposeVersionId));
   }
+
+  // Memory injection: append to the unified artifact list. Dedup-by-name in
+  // prepareStorageManifest collapses the clash when a checkpoint snapshot
+  // also carries "memory". Resume-path gating is handled in a follow-up
+  // sub-issue (#10910) — today we always append on every path.
+  artifacts = [
+    ...artifacts,
+    { name: AUTO_MEMORY_ARTIFACT_NAME, mountPath: AUTO_MEMORY_MOUNT_PATH },
+  ];
 
   // Validate required fields
   if (!agentComposeVersionId) {
@@ -689,14 +708,6 @@ export async function buildZeroExecutionContext(
     mergedVars,
   );
 
-  // Synthesize memory as an additional artifact mounted directly at Claude
-  // Code's auto-memory path. This replaces the guest-agent symlink bootstrap:
-  // the runner mounts memory at AUTO_MEMORY_MOUNT_PATH so Claude Code finds
-  // it without any in-sandbox symlink work.
-  const memoryArtifacts: AdditionalArtifact[] = [
-    { name: AUTO_MEMORY_ARTIFACT_NAME, mountPath: AUTO_MEMORY_MOUNT_PATH },
-  ];
-
   // Build final execution context
   return {
     context: {
@@ -712,7 +723,6 @@ export async function buildZeroExecutionContext(
       secretConnectorMap,
       sandboxToken: params.sandboxToken,
       artifacts,
-      additionalArtifacts: memoryArtifacts,
       volumeVersions,
       additionalVolumes,
       environment,

--- a/turbo/apps/web/src/lib/zero/context/resolve-source.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-source.ts
@@ -17,7 +17,7 @@ import {
   providerIncompatible,
 } from "../../shared/errors";
 import { logger } from "../../shared/logger";
-import type { ResumeSession } from "../../infra/run/types";
+import type { ContextArtifact, ResumeSession } from "../../infra/run/types";
 import type { AdditionalVolume } from "../../infra/storage/types";
 import {
   resolveCheckpoint,
@@ -198,7 +198,7 @@ export function applyResolutionDefaults(
 ): {
   agentComposeVersionId: string;
   agentCompose: unknown;
-  artifacts: Record<string, string>;
+  artifacts: ContextArtifact[];
   vars: Record<string, string> | undefined;
   volumeVersions: Record<string, string> | undefined;
   additionalVolumes: AdditionalVolume[] | undefined;
@@ -209,9 +209,9 @@ export function applyResolutionDefaults(
       params.agentComposeVersionId || resolution.agentComposeVersionId,
     agentCompose: resolution.agentCompose,
     // Artifacts are resolution-only on purpose — when resuming a session the
-    // artifact name→version map is dictated by the checkpoint/session snapshot
-    // and must not be overridden by incoming run params, which don't carry
-    // artifacts at this entry point.
+    // artifact list is dictated by the checkpoint/session snapshot and must
+    // not be overridden by incoming run params, which don't carry artifacts
+    // at this entry point.
     artifacts: resolution.artifacts,
     vars: params.vars || resolution.vars,
     volumeVersions: params.volumeVersions || resolution.volumeVersions,

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -120,7 +120,7 @@ export async function enqueueRun(
           userId,
           orgId,
           agentComposeId,
-          artifactNames: params.artifacts ? Object.keys(params.artifacts) : [],
+          artifactNames: [],
           conversationId: null,
         })
         .returning({ id: agentSessions.id });

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -585,7 +585,6 @@ async function createZeroRunRecord(
           additionalVolumes: runParams.additionalVolumes,
           resumedFromCheckpointId: runParams.resumedFromCheckpointId,
           sessionId: runParams.sessionId,
-          artifacts: runParams.artifacts,
         });
       });
       emit(CHAT_REQUEST_OPS.create_run_insert_run_record, insertT.ms);


### PR DESCRIPTION
## Summary

Closes #10909 (part of Epic #10906).

- Collapse the old `context.artifacts` (Record<name,version>) and `context.additionalArtifacts` (AdditionalArtifact[]) split into a single `ContextArtifact[]` where every entry carries `{name, version?, mountPath}`.
- Delete the `AdditionalArtifact` type and the hardcoded `mountPath = workingDir` rule in `storage-resolver`.
- Make resolvers (`resolveCheckpoint`, `resolveSession`, `resolveConversation`) tolerant: they accept both legacy Record snapshots and new-shape array snapshots, translating via a mountPath heuristic (memory → `AUTO_MEMORY_MOUNT_PATH`, otherwise `workingDir`).
- Filter auto-memory out of `agent_sessions.artifact_names` at insert time so it is not recorded as a user-declared artifact (the zero layer re-appends it on every run).

## Test plan

- [x] Integration tests for resolvers (legacy Record decode, new array pass-through, empty/null handling)
- [x] Existing API route tests updated for the auto-memory filter and new artifact shape
- [x] Storage prepare-manifest tests updated for the new 8-arg signature
- [x] Lint (`pnpm turbo run lint`) — clean
- [x] Type check (`pnpm check-types`) — clean
- [x] Knip (`pnpm knip`) — clean (pre-existing configuration hints only)
- [x] Web test suite (`pnpm -F web exec vitest`) — 3784/3785 pass (one unrelated voice-chat-cleanup flake that passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)