### PR TITLE
fix(zero): skip memory injection on checkpoint/session resume paths (#10910)

### DIFF
--- a/turbo/apps/web/src/lib/infra/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/infra/storage/storage-service.ts
@@ -443,10 +443,11 @@ async function resolveArtifactEntry(
 }
 
 /**
- * Dedup by name, last wins. Callers build artifact lists from multiple
- * sources (snapshot, CLI --artifact flag, auto-memory injection) and may
- * introduce duplicate names; collapsing here lets the auto-injected memory
- * entry override a matching checkpoint snapshot without any upstream awareness.
+ * Dedup by name, last wins. Callers compose artifact lists from multiple
+ * sources (resolution snapshot, CLI --artifact flag, new-run auto-memory
+ * injection). On resume the resolution is authoritative — Zero no longer
+ * re-injects memory, so the only overlap this dedup still covers is a
+ * user-declared `memory` entry on a new run colliding with the injected one.
  */
 function dedupArtifactsByName(artifacts: ContextArtifact[]): ContextArtifact[] {
   const byName = new Map<string, ContextArtifact>();

--- a/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
@@ -6,13 +6,20 @@ import {
 } from "../../../__tests__/test-helpers";
 import {
   createTestCompose,
+  createTestRun,
   createTestSecret,
   createTestVariable,
   createTestUserConnector,
+  completeTestRun,
   findTestRunnerJobEntry,
   insertTestConnectorSecret,
 } from "../../../__tests__/api-test-helpers";
 import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
+import {
+  setTestSessionArtifactNames,
+  setTestSessionFramework,
+} from "../../../__tests__/db-test-seeders/agents";
+import { setTestCheckpointArtifactSnapshots } from "../../../__tests__/db-test-seeders/runs";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
 import { createZeroRun } from "../zero-run-service";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
@@ -24,6 +31,10 @@ import { setVariable } from "../variable/variable-service";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { isNoModelProvider } from "../../shared/errors";
 import { reloadEnv } from "../../../env";
+import {
+  AUTO_MEMORY_ARTIFACT_NAME,
+  AUTO_MEMORY_MOUNT_PATH,
+} from "../../infra/storage/types";
 import type { TriggerSource } from "@vm0/core/contracts/logs";
 
 const context = testContext();
@@ -469,6 +480,99 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
       expect(job!.executionContext.environment).toMatchObject({
         MY_CUSTOM_SECRET: "custom-value",
       });
+    });
+  });
+
+  describe("Auto-memory injection gating", () => {
+    it("new run injects memory exactly once at AUTO_MEMORY_MOUNT_PATH", async () => {
+      const result = await createZeroRun(baseParams());
+      await context.mocks.flushAfter();
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      const memoryEntries =
+        job!.executionContext.storageManifest!.artifacts.filter((a) => {
+          return a.vasStorageName === AUTO_MEMORY_ARTIFACT_NAME;
+        });
+      expect(memoryEntries).toHaveLength(1);
+      expect(memoryEntries[0]!.mountPath).toBe(AUTO_MEMORY_MOUNT_PATH);
+    });
+
+    it("checkpoint resume trusts resolution memory entry", async () => {
+      const seed = await createTestRun(agentId, "seed");
+      const { checkpointId } = await completeTestRun(user.userId, seed.runId);
+      await setTestCheckpointArtifactSnapshots(checkpointId, {
+        [AUTO_MEMORY_ARTIFACT_NAME]: "latest",
+      });
+
+      const resumed = await createTestRun(agentId, "resume", { checkpointId });
+      await context.mocks.flushAfter();
+
+      const job = await findTestRunnerJobEntry(resumed.runId);
+      expect(job).toBeDefined();
+      const memoryEntries =
+        job!.executionContext.storageManifest!.artifacts.filter((a) => {
+          return a.vasStorageName === AUTO_MEMORY_ARTIFACT_NAME;
+        });
+      expect(memoryEntries).toHaveLength(1);
+      expect(memoryEntries[0]!.mountPath).toBe(AUTO_MEMORY_MOUNT_PATH);
+    });
+
+    it("session continue trusts resolution memory entry", async () => {
+      const seed = await createZeroRun(baseParams());
+      await context.mocks.flushAfter();
+      await completeTestRun(user.userId, seed.runId);
+      await setTestSessionFramework(seed.sessionId, "claude-code");
+      await setTestSessionArtifactNames(seed.sessionId, [
+        AUTO_MEMORY_ARTIFACT_NAME,
+      ]);
+
+      const resumed = await createZeroRun(
+        baseParams({ sessionId: seed.sessionId }),
+      );
+      await context.mocks.flushAfter();
+
+      const job = await findTestRunnerJobEntry(resumed.runId);
+      expect(job).toBeDefined();
+      const memoryEntries =
+        job!.executionContext.storageManifest!.artifacts.filter((a) => {
+          return a.vasStorageName === AUTO_MEMORY_ARTIFACT_NAME;
+        });
+      expect(memoryEntries).toHaveLength(1);
+      expect(memoryEntries[0]!.mountPath).toBe(AUTO_MEMORY_MOUNT_PATH);
+    });
+
+    it("resume with no memory in resolution skips injection and warns", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const seed = await createTestRun(agentId, "seed empty");
+        const { checkpointId } = await completeTestRun(user.userId, seed.runId);
+        await setTestCheckpointArtifactSnapshots(checkpointId, []);
+
+        const resumed = await createTestRun(agentId, "resume empty", {
+          checkpointId,
+        });
+        await context.mocks.flushAfter();
+
+        const job = await findTestRunnerJobEntry(resumed.runId);
+        expect(job).toBeDefined();
+        const memoryEntries =
+          job!.executionContext.storageManifest!.artifacts.filter((a) => {
+            return a.vasStorageName === AUTO_MEMORY_ARTIFACT_NAME;
+          });
+        expect(memoryEntries).toHaveLength(0);
+
+        const warnCalls = warnSpy.mock.calls.filter((args) => {
+          return args.some((arg) => {
+            return (
+              typeof arg === "string" && arg.includes("no memory artifact")
+            );
+          });
+        });
+        expect(warnCalls.length).toBeGreaterThan(0);
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -23,6 +23,7 @@ import type {
   ExecutionContext,
   ResumeSession,
 } from "../infra/run/types";
+import type { ConversationResolution } from "../infra/run/resolvers";
 import type { AdditionalVolume } from "../infra/storage/types";
 import {
   AUTO_MEMORY_ARTIFACT_NAME,
@@ -64,21 +65,35 @@ export {
 const log = logger("zero:build-context");
 
 /**
- * Append the auto-memory artifact to the unified artifact list.
- *
- * Dedup-by-name in prepareStorageManifest collapses the clash when a checkpoint
- * snapshot also carries "memory". Resume-path gating is handled in a follow-up
- * sub-issue (#10910) — today we always append on every Zero path, which is why
- * this helper is shared by both resolveCliRunContext and
- * buildZeroExecutionContext.
+ * Append the auto-memory artifact when this is a new run. On resume paths
+ * (checkpoint, session, conversation continue) the resolver already emitted
+ * memory at AUTO_MEMORY_MOUNT_PATH in resolution.artifacts — re-injecting here
+ * would risk shadowing a divergent user-declared artifact named "memory".
+ * When the resolution has no memory entry (very old data that predates
+ * memory-as-artifact) we log and skip rather than silently mount over a path
+ * the user may have declared for a different purpose.
  */
-function appendAutoMemoryArtifact(
+function injectAutoMemoryArtifactIfNewRun(
   artifacts: ContextArtifact[],
+  resolution: ConversationResolution | null,
+  logContext: Record<string, string>,
 ): ContextArtifact[] {
-  return [
-    ...artifacts,
-    { name: AUTO_MEMORY_ARTIFACT_NAME, mountPath: AUTO_MEMORY_MOUNT_PATH },
-  ];
+  if (resolution === null) {
+    return [
+      ...artifacts,
+      { name: AUTO_MEMORY_ARTIFACT_NAME, mountPath: AUTO_MEMORY_MOUNT_PATH },
+    ];
+  }
+  const hasMemory = artifacts.some((a) => {
+    return a.name === AUTO_MEMORY_ARTIFACT_NAME;
+  });
+  if (!hasMemory) {
+    log.warn(
+      "Resume resolution has no memory artifact — skipping auto-injection",
+      logContext,
+    );
+  }
+  return artifacts;
 }
 
 /**
@@ -456,8 +471,11 @@ export async function resolveCliRunContext(
     );
   }
 
-  // Memory injection — see appendAutoMemoryArtifact().
-  artifacts = appendAutoMemoryArtifact(artifacts);
+  // Memory injection — see injectAutoMemoryArtifactIfNewRun().
+  artifacts = injectAutoMemoryArtifactIfNewRun(artifacts, resolution, {
+    userId: params.userId,
+    orgId: params.orgId,
+  });
 
   // Load compose content if we have a version ID
   if (!agentCompose && agentComposeVersionId) {
@@ -625,8 +643,10 @@ export async function buildZeroExecutionContext(
       (await loadAgentComposeForNewRun(agentComposeVersionId));
   }
 
-  // Memory injection — see appendAutoMemoryArtifact().
-  artifacts = appendAutoMemoryArtifact(artifacts);
+  // Memory injection — see injectAutoMemoryArtifactIfNewRun().
+  artifacts = injectAutoMemoryArtifactIfNewRun(artifacts, resolution, {
+    runId: params.runId,
+  });
 
   // Validate required fields
   if (!agentComposeVersionId) {


### PR DESCRIPTION
## Summary
- Gate the auto-memory artifact append on `resolution === null` — on checkpoint/session/conversation resume the resolver's unified `ContextArtifact[]` already carries memory at `AUTO_MEMORY_MOUNT_PATH`, so re-injecting was redundant and risked shadowing a divergent user-declared `memory` artifact.
- On the old-data edge (resume whose resolution lacks a `memory` entry) log a warn and do NOT re-inject — fail visibly rather than silently mount over a user-declared path.
- No behavioural change on new runs: `dedupArtifactsByName` still covers the user-declared `memory` collision case.

Closes #10910.

## Changes
- `build-zero-context.ts`: rename `appendAutoMemoryArtifact` → `injectAutoMemoryArtifactIfNewRun`, widen signature to take `resolution` + log context, gate append on `resolution === null`, warn-only on missing-memory resume.
- `build-zero-context.ts`: both call sites (`resolveCliRunContext`, `buildZeroExecutionContext`) pass the in-scope `resolution`.
- `storage-service.ts`: JSDoc on `dedupArtifactsByName` updated — on resume the resolution is authoritative, dedup now only covers user-declared `memory` collisions on new runs (no behavioural change).
- `build-zero-context.test.ts`: four new integration tests covering new-run, checkpoint resume with memory in snapshot, session continue with memory in `artifactNames`, and the old-data warn path.

## Test plan
- [x] `pnpm -F web exec vitest run src/lib/zero/__tests__/build-zero-context.test.ts` — 18 passed
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — clean
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)