### PR TITLE
refactor(guest-agent): serialize telemetry uploads via single-writer actor

### DIFF
--- a/crates/guest-agent/src/error.rs
+++ b/crates/guest-agent/src/error.rs
@@ -17,4 +17,7 @@ pub enum AgentError {
 
     #[error("checkpoint: {0}")]
     Checkpoint(String),
+
+    #[error("telemetry uploader unavailable")]
+    TelemetryUnavailable,
 }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -10,7 +10,7 @@ use guest_agent::heartbeat;
 use guest_agent::masker;
 use guest_agent::metrics;
 use guest_agent::paths;
-use guest_agent::telemetry;
+use guest_agent::telemetry::{Telemetry, UploadMode};
 
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info};
@@ -35,9 +35,11 @@ async fn run() -> i32 {
     // Validate required env vars
     if env::working_dir().is_empty() {
         log_error!(LOG_TAG, "Fatal: VM0_WORKING_DIR is required but not set");
-        let masker = masker::SecretMasker::from_env();
+        let masker = Arc::new(masker::SecretMasker::from_env());
+        let telemetry = Telemetry::spawn(masker);
         log_info!(LOG_TAG, "▷ Cleanup");
-        final_telemetry(&masker).await;
+        final_telemetry(&telemetry).await;
+        telemetry.shutdown().await;
         log_info!(LOG_TAG, "Background processes stopped");
         log_info!(LOG_TAG, "✗ Sandbox failed (exit code 1)");
         return 1;
@@ -72,11 +74,7 @@ async fn run() -> i32 {
     record_sandbox_op("metrics_collector_start", t.elapsed(), true, None);
 
     let t = Instant::now();
-    let telemetry_handle = tokio::spawn({
-        let shutdown = shutdown.clone();
-        let masker = masker.clone();
-        async move { telemetry::telemetry_loop(shutdown, masker).await }
-    });
+    let telemetry = Telemetry::spawn(masker.clone());
     log_info!(LOG_TAG, "Telemetry upload started");
     record_sandbox_op("telemetry_upload_start", t.elapsed(), true, None);
 
@@ -84,12 +82,13 @@ async fn run() -> i32 {
     // `execute` owns the final telemetry upload — on the success path it's run
     // in parallel with `checkpoint` so the ~1s upload doesn't serialize behind
     // the ~4s snapshot work.
-    let exit_code = execute(&masker, start, heartbeat_handle).await;
+    let exit_code = execute(&masker, start, heartbeat_handle, &telemetry).await;
 
-    // Stop all background processes (heartbeat, metrics, telemetry)
+    // Stop all background processes. Telemetry uses its own command
+    // channel; `shutdown` only covers heartbeat/metrics.
     shutdown.cancel();
     let _ = metrics_handle.await;
-    let _ = telemetry_handle.await;
+    telemetry.shutdown().await;
     log_info!(LOG_TAG, "Background processes stopped");
 
     if exit_code == 0 {
@@ -107,6 +106,7 @@ async fn execute(
     masker: &masker::SecretMasker,
     start: Instant,
     heartbeat_handle: tokio::task::JoinHandle<Result<(), error::AgentError>>,
+    telemetry: &Telemetry,
 ) -> i32 {
     // Pre-warm kernel DNS cache for the CLI's API endpoint.
     // Fire-and-forget: runs in background so the cache is populated by the
@@ -186,25 +186,13 @@ async fn execute(
         log_info!(LOG_TAG, "✗ Execution failed ({}s)", cli_elapsed.as_secs());
     }
 
-    // Checkpoint on success (skip when no API — local/test mode). The final
-    // telemetry upload runs in two phases to keep the operator-visible log
-    // output identical to the pre-parallelization sequence while still
-    // overlapping the ~1s upload with checkpoint:
-    //   1. A silent first pass inside `tokio::join!` drains the pre-checkpoint
-    //      sandbox_ops under cover of `checkpoint::create_checkpoint` — no
-    //      log banner, no error log, no `record_sandbox_op`. On failure,
-    //      position tracking doesn't advance so the catch-up re-reads the
-    //      same delta.
-    //   2. After checkpoint completes, `final_telemetry` runs serially as
-    //      the pre-parallelization "cleanup" step — it emits the `▷ Cleanup`
-    //      lifecycle banner, the `"Performing final telemetry upload..."`
-    //      log inside `final_upload`, the failure log on error, and records
-    //      the `final_telemetry_upload` sandbox op.
-    // The catch-up step also captures records checkpoint wrote after the
-    // parallel pass snapshotted the file (`session_id_read`, VAS snapshot
-    // timings, `checkpoint_total`, etc) — `telemetry_loop` breaks on
-    // shutdown without a final flush, so without this serial pass those
-    // records would never reach the server.
+    // Checkpoint on success (skip when no API — local/test mode). The
+    // pre-checkpoint flush runs in `tokio::join!` with the snapshot work so
+    // its ~1s upload overlaps the ~4s checkpoint. The post-checkpoint flush
+    // catches records checkpoint itself wrote (`session_id_read`, VAS
+    // snapshot timings, `checkpoint_total`, etc.) and is the EOF-consuming
+    // final pass. Both go through the single-writer uploader, so the two
+    // flushes never race the periodic tick on the pos files.
     if cli_exit_code == 0 && exit_code == 0 && env::has_api() {
         log_info!(LOG_TAG, "claude-code completed successfully");
 
@@ -212,7 +200,7 @@ async fn execute(
         let cp_start = Instant::now();
         let (cp_result, _) = tokio::join!(
             checkpoint::create_checkpoint(),
-            telemetry::final_upload_silent(masker),
+            telemetry.flush(UploadMode::Live),
         );
         match cp_result {
             Ok(()) => {
@@ -238,7 +226,7 @@ async fn execute(
                 // returned.
                 log_info!(LOG_TAG, "▷ Cleanup");
                 complete::report_success(env::sandbox_id(), env::sandbox_reuse_result()).await;
-                final_telemetry(masker).await;
+                final_telemetry(telemetry).await;
             }
             Err(e) => {
                 let msg = format!("Checkpoint failed: {e}");
@@ -255,7 +243,7 @@ async fn execute(
                 // provider.complete() fallback posts exitCode=1, triggering
                 // the route's "checkpoint not found → failed" branch.
                 log_info!(LOG_TAG, "▷ Cleanup");
-                final_telemetry(masker).await;
+                final_telemetry(telemetry).await;
             }
         }
     } else {
@@ -265,7 +253,7 @@ async fn execute(
             log_info!(LOG_TAG, "claude-code failed with exit code {cli_exit_code}");
         }
         log_info!(LOG_TAG, "▷ Cleanup");
-        final_telemetry(masker).await;
+        final_telemetry(telemetry).await;
     }
 
     exit_code
@@ -273,9 +261,10 @@ async fn execute(
 
 /// Final telemetry upload — records timing and logs on failure.
 /// The complete API is called by the runner after VM exits, not by guest-agent.
-async fn final_telemetry(masker: &masker::SecretMasker) {
+async fn final_telemetry(telemetry: &Telemetry) {
+    log_info!(LOG_TAG, "Performing final telemetry upload...");
     let telemetry_start = Instant::now();
-    let telemetry_ok = telemetry::final_upload(masker).await.is_ok();
+    let telemetry_ok = telemetry.flush(UploadMode::Final).await.is_ok();
     if !telemetry_ok {
         log_error!(LOG_TAG, "Final telemetry upload failed");
     }

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -136,9 +136,10 @@ fn save_position(pos_path: &str, pos: u64) {
 /// `UploadMode::Final` should be used only for the very last upload before
 /// the agent exits — any trailing fragment after the last newline is then
 /// consumed as-is, accepting a small mid-write race window in exchange for
-/// not losing the tail. Every earlier upload (periodic tick and the silent
-/// pre-checkpoint pass) must use `UploadMode::Live` so a later pass can
-/// safely pick up the tail once the producer completes the line.
+/// not losing the tail. Every earlier upload (periodic tick and the
+/// pre-checkpoint `flush(UploadMode::Live)`) must use `UploadMode::Live`
+/// so a later pass can safely pick up the tail once the producer
+/// completes the line.
 async fn upload_telemetry(masker: &SecretMasker, mode: UploadMode) -> Result<(), AgentError> {
     // Read deltas
     let (system_log, log_pos) = read_file_delta(

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -1,8 +1,14 @@
-//! Telemetry uploader — incremental file reads with position tracking.
+//! Telemetry uploader — single-writer ownership of position files.
 //!
-//! Periodically reads new data from log files and uploads to the
-//! telemetry endpoint. Position files track how far we've read so
-//! we don't re-upload on the next tick.
+//! All reads of the log files and writes to the `*_pos.txt` files happen
+//! on one tokio task ([`run`]). The periodic tick and any caller-driven
+//! flushes both flow through the same `tokio::select!`, so uploads are
+//! serialized — eliminating the tick-vs-final race that used to regress
+//! the position file (#11008).
+//!
+//! Callers interact via [`Telemetry`]: spawn the task with
+//! [`Telemetry::spawn`], request uploads with [`Telemetry::flush`], and
+//! release with [`Telemetry::shutdown`].
 
 use crate::constants;
 use crate::env;
@@ -11,39 +17,50 @@ use crate::http;
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::urls;
-use guest_common::{log_info, log_warn};
+use guest_common::log_warn;
 use serde_json::{Value, json};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio_util::sync::CancellationToken;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tokio::time::MissedTickBehavior;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
-/// Whether an upload pass should defer a trailing fragment to the next tick,
-/// or consume it as-is because no next tick is coming.
+/// Buffer size for the command channel. Only one flush is in flight at a
+/// time during cleanup, so a small bounded queue is plenty.
+const COMMAND_CHANNEL_CAPACITY: usize = 8;
+
+/// Whether an upload pass should defer a trailing fragment to the next
+/// pass, or consume it as-is because no next pass is coming.
 ///
-/// `Tick` is used by the periodic uploader and the silent pre-checkpoint
-/// pass. `Final` is reserved for the very last upload before agent exit.
+/// `Live` is used while the producer is still actively writing the log
+/// files — both periodic ticks and the pre-checkpoint flush. The trailing
+/// bytes after the last newline are left in place so the next pass can
+/// pick them up once the producer completes the line.
+///
+/// `Final` is the very last upload before agent exit. There is no next
+/// pass, so the EOF tail is consumed verbatim.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum UploadMode {
-    Tick,
+pub enum UploadMode {
+    Live,
     Final,
 }
 
 /// Read new bytes from `file_path` starting at the position stored in `pos_path`.
 /// Returns the new content and the updated position.
 ///
-/// In `Tick` mode, the read is aligned to the last newline: any trailing
+/// In `Live` mode, the read is aligned to the last newline: any trailing
 /// bytes after the last `\n` are treated as an in-progress write by the
-/// producer and left for the next tick. This prevents the producer-consumer
+/// producer and left for the next pass. This prevents the producer-consumer
 /// race from splitting a log line mid-write, which would corrupt UTF-8
 /// multibyte characters via `from_utf8_lossy` (the broken byte is replaced
 /// by U+FFFD and permanently lost, since the position has already advanced
 /// past it).
 ///
 /// In `Final` mode, the tail is consumed as-is — there will be no subsequent
-/// tick to pick it up. Any trailing fragment without a newline is uploaded
+/// pass to pick it up. Any trailing fragment without a newline is uploaded
 /// verbatim.
 fn read_file_delta(file_path: &str, pos_path: &str, mode: UploadMode) -> (String, u64) {
     let last_pos: u64 = std::fs::read_to_string(pos_path)
@@ -120,7 +137,7 @@ fn save_position(pos_path: &str, pos: u64) {
 /// the agent exits — any trailing fragment after the last newline is then
 /// consumed as-is, accepting a small mid-write race window in exchange for
 /// not losing the tail. Every earlier upload (periodic tick and the silent
-/// pre-checkpoint pass) must use `UploadMode::Tick` so a later pass can
+/// pre-checkpoint pass) must use `UploadMode::Live` so a later pass can
 /// safely pick up the tail once the producer completes the line.
 async fn upload_telemetry(masker: &SecretMasker, mode: UploadMode) -> Result<(), AgentError> {
     // Read deltas
@@ -174,57 +191,114 @@ async fn upload_telemetry(masker: &SecretMasker, mode: UploadMode) -> Result<(),
     }
 }
 
-/// Background loop uploading telemetry every `TELEMETRY_INTERVAL_SECS`.
-pub async fn telemetry_loop(shutdown: CancellationToken, masker: Arc<SecretMasker>) {
+/// Commands accepted by the uploader task.
+enum Cmd {
+    /// Flush new telemetry now and report the result back via `reply`.
+    /// `mode` is propagated to [`upload_telemetry`]; see [`UploadMode`].
+    Flush {
+        mode: UploadMode,
+        reply: oneshot::Sender<Result<(), AgentError>>,
+    },
+    /// Stop the loop. Any in-flight upload completes first.
+    Shutdown,
+}
+
+/// Owning handle to the uploader task.
+///
+/// Holds both the command channel and the spawned task's [`JoinHandle`],
+/// so callers see one lifecycle object rather than juggling two.
+/// Construct with [`Self::spawn`]; release with [`Self::shutdown`].
+pub struct Telemetry {
+    tx: mpsc::Sender<Cmd>,
+    handle: JoinHandle<()>,
+}
+
+impl Telemetry {
+    /// Spawn the uploader task and return an owning handle.
+    ///
+    /// Spawn **at most one instance per process.** The pos files
+    /// (`paths::telemetry_*_pos_file`) are process-global; two uploader
+    /// tasks would each call [`upload_telemetry`] on the same files,
+    /// reintroducing the multi-writer race that the channel was built
+    /// to eliminate (#11008). The type system can't enforce this — the
+    /// constraint is the shared pos paths, not the channel.
+    pub fn spawn(masker: Arc<SecretMasker>) -> Self {
+        let (tx, rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
+        let handle = tokio::spawn(run(rx, masker));
+        Self { tx, handle }
+    }
+
+    /// Trigger a telemetry upload and await completion.
+    ///
+    /// Use [`UploadMode::Live`] for any flush while the agent is still
+    /// running (the producer continues writing). Use [`UploadMode::Final`]
+    /// for the very last flush before exit, which consumes the EOF tail.
+    pub async fn flush(&self, mode: UploadMode) -> Result<(), AgentError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(Cmd::Flush {
+                mode,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| AgentError::TelemetryUnavailable)?;
+        reply_rx
+            .await
+            .map_err(|_| AgentError::TelemetryUnavailable)?
+    }
+
+    /// Stop the uploader and await graceful task termination.
+    ///
+    /// Consumes `self`, so no further commands can be sent after this
+    /// call. Any commands queued before `shutdown` are processed first
+    /// (the loop is FIFO); the task exits when it dequeues the
+    /// `Shutdown` command.
+    pub async fn shutdown(self) {
+        let _ = self.tx.send(Cmd::Shutdown).await;
+        let _ = self.handle.await;
+    }
+}
+
+/// Single-writer task. Owns all pos-file mutations.
+///
+/// `biased` select ensures a queued Flush wins over a ready tick at any
+/// select boundary, so a caller-driven flush is never blocked behind a
+/// tick that hasn't started yet. (A tick already in its `await` cannot
+/// be preempted; the worst-case wait for a flush is one in-flight tick.)
+async fn run(mut rx: mpsc::Receiver<Cmd>, masker: Arc<SecretMasker>) {
     if !env::has_api() {
-        shutdown.cancelled().await;
+        // Drain commands so callers don't block on `reply_rx`. Flushes
+        // are a no-op (no API to upload to); Shutdown ends the loop.
+        while let Some(cmd) = rx.recv().await {
+            match cmd {
+                Cmd::Flush { reply, .. } => {
+                    let _ = reply.send(Ok(()));
+                }
+                Cmd::Shutdown => break,
+            }
+        }
         return;
     }
 
     let mut interval =
         tokio::time::interval(Duration::from_secs(constants::TELEMETRY_INTERVAL_SECS));
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
     loop {
         tokio::select! {
-            _ = shutdown.cancelled() => break,
+            biased;
+            cmd = rx.recv() => match cmd {
+                Some(Cmd::Flush { mode, reply }) => {
+                    let result = upload_telemetry(&masker, mode).await;
+                    let _ = reply.send(result);
+                }
+                Some(Cmd::Shutdown) | None => break,
+            },
             _ = interval.tick() => {
-                let _ = upload_telemetry(&masker, UploadMode::Tick).await;
+                let _ = upload_telemetry(&masker, UploadMode::Live).await;
             }
         }
     }
-}
-
-/// Final telemetry upload before agent completion.
-///
-/// Uses `UploadMode::Final` to consume the EOF tail: there is no subsequent
-/// upload that could pick up an otherwise-deferred fragment. A small mid-
-/// write race remains — vsock-guest may still be writing a chunk of
-/// system_log when we snapshot — but one potentially-split final line is a
-/// better tradeoff than silently dropping the whole tail.
-pub async fn final_upload(masker: &SecretMasker) -> Result<(), AgentError> {
-    if !env::has_api() {
-        return Ok(());
-    }
-    log_info!(LOG_TAG, "Performing final telemetry upload...");
-    upload_telemetry(masker, UploadMode::Final).await
-}
-
-/// Same as [`final_upload`] but without the log banner or error log.
-/// Used by the parallel-with-checkpoint first pass in `main.rs` so the
-/// operator-visible log output stays identical to the pre-parallelization
-/// sequence: only the post-`▷ Cleanup` catch-up emits the banner, and
-/// a first-pass failure is silently deferred to the catch-up (which reads
-/// the same unchanged file position and re-uploads the delta).
-///
-/// Uses `UploadMode::Tick` because more log data is still being written
-/// during `▷ Cleanup` after this returns — the real end-of-life flush is
-/// [`final_upload`]. If this pass ate the EOF tail mid-write, it could
-/// split a UTF-8 multibyte character and the catch-up would skip past the
-/// broken byte, losing the character permanently.
-pub async fn final_upload_silent(masker: &SecretMasker) -> Result<(), AgentError> {
-    if !env::has_api() {
-        return Ok(());
-    }
-    upload_telemetry(masker, UploadMode::Tick).await
 }
 
 #[cfg(test)]
@@ -242,7 +316,7 @@ mod tests {
         let (content, new_pos) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(content, "hello world\n");
         assert_eq!(new_pos, 12);
@@ -260,7 +334,7 @@ mod tests {
         let (content, new_pos) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(content, "world\n");
         assert_eq!(new_pos, 12);
@@ -277,7 +351,7 @@ mod tests {
         let (content, new_pos) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert!(content.is_empty());
         assert_eq!(new_pos, 4);
@@ -292,7 +366,7 @@ mod tests {
         let (content, new_pos) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert!(content.is_empty());
         assert_eq!(new_pos, 0);
@@ -308,7 +382,7 @@ mod tests {
         let (entries, new_pos) = read_jsonl_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0]["a"], 1);
@@ -337,7 +411,7 @@ mod tests {
         let (content, new_pos) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert!(content.is_empty());
         assert_eq!(new_pos, 100);
@@ -355,7 +429,7 @@ mod tests {
         let (content, new_pos) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(content, "data\n");
         assert_eq!(new_pos, 5);
@@ -371,7 +445,7 @@ mod tests {
         let (entries, new_pos) = read_jsonl_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert!(entries.is_empty());
         assert_eq!(new_pos, 0);
@@ -387,14 +461,14 @@ mod tests {
         let (entries, new_pos) = read_jsonl_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert!(entries.is_empty());
         assert!(new_pos > 0);
     }
 
-    /// Tick mode: an in-progress line (no trailing \n) must be deferred
-    /// to the next tick instead of being uploaded half-written.
+    /// Live mode: an in-progress line (no trailing \n) must be deferred
+    /// to the next pass instead of being uploaded half-written.
     #[test]
     fn read_file_delta_defers_trailing_fragment() {
         let dir = tempfile::tempdir().unwrap();
@@ -403,11 +477,11 @@ mod tests {
         // Two complete lines followed by a partial write.
         fs::write(&file, "line1\nline2\npartial").unwrap();
 
-        // First tick: read up to the last newline, leave "partial" behind.
+        // First pass: read up to the last newline, leave "partial" behind.
         let (content, new_pos) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(content, "line1\nline2\n");
         assert_eq!(new_pos, 12);
@@ -416,18 +490,18 @@ mod tests {
         fs::write(&file, "line1\nline2\npartial done\n").unwrap();
         fs::write(&pos, "12").unwrap();
 
-        // Second tick: now "partial done\n" is complete.
+        // Second pass: now "partial done\n" is complete.
         let (content2, new_pos2) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(content2, "partial done\n");
         assert_eq!(new_pos2, 25);
     }
 
     /// Final pass: trailing fragment without a newline must be consumed,
-    /// since there will be no subsequent tick to pick it up.
+    /// since there will be no subsequent pass to pick it up.
     #[test]
     fn read_file_delta_final_pass_consumes_fragment() {
         let dir = tempfile::tempdir().unwrap();
@@ -444,10 +518,10 @@ mod tests {
         assert_eq!(new_pos, 13);
     }
 
-    /// Regression: a multibyte UTF-8 character split across two ticks must
-    /// survive intact. Before the fix, `from_utf8_lossy` replaced each
-    /// split byte with U+FFFD and the broken char was permanently lost
-    /// because `save_position` had advanced past it.
+    /// Regression: a multibyte UTF-8 character split across two passes
+    /// must survive intact. Before the fix, `from_utf8_lossy` replaced
+    /// each split byte with U+FFFD and the broken char was permanently
+    /// lost because `save_position` had advanced past it.
     #[test]
     fn read_file_delta_utf8_multibyte_survives_split() {
         let dir = tempfile::tempdir().unwrap();
@@ -459,11 +533,11 @@ mod tests {
         partial.push(0xE4);
         fs::write(&file, &partial).unwrap();
 
-        // First tick: stops at the newline, leaves the orphan 0xE4 behind.
+        // First pass: stops at the newline, leaves the orphan 0xE4 behind.
         let (content, new_pos) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(content, "prefix\n");
         assert_eq!(new_pos, 7);
@@ -475,11 +549,11 @@ mod tests {
         complete.extend_from_slice(b"\n");
         fs::write(&file, &complete).unwrap();
 
-        // Second tick: reads the complete multibyte character.
+        // Second pass: reads the complete multibyte character.
         let (content2, new_pos2) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(content2, "中\n");
         assert_eq!(new_pos2, complete.len() as u64);
@@ -489,7 +563,7 @@ mod tests {
 
     /// A JSONL file with a partially-written trailing record must not have
     /// that record silently dropped. The half line is deferred to the next
-    /// tick, and once the producer completes it, the entry is uploaded.
+    /// pass, and once the producer completes it, the entry is uploaded.
     #[test]
     fn read_jsonl_delta_defers_partial_line() {
         let dir = tempfile::tempdir().unwrap();
@@ -497,11 +571,11 @@ mod tests {
         let pos = dir.path().join("data.pos");
         fs::write(&file, "{\"a\":1}\n{\"b\":2").unwrap();
 
-        // First tick: only {"a":1} is complete.
+        // First pass: only {"a":1} is complete.
         let (entries, new_pos) = read_jsonl_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["a"], 1);
@@ -513,18 +587,18 @@ mod tests {
         let (entries2, new_pos2) = read_jsonl_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(entries2.len(), 1);
         assert_eq!(entries2[0]["b"], 2);
         assert_eq!(new_pos2, 16);
     }
 
-    /// Tick mode, first tick, delta contains no newline at all. Must
+    /// Live mode, first pass, delta contains no newline at all. Must
     /// return empty without advancing the position so the data is
     /// picked up intact once the producer writes the terminating \n.
     #[test]
-    fn read_file_delta_tick_no_newline_at_all() {
+    fn read_file_delta_live_no_newline_at_all() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("log.txt");
         let pos = dir.path().join("log.pos");
@@ -533,17 +607,17 @@ mod tests {
         let (content, new_pos) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert!(content.is_empty());
         assert_eq!(new_pos, 0);
 
-        // Producer completes the line — the next tick picks up everything.
+        // Producer completes the line — the next pass picks up everything.
         fs::write(&file, "partial done\n").unwrap();
         let (content2, new_pos2) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(content2, "partial done\n");
         assert_eq!(new_pos2, 13);
@@ -581,11 +655,11 @@ mod tests {
         partial.extend_from_slice(&[0xF0, 0x9F]);
         fs::write(&file, &partial).unwrap();
 
-        // First tick stops at \n, defers the orphan bytes.
+        // First pass stops at \n, defers the orphan bytes.
         let (content, new_pos) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(content, "prefix\n");
         assert_eq!(new_pos, 7);
@@ -600,19 +674,19 @@ mod tests {
         let (content2, new_pos2) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(content2, "😀\n");
         assert_eq!(new_pos2, complete.len() as u64);
         assert!(!content2.contains('\u{FFFD}'));
     }
 
-    /// Documents the final_pass behavior under the residual mid-chunk
+    /// Documents the `Final` mode behavior under the residual mid-chunk
     /// race tracked in #11010: if vsock-guest's chunk boundary split a
-    /// UTF-8 character, final_upload sees invalid bytes. The code must
-    /// replace them with U+FFFD and advance the position — not panic,
-    /// not truncate the tail. Guards against accidental replacement of
-    /// `from_utf8_lossy` with the stricter `from_utf8`.
+    /// UTF-8 character, the final flush sees invalid bytes. The code
+    /// must replace them with U+FFFD and advance the position — not
+    /// panic, not truncate the tail. Guards against accidental
+    /// replacement of `from_utf8_lossy` with the stricter `from_utf8`.
     #[test]
     fn read_file_delta_final_pass_invalid_utf8_replaces_with_fffd() {
         let dir = tempfile::tempdir().unwrap();
@@ -633,26 +707,27 @@ mod tests {
         assert_eq!(new_pos, 5);
     }
 
-    /// Regression for the `final_upload_silent` bug: the pre-checkpoint
-    /// pass must not consume an in-flight UTF-8 byte sequence. Simulates
-    /// the real call sequence — `final_upload_silent` (newline-aligned),
-    /// producer continues writing, `final_upload` catch-up (consumes EOF).
+    /// Regression for the pre-checkpoint flush UTF-8 bug: the
+    /// pre-checkpoint flush (`UploadMode::Live`) must not consume an
+    /// in-flight UTF-8 byte sequence. Simulates the real sequence — Live
+    /// flush (newline-aligned), producer continues writing, Final
+    /// catch-up flush (consumes EOF).
     #[test]
-    fn silent_pass_then_final_catch_up_preserves_utf8() {
+    fn live_pass_then_final_catch_up_preserves_utf8() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("log.txt");
         let pos = dir.path().join("log.pos");
-        // Producer state at the moment the silent pass fires: "log\n" plus
-        // the first byte of "中" (0xE4).
+        // Producer state at the moment the Live flush fires: "log\n"
+        // plus the first byte of "中" (0xE4).
         let mut partial = Vec::from("log\n");
         partial.push(0xE4);
         fs::write(&file, &partial).unwrap();
 
-        // Silent pre-checkpoint pass: newline-aligned, defers the orphan byte.
+        // Pre-checkpoint Live flush: newline-aligned, defers the orphan byte.
         let (content, new_pos) = read_file_delta(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
-            UploadMode::Tick,
+            UploadMode::Live,
         );
         assert_eq!(content, "log\n");
         assert_eq!(new_pos, 4);

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -859,20 +859,20 @@ async fn send_event_failure_writes_error_flag() {
 }
 
 // =========================================================================
-// Group 8: final_upload delta semantics
+// Group 8: telemetry flush delta semantics
 //
-// These back the parallel-checkpoint-with-catch-up pattern in `main.rs`:
-// on the happy path, the first `final_upload` runs concurrently with
+// Backs the parallel-checkpoint-with-catch-up pattern in `main.rs`: the
+// first `flush(UploadMode::Live)` runs concurrently with
 // `checkpoint::create_checkpoint` and reads the `sandbox_ops` log before
-// checkpoint's sub-op records are written; a second `final_upload` after
-// the join picks up the delta. If `final_upload` ever stopped being
-// incremental — re-reading from offset 0 — that pattern would duplicate
-// records; if position-tracking broke in the other direction, checkpoint
-// sub-ops would be lost entirely.
+// checkpoint's sub-op records are written; a second
+// `flush(UploadMode::Final)` after the join picks up the delta. If the
+// uploader ever stopped being incremental — re-reading from offset 0 —
+// that pattern would duplicate records; if position-tracking broke in
+// the other direction, checkpoint sub-ops would be lost entirely.
 // =========================================================================
 
 #[tokio::test]
-async fn final_upload_is_incremental_between_calls() {
+async fn flush_is_incremental_between_calls() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
 
@@ -898,20 +898,25 @@ async fn final_upload_is_incremental_between_calls() {
         then.status(200);
     });
 
-    let masker = SecretMasker::from_raw("");
+    let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker);
 
-    // Pre-checkpoint record → parallel-pass upload captures it.
+    // Pre-checkpoint record → first flush captures it.
     guest_common::telemetry::record_sandbox_op("first_op", Duration::from_millis(10), true, None);
-    guest_agent::telemetry::final_upload(&masker)
+    telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
         .await
-        .expect("first upload should succeed");
+        .expect("first flush should succeed");
 
     // Simulates a checkpoint sub-op written AFTER the parallel pass read
-    // the sandbox_ops file. The catch-up must pick it up.
+    // the sandbox_ops file. The catch-up flush must pick it up.
     guest_common::telemetry::record_sandbox_op("second_op", Duration::from_millis(20), true, None);
-    guest_agent::telemetry::final_upload(&masker)
+    telemetry
+        .flush(guest_agent::telemetry::UploadMode::Final)
         .await
-        .expect("catch-up upload should succeed");
+        .expect("catch-up flush should succeed");
+
+    telemetry.shutdown().await;
 
     // The first upload carried `first_op` and matched `first_op_mock`.
     // The catch-up MUST NOT have carried `first_op` (position tracking
@@ -922,6 +927,132 @@ async fn final_upload_is_incremental_between_calls() {
 
     first_op_mock.delete_async().await;
     catchup_mock.delete_async().await;
+    let _ = std::fs::remove_file(ops_file);
+    let _ = std::fs::remove_file(pos_file);
+}
+
+/// Regression for #11008: every flush goes through the same select arm,
+/// so `save_position` is single-writer. Even when many concurrent
+/// `flush(UploadMode::Live)` calls race on `tokio::join!`, the pos file
+/// ends at exactly one byte advance (the first flush sees the delta,
+/// every subsequent flush sees an empty file) — never regresses, never
+/// duplicates the upload past the first.
+#[tokio::test]
+async fn concurrent_flushes_do_not_regress_pos_file() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let ops_file = guest_common::telemetry::sandbox_ops_log();
+    let pos_file = guest_agent::paths::telemetry_sandbox_ops_pos_file();
+    let _ = std::fs::remove_file(ops_file);
+    let _ = std::fs::remove_file(pos_file);
+
+    let upload_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.status(200);
+    });
+
+    let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker);
+
+    // Record one op, then fire several concurrent flushes. Pre-refactor a
+    // tick + final could both read the same pos and race on save_position;
+    // post-refactor the select serialises them, so only the first sees a
+    // non-empty delta and only one HTTP POST happens.
+    guest_common::telemetry::record_sandbox_op("only_op", Duration::from_millis(5), true, None);
+
+    let (r1, r2, r3) = tokio::join!(
+        telemetry.flush(guest_agent::telemetry::UploadMode::Live),
+        telemetry.flush(guest_agent::telemetry::UploadMode::Live),
+        telemetry.flush(guest_agent::telemetry::UploadMode::Live),
+    );
+    r1.expect("flush 1 ok");
+    r2.expect("flush 2 ok");
+    r3.expect("flush 3 ok");
+
+    telemetry.shutdown().await;
+
+    // Pos file points at end of the file — no regression.
+    let pos: u64 = std::fs::read_to_string(pos_file)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    let file_len = std::fs::metadata(ops_file).unwrap().len();
+    assert_eq!(pos, file_len, "pos must match file length, no regression");
+
+    // Exactly one upload carried the delta — the others saw empty files.
+    upload_mock.assert_calls_async(1).await;
+
+    upload_mock.delete_async().await;
+    let _ = std::fs::remove_file(ops_file);
+    let _ = std::fs::remove_file(pos_file);
+}
+
+/// Pins three invariants that have no other test coverage:
+/// 1. `flush` propagates the upload's `Err` to the caller (rather than
+///    swallowing it via `let _ = reply.send(...)`).
+/// 2. The uploader loop **keeps running** after a failed upload — a
+///    subsequent `flush` must succeed, not return `TelemetryUnavailable`.
+/// 3. A failed upload does **not** advance the pos file, so the deferred
+///    delta is re-included in the next attempt (and uploaded once
+///    HTTP recovers).
+#[tokio::test]
+async fn flush_propagates_error_then_loop_recovers() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let ops_file = guest_common::telemetry::sandbox_ops_log();
+    let pos_file = guest_agent::paths::telemetry_sandbox_ops_pos_file();
+    let _ = std::fs::remove_file(ops_file);
+    let _ = std::fs::remove_file(pos_file);
+
+    let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker);
+
+    // Force upload_telemetry to fire HTTP by writing a delta.
+    guest_common::telemetry::record_sandbox_op(
+        "first_attempt_op",
+        Duration::from_millis(5),
+        true,
+        None,
+    );
+
+    // First attempt: server returns 500.
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.status(500);
+    });
+
+    let r1 = telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await;
+    assert!(r1.is_err(), "flush must propagate the HTTP 500 to caller");
+    fail_mock.assert_calls_async(1).await;
+    fail_mock.delete_async().await;
+
+    // Second attempt: server returns 200, AND must still see
+    // `first_attempt_op` in the body because the failed first upload
+    // did not advance the pos file.
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/telemetry")
+            .body_includes("first_attempt_op");
+        then.status(200);
+    });
+
+    let r2 = telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await;
+    assert!(
+        r2.is_ok(),
+        "loop must keep accepting flushes after a failed upload, got {r2:?}",
+    );
+    success_mock.assert_calls_async(1).await;
+
+    telemetry.shutdown().await;
+
+    success_mock.delete_async().await;
     let _ = std::fs::remove_file(ops_file);
     let _ = std::fs::remove_file(pos_file);
 }

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -931,12 +931,23 @@ async fn flush_is_incremental_between_calls() {
     let _ = std::fs::remove_file(pos_file);
 }
 
-/// Regression for #11008: every flush goes through the same select arm,
-/// so `save_position` is single-writer. Even when many concurrent
-/// `flush(UploadMode::Live)` calls race on `tokio::join!`, the pos file
-/// ends at exactly one byte advance (the first flush sees the delta,
-/// every subsequent flush sees an empty file) — never regresses, never
-/// duplicates the upload past the first.
+/// Regression for #11008. Combines two distinct guarantees that
+/// together produce the "exactly one HTTP POST" assertion:
+///
+/// 1. **Channel serialization**: every flush goes through the same
+///    `tokio::select!` arm in `run()`, so `upload_telemetry` calls are
+///    strictly sequential — `save_position` is single-writer.
+/// 2. **Empty-delta short-circuit**: the second and third flushes
+///    observe `pos == file_len` after the first flush advanced the
+///    position, hit the `system_log.is_empty() && metrics.is_empty()
+///    && sandbox_ops.is_empty()` early-return in `upload_telemetry`,
+///    and skip HTTP entirely.
+///
+/// Without (1), two flushes could read the same pos and post twice.
+/// Without (2), three flushes would all serialize but each would post
+/// (the second and third with empty bodies). Asserting `calls == 1`
+/// pins both: pos never regresses (1) and empty deltas don't generate
+/// HTTP traffic (2).
 #[tokio::test]
 async fn concurrent_flushes_do_not_regress_pos_file() {
     let _guard = TEST_MUTEX.lock().unwrap();


### PR DESCRIPTION
## Summary

- Eliminates the multi-writer race on `*_pos.txt` files (#11008) by giving an actor task exclusive ownership of the pos files; periodic ticks and caller-driven flushes flow through the same `tokio::select!`
- New `Telemetry` API: `spawn` / `flush(UploadMode::{Live,Final})` / `shutdown`; replaces `telemetry_loop` / `final_upload` / `final_upload_silent`
- Adds three integration tests pinning the new contract: incremental delta semantics, single-writer serialization under concurrent flush, and error-propagation + loop-survival + pos-non-advance after failed upload

## Background

`telemetry_loop` ticked every 30s while `execute()` ran `final_upload_silent` in `tokio::join!` with `create_checkpoint`, then called `final_upload` post-checkpoint. Each path independently did `read pos → await HTTP → save pos` against the same files, so two overlapping passes could each read pos=X, upload different deltas, and have the later writer regress the position. Next tick re-uploaded the duplicated bytes (#11008).

The fix is structural, not a Mutex: the pos files become private to a single tokio task. Callers send `Cmd::Flush { mode, reply }` over an mpsc channel; `tokio::select!` with `biased` gives caller flushes priority over ticks at any select boundary. Multi-writer races are now impossible by construction, not by convention.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy -p guest-agent --all-targets -- -D warnings`
- [x] `cargo fmt --check -p guest-agent`
- [x] `cargo test -p guest-agent --lib` (96 passed)
- [x] `cargo test -p guest-agent --test integration` (35 passed; 3 new)
- [ ] CI: lint + cli-e2e + serial passes

## Notes

- `Telemetry::spawn` doc warns against multiple instances per process — pos paths are global, two uploaders would reintroduce the race the channel was built to remove. Type system can't enforce this; the constraint is the shared pos paths, not the channel.
- Resource cleanup: `shutdown(self)` consumes the handle and awaits graceful termination. Drop without shutdown detaches the task, which exits naturally when the channel closes (≤1 in-flight HTTP RTT). No leaks.
- Performance: common case identical to before (channel overhead is sub-microsecond vs ~1s HTTP). Pathological case (slow telemetry endpoint) caps the silent flush wait at one in-flight tick — same as the old code's worst case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)