### PR TITLE
fix(mitm-addon): retarget seed-consistency test at usage_pricing + trigger on dev-seed.ts

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -62,6 +62,7 @@ jobs:
     outputs:
       any-changed: ${{ steps.detect.outputs.any-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
+      mitm-addon-turbo-changed: ${{ steps.detect.outputs.mitm-addon-turbo-changed }}
       ably-subscriber-changed: ${{ steps.detect.outputs.ably-subscriber-changed }}
       runner-changed: ${{ steps.detect.outputs.runner-changed }}
       guest-init-changed: ${{ steps.detect.outputs.guest-init-changed }}
@@ -122,6 +123,17 @@ jobs:
             echo "any-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "any-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Files outside crates/ that mitm-addon tests read directly. Written
+          # AFTER the any-changed aggregation so a dev-seed.ts edit doesn't
+          # force every crate job to re-run; only mitm-addon-test needs it.
+          # Keep in sync with paths referenced in
+          # crates/runner/mitm-addon/tests/.
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^turbo/apps/web/scripts/dev-seed\.ts$"; then
+            echo "mitm-addon-turbo-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "mitm-addon-turbo-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Select metal host
@@ -236,7 +248,9 @@ jobs:
   mitm-addon-test:
     runs-on: ubuntu-latest
     needs: [detect]
-    if: needs.detect.outputs.any-changed == 'true'
+    if: |
+      needs.detect.outputs.any-changed == 'true' ||
+      needs.detect.outputs.mitm-addon-turbo-changed == 'true'
     steps:
       - uses: actions/checkout@v6
 

--- a/crates/runner/mitm-addon/tests/test_x_billing.py
+++ b/crates/runner/mitm-addon/tests/test_x_billing.py
@@ -329,24 +329,29 @@ class TestSeedConsistency:
         )
         if not seed_path.exists():
             pytest.fail(
-                f"dev-seed.ts not found at {seed_path}.  The X_CONNECTOR_PRICING "
-                "block has likely moved — update this test's path computation."
+                f"dev-seed.ts not found at {seed_path}.  The X connector "
+                "pricing block has likely moved — update this test's path "
+                "computation."
             )
         text = seed_path.read_text()
-        # Walk from the X_CONNECTOR_PRICING declaration to its closing
-        # bracket so we don't accidentally scoop up other category-like
-        # strings elsewhere in the file.
+        # Scope the scan to the `usageGroup("connector", "x", [...])` call so
+        # we don't scoop up categories for other connectors / kinds that share
+        # the same `USAGE_PRICING` array.
+        start_marker = 'usageGroup("connector", "x", ['
         try:
-            start = text.index("const X_CONNECTOR_PRICING")
-            end = text.index("];", start)
+            start = text.index(start_marker)
+            end = text.index("])", start)
         except ValueError:
             pytest.fail(
-                "Could not locate the `const X_CONNECTOR_PRICING = [...]` block "
-                f"in {seed_path}.  Either the variable was renamed or the array "
-                "syntax changed — update this test to match."
+                f"Could not locate the `{start_marker}...])` block in "
+                f"{seed_path}.  Either the helper was renamed, the connector "
+                "key changed, or the call shape changed — update this test to "
+                "match."
             )
         block = text[start:end]
-        return set(re.findall(r'category:\s*"([^"]+)"', block))
+        # Entries are tuples: `["<category>", usd(<price>), <quantity>]`. The
+        # category is the first string in each tuple.
+        return set(re.findall(r'\[\s*"([^"]+)"\s*,', block))
 
     def _emitted_buckets(self) -> set[str]:
         emitted = set(_PERMISSION_TO_BUCKET.values())
@@ -381,6 +386,7 @@ class TestSeedConsistency:
         unrecognised includes type."""
         seed = self._load_seed_categories()
         assert "__fallback__" in seed, (
-            "dev-seed.ts lost the `__fallback__` X_CONNECTOR_PRICING row.  "
-            "Unknown includes keys would bill at $0 — restore the row."
+            "dev-seed.ts lost the `__fallback__` row in the X connector "
+            "usageGroup.  Unknown includes keys would bill at $0 — restore "
+            "the row."
         )


### PR DESCRIPTION
## Summary

`main` is broken: `tests/test_x_billing.py::TestSeedConsistency` fails both cases with *"Could not locate the `const X_CONNECTOR_PRICING = [...]` block"*.

Two independent bugs landed together:

1. **Test got stale.** #10979 renamed `X_CONNECTOR_PRICING` → `USAGE_PRICING` in `turbo/apps/web/scripts/dev-seed.ts` and switched entries from `{ category: "xxx", ... }` objects to `usageGroup("connector", "x", [["xxx", usd(...), 1], ...])` tuples. The Python check was raw-string-matching the old shape.
2. **CI didn't notice.** `mitm-addon-test` gates on `detect.outputs.any-changed`, which only aggregates changes under `crates/` via `scripts/crate-changed.sh`. A `turbo/` edit that this test reads doesn't trigger the job, so #10979 merged green.

## Changes

**`crates/runner/mitm-addon/tests/test_x_billing.py`**
- `_load_seed_categories` now anchors on `usageGroup("connector", "x", [...])` and extracts the first string of each tuple. The scan stays inside the X connector call, so the Gemini image rows (and any future `usageGroup` calls) in the same `USAGE_PRICING` array don't leak into the seed set.

**`.github/workflows/crates.yml`**
- New `mitm-addon-turbo-changed` output on `detect`, watching `turbo/apps/web/scripts/dev-seed.ts`. Written *after* the `any-changed` aggregation so a seed-only edit doesn't pull every crate job along.
- `mitm-addon-test` `if:` extended with `|| needs.detect.outputs.mitm-addon-turbo-changed == 'true'`. The existing `check_result "mitm-addon-test" ... "true"` gate already allows skipped, so no-op paths are unchanged.

## Test plan

- [x] `cd crates/runner/mitm-addon && python -m pytest tests/test_x_billing.py -v` → 7/7 pass locally (previously 2 failed).
- [x] New parse finds 26 categories including `__fallback__` and `content.create_with_url`.
- [x] `ruff check` + `ruff format --check` clean on the modified file.
- [x] `yaml.safe_load` confirms the workflow is valid.
- [ ] CI green on this PR (verifies the new trigger: this PR doesn't touch `crates/` but does touch `.github/workflows/crates.yml`, so `mitm-addon-test` should run via the `ci-changed` branch of `any-changed`).

## Follow-ups out of scope

- `test_x_billing.py` also reads `turbo/packages/core/src/firewalls/x.generated.ts` (a postinstall-generated file). A rename / schema change there would hit the same CI gap. Worth a later pass to add that source and its generator inputs to `mitm-addon-turbo-changed`, but not needed to unblock `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)