### PR TITLE
feat(telemetry): add enqueue/dequeue spans to zero-run queue

### DIFF
--- a/turbo/apps/web/src/lib/infra/metrics/instruments.ts
+++ b/turbo/apps/web/src/lib/infra/metrics/instruments.ts
@@ -6,6 +6,7 @@ export function recordSandboxOperation(attrs: {
   durationMs: number;
   success: boolean;
   runId: string;
+  dimensions?: Record<string, unknown>;
 }): void {
   ingestSandboxOpLog({
     source: "web",
@@ -13,6 +14,7 @@ export function recordSandboxOperation(attrs: {
     sandbox_type: attrs.sandboxType,
     duration_ms: attrs.durationMs,
     run_id: attrs.runId,
+    ...attrs.dimensions,
   });
 }
 

--- a/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
@@ -259,5 +259,7 @@ function buildPreparedContext(
     captureNetworkBodies: context.captureNetworkBodies || false,
 
     billableFirewalls: context.billableFirewalls,
+
+    wasQueued: context.wasQueued ?? false,
   };
 }

--- a/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
@@ -32,13 +32,18 @@ const log = logger("executor:runner");
 export async function executeRunnerJob(
   context: PreparedContext,
 ): Promise<ExecutorResult> {
-  // Record api_to_dispatch metric
+  // Record api_to_dispatch metric. was_queued distinguishes runs that came
+  // through the org queue (apiStartTime was reset at dequeue) from direct
+  // dispatch, so latency queries can slice by dispatch path.
   recordSandboxOperation({
     sandboxType: "runner",
     actionType: "api_to_executor",
     durationMs: Date.now() - context.apiStartTime,
     success: true,
     runId: context.runId,
+    dimensions: {
+      was_queued: context.wasQueued,
+    },
   });
 
   const runnerGroup = context.runnerGroup;

--- a/turbo/apps/web/src/lib/infra/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/types.ts
@@ -76,6 +76,10 @@ export interface PreparedContext {
   featureFlags: Record<string, boolean> | null;
 
   billableFirewalls: string[];
+
+  // True when the run was dispatched from the org queue. Used to split
+  // api_to_executor latency in Axiom between queue-dispatch and direct-dispatch.
+  wasQueued: boolean;
 }
 
 /**

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -28,6 +28,7 @@ import { type RunStatus, type GetRunResponse } from "@vm0/core/contracts/runs";
 import type { OrgTier } from "@vm0/core/contracts/orgs";
 import type { FirewallPolicies } from "@vm0/core/contracts/firewalls";
 import type { ConnectorType } from "@vm0/core/contracts/connectors";
+import type { TriggerSource } from "@vm0/core/contracts/logs";
 import { publishCancelNotification } from "../realtime/client";
 import type { CancelRunResult } from "../../zero/zero-run-cancel";
 
@@ -133,6 +134,10 @@ export interface CreateRunParams {
     composeContent: AgentComposeYaml;
     compose: { id: string; userId: string; orgId: string };
   };
+  // Origin of the run request (e.g. "cli", "web", "schedule", "slack").
+  // Threaded through to queue telemetry so enqueue/dequeue spans can be split
+  // by trigger in Axiom; only populated on the zero path.
+  triggerSource?: TriggerSource;
 }
 
 export interface CreateRunResult {

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -125,6 +125,11 @@ export interface ExecutionContext {
   // API start time for E2E timing metrics — epoch millis captured at the route
   // handler's first line by the caller (see issue #9936).
   apiStartTime: number;
+
+  // True when the run was previously enqueued and is now being dispatched from
+  // the queue. Used only for telemetry (was_queued dimension on api_to_executor)
+  // so latency queries can separate queue-dispatch from direct-dispatch runs.
+  wasQueued?: boolean;
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -57,6 +57,7 @@ import { publishChatThreadRunUpdated } from "./chat-thread/chat-message-service"
 import type { TriggerSource } from "@vm0/core/contracts/logs";
 import type { OrgTier } from "@vm0/core/contracts/orgs";
 import type { QueueResponse } from "@vm0/core/contracts/runs";
+import { recordSandboxOperation } from "../infra/metrics";
 
 const log = logger("zero:run-queue-service");
 
@@ -166,6 +167,25 @@ export async function enqueueRun(
   });
 
   log.debug(`Enqueued run ${run.id} for user ${userId}`);
+
+  // Point-in-time telemetry for queue entry. Depth is directional (racing
+  // inserts/deletes can skew by ±1) but correlates with queue pressure per
+  // org. Counted after the insert so the new entry is included.
+  const [depthRow] = await globalThis.services.db
+    .select({ depth: count() })
+    .from(agentRunQueue)
+    .where(eq(agentRunQueue.orgId, orgId));
+  recordSandboxOperation({
+    sandboxType: "runner",
+    actionType: "enqueue_zero_run",
+    durationMs: 0,
+    success: true,
+    runId: run.id,
+    dimensions: {
+      queue_depth: Number(depthRow?.depth ?? 0),
+      trigger_source: params.triggerSource ?? null,
+    },
+  });
 
   // Notify all org members whose queue view should refresh.
   await publishOrgSignal(orgId, "queue:changed");
@@ -314,8 +334,9 @@ async function dequeueNextAtomic(
         user_id: string;
         encrypted_params: string | null;
         model_provider: string | null;
+        created_at: Date;
       }>(
-        sql`SELECT q.run_id, q.user_id, q.encrypted_params, zr.model_provider
+        sql`SELECT q.run_id, q.user_id, q.encrypted_params, zr.model_provider, q.created_at
          FROM agent_run_queue q
          JOIN agent_runs r ON r.id = q.run_id
          LEFT JOIN zero_runs zr ON zr.id = r.id
@@ -364,6 +385,25 @@ async function dequeueNextAtomic(
           log.debug(`Run ${row.run_id} already processed, skipping`);
           continue;
         }
+
+        // Remaining queue depth for this org, inside the same advisory lock
+        // so the number reflects the post-dequeue state exactly.
+        const [remainingRow] = await tx
+          .select({ depth: count() })
+          .from(agentRunQueue)
+          .where(eq(agentRunQueue.orgId, orgId));
+
+        const enqueuedAtMs = new Date(row.created_at).getTime();
+        recordSandboxOperation({
+          sandboxType: "runner",
+          actionType: "dequeue_zero_run",
+          durationMs: Date.now() - enqueuedAtMs,
+          success: true,
+          runId: row.run_id,
+          dimensions: {
+            queue_depth_at_dequeue: Number(remainingRow?.depth ?? 0),
+          },
+        });
 
         log.debug(`Dequeued run ${row.run_id} for org ${orgId}`);
         return {
@@ -559,6 +599,9 @@ export async function dispatchQueuedZeroRun(
     runId,
     apiStartTime,
   });
+  // Tag the context so the downstream api_to_executor span records
+  // was_queued=true for runs that came through the queue.
+  contextResult.context.wasQueued = true;
 
   // Update zero_runs with resolved model fields before dispatch so metadata
   // is recorded even if dispatch succeeds but a later step fails.

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -163,18 +163,24 @@ export async function enqueueRun(
       expiresAt,
     });
 
-    return { ...inserted, sessionId };
+    // Post-insert queue depth, captured inside the same transaction so the
+    // enqueue hot path doesn't pay a separate round-trip after commit.
+    // Directional (racing inserts/deletes across orgs can skew by ±1) but
+    // correlates with queue pressure per org.
+    const [depthRow] = await tx
+      .select({ depth: count() })
+      .from(agentRunQueue)
+      .where(eq(agentRunQueue.orgId, orgId));
+
+    return {
+      ...inserted,
+      sessionId,
+      queueDepth: Number(depthRow?.depth ?? 0),
+    };
   });
 
   log.debug(`Enqueued run ${run.id} for user ${userId}`);
 
-  // Point-in-time telemetry for queue entry. Depth is directional (racing
-  // inserts/deletes can skew by ±1) but correlates with queue pressure per
-  // org. Counted after the insert so the new entry is included.
-  const [depthRow] = await globalThis.services.db
-    .select({ depth: count() })
-    .from(agentRunQueue)
-    .where(eq(agentRunQueue.orgId, orgId));
   recordSandboxOperation({
     sandboxType: "runner",
     actionType: "enqueue_zero_run",
@@ -182,7 +188,7 @@ export async function enqueueRun(
     success: true,
     runId: run.id,
     dimensions: {
-      queue_depth: Number(depthRow?.depth ?? 0),
+      queue_depth: run.queueDepth,
       trigger_source: params.triggerSource ?? null,
     },
   });

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -499,6 +499,7 @@ async function createZeroRunRecord(
     orgTier,
     additionalVolumes: skillVolumes.length > 0 ? skillVolumes : undefined,
     debugNoMockClaude: params.debugNoMockClaude,
+    triggerSource: params.triggerSource,
   };
 
   // ── Round 3: Pre-flight checks (need compose content) ───────────────


### PR DESCRIPTION
## Summary

- Add `enqueue_zero_run` and `dequeue_zero_run` spans on the existing `vm0-sandbox-op-log-prod` dataset so queue wait time is measurable.
- Add a `was_queued` dimension to `api_to_executor` so the existing latency metric can be split by dispatch path.
- No business-logic changes — pure observability.

## Context

Ref: #10953

With the epic #10953 changes merged, `api_to_cli_init` P50 dropped from ~5566ms to ~3582ms. The next biggest remaining bucket is `api_to_executor` (~2106ms P50). Investigation revealed the queue layer has zero telemetry, and a deliberate design choice in `dispatchQueuedZeroRun` hides queue wait from the existing metric:

- `turbo/apps/web/src/lib/zero/zero-run-queue-service.ts:503-506` resets `apiStartTime` at dequeue ("queue wait time is intentionally excluded from startup latency"). That is correct product behavior, but it means the existing `api_to_executor` span only measures post-dequeue → executor time, and the actual queue wait was invisible in Axiom.

Before optimizing the queue path, this PR adds the observability needed to make the next round data-driven.

## Changes

- `enqueue_zero_run` — emitted at the end of `enqueueRun()` with `durationMs: 0` (point-in-time). Dimensions: `queue_depth` (post-insert count, directional), `trigger_source`.
- `dequeue_zero_run` — emitted inside `dequeueNextAtomic()` after the FIFO pull + status transition. `durationMs = Date.now() - enqueuedAt` — this IS the queue wait. Dimensions: `queue_depth_at_dequeue` (remaining depth counted inside the advisory lock).
- `was_queued` dimension on `api_to_executor` in `runner-executor.ts` — threaded via `wasQueued: boolean` on `ExecutionContext` / `PreparedContext`. `dispatchQueuedZeroRun` sets it to `true`; direct dispatch leaves the default `false`.
- `recordSandboxOperation()` now accepts an optional `dimensions` record so callers can attach extra schemaless fields without a second helper.

## Out of scope

- `apiStartTime` reset behavior is preserved — deliberate product decision.
- `api_to_executor` is not renamed or removed, only extended.
- No queue logic optimization.

## Test plan

- [x] `pnpm -F web lint`
- [x] `pnpm -F web check-types` (errors shown are pre-existing on `main`, none in files touched by this PR)
- [x] `pnpm format` (no changes)
- [x] `pnpm -F web exec vitest run src/lib/zero/__tests__/run-queue-service.test.ts src/lib/zero/__tests__/zero-run-service.test.ts` — 47 passed
- [ ] After merge: confirm new spans appear in `vm0-sandbox-op-log-prod` with correct dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)