### PR TITLE
test: drain voice chat reasoner dispatch in test

### DIFF
--- a/turbo/apps/web/src/lib/zero/voice-chat/__tests__/trigger-reasoning.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/__tests__/trigger-reasoning.test.ts
@@ -279,7 +279,7 @@ describe("triggerReasoning", () => {
   });
 
   it("H7 — creates task rows and system_notes for each missing task the reasoner detects", async () => {
-    context.setupMocks();
+    const mocks = context.setupMocks();
     vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     reloadEnv();
 
@@ -320,6 +320,9 @@ describe("triggerReasoning", () => {
     server.use(handler.handler);
 
     await triggerReasoning(sessionId);
+    // Missing-task creation schedules createZeroRun() dispatch via waitUntil().
+    // Drain it here so its runner "job" Ably publish cannot leak into H6.
+    await mocks.flushAfter();
 
     // The reasoner summary write should succeed
     const row = await getTestVoiceChatSessionReasoningState(sessionId);


### PR DESCRIPTION
## Summary
- drain the missing-task test's deferred waitUntil dispatch before continuing
- prevent runner job Ably publishes from leaking into the no-op H6 assertion

## Tests
- pnpm exec vitest run --dir src/lib/zero/voice-chat/__tests__
- pnpm test (apps/web)

## Note
- local pre-commit check-types currently fails in @vm0/core generated firewall files unrelated to this change