### PR TITLE
refactor(sandbox-fc): remove unused prerequisite config

### DIFF
--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -36,7 +36,7 @@ pub(crate) async fn check_prerequisites(
         check_file_exists(&snapshot.cow_path, "snapshot cow", &mut errors);
     }
     check_kvm(&mut errors);
-    check_required_commands(config, &mut errors);
+    check_required_commands(&mut errors);
     ensure_runtime_dir(&mut errors);
 
     if errors.is_empty() {
@@ -69,7 +69,7 @@ fn check_kvm(errors: &mut Vec<String>) {
     }
 }
 
-fn check_required_commands(_config: &PrerequisiteConfig<'_>, errors: &mut Vec<String>) {
+fn check_required_commands(errors: &mut Vec<String>) {
     let commands = [
         "ip",
         "iptables",


### PR DESCRIPTION
## Summary
- Remove the unused config argument from check_required_commands
- Update the only call site to pass just the errors accumulator

## Verification
- cargo fmt --manifest-path crates/sandbox-fc/Cargo.toml --check
- cargo test --manifest-path crates/sandbox-fc/Cargo.toml
- pre-commit hook: cargo-fmt, cargo-clippy

Closes #11104