### PR TITLE
fix(schedule): demote insufficient-credits skip from error to warn

### DIFF
--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -810,14 +810,15 @@ export async function executeDueSchedules(): Promise<{
         orgId: schedule.orgId,
         userId: schedule.userId,
         error: error instanceof Error ? error.message : String(error),
+        // Include stack on the error path so Axiom retains it for diagnosis
+        // of real system failures. Credit rejections don't need a stack —
+        // they're a deterministic user state, not a bug.
+        stack: error instanceof Error ? error.stack : undefined,
       };
       if (isCreditError) {
         log.warn("Schedule skipped: insufficient credits", failureContext);
       } else {
-        log.error(
-          `Failed to execute schedule ${schedule.name}:`,
-          failureContext,
-        );
+        log.error("Schedule pre-run failed", failureContext);
       }
 
       // Pre-run failure: increment consecutive failures and schedule next attempt

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -6,7 +6,12 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { decryptSecretsMap } from "../../shared/crypto";
-import { notFound, badRequest, schedulePast } from "@vm0/api-services/errors";
+import {
+  notFound,
+  badRequest,
+  schedulePast,
+  isInsufficientCredits,
+} from "@vm0/api-services/errors";
 import { logger } from "../../shared/logger";
 import { createZeroRun } from "../zero-run-service";
 import { buildSchedulePrompt } from "../integration-prompt";
@@ -793,7 +798,27 @@ export async function executeDueSchedules(): Promise<{
       await executeSchedule(schedule, Date.now());
       executed++;
     } catch (error) {
-      log.error(`Failed to execute schedule ${schedule.name}:`, error);
+      // InsufficientCredits is an expected user-state rejection (HTTP 402),
+      // not a system bug — log it at `warn` so it doesn't trip Axiom's
+      // error-level alerts. All other failures stay at `error`. Both paths
+      // share the consecutive-failures + auto-disable book-keeping below,
+      // which eventually stops the per-tick log on a persistently empty org.
+      const isCreditError = isInsufficientCredits(error);
+      const failureContext = {
+        scheduleId: schedule.id,
+        scheduleName: schedule.name,
+        orgId: schedule.orgId,
+        userId: schedule.userId,
+        error: error instanceof Error ? error.message : String(error),
+      };
+      if (isCreditError) {
+        log.warn("Schedule skipped: insufficient credits", failureContext);
+      } else {
+        log.error(
+          `Failed to execute schedule ${schedule.name}:`,
+          failureContext,
+        );
+      }
 
       // Pre-run failure: increment consecutive failures and schedule next attempt
       // (mirrors callback failure handling from #8430)
@@ -831,7 +856,10 @@ export async function executeDueSchedules(): Promise<{
         log.warn("Schedule auto-disabled after consecutive pre-run failures", {
           scheduleId: schedule.id,
           scheduleName: schedule.name,
+          orgId: schedule.orgId,
+          userId: schedule.userId,
           consecutiveFailures: newFailureCount,
+          reason: isCreditError ? "insufficient_credits" : "pre_run_failure",
         });
       }
 


### PR DESCRIPTION
## Summary

Closes #11128.

`InsufficientCreditsError` is an expected HTTP 402 user-state rejection from `checkOrgCreditsForRun`, **not a system bug**. But `executeDueSchedules`'s generic catch logged it at `error` level, which trips Axiom's error-level alerts and auto-files GitHub bug issues like #11128.

This change special-cases `isInsufficientCredits` in the catch block:

- **Log severity**: `error` → `warn` for credit failures only. All other failures still log at `error`.
- **Structured context**: every failure log now includes `scheduleId / scheduleName / orgId / userId / error` so operators can identify whose schedule was skipped instead of digging through deployments.
- **Bookkeeping unchanged**: `consecutiveFailures` still increments and the schedule still auto-disables after 3 ticks, so per-tick log noise eventually stops on a persistently empty org.

The auto-disable warn line also gains `orgId / userId / reason` for the same observability reason.

## Why not also stop incrementing `consecutiveFailures`?

Considered. Without the increment, a credit-exhausted schedule would log at warn every minute forever — same noise problem, just at a different level. Keeping the auto-disable behavior bounds the noise to 3 ticks (~3 minutes) per credit-exhaustion event, after which the user explicitly re-enables once they top up. That's the existing contract for "schedule auto-disabled" — credit exhaustion just gets clearer attribution.

## Test plan

- [x] `pnpm -F web exec vitest run app/api/cron/execute-schedules` — 20 pass
- [x] `pnpm -F web exec vitest run app/api/internal/callbacks/schedule app/api/zero/schedules src/lib/zero/__tests__/credit-check.test.ts src/lib/zero/__tests__/pre-run-checks.test.ts` — 77 pass
- [x] `pnpm check-types` — green
- [x] `pnpm format`, lefthook (prettier + knip + commitlint) — green
- [ ] After merge: confirm credit-exhausted schedules no longer auto-file Axiom bug issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)