### PR TITLE
fix: adjust chat run error messaging

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -29,6 +29,7 @@ import {
   setTestRunStatus,
 } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import { mockAblyPublish } from "../../../../../../src/__tests__/ably-mock";
+import { transitionRunStatus } from "../../../../../../src/lib/infra/run/run-status";
 
 vi.mock("web-push", async (importActual) => {
   const actual = await importActual<{ WebPushError: typeof WebPushError }>();
@@ -62,8 +63,9 @@ describe("POST /api/internal/callbacks/chat", () => {
   /** Create a thread via route handler, then a run, session, and callback in DB. */
   async function setupRunAndThread(
     options: {
-      status?: "completed" | "failed";
+      status?: "completed" | "failed" | "running";
       result?: Record<string, unknown>;
+      createdAt?: Date;
     } = {},
   ) {
     const { status = "completed" } = options;
@@ -86,6 +88,7 @@ describe("POST /api/internal/callbacks/chat", () => {
     const { runId } = await seedTestRun(user.userId, agentId, {
       status,
       result: options.result,
+      createdAt: options.createdAt,
     });
 
     // Create an agent session (used for session continuity via run result)
@@ -102,6 +105,47 @@ describe("POST /api/internal/callbacks/chat", () => {
     });
 
     return { threadId, runId, secret, sessionId: session.id };
+  }
+
+  async function setupRunInThread(options: {
+    threadId: string;
+    prompt: string;
+    createdAt: Date;
+  }) {
+    const { runId } = await seedTestRun(user.userId, agentId, {
+      status: "running",
+      prompt: options.prompt,
+      createdAt: options.createdAt,
+    });
+    await addTestRunToThread(
+      options.threadId,
+      runId,
+      user.userId,
+      options.prompt,
+    );
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/chat",
+      payload: { threadId: options.threadId, agentId },
+    });
+
+    return { runId, secret };
+  }
+
+  async function markRunFailedForCallback(
+    runId: string,
+    errorMessage: string,
+  ): Promise<void> {
+    await transitionRunStatus(
+      runId,
+      {
+        status: "failed",
+        completedAt: new Date(),
+        error: errorMessage,
+      },
+      ["pending", "running"],
+    );
   }
 
   /** Get thread detail and extract latestSessionId. */
@@ -413,9 +457,13 @@ describe("POST /api/internal/callbacks/chat", () => {
         return m.role === "assistant" && m.error !== null;
       });
       expect(errorMsg).toBeDefined();
-      expect(errorMsg!.content).toBe("Agent crashed");
+      expect(errorMsg!.content).toBe(
+        "Oops, something went wrong. Please try again later.",
+      );
       expect(errorMsg!.runId).toBe(runId);
-      expect(errorMsg!.error).toBe("Agent crashed");
+      expect(errorMsg!.error).toBe(
+        "Oops, something went wrong. Please try again later.",
+      );
 
       // The insert fans out chatThreadMessageCreated so the frontend's paged
       // message view refetches and the cancelled/error row appears without
@@ -424,6 +472,91 @@ describe("POST /api/internal/callbacks/chat", () => {
         `chatThreadMessageCreated:${threadId}`,
         null,
       );
+    });
+
+    it("should show a report link after consecutive generic run errors", async () => {
+      const first = await setupRunAndThread({
+        status: "running",
+        createdAt: new Date("2026-03-10T00:00:00Z"),
+      });
+      await markRunFailedForCallback(first.runId, "First runner failure");
+
+      const firstResponse = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId: first.runId,
+            status: "failed",
+            error: "First runner failure",
+            payload: { threadId: first.threadId, agentId },
+          },
+          first.secret,
+        ),
+      );
+      expect(firstResponse.status).toBe(200);
+
+      const second = await setupRunInThread({
+        threadId: first.threadId,
+        prompt: "try again",
+        createdAt: new Date("2026-03-10T00:01:00Z"),
+      });
+      await markRunFailedForCallback(second.runId, "Second runner failure");
+
+      const secondResponse = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId: second.runId,
+            status: "failed",
+            error: "Second runner failure",
+            payload: { threadId: first.threadId, agentId },
+          },
+          second.secret,
+        ),
+      );
+      expect(secondResponse.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(first.threadId);
+      const errorMessages = chatMessages.filter((message) => {
+        return message.role === "assistant" && message.error !== null;
+      });
+      expect(errorMessages).toHaveLength(2);
+      expect(errorMessages[0]!.error).toBe(
+        "Oops, something went wrong. Please try again later.",
+      );
+      expect(errorMessages[1]!.error).toBe(
+        `An unexpected error occurred. [Report this issue](/runs/${second.runId}/report-error)`,
+      );
+    });
+
+    it("should preserve actionable failed run errors", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread({
+        status: "failed",
+      });
+      const actionableError =
+        "No model provider configured. Run 'zero org model-provider setup' to configure one, or add environment variables to your vm0.yaml.";
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "failed",
+            error: actionableError,
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      const errorMsg = chatMessages.find((message) => {
+        return message.role === "assistant" && message.error !== null;
+      });
+      expect(errorMsg?.error).toBe(actionableError);
+      expect(errorMsg?.content).toBe(actionableError);
     });
 
     it("should not derive sessionId on failed run without agentSessionId", async () => {
@@ -980,7 +1113,9 @@ describe("POST /api/internal/callbacks/chat", () => {
         mockSendNotification.mock.calls[0]![1] as string,
       );
       expect(payload.title).toBe("test prompt");
-      expect(payload.body).toContain("Agent crashed");
+      expect(payload.body).toContain(
+        "Oops, something went wrong. Please try again later.",
+      );
       expect(payload.url).toBe(`/chats/${threadId}`);
     });
 

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -12,6 +12,7 @@ import {
   getLatestMessagesByThreadId,
   PREVIOUS_CONTEXT_MESSAGES,
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
+import { formatChatRunErrorMessage } from "../../../../../src/lib/zero/chat-thread/chat-run-error-message";
 import {
   generateChatTitle,
   generateChatNotificationSummary,
@@ -236,19 +237,25 @@ async function handleFailed(
   userId: string,
   errorMessage: string,
 ): Promise<void> {
+  const displayErrorMessage = await formatChatRunErrorMessage({
+    chatThreadId: threadId,
+    runId,
+    errorMessage,
+  });
+
   await insertChatMessage({
     chatThreadId: threadId,
     userId,
     role: "assistant",
-    content: errorMessage,
+    content: displayErrorMessage,
     runId,
-    error: errorMessage,
+    error: displayErrorMessage,
   });
 
   // Send push notification (best-effort)
   await sendUserPushNotifications(userId, {
     title: prompt.slice(0, 60),
-    body: `Task failed: ${errorMessage.slice(0, 80)}`,
+    body: `Task failed: ${displayErrorMessage.slice(0, 80)}`,
     url: `/chats/${threadId}`,
   });
 }

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
@@ -10,6 +10,7 @@ import {
   resolveAttachFileUrls,
   type MessageRow,
 } from "../../../../../../src/lib/zero/chat-thread";
+import { formatChatRunErrorMessage } from "../../../../../../src/lib/zero/chat-thread/chat-run-error-message";
 import { isNotFound } from "../../../../../../src/lib/shared/errors";
 
 const router = tsr.router(chatThreadMessagesContract, {
@@ -59,9 +60,17 @@ const router = tsr.router(chatThreadMessagesContract, {
           // event-backed rows and error rows use their own error field.
           const isLegacyPlaceholder =
             row.sequenceNumber === null && row.content === null && !row.error;
-          const effectiveError = isLegacyPlaceholder
+          const rawEffectiveError = isLegacyPlaceholder
             ? (row.runError ?? undefined)
             : (row.error ?? undefined);
+          const effectiveError =
+            rawEffectiveError && isLegacyPlaceholder && row.runId
+              ? await formatChatRunErrorMessage({
+                  chatThreadId: params.threadId,
+                  runId: row.runId,
+                  errorMessage: rawEffectiveError,
+                })
+              : rawEffectiveError;
           const attachFiles =
             row.attachFiles && row.attachFiles.length > 0
               ? await resolveAttachFileUrls(userId, row.attachFiles)

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
@@ -1,0 +1,86 @@
+import { RUN_ERROR_GUIDANCE } from "@vm0/core/contracts/errors";
+import { asc, eq } from "drizzle-orm";
+import { agentRuns } from "../../../db/schema/agent-run";
+import { zeroRuns } from "../../../db/schema/zero-run";
+
+const REPORT_ERROR_STREAK_THRESHOLD = 2;
+
+const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
+  "Oops, something went wrong. Please try again later.";
+const CHAT_RUN_REPORTABLE_ERROR_MESSAGE = "An unexpected error occurred.";
+
+const ACTIONABLE_ERROR_SNIPPETS = [
+  ...Object.values(RUN_ERROR_GUIDANCE).flatMap((guidance) => {
+    return [guidance.title, guidance.guidance];
+  }),
+  "Cannot continue session",
+  "Invalid signature in thinking block",
+] as const;
+
+function isActionableRunError(errorMessage: string): boolean {
+  const normalized = errorMessage.toLowerCase();
+  return ACTIONABLE_ERROR_SNIPPETS.some((snippet) => {
+    return normalized.includes(snippet.toLowerCase());
+  });
+}
+
+function buildReportableErrorMessage(runId: string): string {
+  return `${CHAT_RUN_REPORTABLE_ERROR_MESSAGE} [Report this issue](/runs/${encodeURIComponent(runId)}/report-error)`;
+}
+
+async function getGenericErrorStreakForRun(params: {
+  chatThreadId: string;
+  runId: string;
+  currentErrorMessage: string;
+}): Promise<number> {
+  const rows = await globalThis.services.db
+    .select({
+      runId: zeroRuns.id,
+      error: agentRuns.error,
+    })
+    .from(zeroRuns)
+    .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
+    .where(eq(zeroRuns.chatThreadId, params.chatThreadId))
+    .orderBy(asc(agentRuns.createdAt), asc(agentRuns.id));
+
+  let streak = 0;
+  for (const row of rows) {
+    const errorMessage =
+      row.runId === params.runId ? params.currentErrorMessage : row.error;
+    if (!errorMessage?.trim()) {
+      streak = 0;
+    } else if (isActionableRunError(errorMessage)) {
+      streak = 0;
+    } else {
+      streak += 1;
+    }
+
+    if (row.runId === params.runId) {
+      return streak;
+    }
+  }
+
+  return 1;
+}
+
+export async function formatChatRunErrorMessage(params: {
+  chatThreadId: string;
+  runId: string;
+  errorMessage: string;
+}): Promise<string> {
+  const errorMessage = params.errorMessage.trim() || "Run failed";
+
+  if (isActionableRunError(errorMessage)) {
+    return errorMessage;
+  }
+
+  const streak = await getGenericErrorStreakForRun({
+    chatThreadId: params.chatThreadId,
+    runId: params.runId,
+    currentErrorMessage: errorMessage,
+  });
+
+  return streak >= REPORT_ERROR_STREAK_THRESHOLD
+    ? buildReportableErrorMessage(params.runId)
+    : CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
+}

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -10,6 +10,7 @@ import {
   getLatestSessionIdForThread,
   publishThreadListChanged,
 } from "./chat-message-service";
+import { formatChatRunErrorMessage } from "./chat-run-error-message";
 import {
   type PersistedAttachment,
   type ResolvedAttachFile,
@@ -347,9 +348,17 @@ export async function getChatThreadMessages(
       // falls back to agent_runs.error, covering the case where the terminal
       // callback failed to deliver and chat_messages.error was never written.
       const isPlaceholder = row.sequenceNumber === null;
-      const effectiveError = isPlaceholder
+      const rawEffectiveError = isPlaceholder
         ? (row.error ?? row.runError ?? undefined)
         : (row.error ?? undefined);
+      const effectiveError =
+        rawEffectiveError && isPlaceholder && !row.error && row.runId
+          ? await formatChatRunErrorMessage({
+              chatThreadId: threadId,
+              runId: row.runId,
+              errorMessage: rawEffectiveError,
+            })
+          : rawEffectiveError;
 
       const attachFiles =
         row.attachFiles && row.attachFiles.length > 0


### PR DESCRIPTION
## Summary
- decide generic chat run error severity in the web server chat callback layer
- write the retry message for the first generic failed run and only write the report link after two consecutive generic failed runs in the same chat thread
- keep actionable errors such as model-provider guidance unmasked, and apply the same formatter to run-error fallback reads
- remove the frontend streak/counting logic so the UI renders the server-provided error message

## Verification
- pnpm -C turbo -F @vm0/core check-types
- pnpm -C turbo -F @vm0/app check-types
- pnpm -C turbo -F web check-types
- pnpm -C turbo -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-session-chat-page.test.tsx

## Local test note
- pnpm -C turbo -F web exec vitest run app/api/internal/callbacks/chat/__tests__/route.test.ts -t "failed run|consecutive generic|actionable" is blocked by the local test DB missing agent_sessions.artifacts; local db:migrate is still blocked by duplicate starter_grant rows in credit_expires_record.