### PR TITLE
fix(web): notify runners on org/user deletion cancel path

### DIFF
--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-deletion-service.test.ts
@@ -35,7 +35,11 @@ import { findTestSlackOrgInstallation } from "../../../../__tests__/db-test-asse
 import { createTestZeroAgent } from "../../../../__tests__/db-test-seeders/agents";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
 import { deleteOrgData } from "../org-deletion-service";
-import { seedTestRun } from "../../../../__tests__/db-test-seeders/runs";
+import {
+  seedTestRun,
+  setTestRunRunnerGroup,
+} from "../../../../__tests__/db-test-seeders/runs";
+import { mockAblyPublish } from "../../../../__tests__/ably-mock";
 
 const context = testContext();
 
@@ -77,6 +81,47 @@ describe("deleteOrgData", () => {
     expect(await findTestRunRecord(pendingRunId)).toBeUndefined();
     expect(await findTestRunRecord(runningRunId)).toBeUndefined();
     expect(await findTestQueueEntry(queuedRunId)).toBeUndefined();
+  });
+
+  it("should notify runner groups for in-flight runs before deletion (#10763)", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+
+    const { composeId } = await createTestCompose(uniqueId("cancel-notify"));
+
+    const { runId: runningRunId } = await seedTestRun(userId, composeId, {
+      status: "running",
+      startedAt: new Date(),
+    });
+    await setTestRunRunnerGroup(runningRunId, "test-group-running");
+
+    // Queued run — runnerGroup null; must not produce a publish even though
+    // it transitions to cancelled.
+    const { runId: queuedRunId } = await seedTestRun(userId, composeId, {
+      status: "queued",
+    });
+
+    // Completed run with a runnerGroup — already terminal; the UPDATE's
+    // status filter excludes it and nothing should be published for it.
+    const { runId: completedRunId } = await seedTestRun(userId, composeId, {
+      status: "completed",
+      completedAt: new Date(),
+    });
+    await setTestRunRunnerGroup(completedRunId, "test-group-completed");
+
+    mockAblyPublish.mockClear();
+
+    await deleteOrgData(orgId);
+
+    const cancelPublishes = mockAblyPublish.mock.calls.filter((call) => {
+      return call[0] === "cancel";
+    });
+    const cancelledRunIds = cancelPublishes.map((call) => {
+      return (call[1] as { runId?: string }).runId;
+    });
+    expect(cancelledRunIds).toEqual([runningRunId]);
+    expect(cancelledRunIds).not.toContain(queuedRunId);
+    expect(cancelledRunIds).not.toContain(completedRunId);
   });
 
   it("should cascade delete agent composes and children", async () => {

--- a/turbo/apps/web/src/lib/zero/org/org-deletion-service.ts
+++ b/turbo/apps/web/src/lib/zero/org/org-deletion-service.ts
@@ -19,18 +19,20 @@ import { orgMembersMetadata } from "../../../db/schema/org-members-metadata";
 import { orgCache } from "../../../db/schema/org-cache";
 import { orgMetadata } from "../../../db/schema/org-metadata";
 import { cleanupWorkspaceInstallation } from "../slack-org/connect-service";
+import { publishCancelNotification } from "../../infra/realtime/client";
 
 const log = logger("service:org-deletion");
 
 /**
- * Cancel all pending/running/queued agent runs for an org.
- * Bulk cancel only updates status — no side effects needed since the
- * entire org is being deleted.
+ * Cancel all pending/running/queued agent runs for an org and notify
+ * runners so mitmproxy stops emitting webhooks before the rows are
+ * deleted. The Ably publish is best-effort — on failure, the runner
+ * continues to natural completion (see publishCancelNotification).
  */
 async function cancelOrgRuns(orgId: string): Promise<void> {
   const db = globalThis.services.db;
 
-  const result = await db
+  const cancelled = await db
     .update(agentRuns)
     .set({ status: "cancelled", completedAt: new Date() })
     .where(
@@ -38,11 +40,22 @@ async function cancelOrgRuns(orgId: string): Promise<void> {
         eq(agentRuns.orgId, orgId),
         inArray(agentRuns.status, ["queued", "pending", "running"]),
       ),
-    );
+    )
+    .returning({ id: agentRuns.id, runnerGroup: agentRuns.runnerGroup });
 
   await db.delete(agentRunQueue).where(eq(agentRunQueue.orgId, orgId));
 
-  log.info("org runs cancelled", { orgId, count: result.rowCount });
+  await Promise.allSettled(
+    cancelled
+      .filter((r) => {
+        return r.runnerGroup !== null;
+      })
+      .map((r) => {
+        return publishCancelNotification(r.runnerGroup!, r.id);
+      }),
+  );
+
+  log.info("org runs cancelled", { orgId, count: cancelled.length });
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/user/__tests__/user-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/user/__tests__/user-deletion-service.test.ts
@@ -39,7 +39,11 @@ import { countSlackConnectionRows } from "../../../../__tests__/db-test-assertio
 import { insertTestComposeJob } from "../../../../__tests__/db-test-seeders/agents";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
 import { deleteUserData } from "../user-deletion-service";
-import { seedTestRun } from "../../../../__tests__/db-test-seeders/runs";
+import {
+  seedTestRun,
+  setTestRunRunnerGroup,
+} from "../../../../__tests__/db-test-seeders/runs";
+import { mockAblyPublish } from "../../../../__tests__/ably-mock";
 
 const context = testContext();
 
@@ -81,6 +85,43 @@ describe("deleteUserData", () => {
     expect(await findTestRunRecord(pendingRunId)).toBeUndefined();
     expect(await findTestRunRecord(runningRunId)).toBeUndefined();
     expect(await findTestQueueEntry(queuedRunId)).toBeUndefined();
+  });
+
+  it("should notify runner groups for in-flight runs before deletion (#10763)", async () => {
+    context.setupMocks();
+    const { userId } = await context.setupUser();
+
+    const { composeId } = await createTestCompose(uniqueId("cancel-notify"));
+
+    const { runId: runningRunId } = await seedTestRun(userId, composeId, {
+      status: "running",
+      startedAt: new Date(),
+    });
+    await setTestRunRunnerGroup(runningRunId, "test-group-running");
+
+    const { runId: queuedRunId } = await seedTestRun(userId, composeId, {
+      status: "queued",
+    });
+
+    const { runId: completedRunId } = await seedTestRun(userId, composeId, {
+      status: "completed",
+      completedAt: new Date(),
+    });
+    await setTestRunRunnerGroup(completedRunId, "test-group-completed");
+
+    mockAblyPublish.mockClear();
+
+    await deleteUserData(userId);
+
+    const cancelPublishes = mockAblyPublish.mock.calls.filter((call) => {
+      return call[0] === "cancel";
+    });
+    const cancelledRunIds = cancelPublishes.map((call) => {
+      return (call[1] as { runId?: string }).runId;
+    });
+    expect(cancelledRunIds).toEqual([runningRunId]);
+    expect(cancelledRunIds).not.toContain(queuedRunId);
+    expect(cancelledRunIds).not.toContain(completedRunId);
   });
 
   it("should cascade delete agent composes and children", async () => {

--- a/turbo/apps/web/src/lib/zero/user/user-deletion-service.ts
+++ b/turbo/apps/web/src/lib/zero/user/user-deletion-service.ts
@@ -23,18 +23,20 @@ import { orgMembersCache } from "../../../db/schema/org-members-cache";
 import { orgMembersMetadata } from "../../../db/schema/org-members-metadata";
 import { userCache } from "../../../db/schema/user-cache";
 import { users } from "../../../db/schema/user";
+import { publishCancelNotification } from "../../infra/realtime/client";
 
 const log = logger("service:user-deletion");
 
 /**
- * Cancel all pending/running/queued agent runs for a user.
- * Bulk cancel only updates status — no side effects needed since the
- * entire user is being deleted.
+ * Cancel all pending/running/queued agent runs for a user and notify
+ * runners so mitmproxy stops emitting webhooks before the rows are
+ * deleted. The Ably publish is best-effort — on failure, the runner
+ * continues to natural completion (see publishCancelNotification).
  */
 async function cancelUserRuns(userId: string): Promise<void> {
   const db = globalThis.services.db;
 
-  const result = await db
+  const cancelled = await db
     .update(agentRuns)
     .set({ status: "cancelled", completedAt: new Date() })
     .where(
@@ -42,11 +44,22 @@ async function cancelUserRuns(userId: string): Promise<void> {
         eq(agentRuns.userId, userId),
         inArray(agentRuns.status, ["queued", "pending", "running"]),
       ),
-    );
+    )
+    .returning({ id: agentRuns.id, runnerGroup: agentRuns.runnerGroup });
 
   await db.delete(agentRunQueue).where(eq(agentRunQueue.userId, userId));
 
-  log.info("user runs cancelled", { userId, count: result.rowCount });
+  await Promise.allSettled(
+    cancelled
+      .filter((r) => {
+        return r.runnerGroup !== null;
+      })
+      .map((r) => {
+        return publishCancelNotification(r.runnerGroup!, r.id);
+      }),
+  );
+
+  log.info("user runs cancelled", { userId, count: cancelled.length });
 }
 
 /**


### PR DESCRIPTION
## Summary
- `cancelOrgRuns` / `cancelUserRuns` now publish Ably `cancel` to the runner-group of every in-flight run before the bulk DELETE, stopping zombie compute on accounts being wiped and shrinking the #10725 FK-violation window
- Switched to `UPDATE … RETURNING` so the notify list is atomic with the status transition (no SELECT-then-UPDATE race)
- Dropped the misleading "no side effects needed since the entire org is being deleted" comment — the runner is an external process and very much needs to be told
- Integration tests added to both deletion suites

## What this doesn't close
Webhooks already submitted to mitmproxy's `ThreadPoolExecutor` before the cancel event arrives are still in flight; that residual gap is addressed by the server-side `23503` catch under #10725. Same for `deleteComposeById`'s TOCTOU window — out of scope here.

Closes #10763

## Test plan
- [x] `org-deletion-service.test.ts` — new `should notify runner groups for in-flight runs before deletion (#10763)` case; asserts running→publish, queued→no publish (null runnerGroup), completed→no publish (filtered by status)
- [x] `user-deletion-service.test.ts` — mirrored case
- [x] `pnpm -F web exec vitest run …` — both suites green (28 tests)
- [x] `pnpm turbo run lint --filter=web` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` / `pnpm knip` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)