### PR TITLE
chore(deps): bump postcss to 8.5.10 to patch xss advisory

### DIFF
--- a/turbo/package.json
+++ b/turbo/package.json
@@ -73,13 +73,8 @@
       "yaml": ">=2.8.3",
       "smol-toml": ">=1.6.1",
       "@opentelemetry/instrumentation": ">=0.213.0",
-      "zod": "4.3.6"
-    },
-    "auditConfig": {
-      "ignoreGhsas": [
-        "GHSA-gh4j-gqv2-49f6",
-        "GHSA-w5hq-g745-h8pq"
-      ]
+      "zod": "4.3.6",
+      "postcss": ">=8.5.10"
     }
   },
   "packageManager": "pnpm@10.15.0",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -25,6 +25,7 @@ overrides:
   smol-toml: '>=1.6.1'
   '@opentelemetry/instrumentation': '>=0.213.0'
   zod: 4.3.6
+  postcss: '>=8.5.10'
 
 importers:
 
@@ -129,7 +130,7 @@ importers:
         version: 7.5.13
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@swc/core@1.15.21(@swc/helpers@0.5.20))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(@swc/core@1.15.21(@swc/helpers@0.5.20))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -523,8 +524,8 @@ importers:
         specifier: 0.21.1
         version: 0.21.1
       postcss:
-        specifier: ^8.5.6
-        version: 8.5.8
+        specifier: '>=8.5.10'
+        version: 8.5.10
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -707,7 +708,7 @@ importers:
         version: link:../typescript-config
       autoprefixer:
         specifier: ^10.4.21
-        version: 10.4.27(postcss@8.5.8)
+        version: 10.4.27(postcss@8.5.10)
       eslint:
         specifier: ^9.34.0
         version: 9.39.4(jiti@2.6.1)
@@ -721,8 +722,8 @@ importers:
         specifier: 0.21.1
         version: 0.21.1
       postcss:
-        specifier: ^8.5.3
-        version: 8.5.8
+        specifier: '>=8.5.10'
+        version: 8.5.10
       tailwindcss:
         specifier: ^4.1.3
         version: 4.2.2
@@ -4899,7 +4900,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.10'
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -7225,7 +7226,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: '>=8.5.10'
       tsx: ^4.8.1
       yaml: '>=2.8.3'
     peerDependenciesMeta:
@@ -7245,12 +7246,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -8012,7 +8009,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: '>=8.5.10'
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -12099,7 +12096,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
-      postcss: 8.5.8
+      postcss: 8.5.10
       tailwindcss: 4.2.2
 
   '@tailwindcss/typography@0.5.19(tailwindcss@4.2.2)':
@@ -12997,13 +12994,13 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.27(postcss@8.5.8):
+  autoprefixer@10.4.27(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001781
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.8
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -15287,7 +15284,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.12
       caniuse-lite: 1.0.30001781
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(react@19.2.4)
@@ -15649,12 +15646,12 @@ snapshots:
 
   postal-mime@2.7.3: {}
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.8
+      postcss: 8.5.10
       tsx: 4.21.0
       yaml: 2.8.3
 
@@ -15665,13 +15662,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.8:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -16629,7 +16620,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@swc/core@1.15.21(@swc/helpers@0.5.20))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(@swc/core@1.15.21(@swc/helpers@0.5.20))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -16640,7 +16631,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.0
       source-map: 0.7.6
@@ -16650,7 +16641,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       '@swc/core': 1.15.21(@swc/helpers@0.5.20)
-      postcss: 8.5.8
+      postcss: 8.5.10
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -16889,7 +16880,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.10
       rolldown: 1.0.0-rc.12(@emnapi/runtime@1.9.1)
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
## Summary

- `pnpm audit` CI is failing on [GHSA-qx2v-qp2m-jg93 / CVE-2026-41305](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) — postcss <8.5.10 does not escape `</style>` sequences when stringifying CSS, enabling XSS if user-submitted CSS is re-embedded in `<style>` tags.
- Fixed by adding `"postcss": ">=8.5.10"` to the pnpm `overrides` block. Pulls both the direct `apps/web>postcss` (was 8.5.6) and transitive `apps/web>next>postcss` (was 8.4.31) up to 8.5.10.
- Dropped a pre-existing duplicate `auditConfig` block in `turbo/package.json` (lines 50 and 79 were identical) flagged by JSON lint once I touched the file.

## Test plan

- [x] `cd turbo && pnpm audit --prod --ignore-registry-errors` — exit 0, postcss advisory gone
- [x] `pnpm why postcss` — all resolutions show 8.5.10
- [ ] CI green (lint / test / security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)