### PR TITLE
fix(web): dispatch cancel side effects for voice-chat mismatch path

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/__tests__/route.test.ts
@@ -7,7 +7,12 @@ import {
   createTestCallback,
   createSignedCallbackRequest,
 } from "../../../../../../src/__tests__/api-test-helpers";
-import { setTestRunVars } from "../../../../../../src/__tests__/db-test-seeders/runs";
+import {
+  setTestRunRunnerGroup,
+  setTestRunStatus,
+  setTestRunVars,
+} from "../../../../../../src/__tests__/db-test-seeders/runs";
+import { findTestRunRecord } from "../../../../../../src/__tests__/db-test-assertions/runs";
 import { mockAblyPublish } from "../../../../../../src/__tests__/ably-mock";
 import {
   getTestVoiceChatCandidateTask,
@@ -253,6 +258,75 @@ describe("POST /api/internal/callbacks/voice-chat-candidate", () => {
       return i.role === "system_note";
     });
     expect(note).toBeDefined();
+  });
+
+  it("dispatches cancel side effects for in-flight runs on agent mismatch (#10762)", async () => {
+    // Triggering callback carries a mismatched agentId — takes the mismatch
+    // branch inside completeVoiceChatCandidateTask and triggers
+    // cancelSessionPendingRuns for the session.
+    const {
+      runId: triggerRunId,
+      taskId: triggerTaskId,
+      session,
+      secret,
+    } = await setupTaskWithCallback({
+      agentIdOnRun: "00000000-0000-0000-0000-000000000000",
+    });
+
+    // Seed a second in-flight voice-chat-candidate task for the same session.
+    // The voice-chat task stays in its default (pending/queued) state, but
+    // we flip the underlying agent_run to `running` so cancelRun observes
+    // previousStatus === 'running' and dispatchCancelSideEffects is expected
+    // to publish an Ably cancel notification to the runner group.
+    const taskResponse = await createTaskPOST(
+      postRequest(`/${session.id}/tasks`, {
+        prompt: "secondary in-flight",
+        callId: uniqueId("call"),
+      }),
+      paramsFor(session.id),
+    );
+    const { task: secondary } = (await taskResponse.json()) as {
+      task: { id: string; runId: string };
+    };
+
+    await setTestRunStatus(secondary.runId, "running");
+    await setTestRunRunnerGroup(secondary.runId, "test-group");
+
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([]);
+    mockAblyPublish.mockClear();
+
+    const response = await POST(
+      createSignedCallbackRequest(
+        CALLBACK_URL,
+        {
+          runId: triggerRunId,
+          status: "completed",
+          payload: { taskId: triggerTaskId },
+        },
+        secret,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+
+    // Flush the callback route's after() so dispatchCancelSideEffects runs.
+    await context.mocks.flushAfter();
+
+    // Secondary agent_run must have been moved to `cancelled` — this is the
+    // DB-level outcome of cancelRun running inside cancelSessionPendingRuns.
+    const secondaryRow = await findTestRunRecord(secondary.runId);
+    expect(secondaryRow!.status).toBe("cancelled");
+
+    // Runner-group Ably cancel must have been published (the specific
+    // side effect that was previously missing). Channel name is opaque
+    // through the shared mock, so match on event + payload.
+    const cancelPublish = mockAblyPublish.mock.calls.find((call) => {
+      return (
+        call[0] === "cancel" &&
+        (call[1] as { runId?: string } | null)?.runId === secondary.runId
+      );
+    });
+    expect(cancelPublish).toBeDefined();
   });
 
   it("returns 200 for unknown taskId (defensive per epic risk table)", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/route.ts
@@ -14,6 +14,7 @@ import {
   drainOrgQueue,
 } from "../../../../../src/lib/zero/zero-run-queue-service";
 import { processOrgCredits } from "../../../../../src/lib/zero/credit/credit-service";
+import { processOrgUsageEvents } from "../../../../../src/lib/zero/credit/usage-event-service";
 import { isNotFound } from "../../../../../src/lib/shared/errors";
 import type { VoiceChatCallbackPayload } from "../../../../../src/lib/infra/callback/callback-payloads";
 import { logger } from "../../../../../src/lib/shared/logger";
@@ -126,8 +127,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Mismatch path cancelled one or more pending/queued runs. Dispatch the
   // side effects (Ably cancel, registered callbacks, queue drain) once per
-  // run, then process org credits once for the batch — all cancelled runs
-  // share the session's org.
+  // run, then process org credits + usage events once for the batch —
+  // all cancelled runs share the session's org.
   if (cancelledRuns.length > 0) {
     const orgId = cancelledRuns[0]!.orgId;
     after(async () => {
@@ -138,7 +139,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         });
         if (active) anyActive = true;
       }
-      if (anyActive) await processOrgCredits(orgId);
+      if (anyActive) {
+        await processOrgCredits(orgId);
+        await processOrgUsageEvents(orgId);
+      }
     });
   }
 

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/route.ts
@@ -7,6 +7,13 @@ import { getRunOutputText } from "../../../../../src/lib/infra/run/extract-run-o
 import { completeVoiceChatCandidateTask } from "../../../../../src/lib/zero/voice-chat-candidate/task-service";
 import { triggerReasoning } from "../../../../../src/lib/zero/voice-chat-candidate/trigger-reasoning";
 import { publishUserSignal } from "../../../../../src/lib/infra/realtime/client";
+import { dispatchCancelSideEffects } from "../../../../../src/lib/infra/run/run-service";
+import type { CancelRunResult } from "../../../../../src/lib/zero/zero-run-cancel";
+import {
+  dispatchQueuedZeroRun,
+  drainOrgQueue,
+} from "../../../../../src/lib/zero/zero-run-queue-service";
+import { processOrgCredits } from "../../../../../src/lib/zero/credit/credit-service";
 import { isNotFound } from "../../../../../src/lib/shared/errors";
 import type { VoiceChatCallbackPayload } from "../../../../../src/lib/infra/callback/callback-payloads";
 import { logger } from "../../../../../src/lib/shared/logger";
@@ -84,6 +91,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   let sessionId: string;
   let userId: string;
+  let cancelledRuns: CancelRunResult[];
   try {
     const outcome = await completeVoiceChatCandidateTask({
       taskId: payload.taskId,
@@ -93,6 +101,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     });
     sessionId = outcome.session.id;
     userId = outcome.session.userId;
+    cancelledRuns = outcome.cancelledRuns;
   } catch (err) {
     if (isNotFound(err)) {
       log.warn("voice-chat-candidate task not found — ignoring callback", {
@@ -114,6 +123,24 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   after(() => {
     return triggerReasoning(sessionId);
   });
+
+  // Mismatch path cancelled one or more pending/queued runs. Dispatch the
+  // side effects (Ably cancel, registered callbacks, queue drain) once per
+  // run, then process org credits once for the batch — all cancelled runs
+  // share the session's org.
+  if (cancelledRuns.length > 0) {
+    const orgId = cancelledRuns[0]!.orgId;
+    after(async () => {
+      let anyActive = false;
+      for (const result of cancelledRuns) {
+        const active = await dispatchCancelSideEffects(result, (oid) => {
+          return drainOrgQueue(oid, dispatchQueuedZeroRun);
+        });
+        if (active) anyActive = true;
+      }
+      if (anyActive) await processOrgCredits(orgId);
+    });
+  }
 
   return NextResponse.json({ success: true });
 }

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -411,6 +411,26 @@ export async function setTestRunStatus(
 }
 
 /**
+ * Set `agent_runs.runner_group` for a run.
+ *
+ * @why-db-direct `agent_runs.runner_group` is assigned by the dispatch
+ * pipeline once the execution context has been built. Tests that need a
+ * specific runner group without standing up the full dispatch path (e.g. to
+ * force `publishCancelNotification` in cancel-flow tests) must seed it
+ * directly.
+ */
+export async function setTestRunRunnerGroup(
+  runId: string,
+  runnerGroup: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(agentRuns)
+    .set({ runnerGroup })
+    .where(eq(agentRuns.id, runId));
+}
+
+/**
  * Set `agent_runs.vars` JSONB for a run.
  *
  * @why-db-direct `agent_runs.vars` is written by the runner during execution;

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/task-service.ts
@@ -6,7 +6,7 @@ import {
   voiceChatTasks,
 } from "../../../db/schema/voice-chat";
 import { type CreateZeroRunResult } from "../zero-run-service";
-import { cancelRun } from "../zero-run-cancel";
+import { cancelRun, type CancelRunResult } from "../zero-run-cancel";
 import { isRunNotCancellable, notFound } from "../../shared/errors";
 import { logger } from "../../shared/logger";
 
@@ -63,6 +63,7 @@ export async function completeVoiceChatCandidateTask(params: {
   item: ItemRow;
   task: TaskRow;
   session: { id: string; userId: string };
+  cancelledRuns: CancelRunResult[];
 }> {
   const db = globalThis.services.db;
 
@@ -192,14 +193,15 @@ export async function completeVoiceChatCandidateTask(params: {
     };
   });
 
-  if (outcome.mismatch) {
-    await cancelSessionPendingRuns(outcome.session);
-  }
+  const cancelledRuns = outcome.mismatch
+    ? await cancelSessionPendingRuns(outcome.session)
+    : [];
 
   return {
     task: outcome.task,
     item: outcome.item,
     session: { id: outcome.session.id, userId: outcome.session.userId },
+    cancelledRuns,
   };
 }
 
@@ -337,16 +339,23 @@ export async function appendTaskAssistantResult(params: {
   return { sessionId: row.sessionId, userId: session.userId };
 }
 
+// Returns the `CancelRunResult` for each run this call actually transitioned
+// to `cancelled`. `alreadyCancelled` replays are filtered out — the original
+// caller owned their side effects. The caller is responsible for invoking
+// `dispatchCancelSideEffects` / `processOrgCredits`; this module stays free of
+// Next.js request-context coupling so non-HTTP callers remain safe.
 async function cancelSessionPendingRuns(session: {
   id: string;
   orgId: string;
   userId: string;
-}): Promise<void> {
+}): Promise<CancelRunResult[]> {
   const pending = await listPendingVoiceChatCandidateTasks(session.id);
+  const cancelled: CancelRunResult[] = [];
   for (const task of pending) {
     if (!task.runId) continue;
     try {
-      await cancelRun(task.runId, session.userId, session.orgId);
+      const result = await cancelRun(task.runId, session.userId, session.orgId);
+      if (!result.alreadyCancelled) cancelled.push(result);
     } catch (err) {
       // Only swallow the expected "already terminal" signal from the run
       // state machine. Any other error (DB failure, permission mismatch,
@@ -359,6 +368,7 @@ async function cancelSessionPendingRuns(session: {
       );
     }
   }
+  return cancelled;
 }
 
 function formatTaskResult(params: {


### PR DESCRIPTION
## Summary
- Closes #10762
- `cancelSessionPendingRuns` was dropping the `cancelRun` result on the voice-chat-candidate agent-mismatch path, so cancelled runs transitioned in the DB but never fired `dispatchCancelSideEffects`: **no Ably cancel to the runner, no user webhooks, no queue drain, no credit reconciliation**. Matches the `/api/zero/runs/:id/cancel` and `/api/agent/runs/:id/cancel` pattern that already does this correctly.
- Surface `CancelRunResult[]` from `cancelSessionPendingRuns` up through `completeVoiceChatCandidateTask`; the callback route schedules one `after()` that calls `dispatchCancelSideEffects` per run (per-run Ably/callback/drain) and `processOrgCredits` once per batch.
- `task-service.ts` stays a pure lib — no `next/server` import, no coupling to Next.js request context. Future non-HTTP callers (cron/scripts) remain safe.
- The ` voice-chat/task-service.ts:178` location in the issue body was removed by #10764 when the backend voice-chat surface was deleted; only voice-chat-candidate needs this fix.

## Changes
- \`turbo/apps/web/src/lib/zero/voice-chat-candidate/task-service.ts\` — \`cancelSessionPendingRuns\` returns \`CancelRunResult[]\` (filters out \`alreadyCancelled\`); \`completeVoiceChatCandidateTask\` return shape gains \`cancelledRuns\`.
- \`turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/route.ts\` — new \`after()\` walks \`outcome.cancelledRuns\`, invokes \`dispatchCancelSideEffects\` per run with the real drain closure (\`drainOrgQueue + dispatchQueuedZeroRun\`), and \`processOrgCredits(orgId)\` once iff any run was previously active.
- \`turbo/apps/web/src/__tests__/db-test-seeders/runs.ts\` — new \`setTestRunRunnerGroup\` helper (\`@why-db-direct\`: dispatch pipeline assigns the group; tests that force \`publishCancelNotification\` need to seed it).
- \`turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/__tests__/route.test.ts\` — extended mismatch case seeds a second in-flight run (\`running\` + \`runnerGroup\`); asserts the \`agent_runs\` row is \`cancelled\` and a runner-group Ably \`cancel\` publish was emitted.

## Test plan
- [x] \`pnpm -F web exec vitest run app/api/internal/callbacks/voice-chat-candidate\` — 8 pass including the new \`dispatches cancel side effects for in-flight runs on agent mismatch (#10762)\`
- [x] \`pnpm -F web exec vitest run src/lib/zero/voice-chat-candidate\` — 21 pass
- [x] \`pnpm turbo run lint --filter=web\` — 0 errors
- [x] \`pnpm check-types\` — clean
- [x] \`pnpm knip\` — no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)