### PR TITLE
test: stabilize sync skills freshness test

### DIFF
--- a/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
@@ -167,25 +167,15 @@ describe("GET /api/cron/sync-skills", () => {
 
   describe("Freshness check", () => {
     it("should skip sync when commit SHA is unchanged", async () => {
-      const tarball = createFullTarball([
-        EXTRA_SKILLS.alphaSkill,
-        EXTRA_SKILLS.betaSkill,
-      ]);
-      setupMswHandlers(testSha, tarball);
+      await setAllTestSkillsCommitSha(testSha);
+      setupGitRefsHandler(testSha);
 
-      // First sync — updates commitSha on all skills
-      const response1 = await GET(cronRequest(cronSecret));
-      expect(response1.status).toBe(200);
-      const data1 = await response1.json();
-      expect(data1.success).toBe(true);
-
-      // Second sync with same commit SHA — should skip
-      const response2 = await GET(cronRequest(cronSecret));
-      expect(response2.status).toBe(200);
-      const data2 = await response2.json();
-      expect(data2.synced).toBe(0);
-      expect(data2.skipped).toBe(0);
-      expect(data2.total).toBe(0);
+      const response = await GET(cronRequest(cronSecret));
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.synced).toBe(0);
+      expect(data.skipped).toBe(0);
+      expect(data.total).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary
- make the sync-skills freshness test seed the unchanged commit SHA directly
- keep full tarball extraction/S3/DB upsert coverage in the existing full and incremental sync tests
- remove the expensive first full sync from the freshness-only case

## Verification
- pnpm exec vitest run --dir app/api/cron/sync-skills
- pnpm db:reset
- pnpm test
- pre-commit hooks passed with normal git commit (no --no-verify)
