### PR TITLE
docs(guest-common): update crate overview

### DIFF
--- a/crates/guest-common/src/lib.rs
+++ b/crates/guest-common/src/lib.rs
@@ -1,9 +1,8 @@
-//! Common utilities for VM scripts.
+//! Shared logging and telemetry utilities for guest-side VM tools.
 //!
-//! This crate provides shared functionality for VM-side tools:
-//! - Environment variable accessors
-//! - Telemetry recording
-//! - Logging macros
+//! This crate provides:
+//! - Structured stderr logging macros
+//! - Sandbox operation telemetry helpers
 
 pub mod log;
 pub mod telemetry;


### PR DESCRIPTION
## Summary
- update the guest-common crate-level docs to match the currently exported logging and telemetry modules
- remove the stale environment accessor reference after the env module was inlined into telemetry

## Tests
- cargo fmt --manifest-path crates/Cargo.toml -p guest-common --check
- cargo test --manifest-path crates/Cargo.toml -p guest-common
- pre-commit: cargo-fmt, cargo-clippy

Closes #11138