### PR TITLE
chore(rust): update dependencies (2026-04-25)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
@@ -941,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "debugid"
@@ -1533,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -2611,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",


### PR DESCRIPTION
## Summary

Weekly Rust dependency refresh via `cargo update --verbose` on the `crates/` workspace. Only `Cargo.lock` changed — no `Cargo.toml` edits were required this week.

## Updated dependencies

| Crate | From | To |
| --- | --- | --- |
| cc | 1.2.60 | 1.2.61 |
| crc-catalog | 2.4.0 | 2.5.0 |
| data-encoding | 2.10.0 | 2.11.0 |
| hybrid-array | 0.4.10 | 0.4.11 |
| rustls-pki-types | 1.14.0 | 1.14.1 |

5 transitive dependencies bumped (patch/minor only).

## Dependencies that could NOT be updated

`cargo update --verbose` reported these as `Unchanged ... (available: ...)` — newer majors exist but are blocked by upstream version constraints, not by our `Cargo.toml`:

| Crate | Pinned to | Available | Blocking constraint |
| --- | --- | --- | --- |
| `crc` | 3.3.0 | 3.4.0 | Pinned by `crc-fast 1.9.0` (transitive via `aws-smithy-checksums`) |
| `crc-fast` | 1.9.0 | 1.10.0 | Pinned by `aws-smithy-checksums 0.64.7` (transitive via `aws-sdk-s3`) |
| `generic-array` | 0.14.7 | 0.14.9 | Pinned by `digest 0.10.7` and `block-buffer 0.10.4` |

These will pick up automatically when `aws-sdk-s3` / `aws-smithy-checksums` / RustCrypto release new versions that loosen the constraint. No action needed on our side.

## Manual `Cargo.toml` version bumps

None this cycle. A few sub-1.0 workspace deps have newer minors available (`nix 0.31`, `tokio-tungstenite 0.29`, `sentry 0.47`, etc.), but per Rust semver convention sub-1.0 minor bumps are breaking and were skipped to keep this PR low-risk. Those should be reviewed individually in a follow-up.

## Test status

`cargo build --workspace` → ok
`cargo test --workspace --no-fail-fast` → all suites green, 0 failures across unit + integration + doc tests.