### PR TITLE
feat: load chat messages from last user message with backward pagination

### DIFF
--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -1,4 +1,4 @@
-import { command, state } from "ccstate";
+import { command, state, type Command } from "ccstate";
 import { onRef } from "./utils.ts";
 import { logger } from "./log.ts";
 
@@ -56,6 +56,10 @@ function scrollInfo(el: HTMLElement) {
 interface RestoreState {
   pendingRestorePosition: number | null;
   suppressNextScrollToBottom: boolean;
+  // Snapshot taken just before prepending older messages. The ResizeObserver
+  // detects the resulting height increase and adds the delta to scrollTop so
+  // the user's viewport stays anchored on the same content.
+  pendingPrependScrollHeight: number | null;
 }
 
 function attachUserInputListeners(
@@ -118,6 +122,8 @@ function observeContainerResize(
  * a chance to invoke `scrollToBottom$`. The cache is cleared once the user
  * scrolls back to the bottom.
  */
+export type RecordScrollHeightForPrepend$ = Command<void, []>;
+
 export function createScrollSignals(id?: string) {
   const internalScrollContainer$ = state<HTMLElement | null>(null);
   const autoScrollDisabled$ = state(false);
@@ -129,6 +135,7 @@ export function createScrollSignals(id?: string) {
   const restoreState: RestoreState = {
     pendingRestorePosition: null,
     suppressNextScrollToBottom: false,
+    pendingPrependScrollHeight: null,
   };
 
   const setScrollContainer$ = onRef(
@@ -212,6 +219,15 @@ export function createScrollSignals(id?: string) {
             }
             return;
           }
+          if (restoreState.pendingPrependScrollHeight !== null) {
+            const delta = el.scrollHeight - restoreState.pendingPrependScrollHeight;
+            restoreState.pendingPrependScrollHeight = null;
+            if (delta > 0) {
+              el.scrollTop += delta;
+              L.debug("prepend compensation applied", `delta=${delta}`, scrollInfo(el));
+            }
+            return;
+          }
           if (!disabled) {
             el.scrollTop = el.scrollHeight;
           }
@@ -253,6 +269,17 @@ export function createScrollSignals(id?: string) {
     scrollEl.scrollTop = scrollEl.scrollHeight;
   });
 
+  // Snapshot the container's current scrollHeight before prepending messages.
+  // The ResizeObserver callback will detect the resulting height increase and
+  // compensate scrollTop so the viewport stays anchored on the same content.
+  const recordScrollHeightForPrepend$ = command(({ get }) => {
+    const el = get(internalScrollContainer$);
+    if (el) {
+      restoreState.pendingPrependScrollHeight = el.scrollHeight;
+      L.debug("recordScrollHeightForPrepend$", `height=${el.scrollHeight}`);
+    }
+  });
+
   // Scrolling to top is an explicit opt-out of auto-scroll — disable it so
   // ResizeObserver doesn't snap back to the bottom when new messages arrive.
   const scrollToTop$ = command(({ get, set }) => {
@@ -268,5 +295,11 @@ export function createScrollSignals(id?: string) {
     scrollEl.scrollTop = 0;
   });
 
-  return { setScrollContainer$, autoScroll$, scrollToBottom$, scrollToTop$ };
+  return {
+    setScrollContainer$,
+    autoScroll$,
+    scrollToBottom$,
+    scrollToTop$,
+    recordScrollHeightForPrepend$,
+  };
 }

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -99,6 +99,95 @@ function observeContainerResize(
   });
 }
 
+interface ScrollHandlerContext {
+  el: HTMLElement;
+  restoreState: RestoreState;
+  id: string | undefined;
+  lastUserInputAt: { v: number };
+  lastKnownScrollTop: { v: number };
+  isDisabled: () => boolean;
+  setDisabled: (v: boolean) => void;
+  clearCache: () => void;
+  saveCache: (top: number) => void;
+}
+
+function buildScrollHandler(ctx: ScrollHandlerContext) {
+  return () => {
+    const { el, restoreState, lastUserInputAt, lastKnownScrollTop } = ctx;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const userRecent =
+      performance.now() - lastUserInputAt.v < USER_INPUT_WINDOW_MS;
+    if (restoreState.pendingRestorePosition !== null && userRecent) {
+      restoreState.pendingRestorePosition = null;
+    }
+    if (distanceFromBottom <= AT_BOTTOM_THRESHOLD) {
+      const wasDisabled = ctx.isDisabled();
+      ctx.setDisabled(false);
+      ctx.clearCache();
+      if (wasDisabled) {
+        L.debug("re-enabled (at bottom)", scrollInfo(el));
+      }
+    } else if (el.scrollTop < lastKnownScrollTop.v) {
+      // Only treat a scrollTop decrease as "user scrolled up" when it
+      // coincides with a recent user input. The browser can also decrease
+      // scrollTop on its own — when content below the viewport shrinks it
+      // clamps to the new max, and scroll anchoring can nudge position on
+      // layout changes. Those programmatic shifts should not disable
+      // auto-scroll; we want ResizeObserver to snap back to the bottom.
+      if (userRecent) {
+        const wasDisabled = ctx.isDisabled();
+        ctx.setDisabled(true);
+        if (!wasDisabled) {
+          L.debug("DISABLED (scrolled up)", scrollInfo(el));
+        }
+      } else {
+        L.debug("scrollTop decreased without user input", scrollInfo(el));
+      }
+    }
+    if (ctx.id !== undefined && ctx.isDisabled()) {
+      ctx.saveCache(el.scrollTop);
+    }
+    lastKnownScrollTop.v = el.scrollTop;
+  };
+}
+
+interface ResizeHandlerContext {
+  el: HTMLElement;
+  restoreState: RestoreState;
+  isDisabled: () => boolean;
+}
+
+function buildResizeHandler(ctx: ResizeHandlerContext) {
+  return () => {
+    const { el, restoreState } = ctx;
+    const disabled = ctx.isDisabled();
+    L.debug("ResizeObserver fired", scrollInfo(el), `disabled=${disabled}`);
+    if (restoreState.pendingRestorePosition !== null) {
+      el.scrollTop = restoreState.pendingRestorePosition;
+      if (el.scrollTop >= restoreState.pendingRestorePosition) {
+        restoreState.pendingRestorePosition = null;
+      }
+      return;
+    }
+    if (restoreState.pendingPrependScrollHeight !== null) {
+      const delta = el.scrollHeight - restoreState.pendingPrependScrollHeight;
+      restoreState.pendingPrependScrollHeight = null;
+      if (delta > 0) {
+        el.scrollTop += delta;
+        L.debug(
+          "prepend compensation applied",
+          `delta=${delta}`,
+          scrollInfo(el),
+        );
+      }
+      return;
+    }
+    if (!disabled) {
+      el.scrollTop = el.scrollHeight;
+    }
+  };
+}
+
 /**
  * Factory that creates scroll-management signals for a scrollable container.
  *
@@ -127,11 +216,6 @@ export type RecordScrollHeightForPrepend$ = Command<void, []>;
 export function createScrollSignals(id?: string) {
   const internalScrollContainer$ = state<HTMLElement | null>(null);
   const autoScrollDisabled$ = state(false);
-  // `pendingRestorePosition` is held while ResizeObserver is still growing the
-  // container up to a saved position — set scrollTop clamps early and needs to
-  // be re-applied. `suppressNextScrollToBottom` is set when bind-time restore
-  // happened and the caller has not yet fired its post-load scrollToBottom$.
-  // That call must be suppressed so it doesn't override the restored position.
   const restoreState: RestoreState = {
     pendingRestorePosition: null,
     suppressNextScrollToBottom: false,
@@ -153,87 +237,39 @@ export function createScrollSignals(id?: string) {
         L.debug("container bound → restoring", `id=${id}`, `saved=${saved}`);
       }
 
-      let lastKnownScrollTop = el.scrollTop;
-      let lastUserInputAt = 0;
+      const lastKnownScrollTop = { v: el.scrollTop };
+      const lastUserInputAt = { v: 0 };
 
       const markUserInput = () => {
-        lastUserInputAt = performance.now();
+        lastUserInputAt.v = performance.now();
         restoreState.suppressNextScrollToBottom = false;
       };
 
-      const onScroll = () => {
-        const distanceFromBottom =
-          el.scrollHeight - el.scrollTop - el.clientHeight;
-        const userRecent =
-          performance.now() - lastUserInputAt < USER_INPUT_WINDOW_MS;
-        if (restoreState.pendingRestorePosition !== null && userRecent) {
-          restoreState.pendingRestorePosition = null;
-        }
-        if (distanceFromBottom <= AT_BOTTOM_THRESHOLD) {
-          const wasDisabled = get(autoScrollDisabled$);
-          set(autoScrollDisabled$, false);
-          if (id !== undefined) {
-            set(clearCachedScrollTop$, id);
-          }
-          if (wasDisabled) {
-            L.debug("re-enabled (at bottom)", scrollInfo(el));
-          }
-        } else if (el.scrollTop < lastKnownScrollTop) {
-          // Only treat a scrollTop decrease as "user scrolled up" when it
-          // coincides with a recent user input. The browser can also decrease
-          // scrollTop on its own — when content below the viewport shrinks it
-          // clamps to the new max, and scroll anchoring can nudge position on
-          // layout changes. Those programmatic shifts should not disable
-          // auto-scroll; we want ResizeObserver to snap back to the bottom.
-          if (userRecent) {
-            const wasDisabled = get(autoScrollDisabled$);
-            set(autoScrollDisabled$, true);
-            if (!wasDisabled) {
-              L.debug("DISABLED (scrolled up)", scrollInfo(el));
-            }
-          } else {
-            L.debug("scrollTop decreased without user input", scrollInfo(el));
-          }
-        }
-        if (id !== undefined && get(autoScrollDisabled$)) {
-          set(setCachedScrollTop$, id, el.scrollTop);
-        }
-        lastKnownScrollTop = el.scrollTop;
+      const ctx: ScrollHandlerContext = {
+        el,
+        restoreState,
+        id,
+        lastUserInputAt,
+        lastKnownScrollTop,
+        isDisabled: () => get(autoScrollDisabled$),
+        setDisabled: (v) => set(autoScrollDisabled$, v),
+        clearCache: () => {
+          if (id !== undefined) set(clearCachedScrollTop$, id);
+        },
+        saveCache: (top) => {
+          if (id !== undefined) set(setCachedScrollTop$, id, top);
+        },
       };
 
-      attachUserInputListeners(el, markUserInput, onScroll, signal);
-
-      observeContainerResize(
+      const onScroll = buildScrollHandler(ctx);
+      const onResize = buildResizeHandler({
         el,
-        () => {
-          const disabled = get(autoScrollDisabled$);
-          L.debug(
-            "ResizeObserver fired",
-            scrollInfo(el),
-            `disabled=${disabled}`,
-          );
-          if (restoreState.pendingRestorePosition !== null) {
-            el.scrollTop = restoreState.pendingRestorePosition;
-            if (el.scrollTop >= restoreState.pendingRestorePosition) {
-              restoreState.pendingRestorePosition = null;
-            }
-            return;
-          }
-          if (restoreState.pendingPrependScrollHeight !== null) {
-            const delta = el.scrollHeight - restoreState.pendingPrependScrollHeight;
-            restoreState.pendingPrependScrollHeight = null;
-            if (delta > 0) {
-              el.scrollTop += delta;
-              L.debug("prepend compensation applied", `delta=${delta}`, scrollInfo(el));
-            }
-            return;
-          }
-          if (!disabled) {
-            el.scrollTop = el.scrollHeight;
-          }
-        },
-        signal,
-      );
+        restoreState,
+        isDisabled: ctx.isDisabled,
+      });
+
+      attachUserInputListeners(el, markUserInput, onScroll, signal);
+      observeContainerResize(el, onResize, signal);
 
       signal.addEventListener("abort", () => {
         L.debug("container unbound (abort)");

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -251,8 +251,12 @@ export function createScrollSignals(id?: string) {
         id,
         lastUserInputAt,
         lastKnownScrollTop,
-        isDisabled: () => get(autoScrollDisabled$),
-        setDisabled: (v) => set(autoScrollDisabled$, v),
+        isDisabled: () => {
+          return get(autoScrollDisabled$);
+        },
+        setDisabled: (v) => {
+          set(autoScrollDisabled$, v);
+        },
         clearCache: () => {
           if (id !== undefined) {
             set(clearCachedScrollTop$, id);

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -254,10 +254,14 @@ export function createScrollSignals(id?: string) {
         isDisabled: () => get(autoScrollDisabled$),
         setDisabled: (v) => set(autoScrollDisabled$, v),
         clearCache: () => {
-          if (id !== undefined) set(clearCachedScrollTop$, id);
+          if (id !== undefined) {
+            set(clearCachedScrollTop$, id);
+          }
         },
         saveCache: (top) => {
-          if (id !== undefined) set(setCachedScrollTop$, id, top);
+          if (id !== undefined) {
+            set(setCachedScrollTop$, id, top);
+          }
         },
       };
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -73,6 +73,12 @@ export const setupChatPage$ = command(
     await get(thread.groupedChatMessages$);
     signal.throwIfAborted();
 
+    // Seed hasOlderMessages$ from the already-cached initial fetch result.
+    // This must run after groupedChatMessages$ resolves so the computed value
+    // is available without issuing a second HTTP request.
+    await set(thread.syncInitialHasMore$);
+    signal.throwIfAborted();
+
     // The list is mounted with visibility:hidden under the skeleton so
     // scrollHeight is already correct; wait one frame for React to commit
     // the message DOM, then scroll and reveal in the same tick.

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -76,7 +76,7 @@ export const setupChatPage$ = command(
     // Seed hasOlderMessages$ from the already-cached initial fetch result.
     // This must run after groupedChatMessages$ resolves so the computed value
     // is available without issuing a second HTTP request.
-    await set(thread.syncInitialHasMore$);
+    await set(thread.syncInitialHasMore$, signal);
     signal.throwIfAborted();
 
     // The list is mounted with visibility:hidden under the skeleton so

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -705,7 +705,7 @@ function createTopSentinelRef(
           if (!get(hasOlderMessages$)) {
             return;
           }
-          set(loadOlderMessages$, signal);
+          void set(loadOlderMessages$, signal);
         },
         { threshold: 0.1 },
       );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -9,9 +9,7 @@ import {
 import { animationFrame, delay } from "signal-timers";
 import {
   createDeferredPromise,
-  detach,
   onRef,
-  Reason,
   resetSignal,
   setLoop,
 } from "../utils.ts";
@@ -698,7 +696,13 @@ function createTopSentinelRef(
   loadOlderMessages$: Command<Promise<void>, [AbortSignal]>,
 ) {
   return onRef(
-    command(({ get, set }, el: HTMLElement, signal: AbortSignal) => {
+    command(async ({ get, set }, el: HTMLElement, signal: AbortSignal) => {
+      // `notify` is replaced at the start of each iteration. The
+      // IntersectionObserver callback calls it to unblock the awaiting
+      // loop. All Promise-returning calls are properly awaited so no
+      // floating promises are created.
+      let notify: ((value: void) => void) | null = null;
+
       const observer = new IntersectionObserver(
         (entries) => {
           if (!entries[0]?.isIntersecting) {
@@ -707,8 +711,9 @@ function createTopSentinelRef(
           if (!get(hasOlderMessages$)) {
             return;
           }
-          // Fire-and-forget: IntersectionObserver callbacks are synchronous.
-          detach(set(loadOlderMessages$, signal), Reason.DomCallback);
+          const fn = notify;
+          notify = null;
+          fn?.();
         },
         { threshold: 0.1 },
       );
@@ -716,6 +721,14 @@ function createTopSentinelRef(
       signal.addEventListener("abort", () => {
         observer.disconnect();
       });
+
+      while (!signal.aborted) {
+        const deferred = createDeferredPromise<void>(signal);
+        notify = deferred.resolve;
+        await deferred.promise;
+        signal.throwIfAborted();
+        await set(loadOlderMessages$, signal);
+      }
     }),
   );
 }

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1,4 +1,11 @@
-import { command, computed, state, type Command, type Computed } from "ccstate";
+import {
+  command,
+  computed,
+  state,
+  type Command,
+  type Computed,
+  type State,
+} from "ccstate";
 import { animationFrame, delay } from "signal-timers";
 import {
   createDeferredPromise,
@@ -7,7 +14,10 @@ import {
   setLoop,
 } from "../utils.ts";
 import { setAblyLoop$ } from "../realtime.ts";
-import { createScrollSignals } from "../auto-scroll.ts";
+import {
+  createScrollSignals,
+  type RecordScrollHeightForPrepend$,
+} from "../auto-scroll.ts";
 import {
   createDraftSignals,
   type DraftSignals,
@@ -174,6 +184,13 @@ export interface ChatThreadSignals {
   // ── Paged messages (sole rendering path) ─────────────────────────────────
   latestChatMessageId$: Computed<Promise<string | undefined>>;
   groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>;
+  // True when older messages exist before the initial anchor. Drives the
+  // scroll-up-to-load-more UI.
+  hasOlderMessages$: State<boolean>;
+  // Seeds hasOlderMessages$ from the initial fetch without a second request.
+  // Called once in chat-page-setup after groupedChatMessages$ first resolves.
+  syncInitialHasMore$: Command<Promise<void>, []>;
+  loadOlderMessages$: Command<Promise<void>, [AbortSignal]>;
   latestRunStatus$: Computed<Promise<string | null>>;
   allFinished$: Computed<Promise<boolean>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
@@ -588,27 +605,45 @@ function mergeIntoGroups(
   return result;
 }
 
-function createPagedMessages(threadId: string) {
-  // Initial page — threadId is captured in closure so this computed runs
-  // exactly once per thread signal instance. View subscription is what
-  // triggers the fetch.
-  const initialMessages$ = computed(
-    async (get): Promise<PagedChatMessage[]> => {
+function createPagedMessages(
+  threadId: string,
+  recordScrollHeightForPrepend$: RecordScrollHeightForPrepend$,
+) {
+  // Initial page — anchored at the last user message so the UI opens at the
+  // start of the latest conversation turn. Returns both the message list and
+  // `hasMore` so a single fetch populates both without a second request.
+  const initialFetch$ = computed(
+    async (
+      get,
+    ): Promise<{ messages: PagedChatMessage[]; hasMore: boolean }> => {
       const client = get(zeroClient$)(chatThreadMessagesContract);
       const result = await accept(
+        // No sinceId/beforeId → server picks the last-user-message anchor
         client.list({
           params: { threadId },
           query: { limit: 50 },
         }),
         [200],
       );
-      L.debug("initialMessages$", {
+      L.debug("initialFetch$", {
         threadId,
         count: result.body.messages.length,
+        hasMore: result.body.hasMore,
       });
-      return result.body.messages;
+      return {
+        messages: result.body.messages,
+        hasMore: result.body.hasMore ?? false,
+      };
     },
   );
+
+  // Whether there are messages older than the initial anchor. Seeded from the
+  // first API response and updated after each backward page load.
+  const hasOlderMessages$ = state(false);
+
+  // Older messages loaded via backward pagination (prepended). Stored
+  // separately so they don't invalidate the initialFetch$ computed.
+  const olderMessages$ = state<PagedChatMessage[]>([]);
 
   // Everything beyond the initial page: subsequent fetchNextPage results
   // and optimistic inserts. Dedup on write (keyed by id).
@@ -637,11 +672,20 @@ function createPagedMessages(threadId: string) {
 
   const groupedChatMessages$ = computed(
     async (get): Promise<GroupedChatMessageGroup[]> => {
-      const initial = await get(initialMessages$);
+      const { messages: initial } = await get(initialFetch$);
+      const older = get(olderMessages$);
       const deltas = get(deltaMessages$);
-      return mergeIntoGroups([], [...initial, ...deltas]);
+      return mergeIntoGroups([], [...older, ...initial, ...deltas]);
     },
   );
+
+  // Reads `hasMore` from the already-resolved initialFetch$ and stores it in
+  // the writable hasOlderMessages$ state so loadOlderMessages$ can update it.
+  // Called once from chat-page-setup after the initial fetch completes.
+  const syncInitialHasMore$ = command(async ({ get, set }) => {
+    const { hasMore } = await get(initialFetch$);
+    set(hasOlderMessages$, hasMore);
+  });
 
   const latestChatMessageId$ = computed(
     async (get): Promise<string | undefined> => {
@@ -652,6 +696,16 @@ function createPagedMessages(threadId: string) {
       }
       const msgs = lastGroup.messages;
       return msgs[msgs.length - 1]?.id;
+    },
+  );
+
+  // ID of the oldest currently-loaded message — used as the `beforeId` cursor
+  // for backward pagination.
+  const oldestMessageId$ = computed(
+    async (get): Promise<string | undefined> => {
+      const groups = await get(groupedChatMessages$);
+      const firstGroup = groups[0];
+      return firstGroup?.messages[0]?.id;
     },
   );
 
@@ -691,6 +745,65 @@ function createPagedMessages(threadId: string) {
     return false;
   });
 
+  // Load older messages (backward pagination). Records the current
+  // scrollHeight before prepending so the scroll position is preserved.
+  const loadOlderMessages$ = command(
+    async ({ get, set }, signal: AbortSignal) => {
+      if (!get(hasOlderMessages$)) {
+        return;
+      }
+
+      const beforeId = await get(oldestMessageId$);
+      signal.throwIfAborted();
+      if (!beforeId) {
+        return;
+      }
+
+      const client = get(zeroClient$)(chatThreadMessagesContract);
+      const result = await accept(
+        client.list({
+          params: { threadId },
+          query: { beforeId, limit: 50 },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+
+      const { messages, hasMore } = result.body;
+      L.debug("loadOlderMessages$", {
+        threadId,
+        beforeId,
+        count: messages.length,
+        hasMore,
+      });
+
+      if (messages.length === 0) {
+        set(hasOlderMessages$, false);
+        return;
+      }
+
+      // Snapshot scrollHeight before the state update so the ResizeObserver
+      // can compensate after React re-renders the prepended messages.
+      set(recordScrollHeightForPrepend$);
+
+      set(olderMessages$, (prev) => {
+        const byId = new Map<string, PagedChatMessage>();
+        for (const m of messages) {
+          byId.set(m.id, m);
+        }
+        for (const m of prev) {
+          byId.set(m.id, m);
+        }
+        return Array.from(byId.values()).sort((a, b) => {
+          return a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0;
+        });
+      });
+
+      set(hasOlderMessages$, hasMore ?? false);
+    },
+  );
+
   const insertOptimisticMessage$ = command(({ set }, msg: PagedChatMessage) => {
     set(appendDeltaMessages$, [msg]);
   });
@@ -698,6 +811,9 @@ function createPagedMessages(threadId: string) {
   return {
     latestChatMessageId$,
     groupedChatMessages$,
+    hasOlderMessages$,
+    loadOlderMessages$,
+    syncInitialHasMore$,
     fetchNextPage$,
     insertOptimisticMessage$,
   };
@@ -1071,8 +1187,13 @@ function createChatThreadSignals(
   const { threadData$, reloadThread$ } = createThreadData(threadId);
   const { modelSelection$, setModelSelection$ } =
     createModelSelection(threadData$);
-  const { setScrollContainer$, autoScroll$, scrollToBottom$, scrollToTop$ } =
-    createScrollSignals(threadId);
+  const {
+    setScrollContainer$,
+    autoScroll$,
+    scrollToBottom$,
+    scrollToTop$,
+    recordScrollHeightForPrepend$,
+  } = createScrollSignals(threadId);
   const { skeletonVisible$, hideSkeleton$ } = createSkeletonSignals();
   const { composerFileInput$, setComposerFileInput$ } =
     createComposerFileInput();
@@ -1087,9 +1208,12 @@ function createChatThreadSignals(
   const {
     latestChatMessageId$,
     groupedChatMessages$,
+    hasOlderMessages$,
+    loadOlderMessages$,
+    syncInitialHasMore$,
     fetchNextPage$,
     insertOptimisticMessage$,
-  } = createPagedMessages(threadId);
+  } = createPagedMessages(threadId, recordScrollHeightForPrepend$);
 
   const { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ } =
     createDraftSync(threadId, draft);
@@ -1152,6 +1276,9 @@ function createChatThreadSignals(
     scheduleDraftSync$,
     latestChatMessageId$,
     groupedChatMessages$,
+    hasOlderMessages$,
+    loadOlderMessages$,
+    syncInitialHasMore$,
     latestRunStatus$,
     allFinished$,
     fetchNextPage$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -191,6 +191,9 @@ export interface ChatThreadSignals {
   // Called once in chat-page-setup after groupedChatMessages$ first resolves.
   syncInitialHasMore$: Command<Promise<void>, []>;
   loadOlderMessages$: Command<Promise<void>, [AbortSignal]>;
+  // Bind to the top-sentinel element. Sets up an IntersectionObserver that
+  // triggers loadOlderMessages$ when the sentinel enters the viewport.
+  setTopSentinelRef$: Command<(() => void) | undefined, [HTMLElement | null]>;
   latestRunStatus$: Computed<Promise<string | null>>;
   allFinished$: Computed<Promise<boolean>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
@@ -605,51 +608,10 @@ function mergeIntoGroups(
   return result;
 }
 
-function createPagedMessages(
-  threadId: string,
-  recordScrollHeightForPrepend$: RecordScrollHeightForPrepend$,
-) {
-  // Initial page — anchored at the last user message so the UI opens at the
-  // start of the latest conversation turn. Returns both the message list and
-  // `hasMore` so a single fetch populates both without a second request.
-  const initialFetch$ = computed(
-    async (
-      get,
-    ): Promise<{ messages: PagedChatMessage[]; hasMore: boolean }> => {
-      const client = get(zeroClient$)(chatThreadMessagesContract);
-      const result = await accept(
-        // No sinceId/beforeId → server picks the last-user-message anchor
-        client.list({
-          params: { threadId },
-          query: { limit: 50 },
-        }),
-        [200],
-      );
-      L.debug("initialFetch$", {
-        threadId,
-        count: result.body.messages.length,
-        hasMore: result.body.hasMore,
-      });
-      return {
-        messages: result.body.messages,
-        hasMore: result.body.hasMore ?? false,
-      };
-    },
-  );
+type DeltaMessages$ = State<PagedChatMessage[]>;
 
-  // Whether there are messages older than the initial anchor. Seeded from the
-  // first API response and updated after each backward page load.
-  const hasOlderMessages$ = state(false);
-
-  // Older messages loaded via backward pagination (prepended). Stored
-  // separately so they don't invalidate the initialFetch$ computed.
-  const olderMessages$ = state<PagedChatMessage[]>([]);
-
-  // Everything beyond the initial page: subsequent fetchNextPage results
-  // and optimistic inserts. Dedup on write (keyed by id).
-  const deltaMessages$ = state<PagedChatMessage[]>([]);
-
-  const appendDeltaMessages$ = command(({ set }, msgs: PagedChatMessage[]) => {
+function createAppendDelta(deltaMessages$: DeltaMessages$) {
+  return command(({ set }, msgs: PagedChatMessage[]) => {
     if (msgs.length === 0) {
       return;
     }
@@ -669,6 +631,124 @@ function createPagedMessages(
       return changed ? Array.from(byId.values()) : prev;
     });
   });
+}
+
+function createOlderMessagesLoader(
+  threadId: string,
+  hasOlderMessages$: State<boolean>,
+  olderMessages$: State<PagedChatMessage[]>,
+  oldestMessageId$: Computed<Promise<string | undefined>>,
+  recordScrollHeightForPrepend$: RecordScrollHeightForPrepend$,
+) {
+  return command(async ({ get, set }, signal: AbortSignal) => {
+    if (!get(hasOlderMessages$)) {
+      return;
+    }
+    const beforeId = await get(oldestMessageId$);
+    signal.throwIfAborted();
+    if (!beforeId) {
+      return;
+    }
+    const client = get(zeroClient$)(chatThreadMessagesContract);
+    const result = await accept(
+      client.list({
+        params: { threadId },
+        query: { beforeId, limit: 50 },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    const { messages, hasMore } = result.body;
+    L.debug("loadOlderMessages$", {
+      threadId,
+      beforeId,
+      count: messages.length,
+      hasMore,
+    });
+    if (messages.length === 0) {
+      set(hasOlderMessages$, false);
+      return;
+    }
+    set(recordScrollHeightForPrepend$);
+    set(olderMessages$, (prev) => {
+      const byId = new Map<string, PagedChatMessage>();
+      for (const m of messages) {
+        byId.set(m.id, m);
+      }
+      for (const m of prev) {
+        byId.set(m.id, m);
+      }
+      return Array.from(byId.values()).sort((a, b) => {
+        return a.createdAt < b.createdAt
+          ? -1
+          : a.createdAt > b.createdAt
+            ? 1
+            : 0;
+      });
+    });
+    set(hasOlderMessages$, hasMore ?? false);
+  });
+}
+
+function createTopSentinelRef(
+  hasOlderMessages$: State<boolean>,
+  loadOlderMessages$: Command<Promise<void>, [AbortSignal]>,
+) {
+  return onRef(
+    command(({ get, set }, el: HTMLElement, signal: AbortSignal) => {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (!entries[0]?.isIntersecting) {
+            return;
+          }
+          if (!get(hasOlderMessages$)) {
+            return;
+          }
+          set(loadOlderMessages$, signal);
+        },
+        { threshold: 0.1 },
+      );
+      observer.observe(el);
+      signal.addEventListener("abort", () => {
+        observer.disconnect();
+      });
+    }),
+  );
+}
+
+function createPagedMessages(
+  threadId: string,
+  recordScrollHeightForPrepend$: RecordScrollHeightForPrepend$,
+) {
+  // Initial page — anchored at the last user message so the UI opens at the
+  // start of the latest conversation turn. Returns both the message list and
+  // `hasMore` so a single fetch populates both without a second request.
+  const initialFetch$ = computed(
+    async (
+      get,
+    ): Promise<{ messages: PagedChatMessage[]; hasMore: boolean }> => {
+      const client = get(zeroClient$)(chatThreadMessagesContract);
+      const result = await accept(
+        client.list({ params: { threadId }, query: { limit: 50 } }),
+        [200],
+      );
+      L.debug("initialFetch$", {
+        threadId,
+        count: result.body.messages.length,
+        hasMore: result.body.hasMore,
+      });
+      return {
+        messages: result.body.messages,
+        hasMore: result.body.hasMore ?? false,
+      };
+    },
+  );
+
+  const hasOlderMessages$ = state(false);
+  const olderMessages$ = state<PagedChatMessage[]>([]);
+  const deltaMessages$ = state<PagedChatMessage[]>([]);
+  const appendDeltaMessages$ = createAppendDelta(deltaMessages$);
 
   const groupedChatMessages$ = computed(
     async (get): Promise<GroupedChatMessageGroup[]> => {
@@ -679,9 +759,6 @@ function createPagedMessages(
     },
   );
 
-  // Reads `hasMore` from the already-resolved initialFetch$ and stores it in
-  // the writable hasOlderMessages$ state so loadOlderMessages$ can update it.
-  // Called once from chat-page-setup after the initial fetch completes.
   const syncInitialHasMore$ = command(async ({ get, set }) => {
     const { hasMore } = await get(initialFetch$);
     set(hasOlderMessages$, hasMore);
@@ -699,8 +776,6 @@ function createPagedMessages(
     },
   );
 
-  // ID of the oldest currently-loaded message — used as the `beforeId` cursor
-  // for backward pagination.
   const oldestMessageId$ = computed(
     async (get): Promise<string | undefined> => {
       const groups = await get(groupedChatMessages$);
@@ -712,7 +787,6 @@ function createPagedMessages(
   const fetchNextPage$ = command(async ({ get, set }, signal: AbortSignal) => {
     const sinceId = await get(latestChatMessageId$);
     signal.throwIfAborted();
-
     const client = get(zeroClient$)(chatThreadMessagesContract);
     const result = await accept(
       client.list({
@@ -723,7 +797,6 @@ function createPagedMessages(
       [200],
     );
     signal.throwIfAborted();
-
     L.debug("fetchNextPage$", {
       threadId,
       sinceId,
@@ -736,72 +809,24 @@ function createPagedMessages(
           return { id: m.id, runId: m.runId, status: m.status };
         }),
     });
-
     if (result.body.messages.length === 0) {
       return true;
     }
-
     set(appendDeltaMessages$, result.body.messages);
     return false;
   });
 
-  // Load older messages (backward pagination). Records the current
-  // scrollHeight before prepending so the scroll position is preserved.
-  const loadOlderMessages$ = command(
-    async ({ get, set }, signal: AbortSignal) => {
-      if (!get(hasOlderMessages$)) {
-        return;
-      }
+  const loadOlderMessages$ = createOlderMessagesLoader(
+    threadId,
+    hasOlderMessages$,
+    olderMessages$,
+    oldestMessageId$,
+    recordScrollHeightForPrepend$,
+  );
 
-      const beforeId = await get(oldestMessageId$);
-      signal.throwIfAborted();
-      if (!beforeId) {
-        return;
-      }
-
-      const client = get(zeroClient$)(chatThreadMessagesContract);
-      const result = await accept(
-        client.list({
-          params: { threadId },
-          query: { beforeId, limit: 50 },
-          fetchOptions: { signal },
-        }),
-        [200],
-      );
-      signal.throwIfAborted();
-
-      const { messages, hasMore } = result.body;
-      L.debug("loadOlderMessages$", {
-        threadId,
-        beforeId,
-        count: messages.length,
-        hasMore,
-      });
-
-      if (messages.length === 0) {
-        set(hasOlderMessages$, false);
-        return;
-      }
-
-      // Snapshot scrollHeight before the state update so the ResizeObserver
-      // can compensate after React re-renders the prepended messages.
-      set(recordScrollHeightForPrepend$);
-
-      set(olderMessages$, (prev) => {
-        const byId = new Map<string, PagedChatMessage>();
-        for (const m of messages) {
-          byId.set(m.id, m);
-        }
-        for (const m of prev) {
-          byId.set(m.id, m);
-        }
-        return Array.from(byId.values()).sort((a, b) => {
-          return a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0;
-        });
-      });
-
-      set(hasOlderMessages$, hasMore ?? false);
-    },
+  const setTopSentinelRef$ = createTopSentinelRef(
+    hasOlderMessages$,
+    loadOlderMessages$,
   );
 
   const insertOptimisticMessage$ = command(({ set }, msg: PagedChatMessage) => {
@@ -813,6 +838,7 @@ function createPagedMessages(
     groupedChatMessages$,
     hasOlderMessages$,
     loadOlderMessages$,
+    setTopSentinelRef$,
     syncInitialHasMore$,
     fetchNextPage$,
     insertOptimisticMessage$,
@@ -1210,6 +1236,7 @@ function createChatThreadSignals(
     groupedChatMessages$,
     hasOlderMessages$,
     loadOlderMessages$,
+    setTopSentinelRef$,
     syncInitialHasMore$,
     fetchNextPage$,
     insertOptimisticMessage$,
@@ -1278,6 +1305,7 @@ function createChatThreadSignals(
     groupedChatMessages$,
     hasOlderMessages$,
     loadOlderMessages$,
+    setTopSentinelRef$,
     syncInitialHasMore$,
     latestRunStatus$,
     allFinished$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -189,7 +189,7 @@ export interface ChatThreadSignals {
   hasOlderMessages$: State<boolean>;
   // Seeds hasOlderMessages$ from the initial fetch without a second request.
   // Called once in chat-page-setup after groupedChatMessages$ first resolves.
-  syncInitialHasMore$: Command<Promise<void>, []>;
+  syncInitialHasMore$: Command<Promise<void>, [AbortSignal]>;
   loadOlderMessages$: Command<Promise<void>, [AbortSignal]>;
   // Bind to the top-sentinel element. Sets up an IntersectionObserver that
   // triggers loadOlderMessages$ when the sentinel enters the viewport.
@@ -707,7 +707,7 @@ function createTopSentinelRef(
           }
           // Fire-and-forget: IntersectionObserver callbacks are synchronous,
           // rejection is intentionally swallowed (signal aborts clean up).
-          set(loadOlderMessages$, signal).catch(() => undefined);
+          set(loadOlderMessages$, signal).catch(() => {});
         },
         { threshold: 0.1 },
       );
@@ -761,10 +761,13 @@ function createPagedMessages(
     },
   );
 
-  const syncInitialHasMore$ = command(async ({ get, set }) => {
-    const { hasMore } = await get(initialFetch$);
-    set(hasOlderMessages$, hasMore);
-  });
+  const syncInitialHasMore$ = command(
+    async ({ get, set }, signal: AbortSignal) => {
+      const { hasMore } = await get(initialFetch$);
+      signal.throwIfAborted();
+      set(hasOlderMessages$, hasMore);
+    },
+  );
 
   const latestChatMessageId$ = computed(
     async (get): Promise<string | undefined> => {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -9,7 +9,9 @@ import {
 import { animationFrame, delay } from "signal-timers";
 import {
   createDeferredPromise,
+  detach,
   onRef,
+  Reason,
   resetSignal,
   setLoop,
 } from "../utils.ts";
@@ -705,9 +707,8 @@ function createTopSentinelRef(
           if (!get(hasOlderMessages$)) {
             return;
           }
-          // Fire-and-forget: IntersectionObserver callbacks are synchronous,
-          // rejection is intentionally swallowed (signal aborts clean up).
-          set(loadOlderMessages$, signal).catch(() => {});
+          // Fire-and-forget: IntersectionObserver callbacks are synchronous.
+          detach(set(loadOlderMessages$, signal), Reason.DomCallback);
         },
         { threshold: 0.1 },
       );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -705,7 +705,9 @@ function createTopSentinelRef(
           if (!get(hasOlderMessages$)) {
             return;
           }
-          void set(loadOlderMessages$, signal);
+          // Fire-and-forget: IntersectionObserver callbacks are synchronous,
+          // rejection is intentionally swallowed (signal aborts clean up).
+          set(loadOlderMessages$, signal).catch(() => undefined);
         },
         { threshold: 0.1 },
       );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import { useRef, useEffect, type CSSProperties } from "react";
 import {
   useGet,
   useSet,
@@ -275,6 +275,32 @@ function ZeroChatThreadPageInner({
   const setScrollContainer = useSet(thread.setScrollContainer$);
   const skeletonVisible = useGet(thread.skeletonVisible$);
   const lightboxUrl = useGet(attachmentLightboxUrl$);
+  const hasOlderMessages = useGet(thread.hasOlderMessages$);
+  const loadOlderMessages = useSet(thread.loadOlderMessages$);
+
+  // Trigger backward pagination when an IntersectionObserver detects the
+  // sentinel at the top of the message list entering the viewport.
+  const topSentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = topSentinelRef.current;
+    if (!el || !hasOlderMessages) {
+      return;
+    }
+    const controller = new AbortController();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          void loadOlderMessages(controller.signal);
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => {
+      controller.abort();
+      observer.disconnect();
+    };
+  }, [hasOlderMessages, loadOlderMessages]);
 
   return (
     <div className="flex flex-1 flex-col min-h-0 bg-transparent">
@@ -292,6 +318,14 @@ function ZeroChatThreadPageInner({
               className="w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4 overflow-visible"
               style={{ visibility: skeletonVisible ? "hidden" : "visible" }}
             >
+              {hasOlderMessages && (
+                <div ref={topSentinelRef} className="flex justify-center py-2">
+                  <div className="flex items-center gap-2 text-muted-foreground text-xs">
+                    <Skeleton className="h-3 w-3 rounded-full" />
+                    <span>Loading older messages…</span>
+                  </div>
+                </div>
+              )}
               {sessionError && (
                 <div className="flex-1 flex items-center justify-center py-16">
                   <div className="flex items-center gap-2 text-destructive">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, type CSSProperties } from "react";
+import { type CSSProperties } from "react";
 import {
   useGet,
   useSet,
@@ -276,31 +276,7 @@ function ZeroChatThreadPageInner({
   const skeletonVisible = useGet(thread.skeletonVisible$);
   const lightboxUrl = useGet(attachmentLightboxUrl$);
   const hasOlderMessages = useGet(thread.hasOlderMessages$);
-  const loadOlderMessages = useSet(thread.loadOlderMessages$);
-
-  // Trigger backward pagination when an IntersectionObserver detects the
-  // sentinel at the top of the message list entering the viewport.
-  const topSentinelRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = topSentinelRef.current;
-    if (!el || !hasOlderMessages) {
-      return;
-    }
-    const controller = new AbortController();
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) {
-          void loadOlderMessages(controller.signal);
-        }
-      },
-      { threshold: 0.1 },
-    );
-    observer.observe(el);
-    return () => {
-      controller.abort();
-      observer.disconnect();
-    };
-  }, [hasOlderMessages, loadOlderMessages]);
+  const setTopSentinelRef = useSet(thread.setTopSentinelRef$);
 
   return (
     <div className="flex flex-1 flex-col min-h-0 bg-transparent">
@@ -319,7 +295,10 @@ function ZeroChatThreadPageInner({
               style={{ visibility: skeletonVisible ? "hidden" : "visible" }}
             >
               {hasOlderMessages && (
-                <div ref={topSentinelRef} className="flex justify-center py-2">
+                <div
+                  ref={setTopSentinelRef}
+                  className="flex justify-center py-2"
+                >
                   <div className="flex items-center gap-2 text-muted-foreground text-xs">
                     <Skeleton className="h-3 w-3 rounded-full" />
                     <span>Loading older messages…</span>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties } from "react";
+import type { CSSProperties } from "react";
 import {
   useGet,
   useSet,

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
@@ -188,7 +188,7 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     expect(data.messages[1].content).toBe("Third");
   });
 
-  it("should return the latest N messages (still ASC) when no cursor is provided and total exceeds the limit", async () => {
+  it("anchors at the last user message when no cursor is provided", async () => {
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {
         method: "POST",
@@ -198,7 +198,9 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     );
     const { id: threadId } = await createRes.json();
 
-    // Insert 3 messages, then request with limit=2
+    // Insert 3 messages: A (user), B (assistant), C (user).
+    // The no-cursor path anchors at the last user message (C), so only C is
+    // returned and hasMore=true because A and B precede the anchor.
     await insertTestChatMessage({
       chatThreadId: threadId,
       userId: testUserId,
@@ -220,15 +222,15 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
 
     const response = await GET(
       createTestRequest(
-        `http://localhost:3000/api/zero/chat-threads/${threadId}/messages?limit=2`,
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/messages`,
       ),
     );
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.messages).toHaveLength(2);
-    expect(data.messages[0].content).toBe("B");
-    expect(data.messages[1].content).toBe("C");
+    expect(data.messages).toHaveLength(1);
+    expect(data.messages[0].content).toBe("C");
+    expect(data.hasMore).toBe(true);
   });
 
   it("should return only user message when run has no assistant events", async () => {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
@@ -42,7 +42,11 @@ const router = tsr.router(chatThreadMessagesContract, {
         rows = result.messages;
         hasMore = result.hasMore;
       } else if (query.sinceId) {
-        rows = await getMessagesSince(params.threadId, query.sinceId, query.limit);
+        rows = await getMessagesSince(
+          params.threadId,
+          query.sinceId,
+          query.limit,
+        );
       } else {
         const result = await getMessagesFromLastUserMessage(params.threadId);
         rows = result.messages;

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
@@ -4,8 +4,11 @@ import { initServices } from "../../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../../src/lib/auth/get-auth-context";
 import {
   getChatThread,
+  getMessagesBefore,
+  getMessagesFromLastUserMessage,
   getMessagesSince,
   resolveAttachFileUrls,
+  type MessageRow,
 } from "../../../../../../src/lib/zero/chat-thread";
 import { isNotFound } from "../../../../../../src/lib/shared/errors";
 
@@ -27,11 +30,24 @@ const router = tsr.router(chatThreadMessagesContract, {
       // Ownership check — throws notFound if user doesn't own the thread
       await getChatThread(params.threadId, userId);
 
-      const rows = await getMessagesSince(
-        params.threadId,
-        query.sinceId,
-        query.limit,
-      );
+      let rows: MessageRow[];
+      let hasMore: boolean | undefined;
+
+      if (query.beforeId) {
+        const result = await getMessagesBefore(
+          params.threadId,
+          query.beforeId,
+          query.limit,
+        );
+        rows = result.messages;
+        hasMore = result.hasMore;
+      } else if (query.sinceId) {
+        rows = await getMessagesSince(params.threadId, query.sinceId, query.limit);
+      } else {
+        const result = await getMessagesFromLastUserMessage(params.threadId);
+        rows = result.messages;
+        hasMore = result.hasMore;
+      }
 
       const messages = await Promise.all(
         rows.map(async (row) => {
@@ -61,7 +77,7 @@ const router = tsr.router(chatThreadMessagesContract, {
 
       return {
         status: 200 as const,
-        body: { messages },
+        body: { messages, ...(hasMore !== undefined ? { hasMore } : {}) },
       };
     } catch (error) {
       if (isNotFound(error)) {

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
@@ -316,7 +316,9 @@ export async function getLatestMessagesByThreadId(
  * Falls back to the latest 50 messages when the thread has no user messages.
  * Also returns `hasMore` so callers can offer backward pagination.
  */
-export async function getMessagesFromLastUserMessage(chatThreadId: string): Promise<{
+export async function getMessagesFromLastUserMessage(
+  chatThreadId: string,
+): Promise<{
   messages: MessageRow[];
   hasMore: boolean;
 }> {

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
@@ -33,7 +33,7 @@ const messageRowProjection = {
   attachFiles: chatMessages.attachFiles,
 } as const;
 
-type MessageRow = {
+export type MessageRow = {
   id: string;
   role: string;
   content: string | null;
@@ -306,6 +306,136 @@ export async function getLatestMessagesByThreadId(
       content: row.content as string,
     };
   });
+}
+
+/**
+ * Fetch messages starting from the last user message (inclusive) to the end of
+ * the thread, ordered chronologically. On entry, the UI anchors at the start
+ * of the latest conversation turn rather than loading an arbitrary slice.
+ *
+ * Falls back to the latest 50 messages when the thread has no user messages.
+ * Also returns `hasMore` so callers can offer backward pagination.
+ */
+export async function getMessagesFromLastUserMessage(chatThreadId: string): Promise<{
+  messages: MessageRow[];
+  hasMore: boolean;
+}> {
+  const db = globalThis.services.db;
+
+  const columns = {
+    id: chatMessages.id,
+    role: chatMessages.role,
+    content: chatMessages.content,
+    runId: chatMessages.runId,
+    error: chatMessages.error,
+    sequenceNumber: chatMessages.sequenceNumber,
+    createdAt: chatMessages.createdAt,
+    runStatus: agentRuns.status,
+    runError: agentRuns.error,
+    attachFiles: chatMessages.attachFiles,
+  };
+
+  const [lastUserMsg] = await db
+    .select({ id: chatMessages.id })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, chatThreadId),
+        eq(chatMessages.role, "user"),
+      ),
+    )
+    .orderBy(desc(chatMessages.createdAt), desc(chatMessages.sequenceNumber))
+    .limit(1);
+
+  if (!lastUserMsg) {
+    const rows = await db
+      .select(columns)
+      .from(chatMessages)
+      .leftJoin(agentRuns, eq(chatMessages.runId, agentRuns.id))
+      .where(eq(chatMessages.chatThreadId, chatThreadId))
+      .orderBy(desc(chatMessages.createdAt), desc(chatMessages.sequenceNumber))
+      .limit(50);
+    return { messages: rows.reverse(), hasMore: false };
+  }
+
+  const fromAnchor = sql`(
+    ${chatMessages.createdAt},
+    COALESCE(${chatMessages.sequenceNumber}, -1)
+  ) >= (
+    SELECT cm.created_at, COALESCE(cm.sequence_number, -1)
+    FROM chat_messages cm WHERE cm.id = ${lastUserMsg.id}
+  )`;
+
+  const messages = await db
+    .select(columns)
+    .from(chatMessages)
+    .leftJoin(agentRuns, eq(chatMessages.runId, agentRuns.id))
+    .where(and(eq(chatMessages.chatThreadId, chatThreadId), fromAnchor))
+    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));
+
+  const beforeAnchor = sql`(
+    ${chatMessages.createdAt},
+    COALESCE(${chatMessages.sequenceNumber}, -1)
+  ) < (
+    SELECT cm.created_at, COALESCE(cm.sequence_number, -1)
+    FROM chat_messages cm WHERE cm.id = ${lastUserMsg.id}
+  )`;
+
+  const [older] = await db
+    .select({ id: chatMessages.id })
+    .from(chatMessages)
+    .where(and(eq(chatMessages.chatThreadId, chatThreadId), beforeAnchor))
+    .limit(1);
+
+  return { messages, hasMore: older !== undefined };
+}
+
+/**
+ * Fetch up to `limit` messages strictly before the cursor message, returned
+ * in chronological order (ASC). Used for backward pagination when the user
+ * scrolls up to load older history.
+ *
+ * Fetches `limit + 1` rows internally so `hasMore` can be derived in a single
+ * query without a separate COUNT probe.
+ */
+export async function getMessagesBefore(
+  chatThreadId: string,
+  beforeId: string,
+  limit: number,
+): Promise<{ messages: MessageRow[]; hasMore: boolean }> {
+  const db = globalThis.services.db;
+
+  const columns = {
+    id: chatMessages.id,
+    role: chatMessages.role,
+    content: chatMessages.content,
+    runId: chatMessages.runId,
+    error: chatMessages.error,
+    sequenceNumber: chatMessages.sequenceNumber,
+    createdAt: chatMessages.createdAt,
+    runStatus: agentRuns.status,
+    runError: agentRuns.error,
+    attachFiles: chatMessages.attachFiles,
+  };
+
+  const cursorCondition = sql`(
+    ${chatMessages.createdAt},
+    COALESCE(${chatMessages.sequenceNumber}, -1)
+  ) < (
+    SELECT cm.created_at, COALESCE(cm.sequence_number, -1)
+    FROM chat_messages cm WHERE cm.id = ${beforeId}
+  )`;
+
+  const rows = await db
+    .select(columns)
+    .from(chatMessages)
+    .leftJoin(agentRuns, eq(chatMessages.runId, agentRuns.id))
+    .where(and(eq(chatMessages.chatThreadId, chatThreadId), cursorCondition))
+    .orderBy(desc(chatMessages.createdAt), desc(chatMessages.sequenceNumber))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  return { messages: rows.slice(0, limit).reverse(), hasMore };
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/chat-thread/index.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/index.ts
@@ -10,4 +10,9 @@ export {
   markThreadRead,
   resolveAttachFileUrls,
 } from "./chat-thread-service";
-export { getMessagesSince } from "./chat-message-service";
+export {
+  getMessagesBefore,
+  getMessagesFromLastUserMessage,
+  getMessagesSince,
+  type MessageRow,
+} from "./chat-message-service";

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -387,7 +387,15 @@ export const chatSearchContract = c.router({
 
 /**
  * Paginated chat messages contract (/api/zero/chat-threads/:threadId/messages)
- * Cursor-based pagination using message UUID as sinceId.
+ * Cursor-based pagination using message UUID as sinceId / beforeId.
+ *
+ * Query params (mutually exclusive):
+ *   sinceId  — forward pagination: messages strictly after this cursor
+ *   beforeId — backward pagination: messages strictly before this cursor
+ *   (neither) — initial load anchored at the last user message
+ *
+ * Response includes `hasMore` for initial load and backward pagination so the
+ * UI knows whether to offer upward scroll loading.
  */
 const pagedChatMessageSchema = z.object({
   id: z.string(),
@@ -408,11 +416,13 @@ export const chatThreadMessagesContract = c.router({
     pathParams: z.object({ threadId: z.string() }),
     query: z.object({
       sinceId: z.string().uuid().optional(),
+      beforeId: z.string().uuid().optional(),
       limit: z.coerce.number().min(1).max(50).default(50),
     }),
     responses: {
       200: z.object({
         messages: z.array(pagedChatMessageSchema),
+        hasMore: z.boolean().optional(),
       }),
       401: apiErrorSchema,
       404: apiErrorSchema,


### PR DESCRIPTION
## Summary

- **Initial load anchor**: Replace the fixed last-50-messages fetch with a new `getMessagesFromLastUserMessage` query that anchors the view at the start of the latest conversation turn (last user message + all messages after it)
- **Backward pagination**: New `getMessagesBefore` cursor-based query + `beforeId` contract param let the UI load older history on demand
- **Scroll compensation**: `recordScrollHeightForPrepend$` in `auto-scroll.ts` snapshots `scrollHeight` before prepending; the ResizeObserver callback compensates `scrollTop` so the viewport doesn't jump
- **Frontend signals**: `hasOlderMessages$` (state) and `loadOlderMessages$` (command) wired through `ChatThreadSignals`; `syncInitialHasMore$` seeds the state from the already-cached initial fetch (no second HTTP request)
- **UI**: An `IntersectionObserver` sentinel at the top of the message list triggers `loadOlderMessages$` when the user scrolls up; a skeleton indicator is shown while loading

## What's left for you to pick up

- **Tests**: Add integration tests for the two new service functions (`getMessagesFromLastUserMessage`, `getMessagesBefore`) in the existing `route.test.ts` suite
- **Loading guard**: `loadOlderMessages$` currently has no in-flight guard — if the sentinel stays in view after one page loads, the observer can fire again immediately. Consider adding an `isLoadingOlderMessages$` state to debounce
- **Scroll position after prepend**: Verify the ResizeObserver compensation feels smooth in practice; may need tweaking if the container uses CSS scroll anchoring

## Test plan

- [ ] Open a thread with >50 messages; verify only messages from the last user turn are shown on load
- [ ] Scroll to the top; verify older messages load and the viewport does not jump
- [ ] Verify new messages via Ably still auto-scroll to the bottom as before
- [ ] Verify threads with no user messages fall back to showing the latest 50 messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)