### PR TITLE
perf(guest-agent): skip vas snapshot for unchanged artifacts (part 2 of #10967)

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -2,6 +2,7 @@
 
 use crate::artifact;
 use crate::constants;
+use crate::content_hash;
 use crate::env;
 use crate::error::AgentError;
 use crate::http;
@@ -141,6 +142,38 @@ async fn snapshot_artifacts() -> Result<Option<serde_json::Value>, AgentError> {
             entry.mount_path
         );
         let files = artifact::walk_files(&entry.mount_path).await?;
+
+        // Skip the VAS round-trips when the mount is byte-identical to what
+        // was originally mounted. `version_id` in VAS *is* the content hash
+        // (same SHA-256 the web producer emits), so an equality check on the
+        // locally-recomputed hash is sufficient — no extra metadata needed.
+        // See #10967 for the ~3.9s-per-checkpoint motivation.
+        let skip_check_start = std::time::Instant::now();
+        let local_hash = content_hash::compute_content_hash(
+            &entry.storage_id,
+            files.iter().map(|f| (f.path.as_str(), f.hash.as_str())),
+        );
+        if local_hash == entry.version_id {
+            log_info!(
+                LOG_TAG,
+                "VAS artifact snapshot skipped (unchanged since mount): {}@{}",
+                entry.name,
+                entry.version_id
+            );
+            record_sandbox_op(
+                "artifact_snapshot_skipped",
+                skip_check_start.elapsed(),
+                true,
+                None,
+            );
+            results.push(build_artifact_snapshot_entry(
+                &entry.name,
+                &entry.version_id,
+                &entry.mount_path,
+            ));
+            continue;
+        }
+
         let snapshot = artifact::create_snapshot(
             &entry.mount_path,
             files,

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -137,7 +137,7 @@ async fn snapshot_artifacts() -> Result<Option<serde_json::Value>, AgentError> {
     for entry in entries {
         log_info!(
             LOG_TAG,
-            "Creating VAS snapshot for artifact '{}' at {}",
+            "Processing artifact '{}' at {}",
             entry.name,
             entry.mount_path
         );
@@ -174,6 +174,11 @@ async fn snapshot_artifacts() -> Result<Option<serde_json::Value>, AgentError> {
             continue;
         }
 
+        log_info!(
+            LOG_TAG,
+            "Creating VAS snapshot for artifact '{}'",
+            entry.name
+        );
         let snapshot = artifact::create_snapshot(
             &entry.mount_path,
             files,

--- a/crates/guest-agent/src/content_hash.rs
+++ b/crates/guest-agent/src/content_hash.rs
@@ -1,0 +1,111 @@
+//! Content-addressable storage hash — Rust port of the TS implementation
+//! at `turbo/apps/web/src/lib/infra/storage/content-hash.ts`.
+//!
+//! `version_id` in VAS *is* this hash — the TS function is the sole producer
+//! across every prepare/commit route. Guest-side we recompute it locally so
+//! the checkpoint step can skip the prepare+commit round-trips when the
+//! artifact is unchanged since mount (see issue #10967).
+//!
+//! The two implementations must stay byte-identical; `ts_parity.rs` in the
+//! test suite carries fixtures shared with the TS side.
+
+use sha2::{Digest, Sha256};
+
+/// Compute the content hash for a storage version.
+///
+/// Format matches the TS reference:
+/// - empty files: `sha256("storage:<id>\n")`
+/// - non-empty: `sha256("storage:<id>\n<path>:<hash>\n<path>:<hash>…")`
+///   with entries sorted lexicographically.
+///
+/// The Rust byte-wise sort agrees with JS's default `Array.sort()` for any
+/// BMP code points (UTF-8 byte order and UTF-16 code-unit order coincide
+/// there). Non-BMP characters in a file path are the only theoretical
+/// divergence and are not present in current VAS-backed workloads.
+pub(crate) fn compute_content_hash<'a, I>(storage_id: &str, files: I) -> String
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    let mut entries: Vec<String> = files
+        .into_iter()
+        .map(|(path, hash)| format!("{path}:{hash}"))
+        .collect();
+
+    let mut hasher = Sha256::new();
+    if entries.is_empty() {
+        hasher.update(format!("storage:{storage_id}\n").as_bytes());
+    } else {
+        entries.sort();
+        let combined = format!("storage:{storage_id}\n{}", entries.join("\n"));
+        hasher.update(combined.as_bytes());
+    }
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Fixtures below are shared with the TS parity test at
+    // `turbo/apps/web/src/lib/infra/storage/__tests__/content-hash-parity.test.ts`.
+    // Any change here must be mirrored there (and vice versa); CI runs both
+    // sides, so a drift between TS `computeContentHashFromHashes` and this
+    // Rust port fails fast.
+    const STORAGE_A: &str = "01234567-89ab-cdef-0123-456789abcdef";
+    const STORAGE_B: &str = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+    #[test]
+    fn empty_files_hashes_storage_prefix_only() {
+        let got = compute_content_hash(STORAGE_A, std::iter::empty());
+        assert_eq!(
+            got,
+            "4c679c352da0ad578c21cc413e4afa83c32d467424725129795dda25d1c5ea4e"
+        );
+    }
+
+    #[test]
+    fn single_file() {
+        let got = compute_content_hash(STORAGE_A, [("a.txt", "deadbeef")]);
+        assert_eq!(
+            got,
+            "3d7165d60d7fd53858323feb1cc04b0116aee77858b4aea45beba855f7816fc0"
+        );
+    }
+
+    #[test]
+    fn multiple_files_sorted_regardless_of_input_order() {
+        let got = compute_content_hash(
+            STORAGE_A,
+            [("b.txt", "222"), ("a.txt", "111"), ("c.txt", "333")],
+        );
+        assert_eq!(
+            got,
+            "384d77579354ce230d8a7465343e1530e2561eab48a94d63e0bf80f90307e24c"
+        );
+    }
+
+    #[test]
+    fn different_storage_id_yields_different_hash() {
+        let got = compute_content_hash(STORAGE_B, std::iter::empty());
+        assert_eq!(
+            got,
+            "d87bf91de459004a9512e649c3484a8ced316fe5547149ec3f6b6ae669ac79ff"
+        );
+    }
+
+    #[test]
+    fn nested_paths_sort_lexicographically() {
+        let got = compute_content_hash(
+            STORAGE_A,
+            [
+                ("src/main.rs", "bbb"),
+                ("README.md", "ccc"),
+                ("src/lib.rs", "aaa"),
+            ],
+        );
+        assert_eq!(
+            got,
+            "e7158d0cbdae3793daa8352a6197eab9f772d8cb8784c941d921e81f5d4b09d6"
+        );
+    }
+}

--- a/crates/guest-agent/src/content_hash.rs
+++ b/crates/guest-agent/src/content_hash.rs
@@ -6,8 +6,10 @@
 //! the checkpoint step can skip the prepare+commit round-trips when the
 //! artifact is unchanged since mount (see issue #10967).
 //!
-//! The two implementations must stay byte-identical; `ts_parity.rs` in the
-//! test suite carries fixtures shared with the TS side.
+//! The two implementations must stay byte-identical. The inline `#[cfg(test)]`
+//! suite below and its TS counterpart at
+//! `turbo/apps/web/src/lib/infra/storage/__tests__/content-hash-parity.test.ts`
+//! hardcode the same fixture vectors — a drift on either side fails CI.
 
 use sha2::{Digest, Sha256};
 

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -5,6 +5,7 @@ pub mod checkpoint;
 pub mod cli;
 pub mod complete;
 mod constants;
+mod content_hash;
 pub mod env;
 pub mod error;
 pub mod events;

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -196,9 +196,6 @@ pub struct ArtifactEntry {
     pub vas_storage_name: String,
     /// Storage UUID, used guest-side to locally recompute the content hash
     /// and skip VAS calls when an artifact is unchanged since mount.
-    /// `#[serde(default)]` so manifests from older web deploys (which do
-    /// not set this field) still deserialize cleanly.
-    #[serde(default)]
     pub vas_storage_id: String,
     pub vas_version_id: String,
 }
@@ -588,6 +585,7 @@ mod tests {
             "artifacts": [{
                 "mountPath": "/artifacts",
                 "vasStorageName": "my-artifact",
+                "vasStorageId": "sid-1",
                 "vasVersionId": "v1"
             }]
         });
@@ -605,11 +603,13 @@ mod tests {
                 {
                     "mountPath": "/workspace",
                     "vasStorageName": "art-a",
+                    "vasStorageId": "sid-a",
                     "vasVersionId": "v1"
                 },
                 {
                     "mountPath": "/data",
                     "vasStorageName": "art-b",
+                    "vasStorageId": "sid-b",
                     "vasVersionId": "v2"
                 }
             ]

--- a/turbo/apps/web/src/lib/infra/storage/__tests__/content-hash-parity.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/content-hash-parity.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { computeContentHashFromHashes } from "../content-hash";
+
+/**
+ * Lockstep parity vectors with the Rust guest-agent port at
+ * `crates/guest-agent/src/content_hash.rs`. Both sides run the *same* inputs
+ * through their respective implementations and assert the *same* hex output.
+ *
+ * If the TS producer changes shape (prefix, separator, sort, encoding) without
+ * a matching change on the Rust side, the guest-side skip check in
+ * `checkpoint::snapshot_artifacts` will silently disagree with the version_id
+ * VAS actually assigns — every snapshot would then be uploaded unnecessarily,
+ * or worse, a matching hash would fail to match. Keeping the vectors mirrored
+ * in both test suites turns that drift into a CI failure on whichever side
+ * diverged first.
+ */
+describe("content-hash TS↔Rust parity", () => {
+  const STORAGE_A = "01234567-89ab-cdef-0123-456789abcdef";
+  const STORAGE_B = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+  it("empty files hashes storage prefix only", () => {
+    expect(computeContentHashFromHashes(STORAGE_A, [])).toBe(
+      "4c679c352da0ad578c21cc413e4afa83c32d467424725129795dda25d1c5ea4e",
+    );
+  });
+
+  it("single file", () => {
+    expect(
+      computeContentHashFromHashes(STORAGE_A, [
+        { path: "a.txt", hash: "deadbeef", size: 0 },
+      ]),
+    ).toBe("3d7165d60d7fd53858323feb1cc04b0116aee77858b4aea45beba855f7816fc0");
+  });
+
+  it("multiple files sorted regardless of input order", () => {
+    expect(
+      computeContentHashFromHashes(STORAGE_A, [
+        { path: "b.txt", hash: "222", size: 0 },
+        { path: "a.txt", hash: "111", size: 0 },
+        { path: "c.txt", hash: "333", size: 0 },
+      ]),
+    ).toBe("384d77579354ce230d8a7465343e1530e2561eab48a94d63e0bf80f90307e24c");
+  });
+
+  it("different storage id yields different hash", () => {
+    expect(computeContentHashFromHashes(STORAGE_B, [])).toBe(
+      "d87bf91de459004a9512e649c3484a8ced316fe5547149ec3f6b6ae669ac79ff",
+    );
+  });
+
+  it("nested paths sort lexicographically", () => {
+    expect(
+      computeContentHashFromHashes(STORAGE_A, [
+        { path: "src/main.rs", hash: "bbb", size: 0 },
+        { path: "README.md", hash: "ccc", size: 0 },
+        { path: "src/lib.rs", hash: "aaa", size: 0 },
+      ]),
+    ).toBe("e7158d0cbdae3793daa8352a6197eab9f772d8cb8784c941d921e81f5d4b09d6");
+  });
+});


### PR DESCRIPTION
## Summary
- Rust port of `computeContentHashFromHashes`; after `walk_files`, guest compares the locally-recomputed hash to `entry.version_id` and — on match — reuses that `version_id` directly instead of calling VAS prepare+commit. ~3.9s saved per unchanged artifact per checkpoint (#10967).
- New `artifact_snapshot_skipped` telemetry op exposes the skip rate.
- TS↔Rust parity is pinned with mirrored fixture suites (`content_hash.rs` + `content-hash-parity.test.ts`); a drift on either side fails CI before the guest can silently disagree with VAS.
- Drops `#[serde(default)]` on runner `vas_storage_id` now that web 12.297.0 (shipping the producer side of #10978) is live — runner strict-parses the manifest going forward.

## Test plan
- [x] `cargo test -p guest-agent` — 5 new `content_hash` unit tests + all existing pass
- [x] `cargo test -p runner` — 768 pass (2 fixtures updated to include `vasStorageId`)
- [x] `pnpm -F web exec vitest run content-hash-parity` — 5 TS fixtures match their Rust counterparts byte-for-byte
- [x] `cargo clippy -p guest-agent -p runner --all-targets -- -D warnings` — clean
- [ ] Merge-queue CI green

Closes #10967 (part 1 landed in #10978).

🤖 Generated with [Claude Code](https://claude.com/claude-code)