### PR TITLE
fix(core): guide users to add https:// in firewall url errors

### DIFF
--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -451,6 +451,20 @@ describe("validateBaseUrl", () => {
   it("should reject invalid URLs", () => {
     expect(() => {
       return validateBaseUrl("not-a-url", "fw");
+    }).toThrow('URL must include a scheme (e.g. "https://not-a-url")');
+  });
+
+  it("suggests adding https:// when the scheme is missing", () => {
+    expect(() => {
+      return validateBaseUrl("attia-n8n.duckdns.org/api/v1", "n8n");
+    }).toThrow(
+      'URL must include a scheme (e.g. "https://attia-n8n.duckdns.org/api/v1")',
+    );
+  });
+
+  it("falls back to the generic message when scheme is present but URL is malformed", () => {
+    expect(() => {
+      return validateBaseUrl("https://exa mple.com", "fw");
     }).toThrow("not a valid URL");
   });
 

--- a/turbo/packages/core/src/contracts/firewalls.ts
+++ b/turbo/packages/core/src/contracts/firewalls.ts
@@ -456,6 +456,11 @@ export function validateBaseUrl(base: string, serviceName: string): void {
   try {
     url = new URL(base);
   } catch {
+    if (!base.includes("://")) {
+      throw new Error(
+        `Invalid base URL "${base}" in firewall "${serviceName}": URL must include a scheme (e.g. "https://${base}")`,
+      );
+    }
     throw new Error(
       `Invalid base URL "${base}" in firewall "${serviceName}": not a valid URL`,
     );


### PR DESCRIPTION
## Summary
- Validator for firewall base URLs now detects the common "missing scheme" case and returns an actionable error including the user's input prefixed with `https://`
- Other URL parse failures (scheme present, something else wrong) keep the existing wording
- Mirrors the precedent already used by `validateBaseUrlParams()` for parameterized URLs

## Why
External user configured an n8n connector with `attia-n8n.duckdns.org/api/v1` (no scheme), hit `Invalid base URL ...: not a valid URL`, retried 3 times in a minute without fixing, and gave up. The fix is trivial (add `https://`) but the error message did not say so.

Closes #10923

## Test plan
- [x] `firewall-expander.test.ts`: existing "reject invalid URLs" case now asserts the scheme-hint wording
- [x] New case pins the hint for the exact n8n input (`attia-n8n.duckdns.org/api/v1`)
- [x] New case pins the generic fallback for a scheme-present-but-malformed input
- [x] `pnpm -F @vm0/core exec vitest run src/contracts/__tests__/firewall-expander.test.ts` — 69/69 pass locally
- [x] `pnpm turbo run lint` / `pnpm check-types` / `pnpm format` / `pnpm knip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)