### PR TITLE
fix(runner): unify error log for claimed-but-failed job

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1178,7 +1178,6 @@ fn spawn_job(
                 )
             }
             Err(e) => {
-                error!(run_id = %run_id, error = %e, "executor task panicked");
                 // Panic lost the in-flight telemetry buffer; substitute an
                 // empty collector so the post-complete flush path stays
                 // unconditional. `flush` early-returns on empty pending_ops.
@@ -1189,7 +1188,7 @@ fn spawn_job(
                 );
                 (
                     1,
-                    Some(format!("internal error: {e}")),
+                    Some(format!("executor task panicked: {e}")),
                     None,
                     String::new(),
                     None,
@@ -1197,6 +1196,18 @@ fn spawn_job(
                 )
             }
         };
+
+        // Single sink for any claimed job's terminal state. Cancellation gets
+        // its own info marker; everything else with `err` set is a failure
+        // (panics, executor internal errors, non-zero exits with
+        // stderr/guest error file).
+        match (job_cancel.is_cancelled(), err.as_deref()) {
+            (true, _) => info!(run_id = %run_id, exit_code, "job cancelled"),
+            (false, Some(e)) => {
+                error!(run_id = %run_id, exit_code, error = %e, "job execution failed");
+            }
+            (false, None) => {}
+        }
 
         // Decide: park sandbox for reuse, or stop + destroy.
         let parked = if let Some(mut sandbox) = sandbox {

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1137,6 +1137,8 @@ fn spawn_job(
     let sandbox_token = context.sandbox_token.clone();
     let exec_config_for_deferred = Arc::clone(&exec_config);
 
+    let reused = reuse_entry.is_some();
+
     jobs.spawn(async move {
         // Inner spawn isolates panics: if execute_job panics, the outer task
         // still reports completion and releases budget.
@@ -1200,13 +1202,13 @@ fn spawn_job(
         // Single sink for any claimed job's terminal state. Cancellation gets
         // its own info marker; everything else with `err` set is a failure
         // (panics, executor internal errors, non-zero exits with
-        // stderr/guest error file).
+        // stderr/guest error file); otherwise the job finished normally.
         match (job_cancel.is_cancelled(), err.as_deref()) {
-            (true, _) => info!(run_id = %run_id, exit_code, "job cancelled"),
+            (true, _) => info!(run_id = %run_id, exit_code, reused, "job cancelled"),
             (false, Some(e)) => {
-                error!(run_id = %run_id, exit_code, error = %e, "job execution failed");
+                error!(run_id = %run_id, exit_code, reused, error = %e, "job execution failed");
             }
-            (false, None) => {}
+            (false, None) => info!(run_id = %run_id, exit_code, reused, "job finished"),
         }
 
         // Decide: park sandbox for reuse, or stop + destroy.

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory, SandboxId};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 use crate::ids::RunId;
 
@@ -94,16 +94,13 @@ pub async fn execute_job(
     .await
     {
         Ok(outcome) => outcome,
-        Err(e) => {
-            error!(run_id = %run_id, error = %e, "job execution failed");
-            ExecuteOutcome {
-                exit_code: 1,
-                error: Some(e.to_string()),
-                sandbox: None,
-                source_ip: String::new(),
-                guest_session_id: None,
-            }
-        }
+        Err(e) => ExecuteOutcome {
+            exit_code: 1,
+            error: Some(e.to_string()),
+            sandbox: None,
+            source_ip: String::new(),
+            guest_session_id: None,
+        },
     };
 
     info!(run_id = %run_id, exit_code = outcome.exit_code, "job finished");

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -103,7 +103,6 @@ pub async fn execute_job(
         },
     };
 
-    info!(run_id = %run_id, exit_code = outcome.exit_code, "job finished");
     (outcome, telemetry)
 }
 
@@ -144,7 +143,6 @@ pub async fn execute_job_reuse(
     )
     .await;
 
-    info!(run_id = %run_id, exit_code = outcome.exit_code, reused = true, "job finished");
     (outcome, telemetry)
 }
 


### PR DESCRIPTION
## Summary

- Consolidate scattered failure logs in `spawn_job` into a single sink right after the inner-task `match` — one `error!("job execution failed")` for any claimed-but-not-successfully-executed job, plus an `info!("job cancelled")` marker for user cancellation.
- Internal `run_in_sandbox` failures (clock fix, entropy reseed, storage download, agent execute, sandbox crash) and non-zero user-command exits with stderr/guest error file were previously dropped from runner logs — they only reached the API via `provider.complete`. They now show up alongside the existing create/start failure log.
- Panic branch's message is folded into `err` (`"executor task panicked: ..."`) so the source is preserved in the unified line; removes the duplicate panic-specific `error!`.

## Test plan
- [x] `cargo clippy -p runner --no-deps` clean
- [x] `cargo test -p runner --bin runner executor::` — 112 passed
- [ ] Verify in production logs: cancelled jobs show `job cancelled` info, internal failures show `job execution failed` error with the upstream error string

🤖 Generated with [Claude Code](https://claude.com/claude-code)