### PR TITLE
feat(chat): limit default thread list with load all

### DIFF
--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -21,6 +21,10 @@ load '../../helpers/browser'
 setup_file() {
   browser_setup
 
+  if [[ -n "${CLERK_SECRET_KEY:-}" ]]; then
+    delete_e2e_account_if_exists
+  fi
+
   # Generate a password for sign-up
   SIGNUP_PASSWORD="$(generate_password)"
   export SIGNUP_PASSWORD

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -126,7 +126,7 @@ export const apiAgentsHandlers = [
 
   // GET /api/zero/chat-threads
   mockApi(chatThreadsContract.list, ({ respond }) => {
-    return respond(200, { threads: [] });
+    return respond(200, { threads: [], hasMore: false });
   }),
 
   // POST /api/zero/chat-threads (create new thread)

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -19,6 +19,7 @@ import {
 export { reloadChatThreads$ } from "./chat-thread-list-reload.ts";
 
 const internalChatAgentId$ = state<string | null>(null);
+const internalLoadAllChatThreads$ = state(false);
 
 export const currentChatAgentId$ = computed(
   async (get): Promise<string | null> => {
@@ -135,29 +136,59 @@ export const patchThreadRead$ = command(({ set }, _threadId: string) => {
   set(reloadChatThreads$);
 });
 
-export const chatThreads$ = computed(async (get) => {
-  get(reloadChatThreadsCounter$);
+interface ChatThreadListResult {
+  threads: ChatThreadListItem[];
+  hasMore: boolean;
+}
 
-  const agentId = await get(currentChatAgentId$);
-  if (!agentId) {
-    return [];
-  }
+export const loadAllChatThreads$ = command(({ set }) => {
+  set(internalLoadAllChatThreads$, true);
+});
 
-  const client = get(zeroClient$)(chatThreadsContract);
-  const result = await accept(
-    client.list({ query: { agentId: agentId } }),
-    [200],
-  );
-  const threads = result.body.threads;
+const chatThreadListResult$ = computed(
+  async (get): Promise<ChatThreadListResult> => {
+    get(reloadChatThreadsCounter$);
+    const includeAll = get(internalLoadAllChatThreads$);
 
-  const currentThread = await get(currentChatThread$);
-  return threads.map((t) => {
+    const agentId = await get(currentChatAgentId$);
+    if (!agentId) {
+      return { threads: [], hasMore: false };
+    }
+
+    const client = get(zeroClient$)(chatThreadsContract);
+    const result = await accept(
+      client.list({
+        query: {
+          agentId: agentId,
+          ...(includeAll ? ({ all: "true" } as const) : {}),
+        },
+      }),
+      [200],
+    );
+    const threads = result.body.threads;
+
+    const currentThread = await get(currentChatThread$);
     return {
-      ...t,
-      title:
-        t.id === currentThread?.id ? t.title || currentThread.title : t.title,
+      threads: threads.map((t) => {
+        return {
+          ...t,
+          title:
+            t.id === currentThread?.id
+              ? t.title || currentThread.title
+              : t.title,
+        };
+      }),
+      hasMore: result.body.hasMore,
     };
-  });
+  },
+);
+
+export const chatThreads$ = computed(async (get) => {
+  return (await get(chatThreadListResult$)).threads;
+});
+
+export const chatThreadsHasMore$ = computed(async (get) => {
+  return (await get(chatThreadListResult$)).hasMore;
 });
 
 /**

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
@@ -25,7 +25,7 @@ const mockApi = createMockApi(context);
 function setupBaseHandlers(threadId: string) {
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads: [] });
+      return respond(200, { threads: [], hasMore: false });
     }),
     mockApi(chatThreadMessagesContract.list, ({ respond }) => {
       return respond(200, { messages: [] });

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/latest-run-status.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/latest-run-status.test.ts
@@ -28,7 +28,7 @@ describe("latestRunStatus$", () => {
 
     server.use(
       mockApi(chatThreadsContract.list, ({ respond }) => {
-        return respond(200, { threads: [] });
+        return respond(200, { threads: [], hasMore: false });
       }),
       mockApi(chatThreadMessagesContract.list, ({ respond }) => {
         return respond(200, { messages: [] });
@@ -73,7 +73,7 @@ describe("latestRunStatus$", () => {
 
     server.use(
       mockApi(chatThreadsContract.list, ({ respond }) => {
-        return respond(200, { threads: [] });
+        return respond(200, { threads: [], hasMore: false });
       }),
       mockApi(chatThreadMessagesContract.list, ({ respond }) => {
         return respond(200, { messages: [] });
@@ -118,7 +118,7 @@ describe("latestRunStatus$", () => {
 
     server.use(
       mockApi(chatThreadsContract.list, ({ respond }) => {
-        return respond(200, { threads: [] });
+        return respond(200, { threads: [], hasMore: false });
       }),
       mockApi(chatThreadMessagesContract.list, ({ respond }) => {
         return respond(200, { messages: [] });

--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -23,7 +23,9 @@ import { prepareUserMessageFromDraft$ } from "./resolve-draft-attachments.ts";
 
 export {
   chatThreads$,
+  chatThreadsHasMore$,
   currentChatThread$,
+  loadAllChatThreads$,
   reloadChatThreads$,
 } from "../agent-chat.ts";
 

--- a/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
@@ -38,7 +38,7 @@ function mockAPIs() {
   ]);
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads: [] });
+      return respond(200, { threads: [], hasMore: false });
     }),
   );
 }

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -42,7 +42,7 @@ function mockAPIs() {
   setMockTeam(createMockTeamWithSubagents());
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads: [] });
+      return respond(200, { threads: [], hasMore: false });
     }),
     mockApi(zeroComposesMainContract.getByName, ({ respond }) => {
       return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/agent-chat-keyboard.test.tsx
@@ -32,6 +32,7 @@ function mockThreadList(threads: { id: string; title: string }[]) {
             running: false,
           };
         }),
+        hasMore: false,
       });
     }),
   );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
@@ -56,6 +56,7 @@ function mockThreadList(threads: { id: string; title: string }[]) {
             running: false,
           };
         }),
+        hasMore: false,
       });
     }),
   );
@@ -179,6 +180,7 @@ describe("chat page keyboard shortcuts", () => {
               running: false,
             },
           ],
+          hasMore: false,
         });
       }),
       mockApi(chatThreadByIdContract.get, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -94,7 +94,7 @@ export function mockSubagentThread(threadId: string) {
       });
     }),
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads: [] });
+      return respond(200, { threads: [], hasMore: false });
     }),
     mockApi(zeroAgentsByIdContract.get, ({ params, respond }) => {
       const agents: Record<
@@ -356,7 +356,7 @@ export function mockChatLifecycle(options?: {
       });
     }),
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads: threadList });
+      return respond(200, { threads: threadList, hasMore: false });
     }),
     mockApi(chatThreadsContract.create, ({ respond }) => {
       return respond(201, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-title-refresh.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-title-refresh.test.tsx
@@ -43,6 +43,7 @@ describe("chat title refresh", () => {
               running: false,
             },
           ],
+          hasMore: false,
         });
       }),
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/recent-thread-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/recent-thread-skeleton.test.tsx
@@ -54,6 +54,7 @@ function mockAgentsWithThreads() {
             running: false,
           },
         ],
+        hasMore: false,
       });
     }),
     mockApi(chatThreadByIdContract.get, ({ respond }) => {
@@ -98,7 +99,7 @@ describe("recent thread skeleton (#7546)", () => {
     server.use(
       mockApi(chatThreadsContract.list, async ({ respond }) => {
         await hangDeferred.promise;
-        return respond(200, { threads: [] });
+        return respond(200, { threads: [], hasMore: false });
       }),
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -52,7 +52,7 @@ function mockAPIs() {
 
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads });
+      return respond(200, { threads, hasMore: false });
     }),
     mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
       const thread = threads.find((t) => {
@@ -199,7 +199,7 @@ describe("sidebar chat delete", () => {
 
     server.use(
       mockApi(chatThreadsContract.list, ({ respond }) => {
-        return respond(200, { threads });
+        return respond(200, { threads, hasMore: false });
       }),
       mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
         const thread = threads.find((t) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-navigation.test.tsx
@@ -33,6 +33,7 @@ function mockAPIs() {
             running: false,
           },
         ],
+        hasMore: false,
       });
     }),
     mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -113,7 +113,7 @@ function mockSubagentAPIs() {
       });
     }),
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads });
+      return respond(200, { threads, hasMore: false });
     }),
     mockApi(chatThreadByIdContract.get, ({ respond }) => {
       return respond(200, {
@@ -277,6 +277,7 @@ describe("sidebar new chat navigation", () => {
               running: false,
             },
           ],
+          hasMore: false,
         });
       }),
       mockApi(chatThreadByIdContract.get, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx
@@ -46,7 +46,7 @@ interface ThreadFixture {
 function mockAPIs(threadsRef: { current: ThreadFixture[] }) {
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads: threadsRef.current });
+      return respond(200, { threads: threadsRef.current, hasMore: false });
     }),
     mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
       return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-unify-chat-threads.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-unify-chat-threads.test.tsx
@@ -73,6 +73,7 @@ function mockUnifiedThreads(observedQueries: ListQuery[]) {
             running: false,
           },
         ],
+        hasMore: false,
       });
     }),
     mockApi(chatThreadByIdContract.get, ({ params, respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Display and interaction tests for ZeroChatListPage (/chats).
+ *
+ * Covers the "Load all" button that appears when the server returns
+ * hasMore=true, and verifies it disappears after loading all threads.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { server } from "../../../mocks/server.ts";
+import { chatThreadsContract } from "@vm0/core/contracts/chat-threads";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
+
+const context = testContext();
+const mockApi = createMockApi(context);
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+beforeEach(() => {
+  setMockUserPreferences({ pinnedAgentIds: [] });
+});
+
+describe("zero chat list page - load all button (CHAT-LIST-001)", () => {
+  it("shows Load all when server returns hasMore=true and hides it after clicking", async () => {
+    const user = userEvent.setup();
+
+    const recentThread = {
+      id: "thread-recent",
+      title: "Recent chat",
+      agent: { id: AGENT_ID, avatarUrl: null },
+      createdAt: "2026-03-10T00:00:00Z",
+      updatedAt: "2026-03-10T00:00:00Z",
+      isRead: false,
+      isArchived: false,
+      running: false,
+    };
+    const olderThread = {
+      id: "thread-older",
+      title: "Older chat",
+      agent: { id: AGENT_ID, avatarUrl: null },
+      createdAt: "2026-03-09T00:00:00Z",
+      updatedAt: "2026-03-09T00:00:00Z",
+      isRead: false,
+      isArchived: false,
+      running: false,
+    };
+
+    server.use(
+      mockApi(chatThreadsContract.list, ({ query, respond }) => {
+        return respond(200, {
+          threads:
+            query.all === "true" ? [recentThread, olderThread] : [recentThread],
+          hasMore: query.all !== "true",
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats" });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Recent chat").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Load all").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText("Older chat")).not.toBeInTheDocument();
+
+    await user.click(screen.getAllByText("Load all")[0]);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Older chat").length).toBeGreaterThan(0);
+      expect(screen.queryByText("Load all")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page-display.test.tsx
@@ -32,7 +32,7 @@ function mockAPIs(overrides: Partial<ScheduleResponse> = {}) {
   ]);
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads: [] });
+      return respond(200, { threads: [], hasMore: false });
     }),
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page-interaction.test.tsx
@@ -37,7 +37,7 @@ function mockAPIs(overrides: Partial<ScheduleResponse> = {}) {
   ]);
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads: [] });
+      return respond(200, { threads: [], hasMore: false });
     }),
   );
 }
@@ -160,7 +160,7 @@ describe("zero schedule detail page - toggle switch changes enabled state (SCHED
         });
       }),
       mockApi(chatThreadsContract.list, ({ respond }) => {
-        return respond(200, { threads: [] });
+        return respond(200, { threads: [], hasMore: false });
       }),
     );
 
@@ -250,7 +250,7 @@ describe("zero schedule detail page - instruction save button saves instructions
         });
       }),
       mockApi(chatThreadsContract.list, ({ respond }) => {
-        return respond(200, { threads: [] });
+        return respond(200, { threads: [], hasMore: false });
       }),
       mockApi(zeroSchedulesMainContract.deploy, ({ respond }) => {
         saved = true;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
@@ -57,7 +57,7 @@ function mockAPIsWithSubagents({
   setMockUserPreferences({ pinnedAgentIds });
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads: [] });
+      return respond(200, { threads: [], hasMore: false });
     }),
     mockApi(chatThreadByIdContract.get, ({ respond }) => {
       return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
@@ -68,7 +68,7 @@ function mockBaseAPIs(
   setMockTeam(agents);
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads });
+      return respond(200, { threads, hasMore: false });
     }),
   );
 }
@@ -117,6 +117,62 @@ describe("zero sidebar - chat thread list display (SIDEBAR-D-001)", () => {
       expect(within(sidebar).getByText("Fix the bug")).toBeInTheDocument();
     });
   });
+
+  it("shows Load all when the server has hidden older threads", async () => {
+    const user = userEvent.setup();
+    const firstThread = {
+      id: "thread-1",
+      title: "Recent chat",
+      agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
+      createdAt: "2026-03-10T00:00:00Z",
+      updatedAt: "2026-03-10T00:00:00Z",
+      isRead: false,
+      isArchived: false,
+      running: false,
+    };
+    const olderThread = {
+      id: "thread-2",
+      title: "Older chat",
+      agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
+      createdAt: "2026-03-09T00:00:00Z",
+      updatedAt: "2026-03-09T00:00:00Z",
+      isRead: false,
+      isArchived: false,
+      running: false,
+    };
+    const observedAllValues: ("true" | undefined)[] = [];
+
+    mockBaseAPIs();
+    server.use(
+      mockApi(chatThreadsContract.list, ({ query, respond }) => {
+        observedAllValues.push(query.all);
+        return respond(200, {
+          threads:
+            query.all === "true" ? [firstThread, olderThread] : [firstThread],
+          hasMore: query.all !== "true",
+        });
+      }),
+    );
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      const sidebar = getSidebar();
+      expect(within(sidebar).getByText("Recent chat")).toBeInTheDocument();
+      expect(within(sidebar).getByText("Load all")).toBeInTheDocument();
+    });
+    expect(
+      within(getSidebar()).queryByText("Older chat"),
+    ).not.toBeInTheDocument();
+
+    await user.click(within(getSidebar()).getByText("Load all"));
+
+    await waitFor(() => {
+      const sidebar = getSidebar();
+      expect(within(sidebar).getByText("Older chat")).toBeInTheDocument();
+      expect(within(sidebar).queryByText("Load all")).not.toBeInTheDocument();
+    });
+    expect(observedAllValues).toContain("true");
+  });
 });
 
 describe("zero sidebar - loading state (SIDEBAR-D-002)", () => {
@@ -125,7 +181,7 @@ describe("zero sidebar - loading state (SIDEBAR-D-002)", () => {
     server.use(
       mockApi(chatThreadsContract.list, async ({ respond }) => {
         await deferred.promise;
-        return respond(200, { threads: [] });
+        return respond(200, { threads: [], hasMore: false });
       }),
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -114,7 +114,7 @@ function mockBaseAPIs(options?: {
   setMockTeam(agents);
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads });
+      return respond(200, { threads, hasMore: false });
     }),
     mockApi(zeroAgentsByIdContract.get, ({ params, respond }) => {
       const agents: Record<
@@ -354,7 +354,7 @@ describe("zero sidebar - confirm delete removes thread (SIDEBAR-D-019)", () => {
     setMockTeam([makeDefaultAgent()]);
     server.use(
       mockApi(chatThreadsContract.list, ({ respond }) => {
-        return respond(200, { threads });
+        return respond(200, { threads, hasMore: false });
       }),
       mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
         const thread = threads.find((t) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
@@ -108,7 +108,7 @@ function mockBaseAPIs(options?: {
   setMockTeam(agents);
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads });
+      return respond(200, { threads, hasMore: false });
     }),
   );
 }
@@ -293,7 +293,7 @@ describe("zero sidebar - chat section stable during agent id reload (SIDEBAR-D-0
     server.use(
       mockApi(chatThreadsContract.list, async ({ respond }) => {
         await hangDeferred.promise;
-        return respond(200, { threads: [] });
+        return respond(200, { threads: [], hasMore: false });
       }),
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -67,7 +67,7 @@ function mockAPIs({
       ]);
     }),
     mockApi(chatThreadsContract.list, ({ respond }) => {
-      return respond(200, { threads });
+      return respond(200, { threads, hasMore: false });
     }),
     mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
       return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -10,6 +10,7 @@ import {
   IconX,
   IconPlus,
   IconChevronRight,
+  IconChevronDown,
   IconTrash,
 } from "@tabler/icons-react";
 import type { ChatThreadListItem } from "@vm0/core/contracts/chat-threads";
@@ -35,6 +36,8 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   chatThreads$,
+  chatThreadsHasMore$,
+  loadAllChatThreads$,
   deleteChatThread$,
   createNewChatThread$,
 } from "../../signals/chat-page/chat-message.ts";
@@ -151,8 +154,10 @@ function ChatThreads() {
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
   const deleteChatThread = useSet(deleteChatThread$);
   const pageSignal = useGet(pageSignal$);
+  const loadAllChatThreads = useSet(loadAllChatThreads$);
 
   const chatThreads = useLastResolved(chatThreads$) ?? [];
+  const hasMoreChatThreads = useLastResolved(chatThreadsHasMore$) ?? false;
   const features = useLastResolved(featureSwitch$);
   const showReadIndicator =
     features?.[FeatureSwitchKey.ChatThreadReadIndicator] ?? false;
@@ -178,13 +183,31 @@ function ChatThreads() {
     detach(deleteChatThread(threadId, pageSignal), Reason.DomCallback);
   }
 
+  const loadAllButton = hasMoreChatThreads ? (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={() => {
+        loadAllChatThreads();
+      }}
+      className="mt-1 h-8 w-full justify-center text-xs text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+    >
+      <IconChevronDown size={14} stroke={2} />
+      Load all
+    </Button>
+  ) : null;
+
   if (filteredChatThreads.length === 0) {
     return (
-      <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
-        {trimmedTerm
-          ? "No chats match your search"
-          : "Start a conversation and it'll show up here"}
-      </p>
+      <>
+        <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
+          {trimmedTerm
+            ? "No chats match your search"
+            : "Start a conversation and it'll show up here"}
+        </p>
+        {loadAllButton}
+      </>
     );
   }
   return (
@@ -200,6 +223,7 @@ function ChatThreads() {
           />
         );
       })}
+      {loadAllButton}
       <Dialog
         open={pendingDeleteThreadId !== null}
         onOpenChange={(open) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
@@ -7,7 +7,13 @@ import {
   useLastResolved,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { IconPlus, IconSearch, IconX, IconTrash } from "@tabler/icons-react";
+import {
+  IconChevronDown,
+  IconPlus,
+  IconSearch,
+  IconX,
+  IconTrash,
+} from "@tabler/icons-react";
 import {
   Button,
   Dialog,
@@ -21,6 +27,8 @@ import {
 import type { ChatThreadListItem } from "@vm0/core/contracts/chat-threads";
 import {
   chatThreads$,
+  chatThreadsHasMore$,
+  loadAllChatThreads$,
   deleteChatThread$,
   createNewChatThread$,
 } from "../../signals/chat-page/chat-message.ts";
@@ -46,6 +54,7 @@ export function ZeroChatListPage() {
     recentSessionsLoadable.state === "hasData"
       ? recentSessionsLoadable.data
       : [];
+  const hasMoreChatThreads = useLastResolved(chatThreadsHasMore$) ?? false;
   const loading = recentSessionsLoadable.state === "loading";
   const error =
     recentSessionsLoadable.state === "hasError"
@@ -66,6 +75,7 @@ export function ZeroChatListPage() {
 
   const searchTerm = useGet(chatListQuery$);
   const setSearchTerm = useSet(setChatListQuery$);
+  const loadAllChatThreads = useSet(loadAllChatThreads$);
 
   const trimmedTerm = searchTerm.trim().toLowerCase();
   const filteredSessions = trimmedTerm
@@ -150,6 +160,8 @@ export function ZeroChatListPage() {
           searchTerm={searchTerm}
           selectedRecentId={selectedRecentId}
           onRecentSelect={onRecentSelect}
+          onLoadAll={loadAllChatThreads}
+          hasMore={hasMoreChatThreads}
         />
       </div>
     </div>
@@ -163,6 +175,8 @@ function ChatList({
   searchTerm,
   selectedRecentId,
   onRecentSelect,
+  onLoadAll,
+  hasMore,
 }: {
   loading: boolean;
   error: string | null;
@@ -170,6 +184,8 @@ function ChatList({
   searchTerm: string;
   selectedRecentId: string | null;
   onRecentSelect: (id: string) => void;
+  onLoadAll: () => void;
+  hasMore: boolean;
 }) {
   const pendingDeleteThreadId = useGet(pendingDeleteThreadId$);
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
@@ -205,11 +221,19 @@ function ChatList({
 
   if (sessions.length === 0) {
     return (
-      <p className="px-3 py-8 text-sm text-muted-foreground text-center">
-        {searchTerm.trim()
-          ? "No chats match your search"
-          : "Start a conversation and it'll show up here"}
-      </p>
+      <div className="flex flex-col items-center gap-3 px-3 py-8">
+        <p className="text-sm text-muted-foreground text-center">
+          {searchTerm.trim()
+            ? "No chats match your search"
+            : "Start a conversation and it'll show up here"}
+        </p>
+        {hasMore && (
+          <Button type="button" variant="outline" size="sm" onClick={onLoadAll}>
+            <IconChevronDown size={14} stroke={2} />
+            Load all
+          </Button>
+        )}
+      </div>
     );
   }
 
@@ -230,6 +254,18 @@ function ChatList({
           );
         })}
       </div>
+      {hasMore && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onLoadAll}
+          className="mt-3 w-full"
+        >
+          <IconChevronDown size={14} stroke={2} />
+          Load all
+        </Button>
+      )}
 
       <Dialog
         open={pendingDeleteThreadId !== null}

--- a/turbo/apps/web/app/api/zero/chat-threads/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
   createTestCompose,
   getOrgCacheEntry,
   insertTestChatMessage,
+  insertTestChatThread,
   setTestChatThreadLastReadAt,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
@@ -198,6 +199,7 @@ describe("GET /api/zero/chat-threads - List Threads", () => {
 
     expect(response.status).toBe(200);
     expect(data.threads).toEqual([]);
+    expect(data.hasMore).toBe(false);
   });
 
   it("should list created threads", async () => {
@@ -228,6 +230,77 @@ describe("GET /api/zero/chat-threads - List Threads", () => {
     expect(data.threads[0].id).toBeDefined();
     expect(data.threads[0].createdAt).toBeDefined();
     expect(data.threads[0].updatedAt).toBeDefined();
+    expect(data.hasMore).toBe(false);
+  });
+
+  it("defaults to the newest 25 when all threads are older than 24 hours", async () => {
+    const now = Date.now();
+    const fortyEightHours = 48 * 60 * 60 * 1000;
+    const ids: string[] = [];
+
+    for (let i = 0; i < 30; i += 1) {
+      const createdAt = new Date(now - fortyEightHours - (29 - i) * 1000);
+      ids.push(
+        await insertTestChatThread(
+          user.userId,
+          testComposeId,
+          `Old thread ${i}`,
+          createdAt,
+        ),
+      );
+    }
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.threads).toHaveLength(25);
+    expect(data.hasMore).toBe(true);
+    expect(
+      data.threads.map((t: { id: string }) => {
+        return t.id;
+      }),
+    ).toEqual(ids.slice(5).reverse());
+
+    const allResponse = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}&all=true`,
+      ),
+    );
+    const allData = await allResponse.json();
+
+    expect(allResponse.status).toBe(200);
+    expect(allData.threads).toHaveLength(30);
+    expect(allData.hasMore).toBe(false);
+  });
+
+  it("includes more than 25 threads when they are active within 24 hours", async () => {
+    const now = Date.now();
+
+    for (let i = 0; i < 30; i += 1) {
+      const createdAt = new Date(now - (29 - i) * 1000);
+      await insertTestChatThread(
+        user.userId,
+        testComposeId,
+        `Recent thread ${i}`,
+        createdAt,
+      );
+    }
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.threads).toHaveLength(30);
+    expect(data.hasMore).toBe(false);
   });
 
   it("reports isRead=true and isArchived=false for a thread with no messages", async () => {

--- a/turbo/apps/web/app/api/zero/chat-threads/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/route.ts
@@ -104,12 +104,14 @@ const router = tsr.router(chatThreadsContract, {
       }
     }
 
-    const threads = await listChatThreads(userId, callerOrgId, query.agentId);
+    const result = await listChatThreads(userId, callerOrgId, query.agentId, {
+      includeAll: query.all === "true",
+    });
 
     return {
       status: 200 as const,
       body: {
-        threads: threads.map((t) => {
+        threads: result.threads.map((t) => {
           return {
             id: t.id,
             title: t.title,
@@ -124,6 +126,7 @@ const router = tsr.router(chatThreadsContract, {
             running: t.running,
           };
         }),
+        hasMore: result.hasMore,
       },
     };
   },

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -399,11 +399,17 @@ export async function insertTestChatThread(
   userId: string,
   agentComposeId: string,
   title: string,
+  createdAt?: Date,
 ): Promise<string> {
   initServices();
   const [thread] = await globalThis.services.db
     .insert(chatThreads)
-    .values({ userId, agentComposeId, title })
+    .values({
+      userId,
+      agentComposeId,
+      title,
+      ...(createdAt ? { createdAt } : {}),
+    })
     .returning({ id: chatThreads.id });
   return thread!.id;
 }

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -1,4 +1,15 @@
-import { eq, and, desc, inArray, isNull, sql, or, lt } from "drizzle-orm";
+import {
+  eq,
+  and,
+  desc,
+  inArray,
+  isNull,
+  sql,
+  or,
+  lt,
+  gte,
+  lte,
+} from "drizzle-orm";
 import { chatThreads } from "../../../db/schema/chat-thread";
 import { chatMessages } from "../../../db/schema/chat-message";
 import { zeroRuns } from "../../../db/schema/zero-run";
@@ -45,6 +56,13 @@ export async function createChatThread(
   return thread;
 }
 
+const DEFAULT_CHAT_THREAD_LIST_LIMIT = 25;
+const DEFAULT_CHAT_THREAD_LIST_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+interface ListChatThreadsOptions {
+  includeAll?: boolean;
+}
+
 /**
  * List chat threads for a user, ordered by the latest message's createdAt desc
  * (threads with no messages fall back to the thread's own createdAt). This
@@ -68,8 +86,9 @@ export async function listChatThreads(
   userId: string,
   orgId: string,
   agentComposeId?: string,
-): Promise<
-  Array<{
+  options: ListChatThreadsOptions = {},
+): Promise<{
+  threads: Array<{
     id: string;
     title: string | null;
     agentId: string;
@@ -79,8 +98,9 @@ export async function listChatThreads(
     isRead: boolean;
     lastMessageArchivedAt: Date | null;
     running: boolean;
-  }>
-> {
+  }>;
+  hasMore: boolean;
+}> {
   const lastMessage = globalThis.services.db
     .select({
       chatThreadId: chatMessages.chatThreadId,
@@ -102,7 +122,8 @@ export async function listChatThreads(
     filters.push(eq(chatThreads.agentComposeId, agentComposeId));
   }
 
-  const threads = await globalThis.services.db
+  const activityAtExpression = sql<Date>`COALESCE(${lastMessage.createdAt}, ${chatThreads.createdAt})`;
+  const rankedThreads = globalThis.services.db
     .select({
       id: chatThreads.id,
       title: chatThreads.title,
@@ -114,7 +135,7 @@ export async function listChatThreads(
         WHEN ${lastMessage.createdAt} IS NULL THEN true
         WHEN ${chatThreads.lastReadAt} IS NULL THEN false
         ELSE ${chatThreads.lastReadAt} >= ${lastMessage.createdAt}
-      END`,
+      END`.as("is_read"),
       lastMessageArchivedAt: lastMessage.archivedAt,
       running: sql<boolean>`EXISTS (
         SELECT 1
@@ -122,7 +143,13 @@ export async function listChatThreads(
         INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
         WHERE ${zeroRuns.chatThreadId} = ${chatThreads.id}
           AND ${agentRuns.status} IN ('queued', 'pending', 'running')
-      )`,
+      )`.as("running"),
+      activityAt: activityAtExpression.as("activity_at"),
+      activityRank:
+        sql<number>`ROW_NUMBER() OVER (ORDER BY ${activityAtExpression} DESC)`.as(
+          "activity_rank",
+        ),
+      totalCount: sql<number>`COUNT(*) OVER ()`.as("total_count"),
     })
     .from(chatThreads)
     .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
@@ -131,11 +158,41 @@ export async function listChatThreads(
       and(eq(lastMessage.chatThreadId, chatThreads.id), eq(lastMessage.rn, 1)),
     )
     .where(and(...filters))
-    .orderBy(
-      desc(sql`COALESCE(${lastMessage.createdAt}, ${chatThreads.createdAt})`),
-    );
+    .as("ranked_threads");
 
-  return threads;
+  const includeAll = options.includeAll ?? false;
+  const cutoff = new Date(Date.now() - DEFAULT_CHAT_THREAD_LIST_WINDOW_MS);
+  const rows = await globalThis.services.db
+    .select({
+      id: rankedThreads.id,
+      title: rankedThreads.title,
+      agentId: rankedThreads.agentId,
+      agentAvatarUrl: rankedThreads.agentAvatarUrl,
+      createdAt: rankedThreads.createdAt,
+      updatedAt: rankedThreads.updatedAt,
+      isRead: rankedThreads.isRead,
+      lastMessageArchivedAt: rankedThreads.lastMessageArchivedAt,
+      running: rankedThreads.running,
+      totalCount: rankedThreads.totalCount,
+    })
+    .from(rankedThreads)
+    .where(
+      includeAll
+        ? undefined
+        : or(
+            lte(rankedThreads.activityRank, DEFAULT_CHAT_THREAD_LIST_LIMIT),
+            gte(rankedThreads.activityAt, cutoff),
+          ),
+    )
+    .orderBy(desc(rankedThreads.activityAt));
+
+  const totalCount = Number(rows[0]?.totalCount ?? rows.length);
+  return {
+    threads: rows.map(({ totalCount: _totalCount, ...thread }) => {
+      return thread;
+    }),
+    hasMore: !includeAll && totalCount > rows.length,
+  };
 }
 
 /**

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -173,9 +173,13 @@ export const chatThreadsContract = c.router({
     headers: authHeadersSchema,
     query: z.object({
       agentId: z.string().min(1).optional(),
+      all: z.literal("true").optional(),
     }),
     responses: {
-      200: z.object({ threads: z.array(chatThreadListItemSchema) }),
+      200: z.object({
+        threads: z.array(chatThreadListItemSchema),
+        hasMore: z.boolean(),
+      }),
       401: apiErrorSchema,
       404: apiErrorSchema,
     },


### PR DESCRIPTION
## Summary

- Limit the default chat thread list to the union of threads active in the last 24 hours and the most recent 25 threads.
- Add `all=true` and `hasMore` to the chat threads list contract so clients can opt into the full list.
- Add `Load all` controls to the sidebar thread list and the chat list page when the server reports hidden older threads.

## Impact

The sidebar avoids loading large historical thread lists by default while still preserving dense recent activity. Users can load the full history explicitly with one click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)