### PR TITLE
chore(observability): remove deprecated api_step_callbacks_and_token span

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -411,7 +411,7 @@ describe("POST /api/zero/chat/messages", () => {
         }
       });
 
-      it("emits the 3-way split of api_step_callbacks_and_token alongside the back-compat parent", async () => {
+      it("emits the 3-way diagnostic split for the callbacks+token phase", async () => {
         // Spans below are source="web" (recordSandboxOperation), not web-chat.
         // They are emitted by buildAndDispatchRun inside the after() callback
         // so the spy must survive until flushAfter() drains the queue.
@@ -451,33 +451,20 @@ describe("POST /api/zero/chat/messages", () => {
             }),
           );
 
-          // Back-compat parent span — still emitted for ~1 release cycle.
-          expect(byOp.has("api_step_callbacks_and_token")).toBe(true);
-
           // Three-way split — only emitted when the chat route stamped both
           // responseReady (via markResponseReady) and dispatchStart.
           expect(byOp.has("api_phase1_post_tx_sync")).toBe(true);
           expect(byOp.has("api_after_scheduling_gap")).toBe(true);
           expect(byOp.has("api_phase2_callbacks_token_pure")).toBe(true);
 
-          const parent = byOp.get("api_step_callbacks_and_token")!;
           const phase1 = byOp.get("api_phase1_post_tx_sync")!;
           const gap = byOp.get("api_after_scheduling_gap")!;
           const phase2 = byOp.get("api_phase2_callbacks_token_pure")!;
 
-          // All four should be non-negative numbers.
-          for (const span of [parent, phase1, gap, phase2]) {
+          for (const span of [phase1, gap, phase2]) {
             expect(typeof span.duration_ms).toBe("number");
             expect(span.duration_ms).toBeGreaterThanOrEqual(0);
           }
-
-          // The three children should sum to the parent within a small
-          // tolerance (same-process Date.now() jitter only).
-          const childrenSum =
-            phase1.duration_ms + gap.duration_ms + phase2.duration_ms;
-          expect(
-            Math.abs(childrenSum - parent.duration_ms),
-          ).toBeLessThanOrEqual(10);
         } finally {
           spanSpy.mockRestore();
         }

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -345,18 +345,9 @@ export async function buildAndDispatchRun(opts: {
         op: "api_step_validate_and_insert",
         ms: timings.transaction - timings.authorize,
       },
-      {
-        op: "api_step_callbacks_and_token",
-        ms: timings.token - timings.transaction,
-      },
-      // Split of api_step_callbacks_and_token into 3 diagnostic spans to
-      // isolate the Vercel after() scheduling gap from Phase-1 residual work
-      // and Phase-2 real work. Only the chat route stamps both anchors; other
-      // callers (telegram, slack, email, github, schedule, voice-chat) leave
-      // them undefined, and the split is skipped. The back-compat parent span
-      // above continues to emit unchanged for ~1 release cycle — once the
-      // three below are confirmed populated in Axiom, the parent (and this
-      // comment) can be removed in a follow-up PR.
+      // Only the chat route stamps both anchors; other callers (telegram,
+      // slack, email, github, schedule, voice-chat) leave them undefined, and
+      // the split is skipped.
       ...(timings.responseReady !== undefined &&
       timings.dispatchStart !== undefined
         ? [
@@ -439,10 +430,9 @@ export interface CreateRunRecordResult {
   transactionTime: number;
   /**
    * Stamped by the route handler via CreateZeroRunResult.markResponseReady()
-   * right before returning HTTP 201. Used by the instrumentation split of
-   * api_step_callbacks_and_token into Phase-1 residual / after()-scheduling /
-   * Phase-2 spans. Undefined on non-chat triggers that don't participate in
-   * the marker protocol.
+   * right before returning HTTP 201. Anchors the Phase-1 residual /
+   * after()-scheduling / Phase-2 diagnostic span split. Undefined on non-chat
+   * triggers that don't participate in the marker protocol.
    */
   responseReadyAt?: number;
 }


### PR DESCRIPTION
## Summary

Remove the back-compat parent span `api_step_callbacks_and_token` from the dispatch instrumentation in `run-service.ts`. The 3 diagnostic sub-spans introduced in #10992 are now populated in Axiom and supersede the parent.

## Why now

- All 3 replacements (`api_phase1_post_tx_sync`, `api_after_scheduling_gap`, `api_phase2_callbacks_token_pure`) have been confirmed populated in Axiom for the last 3+ hours.
- The parent span was misleading to interpret: 99% of its P95 (1882ms) is the Vercel `after()` scheduling gap, not real work. The pure callbacks+token work (`api_phase2_callbacks_token_pure`) is only P95 104ms.
- The existing code already called out this cleanup as pending; that follow-up is now ready.

## Changes

- Drop the `api_step_callbacks_and_token` entry from the steps array in `run-service.ts`.
- Drop the back-compat comment block.
- Keep the `responseReady`/`dispatchStart` conditional wrapper — those anchors are still undefined on non-chat callers (telegram, slack, email, github, schedule, voice-chat).
- Keep `DispatchTimings` and the sub-span emission logic unchanged.
- Update the related test in `route.test.ts` to drop parent-span assertions (children-sum-to-parent check is no longer meaningful without a parent).

Refs: #10796

## Test plan

- [x] `pnpm turbo run lint`
- [x] `pnpm check-types`
- [x] `pnpm format`
- [x] `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/route.test.ts src/lib/infra/run` (68 passed)
- [x] `pnpm knip` (no issues)
- [ ] Verify Axiom continues to ingest the 3 sub-spans after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)