### PR TITLE
fix(mitm-addon): detect x tweet urls conservatively

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -255,11 +255,29 @@ def classify_includes_bucket(key: str) -> str | None:
     return _INCLUDES_TO_BUCKET.get(key)
 
 
-# URL detector for tweet body refinement.  Matches any http(s) scheme,
-# covering the common case; we stay on the expensive ``with_url`` bucket
-# when the text can't be inspected or when quote/media are attached
-# (both render as link previews and may be billed as "with URL" by X).
-_URL_RE = re.compile(r"https?://")
+# URL detector for tweet body refinement.  This is intentionally
+# twitter-text-inspired without vendoring twitter-text's full TLD table
+# and Unicode parser: billing needs a conservative "could X auto-link
+# this?" boolean, not link indices.  Keep protocol matching
+# case-insensitive and allow scheme-less domains, but retain the
+# important boundary guards so emails, mentions, hashtags and cashtags
+# do not look like URLs.
+_URL_PRECEDING_CHARS = r"A-Za-z0-9@\uFF20$#\uFF03"
+_URL_WITH_PROTOCOL_RE = re.compile(rf"(?<![{_URL_PRECEDING_CHARS}])https?://", re.IGNORECASE)
+_DOMAIN_LABEL = r"[a-z0-9](?:[a-z0-9_-]{0,61}[a-z0-9])?"
+_TLD = r"(?:[a-z]{2,63}|xn--[a-z0-9-]{2,59})"
+_BARE_DOMAIN_RE = re.compile(
+    rf"(?<![{_URL_PRECEDING_CHARS}._/-])"
+    rf"(?:{_DOMAIN_LABEL}\.)+{_TLD}"
+    r"(?=$|[^a-z0-9@+.-]|\.(?:$|[^a-z0-9]))",
+    re.IGNORECASE,
+)
+
+
+def _tweet_text_likely_contains_url(text: str) -> bool:
+    return (
+        _URL_WITH_PROTOCOL_RE.search(text) is not None or _BARE_DOMAIN_RE.search(text) is not None
+    )
 
 
 def refine_bucket_with_body(bucket: str, method: str, path: str, body: bytes | None) -> str:
@@ -299,6 +317,6 @@ def refine_bucket_with_body(bucket: str, method: str, path: str, body: bytes | N
     text = obj.get("text")
     if not isinstance(text, str):
         return bucket
-    if _URL_RE.search(text):
+    if _tweet_text_likely_contains_url(text):
         return bucket
     return "content.create"

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -2332,7 +2332,20 @@ class TestReportConnectorUsage:
         assert p["category"] == "content.create"
         assert p["quantity"] == 1
 
-    def test_tweet_create_with_url_stays_on_with_url_bucket(self, tmp_path, real_flow):
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "check https://example.com",
+            "check HTTPS://example.com",
+            "check HtTp://www.ExaMPLE.COM/index.html",
+            "Visit vm0.ai for details",
+            "Visit vm0.ai.",
+            "(vm0.ai)",
+            "Open example.com/path/to/resource?search=foo&lang=en",
+            "Open xn--r8jz45g.xn--zckzah",
+        ],
+    )
+    def test_tweet_create_with_url_stays_on_with_url_bucket(self, tmp_path, real_flow, text):
         """POST /2/tweets whose text contains a URL stays on the
         Content: Create (with URL) bucket."""
         flow = self._make_x_flow(
@@ -2345,9 +2358,41 @@ class TestReportConnectorUsage:
             rule="POST /2/tweets",
         )
         flow.request.method = "POST"
-        flow.request.content = json.dumps({"text": "check https://example.com"}).encode()
+        flow.request.content = json.dumps({"text": text}).encode()
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "content.create_with_url"
+        assert p["quantity"] == 1
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Email support@example.com",
+            "Mention @twitter.com",
+            "Tag #twitter.com",
+            "Cash $twitter.com",
+            "Path /twitter.com",
+            "Archive long.test.tar.bz2",
+            "Word abcHTTPS://example.com",
+        ],
+    )
+    def test_tweet_create_url_like_non_links_downgrade_to_content_create(
+        self, tmp_path, real_flow, text
+    ):
+        """twitter-text-style boundary guards avoid obvious non-link
+        domains while still allowing plain text to downgrade."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets",
+            body=json.dumps({"data": {"id": "1"}}).encode(),
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+        )
+        flow.request.method = "POST"
+        flow.request.content = json.dumps({"text": text}).encode()
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "content.create"
         assert p["quantity"] == 1
 
     def test_tweet_create_quote_or_media_stays_on_with_url_bucket(self, tmp_path, real_flow):
@@ -2358,6 +2403,8 @@ class TestReportConnectorUsage:
             json.dumps({"text": "nice", "quote_tweet_id": "abc"}).encode(),
             # attached media
             json.dumps({"text": "pic", "media": {"media_ids": ["42"]}}).encode(),
+            # attached card
+            json.dumps({"text": "card", "card_uri": "card://123"}).encode(),
         ]:
             flow = self._make_x_flow(
                 real_flow,


### PR DESCRIPTION
## Summary

- Replace the case-sensitive scheme-only X tweet URL check with a small twitter-text-inspired detector.
- Keep `POST /2/tweets` on `content.create_with_url` for uppercase/mixed-case schemes, bare domains, punctuation-delimited domains, and punycode domains.
- Preserve conservative boundary guards so obvious non-links like email addresses, mentions, hashtags, cashtags, path fragments, archive-like suffixes, and embedded schemes can still downgrade to `content.create`.
- Keep quote tweets, media attachments, and `card_uri` on the with-URL bucket.

Closes #11110

## Tests

- `python3 -m pytest tests/test_handlers.py -k tweet_create -v`
- `python3 -m pytest tests/test_x_billing.py -v`
- `ruff check src/usage/providers/connectors/x_billing.py tests/test_handlers.py`
- `ruff format --check src/usage/providers/connectors/x_billing.py tests/test_handlers.py`
- `git diff --check`

Note: I also attempted `python3 -m pytest tests/ -v` locally, but this environment repeatedly hung in the unrelated `tests/test_connectors.py` area before reaching the X billing tests. The targeted regression and consistency tests above pass.
