### PR TITLE
feat: enable audio input by default

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -199,7 +199,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "lancy@vm0.ai",
     description:
       "Enable voice input (microphone + STT) in chat — gates the mic button and the /api/zero/voice-io/stt route",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.AudioOutput]: {
     maintainer: "lancy@vm0.ai",


### PR DESCRIPTION
## Summary
- Enable the `AudioInput` feature switch globally by setting it on in the core registry.
- This makes the chat microphone/STT path available by default while keeping existing quota checks and route logic unchanged.

## Tests
- `pnpm -F @vm0/core test src/__tests__/feature-switch.test.ts`
- `pnpm exec oxlint src/feature-switch.ts`
- `pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/feature-switch.ts`
- `pnpm exec eslint src/feature-switch.ts --max-warnings 0`
- `git diff --check`
- pre-commit: prettier + knip