### PR TITLE
fix(api-contracts): validate run id path/body params as uuid

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
@@ -77,9 +77,9 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
 
   describe("Error Handling", () => {
     it("should return 401 for unauthenticated request", async () => {
-      mockClerk({ userId: null });
-
       const run = await createTestRun(testComposeId, "Test run");
+
+      mockClerk({ userId: null });
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${run.runId}`,

--- a/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
@@ -105,6 +105,20 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
       expect(data.error.message).toContain("not found");
     });
 
+    // Regression for #11126: short non-UUID id used to flow into drizzle and
+    // surface as a postgres `22P02 invalid input syntax for type uuid` 500.
+    it("should return 400 when id is not a valid UUID", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs/2b9b2303",
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
     it("should return 404 for run belonging to another user", async () => {
       // Create another user and their run
       const otherUser = await context.setupUser({ prefix: "other" });

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -201,9 +201,9 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
 
   describe("Error Handling", () => {
     it("should return 401 for unauthenticated request", async () => {
-      mockClerk({ userId: null });
-
       const run = await createTestRun(testComposeId, "Run to cancel");
+
+      mockClerk({ userId: null });
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${run.runId}/cancel`,

--- a/turbo/apps/web/app/api/zero/report-error/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/report-error/__tests__/route.test.ts
@@ -94,6 +94,20 @@ describe("POST /api/zero/report-error", () => {
     expect(data.error.code).toBe("RUN_NOT_FOUND");
   });
 
+  // Regression for #11126: short non-UUID runId used to flow into drizzle and
+  // surface as a postgres `22P02 invalid input syntax for type uuid` 500.
+  it("should return 400 when runId is not a valid UUID", async () => {
+    const response = await postReportError({
+      runId: "2b9b2303",
+      title: "Bug",
+      description: "Desc",
+    });
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    expect(data.error.code).toBe("BAD_REQUEST");
+  });
+
   it("should return 400 for non-failed run", async () => {
     const compose = await createTestCompose(`agent-${uniqueId("rpt")}`);
     const { runId } = await seedTestRun(userId, compose.composeId, {

--- a/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
@@ -59,6 +59,19 @@ describe("GET /api/zero/runs/:id", () => {
     expect(response.status).toBe(404);
   });
 
+  // Regression for #11126: short non-UUID id used to flow into drizzle and
+  // surface as a postgres `22P02 invalid input syntax for type uuid` 500.
+  it("should return 400 when id is not a valid UUID", async () => {
+    const userId = uniqueId("zrun-bad");
+    await setupOrg(userId);
+
+    const response = await GET(createTestRequest(runUrl("2b9b2303")));
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    expect(data.error.code).toBe("BAD_REQUEST");
+  });
+
   it("should return 401 when not authenticated", async () => {
     mockClerk({ userId: null });
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
@@ -63,7 +63,9 @@ describe("GET /api/zero/runs/:id", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/runs/some-id"),
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000",
+      ),
     );
     expect(response.status).toBe(401);
   });
@@ -73,9 +75,12 @@ describe("GET /api/zero/runs/:id", () => {
     const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/runs/some-id", {
-        headers: { Authorization: `Bearer ${token}` },
-      }),
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      ),
     );
     expect(response.status).toBe(403);
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
@@ -105,9 +105,12 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest("http://localhost:3000/api/zero/runs/some-id/cancel", {
-        method: "POST",
-      }),
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/cancel",
+        {
+          method: "POST",
+        },
+      ),
     );
     expect(response.status).toBe(401);
   });
@@ -117,10 +120,13 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     const token = await generateSandboxToken("user-1", "run-1", "org-test");
 
     const response = await POST(
-      createTestRequest("http://localhost:3000/api/zero/runs/some-id/cancel", {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
-      }),
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/cancel",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      ),
     );
     expect(response.status).toBe(403);
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
@@ -143,7 +143,9 @@ describe("GET /api/zero/runs/:id/context", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/runs/some-id/context"),
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/context",
+      ),
     );
     expect(response.status).toBe(401);
   });

--- a/turbo/apps/web/app/api/zero/runs/[id]/network/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/network/__tests__/route.test.ts
@@ -124,7 +124,9 @@ describe("GET /api/zero/runs/:id/network", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/runs/some-id/network"),
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/network",
+      ),
     );
     expect(response.status).toBe(401);
   });

--- a/turbo/apps/web/app/api/zero/runs/[id]/runner/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/runner/__tests__/route.test.ts
@@ -97,7 +97,9 @@ describe("GET /api/zero/runs/:id/runner", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/runs/some-id/runner"),
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/runner",
+      ),
     );
     expect(response.status).toBe(401);
   });

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -259,7 +259,7 @@ export const runsByIdContract = c.router({
     path: "/api/agent/runs/:id",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     responses: {
       200: getRunResponseSchema,
@@ -293,7 +293,7 @@ export const runsCancelContract = c.router({
     path: "/api/agent/runs/:id/cancel",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     body: z.undefined(),
     responses: {
@@ -320,7 +320,7 @@ export const runEventsContract = c.router({
     path: "/api/agent/runs/:id/events",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     query: z.object({
       since: z.coerce.number().default(-1),
@@ -442,7 +442,7 @@ export const runTelemetryContract = c.router({
     path: "/api/agent/runs/:id/telemetry",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     responses: {
       200: telemetryResponseSchema,
@@ -466,7 +466,7 @@ export const runSystemLogContract = c.router({
     path: "/api/agent/runs/:id/telemetry/system-log",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     query: z.object({
       since: z.coerce.number().optional(),
@@ -495,7 +495,7 @@ export const runMetricsContract = c.router({
     path: "/api/agent/runs/:id/telemetry/metrics",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     query: z.object({
       since: z.coerce.number().optional(),
@@ -524,7 +524,7 @@ export const runAgentEventsContract = c.router({
     path: "/api/agent/runs/:id/telemetry/agent",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     query: z.object({
       since: z.coerce.number().optional(),
@@ -553,7 +553,7 @@ export const runNetworkLogsContract = c.router({
     path: "/api/agent/runs/:id/telemetry/network",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     query: z.object({
       since: z.coerce.number().optional(),

--- a/turbo/packages/api-contracts/src/contracts/zero-report-error.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-report-error.ts
@@ -5,7 +5,7 @@ import { apiErrorSchema } from "./errors";
 const c = initContract();
 
 const reportErrorBodySchema = z.object({
-  runId: z.string().min(1, "Run ID is required"),
+  runId: z.uuid("Run ID must be a valid UUID"),
   title: z.string().min(1, "Title is required"),
   description: z.string().optional(),
 });

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -70,7 +70,7 @@ export const zeroRunsByIdContract = c.router({
     path: "/api/zero/runs/:id",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     responses: {
       200: getRunResponseSchema,
@@ -92,7 +92,7 @@ export const zeroRunsCancelContract = c.router({
     path: "/api/zero/runs/:id/cancel",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     body: z.undefined(),
     responses: {
@@ -134,7 +134,7 @@ export const zeroRunAgentEventsContract = c.router({
     path: "/api/zero/runs/:id/telemetry/agent",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     query: z.object({
       since: z.coerce.number().optional(),
@@ -211,7 +211,7 @@ export const zeroRunContextContract = c.router({
     path: "/api/zero/runs/:id/context",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     responses: {
       200: runContextResponseSchema,
@@ -233,7 +233,7 @@ export const zeroRunNetworkLogsContract = c.router({
     path: "/api/zero/runs/:id/network",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     query: z.object({
       since: z.coerce.number().optional(),
@@ -267,7 +267,7 @@ export const zeroRunRunnerContract = c.router({
     path: "/api/zero/runs/:id/runner",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Run ID is required"),
+      id: z.uuid("Run ID must be a valid UUID"),
     }),
     responses: {
       200: runRunnerResponseSchema,


### PR DESCRIPTION
## Summary

Closes #11126.

`agent_runs.id` is a postgres `uuid` column, but the run id path parameter on `runsByIdContract`, `runAgentEventsContract`, and the other agent/zero run contracts was only validated as `z.string().min(1)`. A short non-UUID like `2b9b2303` (e.g. someone copying the 8-char short id rendered by `vm0 logs search`) passed zod, hit drizzle, and surfaced as a 500 from the postgres `22P02 invalid input syntax for type uuid`.

This PR tightens the schemas to `z.uuid(...)`. The existing ts-rest path-params handler now returns 400 BAD_REQUEST instead of letting the bad id reach the database. Same fix applied to the `runId` body field on `zeroReportErrorContract.submit`.

Touched contracts:
- `runs.ts`: byId, cancel, events, telemetry, system-log, metrics, agent-events, network-logs (8 path params)
- `zero-runs.ts`: byId, cancel, agent-events, context, network-logs, runner (6 path params)
- `zero-report-error.ts`: submit body `runId`

## Test plan

- [x] Existing `pnpm -F @vm0/api-contracts exec vitest` passes (572 tests)
- [x] `pnpm -F web exec vitest run app/api/agent/runs app/api/zero/runs app/api/zero/report-error` passes (303 tests)
- [x] `pnpm -F @vm0/cli exec vitest` passes (1058 tests)
- [x] `pnpm -F @vm0/app exec vitest` passes (175 tests on signals/zero-page + signals/report-error)
- [x] `pnpm turbo run lint` clean
- [x] `pnpm check-types` clean
- [x] Existing 401-unauthenticated test cases that were using hardcoded `"some-id"` strings updated to use a placeholder uuid so path-params validation no longer short-circuits the auth assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)