### PR TITLE
refactor(checkpoint): tolerate array-shape artifact snapshots end-to-end

### DIFF
--- a/turbo/apps/web/app/api/agent/checkpoints/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/checkpoints/[id]/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
   completeTestRun,
   getOrgCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { setTestCheckpointArtifactSnapshots } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import {
   testContext,
   uniqueId,
@@ -135,6 +136,32 @@ describe("GET /api/agent/checkpoints/:id", () => {
 
     expect(response.status).toBe(404);
     expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should project array-shape artifactSnapshots to Record on the response wire", async () => {
+    // Post-#10911 guest-agents persist Array<{name, version, mountPath}> in
+    // the JSONB column. The outbound wire stays Record-shaped for CLI
+    // consumers, so the GET handler must normalise.
+    const { runId } = await createTestRun(testComposeId, "Array snapshot");
+    const { checkpointId } = await completeTestRun(user.userId, runId);
+
+    await setTestCheckpointArtifactSnapshots(checkpointId, [
+      { name: "frontend", version: "v-fe-1", mountPath: "/workspace/fe" },
+      { name: "backend", version: "v-be-2", mountPath: "/workspace/be" },
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/checkpoints/${checkpointId}`,
+    );
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.artifactSnapshots).toEqual({
+      frontend: "v-fe-1",
+      backend: "v-be-2",
+    });
   });
 
   it("should return 401 when not authenticated", async () => {

--- a/turbo/apps/web/app/api/agent/checkpoints/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/checkpoints/[id]/route.ts
@@ -10,6 +10,7 @@ import { checkpoints } from "../../../../../src/db/schema/checkpoint";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
+import { decodeToRecord } from "../../../../../src/lib/infra/checkpoint/decode-artifact-snapshots";
 
 interface AgentComposeSnapshot {
   agentComposeVersionId: string;
@@ -77,8 +78,10 @@ const router = tsr.router(checkpointsByIdContract, {
 
     const agentComposeSnapshot =
       checkpoint.agentComposeSnapshot as AgentComposeSnapshot;
-    const artifactSnapshots =
-      (checkpoint.artifactSnapshots as Record<string, string> | null) ?? null;
+    // `checkpoint.artifactSnapshots` is a JSONB column; post-#10911 it may be
+    // either the legacy Record or the canonical Array shape. Normalise to
+    // Record on the outbound wire — CLI consumers still expect that shape.
+    const artifactSnapshots = decodeToRecord(checkpoint.artifactSnapshots);
     const volumeVersionsSnapshot =
       checkpoint.volumeVersionsSnapshot as VolumeVersionsSnapshot | null;
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -378,6 +378,52 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       expect(checkpoint).toBeDefined();
       expect(checkpoint!.artifactSnapshots).toEqual(artifactSnapshots);
     });
+
+    it("should persist canonical array-shape artifactSnapshots verbatim", async () => {
+      // Post-#10911 payload: Array<{name, version, mountPath}>. Receiver
+      // persists the array shape to the JSONB column unchanged; the 200
+      // response echoes the stored shape.
+      const artifactSnapshots = [
+        {
+          name: "artifact-a",
+          version: "version-aaa",
+          mountPath: "/workspace/a",
+        },
+        {
+          name: "artifact-b",
+          version: "version-bbb",
+          mountPath: "/workspace/b",
+        },
+      ];
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "array-shape-session",
+            cliAgentSessionHistoryHash: sha256("array-shape-history"),
+            artifactSnapshots,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.artifacts).toEqual(artifactSnapshots);
+
+      const checkpoint = await findTestCheckpoint(testRunId);
+      expect(checkpoint).toBeDefined();
+      expect(checkpoint!.artifactSnapshots).toEqual(artifactSnapshots);
+    });
   });
 
   describe("Session independence", () => {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -312,6 +312,71 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(result.artifact).toEqual(artifactSnapshots);
     });
 
+    it("should project array-shape artifactSnapshots to Record in result.artifact", async () => {
+      // Post-#10911 guest-agents emit Array<{name, version, mountPath}>.
+      // RunResult.artifact is still Record-shaped for downstream consumers,
+      // so the complete-webhook must normalise on the way out.
+      const arrayShape = [
+        {
+          name: "frontend-build",
+          version: "v-frontend-1",
+          mountPath: "/workspace/fe",
+        },
+        {
+          name: "backend-build",
+          version: "v-backend-2",
+          mountPath: "/workspace/be",
+        },
+      ];
+
+      const checkpointRequest = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "array-shape-complete",
+            cliAgentSessionHistoryHash:
+              "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
+            artifactSnapshots: arrayShape,
+          }),
+        },
+      );
+      const checkpointResponse = await checkpointWebhook(checkpointRequest);
+      expect(checkpointResponse.status).toBe(200);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const run = await findTestRunRecord(testRunId);
+      expect(run!.status).toBe("completed");
+      const result = run!.result as { artifact?: Record<string, string> };
+      expect(result.artifact).toEqual({
+        "frontend-build": "v-frontend-1",
+        "backend-build": "v-backend-2",
+      });
+    });
+
     it("should store error with report URL on failed completion", async () => {
       // Create run directly in DB in running state to avoid runner_job_queue issues
       const { runId } = await seedTestRun(user.userId, testComposeId, {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -14,6 +14,7 @@ import {
   dispatchTerminalSideEffects,
 } from "../../../../../src/lib/infra/run/run-status";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
+import { decodeToRecord } from "../../../../../src/lib/infra/checkpoint/decode-artifact-snapshots";
 import type { RunResult } from "../../../../../src/lib/infra/run/types";
 import { logger } from "../../../../../src/lib/shared/logger";
 import {
@@ -47,13 +48,18 @@ function scheduleTerminalSideEffects(
 
 /**
  * Build a RunResult from a checkpoint record.
+ *
+ * `checkpoint.artifactSnapshots` is a JSONB column (runtime type `unknown`)
+ * that may contain either the legacy Record<name, version> shape or the
+ * canonical Array<{name, version, mountPath}>. `RunResult.artifact` is still
+ * Record-shaped for downstream consumers, so we project the array shape back
+ * to Record on the way out. Empty payloads project to null and are dropped.
  */
 function buildRunResult(
   checkpoint: typeof checkpoints.$inferSelect,
   sessionId: string | undefined,
 ): RunResult {
-  const artifactSnapshots =
-    (checkpoint.artifactSnapshots as Record<string, string> | null) ?? null;
+  const artifactRecord = decodeToRecord(checkpoint.artifactSnapshots);
   const volumeVersions = checkpoint.volumeVersionsSnapshot as
     | { versions: Record<string, string> }
     | undefined;
@@ -65,8 +71,8 @@ function buildRunResult(
     volumes: volumeVersions?.versions,
   };
 
-  if (artifactSnapshots && Object.keys(artifactSnapshots).length > 0) {
-    result.artifact = artifactSnapshots;
+  if (artifactRecord) {
+    result.artifact = artifactRecord;
   }
 
   return result;

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -13,6 +13,7 @@ import type {
   AgentComposeSnapshot,
   VolumeVersionsSnapshot,
 } from "./types";
+import { isEmptyArtifactPayload } from "./decode-artifact-snapshots";
 
 const log = logger("checkpoint");
 
@@ -143,9 +144,14 @@ export async function createCheckpoint(
       }
     : null;
 
-  const rawMap = request.artifactSnapshots ?? null;
-  const hasMap = rawMap !== null && Object.keys(rawMap).length > 0;
-  const artifactSnapshotsMap = hasMap ? rawMap : null;
+  // Persist the artifactSnapshots payload verbatim to the JSONB column —
+  // accepts both the legacy Record<name, version> shape and the canonical
+  // Array<{name, version, mountPath}> shape. Empty payloads (null, {}, [])
+  // collapse to NULL so "no artifacts" has a single on-disk representation.
+  const rawPayload = request.artifactSnapshots ?? null;
+  const artifactSnapshotsForDb = isEmptyArtifactPayload(rawPayload)
+    ? null
+    : rawPayload;
 
   const snapshotFields = {
     conversationId: conversation.id,
@@ -153,7 +159,7 @@ export async function createCheckpoint(
       string,
       unknown
     >,
-    artifactSnapshots: artifactSnapshotsMap,
+    artifactSnapshots: artifactSnapshotsForDb,
     volumeVersionsSnapshot: enrichedVolumeSnapshot as unknown as Record<
       string,
       unknown
@@ -200,7 +206,7 @@ export async function createCheckpoint(
     checkpointId: checkpoint.id,
     agentSessionId: agentSession.id,
     conversationId: conversation.id,
-    artifacts: artifactSnapshotsMap ?? undefined,
+    artifacts: artifactSnapshotsForDb ?? undefined,
     volumes,
   };
 }

--- a/turbo/apps/web/src/lib/infra/checkpoint/decode-artifact-snapshots.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/decode-artifact-snapshots.ts
@@ -1,0 +1,145 @@
+import { badRequest } from "../../shared/errors";
+import type { ContextArtifact } from "../run/types";
+import {
+  AUTO_MEMORY_ARTIFACT_NAME,
+  AUTO_MEMORY_MOUNT_PATH,
+} from "../storage/types";
+
+/**
+ * Decoders for the `checkpoints.artifact_snapshots` JSONB column.
+ *
+ * The column accepts two shapes (see #10909 for the reader-tolerance rollout
+ * and #10911 for the writer flip):
+ *
+ * - Legacy: `Record<name, version>` — pre-#10911 guest-agent payloads. No
+ *   mountPath, so readers that need one stamp it via a name heuristic
+ *   ("memory" → AUTO_MEMORY_MOUNT_PATH, anything else → workingDir).
+ * - Canonical: `Array<{name, version, mountPath}>` — post-#10911 payloads.
+ *   Carries the mount path per entry; no heuristics required.
+ *
+ * All runtime validation lives here so malformed historical rows fail fast
+ * with a descriptive error rather than surfacing much later as an opaque
+ * mount failure.
+ */
+
+/**
+ * Is `raw` a "no artifacts" payload? Treats null/undefined, empty record, and
+ * empty array all as equivalent to "persist NULL." Exported so write-paths
+ * can normalise before inserting to the JSONB column without needing to know
+ * which shape the caller sent.
+ */
+export function isEmptyArtifactPayload(raw: unknown): boolean {
+  if (raw === null || raw === undefined) return true;
+  if (Array.isArray(raw)) return raw.length === 0;
+  if (typeof raw === "object") return Object.keys(raw).length === 0;
+  return false;
+}
+
+/**
+ * Decode the JSONB column into the unified `ContextArtifact[]` form consumed
+ * by `resolve-checkpoint.ts` (and any other code path that needs mountPath
+ * stamped on every entry). Legacy entries get their mountPath via the name
+ * heuristic.
+ */
+export function decodeToContextArtifacts(
+  raw: unknown,
+  workingDir: string,
+): ContextArtifact[] {
+  if (raw === null || raw === undefined) return [];
+
+  if (Array.isArray(raw)) {
+    return raw.map((entry, i) => {
+      if (!isContextArtifact(entry)) {
+        throw badRequest(
+          `Invalid checkpoint: artifactSnapshots[${i}] is not a valid ContextArtifact`,
+        );
+      }
+      return entry;
+    });
+  }
+
+  if (typeof raw !== "object") {
+    throw badRequest(
+      "Invalid checkpoint: artifactSnapshots must be an array or object",
+    );
+  }
+
+  return Object.entries(raw as Record<string, unknown>).map(
+    ([name, version]) => {
+      if (typeof version !== "string") {
+        throw badRequest(
+          `Invalid checkpoint: artifactSnapshots["${name}"] must be a string version`,
+        );
+      }
+      return {
+        name,
+        version,
+        mountPath:
+          name === AUTO_MEMORY_ARTIFACT_NAME
+            ? AUTO_MEMORY_MOUNT_PATH
+            : workingDir,
+      };
+    },
+  );
+}
+
+/**
+ * Project the JSONB column to a `Record<name, version>` for outbound surfaces
+ * that currently speak the legacy shape (e.g., `RunResult.artifact`, the CLI
+ * `GET /api/agent/checkpoints/:id` response arm). mountPath is discarded; a
+ * name collision in the array shape — which should never happen for a
+ * well-formed snapshot — lets the last entry win, matching Object-literal
+ * semantics.
+ *
+ * Returns `null` when the payload is empty (see `isEmptyArtifactPayload`).
+ */
+export function decodeToRecord(raw: unknown): Record<string, string> | null {
+  if (isEmptyArtifactPayload(raw)) return null;
+
+  if (Array.isArray(raw)) {
+    const result: Record<string, string> = {};
+    for (const [i, entry] of raw.entries()) {
+      if (!isContextArtifact(entry)) {
+        throw badRequest(
+          `Invalid checkpoint: artifactSnapshots[${i}] is not a valid ContextArtifact`,
+        );
+      }
+      if (entry.version === undefined) {
+        throw badRequest(
+          `Invalid checkpoint: artifactSnapshots[${i}] has no version`,
+        );
+      }
+      result[entry.name] = entry.version;
+    }
+    return result;
+  }
+
+  if (typeof raw !== "object" || raw === null) {
+    throw badRequest(
+      "Invalid checkpoint: artifactSnapshots must be an array or object",
+    );
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const result: Record<string, string> = {};
+  for (const [name, version] of Object.entries(obj)) {
+    if (typeof version !== "string") {
+      throw badRequest(
+        `Invalid checkpoint: artifactSnapshots["${name}"] must be a string version`,
+      );
+    }
+    result[name] = version;
+  }
+  return result;
+}
+
+function isContextArtifact(value: unknown): value is ContextArtifact {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  if (typeof entry.name !== "string") return false;
+  if (typeof entry.mountPath !== "string") return false;
+  if (entry.version !== undefined && typeof entry.version !== "string") {
+    return false;
+  }
+  return true;
+}

--- a/turbo/apps/web/src/lib/infra/checkpoint/types.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/types.ts
@@ -3,6 +3,20 @@
  */
 
 /**
+ * Artifact snapshot payload shapes the writer may send. Legacy Record is still
+ * accepted (pre-#10911 guest-agents) and the canonical array shape carries
+ * mountPath per entry (post-#10911). Receiver tolerance lives in
+ * `decode-artifact-snapshots.ts`.
+ *
+ * Note: the array-entry's `version` is always a resolved concrete string —
+ * distinct from `ContextArtifact` (execution-context type) where `version` is
+ * optional and defaults to "latest".
+ */
+export type ArtifactSnapshotsPayload =
+  | Record<string, string>
+  | Array<{ name: string; version: string; mountPath: string }>;
+
+/**
  * Agent compose snapshot stored in checkpoint
  * Uses version ID for reproducibility (content-addressed versioning)
  * Note: Environment is re-expanded from vars/secrets on resume, not stored
@@ -37,10 +51,10 @@ export interface CheckpointRequest {
   cliAgentType: string;
   cliAgentSessionId: string;
   cliAgentSessionHistoryHash: string;
-  // Multi-artifact snapshot map: artifactName -> versionId. Emitted
-  // unconditionally by the guest-agent; may be empty or missing when the
-  // guest snapshotted nothing.
-  artifactSnapshots?: Record<string, string>;
+  // Multi-artifact snapshot payload. Accepts both legacy Record (pre-#10911)
+  // and canonical array (post-#10911) shapes; persisted verbatim to the
+  // JSONB column. May be empty or missing when the guest snapshotted nothing.
+  artifactSnapshots?: ArtifactSnapshotsPayload;
   volumeVersionsSnapshot?: VolumeVersionsSnapshot;
 }
 
@@ -51,6 +65,6 @@ export interface CheckpointResponse {
   checkpointId: string;
   agentSessionId: string;
   conversationId: string;
-  artifacts?: Record<string, string>;
+  artifacts?: ArtifactSnapshotsPayload;
   volumes?: Record<string, string>;
 }

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
@@ -9,13 +9,9 @@ import type {
   AgentComposeSnapshot,
   VolumeVersionsSnapshot,
 } from "../../checkpoint/types";
+import { decodeToContextArtifacts } from "../../checkpoint/decode-artifact-snapshots";
 import type { AgentComposeYaml } from "../../agent-compose/types";
 import type { ConversationResolution } from "./types";
-import type { ContextArtifact } from "../types";
-import {
-  AUTO_MEMORY_ARTIFACT_NAME,
-  AUTO_MEMORY_MOUNT_PATH,
-} from "../../storage/types";
 import { extractWorkingDir } from "../utils";
 import { resolveSessionHistory } from "./resolve-session-history";
 
@@ -52,7 +48,7 @@ export async function resolveCheckpoint(
   const agentComposeSnapshot =
     checkpoint.agentComposeSnapshot as unknown as AgentComposeSnapshot;
   // artifactSnapshots is a Drizzle jsonb column (runtime type `unknown`).
-  // decodeCheckpointArtifacts does the runtime shape check; never cast here.
+  // decodeToContextArtifacts does the runtime shape check; never cast here.
   const rawArtifacts: unknown = checkpoint.artifactSnapshots;
   const checkpointVolumeVersions =
     checkpoint.volumeVersionsSnapshot as VolumeVersionsSnapshot | null;
@@ -125,7 +121,7 @@ export async function resolveCheckpoint(
   }
   const agentCompose = version.content as AgentComposeYaml;
   const workingDir = extractWorkingDir(agentCompose);
-  const artifacts = decodeCheckpointArtifacts(rawArtifacts, workingDir);
+  const artifacts = decodeToContextArtifacts(rawArtifacts, workingDir);
 
   return {
     conversationId: checkpoint.conversationId,
@@ -141,70 +137,4 @@ export async function resolveCheckpoint(
     volumeVersions: checkpointVolumeVersions?.versions,
     additionalVolumes: checkpointAdditionalVolumes,
   };
-}
-
-/**
- * Decode checkpoint.artifactSnapshots into the unified ContextArtifact[] form.
- *
- * Input is a Drizzle `jsonb` column (runtime type `unknown`), so every branch
- * must validate the shape at runtime — a malformed historical row should fail
- * fast here with a descriptive error rather than surface much later as an
- * opaque mount failure.
- *
- * Accepts both shapes:
- * - Legacy: `Record<name, version>` — stamped with a mountPath via the name
- *   heuristic ("memory" → AUTO_MEMORY_MOUNT_PATH, anything else → workingDir).
- * - New: `Array<{name, version?, mountPath}>` — validated and passed through.
- */
-function decodeCheckpointArtifacts(
-  raw: unknown,
-  workingDir: string,
-): ContextArtifact[] {
-  if (raw === null || raw === undefined) return [];
-
-  if (Array.isArray(raw)) {
-    return raw.map((entry, i) => {
-      if (!isContextArtifact(entry)) {
-        throw badRequest(
-          `Invalid checkpoint: artifactSnapshots[${i}] is not a valid ContextArtifact`,
-        );
-      }
-      return entry;
-    });
-  }
-
-  if (typeof raw !== "object") {
-    throw badRequest(
-      "Invalid checkpoint: artifactSnapshots must be an array or object",
-    );
-  }
-
-  return Object.entries(raw as Record<string, unknown>).map(
-    ([name, version]) => {
-      if (typeof version !== "string") {
-        throw badRequest(
-          `Invalid checkpoint: artifactSnapshots["${name}"] must be a string version`,
-        );
-      }
-      return {
-        name,
-        version,
-        mountPath:
-          name === AUTO_MEMORY_ARTIFACT_NAME
-            ? AUTO_MEMORY_MOUNT_PATH
-            : workingDir,
-      };
-    },
-  );
-}
-
-function isContextArtifact(value: unknown): value is ContextArtifact {
-  if (typeof value !== "object" || value === null) return false;
-  const entry = value as Record<string, unknown>;
-  if (typeof entry.name !== "string") return false;
-  if (typeof entry.mountPath !== "string") return false;
-  if (entry.version !== undefined && typeof entry.version !== "string") {
-    return false;
-  }
-  return true;
 }

--- a/turbo/packages/core/src/contracts/sessions.ts
+++ b/turbo/packages/core/src/contracts/sessions.ts
@@ -35,6 +35,25 @@ const volumeVersionsSnapshotSchema = z.object({
 });
 
 /**
+ * Artifact snapshots schema.
+ *
+ * Tolerant union accepting both the legacy `Record<name, version>` map
+ * (pre-#10911 guest-agent payloads) and the canonical `Array<{name, version,
+ * mountPath}>` form (post-#10911). The GET-by-id handler echoes whatever shape
+ * is stored in the JSONB column; CLI consumers tolerate both via the union.
+ */
+const artifactSnapshotsSchema = z.union([
+  z.record(z.string(), z.string()),
+  z.array(
+    z.object({
+      name: z.string(),
+      version: z.string(),
+      mountPath: z.string(),
+    }),
+  ),
+]);
+
+/**
  * Checkpoint response schema
  * Represents an immutable snapshot of agent run state
  */
@@ -43,9 +62,11 @@ const checkpointResponseSchema = z.object({
   runId: z.string(),
   conversationId: z.string(),
   agentComposeSnapshot: agentComposeSnapshotSchema,
-  // Multi-artifact snapshot map: artifact name → version id. Null when the
-  // checkpoint has no artifacts.
-  artifactSnapshots: z.record(z.string(), z.string()).nullable(),
+  // Multi-artifact snapshot payload. Accepts both the legacy
+  // `Record<name, version>` map and the canonical
+  // `Array<{name, version, mountPath}>` form. Null when the checkpoint has
+  // no artifacts.
+  artifactSnapshots: artifactSnapshotsSchema.nullable(),
   volumeVersionsSnapshot: volumeVersionsSnapshotSchema.nullable(),
   createdAt: z.string(),
 });

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -46,6 +46,26 @@ const agentEventSchema = z
   .passthrough();
 
 /**
+ * Artifact snapshots schema.
+ *
+ * Tolerant union accepting both the legacy `Record<name, version>` map
+ * (pre-#10911 guest-agent payloads) and the canonical `Array<{name, version,
+ * mountPath}>` form (post-#10911). Receivers persist the payload verbatim to
+ * the JSONB column and normalise only at read-out boundaries — keeping this
+ * schema itself shape-preserving.
+ */
+const artifactSnapshotsSchema = z.union([
+  z.record(z.string(), z.string()),
+  z.array(
+    z.object({
+      name: z.string(),
+      version: z.string(),
+      mountPath: z.string(),
+    }),
+  ),
+]);
+
+/**
  * Volume versions snapshot schema
  */
 const volumeVersionsSnapshotSchema = z.object({
@@ -146,9 +166,11 @@ export const webhookCheckpointsContract = c.router({
             64,
             "cliAgentSessionHistoryHash must be a 64-character SHA-256 hex string",
           ),
-        // Multi-artifact snapshot map: artifact name → version id.
-        // Authoritative payload persisted to checkpoints.artifact_snapshots.
-        artifactSnapshots: z.record(z.string(), z.string()).optional(),
+        // Multi-artifact snapshot payload. Accepts both the legacy
+        // `Record<name, version>` map and the canonical
+        // `Array<{name, version, mountPath}>` form. Authoritative payload
+        // persisted verbatim to checkpoints.artifact_snapshots.
+        artifactSnapshots: artifactSnapshotsSchema.optional(),
         volumeVersionsSnapshot: volumeVersionsSnapshotSchema.optional(),
       })
       .strict(),
@@ -157,7 +179,7 @@ export const webhookCheckpointsContract = c.router({
         checkpointId: z.string(),
         agentSessionId: z.string(),
         conversationId: z.string(),
-        artifacts: z.record(z.string(), z.string()).optional(),
+        artifacts: artifactSnapshotsSchema.optional(),
         volumes: z.record(z.string(), z.string()).optional(),
       }),
       400: apiErrorSchema,


### PR DESCRIPTION
## Summary

Precondition PR for #10911 (Epic #10906). Widens the Zod contracts and fixes the remaining three receiver cast sites to accept both the legacy `Record<name, version>` shape and the canonical `Array<{name, version, mountPath}>` shape for `artifactSnapshots`.

After this PR ships to production, #10911's Rust writer flip can safely emit the new array shape without 400-ing old receivers.

## Changes

- **Contracts (`@vm0/core`)**: `webhooks.ts:151` and `sessions.ts:48` now use a `z.union([record, array])`. The response `artifacts` field on `POST /api/webhooks/agent/checkpoints` also widens.
- **Shared decoder (`lib/infra/checkpoint/decode-artifact-snapshots.ts`)**: lifts the tolerant decoder previously private to `resolve-checkpoint.ts`. Exports:
  - `decodeToContextArtifacts(raw, workingDir)` — existing resolver behavior (consumed by `resolve-checkpoint.ts`)
  - `decodeToRecord(raw)` — projects array-shape entries to `{name → version}` for outbound Record-shape surfaces
  - `isEmptyArtifactPayload(raw)` — shape-agnostic empty-payload check for write paths
- **`checkpoint-service.ts`**: persist payload verbatim (both shapes); empty arrays / records / null all collapse to DB NULL.
- **`complete/route.ts` `buildRunResult`**: was `checkpoint.artifactSnapshots as Record<string, string>` — now uses `decodeToRecord` so array-shape rows still surface correctly in `RunResult.artifact`.
- **`agent/checkpoints/[id]/route.ts` GET**: same cast fix via `decodeToRecord`; outbound wire stays Record-shape for CLI consumers.
- **`resolve-checkpoint.ts`**: imports the lifted helper, removes the local copy.

## Deploy order

This PR ships first. #10911's writer flip waits until this is live in production — per epic #10906's precondition rule.

## Test plan

- [x] `pnpm -F @vm0/core lint`
- [x] `pnpm -F web lint`
- [x] `pnpm check-types` (all packages)
- [x] `pnpm format`
- [x] `pnpm knip`
- [x] `pnpm -F web exec vitest run src/lib/infra/run/resolvers/__tests__/` (7 passed)
- [x] `pnpm -F web exec vitest run app/api/webhooks/agent/checkpoints/__tests__/route.test.ts` (18 passed; +1 new array-shape test)
- [x] `pnpm -F web exec vitest run app/api/webhooks/agent/complete/__tests__/route.test.ts` (27 passed; +1 new array-shape→record test)
- [x] `pnpm -F web exec vitest run app/api/agent/checkpoints/` (6 passed; +1 new array-shape response-normalisation test)

Closes: none (precondition for #10911)
Related: #10906 (epic), #10911 (sibling writer flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)