### PR TITLE
fix(pricing): render structured data server-side

### DIFF
--- a/turbo/apps/web/app/[locale]/pricing/page.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import { PricingPageClient } from "./PricingPageClient";
 import type { Locale } from "../../../i18n";
 import { buildLocaleAlternates } from "../../lib/seo/alternates";
@@ -170,19 +169,22 @@ export default async function PricingPage({ params }: PageProps) {
 
   return (
     <>
-      <Script
+      <script
         id="json-ld-breadcrumb"
         type="application/ld+json"
+        suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
-      <Script
+      <script
         id="json-ld-pricing"
         type="application/ld+json"
+        suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: JSON.stringify(pricingJsonLd) }}
       />
-      <Script
+      <script
         id="json-ld-faq"
         type="application/ld+json"
+        suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
       />
       <PricingPageClient />


### PR DESCRIPTION
## Summary

The pricing page's JSON-LD (breadcrumb, pricing offers, FAQ) was wrapped in `next/script`'s `<Script>` component with no `strategy` — this defaults to `afterInteractive`, which injects scripts on the **client** after hydration and never in the SSR HTML.

Result: crawlers that only fetch HTML (and View Source / most SEO tools) never saw the structured data. The FAQ/pricing schema updates from #10664 looked "gone on prod" even though the PR was deployed.

Swap to plain `<script type="application/ld+json" dangerouslySetInnerHTML={...} />` so the JSON-LD lands in the server response. This matches the pattern already used in `blog/page.tsx`, `use-cases/page.tsx`, etc.

## Verification

Before — `curl https://www.vm0.ai/en/pricing | grep application/ld+json`:
- 3 generic site-level schemas from `app/layout.tsx` (Organization, WebSite, SoftwareApplication)
- **No** `id="json-ld-{breadcrumb,pricing,faq}"` anywhere

After this change, all three should appear in the SSR HTML.

## Follow-up

`turbo/apps/web/app/[locale]/security/page.tsx:78` has the same latent bug (`next/script` for JSON-LD). Not fixed here to keep scope tight — will land in a separate PR.

## Test plan

- [ ] `curl https://<preview>/en/pricing | grep 'id="json-ld-'` returns all three IDs
- [ ] Validate via https://search.google.com/test/rich-results on the preview URL
- [ ] Confirm Pro = 2, Team = 5 concurrent agents appear in the pricing schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)