### PR TITLE
fix(mitm-addon): guard flow.request.content against bad content-encoding

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -258,20 +258,26 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     log_entry["request_headers"] = _redact_headers(flow.request.headers)
 
     # Request body
-    if flow.request.content:
+    if flow.request.raw_content:
         req_ct = flow.request.headers.get("content-type", "")
-        body = flow.request.content
-        truncated = len(body) > STREAM_BUFFER_LIMIT
-        if truncated:
-            body = _truncate_bytes_utf8_safe(body, STREAM_BUFFER_LIMIT)
-        encoded, encoding = _encode_body(body, req_ct)
-        if encoded is not None:
-            log_entry["request_body"] = encoded
-            log_entry["request_body_encoding"] = encoding
-            if truncated:
-                log_entry["request_body_truncated"] = True
-        else:
+        try:
+            body = flow.request.content
+        except (zlib.error, ValueError):
+            # ZlibError (decompression failure) or ValueError from mitmproxy
+            # when Content-Encoding doesn't match the body bytes.
             log_entry["request_body_encoding"] = "binary"
+        else:
+            truncated = len(body) > STREAM_BUFFER_LIMIT
+            if truncated:
+                body = _truncate_bytes_utf8_safe(body, STREAM_BUFFER_LIMIT)
+            encoded, encoding = _encode_body(body, req_ct)
+            if encoded is not None:
+                log_entry["request_body"] = encoded
+                log_entry["request_body_encoding"] = encoding
+                if truncated:
+                    log_entry["request_body_truncated"] = True
+            else:
+                log_entry["request_body_encoding"] = "binary"
 
     # Response headers
     if flow.response:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -457,7 +457,7 @@ def response(flow: http.HTTPFlow) -> None:
     firewall_action = flow.metadata.get("firewall_action", "ALLOW")
 
     # Calculate sizes
-    request_size = len(flow.request.content) if flow.request.content else 0
+    request_size = len(flow.request.raw_content or b"")
     # Use buffered body length when complete; fall back to Content-Length header.
     stream_buf = flow.metadata.get("stream_buffer")
     stream_state = flow.metadata.get("stream_buffer_state")
@@ -580,7 +580,7 @@ def error(flow: http.HTTPFlow) -> None:
         host = flow.request.pretty_host
         port = flow.request.port
 
-    request_size = len(flow.request.content) if flow.request.content else 0
+    request_size = len(flow.request.raw_content or b"")
     error_msg = flow.error.msg if flow.error else "unknown error"
 
     # [NETWORK_LOG_FIELDS] — keep in sync with response() and runs.ts schema

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -8,6 +8,7 @@ in the ``usage_event`` table.
 import json
 import urllib.parse
 import uuid
+import zlib
 from collections.abc import Callable
 from typing import TypedDict
 
@@ -411,11 +412,18 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
     endpoint_bucket = classify_bucket(permission, flow.request.method, request_path)
     if endpoint_bucket is None:
         return
+    try:
+        request_body = flow.request.content
+    except (zlib.error, ValueError):
+        # Bogus Content-Encoding on the request: stay on the conservative
+        # (more expensive) bucket, matching refine_bucket_with_body's own
+        # "never under-charge" rule for parse failures.
+        request_body = None
     endpoint_bucket = refine_bucket_with_body(
         endpoint_bucket,
         flow.request.method,
         request_path,
-        flow.request.content,
+        request_body,
     )
 
     req_meta = _parse_request_metadata(flow)

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -86,6 +86,7 @@ def real_flow():
         request_body: bytes | None = None,
         request_headers: http.Headers | None = None,
         request_content_type: str | None = None,
+        request_encoding: str | None = None,
         with_response: bool = True,
         response_status: int = 200,
         response_body: bytes | None = None,
@@ -101,6 +102,8 @@ def real_flow():
             if request_content_type:
                 pairs.insert(0, ("Content-Type", request_content_type))
             req_headers = _headers(*pairs)
+        if request_encoding:
+            req_headers[b"Content-Encoding"] = request_encoding.encode()
         req = tutils.treq(
             scheme=scheme.encode(),
             method=method.encode(),

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -340,6 +340,28 @@ class TestAddCaptureFields:
         assert "response_body" not in entry  # response body skipped
         assert entry["response_body_encoding"] == "binary"  # marked as binary
 
+    def test_request_decompression_error_marks_body_binary(self, real_flow, headers):
+        # Content-Encoding: gzip + non-gzip bytes on the REQUEST side makes
+        # flow.request.content raise ValueError.  add_capture_fields must
+        # catch it and mark request_body_encoding as binary, mirroring the
+        # response-side behaviour (#10792).
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+            request_body=b"not gzip at all",
+            request_encoding="gzip",
+            response_body=b"ok",
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry  # body skipped
+        assert entry["request_body_encoding"] == "binary"  # marked as binary
+        assert "request_headers" in entry  # headers still captured
+        assert "response_body" in entry  # response unaffected
+
     def test_binary_request_body_marks_encoding(self, real_flow, headers):
         flow = real_flow(
             method="POST",


### PR DESCRIPTION
## Summary
- Four call sites touching `flow.request.content` now survive a bogus `Content-Encoding` on the request side
- `mitm_addon.py` `request_size` now uses wire bytes (`raw_content`), matching response-side semantics at the neighbouring line
- `body_utils.py` request-body capture mirrors the existing response-side guard — falls back to `request_body_encoding = "binary"`
- `usage/providers/connectors/x.py` falls back to the conservative bucket when the request body can't be decoded
- New regression test asserts the request-side decode-failure contract

## Why
A registered VM sending a POST with `Content-Encoding: gzip` and non-gzip body crashed `response()` / `error()` / `add_capture_fields()` / X billing handler through unguarded `flow.request.content` accesses. Observable symptom was a silent gap in the network log for the affected flow — hard to attribute in production, so the fix is low-drama but real.

The issue originally suggested wrapping every `.content` access in `try/except`. Two of the four sites (`mitm_addon.py:460` / `:583`) only need size — `raw_content` gives wire bytes, never raises, and removes the crash without a `try/except`. It also fixes a pre-existing semantic asymmetry where `request_size` was decompressed bytes while `response_size` was wire bytes. The two sites that genuinely need the decompressed body keep a `try/except` matching the response-side precedent.

Closes #10792

## Test plan
- [x] `tests/test_body_capture.py::test_request_decompression_error_marks_body_binary` — new, pins the request-side contract (body skipped, encoding marked binary, headers kept, response unaffected)
- [x] `tests/test_body_capture.py::test_response_decompression_error_skips_body` — existing, still passes (response-side unchanged)
- [x] `python -m pytest tests/` — 500 passed
- [x] `ruff check .` / `ruff format --check .`
- [x] `cargo check -p runner` — embedded addon still compiles into the runner binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)