### PR TITLE
fix: remove chat switch cleanup regressions

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -75,22 +75,6 @@
   animation: zero-shimmer 3.5s linear infinite;
 }
 
-/* Inline streaming indicator: staggered dot-trail pulse wave */
-@keyframes zero-dot-trail {
-  0%,
-  100% {
-    opacity: 0.25;
-    transform: scale(0.75);
-  }
-  30% {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-.zero-dot-trail-item {
-  animation: zero-dot-trail 1.2s ease-in-out infinite;
-}
-
 /* Thinking indicator: 3-block loader */
 .zero-blocks {
   display: inline-grid;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -176,7 +176,7 @@ describe("sidebar new chat navigation", () => {
     // Wait for thread list to load
     const newChatButton = await waitFor(() => {
       expect(screen.getByText("Subagent thread")).toBeInTheDocument();
-      return screen.getByLabelText("New chat");
+      return screen.getByLabelText(/^New chat/);
     });
 
     click(newChatButton);
@@ -198,7 +198,7 @@ describe("sidebar new chat navigation", () => {
     // Wait for thread list to load — confirms currentChatAgentId$ has resolved
     const newChatButton = await waitFor(() => {
       expect(screen.getByText("Subagent thread")).toBeInTheDocument();
-      return screen.getByLabelText("New chat");
+      return screen.getByLabelText(/^New chat/);
     });
 
     click(newChatButton);
@@ -234,7 +234,7 @@ describe("sidebar new chat navigation", () => {
     // Wait for thread list to load
     const newChatButton = await waitFor(() => {
       expect(screen.getByText("Subagent thread")).toBeInTheDocument();
-      return screen.getByLabelText("New chat");
+      return screen.getByLabelText(/^New chat/);
     });
 
     click(newChatButton);
@@ -308,7 +308,7 @@ describe("sidebar new chat navigation", () => {
       expect(
         document.querySelector(`a[href="/chats/new-thread-id"]`),
       ).toBeInTheDocument();
-      return screen.getByLabelText("New chat");
+      return screen.getByLabelText(/^New chat/);
     });
 
     click(newChatButton);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-unify-chat-threads.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-unify-chat-threads.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Unified chat-threads sidebar behaviour (#10162).
+ * Agent-scoped chat-threads sidebar behaviour after unified-list removal.
  */
 
 import { describe, expect, it } from "vitest";
@@ -154,16 +154,16 @@ describe("sidebar chat threads (#10162)", () => {
     ).toBeFalsy();
   });
 
-  it("renders the unified title 'Chats'", async () => {
+  it("renders the agent-scoped title 'Chats with Zero'", async () => {
     const observed: ListQuery[] = [];
     mockThreads(observed);
     detachedSetupPage({ context, path: "/" });
 
     await waitFor(() => {
-      expect(within(getSidebar()).getByText("Chats")).toBeInTheDocument();
+      expect(
+        within(getSidebar()).getByText("Chats with Zero"),
+      ).toBeInTheDocument();
     });
-    expect(
-      within(getSidebar()).queryByText(/^Chats with /),
-    ).not.toBeInTheDocument();
+    expect(within(getSidebar()).queryByText(/^Chats$/)).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
@@ -1,9 +1,8 @@
 /**
  * Tests for zero-chat-list-page.tsx
  *
- * Tests the chat list page with unified labels (after graduate unified chat
- * labels as permanent default, removing per-agent avatar display from header
- * and thread items).
+ * Tests the chat list page with agent-scoped labels (matching the sidebar
+ * after unified-list removal).
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -62,23 +61,25 @@ function setupPage() {
 }
 
 describe("zero chat list page - header and title", () => {
-  it("should render the page with unified 'Chats' title (CHAT-LIST-001)", async () => {
+  it("should render the page with agent-scoped 'Chats with Zero' title (CHAT-LIST-001)", async () => {
     mockChatThreads(createMockThreads());
     setupPage();
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: "Chats" }),
+        screen.getByRole("heading", { name: "Chats with Zero" }),
       ).toBeInTheDocument();
     });
   });
 
-  it("should show unified 'Search chats' placeholder (CHAT-LIST-002)", async () => {
+  it("should show agent-scoped 'Search chat with Zero' placeholder (CHAT-LIST-002)", async () => {
     mockChatThreads(createMockThreads());
     setupPage();
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText("Search chats")).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("Search chat with Zero"),
+      ).toBeInTheDocument();
     });
   });
 
@@ -191,7 +192,7 @@ describe("zero chat list page - search", () => {
       expect(screen.getAllByText("First chat thread")[0]).toBeInTheDocument();
     });
 
-    const searchInput = screen.getByPlaceholderText("Search chats");
+    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
     await userEvent.type(searchInput, "First");
 
     await waitFor(() => {
@@ -212,7 +213,7 @@ describe("zero chat list page - search", () => {
       expect(screen.getAllByText("First chat thread")[0]).toBeInTheDocument();
     });
 
-    const searchInput = screen.getByPlaceholderText("Search chats");
+    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
     await userEvent.type(searchInput, "nonexistent");
 
     await waitFor(() => {
@@ -230,7 +231,7 @@ describe("zero chat list page - search", () => {
       expect(screen.getAllByText("First chat thread")[0]).toBeInTheDocument();
     });
 
-    const searchInput = screen.getByPlaceholderText("Search chats");
+    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
     await userEvent.type(searchInput, "First");
 
     await waitFor(() => {
@@ -255,7 +256,7 @@ describe("zero chat list page - search", () => {
       expect(screen.getAllByText("First chat thread")[0]).toBeInTheDocument();
     });
 
-    const searchInput = screen.getByPlaceholderText("Search chats");
+    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
     await userEvent.type(searchInput, "first");
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
@@ -184,7 +184,7 @@ describe("zero sidebar - search results filter (SIDEBAR-D-003)", () => {
 
     const searchChatsBtn1 = screen.getByLabelText("Search chats");
     click(searchChatsBtn1);
-    const searchInput = screen.getByPlaceholderText("Search chats");
+    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
     await user.type(searchInput, "deploy");
 
     expect(
@@ -227,7 +227,7 @@ describe("zero sidebar - search term displays in input (SIDEBAR-D-004)", () => {
 
     const searchChatsBtn2 = screen.getByLabelText("Search chats");
     click(searchChatsBtn2);
-    const searchInput = screen.getByPlaceholderText("Search chats");
+    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
     await user.type(searchInput, "deploy");
 
     expect(searchInput).toHaveValue("deploy");
@@ -388,7 +388,7 @@ describe("zero sidebar - new chat button enabled/disabled state (SIDEBAR-D-010)"
     });
 
     await waitFor(() => {
-      const newChatButton = screen.getByLabelText("New chat");
+      const newChatButton = screen.getByLabelText("New chat with Zero");
       expect(newChatButton).not.toBeDisabled();
     });
   });
@@ -414,16 +414,16 @@ describe("zero sidebar - new chat button enabled/disabled state (SIDEBAR-D-010)"
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("New chat")).toBeDefined();
+      expect(screen.getByLabelText("New chat with Zero")).toBeDefined();
     });
 
     // Trigger new chat creation
-    const newChatBtn = screen.getByLabelText("New chat");
+    const newChatBtn = screen.getByLabelText("New chat with Zero");
     click(newChatBtn);
 
     // Button should become disabled while POST is in flight
     await waitFor(() => {
-      expect(screen.getByLabelText("New chat")).toBeDisabled();
+      expect(screen.getByLabelText("New chat with Zero")).toBeDisabled();
     });
 
     deferred.resolve();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -228,7 +228,7 @@ describe("zero sidebar - search input accepts text (SIDEBAR-D-015)", () => {
     const searchChatsBtn1 = screen.getByLabelText("Search chats");
     click(searchChatsBtn1);
 
-    const searchInput = screen.getByPlaceholderText("Search chats");
+    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
     await user.type(searchInput, "hello");
 
     expect(searchInput).toHaveValue("hello");
@@ -257,7 +257,7 @@ describe("zero sidebar - clear search button resets search (SIDEBAR-D-016)", () 
     const searchChatsBtn2 = screen.getByLabelText("Search chats");
     click(searchChatsBtn2);
 
-    const searchInput = screen.getByPlaceholderText("Search chats");
+    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
     await user.type(searchInput, "First");
 
     expect(screen.queryByText("Second chat")).not.toBeInTheDocument();
@@ -312,7 +312,7 @@ describe("zero sidebar - new chat button creates session (SIDEBAR-D-017)", () =>
       expect(
         screen.getByText("Start a conversation and it'll show up here"),
       ).toBeInTheDocument();
-      return screen.getByLabelText("New chat");
+      return screen.getByLabelText("New chat with Zero");
     });
 
     click(newChatButton);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx
@@ -119,7 +119,7 @@ beforeEach(() => {
 });
 
 describe("zero sidebar - chat session list collapses and expands (SIDEBAR-D-011)", () => {
-  it("toggles chat thread list visibility when Chats header is clicked", async () => {
+  it("toggles chat thread list visibility when Chats with Zero header is clicked", async () => {
     mockBaseAPIs({
       threads: [
         makeThread("thread-1", "Deploy to prod", "2026-03-10T00:00:00Z"),
@@ -135,8 +135,8 @@ describe("zero sidebar - chat session list collapses and expands (SIDEBAR-D-011)
       expect(screen.getByText("Deploy to prod")).toBeInTheDocument();
     });
 
-    // Collapse: click the "Chats" header span
-    const chatsHeader = screen.getByText("Chats");
+    // Collapse: click the "Chats with Zero" header span
+    const chatsHeader = screen.getByText("Chats with Zero");
     click(chatsHeader);
 
     // Thread list should be hidden

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -164,7 +164,7 @@ describe("zero sidebar", () => {
     click(searchButton);
 
     // Type search query
-    const searchInput = screen.getByPlaceholderText("Search chats");
+    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
     await fill(searchInput, "First");
 
     // Only matching thread should be visible
@@ -189,7 +189,7 @@ describe("zero sidebar", () => {
     click(searchButton);
 
     // Type search query that filters out one thread
-    const searchInput = screen.getByPlaceholderText("Search chats");
+    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
     await fill(searchInput, "First");
 
     expect(screen.queryByText("Second chat")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -665,45 +665,6 @@ function ThinkingIndicator({ thread }: { thread: ChatThreadSignals }) {
   );
 }
 
-// Absolutely positioned so it contributes zero layout — the surrounding
-// message bubble's height is unchanged whether the cursor is shown or not.
-function InlineStreamingCursor({
-  thread,
-  groupBeginMessageId,
-}: {
-  thread: ChatThreadSignals;
-  groupBeginMessageId: string;
-}) {
-  const allFinished = useLastResolved(thread.allFinished$) ?? false;
-  const groups = useLastResolved(thread.groupedChatMessages$) ?? [];
-  const lastGroup = groups[groups.length - 1];
-  const isLastAssistantGroup =
-    !!lastGroup &&
-    lastGroup.role === "assistant" &&
-    lastGroup.beginMessageId === groupBeginMessageId;
-
-  if (allFinished || !isLastAssistantGroup) {
-    return null;
-  }
-
-  return (
-    <span
-      aria-hidden
-      className="pointer-events-none absolute -bottom-2 left-0 flex gap-1.5 animate-in fade-in duration-200"
-    >
-      {[0, 120, 240, 360, 480, 600, 720, 840].map((delay) => {
-        return (
-          <span
-            key={delay}
-            className="zero-dot-trail-item inline-block size-1 rounded-full bg-foreground/50"
-            style={{ animationDelay: `${delay}ms` }}
-          />
-        );
-      })}
-    </span>
-  );
-}
-
 /**
  * Parse inline attachment lines from message content.
  * Matches `[Attached file: name](url)` optionally followed by a curl line.
@@ -1331,10 +1292,6 @@ function PagedAssistantGroup({
           {group.messages.map((msg) => {
             return <PagedAssistantMessageItem key={msg.id} message={msg} />;
           })}
-          <InlineStreamingCursor
-            thread={thread}
-            groupBeginMessageId={group.beginMessageId}
-          />
         </div>
       </div>
       <PagedGroupActions group={group} content={fullContent} thread={thread} />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-shared.tsx
@@ -1,18 +1,21 @@
 import { useLastResolved } from "ccstate-react";
 import { agents$ } from "../../signals/agent.ts";
+import { currentChatAgentDisplayName$ } from "../../signals/agent-chat.ts";
 import { resolveAvatarUrl, resolveAvatarSvgConfig } from "./avatar-utils.ts";
 import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
 
 /**
- * Returns unified label/placeholder strings for the chat thread list.
- * Used by both the sidebar thread list and the full chat-list page so the
- * two surfaces stay in sync without duplicating the logic.
+ * Returns labels for the current agent-scoped chat thread list.
+ * Used by both the sidebar thread list and the full chat-list page so the two
+ * surfaces stay in sync without duplicating the logic.
  */
 export function useChatThreadsTitleLabels() {
+  const agentDisplayName = useLastResolved(currentChatAgentDisplayName$);
+  const agentName = agentDisplayName ?? "Zero";
   return {
-    titleLabel: "Chats",
-    searchPlaceholder: "Search chats",
-    newChatAriaLabel: "New chat",
+    titleLabel: `Chats with ${agentName}`,
+    searchPlaceholder: `Search chat with ${agentName}`,
+    newChatAriaLabel: `New chat with ${agentName}`,
   };
 }
 


### PR DESCRIPTION
## Summary
- remove the accidentally rolled-out inline thinking dot trail rendering and its CSS
- restore agent-scoped chat list labels such as `Chats with Zero`
- update sidebar tests for the retained per-agent chat wording

## Verification
- `pnpm exec vitest run src/views/zero-page/__tests__/sidebar-unify-chat-threads.test.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx src/views/zero-page/__tests__/zero-sidebar-display.test.tsx src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx src/views/zero-page/__tests__/sidebar-navigation.test.tsx src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx`
- `pnpm exec oxlint src/views/zero-page/zero-sidebar-shared.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/sidebar-unify-chat-threads.test.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx src/views/zero-page/__tests__/zero-sidebar-display.test.tsx src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx src/views/zero-page/__tests__/sidebar-navigation.test.tsx src/views/zero-page/__tests__/zero-sidebar-navigation-state.test.tsx`
- `pnpm exec tsc --noEmit`
- pre-commit: prettier, knip, commitlint
