### PR TITLE
ci(mitm-addon): broaden turbo trigger to all of turbo/

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -125,12 +125,13 @@ jobs:
             echo "any-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Files outside crates/ that mitm-addon tests read directly. Written
-          # AFTER the any-changed aggregation so a dev-seed.ts edit doesn't
-          # force every crate job to re-run; only mitm-addon-test needs it.
-          # Keep in sync with paths referenced in
-          # crates/runner/mitm-addon/tests/.
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^turbo/apps/web/scripts/dev-seed\.ts$"; then
+          # mitm-addon tests include cross-language consistency checks that
+          # read turbo/ files (e.g. dev-seed.ts, generated firewall specs) as
+          # the source of truth. Any turbo/ change could drift the contract,
+          # so trigger mitm-addon-test on all turbo/ edits. Written AFTER the
+          # any-changed aggregation so a turbo-only edit doesn't force every
+          # crate job to re-run.
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^turbo/"; then
             echo "mitm-addon-turbo-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "mitm-addon-turbo-changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Follow-up to #11000. The narrow `^turbo/apps/web/scripts/dev-seed\.ts$` filter only covers one of the cross-language contracts checked by `crates/runner/mitm-addon/tests/test_x_billing.py`. The same file also reads `turbo/packages/core/src/firewalls/x.generated.ts`, which is materialised at postinstall by `turbo/packages/firewalls-generator`. A change to the generator or its inputs would drift the test silently — the same trap that let #10979 land green.

Maintaining a per-path allowlist mirrors the test's internal coupling and rots whenever the test grows a new turbo dependency. Replace it with a blanket `^turbo/` match.

## Trade-off

`mitm-addon-test` will now run on every turbo-touching PR. The job takes ~1.5 min and runs in parallel with the other crate jobs, so it doesn't extend the critical path. The trigger remains written after the `any-changed` aggregation, so turbo-only PRs still don't drag every other crate job along with them.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` confirms the workflow is valid.
- [ ] CI green on this PR (this PR itself touches `.github/workflows/crates.yml`, so `mitm-addon-test` will run via the existing `ci-changed` branch — verifies the rule still parses, but the new `^turbo/` arm is exercised on the next turbo-only PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)