### PR TITLE
fix: stabilize run stdout event visibility

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -145,13 +145,54 @@ fn build_claude_command(use_mock: bool) -> Vec<String> {
     cmd
 }
 
+struct PreparedEvent {
+    sequence: u32,
+    payload: serde_json::Value,
+}
+
+#[derive(Default)]
+struct AckedEventPrefix {
+    next_expected: u32,
+    last_contiguous: Option<u32>,
+    prefix_broken: bool,
+}
+
+impl AckedEventPrefix {
+    fn record_success(&mut self, sequence: u32) {
+        if self.prefix_broken {
+            return;
+        }
+
+        if sequence == self.next_expected {
+            self.last_contiguous = Some(sequence);
+            self.next_expected = sequence.saturating_add(1);
+        } else if sequence > self.next_expected {
+            self.prefix_broken = true;
+        }
+    }
+
+    fn record_failure(&mut self, sequence: u32) {
+        if sequence >= self.next_expected {
+            self.prefix_broken = true;
+        }
+    }
+
+    fn last_contiguous(&self) -> Option<u32> {
+        self.last_contiguous
+    }
+}
+
+pub struct CliExecutionResult {
+    pub exit_code: i32,
+    pub stderr_lines: Vec<String>,
+    pub last_event_sequence: Option<u32>,
+}
+
 /// Execute the CLI process, streaming JSONL events and racing against heartbeat.
-///
-/// Returns `(exit_code, stderr_lines)`.
 pub async fn execute_cli(
     masker: &SecretMasker,
     mut heartbeat_handle: tokio::task::JoinHandle<Result<(), AgentError>>,
-) -> Result<(i32, Vec<String>), AgentError> {
+) -> Result<CliExecutionResult, AgentError> {
     log_info!(LOG_TAG, "Starting claude-code execution...");
 
     let cmd = build_cli_command()?;
@@ -190,7 +231,7 @@ pub async fn execute_cli(
         .ok_or_else(|| AgentError::Execution("no stderr".into()))?;
 
     // Stderr collector
-    let stderr_handle = tokio::spawn(async move {
+    let mut stderr_handle = tokio::spawn(async move {
         let mut lines = Vec::new();
         let mut reader = tokio::io::BufReader::new(stderr).lines();
         while let Ok(Some(line)) = reader.next_line().await {
@@ -254,13 +295,21 @@ pub async fn execute_cli(
     // Background event sender: HTTP POSTs happen here, never in the
     // stdout reading loop.  Unbounded channel because events are small
     // and CLI lifetime is bounded by JOB_TIMEOUT.
-    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<serde_json::Value>();
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
     let event_sender = tokio::spawn(async move {
-        while let Some(payload) = event_rx.recv().await {
-            if let Err(e) = events::post_event(&payload).await {
-                log_warn!(LOG_TAG, "Event send failed: {e}");
+        let mut acked_prefix = AckedEventPrefix::default();
+        while let Some(event) = event_rx.recv().await {
+            match events::post_event(&event.payload).await {
+                Ok(()) => {
+                    acked_prefix.record_success(event.sequence);
+                }
+                Err(e) => {
+                    acked_prefix.record_failure(event.sequence);
+                    log_warn!(LOG_TAG, "Event send failed: {e}");
+                }
             }
         }
+        acked_prefix.last_contiguous()
     });
 
     let event_result: Result<(), AgentError> = loop {
@@ -314,7 +363,12 @@ pub async fn execute_cli(
                             // Prepare event (fast: mask secrets, add seq) and enqueue
                             // for background sending.  Never blocks the reading loop.
                             if let Some(payload) = events::prepare_event(&mut event, seq, masker)
-                                && event_tx.send(payload).is_err()
+                                && event_tx
+                                    .send(PreparedEvent {
+                                        sequence: seq,
+                                        payload,
+                                    })
+                                    .is_err()
                             {
                                 log_warn!(LOG_TAG, "Event channel closed, dropping event seq={seq}");
                             }
@@ -450,12 +504,19 @@ pub async fn execute_cli(
     // On error (e.g. heartbeat failure) the server is likely unreachable,
     // so we drop unsent events to avoid stalling on retries.
     drop(event_tx);
+    let mut last_event_sequence = None;
     if event_result.is_ok() {
-        if let Err(e) = event_sender.await {
-            log_warn!(LOG_TAG, "Event sender task failed: {e}");
+        match event_sender.await {
+            Ok(sequence) => {
+                last_event_sequence = sequence;
+            }
+            Err(e) => {
+                log_warn!(LOG_TAG, "Event sender task failed: {e}");
+            }
         }
     } else {
         event_sender.abort();
+        let _ = event_sender.await;
     }
 
     let status = match cli_status {
@@ -482,30 +543,36 @@ pub async fn execute_cli(
 
     // Apply the same drain deadline to stderr — orphaned child processes
     // may hold the stderr fd open just like stdout.
-    let stderr_lines = match tokio::time::timeout(
-        Duration::from_secs(constants::STDOUT_DRAIN_DEADLINE_SECS),
-        stderr_handle,
-    )
-    .await
-    {
-        Ok(Ok(lines)) => lines,
-        Ok(Err(e)) => {
-            log_warn!(LOG_TAG, "stderr collector panicked: {e}");
-            Vec::new()
-        }
-        Err(_) => {
+    let stderr_timeout =
+        tokio::time::sleep(Duration::from_secs(constants::STDOUT_DRAIN_DEADLINE_SECS));
+    tokio::pin!(stderr_timeout);
+    let stderr_lines = tokio::select! {
+        result = &mut stderr_handle => match result {
+            Ok(lines) => lines,
+            Err(e) => {
+                log_warn!(LOG_TAG, "stderr collector panicked: {e}");
+                Vec::new()
+            }
+        },
+        () = &mut stderr_timeout => {
             log_warn!(
                 LOG_TAG,
                 "stderr drain timeout, possible orphaned child process"
             );
+            stderr_handle.abort();
+            let _ = stderr_handle.await;
             Vec::new()
-        }
+        },
     };
 
     // If event loop had an error, propagate it
     event_result?;
 
-    Ok((exit_code, stderr_lines))
+    Ok(CliExecutionResult {
+        exit_code,
+        stderr_lines,
+        last_event_sequence,
+    })
 }
 
 #[cfg(test)]
@@ -688,6 +755,53 @@ mod tests {
     fn build_claude_args_prompt_always_last() {
         let args = build_claude_args("", "", "", "", "", "my prompt");
         assert_eq!(args.last().unwrap(), "my prompt");
+    }
+
+    // -----------------------------------------------------------------
+    // AckedEventPrefix
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn acked_event_prefix_advances_on_contiguous_successes() {
+        let mut prefix = AckedEventPrefix::default();
+
+        prefix.record_success(0);
+        prefix.record_success(1);
+        prefix.record_success(2);
+
+        assert_eq!(prefix.last_contiguous(), Some(2));
+    }
+
+    #[test]
+    fn acked_event_prefix_stops_at_first_failed_event() {
+        let mut prefix = AckedEventPrefix::default();
+
+        prefix.record_success(0);
+        prefix.record_failure(1);
+        prefix.record_success(2);
+
+        assert_eq!(prefix.last_contiguous(), Some(0));
+    }
+
+    #[test]
+    fn acked_event_prefix_has_no_watermark_when_first_event_fails() {
+        let mut prefix = AckedEventPrefix::default();
+
+        prefix.record_failure(0);
+        prefix.record_success(1);
+
+        assert_eq!(prefix.last_contiguous(), None);
+    }
+
+    #[test]
+    fn acked_event_prefix_rejects_success_gap() {
+        let mut prefix = AckedEventPrefix::default();
+
+        prefix.record_success(0);
+        prefix.record_success(2);
+        prefix.record_success(3);
+
+        assert_eq!(prefix.last_contiguous(), Some(0));
     }
 
     // -----------------------------------------------------------------

--- a/crates/guest-agent/src/complete.rs
+++ b/crates/guest-agent/src/complete.rs
@@ -31,6 +31,8 @@ struct CompletePayload<'a> {
     run_id: &'a str,
     exit_code: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    last_event_sequence: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     sandbox_id: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     sandbox_reuse_result: Option<&'a str>,
@@ -48,9 +50,17 @@ fn as_optional(value: &str) -> Option<&str> {
 /// empty strings are serialized as absent so an unset env var is equivalent
 /// to omitting the field.
 ///
+/// `last_event_sequence` is the highest contiguous agent event sequence whose
+/// events webhook POST succeeded. The host uses it as a best-effort Axiom
+/// visibility watermark before marking the run completed.
+///
 /// Fire-and-forget. Returns `()` and never propagates errors — the runner's
 /// fallback call covers any failure here.
-pub async fn report_success(sandbox_id: &str, sandbox_reuse_result: &str) {
+pub async fn report_success(
+    sandbox_id: &str,
+    sandbox_reuse_result: &str,
+    last_event_sequence: Option<u32>,
+) {
     if !env::has_api() {
         return;
     }
@@ -58,6 +68,7 @@ pub async fn report_success(sandbox_id: &str, sandbox_reuse_result: &str) {
     let payload = CompletePayload {
         run_id: env::run_id(),
         exit_code: 0,
+        last_event_sequence,
         sandbox_id: as_optional(sandbox_id),
         sandbox_reuse_result: as_optional(sandbox_reuse_result),
     };
@@ -79,6 +90,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            last_event_sequence: None,
             sandbox_id: None,
             sandbox_reuse_result: None,
         };
@@ -91,6 +103,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            last_event_sequence: None,
             sandbox_id: Some("abc"),
             sandbox_reuse_result: Some("reused"),
         };
@@ -108,6 +121,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            last_event_sequence: None,
             sandbox_id: None,
             sandbox_reuse_result: Some("poolMiss"),
         };
@@ -121,6 +135,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            last_event_sequence: None,
             sandbox_id: Some("sid"),
             sandbox_reuse_result: None,
         };
@@ -133,5 +148,21 @@ mod tests {
     fn as_optional_treats_empty_as_none() {
         assert_eq!(as_optional(""), None);
         assert_eq!(as_optional("value"), Some("value"));
+    }
+
+    #[test]
+    fn payload_includes_last_event_sequence_when_present() {
+        let payload = CompletePayload {
+            run_id: "run-123",
+            exit_code: 0,
+            last_event_sequence: Some(7),
+            sandbox_id: None,
+            sandbox_reuse_result: None,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert_eq!(
+            json,
+            r#"{"runId":"run-123","exitCode":0,"lastEventSequence":7}"#
+        );
     }
 }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -141,14 +141,21 @@ async fn execute(
     // Execution phase
     log_info!(LOG_TAG, "▷ Execution");
     let cli_start = Instant::now();
+    let mut last_event_sequence = None;
     let (mut exit_code, error_message) = match cli::execute_cli(masker, heartbeat_handle).await {
-        Ok((code, stderr_lines)) => {
+        Ok(cli_result) => {
+            last_event_sequence = cli_result.last_event_sequence;
+            let code = cli_result.exit_code;
             if code != 0 {
-                let msg = if stderr_lines.is_empty() {
+                let msg = if cli_result.stderr_lines.is_empty() {
                     format!("Agent exited with code {code}")
                 } else {
-                    log_info!(LOG_TAG, "Captured {} stderr lines", stderr_lines.len());
-                    stderr_lines.join(" ")
+                    log_info!(
+                        LOG_TAG,
+                        "Captured {} stderr lines",
+                        cli_result.stderr_lines.len()
+                    );
+                    cli_result.stderr_lines.join(" ")
                 };
                 (code, msg)
             } else {
@@ -225,7 +232,12 @@ async fn execute(
                 // status transition already happened the moment /complete
                 // returned.
                 log_info!(LOG_TAG, "▷ Cleanup");
-                complete::report_success(env::sandbox_id(), env::sandbox_reuse_result()).await;
+                complete::report_success(
+                    env::sandbox_id(),
+                    env::sandbox_reuse_result(),
+                    last_event_sequence,
+                )
+                .await;
                 final_telemetry(telemetry).await;
             }
             Err(e) => {

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -1090,6 +1090,7 @@ async fn complete_report_success_posts_full_payload_when_metadata_present() {
             .json_body(json!({
                 "runId": "test-run-001",
                 "exitCode": 0,
+                "lastEventSequence": 7,
                 "sandboxId": "00000000-0000-4000-8000-000000000abc",
                 "sandboxReuseResult": "reused",
             }));
@@ -1102,6 +1103,7 @@ async fn complete_report_success_posts_full_payload_when_metadata_present() {
     guest_agent::complete::report_success(
         guest_agent::env::sandbox_id(),
         guest_agent::env::sandbox_reuse_result(),
+        Some(7),
     )
     .await;
 
@@ -1129,7 +1131,7 @@ async fn complete_report_success_omits_metadata_when_env_absent() {
         then.status(200).json_body(json!({"success": true}));
     });
 
-    guest_agent::complete::report_success("", "").await;
+    guest_agent::complete::report_success("", "", None).await;
 
     mock.assert_calls_async(1).await;
     mock.delete_async().await;
@@ -1150,6 +1152,7 @@ async fn complete_report_success_swallows_server_error() {
     guest_agent::complete::report_success(
         guest_agent::env::sandbox_id(),
         guest_agent::env::sandbox_reuse_result(),
+        None,
     )
     .await;
 
@@ -1177,6 +1180,7 @@ async fn complete_report_success_swallows_4xx_auth_error() {
     guest_agent::complete::report_success(
         guest_agent::env::sandbox_id(),
         guest_agent::env::sandbox_reuse_result(),
+        None,
     )
     .await;
 

--- a/crates/guest-agent/tests/post_result_reap.rs
+++ b/crates/guest-agent/tests/post_result_reap.rs
@@ -30,7 +30,8 @@ async fn post_result_reap_sigterm_kills_hung_cli() -> Result<(), Box<dyn std::er
     .await
     .expect("execute_cli did not return within 15s — reap likely broken");
 
-    let (exit_code, _stderr) = result.expect("execute_cli returned Err");
+    let result = result.expect("execute_cli returned Err");
+    let exit_code = result.exit_code;
 
     // On pathologically slow runners the sigkill escalation may fire
     // before SIGTERM actually terminates the mock; accept either.

--- a/crates/guest-agent/tests/post_result_reap_happy.rs
+++ b/crates/guest-agent/tests/post_result_reap_happy.rs
@@ -40,7 +40,8 @@ async fn post_result_reap_stays_silent_on_clean_exit() -> Result<(), Box<dyn std
     .expect("execute_cli did not return within 15s on the happy path");
     let elapsed = started.elapsed();
 
-    let (exit_code, _stderr) = result.expect("execute_cli returned Err");
+    let result = result.expect("execute_cli returned Err");
+    let exit_code = result.exit_code;
 
     // Clean exit(0) — if this is SIGTERM_EXIT / SIGKILL_EXIT, the
     // reap fired against a healthy CLI, which is a correctness bug.

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -34,7 +34,8 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
     .await
     .expect("execute_cli did not return within 15s — sigkill escalation likely broken");
 
-    let (exit_code, _stderr) = result.expect("execute_cli returned Err");
+    let result = result.expect("execute_cli returned Err");
+    let exit_code = result.exit_code;
 
     // SIGKILL (9) → 128 + 9 = 137. SIGTERM is SIG_IGN'd in the mock,
     // so 143 here would mean our SIGTERM somehow won a race it can't

--- a/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
@@ -150,21 +150,29 @@ describe("zero run command", () => {
               });
             }
 
-            return HttpResponse.json({
-              events: [
-                {
-                  sequenceNumber: 1,
-                  eventType: "assistant",
-                  eventData: {
-                    type: "assistant",
-                    message: {
-                      role: "assistant",
-                      content: [{ type: "text", text: "second page" }],
+            if (eventPolls === 2) {
+              return HttpResponse.json({
+                events: [
+                  {
+                    sequenceNumber: 1,
+                    eventType: "assistant",
+                    eventData: {
+                      type: "assistant",
+                      message: {
+                        role: "assistant",
+                        content: [{ type: "text", text: "second page" }],
+                      },
                     },
+                    createdAt: "2025-01-01T00:00:00Z",
                   },
-                  createdAt: "2025-01-01T00:00:00Z",
-                },
-              ],
+                ],
+                hasMore: false,
+                framework: "claude-code",
+              });
+            }
+
+            return HttpResponse.json({
+              events: [],
               hasMore: false,
               framework: "claude-code",
             });
@@ -179,17 +187,134 @@ describe("zero run command", () => {
         "test prompt",
       ]);
 
-      expect(eventPolls).toBe(2);
+      expect(eventPolls).toBeGreaterThanOrEqual(2);
       expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining("second page"),
       );
     });
 
-    it("should not render events past a sequence gap", async () => {
+    it("should drain terminal events that appear after completion", async () => {
+      let eventPolls = 0;
+
       server.use(
         http.get(
           "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
           () => {
+            eventPolls++;
+            if (eventPolls === 1) {
+              return HttpResponse.json({
+                events: [
+                  {
+                    sequenceNumber: 0,
+                    eventType: "assistant",
+                    eventData: {
+                      type: "assistant",
+                      message: {
+                        role: "assistant",
+                        content: [{ type: "text", text: "before completion" }],
+                      },
+                    },
+                    createdAt: "2025-01-01T00:00:00Z",
+                  },
+                ],
+                hasMore: false,
+                framework: "claude-code",
+              });
+            }
+
+            if (eventPolls === 2) {
+              return HttpResponse.json({
+                events: [
+                  {
+                    sequenceNumber: 1,
+                    eventType: "assistant",
+                    eventData: {
+                      type: "assistant",
+                      message: {
+                        role: "assistant",
+                        content: [{ type: "text", text: "after completion" }],
+                      },
+                    },
+                    createdAt: "2025-01-01T00:00:00Z",
+                  },
+                ],
+                hasMore: false,
+                framework: "claude-code",
+              });
+            }
+
+            return HttpResponse.json({
+              events: [],
+              hasMore: false,
+              framework: "claude-code",
+            });
+          },
+        ),
+      );
+
+      await mainRunCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentId,
+        "test prompt",
+      ]);
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining("before completion"),
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining("after completion"),
+      );
+    });
+
+    it("should render the latest terminal status after drain", async () => {
+      let runPolls = 0;
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/runs/:id", () => {
+          runPolls++;
+          if (runPolls === 1) {
+            return HttpResponse.json({
+              ...defaultGetRunResponse,
+              status: "timeout",
+              result: undefined,
+            });
+          }
+
+          return HttpResponse.json(defaultGetRunResponse);
+        }),
+      );
+
+      await mainRunCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentId,
+        "test prompt",
+      ]);
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining("Run completed successfully"),
+      );
+      expect(mockConsoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining("Run timed out"),
+      );
+    });
+
+    it("should not render events past a sequence gap", async () => {
+      let eventPolls = 0;
+      server.use(
+        http.get(
+          "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+          () => {
+            eventPolls++;
+            if (eventPolls > 1) {
+              return HttpResponse.json({
+                events: [],
+                hasMore: false,
+                framework: "claude-code",
+              });
+            }
+
             return HttpResponse.json({
               events: [
                 {

--- a/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
@@ -121,6 +121,124 @@ describe("zero run command", () => {
       );
     });
 
+    it("should drain visible event pages before rendering completion", async () => {
+      let eventPolls = 0;
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+          () => {
+            eventPolls++;
+            if (eventPolls === 1) {
+              return HttpResponse.json({
+                events: [
+                  {
+                    sequenceNumber: 0,
+                    eventType: "assistant",
+                    eventData: {
+                      type: "assistant",
+                      message: {
+                        role: "assistant",
+                        content: [{ type: "text", text: "first page" }],
+                      },
+                    },
+                    createdAt: "2025-01-01T00:00:00Z",
+                  },
+                ],
+                hasMore: true,
+                framework: "claude-code",
+              });
+            }
+
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      role: "assistant",
+                      content: [{ type: "text", text: "second page" }],
+                    },
+                  },
+                  createdAt: "2025-01-01T00:00:00Z",
+                },
+              ],
+              hasMore: false,
+              framework: "claude-code",
+            });
+          },
+        ),
+      );
+
+      await mainRunCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentId,
+        "test prompt",
+      ]);
+
+      expect(eventPolls).toBe(2);
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining("second page"),
+      );
+    });
+
+    it("should not render events past a sequence gap", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 0,
+                  eventType: "assistant",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      role: "assistant",
+                      content: [{ type: "text", text: "before gap" }],
+                    },
+                  },
+                  createdAt: "2025-01-01T00:00:00Z",
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "assistant",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      role: "assistant",
+                      content: [{ type: "text", text: "after gap" }],
+                    },
+                  },
+                  createdAt: "2025-01-01T00:00:00Z",
+                },
+              ],
+              hasMore: false,
+              framework: "claude-code",
+            });
+          },
+        ),
+      );
+
+      await mainRunCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentId,
+        "test prompt",
+      ]);
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining("before gap"),
+      );
+      expect(console.log).not.toHaveBeenCalledWith(
+        expect.stringContaining("after gap"),
+      );
+    });
+
     it("should pass model-provider option to API", async () => {
       let capturedBody: Record<string, unknown> | undefined;
 

--- a/turbo/apps/cli/src/commands/zero/run/shared.ts
+++ b/turbo/apps/cli/src/commands/zero/run/shared.ts
@@ -9,6 +9,17 @@ interface SequencedEvent {
   sequenceNumber: number;
 }
 
+type ZeroRunResponse = Awaited<ReturnType<typeof getZeroRun>>;
+type TerminalRunStatus = "completed" | "failed" | "timeout" | "cancelled";
+type TerminalRunResponse = ZeroRunResponse & { status: TerminalRunStatus };
+
+const TERMINAL_RUN_STATUSES: readonly TerminalRunStatus[] = [
+  "completed",
+  "failed",
+  "timeout",
+  "cancelled",
+];
+
 /**
  * Safely narrow GetRunResponse.result to RunResult.
  * GetRunResponse.result has all fields optional (due to .passthrough()),
@@ -50,6 +61,90 @@ function filterContiguousEvents<T extends SequencedEvent>(
   return contiguousEvents;
 }
 
+const POLL_INTERVAL_MS = 1000;
+const TERMINAL_DRAIN_POLL_INTERVAL_MS = 500;
+const TERMINAL_DRAIN_IDLE_MS = 1000;
+const TERMINAL_DRAIN_MAX_MS = 3000;
+
+function isTerminalRunResponse(
+  runResponse: ZeroRunResponse,
+): runResponse is TerminalRunResponse {
+  return TERMINAL_RUN_STATUSES.includes(
+    runResponse.status as TerminalRunStatus,
+  );
+}
+
+function shouldDrainNextEventPage<T>(
+  eventsResponse: { hasMore: boolean; events: T[] },
+  contiguousEvents: T[],
+): boolean {
+  return (
+    eventsResponse.hasMore &&
+    contiguousEvents.length > 0 &&
+    contiguousEvents.length === eventsResponse.events.length
+  );
+}
+
+function hasSequenceGap<T>(
+  eventsResponse: { events: T[] },
+  contiguousEvents: T[],
+): boolean {
+  return (
+    eventsResponse.events.length > 0 &&
+    contiguousEvents.length < eventsResponse.events.length
+  );
+}
+
+function shouldCompleteTerminalDrain(
+  terminalSeenAt: number,
+  lastTerminalProgressAt: number,
+  blockedByGap: boolean,
+): boolean {
+  const now = Date.now();
+  const terminalElapsedMs = now - terminalSeenAt;
+  const terminalIdleMs = now - lastTerminalProgressAt;
+  return (
+    terminalElapsedMs >= TERMINAL_DRAIN_MAX_MS ||
+    (!blockedByGap && terminalIdleMs >= TERMINAL_DRAIN_IDLE_MS)
+  );
+}
+
+function renderTerminalRunResult(
+  runId: string,
+  runResponse: TerminalRunResponse,
+): PollResult {
+  if (runResponse.status === "completed") {
+    EventRenderer.renderRunCompleted(
+      runResponse.result ? toRunResult(runResponse.result) : undefined,
+    );
+    return {
+      succeeded: true,
+      runId,
+      sessionId: runResponse.result?.agentSessionId,
+      checkpointId: runResponse.result?.checkpointId,
+    };
+  }
+
+  if (runResponse.status === "failed") {
+    EventRenderer.renderRunFailed(runResponse.error, runId);
+    return { succeeded: false, runId };
+  }
+
+  if (runResponse.status === "timeout") {
+    console.error(chalk.red("\n✗ Run timed out"));
+    return { succeeded: false, runId };
+  }
+
+  console.error(chalk.yellow("\n✗ Run cancelled"));
+  return { succeeded: false, runId };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    return setTimeout(resolve, ms);
+  });
+}
+
 /**
  * Poll for zero run events until run completes.
  * Uses dual-poll approach: telemetry endpoint for events, getById for status.
@@ -63,7 +158,9 @@ export async function pollZeroEvents(
   let lastSequence = -1;
   let complete = false;
   let result: PollResult = { succeeded: true, runId };
-  const pollIntervalMs = 1000;
+  let terminalRunResponse: TerminalRunResponse | undefined;
+  let terminalSeenAt = 0;
+  let lastTerminalProgressAt = 0;
 
   while (!complete) {
     // 1. Fetch events from telemetry endpoint
@@ -91,53 +188,51 @@ export async function pollZeroEvents(
     if (contiguousEvents.length > 0) {
       lastSequence =
         contiguousEvents[contiguousEvents.length - 1]!.sequenceNumber;
+      if (terminalRunResponse) {
+        lastTerminalProgressAt = Date.now();
+      }
     }
+
+    const blockedByGap = hasSequenceGap(eventsResponse, contiguousEvents);
 
     // If this page is fully contiguous and the server says more are already
     // queryable, drain the next page before checking terminal status. Otherwise
     // a completed run with >100 unseen events would render only the final page's
     // first batch and then exit.
-    if (
-      eventsResponse.hasMore &&
-      contiguousEvents.length > 0 &&
-      contiguousEvents.length === eventsResponse.events.length
-    ) {
+    if (shouldDrainNextEventPage(eventsResponse, contiguousEvents)) {
       continue;
     }
 
-    // 4. Fetch run status separately
+    // 4. Fetch run status separately. During terminal drain, keep the latest
+    // terminal state because timeout runs can still be upgraded to completed.
     const runResponse = await getZeroRun(runId);
-    const runStatus = runResponse.status;
+    if (isTerminalRunResponse(runResponse)) {
+      if (!terminalRunResponse) {
+        terminalSeenAt = Date.now();
+        lastTerminalProgressAt = terminalSeenAt;
+      }
+      terminalRunResponse = runResponse;
+    }
 
-    if (runStatus === "completed") {
-      complete = true;
-      EventRenderer.renderRunCompleted(
-        runResponse.result ? toRunResult(runResponse.result) : undefined,
-      );
-      result = {
-        succeeded: true,
-        runId,
-        sessionId: runResponse.result?.agentSessionId,
-        checkpointId: runResponse.result?.checkpointId,
-      };
-    } else if (runStatus === "failed") {
-      complete = true;
-      EventRenderer.renderRunFailed(runResponse.error, runId);
-      result = { succeeded: false, runId };
-    } else if (runStatus === "timeout") {
-      complete = true;
-      console.error(chalk.red("\n✗ Run timed out"));
-      result = { succeeded: false, runId };
-    } else if (runStatus === "cancelled") {
-      complete = true;
-      console.error(chalk.yellow("\n✗ Run cancelled"));
-      result = { succeeded: false, runId };
+    if (terminalRunResponse) {
+      if (
+        shouldCompleteTerminalDrain(
+          terminalSeenAt,
+          lastTerminalProgressAt,
+          blockedByGap,
+        )
+      ) {
+        result = renderTerminalRunResult(runId, terminalRunResponse);
+        complete = true;
+      }
     }
 
     if (!complete) {
-      await new Promise((resolve) => {
-        return setTimeout(resolve, pollIntervalMs);
-      });
+      await sleep(
+        terminalRunResponse
+          ? TERMINAL_DRAIN_POLL_INTERVAL_MS
+          : POLL_INTERVAL_MS,
+      );
     }
   }
 

--- a/turbo/apps/cli/src/commands/zero/run/shared.ts
+++ b/turbo/apps/cli/src/commands/zero/run/shared.ts
@@ -5,6 +5,10 @@ import { parseEvent } from "../../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../../lib/events/event-renderer";
 import type { PollResult, EventRenderingOptions } from "../../run/shared";
 
+interface SequencedEvent {
+  sequenceNumber: number;
+}
+
 /**
  * Safely narrow GetRunResponse.result to RunResult.
  * GetRunResponse.result has all fields optional (due to .passthrough()),
@@ -23,6 +27,27 @@ function toRunResult(result: {
     return undefined;
   }
   return { checkpointId, agentSessionId, conversationId };
+}
+
+function filterContiguousEvents<T extends SequencedEvent>(
+  events: T[],
+  lastSequence: number,
+): T[] {
+  const contiguousEvents: T[] = [];
+  let expectedSequence = lastSequence + 1;
+
+  for (const event of events) {
+    if (event.sequenceNumber < expectedSequence) {
+      continue;
+    }
+    if (event.sequenceNumber !== expectedSequence) {
+      break;
+    }
+    contiguousEvents.push(event);
+    expectedSequence++;
+  }
+
+  return contiguousEvents;
 }
 
 /**
@@ -48,8 +73,13 @@ export async function pollZeroEvents(
       order: "asc",
     });
 
+    const contiguousEvents = filterContiguousEvents(
+      eventsResponse.events,
+      lastSequence,
+    );
+
     // 2. Parse and render each event
-    for (const event of eventsResponse.events) {
+    for (const event of contiguousEvents) {
       const eventData = event.eventData as Record<string, unknown>;
       const parsed = parseEvent(eventData);
       if (parsed) {
@@ -58,12 +88,21 @@ export async function pollZeroEvents(
     }
 
     // 3. Track last sequence number for pagination
-    if (eventsResponse.events.length > 0) {
-      lastSequence = Math.max(
-        ...eventsResponse.events.map((e) => {
-          return e.sequenceNumber;
-        }),
-      );
+    if (contiguousEvents.length > 0) {
+      lastSequence =
+        contiguousEvents[contiguousEvents.length - 1]!.sequenceNumber;
+    }
+
+    // If this page is fully contiguous and the server says more are already
+    // queryable, drain the next page before checking terminal status. Otherwise
+    // a completed run with >100 unseen events would render only the final page's
+    // first batch and then exit.
+    if (
+      eventsResponse.hasMore &&
+      contiguousEvents.length > 0 &&
+      contiguousEvents.length === eventsResponse.events.length
+    ) {
+      continue;
     }
 
     // 4. Fetch run status separately

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -667,6 +667,37 @@ describe("GET /api/agent/runs/:id/events", () => {
       expect(result[0]!.sequenceNumber).toBe(0);
     });
 
+    it("should skip duplicate sequence numbers while preserving the prefix", () => {
+      const events = [
+        createAxiomAgentEvent({
+          runId: testRunId,
+          sequenceNumber: 0,
+          eventType: "event_0",
+          eventData: { type: "event_0" },
+        }),
+        createAxiomAgentEvent({
+          runId: testRunId,
+          sequenceNumber: 0,
+          eventType: "event_0_duplicate",
+          eventData: { type: "event_0_duplicate" },
+        }),
+        createAxiomAgentEvent({
+          runId: testRunId,
+          sequenceNumber: 1,
+          eventType: "event_1",
+          eventData: { type: "event_1" },
+        }),
+      ];
+
+      const result = filterConsecutiveEvents(events, -1);
+
+      expect(
+        result.map((e) => {
+          return e.sequenceNumber;
+        }),
+      ).toEqual([0, 1]);
+    });
+
     it("should handle single event with gap", () => {
       const events = [
         createAxiomAgentEvent({

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/filter-events.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/filter-events.ts
@@ -27,6 +27,9 @@ export function filterConsecutiveEvents(
   let expectedSeq = since + 1;
 
   for (const event of events) {
+    if (event.sequenceNumber < expectedSeq) {
+      continue;
+    }
     if (event.sequenceNumber === expectedSeq) {
       consecutiveEvents.push(event);
       expectedSeq++;

--- a/turbo/apps/web/app/api/internal/event-consumers/axiom/route.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/axiom/route.ts
@@ -36,12 +36,25 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   });
 
   const axiomDataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
-  ingestToAxiom(axiomDataset, axiomEvents);
+  const ingested = ingestToAxiom(axiomDataset, axiomEvents);
+  if (!ingested) {
+    return NextResponse.json(
+      { error: "Axiom agent-run-events dataset is not configured" },
+      { status: 503 },
+    );
+  }
   // Flush explicitly: this route uses NextResponse (not ts-rest-handler), so
   // flushAxiom() is not called automatically at the response boundary.
   // Without this, the SDK buffer is never flushed during this serverless
   // function's lifetime, and the CLI sees no events when polling Axiom.
-  await flushAxiom();
+  try {
+    await flushAxiom({ throwOnError: true, client: "sessions" });
+  } catch {
+    return NextResponse.json(
+      { error: "Axiom agent-run-events flush failed" },
+      { status: 503 },
+    );
+  }
 
   return NextResponse.json({ received: events.length });
 }

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -53,6 +53,8 @@ describe("POST /api/webhooks/agent/complete", () => {
   let testToken: string;
 
   beforeEach(async () => {
+    vi.stubEnv("AXIOM_TOKEN_SESSIONS", "test-sessions-token");
+    reloadEnv();
     context.setupMocks();
     user = await context.setupUser();
 
@@ -70,6 +72,35 @@ describe("POST /api/webhooks/agent/complete", () => {
     // Reset auth mock for webhook tests (which use token auth, not Clerk)
     mockClerk({ userId: null });
   });
+
+  async function createCheckpoint(runId = testRunId, token = testToken) {
+    const checkpointRequest = createTestRequest(
+      "http://localhost:3000/api/webhooks/agent/checkpoints",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          runId,
+          cliAgentType: "claude-code",
+          cliAgentSessionId: "test-session",
+          cliAgentSessionHistoryHash:
+            "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
+          artifactSnapshots: [
+            {
+              name: "test-artifact",
+              version: "v1",
+              mountPath: "/home/user/workspace",
+            },
+          ],
+        }),
+      },
+    );
+    const checkpointResponse = await checkpointWebhook(checkpointRequest);
+    expect(checkpointResponse.status).toBe(200);
+  }
 
   describe("Authentication", () => {
     it("should reject complete without authentication", async () => {
@@ -139,6 +170,30 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.error.message).toContain("exitCode");
+    });
+
+    it("should reject negative lastEventSequence", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+            lastEventSequence: -1,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("lastEventSequence");
     });
   });
 
@@ -218,32 +273,7 @@ describe("POST /api/webhooks/agent/complete", () => {
   describe("Success", () => {
     it("should handle successful completion (exitCode=0)", async () => {
       // Create checkpoint first (required for successful completion)
-      const checkpointRequest = createTestRequest(
-        "http://localhost:3000/api/webhooks/agent/checkpoints",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${testToken}`,
-          },
-          body: JSON.stringify({
-            runId: testRunId,
-            cliAgentType: "claude-code",
-            cliAgentSessionId: "test-session",
-            cliAgentSessionHistoryHash:
-              "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-            artifactSnapshots: [
-              {
-                name: "test-artifact",
-                version: "v1",
-                mountPath: "/home/user/workspace",
-              },
-            ],
-          }),
-        },
-      );
-      const checkpointResponse = await checkpointWebhook(checkpointRequest);
-      expect(checkpointResponse.status).toBe(200);
+      await createCheckpoint();
 
       // Now complete the run
       const request = createTestRequest(
@@ -267,6 +297,99 @@ describe("POST /api/webhooks/agent/complete", () => {
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.status).toBe("completed");
+    });
+
+    it("should wait for the lastEventSequence prefix before successful completion", async () => {
+      await createCheckpoint();
+      context.mocks.axiom.queryAxiom
+        .mockResolvedValueOnce([
+          { _time: "2026-01-01T00:00:00.000Z", sequenceNumber: 0 },
+          { _time: "2026-01-01T00:00:00.000Z", sequenceNumber: 2 },
+        ])
+        .mockResolvedValueOnce([
+          { _time: "2026-01-01T00:00:00.000Z", sequenceNumber: 1 },
+          { _time: "2026-01-01T00:00:00.000Z", sequenceNumber: 2 },
+        ]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+            lastEventSequence: 2,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const run = await findTestRunRecord(testRunId);
+      expect(run!.status).toBe("completed");
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledTimes(2);
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledWith(
+        expect.stringContaining(`runId == "${testRunId}"`),
+        { maxRetries: 0 },
+      );
+    });
+
+    it("should fail open when Axiom visibility query fails", async () => {
+      await createCheckpoint();
+      context.mocks.axiom.queryAxiom.mockRejectedValueOnce(
+        new Error("axiom unavailable"),
+      );
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+            lastEventSequence: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const run = await findTestRunRecord(testRunId);
+      expect(run!.status).toBe("completed");
+    });
+
+    it("should skip the Axiom visibility barrier when watermark is absent", async () => {
+      await createCheckpoint();
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(context.mocks.axiom.queryAxiom).not.toHaveBeenCalled();
     });
 
     it("should project array-shape artifactSnapshots to Record in result.artifact", async () => {
@@ -404,6 +527,35 @@ describe("POST /api/webhooks/agent/complete", () => {
       const run = await findTestRunRecord(runId);
       expect(run!.error).not.toContain("Agent crashed with custom message");
       expect(run!.error).toContain(`/runs/${runId}/report-error`);
+    });
+
+    it("should not wait for Axiom visibility on failed completion", async () => {
+      const { runId } = await seedTestRun(user.userId, testComposeId, {
+        status: "running",
+        prompt: "Test prompt",
+      });
+      const token = await createTestSandboxToken(user.userId, runId);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            runId,
+            exitCode: 1,
+            lastEventSequence: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(context.mocks.axiom.queryAxiom).not.toHaveBeenCalled();
     });
   });
 

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -23,6 +23,7 @@ import {
 } from "../../../../../src/lib/zero/zero-run-queue-service";
 import { processOrgCredits } from "../../../../../src/lib/zero/credit/credit-service";
 import { processOrgUsageEvents } from "../../../../../src/lib/zero/credit/usage-event-service";
+import { waitForAgentEventPrefixVisible } from "../../../../../src/lib/infra/run/agent-event-visibility";
 import { after } from "next/server";
 import { env } from "../../../../../src/env";
 
@@ -186,6 +187,25 @@ const router = tsr.router(webhookCompleteContract, {
         .limit(1);
 
       const result = buildRunResult(checkpoint, session?.id);
+
+      if (body.lastEventSequence !== undefined) {
+        const visibility = await waitForAgentEventPrefixVisible(
+          body.runId,
+          body.lastEventSequence,
+        );
+
+        if (!visibility.visible) {
+          log.warn("Completing run before all agent events are Axiom-visible", {
+            runId: body.runId,
+            targetSequence: visibility.targetSequence,
+            visibleThrough: visibility.visibleThrough,
+            attempts: visibility.attempts,
+            elapsedMs: visibility.elapsedMs,
+            reason: visibility.reason,
+            error: visibility.error,
+          });
+        }
+      }
 
       // Atomically transition to "completed". Also accept "timeout" so a
       // sandbox that eventually reports success after a heartbeat-timeout

--- a/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
@@ -586,6 +586,47 @@ describe("POST /api/webhooks/agent/events", () => {
       expect(ingestToAxiomSpy).toHaveBeenCalled();
     });
 
+    it("should not dispatch optional consumers when required Axiom fails", async () => {
+      let creditCalls = 0;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/internal/event-consumers/credit",
+          () => {
+            creditCalls++;
+            return HttpResponse.json({ processed: 1 });
+          },
+        ),
+      );
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/events",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            events: [
+              {
+                type: "result",
+                sequenceNumber: 0,
+                timestamp: Date.now(),
+                uuid: randomUUID(),
+                total_cost_usd: 0.01,
+              },
+            ],
+          }),
+        },
+      );
+
+      const response = await postAndFlush(request);
+
+      expect(response.status).toBe(500);
+      expect(creditCalls).toBe(0);
+    });
+
     it("should reject events when Axiom flush fails", async () => {
       ingestToAxiomSpy.mockReturnValue(true);
       context.mocks.axiom.flushAxiom.mockRejectedValueOnce(

--- a/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
@@ -88,7 +88,7 @@ describe("POST /api/webhooks/agent/events", () => {
     // Setup spy on ingestToAxiom - returns true by default
     ingestToAxiomSpy = vi
       .spyOn(axiomModule, "ingestToAxiom")
-      .mockResolvedValue(true);
+      .mockReturnValue(true);
 
     // Reset auth mock for webhook tests (which use token auth)
     mockClerk({ userId: null });
@@ -545,13 +545,13 @@ describe("POST /api/webhooks/agent/events", () => {
     });
   });
 
-  describe("DB fallback (Axiom not configured)", () => {
+  describe("Required Axiom dispatch", () => {
     beforeEach(() => {
       // Simulate Axiom not configured
-      ingestToAxiomSpy.mockResolvedValue(false);
+      ingestToAxiomSpy.mockReturnValue(false);
     });
 
-    it("should store events to DB when Axiom is not configured", async () => {
+    it("should reject events when Axiom is not configured", async () => {
       const request = createTestRequest(
         "http://localhost:3000/api/webhooks/agent/events",
         {
@@ -582,15 +582,83 @@ describe("POST /api/webhooks/agent/events", () => {
 
       const response = await postAndFlush(request);
 
-      expect(response.status).toBe(200);
-      const data = await response.json();
-      expect(data.received).toBe(2);
-      expect(data.firstSequence).toBe(0);
-      expect(data.lastSequence).toBe(1);
+      expect(response.status).toBe(500);
+      expect(ingestToAxiomSpy).toHaveBeenCalled();
     });
 
-    it("should not store to DB when Axiom ingest succeeds", async () => {
-      ingestToAxiomSpy.mockResolvedValue(true);
+    it("should reject events when Axiom flush fails", async () => {
+      ingestToAxiomSpy.mockReturnValue(true);
+      context.mocks.axiom.flushAxiom.mockRejectedValueOnce(
+        new Error("flush failed"),
+      );
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/events",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            events: [
+              {
+                type: "test",
+                sequenceNumber: 0,
+                timestamp: Date.now(),
+                data: {},
+              },
+            ],
+          }),
+        },
+      );
+
+      const response = await postAndFlush(request);
+
+      expect(response.status).toBe(500);
+    });
+
+    it("should accept events when an optional consumer fails", async () => {
+      ingestToAxiomSpy.mockReturnValue(true);
+      server.use(
+        http.post(
+          "http://localhost:3000/api/internal/event-consumers/credit",
+          () => {
+            return HttpResponse.json({ error: "credit down" }, { status: 503 });
+          },
+        ),
+      );
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/events",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            events: [
+              {
+                type: "test",
+                sequenceNumber: 0,
+                timestamp: Date.now(),
+                data: {},
+              },
+            ],
+          }),
+        },
+      );
+
+      const response = await postAndFlush(request);
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should accept events when Axiom ingest and flush succeeds", async () => {
+      ingestToAxiomSpy.mockReturnValue(true);
 
       const request = createTestRequest(
         "http://localhost:3000/api/webhooks/agent/events",
@@ -617,8 +685,11 @@ describe("POST /api/webhooks/agent/events", () => {
       const response = await postAndFlush(request);
       expect(response.status).toBe(200);
 
-      // Axiom ingest returned true, DB fallback should not run
       expect(ingestToAxiomSpy).toHaveBeenCalled();
+      expect(context.mocks.axiom.flushAxiom).toHaveBeenCalledWith({
+        throwOnError: true,
+        client: "sessions",
+      });
     });
   });
 

--- a/turbo/apps/web/app/api/webhooks/agent/events/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/route.ts
@@ -73,7 +73,8 @@ const router = tsr.router(webhookEventsContract, {
     // /api/agent/runs/:id/events — including the CLI — can see events as soon as the
     // webhook returns. With `after()`, fast mock-claude runs completed before Axiom
     // ingestion finished, leaving the CLI with no `● Bash(...)` rendering.
-    // Per-consumer failures are swallowed inside the dispatcher (Promise.allSettled).
+    // Optional consumer failures are isolated inside the dispatcher. Required
+    // consumers (currently Axiom, used by CLI event polling) propagate failure.
     const dispatchStart = Date.now();
     await dispatchToEventConsumers(body.runId, body.events, {
       userId,

--- a/turbo/apps/web/src/lib/infra/event-consumer/dispatch.ts
+++ b/turbo/apps/web/src/lib/infra/event-consumer/dispatch.ts
@@ -6,6 +6,14 @@ import { logger } from "../../shared/logger";
 
 const log = logger("event-consumer:dispatch");
 
+function requiredEventConsumerDispatchError(failures: string[]): Error {
+  const error = new Error(
+    `Required event consumer dispatch failed: ${failures.join(", ")}`,
+  );
+  error.name = "RequiredEventConsumerDispatchError";
+  return error;
+}
+
 /**
  * In local dev, rewrite self-referencing tunnel URLs to localhost.
  */
@@ -20,8 +28,9 @@ function resolveBaseUrl(baseUrl: string): string {
  * Dispatch agent events to all registered consumers whose eventTypes filter
  * matches at least one event in the batch.
  *
- * Uses `Promise.allSettled` — one consumer's failure does not affect others.
- * Failures are logged but not propagated to the caller.
+ * Uses `Promise.allSettled` so all matching consumers get a chance to run.
+ * Optional consumer failures are logged; required consumer failures are
+ * propagated to the caller after every consumer has settled.
  */
 export async function dispatchToEventConsumers(
   runId: string,
@@ -32,7 +41,7 @@ export async function dispatchToEventConsumers(
   const baseUrl = resolveBaseUrl(VM0_API_URL ?? "http://localhost:3000");
 
   const results = await Promise.allSettled(
-    eventConsumers.map((consumer) => {
+    eventConsumers.map(async (consumer) => {
       const matchingEvents = consumer.eventTypes
         ? events.filter((e) => {
             return consumer.eventTypes!.includes(e.type);
@@ -56,7 +65,7 @@ export async function dispatchToEventConsumers(
         timestamp,
       );
 
-      return fetch(baseUrl + consumer.path, {
+      const response = await fetch(baseUrl + consumer.path, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -65,16 +74,36 @@ export async function dispatchToEventConsumers(
         },
         body,
       });
+      if (!response.ok) {
+        const responseBody = await response.text().catch(() => {
+          return "";
+        });
+        throw new Error(
+          `HTTP ${response.status}${responseBody ? `: ${responseBody}` : ""}`,
+        );
+      }
+      await response.arrayBuffer().catch(() => {
+        return undefined;
+      });
     }),
   );
 
+  const requiredFailures: string[] = [];
   for (let i = 0; i < results.length; i++) {
     const result = results[i];
     if (result && result.status === "rejected") {
+      const consumer = eventConsumers[i];
       log.error(`Event consumer "${eventConsumers[i]?.name}" failed`, {
         runId,
         error: result.reason,
       });
+      if (consumer?.required) {
+        requiredFailures.push(consumer.name);
+      }
     }
+  }
+
+  if (requiredFailures.length > 0) {
+    throw requiredEventConsumerDispatchError(requiredFailures);
   }
 }

--- a/turbo/apps/web/src/lib/infra/event-consumer/dispatch.ts
+++ b/turbo/apps/web/src/lib/infra/event-consumer/dispatch.ts
@@ -6,6 +6,13 @@ import { logger } from "../../shared/logger";
 
 const log = logger("event-consumer:dispatch");
 
+interface DispatchableConsumer {
+  name: string;
+  path: string;
+  required?: boolean;
+  events: AgentEvent[];
+}
+
 function requiredEventConsumerDispatchError(failures: string[]): Error {
   const error = new Error(
     `Required event consumer dispatch failed: ${failures.join(", ")}`,
@@ -24,13 +31,88 @@ function resolveBaseUrl(baseUrl: string): string {
     : baseUrl;
 }
 
+async function dispatchToConsumer(
+  consumer: DispatchableConsumer,
+  runId: string,
+  context: RunEventContext,
+  baseUrl: string,
+  secretsEncryptionKey: string,
+): Promise<void> {
+  const body = JSON.stringify({
+    runId,
+    events: consumer.events,
+    context,
+  });
+
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signature = computeHmacSignature(body, secretsEncryptionKey, timestamp);
+
+  const response = await fetch(baseUrl + consumer.path, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VM0-Signature": signature,
+      "X-VM0-Timestamp": timestamp.toString(),
+    },
+    body,
+  });
+  if (!response.ok) {
+    const responseBody = await response.text().catch(() => {
+      return "";
+    });
+    throw new Error(
+      `HTTP ${response.status}${responseBody ? `: ${responseBody}` : ""}`,
+    );
+  }
+  await response.arrayBuffer().catch(() => {
+    return undefined;
+  });
+}
+
+async function dispatchConsumerGroup(
+  consumers: DispatchableConsumer[],
+  runId: string,
+  context: RunEventContext,
+  baseUrl: string,
+  secretsEncryptionKey: string,
+): Promise<string[]> {
+  const results = await Promise.allSettled(
+    consumers.map((consumer) => {
+      return dispatchToConsumer(
+        consumer,
+        runId,
+        context,
+        baseUrl,
+        secretsEncryptionKey,
+      );
+    }),
+  );
+
+  const failures: string[] = [];
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result && result.status === "rejected") {
+      const consumer = consumers[i];
+      log.error(`Event consumer "${consumer?.name}" failed`, {
+        runId,
+        error: result.reason,
+      });
+      if (consumer?.required) {
+        failures.push(consumer.name);
+      }
+    }
+  }
+
+  return failures;
+}
+
 /**
  * Dispatch agent events to all registered consumers whose eventTypes filter
  * matches at least one event in the batch.
  *
- * Uses `Promise.allSettled` so all matching consumers get a chance to run.
- * Optional consumer failures are logged; required consumer failures are
- * propagated to the caller after every consumer has settled.
+ * Required consumers run first. Optional consumers run only after required
+ * consumers succeed, so a required failure cannot trigger webhook retry after
+ * non-idempotent optional side effects have already been written.
  */
 export async function dispatchToEventConsumers(
   runId: string,
@@ -40,8 +122,8 @@ export async function dispatchToEventConsumers(
   const { SECRETS_ENCRYPTION_KEY, VM0_API_URL } = env();
   const baseUrl = resolveBaseUrl(VM0_API_URL ?? "http://localhost:3000");
 
-  const results = await Promise.allSettled(
-    eventConsumers.map(async (consumer) => {
+  const consumers = eventConsumers
+    .map((consumer): DispatchableConsumer | null => {
       const matchingEvents = consumer.eventTypes
         ? events.filter((e) => {
             return consumer.eventTypes!.includes(e.type);
@@ -49,61 +131,44 @@ export async function dispatchToEventConsumers(
         : events;
 
       if (matchingEvents.length === 0) {
-        return Promise.resolve();
+        return null;
       }
 
-      const body = JSON.stringify({
-        runId,
+      return {
+        name: consumer.name,
+        path: consumer.path,
+        required: consumer.required,
         events: matchingEvents,
-        context,
-      });
+      };
+    })
+    .filter((consumer): consumer is DispatchableConsumer => {
+      return consumer !== null;
+    });
 
-      const timestamp = Math.floor(Date.now() / 1000);
-      const signature = computeHmacSignature(
-        body,
-        SECRETS_ENCRYPTION_KEY,
-        timestamp,
-      );
+  const requiredConsumers = consumers.filter((consumer) => {
+    return consumer.required;
+  });
+  const optionalConsumers = consumers.filter((consumer) => {
+    return !consumer.required;
+  });
 
-      const response = await fetch(baseUrl + consumer.path, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-VM0-Signature": signature,
-          "X-VM0-Timestamp": timestamp.toString(),
-        },
-        body,
-      });
-      if (!response.ok) {
-        const responseBody = await response.text().catch(() => {
-          return "";
-        });
-        throw new Error(
-          `HTTP ${response.status}${responseBody ? `: ${responseBody}` : ""}`,
-        );
-      }
-      await response.arrayBuffer().catch(() => {
-        return undefined;
-      });
-    }),
+  const requiredFailures = await dispatchConsumerGroup(
+    requiredConsumers,
+    runId,
+    context,
+    baseUrl,
+    SECRETS_ENCRYPTION_KEY,
   );
-
-  const requiredFailures: string[] = [];
-  for (let i = 0; i < results.length; i++) {
-    const result = results[i];
-    if (result && result.status === "rejected") {
-      const consumer = eventConsumers[i];
-      log.error(`Event consumer "${eventConsumers[i]?.name}" failed`, {
-        runId,
-        error: result.reason,
-      });
-      if (consumer?.required) {
-        requiredFailures.push(consumer.name);
-      }
-    }
-  }
 
   if (requiredFailures.length > 0) {
     throw requiredEventConsumerDispatchError(requiredFailures);
   }
+
+  await dispatchConsumerGroup(
+    optionalConsumers,
+    runId,
+    context,
+    baseUrl,
+    SECRETS_ENCRYPTION_KEY,
+  );
 }

--- a/turbo/apps/web/src/lib/infra/event-consumer/registry.ts
+++ b/turbo/apps/web/src/lib/infra/event-consumer/registry.ts
@@ -4,12 +4,13 @@ import type { EventConsumerConfig } from "./types";
  * Registry of event consumers.
  *
  * The events webhook dispatches matching events to each consumer via HTTP POST.
- * Consumers are independent — one consumer's failure does not affect others.
+ * Optional consumers are isolated; required consumers make dispatch fail.
  */
 export const eventConsumers: EventConsumerConfig[] = [
   {
     name: "axiom",
     path: "/api/internal/event-consumers/axiom",
+    required: true,
   },
   {
     name: "credit",

--- a/turbo/apps/web/src/lib/infra/event-consumer/types.ts
+++ b/turbo/apps/web/src/lib/infra/event-consumer/types.ts
@@ -35,6 +35,8 @@ export interface EventConsumerConfig {
   name: string;
   /** Route path relative to the API base URL. */
   path: string;
+  /** When true, dispatch failure makes the events webhook fail. */
+  required?: boolean;
   /**
    * When set, only events whose `type` is in this list are forwarded.
    * When omitted/empty, ALL events are forwarded.

--- a/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitForAgentEventPrefixVisible } from "../agent-event-visibility";
+
+describe("waitForAgentEventPrefixVisible", () => {
+  it("waits until Axiom exposes the contiguous prefix", async () => {
+    let now = 0;
+    const queryAxiomFn = vi
+      .fn()
+      .mockResolvedValueOnce([{ sequenceNumber: 0 }, { sequenceNumber: 2 }])
+      .mockResolvedValueOnce([{ sequenceNumber: 1 }, { sequenceNumber: 2 }]);
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 2, {
+      timeoutMs: 1_000,
+      intervalMs: 10,
+      queryAxiomFn,
+      now: () => {
+        return now;
+      },
+      sleep: async (ms) => {
+        now += ms;
+      },
+    });
+
+    expect(result).toMatchObject({
+      visible: true,
+      visibleThrough: 2,
+      reason: "visible",
+    });
+    expect(queryAxiomFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses only sequenceNumber and does not require result events", async () => {
+    const queryAxiomFn = vi.fn().mockResolvedValue([
+      { sequenceNumber: 0, eventType: "tool_use" },
+      { sequenceNumber: 1, eventType: "user" },
+    ]);
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 1, {
+      queryAxiomFn,
+    });
+
+    expect(result.visible).toBe(true);
+    expect(result.visibleThrough).toBe(1);
+  });
+
+  it("continues querying when the visible prefix spans multiple batches", async () => {
+    const queryAxiomFn = vi
+      .fn()
+      .mockResolvedValueOnce([{ sequenceNumber: 0 }, { sequenceNumber: 1 }])
+      .mockResolvedValueOnce([{ sequenceNumber: 2 }, { sequenceNumber: 3 }]);
+    const sleep = vi.fn(async () => {});
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 3, {
+      timeoutMs: 1_000,
+      batchSize: 2,
+      queryAxiomFn,
+      sleep,
+    });
+
+    expect(result).toMatchObject({
+      visible: true,
+      visibleThrough: 3,
+      reason: "visible",
+    });
+    expect(queryAxiomFn).toHaveBeenCalledTimes(2);
+    expect(queryAxiomFn.mock.calls[1]?.[0]).toContain(
+      "| where sequenceNumber > 1",
+    );
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("returns timeout when the prefix remains incomplete", async () => {
+    let now = 0;
+    const queryAxiomFn = vi.fn().mockResolvedValue([{ sequenceNumber: 1 }]);
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 0, {
+      timeoutMs: 25,
+      intervalMs: 10,
+      queryAxiomFn,
+      now: () => {
+        return now;
+      },
+      sleep: async (ms) => {
+        now += ms;
+      },
+    });
+
+    expect(result).toMatchObject({
+      visible: false,
+      visibleThrough: -1,
+      targetSequence: 0,
+      reason: "timeout",
+    });
+    expect(queryAxiomFn).toHaveBeenCalled();
+  });
+
+  it("recovers from transient Axiom query errors", async () => {
+    let now = 0;
+    const queryAxiomFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("axiom down"))
+      .mockResolvedValueOnce([{ sequenceNumber: 0 }]);
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 0, {
+      timeoutMs: 1_000,
+      intervalMs: 10,
+      queryAxiomFn,
+      now: () => {
+        return now;
+      },
+      sleep: async (ms) => {
+        now += ms;
+      },
+    });
+
+    expect(result).toMatchObject({
+      visible: true,
+      visibleThrough: 0,
+      targetSequence: 0,
+      reason: "visible",
+    });
+    expect(queryAxiomFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails open after repeated Axiom query errors", async () => {
+    let now = 0;
+    const queryAxiomFn = vi.fn().mockRejectedValue(new Error("axiom down"));
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 0, {
+      timeoutMs: 25,
+      intervalMs: 10,
+      queryAxiomFn,
+      now: () => {
+        return now;
+      },
+      sleep: async (ms) => {
+        now += ms;
+      },
+    });
+
+    expect(result).toMatchObject({
+      visible: false,
+      visibleThrough: -1,
+      targetSequence: 0,
+      reason: "query_error",
+    });
+    expect(result.error).toBeInstanceOf(Error);
+    expect(queryAxiomFn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
+++ b/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
@@ -1,0 +1,230 @@
+import "server-only";
+import {
+  DATASETS,
+  getDatasetName,
+  isAxiomDatasetConfigured,
+  queryAxiom,
+  type QueryAxiomOptions,
+} from "../../shared/axiom";
+
+const DEFAULT_TIMEOUT_MS = 2_000;
+const DEFAULT_INTERVAL_MS = 100;
+const DEFAULT_BATCH_SIZE = 500;
+
+interface AxiomAgentEventSequence {
+  sequenceNumber: number;
+}
+
+type QueryAxiomFn = <T>(
+  apl: string,
+  options?: QueryAxiomOptions,
+) => Promise<T[]>;
+
+interface WaitOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+  batchSize?: number;
+  queryAxiomFn?: QueryAxiomFn;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+interface AgentEventVisibilityResult {
+  visible: boolean;
+  visibleThrough: number;
+  targetSequence: number;
+  attempts: number;
+  elapsedMs: number;
+  reason: "visible" | "not_configured" | "timeout" | "query_error";
+  error?: unknown;
+}
+
+function escapeApl(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  if (timeoutMs <= 0) {
+    throw new Error("Axiom visibility query timed out");
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error("Axiom visibility query timed out"));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function advanceVisiblePrefix(
+  events: AxiomAgentEventSequence[],
+  visibleThrough: number,
+): number {
+  let nextVisibleThrough = visibleThrough;
+  let expected = nextVisibleThrough + 1;
+
+  for (const event of events) {
+    if (event.sequenceNumber < expected) {
+      continue;
+    }
+    if (event.sequenceNumber !== expected) {
+      break;
+    }
+    nextVisibleThrough = event.sequenceNumber;
+    expected++;
+  }
+
+  return nextVisibleThrough;
+}
+
+function buildAgentEventVisibilityQuery(
+  dataset: string,
+  runId: string,
+  visibleThrough: number,
+  batchSize: number,
+): string {
+  return `['${dataset}']
+| where runId == "${escapeApl(runId)}"
+| where sequenceNumber > ${visibleThrough}
+| project sequenceNumber
+| order by sequenceNumber asc
+| limit ${batchSize}`;
+}
+
+/**
+ * Best-effort Axiom visibility barrier for successful run completion.
+ *
+ * The guest reports the highest event sequence whose events webhook POST
+ * completed. Before exposing the run as completed, wait briefly until Axiom
+ * can query the contiguous sequence prefix through that watermark.
+ */
+export async function waitForAgentEventPrefixVisible(
+  runId: string,
+  targetSequence: number,
+  options: WaitOptions = {},
+): Promise<AgentEventVisibilityResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const queryAxiomFn = options.queryAxiomFn ?? queryAxiom;
+  const sleepFn = options.sleep ?? sleep;
+  const now = options.now ?? Date.now;
+  const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
+
+  const startedAt = now();
+  if (!options.queryAxiomFn && !isAxiomDatasetConfigured(dataset)) {
+    return {
+      visible: false,
+      visibleThrough: -1,
+      targetSequence,
+      attempts: 0,
+      elapsedMs: 0,
+      reason: "not_configured",
+    };
+  }
+
+  const deadline = startedAt + timeoutMs;
+  let visibleThrough = -1;
+  let attempts = 0;
+  let lastQueryError: unknown;
+
+  outer: while (now() < deadline) {
+    let advancedInThisPass = false;
+
+    do {
+      attempts++;
+      const remainingMs = deadline - now();
+      const apl = buildAgentEventVisibilityQuery(
+        dataset,
+        runId,
+        visibleThrough,
+        batchSize,
+      );
+
+      let events: AxiomAgentEventSequence[];
+      try {
+        events = await withTimeout(
+          queryAxiomFn<AxiomAgentEventSequence>(apl, { maxRetries: 0 }),
+          remainingMs,
+        );
+        lastQueryError = undefined;
+      } catch (error) {
+        lastQueryError = error;
+        const remainingAfterErrorMs = deadline - now();
+        if (remainingAfterErrorMs <= 0) {
+          break outer;
+        }
+        await sleepFn(Math.min(intervalMs, remainingAfterErrorMs));
+        continue outer;
+      }
+
+      const previousVisibleThrough = visibleThrough;
+      visibleThrough = advanceVisiblePrefix(events, visibleThrough);
+
+      if (visibleThrough >= targetSequence) {
+        return {
+          visible: true,
+          visibleThrough,
+          targetSequence,
+          attempts,
+          elapsedMs: now() - startedAt,
+          reason: "visible",
+        };
+      }
+
+      advancedInThisPass = visibleThrough > previousVisibleThrough;
+      if (!advancedInThisPass || events.length < batchSize) {
+        break;
+      }
+    } while (now() < deadline);
+
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) {
+      break;
+    }
+    await sleepFn(Math.min(intervalMs, remainingMs));
+  }
+
+  if (lastQueryError) {
+    return {
+      visible: false,
+      visibleThrough,
+      targetSequence,
+      attempts,
+      elapsedMs: now() - startedAt,
+      reason: "query_error",
+      error: lastQueryError,
+    };
+  }
+
+  return {
+    visible: false,
+    visibleThrough,
+    targetSequence,
+    attempts,
+    elapsedMs: now() - startedAt,
+    reason: "timeout",
+  };
+}

--- a/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
@@ -91,6 +91,27 @@ describe("flushAxiom", () => {
 
     expect(mockFlush).toHaveBeenCalled();
   });
+
+  it("throws flush failures when requested", async () => {
+    mockFlush.mockRejectedValue(new Error("flush down"));
+
+    ingestToAxiom("vm0-sandbox-telemetry-system-dev", [{ a: 1 }]);
+
+    await expect(flushAxiom({ throwOnError: true })).rejects.toThrow(
+      "Axiom flush failed",
+    );
+  });
+
+  it("can flush only the sessions client", async () => {
+    mockFlush.mockResolvedValue(undefined);
+
+    ingestToAxiom("vm0-agent-run-events-dev", [{ a: 1 }]);
+    ingestToAxiom("vm0-sandbox-telemetry-system-dev", [{ b: 2 }]);
+
+    await flushAxiom({ client: "sessions" });
+
+    expect(mockFlush).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -179,6 +200,15 @@ describe("queryAxiom", () => {
     mockQuery.mockRejectedValue(new Error("network timeout"));
 
     await expect(queryAxiom(apl)).rejects.toThrow("network timeout");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports disabling rate-limit retries", async () => {
+    mockQuery.mockRejectedValue(new Error("429 rate limit"));
+
+    await expect(queryAxiom(apl, { maxRetries: 0 })).rejects.toThrow(
+      "429 rate limit",
+    );
     expect(mockQuery).toHaveBeenCalledTimes(1);
   });
 });

--- a/turbo/apps/web/src/lib/shared/axiom/client.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/client.ts
@@ -25,6 +25,12 @@ function getClientForDataset(dataset: string): Axiom | null {
     : getTelemetryInstance(env().AXIOM_TOKEN_TELEMETRY);
 }
 
+export function isAxiomDatasetConfigured(dataset: string): boolean {
+  return isSessionsDataset(dataset)
+    ? Boolean(env().AXIOM_TOKEN_SESSIONS)
+    : Boolean(env().AXIOM_TOKEN_TELEMETRY);
+}
+
 /**
  * Extract the dataset name from an APL query string.
  * APL queries always start with ['dataset-name'].
@@ -63,18 +69,44 @@ export function ingestToAxiom(
  * Call at request/response boundaries to ensure buffered events are sent
  * before the serverless function terminates.
  *
- * Errors are logged but not propagated — telemetry data is non-critical
- * and a flush failure must not break the request/response cycle.
+ * Errors are logged by default. Callers that need durability for a specific
+ * request path can opt into propagation with `throwOnError`.
  */
-export async function flushAxiom(): Promise<void> {
-  const results = await Promise.allSettled([
-    getSessionsClient()?.flush(),
-    getTelemetryClient()?.flush(),
-  ]);
-  for (const r of results) {
+interface FlushAxiomOptions {
+  throwOnError?: boolean;
+  client?: "all" | "sessions" | "telemetry";
+}
+
+export async function flushAxiom(
+  options: FlushAxiomOptions = {},
+): Promise<void> {
+  const client = options.client ?? "all";
+  const flushes: Array<{ name: string; promise: Promise<void> | undefined }> =
+    [];
+  if (client === "all" || client === "sessions") {
+    flushes.push({ name: "sessions", promise: getSessionsClient()?.flush() });
+  }
+  if (client === "all" || client === "telemetry") {
+    flushes.push({ name: "telemetry", promise: getTelemetryClient()?.flush() });
+  }
+
+  const results = await Promise.allSettled(
+    flushes.map((flush) => {
+      return flush.promise;
+    }),
+  );
+  const errors: unknown[] = [];
+  for (const [i, r] of results.entries()) {
     if (r.status === "rejected") {
-      log.error("Axiom flush failed:", r.reason);
+      errors.push(r.reason);
+      log.error(
+        `Axiom ${flushes[i]?.name ?? "unknown"} flush failed:`,
+        r.reason,
+      );
     }
+  }
+  if (options.throwOnError && errors.length > 0) {
+    throw new AggregateError(errors, "Axiom flush failed");
   }
 }
 
@@ -82,6 +114,10 @@ export async function flushAxiom(): Promise<void> {
 
 const MAX_QUERY_RETRIES = 3;
 const QUERY_BACKOFF_BASE_MS = 2000;
+
+export interface QueryAxiomOptions {
+  maxRetries?: number;
+}
 
 function isRateLimitError(error: unknown): boolean {
   if (error instanceof Error) {
@@ -113,6 +149,7 @@ function extractRetryAfterMs(error: unknown): number | null {
  */
 export async function queryAxiom<T = Record<string, unknown>>(
   apl: string,
+  options: QueryAxiomOptions = {},
 ): Promise<T[]> {
   const dataset = extractDatasetFromApl(apl);
   // If we can't determine the dataset, default to telemetry client (broader scope)
@@ -124,7 +161,9 @@ export async function queryAxiom<T = Record<string, unknown>>(
     return [];
   }
 
-  for (let attempt = 0; attempt <= MAX_QUERY_RETRIES; attempt++) {
+  const maxRetries = options.maxRetries ?? MAX_QUERY_RETRIES;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       const result = await client.query(apl);
       // Axiom stores _time separately from data, merge them for the response
@@ -134,12 +173,12 @@ export async function queryAxiom<T = Record<string, unknown>>(
         }) ?? []
       );
     } catch (error) {
-      if (attempt < MAX_QUERY_RETRIES && isRateLimitError(error)) {
+      if (attempt < maxRetries && isRateLimitError(error)) {
         const waitMs =
           extractRetryAfterMs(error) ??
           QUERY_BACKOFF_BASE_MS * Math.pow(2, attempt);
         log.warn(
-          `Axiom query rate limited, retrying in ${waitMs}ms (attempt ${attempt + 1}/${MAX_QUERY_RETRIES})`,
+          `Axiom query rate limited, retrying in ${waitMs}ms (attempt ${attempt + 1}/${maxRetries})`,
         );
         await new Promise((r) => {
           return setTimeout(r, waitMs);

--- a/turbo/apps/web/src/lib/shared/axiom/index.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/index.ts
@@ -2,6 +2,8 @@ export {
   ingestToAxiom,
   flushAxiom,
   queryAxiom,
+  isAxiomDatasetConfigured,
+  type QueryAxiomOptions,
   ingestRequestLog,
   ingestSandboxOpLog,
 } from "./client";

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -112,6 +112,7 @@ export const webhookCompleteContract = c.router({
       runId: z.string().min(1, "runId is required"),
       exitCode: z.number(),
       error: z.string().optional(),
+      lastEventSequence: z.number().int().nonnegative().optional(),
       // Sandbox id the run executed against. Optional because a run that fails
       // before VM creation has no sandbox. Persisted to agent_runs.sandbox_id;
       // the 255-char cap matches the DB column (defense in depth).


### PR DESCRIPTION
## Summary

- make agent event Axiom ingestion required and flushed before events webhook success
- pass the guest acked event watermark to complete and wait briefly for Axiom visibility before marking runs completed
- make CLI/event readers render only contiguous sequence prefixes and tolerate duplicate sequence numbers
- add coverage for Axiom visibility polling, required dispatch failures, CLI sequence gaps, and duplicate event filtering

## Verification

- cargo test --manifest-path crates/Cargo.toml -p guest-agent -- --test-threads=1
- pnpm exec vitest run ./src/lib/infra/run/__tests__/agent-event-visibility.test.ts ./app/api/webhooks/agent/events/__tests__/route.test.ts ./src/lib/shared/axiom/__tests__/client.test.ts ./app/api/webhooks/agent/complete/__tests__/route.test.ts
- pnpm exec vitest run ./app/api/agent/runs/\[id\]/events/__tests__/route.test.ts
- pnpm test (apps/cli)
- pnpm check-types (apps/cli)
- pnpm test (packages/api-contracts)
- pnpm check-types (packages/api-contracts)
- pnpm lint (apps/web)
- pnpm check-types (apps/web)
- pre-commit hook: prettier, knip, workspace check-types, commitlint
