### PR TITLE
fix: improve mobile chat composer icon spacing and model picker display

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
@@ -34,6 +34,10 @@ import {
   setMockFeatureSwitches,
   resetMockFeatureSwitches,
 } from "../../../mocks/handlers/api-feature-switches.ts";
+import {
+  setMockTeam,
+  resetMockTeam,
+} from "../../../mocks/handlers/api-agents.ts";
 import { setChatShortcutHelpOpen$ } from "../../../signals/chat-page/chat-shortcut-help.ts";
 import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
 
@@ -143,16 +147,46 @@ describe("chat composer — mobile icon trigger", () => {
   beforeEach(() => {
     resetMockOrgModelProviders();
     resetMockFeatureSwitches();
+    resetMockTeam();
   });
 
-  // CHAT-MP-MOBILE-001: When the composer renders the picker, the trigger
-  // must contain BOTH a mobile-only icon branch (`sm:hidden`) and a
-  // desktop-only label branch (`hidden sm:inline-flex`). Both render to the
-  // DOM at all times — the visibility switch is pure CSS — so the test can
-  // assert the structure directly without viewport simulation.
+  const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+  async function openAgentChatWithPicker(): Promise<void> {
+    setMockTeam([
+      {
+        id: AGENT_ID,
+        displayName: "Test Agent",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "v1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    // Wait until the picker trigger mounts
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+      ).toBeInTheDocument();
+    });
+  }
+
+  // CHAT-MP-MOBILE-001: On the agent chat landing page, the composer renders
+  // the picker with mobileIconTrigger enabled — the trigger must contain BOTH
+  // a mobile-only icon branch (`sm:hidden`) and a desktop-only label branch
+  // (`hidden sm:inline-flex`). Both render to the DOM at all times because
+  // the visibility switch is pure CSS.
   it("renders provider icon on mobile and model label on desktop (CHAT-MP-MOBILE-001)", async () => {
     enableModelPicker();
-    await openThreadWithPicker();
+    await openAgentChatWithPicker();
 
     const trigger = screen.getByRole("combobox", { name: "Claude Sonnet 4.6" });
 
@@ -172,10 +206,11 @@ describe("chat composer — mobile icon trigger", () => {
     expect(providerImg?.getAttribute("alt")).toBe("");
   });
 
-  // CHAT-MP-MOBILE-002: When no provider is marked as the workspace default
-  // and the user has not picked a model, `resolved` is null — the trigger
-  // falls back to the placeholder label on desktop and must still show an
-  // icon (IconCpu) on mobile so the control never appears empty.
+  // CHAT-MP-MOBILE-002: On the agent chat landing page, when no provider is
+  // marked as the workspace default and the user has not picked a model,
+  // `resolved` is null — the trigger falls back to the placeholder label on
+  // desktop and must still show an icon (IconCpu) on mobile so the control
+  // never appears empty.
   it("falls back to IconCpu on mobile when no provider resolves (CHAT-MP-MOBILE-002)", async () => {
     // A provider exists (so the composer renders the picker) but none is
     // marked as default, so `effectiveDefault` is null.
@@ -197,8 +232,19 @@ describe("chat composer — mobile icon trigger", () => {
       },
     ]);
 
-    mockChatLifecycle({ threadId: THREAD_ID });
-    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+    setMockTeam([
+      {
+        id: AGENT_ID,
+        displayName: "Test Agent",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "v1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
 
     await waitFor(() => {
       return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -188,6 +188,10 @@ interface ZeroChatComposerProps {
     disabled?: boolean;
     /** The agent-level default model, shown as a "Default" tag in the dropdown. */
     agentDefault?: ModelProviderSelection | null;
+    /** When true, trigger shows only model name without provider label. Defaults to true. */
+    compactTrigger?: boolean;
+    /** When true, trigger shows a provider icon on mobile instead of text. Defaults to true. */
+    mobileIconTrigger?: boolean;
   };
 }
 
@@ -566,7 +570,7 @@ function MicButton({
             className={cn(
               "inline-flex shrink-0 items-center justify-center rounded-lg transition-colors",
               recording || transcribing
-                ? "gap-[3px] h-9 w-[52px] bg-[#2E9E9F] text-white hover:bg-[#279394]"
+                ? "gap-[3px] h-9 w-[52px] mr-2 bg-[#2E9E9F] text-white hover:bg-[#279394]"
                 : "h-9 w-9 text-muted-foreground hover:bg-accent hover:text-foreground",
             )}
             onClick={handleClick}
@@ -1075,8 +1079,8 @@ export function ZeroChatComposer({
                           "hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
                         )}
                         sessionProviderType={modelPicker.sessionProviderType}
-                        compactTrigger
-                        mobileIconTrigger
+                        compactTrigger={modelPicker.compactTrigger ?? true}
+                        mobileIconTrigger={modelPicker.mobileIconTrigger ?? true}
                         open={modelPickerOpen}
                         onOpenChange={setModelPickerOpen}
                         disabled={modelPicker.disabled}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -508,6 +508,7 @@ function ChatThreadComposer({
                   // continuity.
                   disabled: hasUserMessages,
                   agentDefault: agentModelDefault,
+                  mobileIconTrigger: false,
                 }
               : undefined
           }


### PR DESCRIPTION
## Summary
- Add right margin (`mr-2`) to voice mic button when recording/transcribing, matching the spacing of the adjacent submit button on mobile
- Expose `compactTrigger` and `mobileIconTrigger` options in `modelPicker` prop type so callers can control how the model provider picker renders
- Chat thread page (`/chats/:threadId`): show full text label in model provider picker on mobile instead of icon-only
- Agent chat landing page (`/agents/:agentId/chat`): keep icon-only display (unchanged behavior)

## Test plan
- [ ] Mobile: voice button in active (recording) state has right spacing before the submit button
- [ ] Mobile: chat thread page model picker shows text label instead of just a provider icon
- [ ] Mobile: agent chat landing page model picker still shows provider icon (no regression)
- [ ] Desktop: model picker behavior is unchanged across both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)