### PR TITLE
fix: improve mobile composer controls

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
@@ -157,12 +157,14 @@ describe("chat composer — mobile icon trigger", () => {
     const trigger = screen.getByRole("combobox", { name: "Claude Sonnet 4.6" });
 
     // Desktop branch: label text lives inside a `hidden sm:inline-flex` span.
-    const desktopSpan = trigger.querySelector("span.hidden.sm\\:inline-flex");
+    const desktopSpan = trigger.querySelector(
+      String.raw`span.hidden.sm\:inline-flex`,
+    );
     expect(desktopSpan).not.toBeNull();
     expect(desktopSpan?.textContent).toContain("Claude Sonnet 4.6");
 
     // Mobile branch: provider icon lives inside a `sm:hidden` span.
-    const mobileSpan = trigger.querySelector("span.sm\\:hidden");
+    const mobileSpan = trigger.querySelector(String.raw`span.sm\:hidden`);
     expect(mobileSpan).not.toBeNull();
     // ProviderIcon renders an `<img alt="">` for known provider types.
     const providerImg = mobileSpan?.querySelector("img");
@@ -209,13 +211,15 @@ describe("chat composer — mobile icon trigger", () => {
     });
 
     // Desktop branch renders the placeholder label.
-    const desktopSpan = trigger.querySelector("span.hidden.sm\\:inline-flex");
+    const desktopSpan = trigger.querySelector(
+      String.raw`span.hidden.sm\:inline-flex`,
+    );
     expect(desktopSpan).not.toBeNull();
     expect(desktopSpan?.textContent).toContain("Default");
 
     // Mobile branch still exists; since no provider resolved, ProviderIcon's
     // `<img>` is NOT rendered — the IconCpu SVG fallback fills the slot.
-    const mobileSpan = trigger.querySelector("span.sm\\:hidden");
+    const mobileSpan = trigger.querySelector(String.raw`span.sm\:hidden`);
     expect(mobileSpan).not.toBeNull();
     expect(mobileSpan?.querySelector("img")).toBeNull();
     expect(mobileSpan?.querySelector("svg")).not.toBeNull();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Integration tests for the chat composer's mod+alt+. shortcut that opens
- * the model picker dropdown.
+ * the model picker dropdown, plus the mobile-icon trigger rendering.
  *
  * Entry point: /chats/:id thread page
  * Mock (external): Web API via MSW — feature switch, org model providers,
@@ -14,6 +14,10 @@
  *   Composer section so users can discover the binding.
  * - When the caller has not opted into a model picker (no modelPicker prop),
  *   the shortcut is a no-op — it must not throw or surface a listbox.
+ * - The composer passes `mobileIconTrigger` so the trigger renders the
+ *   provider icon on mobile (`sm:hidden`) and the model label on desktop
+ *   (`hidden sm:inline-flex`). Both nodes render in the DOM simultaneously
+ *   because the switch is pure CSS — no viewport simulation is needed.
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
@@ -132,6 +136,89 @@ describe("chat composer — mod+alt+. opens the model picker", () => {
     // And the textarea text must not have captured the period as typed input —
     // processShortcut always calls preventDefault() regardless of the guard.
     expect(textarea.value).toBe("");
+  });
+});
+
+describe("chat composer — mobile icon trigger", () => {
+  beforeEach(() => {
+    resetMockOrgModelProviders();
+    resetMockFeatureSwitches();
+  });
+
+  // CHAT-MP-MOBILE-001: When the composer renders the picker, the trigger
+  // must contain BOTH a mobile-only icon branch (`sm:hidden`) and a
+  // desktop-only label branch (`hidden sm:inline-flex`). Both render to the
+  // DOM at all times — the visibility switch is pure CSS — so the test can
+  // assert the structure directly without viewport simulation.
+  it("renders provider icon on mobile and model label on desktop (CHAT-MP-MOBILE-001)", async () => {
+    enableModelPicker();
+    await openThreadWithPicker();
+
+    const trigger = screen.getByRole("combobox", { name: "Claude Sonnet 4.6" });
+
+    // Desktop branch: label text lives inside a `hidden sm:inline-flex` span.
+    const desktopSpan = trigger.querySelector("span.hidden.sm\\:inline-flex");
+    expect(desktopSpan).not.toBeNull();
+    expect(desktopSpan?.textContent).toContain("Claude Sonnet 4.6");
+
+    // Mobile branch: provider icon lives inside a `sm:hidden` span.
+    const mobileSpan = trigger.querySelector("span.sm\\:hidden");
+    expect(mobileSpan).not.toBeNull();
+    // ProviderIcon renders an `<img alt="">` for known provider types.
+    const providerImg = mobileSpan?.querySelector("img");
+    expect(providerImg).not.toBeNull();
+    expect(providerImg?.getAttribute("alt")).toBe("");
+  });
+
+  // CHAT-MP-MOBILE-002: When no provider is marked as the workspace default
+  // and the user has not picked a model, `resolved` is null — the trigger
+  // falls back to the placeholder label on desktop and must still show an
+  // icon (IconCpu) on mobile so the control never appears empty.
+  it("falls back to IconCpu on mobile when no provider resolves (CHAT-MP-MOBILE-002)", async () => {
+    // A provider exists (so the composer renders the picker) but none is
+    // marked as default, so `effectiveDefault` is null.
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ModelProviderSelection]: true,
+    });
+    setMockOrgModelProviders([
+      {
+        id: PROVIDER_ID,
+        type: "anthropic-api-key",
+        framework: "claude-code",
+        secretName: "ANTHROPIC_API_KEY",
+        authMethod: null,
+        secretNames: null,
+        isDefault: false,
+        selectedModel: DEFAULT_MODEL,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+
+    mockChatLifecycle({ threadId: THREAD_ID });
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    // The trigger aria-label falls back to the placeholder ("Default") when
+    // no provider is marked as the inherited default.
+    const trigger = await waitFor(() => {
+      return screen.getByRole("combobox", { name: "Default" });
+    });
+
+    // Desktop branch renders the placeholder label.
+    const desktopSpan = trigger.querySelector("span.hidden.sm\\:inline-flex");
+    expect(desktopSpan).not.toBeNull();
+    expect(desktopSpan?.textContent).toContain("Default");
+
+    // Mobile branch still exists; since no provider resolved, ProviderIcon's
+    // `<img>` is NOT rendered — the IconCpu SVG fallback fills the slot.
+    const mobileSpan = trigger.querySelector("span.sm\\:hidden");
+    expect(mobileSpan).not.toBeNull();
+    expect(mobileSpan?.querySelector("img")).toBeNull();
+    expect(mobileSpan?.querySelector("svg")).not.toBeNull();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1,4 +1,5 @@
 import type { MouseEvent, ReactNode } from "react";
+import { IconCpu } from "@tabler/icons-react";
 import {
   Select,
   SelectContent,
@@ -28,6 +29,7 @@ import {
   getUILabel,
   getVm0ModelMultiplier,
 } from "./settings/provider-ui-config";
+import { ProviderIcon } from "./settings/provider-icons";
 
 export interface ModelProviderSelection {
   modelProviderId: string;
@@ -57,6 +59,11 @@ interface ModelProviderPickerProps {
    * space is tight and the full breakdown lives in the open dropdown.
    */
   compactTrigger?: boolean;
+  /**
+   * When true, the trigger renders as a provider icon on mobile while keeping
+   * the normal label on larger screens.
+   */
+  mobileIconTrigger?: boolean;
   /** Controlled open state for programmatic toggle (e.g. keyboard shortcut). */
   open?: boolean;
   /** Callback when the open state changes. */
@@ -236,6 +243,7 @@ interface TriggerLabelProps {
   effectiveDefault: ModelProviderSelection | null;
   placeholder: string;
   compact: boolean;
+  mobileIcon: boolean;
 }
 
 function TriggerLabel({
@@ -244,27 +252,46 @@ function TriggerLabel({
   effectiveDefault,
   placeholder,
   compact,
+  mobileIcon,
 }: TriggerLabelProps) {
   // When no explicit value, show the effective default model name
   const resolved = value ?? effectiveDefault;
   if (!resolved) {
-    return <span>{placeholder}</span>;
+    return (
+      <ResponsiveTriggerContent
+        mobileIcon={mobileIcon}
+        provider={undefined}
+        label={<span>{placeholder}</span>}
+      />
+    );
   }
   const displayName = getModelDisplayName(resolved.selectedModel);
-  if (compact) {
-    return <span className="truncate">{displayName}</span>;
-  }
   const provider = providers.find((p) => {
     return p.id === resolved.modelProviderId;
   });
+  if (compact) {
+    return (
+      <ResponsiveTriggerContent
+        mobileIcon={mobileIcon}
+        provider={provider}
+        label={<span className="truncate">{displayName}</span>}
+      />
+    );
+  }
   if (!provider) {
-    return <span>{displayName}</span>;
+    return (
+      <ResponsiveTriggerContent
+        mobileIcon={mobileIcon}
+        provider={undefined}
+        label={<span>{displayName}</span>}
+      />
+    );
   }
   const multiplier =
     provider.type === "vm0"
       ? getVm0ModelMultiplier(resolved.selectedModel)
       : undefined;
-  return (
+  const label = (
     <span className="flex items-center gap-1.5 min-w-0">
       <span className="truncate">{displayName}</span>
       <span className="shrink-0 text-xs text-muted-foreground">
@@ -272,6 +299,41 @@ function TriggerLabel({
       </span>
       {multiplier !== undefined && <MultiplierBadge multiplier={multiplier} />}
     </span>
+  );
+  return (
+    <ResponsiveTriggerContent
+      mobileIcon={mobileIcon}
+      provider={provider}
+      label={label}
+    />
+  );
+}
+
+function ResponsiveTriggerContent({
+  mobileIcon,
+  provider,
+  label,
+}: {
+  mobileIcon: boolean;
+  provider: ModelProviderResponse | undefined;
+  label: ReactNode;
+}) {
+  if (!mobileIcon) {
+    return label;
+  }
+  return (
+    <>
+      <span className="flex items-center justify-center sm:hidden">
+        {provider ? (
+          <ProviderIcon type={provider.type} size={18} />
+        ) : (
+          <IconCpu size={18} stroke={1.5} />
+        )}
+      </span>
+      <span className="hidden min-w-0 sm:inline-flex sm:items-center">
+        {label}
+      </span>
+    </>
   );
 }
 
@@ -299,6 +361,7 @@ function DisabledPickerLabel({
   value,
   placeholder,
   compactTrigger,
+  mobileIconTrigger,
   triggerClassName,
   agentDefault,
 }: Pick<
@@ -307,11 +370,13 @@ function DisabledPickerLabel({
   | "value"
   | "placeholder"
   | "compactTrigger"
+  | "mobileIconTrigger"
   | "triggerClassName"
   | "agentDefault"
 > & {
   placeholder: string;
   compactTrigger: boolean;
+  mobileIconTrigger: boolean;
 }) {
   const { effectiveDefault } = resolveEffectiveDefault(agentDefault, providers);
   const resolved = value ?? effectiveDefault;
@@ -332,6 +397,7 @@ function DisabledPickerLabel({
         effectiveDefault={effectiveDefault}
         placeholder={placeholder}
         compact={compactTrigger}
+        mobileIcon={mobileIconTrigger}
       />
     </span>
   );
@@ -434,6 +500,7 @@ function ModelSelectDropdown({
   placeholder,
   triggerClassName,
   compactTrigger,
+  mobileIconTrigger,
   onChange,
   open,
   onOpenChange,
@@ -447,6 +514,7 @@ function ModelSelectDropdown({
   placeholder: string;
   triggerClassName: string | undefined;
   compactTrigger: boolean;
+  mobileIconTrigger: boolean;
   onChange: (value: ModelProviderSelection | null) => void;
   open: boolean | undefined;
   onOpenChange: ((open: boolean) => void) | undefined;
@@ -477,6 +545,7 @@ function ModelSelectDropdown({
             effectiveDefault={effectiveDefault}
             placeholder={placeholder}
             compact={compactTrigger}
+            mobileIcon={mobileIconTrigger}
           />
         </SelectValue>
       </SelectTrigger>
@@ -521,6 +590,7 @@ export function ModelProviderPicker({
   triggerClassName,
   sessionProviderType,
   compactTrigger = false,
+  mobileIconTrigger = false,
   open,
   onOpenChange,
   disabled = false,
@@ -534,6 +604,7 @@ export function ModelProviderPicker({
         value={value}
         placeholder={placeholder}
         compactTrigger={compactTrigger}
+        mobileIconTrigger={mobileIconTrigger}
         triggerClassName={triggerClassName}
         agentDefault={agentDefault}
       />
@@ -555,6 +626,7 @@ export function ModelProviderPicker({
       placeholder={placeholder}
       triggerClassName={triggerClassName}
       compactTrigger={compactTrigger}
+      mobileIconTrigger={mobileIconTrigger}
       onChange={onChange}
       open={open}
       onOpenChange={onOpenChange}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -226,11 +226,11 @@ function ConnectorTriggerIcons({
     return <IconPlug size={18} stroke={1.5} />;
   }
   return (
-    <span className="flex items-center -space-x-1.5">
+    <span className="flex items-center -space-x-2 sm:-space-x-1.5">
       {enabled.map((c) => {
         return (
           <span key={c.type} className="relative shrink-0">
-            <span className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-background zero-border">
+            <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background zero-border sm:h-7 sm:w-7">
               <ConnectorIcon type={c.type as ConnectorType} size={16} />
             </span>
           </span>
@@ -406,7 +406,7 @@ function ConnectorsPopoverButton({
             <TooltipTrigger asChild>
               <button
                 type="button"
-                className="inline-flex shrink-0 items-center justify-center rounded-lg h-9 min-w-9 px-1.5 hover:bg-accent transition-colors"
+                className="inline-flex h-8 min-w-8 shrink-0 items-center justify-center rounded-lg px-1 transition-colors hover:bg-accent sm:h-9 sm:min-w-9 sm:px-1.5"
                 aria-label="Connectors"
               >
                 <ConnectorTriggerIcons connectors={agentConnectors} />
@@ -944,13 +944,13 @@ export function ZeroChatComposer({
               onPaste={handlePaste}
             />
             <div className="flex items-center justify-between gap-2 px-4 pb-3 pt-1">
-              <div className="flex items-center gap-1 text-muted-foreground">
+              <div className="flex items-center gap-0 text-muted-foreground sm:gap-1">
                 <TooltipProvider delayDuration={300}>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <button
                         type="button"
-                        className="p-[9px] rounded-lg hover:bg-accent hover:text-foreground transition-colors duration-200"
+                        className="rounded-lg p-2 transition-colors duration-200 hover:bg-accent hover:text-foreground sm:p-[9px]"
                         aria-label="Attach"
                         onClick={handleFileSelect}
                       >
@@ -972,7 +972,7 @@ export function ZeroChatComposer({
                   onToggle={handleToggle}
                 />
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-0 sm:gap-2">
                 {actionsLoading ? (
                   <Skeleton
                     className={cn(
@@ -989,11 +989,13 @@ export function ZeroChatComposer({
                         onChange={modelPicker.onChange}
                         placeholder="Default"
                         triggerClassName={cn(
-                          "h-9 w-auto max-w-[12rem] gap-1 border-transparent bg-transparent px-2 text-sm text-muted-foreground transition-colors",
+                          "h-9 w-9 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:w-auto sm:max-w-[12rem] sm:gap-1 sm:px-2",
+                          "[&>span]:flex [&>span]:items-center [&>span]:justify-center sm:[&>span]:justify-start [&>svg]:hidden sm:[&>svg]:block",
                           "hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
                         )}
                         sessionProviderType={modelPicker.sessionProviderType}
                         compactTrigger
+                        mobileIconTrigger
                         open={modelPickerOpen}
                         onOpenChange={setModelPickerOpen}
                         disabled={modelPicker.disabled}
@@ -1001,7 +1003,7 @@ export function ZeroChatComposer({
                         inheritLabel="agent"
                       />
                     )}
-                    <div className="mx-0.5 h-5 w-px bg-border/60" />
+                    <div className="mx-0 h-5 w-px bg-border/60 sm:mx-0.5" />
                     <MicButton
                       onTranscribed={(text) => {
                         const base = input;


### PR DESCRIPTION
## Summary
- show the model picker as a provider icon on mobile while keeping the full label on desktop
- tighten mobile spacing for composer attachment/connectors and action controls
- preserve desktop composer spacing and existing picker behavior

## Tests
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app test -- src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx src/views/zero-page/__tests__/model-provider-picker-display.test.tsx
- git diff --check