### PR TITLE
feat(eslint): add no-global-assignment rule banning new globals

### DIFF
--- a/turbo/apps/web/.oxlintrc.json
+++ b/turbo/apps/web/.oxlintrc.json
@@ -32,6 +32,7 @@
         "custom-eslint/index.ts",
         "custom-eslint/rules/no-direct-db-in-tests.ts",
         "custom-eslint/rules/no-duplicate-migration-prefix.ts",
+        "custom-eslint/rules/no-global-assignment.ts",
         "custom-eslint/rules/no-relative-vi-mock.ts",
         "custom-eslint/rules/no-request-json-as.ts",
         "app/**/page.tsx",

--- a/turbo/apps/web/app/api/cron/voice-chat-cleanup/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/voice-chat-cleanup/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
   countTestVoiceChatSessionsByReasoningStatus,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { reloadEnv } from "../../../../../src/env";
+import { nextAfterCallbacks } from "../../../../../src/__tests__/next-after-hooks";
 
 vi.hoisted(() => {
   vi.stubEnv("CRON_SECRET", "test-cron-secret");
@@ -52,7 +53,7 @@ describe("GET /api/cron/voice-chat-cleanup", () => {
       });
 
       // Pre-cron: after() queue is empty.
-      expect(globalThis.nextAfterCallbacks.length).toBe(0);
+      expect(nextAfterCallbacks.length).toBe(0);
 
       const response = await GET(cronRequest("test-cron-secret"));
       const body = await response.json();
@@ -62,7 +63,7 @@ describe("GET /api/cron/voice-chat-cleanup", () => {
       expect(row?.reasoningStatus).toBe("idle");
 
       // Exactly one after() callback was queued: the re-tick for this session.
-      expect(globalThis.nextAfterCallbacks.length).toBe(1);
+      expect(nextAfterCallbacks.length).toBe(1);
     });
 
     it("T6 — does not touch a non-stuck reasoner (lastSummaryAt within 5 min)", async () => {

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
@@ -14,15 +14,19 @@ import { GET as linkGET } from "../../../../api/integrations/telegram/link/route
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 import { POST } from "../[telegramBotId]/route";
+import {
+  nextAfterArgForms,
+  nextAfterCallbacks,
+} from "../../../../../src/__tests__/next-after-hooks";
 
 // Uses the shared `next/server` mock from src/__tests__/setup.ts, which records
-// both the argument form (globalThis.nextAfterArgForms) and the callback queue
-// (globalThis.nextAfterCallbacks). Tests draining the queue use the helper
-// below; regression tests that only care about the argument form assert on
-// globalThis.nextAfterArgForms directly.
+// both the argument form (nextAfterArgForms) and the callback queue
+// (nextAfterCallbacks) in src/__tests__/next-after-hooks.ts. Tests draining
+// the queue use the helper below; regression tests that only care about the
+// argument form assert on nextAfterArgForms directly.
 async function flushAfterCallbacks() {
-  const callbacks = [...globalThis.nextAfterCallbacks];
-  globalThis.nextAfterCallbacks = [];
+  const callbacks = [...nextAfterCallbacks];
+  nextAfterCallbacks.length = 0;
   await Promise.all(
     callbacks.map((cb) => {
       return cb();
@@ -152,7 +156,7 @@ describe("POST /api/telegram/webhook/[telegramBotId]", () => {
     expect(response.status).toBe(200);
 
     // after() was called (handler was dispatched)
-    expect(globalThis.nextAfterCallbacks.length).toBe(1);
+    expect(nextAfterCallbacks.length).toBe(1);
 
     // Handler errors are caught gracefully (no unhandled rejections)
     await flushAfterCallbacks();
@@ -174,7 +178,7 @@ describe("POST /api/telegram/webhook/[telegramBotId]", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(globalThis.nextAfterCallbacks.length).toBe(1);
+    expect(nextAfterCallbacks.length).toBe(1);
     await flushAfterCallbacks();
   });
 
@@ -284,7 +288,7 @@ describe("POST /api/telegram/webhook/[telegramBotId]", () => {
         params: Promise.resolve({ telegramBotId }),
       });
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
 
     it("registers @mention handler via callback form", async () => {
@@ -303,7 +307,7 @@ describe("POST /api/telegram/webhook/[telegramBotId]", () => {
         params: Promise.resolve({ telegramBotId }),
       });
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
 
     it("registers reply-to-bot handler via callback form", async () => {
@@ -326,7 +330,7 @@ describe("POST /api/telegram/webhook/[telegramBotId]", () => {
         params: Promise.resolve({ telegramBotId }),
       });
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
 
     it("registers /start command handler via callback form", async () => {
@@ -344,7 +348,7 @@ describe("POST /api/telegram/webhook/[telegramBotId]", () => {
         params: Promise.resolve({ telegramBotId }),
       });
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -29,6 +29,7 @@ import { createTestEmailThreadSession } from "../../../../../../src/__tests__/db
 import { generateReplyToken } from "../../../../../../src/lib/zero/email/handlers/shared";
 import { createTestZeroAgent } from "../../../../../../src/__tests__/db-test-seeders/agents";
 import { reloadEnv } from "../../../../../../src/env";
+import { nextAfterCallbacks } from "../../../../../../src/__tests__/next-after-hooks";
 import {
   testContext,
   uniqueId,
@@ -609,7 +610,7 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(response.status).toBe(200);
 
       // Only one after() callback: dispatchCallbacks
-      expect(globalThis.nextAfterCallbacks).toHaveLength(1);
+      expect(nextAfterCallbacks).toHaveLength(1);
       await context.mocks.flushAfter();
     });
 

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { nextAfterCallbacks } from "../../../../../../src/__tests__/next-after-hooks";
 import { randomUUID } from "crypto";
 
 // Only mock external services
@@ -226,7 +227,7 @@ describe("POST /api/webhooks/agent/heartbeat", () => {
       expect(response.status).toBe(200);
 
       // The heartbeat handler should have registered an after() callback
-      expect(globalThis.nextAfterCallbacks).toHaveLength(1);
+      expect(nextAfterCallbacks).toHaveLength(1);
 
       // Flush and verify it doesn't throw (no callbacks registered for this run)
       await context.mocks.flushAfter();

--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -18,6 +18,7 @@ import {
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { POST } from "../route";
 import { reloadEnv } from "../../../../../src/env";
+import { nextAfterArgForms } from "../../../../../src/__tests__/next-after-hooks";
 
 const context = testContext();
 
@@ -703,7 +704,7 @@ describe("POST /api/webhooks/github", () => {
       );
       await POST(request);
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
 
     it("registers issue_comment handler via callback form", async () => {
@@ -721,7 +722,7 @@ describe("POST /api/webhooks/github", () => {
       );
       await POST(request);
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
 
     it("registers installation handler via callback form", async () => {
@@ -735,7 +736,7 @@ describe("POST /api/webhooks/github", () => {
       });
       await POST(request);
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -23,6 +23,7 @@ import {
   clearComposeHeadVersion,
 } from "../../../../../../src/__tests__/db-test-seeders/agents";
 import { reloadEnv } from "../../../../../../src/env";
+import { nextAfterArgForms } from "../../../../../../src/__tests__/next-after-hooks";
 
 vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
   const actual =
@@ -1202,7 +1203,7 @@ describe("POST /api/zero/slack/events", () => {
 
       await POST(request);
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
 
     it("registers direct_message handler via callback form", async () => {
@@ -1227,7 +1228,7 @@ describe("POST /api/zero/slack/events", () => {
 
       await POST(request);
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
 
     it("registers app_home_opened (home) handler via callback form", async () => {
@@ -1249,7 +1250,7 @@ describe("POST /api/zero/slack/events", () => {
 
       await POST(request);
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
 
     it("registers app_home_opened (messages) handler via callback form", async () => {
@@ -1271,7 +1272,7 @@ describe("POST /api/zero/slack/events", () => {
 
       await POST(request);
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
 
     it("registers app_uninstalled cleanup via callback form", async () => {
@@ -1288,7 +1289,7 @@ describe("POST /api/zero/slack/events", () => {
 
       await POST(request);
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
 
     it("registers tokens_revoked cleanup via callback form", async () => {
@@ -1308,7 +1309,7 @@ describe("POST /api/zero/slack/events", () => {
 
       await POST(request);
 
-      expect(globalThis.nextAfterArgForms).toEqual(["fn"]);
+      expect(nextAfterArgForms).toEqual(["fn"]);
     });
   });
 

--- a/turbo/apps/web/custom-eslint/__tests__/no-global-assignment.test.ts
+++ b/turbo/apps/web/custom-eslint/__tests__/no-global-assignment.test.ts
@@ -1,0 +1,117 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-global-assignment.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+const ALLOWED_INIT_SERVICES = "/abs/src/lib/init-services.ts";
+const ALLOWED_GLOBAL_DTS = "/abs/src/types/global.d.ts";
+const REGULAR_FILE = "/abs/src/lib/some-feature.ts";
+
+ruleTester.run("no-global-assignment", rule, {
+  valid: [
+    // Reads of the sanctioned singleton are fine
+    {
+      code: "const db = globalThis.services.db;",
+      filename: REGULAR_FILE,
+    },
+    {
+      code: "globalThis.services.db.select();",
+      filename: REGULAR_FILE,
+    },
+    // Deep-chain mutation is a mutation of a property on `services`, not on
+    // the global itself. Out of scope for this rule.
+    {
+      code: "globalThis.services.cache = new Map();",
+      filename: REGULAR_FILE,
+    },
+    // DOM writes are untouched — the rule only covers globalThis/global
+    {
+      code: "window.location.href = '/';",
+      filename: REGULAR_FILE,
+    },
+    {
+      code: "Object.defineProperty(window, 'matchMedia', { value: fn });",
+      filename: REGULAR_FILE,
+    },
+    {
+      code: "self.foo = 1;",
+      filename: REGULAR_FILE,
+    },
+    // Allowlisted files can install globals freely
+    {
+      code: "Object.defineProperty(globalThis, 'services', { get: () => s });",
+      filename: ALLOWED_INIT_SERVICES,
+    },
+    {
+      code: "globalThis.anything = 1;",
+      filename: ALLOWED_INIT_SERVICES,
+    },
+    {
+      code: "declare global { var services: Services; }",
+      filename: ALLOWED_GLOBAL_DTS,
+    },
+    // Assignments to local objects (not a global root) are untouched
+    {
+      code: "const x = { services: 1 }; x.services = 2;",
+      filename: REGULAR_FILE,
+    },
+  ],
+  invalid: [
+    {
+      code: "globalThis.foo = 1;",
+      filename: REGULAR_FILE,
+      errors: [{ messageId: "noGlobalAssignment" }],
+    },
+    {
+      code: "globalThis['foo'] = 1;",
+      filename: REGULAR_FILE,
+      errors: [{ messageId: "noGlobalAssignment" }],
+    },
+    {
+      code: "global.foo = 1;",
+      filename: REGULAR_FILE,
+      errors: [{ messageId: "noGlobalAssignment" }],
+    },
+    {
+      code: "(globalThis as any).foo = 1;",
+      filename: REGULAR_FILE,
+      errors: [{ messageId: "noGlobalAssignment" }],
+    },
+    {
+      code: "Object.defineProperty(globalThis, 'foo', { value: 1 });",
+      filename: REGULAR_FILE,
+      errors: [{ messageId: "noGlobalDefineProperty" }],
+    },
+    {
+      code: "Reflect.defineProperty(globalThis, 'foo', { value: 1 });",
+      filename: REGULAR_FILE,
+      errors: [{ messageId: "noGlobalDefineProperty" }],
+    },
+    {
+      code: "Object.defineProperty(global, 'foo', { value: 1 });",
+      filename: REGULAR_FILE,
+      errors: [{ messageId: "noGlobalDefineProperty" }],
+    },
+    {
+      code: "Object.assign(globalThis, { foo: 1 });",
+      filename: REGULAR_FILE,
+      errors: [{ messageId: "noGlobalAssign" }],
+    },
+    {
+      code: "declare global { var foo: number; }",
+      filename: REGULAR_FILE,
+      errors: [{ messageId: "noDeclareGlobal" }],
+    },
+    {
+      // Services re-declaration outside the allowlisted files is still banned
+      code: "declare global { var services: Services; }",
+      filename: REGULAR_FILE,
+      errors: [{ messageId: "noDeclareGlobal" }],
+    },
+  ],
+});

--- a/turbo/apps/web/custom-eslint/index.ts
+++ b/turbo/apps/web/custom-eslint/index.ts
@@ -5,10 +5,12 @@
  * - no-direct-db-in-tests: Don't access database directly in test files
  * - no-relative-vi-mock: Don't use relative paths in vi.mock()
  * - no-duplicate-migration-prefix: Prevent duplicate migration file prefixes
+ * - no-global-assignment: Don't attach new properties to globalThis/global
  */
 
 import noDirectDbInTests from "./rules/no-direct-db-in-tests.ts";
 import noDuplicateMigrationPrefix from "./rules/no-duplicate-migration-prefix.ts";
+import noGlobalAssignment from "./rules/no-global-assignment.ts";
 import noRelativeViMock from "./rules/no-relative-vi-mock.ts";
 import noRequestJsonAs from "./rules/no-request-json-as.ts";
 
@@ -20,6 +22,7 @@ const plugin = {
   rules: {
     "no-direct-db-in-tests": noDirectDbInTests,
     "no-duplicate-migration-prefix": noDuplicateMigrationPrefix,
+    "no-global-assignment": noGlobalAssignment,
     "no-relative-vi-mock": noRelativeViMock,
     "no-request-json-as": noRequestJsonAs,
   },

--- a/turbo/apps/web/custom-eslint/rules/no-global-assignment.ts
+++ b/turbo/apps/web/custom-eslint/rules/no-global-assignment.ts
@@ -1,0 +1,180 @@
+/**
+ * ESLint rule: no-global-assignment
+ *
+ * Disallows attaching new properties to the runtime global object. The
+ * `globalThis.services` singleton in src/lib/init-services.ts is the one
+ * sanctioned global in this app; every other global escapes the serverless
+ * lifecycle guarantees we rely on (Vercel Fluid pool reuse, per-request
+ * isolation) and creates state that outlives a single request.
+ *
+ * Flags:
+ *   - globalThis.X = v  /  global.X = v
+ *   - globalThis["X"] = v  /  global["X"] = v
+ *   - Object.defineProperty(globalThis, ...) / Reflect.defineProperty(globalThis, ...)
+ *   - Object.assign(globalThis, ...)
+ *   - declare global { ... } blocks
+ *
+ * The rule targets `globalThis` and `global` (Node aliases of the same
+ * object). `window` and `self` are intentionally NOT covered — browser code
+ * mutates `window.location`, installs DOM polyfills via
+ * `Object.defineProperty(window, ...)`, etc., which are not the same class
+ * of problem.
+ *
+ * Only direct-child writes are flagged. `globalThis.services.db = x` mutates
+ * a property on `services`, not on the global, and is allowed (though
+ * generally also a bad idea — that's not this rule's job).
+ *
+ * Exempt files (file-suffix match, Posix-normalized):
+ *   - src/lib/init-services.ts      (installs the sanctioned singleton)
+ *   - src/types/global.d.ts          (ambient declaration of Services)
+ *
+ * Good:
+ *   const db = globalThis.services.db;
+ *   window.location.href = "/";
+ *
+ * Bad:
+ *   globalThis.myCache = new Map();
+ *   Object.defineProperty(globalThis, "myHook", { value: fn });
+ *   declare global { var myCache: Map<string, unknown>; }
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+const GLOBAL_ROOT_NAMES = new Set(["globalThis", "global"]);
+
+const ALLOWED_FILE_SUFFIXES = [
+  "src/lib/init-services.ts",
+  "src/types/global.d.ts",
+];
+
+function isAllowedFile(filename: string): boolean {
+  const posix = filename.replace(/\\/g, "/");
+  return ALLOWED_FILE_SUFFIXES.some((suffix) => {
+    return posix.endsWith(suffix);
+  });
+}
+
+function unwrapTypeAssertions(node: TSESTree.Node): TSESTree.Node {
+  let current = node;
+  while (
+    current.type === AST_NODE_TYPES.TSAsExpression ||
+    current.type === AST_NODE_TYPES.TSTypeAssertion ||
+    current.type === AST_NODE_TYPES.TSNonNullExpression ||
+    current.type === AST_NODE_TYPES.TSSatisfiesExpression
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function globalRootName(node: TSESTree.Node): string | undefined {
+  const unwrapped = unwrapTypeAssertions(node);
+  if (
+    unwrapped.type === AST_NODE_TYPES.Identifier &&
+    GLOBAL_ROOT_NAMES.has(unwrapped.name)
+  ) {
+    return unwrapped.name;
+  }
+  return undefined;
+}
+
+export default createRule({
+  name: "no-global-assignment",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow attaching new properties to globalThis/global. The globalThis.services pattern in src/lib/init-services.ts is the only sanctioned global.",
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      noGlobalAssignment:
+        "Do not assign to `{{root}}.*`. Globals are banned except for the `globalThis.services` pattern defined in `src/lib/init-services.ts` and `src/types/global.d.ts`.",
+      noGlobalDefineProperty:
+        "Do not call `{{method}}` on `{{root}}`. Globals are banned except for the `globalThis.services` pattern defined in `src/lib/init-services.ts`.",
+      noGlobalAssign:
+        "Do not use `Object.assign` to attach properties to `{{root}}`. Globals are banned except for the `globalThis.services` pattern.",
+      noDeclareGlobal:
+        "Do not add `declare global` blocks. Extend the `Services` type in `src/types/global.d.ts` if you need to expose a new service.",
+    },
+  },
+  create(context) {
+    if (isAllowedFile(context.filename)) {
+      return {};
+    }
+
+    return {
+      AssignmentExpression(node: TSESTree.AssignmentExpression) {
+        if (node.left.type !== AST_NODE_TYPES.MemberExpression) {
+          return;
+        }
+        const root = globalRootName(node.left.object);
+        if (!root) {
+          return;
+        }
+        context.report({
+          node,
+          messageId: "noGlobalAssignment",
+          data: { root },
+        });
+      },
+
+      CallExpression(node: TSESTree.CallExpression) {
+        const callee = node.callee;
+        if (
+          callee.type !== AST_NODE_TYPES.MemberExpression ||
+          callee.object.type !== AST_NODE_TYPES.Identifier ||
+          callee.property.type !== AST_NODE_TYPES.Identifier
+        ) {
+          return;
+        }
+        const firstArg = node.arguments[0];
+        if (!firstArg) {
+          return;
+        }
+        const root = globalRootName(firstArg);
+        if (!root) {
+          return;
+        }
+
+        const isDefineProperty =
+          (callee.object.name === "Object" ||
+            callee.object.name === "Reflect") &&
+          callee.property.name === "defineProperty";
+        if (isDefineProperty) {
+          context.report({
+            node,
+            messageId: "noGlobalDefineProperty",
+            data: {
+              root,
+              method: `${callee.object.name}.defineProperty`,
+            },
+          });
+          return;
+        }
+
+        const isObjectAssign =
+          callee.object.name === "Object" && callee.property.name === "assign";
+        if (isObjectAssign) {
+          context.report({
+            node,
+            messageId: "noGlobalAssign",
+            data: { root },
+          });
+        }
+      },
+
+      TSModuleDeclaration(node: TSESTree.TSModuleDeclaration) {
+        if (node.global === true) {
+          context.report({
+            node,
+            messageId: "noDeclareGlobal",
+          });
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/web/eslint.config.js
+++ b/turbo/apps/web/eslint.config.js
@@ -107,6 +107,8 @@ export default [
     rules: {
       // Check for duplicate migration prefixes (runs once per lint process)
       "web/no-duplicate-migration-prefix": "error",
+      // Ban new globals — the globalThis.services pattern is the only sanctioned one
+      "web/no-global-assignment": "error",
     },
   },
   {

--- a/turbo/apps/web/src/__tests__/next-after-hooks.ts
+++ b/turbo/apps/web/src/__tests__/next-after-hooks.ts
@@ -1,0 +1,21 @@
+// Test-only storage for Next.js `after()` callbacks captured by the
+// next/server mock in setup.ts. Exposed as module-scoped arrays so tests
+// can import them directly instead of reaching through globalThis.
+//
+// The arrays are mutated in place (never reassigned) so every importer
+// shares the same reference across the test lifecycle. Call
+// `resetNextAfterHooks()` from lifecycle hooks or between drain loops.
+
+export const nextAfterCallbacks: Array<() => Promise<unknown>> = [];
+
+// Per-call record of the after() argument form: "fn" when called with a
+// callback, "promise" when called with an already-started promise. Callback
+// form is required for nested after() to propagate the Next.js request
+// context — promise form defers a chain that may register nested after()
+// calls after the context has been finalized.
+export const nextAfterArgForms: Array<"fn" | "promise"> = [];
+
+export function resetNextAfterHooks(): void {
+  nextAfterCallbacks.length = 0;
+  nextAfterArgForms.length = 0;
+}

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -1,6 +1,11 @@
 import "@testing-library/jest-dom/vitest";
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { server } from "../mocks/server";
+import {
+  nextAfterArgForms,
+  nextAfterCallbacks,
+  resetNextAfterHooks,
+} from "./next-after-hooks";
 
 // Stub environment variables before any imports.
 // Using vi.hoisted() ensures stubs run before module imports.
@@ -69,9 +74,6 @@ const resetEnv = vi.hoisted(() => {
       "GITHUB_APP_PRIVATE_KEY",
       "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQ2FkZ0VnSzU4SVAzV3gKNkFvbDRxR09iTHhUV2dVd3pOckVrT0Z3anFIUEN6a2VXaHZuVWhBaDc5bnpVT1l5MG12akF0NFJTSFdGck9aNQp4eXVqS3p3OGNrY3ZiVDBrNmYyMHVsUHJNQStUSGMrYmZHQ1lNRmJzVk0vbTQydldtSkdTMDJ1bTIyZzAxb3lZCmxROEhEUXhRMjBva2tzclJ5c0lqWWx3WHloVWpoVFZnNkpGWVlVUEhiT2t1bHlhVmZUcVNmNmN3QUVGWTUrMWgKaUhFMmtBQllsdUFiY2JQeTBzVUIzblRxa2NuV3laWVBSTHplcUtUN1hEaDltL2hGSVJPWEtTS01ZWXZCWVROcQpaOXl5cDJpVHJsenR1NkZWcG1rdUlMZGpGQlJSQjg1azd5amlyZlp4NjExbWE0V3g1M05FTFB4ekY0QVRaZkdGCmlvR2s2WVZsQWdNQkFBRUNnZ0VBQ014NGozSFVyeFpZV01CUVZheWxpZFN4WEtrbjJ3b01XejZxak93ZkZRbDkKWVRoK1Z1ekNqUUJhQU1XR3UzWG5uZWlqcUVYaHBmSDl0Z210dDIrRzBLV3MzdXVBM0dtMDRWYnM0VnlkUW9MagorT1k2cFdpNWh1Qms0SERiaTMrbzZUMkFhQ0tlK3NXUEFFRWJlRW9hdmI5a0o1V3lGb1hQamM3MFVvbVpMeXI0CmZ6ODRDVGpBUFpMT1dDendJOVB6YURNdTFkL2J3bWdWNnpMN2pGaDU5Tlhka1FXdVd4TG1KVjV5dTBYdW5iZE8KbGlJbGFLTG9yQ045bTV0dksrOFFPYVRiM0VKckdCdm9HR2FqTThFKzU5TnRiazAwNGxuN3BLTnVDVzZ5SDBRTgpPM1A1VEFaT09CQUVieVZVZm80eW5wZTQ3VStyd296OHB5aWdCOFFXZ1FLQmdRREExU0ZhajB2cDNxN0hMSXFMCmsySU92ejZnVkEyS1IyRVdRbk5HRFdjT0UrVXJ2aC93bjVYN0lKTkFkQU9ORFFDQWFEa2hlSTFUMXFjYStSRWkKTzNaaVhXUlZ0QWRTdTJmenAveFMySkVqV05qT2UyTHd4Q2RmRmk1cEhQdnZNZWpQL0NsaHZyWFQzOE5xZ3dmNgpVV2t1ckpvRFR0SEFKRjF1dWNVbzVpT3k1UUtCZ1FETkR3dmFjRjFXbUd4bVJnM2pBanl2OEJVd2FSTTZCazc3Cmc1NE91MTk1dG54dUdpS2NQUHcyU3V5SWQ0bm9aaWQ5SWhuSUZzd2xQSDI1eWU5dVBwYkhNR2Njc0xLNTU0S1IKelpUZEg3NVpVUmo2OXYzTStJQi9PWmY3citkUk85ZGFNYUF6TFdRYWhjdjFXSDVMb1FxZjhoV0k1eEI3RnFKawpUaWtTdEpUZ2dRS0JnR1I4ckd6c3o3cUgrTHlDVVpCNnRWYktBbkM2WEhQNnpuVXpHNjhkdk41eEw3T2oyREVrCmVKdnRWYzc0cGdFVERYZmMyQ2pCRWFUbTd4MzNQUjZCcmllRVU0ejF5L3NvL2ZyVFI0SkVxUjJxWnhEeTY1UmMKSThoQlh0NFg1Skc1aUlFWi90YVk4MWY5KzIrOTZLSmhXbGFnUzRIOXlRQS84eENJYmwzcDBDQ2hBb0dBQ01ZQQpCOVNPNmNtVHVieDlrNXpnNDlZdDBlaHMvaXFPN292dkUwcEpCM2diVXNxamVIUFRocThsOTZERnNiL05LTGx3CnlQTFF3VGNaV2YyZDFPV3dwYzBZWEUzakY3a2tDUUQyd1k4K0lhd3FtWEkvNGFrd05rRk1rMlF2VFhaMS9GSHIKUE1WUVp5SWFXK0R4Wm1MNWhXWmlMWDFWWXk3UXUrSHNOL1NwK2dFQ2dZRUFvS1dhV3JXM2VEVkl5WFVtazRoQgo2OGt5RG9iWldpTGlkU2FlUG1UYk91Mnp3YWt3eTIraDhyUGpuZXl1eWgyYzNsZjlqYnhQM2NhU2JwV1JZQjFoCnQwVThUZ3JwMDZ3TlBvSUNiWWI1OU12UTBscXVpeG9IejUvbUhEb2dtTWhkcEM4NHlpSVd6TmgvQmxRSlVrbFgKaEZnT3dkWFloQ250Qi9Nc0YxMTdtdHc9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K",
     );
-    // Initialize Next.js after() callback queue (shared with test-helpers.ts flushAfter)
-    globalThis.nextAfterCallbacks = [];
-    globalThis.nextAfterArgForms = [];
   };
   fn(); // Initial call before imports
   return fn;
@@ -95,12 +97,12 @@ vi.mock("next/server", async (importOriginal) => {
     ...original,
     after: (fnOrPromise: (() => Promise<unknown>) | Promise<unknown>) => {
       if (typeof fnOrPromise === "function") {
-        globalThis.nextAfterArgForms.push("fn");
-        globalThis.nextAfterCallbacks.push(fnOrPromise);
+        nextAfterArgForms.push("fn");
+        nextAfterCallbacks.push(fnOrPromise);
       } else {
-        globalThis.nextAfterArgForms.push("promise");
+        nextAfterArgForms.push("promise");
         // Wrap promise in a function for consistent handling in flushAfter()
-        globalThis.nextAfterCallbacks.push(() => {
+        nextAfterCallbacks.push(() => {
           return fnOrPromise;
         });
       }
@@ -300,8 +302,7 @@ beforeAll(() => {
 beforeEach(() => {
   resetEnv();
   reloadEnv();
-  globalThis.nextAfterCallbacks = [];
-  globalThis.nextAfterArgForms = [];
+  resetNextAfterHooks();
 });
 
 afterEach(() => {

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -20,6 +20,7 @@ import { randomUUID } from "crypto";
 import { inArray } from "drizzle-orm";
 import { Axiom } from "@axiomhq/js";
 import { mockClerk, clearClerkMock } from "./clerk-mock";
+import { nextAfterCallbacks } from "./next-after-hooks";
 import { initServices } from "../lib/init-services";
 import * as s3Client from "../lib/infra/s3/s3-client";
 import * as axiomClient from "../lib/shared/axiom/client";
@@ -404,9 +405,9 @@ export function testContext(): TestContext {
       async flushAfter() {
         // Drain iteratively so callbacks that schedule more after() calls
         // (e.g. createZeroRun's deferred dispatch) are also executed.
-        while (globalThis.nextAfterCallbacks.length > 0) {
-          const callbacks = [...globalThis.nextAfterCallbacks];
-          globalThis.nextAfterCallbacks = [];
+        while (nextAfterCallbacks.length > 0) {
+          const callbacks = [...nextAfterCallbacks];
+          nextAfterCallbacks.length = 0;
           await Promise.all(
             callbacks.map((fn) => {
               return fn();

--- a/turbo/apps/web/src/types/global.d.ts
+++ b/turbo/apps/web/src/types/global.d.ts
@@ -22,12 +22,4 @@ export type Services = {
 declare global {
   // getter ensures it's always defined after initServices()
   var services: Services;
-  // Captured Next.js after() callbacks for test assertions (see setup.ts)
-  var nextAfterCallbacks: Array<() => Promise<unknown>>;
-  // Per-call record of the after() argument form: "fn" when called with a
-  // callback, "promise" when called with an already-started promise. Callback
-  // form is required for nested after() to propagate the Next.js request
-  // context — promise form defers a chain that may register nested after()
-  // calls after the context has been finalized.
-  var nextAfterArgForms: Array<"fn" | "promise">;
 }


### PR DESCRIPTION
## Summary
- New custom ESLint rule **`web/no-global-assignment`** that bans attaching new properties to `globalThis` / `global` outside two allowlisted files (`src/lib/init-services.ts` and `src/types/global.d.ts`), leaving the `globalThis.services` singleton as the only sanctioned global.
- Migrates the two test-only Next.js `after()` tracking arrays (`nextAfterCallbacks`, `nextAfterArgForms`) off `globalThis` into a new `src/__tests__/next-after-hooks.ts` module so the file-based allowlist stays minimal.

## What the rule flags
- `globalThis.X = v` / `global.X = v` (including computed `globalThis["X"] = v`)
- `Object.defineProperty(globalThis, ...)` / `Reflect.defineProperty(globalThis, ...)`
- `Object.assign(globalThis, { ... })`
- `declare global { ... }` blocks

TypeScript casts (`as any`, `as unknown`, `!`, `satisfies`) are unwrapped so they cannot hide a global write. The rule is scoped to `globalThis` / `global`; `window` / `self` are intentionally left alone so browser code can still do `window.location.href = '/'` and test DOM polyfills via `Object.defineProperty(window, 'matchMedia', ...)`.

Only direct-child writes are flagged — `globalThis.services.db = x` mutates a property on `services`, not on the global itself, and is not this rule's concern.

## Why
Vercel Fluid reuses module state across requests, so any property attached to the runtime global outlives a single request. The `globalThis.services` pattern handles this carefully (lazy getters, idempotent `initServices()`, `attachDatabasePool` lifecycle). Anything else — a stray cache, a polyfill, a "just-in-case" singleton — skips those guarantees and becomes cross-request state. This lint rule makes the boundary explicit so new globals don't creep in.

## Test plan
- [x] Rule unit tests (`custom-eslint/__tests__/no-global-assignment.test.ts`) cover all 5 AST pattern families, the file allowlist, and the `as any` escape — 20 cases, all pass.
- [x] `pnpm -F web exec eslint . --max-warnings 0` clean on the full web workspace.
- [x] `pnpm -F web run check-types` passes.
- [x] The 6 test files that referenced the migrated globals all pass (`voice-chat-cleanup`, `webhooks/github`, `zero/slack/events`, `webhooks/agent/heartbeat`, `telegram/webhook`, `webhooks/agent/complete` — 119/119).
- [x] Probe test: temporarily injecting `globalThis.probe = 1` into a non-allowlisted file produces the expected lint error.
- [ ] Full CI run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)