### PR TITLE
refactor(sandbox): clarify error taxonomy

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1977,7 +1977,13 @@ mod tests {
         let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
-        env.handle.discover_entered.notified().await;
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            env.handle.discover_entered.notified(),
+        )
+        .await
+        .expect("run() did not enter discover_fut select! within 2s");
+
         let run_id = RunId::new_v4();
         push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
@@ -4412,9 +4418,10 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn park_failure_destroys_sandbox_and_skips_pool() {
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-        overrides.push_park_result(Err(sandbox::SandboxError::IdleTransition(
-            "simulated balloon failure".into(),
-        )));
+        overrides.push_park_result(Err(sandbox::SandboxError::IdleTransition {
+            transition: sandbox::SandboxIdleTransition::Park,
+            message: "simulated balloon failure".into(),
+        }));
         let counter = Arc::clone(&overrides);
         let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
         let budget = Arc::clone(&config.budget);
@@ -4463,9 +4470,10 @@ mod tests {
         // path's call against the pre-seeded sandbox.
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
         let counter = Arc::clone(&overrides);
-        overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition(
-            "simulated unpark failure".into(),
-        )));
+        overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+            transition: sandbox::SandboxIdleTransition::Unpark,
+            message: "simulated unpark failure".into(),
+        }));
         let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
         let budget = Arc::clone(&config.budget);
         let idle_pool = Arc::clone(&config.idle_pool);

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1976,8 +1976,34 @@ mod tests {
     // Sandbox-interacting function tests (using sandbox-mock)
     // -----------------------------------------------------------------------
 
-    use sandbox::{ExecResult, SandboxError};
+    use sandbox::{
+        ExecResult, SandboxError, SandboxInitializationPhase, SandboxOperation,
+        SandboxOperationReason,
+    };
     use sandbox_mock::MockSandbox;
+
+    fn sandbox_exec_error(message: impl Into<String>) -> SandboxError {
+        SandboxError::Operation {
+            operation: SandboxOperation::Exec,
+            reason: SandboxOperationReason::Guest,
+            message: message.into(),
+        }
+    }
+
+    fn sandbox_write_file_error(message: impl Into<String>) -> SandboxError {
+        SandboxError::Operation {
+            operation: SandboxOperation::WriteFile,
+            reason: SandboxOperationReason::Guest,
+            message: message.into(),
+        }
+    }
+
+    fn sandbox_create_error(message: impl Into<String>) -> SandboxError {
+        SandboxError::Initialization {
+            phase: SandboxInitializationPhase::SandboxAllocation,
+            message: message.into(),
+        }
+    }
 
     #[tokio::test]
     async fn fix_guest_clock_calls_date_command() {
@@ -1989,7 +2015,7 @@ mod tests {
     #[tokio::test]
     async fn fix_guest_clock_propagates_exec_error() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("timeout".into())));
+        sandbox.push_exec_result(Err(sandbox_exec_error("timeout")));
         let result = fix_guest_clock(&sandbox).await;
         assert!(result.is_err());
     }
@@ -2005,7 +2031,7 @@ mod tests {
     async fn reseed_guest_entropy_propagates_exec_error() {
         let sandbox = MockSandbox::new("test");
         // Sandbox-level failure (vsock connection issue).
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("reseed failed".into())));
+        sandbox.push_exec_result(Err(sandbox_exec_error("reseed failed")));
         let result = reseed_guest_entropy(&sandbox).await;
         assert!(result.is_err());
     }
@@ -2040,7 +2066,7 @@ mod tests {
         let ctx = minimal_context();
         // No timezone — should skip without calling exec.
         // Push an error to detect if exec is called unexpectedly.
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("should not be called".into())));
+        sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
         sync_guest_timezone(&sandbox, &ctx).await;
     }
 
@@ -2050,7 +2076,7 @@ mod tests {
         let mut ctx = minimal_context();
         ctx.user_timezone = Some("$(rm -rf /)".into());
         // Push an error to detect if exec is called — it should NOT be.
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("should not be called".into())));
+        sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
         sync_guest_timezone(&sandbox, &ctx).await;
     }
 
@@ -2059,7 +2085,7 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         let mut ctx = minimal_context();
         ctx.user_timezone = Some(String::new());
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("should not be called".into())));
+        sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
         sync_guest_timezone(&sandbox, &ctx).await;
     }
 
@@ -2102,7 +2128,7 @@ mod tests {
     #[tokio::test]
     async fn read_guest_error_file_returns_none_on_exec_error() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("vsock timeout".into())));
+        sandbox.push_exec_result(Err(sandbox_exec_error("vsock timeout")));
         let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
         assert!(msg.is_none());
     }
@@ -2185,7 +2211,7 @@ mod tests {
         };
         // Should return Ok without calling exec or write_file.
         // Push an error to detect unexpected calls.
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("should not be called".into())));
+        sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
         restore_session(&sandbox, &ctx, &session).await.unwrap();
     }
 
@@ -2298,8 +2324,8 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         let ctx = minimal_context();
 
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("vsock down".into())));
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("vsock down".into())));
+        sandbox.push_exec_result(Err(sandbox_exec_error("vsock down")));
+        sandbox.push_exec_result(Err(sandbox_exec_error("vsock down")));
 
         copy_guest_logs(&sandbox, &ctx, &log_paths).await;
 
@@ -2356,7 +2382,7 @@ mod tests {
     #[tokio::test]
     async fn download_storages_fails_on_write_file_error() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_write_file_result(Err(SandboxError::ExecFailed("vsock write failed".into())));
+        sandbox.push_write_file_result(Err(sandbox_write_file_error("vsock write failed")));
         let ctx = minimal_context();
         let manifest = StorageManifest {
             storages: vec![],
@@ -2378,7 +2404,7 @@ mod tests {
             session_history: r#"{"type":"init"}"#.into(),
         };
         // First exec (mkdir) succeeds by default, write_file fails.
-        sandbox.push_write_file_result(Err(SandboxError::ExecFailed("disk full".into())));
+        sandbox.push_write_file_result(Err(sandbox_write_file_error("disk full")));
         let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
         assert!(err.to_string().contains("disk full"), "got: {err}");
     }
@@ -2392,7 +2418,7 @@ mod tests {
             session_history: "data".into(),
         };
         // mkdir exec fails
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("vsock down".into())));
+        sandbox.push_exec_result(Err(sandbox_exec_error("vsock down")));
         let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
         assert!(err.to_string().contains("vsock down"), "got: {err}");
     }
@@ -2542,7 +2568,7 @@ mod tests {
         let config = test_executor_config(dir.path()).await;
         let mut factory = MockSandboxFactory::new();
         factory.startup().await.unwrap();
-        factory.push_create_result(Err(SandboxError::CreationFailed("no free devices".into())));
+        factory.push_create_result(Err(sandbox_create_error("no free devices")));
 
         let err = run_execute_inner(&factory, &minimal_context(), &config, &default_params())
             .await
@@ -2604,7 +2630,7 @@ mod tests {
         let config = test_executor_config(dir.path()).await;
         let mut factory = MockSandboxFactory::new();
         factory.startup().await.unwrap();
-        factory.push_create_result(Err(SandboxError::CreationFailed("boom".into())));
+        factory.push_create_result(Err(sandbox_create_error("boom")));
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let (outcome, _telemetry) = execute_job(
@@ -2851,7 +2877,7 @@ mod tests {
 
         // Build a MockSandbox that fails on the first exec (fix_guest_clock)
         let sandbox = MockSandbox::new("reuse-clock-fail");
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("vsock broken".into())));
+        sandbox.push_exec_result(Err(sandbox_exec_error("vsock broken")));
 
         let idle_entry = crate::idle_pool::IdleEntry {
             sandbox: Box::new(sandbox),
@@ -2894,7 +2920,7 @@ mod tests {
             stdout: Vec::new(),
             stderr: Vec::new(),
         }));
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("reseed timeout".into())));
+        sandbox.push_exec_result(Err(sandbox_exec_error("reseed timeout")));
 
         let idle_entry = crate::idle_pool::IdleEntry {
             sandbox: Box::new(sandbox),
@@ -2933,7 +2959,7 @@ mod tests {
         let sandbox = MockSandbox::new("reuse-session-fail");
         // clock fix and reseed succeed (default), then mkdir exec succeeds,
         // but write_file for session history fails.
-        sandbox.push_write_file_result(Err(SandboxError::ExecFailed("disk full".into())));
+        sandbox.push_write_file_result(Err(sandbox_write_file_error("disk full")));
 
         let mut ctx = minimal_context();
         ctx.resume_session = Some(ResumeSession {

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use sandbox::{Sandbox, SandboxConfig, SandboxError, SandboxFactory};
+use sandbox::{
+    Sandbox, SandboxConfig, SandboxError, SandboxFactory, SandboxInitializationPhase,
+    SandboxInvalidStateContext,
+};
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
@@ -258,9 +261,11 @@ impl SandboxFactory for FirecrackerFactory {
 
     async fn startup(&mut self) -> sandbox::Result<()> {
         if self.started {
-            return Err(SandboxError::CreationFailed(
-                "factory already started".into(),
-            ));
+            return Err(SandboxError::InvalidState {
+                context: SandboxInvalidStateContext::Factory,
+                state: "started".into(),
+                message: "factory already started".into(),
+            });
         }
 
         // Create netns pool only if not provided externally (shared pool case).
@@ -271,7 +276,10 @@ impl SandboxFactory for FirecrackerFactory {
                 dns_port: self.config.dns_port,
             })
             .await
-            .map_err(|e| SandboxError::CreationFailed(format!("netns pool: {e}")))?;
+            .map_err(|e| SandboxError::Initialization {
+                phase: SandboxInitializationPhase::Factory,
+                message: format!("netns pool: {e}"),
+            })?;
             info!(
                 elapsed_ms = t.elapsed().as_millis() as u64,
                 "netns pool created"
@@ -283,7 +291,10 @@ impl SandboxFactory for FirecrackerFactory {
         let rootfs = &self.config.rootfs_path;
         let base_size = tokio::fs::metadata(rootfs)
             .await
-            .map_err(|e| SandboxError::CreationFailed(format!("base image metadata: {e}")))?
+            .map_err(|e| SandboxError::Initialization {
+                phase: SandboxInitializationPhase::Factory,
+                message: format!("base image metadata: {e}"),
+            })?
             .len();
 
         info!(
@@ -328,18 +339,25 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
+        if !self.started {
+            return Err(SandboxError::InvalidState {
+                context: SandboxInvalidStateContext::Factory,
+                state: "not started".into(),
+                message: "factory not started".into(),
+            });
+        }
+
         let id = config.id.to_string();
         let sock_paths = SockPaths::new(self.runtime_paths.sock_dir(&id));
 
         // Acquire a pre-warmed COW slot from the pool.
         // The slot provides: workspace dir (already created) and cow file.
-        let slot = self
-            .cow_pool()
-            .lock()
-            .await
-            .acquire()
-            .await
-            .map_err(|e| SandboxError::CreationFailed(format!("acquire COW slot: {e}")))?;
+        let slot = self.cow_pool().lock().await.acquire().await.map_err(|e| {
+            SandboxError::Initialization {
+                phase: SandboxInitializationPhase::SandboxAllocation,
+                message: format!("acquire COW slot: {e}"),
+            }
+        })?;
 
         // The slot workspace is {workspaces_dir}/{slot_uuid}/.
         // Rename to {workspaces_dir}/{sandbox_id}/ for doctor correlation.
@@ -352,9 +370,10 @@ impl SandboxFactory for FirecrackerFactory {
         if let Err(e) = tokio::fs::rename(&slot.workspace, &target_workspace).await {
             // Rollback: remove the slot workspace and COW file.
             crate::cow_pool::destroy_slot(slot);
-            return Err(SandboxError::CreationFailed(format!(
-                "rename workspace: {e}"
-            )));
+            return Err(SandboxError::Initialization {
+                phase: SandboxInitializationPhase::SandboxAllocation,
+                message: format!("rename workspace: {e}"),
+            });
         }
 
         let sandbox_paths = SandboxPaths::new(target_workspace);
@@ -372,9 +391,10 @@ impl SandboxFactory for FirecrackerFactory {
             let sd = sock_paths.dir().to_owned();
             let _ = tokio::fs::remove_dir_all(&ws).await;
             let _ = tokio::fs::remove_dir_all(&sd).await;
-            return Err(SandboxError::CreationFailed(format!(
-                "mkdir vsock dir: {e}"
-            )));
+            return Err(SandboxError::Initialization {
+                phase: SandboxInitializationPhase::SandboxAllocation,
+                message: format!("mkdir vsock dir: {e}"),
+            });
         }
 
         // Acquire a network namespace from the pool.
@@ -385,15 +405,22 @@ impl SandboxFactory for FirecrackerFactory {
                 let sd = sock_paths.dir().to_owned();
                 let _ = tokio::fs::remove_dir_all(&ws).await;
                 let _ = tokio::fs::remove_dir_all(&sd).await;
-                return Err(SandboxError::CreationFailed(format!("acquire netns: {e}")));
+                return Err(SandboxError::Initialization {
+                    phase: SandboxInitializationPhase::SandboxAllocation,
+                    message: format!("acquire netns: {e}"),
+                });
             }
         };
 
         // Create NBD COW device (~15ms via netlink, no subprocess).
-        let base_image = self
-            .base_image_path
-            .as_ref()
-            .ok_or_else(|| SandboxError::CreationFailed("factory not started".into()))?;
+        let base_image =
+            self.base_image_path
+                .as_ref()
+                .ok_or_else(|| SandboxError::InvalidState {
+                    context: SandboxInvalidStateContext::Factory,
+                    state: "started without base image".into(),
+                    message: "factory base image path missing".into(),
+                })?;
         let cow_device = match NbdCowDevice::create(
             base_image,
             &cow_file,
@@ -411,9 +438,10 @@ impl SandboxFactory for FirecrackerFactory {
                 }
                 let _ = tokio::fs::remove_dir_all(sandbox_paths.workspace()).await;
                 let _ = tokio::fs::remove_dir_all(sock_paths.dir()).await;
-                return Err(SandboxError::CreationFailed(format!(
-                    "create NBD COW device: {e}"
-                )));
+                return Err(SandboxError::Initialization {
+                    phase: SandboxInitializationPhase::SandboxAllocation,
+                    message: format!("create NBD COW device: {e}"),
+                });
             }
         };
 
@@ -614,6 +642,84 @@ mod tests {
             host_device: "test-ve".into(),
             peer_ip: "10.200.0.2".into(),
         }
+    }
+
+    fn test_config(base_dir: PathBuf) -> FirecrackerConfig {
+        FirecrackerConfig {
+            binary_path: PathBuf::from("/tmp/firecracker"),
+            kernel_path: PathBuf::from("/tmp/vmlinux"),
+            rootfs_path: PathBuf::from("/tmp/rootfs.ext4"),
+            base_dir,
+            profile: "vm0/default".into(),
+            proxy_port: None,
+            dns_port: None,
+            snapshot: None,
+        }
+    }
+
+    fn test_factory(started: bool) -> FirecrackerFactory {
+        FirecrackerFactory {
+            config: test_config(PathBuf::from("/tmp/factory-test-base")),
+            factory_paths: FactoryPaths::new(PathBuf::from("/tmp/factory-test")),
+            runtime_paths: RuntimePaths::new(),
+            netns_pool: None,
+            device_pool: std::sync::Arc::new(tokio::sync::Mutex::new(
+                nbd_cow::pool::DevicePool::new(nbd_cow::pool::DevicePoolConfig::default()),
+            )),
+            base_image_path: None,
+            base_image_size: 0,
+            cow_pool: None,
+            started,
+            leak_tx: None,
+            leak_cleanup_handle: None,
+        }
+    }
+
+    fn assert_factory_invalid_state(
+        err: SandboxError,
+        expected_state: &str,
+        expected_message: &str,
+    ) {
+        match err {
+            SandboxError::InvalidState {
+                context,
+                state,
+                message,
+            } => {
+                assert_eq!(context, SandboxInvalidStateContext::Factory);
+                assert_eq!(state, expected_state);
+                assert_eq!(message, expected_message);
+            }
+            other => panic!("expected factory invalid-state error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn startup_rejects_already_started_factory() {
+        let mut factory = test_factory(true);
+
+        let err = factory.startup().await.unwrap_err();
+
+        assert_factory_invalid_state(err, "started", "factory already started");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_not_started_factory() {
+        let factory = test_factory(false);
+        let config = sandbox::SandboxConfig {
+            id: sandbox::SandboxId::new_v4(),
+            resources: sandbox::ResourceLimits {
+                cpu_count: 1,
+                memory_mb: 512,
+            },
+        };
+
+        let err = match factory.create(config).await {
+            Ok(_) => panic!("create should fail before startup"),
+            Err(err) => err,
+        };
+
+        assert_factory_invalid_state(err, "not started", "factory not started");
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -20,7 +20,7 @@ pub(crate) struct PrerequisiteConfig<'a> {
 /// Verify that all required system prerequisites are present.
 ///
 /// Checks firecracker binary, kernel, rootfs, `/dev/kvm`, and network commands.
-/// Collects all failures and returns them in a single `BackendNotAvailable` error.
+/// Collects all failures and returns them in a single `BackendUnavailable` error.
 pub(crate) async fn check_prerequisites(
     config: &PrerequisiteConfig<'_>,
 ) -> Result<(), SandboxError> {
@@ -42,7 +42,9 @@ pub(crate) async fn check_prerequisites(
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(SandboxError::BackendNotAvailable(errors.join("; ")))
+        Err(SandboxError::BackendUnavailable {
+            message: errors.join("; "),
+        })
     }
 }
 

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -4,7 +4,8 @@ use async_trait::async_trait;
 use tracing::{info, warn};
 
 use sandbox::{
-    FactoryConfig, RuntimeProvider, SandboxError, SandboxFactory, SandboxRuntime, SnapshotRef,
+    FactoryConfig, RuntimeProvider, SandboxError, SandboxFactory, SandboxInitializationPhase,
+    SandboxRuntime, SnapshotRef,
 };
 
 use nbd_cow::pool::{DevicePool, DevicePoolConfig};
@@ -38,7 +39,10 @@ impl FirecrackerRuntime {
             dns_port: config.dns_port,
         })
         .await
-        .map_err(|e| SandboxError::CreationFailed(format!("netns pool: {e}")))?;
+        .map_err(|e| SandboxError::Initialization {
+            phase: SandboxInitializationPhase::Runtime,
+            message: format!("netns pool: {e}"),
+        })?;
         info!(
             elapsed_ms = t.elapsed().as_millis() as u64,
             "runtime netns pool created"

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1,10 +1,13 @@
+use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use sandbox::{
-    ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig, SandboxError, SpawnHandle,
+    ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig, SandboxError,
+    SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
+    SpawnHandle,
 };
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::Notify;
@@ -145,6 +148,35 @@ impl FirecrackerSandbox {
         SandboxState::from_u8(self.state.load(Ordering::Acquire))
     }
 
+    fn not_running_error(&self, operation: SandboxOperation) -> SandboxError {
+        SandboxError::InvalidState {
+            context: SandboxInvalidStateContext::Operation(operation),
+            state: self.current_state().to_string(),
+            message: "sandbox not running".into(),
+        }
+    }
+
+    fn backend_crashed_error(operation: SandboxOperation) -> SandboxError {
+        SandboxError::Operation {
+            operation,
+            reason: SandboxOperationReason::BackendCrashed,
+            message: "firecracker process crashed".into(),
+        }
+    }
+
+    fn operation_error(operation: SandboxOperation, error: io::Error) -> SandboxError {
+        let reason = if error.kind() == io::ErrorKind::TimedOut {
+            SandboxOperationReason::Timeout
+        } else {
+            SandboxOperationReason::Guest
+        };
+        SandboxError::Operation {
+            operation,
+            reason,
+            message: error.to_string(),
+        }
+    }
+
     /// Atomically transition between states using CAS. Returns `true` if the
     /// transition succeeded, `false` if the current state did not match `from`.
     fn transition(&self, from: SandboxState, to: SandboxState) -> bool {
@@ -199,12 +231,16 @@ impl FirecrackerSandbox {
     /// Start using a fresh boot with `--config-file --api-sock`.
     async fn start_fresh(&mut self) -> sandbox::Result<()> {
         let config = self.build_config();
-        let config_json = serde_json::to_string_pretty(&config)
-            .map_err(|e| SandboxError::StartFailed(format!("serialize config: {e}")))?;
+        let config_json =
+            serde_json::to_string_pretty(&config).map_err(|e| SandboxError::Start {
+                message: format!("serialize config: {e}"),
+            })?;
 
         tokio::fs::write(self.sandbox_paths.config(), config_json.as_bytes())
             .await
-            .map_err(|e| SandboxError::StartFailed(format!("write config: {e}")))?;
+            .map_err(|e| SandboxError::Start {
+                message: format!("write config: {e}"),
+            })?;
 
         let api_sock = self.sock_paths.api_sock();
 
@@ -223,7 +259,9 @@ impl FirecrackerSandbox {
             .process_group(0)
             .kill_on_drop(true)
             .spawn()
-            .map_err(|e| SandboxError::StartFailed(format!("spawn firecracker: {e}")))?;
+            .map_err(|e| SandboxError::Start {
+                message: format!("spawn firecracker: {e}"),
+            })?;
 
         self.firecracker_pid = child.id();
         monitor_process(
@@ -240,16 +278,22 @@ impl FirecrackerSandbox {
         let crash = Arc::clone(&self.crash_notify);
         tokio::select! {
             result = client.wait_for_ready(API_READY_TIMEOUT) => {
-                result.map_err(|e| SandboxError::StartFailed(format!(
-                    "API not ready: {e} (api_sock={})",
-                    api_sock.display()
-                )))?;
+                result.map_err(|e| {
+                    SandboxError::Start {
+                        message: format!(
+                            "API not ready: {e} (api_sock={})",
+                            api_sock.display()
+                        ),
+                    }
+                })?;
             }
             () = crash.notified() => {
-                return Err(SandboxError::StartFailed(format!(
-                    "firecracker process exited before API became ready (api_sock={})",
-                    api_sock.display()
-                )));
+                return Err(SandboxError::Start {
+                    message: format!(
+                        "firecracker process exited before API became ready (api_sock={})",
+                        api_sock.display()
+                    ),
+                });
             }
         }
 
@@ -259,21 +303,27 @@ impl FirecrackerSandbox {
 
     /// Start from a snapshot using `--api-sock` and bind mounts.
     async fn start_from_snapshot(&mut self) -> sandbox::Result<()> {
-        let snapshot = self
-            .factory_config
-            .snapshot
-            .as_ref()
-            .ok_or_else(|| SandboxError::StartFailed("missing snapshot config".into()))?;
+        let snapshot =
+            self.factory_config
+                .snapshot
+                .as_ref()
+                .ok_or_else(|| SandboxError::Start {
+                    message: "missing snapshot config".into(),
+                })?;
 
         // Ensure bind mount target directories exist.
         tokio::fs::create_dir_all(&snapshot.vsock_bind_dir)
             .await
-            .map_err(|e| SandboxError::StartFailed(format!("mkdir snapshot vsock: {e}")))?;
+            .map_err(|e| SandboxError::Start {
+                message: format!("mkdir snapshot vsock: {e}"),
+            })?;
 
         if let Some(parent) = snapshot.drive_bind_path.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
-                .map_err(|e| SandboxError::StartFailed(format!("mkdir snapshot drive: {e}")))?;
+                .map_err(|e| SandboxError::Start {
+                    message: format!("mkdir snapshot drive: {e}"),
+                })?;
         }
 
         // Verify sock dir exists before spawning — if this fails, we know
@@ -282,10 +332,9 @@ impl FirecrackerSandbox {
         let sock_dir = self.sock_paths.dir();
         let sock_dir_exists = tokio::fs::try_exists(sock_dir).await.unwrap_or(false);
         if !sock_dir_exists {
-            return Err(SandboxError::StartFailed(format!(
-                "sock dir missing before spawn: {}",
-                sock_dir.display()
-            )));
+            return Err(SandboxError::Start {
+                message: format!("sock dir missing before spawn: {}", sock_dir.display()),
+            });
         }
         let cow_device_path = self.cow_device.device_path();
         info!(
@@ -333,7 +382,9 @@ impl FirecrackerSandbox {
             .process_group(0)
             .kill_on_drop(true)
             .spawn()
-            .map_err(|e| SandboxError::StartFailed(format!("spawn firecracker: {e}")))?;
+            .map_err(|e| SandboxError::Start {
+                message: format!("spawn firecracker: {e}"),
+            })?;
 
         self.firecracker_pid = child.id();
         monitor_process(
@@ -353,17 +404,21 @@ impl FirecrackerSandbox {
             result = client.wait_for_ready(API_READY_TIMEOUT) => {
                 result.map_err(|e| {
                     let sock_dir_after = sock_dir.exists();
-                    SandboxError::StartFailed(format!(
-                        "API not ready: {e} (api_sock={}, sock_dir_exists_after={sock_dir_after})",
-                        api_sock.display()
-                    ))
+                    SandboxError::Start {
+                        message: format!(
+                            "API not ready: {e} (api_sock={}, sock_dir_exists_after={sock_dir_after})",
+                            api_sock.display()
+                        ),
+                    }
                 })?;
             }
             () = crash.notified() => {
-                return Err(SandboxError::StartFailed(format!(
-                    "firecracker process exited before API became ready (api_sock={})",
-                    api_sock.display()
-                )));
+                return Err(SandboxError::Start {
+                    message: format!(
+                        "firecracker process exited before API became ready (api_sock={})",
+                        api_sock.display()
+                    ),
+                });
             }
         }
 
@@ -373,7 +428,9 @@ impl FirecrackerSandbox {
         client
             .load_snapshot(&snapshot_str, &memory_str)
             .await
-            .map_err(|e| SandboxError::StartFailed(format!("snapshot load failed: {e}")))?;
+            .map_err(|e| SandboxError::Start {
+                message: format!("snapshot load failed: {e}"),
+            })?;
 
         info!(id = %self.id, "snapshot loaded and resumed");
         Ok(())
@@ -507,7 +564,11 @@ impl Sandbox for FirecrackerSandbox {
 
     async fn start(&mut self) -> sandbox::Result<()> {
         if self.current_state() != SandboxState::Created {
-            return Err(SandboxError::StartFailed("sandbox already started".into()));
+            return Err(SandboxError::InvalidState {
+                context: SandboxInvalidStateContext::Sandbox,
+                state: self.current_state().to_string(),
+                message: "sandbox already started".into(),
+            });
         }
 
         // Start the vsock listener BEFORE launching Firecracker.
@@ -534,11 +595,15 @@ impl Sandbox for FirecrackerSandbox {
             Ok(Ok(g)) => g,
             Ok(Err(e)) => {
                 self.kill_process().await;
-                return Err(SandboxError::StartFailed(format!("vsock connection: {e}")));
+                return Err(SandboxError::Start {
+                    message: format!("vsock connection: {e}"),
+                });
             }
             Err(e) => {
                 self.kill_process().await;
-                return Err(SandboxError::StartFailed(format!("vsock task: {e}")));
+                return Err(SandboxError::Start {
+                    message: format!("vsock task: {e}"),
+                });
             }
         };
 
@@ -550,9 +615,9 @@ impl Sandbox for FirecrackerSandbox {
         if !self.transition(SandboxState::Created, SandboxState::Running) {
             self.guest.lock().await.take();
             self.kill_process().await;
-            return Err(SandboxError::StartFailed(
-                "process exited during startup".into(),
-            ));
+            return Err(SandboxError::Start {
+                message: "process exited during startup".into(),
+            });
         }
 
         // Start control socket server for `runner exec`.
@@ -647,7 +712,7 @@ impl Sandbox for FirecrackerSandbox {
     // memory again. Ordering: resume before deflate — the guest needs
     // running vCPUs to process the deflate.
     //
-    // Both methods propagate PATCH failures as `IdleTransition` errors —
+    // Both methods propagate PATCH failures as `IdleTransition(Park|Unpark)` errors —
     // on failure the caller (runner) destroys the sandbox and falls
     // through to fresh-create. Firecracker's pause/resume returns 400
     // when the VM is already in the target state; within park/unpark
@@ -694,16 +759,17 @@ impl Sandbox for FirecrackerSandbox {
     // anyway — just with a less specific message.
 
     async fn exec(&self, request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
-        let guest = self.guest.lock().await.as_ref().cloned().ok_or_else(|| {
-            SandboxError::ExecFailed(format!(
-                "sandbox not running (state: {})",
-                self.current_state()
-            ))
-        })?;
+        let guest = self
+            .guest
+            .lock()
+            .await
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| self.not_running_error(SandboxOperation::Exec))?;
 
         tokio::select! {
             result = guest.exec(request.cmd, request.timeout_ms(), request.env, request.sudo) => {
-                let result = result.map_err(|e| SandboxError::ExecFailed(e.to_string()))?;
+                let result = result.map_err(|e| Self::operation_error(SandboxOperation::Exec, e))?;
                 Ok(ExecResult {
                     exit_code: result.exit_code,
                     stdout: result.stdout,
@@ -711,25 +777,26 @@ impl Sandbox for FirecrackerSandbox {
                 })
             }
             _ = self.crash_notify.notified() => {
-                Err(SandboxError::ExecFailed("firecracker process crashed".into()))
+                Err(Self::backend_crashed_error(SandboxOperation::Exec))
             }
         }
     }
 
     async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
-        let guest = self.guest.lock().await.as_ref().cloned().ok_or_else(|| {
-            SandboxError::ExecFailed(format!(
-                "sandbox not running (state: {})",
-                self.current_state()
-            ))
-        })?;
+        let guest = self
+            .guest
+            .lock()
+            .await
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| self.not_running_error(SandboxOperation::WriteFile))?;
 
         tokio::select! {
             result = guest.write_file(path, content, false) => {
-                result.map_err(|e| SandboxError::ExecFailed(e.to_string()))
+                result.map_err(|e| Self::operation_error(SandboxOperation::WriteFile, e))
             }
             _ = self.crash_notify.notified() => {
-                Err(SandboxError::ExecFailed("firecracker process crashed".into()))
+                Err(Self::backend_crashed_error(SandboxOperation::WriteFile))
             }
         }
     }
@@ -739,20 +806,21 @@ impl Sandbox for FirecrackerSandbox {
         request: &ExecRequest<'_>,
         stdout_log_path: Option<&str>,
     ) -> sandbox::Result<SpawnHandle> {
-        let guest = self.guest.lock().await.as_ref().cloned().ok_or_else(|| {
-            SandboxError::ExecFailed(format!(
-                "sandbox not running (state: {})",
-                self.current_state()
-            ))
-        })?;
+        let guest = self
+            .guest
+            .lock()
+            .await
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| self.not_running_error(SandboxOperation::SpawnWatch))?;
 
         tokio::select! {
             result = guest.spawn_watch(request.cmd, request.timeout_ms(), request.env, request.sudo, stdout_log_path) => {
-                let (pid, stdout_rx) = result.map_err(|e| SandboxError::ExecFailed(e.to_string()))?;
+                let (pid, stdout_rx) = result.map_err(|e| Self::operation_error(SandboxOperation::SpawnWatch, e))?;
                 Ok(SpawnHandle { pid, stdout_rx: Some(stdout_rx) })
             }
             _ = self.crash_notify.notified() => {
-                Err(SandboxError::ExecFailed("firecracker process crashed".into()))
+                Err(Self::backend_crashed_error(SandboxOperation::SpawnWatch))
             }
         }
     }
@@ -762,16 +830,17 @@ impl Sandbox for FirecrackerSandbox {
         handle: SpawnHandle,
         timeout: Duration,
     ) -> sandbox::Result<ProcessExit> {
-        let guest = self.guest.lock().await.as_ref().cloned().ok_or_else(|| {
-            SandboxError::ExecFailed(format!(
-                "sandbox not running (state: {})",
-                self.current_state()
-            ))
-        })?;
+        let guest = self
+            .guest
+            .lock()
+            .await
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| self.not_running_error(SandboxOperation::WaitExit))?;
 
         tokio::select! {
             result = guest.wait_for_exit(handle.pid, timeout) => {
-                let event = result.map_err(|e| SandboxError::ExecFailed(e.to_string()))?;
+                let event = result.map_err(|e| Self::operation_error(SandboxOperation::WaitExit, e))?;
                 Ok(ProcessExit {
                     pid: event.pid,
                     exit_code: event.exit_code,
@@ -780,7 +849,7 @@ impl Sandbox for FirecrackerSandbox {
                 })
             }
             _ = self.crash_notify.notified() => {
-                Err(SandboxError::ExecFailed("firecracker process crashed".into()))
+                Err(Self::backend_crashed_error(SandboxOperation::WaitExit))
             }
         }
     }
@@ -891,7 +960,10 @@ async fn park_inner(
         client
             .patch_balloon(target)
             .await
-            .map_err(|e| SandboxError::IdleTransition(format!("balloon inflate: {e}")))?;
+            .map_err(|e| SandboxError::IdleTransition {
+                transition: SandboxIdleTransition::Park,
+                message: format!("balloon inflate: {e}"),
+            })?;
 
         // Wait for the guest to fully inflate the balloon before pausing
         // vCPUs. The guest balloon driver needs running vCPUs to process
@@ -912,7 +984,12 @@ async fn park_inner(
         Err(ApiError::Http { status: 400, .. }) => {
             info!(id = %log_id, "vm already paused, continuing park");
         }
-        Err(e) => return Err(SandboxError::IdleTransition(format!("vm pause: {e}"))),
+        Err(e) => {
+            return Err(SandboxError::IdleTransition {
+                transition: SandboxIdleTransition::Park,
+                message: format!("vm pause: {e}"),
+            });
+        }
     }
 
     *is_parked = true;
@@ -949,7 +1026,12 @@ async fn unpark_inner(
         Err(ApiError::Http { status: 400, .. }) => {
             info!(id = %log_id, "vm already running, continuing unpark");
         }
-        Err(e) => return Err(SandboxError::IdleTransition(format!("vm resume: {e}"))),
+        Err(e) => {
+            return Err(SandboxError::IdleTransition {
+                transition: SandboxIdleTransition::Unpark,
+                message: format!("vm resume: {e}"),
+            });
+        }
     }
 
     let park_touched_controller = memory_mb > balloon::MIN_GUEST_MIB;
@@ -980,7 +1062,10 @@ async fn unpark_inner(
         client
             .patch_balloon(0)
             .await
-            .map_err(|e| SandboxError::IdleTransition(format!("balloon deflate: {e}")))?;
+            .map_err(|e| SandboxError::IdleTransition {
+                transition: SandboxIdleTransition::Unpark,
+                message: format!("balloon deflate: {e}"),
+            })?;
 
         *balloon_controller = Some(balloon::spawn(
             api_sock.to_path_buf(),
@@ -1015,6 +1100,42 @@ mod tests {
         })
         .await
         .unwrap();
+    }
+
+    fn assert_idle_transition(result: sandbox::Result<()>, expected: SandboxIdleTransition) {
+        match result {
+            Err(SandboxError::IdleTransition { transition, .. }) => {
+                assert_eq!(transition, expected);
+            }
+            other => panic!("expected {expected} idle transition error, got {other:?}"),
+        }
+    }
+
+    fn assert_operation_reason(error: SandboxError, expected: SandboxOperationReason) {
+        match error {
+            SandboxError::Operation { reason, .. } => assert_eq!(reason, expected),
+            other => panic!("expected operation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn operation_error_classifies_io_timeout() {
+        let err = FirecrackerSandbox::operation_error(
+            SandboxOperation::WaitExit,
+            io::Error::new(io::ErrorKind::TimedOut, "wait timeout"),
+        );
+
+        assert_operation_reason(err, SandboxOperationReason::Timeout);
+    }
+
+    #[test]
+    fn operation_error_classifies_non_timeout_as_guest() {
+        let err = FirecrackerSandbox::operation_error(
+            SandboxOperation::Exec,
+            io::Error::new(io::ErrorKind::BrokenPipe, "connection closed"),
+        );
+
+        assert_operation_reason(err, SandboxOperationReason::Guest);
     }
 
     /// Exercise the `monitor_process` crash detection flow through the real
@@ -1394,7 +1515,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(SandboxError::IdleTransition(_))));
+        assert_idle_transition(result, SandboxIdleTransition::Unpark);
         assert!(is_parked, "flag must stay true on failure");
         assert!(
             controller.is_none(),
@@ -1638,7 +1759,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(SandboxError::IdleTransition(_))));
+        assert_idle_transition(result, SandboxIdleTransition::Park);
         assert!(!is_parked, "flag must stay false on failure");
         assert!(controller.is_none());
 
@@ -1676,7 +1797,7 @@ mod tests {
         let mut is_parked = false;
 
         let first = park_inner(&mut is_parked, 2048, &mut controller, &sock, "retry").await;
-        assert!(matches!(first, Err(SandboxError::IdleTransition(_))));
+        assert_idle_transition(first, SandboxIdleTransition::Park);
         assert!(!is_parked);
         assert!(controller.is_none());
 
@@ -1715,7 +1836,7 @@ mod tests {
             "retry",
         )
         .await;
-        assert!(matches!(first, Err(SandboxError::IdleTransition(_))));
+        assert_idle_transition(first, SandboxIdleTransition::Unpark);
         assert!(is_parked, "flag must stay true on failure");
         assert!(controller.is_none());
 
@@ -1762,7 +1883,7 @@ mod tests {
 
         let result = park_inner(&mut is_parked, 2048, &mut controller, &sock, "pause-fail").await;
 
-        assert!(matches!(result, Err(SandboxError::IdleTransition(_))));
+        assert_idle_transition(result, SandboxIdleTransition::Park);
         assert!(!is_parked, "flag must stay false on failure");
         // Controller was aborted before balloon PATCH.
         assert!(controller.is_none());
@@ -1794,7 +1915,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(SandboxError::IdleTransition(_))));
+        assert_idle_transition(result, SandboxIdleTransition::Unpark);
         assert!(is_parked, "flag must stay true on failure");
         assert!(controller.is_none(), "controller must not be respawned");
 
@@ -1829,7 +1950,7 @@ mod tests {
             "idem",
         )
         .await;
-        assert!(matches!(first, Err(SandboxError::IdleTransition(_))));
+        assert_idle_transition(first, SandboxIdleTransition::Unpark);
         assert!(is_parked, "flag must stay true after partial failure");
 
         // Second attempt: resume 400 (idempotent), deflate OK.
@@ -1966,7 +2087,7 @@ mod tests {
 
         let result = park_inner(&mut is_parked, 512, &mut controller, &sock, "small-fail").await;
 
-        assert!(matches!(result, Err(SandboxError::IdleTransition(_))));
+        assert_idle_transition(result, SandboxIdleTransition::Park);
         assert!(!is_parked, "flag must stay false on failure");
         // Key assertion: controller is preserved for small VMs (no balloon
         // work was done, so no need to abort the controller).

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -64,9 +64,9 @@ pub struct MockSandboxOverrides {
     /// When set, `wait_exit` awaits this [`tokio::sync::Notify`] before
     /// returning — giving the test a window to cancel the job.
     wait_exit_gate: Option<Arc<tokio::sync::Notify>>,
-    /// When `Some`, `wait_exit` returns `Err(SandboxError::ExecFailed(msg))`
-    /// to simulate timeout or crash. The stdout channel sender is also kept
-    /// alive in `MockSandbox` so the drain task would block without the fix.
+    /// When `Some`, `wait_exit` returns a wait-exit operation error to
+    /// simulate timeout or crash. The stdout channel sender is also kept alive
+    /// in `MockSandbox` so the drain task would block without the fix.
     wait_exit_error: Option<String>,
     /// FIFO queue of park results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
@@ -337,7 +337,11 @@ impl Sandbox for MockSandbox {
             }
             // Return error when configured (simulates timeout or crash).
             if let Some(ref msg) = overrides.wait_exit_error {
-                return Err(SandboxError::ExecFailed(msg.clone()));
+                return Err(SandboxError::Operation {
+                    operation: SandboxOperation::WaitExit,
+                    reason: SandboxOperationReason::Timeout,
+                    message: msg.clone(),
+                });
             }
             // Return override exit code when configured.
             if let Some(code) = overrides.wait_exit_code {
@@ -610,7 +614,11 @@ mod tests {
             stdout: b"out".to_vec(),
             stderr: b"err".to_vec(),
         }));
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("boom".into())));
+        sandbox.push_exec_result(Err(SandboxError::Operation {
+            operation: SandboxOperation::Exec,
+            reason: SandboxOperationReason::Guest,
+            message: "boom".into(),
+        }));
 
         let req = ExecRequest {
             cmd: "test",
@@ -711,7 +719,11 @@ mod tests {
     #[tokio::test]
     async fn sandbox_write_file_queued_error() {
         let sandbox = MockSandbox::new("test-1");
-        sandbox.push_write_file_result(Err(SandboxError::ExecFailed("disk full".into())));
+        sandbox.push_write_file_result(Err(SandboxError::Operation {
+            operation: SandboxOperation::WriteFile,
+            reason: SandboxOperationReason::Guest,
+            message: "disk full".into(),
+        }));
 
         let result = sandbox.write_file("/tmp/test.txt", b"data").await;
         assert!(result.is_err());
@@ -724,7 +736,10 @@ mod tests {
     async fn factory_create_queued_error() {
         let mut factory = MockSandboxFactory::new();
         factory.startup().await.unwrap();
-        factory.push_create_result(Err(SandboxError::CreationFailed("out of resources".into())));
+        factory.push_create_result(Err(SandboxError::Initialization {
+            phase: SandboxInitializationPhase::SandboxAllocation,
+            message: "out of resources".into(),
+        }));
 
         let config = SandboxConfig {
             id: sandbox::SandboxId::new_v4(),

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -1,55 +1,172 @@
 //! Error and result types for sandbox runtime, factory, and sandbox operations.
 //!
-//! The variants group failures by the public API phase where they are reported.
-//! Backend implementations may include additional detail in the variant payload.
+//! [`SandboxError`] is the public error boundary for the sandbox crate. The
+//! variants keep backend-specific details in human-readable messages while
+//! exposing structured categories for initialization phases, lifecycle state
+//! errors, running operations, and idle transitions.
+
+use std::fmt;
 
 /// Error type returned by the sandbox crate's public APIs.
-///
-/// These variants describe the current runtime, factory, lifecycle, and
-/// operation boundaries exposed by the crate. They intentionally avoid
-/// backend-specific details so implementations can share the same public error
-/// surface.
 #[derive(Debug, thiserror::Error)]
 pub enum SandboxError {
     /// Required backend prerequisites are unavailable.
-    ///
-    /// This is used when the host environment cannot support the selected
-    /// backend before runtime, factory, or sandbox creation can proceed.
-    #[error("backend not available: {0}")]
-    BackendNotAvailable(String),
-
-    /// Runtime, factory, or sandbox creation failed.
-    ///
-    /// This covers resource initialization and allocation failures before a
-    /// created sandbox is started.
-    #[error("sandbox creation failed: {0}")]
-    CreationFailed(String),
-
-    /// A created sandbox failed to start.
-    ///
-    /// This covers failures while booting the backing environment and making the
-    /// sandbox ready to serve operations.
-    #[error("sandbox start failed: {0}")]
-    StartFailed(String),
-
-    /// A running sandbox operation failed.
-    ///
-    /// Despite the variant name, this covers the current operation surface,
-    /// including exec, file writes, process spawning, and wait/exit handling.
-    #[error("execution failed: {0}")]
-    ExecFailed(String),
-
-    /// Parking or unparking an idle sandbox failed.
-    #[error("idle transition failed: {0}")]
-    IdleTransition(String),
+    #[error("backend unavailable: {message}")]
+    BackendUnavailable { message: String },
 
     /// Runtime, factory, or sandbox configuration was rejected.
-    #[error("invalid configuration: {0}")]
-    InvalidConfig(String),
+    #[error("invalid configuration: {message}")]
+    Configuration { message: String },
+
+    /// Runtime, factory, or sandbox allocation initialization failed.
+    #[error("sandbox {phase} initialization failed: {message}")]
+    Initialization {
+        phase: SandboxInitializationPhase,
+        message: String,
+    },
+
+    /// A created sandbox failed while booting or becoming ready.
+    #[error("sandbox start failed: {message}")]
+    Start { message: String },
+
+    /// The requested action is invalid for the current runtime, factory, or
+    /// sandbox state.
+    #[error("invalid state for {context} (state: {state}): {message}")]
+    InvalidState {
+        context: SandboxInvalidStateContext,
+        state: String,
+        message: String,
+    },
+
+    /// A running sandbox operation failed after state validation.
+    #[error("sandbox {operation} failed ({reason}): {message}")]
+    Operation {
+        operation: SandboxOperation,
+        reason: SandboxOperationReason,
+        message: String,
+    },
+
+    /// Parking or unparking an idle sandbox failed.
+    #[error("sandbox {transition} failed: {message}")]
+    IdleTransition {
+        transition: SandboxIdleTransition,
+        message: String,
+    },
 
     /// An underlying host I/O operation failed.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+/// Initialization phase that produced a [`SandboxError::Initialization`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SandboxInitializationPhase {
+    /// Runtime-wide shared resource initialization.
+    Runtime,
+    /// Factory-level initialization.
+    Factory,
+    /// Per-sandbox allocation before sandbox start.
+    SandboxAllocation,
+}
+
+impl fmt::Display for SandboxInitializationPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Runtime => f.write_str("runtime"),
+            Self::Factory => f.write_str("factory"),
+            Self::SandboxAllocation => f.write_str("sandbox allocation"),
+        }
+    }
+}
+
+/// Public sandbox operation associated with an operation failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SandboxOperation {
+    /// [`Sandbox::exec`](crate::Sandbox::exec).
+    Exec,
+    /// [`Sandbox::write_file`](crate::Sandbox::write_file).
+    WriteFile,
+    /// [`Sandbox::spawn_watch`](crate::Sandbox::spawn_watch).
+    SpawnWatch,
+    /// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit).
+    WaitExit,
+}
+
+impl fmt::Display for SandboxOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Exec => f.write_str("exec"),
+            Self::WriteFile => f.write_str("write file"),
+            Self::SpawnWatch => f.write_str("spawn watch"),
+            Self::WaitExit => f.write_str("wait exit"),
+        }
+    }
+}
+
+/// Root-cause category for a running sandbox operation failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SandboxOperationReason {
+    /// The guest-side operation or IPC call returned an error.
+    Guest,
+    /// The backend process crashed while the operation was in flight.
+    BackendCrashed,
+    /// The operation timed out.
+    Timeout,
+    /// The operation failed for another reason.
+    Other,
+}
+
+impl fmt::Display for SandboxOperationReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Guest => f.write_str("guest"),
+            Self::BackendCrashed => f.write_str("backend crashed"),
+            Self::Timeout => f.write_str("timeout"),
+            Self::Other => f.write_str("other"),
+        }
+    }
+}
+
+/// Idle transition associated with an idle-transition failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SandboxIdleTransition {
+    /// Parking an active sandbox for idle reuse.
+    Park,
+    /// Unparking an idle sandbox before reuse.
+    Unpark,
+}
+
+impl fmt::Display for SandboxIdleTransition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Park => f.write_str("park"),
+            Self::Unpark => f.write_str("unpark"),
+        }
+    }
+}
+
+/// API context where an invalid state was observed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SandboxInvalidStateContext {
+    /// Runtime-level state.
+    Runtime,
+    /// Factory-level state.
+    Factory,
+    /// Sandbox lifecycle state.
+    Sandbox,
+    /// State required for a specific running sandbox operation.
+    Operation(SandboxOperation),
+}
+
+impl fmt::Display for SandboxInvalidStateContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Runtime => f.write_str("runtime"),
+            Self::Factory => f.write_str("factory"),
+            Self::Sandbox => f.write_str("sandbox"),
+            Self::Operation(operation) => write!(f, "{operation} operation"),
+        }
+    }
 }
 
 /// Convenient result alias for sandbox crate public APIs.

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -11,7 +11,10 @@ pub use config::{
     FactoryConfig, ResourceLimits, RuntimeConfig, SandboxConfig, SandboxId, SnapshotRef,
 };
 pub use control::{RemoteExecResult, SandboxControl, SandboxControlError};
-pub use error::{Result, SandboxError};
+pub use error::{
+    Result, SandboxError, SandboxIdleTransition, SandboxInitializationPhase,
+    SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
+};
 pub use factory::SandboxFactory;
 pub use runtime::{RuntimeProvider, SandboxRuntime};
 pub use sandbox::Sandbox;

--- a/crates/sandbox/tests/error.rs
+++ b/crates/sandbox/tests/error.rs
@@ -1,0 +1,100 @@
+use sandbox::{
+    SandboxError, SandboxIdleTransition, SandboxInitializationPhase, SandboxInvalidStateContext,
+    SandboxOperation, SandboxOperationReason,
+};
+
+#[test]
+fn initialization_error_exposes_phase() {
+    let err = SandboxError::Initialization {
+        phase: SandboxInitializationPhase::Runtime,
+        message: "netns pool".into(),
+    };
+
+    match err {
+        SandboxError::Initialization { phase, message } => {
+            assert_eq!(phase, SandboxInitializationPhase::Runtime);
+            assert_eq!(message, "netns pool");
+        }
+        other => panic!("expected initialization error, got {other:?}"),
+    }
+}
+
+#[test]
+fn operation_error_exposes_operation_and_reason() {
+    let err = SandboxError::Operation {
+        operation: SandboxOperation::WriteFile,
+        reason: SandboxOperationReason::Guest,
+        message: "disk full".into(),
+    };
+
+    match err {
+        SandboxError::Operation {
+            operation,
+            reason,
+            message,
+        } => {
+            assert_eq!(operation, SandboxOperation::WriteFile);
+            assert_eq!(reason, SandboxOperationReason::Guest);
+            assert_eq!(message, "disk full");
+        }
+        other => panic!("expected operation error, got {other:?}"),
+    }
+}
+
+#[test]
+fn invalid_state_error_exposes_context_and_state() {
+    let err = SandboxError::InvalidState {
+        context: SandboxInvalidStateContext::Operation(SandboxOperation::Exec),
+        state: "stopped".into(),
+        message: "sandbox not running".into(),
+    };
+
+    match err {
+        SandboxError::InvalidState {
+            context,
+            state,
+            message,
+        } => {
+            assert_eq!(
+                context,
+                SandboxInvalidStateContext::Operation(SandboxOperation::Exec)
+            );
+            assert_eq!(state, "stopped");
+            assert_eq!(message, "sandbox not running");
+        }
+        other => panic!("expected invalid state error, got {other:?}"),
+    }
+}
+
+#[test]
+fn idle_transition_error_exposes_transition() {
+    let err = SandboxError::IdleTransition {
+        transition: SandboxIdleTransition::Unpark,
+        message: "vm resume".into(),
+    };
+
+    match err {
+        SandboxError::IdleTransition {
+            transition,
+            message,
+        } => {
+            assert_eq!(transition, SandboxIdleTransition::Unpark);
+            assert_eq!(message, "vm resume");
+        }
+        other => panic!("expected idle transition error, got {other:?}"),
+    }
+}
+
+#[test]
+fn display_includes_category_and_message() {
+    let err = SandboxError::Operation {
+        operation: SandboxOperation::WaitExit,
+        reason: SandboxOperationReason::BackendCrashed,
+        message: "firecracker process crashed".into(),
+    };
+
+    let text = err.to_string();
+    assert!(text.contains("wait exit"), "got: {text}");
+    assert!(text.contains("backend crashed"), "got: {text}");
+    assert!(text.contains("firecracker process crashed"), "got: {text}");
+}


### PR DESCRIPTION
## Summary

- Replace the coarse `SandboxError` variants with structured variants for backend availability, configuration, initialization phase, start, invalid state, operation failure, and idle transition.
- Re-export structured sandbox error context enums and update firecracker, mock, and runner call sites to construct variants directly.
- Add sandbox error model tests that assert structured fields and display output.

Closes #11169

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox --no-deps`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox -p sandbox-mock -p sandbox-fc -p runner --all-targets -- -D warnings`
