### PR TITLE
fix: resolve scroll flicker on chat page load and new message arrival

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -74,12 +74,20 @@ export const setupChatPage$ = command(
     signal.throwIfAborted();
 
     // The list is mounted with visibility:hidden under the skeleton so
-    // scrollHeight is already correct; wait one frame for React to commit
-    // the message DOM, then scroll and reveal in the same tick.
+    // scrollHeight is already correct. Scroll to bottom in the current frame
+    // so the position is correct on first paint, then hide the skeleton in the
+    // next frame. Separating the two ensures ChatThreadComposer's re-render
+    // (actionsLoading false → real buttons) cannot race with scrollToBottom$
+    // and cause a visible scroll jump.
     animationFrame(
       () => {
         set(thread.scrollToBottom$);
-        set(thread.hideSkeleton$);
+        animationFrame(
+          () => {
+            set(thread.hideSkeleton$);
+          },
+          { signal },
+        );
       },
       { signal },
     );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -174,6 +174,7 @@ export interface ChatThreadSignals {
   // ── Paged messages (sole rendering path) ─────────────────────────────────
   latestChatMessageId$: Computed<Promise<string | undefined>>;
   groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>;
+  hasUserMessages$: Computed<Promise<boolean>>;
   latestRunStatus$: Computed<Promise<string | null>>;
   allFinished$: Computed<Promise<boolean>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
@@ -1124,6 +1125,15 @@ function createChatThreadSignals(
     return thread?.activeRuns[0]?.status ?? null;
   });
 
+  // Stable boolean that flips false→true once a user message exists. Using a
+  // dedicated signal (rather than deriving inline from groupedChatMessages$)
+  // means ChatThreadComposer only re-renders when this value actually changes,
+  // not on every message arrival after the first user turn.
+  const hasUserMessages$ = computed(async (get): Promise<boolean> => {
+    const groups = await get(groupedChatMessages$);
+    return groups.some((g) => g.role === "user");
+  });
+
   return {
     threadData$,
     modelSelection$,
@@ -1152,6 +1162,7 @@ function createChatThreadSignals(
     scheduleDraftSync$,
     latestChatMessageId$,
     groupedChatMessages$,
+    hasUserMessages$,
     latestRunStatus$,
     allFinished$,
     fetchNextPage$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-scroll-regression.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-scroll-regression.test.tsx
@@ -1,0 +1,319 @@
+/**
+ * Regression guards for scroll-flicker bugs introduced in b4ea355d and 1550e48c.
+ *
+ * b4ea355d — ChatThreadComposer now subscribes to skeletonVisible$, which means it
+ *   re-renders when hideSkeleton$ fires in the same animationFrame as scrollToBottom$.
+ *   Guard (CHAT-COMPOSER-SCROLL-001): scroll position and auto-scroll remain intact
+ *   after the composer transitions from actionsLoading=true to actionsLoading=false.
+ *
+ * 1550e48c — The model picker lock condition changed from threadData.modelProviderId
+ *   (stable after first resolve) to hasUserMessages (re-evaluated on every Ably
+ *   message event). Every new message can now trigger a ChatThreadComposer re-render.
+ *   Guard (CHAT-COMPOSER-SCROLL-002): scroll position and auto-scroll remain intact
+ *   after the picker transitions from interactive to locked on the first user message.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import {
+  chatThreadByIdContract,
+  chatThreadMessagesContract,
+} from "@vm0/core/contracts/chat-threads";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
+import { createChatMessage } from "../../../mocks/mock-helpers.ts";
+import { setMockOrgModelProviders } from "../../../mocks/handlers/api-org-model-providers.ts";
+import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.ts";
+
+const context = testContext();
+const mockApi = createMockApi(context);
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
+
+// Attach a MutationObserver that gives the scroll container a non-zero
+// scrollHeight as soon as it appears so scrollToBottom$ has a real value.
+function interceptScrollContainer(scrollHeight: number): MutationObserver {
+  const obs = new MutationObserver(() => {
+    const el = document.querySelector<HTMLElement>("[data-scroll-container]");
+    if (!el) return;
+    Object.defineProperty(el, "scrollHeight", {
+      get: () => scrollHeight,
+      configurable: true,
+    });
+  });
+  obs.observe(document.body, { childList: true, subtree: true });
+  return obs;
+}
+
+// Capture the first ResizeObserver instantiated (the one created by
+// createScrollSignals), replacing the global with a no-op mock. Call
+// restore() in a finally block to reinstate the original.
+function captureFirstResizeObserver(): {
+  getCallback: () => ResizeObserverCallback | null;
+  restore: () => void;
+} {
+  let captured: ResizeObserverCallback | null = null;
+  const original = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = class MockResizeObserver {
+    constructor(cb: ResizeObserverCallback) {
+      if (captured === null) captured = cb;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  return {
+    getCallback: () => captured,
+    restore: () => {
+      globalThis.ResizeObserver = original;
+    },
+  };
+}
+
+// ─── CHAT-COMPOSER-SCROLL-001 (b4ea355d regression) ─────────────────────────
+
+// When messages finish loading, chat-page-setup fires scrollToBottom$ then
+// hideSkeleton$ in the same animationFrame. hideSkeleton$ flips skeletonVisible$
+// to false, which ChatThreadComposer subscribes to via actionsLoading. The
+// subsequent React commit (Skeleton → real buttons) must not reset scrollTop or
+// disable auto-scroll.
+describe("chat scroll — skeleton hide does not disrupt scroll or auto-scroll (CHAT-COMPOSER-SCROLL-001)", () => {
+  it("scrollTop stays at scrollHeight after skeleton hides and composer shows real buttons", async () => {
+    const messagesDeferred = createDeferredPromise<void>(context.signal);
+
+    server.use(
+      mockApi(chatThreadMessagesContract.list, async ({ query, respond }) => {
+        if (query.sinceId) return respond(200, { messages: [] });
+        await messagesDeferred.promise;
+        return respond(200, {
+          messages: [
+            {
+              id: "msg-1",
+              role: "user" as const,
+              content: "Hello",
+              createdAt: "2026-03-10T00:00:00Z",
+            },
+            {
+              id: "msg-2",
+              role: "assistant" as const,
+              content: "World",
+              createdAt: "2026-03-10T00:00:01Z",
+            },
+          ],
+        });
+      }),
+      mockApi(chatThreadByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          id: "thread-ccs-001",
+          title: null,
+          agentId: AGENT_ID,
+          chatMessages: [],
+          latestSessionId: null,
+          activeRunIds: [],
+          draftContent: null,
+          draftAttachments: null,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    const scrollObs = interceptScrollContainer(800);
+    const { getCallback: getResizeCb, restore: restoreRO } =
+      captureFirstResizeObserver();
+
+    try {
+      detachedSetupPage({ context, path: "/chats/thread-ccs-001" });
+
+      // While messages are loading the skeleton overlay must be up and the
+      // composer must be in actionsLoading=true state (Skeleton shown, no Send).
+      await waitFor(() => {
+        expect(document.querySelector("[data-chat-skeleton]")).not.toBeNull();
+      });
+      expect(screen.queryByLabelText("Send")).toBeNull();
+
+      // Resolve messages — triggers: scrollToBottom$ then hideSkeleton$ (same frame).
+      messagesDeferred.resolve();
+
+      // Skeleton disappears (hideSkeleton$ fired, skeletonVisible$ → false).
+      await waitFor(() => {
+        expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+      });
+
+      // Messages must now be visible.
+      await waitFor(() => {
+        expect(screen.getByText("Hello")).toBeInTheDocument();
+      });
+
+      const scrollContainer = document.querySelector<HTMLElement>(
+        "[data-scroll-container]",
+      );
+      expect(scrollContainer).not.toBeNull();
+
+      // scrollTop must equal scrollHeight after both scrollToBottom$ and the
+      // subsequent composer re-render (Skeleton → real buttons) have committed.
+      expect(scrollContainer!.scrollTop).toBe(800);
+
+      // Composer must now render real buttons — actionsLoading is false.
+      await waitFor(() => {
+        expect(screen.getByLabelText("Send")).toBeInTheDocument();
+      });
+
+      // Auto-scroll must still be enabled. Fire the ResizeObserver as if new
+      // content appeared inside the scroll container (e.g. a streaming token)
+      // and verify it snaps back to scrollHeight.
+      const resizeCb = getResizeCb();
+      expect(resizeCb).not.toBeNull();
+      resizeCb!([], {} as ResizeObserver);
+      expect(scrollContainer!.scrollTop).toBe(800);
+    } finally {
+      scrollObs.disconnect();
+      restoreRO();
+    }
+  });
+});
+
+// ─── CHAT-COMPOSER-SCROLL-002 (1550e48c regression) ──────────────────────────
+
+// hasUserMessages is re-evaluated every time groupedChatMessages$ resolves. When
+// the first user message arrives via Ably, ChatThreadComposer re-renders and the
+// model picker transitions from interactive (combobox) to locked (span). This
+// re-render must not reset scrollTop or disable auto-scroll.
+describe("chat scroll — Ably user-message event does not disrupt scroll or auto-scroll (CHAT-COMPOSER-SCROLL-002)", () => {
+  beforeEach(() => {
+    setMockFeatureSwitches({ [FeatureSwitchKey.ModelProviderSelection]: true });
+    setMockOrgModelProviders([
+      {
+        id: PROVIDER_ID,
+        type: "anthropic-api-key",
+        framework: "claude-code",
+        secretName: "ANTHROPIC_API_KEY",
+        authMethod: null,
+        secretNames: null,
+        isDefault: true,
+        selectedModel: "claude-sonnet-4-6",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+  });
+
+  it("scrollTop stays at scrollHeight and picker locks after first user message arrives via Ably (CHAT-COMPOSER-SCROLL-002)", async () => {
+    let userMessageArrived = false;
+
+    server.use(
+      mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
+        if (query.sinceId) {
+          if (userMessageArrived) {
+            return respond(200, {
+              messages: [
+                {
+                  id: "msg-user-1",
+                  role: "user" as const,
+                  content: "New user message",
+                  createdAt: "2026-03-10T00:00:01Z",
+                },
+              ],
+            });
+          }
+          return respond(200, { messages: [] });
+        }
+        // Initial load: assistant-only thread — hasUserMessages = false, picker interactive.
+        return respond(200, {
+          messages: [
+            {
+              id: "msg-0",
+              role: "assistant" as const,
+              content: "Welcome",
+              createdAt: "2026-03-10T00:00:00Z",
+            },
+          ],
+        });
+      }),
+      mockApi(chatThreadByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          id: "thread-ccs-002",
+          title: null,
+          agentId: AGENT_ID,
+          chatMessages: [],
+          latestSessionId: null,
+          latestSessionProviderType: null,
+          activeRunIds: [],
+          draftContent: null,
+          draftAttachments: null,
+          modelProviderId: null,
+          selectedModel: null,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    const scrollObs = interceptScrollContainer(900);
+    const { getCallback: getResizeCb, restore: restoreRO } =
+      captureFirstResizeObserver();
+
+    try {
+      detachedSetupPage({ context, path: "/chats/thread-ccs-002" });
+
+      // Initial load: assistant message displayed, picker is interactive.
+      await waitFor(() => {
+        expect(screen.getByText("Welcome")).toBeInTheDocument();
+      });
+
+      const scrollContainer = document.querySelector<HTMLElement>(
+        "[data-scroll-container]",
+      );
+      expect(scrollContainer).not.toBeNull();
+      expect(scrollContainer!.scrollTop).toBe(900);
+
+      // Picker must be interactive — no user messages yet (hasUserMessages = false).
+      await waitFor(() => {
+        expect(
+          screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
+        ).toBeInTheDocument();
+      });
+
+      // Simulate a user message arriving via Ably. This fires
+      // chatThreadMessageCreated:thread-ccs-002, which triggers loadPagedMessages$
+      // to re-poll with sinceId. The mock now returns the new user message.
+      userMessageArrived = true;
+      createChatMessage("thread-ccs-002");
+
+      // The new message must appear — groupedChatMessages$ has resolved with a
+      // user message, so hasUserMessages = true.
+      await waitFor(() => {
+        expect(screen.getByText("New user message")).toBeInTheDocument();
+      });
+
+      // scrollTop must still be at bottom despite the composer re-render caused
+      // by the hasUserMessages transition (false → true).
+      expect(scrollContainer!.scrollTop).toBe(900);
+
+      // The picker must now be locked — hasUserMessages = true means provider
+      // must stay consistent within the session.
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
+        ).toBeNull();
+        const label = screen.getByLabelText("Claude Sonnet 4.6");
+        expect(label.tagName).toBe("SPAN");
+      });
+
+      // Auto-scroll must remain enabled — fire ResizeObserver to confirm it
+      // would still snap new content to the bottom.
+      const resizeCb = getResizeCb();
+      expect(resizeCb).not.toBeNull();
+      resizeCb!([], {} as ResizeObserver);
+      expect(scrollContainer!.scrollTop).toBe(900);
+    } finally {
+      scrollObs.disconnect();
+      restoreRO();
+    }
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-scroll-regression.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-scroll-regression.test.tsx
@@ -40,7 +40,9 @@ const PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
 function interceptScrollContainer(scrollHeight: number): MutationObserver {
   const obs = new MutationObserver(() => {
     const el = document.querySelector<HTMLElement>("[data-scroll-container]");
-    if (!el) return;
+    if (!el) {
+      return;
+    }
     Object.defineProperty(el, "scrollHeight", {
       get: () => scrollHeight,
       configurable: true,
@@ -61,7 +63,9 @@ function captureFirstResizeObserver(): {
   const original = globalThis.ResizeObserver;
   globalThis.ResizeObserver = class MockResizeObserver {
     constructor(cb: ResizeObserverCallback) {
-      if (captured === null) captured = cb;
+      if (captured === null) {
+        captured = cb;
+      }
     }
     observe() {}
     unobserve() {}
@@ -88,7 +92,9 @@ describe("chat scroll — skeleton hide does not disrupt scroll or auto-scroll (
 
     server.use(
       mockApi(chatThreadMessagesContract.list, async ({ query, respond }) => {
-        if (query.sinceId) return respond(200, { messages: [] });
+        if (query.sinceId) {
+          return respond(200, { messages: [] });
+        }
         await messagesDeferred.promise;
         return respond(200, {
           messages: [

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -356,9 +356,9 @@ function ChatThreadComposer({
 }) {
   const groups = useLastResolved(thread.groupedChatMessages$) ?? [];
   const hasMessages = groups.length > 0;
-  const hasUserMessages = groups.some((g) => {
-    return g.role === "user";
-  });
+  // Read from a dedicated signal so this component only re-renders when the
+  // boolean actually changes (false → true), not on every subsequent message.
+  const hasUserMessages = useLastResolved(thread.hasUserMessages$) ?? false;
   const displayName = useLastResolved(thread.agentDisplayName$) ?? "Zero";
   const allFinishedLoadable = useLastLoadable(thread.allFinished$);
   const allFinished =


### PR DESCRIPTION
## Root cause

Two commits introduced scroll flicker on the chat thread page:

**b4ea355d** — `ChatThreadComposer` started subscribing to `skeletonVisible$` (via `actionsLoading`). This meant that when `hideSkeleton$` fired in the same `animationFrame` as `scrollToBottom$`, a React re-render of the composer (Skeleton → real buttons) raced with the scroll positioning and could cause a brief layout shift.

**1550e48c** — The model picker lock condition changed from the stable `threadData.modelProviderId` to `hasUserMessages` (derived inline from `groupedChatMessages$`). Every Ably message event now triggered a `ChatThreadComposer` re-render, causing repeated layout pressure on the scroll container.

## Fixes

**`chat-page-setup.ts`** — Double-rAF: scroll to bottom in frame N, hide skeleton in frame N+1. The composer re-render now happens after the scroll position is already painted, eliminating the race.

**`create-chat-thread.ts`** — Add `hasUserMessages$` as a dedicated computed signal derived from `groupedChatMessages$`. Since ccstate memoizes primitive results, this signal only notifies subscribers when the boolean actually changes (false → true, once per thread), not on every message arrival.

**`zero-chat-thread-page.tsx`** — `ChatThreadComposer` reads `useLastResolved(thread.hasUserMessages$)` instead of deriving the boolean inline from `groups`. The component no longer re-renders on every subsequent message after the first user turn.

## Regression tests (same PR)

- **CHAT-COMPOSER-SCROLL-001** — skeleton hide: `scrollTop` stays at `scrollHeight`, auto-scroll remains enabled
- **CHAT-COMPOSER-SCROLL-002** — Ably user-message event: `scrollTop` stays at `scrollHeight`, picker locks correctly, auto-scroll remains enabled

## Test plan

- [ ] `pnpm test --filter platform` — two new tests green
- [ ] Open a new thread, send a message — no scroll jump at page load or after send
- [ ] Open an existing thread with messages — no scroll jump on initial load