### PR TITLE
fix(runner): make idle vm budget release panic-safe

### DIFF
--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -166,7 +166,13 @@ impl DevicePool {
         if !self.active {
             return;
         }
-        self.in_flight.remove(&index);
+        if !self.in_flight.remove(&index) {
+            tracing::warn!(
+                device_index = index,
+                "device release ignored because index is not in flight"
+            );
+            return;
+        }
         self.cooldown.push_back(CooldownSlot {
             index,
             released_at: Instant::now(),
@@ -295,4 +301,35 @@ fn scan_free_device(max_devices: u32, exclude: &[u32]) -> Result<u32> {
     }
 
     Err(NbdCowError::NoFreeDevice)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_pool_with_in_flight(index: u32) -> DevicePool {
+        DevicePool {
+            active: true,
+            // Keep the ready queue full so `release()` does not spawn host
+            // sysfs validation tasks in this unit test.
+            ready: VecDeque::from([0, 1, 2, 4]),
+            cooldown: VecDeque::new(),
+            pending: tokio::task::JoinSet::new(),
+            max_devices: 8,
+            config: DevicePoolConfig::default(),
+            in_flight: HashSet::from([index]),
+        }
+    }
+
+    #[test]
+    fn release_ignores_duplicate_index() {
+        let mut pool = test_pool_with_in_flight(3);
+
+        pool.release(3);
+        pool.release(3);
+
+        assert_eq!(pool.cooldown.len(), 1);
+        assert_eq!(pool.cooldown.front().map(|slot| slot.index), Some(3));
+        assert!(pool.in_flight.is_empty());
+    }
 }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -18,7 +18,9 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::executor::{self, ExecutorConfig};
 use crate::host;
 use crate::http::HttpClient;
-use crate::idle_pool::{IdleEntry, IdlePool, IdlePoolConfig, ParkResult};
+use crate::idle_pool::{
+    IdleDestroyPayload, IdleEntry, IdlePool, IdlePoolConfig, ParkResult, ReusableIdleSandbox,
+};
 use crate::kmsg_log;
 use crate::lock;
 use crate::network_logs;
@@ -26,7 +28,7 @@ use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
 use crate::provider::{ApiProvider, JobProvider, LocalProvider};
 use crate::proxy;
-use crate::resource_budget::ResourceBudget;
+use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::status::{RunnerMode, StatusTracker};
 use crate::telemetry::JobTelemetry;
@@ -550,7 +552,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let mut spawn_ctx = SpawnContext {
         provider: Arc::clone(&provider),
         exec_config: Arc::clone(&exec_config),
-        budget: Arc::clone(&budget),
         idle_pool: Arc::clone(&idle_pool),
         status: Arc::clone(&status),
         mode: current_mode,
@@ -576,7 +577,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     // Soft drain entry. Destroy the idle pool once (releases
                     // budget — matches pre-split teardown behavior), then keep
                     // servicing the shared reactor while jobs finish.
-                    drain_idle_pool(&idle_pool, &budget, &status, "draining").await;
+                    drain_idle_pool(&idle_pool, &status, "draining").await;
                     draining_idle_pool_drained = true;
                 }
                 if jobs.is_empty() {
@@ -621,8 +622,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         count = expired.len(),
                         "reclaiming expired idle VMs for resource pressure"
                     );
-                    destroy_idle_entries_and_wait(expired, &budget, "budget_pressure_expired")
-                        .await;
+                    destroy_idle_entries_and_wait(expired, "budget_pressure_expired").await;
                     continue;
                 }
 
@@ -634,14 +634,13 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     info!(
                         session_id = %evicted.session_id,
                         profile = %evicted.profile_name,
+                        vcpu = evicted.budget_lease.vcpu(),
+                        memory_mb = evicted.budget_lease.memory_mb(),
                         "evicting idle VM for resource pressure"
                     );
-                    // Inline destroy so budget.release() happens synchronously
-                    // before the loop re-checks can_afford().
-                    let vcpu = evicted.vcpu;
-                    let memory_mb = evicted.memory_mb;
-                    evicted.stop_and_destroy().await;
-                    budget.release(vcpu, memory_mb);
+                    // Wait for the destroy task so the idle entry's lease is
+                    // dropped before the loop re-checks can_afford().
+                    destroy_idle_entries_and_wait(vec![evicted], "budget_pressure_oldest").await;
                     continue;
                 }
             }
@@ -713,8 +712,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 drop(pool);
                 status.set_idle_info(idle_vms).await;
                 for entry in expired {
-                    let b = Arc::clone(&budget);
-                    destroy_tasks.spawn(destroy_idle_entry(entry, b));
+                    spawn_destroy_idle_entry(&mut destroy_tasks, entry, "idle_expired");
                 }
             }
             // Heartbeat: report runner state to the server
@@ -743,7 +741,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Drain idle pool first — these VMs hold budget reservations. This
     // also clears `idle_vms` in status.json so the final snapshot is
     // consistent with the empty pool.
-    drain_idle_pool(&idle_pool, &budget, &status, "shutdown").await;
+    drain_idle_pool(&idle_pool, &status, "shutdown").await;
 
     provider.shutdown().await;
 
@@ -880,9 +878,10 @@ async fn handle_discovered_job(job: DiscoveredJob, mut ctx: DiscoveredJobContext
     };
     // Reserve resources before claiming so we don't waste a job that another
     // runner could handle.
-    if !ctx.budget.try_reserve(job_vcpu, job_memory) {
+    let Some(job_lease) = ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)
+    else {
         return;
-    }
+    };
     // Insert cancel token before claiming so it is available when discover()
     // next processes a buffered Ably cancel event. Skip duplicates from push +
     // poll races; overwriting would break cancel delivery for the executor.
@@ -890,7 +889,7 @@ async fn handle_discovered_job(job: DiscoveredJob, mut ctx: DiscoveredJobContext
     {
         let mut tokens = ctx.cancel_tokens.lock().await;
         if tokens.contains_key(&run_id) {
-            ctx.budget.release(job_vcpu, job_memory);
+            drop(job_lease);
             return;
         }
         tokens.insert(run_id, job_cancel.clone());
@@ -908,20 +907,13 @@ async fn handle_discovered_job(job: DiscoveredJob, mut ctx: DiscoveredJobContext
         // runner, or the provider rejected the job. Release the reservation and
         // cancel token so the runner can continue.
         ctx.cancel_tokens.lock().await.remove(&run_id);
-        ctx.budget.release(job_vcpu, job_memory);
+        drop(job_lease);
         return;
     };
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
 
-    let (reuse_entry, reuse_result) = try_reuse_from_pool(
-        run_id,
-        &profile_name,
-        job_vcpu,
-        job_memory,
-        &context,
-        &mut ctx,
-    )
-    .await;
+    let (reuse_entry, active_lease, reuse_result) =
+        try_reuse_from_pool(run_id, &profile_name, &context, job_lease, &mut ctx).await;
 
     // Determine sandbox_id after the reuse decision. On reuse, the sandbox keeps
     // its original identity; on a fresh create, allocate a new UUID for the
@@ -936,6 +928,7 @@ async fn handle_discovered_job(job: DiscoveredJob, mut ctx: DiscoveredJobContext
         profile_name,
         vcpu: job_vcpu,
         memory_mb: job_memory,
+        budget_lease: active_lease,
         restore_guest_state: *restore_guest_state,
         factory: Arc::clone(factory),
         cancel: job_cancel,
@@ -954,13 +947,12 @@ async fn handle_discovered_job(job: DiscoveredJob, mut ctx: DiscoveredJobContext
 async fn try_reuse_from_pool(
     run_id: RunId,
     profile_name: &str,
-    job_vcpu: u32,
-    job_memory: u32,
     context: &ExecutionContext,
+    job_lease: BudgetLease,
     ctx: &mut DiscoveredJobContext<'_>,
-) -> (Option<IdleEntry>, SandboxReuseResult) {
+) -> (Option<ReusableIdleSandbox>, BudgetLease, SandboxReuseResult) {
     let Some(session_id) = context.session_id() else {
-        return (None, SandboxReuseResult::NoSessionId);
+        return (None, job_lease, SandboxReuseResult::NoSessionId);
     };
 
     // Take the entry under the pool lock, then drop the lock before any awaits
@@ -978,9 +970,12 @@ async fn try_reuse_from_pool(
                         session_id,
                         "reusing idle VM for session"
                     );
-                    // Idle entry already holds budget — release the new reservation.
-                    ctx.budget.release(job_vcpu, job_memory);
-                    (Some(entry), SandboxReuseResult::Reused)
+                    // Idle entry already holds budget. Drop the speculative
+                    // fresh-job lease and move the idle lease to the outer job
+                    // task before handing the sandbox to the executor.
+                    drop(job_lease);
+                    let (idle_sandbox, idle_lease) = entry.into_reuse_parts();
+                    (Some(idle_sandbox), idle_lease, SandboxReuseResult::Reused)
                 }
                 Err(e) => {
                     warn!(
@@ -989,9 +984,8 @@ async fn try_reuse_from_pool(
                         error = %e,
                         "unpark failed, destroying idle VM and falling through to fresh create"
                     );
-                    let b = Arc::clone(ctx.budget);
-                    ctx.destroy_tasks.spawn(destroy_idle_entry(entry, b));
-                    (None, SandboxReuseResult::UnparkFailed)
+                    spawn_destroy_idle_entry(ctx.destroy_tasks, entry, "reuse_unpark_failed");
+                    (None, job_lease, SandboxReuseResult::UnparkFailed)
                 }
             }
         }
@@ -1003,9 +997,8 @@ async fn try_reuse_from_pool(
                 new_profile = %profile_name,
                 "idle VM profile mismatch, destroying"
             );
-            let b = Arc::clone(ctx.budget);
-            ctx.destroy_tasks.spawn(destroy_idle_entry(stale, b));
-            (None, SandboxReuseResult::ProfileMismatch)
+            spawn_destroy_idle_entry(ctx.destroy_tasks, stale, "reuse_profile_mismatch");
+            (None, job_lease, SandboxReuseResult::ProfileMismatch)
         }
         None => {
             info!(
@@ -1013,7 +1006,7 @@ async fn try_reuse_from_pool(
                 session_id,
                 "no idle VM found for session"
             );
-            (None, SandboxReuseResult::PoolMiss)
+            (None, job_lease, SandboxReuseResult::PoolMiss)
         }
     }
 }
@@ -1023,6 +1016,7 @@ struct JobProfile {
     profile_name: String,
     vcpu: u32,
     memory_mb: u32,
+    budget_lease: BudgetLease,
     restore_guest_state: bool,
     factory: SharedFactory,
     cancel: CancellationToken,
@@ -1049,7 +1043,6 @@ type SharedIdlePool = Arc<tokio::sync::Mutex<IdlePool>>;
 struct SpawnContext {
     provider: Arc<dyn JobProvider>,
     exec_config: Arc<ExecutorConfig>,
-    budget: Arc<ResourceBudget>,
     idle_pool: SharedIdlePool,
     status: Arc<StatusTracker>,
     /// Snapshot of [`RunnerMode`] at spawn time. Each `jobs.spawn` captures
@@ -1084,7 +1077,7 @@ fn spawn_job(
     context: ExecutionContext,
     sandbox_id: SandboxId,
     job_profile: JobProfile,
-    reuse_entry: Option<IdleEntry>,
+    reuse_entry: Option<ReusableIdleSandbox>,
     reuse_result: SandboxReuseResult,
     ctx: &SpawnContext,
     jobs: &mut JoinSet<Option<RunId>>,
@@ -1093,6 +1086,7 @@ fn spawn_job(
     let session_id = context.session_id().map(String::from);
     let vcpu = job_profile.vcpu;
     let memory_mb = job_profile.memory_mb;
+    let active_lease = job_profile.budget_lease;
     let profile_name = job_profile.profile_name;
     let factory = job_profile.factory;
     let job_cancel = job_profile.cancel;
@@ -1110,7 +1104,6 @@ fn spawn_job(
 
     let provider = Arc::clone(&ctx.provider);
     let exec_config = Arc::clone(&ctx.exec_config);
-    let budget = Arc::clone(&ctx.budget);
     let status = Arc::clone(&ctx.status);
     let idle_pool = Arc::clone(&ctx.idle_pool);
     let park_notify = Arc::clone(&ctx.park_notify);
@@ -1128,6 +1121,8 @@ fn spawn_job(
     let reused = reuse_entry.is_some();
 
     jobs.spawn(async move {
+        let mut active_lease = Some(active_lease);
+
         // Inner spawn isolates panics: if execute_job panics, the outer task
         // still reports completion and releases budget.
         let cancel = job_cancel.clone();
@@ -1224,63 +1219,75 @@ fn spawn_job(
                     stop_and_destroy_sandbox(sandbox, &**factory_for_cleanup).await;
                     false
                 } else {
-                    let mut pool = idle_pool.lock().await;
-                    let idle_timeout = pool.default_timeout();
-                    let entry = IdleEntry {
-                        sandbox,
-                        factory: factory_for_cleanup,
-                        session_id: session_id.to_string(),
-                        sandbox_id,
-                        profile_name,
-                        vcpu,
-                        memory_mb,
-                        source_ip,
-                        parked_at: std::time::Instant::now(),
-                        idle_timeout,
-                        storage_fingerprints,
-                    };
-                    match pool.park(session_id.to_string(), entry) {
-                        ParkResult::Parked => {
-                            info!(run_id = %run_id, session_id, "VM parked for reuse");
-                            // Push fresh idle state to status.json BEFORE
-                            // `status.remove_run` (below) clears the run_id
-                            // from active_runs. Without this, doctor would
-                            // briefly see the FC as unknown (neither active
-                            // nor idle) until the next idle_cleanup tick
-                            // (~10s), producing transient false-positive
-                            // FirecrackerNotInStatus warnings.
-                            let idle_vms = pool.held_snapshot();
-                            drop(pool);
-                            status.set_idle_info(idle_vms).await;
-                            park_notify.notify_one();
-                            true
+                    match active_lease.take() {
+                        Some(lease) => {
+                            let mut pool = idle_pool.lock().await;
+                            let idle_timeout = pool.default_timeout();
+                            let entry = IdleEntry {
+                                sandbox,
+                                factory: factory_for_cleanup,
+                                session_id: session_id.to_string(),
+                                sandbox_id,
+                                profile_name,
+                                budget_lease: lease,
+                                source_ip,
+                                parked_at: std::time::Instant::now(),
+                                idle_timeout,
+                                storage_fingerprints,
+                            };
+                            match pool.park(session_id.to_string(), entry) {
+                                ParkResult::Parked => {
+                                    info!(run_id = %run_id, session_id, "VM parked for reuse");
+                                    // Push fresh idle state to status.json BEFORE
+                                    // `status.remove_run` (below) clears the run_id
+                                    // from active_runs. Without this, doctor would
+                                    // briefly see the FC as unknown (neither active
+                                    // nor idle) until the next idle_cleanup tick
+                                    // (~10s), producing transient false-positive
+                                    // FirecrackerNotInStatus warnings.
+                                    let idle_vms = pool.held_snapshot();
+                                    drop(pool);
+                                    status.set_idle_info(idle_vms).await;
+                                    park_notify.notify_one();
+                                    true
+                                }
+                                ParkResult::Evicted(evicted) => {
+                                    info!(run_id = %run_id, session_id, "VM parked, evicting previous");
+                                    let idle_vms = pool.held_snapshot();
+                                    drop(pool);
+                                    status.set_idle_info(idle_vms).await;
+                                    // Notify immediately — session is already in pool.
+                                    // Don't wait for stop_and_destroy which can be slow.
+                                    park_notify.notify_one();
+                                    // The evicted entry was park()ed when it entered the
+                                    // pool; destroying a parked sandbox is safe — Drop
+                                    // aborts any leftover handles and the FC process is
+                                    // killed regardless of balloon state.
+                                    destroy_idle_entries_and_wait(vec![evicted], "park_replaced")
+                                        .await;
+                                    true
+                                }
+                                ParkResult::PoolFull(rejected) => {
+                                    info!(run_id = %run_id, session_id, "idle pool full, destroying VM");
+                                    drop(pool);
+                                    // Pool unchanged (park rejected) — no status
+                                    // update needed. The rejected sandbox was just
+                                    // park()ed above; destroying a parked sandbox is
+                                    // safe — see Evicted arm for rationale.
+                                    let (payload, lease) = rejected.into_destroy_parts();
+                                    active_lease = Some(lease);
+                                    destroy_idle_payload_and_wait(payload, "park_rejected").await;
+                                    false
+                                }
+                            }
                         }
-                        ParkResult::Evicted(evicted) => {
-                            info!(run_id = %run_id, session_id, "VM parked, evicting previous");
-                            let idle_vms = pool.held_snapshot();
-                            drop(pool);
-                            status.set_idle_info(idle_vms).await;
-                            // Notify immediately — session is already in pool.
-                            // Don't wait for stop_and_destroy which can be slow.
-                            park_notify.notify_one();
-                            let evict_vcpu = evicted.vcpu;
-                            let evict_mem = evicted.memory_mb;
-                            // The evicted entry was park()ed when it entered the
-                            // pool; destroying a parked sandbox is safe — Drop
-                            // aborts any leftover handles and the FC process is
-                            // killed regardless of balloon state.
-                            evicted.stop_and_destroy().await;
-                            budget.release(evict_vcpu, evict_mem);
-                            true
-                        }
-                        ParkResult::PoolFull(rejected) => {
-                            info!(run_id = %run_id, session_id, "idle pool full, destroying VM");
-                            drop(pool);
-                            // Pool unchanged (park rejected) — no status
-                            // update needed. The rejected sandbox was just
-                            // park()ed above; destroying a parked sandbox is
-                            // safe — see Evicted arm for rationale.
-                            rejected.stop_and_destroy().await;
+                        None => {
+                            error!(
+                                run_id = %run_id,
+                                session_id,
+                                "active budget lease missing before parking"
+                            );
+                            stop_and_destroy_sandbox(sandbox, &**factory_for_cleanup).await;
                             false
                         }
                     }
@@ -1308,7 +1315,7 @@ fn spawn_job(
 
         // Release budget only if sandbox was NOT parked (parked VMs hold their budget).
         if !parked {
-            budget.release(vcpu, memory_mb);
+            drop(active_lease.take());
         }
 
         // Best-effort telemetry, deferred past `provider.complete` so the
@@ -1343,7 +1350,6 @@ fn spawn_job(
 /// (e.g. "draining" vs "shutdown").
 async fn drain_idle_pool(
     idle_pool: &SharedIdlePool,
-    budget: &Arc<ResourceBudget>,
     status: &StatusTracker,
     context: &'static str,
 ) {
@@ -1352,7 +1358,7 @@ async fn drain_idle_pool(
         return;
     }
     info!(count = entries.len(), context, "destroying idle VMs");
-    destroy_idle_entries_and_wait(entries, budget, context).await;
+    destroy_idle_entries_and_wait(entries, context).await;
     status.set_idle_info(Vec::new()).await;
 }
 
@@ -1385,18 +1391,22 @@ async fn evict_oldest_idle_entry(
     Some(evicted)
 }
 
-/// Destroy idle entries in parallel and wait until their budgets are released.
-async fn destroy_idle_entries_and_wait(
-    entries: Vec<IdleEntry>,
-    budget: &Arc<ResourceBudget>,
+fn spawn_destroy_idle_entry(
+    destroy_tasks: &mut JoinSet<()>,
+    entry: IdleEntry,
     context: &'static str,
 ) {
+    destroy_tasks.spawn(destroy_idle_entry(entry, context));
+}
+
+/// Destroy idle entries in parallel and wait until their leases are dropped.
+async fn destroy_idle_entries_and_wait(entries: Vec<IdleEntry>, context: &'static str) {
     // Destroy in parallel — each `stop_and_destroy` is ~1–3s (FC shutdown +
     // cgroup/NBD/netns teardown). Serial destroy blows past shutdown and
     // budget-pressure recovery budgets on multi-VM cleanup.
     let mut set = tokio::task::JoinSet::new();
     for entry in entries {
-        set.spawn(destroy_idle_entry(entry, Arc::clone(budget)));
+        set.spawn(destroy_idle_entry(entry, context));
     }
     while let Some(result) = set.join_next().await {
         if let Err(e) = result {
@@ -1405,12 +1415,17 @@ async fn destroy_idle_entries_and_wait(
     }
 }
 
-/// Destroy an idle sandbox entry and release its budget.
-async fn destroy_idle_entry(entry: IdleEntry, budget: Arc<ResourceBudget>) {
-    let vcpu = entry.vcpu;
-    let memory_mb = entry.memory_mb;
+/// Destroy an idle sandbox entry. Its budget lease is released by Drop.
+async fn destroy_idle_entry(entry: IdleEntry, _context: &'static str) {
     entry.stop_and_destroy().await;
-    budget.release(vcpu, memory_mb);
+}
+
+async fn destroy_idle_payload_and_wait(payload: IdleDestroyPayload, context: &'static str) {
+    let handle = tokio::spawn(payload.stop_and_destroy());
+    match handle.await {
+        Ok(()) => {}
+        Err(e) => warn!(context, error = %e, "idle payload destroy task panicked"),
+    }
 }
 
 /// Stop a sandbox and destroy it via its factory.
@@ -1532,6 +1547,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     use crate::idle_pool::{IdleEntry, IdlePool, IdlePoolConfig, ParkResult};
+    use async_trait::async_trait;
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
     fn test_profiles() -> BTreeMap<String, config::ProfileConfig> {
@@ -1550,19 +1566,51 @@ mod tests {
     }
 
     fn make_idle_entry(session_id: &str) -> IdleEntry {
+        let budget = Arc::new(ResourceBudget::new(1, 1, 1.0, 0));
         IdleEntry {
             sandbox: Box::new(MockSandbox::new("test")),
             factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
             session_id: session_id.into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            vcpu: 2,
-            memory_mb: 4096,
+            budget_lease: ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
             source_ip: "10.0.0.1".into(),
             parked_at: std::time::Instant::now(),
             idle_timeout: Duration::from_secs(300),
             storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
         }
+    }
+
+    struct PanickingDestroyFactory;
+
+    #[async_trait]
+    impl SandboxFactory for PanickingDestroyFactory {
+        fn name(&self) -> &str {
+            "panic-destroy"
+        }
+
+        fn config_hash(&self) -> String {
+            "panic-destroy".into()
+        }
+
+        async fn startup(&mut self) -> sandbox::Result<()> {
+            Ok(())
+        }
+
+        async fn create(
+            &self,
+            _config: sandbox::SandboxConfig,
+        ) -> sandbox::Result<Box<dyn Sandbox>> {
+            Err(sandbox::SandboxError::CreationFailed(
+                "test factory is only used for destroy".into(),
+            ))
+        }
+
+        async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {
+            panic!("simulated destroy panic");
+        }
+
+        async fn shutdown(&mut self) {}
     }
 
     #[test]
@@ -1670,6 +1718,28 @@ mod tests {
         );
         // saturating_sub prevents underflow: 0 - 1 → 0
         assert_eq!(state.running_count, 0);
+    }
+
+    #[tokio::test]
+    async fn idle_destroy_panic_releases_budget_lease() {
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let entry = IdleEntry {
+            sandbox: Box::new(MockSandbox::new("panic-destroy")),
+            factory: Arc::new(Box::new(PanickingDestroyFactory) as Box<dyn SandboxFactory>),
+            session_id: "sess-panic".into(),
+            sandbox_id: SandboxId::new_v4(),
+            profile_name: "vm0/default".into(),
+            budget_lease: lease,
+            source_ip: "10.0.0.1".into(),
+            parked_at: std::time::Instant::now(),
+            idle_timeout: Duration::from_secs(300),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        };
+
+        destroy_idle_entries_and_wait(vec![entry], "test_destroy_panic").await;
+
+        assert_eq!(budget.allocated(), (0, 0, 0));
     }
 
     // =======================================================================
@@ -3205,8 +3275,7 @@ mod tests {
     fn make_test_idle_entry(
         session_id: &str,
         profile_name: &str,
-        vcpu: u32,
-        memory_mb: u32,
+        budget_lease: BudgetLease,
         parked_at: std::time::Instant,
         idle_timeout: Duration,
     ) -> IdleEntry {
@@ -3216,8 +3285,7 @@ mod tests {
             session_id: session_id.into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: profile_name.into(),
-            vcpu,
-            memory_mb,
+            budget_lease,
             source_ip: "10.0.0.1".into(),
             parked_at,
             idle_timeout,
@@ -3230,18 +3298,17 @@ mod tests {
     /// to the completion payload.
     async fn seed_idle_pool(
         pool: &SharedIdlePool,
-        budget: &ResourceBudget,
+        budget: &Arc<ResourceBudget>,
         session_id: &str,
         profile_name: &str,
         vcpu: u32,
         memory_mb: u32,
     ) -> SandboxId {
-        assert!(budget.try_reserve(vcpu, memory_mb));
+        let budget_lease = ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).unwrap();
         let entry = make_test_idle_entry(
             session_id,
             profile_name,
-            vcpu,
-            memory_mb,
+            budget_lease,
             std::time::Instant::now(),
             Duration::from_secs(300),
         );
@@ -3254,9 +3321,10 @@ mod tests {
 
     /// Poll until `budget.allocated().2` (running_count) reaches `expected`.
     ///
-    /// `budget.release()` runs after `provider.complete()` in the spawned job
-    /// task, so `wait_completion()` returning does NOT guarantee the budget has
-    /// been released yet. This helper avoids fixed sleeps as synchronization.
+    /// The active budget lease is dropped after `provider.complete()` in the
+    /// spawned job task, so `wait_completion()` returning does NOT guarantee
+    /// the budget has been released yet. This helper avoids fixed sleeps as
+    /// synchronization.
     async fn wait_budget_count(budget: &ResourceBudget, expected: usize, timeout: Duration) {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
@@ -3291,18 +3359,17 @@ mod tests {
     /// Pre-populate idle pool with an expired entry (parked 400s ago, timeout 300s).
     async fn seed_idle_pool_expired(
         pool: &SharedIdlePool,
-        budget: &ResourceBudget,
+        budget: &Arc<ResourceBudget>,
         session_id: &str,
         profile_name: &str,
         vcpu: u32,
         memory_mb: u32,
     ) {
-        assert!(budget.try_reserve(vcpu, memory_mb));
+        let budget_lease = ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).unwrap();
         let entry = make_test_idle_entry(
             session_id,
             profile_name,
-            vcpu,
-            memory_mb,
+            budget_lease,
             std::time::Instant::now() - Duration::from_secs(400),
             Duration::from_secs(300),
         );
@@ -3322,15 +3389,15 @@ mod tests {
 
     async fn seed_idle_pool_with_timing(
         pool: &SharedIdlePool,
-        budget: &ResourceBudget,
+        budget: &Arc<ResourceBudget>,
         spec: TestIdleEntrySpec<'_>,
     ) {
-        assert!(budget.try_reserve(spec.vcpu, spec.memory_mb));
+        let budget_lease =
+            ResourceBudget::try_reserve_lease(budget, spec.vcpu, spec.memory_mb).unwrap();
         let entry = make_test_idle_entry(
             spec.session_id,
             spec.profile_name,
-            spec.vcpu,
-            spec.memory_mb,
+            budget_lease,
             spec.parked_at,
             spec.idle_timeout,
         );
@@ -3426,8 +3493,9 @@ mod tests {
         assert!(completion.is_some(), "job should complete");
         assert_eq!(completion.unwrap().exit_code, 0);
 
-        // budget.release() runs after provider.complete() in the spawned task,
-        // so wait_completion returning doesn't guarantee it has executed yet.
+        // The active budget lease is dropped after provider.complete() in the
+        // spawned task, so wait_completion returning doesn't guarantee it has
+        // executed yet.
         // Poll until budget is fully released rather than using a fixed sleep.
         wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
 
@@ -3656,7 +3724,7 @@ mod tests {
         // perspective. Advance 11s to ensure at least one full tick fires.
         tokio::time::sleep(Duration::from_secs(11)).await;
 
-        // Eviction spawns a destroy_task that calls budget.release() async.
+        // Eviction spawns a destroy_task that releases the idle entry lease.
         // Poll until it completes.
         wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
 
@@ -4506,7 +4574,8 @@ mod tests {
                 })
                 .await
                 .expect("create sandbox");
-            assert!(budget.try_reserve(2, 4096), "reserve seeded budget");
+            let budget_lease =
+                ResourceBudget::try_reserve_lease(&budget, 2, 4096).expect("reserve seeded budget");
             let _ = pool.park(
                 "sess-unpark-fail".to_string(),
                 IdleEntry {
@@ -4515,8 +4584,7 @@ mod tests {
                     session_id: "sess-unpark-fail".to_string(),
                     sandbox_id: SandboxId::new_v4(),
                     profile_name: "vm0/default".into(),
-                    vcpu: 2,
-                    memory_mb: 4096,
+                    budget_lease,
                     source_ip: "10.0.0.1".into(),
                     parked_at: std::time::Instant::now(),
                     idle_timeout: Duration::from_secs(300),

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -965,7 +965,7 @@ async fn try_reuse_from_pool(
     };
     match taken {
         Some(mut entry) if entry.profile_name == profile_name => {
-            match entry.sandbox.unpark().await {
+            match unpark_sandbox_panic_safe(entry.sandbox.as_mut()).await {
                 Ok(()) => {
                     info!(
                         run_id = %run_id,
@@ -1211,7 +1211,7 @@ fn spawn_job(
                 // Inflate the guest balloon BEFORE acquiring the pool lock —
                 // the HTTP call to Firecracker can take milliseconds, and we
                 // must not block other take/park operations on it.
-                if let Err(e) = sandbox.park().await {
+                if let Err(e) = park_sandbox_panic_safe(sandbox.as_mut()).await {
                     warn!(
                         run_id = %run_id,
                         session_id,
@@ -1340,6 +1340,22 @@ fn spawn_job(
 
         Some(run_id)
     });
+}
+
+async fn park_sandbox_panic_safe(sandbox: &mut dyn Sandbox) -> Result<(), String> {
+    match AssertUnwindSafe(sandbox.park()).catch_unwind().await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(e.to_string()),
+        Err(_) => Err("sandbox park panicked".into()),
+    }
+}
+
+async fn unpark_sandbox_panic_safe(sandbox: &mut dyn Sandbox) -> Result<(), String> {
+    match AssertUnwindSafe(sandbox.unpark()).catch_unwind().await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(e.to_string()),
+        Err(_) => Err("sandbox unpark panicked".into()),
+    }
 }
 
 /// Drain the idle pool: destroy every entry in parallel and wait for all
@@ -3483,6 +3499,63 @@ mod tests {
         sandbox_id
     }
 
+    async fn seed_idle_pool_with_overrides(
+        pool: &SharedIdlePool,
+        budget: &Arc<ResourceBudget>,
+        overrides: &Arc<sandbox_mock::MockSandboxOverrides>,
+        session_id: &str,
+        profile_name: &str,
+        vcpu: u32,
+        memory_mb: u32,
+    ) -> SandboxId {
+        let runtime = sandbox_mock::MockSandboxRuntime::with_overrides(Arc::clone(overrides));
+        let mut factory = runtime
+            .create_factory(sandbox::FactoryConfig {
+                profile: profile_name.into(),
+                binary_path: PathBuf::new(),
+                kernel_path: PathBuf::new(),
+                rootfs_path: PathBuf::new(),
+                base_dir: PathBuf::new(),
+                snapshot: None,
+            })
+            .await
+            .expect("create factory");
+        factory.startup().await.expect("startup");
+        let factory_arc: Arc<Box<dyn sandbox::SandboxFactory>> = Arc::new(factory);
+        let sandbox_id = SandboxId::new_v4();
+        let sandbox = factory_arc
+            .create(sandbox::SandboxConfig {
+                id: sandbox_id,
+                resources: sandbox::ResourceLimits {
+                    cpu_count: vcpu,
+                    memory_mb,
+                },
+            })
+            .await
+            .expect("create sandbox");
+        let budget_lease =
+            ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).expect("reserve budget");
+
+        let mut guard = pool.lock().await;
+        let result = guard.park(
+            session_id.to_string(),
+            IdleEntry {
+                sandbox,
+                factory: factory_arc,
+                session_id: session_id.to_string(),
+                sandbox_id,
+                profile_name: profile_name.into(),
+                budget_lease,
+                source_ip: "10.0.0.1".into(),
+                parked_at: std::time::Instant::now(),
+                idle_timeout: Duration::from_secs(300),
+                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+            },
+        );
+        assert!(matches!(result, ParkResult::Parked));
+        sandbox_id
+    }
+
     /// Poll until `budget.allocated().2` (running_count) reaches `expected`.
     ///
     /// The active budget lease is dropped after `provider.complete()` in the
@@ -4724,6 +4797,38 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn park_panic_destroys_sandbox_reports_completion_and_releases_budget() {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_park_panic("simulated park panic");
+        let counter = Arc::clone(&overrides);
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+        let budget = Arc::clone(&config.budget);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-park-panic")),
+        );
+
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "park panic must not skip provider.complete");
+        assert_eq!(c.unwrap().exit_code, 0);
+
+        wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
+        assert_eq!(idle_pool.lock().await.len(), 0);
+        assert_eq!(counter.park_call_count(), 1);
+
+        shutdown(&env, run_handle).await;
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
         let hooks = BlockingDestroyHooks::new();
         let (config, env) = build_mock_run_config_with_runtime(
@@ -4821,50 +4926,16 @@ mod tests {
 
         // Pre-seed via the factory so the seeded MockSandbox shares the
         // override set (and consumes the queued unpark error).
-        {
-            let mut pool = idle_pool.lock().await;
-            let runtime = sandbox_mock::MockSandboxRuntime::with_overrides(Arc::clone(&counter));
-            let mut factory = runtime
-                .create_factory(sandbox::FactoryConfig {
-                    profile: "vm0/default".into(),
-                    binary_path: PathBuf::new(),
-                    kernel_path: PathBuf::new(),
-                    rootfs_path: PathBuf::new(),
-                    base_dir: PathBuf::new(),
-                    snapshot: None,
-                })
-                .await
-                .expect("create factory");
-            factory.startup().await.expect("startup");
-            let factory_arc: Arc<Box<dyn sandbox::SandboxFactory>> = Arc::new(factory);
-            let sandbox = factory_arc
-                .create(sandbox::SandboxConfig {
-                    id: SandboxId::new_v4(),
-                    resources: sandbox::ResourceLimits {
-                        cpu_count: 2,
-                        memory_mb: 4096,
-                    },
-                })
-                .await
-                .expect("create sandbox");
-            let budget_lease =
-                ResourceBudget::try_reserve_lease(&budget, 2, 4096).expect("reserve seeded budget");
-            let _ = pool.park(
-                "sess-unpark-fail".to_string(),
-                IdleEntry {
-                    sandbox,
-                    factory: factory_arc,
-                    session_id: "sess-unpark-fail".to_string(),
-                    sandbox_id: SandboxId::new_v4(),
-                    profile_name: "vm0/default".into(),
-                    budget_lease,
-                    source_ip: "10.0.0.1".into(),
-                    parked_at: std::time::Instant::now(),
-                    idle_timeout: Duration::from_secs(300),
-                    storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-                },
-            );
-        }
+        seed_idle_pool_with_overrides(
+            &idle_pool,
+            &budget,
+            &counter,
+            "sess-unpark-fail",
+            "vm0/default",
+            2,
+            4096,
+        )
+        .await;
         assert_eq!(idle_pool.lock().await.len(), 1, "pool seeded");
 
         let run_handle = tokio::spawn(run(config));
@@ -4905,6 +4976,52 @@ mod tests {
             1,
             "expected exactly one park (the fresh-create's)"
         );
+
+        shutdown(&env, run_handle).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unpark_panic_destroys_idle_entry_and_falls_through() {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let counter = Arc::clone(&overrides);
+        overrides.push_unpark_panic("simulated unpark panic");
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+        let budget = Arc::clone(&config.budget);
+        let idle_pool = Arc::clone(&config.idle_pool);
+
+        seed_idle_pool_with_overrides(
+            &idle_pool,
+            &budget,
+            &counter,
+            "sess-unpark-panic",
+            "vm0/default",
+            2,
+            4096,
+        )
+        .await;
+
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-unpark-panic")),
+        );
+
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .expect("fresh-create job should still complete");
+        assert_eq!(c.exit_code, 0);
+        assert_eq!(c.reuse_result, Some(SandboxReuseResult::UnparkFailed));
+
+        wait_budget_count(&budget, 1, Duration::from_secs(2)).await;
+        assert_eq!(counter.unpark_call_count(), 1);
+        assert_eq!(counter.park_call_count(), 1);
+        assert_eq!(idle_pool.lock().await.len(), 1);
 
         shutdown(&env, run_handle).await;
     }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1,9 +1,11 @@
 use std::collections::{BTreeMap, HashMap};
+use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Args;
+use futures_util::FutureExt;
 use sandbox::{RuntimeProvider, Sandbox, SandboxFactory, SandboxId, SandboxRuntime};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -1430,10 +1432,18 @@ async fn destroy_idle_payload_and_wait(payload: IdleDestroyPayload, context: &'s
 
 /// Stop a sandbox and destroy it via its factory.
 async fn stop_and_destroy_sandbox(mut sandbox: Box<dyn Sandbox>, factory: &dyn SandboxFactory) {
-    if let Err(e) = sandbox.stop().await {
-        warn!(error = %e, "sandbox stop failed");
+    match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => warn!(error = %e, "sandbox stop failed"),
+        Err(_) => warn!("sandbox stop panicked"),
     }
-    factory.destroy(sandbox).await;
+    if AssertUnwindSafe(factory.destroy(sandbox))
+        .catch_unwind()
+        .await
+        .is_err()
+    {
+        warn!("sandbox destroy panicked");
+    }
 }
 
 /// Handle a completed job from the JoinSet, cleaning up cancel tokens.
@@ -1541,6 +1551,7 @@ fn collect_heartbeat_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     // -----------------------------------------------------------------------
     // collect_heartbeat_state: running_count excludes idle VMs
@@ -1599,15 +1610,128 @@ mod tests {
 
         async fn create(
             &self,
-            _config: sandbox::SandboxConfig,
+            config: sandbox::SandboxConfig,
         ) -> sandbox::Result<Box<dyn Sandbox>> {
-            Err(sandbox::SandboxError::CreationFailed(
-                "test factory is only used for destroy".into(),
-            ))
+            Ok(Box::new(MockSandbox::new(config.id.to_string())))
         }
 
         async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {
             panic!("simulated destroy panic");
+        }
+
+        async fn shutdown(&mut self) {}
+    }
+
+    struct PanickingDestroyRuntime;
+
+    #[async_trait]
+    impl SandboxRuntime for PanickingDestroyRuntime {
+        async fn create_factory(
+            &self,
+            _config: sandbox::FactoryConfig,
+        ) -> sandbox::Result<Box<dyn SandboxFactory>> {
+            Ok(Box::new(PanickingDestroyFactory))
+        }
+
+        async fn shutdown(&mut self) {}
+    }
+
+    struct RecordingDestroyFactory {
+        destroy_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl SandboxFactory for RecordingDestroyFactory {
+        fn name(&self) -> &str {
+            "recording-destroy"
+        }
+
+        fn config_hash(&self) -> String {
+            "recording-destroy".into()
+        }
+
+        async fn startup(&mut self) -> sandbox::Result<()> {
+            Ok(())
+        }
+
+        async fn create(
+            &self,
+            config: sandbox::SandboxConfig,
+        ) -> sandbox::Result<Box<dyn Sandbox>> {
+            Ok(Box::new(MockSandbox::new(config.id.to_string())))
+        }
+
+        async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {
+            self.destroy_count.fetch_add(1, Ordering::SeqCst);
+        }
+
+        async fn shutdown(&mut self) {}
+    }
+
+    #[derive(Clone)]
+    struct BlockingDestroyHooks {
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+        destroy_count: Arc<AtomicUsize>,
+    }
+
+    impl BlockingDestroyHooks {
+        fn new() -> Self {
+            Self {
+                entered: Arc::new(tokio::sync::Notify::new()),
+                release: Arc::new(tokio::sync::Notify::new()),
+                destroy_count: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    struct BlockingDestroyRuntime {
+        hooks: BlockingDestroyHooks,
+    }
+
+    #[async_trait]
+    impl SandboxRuntime for BlockingDestroyRuntime {
+        async fn create_factory(
+            &self,
+            _config: sandbox::FactoryConfig,
+        ) -> sandbox::Result<Box<dyn SandboxFactory>> {
+            Ok(Box::new(BlockingDestroyFactory {
+                hooks: self.hooks.clone(),
+            }))
+        }
+
+        async fn shutdown(&mut self) {}
+    }
+
+    struct BlockingDestroyFactory {
+        hooks: BlockingDestroyHooks,
+    }
+
+    #[async_trait]
+    impl SandboxFactory for BlockingDestroyFactory {
+        fn name(&self) -> &str {
+            "blocking-destroy"
+        }
+
+        fn config_hash(&self) -> String {
+            "blocking-destroy".into()
+        }
+
+        async fn startup(&mut self) -> sandbox::Result<()> {
+            Ok(())
+        }
+
+        async fn create(
+            &self,
+            config: sandbox::SandboxConfig,
+        ) -> sandbox::Result<Box<dyn Sandbox>> {
+            Ok(Box::new(MockSandbox::new(config.id.to_string())))
+        }
+
+        async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {
+            self.hooks.destroy_count.fetch_add(1, Ordering::SeqCst);
+            self.hooks.entered.notify_waiters();
+            self.hooks.release.notified().await;
         }
 
         async fn shutdown(&mut self) {}
@@ -1739,6 +1863,46 @@ mod tests {
 
         destroy_idle_entries_and_wait(vec![entry], "test_destroy_panic").await;
 
+        assert_eq!(budget.allocated(), (0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn idle_stop_panic_still_attempts_destroy_and_releases_budget_lease() {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_stop_panic("simulated idle stop panic");
+        let sandbox_factory = MockSandboxFactory::with_overrides(overrides);
+        let sandbox = sandbox_factory
+            .create(sandbox::SandboxConfig {
+                id: SandboxId::new_v4(),
+                resources: sandbox::ResourceLimits {
+                    cpu_count: 2,
+                    memory_mb: 4096,
+                },
+            })
+            .await
+            .expect("create sandbox");
+
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let destroy_count = Arc::new(AtomicUsize::new(0));
+        let entry = IdleEntry {
+            sandbox,
+            factory: Arc::new(Box::new(RecordingDestroyFactory {
+                destroy_count: Arc::clone(&destroy_count),
+            }) as Box<dyn SandboxFactory>),
+            session_id: "sess-stop-panic".into(),
+            sandbox_id: SandboxId::new_v4(),
+            profile_name: "vm0/default".into(),
+            budget_lease: lease,
+            source_ip: "10.0.0.1".into(),
+            parked_at: std::time::Instant::now(),
+            idle_timeout: Duration::from_secs(300),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        };
+
+        entry.stop_and_destroy().await;
+
+        assert_eq!(destroy_count.load(Ordering::SeqCst), 1);
         assert_eq!(budget.allocated(), (0, 0, 0));
     }
 
@@ -3505,6 +3669,38 @@ mod tests {
         shutdown(&env, run_handle).await;
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn active_destroy_panic_still_reports_completion_and_releases_budget() {
+        let (config, env) = build_mock_run_config_with_runtime(
+            test_profiles(),
+            8,
+            32768,
+            4,
+            MockJobProvider::new,
+            Box::new(PanickingDestroyRuntime),
+            "http://localhost:0",
+        );
+        let budget = Arc::clone(&config.budget);
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = RunId::new_v4();
+        push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(
+            completion.is_some(),
+            "destroy panic must not skip provider.complete"
+        );
+        assert_eq!(completion.unwrap().exit_code, 0);
+
+        wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+
+        shutdown(&env, run_handle).await;
+    }
+
     // -----------------------------------------------------------------------
     // Test 12: Park notification triggers immediate heartbeat
     // -----------------------------------------------------------------------
@@ -4523,6 +4719,83 @@ mod tests {
             1,
             "park() should have been attempted exactly once"
         );
+
+        shutdown(&env, run_handle).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
+        let hooks = BlockingDestroyHooks::new();
+        let (config, env) = build_mock_run_config_with_runtime(
+            test_profiles(),
+            8,
+            16384,
+            4,
+            MockJobProvider::new,
+            Box::new(BlockingDestroyRuntime {
+                hooks: hooks.clone(),
+            }),
+            "http://localhost:0",
+        );
+        let budget = Arc::clone(&config.budget);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        {
+            let mut pool = idle_pool.lock().await;
+            *pool = IdlePool::new(IdlePoolConfig {
+                default_timeout: Duration::from_secs(300),
+                max_idle: 1,
+            });
+        }
+        seed_idle_pool(&idle_pool, &budget, "sess-existing", "vm0/default", 2, 4096).await;
+        assert_eq!(budget.allocated().2, 1, "seeded idle entry holds budget");
+
+        let destroy_entered = hooks.entered.notified();
+        tokio::pin!(destroy_entered);
+        destroy_entered.as_mut().enable();
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-rejected")),
+        );
+
+        tokio::time::timeout(Duration::from_secs(5), destroy_entered)
+            .await
+            .expect("pool-full destroy should start");
+        assert_eq!(
+            hooks.destroy_count.load(Ordering::SeqCst),
+            1,
+            "rejected VM should be sent to destroy"
+        );
+        assert_eq!(
+            budget.allocated().2,
+            2,
+            "rejected active VM must retain its budget while destroy is in-flight"
+        );
+        {
+            let completions = env.handle.completions.lock().unwrap();
+            assert!(
+                !completions.iter().any(|c| c.run_id == run_id),
+                "provider.complete must wait until rejected VM destroy finishes"
+            );
+        }
+
+        hooks.release.notify_waiters();
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "job should complete after rejected VM destroy");
+        assert_eq!(c.unwrap().exit_code, 0);
+
+        wait_budget_count(&budget, 1, Duration::from_secs(2)).await;
+        let pool = idle_pool.lock().await;
+        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.held_sessions(), vec!["sess-existing"]);
+        drop(pool);
 
         shutdown(&env, run_handle).await;
     }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2654,7 +2654,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-        overrides.push_start_result(Err(SandboxError::StartFailed("boot failed".into())));
+        overrides.push_start_result(Err(SandboxError::ExecFailed("boot failed".into())));
         let mut factory = DestroyPanicFactory {
             inner: MockSandboxFactory::with_overrides(overrides),
         };

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -18,7 +18,7 @@ const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
-use crate::idle_pool::IdleEntry;
+use crate::idle_pool::ReusableIdleSandbox;
 use crate::kmsg_log;
 use crate::paths::{HomePaths, LogPaths, guest};
 use crate::proxy::{self, ProxyRegistryHandle};
@@ -114,7 +114,7 @@ pub async fn execute_job(
 /// flush telemetry after firing `provider.complete` (see [`execute_job`] for
 /// rationale).
 pub async fn execute_job_reuse(
-    idle_entry: IdleEntry,
+    idle_sandbox: ReusableIdleSandbox,
     context: ExecutionContext,
     config: &ExecutorConfig,
     cancel: CancellationToken,
@@ -126,9 +126,9 @@ pub async fn execute_job_reuse(
     record_reuse_result(&mut telemetry, SandboxReuseResult::Reused);
     record_api_latency("api_to_vm_start", &context, &mut telemetry);
 
-    let source_ip = idle_entry.source_ip.clone();
-    let prev_storage = idle_entry.storage_fingerprints;
-    let sandbox = idle_entry.sandbox;
+    let source_ip = idle_sandbox.source_ip;
+    let prev_storage = idle_sandbox.storage_fingerprints;
+    let sandbox = idle_sandbox.sandbox;
 
     // execute_reused_sandbox never returns Err — it always returns the sandbox
     // in the outcome so the caller can stop + destroy it on failure.
@@ -2455,6 +2455,11 @@ mod tests {
         }
     }
 
+    fn test_budget_lease() -> crate::resource_budget::BudgetLease {
+        let budget = Arc::new(crate::resource_budget::ResourceBudget::new(1, 1, 1.0, 0));
+        crate::resource_budget::ResourceBudget::try_reserve_lease(&budget, 2, 2048).unwrap()
+    }
+
     fn test_telemetry(config: &ExecutorConfig, ctx: &ExecutionContext) -> JobTelemetry {
         crate::telemetry::JobTelemetry::new(
             config.http.clone(),
@@ -2687,8 +2692,7 @@ mod tests {
             session_id: "test-session".into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            vcpu: 2,
-            memory_mb: 2048,
+            budget_lease: test_budget_lease(),
             source_ip: outcome.source_ip,
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
@@ -2696,9 +2700,10 @@ mod tests {
         };
 
         // Reuse the sandbox for a second turn
+        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
         let cancel = tokio_util::sync::CancellationToken::new();
         let (reuse_outcome, _telemetry) =
-            execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
+            execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
         assert_eq!(reuse_outcome.exit_code, 0);
         assert!(reuse_outcome.error.is_none());
         assert!(reuse_outcome.sandbox.is_some());
@@ -2744,8 +2749,7 @@ mod tests {
             session_id: "test-session".into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            vcpu: 2,
-            memory_mb: 2048,
+            budget_lease: test_budget_lease(),
             source_ip: outcome.source_ip,
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
@@ -2763,8 +2767,9 @@ mod tests {
         });
 
         let cancel = tokio_util::sync::CancellationToken::new();
+        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
         let (reuse_outcome, _telemetry) =
-            execute_job_reuse(idle_entry, ctx2, &config, cancel).await;
+            execute_job_reuse(idle_sandbox, ctx2, &config, cancel).await;
         assert_eq!(reuse_outcome.exit_code, 0);
         assert!(reuse_outcome.sandbox.is_some());
     }
@@ -2809,8 +2814,7 @@ mod tests {
             session_id: "test-session".into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            vcpu: 2,
-            memory_mb: 2048,
+            budget_lease: test_budget_lease(),
             source_ip: outcome.source_ip,
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
@@ -2828,8 +2832,9 @@ mod tests {
 
         // Execute reuse
         let cancel = tokio_util::sync::CancellationToken::new();
+        let (idle_sandbox, _lease) = reuse_entry.into_reuse_parts();
         let (reuse_outcome, _telemetry) =
-            execute_job_reuse(reuse_entry, minimal_context(), &config, cancel).await;
+            execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
         assert_eq!(reuse_outcome.exit_code, 0);
         assert!(reuse_outcome.sandbox.is_some());
     }
@@ -2852,8 +2857,7 @@ mod tests {
             session_id: "test-session".into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            vcpu: 2,
-            memory_mb: 2048,
+            budget_lease: test_budget_lease(),
             source_ip: "10.0.0.1".into(),
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
@@ -2887,8 +2891,7 @@ mod tests {
             session_id: "sess-1".into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            vcpu: 2,
-            memory_mb: 2048,
+            budget_lease: test_budget_lease(),
             source_ip: "10.0.0.1".into(),
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
@@ -2896,8 +2899,9 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
+        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
         let (outcome, _telemetry) =
-            execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
+            execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
 
         assert_eq!(outcome.exit_code, 1);
         assert!(outcome.error.unwrap().contains("vsock broken"));
@@ -2930,8 +2934,7 @@ mod tests {
             session_id: "sess-1".into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            vcpu: 2,
-            memory_mb: 2048,
+            budget_lease: test_budget_lease(),
             source_ip: "10.0.0.1".into(),
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
@@ -2939,8 +2942,9 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
+        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
         let (outcome, _telemetry) =
-            execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
+            execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
 
         assert_eq!(outcome.exit_code, 1);
         assert!(outcome.error.unwrap().contains("reseed timeout"));
@@ -2975,8 +2979,7 @@ mod tests {
             session_id: "sess-abc".into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            vcpu: 2,
-            memory_mb: 2048,
+            budget_lease: test_budget_lease(),
             source_ip: "10.0.0.1".into(),
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
@@ -2984,7 +2987,8 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let (outcome, _telemetry) = execute_job_reuse(idle_entry, ctx, &config, cancel).await;
+        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
+        let (outcome, _telemetry) = execute_job_reuse(idle_sandbox, ctx, &config, cancel).await;
 
         assert_eq!(outcome.exit_code, 1);
         assert!(outcome.error.unwrap().contains("disk full"));
@@ -3479,8 +3483,7 @@ mod tests {
             session_id: "test-session".into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            vcpu: 2,
-            memory_mb: 2048,
+            budget_lease: test_budget_lease(),
             source_ip: outcome.source_ip,
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
@@ -3488,8 +3491,9 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
+        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
         let (_outcome, telemetry) =
-            execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
+            execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
 
         let ops = telemetry.pending_ops_snapshot();
         let reuse_events: Vec<_> = ops

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2654,7 +2654,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-        overrides.push_start_result(Err(SandboxError::ExecFailed("boot failed".into())));
+        overrides.push_start_result(Err(SandboxError::Start {
+            message: "boot failed".into(),
+        }));
         let mut factory = DestroyPanicFactory {
             inner: MockSandboxFactory::with_overrides(overrides),
         };

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};
 
+use futures_util::FutureExt;
 use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory, SandboxId};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -232,7 +234,7 @@ async fn execute_new_sandbox(
     if let Err(e) = sandbox.start().await {
         telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
         unregister_proxy(config, context, &source_ip).await;
-        factory.destroy(sandbox).await;
+        destroy_sandbox_panic_safe(factory, sandbox).await;
         return Err(e.into());
     }
     telemetry.record("vm_create", t.elapsed(), true, None);
@@ -279,6 +281,16 @@ async fn execute_new_sandbox(
         source_ip,
         guest_session_id,
     })
+}
+
+async fn destroy_sandbox_panic_safe(factory: &dyn SandboxFactory, sandbox: Box<dyn Sandbox>) {
+    if AssertUnwindSafe(factory.destroy(sandbox))
+        .catch_unwind()
+        .await
+        .is_err()
+    {
+        warn!("sandbox destroy panicked after start failure");
+    }
 }
 
 /// Run a job inside a reused (kept-alive) sandbox.
@@ -1321,8 +1333,41 @@ mod tests {
     use super::*;
     use crate::ids::RunId;
     use crate::types::{ArtifactEntry, ResumeSession, StorageEntry, StorageManifest};
+    use async_trait::async_trait;
     use sandbox_mock::MockSandboxFactory;
     use std::sync::Arc;
+
+    struct DestroyPanicFactory {
+        inner: MockSandboxFactory,
+    }
+
+    #[async_trait]
+    impl SandboxFactory for DestroyPanicFactory {
+        fn name(&self) -> &str {
+            "destroy-panic"
+        }
+
+        fn config_hash(&self) -> String {
+            "destroy-panic".into()
+        }
+
+        async fn startup(&mut self) -> sandbox::Result<()> {
+            self.inner.startup().await
+        }
+
+        async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
+            self.inner.create(config).await
+        }
+
+        #[allow(clippy::panic)]
+        async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {
+            panic!("simulated destroy panic");
+        }
+
+        async fn shutdown(&mut self) {
+            self.inner.shutdown().await;
+        }
+    }
 
     fn build_env_for_test(ctx: &ExecutionContext, api_url: &str) -> HashMap<String, String> {
         let sid = SandboxId::new_v4().to_string();
@@ -2602,6 +2647,39 @@ mod tests {
         assert_eq!(exit_code, 1);
         let error = error.unwrap();
         assert!(error.contains("wait timeout"), "got: {error}");
+    }
+
+    #[tokio::test]
+    async fn execute_inner_start_failure_destroy_panic_returns_start_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_start_result(Err(SandboxError::StartFailed("boot failed".into())));
+        let mut factory = DestroyPanicFactory {
+            inner: MockSandboxFactory::with_overrides(overrides),
+        };
+        factory.startup().await.unwrap();
+
+        let ctx = minimal_context();
+        let mut telemetry = test_telemetry(&config, &ctx);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let result = execute_new_sandbox(
+            &factory,
+            &ctx,
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::PoolMiss,
+            },
+            &config,
+            &default_params(),
+            &mut telemetry,
+            cancel,
+        )
+        .await;
+
+        assert!(result.is_err(), "start failure must return an error");
+        let err = result.err().unwrap();
+        assert!(err.to_string().contains("boot failed"), "got: {err}");
     }
 
     #[tokio::test]

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use futures_util::FutureExt;
 use sandbox::{Sandbox, SandboxFactory, SandboxId};
 
 use crate::resource_budget::BudgetLease;
@@ -109,10 +111,18 @@ impl IdleDestroyPayload {
     /// Stop the sandbox and destroy it via its factory.
     pub async fn stop_and_destroy(self) {
         let mut sandbox = self.sandbox;
-        if let Err(e) = sandbox.stop().await {
-            tracing::warn!(error = %e, "failed to stop idle sandbox");
+        match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::warn!(error = %e, "failed to stop idle sandbox"),
+            Err(_) => tracing::warn!("idle sandbox stop panicked"),
         }
-        self.factory.destroy(sandbox).await;
+        if AssertUnwindSafe(self.factory.destroy(sandbox))
+            .catch_unwind()
+            .await
+            .is_err()
+        {
+            tracing::warn!("idle sandbox destroy panicked");
+        }
     }
 }
 

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 
 use sandbox::{Sandbox, SandboxFactory, SandboxId};
 
+use crate::resource_budget::BudgetLease;
 use crate::status::IdleVm;
 use crate::types::StorageManifest;
 
@@ -77,8 +78,7 @@ pub struct IdleEntry {
     /// doctor / kill / workspace-dir naming.
     pub sandbox_id: SandboxId,
     pub profile_name: String,
-    pub vcpu: u32,
-    pub memory_mb: u32,
+    pub budget_lease: BudgetLease,
     pub source_ip: String,
     pub parked_at: Instant,
     pub idle_timeout: Duration,
@@ -87,7 +87,25 @@ pub struct IdleEntry {
     pub storage_fingerprints: StorageFingerprints,
 }
 
-impl IdleEntry {
+/// Reusable sandbox state handed to the executor after a successful unpark.
+///
+/// The budget lease is intentionally not part of this payload. The outer job
+/// task owns the active lease so executor panics cannot release capacity before
+/// provider completion and post-job cleanup finish.
+pub struct ReusableIdleSandbox {
+    pub sandbox: Box<dyn Sandbox>,
+    pub sandbox_id: SandboxId,
+    pub source_ip: String,
+    pub storage_fingerprints: StorageFingerprints,
+}
+
+/// Physical resources needed to destroy an idle VM, without its budget lease.
+pub struct IdleDestroyPayload {
+    sandbox: Box<dyn Sandbox>,
+    factory: Arc<Box<dyn SandboxFactory>>,
+}
+
+impl IdleDestroyPayload {
     /// Stop the sandbox and destroy it via its factory.
     pub async fn stop_and_destroy(self) {
         let mut sandbox = self.sandbox;
@@ -95,6 +113,46 @@ impl IdleEntry {
             tracing::warn!(error = %e, "failed to stop idle sandbox");
         }
         self.factory.destroy(sandbox).await;
+    }
+}
+
+impl IdleEntry {
+    /// Stop the sandbox and destroy it via its factory.
+    pub async fn stop_and_destroy(self) {
+        let (payload, _lease) = self.into_destroy_parts();
+        payload.stop_and_destroy().await;
+    }
+
+    pub fn into_reuse_parts(self) -> (ReusableIdleSandbox, BudgetLease) {
+        let Self {
+            sandbox,
+            sandbox_id,
+            source_ip,
+            storage_fingerprints,
+            budget_lease,
+            ..
+        } = self;
+
+        (
+            ReusableIdleSandbox {
+                sandbox,
+                sandbox_id,
+                source_ip,
+                storage_fingerprints,
+            },
+            budget_lease,
+        )
+    }
+
+    pub fn into_destroy_parts(self) -> (IdleDestroyPayload, BudgetLease) {
+        let Self {
+            sandbox,
+            factory,
+            budget_lease,
+            ..
+        } = self;
+
+        (IdleDestroyPayload { sandbox, factory }, budget_lease)
     }
 }
 
@@ -251,7 +309,14 @@ mod tests {
 
     use std::time::Duration;
 
+    use crate::resource_budget::ResourceBudget;
+
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
+
+    fn make_budget_lease(vcpu: u32, memory_mb: u32) -> BudgetLease {
+        let budget = Arc::new(ResourceBudget::new(1, 1, 1.0, 0));
+        ResourceBudget::try_reserve_lease(&budget, vcpu, memory_mb).unwrap()
+    }
 
     fn make_entry(vcpu: u32, memory_mb: u32) -> IdleEntry {
         IdleEntry {
@@ -260,8 +325,7 @@ mod tests {
             session_id: "test-session".into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            vcpu,
-            memory_mb,
+            budget_lease: make_budget_lease(vcpu, memory_mb),
             source_ip: "10.0.0.1".into(),
             parked_at: Instant::now(),
             idle_timeout: Duration::from_secs(300),
@@ -281,8 +345,7 @@ mod tests {
             session_id: "test-session".into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            vcpu,
-            memory_mb,
+            budget_lease: make_budget_lease(vcpu, memory_mb),
             source_ip: "10.0.0.1".into(),
             parked_at,
             idle_timeout,
@@ -307,8 +370,8 @@ mod tests {
         assert_eq!(pool.len(), 1);
 
         let entry = pool.take("session-1").unwrap();
-        assert_eq!(entry.vcpu, 2);
-        assert_eq!(entry.memory_mb, 2048);
+        assert_eq!(entry.budget_lease.vcpu(), 2);
+        assert_eq!(entry.budget_lease.memory_mb(), 2048);
         assert_eq!(pool.len(), 0);
     }
 
@@ -327,15 +390,15 @@ mod tests {
 
         match result {
             ParkResult::Evicted(evicted) => {
-                assert_eq!(evicted.vcpu, 2);
-                assert_eq!(evicted.memory_mb, 2048);
+                assert_eq!(evicted.budget_lease.vcpu(), 2);
+                assert_eq!(evicted.budget_lease.memory_mb(), 2048);
             }
             _ => panic!("expected Evicted"),
         }
 
         assert_eq!(pool.len(), 1);
         let entry = pool.take("session-1").unwrap();
-        assert_eq!(entry.vcpu, 4);
+        assert_eq!(entry.budget_lease.vcpu(), 4);
     }
 
     #[test]
@@ -403,7 +466,7 @@ mod tests {
         );
 
         let evicted = pool.evict_oldest().unwrap();
-        assert_eq!(evicted.vcpu, 2); // the old one
+        assert_eq!(evicted.budget_lease.vcpu(), 2); // the old one
         assert_eq!(pool.len(), 1);
         assert!(pool.take("new").is_some());
     }
@@ -554,7 +617,7 @@ mod tests {
 
         let evicted = pool.evict_expired();
         assert_eq!(evicted.len(), 1);
-        assert_eq!(evicted[0].vcpu, 2); // only the short-timeout entry
+        assert_eq!(evicted[0].budget_lease.vcpu(), 2); // only the short-timeout entry
         assert_eq!(pool.len(), 1);
         assert!(pool.take("long").is_some());
     }
@@ -576,6 +639,6 @@ mod tests {
         assert!(matches!(result, ParkResult::Evicted(_)));
         assert_eq!(pool.len(), 1);
         let entry = pool.take("s1").unwrap();
-        assert_eq!(entry.vcpu, 8);
+        assert_eq!(entry.budget_lease.vcpu(), 8);
     }
 }

--- a/crates/runner/src/resource_budget.rs
+++ b/crates/runner/src/resource_budget.rs
@@ -1,4 +1,6 @@
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use tracing::error;
 
 /// Resource-budget concurrency control.
 ///
@@ -21,10 +23,68 @@ pub struct ResourceBudget {
     state: Mutex<BudgetState>,
 }
 
+/// Owned reservation against a [`ResourceBudget`].
+///
+/// The lease releases its reservation when dropped. Drop must never panic:
+/// idle VM cleanup may run while unwinding from sandbox/factory failures, and
+/// a panic here would turn a cleanup failure into a budget leak or task abort.
+#[must_use = "dropping a BudgetLease releases the reserved resources"]
+pub struct BudgetLease {
+    budget: Option<Arc<ResourceBudget>>,
+    vcpu: u32,
+    memory_mb: u32,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum BudgetReleaseError {
+    Vcpu { running: u32, release: u32 },
+    Memory { running: u32, release: u32 },
+    Count,
+}
+
 struct BudgetState {
     running_vcpu: u32,
     running_memory_mb: u32,
     running_count: usize,
+}
+
+impl BudgetLease {
+    fn new(budget: Arc<ResourceBudget>, vcpu: u32, memory_mb: u32) -> Self {
+        Self {
+            budget: Some(budget),
+            vcpu,
+            memory_mb,
+        }
+    }
+
+    pub fn vcpu(&self) -> u32 {
+        self.vcpu
+    }
+
+    pub fn memory_mb(&self) -> u32 {
+        self.memory_mb
+    }
+
+    fn release_inner(&mut self) {
+        let Some(budget) = self.budget.take() else {
+            return;
+        };
+
+        if let Err(error) = budget.release_reserved(self.vcpu, self.memory_mb) {
+            error!(
+                ?error,
+                vcpu = self.vcpu,
+                memory_mb = self.memory_mb,
+                "failed to release resource budget lease"
+            );
+        }
+    }
+}
+
+impl Drop for BudgetLease {
+    fn drop(&mut self) {
+        self.release_inner();
+    }
 }
 
 impl ResourceBudget {
@@ -84,26 +144,20 @@ impl ResourceBudget {
         true
     }
 
+    /// Try to reserve resources and return an owned lease on success.
+    pub fn try_reserve_lease(budget: &Arc<Self>, vcpu: u32, memory_mb: u32) -> Option<BudgetLease> {
+        if budget.try_reserve(vcpu, memory_mb) {
+            Some(BudgetLease::new(Arc::clone(budget), vcpu, memory_mb))
+        } else {
+            None
+        }
+    }
+
     /// Release resources after a job completes.
+    #[cfg(test)]
     pub fn release(&self, vcpu: u32, memory_mb: u32) {
-        let mut state = self.lock();
-        assert!(
-            state.running_vcpu >= vcpu,
-            "release underflow: running_vcpu ({}) < vcpu ({vcpu})",
-            state.running_vcpu,
-        );
-        assert!(
-            state.running_memory_mb >= memory_mb,
-            "release underflow: running_memory_mb ({}) < memory_mb ({memory_mb})",
-            state.running_memory_mb,
-        );
-        assert!(
-            state.running_count > 0,
-            "release underflow: running_count is 0"
-        );
-        state.running_vcpu -= vcpu;
-        state.running_memory_mb -= memory_mb;
-        state.running_count -= 1;
+        self.release_reserved(vcpu, memory_mb)
+            .expect("release underflow");
     }
 
     /// Check if there is potentially enough budget for a job with the given
@@ -148,6 +202,30 @@ impl ResourceBudget {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         }
+    }
+
+    fn release_reserved(&self, vcpu: u32, memory_mb: u32) -> Result<(), BudgetReleaseError> {
+        let mut state = self.lock();
+        if state.running_vcpu < vcpu {
+            return Err(BudgetReleaseError::Vcpu {
+                running: state.running_vcpu,
+                release: vcpu,
+            });
+        }
+        if state.running_memory_mb < memory_mb {
+            return Err(BudgetReleaseError::Memory {
+                running: state.running_memory_mb,
+                release: memory_mb,
+            });
+        }
+        if state.running_count == 0 {
+            return Err(BudgetReleaseError::Count);
+        }
+
+        state.running_vcpu -= vcpu;
+        state.running_memory_mb -= memory_mb;
+        state.running_count -= 1;
+        Ok(())
     }
 }
 
@@ -203,6 +281,28 @@ mod tests {
         assert!(!budget.try_reserve(2, 2048));
         budget.release(2, 2048);
         assert!(budget.try_reserve(2, 2048)); // works after release
+    }
+
+    #[test]
+    fn lease_drop_frees_resources() {
+        let budget = Arc::new(ResourceBudget::new(4, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 2048).unwrap();
+        assert_eq!(budget.allocated(), (2, 2048, 1));
+
+        drop(lease);
+
+        assert_eq!(budget.allocated(), (0, 0, 0));
+    }
+
+    #[test]
+    fn lease_drop_does_not_panic_on_underflow() {
+        let budget = Arc::new(ResourceBudget::new(4, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 2048).unwrap();
+
+        budget.release(2, 2048);
+        drop(lease);
+
+        assert_eq!(budget.allocated(), (0, 0, 0));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -476,9 +476,6 @@ impl SandboxFactory for FirecrackerFactory {
             }
         };
 
-        // Mark as destroyed so Drop doesn't send to leak cleanup channel.
-        sandbox.destroyed = true;
-
         // Ensure the sandbox is killed before releasing pool resources.
         // After kill(), `sandbox.process` is `None`, so the Drop impl's
         // killpg becomes a no-op when `sandbox` is dropped below.
@@ -519,8 +516,6 @@ impl SandboxFactory for FirecrackerFactory {
                 }
             }
         }
-        drop(sandbox);
-
         // Release device index back to pool with cooldown.
         self.device_pool.lock().await.release(device_index);
 
@@ -542,6 +537,12 @@ impl SandboxFactory for FirecrackerFactory {
         if cow_destroyed && let Err(e) = tokio::fs::remove_dir_all(&workspace).await {
             warn!(id = %sandbox_id, error = %e, "failed to delete workspace");
         }
+
+        // Mark as destroyed only after all explicit cleanup steps complete.
+        // Until this point, `FirecrackerSandbox::Drop` remains armed as a
+        // panic fallback and sends pool resources to the leak-cleanup task.
+        sandbox.destroyed = true;
+        drop(sandbox);
 
         info!(id = %sandbox_id, "sandbox destroyed");
     }

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -73,6 +73,9 @@ pub struct MockSandboxOverrides {
     /// simulate timeout or crash. The stdout channel sender is also kept alive
     /// in `MockSandbox` so the drain task would block without the fix.
     wait_exit_error: Option<String>,
+    /// FIFO queue of start results consumed by every sandbox built with
+    /// these overrides. Empty queue → default Ok(()).
+    start_results: Mutex<VecDeque<Result<()>>>,
     /// FIFO queue of stop behaviours consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     stop_behaviors: Mutex<VecDeque<StopBehavior>>,
@@ -95,6 +98,7 @@ impl MockSandboxOverrides {
             wait_exit_code: None,
             wait_exit_gate: None,
             wait_exit_error: None,
+            start_results: Mutex::new(VecDeque::new()),
             stop_behaviors: Mutex::new(VecDeque::new()),
             park_results: Mutex::new(VecDeque::new()),
             unpark_results: Mutex::new(VecDeque::new()),
@@ -132,6 +136,12 @@ impl MockSandboxOverrides {
     /// Register a pattern matcher consumed on first match.
     pub fn add_exec_matcher(&self, matcher: ExecMatcher) {
         self.exec_matchers.lock_ignoring_poison().push(matcher);
+    }
+
+    /// Queue a `start()` result applied to the next factory-created sandbox.
+    /// Consumed FIFO across all sandboxes; empty queue → default Ok(()).
+    pub fn push_start_result(&self, result: Result<()>) {
+        self.start_results.lock_ignoring_poison().push_back(result);
     }
 
     /// Queue a `stop()` result applied to the next factory-created sandbox.
@@ -261,7 +271,13 @@ impl Sandbox for MockSandbox {
     }
 
     async fn start(&mut self) -> Result<()> {
-        Ok(())
+        let Some(o) = &self.overrides else {
+            return Ok(());
+        };
+        o.start_results
+            .lock_ignoring_poison()
+            .pop_front()
+            .unwrap_or(Ok(()))
     }
 
     async fn stop(&mut self) -> Result<()> {

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -50,6 +50,11 @@ pub struct ExecMatcher {
     pub stderr: Vec<u8>,
 }
 
+enum StopBehavior {
+    Result(Result<()>),
+    Panic(String),
+}
+
 /// Shared behavior overrides propagated from runtime → factory → sandbox.
 ///
 /// Tests create this via [`MockSandboxRuntime::with_overrides`] so every
@@ -68,6 +73,9 @@ pub struct MockSandboxOverrides {
     /// simulate timeout or crash. The stdout channel sender is also kept alive
     /// in `MockSandbox` so the drain task would block without the fix.
     wait_exit_error: Option<String>,
+    /// FIFO queue of stop behaviours consumed by every sandbox built with
+    /// these overrides. Empty queue → default Ok(()).
+    stop_behaviors: Mutex<VecDeque<StopBehavior>>,
     /// FIFO queue of park results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     park_results: Mutex<VecDeque<Result<()>>>,
@@ -87,6 +95,7 @@ impl MockSandboxOverrides {
             wait_exit_code: None,
             wait_exit_gate: None,
             wait_exit_error: None,
+            stop_behaviors: Mutex::new(VecDeque::new()),
             park_results: Mutex::new(VecDeque::new()),
             unpark_results: Mutex::new(VecDeque::new()),
             park_calls: Mutex::new(0),
@@ -123,6 +132,22 @@ impl MockSandboxOverrides {
     /// Register a pattern matcher consumed on first match.
     pub fn add_exec_matcher(&self, matcher: ExecMatcher) {
         self.exec_matchers.lock_ignoring_poison().push(matcher);
+    }
+
+    /// Queue a `stop()` result applied to the next factory-created sandbox.
+    /// Consumed FIFO across all sandboxes; empty queue → default Ok(()).
+    pub fn push_stop_result(&self, result: Result<()>) {
+        self.stop_behaviors
+            .lock_ignoring_poison()
+            .push_back(StopBehavior::Result(result));
+    }
+
+    /// Queue a `stop()` panic applied to the next factory-created sandbox.
+    /// Used by runner tests to exercise panic-safe cleanup boundaries.
+    pub fn push_stop_panic(&self, message: impl Into<String>) {
+        self.stop_behaviors
+            .lock_ignoring_poison()
+            .push_back(StopBehavior::Panic(message.into()));
     }
 
     /// Queue a `park()` result applied to the next factory-created sandbox.
@@ -240,7 +265,15 @@ impl Sandbox for MockSandbox {
     }
 
     async fn stop(&mut self) -> Result<()> {
-        Ok(())
+        let Some(o) = &self.overrides else {
+            return Ok(());
+        };
+        match o.stop_behaviors.lock_ignoring_poison().pop_front() {
+            Some(StopBehavior::Result(result)) => result,
+            #[allow(clippy::panic)]
+            Some(StopBehavior::Panic(message)) => panic!("{message}"),
+            None => Ok(()),
+        }
     }
 
     async fn kill(&mut self) -> Result<()> {

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -50,7 +50,7 @@ pub struct ExecMatcher {
     pub stderr: Vec<u8>,
 }
 
-enum StopBehavior {
+enum LifecycleBehavior {
     Result(Result<()>),
     Panic(String),
 }
@@ -78,13 +78,13 @@ pub struct MockSandboxOverrides {
     start_results: Mutex<VecDeque<Result<()>>>,
     /// FIFO queue of stop behaviours consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
-    stop_behaviors: Mutex<VecDeque<StopBehavior>>,
+    stop_behaviors: Mutex<VecDeque<LifecycleBehavior>>,
     /// FIFO queue of park results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
-    park_results: Mutex<VecDeque<Result<()>>>,
+    park_behaviors: Mutex<VecDeque<LifecycleBehavior>>,
     /// FIFO queue of unpark results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
-    unpark_results: Mutex<VecDeque<Result<()>>>,
+    unpark_behaviors: Mutex<VecDeque<LifecycleBehavior>>,
     /// Total `park()` calls across all sandboxes built from this override set.
     park_calls: Mutex<u32>,
     /// Total `unpark()` calls across all sandboxes built from this override set.
@@ -100,8 +100,8 @@ impl MockSandboxOverrides {
             wait_exit_error: None,
             start_results: Mutex::new(VecDeque::new()),
             stop_behaviors: Mutex::new(VecDeque::new()),
-            park_results: Mutex::new(VecDeque::new()),
-            unpark_results: Mutex::new(VecDeque::new()),
+            park_behaviors: Mutex::new(VecDeque::new()),
+            unpark_behaviors: Mutex::new(VecDeque::new()),
             park_calls: Mutex::new(0),
             unpark_calls: Mutex::new(0),
         }
@@ -149,7 +149,7 @@ impl MockSandboxOverrides {
     pub fn push_stop_result(&self, result: Result<()>) {
         self.stop_behaviors
             .lock_ignoring_poison()
-            .push_back(StopBehavior::Result(result));
+            .push_back(LifecycleBehavior::Result(result));
     }
 
     /// Queue a `stop()` panic applied to the next factory-created sandbox.
@@ -157,19 +157,39 @@ impl MockSandboxOverrides {
     pub fn push_stop_panic(&self, message: impl Into<String>) {
         self.stop_behaviors
             .lock_ignoring_poison()
-            .push_back(StopBehavior::Panic(message.into()));
+            .push_back(LifecycleBehavior::Panic(message.into()));
     }
 
     /// Queue a `park()` result applied to the next factory-created sandbox.
     /// Consumed FIFO across all sandboxes; empty queue → default Ok(()).
     pub fn push_park_result(&self, result: Result<()>) {
-        self.park_results.lock_ignoring_poison().push_back(result);
+        self.park_behaviors
+            .lock_ignoring_poison()
+            .push_back(LifecycleBehavior::Result(result));
+    }
+
+    /// Queue a `park()` panic applied to the next factory-created sandbox.
+    /// Used by runner tests to exercise panic-safe cleanup boundaries.
+    pub fn push_park_panic(&self, message: impl Into<String>) {
+        self.park_behaviors
+            .lock_ignoring_poison()
+            .push_back(LifecycleBehavior::Panic(message.into()));
     }
 
     /// Queue an `unpark()` result applied to the next factory-created sandbox.
     /// Consumed FIFO across all sandboxes; empty queue → default Ok(()).
     pub fn push_unpark_result(&self, result: Result<()>) {
-        self.unpark_results.lock_ignoring_poison().push_back(result);
+        self.unpark_behaviors
+            .lock_ignoring_poison()
+            .push_back(LifecycleBehavior::Result(result));
+    }
+
+    /// Queue an `unpark()` panic applied to the next factory-created sandbox.
+    /// Used by runner tests to exercise panic-safe cleanup boundaries.
+    pub fn push_unpark_panic(&self, message: impl Into<String>) {
+        self.unpark_behaviors
+            .lock_ignoring_poison()
+            .push_back(LifecycleBehavior::Panic(message.into()));
     }
 
     /// Total `park()` calls across all sandboxes built from this override set.
@@ -285,9 +305,9 @@ impl Sandbox for MockSandbox {
             return Ok(());
         };
         match o.stop_behaviors.lock_ignoring_poison().pop_front() {
-            Some(StopBehavior::Result(result)) => result,
+            Some(LifecycleBehavior::Result(result)) => result,
             #[allow(clippy::panic)]
-            Some(StopBehavior::Panic(message)) => panic!("{message}"),
+            Some(LifecycleBehavior::Panic(message)) => panic!("{message}"),
             None => Ok(()),
         }
     }
@@ -307,10 +327,12 @@ impl Sandbox for MockSandbox {
             return Ok(());
         };
         *o.park_calls.lock_ignoring_poison() += 1;
-        o.park_results
-            .lock_ignoring_poison()
-            .pop_front()
-            .unwrap_or(Ok(()))
+        match o.park_behaviors.lock_ignoring_poison().pop_front() {
+            Some(LifecycleBehavior::Result(result)) => result,
+            #[allow(clippy::panic)]
+            Some(LifecycleBehavior::Panic(message)) => panic!("{message}"),
+            None => Ok(()),
+        }
     }
 
     /// Mock unpark: counter + queued-result semantics mirror [`park`]
@@ -322,10 +344,12 @@ impl Sandbox for MockSandbox {
             return Ok(());
         };
         *o.unpark_calls.lock_ignoring_poison() += 1;
-        o.unpark_results
-            .lock_ignoring_poison()
-            .pop_front()
-            .unwrap_or(Ok(()))
+        match o.unpark_behaviors.lock_ignoring_poison().pop_front() {
+            Some(LifecycleBehavior::Result(result)) => result,
+            #[allow(clippy::panic)]
+            Some(LifecycleBehavior::Panic(message)) => panic!("{message}"),
+            None => Ok(()),
+        }
     }
 
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult> {


### PR DESCRIPTION
Closes #11175

## Summary
- add owned `BudgetLease` reservations so idle entries release budget on drop, including unwind paths
- split reused idle sandboxes from their budget lease so executor panics cannot release capacity before provider completion
- route idle-entry destroys through spawned panic boundaries and cover destroy-panic release behavior in tests

## Tests
- `cargo clippy --all-targets --all-features`
- `cargo test -p runner`