### PR TITLE
perf(storages): commit dedup head during prepare

### DIFF
--- a/crates/guest-agent/src/artifact.rs
+++ b/crates/guest-agent/src/artifact.rs
@@ -3,11 +3,13 @@
 //! Flow (caller first walks the mount via [`walk_files`], then invokes
 //! [`create_snapshot`] with the pre-walked file list):
 //! 1. POST `/storages/prepare` with file list → get presigned URLs
-//! 2. If deduplicated, POST `/storages/commit` to update HEAD
-//! 3. Create tar.gz archive
-//! 4. Create manifest.json
-//! 5. PUT archive + manifest to S3
-//! 6. POST `/storages/commit`
+//! 2. If deduplicated and HEAD was committed by prepare, return
+//! 3. If deduplicated without that compatibility signal, POST `/storages/commit`
+//!    to update HEAD
+//! 4. Create tar.gz archive
+//! 5. Create manifest.json
+//! 6. PUT archive + manifest to S3
+//! 7. POST `/storages/commit`
 
 use crate::constants;
 use crate::error::AgentError;
@@ -35,6 +37,8 @@ struct PrepareResponse {
     #[serde(rename = "versionId")]
     version_id: Option<String>,
     existing: Option<bool>,
+    #[serde(rename = "headCommitted")]
+    head_committed: Option<bool>,
     uploads: Option<Uploads>,
 }
 
@@ -140,9 +144,17 @@ pub(crate) async fn create_snapshot(
 
     // Step 2: Deduplication check
     if prep.existing.unwrap_or(false) {
+        if prep.head_committed.unwrap_or(false) {
+            log_info!(
+                LOG_TAG,
+                "Version already exists (deduplicated), HEAD committed by prepare"
+            );
+            return Ok(SnapshotResult { version_id });
+        }
+
         log_info!(
             LOG_TAG,
-            "Version already exists (deduplicated), updating HEAD"
+            "Version already exists (deduplicated), updating HEAD via commit fallback"
         );
         let mut commit_payload = json!({
             "storageName": storage_name,
@@ -427,7 +439,103 @@ fn create_archive(dir_path: &str, tar_path: &Path, file_paths: &[String]) -> boo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use httpmock::prelude::*;
+    use serde_json::json;
     use std::os::unix::fs as unix_fs;
+    use std::sync::LazyLock;
+
+    static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("VM0_API_URL", server.base_url());
+            std::env::set_var("VM0_API_TOKEN", "test-token-abc123");
+        }
+        server
+    });
+
+    #[tokio::test]
+    async fn create_snapshot_skips_dedup_commit_only_when_prepare_committed_head() {
+        let server = &*MOCK_SERVER;
+        let version_id = "a".repeat(64);
+        let files = vec![FileEntry {
+            path: "test.txt".to_string(),
+            hash: "b".repeat(64),
+            size: 100,
+        }];
+
+        let prepare_committed = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(json!({
+                    "versionId": version_id,
+                    "existing": true,
+                    "headCommitted": true
+                }));
+        });
+        let skipped_commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(json!({ "success": true }));
+        });
+
+        let result = create_snapshot(
+            "/unused",
+            files.clone(),
+            "artifact-name",
+            "artifact",
+            "run-1",
+            "message",
+            "parent-version",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.version_id, version_id);
+        prepare_committed.assert_calls_async(1).await;
+        skipped_commit.assert_calls_async(0).await;
+        prepare_committed.delete_async().await;
+        skipped_commit.delete_async().await;
+
+        let prepare_without_signal = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(json!({
+                    "versionId": version_id,
+                    "existing": true
+                }));
+        });
+        let fallback_commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(json!({ "success": true }));
+        });
+
+        let result = create_snapshot(
+            "/unused",
+            files,
+            "artifact-name",
+            "artifact",
+            "run-1",
+            "message",
+            "parent-version",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.version_id, version_id);
+        prepare_without_signal.assert_calls_async(1).await;
+        fallback_commit.assert_calls_async(1).await;
+        prepare_without_signal.delete_async().await;
+        fallback_commit.delete_async().await;
+    }
 
     #[test]
     fn walk_dir_skips_symlinks() {

--- a/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
@@ -3,8 +3,12 @@ import { POST } from "../route";
 import {
   createTestRequest,
   createTestArtifact,
+  findTestStorage,
 } from "../../../../../src/__tests__/api-test-helpers";
-import { testContext } from "../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 
 vi.hoisted(() => {
@@ -14,9 +18,11 @@ vi.hoisted(() => {
 const context = testContext();
 
 describe("POST /api/storages/prepare", () => {
+  let user: UserContext;
+
   beforeEach(async () => {
     context.setupMocks();
-    await context.setupUser();
+    user = await context.setupUser();
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -127,7 +133,48 @@ describe("POST /api/storages/prepare", () => {
 
     const json = await response.json();
     expect(json.existing).toBe(true);
+    expect(json.headCommitted).toBe(true);
     expect(json.uploads).toBeUndefined();
+  });
+
+  it("should update HEAD during prepare when deduplicating an existing version", async () => {
+    const storageName = `dedup-head-${Date.now()}`;
+    const filesA = [{ path: "a.txt", hash: "a".repeat(64), size: 100 }];
+    const filesB = [{ path: "b.txt", hash: "b".repeat(64), size: 200 }];
+
+    const { versionId: versionA } = await createTestArtifact(storageName, {
+      files: filesA,
+    });
+    const { versionId: versionB } = await createTestArtifact(storageName, {
+      files: filesB,
+    });
+
+    const before = await findTestStorage(user.orgId, storageName, "artifact");
+    expect(before?.headVersionId).toBe(versionB);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName,
+          storageType: "artifact",
+          files: filesA,
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const json = await response.json();
+    expect(json.versionId).toBe(versionA);
+    expect(json.existing).toBe(true);
+    expect(json.headCommitted).toBe(true);
+
+    const after = await findTestStorage(user.orgId, storageName, "artifact");
+    expect(after?.headVersionId).toBe(versionA);
   });
 
   it("should compute deterministic version ID from files", async () => {
@@ -194,6 +241,7 @@ describe("POST /api/storages/prepare", () => {
     expect(json.versionId).toBe(versionId);
     // Should NOT return existing: true since S3 files are missing
     expect(json.existing).toBe(false);
+    expect(json.headCommitted).toBeUndefined();
     // Should return upload URLs for re-upload
     expect(json.uploads).toBeDefined();
     expect(json.uploads.archive.key).toBeDefined();
@@ -204,6 +252,42 @@ describe("POST /api/storages/prepare", () => {
     expect(json.uploads.manifest.presignedUrl).toBe(
       "https://mock-presigned-put-url",
     );
+  });
+
+  it("should not update HEAD when deduplicated version is missing S3 files", async () => {
+    const storageName = `s3missing-head-${Date.now()}`;
+    const filesA = [{ path: "a.txt", hash: "a".repeat(64), size: 100 }];
+    const filesB = [{ path: "b.txt", hash: "b".repeat(64), size: 200 }];
+
+    const { versionId: versionA } = await createTestArtifact(storageName, {
+      files: filesA,
+    });
+    const { versionId: versionB } = await createTestArtifact(storageName, {
+      files: filesB,
+    });
+
+    context.mocks.s3.verifyS3FilesExist.mockResolvedValueOnce(false);
+
+    const response = await POST(
+      createTestRequest("http://localhost:3000/api/storages/prepare", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName,
+          storageType: "artifact",
+          files: filesA,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.versionId).toBe(versionA);
+    expect(json.existing).toBe(false);
+    expect(json.headCommitted).toBeUndefined();
+
+    const storage = await findTestStorage(user.orgId, storageName, "artifact");
+    expect(storage?.headVersionId).toBe(versionB);
   });
 
   it("should use orgId (not slug) in upload keys for new storage", async () => {

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -270,14 +270,25 @@ const router = tsr.router(storagesPrepareContract, {
         );
 
         if (s3Exists) {
+          if (storage.headVersionId !== versionId) {
+            await globalThis.services.db
+              .update(storages)
+              .set({
+                headVersionId: versionId,
+                updatedAt: new Date(),
+              })
+              .where(eq(storages.id, storage.id));
+          }
+
           log.debug(
-            `Version ${versionId} exists with S3 files, returning existing`,
+            `Version ${versionId} exists with S3 files, HEAD committed`,
           );
           return {
             status: 200 as const,
             body: {
               versionId,
               existing: true,
+              headCommitted: true,
             },
           };
         }

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import {
   createTestCompose,
   createTestRun,
   createTestSandboxToken,
+  findTestStorage,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -39,6 +40,26 @@ function makePrepareRequest(
       headers,
       body: JSON.stringify({ runId, ...body }),
     },
+  );
+}
+
+async function commitStorage(
+  runId: string,
+  token: string,
+  body: Record<string, unknown>,
+) {
+  return commitPOST(
+    createTestRequest(
+      "http://localhost:3000/api/webhooks/agent/storages/commit",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ runId, ...body }),
+      },
+    ),
   );
 }
 
@@ -162,25 +183,12 @@ describe("POST /api/webhooks/agent/storages/prepare", () => {
     );
     const { versionId } = await prepareResponse.json();
 
-    // Commit → persist version in DB
-    const commitRequest = createTestRequest(
-      "http://localhost:3000/api/webhooks/agent/storages/commit",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${testToken}`,
-        },
-        body: JSON.stringify({
-          runId: testRunId,
-          storageName,
-          storageType: "volume",
-          versionId,
-          files,
-        }),
-      },
-    );
-    await commitPOST(commitRequest);
+    await commitStorage(testRunId, testToken, {
+      storageName,
+      storageType: "volume",
+      versionId,
+      files,
+    });
 
     // Prepare again with same files → should be deduplicated
     const response = await POST(
@@ -194,6 +202,118 @@ describe("POST /api/webhooks/agent/storages/prepare", () => {
     expect(response.status).toBe(200);
     const json = await response.json();
     expect(json.existing).toBe(true);
+    expect(json.headCommitted).toBe(true);
     expect(json).not.toHaveProperty("uploads");
+  });
+
+  it("should update HEAD during prepare when deduplicating an existing version", async () => {
+    const storageName = uniqueId("webhook-dedup-head");
+    const filesA = [{ path: "a.txt", hash: "a".repeat(64), size: 100 }];
+    const filesB = [{ path: "b.txt", hash: "b".repeat(64), size: 200 }];
+
+    const prepareA = await POST(
+      makePrepareRequest(testRunId, testToken, {
+        storageName,
+        storageType: "volume",
+        files: filesA,
+      }),
+    );
+    const { versionId: versionA } = await prepareA.json();
+    await commitStorage(testRunId, testToken, {
+      storageName,
+      storageType: "volume",
+      versionId: versionA,
+      files: filesA,
+    });
+
+    const prepareB = await POST(
+      makePrepareRequest(testRunId, testToken, {
+        storageName,
+        storageType: "volume",
+        files: filesB,
+      }),
+    );
+    const { versionId: versionB } = await prepareB.json();
+    await commitStorage(testRunId, testToken, {
+      storageName,
+      storageType: "volume",
+      versionId: versionB,
+      files: filesB,
+    });
+
+    const before = await findTestStorage(user.orgId, storageName, "volume");
+    expect(before?.headVersionId).toBe(versionB);
+
+    const response = await POST(
+      makePrepareRequest(testRunId, testToken, {
+        storageName,
+        storageType: "volume",
+        files: filesA,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.versionId).toBe(versionA);
+    expect(json.existing).toBe(true);
+    expect(json.headCommitted).toBe(true);
+
+    const after = await findTestStorage(user.orgId, storageName, "volume");
+    expect(after?.headVersionId).toBe(versionA);
+  });
+
+  it("should not update HEAD when deduplicated version is missing S3 files", async () => {
+    const storageName = uniqueId("webhook-s3missing-head");
+    const filesA = [{ path: "a.txt", hash: "a".repeat(64), size: 100 }];
+    const filesB = [{ path: "b.txt", hash: "b".repeat(64), size: 200 }];
+
+    const prepareA = await POST(
+      makePrepareRequest(testRunId, testToken, {
+        storageName,
+        storageType: "volume",
+        files: filesA,
+      }),
+    );
+    const { versionId: versionA } = await prepareA.json();
+    await commitStorage(testRunId, testToken, {
+      storageName,
+      storageType: "volume",
+      versionId: versionA,
+      files: filesA,
+    });
+
+    const prepareB = await POST(
+      makePrepareRequest(testRunId, testToken, {
+        storageName,
+        storageType: "volume",
+        files: filesB,
+      }),
+    );
+    const { versionId: versionB } = await prepareB.json();
+    await commitStorage(testRunId, testToken, {
+      storageName,
+      storageType: "volume",
+      versionId: versionB,
+      files: filesB,
+    });
+
+    context.mocks.s3.verifyS3FilesExist.mockResolvedValueOnce(false);
+
+    const response = await POST(
+      makePrepareRequest(testRunId, testToken, {
+        storageName,
+        storageType: "volume",
+        files: filesA,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.versionId).toBe(versionA);
+    expect(json.existing).toBe(false);
+    expect(json.headCommitted).toBeUndefined();
+
+    const storage = await findTestStorage(user.orgId, storageName, "volume");
+    expect(storage?.headVersionId).toBe(versionB);
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -229,14 +229,25 @@ const router = tsr.router(webhookStoragesPrepareContract, {
         );
 
         if (s3Exists) {
+          if (storage.headVersionId !== versionId) {
+            await globalThis.services.db
+              .update(storages)
+              .set({
+                headVersionId: versionId,
+                updatedAt: new Date(),
+              })
+              .where(eq(storages.id, storage.id));
+          }
+
           log.debug(
-            `Version ${versionId} exists with S3 files, returning existing`,
+            `Version ${versionId} exists with S3 files, HEAD committed`,
           );
           return {
             status: 200 as const,
             body: {
               versionId,
               existing: true,
+              headCommitted: true,
             },
           };
         }

--- a/turbo/apps/web/src/__tests__/db-test-assertions/storage.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/storage.ts
@@ -42,7 +42,14 @@ export async function findTestStorage(
   name: string,
   type: "volume" | "artifact",
 ): Promise<
-  { id: string; name: string; userId: string; s3Prefix: string } | undefined
+  | {
+      id: string;
+      name: string;
+      userId: string;
+      s3Prefix: string;
+      headVersionId: string | null;
+    }
+  | undefined
 > {
   initServices();
   const [result] = await globalThis.services.db
@@ -51,6 +58,7 @@ export async function findTestStorage(
       name: storages.name,
       userId: storages.userId,
       s3Prefix: storages.s3Prefix,
+      headVersionId: storages.headVersionId,
     })
     .from(storages)
     .where(

--- a/turbo/packages/core/src/contracts/storages.ts
+++ b/turbo/packages/core/src/contracts/storages.ts
@@ -172,6 +172,7 @@ export const storagesPrepareContract = c.router({
       200: z.object({
         versionId: z.string(),
         existing: z.boolean(),
+        headCommitted: z.boolean().optional(),
         uploads: z
           .object({
             archive: presignedUploadSchema,

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -413,6 +413,7 @@ export const webhookStoragesPrepareContract = c.router({
       200: z.object({
         versionId: z.string(),
         existing: z.boolean(),
+        headCommitted: z.boolean().optional(),
         uploads: z
           .object({
             archive: presignedUploadSchema,


### PR DESCRIPTION
## Summary

- update public and webhook storage prepare dedup paths to commit `storages.headVersionId` after existing-version S3 verification
- return optional `headCommitted` from prepare as a mixed-version compatibility signal
- make guest-agent skip storage commit only when `existing=true` and `headCommitted=true`, otherwise fall back to the old commit path
- add coverage for public prepare, webhook prepare, and guest-agent compatibility fallback

Closes #10966.

## Tests

- `pnpm --filter @vm0/core test`
- `pnpm --filter @vm0/ui test`
- `pnpm --filter @vm0/firewalls-generator exec vitest run`
- `pnpm --filter @vm0/cli test`
- `pnpm --filter web test`
- `pnpm --filter @vm0/app btest`
- `cargo test --workspace`
- pre-commit: prettier, cargo fmt, cargo clippy, knip, check-file-size

Known unrelated failures:

- `pnpm test` at `turbo/` exits before running test files because Vitest reports projects `@vm0/app` and `@vm0/cli` have different `maxWorkers` with the same `sequence.groupOrder`.
- `pnpm --filter @vm0/app test` has one existing platform test failure in `src/views/zero-page/__tests__/schedule-dialog.test.tsx`: the test assumes the default timezone starts at UTC, but this environment resolves to Korea Standard Time.
