### PR TITLE
fix: add missing display names for OpenRouter-format model IDs

### DIFF
--- a/turbo/packages/core/src/model-display-name.ts
+++ b/turbo/packages/core/src/model-display-name.ts
@@ -11,12 +11,16 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   // Anthropic via OpenRouter / Vercel AI Gateway
   "anthropic/claude-sonnet-4.6": "Claude Sonnet 4.6",
   "anthropic/claude-opus-4.6": "Claude Opus 4.6",
+  "anthropic/claude-opus-4.7": "Claude Opus 4.7",
   "anthropic/claude-sonnet-4.5": "Claude Sonnet 4.5",
   "anthropic/claude-opus-4.5": "Claude Opus 4.5",
   "anthropic/claude-haiku-4.5": "Claude Haiku 4.5",
-  // DeepSeek
+  // DeepSeek (native)
   "deepseek-v4-pro": "DeepSeek V4 Pro",
   "deepseek-v4-flash": "DeepSeek V4 Flash",
+  // DeepSeek via OpenRouter
+  "deepseek/deepseek-v4-pro": "DeepSeek V4 Pro",
+  "deepseek/deepseek-v4-flash": "DeepSeek V4 Flash",
   // MiniMax
   "MiniMax-M2.7": "MiniMax M2.7",
   "MiniMax-M2.1": "MiniMax M2.1",
@@ -34,6 +38,7 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   "glm-4.7": "GLM-4.7",
   "glm-4.5-air": "GLM-4.5 Air",
   "zai/glm-5-turbo": "GLM-5 Turbo",
+  "z-ai/glm-5.1": "GLM-5.1",
 });
 
 /**


### PR DESCRIPTION
## Summary

Fixed 4 missing model display names in `model-display-name.ts`. These OpenRouter-format IDs (`provider/model-name`) were missing mappings, causing raw IDs to show in the UI instead of friendly names.

- `deepseek/deepseek-v4-pro` → "DeepSeek V4 Pro"
- `deepseek/deepseek-v4-flash` → "DeepSeek V4 Flash"
- `anthropic/claude-opus-4.7` → "Claude Opus 4.7"
- `z-ai/glm-5.1` → "GLM-5.1"

## Context

When a user configures OpenRouter as their model provider, the model list uses the `provider/model` format (e.g. `deepseek/deepseek-v4-pro`). The native provider format (`deepseek-v4-pro`) already had display names, but the OpenRouter equivalents were missing. The `getModelDisplayName()` fallback would return the raw ID, which looks bad in the UI.

Also reported: DeepSeek V4 Pro returns 429 via OpenRouter. This was investigated — the model IDs and provider config are correct. The 429 comes from DeepSeek's upstream API through OpenRouter, not from our code.

## Test plan

- [ ] Verify model selector UI shows friendly names for all OpenRouter models
- [ ] Verify `getModelDisplayName()` returns correct names for the 4 added IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)