### PR TITLE
perf(db): switch production db driver from neon websocket to pg tcp pool under fluid

### DIFF
--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -35,6 +35,7 @@
     "@team-plain/typescript-sdk": "^5.12.1",
     "@ts-rest/core": "3.53.0-rc.1",
     "@ts-rest/serverless": "3.53.0-rc.1",
+    "@vercel/functions": "^3.4.4",
     "@vercel/oidc": "^3.2.1",
     "@vm0/core": "workspace:*",
     "@vm0/ui": "workspace:*",

--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -26,9 +26,10 @@ function initEnv() {
         .positive()
         .default(10000),
       // Database driver selection
-      // Defaults to 'neon' (optimized for serverless/Vercel)
-      // Set to 'pg' for local development with standard Postgres
-      DB_DRIVER: z.enum(["pg", "neon"]).default("neon"),
+      // Defaults to 'pg' — node-postgres TCP pool + attachDatabasePool is the
+      // Vercel Fluid + Neon 2026 recommended path. Override to 'neon' only
+      // for environments that specifically need the WebSocket driver.
+      DB_DRIVER: z.enum(["pg", "neon"]).default("pg"),
       CLERK_SECRET_KEY: z.string().min(1),
       E2B_API_KEY: z.string().min(1).optional(),
       VM0_API_URL: z.url().optional(),

--- a/turbo/apps/web/src/lib/init-services.ts
+++ b/turbo/apps/web/src/lib/init-services.ts
@@ -1,6 +1,7 @@
 import { Pool as PgPool } from "pg";
 import { Pool as NeonPool } from "@neondatabase/serverless";
 import Stripe from "stripe";
+import { attachDatabasePool } from "@vercel/functions";
 import { drizzle as drizzleNodePg } from "drizzle-orm/node-postgres";
 import { drizzle as drizzleNeonServerless } from "drizzle-orm/neon-serverless";
 import { schema } from "../db/db";
@@ -59,14 +60,19 @@ export function initServices(): void {
             connectionTimeoutMillis: this.env.DB_POOL_CONNECT_TIMEOUT_MS,
           });
         } else {
-          // Use standard PostgreSQL driver
-          // Set DB_DRIVER=pg for local development or self-hosted deployments
-          _pool = new PgPool({
+          // Standard PostgreSQL TCP driver + Vercel Fluid lifecycle.
+          // `attachDatabasePool` uses `waitUntil` to close idle connections
+          // before Fluid suspends the instance, so the TCP pool can be reused
+          // safely across requests without leaking connections on suspend.
+          // Ref: https://neon.com/docs/guides/vercel-connection-methods
+          const pgPool = new PgPool({
             connectionString: this.env.DATABASE_URL,
             max: this.env.DB_POOL_MAX,
-            idleTimeoutMillis: this.env.DB_POOL_IDLE_TIMEOUT_MS ?? 30000,
+            idleTimeoutMillis: this.env.DB_POOL_IDLE_TIMEOUT_MS ?? 5000,
             connectionTimeoutMillis: this.env.DB_POOL_CONNECT_TIMEOUT_MS,
           });
+          attachDatabasePool(pgPool);
+          _pool = pgPool;
         }
       }
       return _pool;

--- a/turbo/apps/web/src/lib/init-services.ts
+++ b/turbo/apps/web/src/lib/init-services.ts
@@ -49,10 +49,10 @@ export function initServices(): void {
           throw new Error("DATABASE_URL is required at runtime");
         }
         if (useNeon) {
-          // Use Neon serverless driver (default)
-          // Optimized for Neon's connection pooler and serverless environments
-          // Automatically used unless DB_DRIVER=pg is explicitly set
-          // See: https://vercel.com/guides/connection-pooling-with-functions
+          // Opt-in WebSocket driver via @neondatabase/serverless. Kept as a
+          // rollback / escape hatch (set DB_DRIVER=neon to activate) and for
+          // environments without TCP support. The default path is the `pg`
+          // branch below.
           _pool = new NeonPool({
             connectionString: this.env.DATABASE_URL,
             max: this.env.DB_POOL_MAX,
@@ -60,11 +60,14 @@ export function initServices(): void {
             connectionTimeoutMillis: this.env.DB_POOL_CONNECT_TIMEOUT_MS,
           });
         } else {
-          // Standard PostgreSQL TCP driver + Vercel Fluid lifecycle.
-          // `attachDatabasePool` uses `waitUntil` to close idle connections
-          // before Fluid suspends the instance, so the TCP pool can be reused
-          // safely across requests without leaking connections on suspend.
-          // Ref: https://neon.com/docs/guides/vercel-connection-methods
+          // Default: node-postgres TCP pool + Vercel Fluid lifecycle.
+          // `attachDatabasePool` registers a `waitUntil`-based handler that
+          // closes idle connections before Fluid suspends the instance, so
+          // the pool reuses connections across requests without leaking on
+          // suspend.
+          // Refs:
+          //   https://vercel.com/guides/connection-pooling-with-functions
+          //   https://neon.com/docs/guides/vercel-connection-methods
           const pgPool = new PgPool({
             connectionString: this.env.DATABASE_URL,
             max: this.env.DB_POOL_MAX,
@@ -80,14 +83,14 @@ export function initServices(): void {
     get db() {
       if (!_db) {
         if (useNeon) {
-          // Use Neon serverless driver with drizzle
-          // This supports interactive transactions (required for storage commit)
+          // Drizzle adapter paired with the @neondatabase/serverless pool.
           _db = drizzleNeonServerless({
             client: this.pool as NeonPool,
             schema,
           });
         } else {
-          // Use regular pg driver with drizzle (default)
+          // Default Drizzle adapter paired with node-postgres. Supports
+          // interactive transactions (used by storage commit).
           _db = drizzleNodePg(this.pool as PgPool, { schema });
         }
       }

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   apps/cli:
     dependencies:
@@ -138,7 +138,7 @@ importers:
         version: 6.24.1
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -304,7 +304,7 @@ importers:
         version: 8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   apps/web:
     dependencies:
@@ -359,6 +359,9 @@ importers:
       '@ts-rest/serverless':
         specifier: 3.53.0-rc.1
         version: 3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@24.3.0))(next@16.2.3(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@vercel/functions':
+        specifier: ^3.4.4
+        version: 3.4.4(@aws-sdk/credential-provider-web-identity@3.972.31)
       '@vercel/oidc':
         specifier: ^3.2.1
         version: 3.2.1
@@ -530,7 +533,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/core:
     dependencies:
@@ -564,7 +567,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/eslint-config:
     devDependencies:
@@ -618,7 +621,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -728,7 +731,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -4622,6 +4625,15 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vercel/functions@3.4.4':
+    resolution: {integrity: sha512-mdmCTMxAUTT5GMSs/iS4EuovzoofXNbb44/iPFwlgqulnJg3FEf6Sk46kLlZL4zuTTJQPT5YPTdBgZVlYZ5Azg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
   '@vercel/oidc@3.2.1':
     resolution: {integrity: sha512-UUqZ2y+VXHgVH1Luoo+477/NcrO4X+ln38U70ldRgGiWJAuHhtjTm7cCAnyLkl2feg7ZmTBK3F1kvJKFEQc01w==}
     engines: {node: '>= 20'}
@@ -8248,7 +8260,6 @@ packages:
       '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -12646,6 +12657,12 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.31)':
+    dependencies:
+      '@vercel/oidc': 3.2.1
+    optionalDependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.31
+
   '@vercel/oidc@3.2.1': {}
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
@@ -12659,7 +12676,7 @@ snapshots:
       '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -12675,7 +12692,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -12695,7 +12712,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       '@vitest/browser': 4.1.4(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
 
@@ -12744,7 +12761,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -16886,7 +16903,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@emnapi/runtime@1.9.1)(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/runtime@1.9.1)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -16916,7 +16933,20 @@ snapshots:
       '@vitest/ui': 4.1.4(vitest@4.1.4)
       happy-dom: 20.9.0
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vscode-languageserver-textdocument@1.0.12: {}
 


### PR DESCRIPTION
## Summary

Switches the web app's production DB driver from `@neondatabase/serverless` WebSocket `NeonPool` to node-postgres `pg` Pool + `attachDatabasePool`, the Vercel + Neon 2026 recommended path for Fluid Compute. Production is already on Fluid (verified), `DATABASE_URL` is already the pooled (PgBouncer) endpoint, and every non-production environment already uses `pg` — this PR aligns production with the rest of the stack.

**Expected impact** (per investigation in Epic #10953):
- `api_chat_send_*` span P50 floor: **~70 ms → ~5–10 ms**
- `resolveThread` parallel arm wall-clock P50: **~270 ms → ~15–25 ms**
- Eliminates the bimodal queueing tail observed with WebSocket `NeonPool`

## What changes

1. **`init-services.ts`** — wires `attachDatabasePool(pgPool)` into the `pg` Pool branch and tightens default `idleTimeoutMillis` from 30 s → 5 s (Vercel Fluid recommendation)
2. **`env.ts`** — flips `DB_DRIVER` default from `"neon"` to `"pg"`. This is the actual cutover.
3. **`package.json`** — adds `@vercel/functions` dependency

## Why this is low-risk

| Concern | Reality |
|---------|---------|
| "We're introducing a new code path under load" | The `pg` branch already exists in `init-services.ts`, used by local dev (`.env.local.tpl` sets `DB_DRIVER=pg`) and the full test suite (`__tests__/setup.ts:22` stubs `DB_DRIVER=pg`). Only production inherited `"neon"` default |
| "drizzle adapters might behave differently" | `drizzle-orm/node-postgres` and `drizzle-orm/neon-serverless` implement the same Drizzle API. Both talk PG wire protocol to the same Neon PgBouncer endpoint — only the transport differs (TCP vs WebSocket) |
| "Interactive transactions (storage commit) might break" | `node-postgres` supports interactive transactions natively. This is the mainstream Drizzle + Postgres pattern |
| "Fluid might not actually reuse TCP connections" | Fluid is confirmed enabled. `attachDatabasePool` registers a `waitUntil`-based idle-timeout handler so connections close cleanly before suspend — the documented happy path |
| "Concurrency safety under shared-instance Fluid" | Full audit in Epic #10953: all 11 module singletons are lazy-init-synchronous, no code writes request-scoped state to globals, no self-managed AsyncLocalStorage |

## Background

Investigation against production (Epic #10953):
- `EXPLAIN ANALYZE` against production via `READONLY_PROD_DATABASE_URL` shows `resolveThread`'s four queries execute in **0.027 ms – 6.6 ms** at the PG layer
- Same queries report **71 / 74 / 261 / 267 ms** in prod span telemetry — a bimodal distribution consistent with serialized WebSocket handshakes inside NeonPool
- The overhead is entirely application-layer, not SQL. Switching to TCP via `pg.Pool` removes it

`attachDatabasePool` from `@vercel/functions` is a no-op outside Vercel runtime (checks `VERCEL_URL` / `VERCEL_REGION`), so local dev and CI are unaffected.

## Test plan

- [x] `pnpm -F web lint` → 0 errors
- [x] `pnpm -F web check-types` → clean
- [x] `pnpm format` → no changes
- [ ] CI lint / test / deploy / cli-e2e jobs all green
- [ ] Preview deployment boots and serves `/api/zero/chat/messages` end-to-end
- [ ] Monitor `api_chat_send_*` span P50 / P95 on Preview for 24 h via Axiom
- [ ] Watch `api_to_cli_init` and connection-error Sentry issues for any regression

## Rollback

- **Fast**: set `DB_DRIVER=neon` in Vercel Dashboard env vars — overrides the new default back to the WebSocket driver without needing a code revert
- **Full**: revert this PR

## Ref

- Epic: #10953
- Parent tracking: #10796