### PR TITLE
docs(sandbox): document RuntimeProvider create_runtime contract

### DIFF
--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -81,7 +81,11 @@ pub struct FactoryConfig {
     pub snapshot: Option<SnapshotRef>,
 }
 
-/// Configuration for the sandbox runtime (shared resources).
+/// Runtime-wide configuration used to initialize shared backend resources.
+///
+/// These values are discovered before a runtime is created and apply to every
+/// factory produced by that runtime. Per-profile and per-sandbox settings
+/// belong in [`FactoryConfig`] and [`SandboxConfig`].
 pub struct RuntimeConfig {
     /// Proxy port for network traffic interception. Shared across all factories.
     pub proxy_port: Option<u16>,

--- a/crates/sandbox/src/runtime.rs
+++ b/crates/sandbox/src/runtime.rs
@@ -29,5 +29,23 @@ pub trait SandboxRuntime: Send + Sync {
 /// which backend is in use.
 #[async_trait]
 pub trait RuntimeProvider: Send + Sync {
+    /// Create a runtime from runtime-wide configuration.
+    ///
+    /// `config` contains inputs discovered before backend initialization, such
+    /// as proxy ports shared by every factory created from the returned runtime.
+    /// Implementations may validate these values and initialize
+    /// backend-specific shared resources while creating the runtime.
+    ///
+    /// On success, the returned runtime is ready for
+    /// [`SandboxRuntime::create_factory`] calls. This does not create, start, or
+    /// initialize any factory; factory startup remains part of
+    /// [`SandboxRuntime::create_factory`].
+    ///
+    /// The caller owns the returned runtime and is responsible for eventually
+    /// calling [`SandboxRuntime::shutdown`] after all factories created from it
+    /// have been shut down.
+    ///
+    /// Returns an error if the backend cannot initialize the runtime. The trait
+    /// does not guarantee retry semantics after an error.
     async fn create_runtime(&self, config: RuntimeConfig) -> Result<Box<dyn SandboxRuntime>>;
 }


### PR DESCRIPTION
Fixes #11140

## Summary
- Document `RuntimeConfig` as runtime-wide configuration for shared backend resources
- Add method-level docs for `RuntimeProvider::create_runtime`
- Clarify the returned runtime lifecycle, factory startup boundary, shutdown responsibility, and lack of guaranteed retry semantics

## Tests
- `cargo fmt --manifest-path crates/sandbox/Cargo.toml --check`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox`
