### PR TITLE
fix: show provider logo in compact model picker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -276,12 +276,7 @@ function TriggerLabel({
       <ResponsiveTriggerContent
         mobileIcon={mobileIcon}
         iconType={iconType}
-        label={
-          <span className="flex items-center gap-1.5 min-w-0">
-            {iconType && <ProviderIcon type={iconType} size={16} />}
-            <span className="truncate">{displayName}</span>
-          </span>
-        }
+        label={<span className="truncate">{displayName}</span>}
       />
     );
   }
@@ -345,7 +340,7 @@ function ResponsiveTriggerContent({
     return label;
   }
   return (
-    <>
+    <span className="flex items-center min-w-0">
       <span className="flex items-center justify-center sm:hidden">
         {iconType ? (
           <ProviderIcon type={iconType} size={18} />
@@ -353,10 +348,11 @@ function ResponsiveTriggerContent({
           <IconCpu size={18} stroke={1.5} />
         )}
       </span>
-      <span className="hidden min-w-0 sm:inline-flex sm:items-center">
+      <span className="hidden min-w-0 sm:inline-flex sm:items-center sm:gap-1.5">
+        {iconType && <ProviderIcon type={iconType} size={16} />}
         {label}
       </span>
-    </>
+    </span>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -274,7 +274,12 @@ function TriggerLabel({
       <ResponsiveTriggerContent
         mobileIcon={mobileIcon}
         provider={provider}
-        label={<span className="truncate">{displayName}</span>}
+        label={
+          <span className="flex items-center gap-1.5 min-w-0">
+            {provider && <ProviderIcon type={provider.type} size={16} />}
+            <span className="truncate">{displayName}</span>
+          </span>
+        }
       />
     );
   }

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -320,10 +320,14 @@ function resolveIconType(
   provider: ModelProviderResponse | undefined,
   model: string | undefined,
 ): ModelProviderType | undefined {
-  if (!provider) return undefined;
+  if (!provider) {
+    return undefined;
+  }
   if (provider.type === "vm0" && model) {
     const entry = VM0_MODEL_TO_PROVIDER[model];
-    if (entry) return entry.concreteType as ModelProviderType;
+    if (entry) {
+      return entry.concreteType as ModelProviderType;
+    }
   }
   return provider.type;
 }

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -21,6 +21,7 @@ import {
   getDefaultModel,
   getModels,
   MODEL_PROVIDER_TYPES,
+  VM0_MODEL_TO_PROVIDER,
   type ModelProviderResponse,
   type ModelProviderType,
 } from "@vm0/core/contracts/model-providers";
@@ -260,7 +261,7 @@ function TriggerLabel({
     return (
       <ResponsiveTriggerContent
         mobileIcon={mobileIcon}
-        provider={undefined}
+        iconType={undefined}
         label={<span>{placeholder}</span>}
       />
     );
@@ -269,14 +270,15 @@ function TriggerLabel({
   const provider = providers.find((p) => {
     return p.id === resolved.modelProviderId;
   });
+  const iconType = resolveIconType(provider, resolved.selectedModel);
   if (compact) {
     return (
       <ResponsiveTriggerContent
         mobileIcon={mobileIcon}
-        provider={provider}
+        iconType={iconType}
         label={
           <span className="flex items-center gap-1.5 min-w-0">
-            {provider && <ProviderIcon type={provider.type} size={16} />}
+            {iconType && <ProviderIcon type={iconType} size={16} />}
             <span className="truncate">{displayName}</span>
           </span>
         }
@@ -287,7 +289,7 @@ function TriggerLabel({
     return (
       <ResponsiveTriggerContent
         mobileIcon={mobileIcon}
-        provider={undefined}
+        iconType={undefined}
         label={<span>{displayName}</span>}
       />
     );
@@ -308,19 +310,31 @@ function TriggerLabel({
   return (
     <ResponsiveTriggerContent
       mobileIcon={mobileIcon}
-      provider={provider}
+      iconType={iconType}
       label={label}
     />
   );
 }
 
+function resolveIconType(
+  provider: ModelProviderResponse | undefined,
+  model: string | undefined,
+): ModelProviderType | undefined {
+  if (!provider) return undefined;
+  if (provider.type === "vm0" && model) {
+    const entry = VM0_MODEL_TO_PROVIDER[model];
+    if (entry) return entry.concreteType as ModelProviderType;
+  }
+  return provider.type;
+}
+
 function ResponsiveTriggerContent({
   mobileIcon,
-  provider,
+  iconType,
   label,
 }: {
   mobileIcon: boolean;
-  provider: ModelProviderResponse | undefined;
+  iconType: ModelProviderType | undefined;
   label: ReactNode;
 }) {
   if (!mobileIcon) {
@@ -329,8 +343,8 @@ function ResponsiveTriggerContent({
   return (
     <>
       <span className="flex items-center justify-center sm:hidden">
-        {provider ? (
-          <ProviderIcon type={provider.type} size={18} />
+        {iconType ? (
+          <ProviderIcon type={iconType} size={18} />
         ) : (
           <IconCpu size={18} stroke={1.5} />
         )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1070,7 +1070,7 @@ export function ZeroChatComposer({
                         onChange={modelPicker.onChange}
                         placeholder="Default"
                         triggerClassName={cn(
-                          "h-9 w-9 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:w-auto sm:max-w-[12rem] sm:gap-1 sm:px-2",
+                          "h-9 w-9 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:w-auto sm:max-w-[14rem] sm:gap-1 sm:px-2",
                           "[&>span]:flex [&>span]:items-center [&>span]:justify-center sm:[&>span]:justify-start [&>svg]:hidden sm:[&>svg]:block",
                           "hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
                         )}


### PR DESCRIPTION
## Summary
- Add `ProviderIcon` to the compact model picker trigger so the provider logo displays alongside the model name — matches the full picker style used elsewhere
- Bump trigger `max-width` from `12rem` to `14rem` to prevent excessive text truncation after adding the icon

## Changed files
- `turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx` — compact `TriggerLabel` now renders `ProviderIcon` + model name
- `turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx` — widen `sm:max-w` from 12rem → 14rem

## Test plan
- [ ] Open a chat thread with a model selected — verify the provider logo appears next to the model name
- [ ] Check the main Chat Composer — same logo should render in the compact trigger
- [ ] On mobile viewport, verify only the provider icon shows (no text)
- [ ] Verify long model names still truncate gracefully without overlapping the mic button
- [ ] Check disabled state (thread with existing messages) — logo should still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)