### PR TITLE
chore(infra): remove old-shape compat and move auto-memory constants to zero (closes #10913)

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -31,7 +31,7 @@ import { GET as getSessionById } from "../../sessions/[id]/route";
 import { POST as completeWebhook } from "../../../webhooks/agent/complete/route";
 import { POST as pollRoute } from "../../../runners/poll/route";
 import type { AgentComposeYaml } from "../../../../../src/lib/infra/agent-compose/types";
-import { AUTO_MEMORY_MOUNT_PATH } from "../../../../../src/lib/infra/storage/types";
+import { AUTO_MEMORY_MOUNT_PATH } from "../../../../../src/lib/zero/memory";
 import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
 import { bindCustomSkillToAgent } from "../../../../../src/__tests__/db-test-seeders/skills";
 import {

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -15,10 +15,8 @@ import {
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
-import {
-  type AdditionalVolume,
-  AUTO_MEMORY_ARTIFACT_NAME,
-} from "../../../../src/lib/infra/storage/types";
+import type { AdditionalVolume } from "../../../../src/lib/infra/storage/types";
+import { AUTO_MEMORY_ARTIFACT_NAME } from "../../../../src/lib/zero/memory";
 import { and, eq, inArray, desc, gte, lte, sql } from "drizzle-orm";
 import {
   loadCompose,

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -64,9 +64,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentSessionId: "test-session",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshots: {
-              "test-artifact": "version-123",
-            },
+            artifactSnapshots: [
+              {
+                name: "test-artifact",
+                version: "version-123",
+                mountPath: "/home/user/workspace",
+              },
+            ],
           }),
         },
       );
@@ -96,9 +100,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentSessionId: "test-session",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshots: {
-              "test-artifact": "version-123",
-            },
+            artifactSnapshots: [
+              {
+                name: "test-artifact",
+                version: "version-123",
+                mountPath: "/home/user/workspace",
+              },
+            ],
           }),
         },
       );
@@ -125,9 +133,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             // cliAgentSessionId: missing
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshots: {
-              "test-artifact": "version-123",
-            },
+            artifactSnapshots: [
+              {
+                name: "test-artifact",
+                version: "version-123",
+                mountPath: "/home/user/workspace",
+              },
+            ],
           }),
         },
       );
@@ -153,9 +165,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentType: "claude-code",
             cliAgentSessionId: "test-session",
             // cliAgentSessionHistoryHash: missing
-            artifactSnapshots: {
-              "test-artifact": "version-123",
-            },
+            artifactSnapshots: [
+              {
+                name: "test-artifact",
+                version: "version-123",
+                mountPath: "/home/user/workspace",
+              },
+            ],
           }),
         },
       );
@@ -247,9 +263,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentSessionId: "test-session",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshots: {
-              "test-artifact": "version-123",
-            },
+            artifactSnapshots: [
+              {
+                name: "test-artifact",
+                version: "version-123",
+                mountPath: "/home/user/workspace",
+              },
+            ],
           }),
         },
       );
@@ -295,9 +315,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
             cliAgentSessionId: "test-session",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshots: {
-              "test-artifact": "version-123",
-            },
+            artifactSnapshots: [
+              {
+                name: "test-artifact",
+                version: "version-123",
+                mountPath: "/home/user/workspace",
+              },
+            ],
           }),
         },
       );
@@ -312,9 +336,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
 
   describe("Success", () => {
     it("should create checkpoint with single artifact", async () => {
-      const artifactSnapshots = {
-        "test-artifact": "version-123-456",
-      };
+      const artifactSnapshots = [
+        {
+          name: "test-artifact",
+          version: "version-123-456",
+          mountPath: "/home/user/workspace",
+        },
+      ];
 
       const request = createTestRequest(
         "http://localhost:3000/api/webhooks/agent/checkpoints",
@@ -341,68 +369,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       expect(data.checkpointId).toBeDefined();
       expect(data.agentSessionId).toBeDefined();
       expect(data.conversationId).toBeDefined();
-      // Response echoes the normalised canonical shape persisted to the DB,
-      // not the caller's raw Record input.
-      expect(data.artifacts).toEqual([
-        {
-          name: "test-artifact",
-          version: "version-123-456",
-          mountPath: "/home/user/workspace",
-        },
-      ]);
-    });
-
-    it("should persist legacy Record payload as canonical Array via mountPath heuristic", async () => {
-      // Legacy Record input: the writer normalises to canonical
-      // Array<{name, version, mountPath}> via the name heuristic — non-"memory"
-      // entries resolve mountPath to the compose working_dir
-      // (/home/user/workspace for claude-code).
-      const artifactSnapshots = {
-        "artifact-a": "version-aaa",
-        "artifact-b": "version-bbb",
-      };
-
-      const request = createTestRequest(
-        "http://localhost:3000/api/webhooks/agent/checkpoints",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${testToken}`,
-          },
-          body: JSON.stringify({
-            runId: testRunId,
-            cliAgentType: "claude-code",
-            cliAgentSessionId: "multi-artifact-session",
-            cliAgentSessionHistoryHash: sha256("multi-artifact-history"),
-            artifactSnapshots,
-          }),
-        },
-      );
-
-      const response = await POST(request);
-
-      expect(response.status).toBe(200);
-      const data = await response.json();
-      // Response echoes the normalised canonical Array shape, matching the
-      // on-disk representation rather than the caller's raw Record input.
-      const expectedCanonical = [
-        {
-          name: "artifact-a",
-          version: "version-aaa",
-          mountPath: "/home/user/workspace",
-        },
-        {
-          name: "artifact-b",
-          version: "version-bbb",
-          mountPath: "/home/user/workspace",
-        },
-      ];
-      expect(data.artifacts).toEqual(expectedCanonical);
-
-      const checkpoint = await findTestCheckpoint(testRunId);
-      expect(checkpoint).toBeDefined();
-      expect(checkpoint!.artifactSnapshots).toEqual(expectedCanonical);
+      expect(data.artifacts).toEqual(artifactSnapshots);
     });
 
     it("should persist canonical array-shape artifactSnapshots verbatim", async () => {
@@ -454,9 +421,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
 
   describe("Session independence", () => {
     it("should create independent sessions for separate artifact runs", async () => {
-      const artifactSnapshots = {
-        "my-app": "v1",
-      };
+      const artifactSnapshots = [
+        {
+          name: "my-app",
+          version: "v1",
+          mountPath: "/home/user/workspace",
+        },
+      ];
 
       // Allow multiple concurrent runs and re-enable Clerk auth for API route calls
       vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "0");
@@ -593,9 +564,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         cliAgentType: "claude-code",
         cliAgentSessionId: "test-session-unique",
         cliAgentSessionHistoryHash: sha256("test-session-unique-history"),
-        artifactSnapshots: {
-          "test-artifact": "version-123",
-        },
+        artifactSnapshots: [
+          {
+            name: "test-artifact",
+            version: "version-123",
+            mountPath: "/home/user/workspace",
+          },
+        ],
       };
 
       // First request - should succeed

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -228,9 +228,13 @@ describe("POST /api/webhooks/agent/complete", () => {
             cliAgentSessionId: "test-session",
             cliAgentSessionHistoryHash:
               "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshots: {
-              "test-artifact": "v1",
-            },
+            artifactSnapshots: [
+              {
+                name: "test-artifact",
+                version: "v1",
+                mountPath: "/home/user/workspace",
+              },
+            ],
           }),
         },
       );
@@ -259,57 +263,6 @@ describe("POST /api/webhooks/agent/complete", () => {
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.status).toBe("completed");
-    });
-
-    it("should surface full artifact map in result when checkpoint has artifactSnapshots", async () => {
-      const artifactSnapshots = {
-        "frontend-build": "v-frontend-1",
-        "backend-build": "v-backend-2",
-      };
-
-      const checkpointRequest = createTestRequest(
-        "http://localhost:3000/api/webhooks/agent/checkpoints",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${testToken}`,
-          },
-          body: JSON.stringify({
-            runId: testRunId,
-            cliAgentType: "claude-code",
-            cliAgentSessionId: "multi-artifact-complete",
-            cliAgentSessionHistoryHash:
-              "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshots,
-          }),
-        },
-      );
-      const checkpointResponse = await checkpointWebhook(checkpointRequest);
-      expect(checkpointResponse.status).toBe(200);
-
-      const request = createTestRequest(
-        "http://localhost:3000/api/webhooks/agent/complete",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${testToken}`,
-          },
-          body: JSON.stringify({
-            runId: testRunId,
-            exitCode: 0,
-          }),
-        },
-      );
-
-      const response = await POST(request);
-      expect(response.status).toBe(200);
-
-      const run = await findTestRunRecord(testRunId);
-      expect(run!.status).toBe("completed");
-      const result = run!.result as { artifact?: Record<string, string> };
-      expect(result.artifact).toEqual(artifactSnapshots);
     });
 
     it("should project array-shape artifactSnapshots to Record in result.artifact", async () => {
@@ -1083,9 +1036,13 @@ describe("POST /api/webhooks/agent/complete", () => {
               cliAgentSessionId: "recovery-session",
               cliAgentSessionHistoryHash:
                 "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-              artifactSnapshots: {
-                "recovery-artifact": "v1",
-              },
+              artifactSnapshots: [
+                {
+                  name: "recovery-artifact",
+                  version: "v1",
+                  mountPath: "/home/user/workspace",
+                },
+              ],
             }),
           },
         ),

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -1,6 +1,5 @@
 import { and, eq } from "drizzle-orm";
 import { agentRuns } from "../../../db/schema/agent-run";
-import { agentComposeVersions } from "../../../db/schema/agent-compose";
 import { conversations } from "../../../db/schema/conversation";
 import { checkpoints } from "../../../db/schema/checkpoint";
 import { notFound } from "../../shared/errors";
@@ -17,7 +16,6 @@ import {
   decodeToContextArtifacts,
   isEmptyArtifactPayload,
 } from "./decode-artifact-snapshots";
-import { extractWorkingDir } from "../run/utils/extract-working-dir";
 
 const log = logger("checkpoint");
 
@@ -59,17 +57,6 @@ export async function createCheckpoint(
     throw notFound(
       "Agent compose version not found (agent may have been deleted)",
     );
-  }
-
-  // Fetch agent compose version to get composeId for session
-  const [version] = await globalThis.services.db
-    .select()
-    .from(agentComposeVersions)
-    .where(eq(agentComposeVersions.id, run.agentComposeVersionId))
-    .limit(1);
-
-  if (!version) {
-    throw notFound("Agent compose version not found");
   }
 
   log.debug(
@@ -148,23 +135,14 @@ export async function createCheckpoint(
       }
     : null;
 
-  // Normalise the artifactSnapshots payload before persisting — legacy
-  // Record<name, version> inputs get converted to the canonical
-  // Array<{name, version, mountPath}> shape via a mountPath heuristic
-  // (memory → AUTO_MEMORY_MOUNT_PATH, else → compose workingDir). Array-shape
-  // inputs already carry their own mountPath, so we skip the workingDir
-  // lookup — this keeps the writer tolerant of malformed compose content
-  // for canonical-shape payloads. Empty payloads (null, {}, []) collapse to
-  // NULL so "no artifacts" has a single on-disk representation.
+  // Normalise the artifactSnapshots payload before persisting. The webhook
+  // contract now only accepts the canonical Array<{name, version, mountPath}>
+  // shape; empty payloads (null, []) collapse to NULL so "no artifacts" has
+  // a single on-disk representation.
   const rawPayload = request.artifactSnapshots ?? null;
   const artifactSnapshotsForDb = isEmptyArtifactPayload(rawPayload)
     ? null
-    : decodeToContextArtifacts(
-        rawPayload,
-        Array.isArray(rawPayload)
-          ? undefined
-          : extractWorkingDir(version.content),
-      );
+    : decodeToContextArtifacts(rawPayload);
 
   const snapshotFields = {
     conversationId: conversation.id,
@@ -215,11 +193,9 @@ export async function createCheckpoint(
   // Use volume versions from snapshot for return value
   const volumes = volumeSnapshot?.versions;
 
-  // Echo back the normalised canonical shape that was persisted so the
-  // response matches the on-disk representation — not the caller's raw
-  // input shape. Writer inputs always carry a concrete `version` string
-  // (Record values are strings, Array entries require version), so we
-  // assert it here to satisfy the response schema's non-optional version.
+  // Echo back the persisted canonical shape. The webhook contract requires
+  // `version` on every entry, so the undefined-branch assertion guards
+  // against a ContextArtifact leaking in from a non-webhook caller.
   const responseArtifacts = artifactSnapshotsForDb?.map((entry) => {
     if (entry.version === undefined) {
       throw new Error(

--- a/turbo/apps/web/src/lib/infra/checkpoint/decode-artifact-snapshots.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/decode-artifact-snapshots.ts
@@ -1,25 +1,13 @@
 import { badRequest } from "../../shared/errors";
 import type { ContextArtifact } from "../run/types";
-import {
-  AUTO_MEMORY_ARTIFACT_NAME,
-  AUTO_MEMORY_MOUNT_PATH,
-} from "../storage/types";
 
 /**
  * Decoders for the `checkpoints.artifact_snapshots` JSONB column.
  *
- * The column accepts two shapes (see #10909 for the reader-tolerance rollout
- * and #10911 for the writer flip):
- *
- * - Legacy: `Record<name, version>` — pre-#10911 guest-agent payloads. No
- *   mountPath, so readers that need one stamp it via a name heuristic
- *   ("memory" → AUTO_MEMORY_MOUNT_PATH, anything else → workingDir).
- * - Canonical: `Array<{name, version, mountPath}>` — post-#10911 payloads.
- *   Carries the mount path per entry; no heuristics required.
- *
- * All runtime validation lives here so malformed historical rows fail fast
- * with a descriptive error rather than surfacing much later as an opaque
- * mount failure.
+ * The column always stores the canonical `Array<{name, version, mountPath}>`
+ * form. Legacy `Record<name, version>` payloads were migrated in #10912 and
+ * writer support was removed in #10911 — readers therefore reject non-array
+ * payloads with a descriptive error rather than silently tolerating them.
  */
 
 /**
@@ -37,106 +25,55 @@ export function isEmptyArtifactPayload(raw: unknown): boolean {
 
 /**
  * Decode the JSONB column into the unified `ContextArtifact[]` form consumed
- * by `resolve-checkpoint.ts` (and any other code path that needs mountPath
- * stamped on every entry). Legacy `Record<name, version>` entries get their
- * mountPath via the name heuristic, so callers that may hit the legacy path
- * MUST pass `workingDir`. Array-shape payloads carry their own mountPath, so
- * callers that know they only ever handle canonical-shape data can omit it.
+ * by `resolve-checkpoint.ts` and any other code path that needs mountPath
+ * stamped on every entry.
  */
-export function decodeToContextArtifacts(
-  raw: unknown,
-  workingDir?: string,
-): ContextArtifact[] {
+export function decodeToContextArtifacts(raw: unknown): ContextArtifact[] {
   if (raw === null || raw === undefined) return [];
 
-  if (Array.isArray(raw)) {
-    return raw.map((entry, i) => {
-      if (!isContextArtifact(entry)) {
-        throw badRequest(
-          `Invalid checkpoint: artifactSnapshots[${i}] is not a valid ContextArtifact`,
-        );
-      }
-      return entry;
-    });
+  if (!Array.isArray(raw)) {
+    throw badRequest("Invalid checkpoint: artifactSnapshots must be an array");
   }
 
-  if (typeof raw !== "object") {
-    throw badRequest(
-      "Invalid checkpoint: artifactSnapshots must be an array or object",
-    );
-  }
-
-  if (workingDir === undefined) {
-    throw badRequest(
-      "Invalid checkpoint: legacy Record-shape artifactSnapshots require a workingDir",
-    );
-  }
-
-  return Object.entries(raw as Record<string, unknown>).map(
-    ([name, version]) => {
-      if (typeof version !== "string") {
-        throw badRequest(
-          `Invalid checkpoint: artifactSnapshots["${name}"] must be a string version`,
-        );
-      }
-      return {
-        name,
-        version,
-        mountPath:
-          name === AUTO_MEMORY_ARTIFACT_NAME
-            ? AUTO_MEMORY_MOUNT_PATH
-            : workingDir,
-      };
-    },
-  );
+  return raw.map((entry, i) => {
+    if (!isContextArtifact(entry)) {
+      throw badRequest(
+        `Invalid checkpoint: artifactSnapshots[${i}] is not a valid ContextArtifact`,
+      );
+    }
+    return entry;
+  });
 }
 
 /**
  * Project the JSONB column to a `Record<name, version>` for outbound surfaces
  * that currently speak the legacy shape (e.g., `RunResult.artifact`, the CLI
  * `GET /api/agent/checkpoints/:id` response arm). mountPath is discarded; a
- * name collision in the array shape — which should never happen for a
- * well-formed snapshot — lets the last entry win, matching Object-literal
- * semantics.
+ * name collision — which should never happen for a well-formed snapshot —
+ * lets the last entry win, matching Object-literal semantics.
  *
  * Returns `null` when the payload is empty (see `isEmptyArtifactPayload`).
  */
 export function decodeToRecord(raw: unknown): Record<string, string> | null {
   if (isEmptyArtifactPayload(raw)) return null;
 
-  if (Array.isArray(raw)) {
-    const result: Record<string, string> = {};
-    for (const [i, entry] of raw.entries()) {
-      if (!isContextArtifact(entry)) {
-        throw badRequest(
-          `Invalid checkpoint: artifactSnapshots[${i}] is not a valid ContextArtifact`,
-        );
-      }
-      if (entry.version === undefined) {
-        throw badRequest(
-          `Invalid checkpoint: artifactSnapshots[${i}] has no version`,
-        );
-      }
-      result[entry.name] = entry.version;
-    }
-    return result;
+  if (!Array.isArray(raw)) {
+    throw badRequest("Invalid checkpoint: artifactSnapshots must be an array");
   }
 
-  if (typeof raw !== "object" || raw === null) {
-    throw badRequest(
-      "Invalid checkpoint: artifactSnapshots must be an array or object",
-    );
-  }
-
-  const obj = raw as Record<string, unknown>;
   const result: Record<string, string> = {};
-  for (const [name, version] of Object.entries(obj)) {
-    if (typeof version !== "string") {
+  for (const [i, entry] of raw.entries()) {
+    if (!isContextArtifact(entry)) {
       throw badRequest(
-        `Invalid checkpoint: artifactSnapshots["${name}"] must be a string version`,
+        `Invalid checkpoint: artifactSnapshots[${i}] is not a valid ContextArtifact`,
       );
     }
-    result[name] = version;
+    if (entry.version === undefined) {
+      throw badRequest(
+        `Invalid checkpoint: artifactSnapshots[${i}] has no version`,
+      );
+    }
+    result[entry.name] = entry.version;
   }
   return result;
 }

--- a/turbo/apps/web/src/lib/infra/checkpoint/types.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/types.ts
@@ -3,18 +3,16 @@
  */
 
 /**
- * Artifact snapshot payload shapes the writer may send. Legacy Record is still
- * accepted (pre-#10911 guest-agents) and the canonical array shape carries
- * mountPath per entry (post-#10911). Receiver tolerance lives in
- * `decode-artifact-snapshots.ts`.
- *
- * Note: the array-entry's `version` is always a resolved concrete string —
- * distinct from `ContextArtifact` (execution-context type) where `version` is
- * optional and defaults to "latest".
+ * Artifact snapshot payload sent by the writer. Each entry's `version` is
+ * always a resolved concrete string — distinct from `ContextArtifact`
+ * (execution-context type) where `version` is optional and defaults to
+ * "latest".
  */
-export type ArtifactSnapshotsPayload =
-  | Record<string, string>
-  | Array<{ name: string; version: string; mountPath: string }>;
+export type ArtifactSnapshotsPayload = Array<{
+  name: string;
+  version: string;
+  mountPath: string;
+}>;
 
 /**
  * Agent compose snapshot stored in checkpoint
@@ -51,20 +49,16 @@ export interface CheckpointRequest {
   cliAgentType: string;
   cliAgentSessionId: string;
   cliAgentSessionHistoryHash: string;
-  // Multi-artifact snapshot payload. Accepts both legacy Record (pre-#10911)
-  // and canonical array (post-#10911) shapes; persisted verbatim to the
-  // JSONB column. May be empty or missing when the guest snapshotted nothing.
+  // Multi-artifact snapshot payload. Canonical array shape only; persisted
+  // verbatim to the JSONB column. May be empty or missing when the guest
+  // snapshotted nothing.
   artifactSnapshots?: ArtifactSnapshotsPayload;
   volumeVersionsSnapshot?: VolumeVersionsSnapshot;
 }
 
 /**
- * Response from checkpoint creation.
- *
- * `artifacts` always echoes the canonical Array shape that was persisted
- * to the JSONB column — even when the caller sent a legacy Record payload,
- * the writer normalises before persisting and the response echoes the
- * normalised form. This keeps on-wire and on-disk representations in sync.
+ * Response from checkpoint creation. `artifacts` echoes the canonical array
+ * shape persisted to the JSONB column.
  */
 export interface CheckpointResponse {
   checkpointId: string;

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-checkpoint.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-checkpoint.test.ts
@@ -11,17 +11,11 @@ import {
   uniqueId,
   type UserContext,
 } from "../../../../../__tests__/test-helpers";
-import {
-  AUTO_MEMORY_ARTIFACT_NAME,
-  AUTO_MEMORY_MOUNT_PATH,
-} from "../../../storage/types";
 import type { ContextArtifact } from "../../types";
 
 const context = testContext();
 
-const WORKING_DIR = "/home/user/workspace";
-
-describe("resolveCheckpoint — artifactSnapshots shape tolerance", () => {
+describe("resolveCheckpoint — artifactSnapshots decoding", () => {
   let user: UserContext;
   let composeId: string;
 
@@ -32,36 +26,7 @@ describe("resolveCheckpoint — artifactSnapshots shape tolerance", () => {
     composeId = compose.composeId;
   });
 
-  it("decodes legacy Record<name, version> via mountPath heuristic", async () => {
-    const { runId } = await createTestRun(composeId, "legacy shape run");
-    const { checkpointId } = await createTestCheckpoint(user.userId, runId);
-
-    await setTestCheckpointArtifactSnapshots(checkpointId, {
-      [AUTO_MEMORY_ARTIFACT_NAME]: "v-mem",
-      "my-artifact": "v-art",
-    });
-
-    const resolution = await resolveCheckpoint(checkpointId, user.userId);
-
-    expect(resolution.artifacts).toHaveLength(2);
-    const byName = Object.fromEntries(
-      resolution.artifacts.map((a) => {
-        return [a.name, a];
-      }),
-    );
-    expect(byName[AUTO_MEMORY_ARTIFACT_NAME]).toEqual({
-      name: AUTO_MEMORY_ARTIFACT_NAME,
-      version: "v-mem",
-      mountPath: AUTO_MEMORY_MOUNT_PATH,
-    });
-    expect(byName["my-artifact"]).toEqual({
-      name: "my-artifact",
-      version: "v-art",
-      mountPath: WORKING_DIR,
-    });
-  });
-
-  it("passes new-shape ContextArtifact[] through unchanged", async () => {
+  it("passes canonical ContextArtifact[] through unchanged", async () => {
     const { runId } = await createTestRun(composeId, "new shape run");
     const { checkpointId } = await createTestCheckpoint(user.userId, runId);
 
@@ -100,20 +65,6 @@ describe("resolveCheckpoint — artifactSnapshots shape tolerance", () => {
 
     await expect(resolveCheckpoint(checkpointId, user.userId)).rejects.toThrow(
       /artifactSnapshots\[0\]/,
-    );
-  });
-
-  it("rejects legacy Record entries with non-string versions", async () => {
-    const { runId } = await createTestRun(composeId, "malformed record run");
-    const { checkpointId } = await createTestCheckpoint(user.userId, runId);
-
-    // Legacy Record shape where a version is not a string.
-    await setTestCheckpointArtifactSnapshots(checkpointId, {
-      bad: 42,
-    } as unknown as Record<string, string>);
-
-    await expect(resolveCheckpoint(checkpointId, user.userId)).rejects.toThrow(
-      /"bad"/,
     );
   });
 });

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
@@ -14,10 +14,6 @@ import {
   uniqueId,
   type UserContext,
 } from "../../../../../__tests__/test-helpers";
-import {
-  AUTO_MEMORY_ARTIFACT_NAME,
-  AUTO_MEMORY_MOUNT_PATH,
-} from "../../../storage/types";
 
 const context = testContext();
 
@@ -38,33 +34,15 @@ describe("resolveSession — artifacts passthrough", () => {
     const { runId } = await createTestRun(composeId, "session expansion run");
     const { agentSessionId } = await completeTestRun(user.userId, runId);
     await setTestSessionFramework(agentSessionId, "claude-code");
-    await setTestSessionArtifacts(agentSessionId, [
-      {
-        name: AUTO_MEMORY_ARTIFACT_NAME,
-        version: "latest",
-        mountPath: AUTO_MEMORY_MOUNT_PATH,
-      },
+    const entries = [
+      { name: "mem", version: "latest", mountPath: "/opt/mem" },
       { name: "ctx", version: "latest", mountPath: WORKING_DIR },
-    ]);
+    ];
+    await setTestSessionArtifacts(agentSessionId, entries);
 
     const resolution = await resolveSession(agentSessionId, user.userId);
 
-    expect(resolution.artifacts).toHaveLength(2);
-    const byName = Object.fromEntries(
-      resolution.artifacts.map((a) => {
-        return [a.name, a];
-      }),
-    );
-    expect(byName[AUTO_MEMORY_ARTIFACT_NAME]).toEqual({
-      name: AUTO_MEMORY_ARTIFACT_NAME,
-      version: "latest",
-      mountPath: AUTO_MEMORY_MOUNT_PATH,
-    });
-    expect(byName["ctx"]).toEqual({
-      name: "ctx",
-      version: "latest",
-      mountPath: WORKING_DIR,
-    });
+    expect(resolution.artifacts).toEqual(entries);
   });
 
   it("returns empty artifact list when session has no artifacts", async () => {

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
@@ -121,7 +121,7 @@ export async function resolveCheckpoint(
   }
   const agentCompose = version.content as AgentComposeYaml;
   const workingDir = extractWorkingDir(agentCompose);
-  const artifacts = decodeToContextArtifacts(rawArtifacts, workingDir);
+  const artifacts = decodeToContextArtifacts(rawArtifacts);
 
   return {
     conversationId: checkpoint.conversationId,

--- a/turbo/apps/web/src/lib/infra/storage/types.ts
+++ b/turbo/apps/web/src/lib/infra/storage/types.ts
@@ -9,26 +9,6 @@ export type StorageDriver = "vas";
 // Re-export VolumeConfig from agent-config for convenience
 export type { VolumeConfig };
 
-// Derived from /home/user/workspace via Claude Code's project-name encoding:
-// strip leading "/", replace "/" with "-", prepend "-". Since zero always runs
-// with workingDir=/home/user/workspace, the encoded folder is always
-// "-home-user-workspace". Mounting memory directly here removes the need for
-// the guest-agent symlink bootstrap.
-//
-// The legacy DEFAULT_MEMORY_MOUNT_PATH (=/home/user/.vm0/memory) was removed
-// in #10602 — it had no remaining callers once memory started riding in
-// artifacts[] and is not part of any wire contract.
-export const AUTO_MEMORY_MOUNT_PATH =
-  "/home/user/.claude/projects/-home-user-workspace/memory";
-
-/**
- * Storage name used for the auto-synthesized memory artifact. Zero-layer runs
- * always include a ContextArtifact entry with this name mounted at
- * AUTO_MEMORY_MOUNT_PATH so Claude Code finds persistent memory without any
- * in-sandbox symlink bootstrap.
- */
-export const AUTO_MEMORY_ARTIFACT_NAME = "memory";
-
 /**
  * Resolved volume with all template variables replaced
  */

--- a/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
@@ -31,10 +31,7 @@ import { setVariable } from "../variable/variable-service";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { isNoModelProvider } from "../../shared/errors";
 import { reloadEnv } from "../../../env";
-import {
-  AUTO_MEMORY_ARTIFACT_NAME,
-  AUTO_MEMORY_MOUNT_PATH,
-} from "../../infra/storage/types";
+import { AUTO_MEMORY_ARTIFACT_NAME, AUTO_MEMORY_MOUNT_PATH } from "../memory";
 import type { TriggerSource } from "@vm0/core/contracts/logs";
 
 const context = testContext();
@@ -501,9 +498,13 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
     it("checkpoint resume trusts resolution memory entry", async () => {
       const seed = await createTestRun(agentId, "seed");
       const { checkpointId } = await completeTestRun(user.userId, seed.runId);
-      await setTestCheckpointArtifactSnapshots(checkpointId, {
-        [AUTO_MEMORY_ARTIFACT_NAME]: "latest",
-      });
+      await setTestCheckpointArtifactSnapshots(checkpointId, [
+        {
+          name: AUTO_MEMORY_ARTIFACT_NAME,
+          version: "latest",
+          mountPath: AUTO_MEMORY_MOUNT_PATH,
+        },
+      ]);
 
       const resumed = await createTestRun(agentId, "resume", { checkpointId });
       await context.mocks.flushAfter();

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -25,10 +25,7 @@ import type {
 } from "../infra/run/types";
 import type { ConversationResolution } from "../infra/run/resolvers";
 import type { AdditionalVolume } from "../infra/storage/types";
-import {
-  AUTO_MEMORY_ARTIFACT_NAME,
-  AUTO_MEMORY_MOUNT_PATH,
-} from "../infra/storage/types";
+import { AUTO_MEMORY_ARTIFACT_NAME, AUTO_MEMORY_MOUNT_PATH } from "./memory";
 import { expandEnvironmentFromCompose } from "../infra/run/environment";
 import { getUserPreferences } from "./user/user-preferences-service";
 import { getApiTokenConnectorTypes } from "./connector/connector-service";

--- a/turbo/apps/web/src/lib/zero/memory.ts
+++ b/turbo/apps/web/src/lib/zero/memory.ts
@@ -1,0 +1,13 @@
+// AUTO_MEMORY_MOUNT_PATH: derived from Claude Code's project-name encoding
+// of /home/user/workspace (strip leading "/", "/"→"-", prepend "-"). Since
+// Zero always runs with workingDir=/home/user/workspace, the encoded folder
+// is stable. Mounting memory directly here removes the need for the
+// guest-agent symlink bootstrap.
+export const AUTO_MEMORY_MOUNT_PATH =
+  "/home/user/.claude/projects/-home-user-workspace/memory";
+
+// Storage name used for the auto-synthesized memory artifact. Zero-layer
+// runs always include a ContextArtifact entry with this name mounted at
+// AUTO_MEMORY_MOUNT_PATH so Claude Code finds persistent memory without
+// any in-sandbox symlink bootstrap.
+export const AUTO_MEMORY_ARTIFACT_NAME = "memory";

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -46,35 +46,11 @@ const agentEventSchema = z
   .passthrough();
 
 /**
- * Artifact snapshots schema.
- *
- * Tolerant union accepting both the legacy `Record<name, version>` map
- * (pre-#10911 guest-agent payloads) and the canonical `Array<{name, version,
- * mountPath}>` form (post-#10911). Receivers persist the payload verbatim to
- * the JSONB column and normalise only at read-out boundaries — keeping this
- * schema itself shape-preserving.
+ * Artifact snapshots schema — canonical `Array<{name, version, mountPath}>`
+ * form. Legacy `Record<name, version>` support was removed in #10913 after
+ * the DB migration and guest-agent writer flip completed.
  */
-const artifactSnapshotsSchema = z.union([
-  z.record(z.string(), z.string()),
-  z.array(
-    z.object({
-      name: z.string(),
-      version: z.string(),
-      mountPath: z.string(),
-    }),
-  ),
-]);
-
-/**
- * Canonical artifact snapshots response schema.
- *
- * The checkpoint webhook normalises inputs on write (legacy Record payloads
- * are converted to the canonical Array shape before persisting), so the 200
- * response always echoes the canonical Array — never the Record. Keeping the
- * response schema narrower than the request schema surfaces the "on-wire
- * shape == on-disk shape" contract in the type system.
- */
-const canonicalArtifactSnapshotsSchema = z.array(
+const artifactSnapshotsSchema = z.array(
   z.object({
     name: z.string(),
     version: z.string(),
@@ -183,10 +159,9 @@ export const webhookCheckpointsContract = c.router({
             64,
             "cliAgentSessionHistoryHash must be a 64-character SHA-256 hex string",
           ),
-        // Multi-artifact snapshot payload. Accepts both the legacy
-        // `Record<name, version>` map and the canonical
-        // `Array<{name, version, mountPath}>` form. Authoritative payload
-        // persisted verbatim to checkpoints.artifact_snapshots.
+        // Multi-artifact snapshot payload. Canonical
+        // `Array<{name, version, mountPath}>` form persisted verbatim to
+        // checkpoints.artifact_snapshots.
         artifactSnapshots: artifactSnapshotsSchema.optional(),
         volumeVersionsSnapshot: volumeVersionsSnapshotSchema.optional(),
       })
@@ -196,7 +171,7 @@ export const webhookCheckpointsContract = c.router({
         checkpointId: z.string(),
         agentSessionId: z.string(),
         conversationId: z.string(),
-        artifacts: canonicalArtifactSnapshotsSchema.optional(),
+        artifacts: artifactSnapshotsSchema.optional(),
         volumes: z.record(z.string(), z.string()).optional(),
       }),
       400: apiErrorSchema,


### PR DESCRIPTION
## Summary

Wave 4 cleanup for epic #10906 (unify artifact model at infra layer). Finalises the artifact-shape unification now that the DB migration (PR #10931) has landed and prod rows are all canonical `Array<{name, version, mountPath}>`.

## Scope

- **Narrow webhook contract** (`artifactSnapshotsSchema`) to the canonical Array shape only — drops the legacy `Record<name, version>` tolerant union
- **Drop Record branches** from `decodeToContextArtifacts` + `decodeToRecord`
- **Narrow `ArtifactSnapshotsPayload`** to `ContextArtifact[]`
- **Simplify `checkpoint-service`**: drop `extractWorkingDir` and the now-dead `version` lookup
- **Move auto-memory constants** (`AUTO_MEMORY_ARTIFACT_NAME`, `AUTO_MEMORY_MOUNT_PATH`) from `lib/infra/storage/types.ts` → `lib/zero/memory.ts` — infra layer no longer references zero-layer concepts
- **Delete stale legacy-Record test coverage** and convert remaining Record-shape test fixtures to canonical Array

## Test plan

- [x] `pnpm -F web exec vitest run` — 3816 passed / 0 failed
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)