### PR TITLE
ci(runner): raise wait_for_exit budget from 5s to 15s

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1365,7 +1365,11 @@ jobs:
           # is still active afterward so the EXIT trap dumps journalctl at the
           # right diagnostic boundary (instead of hanging inside systemctl stop).
           wait_for_exit() {
-            local svc=$1 budget=${2:-5}
+            # Budget must exceed the 10s heartbeat tick — drain can only
+            # complete on a tick boundary, so anything <10s has no headroom
+            # for the ~9s real teardown work (idle pool + namespace cleanup
+            # + mitm/dns/kmsg shutdown). 15s = 1.5× tick. See issue #10869.
+            local svc=$1 budget=${2:-15}
             echo "--- Waiting up to ${budget}s for $svc to exit ---"
             for i in $(seq 1 "$budget"); do
               systemctl is-active --quiet "vm0-runner-${svc}" || return 0


### PR DESCRIPTION
## Summary

- Raise `wait_for_exit` budget in `runner-upgrade-local` from 5s to 15s.
- 5s is strictly below the 10s heartbeat tick, so drain (which can only complete on a tick boundary) has no headroom for the legitimate ~9s teardown work (idle pool + namespace cleanup + mitm/dns/kmsg shutdown).
- 15s = 1.5× tick.

## Gate check (per issue #10869)

> Do NOT merge this until PR #10864 has been observed for several merges. If flakes persist, ship this.

- #10864 merged 2026-04-23 11:14.
- Post-merge observation: still seeing the `still active after 5s` failure — e.g. PR #10897 on branch `feat/guest-agent-post-result-reap` hit it at 2026-04-23 13:24, needed retries.
- Parallelizing idle-pool drain lowered the mean teardown but not the max; the structural issue (budget < heartbeat period) remains.

Closes #10869.

## Test plan

- [ ] `runner-upgrade-local` passes on this PR
- [ ] Observe a few downstream merges for absence of `still active after` failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)