### PR TITLE
perf(observability): split api_step_callbacks_and_token into 3 diagnostic spans

### DIFF
--- a/turbo/apps/web/app/api/internal/event-consumers/voice-chat-candidate/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/voice-chat-candidate/__tests__/route.test.ts
@@ -77,6 +77,7 @@ async function seedSessionWithQueuedTask() {
         status: "queued",
         createdAt: new Date(),
         sessionId: session.id,
+        markResponseReady: () => {},
       };
     },
   });

--- a/turbo/apps/web/app/api/internal/event-consumers/voice-chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/voice-chat/__tests__/route.test.ts
@@ -77,6 +77,7 @@ async function seedSessionWithQueuedTask() {
         status: "queued",
         createdAt: new Date(),
         sessionId: session.id,
+        markResponseReady: () => {},
       };
     },
   });

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -410,6 +410,78 @@ describe("POST /api/zero/chat/messages", () => {
           spanSpy.mockRestore();
         }
       });
+
+      it("emits the 3-way split of api_step_callbacks_and_token alongside the back-compat parent", async () => {
+        // Spans below are source="web" (recordSandboxOperation), not web-chat.
+        // They are emitted by buildAndDispatchRun inside the after() callback
+        // so the spy must survive until flushAfter() drains the queue.
+        const spanSpy = vi
+          .spyOn(axiomClient, "ingestSandboxOpLog")
+          .mockImplementation(() => {
+            return;
+          });
+
+        try {
+          const response = await POST(
+            createTestRequest(URL, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                agentId,
+                prompt: "hello phase-2 split test",
+              }),
+            }),
+          );
+          expect(response.status).toBe(201);
+
+          // Phase-2 spans are emitted inside the after() callback.
+          await context.mocks.flushAfter();
+
+          const dispatchSpans = spanSpy.mock.calls
+            .map((c) => {
+              return c[0];
+            })
+            .filter((e) => {
+              return e.source === "web";
+            });
+
+          const byOp = new Map(
+            dispatchSpans.map((e) => {
+              return [e.op_type, e];
+            }),
+          );
+
+          // Back-compat parent span — still emitted for ~1 release cycle.
+          expect(byOp.has("api_step_callbacks_and_token")).toBe(true);
+
+          // Three-way split — only emitted when the chat route stamped both
+          // responseReady (via markResponseReady) and dispatchStart.
+          expect(byOp.has("api_phase1_post_tx_sync")).toBe(true);
+          expect(byOp.has("api_after_scheduling_gap")).toBe(true);
+          expect(byOp.has("api_phase2_callbacks_token_pure")).toBe(true);
+
+          const parent = byOp.get("api_step_callbacks_and_token")!;
+          const phase1 = byOp.get("api_phase1_post_tx_sync")!;
+          const gap = byOp.get("api_after_scheduling_gap")!;
+          const phase2 = byOp.get("api_phase2_callbacks_token_pure")!;
+
+          // All four should be non-negative numbers.
+          for (const span of [parent, phase1, gap, phase2]) {
+            expect(typeof span.duration_ms).toBe("number");
+            expect(span.duration_ms).toBeGreaterThanOrEqual(0);
+          }
+
+          // The three children should sum to the parent within a small
+          // tolerance (same-process Date.now() jitter only).
+          const childrenSum =
+            phase1.duration_ms + gap.duration_ms + phase2.duration_ms;
+          expect(
+            Math.abs(childrenSum - parent.duration_ms),
+          ).toBeLessThanOrEqual(10);
+        } finally {
+          spanSpy.mockRestore();
+        }
+      });
     });
 
     describe("Signal Publishing", () => {

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -507,6 +507,9 @@ const router = tsr.router(chatMessagesContract, {
         await publishThreadListChanged(authCtx.userId);
       });
 
+      // Stamp response-ready for the Phase-2 instrumentation split. Idempotent.
+      result.markResponseReady();
+
       return {
         status: 201 as const,
         body: {

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -344,6 +344,31 @@ export async function buildAndDispatchRun(opts: {
         op: "api_step_callbacks_and_token",
         ms: timings.token - timings.transaction,
       },
+      // Split of api_step_callbacks_and_token into 3 diagnostic spans to
+      // isolate the Vercel after() scheduling gap from Phase-1 residual work
+      // and Phase-2 real work. Only the chat route stamps both anchors; other
+      // callers (telegram, slack, email, github, schedule, voice-chat) leave
+      // them undefined, and the split is skipped. The back-compat parent span
+      // above continues to emit unchanged for ~1 release cycle — once the
+      // three below are confirmed populated in Axiom, the parent (and this
+      // comment) can be removed in a follow-up PR.
+      ...(timings.responseReady !== undefined &&
+      timings.dispatchStart !== undefined
+        ? [
+            {
+              op: "api_phase1_post_tx_sync",
+              ms: timings.responseReady - timings.transaction,
+            },
+            {
+              op: "api_after_scheduling_gap",
+              ms: timings.dispatchStart - timings.responseReady,
+            },
+            {
+              op: "api_phase2_callbacks_token_pure",
+              ms: timings.token - timings.dispatchStart,
+            },
+          ]
+        : []),
       { op: "api_step_build_context", ms: buildContextTime - timings.token },
       { op: "api_step_prepare", ms: prepareTime - buildContextTime },
       { op: "api_step_dispatch", ms: dispatchTime - prepareTime },
@@ -407,6 +432,14 @@ export interface CreateRunRecordResult {
   apiStartTime: number;
   authorizeTime: number;
   transactionTime: number;
+  /**
+   * Stamped by the route handler via CreateZeroRunResult.markResponseReady()
+   * right before returning HTTP 201. Used by the instrumentation split of
+   * api_step_callbacks_and_token into Phase-1 residual / after()-scheduling /
+   * Phase-2 spans. Undefined on non-chat triggers that don't participate in
+   * the marker protocol.
+   */
+  responseReadyAt?: number;
 }
 
 /**

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -136,6 +136,21 @@ export interface DispatchTimings {
   apiStart: number;
   authorize: number;
   transaction: number;
+  /**
+   * Stamped by the route handler right before returning HTTP 201, via
+   * CreateZeroRunResult.markResponseReady(). Anchors the end of Phase-1
+   * residual work (persist_run + insert_chat_message + route sync) and the
+   * start of the Next.js after() scheduling gap. Absent on non-chat triggers
+   * that don't participate in the marker protocol.
+   */
+  responseReady?: number;
+  /**
+   * Stamped at the first synchronous line of dispatchZeroRun (inside the
+   * after() callback). Anchors the end of the after() scheduling gap and the
+   * start of Phase-2 real work (registerCallbacks + token generation).
+   * Absent on non-chat triggers (paired with responseReady).
+   */
+  dispatchStart?: number;
   token: number;
   resolveSourceDuration?: number;
   resolveSecretsDuration?: number;

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -655,6 +655,11 @@ async function createZeroRunRecord(
 async function dispatchZeroRun(
   result: ZeroRunRecordResult,
 ): Promise<{ status: RunStatus; sandboxId?: string } | undefined> {
+  // Capture the after() callback entry as the first synchronous line — the
+  // gap between this timestamp and record.responseReadyAt (if stamped by the
+  // route) is the Vercel after() scheduling latency.
+  const dispatchStart = Date.now();
+
   const { record, runParams, orgId, zeroParams } = result;
 
   // Nothing to dispatch if run was enqueued (concurrency limit)
@@ -698,6 +703,8 @@ async function dispatchZeroRun(
         apiStart: record.apiStartTime,
         authorize: record.authorizeTime,
         transaction: record.transactionTime,
+        responseReady: record.responseReadyAt,
+        dispatchStart,
         token: tokenTime,
         resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
         resolveSecretsDuration: contextResult.timings.resolveSecrets,
@@ -739,6 +746,15 @@ export interface CreateZeroRunResult {
   status: RunStatus;
   createdAt: Date;
   sessionId: string;
+  /**
+   * Called by the route handler right before returning the HTTP 201 response.
+   * Stamps the response-ready timestamp used by the Phase-2 instrumentation
+   * split (api_phase1_post_tx_sync / api_after_scheduling_gap /
+   * api_phase2_callbacks_token_pure). Idempotent — later calls are no-ops.
+   * Non-chat callers can ignore this safely; the three split spans are
+   * skipped when the marker is never called.
+   */
+  markResponseReady: () => void;
 }
 
 /**
@@ -770,11 +786,18 @@ export async function createZeroRun(
     });
   }
 
+  const markResponseReady = (): void => {
+    if (result.record && result.record.responseReadyAt === undefined) {
+      result.record.responseReadyAt = Date.now();
+    }
+  };
+
   return {
     runId: result.runId,
     status: result.status,
     createdAt: result.createdAt,
     sessionId: result.sessionId,
+    markResponseReady,
   };
 }
 


### PR DESCRIPTION
## Summary

Splits the single `api_step_callbacks_and_token` span (currently P95 ~1764ms with an unaccounted ~1600ms tail) into three diagnostic spans so the tail can be localized to one of: Phase-1 residual work, Next.js `after()` scheduling gap, or Phase-2 actual work. Pure instrumentation — no latency changes.

Closes #10986

## Span Mapping

| New span | Start → End | Measures |
|---|---|---|
| `api_phase1_post_tx_sync` | `transactionTime` → `responseReady` | `persistZeroRunMetadata` + route's `insertChatMessage` + route sync work |
| `api_after_scheduling_gap` | `responseReady` → `dispatchStart` | ts-rest serialize + HTTP flush + Vercel `after()` scheduling |
| `api_phase2_callbacks_token_pure` | `dispatchStart` → `token` | `registerCallbacks` + `Promise.all([generateZeroToken, generateSandboxToken])` |

The existing `api_step_callbacks_and_token` continues to emit unchanged for ~1 release cycle so existing Axiom dashboards stay green. A follow-up PR will remove it once the three new spans are confirmed populated in production.

## Plumbing

- `CreateZeroRunResult` exposes `markResponseReady: () => void`. Chat route calls it before `return 201`; the closure stamps `responseReadyAt` onto the internal `ZeroRunRecordResult.record` that the `after()` closure already captures.
- `dispatchZeroRun` captures `dispatchStart = Date.now()` as its first synchronous line.
- Both timestamps flow into `buildAndDispatchRun` via `DispatchTimings.responseReady` / `.dispatchStart` and are emitted alongside the existing `api_step_*` spans using `recordSandboxOperation`.
- Non-chat callers (telegram, slack, email, github, schedule, voice-chat) never call `markResponseReady`; the three-way split is skipped for those flows and only the back-compat span emits.

## Verification

Post-merge, run this Axiom query (from issue):

```apl
['vm0-sandbox-op-log-prod']
| where _time > now(-1h)
| where op_type in ('api_phase1_post_tx_sync', 'api_after_scheduling_gap', 'api_phase2_callbacks_token_pure', 'api_step_callbacks_and_token')
| summarize p50=percentile(duration_ms, 50), p95=percentile(duration_ms, 95), count=count() by op_type
```

Expect 4 rows; sum of the three new P50s should match `api_step_callbacks_and_token`'s P50 within ~10%.

## Follow-up

After ~1 release cycle (once the three new spans are verified populated in Axiom), open a follow-up PR to remove the `api_step_callbacks_and_token` emission in `run-service.ts` and the back-compat comment block.

## Test plan

- [x] `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/route.test.ts` — 28/28 pass (includes new 3-span split assertion: all 4 spans fire, children sum ≤10ms from parent)
- [x] `pnpm -F web exec vitest run src/lib/zero/__tests__/zero-run-service.test.ts src/lib/infra/run` — 70/70 pass
- [x] `pnpm -F web exec vitest run app/api/internal/event-consumers/voice-chat{,-candidate}` — 10/10 pass (stub types updated)
- [x] `pnpm -F web run lint` — 0 warnings, 0 errors
- [x] `pnpm check-types` — no new errors (5 preexisting env-dep errors unrelated)
- [x] `pnpm knip` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)