### PR TITLE
refactor: remove ChatThreadListItem.agentId

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -27,7 +27,7 @@ const navigateToAdjacentThread$ = command(
     }
     if (direction === "prev" && idx === 0) {
       // Escape upwards from the first thread to the agent chat page.
-      const agentId = threads[0]!.agent?.id ?? threads[0]!.agentId;
+      const agentId = threads[0]!.agent.id;
       set(detachedNavigateTo$, "/agents/:agentId/chat", {
         pathParams: { agentId },
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-keyboard.test.tsx
@@ -24,7 +24,7 @@ function mockThreadList(threads: { id: string; title: string }[]) {
           return {
             id: t.id,
             title: t.title,
-            agentId: AGENT_ID,
+            agent: { id: AGENT_ID, avatarUrl: null },
             createdAt: "2026-03-10T00:00:00Z",
             updatedAt: "2026-03-10T00:00:00Z",
             isRead: true,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
@@ -48,7 +48,7 @@ function mockThreadList(threads: { id: string; title: string }[]) {
           return {
             id: t.id,
             title: t.title,
-            agentId: AGENT_ID,
+            agent: { id: AGENT_ID, avatarUrl: null },
             createdAt: "2026-03-10T00:00:00Z",
             updatedAt: "2026-03-10T00:00:00Z",
             isRead: true,
@@ -138,9 +138,8 @@ describe("chat page keyboard shortcuts", () => {
     });
   });
 
-  it("mod+shift+up on the first thread uses agent.id when present (not agentId)", async () => {
+  it("mod+shift+up on the first thread uses the list item's agent.id", async () => {
     const user = userEvent.setup();
-    // The thread carries both agentId (legacy) and agent.id (preferred).
     // The escape navigation must use agent.id, not agentId.
     const AGENT_ID_FROM_OBJECT = "a2222222-0000-4000-a000-000000000002";
     // Include the thread's agent in the team so the chat page setup does not
@@ -172,7 +171,6 @@ describe("chat page keyboard shortcuts", () => {
             {
               id: "thread-agent-obj",
               title: "With agent object",
-              agentId: AGENT_ID,
               agent: { id: AGENT_ID_FROM_OBJECT, avatarUrl: null },
               createdAt: "2026-03-10T00:00:00Z",
               updatedAt: "2026-03-10T00:00:00Z",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -154,7 +154,7 @@ export async function sendMessageInUI(
 interface ThreadListItem {
   id: string;
   title: string | null;
-  agentId: string;
+  agent: { id: string; avatarUrl: string | null };
   createdAt: string;
   updatedAt: string;
   isRead: boolean;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-title-refresh.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-title-refresh.test.tsx
@@ -32,7 +32,10 @@ describe("chat title refresh", () => {
               id: "thread-test-1",
               title:
                 threadListFetchCount > 1 ? "AI Generated Title" : "Old Title",
-              agentId: "c0000000-0000-4000-a000-000000000001",
+              agent: {
+                id: "c0000000-0000-4000-a000-000000000001",
+                avatarUrl: null,
+              },
               createdAt: "2026-03-10T00:00:00Z",
               updatedAt: "2026-03-10T00:00:00Z",
               isRead: false,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/recent-thread-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/recent-thread-skeleton.test.tsx
@@ -46,7 +46,7 @@ function mockAgentsWithThreads() {
           {
             id: THREAD_ID,
             title: "My test conversation",
-            agentId: "agent-alpha",
+            agent: { id: "agent-alpha", avatarUrl: null },
             createdAt: "2026-03-10T00:00:00Z",
             updatedAt: "2026-03-10T00:00:00Z",
             isRead: false,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -22,7 +22,7 @@ function makeThread(
 ): {
   id: string;
   title: string;
-  agentId: string;
+  agent: { id: string; avatarUrl: string | null };
   createdAt: string;
   updatedAt: string;
   isRead: boolean;
@@ -32,7 +32,7 @@ function makeThread(
   return {
     id,
     title,
-    agentId: AGENT_ID,
+    agent: { id: AGENT_ID, avatarUrl: null },
     createdAt,
     updatedAt: createdAt,
     isRead: false,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-navigation.test.tsx
@@ -22,7 +22,10 @@ function mockAPIs() {
           {
             id: "thread-abc-123",
             title: "Test conversation",
-            agentId: "c0000000-0000-4000-a000-000000000001",
+            agent: {
+              id: "c0000000-0000-4000-a000-000000000001",
+              avatarUrl: null,
+            },
             createdAt: "2026-03-10T00:00:00Z",
             updatedAt: "2026-03-10T00:00:00Z",
             isRead: false,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -23,7 +23,7 @@ function mockSubagentAPIs() {
   const threads: {
     id: string;
     title: string | null;
-    agentId: string;
+    agent: { id: string; avatarUrl: string | null };
     createdAt: string;
     updatedAt: string;
     isRead: boolean;
@@ -33,7 +33,7 @@ function mockSubagentAPIs() {
     {
       id: "thread-sub-1",
       title: "Subagent thread",
-      agentId: "subagent-compose-id",
+      agent: { id: "subagent-compose-id", avatarUrl: null },
       createdAt: "2026-03-10T00:00:00Z",
       updatedAt: "2026-03-10T00:00:00Z",
       isRead: false,
@@ -146,7 +146,7 @@ function mockSubagentAPIs() {
       const newThread = {
         id: "new-thread-id",
         title: body.title ?? null,
-        agentId: body.agentId,
+        agent: { id: body.agentId, avatarUrl: null },
         createdAt: now,
         updatedAt: now,
         isRead: false,
@@ -270,7 +270,10 @@ describe("sidebar new chat navigation", () => {
             {
               id: "new-thread-id",
               title: null,
-              agentId: "c0000000-0000-4000-a000-000000000001",
+              agent: {
+                id: "c0000000-0000-4000-a000-000000000001",
+                avatarUrl: null,
+              },
               createdAt: "2026-03-10T00:00:00Z",
               updatedAt: "2026-03-10T00:00:00Z",
               isRead: false,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
@@ -35,7 +35,7 @@ const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 interface ThreadFixture {
   id: string;
   title: string;
-  agentId: string;
+  agent: { id: string; avatarUrl: string | null };
   createdAt: string;
   updatedAt: string;
   isRead: boolean;
@@ -82,7 +82,7 @@ describe("sidebar running indicator", () => {
         {
           id: "thread-1",
           title: "Active work",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: true,
@@ -110,7 +110,7 @@ describe("sidebar running indicator", () => {
         {
           id: "thread-selected",
           title: "Selected running",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,
@@ -140,7 +140,7 @@ describe("sidebar running indicator", () => {
         {
           id: "thread-selected-unread",
           title: "Selected unread",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,
@@ -170,7 +170,7 @@ describe("sidebar running indicator", () => {
         {
           id: "thread-both",
           title: "Running and unread",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,
@@ -201,7 +201,7 @@ describe("sidebar running indicator", () => {
         {
           id: "thread-gated",
           title: "Running but gated",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: true,
@@ -228,7 +228,7 @@ describe("sidebar running indicator", () => {
         {
           id: "thread-flips",
           title: "Will flip to running",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: true,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-unify-chat-threads.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-unify-chat-threads.test.tsx
@@ -61,7 +61,6 @@ function mockUnifiedThreads(observedQueries: ListQuery[]) {
           {
             id: "thread-default",
             title: "Default thread",
-            agentId: DEFAULT_AGENT_ID,
             agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
             createdAt: "2026-03-10T00:00:00Z",
             updatedAt: "2026-03-10T00:00:00Z",
@@ -72,7 +71,6 @@ function mockUnifiedThreads(observedQueries: ListQuery[]) {
           {
             id: "thread-sub",
             title: "Sub thread",
-            agentId: SUB_AGENT_ID,
             agent: { id: SUB_AGENT_ID, avatarUrl: null },
             createdAt: "2026-03-09T00:00:00Z",
             updatedAt: "2026-03-09T00:00:00Z",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
@@ -35,7 +35,7 @@ function mockBaseAPIs(
     threads?: {
       id: string;
       title: string;
-      agentId: string;
+      agent: { id: string; avatarUrl: string | null };
       createdAt: string;
       updatedAt: string;
       isRead: boolean;
@@ -89,7 +89,7 @@ describe("zero sidebar - chat thread list display (SIDEBAR-D-001)", () => {
         {
           id: "thread-1",
           title: "Deploy to production",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,
@@ -99,7 +99,7 @@ describe("zero sidebar - chat thread list display (SIDEBAR-D-001)", () => {
         {
           id: "thread-2",
           title: "Fix the bug",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-09T00:00:00Z",
           updatedAt: "2026-03-09T00:00:00Z",
           isRead: false,
@@ -152,7 +152,7 @@ describe("zero sidebar - search results filter (SIDEBAR-D-003)", () => {
         {
           id: "thread-1",
           title: "Deploy to production",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,
@@ -162,7 +162,7 @@ describe("zero sidebar - search results filter (SIDEBAR-D-003)", () => {
         {
           id: "thread-2",
           title: "Fix the bug",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-09T00:00:00Z",
           updatedAt: "2026-03-09T00:00:00Z",
           isRead: false,
@@ -206,7 +206,7 @@ describe("zero sidebar - search term displays in input (SIDEBAR-D-004)", () => {
         {
           id: "thread-1",
           title: "Deploy to production",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -45,7 +45,7 @@ function makeThread(
 ): {
   id: string;
   title: string;
-  agentId: string;
+  agent: { id: string; avatarUrl: string | null };
   createdAt: string;
   updatedAt: string;
   isRead: boolean;
@@ -55,7 +55,7 @@ function makeThread(
   return {
     id,
     title,
-    agentId: DEFAULT_AGENT_ID,
+    agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
     createdAt,
     updatedAt: createdAt,
     isRead: false,
@@ -92,7 +92,7 @@ function mockBaseAPIs(options?: {
   threads?: {
     id: string;
     title: string;
-    agentId: string;
+    agent: { id: string; avatarUrl: string | null };
     createdAt: string;
     updatedAt: string;
     isRead: boolean;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
@@ -39,7 +39,7 @@ function makeThread(
 ): {
   id: string;
   title: string;
-  agentId: string;
+  agent: { id: string; avatarUrl: string | null };
   createdAt: string;
   updatedAt: string;
   isRead: boolean;
@@ -49,7 +49,7 @@ function makeThread(
   return {
     id,
     title,
-    agentId: DEFAULT_AGENT_ID,
+    agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
     createdAt,
     updatedAt: createdAt,
     isRead: false,
@@ -86,7 +86,7 @@ function mockBaseAPIs(options?: {
   threads?: {
     id: string;
     title: string;
-    agentId: string;
+    agent: { id: string; avatarUrl: string | null };
     createdAt: string;
     updatedAt: string;
     isRead: boolean;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -22,7 +22,7 @@ function mockAPIs({
     {
       id: "thread-1",
       title: "First chat",
-      agentId: "c0000000-0000-4000-a000-000000000001",
+      agent: { id: "c0000000-0000-4000-a000-000000000001", avatarUrl: null },
       createdAt: "2026-03-10T00:00:00Z",
       updatedAt: "2026-03-10T00:00:00Z",
       isRead: false,
@@ -32,7 +32,7 @@ function mockAPIs({
     {
       id: "thread-2",
       title: "Second chat",
-      agentId: "c0000000-0000-4000-a000-000000000001",
+      agent: { id: "c0000000-0000-4000-a000-000000000001", avatarUrl: null },
       createdAt: "2026-03-09T00:00:00Z",
       updatedAt: "2026-03-09T00:00:00Z",
       isRead: false,
@@ -44,7 +44,7 @@ function mockAPIs({
   threads?: {
     id: string;
     title: string;
-    agentId: string;
+    agent: { id: string; avatarUrl: string | null };
     createdAt: string;
     updatedAt: string;
     isRead: boolean;

--- a/turbo/apps/web/app/api/zero/chat-threads/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/__tests__/route.test.ts
@@ -571,6 +571,7 @@ describe("GET /api/zero/chat-threads - List Threads", () => {
     expect(response.status).toBe(200);
     expect(data.threads).toHaveLength(1);
     expect(data.threads[0].agent).toBeDefined();
+    expect(data.threads[0]).not.toHaveProperty("agentId");
     expect(data.threads[0].agent.id).toBe(testComposeId);
     expect(data.threads[0].agent).toHaveProperty("avatarUrl");
   });
@@ -697,6 +698,7 @@ describe("GET /api/zero/chat-threads - Unified list (agentId omitted)", () => {
     expect(response.status).toBe(200);
     expect(data.threads).toHaveLength(1);
     expect(data.threads[0].agent).toBeDefined();
+    expect(data.threads[0]).not.toHaveProperty("agentId");
     expect(data.threads[0].agent.id).toBe(composeAId);
     // avatarUrl defaults to null for a freshly seeded zero_agents row.
     expect(data.threads[0].agent).toHaveProperty("avatarUrl");

--- a/turbo/apps/web/app/api/zero/chat-threads/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/route.ts
@@ -113,7 +113,6 @@ const router = tsr.router(chatThreadsContract, {
           return {
             id: t.id,
             title: t.title,
-            agentId: t.agentId,
             agent: {
               id: t.agentId,
               avatarUrl: t.agentAvatarUrl,

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -47,22 +47,12 @@ const chatThreadListItemSchema = z.object({
   id: z.string(),
   title: z.string().nullable(),
   /**
-   * @deprecated Use `agent.id` instead. Will be removed in #10284 once every
-   * consumer reads `agent.id` and the UnifyChatThreads flag has fully rolled out.
-   * Kept temporarily so existing fixtures still parse during the rollout window.
+   * Owning agent snapshot emitted by the server for every list row.
    */
-  agentId: z.string(),
-  /**
-   * Owning agent snapshot. Always emitted by the server; kept optional on the
-   * schema so older fixtures that predate the unified-list rollout still
-   * validate until they are migrated (tracked in #10284).
-   */
-  agent: z
-    .object({
-      id: z.string(),
-      avatarUrl: z.string().nullable(),
-    })
-    .optional(),
+  agent: z.object({
+    id: z.string(),
+    avatarUrl: z.string().nullable(),
+  }),
   createdAt: z.string(),
   updatedAt: z.string(),
   /**


### PR DESCRIPTION
## Summary
- remove deprecated `agentId` from `ChatThreadListItem` and require `agent`
- stop emitting top-level `agentId` from `GET /api/zero/chat-threads`
- update keyboard/sidebar tests and fixtures to use `agent.id`

## Testing
- `pnpm -C turbo exec tsc -p packages/core/tsconfig.json --noEmit`
- `pnpm -C turbo exec tsc -p apps/platform/tsconfig.json --noEmit`
- `pnpm -C turbo/apps/web exec vitest run app/api/zero/chat-threads/__tests__/route.test.ts` *(fails in this environment: missing `@vercel/functions`)*

Closes #10284