### PR TITLE
docs(sandbox-fc): refresh reconcile comment after #10826 closed

### DIFF
--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1239,9 +1239,14 @@ pub async fn cleanup_namespaces_by_index(index: u32) {
 async fn reconcile_orphan_namespaces(locks: &LockPaths, own_index: u32, _own_lock: &Flock<File>) {
     // Own index: critical-path cleanup. Warm-up immediately afterwards
     // starts at ns_index 0 and will collide with any surviving orphan.
-    // `cleanup_namespaces_by_index` currently swallows failures — if it
-    // fails here, the caller will hit EEXIST during warm-up. Tracked in
-    // #10826 (return `Result` and fail-fast from `create()`).
+    // `cleanup_namespaces_by_index` swallows failures by design — its
+    // only fallible step (`ip netns list`) is near-infallible on a
+    // working runner, and the inner deletes go through
+    // `exec_ignore_errors` so a per-namespace `Result` would carry no
+    // signal. If reconcile silently fails here, the EEXIST that
+    // warm-up's `ip netns add` produces is the diagnostic — chronologically
+    // paired with the `error!` at the cleanup site. See #10826 for the
+    // full analysis (closed as won't-fix).
     cleanup_namespaces_by_index(own_index).await;
 
     // Other indexes: advisory cleanup for arbitrary prior runners. Failures


### PR DESCRIPTION
## Summary

- Update the reconcile comment at \`pool.rs:1242\` so it reflects the deliberate trade-off documented in #10826's close-comment analysis, instead of pointing at #10826 as if it were an open follow-up.

## Context

The previous wording read like a TODO:

> \`cleanup_namespaces_by_index\` currently swallows failures — if it fails here, the caller will hit EEXIST during warm-up. Tracked in #10826 (return \`Result\` and fail-fast from \`create()\`).

#10826 closed as won't-fix: \`ip netns list\` is near-infallible on a working runner, and the inner deletes intentionally route through \`exec_ignore_errors\`, so a propagated \`Result\` would carry no per-namespace signal. The new wording records that reasoning so future readers don't think there is open work here.

## Test plan

- [x] \`cargo clippy -p sandbox-fc --target aarch64-unknown-linux-musl --all-targets\` passes (comment-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)