### PR TITLE
test: stabilize usage insight timezone test

### DIFF
--- a/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
@@ -386,10 +386,34 @@ describe("GET /api/zero/usage/insight", () => {
       creditsCharged: 42,
       status: "processed",
     });
-    // Row at 2026-04-20T00:30:00Z
-    // In UTC → day 2026-04-20
-    // In America/Los_Angeles (UTC-7) → 2026-04-19T17:30:00 → day 2026-04-19
-    const rowTime = new Date("2026-04-20T00:30:00Z");
+    // Pick a recent 00:30Z boundary row so it stays inside range=7d while
+    // landing on different calendar days in UTC vs America/Los_Angeles.
+    const now = new Date();
+    const rowTime = new Date(
+      Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate() - 3,
+        0,
+        30,
+      ),
+    );
+    const dateInTimeZone = (date: Date, timeZone: string) => {
+      const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).formatToParts(date);
+      const value = (type: string) => {
+        return parts.find((part) => {
+          return part.type === type;
+        })!.value;
+      };
+      return `${value("year")}-${value("month")}-${value("day")}`;
+    };
+    const expectedUtcDate = dateInTimeZone(rowTime, "UTC");
+    const expectedLaDate = dateInTimeZone(rowTime, "America/Los_Angeles");
     await setTestCreditUsageCreatedAt(cuId, rowTime);
 
     const responseUtc = await GET(
@@ -422,17 +446,11 @@ describe("GET /api/zero/usage/insight", () => {
     const utcBucket = findBucketWith42Credits(dataUtc.buckets);
     const laBucket = findBucketWith42Credits(dataLa.buckets);
 
-    // At least one of the timezone results should have a bucket with our 42 credits
-    expect(utcBucket ?? laBucket).toBeDefined();
-
-    if (utcBucket) {
-      // UTC bucket ts should start with 2026-04-20
-      expect(utcBucket.ts).toContain("2026-04-20");
-    }
-    if (laBucket) {
-      // LA bucket ts should start with 2026-04-19
-      expect(laBucket.ts).toContain("2026-04-19");
-    }
+    expect(utcBucket).toBeDefined();
+    expect(laBucket).toBeDefined();
+    expect(utcBucket!.ts).toContain(expectedUtcDate);
+    expect(laBucket!.ts).toContain(expectedLaDate);
+    expect(expectedUtcDate).not.toBe(expectedLaDate);
   });
 
   it("top-100 truncation — 105 schedules → schedules.length === 100, otherCount === 5", async () => {


### PR DESCRIPTION
## Summary
- make the timezone bucket test use a current-date 00:30Z row
- compute expected UTC and Los Angeles bucket dates dynamically

## Tests
- pnpm exec vitest run app/api/zero/usage/insight/__tests__/route.test.ts
- pnpm --dir turbo exec prettier --check apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
- pre-commit: prettier, knip, check-types