### PR TITLE
perf(chat): avoid redundant chat-threads refetches on navigation

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -39,20 +39,33 @@ afterEach(() => {
 });
 
 describe("setAblyLoop$ with mock Ably", () => {
-  it("resolves when loopCommand$ returns true on first call", async () => {
+  it("does not invoke loopCommand$ before the first ably event", async () => {
     const { store, controller } = setupTestStore();
 
     await store.set(setupRealtime$, controller.signal);
 
-    const body = vi.fn().mockReturnValue(true);
+    const body = vi.fn().mockReturnValue(false);
     const loopCommand$ = command((_store, _signal: AbortSignal) => {
       return body() as boolean;
     });
 
-    await store.set(setAblyLoop$, "topic", loopCommand$, controller.signal);
+    const loopPromise = store.set(
+      setAblyLoop$,
+      "topic",
+      loopCommand$,
+      controller.signal,
+    );
 
-    expect(body).toHaveBeenCalledOnce();
+    // Subscription registers without ever firing the loop body. Callers that
+    // need a baseline tick must run the loop command themselves before
+    // calling setAblyLoop$.
+    await vi.waitFor(() => {
+      expect(hasSubscription("topic")).toBeTruthy();
+    });
+    expect(body).not.toHaveBeenCalled();
+
     controller.abort();
+    await expect(loopPromise).rejects.toThrow();
   });
 
   it("iterates when triggerAblyEvent fires, resolves when body returns true", async () => {
@@ -63,7 +76,7 @@ describe("setAblyLoop$ with mock Ably", () => {
     let calls = 0;
     const loopCommand$ = command((_store, _signal: AbortSignal) => {
       calls++;
-      return calls >= 3;
+      return calls >= 2;
     });
 
     const loopPromise = store.set(
@@ -73,25 +86,24 @@ describe("setAblyLoop$ with mock Ably", () => {
       controller.signal,
     );
 
-    // First call happens immediately inside setAblyLoop$ (calls === 1), then
-    // the loop subscribes and waits on deferred.promise. Match real Ably
-    // semantics: don't fire server-side events until the subscription is
-    // confirmed — otherwise events arrive before the callback is registered
-    // and get dropped on the floor.
+    // The loop subscribes and waits on deferred.promise without running the
+    // body first. Match real Ably semantics: don't fire server-side events
+    // until the subscription is confirmed — otherwise events arrive before
+    // the callback is registered and get dropped on the floor.
     await vi.waitFor(() => {
-      expect(calls).toBe(1);
       expect(hasSubscription("test-topic")).toBeTruthy();
     });
+    expect(calls).toBe(0);
 
-    triggerAblyEvent("test-topic"); // calls === 2, returns false → loop continues
+    triggerAblyEvent("test-topic"); // calls === 1, returns false → loop continues
     await vi.waitFor(() => {
-      expect(calls).toBe(2);
+      expect(calls).toBe(1);
     });
 
-    triggerAblyEvent("test-topic"); // calls === 3, returns true → loop resolves
+    triggerAblyEvent("test-topic"); // calls === 2, returns true → loop resolves
     await loopPromise;
 
-    expect(calls).toBe(3);
+    expect(calls).toBe(2);
     controller.abort();
   });
 
@@ -124,20 +136,20 @@ describe("setAblyLoop$ with mock Ably", () => {
       controller.signal,
     );
 
-    // Wait for both loops' first iteration + subscription registration.
+    // Wait for both subscriptions to register. Loop bodies haven't run yet.
     await vi.waitFor(() => {
-      expect(callsA).toBe(1);
-      expect(callsB).toBe(1);
       expect(hasSubscription("topic-a")).toBeTruthy();
       expect(hasSubscription("topic-b")).toBeTruthy();
     });
+    expect(callsA).toBe(0);
+    expect(callsB).toBe(0);
 
     triggerAblyReconnect();
 
-    // Each subscriber gets poked once → each loop body runs again.
+    // Each subscriber gets poked once → each loop body runs exactly once.
     await vi.waitFor(() => {
-      expect(callsA).toBe(2);
-      expect(callsB).toBe(2);
+      expect(callsA).toBe(1);
+      expect(callsB).toBe(1);
     });
 
     controller.abort();

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -11,10 +11,7 @@ import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { pathParams$ } from "./route.ts";
 import { activeRoute$ } from "./active-route.ts";
-import {
-  reloadChatThreads$,
-  reloadChatThreadsCounter$,
-} from "./chat-thread-list-reload.ts";
+import { reloadChatThreadsCounter$ } from "./chat-thread-list-reload.ts";
 
 export { reloadChatThreads$ } from "./chat-thread-list-reload.ts";
 
@@ -84,8 +81,8 @@ export interface ChatThread {
 
 // Note: `create-chat-thread.ts` has a near-identical `threadData$` inside
 // `createThreadData`. Both are intentionally kept:
-//  - `currentChatThread$` is a route-scoped computed used for sidebar title
-//    merging in `chatThreads$`.
+//  - `currentChatThread$` is a route-scoped computed read by
+//    `zero-connectors.ts` to resolve the current thread's agent.
 //  - `threadData$` lives inside the per-thread signal factory so it can be
 //    invalidated independently (reloadThread$) for the open chat page.
 // The `[200, 404]` accept list and `{ toast: false }` must stay aligned so
@@ -126,15 +123,6 @@ export const currentChatThread$ = computed(
   },
 );
 
-/**
- * Mark a thread as read in the sidebar by triggering a full reload.
- * Uses reload (rather than in-place patch) so the server's authoritative
- * `last_read_at` value is reflected without client-side bookkeeping.
- */
-export const patchThreadRead$ = command(({ set }, _threadId: string) => {
-  set(reloadChatThreads$);
-});
-
 export const chatThreads$ = computed(async (get) => {
   get(reloadChatThreadsCounter$);
 
@@ -148,16 +136,7 @@ export const chatThreads$ = computed(async (get) => {
     client.list({ query: { agentId: agentId } }),
     [200],
   );
-  const threads = result.body.threads;
-
-  const currentThread = await get(currentChatThread$);
-  return threads.map((t) => {
-    return {
-      ...t,
-      title:
-        t.id === currentThread?.id ? t.title || currentThread.title : t.title,
-    };
-  });
+  return result.body.threads;
 });
 
 /**

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -24,7 +24,6 @@ import { prepareUserMessageFromDraft$ } from "./resolve-draft-attachments.ts";
 import {
   currentChatThreadId$,
   reloadChatThreads$,
-  patchThreadRead$,
   type ChatThread,
 } from "../agent-chat.ts";
 import {
@@ -897,7 +896,7 @@ function createRunTracking(
     return thread.activeRunIds.length === 0;
   });
 
-  const markThreadRead$ = command(async ({ get, set }, sig: AbortSignal) => {
+  const markThreadRead$ = command(async ({ get }, sig: AbortSignal) => {
     const client = get(zeroClient$)(chatThreadMarkReadContract);
     await accept(
       client.markRead({
@@ -907,7 +906,9 @@ function createRunTracking(
       }),
       [200],
     );
-    set(patchThreadRead$, threadId);
+    // Server broadcasts `threadListChanged` via Ably on mark-read; the
+    // sidebar reloads from that channel. Bumping reloadChatThreads$ here too
+    // forces a redundant refetch that blocks subsequent keyboard navigation.
   });
 
   const loadPagedMessages$ = command(
@@ -959,10 +960,9 @@ function createRunTracking(
         return false;
       });
 
-      const onReadCursorUpdated$ = command(({ set }) => {
-        set(patchThreadRead$, threadId);
-        return false;
-      });
+      // `chatThreadReadCursorUpdated:<id>` used to bump `patchThreadRead$`
+      // here; dropped because `threadListChanged` already fans out to the
+      // sidebar, and the extra reload blocks keyboard navigation.
 
       await Promise.all([
         set(
@@ -981,12 +981,6 @@ function createRunTracking(
           setAblyLoop$,
           `chatThreadRunUpdated:${thread.id}`,
           onRunChanged$,
-          signal,
-        ),
-        set(
-          setAblyLoop$,
-          `chatThreadReadCursorUpdated:${threadId}`,
-          onReadCursorUpdated$,
           signal,
         ),
       ]);

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -174,10 +174,13 @@ export const setAblyLoop$ = command(
       throw new Error("channel not estibilished");
     }
 
-    const done = await set(loopCommand$, signal);
-    if (done) {
-      return;
-    }
+    // No implicit prime on subscribe. Callers whose loop body sets up
+    // baseline state (voice-chat session instructions, connector
+    // `initialUpdatedAt`) must run the body themselves before calling this.
+    // Chat / queue / slack subscribers don't need a baseline because their
+    // data is fetched through separate computeds, and the implicit prime
+    // fanned out through multiple run/message channels caused duplicate
+    // refetches on every route change.
 
     let deferred = createDeferredPromise(signal);
 

--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -584,6 +584,12 @@ const startAblyLoop$ = command(
       return false;
     });
 
+    // Prime once before subscribing so instructions reach the live DC session
+    // immediately. `setAblyLoop$` no longer primes its subscribers.
+    const done = await set(pollBody$, signal);
+    if (done) {
+      return;
+    }
     await set(setAblyLoop$, ablyTopic(sessionId), pollBody$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -573,6 +573,12 @@ const startAblyLoop$ = command(
       return false;
     });
 
+    // Prime once before subscribing so instructions reach the live DC session
+    // immediately. `setAblyLoop$` no longer primes its subscribers.
+    const done = await set(pollBody$, signal);
+    if (done) {
+      return;
+    }
     await set(setAblyLoop$, ablyTopic(sessionId), pollBody$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -538,6 +538,13 @@ export const connectConnector$ = command(
     await set(awaitRealtimeReady$, signal);
     signal.throwIfAborted();
 
+    // Prime once so `initialUpdatedAt` snapshots the current server state.
+    // `setAblyLoop$` no longer primes its subscribers, and without this the
+    // first ably event would be taken as the baseline instead of signalling
+    // completion.
+    await set(onConnectorChanged$, signal);
+    signal.throwIfAborted();
+
     await raceUnderSignal(signal, (childSignal) => {
       return [
         set(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -302,10 +302,11 @@ describe("sidebar new chat navigation", () => {
       path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
     });
 
-    // Wait for thread list to load (thread with null title appears as "New chat" span)
+    // Wait for thread list to load — the thread row for the not-yet-named
+    // thread is identifiable by its link href.
     const newChatButton = await waitFor(() => {
       expect(
-        screen.getByText("New chat", { selector: "span" }),
+        document.querySelector(`a[href="/chats/new-thread-id"]`),
       ).toBeInTheDocument();
       return screen.getByLabelText("New chat");
     });
@@ -317,10 +318,11 @@ describe("sidebar new chat navigation", () => {
       expect(pathname()).toBe("/chats/new-thread-id");
     });
 
-    // 2. Verify sidebar shows "New chat" entry (thread has title: null)
+    // 2. Verify sidebar row is rendered for the new thread. title is null so
+    //    the row renders a skeleton placeholder instead of literal text.
     await waitFor(() => {
       expect(
-        screen.getByText("New chat", { selector: "span" }),
+        document.querySelector(`a[href="/chats/new-thread-id"]`),
       ).toBeInTheDocument();
     });
 

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -112,9 +112,11 @@ function ChatThreadItem({
             aria-label="Unread"
           />
         )}
-        <span className="truncate min-w-0 flex-1">
-          {session.title ?? "New chat"}
-        </span>
+        {session.title ? (
+          <span className="truncate min-w-0 flex-1">{session.title}</span>
+        ) : (
+          <Skeleton className="h-3 flex-1 min-w-0 rounded" />
+        )}
       </Link>
       <div className="absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
         <TooltipProvider delayDuration={200}>


### PR DESCRIPTION
## Summary

Pressing cmd+shift+up/down to jump between chat threads was noticeably slow (~800ms before the URL would even update on the second press). The adjacent-thread handler awaits `chatThreads$`, and every navigation was invalidating that signal through three redundant paths, forcing a network round-trip before navigation could proceed.

## Changes

- `chatThreads$` no longer depends on `currentChatThread$`. The title-merge fallback (reuse the open thread's fresh title when the list entry is null) is dropped; the sidebar renders a skeleton for nameless rows instead of the literal "New chat" string.
- `markThreadRead$` no longer bumps the sidebar reload after a successful POST. The server already publishes `threadListChanged` on mark-read, so the sidebar reloads once per mark-read instead of three times. With its only caller gone, `patchThreadRead$` is removed.
- Drop the per-thread `chatThreadReadCursorUpdated:<id>` Ably subscription — it existed only to fire `patchThreadRead$`, which is now redundant with `threadListChanged`.
- `setAblyLoop$` no longer runs the loop body once on subscribe. The implicit prime fanned out across every ably subscription; for a chat thread with three channels (`chatThreadMessageCreated`, `chatThreadRunCreated`, `chatThreadRunUpdated`) this fired `onRunChanged$` twice right after mark-read completed, each triggering an extra `threadData$` refetch. Voice chat, voice-chat-candidate, and the connectors OAuth flow legitimately needed that baseline call; they now invoke their loop bodies explicitly before `setAblyLoop$`.

Net effect: a cmd+shift+* press now only waits on the cached thread list (sub-ms with the signal already resolved) before `pushState`. Thread metadata is fetched once per navigation instead of 2-4 times.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/signals/__tests__/realtime.test.ts src/signals/voice-chat/__tests__/voice-chat-session.test.ts src/signals/voice-chat-candidate/__tests__/ src/signals/zero-page/__tests__/zero-connectors.test.ts src/signals/zero-page/__tests__/zero-added-connectors.test.ts src/views/zero-page/__tests__/sidebar-navigation.test.tsx` — all green
- [x] `pnpm format`, `pnpm knip`, `pnpm -F @vm0/app exec tsc --noEmit`, `pnpm -F @vm0/app exec oxlint`, `pnpm -F @vm0/app exec eslint . --max-warnings 0` — all clean
- [ ] Manual: open a chat thread, press cmd+shift+down several times; the sidebar highlight should move instantly and the network panel should show one `/chat-threads/:id`, one `messages?limit=50`, one `mark-read`, and one `chat-threads?agentId=...` per jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)