### PR TITLE
feat(platform): add telegram settings signals

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
@@ -28,6 +28,7 @@ const defaultTelegramStatus: TelegramBotStatus = {
   },
 };
 
+let mockRegisterCounter = 0;
 let mockTelegramList: TelegramListResponse = {
   bots: structuredClone(defaultTelegramBots),
 };
@@ -40,12 +41,57 @@ let mockTelegramStatuses: Record<string, TelegramBotStatus> = {
 // override this handler via server.use(mockApi(zeroIntegrationsTelegramContract.getLinkStatus, ...)).
 let mockLinkStatus: TelegramLinkStatusResponse = { linked: false };
 
-export function resetMockTelegramIntegration(): void {
-  mockTelegramList = { bots: structuredClone(defaultTelegramBots) };
-  mockTelegramStatuses = {
-    [defaultTelegramStatus.id]: structuredClone(defaultTelegramStatus),
+function statusToBot(status: TelegramBotStatus): TelegramBot {
+  return {
+    id: status.id,
+    username: status.username,
+    agent: status.agent,
+    isOwner: status.isOwner,
+    isConnected: status.isConnected,
   };
+}
+
+function setMockTelegramStatuses(statuses: TelegramBotStatus[]): void {
+  mockTelegramStatuses = Object.fromEntries(
+    statuses.map((status) => {
+      return [status.id, structuredClone(status)];
+    }),
+  );
+  mockTelegramList = {
+    bots: statuses.map((status) => {
+      return structuredClone(statusToBot(status));
+    }),
+  };
+}
+
+export function resetMockTelegramIntegration(): void {
+  mockRegisterCounter = 0;
+  setMockTelegramStatuses([defaultTelegramStatus]);
   mockLinkStatus = { linked: false };
+}
+
+export function setMockTelegramIntegration(input: {
+  statuses?: TelegramBotStatus[];
+  linkStatus?: TelegramLinkStatusResponse;
+}): void {
+  if (input.statuses) {
+    setMockTelegramStatuses(input.statuses);
+  }
+  if (input.linkStatus) {
+    mockLinkStatus = structuredClone(input.linkStatus);
+  }
+}
+
+export function getMockTelegramIntegration(): {
+  list: TelegramListResponse;
+  statuses: Record<string, TelegramBotStatus>;
+  linkStatus: TelegramLinkStatusResponse;
+} {
+  return {
+    list: structuredClone(mockTelegramList),
+    statuses: structuredClone(mockTelegramStatuses),
+    linkStatus: structuredClone(mockLinkStatus),
+  };
 }
 
 export const apiIntegrationsTelegramHandlers = [
@@ -72,11 +118,12 @@ export const apiIntegrationsTelegramHandlers = [
           error: { message: "Telegram bot not found", code: "NOT_FOUND" },
         });
       }
-      status.agent = { id: body.defaultAgentId, name: "default-agent" };
+      const agent = { id: body.defaultAgentId, name: "default-agent" };
+      mockTelegramStatuses[status.id] = { ...status, agent };
       mockTelegramList.bots = mockTelegramList.bots.map((bot) => {
-        return bot.id === status.id ? { ...bot, agent: status.agent } : bot;
+        return bot.id === status.id ? { ...bot, agent } : bot;
       });
-      return respond(200, status);
+      return respond(200, mockTelegramStatuses[status.id]!);
     },
   ),
 
@@ -95,11 +142,20 @@ export const apiIntegrationsTelegramHandlers = [
     return respond(200, mockLinkStatus);
   }),
 
-  mockApi(zeroIntegrationsTelegramContract.register, ({ respond }) => {
+  mockApi(zeroIntegrationsTelegramContract.register, ({ body, respond }) => {
+    mockRegisterCounter += 1;
+    const id =
+      mockRegisterCounter === 1
+        ? "bot_registered"
+        : `bot_registered_${mockRegisterCounter}`;
+    const agentId = body.defaultAgentId ?? "compose_1";
     const status: TelegramBotStatus = {
-      id: "bot_registered",
-      username: "registered_bot",
-      agent: { id: "compose_1", name: "default-agent" },
+      id,
+      username:
+        mockRegisterCounter === 1
+          ? "registered_bot"
+          : `registered_bot_${mockRegisterCounter}`,
+      agent: { id: agentId, name: "default-agent" },
       isOwner: true,
       isConnected: false,
       domainConfigured: false,
@@ -111,7 +167,10 @@ export const apiIntegrationsTelegramHandlers = [
       },
     };
     mockTelegramStatuses[status.id] = structuredClone(status);
-    mockTelegramList.bots = [...mockTelegramList.bots, status];
+    mockTelegramList.bots = [
+      ...mockTelegramList.bots,
+      structuredClone(statusToBot(status)),
+    ];
     return respond(201, status);
   }),
 ];

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -16,6 +16,7 @@ import { ROUTES, type RoutePath } from "./route-paths.ts";
 import { setupGlobalMethod$ } from "./bootstrap/global-method.ts";
 import { setupLoggers$ } from "./bootstrap/loggers.ts";
 import { setupSlackConnectPage$ } from "./zero-page/slack-connect-page.ts";
+import { setupTelegramSettingsPage$ } from "./zero-page/telegram-settings-page.ts";
 import { setupActivityPage$ } from "./activity-page/activity-page-setup.ts";
 import { setupActivityDetailPage$ } from "./activity-page/activity-detail-page-setup.ts";
 import { setupActivityInspectPage$ } from "./activity-page/activity-inspect-page-setup.ts";
@@ -148,6 +149,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.settingsSlack,
     setup: setupAuthPageWrapper(setupSlackConnectPage$),
+  },
+  {
+    path: ROUTES.settingsTelegram,
+    setup: setupAuthPageWrapper(setupTelegramSettingsPage$),
   },
   {
     path: ROUTES.activityInspect,

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -20,6 +20,7 @@ export const ROUTES = {
   directedAuthorize: "/connectors/:type/authorize",
   settings: "/settings",
   settingsSlack: "/settings/slack",
+  settingsTelegram: "/settings/telegram",
   settingsApiKeys: "/settings/api-keys",
   onboarding: "/onboarding",
   signInToken: "/sign-in-token",

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TelegramBotStatus } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { pathname$ } from "../../route.ts";
+import {
+  disconnectTelegramBot$,
+  isTelegramIntegrationEnabled$,
+  registerTelegramBot$,
+  telegramBots$,
+  updateTelegramBotAgent$,
+} from "../zero-telegram.ts";
+import {
+  getMockTelegramIntegration,
+  setMockTelegramIntegration,
+} from "../../../mocks/handlers/api-integrations-telegram.ts";
+
+const context = testContext();
+
+function setup({
+  path = "/",
+  enabled = false,
+}: {
+  path?: string;
+  enabled?: boolean;
+} = {}) {
+  detachedSetupPage({
+    context,
+    path,
+    featureSwitches: { [FeatureSwitchKey.TelegramIntegration]: enabled },
+    withoutRender: true,
+  });
+}
+
+function telegramStatus(
+  id: string,
+  overrides: Partial<TelegramBotStatus> = {},
+): TelegramBotStatus {
+  return {
+    id,
+    username: `${id}_bot`,
+    agent: { id: "compose_1", name: "Default agent" },
+    isOwner: true,
+    isConnected: false,
+    domainConfigured: false,
+    environment: {
+      requiredSecrets: [],
+      requiredVars: [],
+      missingSecrets: [],
+      missingVars: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("zero telegram signals", () => {
+  it("derives frontend enablement from feature switches", async () => {
+    setup({ enabled: true });
+
+    await expect(
+      context.store.get(isTelegramIntegrationEnabled$),
+    ).resolves.toBeTruthy();
+  });
+
+  it("keeps the frontend gate disabled when the switch is off", async () => {
+    setup({ enabled: false });
+
+    await expect(
+      context.store.get(isTelegramIntegrationEnabled$),
+    ).resolves.toBeFalsy();
+  });
+
+  it("loads multiple Telegram bots from the multi-bot API", async () => {
+    setMockTelegramIntegration({
+      statuses: [
+        telegramStatus("bot_alpha"),
+        telegramStatus("bot_beta", {
+          agent: { id: "compose_2", name: "Support agent" },
+          isConnected: true,
+        }),
+      ],
+    });
+    setup({ enabled: true });
+
+    await expect(context.store.get(telegramBots$)).resolves.toMatchObject([
+      { id: "bot_alpha", agent: { id: "compose_1" } },
+      { id: "bot_beta", agent: { id: "compose_2" }, isConnected: true },
+    ]);
+  });
+
+  it("registers a bot and refreshes the list state", async () => {
+    setMockTelegramIntegration({ statuses: [] });
+    setup({ enabled: true });
+
+    const registered = await context.store.set(
+      registerTelegramBot$,
+      { botToken: "123:token", defaultAgentId: "compose_9" },
+      context.signal,
+    );
+    const bots = await context.store.get(telegramBots$);
+
+    expect(registered).toMatchObject({
+      id: "bot_registered",
+      agent: { id: "compose_9" },
+    });
+    expect(bots).toMatchObject([
+      { id: "bot_registered", agent: { id: "compose_9" } },
+    ]);
+  });
+
+  it("updates a bot default agent and refreshes mock state", async () => {
+    setMockTelegramIntegration({
+      statuses: [telegramStatus("bot_alpha")],
+    });
+    setup({ enabled: true });
+
+    await context.store.set(
+      updateTelegramBotAgent$,
+      { botId: "bot_alpha", defaultAgentId: "compose_2" },
+      context.signal,
+    );
+
+    expect(getMockTelegramIntegration().statuses.bot_alpha).toMatchObject({
+      agent: { id: "compose_2" },
+    });
+    await expect(context.store.get(telegramBots$)).resolves.toMatchObject([
+      { id: "bot_alpha", agent: { id: "compose_2" } },
+    ]);
+  });
+
+  it("disconnects a bot and refreshes the list state", async () => {
+    setMockTelegramIntegration({
+      statuses: [telegramStatus("bot_alpha"), telegramStatus("bot_beta")],
+    });
+    setup({ enabled: true });
+
+    await context.store.set(
+      disconnectTelegramBot$,
+      "bot_alpha",
+      context.signal,
+    );
+
+    await expect(context.store.get(telegramBots$)).resolves.toMatchObject([
+      { id: "bot_beta" },
+    ]);
+    expect(getMockTelegramIntegration().statuses.bot_alpha).toBeUndefined();
+  });
+});
+
+describe("telegram settings route gating", () => {
+  it("redirects away from /settings/telegram when the switch is disabled", async () => {
+    setup({ path: "/settings/telegram", enabled: false });
+
+    await vi.waitFor(() => {
+      expect(context.store.get(pathname$)).toBe("/works");
+    });
+  });
+
+  it("keeps /settings/telegram reachable when the switch is enabled", async () => {
+    setup({ path: "/settings/telegram", enabled: true });
+
+    await vi.waitFor(() => {
+      expect(context.store.get(pathname$)).toBe("/settings/telegram");
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/telegram-settings-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/telegram-settings-page.ts
@@ -1,0 +1,36 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { isTelegramIntegrationEnabled$ } from "./zero-telegram.ts";
+import { detachedNavigateTo$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { onboardGuard$ } from "./onboard-guard.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+
+export const setupTelegramSettingsPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const enabled = await get(isTelegramIntegrationEnabled$);
+    signal.throwIfAborted();
+
+    if (!enabled) {
+      set(detachedNavigateTo$, ROUTES.works, { replace: true });
+      return;
+    }
+
+    set(
+      updatePage$,
+      createElement("div", {
+        className: "flex flex-1 min-h-0",
+        "data-testid": "telegram-settings-route",
+      }),
+      "sidebar",
+    );
+    set(updateDocumentTitle$, "Telegram");
+    await set(hideAppSkeleton$, signal);
+
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
@@ -1,0 +1,95 @@
+import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  zeroIntegrationsTelegramContract,
+  type TelegramBot,
+  type TelegramBotStatus,
+} from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { zeroClient$ } from "../api-client.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { accept } from "../../lib/accept.ts";
+
+const internalReload$ = state(0);
+
+export const isTelegramIntegrationEnabled$ = computed(async (get) => {
+  const features = await get(featureSwitch$);
+  return features[FeatureSwitchKey.TelegramIntegration] ?? false;
+});
+
+export const telegramBots$ = computed(async (get): Promise<TelegramBot[]> => {
+  get(internalReload$);
+  const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
+  const result = await accept(client.list({ headers: {} }), [200], {
+    toast: false,
+  });
+  return result.body.bots;
+});
+
+const reloadTelegramBots$ = command(({ set }) => {
+  set(internalReload$, (prev) => {
+    return prev + 1;
+  });
+});
+
+export const registerTelegramBot$ = command(
+  async (
+    { get, set },
+    input: { botToken: string; defaultAgentId?: string },
+    signal: AbortSignal,
+  ): Promise<TelegramBotStatus> => {
+    const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
+    const result = await accept(
+      client.register({
+        headers: {},
+        body: input,
+        fetchOptions: { signal },
+      }),
+      [201],
+    );
+    signal.throwIfAborted();
+    set(reloadTelegramBots$);
+    toast.success("Telegram bot added");
+    return (result as { body: TelegramBotStatus }).body;
+  },
+);
+
+export const updateTelegramBotAgent$ = command(
+  async (
+    { get, set },
+    input: { botId: string; defaultAgentId: string },
+    signal: AbortSignal,
+  ): Promise<TelegramBotStatus> => {
+    const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
+    const result = await accept(
+      client.updateBot({
+        headers: {},
+        params: { botId: input.botId },
+        body: { defaultAgentId: input.defaultAgentId },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(reloadTelegramBots$);
+    toast.success("Telegram bot updated");
+    return (result as { body: TelegramBotStatus }).body;
+  },
+);
+
+export const disconnectTelegramBot$ = command(
+  async ({ get, set }, botId: string, signal: AbortSignal): Promise<void> => {
+    const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
+    await accept(
+      client.disconnect({
+        headers: {},
+        params: { botId },
+        fetchOptions: { signal },
+      }),
+      [204],
+    );
+    signal.throwIfAborted();
+    set(reloadTelegramBots$);
+    toast.success("Telegram bot disconnected");
+  },
+);


### PR DESCRIPTION
## Summary
- add /settings/telegram route key and frontend-only feature switch gated setup
- add Telegram ccstate signals for list/register/update/disconnect using the multi-bot contract
- enhance Telegram MSW state helpers and cover signals plus route gating with tests

Closes #11002

## Verification
- cd turbo && pnpm --filter @vm0/app exec vitest run src/signals/zero-page/__tests__/zero-telegram.test.ts
- cd turbo && pnpm --filter @vm0/app exec vitest run src/signals/zero-page/__tests__/zero-telegram.test.ts src/signals/external/__tests__/feature-switch.test.ts
- cd turbo/apps/platform && pnpm exec oxlint src/signals/route-paths.ts src/signals/bootstrap.ts src/signals/zero-page/zero-telegram.ts src/signals/zero-page/telegram-settings-page.ts src/signals/zero-page/__tests__/zero-telegram.test.ts src/mocks/handlers/api-integrations-telegram.ts
- cd turbo/apps/platform && pnpm exec eslint src/signals/route-paths.ts src/signals/bootstrap.ts src/signals/zero-page/zero-telegram.ts src/signals/zero-page/telegram-settings-page.ts src/signals/zero-page/__tests__/zero-telegram.test.ts src/mocks/handlers/api-integrations-telegram.ts --max-warnings 0 --no-warn-ignored

Note: full local pnpm check-types is currently blocked by existing api#check-types errors outside this PR (for example apps/api src/signals/auth/__tests__/clerk-session.test.ts).