### PR TITLE
chore: add check-types to lefthook pre-commit turbo group

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,6 +24,12 @@ pre-commit:
               - rebase
             fail_text: "Knip found unused code. Run 'cd turbo && pnpm knip' to see details."
             timeout: 60
+          - name: check-types
+            run: pnpm check-types
+            root: turbo/
+            glob: "turbo/**/*.{ts,tsx}"
+            fail_text: "TypeScript errors found. Run 'cd turbo && pnpm check-types' to see details."
+            timeout: 120
     - name: crates
       group:
         parallel: true


### PR DESCRIPTION
## Summary

Adds a `check-types` job to the Lefthook pre-commit turbo group, so that `tsc --noEmit` runs automatically on commit when TypeScript files change. Catches TS errors locally before they hit CI.

- Placed after prettier and knip in the piped turbo group (sequential execution)
- Glob-filtered to `turbo/**/*.{ts,tsx}` so it only runs when TS files are staged
- 120s timeout to accommodate full monorepo type check

## Test plan

- [x] Commit with TS error → hook blocks commit with error message
- [x] Commit with non-TS files → hook skipped (glob filter)
- [x] Clean commit with valid TS → hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)