### PR TITLE
fix(runner): treat claim 404 as race-lost, not api error

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -566,7 +566,10 @@ impl ApiClient {
     }
 
     /// Claim a job for execution. Returns [`RunnerError::AlreadyClaimed`] on
-    /// HTTP 409 so callers can continue gracefully.
+    /// HTTP 409 (job row still present, already claimed) and HTTP 404 (job
+    /// row already dequeued by the winner) so callers can continue gracefully.
+    /// Both outcomes are normal contention signals when multiple runners race
+    /// for the same job.
     async fn claim(&self, run_id: RunId) -> RunnerResult<ExecutionContext> {
         let path = format!("/api/runners/jobs/{run_id}/claim");
         let resp = self
@@ -577,7 +580,7 @@ impl ApiClient {
             .await
             .map_err(|e| RunnerError::Api(format!("claim: {e}")))?;
 
-        if resp.status() == StatusCode::CONFLICT {
+        if matches!(resp.status(), StatusCode::CONFLICT | StatusCode::NOT_FOUND) {
             return Err(RunnerError::AlreadyClaimed);
         }
 


### PR DESCRIPTION
Closes #11041.

## Summary

- When multiple runners race for the same job, the winner claims + dequeues the queue row. Losing runners hit the web API and get `404 NOT_FOUND` with body `{"error":{"message":"Job not found in queue","code":"NOT_FOUND"}}`.
- That path was previously mapped to the generic `RunnerError::Api` branch, which `provider::api::claim()` logs at `error` as `claim failed` — producing ~75 spurious error/day in `vm0-web-logs-prod` with no actionable signal.
- This PR maps HTTP 404 to the existing `RunnerError::AlreadyClaimed` variant alongside the 409 case, so the race-lost outcome logs at `info` as `"already claimed, skipping"` — matching the semantics of a normal concurrency race.

## Why map to `AlreadyClaimed` instead of just lowering the log level

Keeps the "race lost" signal centralized at the error-type level. If anything ever changes in the log site (e.g. structured alerting), the `AlreadyClaimed` variant remains the canonical "contended, move on" carrier. Server-side, both 409 ("job row present, already claimed") and 404 ("job row already dequeued") are the same semantic outcome from the runner's POV.

## Test plan

- [x] `cargo check -p runner` passes
- [x] `cargo clippy -p runner --all-targets -- -D warnings` passes
- [x] `cargo fmt -p runner --check` passes
- [ ] After merge: watch `vm0-web-logs-prod` to confirm `claim failed` error count drops to ~0 and `"already claimed, skipping"` at info level reflects the new race-lost volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)