### PR TITLE
fix: copy chat attachments with messages

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -30,6 +30,7 @@ export {
 export {
   zeroChatAttachments$,
   uploadZeroAttachment$,
+  restoreZeroAttachments$,
   removeZeroAttachment$,
   zeroDragOver$,
   setZeroDragOver$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -46,7 +46,10 @@ import { zeroClient$ } from "../api-client.ts";
 import { orgModelProviders$ } from "../external/org-model-providers.ts";
 import { agentById } from "../agent.ts";
 import { pinnedAgentIds$ } from "../zero-page/zero-pinned-agents.ts";
-import { writeToClipboard } from "../zero-page/clipboard.ts";
+import {
+  writeChatMessageToClipboard,
+  type ChatClipboardPayload,
+} from "../zero-page/clipboard.ts";
 import type { GroupedChatMessageGroup } from "./chat-message.ts";
 import { logger } from "../log.ts";
 
@@ -175,7 +178,10 @@ export interface ChatThreadSignals {
   timelineExpandedIds$: Computed<Set<string>>;
   toggleTimelineExpanded$: Command<void, [string]>;
   copiedMessageId$: Computed<string | null>;
-  copyMessage$: Command<Promise<void>, [string, string, AbortSignal]>;
+  copyMessage$: Command<
+    Promise<void>,
+    [string, ChatClipboardPayload, AbortSignal]
+  >;
   // ── Focus ─────────────────────────────────────────────────────────────────
   setInputRef$: Command<(() => void) | undefined, [HTMLElement | null]>;
   focusInput$: Command<void, []>;
@@ -426,10 +432,10 @@ function createThreadUIState() {
     async (
       { get, set },
       messageId: string,
-      content: string,
+      payload: ChatClipboardPayload,
       signal: AbortSignal,
     ) => {
-      const ok = await writeToClipboard(content);
+      const ok = await writeChatMessageToClipboard(payload);
       signal.throwIfAborted();
       if (!ok) {
         return;

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/clipboard.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/clipboard.test.ts
@@ -8,11 +8,7 @@
 
 import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { testContext } from "../../__tests__/test-helpers.ts";
-import {
-  copyToClipboard$,
-  copyStatus$,
-  writeChatMessageToClipboard,
-} from "../clipboard.ts";
+import { copyToClipboard$, copyStatus$ } from "../clipboard.ts";
 
 const context = testContext();
 
@@ -24,30 +20,6 @@ function setupClipboardMock() {
     configurable: true,
   });
   return writeTextMock;
-}
-
-interface TestClipboardItemInstance {
-  items: Record<string, Blob>;
-}
-
-class TestClipboardItem implements TestClipboardItemInstance {
-  readonly items: Record<string, Blob>;
-
-  constructor(items: Record<string, Blob>) {
-    this.items = items;
-  }
-}
-
-function setupRichClipboardMock() {
-  const writeMock = vi.fn<(items: ClipboardItem[]) => Promise<void>>();
-  const writeTextMock = vi.fn<(data: string) => Promise<void>>();
-  vi.stubGlobal("ClipboardItem", TestClipboardItem);
-  Object.defineProperty(navigator, "clipboard", {
-    value: { write: writeMock, writeText: writeTextMock },
-    writable: true,
-    configurable: true,
-  });
-  return { writeMock, writeTextMock };
 }
 
 describe("copyToClipboard$", () => {
@@ -95,45 +67,5 @@ describe("copyToClipboard$", () => {
     await context.store.set(copyToClipboard$, "some text", context.signal);
 
     expect(context.store.get(copyStatus$)).toBe("idle");
-  });
-});
-
-describe("writeChatMessageToClipboard", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.restoreAllMocks();
-  });
-
-  it("writes image attachments as the same text and html payload as other files", async () => {
-    const { writeMock } = setupRichClipboardMock();
-
-    const ok = await writeChatMessageToClipboard({
-      text: "Look at this",
-      attachments: [
-        {
-          id: "file-1",
-          filename: "photo.png",
-          contentType: "image/png",
-          size: 3,
-          url: "http://localhost:3000/f/user-1/file-1/photo.png",
-        },
-      ],
-    });
-
-    expect(ok).toBeTruthy();
-    const item = writeMock.mock.calls[0]?.[0][0] as unknown as
-      | TestClipboardItemInstance
-      | undefined;
-    expect(item).toBeDefined();
-    expect(item?.items["image/png"]).toBeUndefined();
-    const html = await item!.items["text/html"]!.text();
-    expect(html).toContain("data-vm0-chat-message");
-    expect(html).toContain("<img");
-    expect(html).toContain("Look at this");
-    expect(html).toContain("photo.png");
-    const text = await item!.items["text/plain"]!.text();
-    expect(text).toContain("Look at this");
-    expect(text).toContain("Attachments:");
-    expect(text).toContain("photo.png");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/clipboard.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/clipboard.test.ts
@@ -50,11 +50,6 @@ function setupRichClipboardMock() {
   return { writeMock, writeTextMock };
 }
 
-type FetchFn = (
-  input: RequestInfo | URL,
-  init?: RequestInit,
-) => Promise<Response>;
-
 describe("copyToClipboard$", () => {
   let writeTextMock: ReturnType<typeof setupClipboardMock>;
 
@@ -109,14 +104,8 @@ describe("writeChatMessageToClipboard", () => {
     vi.restoreAllMocks();
   });
 
-  it("writes html metadata and the first png image for external paste targets", async () => {
+  it("writes image attachments as the same text and html payload as other files", async () => {
     const { writeMock } = setupRichClipboardMock();
-    const fetchMock = vi
-      .fn<FetchFn>()
-      .mockResolvedValue(
-        new Response(new Blob(["png"], { type: "image/png" }), { status: 200 }),
-      );
-    vi.stubGlobal("fetch", fetchMock);
 
     const ok = await writeChatMessageToClipboard({
       text: "Look at this",
@@ -132,21 +121,18 @@ describe("writeChatMessageToClipboard", () => {
     });
 
     expect(ok).toBeTruthy();
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:3000/f/user-1/file-1/photo.png?raw=1",
-      { mode: "cors" },
-    );
-
     const item = writeMock.mock.calls[0]?.[0][0] as unknown as
       | TestClipboardItemInstance
       | undefined;
     expect(item).toBeDefined();
-    expect(item?.items["image/png"]).toBeInstanceOf(Blob);
+    expect(item?.items["image/png"]).toBeUndefined();
     const html = await item!.items["text/html"]!.text();
     expect(html).toContain("data-vm0-chat-message");
     expect(html).toContain("<img");
+    expect(html).toContain("Look at this");
     expect(html).toContain("photo.png");
     const text = await item!.items["text/plain"]!.text();
+    expect(text).toContain("Look at this");
     expect(text).toContain("Attachments:");
     expect(text).toContain("photo.png");
   });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/clipboard.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/clipboard.test.ts
@@ -6,9 +6,13 @@
  * Real (internal): signals, state management
  */
 
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { testContext } from "../../__tests__/test-helpers.ts";
-import { copyToClipboard$, copyStatus$ } from "../clipboard.ts";
+import {
+  copyToClipboard$,
+  copyStatus$,
+  writeChatMessageToClipboard,
+} from "../clipboard.ts";
 
 const context = testContext();
 
@@ -22,11 +26,45 @@ function setupClipboardMock() {
   return writeTextMock;
 }
 
+interface TestClipboardItemInstance {
+  items: Record<string, Blob>;
+}
+
+class TestClipboardItem implements TestClipboardItemInstance {
+  readonly items: Record<string, Blob>;
+
+  constructor(items: Record<string, Blob>) {
+    this.items = items;
+  }
+}
+
+function setupRichClipboardMock() {
+  const writeMock = vi.fn<(items: ClipboardItem[]) => Promise<void>>();
+  const writeTextMock = vi.fn<(data: string) => Promise<void>>();
+  vi.stubGlobal("ClipboardItem", TestClipboardItem);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { write: writeMock, writeText: writeTextMock },
+    writable: true,
+    configurable: true,
+  });
+  return { writeMock, writeTextMock };
+}
+
+type FetchFn = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
 describe("copyToClipboard$", () => {
   let writeTextMock: ReturnType<typeof setupClipboardMock>;
 
   beforeEach(() => {
     writeTextMock = setupClipboardMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("copies text and sets status to copied", async () => {
@@ -62,5 +100,54 @@ describe("copyToClipboard$", () => {
     await context.store.set(copyToClipboard$, "some text", context.signal);
 
     expect(context.store.get(copyStatus$)).toBe("idle");
+  });
+});
+
+describe("writeChatMessageToClipboard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("writes html metadata and the first png image for external paste targets", async () => {
+    const { writeMock } = setupRichClipboardMock();
+    const fetchMock = vi
+      .fn<FetchFn>()
+      .mockResolvedValue(
+        new Response(new Blob(["png"], { type: "image/png" }), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ok = await writeChatMessageToClipboard({
+      text: "Look at this",
+      attachments: [
+        {
+          id: "file-1",
+          filename: "photo.png",
+          contentType: "image/png",
+          size: 3,
+          url: "http://localhost:3000/f/user-1/file-1/photo.png",
+        },
+      ],
+    });
+
+    expect(ok).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3000/f/user-1/file-1/photo.png?raw=1",
+      { mode: "cors" },
+    );
+
+    const item = writeMock.mock.calls[0]?.[0][0] as unknown as
+      | TestClipboardItemInstance
+      | undefined;
+    expect(item).toBeDefined();
+    expect(item?.items["image/png"]).toBeInstanceOf(Blob);
+    const html = await item!.items["text/html"]!.text();
+    expect(html).toContain("data-vm0-chat-message");
+    expect(html).toContain("<img");
+    expect(html).toContain("photo.png");
+    const text = await item!.items["text/plain"]!.text();
+    expect(text).toContain("Attachments:");
+    expect(text).toContain("photo.png");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -109,6 +109,7 @@ export interface DraftSignals {
   setInput$: Command<void, [string]>;
   attachments$: Computed<ZeroChatAttachment[]>;
   uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
+  restoreAttachments$: Command<void, [PersistedAttachment[]]>;
   removeAttachment$: Command<void, [ZeroChatAttachment]>;
   dragOver$: Computed<boolean>;
   setDragOver$: Command<void, [boolean]>;
@@ -198,6 +199,18 @@ export function createDraftSignals(): DraftSignals {
     },
   );
 
+  const restoreAttachments$ = command(
+    ({ set }, persisted: PersistedAttachment[]) => {
+      if (persisted.length === 0) {
+        return;
+      }
+      const restored = persisted.map(createRestoredAttachment);
+      set(internalAttachments$, (prev) => {
+        return [...prev, ...restored];
+      });
+    },
+  );
+
   const removeAttachment$ = command(
     ({ set }, attachment: ZeroChatAttachment) => {
       set(attachment.cancel$);
@@ -238,6 +251,7 @@ export function createDraftSignals(): DraftSignals {
     setInput$,
     attachments$,
     uploadAttachment$,
+    restoreAttachments$,
     removeAttachment$,
     dragOver$,
     setDragOver$,
@@ -286,6 +300,15 @@ export const uploadZeroAttachment$ = command(
     const draft = get(currentDraft$);
     if (draft) {
       await set(draft.uploadAttachment$, file, signal);
+    }
+  },
+);
+
+export const restoreZeroAttachments$ = command(
+  ({ get, set }, attachments: PersistedAttachment[]) => {
+    const draft = get(currentDraft$);
+    if (draft) {
+      set(draft.restoreAttachments$, attachments);
     }
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/clipboard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/clipboard.ts
@@ -1,5 +1,165 @@
 import { command, computed, state } from "ccstate";
-import { throwIfAbort } from "../utils.ts";
+import { jsonParseOr, throwIfAbort } from "../utils.ts";
+
+const CHAT_MESSAGE_CLIPBOARD_ATTR = "data-vm0-chat-message";
+
+export interface ChatClipboardAttachment {
+  id: string | null;
+  url: string;
+  filename: string;
+  contentType: string;
+  size: number;
+}
+
+export interface ChatClipboardPayload {
+  text: string;
+  attachments: ChatClipboardAttachment[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isChatClipboardAttachment(
+  value: unknown,
+): value is ChatClipboardAttachment {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const id = value.id;
+  return (
+    (typeof id === "string" || id === null) &&
+    typeof value.url === "string" &&
+    typeof value.filename === "string" &&
+    typeof value.contentType === "string" &&
+    typeof value.size === "number"
+  );
+}
+
+function parseChatClipboardPayload(
+  serialized: string,
+): ChatClipboardPayload | null {
+  const parsed = jsonParseOr<unknown>(serialized, null);
+  if (!isRecord(parsed) || typeof parsed.text !== "string") {
+    return null;
+  }
+  if (!Array.isArray(parsed.attachments)) {
+    return null;
+  }
+  if (!parsed.attachments.every(isChatClipboardAttachment)) {
+    return null;
+  }
+  return {
+    text: parsed.text,
+    attachments: parsed.attachments,
+  };
+}
+
+function decodeClipboardPayload(value: string): string | null {
+  // eslint-disable-next-line no-restricted-syntax -- clipboard HTML is untrusted, so malformed URI payloads must be ignored
+  try {
+    return decodeURIComponent(value);
+  } catch (error: unknown) {
+    throwIfAbort(error);
+    return null;
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function formatPlainText(payload: ChatClipboardPayload): string {
+  if (payload.attachments.length === 0) {
+    return payload.text;
+  }
+  const attachments = payload.attachments
+    .map((attachment) => {
+      return `- ${attachment.filename}: ${attachment.url}`;
+    })
+    .join("\n");
+  return [payload.text.trim(), `Attachments:\n${attachments}`]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function formatMessageHtml(payload: ChatClipboardPayload): string {
+  const encoded = escapeHtml(encodeURIComponent(JSON.stringify(payload)));
+  const textHtml = payload.text
+    ? `<div>${escapeHtml(payload.text).replace(/\n/g, "<br>")}</div>`
+    : "";
+  const attachmentsHtml = payload.attachments
+    .map((attachment) => {
+      const name = escapeHtml(attachment.filename);
+      const url = escapeHtml(attachment.url);
+      if (isImageAttachment(attachment)) {
+        return `<div><img src="${url}" alt="${name}" data-vm0-attachment-id="${escapeHtml(attachment.id ?? "")}" /></div>`;
+      }
+      return `<div><a href="${url}" data-vm0-attachment-id="${escapeHtml(attachment.id ?? "")}">${name}</a></div>`;
+    })
+    .join("");
+  return `<div ${CHAT_MESSAGE_CLIPBOARD_ATTR}="${encoded}">${textHtml}${attachmentsHtml}</div>`;
+}
+
+function toRawFileUrl(url: string): string {
+  if (!URL.canParse(url, window.location.origin)) {
+    return url;
+  }
+  const parsed = new URL(url, window.location.origin);
+  if (/^\/f\/[^/]+\/[^/]+\/[^/]+$/.test(parsed.pathname)) {
+    parsed.searchParams.set("raw", "1");
+  }
+  return parsed.toString();
+}
+
+function isImageAttachment(attachment: ChatClipboardAttachment): boolean {
+  return (
+    attachment.contentType.startsWith("image/") ||
+    /\.(png|jpe?g|gif|webp|svg)$/i.test(attachment.filename)
+  );
+}
+
+function clipboardImageMimeType(type: string): string | null {
+  return ["image/png", "image/jpeg", "image/gif", "image/webp"].includes(type)
+    ? type
+    : null;
+}
+
+async function fetchClipboardImage(
+  attachments: ChatClipboardAttachment[],
+): Promise<{ type: string; blob: Blob } | null> {
+  const image = attachments.find(isImageAttachment);
+  if (!image) {
+    return null;
+  }
+  // eslint-disable-next-line no-restricted-syntax -- clipboard image support is best-effort and must fall back when an image URL cannot be fetched
+  try {
+    const response = await fetch(toRawFileUrl(image.url), { mode: "cors" });
+    if (!response.ok) {
+      return null;
+    }
+    const blob = await response.blob();
+    const type = clipboardImageMimeType(blob.type || image.contentType);
+    if (!type) {
+      return null;
+    }
+    return {
+      type,
+      blob: blob.type === type ? blob : blob.slice(0, blob.size, type),
+    };
+  } catch (error: unknown) {
+    throwIfAbort(error);
+    return null;
+  }
+}
+
+async function writeClipboardItem(items: Record<string, Blob>): Promise<void> {
+  await navigator.clipboard.write([new ClipboardItem(items)]);
+}
 
 /**
  * Write text to the clipboard with a legacy fallback.
@@ -36,6 +196,65 @@ export async function writeToClipboard(text: string): Promise<boolean> {
       return false;
     }
   }
+}
+
+export async function writeChatMessageToClipboard(
+  payload: ChatClipboardPayload,
+): Promise<boolean> {
+  const plainText = formatPlainText(payload);
+  if (
+    payload.attachments.length === 0 ||
+    typeof ClipboardItem === "undefined" ||
+    !navigator.clipboard?.write
+  ) {
+    return await writeToClipboard(plainText);
+  }
+
+  const html = formatMessageHtml(payload);
+  const baseItems: Record<string, Blob> = {
+    "text/plain": new Blob([plainText], { type: "text/plain" }),
+    "text/html": new Blob([html], { type: "text/html" }),
+  };
+  const image = await fetchClipboardImage(payload.attachments);
+
+  if (image) {
+    // eslint-disable-next-line no-restricted-syntax -- rich clipboard writes need an image fallback for browsers that reject mixed representations
+    try {
+      await writeClipboardItem({
+        ...baseItems,
+        [image.type]: image.blob,
+      });
+      return true;
+    } catch (error: unknown) {
+      throwIfAbort(error);
+    }
+  }
+
+  // eslint-disable-next-line no-restricted-syntax -- rich clipboard writes fall back to text when the browser blocks ClipboardItem
+  try {
+    await writeClipboardItem(baseItems);
+    return true;
+  } catch (error: unknown) {
+    throwIfAbort(error);
+    return await writeToClipboard(plainText);
+  }
+}
+
+export function readChatMessageFromClipboard(
+  clipboardData: DataTransfer,
+): ChatClipboardPayload | null {
+  const html = clipboardData.getData("text/html");
+  if (!html) {
+    return null;
+  }
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const node = doc.querySelector(`[${CHAT_MESSAGE_CLIPBOARD_ATTR}]`);
+  const encoded = node?.getAttribute(CHAT_MESSAGE_CLIPBOARD_ATTR);
+  if (!encoded) {
+    return null;
+  }
+  const serialized = decodeClipboardPayload(encoded);
+  return serialized ? parseChatClipboardPayload(serialized) : null;
 }
 
 const internalCopyStatus$ = state<"idle" | "copied">("idle");

--- a/turbo/apps/platform/src/signals/zero-page/clipboard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/clipboard.ts
@@ -105,56 +105,11 @@ function formatMessageHtml(payload: ChatClipboardPayload): string {
   return `<div ${CHAT_MESSAGE_CLIPBOARD_ATTR}="${encoded}">${textHtml}${attachmentsHtml}</div>`;
 }
 
-function toRawFileUrl(url: string): string {
-  if (!URL.canParse(url, window.location.origin)) {
-    return url;
-  }
-  const parsed = new URL(url, window.location.origin);
-  if (/^\/f\/[^/]+\/[^/]+\/[^/]+$/.test(parsed.pathname)) {
-    parsed.searchParams.set("raw", "1");
-  }
-  return parsed.toString();
-}
-
 function isImageAttachment(attachment: ChatClipboardAttachment): boolean {
   return (
     attachment.contentType.startsWith("image/") ||
     /\.(png|jpe?g|gif|webp|svg)$/i.test(attachment.filename)
   );
-}
-
-function clipboardImageMimeType(type: string): string | null {
-  return ["image/png", "image/jpeg", "image/gif", "image/webp"].includes(type)
-    ? type
-    : null;
-}
-
-async function fetchClipboardImage(
-  attachments: ChatClipboardAttachment[],
-): Promise<{ type: string; blob: Blob } | null> {
-  const image = attachments.find(isImageAttachment);
-  if (!image) {
-    return null;
-  }
-  // eslint-disable-next-line no-restricted-syntax -- clipboard image support is best-effort and must fall back when an image URL cannot be fetched
-  try {
-    const response = await fetch(toRawFileUrl(image.url), { mode: "cors" });
-    if (!response.ok) {
-      return null;
-    }
-    const blob = await response.blob();
-    const type = clipboardImageMimeType(blob.type || image.contentType);
-    if (!type) {
-      return null;
-    }
-    return {
-      type,
-      blob: blob.type === type ? blob : blob.slice(0, blob.size, type),
-    };
-  } catch (error: unknown) {
-    throwIfAbort(error);
-    return null;
-  }
 }
 
 async function writeClipboardItem(items: Record<string, Blob>): Promise<void> {
@@ -215,20 +170,6 @@ export async function writeChatMessageToClipboard(
     "text/plain": new Blob([plainText], { type: "text/plain" }),
     "text/html": new Blob([html], { type: "text/html" }),
   };
-  const image = await fetchClipboardImage(payload.attachments);
-
-  if (image) {
-    // eslint-disable-next-line no-restricted-syntax -- rich clipboard writes need an image fallback for browsers that reject mixed representations
-    try {
-      await writeClipboardItem({
-        ...baseItems,
-        [image.type]: image.blob,
-      });
-      return true;
-    } catch (error: unknown) {
-      throwIfAbort(error);
-    }
-  }
 
   // eslint-disable-next-line no-restricted-syntax -- rich clipboard writes fall back to text when the browser blocks ClipboardItem
   try {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
@@ -214,6 +214,49 @@ describe("zero chat composer - file input", () => {
       expect(screen.getByLabelText("Remove spec.pdf")).toBeInTheDocument();
     });
   });
+
+  it("preserves clipboard text when pasting files from a mixed external clipboard", async () => {
+    mockChatLifecycle();
+    server.use(
+      ...mockUploadSuccess({
+        id: "upload-1",
+        filename: "photo.png",
+        contentType: "image/png",
+        size: 3,
+        url: "https://example.com/photo.png",
+      }),
+    );
+
+    detachedSetupPage({ context, path: CHAT_PATH });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    const file = new File(["png"], "photo.png", { type: "image/png" });
+
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        getData: (type: string) => {
+          return type === "text/plain" ? "Please use this image" : "";
+        },
+        items: [
+          {
+            kind: "file",
+            getAsFile: () => {
+              return file;
+            },
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(textarea.value).toBe("Please use this image");
+      expect(
+        screen.getByLabelText("Open image preview for photo.png"),
+      ).toBeInTheDocument();
+    });
+  });
 });
 
 describe("zero chat composer - connectors popover", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { zeroConnectorsMainContract } from "@vm0/core/contracts/zero-connectors";
 import { zeroUserConnectorsContract } from "@vm0/core/contracts/user-connectors";
@@ -24,6 +24,32 @@ const mockApi = createMockApi(context);
 
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const CHAT_PATH = `/agents/${AGENT_ID}/chat`;
+
+interface TestClipboardItemInstance {
+  items: Record<string, Blob>;
+}
+
+class TestClipboardItem implements TestClipboardItemInstance {
+  readonly items: Record<string, Blob>;
+
+  constructor(items: Record<string, Blob>) {
+    this.items = items;
+  }
+}
+
+function setupRichClipboardCapture() {
+  const writeMock = vi.fn<(items: ClipboardItem[]) => Promise<void>>();
+  vi.stubGlobal("ClipboardItem", TestClipboardItem);
+  Object.defineProperty(navigator, "clipboard", {
+    value: {
+      write: writeMock,
+      writeText: vi.fn<(data: string) => Promise<void>>(),
+    },
+    writable: true,
+    configurable: true,
+  });
+  return writeMock;
+}
 
 function mockConnectors() {
   setMockConnectors([
@@ -127,6 +153,65 @@ describe("zero chat composer - file input", () => {
       expect(
         screen.getByLabelText("Open image preview for test.png"),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("restores copied chat message attachments when pasted into the composer", async () => {
+    const writeMock = setupRichClipboardCapture();
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "Review this",
+          createdAt: "2026-03-10T00:00:00Z",
+          attachFiles: [
+            {
+              id: "file-1",
+              filename: "spec.pdf",
+              contentType: "application/pdf",
+              size: 1234,
+              url: "http://localhost:3000/f/user-1/file-1/spec.pdf",
+            },
+          ],
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const copyButton = await waitFor(() => {
+      return screen.getByLabelText("Copy message");
+    });
+    click(copyButton);
+
+    await waitFor(() => {
+      expect(writeMock).toHaveBeenCalledWith([expect.any(TestClipboardItem)]);
+    });
+    const item = writeMock.mock.calls[0]?.[0][0] as unknown as
+      | TestClipboardItemInstance
+      | undefined;
+    const html = await item!.items["text/html"]!.text();
+    const text = await item!.items["text/plain"]!.text();
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        getData: (type: string) => {
+          return type === "text/html"
+            ? html
+            : type === "text/plain"
+              ? text
+              : "";
+        },
+        items: [],
+      },
+    });
+
+    await waitFor(() => {
+      expect(textarea.value).toBe("Review this");
+      expect(screen.getByLabelText("Remove spec.pdf")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -775,30 +775,32 @@ export function ZeroChatComposer({
     }
     const plainText = e.clipboardData.getData("text/plain");
     let pastedPlainText = false;
-    for (const item of items) {
-      if (item.kind === "file") {
-        const file = item.getAsFile();
-        if (file) {
-          if (file.size > MAX_FILE_SIZE) {
-            toast.error(`${file.name} exceeds the 1 GB limit`);
-            continue;
-          }
-          e.preventDefault();
-          if (!pastedPlainText && plainText) {
-            const nextInput = insertPastedText(
-              e.currentTarget,
-              input,
-              plainText,
-            );
-            if (nextInput !== input) {
-              onInputChange(nextInput);
-            }
-            pastedPlainText = true;
-          }
-          detach(uploadAttachment(file, rootSignal), Reason.DomCallback);
-          onDraftChange?.();
-        }
+    const applyPlainText = () => {
+      if (pastedPlainText || !plainText) {
+        return;
       }
+      const nextInput = insertPastedText(e.currentTarget, input, plainText);
+      if (nextInput !== input) {
+        onInputChange(nextInput);
+      }
+      pastedPlainText = true;
+    };
+    for (const item of items) {
+      if (item.kind !== "file") {
+        continue;
+      }
+      const file = item.getAsFile();
+      if (!file) {
+        continue;
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        toast.error(`${file.name} exceeds the 1 GB limit`);
+        continue;
+      }
+      e.preventDefault();
+      applyPlainText();
+      detach(uploadAttachment(file, rootSignal), Reason.DomCallback);
+      onDraftChange?.();
     }
   };
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -48,6 +48,7 @@ import type { Command, Computed } from "ccstate";
 import {
   zeroChatAttachments$ as singletonAttachments$,
   uploadZeroAttachment$ as singletonUpload$,
+  restoreZeroAttachments$ as singletonRestore$,
   removeZeroAttachment$ as singletonRemove$,
   canSendZeroChat$ as singletonCanSend$,
   zeroDragOver$ as singletonDragOver$,
@@ -55,6 +56,7 @@ import {
   composerFileInput$ as singletonComposerFileInput$,
   setComposerFileInput$ as singletonSetComposerFileInput$,
 } from "../../signals/chat-page/chat-message.ts";
+import type { PersistedAttachment } from "@vm0/core/contracts/chat-threads";
 import { AttachmentChips } from "./zero-attachment-chips.tsx";
 import {
   CONNECTOR_TYPES,
@@ -117,6 +119,7 @@ import {
   setBillingSubPage$,
 } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
+import { readChatMessageFromClipboard } from "../../signals/zero-page/clipboard.ts";
 
 const MAX_FILE_SIZE = 1024 * 1024 * 1024; // 1 GB — keep in sync with web constants
 
@@ -629,6 +632,9 @@ function useResolvedComposerSignals(
   const uploadAttachment = useSet(
     draft ? draft.uploadAttachment$ : singletonUpload$,
   );
+  const restoreAttachments = useSet(
+    draft ? draft.restoreAttachments$ : singletonRestore$,
+  );
   const removeAttachment = useSet(
     draft ? draft.removeAttachment$ : singletonRemove$,
   );
@@ -647,12 +653,50 @@ function useResolvedComposerSignals(
     canSend,
     attachments,
     uploadAttachment,
+    restoreAttachments,
     removeAttachment,
     fileInputEl,
     setFileInputEl,
     dragOver,
     setDragOver,
   };
+}
+
+function insertPastedText(
+  textarea: HTMLTextAreaElement,
+  currentValue: string,
+  pastedText: string,
+): string {
+  if (!pastedText) {
+    return currentValue;
+  }
+  const start = textarea.selectionStart;
+  const end = textarea.selectionEnd;
+  return `${currentValue.slice(0, start)}${pastedText}${currentValue.slice(end)}`;
+}
+
+function toPersistedAttachments(
+  attachments: readonly {
+    id: string | null;
+    url: string;
+    filename: string;
+    contentType: string;
+    size: number;
+  }[],
+): PersistedAttachment[] {
+  return attachments
+    .filter((attachment): attachment is PersistedAttachment => {
+      return attachment.id !== null;
+    })
+    .map((attachment) => {
+      return {
+        id: attachment.id,
+        url: attachment.url,
+        filename: attachment.filename,
+        contentType: attachment.contentType,
+        size: attachment.size,
+      };
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -691,6 +735,7 @@ export function ZeroChatComposer({
     canSend,
     attachments,
     uploadAttachment,
+    restoreAttachments,
     removeAttachment,
     fileInputEl,
     setFileInputEl,
@@ -703,6 +748,27 @@ export function ZeroChatComposer({
 
   // File upload handlers (paste / drag-drop)
   const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+    const chatPayload = readChatMessageFromClipboard(e.clipboardData);
+    if (chatPayload && chatPayload.attachments.length > 0) {
+      const persistedAttachments = toPersistedAttachments(
+        chatPayload.attachments,
+      );
+      if (persistedAttachments.length > 0) {
+        e.preventDefault();
+        const nextInput = insertPastedText(
+          e.currentTarget,
+          input,
+          chatPayload.text,
+        );
+        if (nextInput !== input) {
+          onInputChange(nextInput);
+        }
+        restoreAttachments(persistedAttachments);
+        onDraftChange?.();
+        return;
+      }
+    }
+
     const items = e.clipboardData?.items;
     if (!items) {
       return;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -773,6 +773,8 @@ export function ZeroChatComposer({
     if (!items) {
       return;
     }
+    const plainText = e.clipboardData.getData("text/plain");
+    let pastedPlainText = false;
     for (const item of items) {
       if (item.kind === "file") {
         const file = item.getAsFile();
@@ -782,6 +784,17 @@ export function ZeroChatComposer({
             continue;
           }
           e.preventDefault();
+          if (!pastedPlainText && plainText) {
+            const nextInput = insertPastedText(
+              e.currentTarget,
+              input,
+              plainText,
+            );
+            if (nextInput !== input) {
+              onInputChange(nextInput);
+            }
+            pastedPlainText = true;
+          }
           detach(uploadAttachment(file, rootSignal), Reason.DomCallback);
           onDraftChange?.();
         }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -74,6 +74,7 @@ import {
   type ChatThreadSignals,
 } from "../../signals/chat-page/create-chat-thread.ts";
 import { ATTACH_ONLY_PLACEHOLDER } from "../../signals/chat-page/resolve-draft-attachments.ts";
+import type { ChatClipboardAttachment } from "../../signals/zero-page/clipboard.ts";
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
 import { orgModelProviders$ } from "../../signals/external/org-model-providers.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
@@ -1016,6 +1017,97 @@ function resolveAttachments(
   });
 }
 
+function attachmentIdFromUrl(url: string): string | null {
+  if (!URL.canParse(url, window.location.origin)) {
+    return null;
+  }
+  const parsed = new URL(url, window.location.origin);
+  const match = parsed.pathname.match(/^\/f\/[^/]+\/([^/]+)\/[^/]+$/);
+  return match?.[1] ?? null;
+}
+
+function inferAttachmentContentType(filename: string, kind: string): string {
+  const lower = filename.toLowerCase();
+  if (lower.endsWith(".png")) {
+    return "image/png";
+  }
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) {
+    return "image/jpeg";
+  }
+  if (lower.endsWith(".gif")) {
+    return "image/gif";
+  }
+  if (lower.endsWith(".webp")) {
+    return "image/webp";
+  }
+  if (lower.endsWith(".svg")) {
+    return "image/svg+xml";
+  }
+  if (lower.endsWith(".mp4")) {
+    return "video/mp4";
+  }
+  if (lower.endsWith(".webm")) {
+    return "video/webm";
+  }
+  if (lower.endsWith(".mov")) {
+    return "video/quicktime";
+  }
+  switch (kind) {
+    case "markdown": {
+      return "text/markdown";
+    }
+    case "text": {
+      return "text/plain";
+    }
+    case "json": {
+      return "application/json";
+    }
+    case "csv": {
+      return "text/csv";
+    }
+    case "pdf": {
+      return "application/pdf";
+    }
+    case "html": {
+      return "text/html";
+    }
+    default: {
+      return "application/octet-stream";
+    }
+  }
+}
+
+function clipboardAttachmentsFromMessage(
+  message: PagedChatMessage,
+  parsed: { filename: string; url: string }[],
+): ChatClipboardAttachment[] {
+  const source =
+    message.attachFiles && message.attachFiles.length > 0
+      ? message.attachFiles
+      : parsed;
+  return source.map((f) => {
+    const contentType =
+      "contentType" in f && typeof f.contentType === "string"
+        ? f.contentType
+        : undefined;
+    const kind = classifyChatAttachment({
+      filename: f.filename,
+      url: f.url,
+      contentType,
+    });
+    return {
+      id:
+        "id" in f && typeof f.id === "string"
+          ? f.id
+          : attachmentIdFromUrl(f.url),
+      filename: f.filename,
+      url: f.url,
+      contentType: contentType ?? inferAttachmentContentType(f.filename, kind),
+      size: "size" in f && typeof f.size === "number" ? f.size : 0,
+    };
+  });
+}
+
 function UserMessageAttachments({
   attachments,
   onImageClick,
@@ -1111,8 +1203,7 @@ function PagedUserMessage({
     cleanContent.trim() === ATTACH_ONLY_PLACEHOLDER
       ? ""
       : cleanContent;
-  const { cleanContent: cleanBodyContent, blocks: bodyBlocks } =
-    parseBodyRenderBlocks(strippedContent);
+  const { blocks: bodyBlocks } = parseBodyRenderBlocks(strippedContent);
   const pageSignal = useGet(pageSignal$);
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
   const openLightbox = (url: string) => {
@@ -1121,18 +1212,24 @@ function PagedUserMessage({
   const copiedId = useGet(thread.copiedMessageId$);
   const copied = copiedId === message.id;
   const copyMessage = useSet(thread.copyMessage$);
+  const allAttachments = resolveAttachments(message, parsed);
+  const clipboardAttachments = clipboardAttachmentsFromMessage(message, parsed);
+  const copyText = strippedContent;
+  const canCopy = copyText.trim().length > 0 || clipboardAttachments.length > 0;
 
   const handleCopy = () => {
-    if (!cleanContent) {
+    if (!canCopy) {
       return;
     }
     detach(
-      copyMessage(message.id, cleanContent, pageSignal),
+      copyMessage(
+        message.id,
+        { text: copyText, attachments: clipboardAttachments },
+        pageSignal,
+      ),
       Reason.DomCallback,
     );
   };
-
-  const allAttachments = resolveAttachments(message, parsed);
 
   return (
     <div data-role="user" className="group">
@@ -1154,7 +1251,7 @@ function PagedUserMessage({
               onImageClick={openLightbox}
             />
           </div>
-          {cleanBodyContent && (
+          {canCopy && (
             <div className="flex justify-end mt-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
               <button
                 type="button"
@@ -1277,7 +1374,11 @@ function PagedGroupActions({
       return;
     }
     detach(
-      copyMessage(group.beginMessageId, content, pageSignal),
+      copyMessage(
+        group.beginMessageId,
+        { text: content, attachments: [] },
+        pageSignal,
+      ),
       Reason.DomCallback,
     );
   };


### PR DESCRIPTION
## Summary
- copy user-message attachments into a structured chat clipboard payload
- include rich HTML and best-effort image blobs for external paste targets
- restore copied chat attachments into the composer as attachment chips when pasted back into chat

## Verification
- pnpm exec vitest run src/signals/zero-page/__tests__/clipboard.test.ts src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
- pnpm --filter @vm0/app lint
- pnpm --filter @vm0/app check-types (fails on existing ts-rest/client type errors across main, e.g. Property body/status does not exist on type never)