### PR TITLE
docs(vsock-guest): fix stale 'sleep 30' reference in slow_exec test

### DIFF
--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -1433,7 +1433,7 @@ mod tests {
         host_stream.write_all(&fast_msg).unwrap();
 
         // Read responses — we need to find seq=2 (the fast one) within 3 seconds.
-        // Before the fix, this would block until sleep 30 finished.
+        // Before the fix, this would block on the slow exec.
         host_stream
             .set_read_timeout(Some(Duration::from_secs(3)))
             .unwrap();


### PR DESCRIPTION
## Summary

- The `slow_exec_does_not_block_fast_exec` regression test sends `sleep 5`, but the rationale comment two lines below still mentioned `sleep 30` from an earlier revision.
- Phrase the comment in terms of "the slow exec" so it stays accurate across future tweaks to the sleep duration.

Closes #11067

## Test plan

- [x] cargo clippy -p vsock-guest --all-targets --all-features (clean)
- [x] Comment-only change; no behavioural impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)