### PR TITLE
chore: ignore codex marker file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,5 +200,5 @@ tmp/
 *.sarif
 junit.xml
 e2e/results/
-.codex/
+.codex
 .agents/


### PR DESCRIPTION
## Summary
- ignore .codex whether it is created as a file or directory
- prevent local Codex marker files from showing up as untracked changes

## Tests
- not run; .gitignore-only change