### PR TITLE
fix(zero): prevent sidebar chat section flicker when agent id reloads

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
@@ -22,6 +22,8 @@ import { pathname } from "../../../signals/location.ts";
 import { setIsScrolled$ } from "../../../signals/zero-page/zero-sidebar-state.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { chatThreadsContract } from "@vm0/core/contracts/chat-threads";
+import { createDeferredPromise } from "../../../signals/utils.ts";
+import { setChatAgentId$ } from "../../../signals/agent-chat.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -261,6 +263,53 @@ describe("zero sidebar - settings button navigates to settings (SIDEBAR-D-025)",
     await waitFor(() => {
       expect(pathname()).toBe("/settings");
     });
+  });
+});
+
+describe("zero sidebar - chat section stable during agent id reload (SIDEBAR-D-066)", () => {
+  it("keeps chat thread list visible when currentChatAgentId$ briefly re-enters loading state", async () => {
+    mockBaseAPIs({
+      threads: [
+        makeThread("thread-1", "Deploy to prod", "2026-03-10T00:00:00Z"),
+      ],
+    });
+    detachedSetupPage({ context, path: "/" });
+
+    // Wait for thread to appear in the sidebar
+    await waitFor(() => {
+      expect(
+        screen.getByRole("navigation", { name: "Sidebar" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Deploy to prod")).toBeInTheDocument();
+    });
+
+    // Make the chat-threads API hang so any re-mount of ChatThreadsSection
+    // (which triggers a fresh chatThreads$ fetch) would show skeleton while
+    // waiting. Resolved after assertions for clean test teardown.
+    const hangDeferred = createDeferredPromise<void>(context.signal);
+    server.use(
+      mockApi(chatThreadsContract.list, async ({ respond }) => {
+        await hangDeferred.promise;
+        return respond(200, { threads: [] });
+      }),
+    );
+
+    // Simulate what setupChatPage does: update the internal agent id, which
+    // briefly drives currentChatAgentId$ through a loading state. With
+    // useLastResolved in ChatThreadsSectionWithKey the key stays stable and
+    // ChatThreadsSection is never remounted, so the thread list must remain
+    // visible without any skeleton appearing.
+    context.store.set(setChatAgentId$, DEFAULT_AGENT_ID);
+
+    // The thread text must remain visible and no skeleton should appear.
+    await waitFor(() => {
+      const nav = screen.getByRole("navigation", { name: "Sidebar" });
+      expect(nav.querySelectorAll(".animate-pulse")).toHaveLength(0);
+      expect(screen.getByText("Deploy to prod")).toBeInTheDocument();
+    });
+
+    // Resolve so the hanging handler finishes cleanly for afterEach.
+    hangDeferred.resolve();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -6,7 +6,6 @@ import {
   useLastResolved,
   useGet,
   useSet,
-  useResolved,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -168,9 +167,11 @@ const FOOTER_NAV = [
   },
 ] as const satisfies readonly FooterNavItem[];
 
-// Leaf component: subscribes to currentChatAgentId$ so ZeroSidebar doesn't re-render on agent changes
+// Leaf component: subscribes to currentChatAgentId$ so ZeroSidebar doesn't re-render on agent changes.
+// useLastResolved keeps the previously-resolved agent ID during re-loads, preventing unnecessary
+// remounts of ChatThreadsSection that would cause the chat list to flash.
 function ChatThreadsSectionWithKey() {
-  const currentChatAgentId = useResolved(currentChatAgentId$);
+  const currentChatAgentId = useLastResolved(currentChatAgentId$);
   return <ChatThreadsSection key={currentChatAgentId} />;
 }
 


### PR DESCRIPTION
## Root Cause

`ChatThreadsSectionWithKey` in `zero-sidebar.tsx` used `useResolved(currentChatAgentId$)` to key the `ChatThreadsSection` component. `useResolved` returns `undefined` whenever the async computed briefly re-enters loading state — which happens every time `setupChatPage` calls `setChatAgentId$` after a thread loads.

The sequence that triggered the flicker:
1. Page loads a chat thread → `setupChatPage` calls `setChatAgentId$(thread.agentId)`
2. `internalChatAgentId$` changes → `currentChatAgentId$` (async computed) briefly re-enters loading state
3. `useResolved` returns `undefined` → `key` goes from `"<agent-id>"` → `undefined` → `"<agent-id>"`
4. React unmounts and remounts `ChatThreadsSection` — the chat thread list disappears and reappears
5. The `OverlayScrollArea` custom scrollbar thumb resets → visible scroll bar flicker

## Fix

Switch `ChatThreadsSectionWithKey` from `useResolved` to `useLastResolved`. The "last resolved" variant retains the previously-resolved agent id during any loading interlude, so the `key` prop stays stable and `ChatThreadsSection` is never unnecessarily remounted.

```tsx
// Before (buggy)
function ChatThreadsSectionWithKey() {
  const currentChatAgentId = useResolved(currentChatAgentId$);
  return <ChatThreadsSection key={currentChatAgentId} />;
}

// After (fixed)
function ChatThreadsSectionWithKey() {
  const currentChatAgentId = useLastResolved(currentChatAgentId$);
  return <ChatThreadsSection key={currentChatAgentId} />;
}
```

## Test plan

- Added regression test `SIDEBAR-D-066` in `zero-sidebar-navigation-state.test.tsx`:
  1. Load page with a thread visible in the sidebar
  2. Install a hanging MSW handler so any chatThreads API re-fetch keeps the data in loading state
  3. Call `context.store.set(setChatAgentId$, DEFAULT_AGENT_ID)` to simulate what `setupChatPage` does
  4. Assert no `.animate-pulse` skeleton elements appear and "Deploy to prod" remains in the DOM throughout
- All existing sidebar navigation state tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)