### PR TITLE
fix: complete posthog instrumentation

### DIFF
--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -26,11 +26,17 @@ export function initPostHog(): void {
   });
 }
 
-export function setPostHogUser(userId: string): void {
+interface PostHogUser {
+  id: string;
+  email: string | undefined;
+  name: string | undefined;
+}
+
+export function setPostHogUser(user: PostHogUser): void {
   if (!POSTHOG_KEY) {
     return;
   }
-  posthog.identify(userId);
+  posthog.identify(user.id, { email: user.email, name: user.name });
 }
 
 export function clearPostHogUser(): void {
@@ -72,3 +78,32 @@ export const markRouteSetupBegin$ = command(({ get, set }) => {
   }
   set(navigationSetupTime$, performance.now());
 });
+
+export const captureNavigationTiming$ = command(({ get, set }) => {
+  const enterTime = get(navigationEnterTime$);
+  if (!POSTHOG_KEY || enterTime === null) {
+    return;
+  }
+  const now = performance.now();
+  const pushStateTime = get(navigationPushStateTime$);
+  const setupTime = get(navigationSetupTime$);
+  posthog.capture("chat_navigation_timing", {
+    total_ms: Math.round(now - enterTime),
+    push_state_ms:
+      pushStateTime !== null
+        ? Math.round(pushStateTime - enterTime)
+        : undefined,
+    setup_begin_ms:
+      setupTime !== null ? Math.round(setupTime - enterTime) : undefined,
+  });
+  set(navigationEnterTime$, null);
+  set(navigationPushStateTime$, null);
+  set(navigationSetupTime$, null);
+});
+
+export function capturePageView(): void {
+  if (!POSTHOG_KEY) {
+    return;
+  }
+  posthog.capture("$pageview");
+}

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -62,7 +62,11 @@ export const setupClerk$ = command(
     // Set initial Sentry user context
     if (clerk.user) {
       setSentryUser(clerk.user.id);
-      setPostHogUser(clerk.user.id);
+      setPostHogUser({
+        id: clerk.user.id,
+        email: clerk.user.primaryEmailAddress?.emailAddress,
+        name: clerk.user.fullName ?? undefined,
+      });
     }
 
     // Track the user ID so we only trigger a reload on actual auth state
@@ -73,7 +77,11 @@ export const setupClerk$ = command(
       // Update Sentry user context on auth state change
       if (clerk.user) {
         setSentryUser(clerk.user.id);
-        setPostHogUser(clerk.user.id);
+        setPostHogUser({
+          id: clerk.user.id,
+          email: clerk.user.primaryEmailAddress?.emailAddress,
+          name: clerk.user.fullName ?? undefined,
+        });
       } else {
         clearSentryUser();
         clearPostHogUser();

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -20,7 +20,10 @@ import {
   clearMatchingOptimisticChatThread$,
   optimisticChatThread$,
 } from "./optimistic-chat-thread-page.ts";
-import { markRouteSetupBegin$ } from "../../lib/posthog.ts";
+import {
+  captureNavigationTiming$,
+  markRouteSetupBegin$,
+} from "../../lib/posthog.ts";
 
 export const setupChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -54,6 +57,7 @@ export const setupChatPage$ = command(
       "sidebar",
     );
     await set(hideAppSkeleton$, signal);
+    set(captureNavigationTiming$);
 
     if (matchingOptimisticThread) {
       set(updateDocumentTitle$, "New chat");

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -7,7 +7,7 @@ import { setPageSignal$ } from "./page-signal.ts";
 import { rootSignal$ } from "./root-signal.ts";
 import { onDomEventFn, resetSignal } from "./utils.ts";
 import { logger } from "./log.ts";
-import { markNavigationPushState$ } from "../lib/posthog.ts";
+import { capturePageView, markNavigationPushState$ } from "../lib/posthog.ts";
 
 const L = logger("Route");
 
@@ -95,6 +95,7 @@ const loadRoute$ = command(async ({ get, set }, signal: AbortSignal) => {
   L.debug("loading route", currentRoute.path);
 
   await set(currentRoute.setup, routeSignal);
+  capturePageView();
 });
 
 const navigateToDefaultWhenInvalid$ = command(({ get, set }) => {

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -95,6 +95,7 @@ const loadRoute$ = command(async ({ get, set }, signal: AbortSignal) => {
   L.debug("loading route", currentRoute.path);
 
   await set(currentRoute.setup, routeSignal);
+  signal.throwIfAborted();
   capturePageView();
 });
 


### PR DESCRIPTION
## Summary

- **identify with user properties**: `setPostHogUser` now passes `email` and `name` from Clerk so users appear as real identities in PostHog instead of anonymous IDs
- **complete navigation timing**: `captureNavigationTiming$` was missing — the three timing signals were collecting timestamps but never calling `posthog.capture()`. Now fires `chat_navigation_timing` event (with `total_ms`, `push_state_ms`, `setup_begin_ms`) after the skeleton hides
- **pageview tracking**: `capturePageView()` added to `loadRoute$` to cover all route transitions (initial load, SPA navigation, popstate), replacing the disabled `capture_pageview` autocapture

## Test plan

- [ ] Sign in and verify PostHog shows user with email/name in Persons view
- [ ] Navigate to a chat thread and verify `chat_navigation_timing` event appears with valid ms values
- [ ] Navigate between routes and verify `$pageview` events fire with sanitized URLs (`/:id` instead of raw UUIDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)