### PR TITLE
docs(nbd-cow): add crate module documentation

### DIFF
--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -1,3 +1,10 @@
+//! Copy-on-write storage layer for `nbd-cow`.
+//!
+//! [`CowLayer`] serves reads from pending writes, then dirty blocks in the COW
+//! file, then the read-only base image. Writes are collected in memory and
+//! flushed to a sparse COW file; a bitmap sidecar records which blocks have been
+//! materialized when snapshots are kept.
+
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::os::unix::fs::FileExt;

--- a/crates/nbd-cow/src/error.rs
+++ b/crates/nbd-cow/src/error.rs
@@ -1,3 +1,8 @@
+//! Error and result types for `nbd-cow`.
+//!
+//! [`NbdCowError`] wraps protocol, I/O, netlink, device allocation, and bounds
+//! errors surfaced by the public APIs.
+
 use crate::protocol::ProtocolError;
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -1,3 +1,26 @@
+//! In-process NBD copy-on-write block devices.
+//!
+//! This crate exposes a Linux NBD device backed by a read-only base image and a
+//! sparse copy-on-write (COW) file. [`NbdCowDevice::create`] connects the device,
+//! starts the request dispatch tasks, and serves reads from pending writes, the
+//! COW file, then the base image. Writes are buffered in memory and flushed to
+//! the sparse COW file according to [`DEFAULT_FLUSH_THRESHOLD`].
+//!
+//! Important defaults are exposed as [`BLOCK_SIZE`], [`NUM_CONNECTIONS`], and
+//! [`DEFAULT_FLUSH_THRESHOLD`].
+//!
+//! The layered implementation is split across:
+//! - [`cow`] for COW storage and dirty bitmap persistence.
+//! - [`pool`] for pre-validated `/dev/nbdN` device allocation.
+//! - [`netlink`] for Linux NBD generic netlink setup and disconnect.
+//! - [`server`] for the in-process NBD dispatch loop.
+//! - [`protocol`] for NBD transmission protocol parsing and serialization.
+//! - [`error`] for crate error and result types.
+//!
+//! Call [`NbdCowDevice::destroy`] or [`NbdCowDevice::destroy_keep_cow`] when the
+//! device should be shut down cleanly. Dropping a device only performs
+//! best-effort cleanup and may discard buffered writes that were not flushed.
+
 pub mod cow;
 pub mod error;
 pub mod netlink;

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -1,3 +1,9 @@
+//! In-process NBD request dispatch.
+//!
+//! [`dispatch`] owns one Unix socket connection passed to the kernel NBD device,
+//! decodes requests with [`crate::protocol`], applies them to
+//! [`crate::cow::CowLayer`], and writes NBD replies back to the kernel.
+
 use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
 use std::sync::Arc;
 


### PR DESCRIPTION
## Summary
- add crate-level rustdoc for the nbd-cow public library entry point
- document the remaining public modules that lacked module-level docs
- link the docs to existing public APIs instead of duplicating constants or implementation details

## Tests
- cargo doc -p nbd-cow --no-deps
- cargo test -p nbd-cow

Closes #11139