### PR TITLE
test: auto-cover views changed 2026-04-24

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -690,6 +690,45 @@ describe("org billing tab - plan card details", () => {
       }),
     ).toBeDefined();
   });
+
+  it("should show Voice input feature in all plan cards on pricing page", async () => {
+    setMockBillingStatus({ tier: "free", credits: 10_000 });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Free plan")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Compare all plans"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Compare plans")).toBeInTheDocument();
+    });
+
+    // Voice input appears in all three plan feature lists (one per plan: Free, Pro, Team)
+    // Free = "Voice input (10/month)", Pro and Team = "Voice input"
+    expect(screen.getAllByText(/Voice input/)).toHaveLength(3);
+  });
+
+  it("should show Voice input with limit in Free plan features", async () => {
+    setMockBillingStatus({ tier: "free", credits: 10_000 });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Free plan")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Compare all plans"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Compare plans")).toBeInTheDocument();
+    });
+
+    // Free plan shows "Voice input (10/month)" while Pro/Team show "Voice input"
+    expect(screen.getByText("Voice input (10/month)")).toBeInTheDocument();
+  });
 });
 
 describe("org billing tab - renewal date display", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
@@ -91,7 +91,7 @@ describe("zero chat composer - file input", () => {
     });
 
     // Attachment button renders with aria-label for accessibility
-    const attachButton = screen.getByRole("button", { name: "Attach" });
+    const attachButton = screen.getByLabelText("Attach");
     expect(attachButton).toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
@@ -80,6 +80,21 @@ describe("zero chat composer - textarea interaction", () => {
 });
 
 describe("zero chat composer - file input", () => {
+  // CHAT-I-022
+  it("renders attachment button with correct accessible label", async () => {
+    mockChatLifecycle();
+
+    detachedSetupPage({ context, path: CHAT_PATH });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+    });
+
+    // Attachment button renders with aria-label for accessibility
+    const attachButton = screen.getByRole("button", { name: "Attach" });
+    expect(attachButton).toBeInTheDocument();
+  });
+
   // CHAT-I-023
   it("shows attachment chip after a file is selected via the file input", async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- Add test coverage for voice input feature text in billing pricing page plan cards
- Add test coverage for attachment button accessibility (aria-label="Attach")

## Test plan
- [x] `pnpm exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx` — 39 tests pass
- [x] `pnpm exec vitest run src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)