### PR TITLE
feat: bump team tier concurrency from 5 to 10

### DIFF
--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -129,7 +129,7 @@ describe("queue drawer", () => {
       expect(screen.getByText("Upgrade to Team")).toBeInTheDocument();
       expect(screen.getByText("$200")).toBeInTheDocument();
       expect(
-        screen.getAllByText("5 concurrent runs").length,
+        screen.getAllByText("20 concurrent runs").length,
       ).toBeGreaterThanOrEqual(1);
     });
   });

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -129,7 +129,7 @@ describe("queue drawer", () => {
       expect(screen.getByText("Upgrade to Team")).toBeInTheDocument();
       expect(screen.getByText("$200")).toBeInTheDocument();
       expect(
-        screen.getAllByText("20 concurrent runs").length,
+        screen.getAllByText("10 concurrent runs").length,
       ).toBeGreaterThanOrEqual(1);
     });
   });

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -52,11 +52,11 @@ const UPGRADE_PATHS = {
     targetLabel: "Team",
     concurrentRuns: 5,
     price: "$200",
-    description: "Scale your team with 5 parallel runs and more credits.",
+    description: "Scale your team with 20 parallel runs and more credits.",
     features: [
       "120,000 credits / month",
       "Pay as you go after that",
-      "5 concurrent runs",
+      "20 concurrent runs",
       "Unlimited total agents",
       "Bring your own LLM keys",
       "Priority support",

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -52,11 +52,11 @@ const UPGRADE_PATHS = {
     targetLabel: "Team",
     concurrentRuns: 5,
     price: "$200",
-    description: "Scale your team with 20 parallel runs and more credits.",
+    description: "Scale your team with 10 parallel runs and more credits.",
     features: [
       "120,000 credits / month",
       "Pay as you go after that",
-      "20 concurrent runs",
+      "10 concurrent runs",
       "Unlimited total agents",
       "Bring your own LLM keys",
       "Priority support",

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -50,7 +50,7 @@ const UPGRADE_PATHS = {
   pro: {
     targetTier: "team",
     targetLabel: "Team",
-    concurrentRuns: 5,
+    concurrentRuns: 10,
     price: "$200",
     description: "Scale your team with 10 parallel runs and more credits.",
     features: [

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -97,7 +97,7 @@ const PLANS = [
     features: [
       "120,000 credits / month",
       "Pay as you go after that",
-      "20 concurrent runs",
+      "10 concurrent runs",
       "Unlimited total agents",
       "Bring your own LLM keys",
       "Voice input",

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -97,7 +97,7 @@ const PLANS = [
     features: [
       "120,000 credits / month",
       "Pay as you go after that",
-      "5 concurrent runs",
+      "20 concurrent runs",
       "Unlimited total agents",
       "Bring your own LLM keys",
       "Voice input",

--- a/turbo/apps/web/app/[locale]/pricing/PricingPageClient.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/PricingPageClient.tsx
@@ -373,7 +373,7 @@ export function PricingPageClient() {
                     description={t("tableFeatures.concurrentRunsDesc")}
                     free="1"
                     pro="2"
-                    team="5"
+                    team="10"
                   />
                   <TableRow
                     feature={t("tableFeatures.totalAgents")}

--- a/turbo/apps/web/app/[locale]/pricing/page.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/page.tsx
@@ -143,7 +143,7 @@ const pricingJsonLd = {
       priceCurrency: "USD",
       billingIncrement: "month",
       description:
-        "120,000 credits/month, 5 concurrent agents, dedicated support, team management",
+        "120,000 credits/month, 20 concurrent agents, dedicated support, team management",
     },
   ],
 };

--- a/turbo/apps/web/app/[locale]/pricing/page.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/page.tsx
@@ -143,7 +143,7 @@ const pricingJsonLd = {
       priceCurrency: "USD",
       billingIncrement: "month",
       description:
-        "120,000 credits/month, 20 concurrent agents, dedicated support, team management",
+        "120,000 credits/month, 10 concurrent agents, dedicated support, team management",
     },
   ],
 };

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -124,7 +124,7 @@
       "description": "Skalieren Sie schnell, ohne Reibung und mit voller Flexibilität.",
       "features": {
         "credits": "120.000 Credits / Monat",
-        "concurrentRuns": "5 gleichzeitige Ausführungen",
+        "concurrentRuns": "10 gleichzeitige Ausführungen",
         "unlimitedAgents": "Unbegrenzte Agenten insgesamt",
         "bringOwnLLM": "Eigene LLM-Schlüssel verwenden",
         "voiceInput": "Spracheingabe",

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -124,7 +124,7 @@
       "description": "Scale fast with zero friction and full flexibility.",
       "features": {
         "credits": "120,000 credits / month",
-        "concurrentRuns": "5 concurrent runs",
+        "concurrentRuns": "20 concurrent runs",
         "unlimitedAgents": "Unlimited total agents",
         "bringOwnLLM": "Bring your own LLM keys",
         "voiceInput": "Voice input",

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -124,7 +124,7 @@
       "description": "Scale fast with zero friction and full flexibility.",
       "features": {
         "credits": "120,000 credits / month",
-        "concurrentRuns": "20 concurrent runs",
+        "concurrentRuns": "10 concurrent runs",
         "unlimitedAgents": "Unlimited total agents",
         "bringOwnLLM": "Bring your own LLM keys",
         "voiceInput": "Voice input",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -124,7 +124,7 @@
       "description": "Escala rápido sin fricción y con total flexibilidad.",
       "features": {
         "credits": "120.000 créditos / mes",
-        "concurrentRuns": "5 ejecuciones simultáneas",
+        "concurrentRuns": "10 ejecuciones simultáneas",
         "unlimitedAgents": "Agentes totales ilimitados",
         "bringOwnLLM": "Usa tus propias claves de LLM",
         "voiceInput": "Entrada por voz",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -124,7 +124,7 @@
       "description": "摩擦ゼロ、完全な柔軟性で素早くスケール。",
       "features": {
         "credits": "120,000クレジット / 月",
-        "concurrentRuns": "5同時実行",
+        "concurrentRuns": "10同時実行",
         "unlimitedAgents": "エージェント数無制限",
         "bringOwnLLM": "自分のLLMキーを使用",
         "voiceInput": "音声入力",

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -27,7 +27,7 @@ export const PENDING_RUN_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const TIER_CONCURRENCY_LIMITS: Record<OrgTier, number> = {
   free: 1,
   pro: 2,
-  team: 20,
+  team: 10,
 };
 
 function getConcurrencyLimitForTier(tier: OrgTier): number {

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -27,7 +27,7 @@ export const PENDING_RUN_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const TIER_CONCURRENCY_LIMITS: Record<OrgTier, number> = {
   free: 1,
   pro: 2,
-  team: 5,
+  team: 20,
 };
 
 function getConcurrencyLimitForTier(tier: OrgTier): number {


### PR DESCRIPTION
## Summary
- Bump Team tier concurrent run limit from 5 to 20
- Update all UI references (pricing page, billing tab, queue drawer) to reflect the new limit

## Test plan
- [ ] Verify `TIER_CONCURRENCY_LIMITS.team` is 20
- [ ] Pricing page shows "20 concurrent agents" for Team plan
- [ ] Billing tab shows "20 concurrent runs" for Team plan
- [ ] Queue drawer shows "20 concurrent runs" for Team upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)