### PR TITLE
feat(telegram): add multi-bot integration api

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
@@ -1,16 +1,24 @@
 import {
   zeroIntegrationsTelegramContract,
+  type TelegramBot,
+  type TelegramBotStatus,
   type TelegramLinkStatusResponse,
-  type TelegramStatusResponse,
+  type TelegramListResponse,
 } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import { mockApi } from "../msw-contract.ts";
 
-const defaultTelegramData: TelegramStatusResponse = {
-  installationId: "install_123",
-  bot: { id: "bot_123", username: "test_bot" },
-  agent: { id: "compose_1", name: "default-agent" },
-  isAdmin: true,
-  isConnected: true,
+const defaultTelegramBots: TelegramBot[] = [
+  {
+    id: "bot_123",
+    username: "test_bot",
+    agent: { id: "compose_1", name: "default-agent" },
+    isOwner: true,
+    isConnected: true,
+  },
+];
+
+const defaultTelegramStatus: TelegramBotStatus = {
+  ...defaultTelegramBots[0]!,
   domainConfigured: false,
   environment: {
     requiredSecrets: ["ANTHROPIC_API_KEY"],
@@ -20,46 +28,90 @@ const defaultTelegramData: TelegramStatusResponse = {
   },
 };
 
-let mockTelegramData: TelegramStatusResponse =
-  structuredClone(defaultTelegramData);
+let mockTelegramList: TelegramListResponse = {
+  bots: structuredClone(defaultTelegramBots),
+};
+let mockTelegramStatuses: Record<string, TelegramBotStatus> = {
+  [defaultTelegramStatus.id]: structuredClone(defaultTelegramStatus),
+};
 
 // Default link-status: unlinked with no installation. Tests that need the
 // linked (telegramUserId) or unlinked-with-installation variants should
-// override this handler via server.use(mockApi(zeroIntegrationsTelegramContract.getLinkStatus, …)).
+// override this handler via server.use(mockApi(zeroIntegrationsTelegramContract.getLinkStatus, ...)).
 let mockLinkStatus: TelegramLinkStatusResponse = { linked: false };
 
 export function resetMockTelegramIntegration(): void {
-  mockTelegramData = structuredClone(defaultTelegramData);
+  mockTelegramList = { bots: structuredClone(defaultTelegramBots) };
+  mockTelegramStatuses = {
+    [defaultTelegramStatus.id]: structuredClone(defaultTelegramStatus),
+  };
   mockLinkStatus = { linked: false };
 }
 
 export const apiIntegrationsTelegramHandlers = [
-  mockApi(zeroIntegrationsTelegramContract.getStatus, ({ respond }) => {
-    return respond(200, mockTelegramData);
+  mockApi(zeroIntegrationsTelegramContract.list, ({ respond }) => {
+    return respond(200, mockTelegramList);
   }),
 
-  mockApi(zeroIntegrationsTelegramContract.update, ({ body, respond }) => {
-    if (body.agentName && mockTelegramData.agent) {
-      mockTelegramData.agent.name = body.agentName;
+  mockApi(zeroIntegrationsTelegramContract.getBot, ({ params, respond }) => {
+    const status = mockTelegramStatuses[params.botId];
+    if (!status) {
+      return respond(404, {
+        error: { message: "Telegram bot not found", code: "NOT_FOUND" },
+      });
     }
-    return respond(200, { ok: true });
+    return respond(200, status);
   }),
 
-  mockApi(zeroIntegrationsTelegramContract.disconnect, ({ respond }) => {
-    return respond(204);
-  }),
+  mockApi(
+    zeroIntegrationsTelegramContract.updateBot,
+    ({ params, body, respond }) => {
+      const status = mockTelegramStatuses[params.botId];
+      if (!status) {
+        return respond(404, {
+          error: { message: "Telegram bot not found", code: "NOT_FOUND" },
+        });
+      }
+      status.agent = { id: body.defaultAgentId, name: "default-agent" };
+      mockTelegramList.bots = mockTelegramList.bots.map((bot) => {
+        return bot.id === status.id ? { ...bot, agent: status.agent } : bot;
+      });
+      return respond(200, status);
+    },
+  ),
+
+  mockApi(
+    zeroIntegrationsTelegramContract.disconnect,
+    ({ params, respond }) => {
+      delete mockTelegramStatuses[params.botId];
+      mockTelegramList.bots = mockTelegramList.bots.filter((bot) => {
+        return bot.id !== params.botId;
+      });
+      return respond(204);
+    },
+  ),
 
   mockApi(zeroIntegrationsTelegramContract.getLinkStatus, ({ respond }) => {
     return respond(200, mockLinkStatus);
   }),
 
   mockApi(zeroIntegrationsTelegramContract.register, ({ respond }) => {
-    return respond(201, {
-      id: "installation_1",
-      botId: "bot_123",
-      botUsername: "test_bot",
-      webhookUrl: "http://localhost/api/telegram/webhook/installation_1",
+    const status: TelegramBotStatus = {
+      id: "bot_registered",
+      username: "registered_bot",
+      agent: { id: "compose_1", name: "default-agent" },
+      isOwner: true,
+      isConnected: false,
       domainConfigured: false,
-    });
+      environment: {
+        requiredSecrets: ["ANTHROPIC_API_KEY"],
+        requiredVars: [],
+        missingSecrets: [],
+        missingVars: [],
+      },
+    };
+    mockTelegramStatuses[status.id] = structuredClone(status);
+    mockTelegramList.bots = [...mockTelegramList.bots, status];
+    return respond(201, status);
   }),
 ];

--- a/turbo/apps/web/app/api/integrations/telegram/[botId]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/[botId]/__tests__/route.test.ts
@@ -215,6 +215,51 @@ describe("/api/integrations/telegram/[botId]", () => {
       expect(data.agent).toEqual({ id: composeId, name });
       expect(data.id).toBe(botId);
     });
+
+    it("returns 403 when defaultAgentId belongs to another org", async () => {
+      const user = await context.setupUser();
+      const botId = uniqueId("bot");
+      await createTestTelegramInstallation({
+        ownerUserId: user.userId,
+        telegramBotId: botId,
+        orgId: user.orgId,
+      });
+      const otherOrgCompose = await context.createAgentCompose(user.userId, {
+        name: uniqueId("other-agent"),
+      });
+
+      const response = await PATCH(
+        botRequest("PATCH", { defaultAgentId: otherOrgCompose.id }),
+        routeParams(botId),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("does not retarget a bot when the owner switches active org", async () => {
+      const user = await context.setupUser();
+      const botId = uniqueId("bot");
+      await createTestTelegramInstallation({
+        ownerUserId: user.userId,
+        telegramBotId: botId,
+        orgId: user.orgId,
+      });
+      const otherOrgCompose = await context.createAgentCompose(user.userId, {
+        name: uniqueId("other-agent"),
+      });
+      mockClerk({ userId: user.userId, orgId: otherOrgCompose.orgId });
+
+      const response = await PATCH(
+        botRequest("PATCH", { defaultAgentId: otherOrgCompose.id }),
+        routeParams(botId),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
   });
 
   describe("DELETE", () => {

--- a/turbo/apps/web/app/api/integrations/telegram/[botId]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/[botId]/__tests__/route.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { HttpResponse, http as mswHttp } from "msw";
+import { DELETE, GET, PATCH } from "../route";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import {
+  createTestCompose,
+  createTestTelegramInstallation,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { server } from "../../../../../../src/mocks/server";
+import { http } from "../../../../../../src/__tests__/msw";
+
+const context = testContext();
+
+function botRequest(method: string, body?: Record<string, unknown>) {
+  return new Request(
+    "http://localhost:3000/api/integrations/telegram/bot_123",
+    {
+      method,
+      ...(body
+        ? {
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        : {}),
+    },
+  );
+}
+
+function routeParams(botId: string) {
+  return { params: Promise.resolve({ botId }) };
+}
+
+function telegramDeleteWebhook() {
+  return http.post(/api\.telegram\.org\/bot.*\/deleteWebhook/, () => {
+    return HttpResponse.json({ ok: true, result: true });
+  });
+}
+
+function telegramOauthHead() {
+  return mswHttp.head("https://oauth.telegram.org/auth", () => {
+    return new HttpResponse(null, {
+      headers: { "content-length": "0" },
+    });
+  });
+}
+
+describe("/api/integrations/telegram/[botId]", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    server.use(telegramOauthHead());
+  });
+
+  describe("GET", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockClerk({ userId: null });
+
+      const response = await GET(botRequest("GET"), routeParams("bot_123"));
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 404 for an unknown bot", async () => {
+      await context.setupUser();
+
+      const response = await GET(botRequest("GET"), routeParams("missing"));
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns full status for an owned bot", async () => {
+      const user = await context.setupUser();
+      const botId = uniqueId("bot");
+      await createTestTelegramInstallation({
+        ownerUserId: user.userId,
+        telegramBotId: botId,
+        orgId: user.orgId,
+      });
+
+      const response = await GET(botRequest("GET"), routeParams(botId));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual(
+        expect.objectContaining({
+          id: botId,
+          username: `bot_${botId}`,
+          isOwner: true,
+          isConnected: false,
+          domainConfigured: false,
+          environment: expect.objectContaining({
+            requiredSecrets: expect.any(Array),
+            requiredVars: expect.any(Array),
+          }),
+        }),
+      );
+      expect(data.agent).toEqual(
+        expect.objectContaining({ id: expect.any(String) }),
+      );
+    });
+
+    it("returns full status for a linked non-owner", async () => {
+      const user = await context.setupUser();
+      const botId = uniqueId("bot");
+      await createTestTelegramInstallation({
+        ownerUserId: "other-owner",
+        vm0UserId: user.userId,
+        telegramBotId: botId,
+        orgId: user.orgId,
+      });
+
+      const response = await GET(botRequest("GET"), routeParams(botId));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.id).toBe(botId);
+      expect(data.isOwner).toBe(false);
+      expect(data.isConnected).toBe(true);
+    });
+
+    it("returns 404 for a bot in another org", async () => {
+      const user = await context.setupUser();
+      const botId = uniqueId("bot");
+      await createTestTelegramInstallation({
+        ownerUserId: user.userId,
+        telegramBotId: botId,
+      });
+
+      const response = await GET(botRequest("GET"), routeParams(botId));
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 404 for a bot the user neither owns nor linked", async () => {
+      const user = await context.setupUser();
+      const botId = uniqueId("bot");
+      await createTestTelegramInstallation({
+        ownerUserId: "other-owner",
+        telegramBotId: botId,
+        orgId: user.orgId,
+      });
+
+      const response = await GET(botRequest("GET"), routeParams(botId));
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("PATCH", () => {
+    it("returns 400 when defaultAgentId is missing", async () => {
+      const user = await context.setupUser();
+      const botId = uniqueId("bot");
+      await createTestTelegramInstallation({
+        ownerUserId: user.userId,
+        telegramBotId: botId,
+        orgId: user.orgId,
+      });
+
+      const response = await PATCH(botRequest("PATCH", {}), routeParams(botId));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("returns 403 for a linked non-owner", async () => {
+      const user = await context.setupUser();
+      const botId = uniqueId("bot");
+      await createTestTelegramInstallation({
+        ownerUserId: "other-owner",
+        vm0UserId: user.userId,
+        telegramBotId: botId,
+        orgId: user.orgId,
+      });
+      const { composeId } = await createTestCompose(uniqueId("agent"));
+
+      const response = await PATCH(
+        botRequest("PATCH", { defaultAgentId: composeId }),
+        routeParams(botId),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("updates the default agent for the owner", async () => {
+      const user = await context.setupUser();
+      const botId = uniqueId("bot");
+      await createTestTelegramInstallation({
+        ownerUserId: user.userId,
+        telegramBotId: botId,
+        orgId: user.orgId,
+      });
+      const { composeId, name } = await createTestCompose(uniqueId("agent"));
+
+      const response = await PATCH(
+        botRequest("PATCH", { defaultAgentId: composeId }),
+        routeParams(botId),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.agent).toEqual({ id: composeId, name });
+      expect(data.id).toBe(botId);
+    });
+  });
+
+  describe("DELETE", () => {
+    it("returns 403 for a linked non-owner", async () => {
+      const user = await context.setupUser();
+      const botId = uniqueId("bot");
+      await createTestTelegramInstallation({
+        ownerUserId: "other-owner",
+        vm0UserId: user.userId,
+        telegramBotId: botId,
+        orgId: user.orgId,
+      });
+
+      const response = await DELETE(botRequest("DELETE"), routeParams(botId));
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("deletes installation and removes webhook for the owner", async () => {
+      const user = await context.setupUser();
+      const botId = uniqueId("bot");
+      await createTestTelegramInstallation({
+        ownerUserId: user.userId,
+        telegramBotId: botId,
+        orgId: user.orgId,
+      });
+      const deleteHandler = telegramDeleteWebhook();
+      server.use(deleteHandler.handler);
+
+      const response = await DELETE(botRequest("DELETE"), routeParams(botId));
+
+      expect(response.status).toBe(204);
+      expect(deleteHandler.mocked).toHaveBeenCalledTimes(1);
+
+      const getResponse = await GET(botRequest("GET"), routeParams(botId));
+      expect(getResponse.status).toBe(404);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/integrations/telegram/[botId]/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/[botId]/route.ts
@@ -1,0 +1,249 @@
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { initServices } from "../../../../../src/lib/init-services";
+import { env } from "../../../../../src/env";
+import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { decryptSecretValue } from "../../../../../src/lib/shared/crypto/secrets-encryption";
+import { logger } from "../../../../../src/lib/shared/logger";
+import { deleteWebhook } from "../../../../../src/lib/zero/telegram/client";
+import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
+import {
+  buildTelegramBotStatus,
+  getTelegramUserLink,
+  type TelegramInstallation,
+} from "../telegram-status";
+
+const patchBodySchema = z.object({
+  defaultAgentId: z.string().trim().min(1),
+});
+
+const log = logger("api:telegram:integration-bot");
+
+function unauthorizedResponse() {
+  return NextResponse.json(
+    { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+    { status: 401 },
+  );
+}
+
+function notFoundResponse() {
+  return NextResponse.json(
+    { error: { message: "Telegram bot not found", code: "NOT_FOUND" } },
+    { status: 404 },
+  );
+}
+
+function forbiddenResponse(message: string) {
+  return NextResponse.json(
+    {
+      error: {
+        message,
+        code: "FORBIDDEN",
+      },
+    },
+    { status: 403 },
+  );
+}
+
+async function loadVisibleInstallation(params: {
+  botId: string;
+  orgId: string;
+  userId: string;
+}): Promise<{
+  installation: TelegramInstallation;
+  isOwner: boolean;
+} | null> {
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.telegramBotId, params.botId))
+    .limit(1);
+
+  if (!installation || installation.orgId !== params.orgId) {
+    return null;
+  }
+
+  const isOwner = installation.ownerUserId === params.userId;
+  if (isOwner) {
+    return { installation, isOwner };
+  }
+
+  const userLink = await getTelegramUserLink(params.botId, params.userId);
+  if (!userLink) {
+    return null;
+  }
+
+  return { installation, isOwner };
+}
+
+/**
+ * GET /api/integrations/telegram/[botId]
+ *
+ * Returns full status for an owned or linked Telegram bot in the active org.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ botId: string }> },
+) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+
+  if (!authCtx) {
+    return unauthorizedResponse();
+  }
+
+  const { botId } = await params;
+  const { org } = await resolveOrg(authCtx);
+  const visible = await loadVisibleInstallation({
+    botId,
+    orgId: org.orgId,
+    userId: authCtx.userId,
+  });
+
+  if (!visible) {
+    return notFoundResponse();
+  }
+
+  return NextResponse.json(
+    await buildTelegramBotStatus(visible.installation, authCtx.userId),
+  );
+}
+
+/**
+ * PATCH /api/integrations/telegram/[botId]
+ *
+ * Owner-only update for the bot default agent.
+ */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ botId: string }> },
+) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+
+  if (!authCtx) {
+    return unauthorizedResponse();
+  }
+
+  const { botId } = await params;
+  const { org } = await resolveOrg(authCtx);
+  const visible = await loadVisibleInstallation({
+    botId,
+    orgId: org.orgId,
+    userId: authCtx.userId,
+  });
+
+  if (!visible) {
+    return notFoundResponse();
+  }
+
+  if (!visible.isOwner) {
+    return forbiddenResponse("Only the bot owner can change the default agent");
+  }
+
+  const parseResult = patchBodySchema.safeParse(await request.json());
+  if (!parseResult.success) {
+    return NextResponse.json(
+      { error: { message: "defaultAgentId is required", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  const [compose] = await globalThis.services.db
+    .select({ id: agentComposes.id, orgId: agentComposes.orgId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, parseResult.data.defaultAgentId))
+    .limit(1);
+
+  if (!compose) {
+    return NextResponse.json(
+      { error: { message: "Agent not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+  if (compose.orgId !== visible.installation.orgId) {
+    return forbiddenResponse(
+      "Telegram bots can only be connected to agents in the bot's organization",
+    );
+  }
+
+  const [updated] = await globalThis.services.db
+    .update(telegramInstallations)
+    .set({ defaultComposeId: compose.id, updatedAt: new Date() })
+    .where(
+      eq(
+        telegramInstallations.telegramBotId,
+        visible.installation.telegramBotId,
+      ),
+    )
+    .returning();
+
+  return NextResponse.json(
+    await buildTelegramBotStatus(
+      updated ?? visible.installation,
+      authCtx.userId,
+    ),
+  );
+}
+
+/**
+ * DELETE /api/integrations/telegram/[botId]
+ *
+ * Owner-only uninstall. Removes webhook best-effort, then deletes installation.
+ */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ botId: string }> },
+) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+
+  if (!authCtx) {
+    return unauthorizedResponse();
+  }
+
+  const { botId } = await params;
+  const { org } = await resolveOrg(authCtx);
+  const visible = await loadVisibleInstallation({
+    botId,
+    orgId: org.orgId,
+    userId: authCtx.userId,
+  });
+
+  if (!visible) {
+    return notFoundResponse();
+  }
+
+  if (!visible.isOwner) {
+    return forbiddenResponse("Only the bot owner can uninstall this bot");
+  }
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const botToken = decryptSecretValue(
+    visible.installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  await deleteWebhook(botToken).catch((error) => {
+    log.warn("Failed to remove Telegram webhook", { error });
+  });
+
+  await globalThis.services.db
+    .delete(telegramInstallations)
+    .where(
+      eq(
+        telegramInstallations.telegramBotId,
+        visible.installation.telegramBotId,
+      ),
+    );
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/turbo/apps/web/app/api/integrations/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/__tests__/route.test.ts
@@ -1,24 +1,19 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { HttpResponse } from "msw";
-import { GET, PATCH, DELETE } from "../route";
+import { GET } from "../route";
 import {
   testContext,
   uniqueId,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import {
-  createTestCompose,
   createTestTelegramInstallation,
+  insertTestTelegramUserLink,
 } from "../../../../../src/__tests__/api-test-helpers";
-import { server } from "../../../../../src/mocks/server";
-import { http } from "../../../../../src/__tests__/msw";
 
 const context = testContext();
 
-function telegramDeleteWebhook() {
-  return http.post(/api\.telegram\.org\/bot.*\/deleteWebhook/, () => {
-    return HttpResponse.json({ ok: true, result: true });
-  });
+function telegramRequest() {
+  return new Request("http://localhost:3000/api/integrations/telegram");
 }
 
 describe("/api/integrations/telegram", () => {
@@ -30,176 +25,66 @@ describe("/api/integrations/telegram", () => {
     it("returns 401 when not authenticated", async () => {
       mockClerk({ userId: null });
 
-      const request = new Request(
-        "http://localhost:3000/api/integrations/telegram",
-      );
-      const response = await GET(request);
+      const response = await GET(telegramRequest());
       const data = await response.json();
 
       expect(response.status).toBe(401);
       expect(data.error.code).toBe("UNAUTHORIZED");
     });
 
-    it("returns 404 when user has no Telegram link", async () => {
+    it("returns an empty list when the user owns no Telegram bots", async () => {
       await context.setupUser();
 
-      const request = new Request(
-        "http://localhost:3000/api/integrations/telegram",
-      );
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(404);
-      expect(data.error.code).toBe("NOT_FOUND");
-    });
-
-    it("returns bot info for linked admin user", async () => {
-      const user = await context.setupUser();
-      await createTestTelegramInstallation({
-        ownerUserId: user.userId,
-        vm0UserId: user.userId,
-        orgId: user.orgId,
-      });
-
-      const request = new Request(
-        "http://localhost:3000/api/integrations/telegram",
-      );
-      const response = await GET(request);
+      const response = await GET(telegramRequest());
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.bot.id).toBeDefined();
-      expect(data.bot.username).toBeDefined();
-      expect(data.agent).toBeDefined();
-      expect(data.isAdmin).toBe(true);
-      expect(data.environment).toBeDefined();
+      expect(data).toEqual({ bots: [] });
     });
 
-    it("returns 200 with isConnected: false when admin has no user link", async () => {
+    it("returns all bots owned by the user in the active org", async () => {
       const user = await context.setupUser();
-      // Create installation with admin but no user link (omit vm0UserId)
+      const firstBotId = uniqueId("bot");
+      const secondBotId = uniqueId("bot");
+
       await createTestTelegramInstallation({
         ownerUserId: user.userId,
+        vm0UserId: user.userId,
+        telegramBotId: firstBotId,
+        orgId: user.orgId,
+      });
+      await createTestTelegramInstallation({
+        ownerUserId: user.userId,
+        telegramBotId: secondBotId,
         orgId: user.orgId,
       });
 
-      const request = new Request(
-        "http://localhost:3000/api/integrations/telegram",
-      );
-      const response = await GET(request);
+      const response = await GET(telegramRequest());
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.isAdmin).toBe(true);
-      expect(data.isConnected).toBe(false);
-      expect(data.bot.username).toBeDefined();
-    });
-
-    it("does not return a linked bot from another org", async () => {
-      const user = await context.setupUser();
-      await createTestTelegramInstallation({
-        ownerUserId: user.userId,
-        vm0UserId: user.userId,
-      });
-
-      const request = new Request(
-        "http://localhost:3000/api/integrations/telegram",
+      expect(data.bots).toHaveLength(2);
+      expect(data.bots).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: firstBotId,
+            username: `bot_${firstBotId}`,
+            isOwner: true,
+            isConnected: true,
+            agent: expect.objectContaining({ id: expect.any(String) }),
+          }),
+          expect.objectContaining({
+            id: secondBotId,
+            username: `bot_${secondBotId}`,
+            isOwner: true,
+            isConnected: false,
+            agent: expect.objectContaining({ id: expect.any(String) }),
+          }),
+        ]),
       );
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(404);
-      expect(data.error.code).toBe("NOT_FOUND");
-    });
-  });
-
-  describe("PATCH", () => {
-    it("returns 401 when not authenticated", async () => {
-      mockClerk({ userId: null });
-
-      const request = new Request(
-        "http://localhost:3000/api/integrations/telegram",
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ agentName: "my-agent" }),
-        },
-      );
-      const response = await PATCH(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(401);
-      expect(data.error.code).toBe("UNAUTHORIZED");
     });
 
-    it("returns 403 for non-admin user", async () => {
-      const user = await context.setupUser();
-      // Create installation where admin is a different user
-      await createTestTelegramInstallation({
-        ownerUserId: "other-owner",
-        vm0UserId: user.userId,
-        orgId: user.orgId,
-      });
-
-      const request = new Request(
-        "http://localhost:3000/api/integrations/telegram",
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ agentName: "my-agent" }),
-        },
-      );
-      const response = await PATCH(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(403);
-      expect(data.error.code).toBe("FORBIDDEN");
-    });
-
-    it("updates default agent for admin", async () => {
-      const user = await context.setupUser();
-      await createTestTelegramInstallation({
-        ownerUserId: user.userId,
-        vm0UserId: user.userId,
-        orgId: user.orgId,
-      });
-
-      // Create a new agent to switch to
-      const newAgentName = uniqueId("new-agent");
-      await createTestCompose(newAgentName);
-
-      const request = new Request(
-        "http://localhost:3000/api/integrations/telegram",
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ agentName: newAgentName }),
-        },
-      );
-      const response = await PATCH(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.ok).toBe(true);
-    });
-  });
-
-  describe("DELETE", () => {
-    it("returns 401 when not authenticated", async () => {
-      mockClerk({ userId: null });
-
-      const request = new Request(
-        "http://localhost:3000/api/integrations/telegram",
-        { method: "DELETE" },
-      );
-      const response = await DELETE(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(401);
-      expect(data.error.code).toBe("UNAUTHORIZED");
-    });
-
-    it("returns 404 for non-admin user", async () => {
+    it("excludes bots owned by other users", async () => {
       const user = await context.setupUser();
       await createTestTelegramInstallation({
         ownerUserId: "other-owner",
@@ -207,43 +92,44 @@ describe("/api/integrations/telegram", () => {
         orgId: user.orgId,
       });
 
-      const request = new Request(
-        "http://localhost:3000/api/integrations/telegram",
-        { method: "DELETE" },
-      );
-      const response = await DELETE(request);
+      const response = await GET(telegramRequest());
       const data = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(data.error.code).toBe("NOT_FOUND");
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ bots: [] });
     });
 
-    it("deletes installation and removes webhook for admin", async () => {
+    it("excludes owned bots from other orgs", async () => {
       const user = await context.setupUser();
       await createTestTelegramInstallation({
         ownerUserId: user.userId,
         vm0UserId: user.userId,
-        orgId: user.orgId,
       });
 
-      const deleteHandler = telegramDeleteWebhook();
-      server.use(deleteHandler.handler);
+      const response = await GET(telegramRequest());
+      const data = await response.json();
 
-      const request = new Request(
-        "http://localhost:3000/api/integrations/telegram",
-        { method: "DELETE" },
-      );
-      const response = await DELETE(request);
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ bots: [] });
+    });
 
-      expect(response.status).toBe(204);
-      expect(deleteHandler.mocked).toHaveBeenCalledTimes(1);
+    it("excludes bots where the user is linked but not the owner", async () => {
+      const user = await context.setupUser();
+      const botId = await createTestTelegramInstallation({
+        ownerUserId: "other-owner",
+        orgId: user.orgId,
+      });
+      await insertTestTelegramUserLink({
+        installationId: botId,
+        telegramUserId: uniqueId("tg-user"),
+        vm0UserId: user.userId,
+      });
 
-      // Verify user is no longer linked
-      const getRequest = new Request(
-        "http://localhost:3000/api/integrations/telegram",
-      );
-      const getResponse = await GET(getRequest);
-      expect(getResponse.status).toBe(404);
+      const response = await GET(telegramRequest());
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ bots: [] });
     });
   });
 });

--- a/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
@@ -200,7 +200,7 @@ describe("/api/integrations/telegram/link", () => {
       mockClerk({ userId: null });
 
       const response = await POST(
-        linkRequest("POST", { installationId: "some-id" }),
+        linkRequest("POST", { telegramBotId: "some-id" }),
       );
       const data = await response.json();
 
@@ -208,7 +208,7 @@ describe("/api/integrations/telegram/link", () => {
       expect(data.error.code).toBe("UNAUTHORIZED");
     });
 
-    it("returns 400 when installationId is missing", async () => {
+    it("returns 400 when telegramBotId is missing", async () => {
       await context.setupUser();
 
       const response = await POST(linkRequest("POST", {}));
@@ -223,7 +223,7 @@ describe("/api/integrations/telegram/link", () => {
 
       const response = await POST(
         linkRequest("POST", {
-          installationId: "00000000-0000-0000-0000-000000000000",
+          telegramBotId: "00000000-0000-0000-0000-000000000000",
         }),
       );
       const data = await response.json();
@@ -240,7 +240,9 @@ describe("/api/integrations/telegram/link", () => {
         orgId: user.orgId,
       });
 
-      const response = await POST(linkRequest("POST", { installationId }));
+      const response = await POST(
+        linkRequest("POST", { telegramBotId: installationId }),
+      );
       const data = await response.json();
 
       expect(response.status).toBe(400);
@@ -259,7 +261,7 @@ describe("/api/integrations/telegram/link", () => {
       const telegramAuth = makeTelegramAuth(telegramUserId);
 
       const response = await POST(
-        linkRequest("POST", { installationId, telegramAuth }),
+        linkRequest("POST", { telegramBotId: installationId, telegramAuth }),
       );
       const data = await response.json();
 
@@ -290,7 +292,7 @@ describe("/api/integrations/telegram/link", () => {
 
       const response = await POST(
         linkRequest("POST", {
-          installationId,
+          telegramBotId: installationId,
           connectSignature: { telegramUserId, timestamp: ts, signature: sig },
         }),
       );
@@ -315,7 +317,7 @@ describe("/api/integrations/telegram/link", () => {
 
       const response = await POST(
         linkRequest("POST", {
-          installationId,
+          telegramBotId: installationId,
           telegramAuth: makeTelegramAuth(99004),
         }),
       );
@@ -335,7 +337,7 @@ describe("/api/integrations/telegram/link", () => {
 
       const response = await POST(
         linkRequest("POST", {
-          installationId,
+          telegramBotId: installationId,
           telegramAuth: {
             id: 12345,
             first_name: "Test",
@@ -360,7 +362,7 @@ describe("/api/integrations/telegram/link", () => {
 
       const response = await POST(
         linkRequest("POST", {
-          installationId,
+          telegramBotId: installationId,
           connectSignature: {
             telegramUserId: "99003",
             timestamp: Math.floor(Date.now() / 1000),

--- a/turbo/apps/web/app/api/integrations/telegram/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/route.ts
@@ -97,7 +97,7 @@ const connectSignatureSchema = z.object({
 });
 
 const linkBodySchema = z.object({
-  installationId: z.string().min(1),
+  telegramBotId: z.string().min(1),
   telegramAuth: telegramAuthSchema.optional(),
   connectSignature: connectSignatureSchema.optional(),
 });
@@ -189,7 +189,7 @@ export async function GET(request: Request) {
  *
  * Create a pending user link for account linking via Telegram.
  * The link auto-completes when the user sends their first message to the bot.
- * Body: { installationId: string }
+ * Body: { telegramBotId: string }
  */
 export async function POST(request: Request) {
   initServices();
@@ -211,7 +211,7 @@ export async function POST(request: Request) {
     return NextResponse.json(
       {
         error: {
-          message: "installationId is required",
+          message: "telegramBotId is required",
           code: "BAD_REQUEST",
         },
       },
@@ -232,7 +232,7 @@ export async function POST(request: Request) {
       orgId: telegramInstallations.orgId,
     })
     .from(telegramInstallations)
-    .where(eq(telegramInstallations.telegramBotId, body.installationId))
+    .where(eq(telegramInstallations.telegramBotId, body.telegramBotId))
     .limit(1);
 
   if (!installation) {
@@ -297,7 +297,7 @@ export async function POST(request: Request) {
 
     if (
       !verifyConnectSignature(
-        body.installationId,
+        body.telegramBotId,
         body.connectSignature.telegramUserId,
         body.connectSignature.timestamp,
         body.connectSignature.signature,

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -1,38 +1,15 @@
 import { NextResponse } from "next/server";
-import { and, eq, desc } from "drizzle-orm";
-import { z } from "zod";
-import { extractAndGroupVariables } from "@vm0/core/variable-expander";
-import { getConnectorProvidedSecretNames } from "@vm0/connectors/connector-utils";
+import { and, desc, eq } from "drizzle-orm";
 import { initServices } from "../../../../src/lib/init-services";
-import { env } from "../../../../src/env";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
-import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "@vm0/db/schema/agent-compose";
-import { listSecrets } from "../../../../src/lib/zero/secret/secret-service";
-import { listVariables } from "../../../../src/lib/zero/variable/variable-service";
-import { listConnectors } from "../../../../src/lib/zero/connector/connector-service";
-import type { AgentComposeYaml } from "../../../../src/lib/infra/agent-compose/types";
-import { decryptSecretValue } from "../../../../src/lib/shared/crypto/secrets-encryption";
-import { deleteWebhook } from "../../../../src/lib/zero/telegram/client";
 import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
-import { logger } from "../../../../src/lib/shared/logger";
-import { checkTelegramDomain } from "../../../../src/lib/zero/telegram/check-domain";
-
-const patchBodySchema = z.object({
-  agentName: z.string().min(1),
-});
-
-const log = logger("api:telegram:integration");
+import { buildTelegramBot } from "./telegram-status";
 
 /**
  * GET /api/integrations/telegram
  *
- * Returns Telegram bot info for the authenticated user,
- * including bot details, current agent, and environment variable status.
+ * Lists Telegram bots owned by the authenticated user in the active org.
  */
 export async function GET(request: Request) {
   initServices();
@@ -46,303 +23,11 @@ export async function GET(request: Request) {
       { status: 401 },
     );
   }
+
   const { userId } = authCtx;
   const { org } = await resolveOrg(authCtx);
 
-  const db = globalThis.services.db;
-
-  // Find user's most recent Telegram link in the active org.
-  const [userLink] = await db
-    .select({
-      id: telegramUserLinks.id,
-      telegramUserId: telegramUserLinks.telegramUserId,
-      installationId: telegramUserLinks.installationId,
-      vm0UserId: telegramUserLinks.vm0UserId,
-      dmWelcomeSent: telegramUserLinks.dmWelcomeSent,
-      createdAt: telegramUserLinks.createdAt,
-      updatedAt: telegramUserLinks.updatedAt,
-    })
-    .from(telegramUserLinks)
-    .innerJoin(
-      telegramInstallations,
-      eq(telegramUserLinks.installationId, telegramInstallations.telegramBotId),
-    )
-    .where(
-      and(
-        eq(telegramUserLinks.vm0UserId, userId),
-        eq(telegramInstallations.orgId, org.orgId),
-      ),
-    )
-    .orderBy(desc(telegramUserLinks.createdAt))
-    .limit(1);
-
-  // Find installation via user link or owner ownership
-  let installation;
-  if (userLink) {
-    [installation] = await db
-      .select()
-      .from(telegramInstallations)
-      .where(eq(telegramInstallations.telegramBotId, userLink.installationId))
-      .limit(1);
-  } else {
-    [installation] = await db
-      .select()
-      .from(telegramInstallations)
-      .where(
-        and(
-          eq(telegramInstallations.ownerUserId, userId),
-          eq(telegramInstallations.orgId, org.orgId),
-        ),
-      )
-      .limit(1);
-  }
-
-  if (!installation) {
-    return NextResponse.json(
-      { error: { message: "No linked Telegram bot", code: "NOT_FOUND" } },
-      { status: 404 },
-    );
-  }
-
-  // Get default agent
-  const [compose] = await db
-    .select({
-      id: agentComposes.id,
-      name: agentComposes.name,
-      headVersionId: agentComposes.headVersionId,
-    })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, installation.defaultComposeId))
-    .limit(1);
-
-  // Extract required secrets/vars from agent compose
-  let requiredSecrets: string[] = [];
-  let requiredVars: string[] = [];
-
-  if (compose?.headVersionId) {
-    const [version] = await db
-      .select({ content: agentComposeVersions.content })
-      .from(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, compose.headVersionId))
-      .limit(1);
-
-    if (version) {
-      const content = version.content as AgentComposeYaml;
-      const grouped = extractAndGroupVariables(content);
-      requiredSecrets = grouped.secrets.map((s) => {
-        return s.name;
-      });
-      requiredVars = grouped.vars.map((v) => {
-        return v.name;
-      });
-    }
-  }
-
-  // Get existing secrets, vars, connectors from the active org.
-  const [userSecrets, userVars, userConnectors] = await Promise.all([
-    listSecrets(org.orgId, userId),
-    listVariables(org.orgId, userId),
-    listConnectors(org.orgId, userId),
-  ]);
-
-  const connectorProvided = getConnectorProvidedSecretNames(
-    userConnectors.map((c) => {
-      return c.type;
-    }),
-  );
-  const existingSecretNames = new Set([
-    ...userSecrets.map((s) => {
-      return s.name;
-    }),
-    ...connectorProvided,
-  ]);
-  const existingVarNames = new Set(
-    userVars.map((v) => {
-      return v.name;
-    }),
-  );
-
-  const missingSecrets = requiredSecrets.filter((name) => {
-    return !existingSecretNames.has(name);
-  });
-  const missingVars = requiredVars.filter((name) => {
-    return !existingVarNames.has(name);
-  });
-
-  const isAdmin = installation.ownerUserId === userId;
-  const isConnected = !!userLink;
-
-  const { NEXT_PUBLIC_APP_URL } = env();
-  const domainConfigured = await checkTelegramDomain(
-    installation.telegramBotId,
-    NEXT_PUBLIC_APP_URL,
-  );
-
-  return NextResponse.json({
-    installationId: installation.telegramBotId,
-    bot: {
-      id: installation.telegramBotId,
-      username: installation.botUsername,
-    },
-    agent: compose ? { id: compose.id, name: compose.name } : null,
-    isAdmin,
-    isConnected,
-    domainConfigured,
-    environment: {
-      requiredSecrets,
-      requiredVars,
-      missingSecrets,
-      missingVars,
-    },
-  });
-}
-
-/**
- * PATCH /api/integrations/telegram
- *
- * Update the default agent for the Telegram bot.
- * Admin only.
- * Body: { agentName: string }
- */
-export async function PATCH(request: Request) {
-  initServices();
-
-  const authHeader = request.headers.get("authorization");
-  const authCtx = await getAuthContext(authHeader ?? undefined);
-
-  if (!authCtx) {
-    return NextResponse.json(
-      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
-      { status: 401 },
-    );
-  }
-  const { userId } = authCtx;
-  const { org: targetOrg } = await resolveOrg(authCtx);
-
-  const parseResult = patchBodySchema.safeParse(await request.json());
-  if (!parseResult.success) {
-    return NextResponse.json(
-      { error: { message: "agentName is required", code: "BAD_REQUEST" } },
-      { status: 400 },
-    );
-  }
-  const body = parseResult.data;
-
-  const db = globalThis.services.db;
-
-  // Find user's Telegram link in the active org.
-  const [userLink] = await db
-    .select({
-      id: telegramUserLinks.id,
-      telegramUserId: telegramUserLinks.telegramUserId,
-      installationId: telegramUserLinks.installationId,
-      vm0UserId: telegramUserLinks.vm0UserId,
-      dmWelcomeSent: telegramUserLinks.dmWelcomeSent,
-      createdAt: telegramUserLinks.createdAt,
-      updatedAt: telegramUserLinks.updatedAt,
-    })
-    .from(telegramUserLinks)
-    .innerJoin(
-      telegramInstallations,
-      eq(telegramUserLinks.installationId, telegramInstallations.telegramBotId),
-    )
-    .where(
-      and(
-        eq(telegramUserLinks.vm0UserId, userId),
-        eq(telegramInstallations.orgId, targetOrg.orgId),
-      ),
-    )
-    .orderBy(desc(telegramUserLinks.createdAt))
-    .limit(1);
-
-  if (!userLink) {
-    return NextResponse.json(
-      { error: { message: "No linked Telegram bot", code: "NOT_FOUND" } },
-      { status: 404 },
-    );
-  }
-
-  // Get installation
-  const [installation] = await db
-    .select()
-    .from(telegramInstallations)
-    .where(eq(telegramInstallations.telegramBotId, userLink.installationId))
-    .limit(1);
-
-  if (!installation) {
-    return NextResponse.json(
-      { error: { message: "Telegram bot not found", code: "NOT_FOUND" } },
-      { status: 404 },
-    );
-  }
-
-  // Owner check
-  if (installation.ownerUserId !== userId) {
-    return NextResponse.json(
-      {
-        error: {
-          message: "Only the bot owner can change the default agent",
-          code: "FORBIDDEN",
-        },
-      },
-      { status: 403 },
-    );
-  }
-
-  // Find agent
-  const [compose] = await db
-    .select({ id: agentComposes.id })
-    .from(agentComposes)
-    .where(
-      and(
-        eq(agentComposes.orgId, targetOrg.orgId),
-        eq(agentComposes.name, body.agentName),
-      ),
-    )
-    .limit(1);
-
-  if (!compose) {
-    return NextResponse.json(
-      { error: { message: "Agent not found", code: "NOT_FOUND" } },
-      { status: 404 },
-    );
-  }
-
-  // Update default agent
-  await db
-    .update(telegramInstallations)
-    .set({ defaultComposeId: compose.id, updatedAt: new Date() })
-    .where(eq(telegramInstallations.telegramBotId, installation.telegramBotId));
-
-  return NextResponse.json({ ok: true });
-}
-
-/**
- * DELETE /api/integrations/telegram
- *
- * Uninstall the Telegram bot. Admin only.
- * Removes webhook from Telegram and deletes the installation (cascades to user_links, sessions, messages).
- */
-export async function DELETE(request: Request) {
-  initServices();
-
-  const authHeader = request.headers.get("authorization");
-  const authCtx = await getAuthContext(authHeader ?? undefined);
-
-  if (!authCtx) {
-    return NextResponse.json(
-      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
-      { status: 401 },
-    );
-  }
-  const { userId } = authCtx;
-  const { org } = await resolveOrg(authCtx);
-
-  const { SECRETS_ENCRYPTION_KEY } = env();
-  const db = globalThis.services.db;
-
-  // Find installation where user is owner
-  const [installation] = await db
+  const installations = await globalThis.services.db
     .select()
     .from(telegramInstallations)
     .where(
@@ -351,33 +36,16 @@ export async function DELETE(request: Request) {
         eq(telegramInstallations.orgId, org.orgId),
       ),
     )
-    .limit(1);
-
-  if (!installation) {
-    return NextResponse.json(
-      {
-        error: {
-          message: "No Telegram bot found or you are not the bot owner",
-          code: "NOT_FOUND",
-        },
-      },
-      { status: 404 },
+    .orderBy(
+      desc(telegramInstallations.createdAt),
+      desc(telegramInstallations.telegramBotId),
     );
-  }
 
-  // Remove webhook from Telegram (non-blocking on failure)
-  const botToken = decryptSecretValue(
-    installation.encryptedBotToken,
-    SECRETS_ENCRYPTION_KEY,
+  const bots = await Promise.all(
+    installations.map((installation) => {
+      return buildTelegramBot(installation, userId);
+    }),
   );
-  await deleteWebhook(botToken).catch((error) => {
-    log.warn("Failed to remove Telegram webhook", { error });
-  });
 
-  // Delete installation (cascades to user_links, thread_sessions, messages)
-  await db
-    .delete(telegramInstallations)
-    .where(eq(telegramInstallations.telegramBotId, installation.telegramBotId));
-
-  return new NextResponse(null, { status: 204 });
+  return NextResponse.json({ bots });
 }

--- a/turbo/apps/web/app/api/integrations/telegram/telegram-status.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/telegram-status.ts
@@ -1,0 +1,173 @@
+import { and, eq } from "drizzle-orm";
+import { getConnectorProvidedSecretNames } from "@vm0/connectors/connector-utils";
+import type {
+  TelegramBot,
+  TelegramBotStatus,
+} from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { extractAndGroupVariables } from "@vm0/core/variable-expander";
+import { env } from "../../../../src/env";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
+import type { AgentComposeYaml } from "../../../../src/lib/infra/agent-compose/types";
+import { listConnectors } from "../../../../src/lib/zero/connector/connector-service";
+import { listSecrets } from "../../../../src/lib/zero/secret/secret-service";
+import { checkTelegramDomain } from "../../../../src/lib/zero/telegram/check-domain";
+import { listVariables } from "../../../../src/lib/zero/variable/variable-service";
+
+export type TelegramInstallation = typeof telegramInstallations.$inferSelect;
+
+type TelegramCompose = {
+  id: string;
+  name: string;
+  headVersionId: string | null;
+};
+
+async function getDefaultCompose(
+  installation: TelegramInstallation,
+): Promise<TelegramCompose | null> {
+  const [compose] = await globalThis.services.db
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      headVersionId: agentComposes.headVersionId,
+    })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, installation.defaultComposeId))
+    .limit(1);
+
+  return compose ?? null;
+}
+
+export async function getTelegramUserLink(
+  telegramBotId: string,
+  userId: string,
+) {
+  const [userLink] = await globalThis.services.db
+    .select({
+      id: telegramUserLinks.id,
+      telegramUserId: telegramUserLinks.telegramUserId,
+      installationId: telegramUserLinks.installationId,
+      vm0UserId: telegramUserLinks.vm0UserId,
+    })
+    .from(telegramUserLinks)
+    .where(
+      and(
+        eq(telegramUserLinks.installationId, telegramBotId),
+        eq(telegramUserLinks.vm0UserId, userId),
+      ),
+    )
+    .limit(1);
+
+  return userLink ?? null;
+}
+
+async function getEnvironmentStatus(
+  compose: TelegramCompose | null,
+  orgId: string,
+  userId: string,
+): Promise<TelegramBotStatus["environment"]> {
+  let requiredSecrets: string[] = [];
+  let requiredVars: string[] = [];
+
+  if (compose?.headVersionId) {
+    const [version] = await globalThis.services.db
+      .select({ content: agentComposeVersions.content })
+      .from(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, compose.headVersionId))
+      .limit(1);
+
+    if (version) {
+      const content = version.content as AgentComposeYaml;
+      const grouped = extractAndGroupVariables(content);
+      requiredSecrets = grouped.secrets.map((secret) => {
+        return secret.name;
+      });
+      requiredVars = grouped.vars.map((variable) => {
+        return variable.name;
+      });
+    }
+  }
+
+  const [userSecrets, userVars, userConnectors] = await Promise.all([
+    listSecrets(orgId, userId),
+    listVariables(orgId, userId),
+    listConnectors(orgId, userId),
+  ]);
+
+  const connectorProvided = getConnectorProvidedSecretNames(
+    userConnectors.map((connector) => {
+      return connector.type;
+    }),
+  );
+  const existingSecretNames = new Set([
+    ...userSecrets.map((secret) => {
+      return secret.name;
+    }),
+    ...connectorProvided,
+  ]);
+  const existingVarNames = new Set(
+    userVars.map((variable) => {
+      return variable.name;
+    }),
+  );
+
+  return {
+    requiredSecrets,
+    requiredVars,
+    missingSecrets: requiredSecrets.filter((name) => {
+      return !existingSecretNames.has(name);
+    }),
+    missingVars: requiredVars.filter((name) => {
+      return !existingVarNames.has(name);
+    }),
+  };
+}
+
+export async function buildTelegramBot(
+  installation: TelegramInstallation,
+  userId: string,
+): Promise<TelegramBot> {
+  const [compose, userLink] = await Promise.all([
+    getDefaultCompose(installation),
+    getTelegramUserLink(installation.telegramBotId, userId),
+  ]);
+
+  return {
+    id: installation.telegramBotId,
+    username: installation.botUsername,
+    agent: compose ? { id: compose.id, name: compose.name } : null,
+    isOwner: installation.ownerUserId === userId,
+    isConnected: !!userLink,
+  };
+}
+
+export async function buildTelegramBotStatus(
+  installation: TelegramInstallation,
+  userId: string,
+): Promise<TelegramBotStatus> {
+  const compose = await getDefaultCompose(installation);
+  const [userLink, environment] = await Promise.all([
+    getTelegramUserLink(installation.telegramBotId, userId),
+    getEnvironmentStatus(compose, installation.orgId, userId),
+  ]);
+
+  const { NEXT_PUBLIC_APP_URL } = env();
+  const domainConfigured = await checkTelegramDomain(
+    installation.telegramBotId,
+    NEXT_PUBLIC_APP_URL,
+  );
+
+  return {
+    id: installation.telegramBotId,
+    username: installation.botUsername,
+    agent: compose ? { id: compose.id, name: compose.name } : null,
+    isOwner: installation.ownerUserId === userId,
+    isConnected: !!userLink,
+    domainConfigured,
+    environment,
+  };
+}

--- a/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { HttpResponse } from "msw";
+import { HttpResponse, http as mswHttp } from "msw";
 import { POST } from "../route";
 import {
   testContext,
   uniqueId,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import { createTestCompose } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestCompose,
+  updateOrgDefaultAgent,
+} from "../../../../../src/__tests__/api-test-helpers";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 
@@ -66,6 +69,14 @@ function telegramSetMyCommands() {
   );
 }
 
+function telegramOauthHead() {
+  return mswHttp.head("https://oauth.telegram.org/auth", () => {
+    return new HttpResponse(null, {
+      headers: { "content-length": "0" },
+    });
+  });
+}
+
 function registerRequest(body: Record<string, unknown>) {
   return new Request("http://localhost:3000/api/telegram/register", {
     method: "POST",
@@ -82,6 +93,7 @@ function testBotId(): string {
 describe("POST /api/telegram/register", () => {
   beforeEach(() => {
     context.setupMocks();
+    server.use(telegramOauthHead());
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -122,7 +134,7 @@ describe("POST /api/telegram/register", () => {
     await context.setupUser();
 
     const botId = testBotId();
-    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { composeId, name } = await createTestCompose(uniqueId("agent"));
 
     const getMeHandler = telegramGetMe(botId, `bot_${botId}`);
     const setWebhookHandler = telegramSetWebhook(true);
@@ -139,14 +151,45 @@ describe("POST /api/telegram/register", () => {
     const body = await response.json();
 
     expect(response.status).toBe(201);
-    expect(body.botId).toBe(botId);
-    expect(body.botUsername).toBe(`bot_${botId}`);
-    expect(body.webhookUrl).toContain("/api/telegram/webhook/");
-    expect(body.id).toBeDefined();
+    expect(body).toEqual(
+      expect.objectContaining({
+        id: botId,
+        username: `bot_${botId}`,
+        agent: { id: composeId, name },
+        isOwner: true,
+        isConnected: false,
+        domainConfigured: false,
+      }),
+    );
+    expect(body.environment).toBeDefined();
 
     expect(getMeHandler.mocked).toHaveBeenCalledTimes(1);
     expect(setWebhookHandler.mocked).toHaveBeenCalledTimes(1);
     expect(setCommandsHandler.mocked).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the active org default agent when defaultAgentId is omitted", async () => {
+    const user = await context.setupUser();
+
+    const botId = testBotId();
+    const { composeId, name } = await createTestCompose(uniqueId("agent"));
+    await updateOrgDefaultAgent(user.orgId, composeId);
+
+    const getMeHandler = telegramGetMe(botId, `default_bot_${botId}`);
+    const setWebhookHandler = telegramSetWebhook(true);
+    const setCommandsHandler = telegramSetMyCommands();
+    server.use(
+      getMeHandler.handler,
+      setWebhookHandler.handler,
+      setCommandsHandler.handler,
+    );
+
+    const response = await POST(registerRequest({ botToken: TEST_BOT_TOKEN }));
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.id).toBe(botId);
+    expect(body.agent).toEqual({ id: composeId, name });
   });
 
   it("returns 409 when bot is already registered", async () => {
@@ -188,13 +231,13 @@ describe("POST /api/telegram/register", () => {
     const getMeHandler = telegramGetMe(botId, `noagent_bot_${botId}`);
     server.use(getMeHandler.handler);
 
-    // No defaultAgentId in body and VM0_DEFAULT_AGENT env var not set
     const response = await POST(registerRequest({ botToken: TEST_BOT_TOKEN }));
     const body = await response.json();
 
     expect(response.status).toBe(400);
     expect(body.error.code).toBe("BAD_REQUEST");
     expect(body.error.message).toContain("No default agent specified");
+    expect(body.error.message).not.toContain("VM0_DEFAULT_AGENT");
   });
 
   it("returns 404 when defaultAgentId references a nonexistent agent", async () => {

--- a/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
@@ -192,6 +192,25 @@ describe("POST /api/telegram/register", () => {
     expect(body.agent).toEqual({ id: composeId, name });
   });
 
+  it("rejects an empty defaultAgentId instead of falling back to the org default", async () => {
+    const user = await context.setupUser();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    await updateOrgDefaultAgent(user.orgId, composeId);
+
+    const getMeHandler = telegramGetMe(testBotId(), "empty_default_bot");
+    server.use(getMeHandler.handler);
+
+    const response = await POST(
+      registerRequest({ botToken: TEST_BOT_TOKEN, defaultAgentId: "" }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("defaultAgentId");
+    expect(getMeHandler.mocked).not.toHaveBeenCalled();
+  });
+
   it("returns 409 when bot is already registered", async () => {
     await context.setupUser();
 

--- a/turbo/apps/web/app/api/telegram/register/route.ts
+++ b/turbo/apps/web/app/api/telegram/register/route.ts
@@ -6,6 +6,7 @@ import { env } from "../../../../src/env";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import {
   getMe,
   setWebhook,
@@ -13,15 +14,14 @@ import {
 } from "../../../../src/lib/zero/telegram/client";
 import { encryptSecretValue } from "../../../../src/lib/shared/crypto/secrets-encryption";
 import { generateCallbackSecret } from "../../../../src/lib/infra/callback/hmac";
-import { resolveDefaultAgentComposeId } from "../../../../src/lib/infra/agent-compose/resolve-default";
 import { logger } from "../../../../src/lib/shared/logger";
-import { checkTelegramDomain } from "../../../../src/lib/zero/telegram/check-domain";
 import { buildTelegramWebhookUrl } from "../../../../src/lib/zero/telegram/webhook-url";
 import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
+import { buildTelegramBotStatus } from "../../integrations/telegram/telegram-status";
 
 const registerBodySchema = z.object({
   botToken: z.string().min(1),
-  defaultAgentId: z.string().optional(),
+  defaultAgentId: z.string().trim().min(1).optional(),
 });
 
 const log = logger("api:telegram:register");
@@ -62,8 +62,13 @@ export async function POST(request: Request) {
 
   const parseResult = registerBodySchema.safeParse(await request.json());
   if (!parseResult.success) {
+    const invalidField = parseResult.error.issues[0]?.path[0];
+    const message =
+      invalidField === "defaultAgentId"
+        ? "defaultAgentId must be non-empty"
+        : "botToken is required";
     return NextResponse.json(
-      { error: { message: "botToken is required", code: "BAD_REQUEST" } },
+      { error: { message, code: "BAD_REQUEST" } },
       { status: 400 },
     );
   }
@@ -113,14 +118,22 @@ export async function POST(request: Request) {
   }
 
   // 3. Resolve default agent
-  const defaultAgentId =
-    body.defaultAgentId ?? (await resolveDefaultAgentComposeId());
+  let defaultAgentId = body.defaultAgentId;
+  if (!defaultAgentId) {
+    const [metadata] = await globalThis.services.db
+      .select({ defaultAgentId: orgMetadata.defaultAgentId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, org.orgId))
+      .limit(1);
+    defaultAgentId = metadata?.defaultAgentId ?? undefined;
+  }
+
   if (!defaultAgentId) {
     return NextResponse.json(
       {
         error: {
           message:
-            "No default agent specified. Provide defaultAgentId or set VM0_DEFAULT_AGENT env var.",
+            "No default agent specified. Provide defaultAgentId or configure a default agent for the active organization.",
           code: "BAD_REQUEST",
         },
       },
@@ -221,21 +234,7 @@ export async function POST(request: Request) {
     log.warn("Failed to register bot commands", { error });
   });
 
-  // Check if domain is configured for Telegram OAuth
-  const { NEXT_PUBLIC_APP_URL } = env();
-  const domainConfigured = await checkTelegramDomain(
-    telegramBotId,
-    NEXT_PUBLIC_APP_URL,
-  );
-
-  return NextResponse.json(
-    {
-      id: installation.telegramBotId,
-      botId: telegramBotId,
-      botUsername: botInfoResult.username,
-      webhookUrl,
-      domainConfigured,
-    },
-    { status: 201 },
-  );
+  return NextResponse.json(await buildTelegramBotStatus(installation, userId), {
+    status: 201,
+  });
 }

--- a/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
@@ -369,6 +369,8 @@ describe("GET /api/zero/usage/insight", () => {
   });
 
   it("TZ shift — same row appears in different date buckets by timezone", async () => {
+    context.mocks.date.setSystemTime(new Date("2026-04-23T15:00:00Z"));
+
     const { userId, orgId } = await context.user;
     const { composeId } = await seedTestCompose({
       userId,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -932,7 +932,8 @@ export {
 export {
   zeroIntegrationsTelegramContract,
   type ZeroIntegrationsTelegramContract,
-  type TelegramStatusResponse,
-  type TelegramRegisterResponse,
+  type TelegramBot,
+  type TelegramBotStatus,
+  type TelegramListResponse,
   type TelegramLinkStatusResponse,
 } from "./zero-integrations-telegram";

--- a/turbo/packages/api-contracts/src/contracts/zero-integrations-telegram.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-integrations-telegram.ts
@@ -11,18 +11,25 @@ const telegramEnvironmentSchema = z.object({
   missingVars: z.array(z.string()),
 });
 
-const telegramStatusResponseSchema = z.object({
-  installationId: z.string(),
-  bot: z.object({ id: z.string(), username: z.string() }),
+const telegramBotSchema = z.object({
+  id: z.string(),
+  username: z.string().nullable(),
   agent: z.object({ id: z.string(), name: z.string() }).nullable(),
-  isAdmin: z.boolean(),
+  isOwner: z.boolean(),
   isConnected: z.boolean(),
+});
+
+const telegramBotStatusSchema = telegramBotSchema.extend({
   domainConfigured: z.boolean(),
   environment: telegramEnvironmentSchema,
 });
 
+const telegramListResponseSchema = z.object({
+  bots: z.array(telegramBotSchema),
+});
+
 const telegramUpdateBodySchema = z.object({
-  agentName: z.string().min(1),
+  defaultAgentId: z.string().trim().min(1),
 });
 
 const telegramLinkStatusResponseSchema = z.discriminatedUnion("linked", [
@@ -37,44 +44,48 @@ const telegramLinkStatusResponseSchema = z.discriminatedUnion("linked", [
 
 const telegramRegisterBodySchema = z.object({
   botToken: z.string().min(1),
-  defaultAgentId: z.string().optional(),
-});
-
-const telegramRegisterResponseSchema = z.object({
-  id: z.string(),
-  botId: z.string(),
-  botUsername: z.string(),
-  webhookUrl: z.string(),
-  domainConfigured: z.boolean(),
+  defaultAgentId: z.string().trim().min(1).optional(),
 });
 
 /**
  * Zero integrations Telegram contract
- * Covers all five Telegram integration endpoints.
+ * Covers all Telegram integration endpoints.
  *
  * Path note: these endpoints use /api/integrations/ and /api/telegram/ (not /api/zero/)
  * because they are served by the platform app directly, not the Zero sub-application.
  * This is intentional and matches the real server routing.
  */
 export const zeroIntegrationsTelegramContract = c.router({
-  getStatus: {
+  list: {
     method: "GET",
     path: "/api/integrations/telegram",
     headers: authHeadersSchema,
     responses: {
-      200: telegramStatusResponseSchema,
+      200: telegramListResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "List Telegram bot integrations owned by the authenticated user",
+  },
+  getBot: {
+    method: "GET",
+    path: "/api/integrations/telegram/:botId",
+    headers: authHeadersSchema,
+    pathParams: z.object({ botId: z.string().min(1) }),
+    responses: {
+      200: telegramBotStatusSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Get Telegram bot integration status for the authenticated user",
+    summary: "Get Telegram bot integration status",
   },
-  update: {
+  updateBot: {
     method: "PATCH",
-    path: "/api/integrations/telegram",
+    path: "/api/integrations/telegram/:botId",
     headers: authHeadersSchema,
+    pathParams: z.object({ botId: z.string().min(1) }),
     body: telegramUpdateBodySchema,
     responses: {
-      200: z.object({ ok: z.boolean() }),
+      200: telegramBotStatusSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
@@ -84,15 +95,17 @@ export const zeroIntegrationsTelegramContract = c.router({
   },
   disconnect: {
     method: "DELETE",
-    path: "/api/integrations/telegram",
+    path: "/api/integrations/telegram/:botId",
     headers: authHeadersSchema,
+    pathParams: z.object({ botId: z.string().min(1) }),
     body: c.noBody(),
     responses: {
       204: c.noBody(),
       401: apiErrorSchema,
+      403: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Uninstall the Telegram bot (admin only)",
+    summary: "Uninstall the Telegram bot",
   },
   getLinkStatus: {
     method: "GET",
@@ -111,9 +124,10 @@ export const zeroIntegrationsTelegramContract = c.router({
     headers: authHeadersSchema,
     body: telegramRegisterBodySchema,
     responses: {
-      201: telegramRegisterResponseSchema,
+      201: telegramBotStatusSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
       404: apiErrorSchema,
       409: apiErrorSchema,
       500: apiErrorSchema,
@@ -125,12 +139,9 @@ export const zeroIntegrationsTelegramContract = c.router({
 
 export type ZeroIntegrationsTelegramContract =
   typeof zeroIntegrationsTelegramContract;
-export type TelegramStatusResponse = z.infer<
-  typeof telegramStatusResponseSchema
->;
-export type TelegramRegisterResponse = z.infer<
-  typeof telegramRegisterResponseSchema
->;
+export type TelegramBot = z.infer<typeof telegramBotSchema>;
+export type TelegramBotStatus = z.infer<typeof telegramBotStatusSchema>;
+export type TelegramListResponse = z.infer<typeof telegramListResponseSchema>;
 export type TelegramLinkStatusResponse = z.infer<
   typeof telegramLinkStatusResponseSchema
 >;

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -48,6 +48,7 @@ export enum FeatureSwitchKey {
   ApiKeys = "apiKeys",
   ConnectorCategories = "connectorCategories",
   PlatformConnectors = "platformConnectors",
+  TelegramIntegration = "telegramIntegration",
   Trinity = "trinity",
   ZapierConnector = "zapierConnector",
 }

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -74,6 +74,7 @@ describe("getAllFeatureStates", () => {
     // PlatformConnectors has STAFF_ORG_ID_HASHES and should be true
     expect(states[FeatureSwitchKey.PlatformConnectors]).toBe(true);
     expect(states[FeatureSwitchKey.ConnectorCategories]).toBe(true);
+    expect(states[FeatureSwitchKey.TelegramIntegration]).toBe(true);
     // Globally enabled should still be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
     // Switches without org hashes should remain false
@@ -86,6 +87,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(states[FeatureSwitchKey.PlatformConnectors]).toBe(false);
     expect(states[FeatureSwitchKey.ConnectorCategories]).toBe(false);
+    expect(states[FeatureSwitchKey.TelegramIntegration]).toBe(false);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -275,6 +275,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.TelegramIntegration]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Show the Telegram integration settings UI. The backend Telegram routes do not consult this frontend rollout flag.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.Trinity]: {
     maintainer: "ethan@vm0.ai",
     description:

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -779,8 +779,9 @@ export {
   type ZeroUploadsContract,
   type UploadPrepareResponse,
   type ZeroIntegrationsTelegramContract,
-  type TelegramStatusResponse,
-  type TelegramRegisterResponse,
+  type TelegramBot,
+  type TelegramBotStatus,
+  type TelegramListResponse,
   type TelegramLinkStatusResponse,
 } from "./contracts";
 export {


### PR DESCRIPTION
## Summary

- Register the frontend-only `TelegramIntegration` feature switch.
- Reshape the Telegram integration contract for multi-bot list/detail/update/delete/register flows.
- Split `/api/integrations/telegram` into a list endpoint plus keyed `/api/integrations/telegram/:botId` routes.
- Update register default-agent behavior, link body naming, platform MSW handlers, and route tests.

## Verification

- `pnpm --filter @vm0/core test -- src/__tests__/feature-switch.test.ts`
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter @vm0/core lint`
- `pnpm --filter @vm0/app lint`
- `pnpm --filter web lint`
- pre-commit: prettier + knip

## Local blockers / unrelated failures

- Targeted web Telegram route tests were invoked with `pnpm --filter web exec vitest run ...`, but the local test DB is behind the checked-in schema (`telegram_installations.owner_user_id` / `org_id` missing). `pnpm --filter web db:migrate` is also blocked by an existing local table conflict (`redemption_codes` already exists). I did not reset the local DB.
- `pnpm --filter web check-types` fails on existing non-Telegram route type errors under `app/api/runners`, `app/api/zero/*`, etc.
- `pnpm --filter @vm0/app check-types` fails on existing platform ts-rest client typing errors unrelated to this Telegram mock update.

Closes #10999
Refs #10239