### PR TITLE
feat(slack): graduate agent switching

### DIFF
--- a/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
@@ -16,18 +16,6 @@ import {
 import { countSlackOrgConnections } from "../../../../../../src/__tests__/db-test-assertions/slack";
 import { reloadEnv } from "../../../../../../src/env";
 
-vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@vm0/core/feature-switch")>();
-  return {
-    ...actual,
-    isFeatureEnabled: vi.fn().mockReturnValue(true),
-  };
-});
-
-const { isFeatureEnabled } = await import("@vm0/core/feature-switch");
-const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
-
 const { POST } = await import("../route");
 
 const SIGNING_SECRET = "test-slack-signing-secret";
@@ -85,7 +73,6 @@ describe("POST /api/zero/slack/commands", () => {
     context.setupMocks();
     user = await context.setupUser();
     reloadEnv();
-    mockIsFeatureEnabled.mockReturnValue(true);
   });
 
   describe("signature verification", () => {
@@ -386,7 +373,7 @@ describe("POST /api/zero/slack/commands", () => {
       expect(mockClient.views.open).not.toHaveBeenCalled();
     });
 
-    it("help output advertises the switch subcommand when feature is enabled", async () => {
+    it("help output advertises the switch subcommand for org-bound workspaces", async () => {
       const workspaceId = uniqueId("T-ws");
       await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
 
@@ -398,11 +385,9 @@ describe("POST /api/zero/slack/commands", () => {
       expect(JSON.stringify(data.blocks)).toContain("/zero switch");
     });
 
-    it("help output omits switch when feature is gated off for the org", async () => {
-      mockIsFeatureEnabled.mockReturnValue(false);
-
+    it("help output omits switch when the workspace is not bound to an org", async () => {
       const workspaceId = uniqueId("T-ws");
-      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await createTestSlackOrgInstallation({ workspaceId, orgId: null });
 
       const body = buildCommandBody({ team_id: workspaceId, text: "help" });
       const request = createCommandRequest(body);
@@ -411,39 +396,6 @@ describe("POST /api/zero/slack/commands", () => {
       const data = await response.json();
       expect(JSON.stringify(data.blocks)).not.toContain("/zero switch");
       expect(JSON.stringify(data.blocks)).toContain("/zero connect");
-    });
-
-    it("returns help (without switch) and does NOT open the picker when feature is gated off", async () => {
-      mockIsFeatureEnabled.mockReturnValue(false);
-
-      const workspaceId = uniqueId("T-ws");
-      const slackUserId = uniqueId("U-slack");
-      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
-      await seedTestSlackOrgConnection({
-        slackUserId,
-        slackWorkspaceId: workspaceId,
-        vm0UserId: user.userId,
-      });
-      const defaultCompose = await createTestCompose(uniqueId("default"));
-      await updateOrgDefaultAgent(user.orgId, defaultCompose.agentId);
-      await createTestCompose(uniqueId("alt"));
-
-      const body = buildCommandBody({
-        team_id: workspaceId,
-        user_id: slackUserId,
-        text: "switch",
-      });
-      const request = createCommandRequest(body);
-      const response = await POST(request);
-
-      expect(response.status).toBe(200);
-      const data = await response.json();
-      expect(data.response_type).toBe("ephemeral");
-      expect(JSON.stringify(data.blocks)).not.toContain("/zero switch");
-
-      const { WebClient } = await import("@slack/web-api");
-      const mockClient = new WebClient();
-      expect(mockClient.views.open).not.toHaveBeenCalled();
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/commands/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
 import { eq, and } from "drizzle-orm";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { initServices } from "../../../../../src/lib/init-services";
 import { env } from "../../../../../src/env";
 import {
@@ -302,19 +300,11 @@ export async function POST(request: Request) {
     .where(eq(slackOrgInstallations.slackWorkspaceId, payload.team_id))
     .limit(1);
 
-  // Whether /zero switch is exposed for this workspace's org. The feature is
-  // staff-gated; for unbound installations we can't evaluate it (no orgId), so
-  // default to off.
-  const switchEnabled = Boolean(
-    installation?.orgId &&
-    isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch, {
-      orgId: installation.orgId,
-    }),
-  );
+  const canSwitchAgents = Boolean(installation?.orgId);
 
   // Handle help command (doesn't require installation)
   if (subCommand === "help" || subCommand === "") {
-    return ephemeral(buildHelpMessage({ canSwitch: switchEnabled }));
+    return ephemeral(buildHelpMessage({ canSwitch: canSwitchAgents }));
   }
 
   // Handle connect command
@@ -366,14 +356,9 @@ export async function POST(request: Request) {
 
   // Handle switch command
   if (subCommand === "switch") {
-    if (!switchEnabled) {
-      // Feature is gated off for this org — treat as unknown, show help
-      // without advertising the switch subcommand.
-      return ephemeral(buildHelpMessage({ canSwitch: false }));
-    }
     return handleSwitch(payload, installation, connection);
   }
 
   // Unknown command
-  return ephemeral(buildHelpMessage({ canSwitch: switchEnabled }));
+  return ephemeral(buildHelpMessage({ canSwitch: canSwitchAgents }));
 }

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -1340,7 +1340,7 @@ describe("POST /api/zero/slack/events", () => {
       clearAlternate: boolean;
       clearDefault: boolean;
     }) {
-      // Default agent — used when the user has no override or feature is off.
+      // Default agent — used when the user has no override.
       const defaultCompose = await createTestCompose(uniqueId("default"));
       await updateOrgDefaultAgent(user.orgId, defaultCompose.agentId);
       if (opts.clearDefault) {
@@ -1464,20 +1464,15 @@ describe("POST /api/zero/slack/events", () => {
       expect(serialized).not.toContain("Sent via");
     });
 
-    it("ignores the user's override and uses the default agent when the feature is gated off for the org", async () => {
-      // Scenario: the user already has a persisted override (e.g. set while
-      // the feature was enabled), but the feature switch has since been
-      // turned off for this org. `resolveEffectiveComposeId` must ignore the
-      // DB override and route through the org default. We verify this the
-      // same way as the no-override case: the error reply carries no footer.
+    it("honors the user's override even when unrelated feature switches return false", async () => {
       mockIsFeatureEnabled.mockReturnValue(false);
 
-      const { workspaceId, slackUserId } = await setupOrgWithOverride({
-        overrideToAlternate: true,
-        clearAlternate: false,
-        // Clear default to force the pre-dispatch error path we can assert on.
-        clearDefault: true,
-      });
+      const { workspaceId, slackUserId, alternate } =
+        await setupOrgWithOverride({
+          overrideToAlternate: true,
+          clearAlternate: true,
+          clearDefault: false,
+        });
 
       const request = createSlackEventRequest({
         type: "event_callback",
@@ -1500,16 +1495,13 @@ describe("POST /api/zero/slack/events", () => {
 
       const { WebClient } = await import("@slack/web-api");
       const mockClient = new WebClient();
-      // postMessage was called because the DEFAULT agent failed pre-dispatch.
-      // If the override were honored, the alternate (which is healthy here)
-      // would have taken the happy path and no error would be posted.
       expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();
       const callArg = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>)
         .mock.calls[0]?.[0] as {
         blocks?: unknown;
       };
       const serialized = JSON.stringify(callArg?.blocks ?? "");
-      expect(serialized).not.toContain("Sent via");
+      expect(serialized).toContain(`Sent via ${alternate.name}`);
     });
 
     it("falls back to the org default when the override points to a compose without a zero_agents row (stale override guard)", async () => {

--- a/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 import { createHmac } from "crypto";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import {
   testContext,
   uniqueId,
@@ -19,18 +19,6 @@ import {
   seedSlackUserAgentPreference,
 } from "../../../../../../src/__tests__/db-test-assertions/slack";
 import { reloadEnv } from "../../../../../../src/env";
-
-vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@vm0/core/feature-switch")>();
-  return {
-    ...actual,
-    isFeatureEnabled: vi.fn().mockReturnValue(true),
-  };
-});
-
-const { isFeatureEnabled } = await import("@vm0/core/feature-switch");
-const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
 
 const { POST } = await import("../route");
 
@@ -97,7 +85,6 @@ describe("POST /api/zero/slack/interactive", () => {
     context.setupMocks();
     user = await context.setupUser();
     reloadEnv();
-    mockIsFeatureEnabled.mockReturnValue(true);
   });
 
   describe("signature verification", () => {
@@ -338,69 +325,6 @@ describe("POST /api/zero/slack/interactive", () => {
       const { WebClient } = await import("@slack/web-api");
       const mockClient = new WebClient();
       expect(mockClient.views.open).toHaveBeenCalledOnce();
-    });
-
-    it("does not open picker when feature is gated off for the org", async () => {
-      mockIsFeatureEnabled.mockReturnValue(false);
-
-      const workspaceId = uniqueId("T-ws");
-      const slackUserId = uniqueId("U-slack");
-      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
-      await seedTestSlackOrgConnection({
-        slackUserId,
-        slackWorkspaceId: workspaceId,
-        vm0UserId: user.userId,
-      });
-      const defaultCompose = await createTestCompose(uniqueId("default"));
-      await updateOrgDefaultAgent(user.orgId, defaultCompose.agentId);
-      await createTestCompose(uniqueId("alt"));
-
-      const request = createInteractiveRequest({
-        type: "block_actions",
-        user: { id: slackUserId, username: "testuser", team_id: workspaceId },
-        team: { id: workspaceId, domain: "test" },
-        trigger_id: "trigger-home",
-        actions: [{ action_id: "home_switch_agent", block_id: "home" }],
-      });
-
-      const response = await POST(request);
-      expect(response.status).toBe(200);
-
-      const { WebClient } = await import("@slack/web-api");
-      const mockClient = new WebClient();
-      expect(mockClient.views.open).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("switch_agent_modal feature gate defense", () => {
-    it("does not persist a preference when the feature is gated off", async () => {
-      mockIsFeatureEnabled.mockReturnValue(false);
-
-      const workspaceId = uniqueId("T-ws");
-      const slackUserId = uniqueId("U-slack");
-      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
-      await seedTestSlackOrgConnection({
-        slackUserId,
-        slackWorkspaceId: workspaceId,
-        vm0UserId: user.userId,
-      });
-      const defaultCompose = await createTestCompose(uniqueId("default"));
-      await updateOrgDefaultAgent(user.orgId, defaultCompose.agentId);
-      const alternate = await createTestCompose(uniqueId("alt"));
-
-      const request = createInteractiveRequest(
-        buildAgentPickerSubmission({
-          workspaceId,
-          slackUserId,
-          selectedValue: alternate.composeId,
-          channelId: "C-origin",
-        }),
-      );
-      const response = await POST(request);
-      expect(response.status).toBe(200);
-
-      const saved = await findSlackUserAgentPreference(user.userId, user.orgId);
-      expect(saved).toBeUndefined();
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
 import { eq, and } from "drizzle-orm";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { initServices } from "../../../../../src/lib/init-services";
 import { env } from "../../../../../src/env";
 import {
@@ -295,16 +293,6 @@ async function handleAgentPickerSubmit(
     return new Response("", { status: 200 });
   }
 
-  // Defense in depth: if the feature is gated off for this org, close the
-  // modal without persisting. The entry points that open the modal are also
-  // gated, so reaching here with the feature off implies the flag flipped
-  // after the user opened the picker.
-  if (
-    !isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch, { orgId: ctx.orgId })
-  ) {
-    return new Response("", { status: 200 });
-  }
-
   const { SECRETS_ENCRYPTION_KEY } = env();
   const botToken = decryptSecretValue(
     ctx.installation.encryptedBotToken,
@@ -368,15 +356,6 @@ async function handleHomeSwitchAgent(
 
   const ctx = await resolveConnectionContext(payload.user.id, payload.team.id);
   if (!ctx) {
-    return;
-  }
-
-  // Feature gate: the App Home button is hidden when the feature is off, but
-  // defend the action entry point too in case a stale client still has the
-  // button visible.
-  if (
-    !isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch, { orgId: ctx.orgId })
-  ) {
     return;
   }
 

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/app-home.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/app-home.ts
@@ -1,6 +1,4 @@
 import { eq, and } from "drizzle-orm";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { slackOrgInstallations } from "../../../../db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../../../db/schema/slack-org-connection";
 import { decryptSecretValue } from "../../../shared/crypto/secrets-encryption";
@@ -105,11 +103,7 @@ export async function refreshOrgAppHome(
     isOverrideActive = Boolean(
       overrideComposeId && overrideComposeId !== defaultComposeId,
     );
-    // Show the Switch button only when both (a) there's a default to switch
-    // from/to and (b) the feature is enabled for this org.
-    canSwitch =
-      Boolean(defaultComposeId) &&
-      isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch, { orgId });
+    canSwitch = Boolean(defaultComposeId);
   }
 
   // Get user email for display

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/shared.ts
@@ -1,6 +1,4 @@
 import { eq, and } from "drizzle-orm";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { slackOrgInstallations } from "../../../../db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../../../db/schema/slack-org-connection";
 import { slackOrgThreadSessions } from "../../../../db/schema/slack-org-thread-session";
@@ -140,18 +138,13 @@ export async function setUserAgentPreference(opts: {
  * Resolve the compose that should respond for this user.
  *
  * Resolution order:
- *   1. If the `SlackAgentSwitch` feature is gated off for the org, skip the
- *      override path entirely — every user falls back to the org default.
- *      This makes the feature switch authoritative: turning it off for an org
- *      immediately stops honoring any persisted overrides, even ones set
- *      while the feature was previously enabled.
- *   2. If a row exists in `slack_user_agent_preferences` and its
+ *   1. If a row exists in `slack_user_agent_preferences` and its
  *      `selectedComposeId` still points to an agent that (a) exists and
  *      (b) belongs to the given org, use it. The org check is a stale-pointer
  *      guard: an override can linger after the target compose is deleted,
  *      archived, or moved to a different org, and silently falling back to
  *      the default is preferable to returning a stale/unauthorized agent.
- *   3. Otherwise return the org default compose id (may be null if the org
+ *   2. Otherwise return the org default compose id (may be null if the org
  *      has no default configured — callers must handle that).
  *
  * This function is called by the mention / DM / App Home handlers; it must
@@ -161,17 +154,15 @@ export async function resolveEffectiveComposeId(
   vm0UserId: string,
   orgId: string,
 ): Promise<string | null> {
-  if (isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch, { orgId })) {
-    const override = await getUserAgentPreference(vm0UserId, orgId);
-    if (override) {
-      const [row] = await globalThis.services.db
-        .select({ id: zeroAgents.id })
-        .from(zeroAgents)
-        .where(and(eq(zeroAgents.id, override), eq(zeroAgents.orgId, orgId)))
-        .limit(1);
-      if (row?.id) {
-        return override;
-      }
+  const override = await getUserAgentPreference(vm0UserId, orgId);
+  if (override) {
+    const [row] = await globalThis.services.db
+      .select({ id: zeroAgents.id })
+      .from(zeroAgents)
+      .where(and(eq(zeroAgents.id, override), eq(zeroAgents.orgId, orgId)))
+      .limit(1);
+    if (row?.id) {
+      return override;
     }
   }
   return resolveDefaultComposeId(orgId);

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -30,9 +30,9 @@ describe("isFeatureEnabled", () => {
   });
 
   it("should return true when orgId hash matches enabledOrgIdHashes", () => {
-    // SlackAgentSwitch has enabledOrgIdHashes: STAFF_ORG_ID_HASHES
+    // PlatformConnectors has enabledOrgIdHashes: STAFF_ORG_ID_HASHES
     expect(
-      isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch, {
+      isFeatureEnabled(FeatureSwitchKey.PlatformConnectors, {
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
     ).toBe(true);
@@ -40,19 +40,19 @@ describe("isFeatureEnabled", () => {
 
   it("should return false when orgId does not match enabledOrgIdHashes", () => {
     expect(
-      isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch, {
+      isFeatureEnabled(FeatureSwitchKey.PlatformConnectors, {
         orgId: "org_nonexistent",
       }),
     ).toBe(false);
   });
 
   it("should return false when no orgId provided but switch has enabledOrgIdHashes", () => {
-    expect(isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch)).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.PlatformConnectors)).toBe(false);
   });
 
   it("should return true when orgId matches even if userId does not", () => {
     expect(
-      isFeatureEnabled(FeatureSwitchKey.SlackAgentSwitch, {
+      isFeatureEnabled(FeatureSwitchKey.PlatformConnectors, {
         userId: "non-matching-user",
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
@@ -71,8 +71,8 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates({
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
-    // SlackAgentSwitch has STAFF_ORG_ID_HASHES and should be true
-    expect(states[FeatureSwitchKey.SlackAgentSwitch]).toBe(true);
+    // PlatformConnectors has STAFF_ORG_ID_HASHES and should be true
+    expect(states[FeatureSwitchKey.PlatformConnectors]).toBe(true);
     // Globally enabled should still be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
     // Switches without org hashes should remain false
@@ -83,7 +83,7 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates({
       orgId: "org_nonexistent",
     });
-    expect(states[FeatureSwitchKey.SlackAgentSwitch]).toBe(false);
+    expect(states[FeatureSwitchKey.PlatformConnectors]).toBe(false);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -40,7 +40,6 @@ export enum FeatureSwitchKey {
   AudioOutput = "audioOutput",
   AutoSkill = "autoSkill",
   ScheduleRunHistory = "scheduleRunHistory",
-  SlackAgentSwitch = "slackAgentSwitch",
   TestOauthConnector = "testOauthConnector",
   ChatHeaderNewButton = "chatHeaderNewButton",
   ChatThreadReadIndicator = "chatThreadReadIndicator",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -265,24 +265,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Gate the custom /settings/api-keys UI for issuing personal access tokens used by the /api/v1 public surface. When disabled, the settings page redirects to / and the sidebar menu item is hidden. The backend /api/v1 verification does NOT consult this flag — previously issued PATs continue to work.",
     enabled: false,
   },
-  [FeatureSwitchKey.SlackAgentSwitch]: {
-    maintainer: "yuma@vm0.ai",
-    description:
-      "Per-user agent override in the org-aware Slack app. When enabled for an org, " +
-      "members can choose which agent replies to their Slack mentions / DMs via " +
-      "`/zero switch` (opens an agent picker modal) or the Switch button on the " +
-      "App Home tab. The help text for `/zero help` also lists the switch subcommand. " +
-      "Selecting an alternate agent persists a row in `slack_user_agent_preferences` " +
-      "so the preference follows the user across every Slack workspace joined under " +
-      "the same org, and subsequent mention / DM replies from a non-default agent " +
-      "carry a `Sent via <agent>` footer so it's clear which agent produced the reply. " +
-      "When gated off, the modal, slash subcommand, App Home button, and help line " +
-      "are hidden AND any existing DB preferences are ignored at read time — every " +
-      "user falls back to the org default agent with no footer. Staff-only during the " +
-      "rollout window defined by `enabledOrgIdHashes`.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ModelProviderSelection]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Remove the `slackAgentSwitch` feature switch from core registry and enum
- Make Slack agent switching and persisted per-user preferences always available for org-bound workspaces
- Update Slack command, interactive, events, and feature-switch tests for the graduated behavior

## Verification
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F web exec vitest run src/lib/zero/slack/__tests__/blocks.test.ts app/api/zero/slack/commands/__tests__/route.test.ts app/api/zero/slack/interactive/__tests__/route.test.ts`
- `pnpm -F web exec vitest run app/api/zero/slack/events/__tests__/route.test.ts -t "honors the user's override"`
- `pnpm -F @vm0/core check-types`
- targeted eslint for changed Slack/core files

## Known local failures
- `pnpm -F web exec vitest run app/api/zero/slack/events/__tests__/route.test.ts` still fails two unrelated DB-schema-dependent tests because local DB lacks `agent_sessions.artifacts`.
- `pnpm -F web exec tsc --noEmit --pretty false` fails on existing unrelated main issues, including missing `@google/genai`, `@vercel/oidc`, `google-auth-library`, and unrelated implicit-any errors.`