### PR TITLE
perf(chat): defer user message insert into after() to speed 201 response

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.incomplete-context.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.incomplete-context.test.ts
@@ -32,7 +32,11 @@ async function sendMessage(body: Record<string, unknown>) {
     }),
   );
   expect(response.status).toBe(201);
-  return response.json() as Promise<{ runId: string; threadId: string }>;
+  const data = (await response.json()) as { runId: string; threadId: string };
+  // insertChatMessage is deferred into after() — drain so subsequent sends
+  // see the user message row when building the incomplete-rounds context.
+  await context.mocks.flushAfter();
+  return data;
 }
 
 describe("POST /api/zero/chat/messages — incomplete rounds context", () => {

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.incomplete-context.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.incomplete-context.test.ts
@@ -9,10 +9,12 @@ import {
   setTestRunResult,
   completeTestRun,
   insertTestAssistantEventMessages,
+  insertTestChatMessage,
   setTestChatMessageAttachFiles,
   setTestChatMessageContent,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { getTestZeroAgentId } from "../../../../../../src/__tests__/db-test-assertions/agents";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import {
   testContext,
   uniqueId,
@@ -37,6 +39,37 @@ async function sendMessage(body: Record<string, unknown>) {
   // see the user message row when building the incomplete-rounds context.
   await context.mocks.flushAfter();
   return data;
+}
+
+/**
+ * Seed a prior round directly in the DB: one agent_runs row with the
+ * requested status + one user chat_messages row linked by runId. Bypasses
+ * the POST + deferred dispatch pipeline so tests that need many historical
+ * rounds in a thread don't pay the per-round dispatch cost. The FINAL send
+ * that reads the incomplete-rounds context still goes through the real
+ * route handler.
+ */
+async function seedPriorRound(params: {
+  userId: string;
+  agentComposeId: string;
+  chatThreadId: string;
+  prompt: string;
+  status?: string;
+}): Promise<{ runId: string }> {
+  const { runId } = await seedTestRun(params.userId, params.agentComposeId, {
+    status: params.status ?? "cancelled",
+    prompt: params.prompt,
+    chatThreadId: params.chatThreadId,
+    triggerSource: "web",
+  });
+  await insertTestChatMessage({
+    chatThreadId: params.chatThreadId,
+    userId: params.userId,
+    role: "user",
+    content: params.prompt,
+    runId,
+  });
+  return { runId };
 }
 
 describe("POST /api/zero/chat/messages — incomplete rounds context", () => {
@@ -231,16 +264,19 @@ describe("POST /api/zero/chat/messages — incomplete rounds context", () => {
   });
 
   it("caps at 20 most-recent incomplete rounds when more exist", async () => {
+    // First round goes through the real route to establish the thread.
     const first = await sendMessage({ agentId, prompt: "seed-0" });
     await setTestRunStatus(first.runId, "cancelled");
 
+    // Seed the remaining 24 cancelled rounds directly — skipping the POST +
+    // deferred dispatch on each keeps the loop well under the 5s timeout in CI.
     for (let i = 1; i < 25; i++) {
-      const sent = await sendMessage({
-        agentId,
+      await seedPriorRound({
+        userId: user.userId,
+        agentComposeId: agentId,
+        chatThreadId: first.threadId,
         prompt: `seed-${i}`,
-        threadId: first.threadId,
       });
-      await setTestRunStatus(sent.runId, "cancelled");
     }
 
     const next = await sendMessage({
@@ -278,18 +314,21 @@ describe("POST /api/zero/chat/messages — incomplete rounds context", () => {
   });
 
   it("handles a long thread (≥100 messages) without scanning all of history", async () => {
-    // Seed 50 successive rounds (~100 chat_messages rows — one user + one
-    // placeholder assistant per round) so the thread is well past the
+    // Seed 50 successive non-cancelled rounds so the thread is well past the
     // PREVIOUS_CONTEXT_MESSAGES bound and past the incomplete-rounds 20-cap.
     // The old `getMessagesByThreadId` scan + JS filter would read every row
     // on every send; under the bounded rewrite this send must still succeed
-    // in reasonable time.
+    // in reasonable time. Loop rounds are seeded directly (status=pending, not
+    // 'cancelled'/'failed'/'timeout') so they don't pay the POST + dispatch
+    // cost and still satisfy the assertion that no incomplete block appears.
     const first = await sendMessage({ agentId, prompt: "round 0" });
     for (let i = 1; i < 50; i++) {
-      await sendMessage({
-        agentId,
+      await seedPriorRound({
+        userId: user.userId,
+        agentComposeId: agentId,
+        chatThreadId: first.threadId,
         prompt: `round ${i}`,
-        threadId: first.threadId,
+        status: "pending",
       });
     }
 
@@ -310,16 +349,19 @@ describe("POST /api/zero/chat/messages — incomplete rounds context", () => {
 
   it("anchors incomplete rounds correctly on a long thread with a mid-thread success", async () => {
     // Pre-success tail: 30+ cancelled rounds the anchor must exclude.
+    // First round goes through the real route to establish the thread; the
+    // remaining pre-success cancels are seeded directly to avoid paying the
+    // POST + dispatch cost 30 times over.
     const first = await sendMessage({ agentId, prompt: "early fail" });
     await setTestRunStatus(first.runId, "cancelled");
 
     for (let i = 0; i < 30; i++) {
-      const sent = await sendMessage({
-        agentId,
+      await seedPriorRound({
+        userId: user.userId,
+        agentComposeId: agentId,
+        chatThreadId: first.threadId,
         prompt: `pre-success ${i}`,
-        threadId: first.threadId,
       });
-      await setTestRunStatus(sent.runId, "cancelled");
     }
 
     // Mid-thread success — stamps `agentSessionId` onto agent_runs.result,

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -198,6 +198,10 @@ describe("POST /api/zero/chat/messages", () => {
       expect(response.status).toBe(201);
       const data = await response.json();
 
+      // insertChatMessage is deferred into after() — drain it before reading
+      // the thread detail so the user message row is visible.
+      await context.mocks.flushAfter();
+
       // Verify the thread contains the user message (no assistant placeholder
       // is inserted at send time — only the user message is appended).
       const threadResponse = await GET(
@@ -342,6 +346,10 @@ describe("POST /api/zero/chat/messages", () => {
           );
           expect(response.status).toBe(201);
           const data = await response.json();
+
+          // The insert_chat_message span is emitted inside after() now —
+          // drain the queue before reading spy calls.
+          await context.mocks.flushAfter();
 
           expect(spanSpy).toHaveBeenCalled();
           const chatSpanEvents = spanSpy.mock.calls
@@ -555,6 +563,9 @@ describe("POST /api/zero/chat/messages", () => {
       expect(response.status).toBe(201);
       const data = await response.json();
 
+      // insertChatMessage is deferred into after() — drain before reading.
+      await context.mocks.flushAfter();
+
       // Verify file IDs are persisted in chat_messages
       const messages = await getTestChatMessagesByThread(data.threadId);
       const userMsg = messages.find((m) => {
@@ -592,6 +603,9 @@ describe("POST /api/zero/chat/messages", () => {
       );
       expect(sendResponse.status).toBe(201);
       const sendData = await sendResponse.json();
+
+      // insertChatMessage is deferred into after() — drain before reading.
+      await context.mocks.flushAfter();
 
       // Mock S3 to return the file for resolution
       context.mocks.s3.listS3Objects.mockImplementation(

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -481,32 +481,43 @@ const router = tsr.router(chatMessagesContract, {
         userProfile: userProfileFromClaims(authCtx),
       });
 
-      // Persist user message to chat_messages.
-      // Only file IDs are stored — metadata is resolved at query time from S3.
-      // insertChatMessage also publishes chatThreadMessageCreated internally,
-      // so the paged-messages view picks up the new row.
-      // Stamp with the runId so the callback's prior-context filter can
-      // exclude this message structurally (by runId) instead of by content.
-      await insertChatMessage({
-        chatThreadId: threadId,
-        userId: authCtx.userId,
-        role: "user",
-        content: body.prompt,
-        runId: result.runId,
-        attachFiles: body.attachFiles?.map((f: AttachFile) => {
-          return f.id;
-        }),
-        id: body.clientMessageId,
-        spanDims: dims,
-      });
-
       // Stamp response-ready for the Phase-2 instrumentation split before
       // registering the signals after() so we can measure its closure-entry
       // offset against the same responseReady anchor used by dispatchZeroRun.
       const responseReadyAt = result.markResponseReady();
 
+      // Persist user message to chat_messages in after() so the 201 response
+      // flushes before the INSERT (+ internal chatThreadMessageCreated publish)
+      // runs. The response body omits the row id and the client renders
+      // optimistically via clientMessageId, so no caller blocks on this write.
+      //
+      // Ordering: insertChatMessage MUST complete before publishUserSignal /
+      // publishThreadListChanged fire — those signals tell other devices to
+      // refetch the thread list / paged-messages view, and they must see the
+      // new row on refetch. The `await`s below preserve that ordering.
       after(async () => {
         const signalsEnterAt = Date.now();
+        try {
+          // Stamp with the runId so the callback's prior-context filter can
+          // exclude this message structurally (by runId) instead of by content.
+          await insertChatMessage({
+            chatThreadId: threadId,
+            userId: authCtx.userId,
+            role: "user",
+            content: body.prompt,
+            runId: result.runId,
+            attachFiles: body.attachFiles?.map((f: AttachFile) => {
+              return f.id;
+            }),
+            id: body.clientMessageId,
+            spanDims: dims,
+          });
+        } catch (err: unknown) {
+          log.error("Deferred insertChatMessage failed", {
+            runId: result.runId,
+            err,
+          });
+        }
         await publishUserSignal(
           [authCtx.userId],
           `chatThreadRunCreated:${threadId}`,


### PR DESCRIPTION
## Summary

Move `insertChatMessage` from the synchronous critical path into the existing `after()` closure on POST `/api/zero/chat/messages`. Axiom telemetry (issue #10796) shows this INSERT currently blocks the 201 for ~67ms P50 / ~320ms P95. The response body is `{ runId, threadId, status, createdAt }` — no reference to the chat_message row — and the web UI renders the user's own message optimistically via `clientMessageId`, so nothing on the client path waits on this write.

Expected improvement on the chat-send critical path: **~67ms P50 / ~320ms P95** faster 201.

## Ordering (load-bearing)

`insertChatMessage` internally calls `publishChatThreadMessageCreated`, which other devices use to refetch the paged-messages view. The two signals that already fire inside the same `after()` closure —  `publishUserSignal(chatThreadRunCreated:…)` and `publishThreadListChanged` — tell those devices to refetch the thread list. If they fired before `insertChatMessage` completed, the refetch would miss the new row.

The closure keeps the chain awaited in this strict order:

```
insertChatMessage → publishUserSignal → publishThreadListChanged
```

So the send-time messaging order is preserved.

## Error handling

`insertChatMessage` is wrapped in `try/catch` so a failed row does not swallow the downstream signals. Rationale: the `zero_runs` record is already persisted synchronously in Phase 1, so users still need to see that the run started even if the message row fails. Same pattern as the `dispatchZeroRun` wrapper in `zero-run-service.ts`. `publishUserSignal` and `publishThreadListChanged` are intentionally NOT wrapped — they already handle their own errors per existing code.

## Test plan

- [x] `cd turbo && pnpm turbo run lint` — clean
- [x] `cd turbo && pnpm check-types` — clean
- [x] `cd turbo && pnpm format` — unchanged
- [x] `pnpm -F web exec vitest run app/api/zero/chat/messages` — 38 passing across `route.test.ts` and `route.incomplete-context.test.ts`
- [x] `cd turbo && pnpm knip` — no new findings

Tests that assert post-insert state now drain `after()` via the existing `context.mocks.flushAfter()` helper before asserting on:
- `chat_messages` row content and attach file IDs
- the `api_chat_send_insert_chat_message_insert` span
- the incomplete-rounds context read by a follow-up send

## Coordination

Concurrent in-flight PR #11035 also edits the same `after()` closure at `turbo/apps/web/app/api/zero/chat/messages/route.ts` to add sub-span instrumentation (`signalsEnterAt` stamp + `api_after_signals_enter_offset`). A rebase is expected after one of the two merges; both changes are compatible — `insertChatMessage` stays at the top of the closure, followed by #11035's `signalsEnterAt` stamp + span emission, followed by the two signal publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)