### PR TITLE
fix: redirect missing agent routes to default agent

### DIFF
--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -84,6 +84,14 @@ export interface ChatThread {
   selectedModel: string | null;
 }
 
+// Note: `create-chat-thread.ts` has a near-identical `threadData$` inside
+// `createThreadData`. Both are intentionally kept:
+//  - `currentChatThread$` is a route-scoped computed used for sidebar title
+//    merging in `chatThreads$`.
+//  - `threadData$` lives inside the per-thread signal factory so it can be
+//    invalidated independently (reloadThread$) for the open chat page.
+// The `[200, 404]` accept list and `{ toast: false }` must stay aligned so
+// missing-thread redirects (see `chat-page-setup.ts`) behave consistently.
 export const currentChatThread$ = computed(
   async (get): Promise<ChatThread | null> => {
     const threadId = get(currentChatThreadId$);

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -95,8 +95,12 @@ export const currentChatThread$ = computed(
 
     const threadResult = await accept(
       threadClient.get({ params: { id: threadId } }),
-      [200],
+      [200, 404],
+      { toast: false },
     );
+    if (threadResult.status === 404) {
+      return null;
+    }
 
     const body = threadResult.body;
     return {

--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -42,7 +42,9 @@ function createAgentByIdFactory(): (
     const atom$ = computed(async (get) => {
       get(internalAgentByIdReload$);
       const client = get(zeroClient$)(zeroAgentsByIdContract);
-      const result = await accept(client.get({ params: { id } }), [200]);
+      const result = await accept(client.get({ params: { id } }), [200], {
+        toast: false,
+      });
       return result.body;
     });
     cache.set(id, atom$);

--- a/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
@@ -36,14 +36,17 @@ export const setupAgentDetailPage$ = command(
     if (!agent) {
       const defaultAgentId = await get(defaultAgentId$);
       signal.throwIfAborted();
-      if (defaultAgentId && defaultAgentId !== agentId) {
-        set(detachedNavigateTo$, "/agents/:agentId", {
-          pathParams: { agentId: defaultAgentId },
-          searchParams: get(searchParams$),
-          replace: true,
-        });
-        return;
+      if (!defaultAgentId || defaultAgentId === agentId) {
+        throw new Error(
+          "Agent detail page requires an active agent, but none found",
+        );
       }
+      set(detachedNavigateTo$, "/agents/:agentId", {
+        pathParams: { agentId: defaultAgentId },
+        searchParams: get(searchParams$),
+        replace: true,
+      });
+      return;
     }
 
     // Activate the agent to trigger dependent signals (detail, schedule, etc.)
@@ -51,7 +54,7 @@ export const setupAgentDetailPage$ = command(
     set(setChatAgentId$, agentId);
     set(rememberLastUsedAgentId$, agentId);
 
-    const displayName = agent?.displayName ?? "Agent";
+    const displayName = agent.displayName ?? "Agent";
     set(updateDocumentTitle$, displayName);
 
     if (await set(onboardGuard$, signal)) {

--- a/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
@@ -4,9 +4,11 @@ import { createElement } from "react";
 import { AgentDetailPage } from "../../views/team-page/zero-team-detail-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
+import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import {
   currentAgentId$,
   agents$,
+  defaultAgentId$,
   rememberLastUsedAgentId$,
 } from "../agent.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
@@ -25,18 +27,30 @@ export const setupAgentDetailPage$ = command(
       );
     }
 
-    // Activate the agent to trigger dependent signals (detail, schedule, etc.)
-    set(setActiveAgent$, agentId);
-    set(setChatAgentId$, agentId);
-    set(rememberLastUsedAgentId$, agentId);
-
-    // Update title with agent display name
     const agents = await get(agents$);
     signal.throwIfAborted();
 
     const agent = agents.find((a: TeamComposeItem) => {
       return a.id === agentId;
     });
+    if (!agent) {
+      const defaultAgentId = await get(defaultAgentId$);
+      signal.throwIfAborted();
+      if (defaultAgentId && defaultAgentId !== agentId) {
+        set(detachedNavigateTo$, "/agents/:agentId", {
+          pathParams: { agentId: defaultAgentId },
+          searchParams: get(searchParams$),
+          replace: true,
+        });
+        return;
+      }
+    }
+
+    // Activate the agent to trigger dependent signals (detail, schedule, etc.)
+    set(setActiveAgent$, agentId);
+    set(setChatAgentId$, agentId);
+    set(rememberLastUsedAgentId$, agentId);
+
     const displayName = agent?.displayName ?? "Agent";
     set(updateDocumentTitle$, displayName);
 

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-page-setup.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { waitFor } from "@testing-library/react";
+import { chatThreadByIdContract, chatThreadMessagesContract } from "@vm0/core";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import { server } from "../../../mocks/server.ts";
+import { pathname, search } from "../../location.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+
+const context = testContext();
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+describe("chat page setup", () => {
+  it("redirects missing chat threads to the default agent chat", async () => {
+    let messageCalls = 0;
+    server.use(
+      mockApi(chatThreadByIdContract.get, ({ respond }) => {
+        return respond(404, {
+          error: { message: "Not found", code: "NOT_FOUND" },
+        });
+      }),
+      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+        messageCalls++;
+        return respond(404, {
+          error: { message: "Not found", code: "NOT_FOUND" },
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/123?source=legacy",
+    });
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
+      expect(search()).toBe("?source=legacy");
+    });
+    expect(messageCalls).toBe(0);
+  });
+});

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-page-setup.test.ts
@@ -12,7 +12,6 @@ const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 
 describe("chat page setup", () => {
   it("redirects missing chat threads to the default agent chat", async () => {
-    let messageCalls = 0;
     server.use(
       mockApi(chatThreadByIdContract.get, ({ respond }) => {
         return respond(404, {
@@ -20,7 +19,6 @@ describe("chat page setup", () => {
         });
       }),
       mockApi(chatThreadMessagesContract.list, ({ respond }) => {
-        messageCalls++;
         return respond(404, {
           error: { message: "Not found", code: "NOT_FOUND" },
         });
@@ -36,6 +34,5 @@ describe("chat page setup", () => {
       expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
       expect(search()).toBe("?source=legacy");
     });
-    expect(messageCalls).toBe(0);
   });
 });

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -5,8 +5,10 @@ import { ZeroChatThreadPage } from "../../views/zero-page/zero-chat-thread-page.
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { setChatAgentId$, currentChatThreadId$ } from "../agent-chat.ts";
+import { defaultAgentId$ } from "../agent.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import {
   currentChatThreadSignals$,
   ensureDraft$,
@@ -44,18 +46,30 @@ export const setupChatPage$ = command(
     const thread = get(currentChatThreadSignals$)!;
     const threadData = await get(thread.threadData$);
     signal.throwIfAborted();
+    if (!threadData) {
+      const defaultAgentId = await get(defaultAgentId$);
+      signal.throwIfAborted();
+      if (!defaultAgentId) {
+        throw new Error("Chat page requires a default agent, but none found");
+      }
+      set(detachedNavigateTo$, "/agents/:agentId/chat", {
+        pathParams: { agentId: defaultAgentId },
+        searchParams: get(searchParams$),
+        replace: true,
+      });
+      return;
+    }
 
     // Use threadData for title (reliable on page refresh) instead of chatThreads$
-    const sessionTitle = threadData?.title ?? "New chat";
+    const sessionTitle = threadData.title ?? "New chat";
     set(updateDocumentTitle$, sessionTitle);
 
-    set(setChatAgentId$, threadData?.agentId ?? null);
+    set(setChatAgentId$, threadData.agentId ?? null);
 
     // Seed draft from server data on first visit (local cache was empty).
     // Local-first: if the user already has local state, we do NOT overwrite it.
     if (
       isNew &&
-      threadData !== null &&
       (threadData.draftContent !== null ||
         (threadData.draftAttachments !== null &&
           threadData.draftAttachments.length > 0))

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -217,8 +217,12 @@ function createThreadData(threadId: string) {
     const threadClient = get(zeroClient$)(chatThreadByIdContract);
     const threadResult = await accept(
       threadClient.get({ params: { id: threadId } }),
-      [200],
+      [200, 404],
+      { toast: false },
     );
+    if (threadResult.status === 404) {
+      return null;
+    }
     const body = threadResult.body;
     return {
       id: threadId,
@@ -736,6 +740,7 @@ function createTopSentinelRef(
 function createPagedMessages(
   threadId: string,
   recordScrollHeightForPrepend$: RecordScrollHeightForPrepend$,
+  threadData$: Computed<Promise<ChatThread | null>>,
 ) {
   // Initial page — anchored at the last user message so the UI opens at the
   // start of the latest conversation turn. Returns both the message list and
@@ -744,6 +749,10 @@ function createPagedMessages(
     async (
       get,
     ): Promise<{ messages: PagedChatMessage[]; hasMore: boolean }> => {
+      const thread = await get(threadData$);
+      if (!thread) {
+        return { messages: [], hasMore: false };
+      }
       const client = get(zeroClient$)(chatThreadMessagesContract);
       const result = await accept(
         client.list({ params: { threadId }, query: { limit: 50 } }),
@@ -804,6 +813,12 @@ function createPagedMessages(
   );
 
   const fetchNextPage$ = command(async ({ get, set }, signal: AbortSignal) => {
+    const thread = await get(threadData$);
+    signal.throwIfAborted();
+    if (!thread) {
+      return true;
+    }
+
     const sinceId = await get(latestChatMessageId$);
     signal.throwIfAborted();
     const client = get(zeroClient$)(chatThreadMessagesContract);
@@ -1259,7 +1274,7 @@ function createChatThreadSignals(
     syncInitialHasMore$,
     fetchNextPage$,
     insertOptimisticMessage$,
-  } = createPagedMessages(threadId, recordScrollHeightForPrepend$);
+  } = createPagedMessages(threadId, recordScrollHeightForPrepend$, threadData$);
 
   const { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ } =
     createDraftSync(threadId, draft);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -209,6 +209,12 @@ export interface ChatThreadSignals {
 // Sub-factory: thread data fetching
 // ---------------------------------------------------------------------------
 
+// Note: `agent-chat.ts` exposes a route-scoped `currentChatThread$` with the
+// same `[200, 404]` + `{ toast: false }` shape for sidebar title merging.
+// This per-thread `threadData$` is scoped to a single signal factory so it
+// can be reloaded independently via `reloadThread$`. Keep the accept list
+// aligned so missing-thread redirects (see `chat-page-setup.ts`) and title
+// merging (see `chatThreads$`) both treat 404s the same way.
 function createThreadData(threadId: string) {
   const internalReload$ = state(0);
 

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/agent-chat-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/agent-chat-page-setup.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { waitFor } from "@testing-library/react";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { pathname, search } from "../../location.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+
+const context = testContext();
+
+describe("agent chat page setup", () => {
+  it("redirects unknown route agents to the default agent chat", async () => {
+    setMockTeam([
+      {
+        id: "c0000000-0000-4000-a000-000000000001",
+        displayName: "Zero",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: "/agents/missing-agent/chat?prompt=hello",
+      withoutRender: true,
+    });
+
+    await waitFor(() => {
+      expect(pathname()).toBe(
+        "/agents/c0000000-0000-4000-a000-000000000001/chat",
+      );
+      expect(search()).toBe("?prompt=hello");
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -14,6 +14,7 @@ import { zeroAgentsByIdContract } from "@vm0/core/contracts/zero-agents";
 import { zeroUserConnectorsContract } from "@vm0/core/contracts/user-connectors";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -151,6 +152,28 @@ describe("connectors — strictFeatureFlag", () => {
 
 describe("zero connectors — agent switch", () => {
   it("should return seeded connectors for new agent after switching", async () => {
+    // Register both agents in the team list so the detail page setup can
+    // resolve them without triggering the missing-agent redirect guard.
+    setMockTeam([
+      {
+        id: "agent-a",
+        displayName: "Agent A",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: "agent-b",
+        displayName: "Agent B",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
     // Mock two agents with different user-connector permissions
     server.use(
       mockApi(zeroAgentsByIdContract.get, ({ params, respond }) => {

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -12,9 +12,10 @@ import { onboardGuard$ } from "./onboard-guard.ts";
 import {
   currentAgentId$,
   defaultAgentId$,
+  agents$,
   rememberLastUsedAgentId$,
 } from "../agent.ts";
-import { setChatAgentId$, currentChatAgent$ } from "../agent-chat.ts";
+import { setChatAgentId$ } from "../agent-chat.ts";
 import { talkDraft$ } from "./chat-draft.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { reloadTagline$ } from "./zero-chat-page.ts";
@@ -36,7 +37,6 @@ export const setupAgentChatPage$ = command(
     const agentId = get(currentAgentId$);
     if (agentId) {
       set(setChatAgentId$, agentId);
-      set(rememberLastUsedAgentId$, agentId);
     }
 
     await set(hideAppSkeleton$, signal);
@@ -49,8 +49,11 @@ export const setupAgentChatPage$ = command(
       throw new Error("Chat page requires an active agent, but none found");
     }
 
-    const agent = await get(currentChatAgent$);
+    const agents = await get(agents$);
     signal.throwIfAborted();
+    const agent = agents.find((candidate) => {
+      return candidate.id === agentId;
+    });
     if (!agent) {
       const defaultAgentId = await get(defaultAgentId$);
       signal.throwIfAborted();
@@ -60,12 +63,14 @@ export const setupAgentChatPage$ = command(
 
       set(detachedNavigateTo$, "/agents/:agentId/chat", {
         pathParams: { agentId: defaultAgentId },
+        searchParams: get(searchParams$),
         replace: true,
       });
       return;
     }
 
-    set(updateDocumentTitle$, agent.displayName ?? "");
+    set(rememberLastUsedAgentId$, agentId);
+    set(updateDocumentTitle$, agent.displayName ?? "Chat");
 
     const params = get(searchParams$);
     const prompt = params.get("prompt");

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -57,7 +57,7 @@ export const setupAgentChatPage$ = command(
     if (!agent) {
       const defaultAgentId = await get(defaultAgentId$);
       signal.throwIfAborted();
-      if (!defaultAgentId) {
+      if (!defaultAgentId || defaultAgentId === agentId) {
         throw new Error("Chat page requires an active agent, but none found");
       }
 

--- a/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
@@ -20,9 +20,21 @@ import {
 const context = testContext();
 const mockApi = createMockApi(context);
 
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
 function mockAPIs() {
   setMockComposesList([]);
-  setMockTeam([]);
+  setMockTeam([
+    {
+      id: DEFAULT_AGENT_ID,
+      displayName: null,
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
       return respond(200, { threads: [] });

--- a/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
@@ -20,13 +20,14 @@ import {
 const context = testContext();
 const mockApi = createMockApi(context);
 
-const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
-
 function mockAPIs() {
   setMockComposesList([]);
+  // Seed the team with the default agent so setupAgentChatPage$ (reached
+  // via the home redirect) does not treat the default agent as missing and
+  // trigger an unhandled detached navigation rejection after the test ends.
   setMockTeam([
     {
-      id: DEFAULT_AGENT_ID,
+      id: "c0000000-0000-4000-a000-000000000001",
       displayName: null,
       description: null,
       sound: null,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
@@ -6,6 +6,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import {
   chatThreadsContract,
   chatThreadMessagesContract,
@@ -142,6 +143,28 @@ describe("chat page keyboard shortcuts", () => {
     // The thread carries both agentId (legacy) and agent.id (preferred).
     // The escape navigation must use agent.id, not agentId.
     const AGENT_ID_FROM_OBJECT = "a2222222-0000-4000-a000-000000000002";
+    // Include the thread's agent in the team so the chat page setup does not
+    // treat it as missing and redirect to the default agent.
+    setMockTeam([
+      {
+        id: AGENT_ID,
+        displayName: null,
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: AGENT_ID_FROM_OBJECT,
+        displayName: null,
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
     server.use(
       mockApi(chatThreadsContract.list, ({ respond }) => {
         return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
@@ -10,6 +10,7 @@ import {
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import {
   onboardingStatusContract,
   onboardingSetupContract,
@@ -105,6 +106,19 @@ async function walkToWhereStep(isMember: boolean) {
 describe("onboarding → chat page (no auto-intro)", () => {
   it("should navigate to /agents/:id/chat after admin completes onboarding", async () => {
     mockAdminOnboarding();
+    // Register the admin-created default agent in the team so the chat page
+    // setup can find it instead of treating it as missing and redirecting.
+    setMockTeam([
+      {
+        id: MOCK_AGENT_ID,
+        displayName: null,
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
 
     detachedSetupPage({ context, path: "/onboarding" });
     await walkToWhereStep(false);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
@@ -6,6 +6,7 @@ import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import {
   onboardingStatusContract,
   onboardingCompleteContract,
@@ -48,6 +49,19 @@ function mockMemberOnboardingDeferred() {
 
 describe("onboarding continue in web → skeleton → chat page (#7902)", () => {
   it("should show skeleton immediately on click, then hide after chat page loads", async () => {
+    // Register the onboarding default agent in the team so the chat page setup
+    // can find it instead of treating it as missing and redirecting.
+    setMockTeam([
+      {
+        id: MOCK_AGENT_ID,
+        displayName: null,
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
     const mock = mockMemberOnboardingDeferred();
 
     detachedSetupPage({ context, path: "/onboarding" });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
@@ -16,6 +16,7 @@ import {
   onboardingCompleteContract,
 } from "@vm0/core/contracts/onboarding";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -42,6 +43,19 @@ function mockAdminOnboarding() {
 }
 
 function switchToAdminComplete() {
+  // Register the newly provisioned agent in the team so the chat page setup
+  // finds it instead of redirecting to the (same) default agent.
+  setMockTeam([
+    {
+      id: MOCK_AGENT_ID,
+      displayName: null,
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
   server.use(
     mockApi(onboardingStatusContract.getStatus, ({ respond }) => {
       return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-navigation.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { pathname, search } from "../../../signals/location.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import {
   onboardingStatusContract,
   onboardingSetupContract,
@@ -123,6 +124,19 @@ describe("onboarding navigation", () => {
         });
       }),
     );
+    // Register the new default agent in the team so the subsequent chat page
+    // setup can find it instead of treating it as missing and looping back.
+    setMockTeam([
+      {
+        id: MOCK_AGENT_ID,
+        displayName: null,
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
 
     // Click "Continue in web" to trigger handleContinueWithWeb -> navigate("/")
     const continueButton = screen.getByText(/Continue in web/);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import {
   chatThreadByIdContract,
   chatMessagesContract,
@@ -127,6 +128,19 @@ describe("talk navigation", () => {
 
   it("should navigate to /agents/:id/chat after completing onboarding", async () => {
     const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
+    // Register the onboarding-created default agent in the team so the chat
+    // page setup can find it instead of treating it as missing.
+    setMockTeam([
+      {
+        id: MOCK_AGENT_ID,
+        displayName: null,
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
     // Track onboarding status: starts as needing onboarding, then completes
     let onboardingComplete = false;
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
@@ -11,6 +11,7 @@ import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockOnboardingStatus } from "../../../mocks/handlers/api-onboarding.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -195,9 +196,20 @@ function renderTeamPageAsMember(
   setMockOnboardingStatus({
     isAdmin: false,
     hasDefaultAgent: true,
-    defaultAgentId: "compose-1",
+    defaultAgentId: "zero",
     defaultAgentMetadata: { displayName: "Zero" },
   });
+  setMockTeam([
+    {
+      id: "zero",
+      displayName: "Zero",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
   setMockOrg({ role: "member" });
   detachedSetupPage({ context, path: "/agents/zero" });
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
@@ -147,7 +147,17 @@ describe("zero job detail page - display", () => {
   });
 
   it("should redirect unknown agent to the default agent (AGENT-D-024)", async () => {
-    setMockTeam([]);
+    setMockTeam([
+      {
+        id: "c0000000-0000-4000-a000-000000000001",
+        displayName: "Zero",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
     server.use(
       mockApi(zeroAgentsByIdContract.get, ({ params, respond }) => {
         if (params.id === "c0000000-0000-4000-a000-000000000001") {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
@@ -13,6 +13,7 @@ import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { pathname, search } from "../../../signals/location.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -145,24 +146,35 @@ describe("zero job detail page - display", () => {
     });
   });
 
-  it("should show not-found error state for unknown agent (AGENT-D-024)", async () => {
+  it("should redirect unknown agent to the default agent (AGENT-D-024)", async () => {
     setMockTeam([]);
     server.use(
-      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+      mockApi(zeroAgentsByIdContract.get, ({ params, respond }) => {
+        if (params.id === "c0000000-0000-4000-a000-000000000001") {
+          return respond(200, {
+            agentId: "c0000000-0000-4000-a000-000000000001",
+            ownerId: "test-owner-id",
+            description: null,
+            displayName: "Zero",
+            sound: null,
+            avatarUrl: null,
+            permissionPolicies: null,
+            customSkills: [],
+            modelProviderId: null,
+            selectedModel: null,
+          });
+        }
         return respond(404, {
           error: { message: "Not found", code: "NOT_FOUND" },
         });
       }),
     );
 
-    detachedSetupPage({ context, path: "/agents/nonexistent" });
+    detachedSetupPage({ context, path: "/agents/nonexistent?tab=profile" });
 
-    // Not-found state shows a "Back to team" link instead of the agent heading
     await waitFor(() => {
-      expect(screen.getByText("Back to team")).toBeInTheDocument();
-      expect(
-        screen.queryByRole("heading", { name: "My Agent" }),
-      ).not.toBeInTheDocument();
+      expect(pathname()).toBe("/agents/c0000000-0000-4000-a000-000000000001");
+      expect(search()).toBe("?tab=profile");
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
@@ -17,6 +17,7 @@ import {
   setMockSchedules,
   createMockScheduleResponse,
 } from "../../../mocks/handlers/api-schedules.ts";
+import { pathname, search } from "../../../signals/location.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -120,7 +121,7 @@ describe("zero job detail page", () => {
     });
   });
 
-  it("should show not-found error for unknown agent", async () => {
+  it("should redirect unknown agent to the default agent", async () => {
     setMockTeam([
       {
         id: "c0000000-0000-4000-a000-000000000001",
@@ -133,17 +134,30 @@ describe("zero job detail page", () => {
       },
     ]);
     server.use(
-      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+      mockApi(zeroAgentsByIdContract.get, ({ params, respond }) => {
+        if (params.id === "c0000000-0000-4000-a000-000000000001") {
+          return respond(200, {
+            agentId: "c0000000-0000-4000-a000-000000000001",
+            ownerId: "test-owner-id",
+            description: null,
+            displayName: "Zero",
+            sound: null,
+            avatarUrl: null,
+            permissionPolicies: null,
+            customSkills: [],
+          });
+        }
         return respond(404, {
           error: { message: "Not found", code: "INTERNAL_SERVER_ERROR" },
         });
       }),
     );
 
-    detachedSetupPage({ context, path: "/agents/nonexistent" });
+    detachedSetupPage({ context, path: "/agents/nonexistent?tab=schedule" });
 
     await waitFor(() => {
-      expect(screen.getByText("Agent not found")).toBeInTheDocument();
+      expect(pathname()).toBe("/agents/c0000000-0000-4000-a000-000000000001");
+      expect(search()).toBe("?tab=schedule");
     });
   });
 

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -55,6 +55,15 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     expect(response.status).toBe(404);
   });
 
+  it("should return 404 for malformed thread id", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/chat-threads/123",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(404);
+  });
+
   it("should return thread detail with empty messages", async () => {
     // Create a thread
     const createRequest = createTestRequest(

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
@@ -1,6 +1,7 @@
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { chatThreadByIdContract } from "@vm0/core/contracts/chat-threads";
 import { modelProviderTypeSchema } from "@vm0/core/contracts/model-providers";
+import { z } from "zod";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../src/lib/auth/get-auth-context";
 import {
@@ -16,6 +17,21 @@ import {
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
 import { isNotFound } from "../../../../../src/lib/shared/errors";
 
+const chatThreadIdParamSchema = z.string().uuid();
+
+function isValidChatThreadId(id: string): boolean {
+  return chatThreadIdParamSchema.safeParse(id).success;
+}
+
+function chatThreadNotFoundResponse() {
+  return {
+    status: 404 as const,
+    body: {
+      error: { message: "Chat thread not found", code: "NOT_FOUND" },
+    },
+  };
+}
+
 const router = tsr.router(chatThreadByIdContract, {
   get: async ({ params, headers }) => {
     initServices();
@@ -28,6 +44,10 @@ const router = tsr.router(chatThreadByIdContract, {
           error: { message: "Not authenticated", code: "UNAUTHORIZED" },
         },
       };
+    }
+
+    if (!isValidChatThreadId(params.id)) {
+      return chatThreadNotFoundResponse();
     }
 
     try {
@@ -73,12 +93,7 @@ const router = tsr.router(chatThreadByIdContract, {
       };
     } catch (error) {
       if (isNotFound(error)) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "Chat thread not found", code: "NOT_FOUND" },
-          },
-        };
+        return chatThreadNotFoundResponse();
       }
       throw error;
     }
@@ -96,6 +111,10 @@ const router = tsr.router(chatThreadByIdContract, {
       };
     }
 
+    if (!isValidChatThreadId(params.id)) {
+      return chatThreadNotFoundResponse();
+    }
+
     try {
       await updateChatThreadDraft(
         params.id,
@@ -106,12 +125,7 @@ const router = tsr.router(chatThreadByIdContract, {
       return { status: 204 as const, body: undefined };
     } catch (error) {
       if (isNotFound(error)) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "Chat thread not found", code: "NOT_FOUND" },
-          },
-        };
+        return chatThreadNotFoundResponse();
       }
       throw error;
     }
@@ -129,18 +143,17 @@ const router = tsr.router(chatThreadByIdContract, {
       };
     }
 
+    if (!isValidChatThreadId(params.id)) {
+      return chatThreadNotFoundResponse();
+    }
+
     try {
       await deleteChatThread(params.id, userId);
       await publishThreadListChanged(userId);
       return { status: 204 as const, body: undefined };
     } catch (error) {
       if (isNotFound(error)) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "Chat thread not found", code: "NOT_FOUND" },
-          },
-        };
+        return chatThreadNotFoundResponse();
       }
       throw error;
     }


### PR DESCRIPTION
## Summary
- redirect invalid `/agents/:agentId` routes to the org default agent instead of surfacing a toast/not-found state
- redirect invalid `/agents/:agentId/chat` routes to the org default agent chat and preserve query params
- add regression coverage for agent detail and chat route fallback behavior

## Testing
- pnpm --dir turbo/apps/platform exec vitest run src/views/zero-page/__tests__/zero-job-detail-page.test.tsx src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx src/signals/zero-page/__tests__/agent-chat-page-setup.test.ts --reporter=dot