### PR TITLE
fix: pricing page responsive layout

### DIFF
--- a/turbo/apps/web/app/[locale]/pricing/PricingPageClient.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/PricingPageClient.tsx
@@ -28,17 +28,9 @@ function PricingCard({
 
   return (
     <div
+      className="pricing-card"
       style={{
-        background: "var(--card-bg)",
-        border: "1px solid var(--border-light)",
-        borderRadius: "12px",
-        padding: "40px 32px",
-        width: "100%",
-        display: "flex",
-        flexDirection: "column",
-        transition: "all 0.3s ease",
         transform: isHovered ? "translateY(-2px)" : "translateY(0)",
-        position: "relative",
       }}
       onMouseEnter={() => {
         return setIsHovered(true);
@@ -174,16 +166,7 @@ export function PricingPageClient() {
       <section className="section-spacing" style={{ paddingTop: 0 }}>
         <div className="container">
           <div style={{ marginBottom: "60px" }}>
-            <div
-              style={{
-                marginBottom: "40px",
-                display: "grid",
-                gridTemplateColumns: "repeat(3, 1fr)",
-                gap: "20px",
-                maxWidth: "1200px",
-                margin: "0 auto 40px",
-              }}
-            >
+            <div className="pricing-cards-grid">
               {/* Free Plan */}
               <PricingCard
                 title="Free"
@@ -246,19 +229,7 @@ export function PricingPageClient() {
           </div>
 
           {/* Pay as you go */}
-          <div
-            style={{
-              background: "var(--card-bg)",
-              border: "1px solid var(--border-light)",
-              borderRadius: "12px",
-              padding: "40px",
-              marginTop: "20px",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: "40px",
-            }}
-          >
+          <div className="pricing-topup">
             <div>
               <h2
                 style={{
@@ -325,27 +296,13 @@ export function PricingPageClient() {
           {/* Feature Comparison Table */}
           <div style={{ marginTop: "60px" }}>
             <h2
-              style={{
-                fontSize: "42px",
-                fontWeight: 400,
-                color: "var(--text-primary)",
-                marginBottom: "60px",
-                textAlign: "center",
-                letterSpacing: "-0.5px",
-              }}
+              className="pricing-section-title"
+              style={{ marginBottom: "60px" }}
             >
               {t("comparePlans")}
             </h2>
             <div style={{ overflowX: "auto" }}>
-              <table
-                style={{
-                  width: "100%",
-                  borderCollapse: "separate",
-                  borderSpacing: 0,
-                  fontSize: "15px",
-                  fontWeight: 300,
-                }}
-              >
+              <table className="pricing-table">
                 <thead>
                   <tr>
                     <th
@@ -539,16 +496,10 @@ export function PricingPageClient() {
           </div>
 
           {/* FAQ Section */}
-          <div style={{ marginTop: "120px", marginBottom: "80px" }}>
+          <div className="pricing-faq-section">
             <h2
-              style={{
-                fontSize: "42px",
-                fontWeight: 400,
-                color: "var(--text-primary)",
-                marginBottom: "60px",
-                textAlign: "center",
-                letterSpacing: "-0.5px",
-              }}
+              className="pricing-section-title"
+              style={{ marginBottom: "60px" }}
             >
               {t("faq.title")}
             </h2>
@@ -717,14 +668,7 @@ function FAQItem({ question, answer }: { question: string; answer: string }) {
 
   return (
     <div
-      style={{
-        background: "var(--card-bg)",
-        border: "1px solid var(--border-light)",
-        borderRadius: "16px",
-        padding: "24px 32px",
-        transition: "border-color 0.2s ease",
-        cursor: "pointer",
-      }}
+      className="pricing-faq-item"
       onClick={() => {
         return setIsExpanded(!isExpanded);
       }}

--- a/turbo/apps/web/app/blog.css
+++ b/turbo/apps/web/app/blog.css
@@ -1245,3 +1245,131 @@
 [data-theme="light"] .blog-post-content tr:nth-child(even) {
   background: rgba(0, 0, 0, 0.02);
 }
+
+/* Pricing Page */
+.pricing-cards-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  max-width: 1200px;
+  margin: 0 auto 40px;
+}
+
+.pricing-topup {
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 40px;
+  margin-top: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 40px;
+}
+
+.pricing-section-title {
+  font-size: 42px;
+  font-weight: 400;
+  color: var(--text-primary);
+  text-align: center;
+  letter-spacing: -0.5px;
+}
+
+.pricing-faq-section {
+  margin-top: 120px;
+  margin-bottom: 80px;
+}
+
+.pricing-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 40px 32px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.pricing-faq-item {
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: 16px;
+  padding: 24px 32px;
+  transition: border-color 0.2s ease;
+  cursor: pointer;
+}
+
+.pricing-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 15px;
+  font-weight: 300;
+  min-width: 600px;
+}
+
+@media (max-width: 768px) {
+  .pricing-cards-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .pricing-topup {
+    flex-direction: column;
+    text-align: center;
+    padding: 32px 24px;
+    gap: 24px;
+  }
+
+  .pricing-section-title {
+    font-size: 28px;
+    margin-bottom: 40px !important;
+  }
+
+  .pricing-faq-section {
+    margin-top: 60px;
+    margin-bottom: 40px;
+  }
+
+  .pricing-card {
+    padding: 32px 24px;
+  }
+
+  .pricing-faq-item {
+    padding: 20px 24px;
+  }
+
+  .pricing-faq-item h3 {
+    font-size: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .pricing-section-title {
+    font-size: 24px;
+    margin-bottom: 32px !important;
+  }
+
+  .pricing-topup {
+    padding: 24px 16px;
+  }
+
+  .pricing-card {
+    padding: 24px 16px;
+  }
+
+  .pricing-faq-section {
+    margin-top: 40px;
+    margin-bottom: 32px;
+  }
+
+  .pricing-faq-item {
+    padding: 16px;
+  }
+
+  .pricing-faq-item h3 {
+    font-size: 15px;
+  }
+}


### PR DESCRIPTION
## Summary
- Pricing cards grid collapses from 3 columns to single column at ≤768px
- Pay-as-you-go section stacks vertically on mobile
- Section titles, card padding, and FAQ margins scale down at 768px and 480px breakpoints
- Comparison table gets `min-width: 600px` with horizontal scroll on narrow screens
- Extracted inline styles to CSS classes (`pricing-cards-grid`, `pricing-topup`, `pricing-card`, `pricing-faq-item`, `pricing-table`, etc.) for responsive control

## Test plan
- [ ] Verify pricing page at desktop (>1024px) — 3-column card layout, horizontal top-up bar
- [ ] Verify at tablet (768px) — cards stack to single column, top-up stacks vertically
- [ ] Verify at mobile (480px) — reduced padding, smaller headings
- [ ] Verify comparison table scrolls horizontally on narrow screens
- [ ] Verify FAQ items have proper padding at all breakpoints
- [ ] Check both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)