### PR TITLE
feat(web): make use-case try-it button prominent

### DIFF
--- a/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
@@ -53,15 +53,15 @@ function Section({
 
 function TryItLink({ href, label }: { href: string; label: string }) {
   return (
-    <div className="mt-2 flex justify-end opacity-0 transition-opacity group-hover:opacity-100 [@media(hover:none)]:opacity-100">
+    <div className="mt-4 flex justify-start">
       <a
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-0.5 text-[13px] font-medium text-[#ed4e01]"
+        className="inline-flex items-center gap-1 rounded-full bg-[#ed4e01] px-4 py-2 text-[13px] font-semibold not-italic text-white shadow-sm transition-colors hover:bg-[#d64601]"
       >
         {label}
-        <IconArrowUpRight size={14} />
+        <IconArrowUpRight size={16} />
       </a>
     </div>
   );
@@ -98,7 +98,7 @@ function PromptVariants({
           );
         })}
       </div>
-      <div className="uc-prompt-block group">
+      <div className="uc-prompt-block">
         {activePrompt}
         <TryItLink
           href={buildPromptHref(activePrompt, connectors, platformUrl)}


### PR DESCRIPTION
## Summary
- Promote the use-case prompt "Try it" link from a hover-revealed text link to an always-visible orange pill button (bg `#ed4e01`, white text, rounded-full, shadow).
- Left-align the CTA under the prompt and drop the `group` / `group-hover` opacity treatment on `uc-prompt-block` since visibility no longer depends on hover.
- Nudge the icon from 14px to 16px to match the heavier button weight.

## Why
The previous link-style CTA was easy to miss on desktop (invisible until hover) and already forced to always-visible on touch devices. A prominent button improves discoverability of the "Try it" flow uniformly across devices.

## Test plan
- [ ] Visit `/[locale]/use-cases/[slug]` and confirm the "Try it" button renders as a filled orange pill without needing hover.
- [ ] Hover the button and confirm the background darkens to `#d64601`.
- [ ] Tap on a touch device and confirm the button opens the prompt in a new tab.