### PR TITLE
chore: remove unused autoskill feature switch

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "../route";
 import {
   createTestRequest,
@@ -36,11 +36,7 @@ import { reloadEnv } from "../../../../../src/env";
 import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Test setup: direct service call for data setup in runs route tests
 import { updateUserPreferences } from "../../../../../src/lib/zero/user/user-preferences-service";
-// eslint-disable-next-line web/no-direct-db-in-tests -- Test setup: direct service call for data setup in runs route tests
-import { updateUserFeatureSwitches } from "../../../../../src/lib/zero/user/feature-switches-service";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { getCustomSkillStorageName } from "@vm0/core/storage-names";
-import * as featureSwitchCore from "@vm0/core/feature-switch";
 import { bindCustomSkillToAgent } from "../../../../../src/__tests__/db-test-seeders/skills";
 
 const context = testContext();
@@ -848,74 +844,6 @@ describe("POST /api/zero/runs", () => {
       });
       expect(ghFw).toBeDefined();
       expect(slackFw).toBeDefined();
-    });
-  });
-
-  describe("AutoSkill guidance injection", () => {
-    let user: UserContext;
-    let agentId: string;
-
-    beforeEach(async () => {
-      user = await context.setupUser();
-      const agentName = uniqueId("skill-agent");
-      await createTestCompose(agentName);
-      agentId = await getTestZeroAgentId(user.orgId, agentName);
-      vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
-      reloadEnv();
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
-    it("should inject skill guidance when AutoSkill feature switch is enabled", async () => {
-      vi.spyOn(featureSwitchCore, "isFeatureEnabled").mockImplementation(
-        (key: FeatureSwitchKey) => {
-          if (key === FeatureSwitchKey.AutoSkill) return true;
-          return false;
-        },
-      );
-
-      const response = await postRun({ agentId, prompt: "Hello" });
-      expect(response.status).toBe(201);
-      const data = await response.json();
-
-      const run = await findTestRunRecord(data.runId);
-      expect(run).toBeDefined();
-      expect(run!.appendSystemPrompt).toContain("# Skill Management Guidance");
-      expect(run!.appendSystemPrompt).toContain("zero skill create");
-    });
-
-    it("should not inject skill guidance when AutoSkill feature switch is disabled", async () => {
-      const response = await postRun({ agentId, prompt: "Hello" });
-      expect(response.status).toBe(201);
-      const data = await response.json();
-
-      const run = await findTestRunRecord(data.runId);
-      expect(run).toBeDefined();
-      expect(run!.appendSystemPrompt).not.toContain(
-        "# Skill Management Guidance",
-      );
-    });
-
-    it("should pass user overrides to AutoSkill feature check", async () => {
-      const spy = vi.spyOn(featureSwitchCore, "isFeatureEnabled");
-
-      await updateUserFeatureSwitches(user.orgId, user.userId, {
-        [FeatureSwitchKey.AutoSkill]: false,
-      });
-
-      const response = await postRun({ agentId, prompt: "Hello" });
-      expect(response.status).toBe(201);
-
-      expect(spy).toHaveBeenCalledWith(
-        FeatureSwitchKey.AutoSkill,
-        expect.objectContaining({
-          overrides: expect.objectContaining({
-            [FeatureSwitchKey.AutoSkill]: false,
-          }),
-        }),
-      );
     });
   });
 });

--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -88,39 +88,3 @@ function buildAgentToolsPrompt(): string {
     "- Report issues to the dev team: `zero developer-support --help`. Requires a two-step consent flow: (1) call without --consent-code to get a code, (2) ask the user to type it, (3) call again with --consent-code. Never submit without the user typing the consent code.",
   ].join("\n");
 }
-
-/**
- * Build behavioral guidance for proactive skill management.
- * Injected when the AutoSkill feature switch is enabled.
- */
-export function buildAutoSkillGuidance(): string {
-  return [
-    "# Skill Management Guidance",
-    "",
-    "You can create and maintain custom skills — reusable procedures that persist across sessions.",
-    "",
-    "## When to Create a Skill",
-    "- After completing a complex, multi-step task (5+ tool calls) that may recur",
-    "- After overcoming errors through a non-obvious workflow",
-    "- When the user asks you to remember a procedure",
-    "",
-    "## When to Update a Skill",
-    "- When using a skill and finding it outdated, incomplete, or incorrect — fix it immediately",
-    "",
-    "## When NOT to Create a Skill",
-    "- For simple one-off tasks",
-    "- For tasks that are already well-documented in existing skills",
-    "",
-    "## How to Manage Skills",
-    "- Create: `zero skill create <name> --dir <path>` (directory must contain SKILL.md)",
-    "- Update: `zero skill edit <name> --dir <path>`",
-    "- View: `zero skill view <name>`",
-    "- List: `zero skill list`",
-    "- Bind to agent: `zero agent edit $ZERO_AGENT_ID --add-skill <name>`",
-    "",
-    "## Quality Standards",
-    "Skills should include: trigger conditions, numbered steps with exact commands, common pitfalls, and verification steps.",
-    "",
-    "Always confirm with the user before creating or deleting a skill.",
-  ].join("\n");
-}

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -5,7 +5,6 @@ import {
   getCustomSkillStorageName,
   getSkillStorageName,
 } from "@vm0/core/storage-names";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { orgTierSchema } from "@vm0/core/contracts/orgs";
 import { resolveFirewallPolicies } from "@vm0/core/firewalls";
@@ -47,11 +46,7 @@ import { buildZeroExecutionContext } from "./build-zero-context";
 import { buildAutoMemoryArtifact } from "./memory";
 import { getOrgMetadata, type OrgMetadata } from "./org/org-metadata-service";
 import { isConcurrentRunLimit } from "../shared/errors";
-import {
-  DISALLOWED_TOOLS,
-  buildAgentPrompt,
-  buildAutoSkillGuidance,
-} from "./agent-prompt";
+import { DISALLOWED_TOOLS, buildAgentPrompt } from "./agent-prompt";
 import { zeroAgents } from "../../db/schema/zero-agent";
 import { zeroRuns } from "../../db/schema/zero-run";
 import { userConnectors } from "../../db/schema/user-connector";
@@ -400,23 +395,12 @@ async function insertRunWithAdvisoryLock(
   };
 }
 
-/** Assemble the final system prompt from parts. Extracted to reduce complexity. */
 function assembleSystemPrompt(
   agentPrompt: string,
   userInfo: string,
   appendSystemPrompt: string | undefined,
-  featureOverrides: Partial<Record<FeatureSwitchKey, boolean>> | undefined,
-  orgId: string,
 ): string {
   const parts = [agentPrompt, userInfo];
-  if (
-    isFeatureEnabled(FeatureSwitchKey.AutoSkill, {
-      orgId,
-      overrides: featureOverrides,
-    })
-  ) {
-    parts.push(buildAutoSkillGuidance());
-  }
   if (appendSystemPrompt) {
     parts.push(appendSystemPrompt);
   }
@@ -615,8 +599,6 @@ async function createZeroRunRecord(
     agentPrompt,
     userInfo,
     params.appendSystemPrompt,
-    featureOverrides,
-    resolved.orgId,
   );
 
   // Construct CreateRunParams (infra knows nothing about ZERO_TOKEN)

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -36,7 +36,6 @@ export enum FeatureSwitchKey {
   AuditLink = "auditLink",
   AudioInput = "audioInput",
   AudioOutput = "audioOutput",
-  AutoSkill = "autoSkill",
   TestOauthConnector = "testOauthConnector",
   ChatHeaderNewButton = "chatHeaderNewButton",
   ChatThreadReadIndicator = "chatThreadReadIndicator",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -198,11 +198,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable audio output in chat (TTS read-aloud + auto-read) — gates the volume/read buttons and the /api/zero/voice-io/tts route",
     enabled: false,
   },
-  [FeatureSwitchKey.AutoSkill]: {
-    maintainer: "lancy@vm0.ai",
-    description: "Enable automatic skill creation in agent prompts",
-    enabled: false,
-  },
   [FeatureSwitchKey.TestOauthConnector]: {
     maintainer: "liangyou@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Remove the `AutoSkill` feature switch: it has not been enabled for any org and the injected "Skill Management Guidance" prompt is no longer useful.
- Delete `buildAutoSkillGuidance()` and simplify `assembleSystemPrompt` accordingly.
- Remove the associated route test block (`AutoSkill guidance injection`) and unused imports.

## Test plan
- [x] `pnpm turbo run lint` — passes
- [x] `pnpm check-types` — passes
- [x] `pnpm -F web exec vitest run app/api/zero/runs/__tests__/route.test.ts` — 46/46 passed
- [x] `pnpm -F @vm0/core exec vitest run` — 788/788 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)