### PR TITLE
chore(observability): split api_after_scheduling_gap into closure-entry subspans

### DIFF
--- a/turbo/apps/web/app/api/internal/event-consumers/voice-chat-candidate/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/voice-chat-candidate/__tests__/route.test.ts
@@ -77,7 +77,9 @@ async function seedSessionWithQueuedTask() {
         status: "queued",
         createdAt: new Date(),
         sessionId: session.id,
-        markResponseReady: () => {},
+        markResponseReady: () => {
+          return undefined;
+        },
       };
     },
   });

--- a/turbo/apps/web/app/api/internal/event-consumers/voice-chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/voice-chat/__tests__/route.test.ts
@@ -77,7 +77,9 @@ async function seedSessionWithQueuedTask() {
         status: "queued",
         createdAt: new Date(),
         sessionId: session.id,
-        markResponseReady: () => {},
+        markResponseReady: () => {
+          return undefined;
+        },
       };
     },
   });

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -457,14 +457,39 @@ describe("POST /api/zero/chat/messages", () => {
           expect(byOp.has("api_after_scheduling_gap")).toBe(true);
           expect(byOp.has("api_phase2_callbacks_token_pure")).toBe(true);
 
+          // Further split of api_after_scheduling_gap — only emitted when the
+          // after() closure in zero-run-service.ts stamped afterEnterAt.
+          expect(byOp.has("api_after_schedule_to_closure")).toBe(true);
+          expect(byOp.has("api_after_closure_to_dispatch")).toBe(true);
+
+          // The signals-path after() callback emits its own closure-entry
+          // offset against the same responseReady anchor.
+          expect(byOp.has("api_after_signals_enter_offset")).toBe(true);
+
           const phase1 = byOp.get("api_phase1_post_tx_sync")!;
           const gap = byOp.get("api_after_scheduling_gap")!;
           const phase2 = byOp.get("api_phase2_callbacks_token_pure")!;
+          const scheduleToClosure = byOp.get("api_after_schedule_to_closure")!;
+          const closureToDispatch = byOp.get("api_after_closure_to_dispatch")!;
+          const signalsOffset = byOp.get("api_after_signals_enter_offset")!;
 
-          for (const span of [phase1, gap, phase2]) {
+          for (const span of [
+            phase1,
+            gap,
+            phase2,
+            scheduleToClosure,
+            closureToDispatch,
+            signalsOffset,
+          ]) {
             expect(typeof span.duration_ms).toBe("number");
             expect(span.duration_ms).toBeGreaterThanOrEqual(0);
           }
+
+          // The two closure-entry subspans sum to api_after_scheduling_gap
+          // within same-process jitter.
+          const gapSum =
+            scheduleToClosure.duration_ms + closureToDispatch.duration_ms;
+          expect(Math.abs(gapSum - gap.duration_ms)).toBeLessThanOrEqual(10);
         } finally {
           spanSpy.mockRestore();
         }

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -51,6 +51,7 @@ import { publishUserSignal } from "../../../../../src/lib/infra/realtime/client"
 import { logger } from "../../../../../src/lib/shared/logger";
 import {
   recordChatSpan,
+  recordSandboxOperation,
   type ChatSpanDimensions,
 } from "../../../../../src/lib/infra/metrics";
 import {
@@ -499,16 +500,32 @@ const router = tsr.router(chatMessagesContract, {
         spanDims: dims,
       });
 
+      // Stamp response-ready for the Phase-2 instrumentation split before
+      // registering the signals after() so we can measure its closure-entry
+      // offset against the same responseReady anchor used by dispatchZeroRun.
+      const responseReadyAt = result.markResponseReady();
+
       after(async () => {
+        const signalsEnterAt = Date.now();
         await publishUserSignal(
           [authCtx.userId],
           `chatThreadRunCreated:${threadId}`,
         );
         await publishThreadListChanged(authCtx.userId);
+        // Cross-referenced with api_after_schedule_to_closure in Axiom to
+        // infer whether Vercel fires the two chat-route after() callbacks in
+        // parallel or serial: near-equal durations imply parallel, a large
+        // gap implies serial.
+        if (responseReadyAt !== undefined) {
+          recordSandboxOperation({
+            sandboxType: "chat",
+            actionType: "api_after_signals_enter_offset",
+            durationMs: signalsEnterAt - responseReadyAt,
+            success: true,
+            runId: result.runId,
+          });
+        }
       });
-
-      // Stamp response-ready for the Phase-2 instrumentation split. Idempotent.
-      result.markResponseReady();
 
       return {
         status: 201 as const,

--- a/turbo/apps/web/src/lib/infra/metrics/instruments.ts
+++ b/turbo/apps/web/src/lib/infra/metrics/instruments.ts
@@ -1,7 +1,7 @@
 import { ingestSandboxOpLog } from "../../shared/axiom";
 
 export function recordSandboxOperation(attrs: {
-  sandboxType: "runner" | "docker";
+  sandboxType: "runner" | "docker" | "chat";
   actionType: string;
   durationMs: number;
   success: boolean;

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -365,6 +365,25 @@ export async function buildAndDispatchRun(opts: {
             },
           ]
         : []),
+      // Further split of api_after_scheduling_gap: isolate pure Vercel
+      // platform scheduling (response flush + after() fire) from JS-local
+      // closure-to-dispatch overhead. Only stamped on the chat path, which
+      // captures afterEnterAt at the first synchronous line of the after()
+      // closure in zero-run-service.ts.
+      ...(timings.responseReady !== undefined &&
+      timings.afterEnterAt !== undefined &&
+      timings.dispatchStart !== undefined
+        ? [
+            {
+              op: "api_after_schedule_to_closure",
+              ms: timings.afterEnterAt - timings.responseReady,
+            },
+            {
+              op: "api_after_closure_to_dispatch",
+              ms: timings.dispatchStart - timings.afterEnterAt,
+            },
+          ]
+        : []),
       { op: "api_step_build_context", ms: buildContextTime - timings.token },
       { op: "api_step_prepare", ms: prepareTime - buildContextTime },
       { op: "api_step_dispatch", ms: dispatchTime - prepareTime },

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -150,6 +150,14 @@ export interface DispatchTimings {
    */
   responseReady?: number;
   /**
+   * Stamped as the first synchronous line of the Next.js after() closure,
+   * before dispatchZeroRun is invoked. Isolates pure platform after()
+   * scheduling (responseReady → afterEnterAt) from JS-local closure-to-
+   * dispatch overhead (afterEnterAt → dispatchStart). Absent on non-chat
+   * triggers (paired with responseReady and dispatchStart).
+   */
+  afterEnterAt?: number;
+  /**
    * Stamped at the first synchronous line of dispatchZeroRun (inside the
    * after() callback). Anchors the end of the after() scheduling gap and the
    * start of Phase-2 real work (registerCallbacks + token generation).

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -735,10 +735,12 @@ async function createZeroRunRecord(
  */
 async function dispatchZeroRun(
   result: ZeroRunRecordResult,
+  afterEnterAt?: number,
 ): Promise<{ status: RunStatus; sandboxId?: string } | undefined> {
-  // Capture the after() callback entry as the first synchronous line — the
-  // gap between this timestamp and record.responseReadyAt (if stamped by the
-  // route) is the Vercel after() scheduling latency.
+  // Captured at the first synchronous line of dispatchZeroRun; paired with
+  // afterEnterAt (stamped inside the after() closure before this call) and
+  // record.responseReadyAt to split the post-response gap into pure platform
+  // scheduling vs. JS-local closure-to-dispatch overhead.
   const dispatchStart = Date.now();
 
   const { record, runParams, orgId, zeroParams } = result;
@@ -785,6 +787,7 @@ async function dispatchZeroRun(
         authorize: record.authorizeTime,
         transaction: record.transactionTime,
         responseReady: record.responseReadyAt,
+        afterEnterAt,
         dispatchStart,
         token: tokenTime,
         resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
@@ -832,10 +835,15 @@ export interface CreateZeroRunResult {
    * Stamps the response-ready timestamp used by the Phase-2 instrumentation
    * split (api_phase1_post_tx_sync / api_after_scheduling_gap /
    * api_phase2_callbacks_token_pure). Idempotent — later calls are no-ops.
-   * Non-chat callers can ignore this safely; the three split spans are
+   * Non-chat callers can ignore the return value; the three split spans are
    * skipped when the marker is never called.
+   *
+   * Returns the stamped timestamp so the caller can reference it from other
+   * after() callbacks (e.g. the chat route's signals callback measures its
+   * own closure-entry offset against it). Returns undefined when the underlying
+   * record was queued rather than inserted.
    */
-  markResponseReady: () => void;
+  markResponseReady: () => number | undefined;
 }
 
 /**
@@ -858,7 +866,8 @@ export async function createZeroRun(
   // (concurrency limit) are drained by the queue worker later.
   if (result.record) {
     after(() => {
-      return dispatchZeroRun(result).catch((err: unknown) => {
+      const afterEnterAt = Date.now();
+      return dispatchZeroRun(result, afterEnterAt).catch((err: unknown) => {
         log.error("Deferred dispatch failed", {
           runId: result.runId,
           err,
@@ -867,10 +876,12 @@ export async function createZeroRun(
     });
   }
 
-  const markResponseReady = (): void => {
-    if (result.record && result.record.responseReadyAt === undefined) {
+  const markResponseReady = (): number | undefined => {
+    if (!result.record) return undefined;
+    if (result.record.responseReadyAt === undefined) {
       result.record.responseReadyAt = Date.now();
     }
+    return result.record.responseReadyAt;
   };
 
   return {


### PR DESCRIPTION
## Summary

Pure instrumentation PR — no behavior change. Introduces three new `sandbox-op-log` spans to pinpoint where the ~1882ms P95 inside `api_after_scheduling_gap` actually goes.

## New spans

| Span | Anchors | What it measures |
|---|---|---|
| `api_after_schedule_to_closure` | `responseReady` → `afterEnterAt` | Pure Vercel platform scheduling, including response flush and after() fire. |
| `api_after_closure_to_dispatch` | `afterEnterAt` → `dispatchStart` | JS-local overhead between after() closure firing and the first line of `dispatchZeroRun` (expected near zero). |
| `api_after_signals_enter_offset` | `responseReady` → signals-callback entry | Fires from the chat route's own `after()` callback (the one that publishes `chatThreadRunCreated` + `chatThreadListChanged`). Cross-referenced in Axiom with `api_after_schedule_to_closure` to infer whether Vercel fires the two route-registered afters in parallel or serial. |

`afterEnterAt` is stamped as the first synchronous line of the `after(() => dispatchZeroRun(...))` closure in `zero-run-service.ts` and threaded through the existing `DispatchTimings` into `buildAndDispatchRun`.

The existing `api_after_scheduling_gap` span is kept unchanged for continuity — `schedule_to_closure + closure_to_dispatch` should sum to it within same-process jitter.

## Why now

Opens directly on the remaining observability gap from #10796. Once deployed and confirmed populated in Axiom we can:

- Decide whether to attack platform-side scheduling (if `api_after_schedule_to_closure` dominates) or JS-local overhead (if `api_after_closure_to_dispatch` is non-trivial).
- Answer the open parallel-vs-serial question about Vercel `after()` ordering, which dictates whether we should consolidate the two route-level `after()` callbacks.

## Shape of the change

- `DispatchTimings.afterEnterAt?: number` added.
- `dispatchZeroRun` accepts `afterEnterAt?` as a second arg and threads it into timings.
- `CreateZeroRunResult.markResponseReady` now returns `number | undefined` (the stamped timestamp) so the chat route can pin its signals-callback span to the same anchor.
- `recordSandboxOperation.sandboxType` union widened to include `"chat"` (the signals span is emitted pre-dispatch, so there is no runner/docker sandbox yet).
- Test mocks for `markResponseReady` updated in the two voice-chat consumer tests (returning `undefined`).

## Test plan

- [x] `pnpm turbo run lint --filter=web`
- [x] `pnpm check-types`
- [x] `pnpm format`
- [x] `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/route.test.ts src/lib/infra/run app/api/internal/event-consumers` (82/82 passed, including new assertions on all three spans and the `schedule_to_closure + closure_to_dispatch ≈ api_after_scheduling_gap` sum check)
- [x] `pnpm knip` (no new issues)
- [ ] After deploy: verify all three new spans populate in Axiom for chat runs over a 30-minute window.

Refs: #10796

🤖 Generated with [Claude Code](https://claude.com/claude-code)