### PR TITLE
chore(rust): update dependencies (2026-04-24)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1878,9 +1878,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"


### PR DESCRIPTION
## Summary

Weekly automated refresh of Rust workspace dependencies via `cargo update`.

### Updated dependencies

| Crate | From | To |
|-------|------|----|
| `libc` | 0.2.185 | 0.2.186 |

All workspace-level direct dependencies in `crates/Cargo.toml` (tokio, serde, reqwest, aws-sdk-s3, clap, etc.) were already on their latest semver-compatible versions before this run; no `Cargo.toml` edits were required.

### Dependencies NOT updated

The following transitive deps have newer minor/patch versions available but are pinned by parents that haven't relaxed their version requirements yet — nothing we can do from our `Cargo.toml`:

| Crate | Current | Available | Blocked by |
|-------|---------|-----------|------------|
| `crc` | 3.3.0 | 3.4.0 | `crc-fast` → `aws-smithy-checksums` → `aws-sdk-s3` |
| `crc-fast` | 1.9.0 | 1.10.0 | `aws-smithy-checksums` → `aws-sdk-s3` |
| `generic-array` | 0.14.7 | 0.14.9 | `block-buffer`/`digest` → `crc-fast`, `sha1` (via `headers`/`httpmock`) |

These will pick up automatically once `aws-smithy-checksums` / `headers` publish updated requirements. No action needed on our side.

### Manual version bumps

None — no workspace pins needed bumping.

### Test status

`cargo test --workspace --no-fail-fast` — **PASS**

All test suites green (~1400+ tests across the workspace, 0 failures). Full build also clean with `cargo build --workspace`.

---

Generated by the scheduled Rust deps refresh task.
