### PR TITLE
fix(chat): avoid redundant thread read requests

### DIFF
--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -54,6 +54,7 @@ export interface ChatThread {
   agentId: string;
   title: string | null;
   latestSessionId: string | null;
+  lastReadMessageId: string | null;
   /**
    * Provider type of the latest run in this thread. Null when the thread has
    * no runs yet. The composer picker uses this to disable options whose base

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-page-setup.test.ts
@@ -1,17 +1,66 @@
 import { describe, expect, it } from "vitest";
 import { waitFor } from "@testing-library/react";
-import { chatThreadByIdContract, chatThreadMessagesContract } from "@vm0/core";
+import {
+  chatThreadByIdContract,
+  chatThreadMarkReadContract,
+  chatThreadMessagesContract,
+  type PagedChatMessage,
+} from "@vm0/core";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { mockApi } from "../../../mocks/msw-contract.ts";
 import { server } from "../../../mocks/server.ts";
+import { hasSubscription } from "../../../mocks/ably.ts";
 import { pathname, search } from "../../location.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 
 const context = testContext();
 const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const FIRST_MESSAGE_ID = "11111111-1111-4111-8111-111111111111";
+
+function mockThreadPage(
+  threadId: string,
+  messages: PagedChatMessage[],
+  lastReadMessageId: string | null,
+) {
+  let markReadCount = 0;
+
+  server.use(
+    mockApi(chatThreadByIdContract.get, ({ respond }) => {
+      return respond(200, {
+        id: threadId,
+        title: null,
+        agentId: DEFAULT_AGENT_ID,
+        chatMessages: [],
+        latestSessionId: null,
+        lastReadMessageId,
+        activeRunIds: [],
+        draftContent: null,
+        draftAttachments: null,
+        createdAt: "2026-04-25T00:00:00Z",
+        updatedAt: "2026-04-25T00:00:00Z",
+      });
+    }),
+    mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+      return respond(200, { messages, hasHistoryBefore: false });
+    }),
+    mockApi(chatThreadMarkReadContract.markRead, ({ respond }) => {
+      markReadCount++;
+      return respond(200, {
+        lastReadMessageId: messages.at(-1)?.id ?? null,
+        changed: markReadCount === 1,
+      });
+    }),
+  );
+
+  return {
+    get markReadCount() {
+      return markReadCount;
+    },
+  };
+}
 
 describe("chat page setup", () => {
-  it("redirects missing chat threads to the default agent chat", async () => {
+  it("redirects missing chat threads through the home route", async () => {
     server.use(
       mockApi(chatThreadByIdContract.get, ({ respond }) => {
         return respond(404, {
@@ -32,7 +81,79 @@ describe("chat page setup", () => {
 
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
-      expect(search()).toBe("?source=legacy");
+      expect(search()).toBe("");
+    });
+  });
+
+  it("does not mark empty chat threads as read", async () => {
+    const threadId = "empty-read-thread";
+    const tracker = mockThreadPage(threadId, [], null);
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        hasSubscription(`chatThreadMessageCreated:${threadId}`),
+      ).toBeTruthy();
+    });
+
+    expect(tracker.markReadCount).toBe(0);
+  });
+
+  it("skips mark-read when the latest loaded message is already read", async () => {
+    const threadId = "already-read-thread";
+    const tracker = mockThreadPage(
+      threadId,
+      [
+        {
+          id: FIRST_MESSAGE_ID,
+          role: "user",
+          content: "Already read",
+          createdAt: "2026-04-25T00:00:00Z",
+        },
+      ],
+      FIRST_MESSAGE_ID,
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        hasSubscription(`chatThreadMessageCreated:${threadId}`),
+      ).toBeTruthy();
+    });
+
+    expect(tracker.markReadCount).toBe(0);
+  });
+
+  it("marks a thread as read when the latest loaded message changes", async () => {
+    const threadId = "changed-read-thread";
+    const tracker = mockThreadPage(
+      threadId,
+      [
+        {
+          id: FIRST_MESSAGE_ID,
+          role: "user",
+          content: "Unread",
+          createdAt: "2026-04-25T00:00:00Z",
+        },
+      ],
+      null,
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+    });
+
+    await waitFor(() => {
+      expect(tracker.markReadCount).toBe(1);
     });
   });
 });

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -4,8 +4,11 @@ import { animationFrame } from "signal-timers";
 import { ZeroChatThreadPage } from "../../views/zero-page/zero-chat-thread-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { defaultAgentId$ } from "../agent.ts";
-import { setChatAgentId$, currentChatThreadId$ } from "../agent-chat.ts";
+import {
+  currentChatAgentId$,
+  setChatAgentId$,
+  currentChatThreadId$,
+} from "../agent-chat.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
@@ -62,24 +65,20 @@ export const setupChatPage$ = command(
       if (matchingOptimisticThread) {
         set(clearMatchingOptimisticChatThread$, matchingOptimisticThread);
       }
-      const defaultAgentId = await get(defaultAgentId$);
-      signal.throwIfAborted();
-      if (defaultAgentId) {
-        set(detachedNavigateTo$, "/agents/:agentId/chat", {
-          pathParams: { agentId: defaultAgentId },
-          searchParams: initialSearchParams,
-          replace: true,
-        });
-      } else {
-        set(detachedNavigateTo$, "/", {
-          searchParams: initialSearchParams,
-          replace: true,
-        });
-      }
+
+      set(detachedNavigateTo$, "/", {
+        searchParams: initialSearchParams,
+        replace: true,
+      });
+
       return;
     }
 
-    set(setChatAgentId$, threadData.agentId);
+    const currentChatAgentId = await get(currentChatAgentId$);
+    signal.throwIfAborted();
+    if (currentChatAgentId !== threadData.agentId) {
+      set(setChatAgentId$, threadData.agentId);
+    }
 
     const sessionTitle = threadData.title ?? "New chat";
     set(updateDocumentTitle$, sessionTitle);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -240,6 +240,7 @@ function createThreadData(
       title: body.title ?? null,
       agentId: body.agentId,
       latestSessionId: body.latestSessionId ?? null,
+      lastReadMessageId: body.lastReadMessageId ?? null,
       latestSessionProviderType: body.latestSessionProviderType ?? null,
       activeRunIds: body.activeRunIds,
       activeRuns: body.activeRuns ?? [],
@@ -923,19 +924,70 @@ interface RunTrackingDeps {
   threadId: string;
   reloadThread$: Command<void, []>;
   threadData$: Computed<Promise<ChatThread | null>>;
+  latestChatMessageId$: Computed<Promise<string | undefined>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
   autoScroll$: Command<void, []>;
   options: ChatThreadSignalOptions;
+}
+
+interface MarkThreadReadDeps {
+  threadId: string;
+  threadData$: Computed<Promise<ChatThread | null>>;
+  latestChatMessageId$: Computed<Promise<string | undefined>>;
+  locallyMarkedReadMessageId$: State<string | undefined>;
+}
+
+function createMarkThreadReadIfNeeded({
+  threadId,
+  threadData$,
+  latestChatMessageId$,
+  locallyMarkedReadMessageId$,
+}: MarkThreadReadDeps) {
+  return command(async ({ get, set }, sig: AbortSignal) => {
+    const latestMessageId = await get(latestChatMessageId$);
+    sig.throwIfAborted();
+    if (!latestMessageId) {
+      return;
+    }
+
+    const thread = await get(threadData$);
+    sig.throwIfAborted();
+    const lastReadMessageId =
+      get(locallyMarkedReadMessageId$) ?? thread?.lastReadMessageId ?? null;
+    if (lastReadMessageId === latestMessageId) {
+      return;
+    }
+
+    const client = get(zeroClient$)(chatThreadMarkReadContract);
+    const result = await accept(
+      client.markRead({
+        params: { id: threadId },
+        fetchOptions: { signal: sig },
+      }),
+      [200],
+    );
+    sig.throwIfAborted();
+    set(
+      locallyMarkedReadMessageId$,
+      result.body.lastReadMessageId ?? latestMessageId,
+    );
+    // Server broadcasts `threadListChanged` via Ably on mark-read; the
+    // sidebar reloads from that channel. Bumping reloadChatThreads$ here too
+    // forces a redundant refetch that blocks subsequent keyboard navigation.
+  });
 }
 
 function createRunTracking({
   threadId,
   reloadThread$,
   threadData$,
+  latestChatMessageId$,
   fetchNextPage$,
   autoScroll$,
   options,
 }: RunTrackingDeps) {
+  const locallyMarkedReadMessageId$ = state<string | undefined>(undefined);
+
   const allFinished$ = computed(async (get) => {
     const cancelRequested = options.localSnapshot
       ? get(options.localSnapshot.cancelRequested$)
@@ -950,18 +1002,11 @@ function createRunTracking({
     return thread.activeRunIds.length === 0;
   });
 
-  const markThreadRead$ = command(async ({ get }, sig: AbortSignal) => {
-    const client = get(zeroClient$)(chatThreadMarkReadContract);
-    await accept(
-      client.markRead({
-        params: { id: threadId },
-        fetchOptions: { signal: sig },
-      }),
-      [200],
-    );
-    // Server broadcasts `threadListChanged` via Ably on mark-read; the
-    // sidebar reloads from that channel. Bumping reloadChatThreads$ here too
-    // forces a redundant refetch that blocks subsequent keyboard navigation.
+  const markThreadReadIfNeeded$ = createMarkThreadReadIfNeeded({
+    threadId,
+    threadData$,
+    latestChatMessageId$,
+    locallyMarkedReadMessageId$,
   });
 
   const loadPagedMessages$ = command(
@@ -994,13 +1039,13 @@ function createRunTracking({
         await visibleDeferred.promise;
         signal.throwIfAborted();
       }
-      await set(markThreadRead$, signal);
+      await set(markThreadReadIfNeeded$, signal);
 
       const onMessageCreated$ = command(async ({ set }, sig: AbortSignal) => {
         await set(fetchNextPage$, sig);
         // Advance read marker when a new message arrives while focused.
         if (document.visibilityState === "visible") {
-          await set(markThreadRead$, sig);
+          await set(markThreadReadIfNeeded$, sig);
         }
         animationFrame(
           () => {
@@ -1295,6 +1340,7 @@ export function createChatThreadSignals(
     threadId,
     reloadThread$,
     threadData$,
+    latestChatMessageId$,
     fetchNextPage$,
     autoScroll$,
     options,

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -133,6 +133,7 @@ const createNewChatThread$ = command(
         title: null,
         agentId: resolvedComposeId,
         latestSessionId: null,
+        lastReadMessageId: null,
         latestSessionProviderType: null,
         activeRunIds: [],
         activeRuns: [],
@@ -168,7 +169,6 @@ const createNewChatThread$ = command(
           replace: true,
         });
       }
-      set(reloadChatThreads$);
     })();
 
     return {
@@ -267,6 +267,7 @@ const sendNewThreadMessage$ = command(
         title: null,
         agentId,
         latestSessionId: null,
+        lastReadMessageId: null,
         latestSessionProviderType: null,
         activeRunIds: [`pending-${threadId}`],
         activeRuns: [{ id: `pending-${threadId}`, status: "pending" }],

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
@@ -80,6 +80,7 @@ const router = tsr.router(chatThreadByIdContract, {
           agentId: thread.agentComposeId,
           chatMessages,
           latestSessionId,
+          lastReadMessageId: thread.lastReadMessageId,
           latestSessionProviderType,
           activeRunIds,
           activeRuns,

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -194,6 +194,7 @@ export async function getChatThread(
   draftAttachments: PersistedAttachment[] | null;
   modelProviderId: string | null;
   selectedModel: string | null;
+  lastReadMessageId: string | null;
   createdAt: Date;
   updatedAt: Date;
 }> {
@@ -218,6 +219,7 @@ export async function getChatThread(
       .parse(thread.draftAttachments ?? null),
     modelProviderId: thread.modelProviderId ?? null,
     selectedModel: thread.selectedModel ?? null,
+    lastReadMessageId: thread.lastReadMessageId ?? null,
     createdAt: thread.createdAt,
     updatedAt: thread.updatedAt,
   };

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -105,6 +105,12 @@ const chatThreadDetailSchema = z.object({
   chatMessages: z.array(storedChatMessageSchema),
   latestSessionId: z.string().nullable(),
   /**
+   * ID of the latest message this user has marked read in this thread.
+   * Null when the thread has never been explicitly marked read. Optional for
+   * back-compat with fixtures/tests that predate the read marker field.
+   */
+  lastReadMessageId: z.string().nullable().optional(),
+  /**
    * Provider type of the latest run in this thread, if any. Used by the
    * composer's model picker to disable options whose base URL differs from
    * the current session — switching mid-session would break continuity.


### PR DESCRIPTION
## Summary
- expose `lastReadMessageId` on chat thread detail
- skip mark-read when a thread has no messages or the latest message is already read
- remove the manual optimistic thread list reload that duplicated the realtime reload
- keep missing-thread redirects aligned with the current home-route behavior

## Tests
- `pnpm --filter @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-page-setup.test.ts --reporter verbose`
- `pnpm --filter @vm0/app exec tsc --noEmit --pretty false --incremental false`
- `pnpm --filter @vm0/app lint`
- `pnpm --filter web exec tsc --noEmit --pretty false --incremental false`
- `pnpm --filter web exec vitest run 'app/api/zero/chat-threads/[id]/__tests__/route.test.ts' 'app/api/zero/chat-threads/[id]/mark-read/__tests__/route.test.ts' --reporter verbose`\n- pre-commit hook: prettier, knip, repo check-types