### PR TITLE
refactor: remove unifyChatThreads feature flag

### DIFF
--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -6,13 +6,11 @@ import {
   type PersistedAttachment,
 } from "@vm0/core/contracts/chat-threads";
 import type { ModelProviderType } from "@vm0/core/contracts/model-providers";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { agentById, defaultAgentId$ } from "./agent.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { pathParams$ } from "./route.ts";
 import { activeRoute$ } from "./active-route.ts";
-import { featureSwitch$ } from "./external/feature-switch.ts";
 import {
   reloadChatThreads$,
   reloadChatThreadsCounter$,
@@ -140,26 +138,17 @@ export const patchThreadRead$ = command(({ set }, _threadId: string) => {
 export const chatThreads$ = computed(async (get) => {
   get(reloadChatThreadsCounter$);
 
-  const features = await get(featureSwitch$);
-  const unifyChatThreads = features[FeatureSwitchKey.UnifyChatThreads] ?? false;
+  const agentId = await get(currentChatAgentId$);
+  if (!agentId) {
+    return [];
+  }
 
   const client = get(zeroClient$)(chatThreadsContract);
-
-  let threads: ChatThreadListItem[];
-  if (unifyChatThreads) {
-    const result = await accept(client.list({ query: {} }), [200]);
-    threads = result.body.threads;
-  } else {
-    const agentId = await get(currentChatAgentId$);
-    if (!agentId) {
-      return [];
-    }
-    const result = await accept(
-      client.list({ query: { agentId: agentId } }),
-      [200],
-    );
-    threads = result.body.threads;
-  }
+  const result = await accept(
+    client.list({ query: { agentId: agentId } }),
+    [200],
+  );
+  const threads = result.body.threads;
 
   const currentThread = await get(currentChatThread$);
   return threads.map((t) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -13,7 +13,6 @@ import {
 } from "@vm0/core/contracts/chat-threads";
 import { zeroTeamContract } from "@vm0/core/contracts/zero-team";
 import { zeroAgentsByIdContract } from "@vm0/core/contracts/zero-agents";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -23,7 +22,7 @@ function mockSubagentAPIs() {
   const threads: {
     id: string;
     title: string | null;
-    agentId: string;
+    agent: { id: string; avatarUrl: string | null };
     createdAt: string;
     updatedAt: string;
     isRead: boolean;
@@ -33,7 +32,7 @@ function mockSubagentAPIs() {
     {
       id: "thread-sub-1",
       title: "Subagent thread",
-      agentId: "subagent-compose-id",
+      agent: { id: "subagent-compose-id", avatarUrl: null },
       createdAt: "2026-03-10T00:00:00Z",
       updatedAt: "2026-03-10T00:00:00Z",
       isRead: false,
@@ -146,7 +145,7 @@ function mockSubagentAPIs() {
       const newThread = {
         id: "new-thread-id",
         title: body.title ?? null,
-        agentId: body.agentId,
+        agent: { id: body.agentId, avatarUrl: null },
         createdAt: now,
         updatedAt: now,
         isRead: false,
@@ -172,7 +171,6 @@ describe("sidebar new chat navigation", () => {
     detachedSetupPage({
       context,
       path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     // Wait for thread list to load
@@ -195,7 +193,6 @@ describe("sidebar new chat navigation", () => {
     detachedSetupPage({
       context,
       path: "/agents/subagent-compose-id/chat",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     // Wait for thread list to load — confirms currentChatAgentId$ has resolved
@@ -232,7 +229,6 @@ describe("sidebar new chat navigation", () => {
     detachedSetupPage({
       context,
       path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     // Wait for thread list to load
@@ -270,7 +266,10 @@ describe("sidebar new chat navigation", () => {
             {
               id: "new-thread-id",
               title: null,
-              agentId: "c0000000-0000-4000-a000-000000000001",
+              agent: {
+                id: "c0000000-0000-4000-a000-000000000001",
+                avatarUrl: null,
+              },
               createdAt: "2026-03-10T00:00:00Z",
               updatedAt: "2026-03-10T00:00:00Z",
               isRead: false,
@@ -301,7 +300,6 @@ describe("sidebar new chat navigation", () => {
     detachedSetupPage({
       context,
       path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     // Wait for thread list to load (thread with null title appears as "New chat" span)

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-unify-chat-threads.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-unify-chat-threads.test.tsx
@@ -1,13 +1,8 @@
 /**
  * Unified chat-threads sidebar behaviour (#10162).
- *
- * The sidebar always uses unified labels ("Chats", "Search chats", "New chat").
- * The `unifyChatThreads` feature switch still controls the API request shape:
- *  - When ON: calls `chatThreadsContract.list` WITHOUT an `agentId` query param
- *  - When OFF: calls with an `agentId` param (scoped to the current agent)
  */
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import {
   chatThreadsContract,
@@ -19,7 +14,6 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
-import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
@@ -148,32 +142,8 @@ function getSidebar(): HTMLElement {
   return screen.getByRole("navigation", { name: "Sidebar" });
 }
 
-describe("sidebar unify chat threads (#10162)", () => {
-  beforeEach(() => {
-    setMockFeatureSwitches({});
-  });
-
-  it("calls list with no agentId when unifyChatThreads is ON", async () => {
-    setMockFeatureSwitches({ unifyChatThreads: true });
-    const observed: ListQuery[] = [];
-    mockUnifiedThreads(observed);
-    detachedSetupPage({ context, path: "/" });
-
-    await waitFor(() => {
-      expect(
-        within(getSidebar()).getByText("Default thread"),
-      ).toBeInTheDocument();
-      expect(within(getSidebar()).getByText("Sub thread")).toBeInTheDocument();
-    });
-    // At least one call went through without agentId — the unified request shape.
-    expect(
-      observed.some((q) => {
-        return q.agentId === undefined;
-      }),
-    ).toBeTruthy();
-  });
-
-  it("always renders the unified title 'Chats' regardless of feature switch", async () => {
+describe("sidebar chat threads (#10162)", () => {
+  it("renders the unified title 'Chats'", async () => {
     const observed: ListQuery[] = [];
     mockUnifiedThreads(observed);
     detachedSetupPage({ context, path: "/" });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
@@ -23,7 +23,6 @@ import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -35,7 +34,7 @@ function mockBaseAPIs(
     threads?: {
       id: string;
       title: string;
-      agentId: string;
+      agent: { id: string; avatarUrl: string | null };
       createdAt: string;
       updatedAt: string;
       isRead: boolean;
@@ -89,7 +88,7 @@ describe("zero sidebar - chat thread list display (SIDEBAR-D-001)", () => {
         {
           id: "thread-1",
           title: "Deploy to production",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,
@@ -99,7 +98,7 @@ describe("zero sidebar - chat thread list display (SIDEBAR-D-001)", () => {
         {
           id: "thread-2",
           title: "Fix the bug",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-09T00:00:00Z",
           updatedAt: "2026-03-09T00:00:00Z",
           isRead: false,
@@ -152,7 +151,7 @@ describe("zero sidebar - search results filter (SIDEBAR-D-003)", () => {
         {
           id: "thread-1",
           title: "Deploy to production",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,
@@ -162,7 +161,7 @@ describe("zero sidebar - search results filter (SIDEBAR-D-003)", () => {
         {
           id: "thread-2",
           title: "Fix the bug",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-09T00:00:00Z",
           updatedAt: "2026-03-09T00:00:00Z",
           isRead: false,
@@ -175,7 +174,6 @@ describe("zero sidebar - search results filter (SIDEBAR-D-003)", () => {
     detachedSetupPage({
       context,
       path: "/",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     await waitFor(() => {
@@ -206,7 +204,7 @@ describe("zero sidebar - search term displays in input (SIDEBAR-D-004)", () => {
         {
           id: "thread-1",
           title: "Deploy to production",
-          agentId: DEFAULT_AGENT_ID,
+          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
           isRead: false,
@@ -219,7 +217,6 @@ describe("zero sidebar - search term displays in input (SIDEBAR-D-004)", () => {
     detachedSetupPage({
       context,
       path: "/",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     await waitFor(() => {
@@ -388,7 +385,6 @@ describe("zero sidebar - new chat button enabled/disabled state (SIDEBAR-D-010)"
     detachedSetupPage({
       context,
       path: "/",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     await waitFor(() => {
@@ -415,7 +411,6 @@ describe("zero sidebar - new chat button enabled/disabled state (SIDEBAR-D-010)"
     detachedSetupPage({
       context,
       path: "/",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -30,7 +30,6 @@ import {
   chatThreadByIdContract,
 } from "@vm0/core/contracts/chat-threads";
 import { zeroAgentsByIdContract } from "@vm0/core/contracts/zero-agents";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -45,7 +44,7 @@ function makeThread(
 ): {
   id: string;
   title: string;
-  agentId: string;
+  agent: { id: string; avatarUrl: string | null };
   createdAt: string;
   updatedAt: string;
   isRead: boolean;
@@ -55,7 +54,7 @@ function makeThread(
   return {
     id,
     title,
-    agentId: DEFAULT_AGENT_ID,
+    agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
     createdAt,
     updatedAt: createdAt,
     isRead: false,
@@ -92,7 +91,7 @@ function mockBaseAPIs(options?: {
   threads?: {
     id: string;
     title: string;
-    agentId: string;
+    agent: { id: string; avatarUrl: string | null };
     createdAt: string;
     updatedAt: string;
     isRead: boolean;
@@ -220,7 +219,6 @@ describe("zero sidebar - search input accepts text (SIDEBAR-D-015)", () => {
     detachedSetupPage({
       context,
       path: "/",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     await waitFor(() => {
@@ -249,7 +247,6 @@ describe("zero sidebar - clear search button resets search (SIDEBAR-D-016)", () 
     detachedSetupPage({
       context,
       path: "/",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     await waitFor(() => {
@@ -307,7 +304,6 @@ describe("zero sidebar - new chat button creates session (SIDEBAR-D-017)", () =>
     detachedSetupPage({
       context,
       path: `/agents/${DEFAULT_AGENT_ID}/chat`,
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     // Wait for the sidebar to finish loading (empty state confirms threads loaded

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
@@ -24,7 +24,6 @@ import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { chatThreadsContract } from "@vm0/core/contracts/chat-threads";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { setChatAgentId$ } from "../../../signals/agent-chat.ts";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -39,7 +38,7 @@ function makeThread(
 ): {
   id: string;
   title: string;
-  agentId: string;
+  agent: { id: string; avatarUrl: string | null };
   createdAt: string;
   updatedAt: string;
   isRead: boolean;
@@ -49,7 +48,7 @@ function makeThread(
   return {
     id,
     title,
-    agentId: DEFAULT_AGENT_ID,
+    agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
     createdAt,
     updatedAt: createdAt,
     isRead: false,
@@ -86,7 +85,7 @@ function mockBaseAPIs(options?: {
   threads?: {
     id: string;
     title: string;
-    agentId: string;
+    agent: { id: string; avatarUrl: string | null };
     createdAt: string;
     updatedAt: string;
     isRead: boolean;
@@ -129,7 +128,6 @@ describe("zero sidebar - chat session list collapses and expands (SIDEBAR-D-011)
     detachedSetupPage({
       context,
       path: "/",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     // Wait for thread to appear

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -22,7 +22,7 @@ function mockAPIs({
     {
       id: "thread-1",
       title: "First chat",
-      agentId: "c0000000-0000-4000-a000-000000000001",
+      agent: { id: "c0000000-0000-4000-a000-000000000001", avatarUrl: null },
       createdAt: "2026-03-10T00:00:00Z",
       updatedAt: "2026-03-10T00:00:00Z",
       isRead: false,
@@ -32,7 +32,7 @@ function mockAPIs({
     {
       id: "thread-2",
       title: "Second chat",
-      agentId: "c0000000-0000-4000-a000-000000000001",
+      agent: { id: "c0000000-0000-4000-a000-000000000001", avatarUrl: null },
       createdAt: "2026-03-09T00:00:00Z",
       updatedAt: "2026-03-09T00:00:00Z",
       isRead: false,
@@ -44,7 +44,7 @@ function mockAPIs({
   threads?: {
     id: string;
     title: string;
-    agentId: string;
+    agent: { id: string; avatarUrl: string | null };
     createdAt: string;
     updatedAt: string;
     isRead: boolean;
@@ -151,7 +151,6 @@ describe("zero sidebar", () => {
     detachedSetupPage({
       context,
       path: "/",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     // Wait for chat threads to render
@@ -178,7 +177,6 @@ describe("zero sidebar", () => {
     detachedSetupPage({
       context,
       path: "/",
-      featureSwitches: { [FeatureSwitchKey.UnifyChatThreads]: true },
     });
 
     // Wait for chat threads to render

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -47,7 +47,6 @@ export enum FeatureSwitchKey {
   ZoomConnector = "zoomConnector",
   ApiKeys = "apiKeys",
   ModelProviderSelection = "modelProviderSelection",
-  UnifyChatThreads = "unifyChatThreads",
   ConnectorCategories = "connectorCategories",
   PlatformConnectors = "platformConnectors",
   Trinity = "trinity",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -265,16 +265,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: true,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.UnifyChatThreads]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Replace the per-agent chat list with a unified Chats view that includes " +
-      "threads from every agent in the user's org (sub-agents included). " +
-      "Gates the sidebar + /chats title/placeholder/aria-label swaps, the per-row " +
-      "agent avatar render, and the unscoped request shape. New-chat creation " +
-      "still uses the current-agent fallback.",
-    enabled: false,
-  },
   [FeatureSwitchKey.ConnectorCategories]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Removes the `UnifyChatThreads` feature flag from `FeatureSwitchKey` enum
- Simplifies `chatThreads$` to always fetch threads scoped to `agentId` (the former off-state behavior), removing the unified no-agentId code path
- Cleans up the related test: removes the "ON" test case, drops the `setMockFeatureSwitches` import, and keeps only the sidebar title assertion

## Test plan

- [ ] Existing test `renders the unified title 'Chats'` still passes
- [ ] Sidebar shows chat threads scoped to the current agent as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)