### PR TITLE
refactor(zero-run-policy): decouple credit check from model-provider selection

### DIFF
--- a/turbo/apps/web/app/api/generate-image/route.ts
+++ b/turbo/apps/web/app/api/generate-image/route.ts
@@ -10,7 +10,7 @@ import { initServices } from "../../../src/lib/init-services";
 import { isApiError } from "../../../src/lib/shared/errors";
 import { processOrgUsageEvents } from "../../../src/lib/zero/credit/usage-event-service";
 import { resolveOrg } from "../../../src/lib/zero/org/resolve-org";
-import { checkOrgCredits } from "../../../src/lib/zero/zero-run-policy";
+import { checkOrgCredits } from "../../../src/lib/zero/credit/check-org-credits";
 
 export const runtime = "nodejs";
 
@@ -157,7 +157,7 @@ async function handlePost(req: NextRequest) {
 
   const db = globalThis.services.db;
   const { org } = await resolveOrg(authCtx);
-  await checkOrgCredits(org.orgId, userId, "vm0", db);
+  await checkOrgCredits(org.orgId, userId, db);
 
   const result = await ai.models.generateContent({
     model: MODEL,

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -547,14 +547,12 @@ describe("POST /api/zero/chat/messages", () => {
       );
     });
 
-    // Two `org_metadata` SELECTs remain per POST after this dedup (Round 2
-    // tier via getOrgMetadata + Round 3 credits via checkOrgCredits). Dedup
-    // target is the duplicate `resolveOrg ↔ Round 2` pair in the
-    // modelSelection branch (3→2) plus the `zero_agents` pair on every POST
-    // (2→1). The checkOrgCredits read is a separate credits-admission path
-    // tracked as a follow-up (out of scope for #10594).
+    // One `org_metadata` SELECT per POST: the `resolveOrg` tier+credits read.
+    // The credits-admission path (checkOrgCreditsForRun) only touches
+    // org_metadata on the vm0 branch; BYOK and default-non-vm0 paths
+    // short-circuit before the balance check (#10951).
     describe("deduplicates per-request reads", () => {
-      it("reads zero_agents once and org_metadata twice without modelSelection", async () => {
+      it("reads zero_agents once and org_metadata once without modelSelection", async () => {
         const counter = createQueryCounter();
         try {
           const response = await POST(
@@ -570,13 +568,13 @@ describe("POST /api/zero/chat/messages", () => {
 
           expect(response.status).toBe(201);
           expect(counter.countMatching(/from\s+"?zero_agents"?/i)).toBe(1);
-          expect(counter.countMatching(/from\s+"?org_metadata"?/i)).toBe(2);
+          expect(counter.countMatching(/from\s+"?org_metadata"?/i)).toBe(1);
         } finally {
           counter.restore();
         }
       });
 
-      it("reads zero_agents once and org_metadata twice with modelSelection (duplicate pair eliminated)", async () => {
+      it("reads zero_agents once and org_metadata once with modelSelection (BYOK fast-exit)", async () => {
         const providerId = await getTestModelProviderIdByType(
           user.orgId,
           "anthropic-api-key",
@@ -600,10 +598,10 @@ describe("POST /api/zero/chat/messages", () => {
 
           expect(response.status).toBe(201);
           expect(counter.countMatching(/from\s+"?zero_agents"?/i)).toBe(1);
-          // 3→2: resolveOrg still reads org_metadata for tier+credits, Round 3
-          // checkOrgCredits reads credits; Round 2 now hits the preload path
-          // built from resolveOrg's already-fetched tier (the eliminated dup).
-          expect(counter.countMatching(/from\s+"?org_metadata"?/i)).toBe(2);
+          // modelProvider="anthropic" triggers checkOrgCreditsForRun's BYOK
+          // fast-exit — no org_metadata read from credits admission. Round 2
+          // uses resolveOrg's preloaded tier (the eliminated dup from #10594).
+          expect(counter.countMatching(/from\s+"?org_metadata"?/i)).toBe(1);
         } finally {
           counter.restore();
         }

--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -25,7 +25,8 @@ import {
   enqueueRun,
   dispatchQueuedZeroRun,
 } from "../zero-run-queue-service";
-import { checkOrgCredits } from "../zero-run-policy";
+import { checkOrgCreditsForRun } from "../zero-run-policy";
+import { checkOrgCredits } from "../credit/check-org-credits";
 import { isInsufficientCredits } from "../../shared/errors";
 import { seedTestRun } from "../../../__tests__/db-test-seeders/runs";
 
@@ -333,7 +334,7 @@ describe("model provider check (queue dispatch path)", () => {
   });
 });
 
-describe("checkOrgCredits (fused CTE branches)", () => {
+describe("checkOrgCredits (general vm0 credit gate)", () => {
   let user: UserContext;
 
   beforeEach(async () => {
@@ -351,10 +352,74 @@ describe("checkOrgCredits (fused CTE branches)", () => {
     throw new Error("expected checkOrgCredits to throw insufficientCredits");
   }
 
+  it("returns OK when member is enabled and credits are available", async () => {
+    await setOrgCredits(user.orgId, 10000);
+    await expect(
+      checkOrgCredits(user.orgId, user.userId),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws when member creditEnabled is false", async () => {
+    await setOrgCredits(user.orgId, 10000);
+    await insertOrgMembersEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      creditEnabled: false,
+    });
+
+    await expectInsufficientCredits(() => {
+      return checkOrgCredits(user.orgId, user.userId);
+    });
+  });
+
+  it("throws when spendable balance (credits − unsettledExpired) is zero", async () => {
+    await setOrgCredits(user.orgId, 5000);
+    // Seed an already-expired record with remaining=5000 so spendable = 0.
+    await insertCreditExpiresRecord({
+      orgId: user.orgId,
+      source: "subscription_renewal",
+      amount: 5000,
+      remaining: 5000,
+      expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+
+    await expectInsufficientCredits(() => {
+      return checkOrgCredits(user.orgId, user.userId);
+    });
+  });
+
+  it("throws when org_metadata row is missing", async () => {
+    await deleteOrgRow(user.orgId);
+    await expectInsufficientCredits(() => {
+      return checkOrgCredits(user.orgId, user.userId);
+    });
+  });
+});
+
+describe("checkOrgCreditsForRun (provider-aware LLM wrapper)", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  async function expectInsufficientCredits(fn: () => Promise<void>) {
+    try {
+      await fn();
+    } catch (err) {
+      expect(isInsufficientCredits(err)).toBe(true);
+      return;
+    }
+    throw new Error(
+      "expected checkOrgCreditsForRun to throw insufficientCredits",
+    );
+  }
+
   it("returns OK when modelProvider is non-vm0 (fast exit, no DB call)", async () => {
     await setOrgCredits(user.orgId, 0);
     await expect(
-      checkOrgCredits(user.orgId, user.userId, "anthropic"),
+      checkOrgCreditsForRun(user.orgId, user.userId, "anthropic"),
     ).resolves.toBeUndefined();
   });
 
@@ -362,7 +427,7 @@ describe("checkOrgCredits (fused CTE branches)", () => {
     await insertOrgDefaultModelProvider(user.orgId, "vm0");
     await setOrgCredits(user.orgId, 10000);
     await expect(
-      checkOrgCredits(user.orgId, user.userId, undefined),
+      checkOrgCreditsForRun(user.orgId, user.userId, undefined),
     ).resolves.toBeUndefined();
   });
 
@@ -376,14 +441,13 @@ describe("checkOrgCredits (fused CTE branches)", () => {
     });
 
     await expectInsufficientCredits(() => {
-      return checkOrgCredits(user.orgId, user.userId, undefined);
+      return checkOrgCreditsForRun(user.orgId, user.userId, undefined);
     });
   });
 
   it("throws when default provider is vm0 and spendable balance (credits − unsettledExpired) is zero", async () => {
     await insertOrgDefaultModelProvider(user.orgId, "vm0");
     await setOrgCredits(user.orgId, 5000);
-    // Seed an already-expired record with remaining=5000 so spendable = 0.
     await insertCreditExpiresRecord({
       orgId: user.orgId,
       source: "subscription_renewal",
@@ -393,7 +457,7 @@ describe("checkOrgCredits (fused CTE branches)", () => {
     });
 
     await expectInsufficientCredits(() => {
-      return checkOrgCredits(user.orgId, user.userId, undefined);
+      return checkOrgCreditsForRun(user.orgId, user.userId, undefined);
     });
   });
 
@@ -401,14 +465,14 @@ describe("checkOrgCredits (fused CTE branches)", () => {
     await insertOrgDefaultModelProvider(user.orgId, "anthropic");
     await setOrgCredits(user.orgId, 0);
     await expect(
-      checkOrgCredits(user.orgId, user.userId, undefined),
+      checkOrgCreditsForRun(user.orgId, user.userId, undefined),
     ).resolves.toBeUndefined();
   });
 
   it("throws when explicit modelProvider is vm0 and org_metadata row is missing", async () => {
     await deleteOrgRow(user.orgId);
     await expectInsufficientCredits(() => {
-      return checkOrgCredits(user.orgId, user.userId, "vm0");
+      return checkOrgCreditsForRun(user.orgId, user.userId, "vm0");
     });
   });
 });

--- a/turbo/apps/web/src/lib/zero/credit/check-org-credits.ts
+++ b/turbo/apps/web/src/lib/zero/credit/check-org-credits.ts
@@ -1,0 +1,65 @@
+import { sql } from "drizzle-orm";
+import { insufficientCredits } from "../../shared/errors";
+import type { Database } from "../../../types/global";
+
+/**
+ * Pre-flight check: ensure the member can spend vm0-bundled credits for this org.
+ *
+ * Throws `insufficientCredits` if either:
+ *   - the member's `credit_enabled` flag is false (hit their billing-cycle cap), or
+ *   - `org_metadata.credits − Σ unsettled-expired ≤ 0`.
+ *
+ * The spendable balance subtracts unsettled expired records so a dormant
+ * non-subscription org whose credits have expired (but haven't yet been
+ * settled by `processOrgCredits` or the next renewal) isn't admitted on its
+ * stale inflated balance — same form `getBillingStatus` presents in the UI.
+ *
+ * Callable from any vm0-billable route. For LLM runs that may use BYOK,
+ * use `checkOrgCreditsForRun` in zero-run-policy which wraps this with
+ * provider resolution and a BYOK fast-exit.
+ *
+ * Accepts an optional `db` so callers inside a transaction (e.g. queue drain
+ * under `pg_advisory_xact_lock`) can keep the read within the same boundary.
+ */
+export async function checkOrgCredits(
+  orgId: string,
+  userId: string,
+  db: Database = globalThis.services.db,
+): Promise<void> {
+  const { rows } = await db.execute<{
+    credit_enabled: boolean | null;
+    credits: string | null;
+    unsettled_expired: string | null;
+  }>(sql`
+    WITH member AS (
+      SELECT credit_enabled FROM org_members_metadata
+      WHERE org_id = ${orgId} AND user_id = ${userId}
+      LIMIT 1
+    ),
+    org AS (
+      SELECT credits FROM org_metadata
+      WHERE org_id = ${orgId}
+      LIMIT 1
+    ),
+    expired AS (
+      SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+      FROM credit_expires_record
+      WHERE org_id = ${orgId}
+        AND expires_at <= now()
+        AND remaining > 0
+    )
+    SELECT
+      (SELECT credit_enabled FROM member) AS credit_enabled,
+      (SELECT credits FROM org) AS credits,
+      (SELECT total FROM expired) AS unsettled_expired
+  `);
+
+  const row = rows[0];
+  if (!row) throw insufficientCredits();
+  if (row.credit_enabled === false) throw insufficientCredits();
+  if (row.credits == null) throw insufficientCredits();
+
+  const credits = Number(row.credits);
+  const unsettledExpired = Number(row.unsettled_expired ?? 0);
+  if (credits - unsettledExpired <= 0) throw insufficientCredits();
+}

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -1,10 +1,9 @@
-import { eq, and, count, gt, or, sql } from "drizzle-orm";
+import { eq, and, count, gt, or } from "drizzle-orm";
 import { env } from "../../env";
 import { agentRuns } from "../../db/schema/agent-run";
 import {
   concurrentRunLimit,
   forbidden,
-  insufficientCredits,
   noModelProvider,
 } from "../shared/errors";
 import { canAccessCompose } from "../infra/agent/compose-access";
@@ -12,6 +11,7 @@ import { logger } from "../shared/logger";
 import { modelProviders } from "../../db/schema/model-provider";
 import { ORG_SENTINEL_USER_ID } from "./org/org-sentinel";
 import { MODEL_PROVIDER_ENV_VARS } from "./context/resolve-model-provider";
+import { checkOrgCredits } from "./credit/check-org-credits";
 import type { Database } from "../../types/global";
 import type { OrgTier } from "@vm0/core/contracts/orgs";
 import type { AgentComposeYaml } from "../infra/agent-compose/types";
@@ -124,97 +124,45 @@ export async function validateComposeRequirements(
 }
 
 /**
- * Pre-flight check: ensure the org has sufficient credits for VM0 runs.
- * Skips for non-VM0 provider runs. Queries orgMetadata + orgMembersMetadata.
+ * LLM-run credit admission. Resolves vm0 vs. BYOK from `modelProvider`
+ * (or the org default when nullish) and delegates to `checkOrgCredits`
+ * for the vm0 case. Returns silently for BYOK — the user pays the
+ * provider, so no vm0 balance is touched.
  *
- * Accepts an optional `db` parameter so callers running inside a transaction
- * (e.g. dequeueNextAtomic with pg_advisory_xact_lock) can pass the transaction
- * object and keep all reads within the same isolation boundary.
- *
- * The spendable balance used for admission is
- *   org_metadata.credits − getUnsettledExpiredAmount(orgId)
- * — the same form `getBillingStatus` presents in the UI. Without this
- * subtraction a dormant non-subscription org whose credits have all expired
- * but haven't been settled yet (nothing triggers `expireCredits` until the
- * next `processOrgCredits` batch or subscription renewal) would be admitted
- * on its stale inflated balance, the run would burn real COGS, and only the
- * next settlement would notice.
+ * Accepts an optional `db` so callers inside a transaction (e.g.
+ * `drainOrgQueue` under `pg_advisory_xact_lock`) keep the read within
+ * the same boundary. Non-LLM callers use `checkOrgCredits` directly.
  */
-export async function checkOrgCredits(
+export async function checkOrgCreditsForRun(
   orgId: string,
   userId: string,
   modelProvider: string | null | undefined,
-  db: typeof globalThis.services.db = globalThis.services.db,
+  db: Database = globalThis.services.db,
 ): Promise<void> {
+  // Fast exit for explicit BYOK — no DB touch.
   if (modelProvider && modelProvider !== "vm0") {
     return;
   }
 
-  // One round-trip to collapse: default provider, member cap, org credits,
-  // unsettled-expired sum. Each subquery hits an index and each scalar
-  // subselect returns NULL when the underlying row is missing.
-  const { rows } = await db.execute<{
-    default_type: string | null;
-    credit_enabled: boolean | null;
-    credits: string | null;
-    unsettled_expired: string | null;
-  }>(sql`
-    WITH default_provider AS (
-      SELECT type FROM model_providers
-      WHERE org_id = ${orgId}
-        AND user_id = ${ORG_SENTINEL_USER_ID}
-        AND is_default = true
-      LIMIT 1
-    ),
-    member AS (
-      SELECT credit_enabled FROM org_members_metadata
-      WHERE org_id = ${orgId} AND user_id = ${userId}
-      LIMIT 1
-    ),
-    org AS (
-      SELECT credits FROM org_metadata
-      WHERE org_id = ${orgId}
-      LIMIT 1
-    ),
-    expired AS (
-      SELECT COALESCE(SUM(remaining), 0)::bigint AS total
-      FROM credit_expires_record
-      WHERE org_id = ${orgId}
-        AND expires_at <= now()
-        AND remaining > 0
-    )
-    SELECT
-      (SELECT type FROM default_provider) AS default_type,
-      (SELECT credit_enabled FROM member) AS credit_enabled,
-      (SELECT credits FROM org) AS credits,
-      (SELECT total FROM expired) AS unsettled_expired
-  `);
-
-  const row = rows[0];
-  if (!row) return;
-
-  const isVm0 = modelProvider === "vm0" || row.default_type === "vm0";
-
-  if (isVm0 && row.credit_enabled === false) {
-    throw insufficientCredits();
+  let isVm0 = modelProvider === "vm0";
+  if (!isVm0) {
+    const [defaultProvider] = await db
+      .select({ type: modelProviders.type })
+      .from(modelProviders)
+      .where(
+        and(
+          eq(modelProviders.orgId, orgId),
+          eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+          eq(modelProviders.isDefault, true),
+        ),
+      )
+      .limit(1);
+    isVm0 = defaultProvider?.type === "vm0";
   }
 
-  if (row.credits == null) {
-    if (isVm0) {
-      throw insufficientCredits();
-    }
-    return;
-  }
+  if (!isVm0) return;
 
-  const credits = Number(row.credits);
-  const unsettledExpired = Number(row.unsettled_expired ?? 0);
-  if (credits - unsettledExpired > 0) {
-    return;
-  }
-
-  if (isVm0) {
-    throw insufficientCredits();
-  }
+  await checkOrgCredits(orgId, userId, db);
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -31,7 +31,7 @@ import {
   checkRunConcurrencyLimit,
   authorizeCompose,
   validateComposeRequirements,
-  checkOrgCredits,
+  checkOrgCreditsForRun,
   checkModelProviderConfigured,
 } from "./zero-run-policy";
 import {
@@ -294,7 +294,7 @@ async function dequeueNextAtomic(
 
       // Look up org tier from org table (source of truth).
       // Falls back to "free" (most conservative limit) if row is missing.
-      // Credits are checked by checkOrgCredits() within this transaction.
+      // Credits are checked by checkOrgCreditsForRun() within this transaction.
       const [orgRow] = await tx
         .select({ tier: orgMetadata.tier })
         .from(orgMetadata)
@@ -331,7 +331,12 @@ async function dequeueNextAtomic(
 
         // Unified pre-flight credit check (org-level + per-member cap)
         try {
-          await checkOrgCredits(orgId, row.user_id, row.model_provider, tx);
+          await checkOrgCreditsForRun(
+            orgId,
+            row.user_id,
+            row.model_provider,
+            tx,
+          );
         } catch (error) {
           if (isInsufficientCredits(error)) {
             await transitionRunStatus(

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -34,7 +34,7 @@ import {
   checkRunConcurrencyLimit,
   authorizeCompose,
   validateComposeRequirements,
-  checkOrgCredits,
+  checkOrgCreditsForRun,
   checkModelProviderConfigured,
 } from "./zero-run-policy";
 import {
@@ -516,7 +516,11 @@ async function createZeroRunRecord(
   }
 
   const round3Credits = timed(async () => {
-    return checkOrgCredits(resolved.orgId, params.userId, params.modelProvider);
+    return checkOrgCreditsForRun(
+      resolved.orgId,
+      params.userId,
+      params.modelProvider,
+    );
   });
   const round3ModelProvider = timed(async () => {
     return checkModelProviderConfigured(


### PR DESCRIPTION
## Summary

Splits `checkOrgCredits(orgId, userId, modelProvider, db)` — which fused four concerns (provider fast-exit, default-provider lookup, member `credit_enabled`, spendable balance) — into two purpose-built functions:

- **`checkOrgCredits(orgId, userId, db)`** in `src/lib/zero/credit/check-org-credits.ts`: general vm0 credit admission. Throws `insufficientCredits` if `credit_enabled = false` or `credits − Σ unsettled-expired ≤ 0`. Callable from any vm0-billable route.
- **`checkOrgCreditsForRun(orgId, userId, modelProvider, db)`** in `src/lib/zero/zero-run-policy.ts`: LLM-run wrapper that resolves vm0 vs. BYOK (via `modelProvider` or the org default when nullish) and delegates to `checkOrgCredits` for the vm0 case. BYOK returns silently.

### Caller migration

| Site | Before | After |
|---|---|---|
| `zero-run-service.ts:519` | `checkOrgCredits(orgId, userId, modelProvider)` | `checkOrgCreditsForRun(...)` — signature-identical rename |
| `zero-run-queue-service.ts:334` | `checkOrgCredits(..., tx)` | `checkOrgCreditsForRun(..., tx)` |
| `generate-image/route.ts` | `checkOrgCredits(orgId, userId, "vm0", db)` — magic string | `checkOrgCredits(orgId, userId, db)` — clean call |

### Why

`generate-image/route.ts` had no LLM concept but was forced to pass `"vm0"` as a magic `modelProvider` argument to defeat the BYOK fast-exit. Future billable endpoints would have copied the same hack. Now vm0-billable routes reach `checkOrgCredits` directly and LLM-specific provider gating lives only where it belongs.

### Behaviour preserved

- BYOK LLM runs: fast exit, no DB. **Unchanged.**
- vm0 LLM runs + vm0 generate-image: member cap + spendable balance check. **Unchanged.**
- Non-vm0 default provider LLM runs: no balance check. **Unchanged.**
- The old dead-code branch (\`if (!row) return\`) is gone; \`checkOrgCredits\` always throws on missing \`org_metadata\` row.

Closes #10951

## Test plan

- [x] Unit tests in `credit-check.test.ts` split into two describe blocks (general gate + provider-aware wrapper); all 18 tests passing.
- [x] Upstream-added `generate-image/__tests__/route.test.ts` still passing (7 tests) — route behaviour unchanged.
- [x] `drainOrgQueue` + `dispatchQueuedZeroRun` integration tests (existing) passing — exercise `checkOrgCreditsForRun` transitively.
- [x] `pnpm -F web exec tsc --noEmit` — zero new errors vs main (15/15 pre-existing, all in `.next/types/**` and `@google/genai` module-not-found).
- [x] Lint (`oxlint` + `eslint`) + Prettier + Knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)