### PR TITLE
fix: restrict pwa install banner to ios/ipados safari only

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/pwa-install.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/pwa-install.test.ts
@@ -3,7 +3,6 @@ import { testContext } from "./test-helpers.ts";
 import {
   installBannerVisible$,
   iosInstallModalOpen$,
-  setupInstallPrompt$,
   triggerInstall$,
   closeIosInstallModal$,
   dismissInstallBanner$,
@@ -14,28 +13,6 @@ const context = testContext();
 afterEach(() => {
   vi.restoreAllMocks();
 });
-
-class BeforeInstallPromptEvent extends Event {
-  readonly platforms: readonly string[] = [];
-  readonly userChoice: Promise<{
-    outcome: "accepted" | "dismissed";
-    platform: string;
-  }>;
-  readonly prompt: () => Promise<void>;
-
-  constructor(
-    promptFn: () => Promise<void> = vi
-      .fn<() => Promise<void>>()
-      .mockResolvedValue(undefined),
-  ) {
-    super("beforeinstallprompt", { cancelable: true, bubbles: false });
-    this.userChoice = Promise.resolve({
-      outcome: "accepted" as const,
-      platform: "",
-    });
-    this.prompt = promptFn;
-  }
-}
 
 function mockMatchMedia(standalone: boolean) {
   vi.spyOn(window, "matchMedia").mockReturnValue({
@@ -58,7 +35,7 @@ function mockIOSSafari(isIOS: boolean) {
 }
 
 describe("installBannerVisible$", () => {
-  it("is false by default (no deferred prompt, not iOS Safari)", () => {
+  it("is false by default (not iOS Safari)", () => {
     mockMatchMedia(false);
     mockIOSSafari(false);
     expect(context.store.get(installBannerVisible$)).toBeFalsy();
@@ -70,7 +47,7 @@ describe("installBannerVisible$", () => {
     expect(context.store.get(installBannerVisible$)).toBeFalsy();
   });
 
-  it("is true when on iOS Safari (no deferred prompt)", () => {
+  it("is true when on iOS Safari", () => {
     mockMatchMedia(false);
     mockIOSSafari(true);
     expect(context.store.get(installBannerVisible$)).toBeTruthy();
@@ -84,16 +61,6 @@ describe("installBannerVisible$", () => {
     context.store.set(dismissInstallBanner$);
     expect(context.store.get(installBannerVisible$)).toBeFalsy();
   });
-
-  it("is true when a deferred install prompt is captured via setupInstallPrompt$", () => {
-    mockMatchMedia(false);
-    mockIOSSafari(false);
-
-    context.store.set(setupInstallPrompt$, context.signal);
-    window.dispatchEvent(new BeforeInstallPromptEvent());
-
-    expect(context.store.get(installBannerVisible$)).toBeTruthy();
-  });
 });
 
 describe("iosInstallModalOpen$", () => {
@@ -101,62 +68,27 @@ describe("iosInstallModalOpen$", () => {
     expect(context.store.get(iosInstallModalOpen$)).toBeFalsy();
   });
 
-  it("opens when triggerInstall$ is called on iOS Safari with no deferred prompt", async () => {
+  it("opens when triggerInstall$ is called on iOS Safari", () => {
     mockMatchMedia(false);
     mockIOSSafari(true);
-    await context.store.set(triggerInstall$, context.signal);
+    context.store.set(triggerInstall$);
     expect(context.store.get(iosInstallModalOpen$)).toBeTruthy();
   });
 
-  it("closes via closeIosInstallModal$", async () => {
+  it("closes via closeIosInstallModal$", () => {
     mockMatchMedia(false);
     mockIOSSafari(true);
-    await context.store.set(triggerInstall$, context.signal);
+    context.store.set(triggerInstall$);
     expect(context.store.get(iosInstallModalOpen$)).toBeTruthy();
 
     context.store.set(closeIosInstallModal$);
     expect(context.store.get(iosInstallModalOpen$)).toBeFalsy();
   });
 
-  it("does not open when not iOS Safari and no deferred prompt", async () => {
+  it("does not open when not iOS Safari", () => {
     mockMatchMedia(false);
     mockIOSSafari(false);
-    await context.store.set(triggerInstall$, context.signal);
+    context.store.set(triggerInstall$);
     expect(context.store.get(iosInstallModalOpen$)).toBeFalsy();
-  });
-});
-
-describe("triggerInstall$ with deferred prompt", () => {
-  it("calls prompt() and clears banner after install", async () => {
-    mockMatchMedia(false);
-    mockIOSSafari(false);
-
-    const mockPromptFn = vi
-      .fn<() => Promise<void>>()
-      .mockResolvedValue(undefined);
-
-    context.store.set(setupInstallPrompt$, context.signal);
-    window.dispatchEvent(new BeforeInstallPromptEvent(mockPromptFn));
-
-    expect(context.store.get(installBannerVisible$)).toBeTruthy();
-
-    await context.store.set(triggerInstall$, context.signal);
-
-    expect(mockPromptFn).toHaveBeenCalledOnce();
-    expect(context.store.get(installBannerVisible$)).toBeFalsy();
-  });
-});
-
-describe("setupInstallPrompt$", () => {
-  it("clears deferred prompt on appinstalled event", () => {
-    mockMatchMedia(false);
-    mockIOSSafari(false);
-
-    context.store.set(setupInstallPrompt$, context.signal);
-    window.dispatchEvent(new BeforeInstallPromptEvent());
-    expect(context.store.get(installBannerVisible$)).toBeTruthy();
-
-    window.dispatchEvent(new Event("appinstalled"));
-    expect(context.store.get(installBannerVisible$)).toBeFalsy();
   });
 });

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -10,7 +10,7 @@ import {
   pathParams$,
 } from "./route.ts";
 import { registerServiceWorker$ } from "../lib/push-notifications.ts";
-import { setupInstallPrompt$ } from "./pwa-install.ts";
+import "./pwa-install.ts";
 import { ROUTES, type RoutePath } from "./route-paths.ts";
 
 import { setupGlobalMethod$ } from "./bootstrap/global-method.ts";
@@ -320,7 +320,6 @@ export const bootstrap$ = command(
       set(setupGlobalMethod$, signal),
       set(registerServiceWorker$, signal),
       set(setupNotificationListener$, signal),
-      set(setupInstallPrompt$, signal),
       set(setupPwaEdgeSwipe$, signal),
       set(setupSidebarShortcut$, signal),
       (async () => {

--- a/turbo/apps/platform/src/signals/pwa-install.ts
+++ b/turbo/apps/platform/src/signals/pwa-install.ts
@@ -2,27 +2,28 @@ import { command, computed, state } from "ccstate";
 import { localStorageSignals } from "./external/local-storage.ts";
 import { isStandaloneMode } from "./zero-page/settings/connectors.ts";
 
-interface BeforeInstallPromptEvent extends Event {
-  readonly platforms: readonly string[];
-  readonly userChoice: Promise<{
-    outcome: "accepted" | "dismissed";
-    platform: string;
-  }>;
-  prompt(): Promise<void>;
-}
-
+/**
+ * Detect Safari on iPhone or iPad.
+ *
+ * iPhone/iPod: UA contains "iPhone" or "iPod" and "Safari" (not CriOS etc.).
+ * iPad (pre-13): UA contains "iPad".
+ * iPadOS 13+: reports as desktop Macintosh UA, but iPad has multi-touch
+ * (>1 maxTouchPoints) whereas macOS trackpads report 0-1.
+ */
 function detectIOSSafari(): boolean {
   const ua = navigator.userAgent;
-  const iosDevice =
-    /iPad|iPhone|iPod/.test(ua) ||
-    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
-  if (!iosDevice) {
+  if (!/Safari/.test(ua) || /CriOS|FxiOS|OPiOS|EdgiOS/.test(ua)) {
     return false;
   }
-  return /Safari/.test(ua) && !/CriOS|FxiOS|OPiOS|EdgiOS/.test(ua);
+  if (/iPhone|iPod/.test(ua)) {
+    return true;
+  }
+  if (/iPad/.test(ua)) {
+    return true;
+  }
+  return /Macintosh/.test(ua) && navigator.maxTouchPoints > 1;
 }
 
-const deferredPrompt$ = state<BeforeInstallPromptEvent | null>(null);
 const iosModalOpen$ = state(false);
 
 const { get$: dismissedRaw$, set$: setDismissed$ } = localStorageSignals(
@@ -36,9 +37,6 @@ export const installBannerVisible$ = computed((get) => {
   if (get(dismissedRaw$) !== null) {
     return false;
   }
-  if (get(deferredPrompt$)) {
-    return true;
-  }
   return detectIOSSafari();
 });
 
@@ -46,38 +44,11 @@ export const iosInstallModalOpen$ = computed((get) => {
   return get(iosModalOpen$);
 });
 
-export const setupInstallPrompt$ = command(({ set }, signal: AbortSignal) => {
-  const onPrompt = (e: Event) => {
-    e.preventDefault();
-    set(deferredPrompt$, e as BeforeInstallPromptEvent);
-  };
-  const onInstalled = () => {
-    set(deferredPrompt$, null);
-  };
-  window.addEventListener("beforeinstallprompt", onPrompt);
-  window.addEventListener("appinstalled", onInstalled);
-  signal.addEventListener("abort", () => {
-    window.removeEventListener("beforeinstallprompt", onPrompt);
-    window.removeEventListener("appinstalled", onInstalled);
-  });
+export const triggerInstall$ = command(({ set }, _signal?: AbortSignal) => {
+  if (detectIOSSafari()) {
+    set(iosModalOpen$, true);
+  }
 });
-
-export const triggerInstall$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const prompt = get(deferredPrompt$);
-    if (prompt) {
-      await prompt.prompt();
-      signal.throwIfAborted();
-      await prompt.userChoice;
-      signal.throwIfAborted();
-      set(deferredPrompt$, null);
-      return;
-    }
-    if (detectIOSSafari()) {
-      set(iosModalOpen$, true);
-    }
-  },
-);
 
 export const closeIosInstallModal$ = command(({ set }) => {
   set(iosModalOpen$, false);


### PR DESCRIPTION
## Summary
- Fix `detectIOSSafari()` to reliably detect iPhone/iPad Safari using layered checks — removes the `MacIntel + maxTouchPoints` false-positive that matched macOS Safari with trackpads
- Remove the `beforeinstallprompt` / `deferredPrompt$` path from `installBannerVisible$` — the install banner now only shows on iOS Safari, not on desktop Chrome or Android Chrome
- Clean up dead code: `BeforeInstallPromptEvent` interface, `deferredPrompt$` state, `setupInstallPrompt$` command, and their test coverage

## Test plan
- [ ] iOS Safari (iPhone/iPad): install banner shows
- [ ] Desktop Chrome: install banner does NOT show
- [ ] Android Chrome: install banner does NOT show
- [ ] macOS Safari: install banner does NOT show
- [ ] Standalone PWA mode: install banner does NOT show

🤖 Generated with [Claude Code](https://claude.com/claude-code)