### PR TITLE
fix: re-add AudioOutput feature switch guards on UI and TTS route

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/auto-read-toggle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/auto-read-toggle.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.ts";
 import { mockSubagentThread } from "./chat-test-helpers.ts";
 import { autoReadEnabled$ } from "../../../signals/voice-io/voice-io-settings.ts";
 
@@ -10,7 +11,19 @@ const context = testContext();
 const THREAD_ID = "thread-auto-read-test";
 
 describe("auto-read toggle", () => {
+  it("does not render when audioOutput feature is off", async () => {
+    mockSubagentThread(THREAD_ID);
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await waitFor(() => {
+      expect(screen.getByText("Assistant")).toBeInTheDocument();
+    });
+
+    expect(screen.queryAllByLabelText("Toggle auto-read")).toHaveLength(0);
+  });
+
   it("renders on chat thread pages", async () => {
+    setMockFeatureSwitches({ audioOutput: true });
     mockSubagentThread(THREAD_ID);
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
@@ -22,6 +35,7 @@ describe("auto-read toggle", () => {
   });
 
   it("starts turned off", async () => {
+    setMockFeatureSwitches({ audioOutput: true });
     mockSubagentThread(THREAD_ID);
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
@@ -35,6 +49,7 @@ describe("auto-read toggle", () => {
   });
 
   it("toggles on after one click", async () => {
+    setMockFeatureSwitches({ audioOutput: true });
     mockSubagentThread(THREAD_ID);
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
@@ -48,6 +63,7 @@ describe("auto-read toggle", () => {
   });
 
   it("toggles back off after two clicks", async () => {
+    setMockFeatureSwitches({ audioOutput: true });
     mockSubagentThread(THREAD_ID);
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
@@ -62,6 +78,7 @@ describe("auto-read toggle", () => {
   });
 
   it("stays hidden on non-chat routes", async () => {
+    setMockFeatureSwitches({ audioOutput: true });
     detachedSetupPage({ context, path: "/agents" });
 
     await waitFor(() => {
@@ -72,6 +89,7 @@ describe("auto-read toggle", () => {
   });
 
   it("renders in the mobile top bar on chat routes", async () => {
+    setMockFeatureSwitches({ audioOutput: true });
     detachedSetupPage({ context, path: "/" });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -180,8 +180,7 @@ function MobileTopBarActions({ activeId }: { activeId: RouteKey | null }) {
   const features = useLastResolved(featureSwitch$);
   const newButtonEnabled =
     features?.[FeatureSwitchKey.ChatHeaderNewButton] ?? false;
-  const audioOutputEnabled =
-    features?.[FeatureSwitchKey.AudioOutput] ?? false;
+  const audioOutputEnabled = features?.[FeatureSwitchKey.AudioOutput] ?? false;
   return (
     <>
       {inChatRoute && audioOutputEnabled && <AutoReadToggleLeaf />}

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -180,9 +180,11 @@ function MobileTopBarActions({ activeId }: { activeId: RouteKey | null }) {
   const features = useLastResolved(featureSwitch$);
   const newButtonEnabled =
     features?.[FeatureSwitchKey.ChatHeaderNewButton] ?? false;
+  const audioOutputEnabled =
+    features?.[FeatureSwitchKey.AudioOutput] ?? false;
   return (
     <>
-      {inChatRoute && <AutoReadToggleLeaf />}
+      {inChatRoute && audioOutputEnabled && <AutoReadToggleLeaf />}
       {inChatRoute &&
         (newButtonEnabled ? (
           <NewOrUnreadChatButtonLeaf />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -191,6 +191,9 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   const displayName = useLastResolved(thread.agentDisplayName$);
   const autoRead = useGet(autoReadEnabled$);
   const toggleAutoReadFn = useSet(toggleAutoRead$);
+  const features = useLastResolved(featureSwitch$);
+  const audioOutputEnabled =
+    features?.[FeatureSwitchKey.AudioOutput] ?? false;
 
   return (
     <header className="hidden sm:flex shrink-0 bg-transparent px-6 py-3 items-center justify-between">
@@ -206,31 +209,33 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
         )}
       </div>
       <div className="hidden sm:flex items-center gap-0.5">
-        <TooltipProvider delayDuration={300}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={() => {
-                  toggleAutoReadFn();
-                }}
-                className={cn(
-                  "p-1.5 rounded-md transition-colors duration-150",
-                  autoRead
-                    ? "text-primary bg-primary/10"
-                    : "text-muted-foreground/60 hover:text-foreground hover:bg-accent",
-                )}
-                aria-label="Toggle auto-read"
-                aria-pressed={autoRead}
-              >
-                <IconVolume2 size={18} stroke={1.5} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {autoRead ? "Auto-read on" : "Auto-read off"}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        {audioOutputEnabled && (
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => {
+                    toggleAutoReadFn();
+                  }}
+                  className={cn(
+                    "p-1.5 rounded-md transition-colors duration-150",
+                    autoRead
+                      ? "text-primary bg-primary/10"
+                      : "text-muted-foreground/60 hover:text-foreground hover:bg-accent",
+                  )}
+                  aria-label="Toggle auto-read"
+                  aria-pressed={autoRead}
+                >
+                  <IconVolume2 size={18} stroke={1.5} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {autoRead ? "Auto-read on" : "Auto-read off"}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
       </div>
     </header>
   );
@@ -1377,6 +1382,9 @@ function PagedGroupActions({
   const copied = copiedId === group.beginMessageId;
   const copyMessage = useSet(thread.copyMessage$);
 
+  const features = useLastResolved(featureSwitch$);
+  const audioOutputEnabled =
+    features?.[FeatureSwitchKey.AudioOutput] ?? false;
   const playingRunId = useGet(ttsPlayingRunId$);
   const firstRunId = group.messages.find((m) => {
     return m.runId;
@@ -1460,7 +1468,7 @@ function PagedGroupActions({
             </Tooltip>
           </TooltipProvider>
         )}
-        {content && firstRunId && (
+        {content && firstRunId && audioOutputEnabled && (
           <TooltipProvider delayDuration={300}>
             <Tooltip>
               <TooltipTrigger asChild>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -192,8 +192,7 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   const autoRead = useGet(autoReadEnabled$);
   const toggleAutoReadFn = useSet(toggleAutoRead$);
   const features = useLastResolved(featureSwitch$);
-  const audioOutputEnabled =
-    features?.[FeatureSwitchKey.AudioOutput] ?? false;
+  const audioOutputEnabled = features?.[FeatureSwitchKey.AudioOutput] ?? false;
 
   return (
     <header className="hidden sm:flex shrink-0 bg-transparent px-6 py-3 items-center justify-between">
@@ -1383,8 +1382,7 @@ function PagedGroupActions({
   const copyMessage = useSet(thread.copyMessage$);
 
   const features = useLastResolved(featureSwitch$);
-  const audioOutputEnabled =
-    features?.[FeatureSwitchKey.AudioOutput] ?? false;
+  const audioOutputEnabled = features?.[FeatureSwitchKey.AudioOutput] ?? false;
   const playingRunId = useGet(ttsPlayingRunId$);
   const firstRunId = group.messages.find((m) => {
     return m.runId;

--- a/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
@@ -10,6 +10,18 @@ import { createTestOrg } from "../../../../../../src/__tests__/api-test-helpers"
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { reloadEnv } from "../../../../../../src/env";
 
+vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@vm0/core/feature-switch")>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn().mockReturnValue(true),
+  };
+});
+
+const { isFeatureEnabled } = await import("@vm0/core/feature-switch");
+const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
+
 vi.hoisted(() => {
   vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
 });
@@ -35,6 +47,7 @@ function ttsRequest(body?: unknown) {
 describe("POST /api/zero/voice-io/tts", () => {
   beforeEach(() => {
     context.setupMocks();
+    mockIsFeatureEnabled.mockReturnValue(true);
     vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
     reloadEnv();
   });
@@ -47,6 +60,18 @@ describe("POST /api/zero/voice-io/tts", () => {
 
     expect(response.status).toBe(401);
     expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 403 when feature switch is disabled", async () => {
+    const userId = uniqueId("zvio-ff");
+    await setupOrg(userId);
+    mockIsFeatureEnabled.mockReturnValue(false);
+
+    const response = await POST(ttsRequest({ text: "hello" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
   });
 
   it("should return 400 when text is empty", async () => {

--- a/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { initServices } from "../../../../../src/lib/init-services";
+import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 import { env } from "../../../../../src/env";
 import { logger } from "../../../../../src/lib/shared/logger";
 
@@ -15,10 +18,28 @@ export async function POST(request: Request): Promise<Response> {
 
   const authHeader = request.headers.get("authorization");
   const authCtx = await getAuthContext(authHeader ?? undefined);
-  if (!authCtx) {
+  if (!authCtx || !authCtx.orgId) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
+    );
+  }
+
+  const overrides = await loadFeatureSwitchOverrides(
+    authCtx.orgId,
+    authCtx.userId,
+  );
+  const enabled = isFeatureEnabled(FeatureSwitchKey.AudioOutput, {
+    orgId: authCtx.orgId,
+    userId: authCtx.userId,
+    overrides,
+  });
+  if (!enabled) {
+    return NextResponse.json(
+      {
+        error: { message: "Audio output is not enabled", code: "FORBIDDEN" },
+      },
+      { status: 403 },
     );
   }
 


### PR DESCRIPTION
## Summary

PR #11022 removed the `AudioOutput` feature switch guards when graduating the feature to "always-on," but the switch in `feature-switch.ts` remains `enabled: false`. This means the UI buttons (auto-read toggle, read-aloud) and the `/api/zero/voice-io/tts` route are all active regardless of the switch state.

This PR restores the feature switch guards across all four locations:

- **`sidebar-layout.tsx`** — `AutoReadToggleLeaf` is now gated by `audioOutputEnabled`
- **`zero-chat-thread-page.tsx`** — `ChatThreadHeader` volume button and `PagedGroupActions` "Read aloud" button are gated
- **`tts/route.ts`** — API route checks `isFeatureEnabled(AudioOutput)` with org/user overrides

The `AudioOutput` feature switch default is `enabled: false`, so voice output will be off by default and can be toggled on per-org or per-user.

## Test plan

- [ ] Voice out buttons (auto-read toggle, read-aloud) do not appear when `AudioOutput` switch is off
- [ ] TTS API returns 403 when `AudioOutput` switch is off
- [ ] Voice out buttons appear and TTS works when `AudioOutput` switch is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)