### PR TITLE
fix(chat): switch to new threads optimistically

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -1,6 +1,7 @@
 import { command, computed, state } from "ccstate";
-import { onRef, resetSignal } from "../utils.ts";
+import { onRef } from "../utils.ts";
 import { detachedNavigateTo$ } from "../route.ts";
+import { updateDocumentTitle$ } from "../document-title.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { zeroOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
 import { navigateToChat$ } from "../zero-page/zero-nav.ts";
@@ -9,6 +10,12 @@ import {
   chatThreads$,
   reloadChatThreads$,
 } from "../agent-chat.ts";
+import { setAblyLoop$ } from "../realtime.ts";
+import {
+  createChatThreadSignals,
+  ensureDraft$,
+  type LocalChatThreadSnapshot,
+} from "./create-chat-thread.ts";
 import {
   chatMessagesContract,
   chatThreadsContract,
@@ -68,30 +75,6 @@ async function createChatThread(
   return { id: result.body.id, title: result.body.title };
 }
 
-// ---------------------------------------------------------------------------
-// Talk-page send signal
-// ---------------------------------------------------------------------------
-
-/**
- * Signal for talk-page sends that must survive page navigation.
- *
- * The talk page navigates from `/agents/:id/chat` to `/chats/:id` on send,
- * which aborts the page-level signal.  This dedicated signal lets the
- * talk page pass a cancellable AbortSignal without coupling to the page
- * lifecycle.  It is reset each time `startNewZeroSession$` fires (which
- * is called before every talk-page send), so stale controllers are
- * cleaned up automatically.
- */
-export const resetTalkSendSignal$ = resetSignal();
-
-// ---------------------------------------------------------------------------
-// Session lifecycle
-// ---------------------------------------------------------------------------
-
-export const startNewZeroSession$ = command(({ set }) => {
-  set(resetTalkSendSignal$);
-});
-
 export const createNewChatThread$ = command(
   async (
     { get, set },
@@ -105,8 +88,6 @@ export const createNewChatThread$ = command(
       toast.error("No agent available for new chat session");
       return null;
     }
-
-    set(startNewZeroSession$);
 
     const createClient = get(zeroClient$);
     const thread = await createChatThread(
@@ -124,6 +105,52 @@ export const createNewChatThread$ = command(
 // Send new thread message (used by agent talk page)
 // ---------------------------------------------------------------------------
 
+export interface SendNewThreadMessageRequest {
+  agentId: string;
+  prompt: string;
+  modelSelection: ModelSelectionRequest | null;
+}
+
+export interface SendNewThreadMessageResult {
+  threadId: string;
+  runId: string;
+}
+
+export interface SendNewThreadMessagePending {
+  threadId: string;
+  pendingThread: ReturnType<typeof createChatThreadSignals>;
+  sendResult: Promise<SendNewThreadMessageResult>;
+}
+
+export const activateNewChatThreadPageLoops$ = command(
+  async (
+    { set },
+    thread: ReturnType<typeof createChatThreadSignals>,
+    threadId: string,
+    signal: AbortSignal,
+  ) => {
+    const onThreadUpdated$ = command(async ({ get, set }, sig: AbortSignal) => {
+      const data = await get(thread.threadData$);
+      sig.throwIfAborted();
+      if (data) {
+        set(updateDocumentTitle$, data.title ?? "New chat");
+      }
+      return false;
+    });
+
+    await Promise.all([
+      set(thread.runPhraseLoop$, signal),
+      set(thread.loadPagedMessages$, signal),
+      set(
+        setAblyLoop$,
+        `chatThreadRunUpdated:${threadId}`,
+        onThreadUpdated$,
+        signal,
+      ),
+    ]);
+  },
+);
+
 /**
  * Send the first message in a new or threadless chat. Returns the threadId.
  * Used by the agent talk page which navigates to the thread after sending.
@@ -135,11 +162,9 @@ export const createNewChatThread$ = command(
 export const sendNewThreadMessage$ = command(
   async (
     { get, set },
-    agentId: string,
-    prompt: string,
-    modelSelection: ModelSelectionRequest | null,
+    { agentId, prompt, modelSelection }: SendNewThreadMessageRequest,
     signal: AbortSignal,
-  ): Promise<string | null> => {
+  ): Promise<SendNewThreadMessagePending | null> => {
     // Mirror the in-thread send path: resolve the talk-page draft's uploaded
     // attachments so the first message carries structured `attachFiles` just
     // like follow-ups do (fixes #10243 for the new-thread entry point).
@@ -154,27 +179,66 @@ export const sendNewThreadMessage$ = command(
       return null;
     }
 
-    const client = get(zeroClient$)(chatMessagesContract);
-    const result = await accept(
-      client.send({
-        body: {
-          agentId,
-          prompt: prepared.prompt,
-          hasTextContent: prepared.hasTextContent,
-          clientMessageId: crypto.randomUUID(),
-          modelSelection,
-          attachFiles: prepared.attachFiles,
+    const threadId = crypto.randomUUID();
+    const clientMessageId = crypto.randomUUID();
+    const cancelRequested$ = state(false);
+    const localSnapshot: LocalChatThreadSnapshot = {
+      threadData: {
+        id: threadId,
+        title: null,
+        agentId,
+        latestSessionId: null,
+        latestSessionProviderType: null,
+        activeRunIds: [`pending-${threadId}`],
+        activeRuns: [{ id: `pending-${threadId}`, status: "pending" }],
+        isLegacySession: false,
+        draftContent: null,
+        draftAttachments: null,
+        modelProviderId: null,
+        selectedModel: null,
+      },
+      messages: [
+        {
+          id: clientMessageId,
+          role: "user",
+          content: prepared.prompt,
+          attachFiles: prepared.attachments,
+          createdAt: new Date().toISOString(),
         },
-        fetchOptions: { signal },
-      }),
-      [201],
-    );
-    signal.throwIfAborted();
-
-    // Drop the now-persisted attachments from the talk draft.
+      ],
+      cancelRequested$,
+    };
+    const { draft: threadDraft } = set(ensureDraft$, threadId);
+    const localThread = createChatThreadSignals(threadId, threadDraft, {
+      localSnapshot,
+    });
+    set(localThread.hideSkeleton$);
     set(draft.clear$);
-    set(reloadChatThreads$);
-    return result.body.threadId;
+
+    const client = get(zeroClient$)(chatMessagesContract);
+    const sendResult = (async (): Promise<SendNewThreadMessageResult> => {
+      const result = await accept(
+        client.send({
+          body: {
+            agentId,
+            prompt: prepared.prompt,
+            clientThreadId: threadId,
+            hasTextContent: prepared.hasTextContent,
+            clientMessageId,
+            modelSelection,
+            attachFiles: prepared.attachFiles,
+          },
+          fetchOptions: { signal },
+        }),
+        [201],
+      );
+      signal.throwIfAborted();
+      set(reloadChatThreads$);
+
+      return { threadId: result.body.threadId, runId: result.body.runId };
+    })();
+
+    return { threadId, pendingThread: localThread, sendResult };
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -39,6 +39,14 @@ export const setupChatPage$ = command(
     if (!thread) {
       throw new Error("thread signals are required to load chat page");
     }
+
+    set(
+      updatePage$,
+      createElement(ZeroChatThreadPage, { key: threadId, thread }),
+      "sidebar",
+    );
+    await set(hideAppSkeleton$, signal);
+
     const threadData = await get(thread.threadData$);
     signal.throwIfAborted();
     if (!threadData) {
@@ -56,14 +64,6 @@ export const setupChatPage$ = command(
     }
 
     set(setChatAgentId$, threadData.agentId ?? null);
-
-    set(
-      updatePage$,
-      createElement(ZeroChatThreadPage, { key: threadId }),
-      "sidebar",
-    );
-
-    await set(hideAppSkeleton$, signal);
 
     // Use threadData for title (reliable on page refresh) instead of chatThreads$
     const sessionTitle = threadData.title ?? "New chat";

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -42,7 +42,7 @@ export const setupChatPage$ = command(
 
     set(
       updatePage$,
-      createElement(ZeroChatThreadPage, { key: threadId, thread }),
+      createElement(ZeroChatThreadPage, { key: threadId }),
       "sidebar",
     );
     await set(hideAppSkeleton$, signal);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -200,6 +200,16 @@ export interface ChatThreadSignals {
   runPhraseLoop$: Command<Promise<void>, [AbortSignal]>;
 }
 
+export interface LocalChatThreadSnapshot {
+  threadData: ChatThread;
+  messages: PagedChatMessage[];
+  cancelRequested$: State<boolean>;
+}
+
+interface ChatThreadSignalOptions {
+  localSnapshot?: LocalChatThreadSnapshot;
+}
+
 // ---------------------------------------------------------------------------
 // Sub-factory: thread data fetching
 // ---------------------------------------------------------------------------
@@ -210,11 +220,18 @@ export interface ChatThreadSignals {
 // can be reloaded independently via `reloadThread$`. Keep the accept list
 // aligned so missing-thread redirects (see `chat-page-setup.ts`) and title
 // merging (see `chatThreads$`) both treat 404s the same way.
-function createThreadData(threadId: string) {
+function createThreadData(
+  threadId: string,
+  options: ChatThreadSignalOptions = {},
+) {
   const internalReload$ = state(0);
 
   const threadData$ = computed(async (get): Promise<ChatThread | null> => {
     get(internalReload$);
+    if (options.localSnapshot) {
+      return options.localSnapshot.threadData;
+    }
+
     const threadClient = get(zeroClient$)(chatThreadByIdContract);
     const threadResult = await accept(
       threadClient.get({ params: { id: threadId } }),
@@ -470,7 +487,11 @@ export const setDraftSyncDebounceMs$ = command(({ set }, ms: number) => {
   set(internalDraftSyncDebounceMs$, ms);
 });
 
-function createDraftSync(threadId: string, draft: DraftSignals) {
+function createDraftSync(
+  threadId: string,
+  draft: DraftSignals,
+  options: ChatThreadSignalOptions = {},
+) {
   // A reset signal is used to abort any in-flight debounced sync when a new
   // change comes in or when the draft is cleared on send.
   const draftSyncReset$ = resetSignal();
@@ -543,6 +564,9 @@ function createDraftSync(threadId: string, draft: DraftSignals) {
   );
 
   const scheduleDraftSync$ = command(async ({ set }, signal: AbortSignal) => {
+    if (options.localSnapshot) {
+      return;
+    }
     const debouncedSignal = set(draftSyncReset$, signal);
     await set(debouncedSyncDraft$, debouncedSignal);
   });
@@ -552,6 +576,9 @@ function createDraftSync(threadId: string, draft: DraftSignals) {
   });
 
   const flushDraftClear$ = command(async ({ set }, signal: AbortSignal) => {
+    if (options.localSnapshot) {
+      return;
+    }
     set(draftSyncReset$);
     await set(syncWithContent$, null, null, signal);
   });
@@ -641,6 +668,7 @@ function createAppendDelta(deltaMessages$: DeltaMessages$) {
 function createInitialPage$(
   threadId: string,
   threadData$: Computed<Promise<ChatThread | null>>,
+  options: ChatThreadSignalOptions = {},
 ) {
   return computed(
     async (
@@ -652,6 +680,12 @@ function createInitialPage$(
       const thread = await get(threadData$);
       if (!thread) {
         return { messages: [], hasHistoryBefore: false };
+      }
+      if (options.localSnapshot) {
+        return {
+          messages: options.localSnapshot.messages,
+          hasHistoryBefore: false,
+        };
       }
       const client = get(zeroClient$)(chatThreadMessagesContract);
       const result = await accept(
@@ -675,10 +709,11 @@ function createInitialPage$(
 function createPagedMessages(
   threadId: string,
   threadData$: Computed<Promise<ChatThread | null>>,
+  options: ChatThreadSignalOptions = {},
 ) {
   const loadedHistoryHasMore$ = state<boolean | null>(null);
   const historyMessages$ = state<PagedChatMessage[]>([]);
-  const initialPage$ = createInitialPage$(threadId, threadData$);
+  const initialPage$ = createInitialPage$(threadId, threadData$, options);
 
   const deltaMessages$ = state<PagedChatMessage[]>([]);
   const appendDeltaMessages$ = createAppendDelta(deltaMessages$);
@@ -725,6 +760,9 @@ function createPagedMessages(
     if (!thread) {
       return true;
     }
+    if (options.localSnapshot) {
+      return true;
+    }
 
     const sinceId = await get(latestChatMessageId$);
     signal.throwIfAborted();
@@ -767,6 +805,7 @@ function createPagedMessages(
     earliestChatMessageId$,
     historyMessages$,
     loadedHistoryHasMore$,
+    options,
   });
 
   return {
@@ -786,17 +825,23 @@ function createLoadHistoryCommand({
   earliestChatMessageId$,
   historyMessages$,
   loadedHistoryHasMore$,
+  options = {},
 }: {
   threadId: string;
   threadData$: Computed<Promise<ChatThread | null>>;
   earliestChatMessageId$: Computed<Promise<string | undefined>>;
   historyMessages$: State<PagedChatMessage[]>;
   loadedHistoryHasMore$: State<boolean | null>;
+  options?: ChatThreadSignalOptions;
 }): Command<Promise<void>, [AbortSignal]> {
   return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
     const thread = await get(threadData$);
     signal.throwIfAborted();
     if (!thread) {
+      set(loadedHistoryHasMore$, false);
+      return;
+    }
+    if (options.localSnapshot) {
       set(loadedHistoryHasMore$, false);
       return;
     }
@@ -881,14 +926,30 @@ function createInputRef() {
 // Factory: createRunTracking
 // ---------------------------------------------------------------------------
 
-function createRunTracking(
-  threadId: string,
-  reloadThread$: Command<void, []>,
-  threadData$: Computed<Promise<ChatThread | null>>,
-  fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>,
-  autoScroll$: Command<void, []>,
-) {
+interface RunTrackingDeps {
+  threadId: string;
+  reloadThread$: Command<void, []>;
+  threadData$: Computed<Promise<ChatThread | null>>;
+  fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
+  autoScroll$: Command<void, []>;
+  options: ChatThreadSignalOptions;
+}
+
+function createRunTracking({
+  threadId,
+  reloadThread$,
+  threadData$,
+  fetchNextPage$,
+  autoScroll$,
+  options,
+}: RunTrackingDeps) {
   const allFinished$ = computed(async (get) => {
+    const cancelRequested = options.localSnapshot
+      ? get(options.localSnapshot.cancelRequested$)
+      : false;
+    if (cancelRequested) {
+      return true;
+    }
     const thread = await get(threadData$);
     if (!thread) {
       return false;
@@ -922,6 +983,9 @@ function createRunTracking(
         threadId,
         activeRunIds: thread.activeRunIds,
       });
+      if (options.localSnapshot) {
+        return;
+      }
 
       // Mark thread as read on open (focus-gated)
       if (document.visibilityState !== "visible") {
@@ -988,13 +1052,16 @@ function createRunTracking(
     },
   );
 
-  const cancelRun$ = command(async ({ get }, signal: AbortSignal) => {
+  const cancelRun$ = command(async ({ get, set }, signal: AbortSignal) => {
+    if (options.localSnapshot) {
+      set(options.localSnapshot.cancelRequested$, true);
+      return;
+    }
     const thread = await get(threadData$);
     signal.throwIfAborted();
     if (!thread) {
       return;
     }
-
     const client = get(zeroClient$)(zeroRunsCancelContract);
     const before = thread.activeRunIds;
     L.debug("cancelRun$ start", { threadId, pendingRunIds: before });
@@ -1184,11 +1251,12 @@ function createPhraseLoop(
 // Factory: createChatThreadSignals
 // ---------------------------------------------------------------------------
 
-function createChatThreadSignals(
+export function createChatThreadSignals(
   threadId: string,
   draft: DraftSignals,
+  options: ChatThreadSignalOptions = {},
 ): ChatThreadSignals {
-  const { threadData$, reloadThread$ } = createThreadData(threadId);
+  const { threadData$, reloadThread$ } = createThreadData(threadId, options);
   const { modelSelection$, setModelSelection$ } =
     createModelSelection(threadData$);
   const {
@@ -1217,7 +1285,7 @@ function createChatThreadSignals(
     fetchNextPage$,
     loadHistory$: loadPagedHistory$,
     insertOptimisticMessage$,
-  } = createPagedMessages(threadId, threadData$);
+  } = createPagedMessages(threadId, threadData$, options);
 
   // Anchor the scroll viewport to current content before the prepend so the
   // ResizeObserver compensation keeps the user reading the same spot.
@@ -1229,14 +1297,15 @@ function createChatThreadSignals(
   );
 
   const { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ } =
-    createDraftSync(threadId, draft);
-  const { allFinished$, loadPagedMessages$, cancelRun$ } = createRunTracking(
+    createDraftSync(threadId, draft, options);
+  const { allFinished$, loadPagedMessages$, cancelRun$ } = createRunTracking({
     threadId,
     reloadThread$,
     threadData$,
     fetchNextPage$,
     autoScroll$,
-  );
+    options,
+  });
 
   const { sendMessage$ } = createSendMessage({
     threadId,

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -6,6 +6,7 @@ import { setChatAgentId$ } from "../agent-chat.ts";
 import { pushState } from "../location.ts";
 import { updatePage$ } from "../react-router.ts";
 import {
+  activateNewChatThreadPageLoops$,
   sendNewThreadMessage$,
   type SendNewThreadMessagePending,
   type SendNewThreadMessageRequest,
@@ -16,11 +17,9 @@ import {
   type ChatThreadSignals,
 } from "./create-chat-thread.ts";
 
-export const renderChatThreadPage$ = command(
-  ({ set }, thread: ChatThreadSignals) => {
-    set(updatePage$, createElement(ZeroChatThreadPage, { thread }), "sidebar");
-  },
-);
+const renderChatThreadPage$ = command(({ set }, thread: ChatThreadSignals) => {
+  set(updatePage$, createElement(ZeroChatThreadPage, { thread }), "sidebar");
+});
 
 export const sendNewThreadOptimistically$ = command(
   async (
@@ -41,11 +40,7 @@ export const sendNewThreadOptimistically$ = command(
 );
 
 export const settleThreadSignals$ = command(
-  async (
-    { get, set },
-    threadId: string,
-    signal: AbortSignal,
-  ): Promise<ChatThreadSignals> => {
+  async ({ get, set }, threadId: string, signal: AbortSignal) => {
     const { draft: threadDraft } = set(ensureDraft$, threadId);
     const realThread = createChatThreadSignals(threadId, threadDraft);
     const threadData = await get(realThread.threadData$);
@@ -63,8 +58,9 @@ export const settleThreadSignals$ = command(
       },
       { signal },
     );
-
     signal.throwIfAborted();
-    return realThread;
+
+    set(renderChatThreadPage$, realThread);
+    await set(activateNewChatThreadPageLoops$, realThread, threadId, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -1,0 +1,70 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { animationFrame } from "signal-timers";
+import { ZeroChatThreadPage } from "../../views/zero-page/zero-chat-thread-page.tsx";
+import { setChatAgentId$ } from "../agent-chat.ts";
+import { pushState } from "../location.ts";
+import { updatePage$ } from "../react-router.ts";
+import {
+  sendNewThreadMessage$,
+  type SendNewThreadMessagePending,
+  type SendNewThreadMessageRequest,
+} from "./chat-message.ts";
+import {
+  createChatThreadSignals,
+  ensureDraft$,
+  type ChatThreadSignals,
+} from "./create-chat-thread.ts";
+
+export const renderChatThreadPage$ = command(
+  ({ set }, thread: ChatThreadSignals) => {
+    set(updatePage$, createElement(ZeroChatThreadPage, { thread }), "sidebar");
+  },
+);
+
+export const sendNewThreadOptimistically$ = command(
+  async (
+    { set },
+    request: SendNewThreadMessageRequest,
+    signal: AbortSignal,
+  ): Promise<SendNewThreadMessagePending | null> => {
+    const result = await set(sendNewThreadMessage$, request, signal);
+    if (!result) {
+      return null;
+    }
+
+    set(renderChatThreadPage$, result.pendingThread);
+    pushState({}, "", `/chats/${result.threadId}`);
+
+    return result;
+  },
+);
+
+export const settleThreadSignals$ = command(
+  async (
+    { get, set },
+    threadId: string,
+    signal: AbortSignal,
+  ): Promise<ChatThreadSignals> => {
+    const { draft: threadDraft } = set(ensureDraft$, threadId);
+    const realThread = createChatThreadSignals(threadId, threadDraft);
+    const threadData = await get(realThread.threadData$);
+    signal.throwIfAborted();
+    if (threadData?.agentId) {
+      set(setChatAgentId$, threadData.agentId);
+    }
+
+    await get(realThread.groupedChatMessages$);
+    signal.throwIfAborted();
+    set(realThread.hideSkeleton$);
+    animationFrame(
+      () => {
+        set(realThread.scrollToBottom$);
+      },
+      { signal },
+    );
+
+    signal.throwIfAborted();
+    return realThread;
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-skeleton-switch.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-skeleton-switch.test.tsx
@@ -81,8 +81,7 @@ describe("chat skeleton on switch", () => {
 
     // Skeleton should be visible while thread-B loads
     await waitFor(() => {
-      const skeletons = document.querySelectorAll(".animate-pulse");
-      expect(skeletons.length).toBeGreaterThan(0);
+      expect(document.querySelector("[data-chat-skeleton]")).not.toBeNull();
     });
 
     // Release deferred so thread-B content loads
@@ -91,6 +90,7 @@ describe("chat skeleton on switch", () => {
     // Eventually thread-B content should load
     await waitFor(() => {
       expect(screen.getByText("Answer for thread-b")).toBeInTheDocument();
+      expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -207,7 +207,7 @@ export function mockChatLifecycle(options?: {
   threadTitle?: string | null;
   onRunCreate?: () => void;
 }): MockLifecycleControl {
-  const threadId = options?.threadId ?? "thread-test-1";
+  let threadId = options?.threadId ?? "thread-test-1";
   const historyMessages = options?.historyMessages ?? [];
   const chatMessages = options?.chatMessages ?? [];
 
@@ -367,6 +367,7 @@ export function mockChatLifecycle(options?: {
     }),
     // Unified chat message endpoint (creates thread + run + association)
     mockApi(chatMessagesContract.send, ({ body, respond }) => {
+      threadId = body.clientThreadId ?? threadId;
       if (body.prompt) {
         runPrompt = body.prompt;
       }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
@@ -13,8 +13,10 @@ import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import {
   chatThreadByIdContract,
+  chatThreadMessagesContract,
   chatMessagesContract,
 } from "@vm0/core/contracts/chat-threads";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 import {
   zeroRunAgentEventsContract,
   zeroRunsByIdContract,
@@ -30,20 +32,22 @@ const mockApi = createMockApi(context);
 
 const PLACEHOLDER = "Ask me to automate workflows, manage tasks...";
 
-function mockChatAPIs() {
+function mockChatAPIs(options?: { waitForSend?: Promise<void> }) {
   server.use(
     // Unified chat message endpoint (creates thread + run + association)
-    mockApi(chatMessagesContract.send, ({ respond }) => {
+    mockApi(chatMessagesContract.send, async ({ body, respond }) => {
+      await options?.waitForSend;
+      const threadId = body.clientThreadId ?? "new-thread-id-123";
       return respond(201, {
         runId: "run-abc-123",
-        threadId: "new-thread-id-123",
+        threadId,
         status: "pending",
         createdAt: "2026-03-10T00:00:00Z",
       });
     }),
-    mockApi(chatThreadByIdContract.get, ({ respond }) => {
+    mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
       return respond(200, {
-        id: "new-thread-id-123",
+        id: params.id,
         title: "Hello",
         agentId: "c0000000-0000-4000-a000-000000000001",
         chatMessages: [],
@@ -54,6 +58,9 @@ function mockChatAPIs() {
         createdAt: "2026-03-10T00:00:00Z",
         updatedAt: "2026-03-10T00:00:00Z",
       });
+    }),
+    mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+      return respond(200, { messages: [], hasHistoryBefore: false });
     }),
     mockApi(zeroRunAgentEventsContract.getAgentEvents, ({ respond }) => {
       return respond(200, {
@@ -120,10 +127,35 @@ describe("talk navigation", () => {
     // Press Enter to send
     await user.keyboard("{Enter}");
 
-    // The URL should navigate to /chat/new-thread-id-123
+    // The URL should navigate to the locally generated chat thread id.
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/new-thread-id-123");
+      expect(pathname()).toMatch(/^\/chats\/[0-9a-f-]{36}$/);
     });
+  });
+
+  it("shows the optimistic first message before the send request returns", async () => {
+    const user = userEvent.setup();
+    const sendDeferred = createDeferredPromise<void>(context.signal);
+    mockChatAPIs({ waitForSend: sendDeferred.promise });
+
+    detachedSetupPage({
+      context,
+      path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
+    });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    await fill(textarea, "Hello before server");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(pathname()).toMatch(/^\/chats\/[0-9a-f-]{36}$/);
+      expect(screen.getByText("Hello before server")).toBeInTheDocument();
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+
+    sendDeferred.resolve();
   });
 
   it("should navigate to /agents/:id/chat after completing onboarding", async () => {

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -67,11 +67,14 @@ import { activeRoute$ } from "../../signals/active-route.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
 import {
+  activateNewChatThreadPageLoops$,
   createNewChatThread$,
-  resetTalkSendSignal$,
-  sendNewThreadMessage$,
-  startNewZeroSession$,
 } from "../../signals/chat-page/chat-message.ts";
+import {
+  renderChatThreadPage$,
+  sendNewThreadOptimistically$,
+  settleThreadSignals$,
+} from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { navigateToChat$ } from "../../signals/zero-page/zero-nav.ts";
 import { voiceChatStatus$ } from "../../signals/voice-chat/voice-chat-session.ts";
 
@@ -382,11 +385,14 @@ export function AgentChatPage() {
     currentChatAgentDisplayName$,
   );
 
-  const sendNewThread = useSet(sendNewThreadMessage$);
-  const startNewSession = useSet(startNewZeroSession$);
-  const resetTalkSendSignal = useSet(resetTalkSendSignal$);
-  const navigateToChatFn = useSet(navigateToChat$);
+  const sendNewThread = useSet(sendNewThreadOptimistically$);
   const { signal: rootSignal } = useGet(rootSignal$);
+  const pageSignal = useGet(pageSignal$);
+  const renderChatThreadPage = useSet(renderChatThreadPage$);
+  const activateNewChatThreadPageLoops = useSet(
+    activateNewChatThreadPageLoops$,
+  );
+  const settleThreadSignals = useSet(settleThreadSignals$);
 
   const orgProviders = useLastResolved(orgModelProviders$);
   const modelSelection = useLastResolved(chatPageModelSelection$) ?? null;
@@ -404,21 +410,36 @@ export function AgentChatPage() {
     if (!currentChatAgentId) {
       return;
     }
-    startNewSession();
-    // Link to rootSignal so the send is cancellable on app/test teardown,
-    // but not on page navigation (unlike pageSignal).
-    const talkSignal = resetTalkSendSignal(rootSignal);
+
     detach(
-      sendNewThread(
-        currentChatAgentId,
-        message,
-        modelSelection,
-        talkSignal,
-      ).then((threadId) => {
-        if (threadId) {
-          navigateToChatFn(threadId);
+      (async () => {
+        const result = await sendNewThread(
+          {
+            agentId: currentChatAgentId,
+            prompt: message,
+            modelSelection,
+          },
+          rootSignal,
+        );
+        if (!result) {
+          return;
         }
-      }),
+
+        await result.sendResult;
+        pageSignal.throwIfAborted();
+
+        const realThread = await settleThreadSignals(
+          result.threadId,
+          pageSignal,
+        );
+        pageSignal.throwIfAborted();
+        renderChatThreadPage(realThread);
+        await activateNewChatThreadPageLoops(
+          realThread,
+          result.threadId,
+          pageSignal,
+        );
+      })(),
       Reason.DomCallback,
     );
   };
@@ -439,7 +460,6 @@ export function AgentChatPage() {
 
   const suggestedPrompts = useLastResolved(suggestedPrompts$) ?? [];
   const navigate = useSet(detachedNavigateTo$);
-  const pageSignal = useGet(pageSignal$);
   const lightboxUrl = useGet(attachmentLightboxUrl$);
 
   const handleSend = (text: string) => {

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -1,5 +1,3 @@
-// TODO(#8609): split large components to comply with max-lines-per-function (128)
-// oxlint-disable max-lines-per-function
 import { Component } from "react";
 import {
   useGet,
@@ -19,6 +17,7 @@ import {
   IconPlus,
   IconUserPlus,
 } from "@tabler/icons-react";
+import type { ConnectorType } from "@vm0/core/contracts/connectors";
 import {
   Button,
   Tooltip,
@@ -66,12 +65,8 @@ import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { activeRoute$ } from "../../signals/active-route.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
+import { createNewChatThread$ } from "../../signals/chat-page/chat-message.ts";
 import {
-  activateNewChatThreadPageLoops$,
-  createNewChatThread$,
-} from "../../signals/chat-page/chat-message.ts";
-import {
-  renderChatThreadPage$,
   sendNewThreadOptimistically$,
   settleThreadSignals$,
 } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
@@ -379,6 +374,115 @@ export function ChatAgentAvatar({
   );
 }
 
+interface SuggestedPrompt {
+  title: string;
+  description: string;
+  prompt: string;
+  connectors?: readonly ConnectorType[];
+}
+
+function SuggestedPromptButton({
+  item,
+  onSelectPrompt,
+}: {
+  item: SuggestedPrompt;
+  onSelectPrompt: (prompt: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="zero-card cursor-pointer p-4 text-left flex flex-col relative group hover:bg-muted/30 transition-colors"
+      onClick={() => {
+        onSelectPrompt(item.prompt);
+      }}
+    >
+      <IconArrowUpRight
+        size={14}
+        stroke={2}
+        className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
+      />
+      <p className="text-sm font-semibold text-foreground pr-5">{item.title}</p>
+      <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
+        {item.description}
+      </p>
+      {item.connectors && item.connectors.length > 0 && (
+        <div className="flex items-center gap-1.5 mt-auto pt-2.5">
+          {item.connectors.map((type) => {
+            return (
+              <span
+                key={type}
+                className="flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background"
+              >
+                <ConnectorIcon type={type} size={14} />
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </button>
+  );
+}
+
+function IdeasUseCasesButton() {
+  const currentChatAgentId = useLastResolved(currentChatAgentId$);
+  const navigate = useSet(detachedNavigateTo$);
+
+  const handleClick = () => {
+    if (!currentChatAgentId) {
+      return;
+    }
+    navigate("/agents/:agentId/ideas", {
+      pathParams: { agentId: currentChatAgentId },
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className="zero-card cursor-pointer p-4 text-left flex flex-col relative group hover:bg-muted/30 transition-colors"
+      onClick={handleClick}
+    >
+      <IconArrowUpRight
+        size={14}
+        stroke={2}
+        className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
+      />
+      <p className="text-sm font-semibold text-foreground pr-5">
+        Ideas &amp; use cases
+      </p>
+      <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
+        Browse use cases across all connectors
+      </p>
+      <div className="flex items-center gap-1.5 mt-auto pt-2.5 text-sm font-medium text-primary">
+        <span>View all</span>
+        <IconArrowUpRight size={14} stroke={2} />
+      </div>
+    </button>
+  );
+}
+
+function SuggestedPromptsGrid({
+  onSelectPrompt,
+}: {
+  onSelectPrompt: (prompt: string) => void;
+}) {
+  const suggestedPrompts = useLastResolved(suggestedPrompts$) ?? [];
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 w-full">
+      {suggestedPrompts.map((item) => {
+        return (
+          <SuggestedPromptButton
+            key={item.title}
+            item={item}
+            onSelectPrompt={onSelectPrompt}
+          />
+        );
+      })}
+      <IdeasUseCasesButton />
+    </div>
+  );
+}
+
 export function AgentChatPage() {
   const currentChatAgentId = useLastResolved(currentChatAgentId$);
   const currentChatAgentDisplayName = useLastResolved(
@@ -388,10 +492,6 @@ export function AgentChatPage() {
   const sendNewThread = useSet(sendNewThreadOptimistically$);
   const { signal: rootSignal } = useGet(rootSignal$);
   const pageSignal = useGet(pageSignal$);
-  const renderChatThreadPage = useSet(renderChatThreadPage$);
-  const activateNewChatThreadPageLoops = useSet(
-    activateNewChatThreadPageLoops$,
-  );
   const settleThreadSignals = useSet(settleThreadSignals$);
 
   const orgProviders = useLastResolved(orgModelProviders$);
@@ -428,17 +528,7 @@ export function AgentChatPage() {
         await result.sendResult;
         pageSignal.throwIfAborted();
 
-        const realThread = await settleThreadSignals(
-          result.threadId,
-          pageSignal,
-        );
-        pageSignal.throwIfAborted();
-        renderChatThreadPage(realThread);
-        await activateNewChatThreadPageLoops(
-          realThread,
-          result.threadId,
-          pageSignal,
-        );
+        await settleThreadSignals(result.threadId, pageSignal);
       })(),
       Reason.DomCallback,
     );
@@ -458,8 +548,6 @@ export function AgentChatPage() {
         )
       : "";
 
-  const suggestedPrompts = useLastResolved(suggestedPrompts$) ?? [];
-  const navigate = useSet(detachedNavigateTo$);
   const lightboxUrl = useGet(attachmentLightboxUrl$);
 
   const handleSend = (text: string) => {
@@ -491,7 +579,6 @@ export function AgentChatPage() {
             </div>
           </div>
 
-          {/* Composer */}
           <ZeroChatComposer
             className="w-full"
             input={input}
@@ -513,76 +600,7 @@ export function AgentChatPage() {
             }
           />
 
-          {/* Suggested prompts */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 w-full">
-            {suggestedPrompts.map(
-              ({ title, description, connectors, prompt }) => {
-                return (
-                  <button
-                    key={title}
-                    type="button"
-                    className="zero-card cursor-pointer p-4 text-left flex flex-col relative group hover:bg-muted/30 transition-colors"
-                    onClick={() => {
-                      return setInput(prompt);
-                    }}
-                  >
-                    <IconArrowUpRight
-                      size={14}
-                      stroke={2}
-                      className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
-                    />
-                    <p className="text-sm font-semibold text-foreground pr-5">
-                      {title}
-                    </p>
-                    <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
-                      {description}
-                    </p>
-                    {connectors && connectors.length > 0 && (
-                      <div className="flex items-center gap-1.5 mt-auto pt-2.5">
-                        {connectors.map((type) => {
-                          return (
-                            <span
-                              key={type}
-                              className="flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background"
-                            >
-                              <ConnectorIcon type={type} size={14} />
-                            </span>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </button>
-                );
-              },
-            )}
-            <button
-              type="button"
-              className="zero-card cursor-pointer p-4 text-left flex flex-col relative group hover:bg-muted/30 transition-colors"
-              onClick={() => {
-                if (currentChatAgentId) {
-                  navigate("/agents/:agentId/ideas", {
-                    pathParams: { agentId: currentChatAgentId },
-                  });
-                }
-              }}
-            >
-              <IconArrowUpRight
-                size={14}
-                stroke={2}
-                className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
-              />
-              <p className="text-sm font-semibold text-foreground pr-5">
-                Ideas &amp; use cases
-              </p>
-              <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
-                Browse use cases across all connectors
-              </p>
-              <div className="flex items-center gap-1.5 mt-auto pt-2.5 text-sm font-medium text-primary">
-                <span>View all</span>
-                <IconArrowUpRight size={14} stroke={2} />
-              </div>
-            </button>
-          </div>
+          <SuggestedPromptsGrid onSelectPrompt={setInput} />
         </div>
       </main>
       {lightboxUrl && <AttachmentLightbox />}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -240,8 +240,15 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
 // ZeroSessionChatPage — real conversation backed by agent runs
 // ---------------------------------------------------------------------------
 
-export function ZeroChatThreadPage() {
-  const thread = useGet(currentChatThreadSignals$);
+interface ZeroChatThreadPageProps {
+  thread?: ChatThreadSignals;
+}
+
+export function ZeroChatThreadPage({
+  thread: threadOverride,
+}: ZeroChatThreadPageProps) {
+  const currentThread = useGet(currentChatThreadSignals$);
+  const thread = threadOverride ?? currentThread;
   const shortcutHelpOpen = useGet(chatShortcutHelpOpen$);
   const setShortcutHelpOpen = useSet(setChatShortcutHelpOpen$);
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -69,10 +69,7 @@ import type {
   GroupedChatMessageGroup,
   PagedChatMessage,
 } from "../../signals/chat-page/chat-message.ts";
-import {
-  currentChatThreadSignals$,
-  type ChatThreadSignals,
-} from "../../signals/chat-page/create-chat-thread.ts";
+import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
 import type { ChatThread } from "../../signals/agent-chat.ts";
 import { ATTACH_ONLY_PLACEHOLDER } from "../../signals/chat-page/resolve-draft-attachments.ts";
 import type { ChatClipboardAttachment } from "../../signals/zero-page/clipboard.ts";
@@ -241,20 +238,12 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
 // ---------------------------------------------------------------------------
 
 interface ZeroChatThreadPageProps {
-  thread?: ChatThreadSignals;
+  thread: ChatThreadSignals;
 }
 
-export function ZeroChatThreadPage({
-  thread: threadOverride,
-}: ZeroChatThreadPageProps) {
-  const currentThread = useGet(currentChatThreadSignals$);
-  const thread = threadOverride ?? currentThread;
+export function ZeroChatThreadPage({ thread }: ZeroChatThreadPageProps) {
   const shortcutHelpOpen = useGet(chatShortcutHelpOpen$);
   const setShortcutHelpOpen = useSet(setChatShortcutHelpOpen$);
-
-  if (!thread) {
-    return null;
-  }
 
   return (
     <>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -69,7 +69,10 @@ import type {
   GroupedChatMessageGroup,
   PagedChatMessage,
 } from "../../signals/chat-page/chat-message.ts";
-import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
+import {
+  currentChatThreadSignals$,
+  type ChatThreadSignals,
+} from "../../signals/chat-page/create-chat-thread.ts";
 import type { ChatThread } from "../../signals/agent-chat.ts";
 import { ATTACH_ONLY_PLACEHOLDER } from "../../signals/chat-page/resolve-draft-attachments.ts";
 import type { ChatClipboardAttachment } from "../../signals/zero-page/clipboard.ts";
@@ -238,12 +241,20 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
 // ---------------------------------------------------------------------------
 
 interface ZeroChatThreadPageProps {
-  thread: ChatThreadSignals;
+  thread?: ChatThreadSignals;
 }
 
-export function ZeroChatThreadPage({ thread }: ZeroChatThreadPageProps) {
+export function ZeroChatThreadPage({
+  thread: threadOverride,
+}: ZeroChatThreadPageProps) {
+  const currentThread = useGet(currentChatThreadSignals$);
+  const thread = threadOverride ?? currentThread;
   const shortcutHelpOpen = useGet(chatShortcutHelpOpen$);
   const setShortcutHelpOpen = useSet(setChatShortcutHelpOpen$);
+
+  if (!thread) {
+    return null;
+  }
 
   return (
     <>

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -130,6 +130,25 @@ describe("POST /api/zero/chat/messages", () => {
       expect(data.createdAt).toBeTruthy();
     });
 
+    it("should create a new thread with the provided clientThreadId", async () => {
+      const clientThreadId = crypto.randomUUID();
+      const response = await POST(
+        createTestRequest(URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentId,
+            prompt: "hello world",
+            clientThreadId,
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.threadId).toBe(clientThreadId);
+    });
+
     it("should reuse existing thread when threadId is provided", async () => {
       // First create a thread via the unified endpoint
       const firstResponse = await POST(

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -183,6 +183,7 @@ async function resolveThread(
   userId: string,
   agentId: string,
   existingThreadId: string | undefined,
+  clientThreadId: string | undefined,
   dims?: ChatSpanDimensions,
 ): Promise<ResolvedThread> {
   const emit = (op: string, ms: number): void => {
@@ -191,7 +192,7 @@ async function resolveThread(
 
   if (!existingThreadId) {
     const createT = await timed(async () => {
-      return createChatThread(userId, agentId);
+      return createChatThread(userId, agentId, null, clientThreadId);
     });
     emit(CHAT_REQUEST_OPS.resolve_thread_create_thread, createT.ms);
     const thread = createT.result;
@@ -382,7 +383,13 @@ const router = tsr.router(chatMessagesContract, {
 
     try {
       const { threadId, sessionId, incompleteContext, isNewThread } =
-        await resolveThread(authCtx.userId, body.agentId, body.threadId, dims);
+        await resolveThread(
+          authCtx.userId,
+          body.agentId,
+          body.threadId,
+          body.clientThreadId,
+          dims,
+        );
 
       const overrideT = await timed(async () => {
         return resolveRunModelOverride(

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -28,10 +28,12 @@ export async function createChatThread(
   userId: string,
   agentComposeId: string,
   title?: string | null,
+  id?: string,
 ): Promise<{ id: string; createdAt: Date }> {
   const [thread] = await globalThis.services.db
     .insert(chatThreads)
     .values({
+      ...(id ? { id } : {}),
       userId,
       agentComposeId,
       title: title ?? null,

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -270,6 +270,7 @@ export const chatMessagesContract = c.router({
       agentId: z.string().min(1),
       prompt: z.string().min(1),
       threadId: z.string().optional(),
+      clientThreadId: z.string().uuid().optional(),
       modelProvider: z.string().optional(),
       /**
        * Per-run model override; persisted on the thread so subsequent runs


### PR DESCRIPTION
## Summary
- render a locally generated chat thread immediately when sending the first talk-page message
- pass clientThreadId through the chat messages API so the server persists the optimistic thread id
- keep optimistic thread rendering, settling, and page-loop activation in the chat-page signals layer
- render the keyed chat thread page before async thread loading so rapid thread switches remount before useLastLoadable can retain stale messages
- split the agent chat landing prompt grid out of AgentChatPage and remove its max-lines-per-function disable
- align the chat lifecycle test mock with client-generated thread ids for failure and cancel flows

## Checks
- pnpm --filter @vm0/app lint
- cd turbo/apps/platform && pnpm exec vitest run src/views/zero-page/__tests__/chat-skeleton-switch.test.tsx src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
- cd turbo/apps/platform && pnpm exec vitest run src/views/zero-page/__tests__/talk-navigation.test.tsx src/views/zero-page/__tests__/chat-completion.test.tsx src/views/zero-page/__tests__/chat-failure-cancel.test.tsx
- pre-commit: prettier, knip