### PR TITLE
feat(telegram): add connect landing page

### DIFF
--- a/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   createTestTelegramInstallation,
   signTestConnectParams,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { signConnectParams } from "../../../../../../src/lib/zero/telegram/connect-token";
 
 const TEST_BOT_TOKEN = "test-bot-token";
 
@@ -374,6 +375,38 @@ describe("/api/integrations/telegram/link", () => {
 
       expect(response.status).toBe(400);
       expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("returns 400 for expired connectSignature", async () => {
+      const user = await context.setupUser();
+      const telegramBotId = uniqueId("bot");
+      const installationId = await createTestTelegramInstallation({
+        telegramBotId,
+        orgId: user.orgId,
+      });
+      const telegramUserId = "99005";
+      const timestamp = Math.floor(Date.now() / 1000) - 601;
+      const signature = signConnectParams(
+        installationId,
+        telegramUserId,
+        timestamp,
+        TEST_BOT_TOKEN,
+      );
+
+      const response = await POST(
+        linkRequest("POST", {
+          telegramBotId: installationId,
+          connectSignature: {
+            telegramUserId,
+            timestamp,
+            signature,
+          },
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("Invalid or expired connect link");
     });
   });
 });

--- a/turbo/apps/web/app/telegram/connect/TelegramConnectClient.tsx
+++ b/turbo/apps/web/app/telegram/connect/TelegramConnectClient.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useAuth } from "@clerk/nextjs";
+import type {
+  TelegramConnectParamError,
+  TelegramConnectParams,
+} from "./connect-params";
+import { useState } from "react";
+
+interface TelegramConnectClientProps {
+  params: TelegramConnectParams | null;
+  paramError: TelegramConnectParamError | null;
+  returnPath: string;
+}
+
+interface TelegramConnectSuccess {
+  botUsername: string;
+  telegramUserId: string;
+}
+
+interface TelegramConnectErrorResponse {
+  error?: {
+    message?: string;
+  };
+}
+
+function signInHref(returnPath: string): string {
+  return `/sign-in?redirect_url=${encodeURIComponent(returnPath)}`;
+}
+
+async function linkTelegramAccount(
+  params: TelegramConnectParams,
+  token: string,
+): Promise<TelegramConnectSuccess> {
+  const response = await fetch("/api/integrations/telegram/link", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      telegramBotId: params.telegramBotId,
+      connectSignature: {
+        telegramUserId: params.telegramUserId,
+        timestamp: params.timestamp,
+        signature: params.signature,
+      },
+    }),
+  });
+
+  const body = (await response.json().catch(() => {
+    return {};
+  })) as TelegramConnectSuccess | TelegramConnectErrorResponse;
+
+  if (!response.ok) {
+    const message =
+      "error" in body && body.error?.message
+        ? body.error.message
+        : "We couldn't connect Telegram. Try again from Telegram.";
+    throw new Error(message);
+  }
+
+  if (!("botUsername" in body) || !("telegramUserId" in body)) {
+    throw new Error("Telegram connected, but the response was incomplete.");
+  }
+
+  return body;
+}
+
+function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-4 py-10 text-foreground">
+      <section className="w-full max-w-[420px] rounded-xl border border-border bg-card p-6 shadow-sm">
+        <div className="mb-6">
+          <p className="text-sm font-medium text-muted-foreground">VM0</p>
+          <h1 className="mt-2 text-2xl font-semibold tracking-normal">
+            Connect Telegram
+          </h1>
+        </div>
+        {children}
+      </section>
+    </main>
+  );
+}
+
+function MessageState({
+  title,
+  message,
+  children,
+}: {
+  title: string;
+  message: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="rounded-lg border border-border bg-background p-4">
+        <h2 className="text-base font-medium">{title}</h2>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          {message}
+        </p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function TelegramConnectClient({
+  params,
+  paramError,
+  returnPath,
+}: TelegramConnectClientProps): React.JSX.Element {
+  const { getToken, isLoaded, isSignedIn } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<TelegramConnectSuccess | null>(null);
+
+  if (paramError || !params) {
+    return (
+      <PageShell>
+        <MessageState
+          title={paramError?.title ?? "Connect link is invalid"}
+          message={
+            paramError?.message ??
+            "Open a fresh /connect link from Telegram and try again."
+          }
+        />
+      </PageShell>
+    );
+  }
+
+  if (!isLoaded) {
+    return (
+      <PageShell>
+        <MessageState
+          title="Checking sign-in"
+          message="Hold on while we check your VM0 session."
+        />
+      </PageShell>
+    );
+  }
+
+  if (!isSignedIn) {
+    return (
+      <PageShell>
+        <MessageState
+          title="Sign in to continue"
+          message="Use your VM0 account before connecting this Telegram user."
+        >
+          <a
+            href={signInHref(returnPath)}
+            className="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Sign in to VM0
+          </a>
+        </MessageState>
+      </PageShell>
+    );
+  }
+
+  if (success) {
+    const telegramHref = `https://t.me/${success.botUsername.replace(/^@/, "")}`;
+    return (
+      <PageShell>
+        <MessageState
+          title="Telegram connected"
+          message={`Telegram user ${success.telegramUserId} is now linked to your VM0 account.`}
+        >
+          <a
+            href={telegramHref}
+            className="inline-flex h-10 items-center justify-center rounded-lg border border-border px-4 text-sm font-medium transition-colors hover:bg-muted"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Open Telegram
+          </a>
+        </MessageState>
+      </PageShell>
+    );
+  }
+
+  const confirm = () => {
+    setLoading(true);
+    setError(null);
+    getToken()
+      .then((token) => {
+        if (!token) {
+          throw new Error("Sign in again before connecting Telegram.");
+        }
+        return linkTelegramAccount(params, token);
+      })
+      .then((result) => {
+        setSuccess(result);
+      })
+      .catch((err: unknown) => {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "We couldn't connect Telegram. Try again from Telegram.",
+        );
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  return (
+    <PageShell>
+      <div className="flex flex-col gap-4">
+        <p className="text-sm leading-6 text-muted-foreground">
+          Confirm that Telegram user {params.telegramUserId} should connect to
+          your VM0 account.
+        </p>
+        {error && (
+          <div
+            className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+        <button
+          type="button"
+          className="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={loading}
+          onClick={confirm}
+        >
+          {loading ? "Connecting..." : "Connect Telegram"}
+        </button>
+      </div>
+    </PageShell>
+  );
+}

--- a/turbo/apps/web/app/telegram/connect/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/telegram/connect/__tests__/page.test.tsx
@@ -3,7 +3,10 @@
 import { useAuth } from "@clerk/nextjs";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { HttpResponse } from "msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { http } from "../../../../src/__tests__/msw";
+import { server } from "../../../../src/mocks/server";
 import { TelegramConnectClient } from "../TelegramConnectClient";
 import {
   parseTelegramConnectParams,
@@ -92,8 +95,10 @@ describe("/telegram/connect", () => {
   });
 
   it("requires sign-in before confirmation", () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
+    const handler = http.post("/api/integrations/telegram/link", () => {
+      return HttpResponse.json({});
+    });
+    server.use(handler.handler);
     mockAuth({ isSignedIn: false });
 
     renderConnectClient();
@@ -104,20 +109,24 @@ describe("/telegram/connect", () => {
       "href",
       expect.stringContaining("/sign-in?redirect_url="),
     );
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(handler.mocked).not.toHaveBeenCalled();
   });
 
   it("posts telegramBotId and connectSignature on confirmation", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
+    let requestBody: unknown;
+    let authorizationHeader: string | null = null;
+    const handler = http.post(
+      "/api/integrations/telegram/link",
+      async ({ request }) => {
+        authorizationHeader = request.headers.get("Authorization");
+        requestBody = await request.json();
+        return HttpResponse.json({
           botUsername: "vm0_test_bot",
           telegramUserId: "99002",
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        });
+      },
     );
-    vi.stubGlobal("fetch", fetchMock);
+    server.use(handler.handler);
     mockAuth({ token: "clerk-token" });
 
     renderConnectClient();
@@ -126,46 +135,35 @@ describe("/telegram/connect", () => {
     );
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(handler.mocked).toHaveBeenCalledTimes(1);
     });
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/integrations/telegram/link",
-      expect.objectContaining({
-        method: "POST",
-        headers: {
-          Authorization: "Bearer clerk-token",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          telegramBotId: "bot-123",
-          connectSignature: {
-            telegramUserId: "99002",
-            timestamp: 1777200000,
-            signature: "a".repeat(64),
-          },
-        }),
-      }),
-    );
+    expect(authorizationHeader).toBe("Bearer clerk-token");
+    expect(requestBody).toEqual({
+      telegramBotId: "bot-123",
+      connectSignature: {
+        telegramUserId: "99002",
+        timestamp: 1777200000,
+        signature: "a".repeat(64),
+      },
+    });
     expect(
       await screen.findByText(/telegram user 99002 is now linked/i),
     ).toBeInTheDocument();
   });
 
   it("surfaces invalid or expired signature errors from the backend", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            error: {
-              message:
-                "Invalid or expired connect link. Please use /connect again in Telegram.",
-            },
-          }),
-          { status: 400, headers: { "Content-Type": "application/json" } },
-        ),
-      ),
-    );
+    const handler = http.post("/api/integrations/telegram/link", () => {
+      return HttpResponse.json(
+        {
+          error: {
+            message:
+              "Invalid or expired connect link. Please use /connect again in Telegram.",
+          },
+        },
+        { status: 400 },
+      );
+    });
+    server.use(handler.handler);
     mockAuth({ token: "clerk-token" });
 
     renderConnectClient();

--- a/turbo/apps/web/app/telegram/connect/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/telegram/connect/__tests__/page.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment happy-dom
+
+import { useAuth } from "@clerk/nextjs";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TelegramConnectClient } from "../TelegramConnectClient";
+import {
+  parseTelegramConnectParams,
+  type TelegramConnectParams,
+} from "../connect-params";
+
+vi.mock("@clerk/nextjs", () => {
+  return {
+    useAuth: vi.fn(),
+  };
+});
+
+const VALID_PARAMS: TelegramConnectParams = {
+  telegramBotId: "bot-123",
+  telegramUserId: "99002",
+  timestamp: 1777200000,
+  signature: "a".repeat(64),
+};
+
+function mockAuth(options: {
+  isLoaded?: boolean;
+  isSignedIn?: boolean;
+  token?: string | null;
+}) {
+  vi.mocked(useAuth).mockReturnValue({
+    isLoaded: options.isLoaded ?? true,
+    isSignedIn: options.isSignedIn ?? true,
+    getToken: vi.fn().mockResolvedValue(options.token ?? "test-token"),
+  } as unknown as ReturnType<typeof useAuth>);
+}
+
+function renderConnectClient(params = VALID_PARAMS) {
+  return render(
+    <TelegramConnectClient
+      params={params}
+      paramError={null}
+      returnPath="/telegram/connect?bot=bot-123&tgUser=99002&ts=1777200000&sig=aaaaaaaa"
+    />,
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("/telegram/connect", () => {
+  it("rejects missing params before rendering the confirmation flow", () => {
+    const parsed = parseTelegramConnectParams({
+      bot: "bot-123",
+      tgUser: "99002",
+      ts: "1777200000",
+    });
+
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.error.title).toBe("Connect link is incomplete");
+    }
+  });
+
+  it("rejects malformed signatures before calling the link route", () => {
+    const parsed = parseTelegramConnectParams({
+      bot: "bot-123",
+      tgUser: "99002",
+      ts: "1777200000",
+      sig: "not-a-signature",
+    });
+
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.error.message).toContain("signature");
+    }
+  });
+
+  it("rejects malformed timestamps before calling the link route", () => {
+    const parsed = parseTelegramConnectParams({
+      bot: "bot-123",
+      tgUser: "99002",
+      ts: "1e3",
+      sig: "a".repeat(64),
+    });
+
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.error.message).toContain("timestamp");
+    }
+  });
+
+  it("requires sign-in before confirmation", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    mockAuth({ isSignedIn: false });
+
+    renderConnectClient();
+
+    expect(
+      screen.getByRole("link", { name: /sign in to vm0/i }),
+    ).toHaveAttribute(
+      "href",
+      expect.stringContaining("/sign-in?redirect_url="),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts telegramBotId and connectSignature on confirmation", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          botUsername: "vm0_test_bot",
+          telegramUserId: "99002",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    mockAuth({ token: "clerk-token" });
+
+    renderConnectClient();
+    await userEvent.click(
+      screen.getByRole("button", { name: /connect telegram/i }),
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/integrations/telegram/link",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer clerk-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          telegramBotId: "bot-123",
+          connectSignature: {
+            telegramUserId: "99002",
+            timestamp: 1777200000,
+            signature: "a".repeat(64),
+          },
+        }),
+      }),
+    );
+    expect(
+      await screen.findByText(/telegram user 99002 is now linked/i),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces invalid or expired signature errors from the backend", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              message:
+                "Invalid or expired connect link. Please use /connect again in Telegram.",
+            },
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+    mockAuth({ token: "clerk-token" });
+
+    renderConnectClient();
+    await userEvent.click(
+      screen.getByRole("button", { name: /connect telegram/i }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Invalid or expired connect link",
+    );
+  });
+});

--- a/turbo/apps/web/app/telegram/connect/connect-params.ts
+++ b/turbo/apps/web/app/telegram/connect/connect-params.ts
@@ -1,0 +1,110 @@
+export interface TelegramConnectParams {
+  telegramBotId: string;
+  telegramUserId: string;
+  timestamp: number;
+  signature: string;
+}
+
+export interface TelegramConnectParamError {
+  title: string;
+  message: string;
+}
+
+type SearchParamValue = string | string[] | undefined;
+type SearchParams = Record<string, SearchParamValue>;
+
+type ParsedTelegramConnectParams =
+  | { ok: true; params: TelegramConnectParams; returnPath: string }
+  | { ok: false; error: TelegramConnectParamError; returnPath: string };
+
+function firstParam(value: SearchParamValue): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function encodeReturnPath(params: TelegramConnectParams): string {
+  const search = new URLSearchParams({
+    bot: params.telegramBotId,
+    tgUser: params.telegramUserId,
+    ts: String(params.timestamp),
+    sig: params.signature,
+  });
+  return `/telegram/connect?${search.toString()}`;
+}
+
+export function parseTelegramConnectParams(
+  searchParams: SearchParams,
+): ParsedTelegramConnectParams {
+  const bot = firstParam(searchParams.bot)?.trim();
+  const tgUser = firstParam(searchParams.tgUser)?.trim();
+  const tsRaw = firstParam(searchParams.ts)?.trim();
+  const sig = firstParam(searchParams.sig)?.trim();
+
+  if (!bot || !tgUser || !tsRaw || !sig) {
+    return {
+      ok: false,
+      returnPath: "/telegram/connect",
+      error: {
+        title: "Connect link is incomplete",
+        message: "Open a fresh /connect link from Telegram and try again.",
+      },
+    };
+  }
+
+  if (!/^\d+$/.test(tgUser)) {
+    return {
+      ok: false,
+      returnPath: "/telegram/connect",
+      error: {
+        title: "Connect link is invalid",
+        message: "The Telegram user on this link is not valid.",
+      },
+    };
+  }
+
+  if (!/^\d+$/.test(tsRaw)) {
+    return {
+      ok: false,
+      returnPath: "/telegram/connect",
+      error: {
+        title: "Connect link is invalid",
+        message: "The timestamp on this link is not valid.",
+      },
+    };
+  }
+
+  const timestamp = Number(tsRaw);
+  if (!Number.isSafeInteger(timestamp) || timestamp <= 0) {
+    return {
+      ok: false,
+      returnPath: "/telegram/connect",
+      error: {
+        title: "Connect link is invalid",
+        message: "The timestamp on this link is not valid.",
+      },
+    };
+  }
+
+  if (!/^[0-9a-f]{64}$/i.test(sig)) {
+    return {
+      ok: false,
+      returnPath: "/telegram/connect",
+      error: {
+        title: "Connect link is invalid",
+        message: "The signature on this link is not valid.",
+      },
+    };
+  }
+
+  const params = {
+    telegramBotId: bot,
+    telegramUserId: tgUser,
+    timestamp,
+    signature: sig,
+  };
+
+  return {
+    ok: true,
+    params,
+    returnPath: encodeReturnPath(params),
+  };
+}

--- a/turbo/apps/web/app/telegram/connect/page.tsx
+++ b/turbo/apps/web/app/telegram/connect/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { TelegramConnectClient } from "./TelegramConnectClient";
+import { parseTelegramConnectParams } from "./connect-params";
+
+interface PageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export const metadata: Metadata = {
+  title: "Connect Telegram - VM0",
+  description: "Connect your Telegram account to VM0.",
+};
+
+export default async function TelegramConnectPage({ searchParams }: PageProps) {
+  const parsed = parseTelegramConnectParams(await searchParams);
+
+  return (
+    <TelegramConnectClient
+      params={parsed.ok ? parsed.params : null}
+      paramError={parsed.ok ? null : parsed.error}
+      returnPath={parsed.returnPath}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add /telegram/connect landing page for signed Telegram connect links
- validate bot, tgUser, ts, and sig before showing the confirmation flow
- require Clerk sign-in before POSTing connectSignature to the existing Telegram link API
- cover the landing page states and expired connectSignature server behavior

## Tests
- pnpm -C turbo -F web exec vitest --run app/telegram/connect
- pnpm -C turbo -F web check-types
- pnpm -C turbo -F web lint
- pnpm -C turbo knip --cache
- pre-commit full typecheck

Closes #11001