### PR TITLE
refactor: remove modelProviderSelection feature switch

### DIFF
--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -44,7 +44,6 @@ export enum FeatureSwitchKey {
   StabilityAiConnector = "stabilityAiConnector",
   ZoomConnector = "zoomConnector",
   ApiKeys = "apiKeys",
-  ModelProviderSelection = "modelProviderSelection",
   ConnectorCategories = "connectorCategories",
   PlatformConnectors = "platformConnectors",
   Trinity = "trinity",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -245,15 +245,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Gate the custom /settings/api-keys UI for issuing personal access tokens used by the /api/v1 public surface. When disabled, the settings page redirects to / and the sidebar menu item is hidden. The backend /api/v1 verification does NOT consult this flag — previously issued PATs continue to work.",
     enabled: false,
   },
-  [FeatureSwitchKey.ModelProviderSelection]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Show the model provider + model picker on the agent profile page and schedule dialog. " +
-      "Allows per-agent and per-schedule model selection, overriding the org default. " +
-      "Staff-only during initial rollout.",
-    enabled: true,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ConnectorCategories]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

Remove the `modelProviderSelection` feature switch — the feature has been fully rolled out (`enabled: true`) and the flag is no longer referenced by any gating logic.

## Changes

- Remove `ModelProviderSelection` from `FeatureSwitchKey` enum
- Remove the switch config entry from `FEATURE_SWITCHES` registry

## Test plan

- [x] Lint passes (oxlint + eslint)
- [x] Type check passes (tsc --noEmit)
- [x] Format check passes (prettier)
- [x] All 788 core package tests pass
- [x] Knip reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)