### PR TITLE
feat: mobile header unread badge for ended threads

### DIFF
--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -158,3 +158,23 @@ export const chatThreads$ = computed(async (get) => {
     };
   });
 });
+
+/**
+ * The earliest ended-but-unread thread that is not the currently open thread.
+ * Used by the mobile header to prompt the user to check pending replies.
+ */
+export const earliestUnreadEndedThread$ = computed(
+  async (get): Promise<ChatThreadListItem | null> => {
+    const threads = await get(chatThreads$);
+    const currentThreadId = get(currentChatThreadId$);
+
+    const candidates = threads
+      .filter((t) => !t.running && !t.isRead && t.id !== currentThreadId)
+      .sort(
+        (a, b) =>
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+      );
+
+    return candidates[0] ?? null;
+  },
+);

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -169,11 +169,14 @@ export const earliestUnreadEndedThread$ = computed(
     const currentThreadId = get(currentChatThreadId$);
 
     const candidates = threads
-      .filter((t) => !t.running && !t.isRead && t.id !== currentThreadId)
-      .sort(
-        (a, b) =>
-          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-      );
+      .filter((t) => {
+        return !t.running && !t.isRead && t.id !== currentThreadId;
+      })
+      .sort((a, b) => {
+        return (
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        );
+      });
 
     return candidates[0] ?? null;
   },

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -20,6 +20,7 @@ import { ZeroSidebar } from "./zero-sidebar.tsx";
 import {
   currentChatAgent$,
   currentChatAgentId$,
+  earliestUnreadEndedThread$,
 } from "../../signals/agent-chat.ts";
 import { createNewChatThread$ } from "../../signals/chat-page/chat-message.ts";
 import { AvatarFromUrl } from "./zero-sidebar-shared.tsx";
@@ -128,13 +129,32 @@ function InviteButtonLeaf() {
   );
 }
 
-function NewChatButtonLeaf() {
+function NewOrUnreadChatButtonLeaf() {
   const currentChatAgentId = useResolved(currentChatAgentId$);
   const [creatingLoadable, createNewChat] =
     useLoadableSet(createNewChatThread$);
   const navigateToChatFn = useSet(navigateToChat$);
   const pageSignal = useGet(pageSignal$);
   const creating = creatingLoadable.state === "loading";
+  const unreadThread = useLastResolved(earliestUnreadEndedThread$);
+
+  if (unreadThread) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          navigateToChatFn(unreadThread.id);
+        }}
+        className="flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
+      >
+        <span
+          className="shrink-0 h-2 w-2 rounded-full bg-primary"
+          aria-label="Unread"
+        />
+        unread
+      </button>
+    );
+  }
 
   const handleNewChat = () => {
     detach(
@@ -169,7 +189,7 @@ function MobileTopBarActions({ activeId }: { activeId: RouteKey | null }) {
     <>
       {inChatRoute && <AutoReadToggleLeaf />}
       {inChatRoute &&
-        (newButtonEnabled ? <NewChatButtonLeaf /> : <InviteButtonLeaf />)}
+        (newButtonEnabled ? <NewOrUnreadChatButtonLeaf /> : <InviteButtonLeaf />)}
     </>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -189,7 +189,11 @@ function MobileTopBarActions({ activeId }: { activeId: RouteKey | null }) {
     <>
       {inChatRoute && <AutoReadToggleLeaf />}
       {inChatRoute &&
-        (newButtonEnabled ? <NewOrUnreadChatButtonLeaf /> : <InviteButtonLeaf />)}
+        (newButtonEnabled ? (
+          <NewOrUnreadChatButtonLeaf />
+        ) : (
+          <InviteButtonLeaf />
+        ))}
     </>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `earliestUnreadEndedThread$` computed to `agent-chat.ts` — finds the earliest ended (not running) + unread chat thread that is not the currently open thread
- Replaces `NewChatButtonLeaf` with `NewOrUnreadChatButtonLeaf` in the mobile top-bar
  - If an unread ended thread exists → shows a primary-colored dot + "unread" label; tap navigates directly to that thread
  - Otherwise → renders the existing "New" button (creates a new chat thread)
- Change is behind the existing `ChatHeaderNewButton` feature flag — no effect when the flag is off

## How it works

```
chatThreads$ (all threads)
  → filter: !running && !isRead && id ≠ currentThreadId
  → sort by createdAt ascending
  → return first match (or null)
```

## Test plan

- [ ] Enable `chatHeaderNewButton` feature flag for your org
- [ ] Open a chat thread; leave another agent's thread with an unread reply
- [ ] Mobile top-bar should show the dot + "unread" instead of "New"
- [ ] Tapping navigates to the unread thread
- [ ] After reading, the dot disappears and "New" is shown again
- [ ] With no unread ended threads, "New" still appears and creates a new chat as before
- [ ] Feature flag off → "Invite" button unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)