### PR TITLE
feat(runner): log axiom telemetry enabled/disabled at startup

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -163,8 +163,13 @@ fn init_tracing_with_file(
 
 /// Initialize tracing with stderr output only (no rolling log file on disk),
 /// plus an optional Axiom layer.
+///
+/// Explicitly writes to stderr so commands like `runner exec` — which pipe the
+/// guest program's stdout through verbatim — don't have tracing lines
+/// interleaved into captured output. The `fmt::layer()` default writer is
+/// stdout, which is the wrong sink for a CLI tool.
 fn init_tracing_stderr(axiom_layer: Option<axiom_layer::AxiomLayer>) {
-    let fmt_layer = tracing_subscriber::fmt::layer();
+    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
     tracing_subscriber::registry()
         .with(fmt_layer)
         .with(axiom_layer)

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -199,23 +199,33 @@ async fn main() -> ExitCode {
         None => (None, None),
     };
 
-    let _guard = match &cli.command {
-        Command::Start(args) => match init_tracing_with_file(&args.config, axiom_layer) {
-            Ok(guard) => Some(guard),
-            Err(e) => {
-                // The failed `init_tracing_with_file` already consumed `axiom_layer`,
-                // so the stderr fallback runs without Axiom — acceptable degraded
-                // mode (home/log-dir setup is already broken at this point).
-                init_tracing_stderr(None);
-                tracing::warn!("file logging unavailable, using stderr only: {e}");
-                None
+    let (_guard, axiom_installed) = match &cli.command {
+        Command::Start(args) => {
+            let was_enabled = axiom_layer.is_some();
+            match init_tracing_with_file(&args.config, axiom_layer) {
+                Ok(guard) => (Some(guard), was_enabled),
+                Err(e) => {
+                    // The failed `init_tracing_with_file` already consumed `axiom_layer`,
+                    // so the stderr fallback runs without Axiom — acceptable degraded
+                    // mode (home/log-dir setup is already broken at this point).
+                    init_tracing_stderr(None);
+                    tracing::warn!("file logging unavailable, using stderr only: {e}");
+                    (None, false)
+                }
             }
-        },
+        }
         _ => {
+            let was_enabled = axiom_layer.is_some();
             init_tracing_stderr(axiom_layer);
-            None
+            (None, was_enabled)
         }
     };
+
+    if axiom_installed {
+        tracing::info!("axiom telemetry enabled");
+    } else {
+        tracing::info!("axiom telemetry disabled");
+    }
 
     let result = match cli.command {
         Command::Setup => cmd::run_setup().await.map(|()| ExitCode::SUCCESS),

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -199,23 +199,20 @@ async fn main() -> ExitCode {
         None => (None, None),
     };
 
+    let was_enabled = axiom_layer.is_some();
     let (_guard, axiom_installed) = match &cli.command {
-        Command::Start(args) => {
-            let was_enabled = axiom_layer.is_some();
-            match init_tracing_with_file(&args.config, axiom_layer) {
-                Ok(guard) => (Some(guard), was_enabled),
-                Err(e) => {
-                    // The failed `init_tracing_with_file` already consumed `axiom_layer`,
-                    // so the stderr fallback runs without Axiom — acceptable degraded
-                    // mode (home/log-dir setup is already broken at this point).
-                    init_tracing_stderr(None);
-                    tracing::warn!("file logging unavailable, using stderr only: {e}");
-                    (None, false)
-                }
+        Command::Start(args) => match init_tracing_with_file(&args.config, axiom_layer) {
+            Ok(guard) => (Some(guard), was_enabled),
+            Err(e) => {
+                // The failed `init_tracing_with_file` already consumed `axiom_layer`,
+                // so the stderr fallback runs without Axiom — acceptable degraded
+                // mode (home/log-dir setup is already broken at this point).
+                init_tracing_stderr(None);
+                tracing::warn!("file logging unavailable, using stderr only: {e}");
+                (None, false)
             }
-        }
+        },
         _ => {
-            let was_enabled = axiom_layer.is_some();
             init_tracing_stderr(axiom_layer);
             (None, was_enabled)
         }


### PR DESCRIPTION
## Summary

- Log whether the Axiom tracing layer was actually installed right after tracing subscriber is set up. Previously there was no indication — operators had to infer from env vars.
- Track the file-logging fallback path accurately: when `init_tracing_with_file` errors, `axiom_layer` has already been consumed and dropped, so the fallback runs without Axiom — report that as disabled rather than enabled.

## Test plan

- [x] \`cargo build -p runner --target aarch64-unknown-linux-musl\` passes
- [x] \`cargo clippy -p runner --target aarch64-unknown-linux-musl --all-targets\` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)