### PR TITLE
feat(guest-agent): emit mount path in artifact snapshots

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -26,6 +26,16 @@ fn fail(op: &str, start: std::time::Instant, msg: impl Into<String>) -> AgentErr
     AgentError::Checkpoint(msg)
 }
 
+/// Shape one entry of the `artifactSnapshots` payload. Keys are the
+/// camelCase names the web Zod receiver (`artifactSnapshotsSchema`) expects.
+fn build_artifact_snapshot_entry(name: &str, version: &str, mount_path: &str) -> serde_json::Value {
+    json!({
+        "name": name,
+        "version": version,
+        "mountPath": mount_path,
+    })
+}
+
 /// Create a checkpoint after a successful run.
 pub async fn create_checkpoint() -> Result<(), AgentError> {
     let start = std::time::Instant::now();
@@ -207,7 +217,9 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
 
     // Snapshot all configured artifacts. Memory rides in env::artifacts()
     // post-#10602, so there is no longer a separate memory arm.
-    let artifact_snapshots: Option<serde_json::Map<String, serde_json::Value>> = {
+    // Payload shape is `Array<{name, version, mountPath}>` per #10911 — the
+    // receiver tolerates the legacy `Record<name, version>` form too (#10919).
+    let artifact_snapshots: Option<serde_json::Value> = {
         let entries = env::artifacts();
         if entries.is_empty() {
             log_info!(
@@ -216,7 +228,7 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
             );
             None
         } else {
-            let mut results = serde_json::Map::new();
+            let mut results = Vec::with_capacity(entries.len());
             for entry in entries {
                 log_info!(
                     LOG_TAG,
@@ -241,12 +253,13 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
                     entry.name,
                     snapshot.version_id
                 );
-                results.insert(
-                    entry.name.clone(),
-                    serde_json::Value::String(snapshot.version_id),
-                );
+                results.push(build_artifact_snapshot_entry(
+                    &entry.name,
+                    &snapshot.version_id,
+                    &entry.mount_path,
+                ));
             }
-            Some(results)
+            Some(serde_json::Value::Array(results))
         }
     };
 
@@ -261,10 +274,7 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
     if let Some(snaps) = artifact_snapshots
         && let Some(obj) = payload.as_object_mut()
     {
-        obj.insert(
-            "artifactSnapshots".to_string(),
-            serde_json::Value::Object(snaps),
-        );
+        obj.insert("artifactSnapshots".to_string(), snaps);
     }
 
     log_info!(LOG_TAG, "Calling checkpoint API...");
@@ -304,5 +314,36 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
         Err(AgentError::Checkpoint(
             "Invalid checkpoint API response".into(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn artifact_snapshot_entry_shape_matches_receiver_schema() {
+        let entry = build_artifact_snapshot_entry("workspace", "v-abc-123", "/workspace");
+        assert_eq!(
+            entry,
+            json!({
+                "name": "workspace",
+                "version": "v-abc-123",
+                "mountPath": "/workspace",
+            })
+        );
+    }
+
+    #[test]
+    fn artifact_snapshot_entry_uses_camel_case_keys() {
+        let entry = build_artifact_snapshot_entry("n", "v", "/m");
+        let obj = entry.as_object().expect("entry must be a JSON object");
+        // Contract-boundary invariant: the web Zod receiver requires camelCase
+        // `mountPath`; a snake_case slip would silently cause a 400 on the
+        // webhook side.
+        assert!(obj.contains_key("name"));
+        assert!(obj.contains_key("version"));
+        assert!(obj.contains_key("mountPath"));
+        assert!(!obj.contains_key("mount_path"));
     }
 }


### PR DESCRIPTION
## Summary

- Flip guest-agent's checkpoint writer from `Map<name, version>` to `Array<{name, version, mountPath}>` so receivers can reproduce mount paths on resume.
- Add a pure `build_artifact_snapshot_entry` helper + two unit tests covering the shape and the camelCase key contract.

## Rollout gate

- Depends on #10919 (web-side tolerant reader), which is live in prod since 2026-04-24 00:00:29Z (commit \`989fc76b\`).
- Receiver tolerates both shapes, so old guest-agents continue to work post-merge.

## New payload sample

\`\`\`json
{
  \"artifactSnapshots\": [
    { \"name\": \"workspace\", \"version\": \"v-abc-123\", \"mountPath\": \"/workspace\" }
  ]
}
\`\`\`

Closes #10911. Part of epic #10906.

## Test plan

- [x] \`cargo fmt\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test\` — 33 lib tests + 3 integration tests pass; 2 new checkpoint tests pass
- [ ] Post-merge DB verification: \`SELECT jsonb_typeof(artifact_snapshots) FROM checkpoints ORDER BY created_at DESC LIMIT 5\` returns \`array\` for new rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)