### PR TITLE
Add empty state illustration to Insights page

### DIFF
--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-page-interaction.test.tsx
@@ -161,15 +161,16 @@ describe("/_/usage page - empty state", () => {
       ).toBeInTheDocument();
     });
 
-    // Totals bar should show 0 credits with zero grand total
+    // Empty state illustration replaces the totals bar when there's no usage
     await waitFor(() => {
-      expect(
-        screen.getByRole("img", { name: /Total credits breakdown/ }),
-      ).toBeInTheDocument();
+      expect(screen.getByText("No usage data yet")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("0")).toBeInTheDocument();
-    expect(screen.getByText("credits")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Start a chat or run a schedule to see your insights here.",
+      ),
+    ).toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-empty-state.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-empty-state.tsx
@@ -11,9 +11,7 @@ export function UsageInsightEmptyState() {
         className="h-24 w-24 object-contain opacity-80"
       />
       <div className="text-center">
-        <p className="text-sm font-medium text-foreground">
-          No usage data yet
-        </p>
+        <p className="text-sm font-medium text-foreground">No usage data yet</p>
         <p className="text-xs text-muted-foreground mt-1">
           Start a chat or run a schedule to see your insights here.
         </p>

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-empty-state.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-empty-state.tsx
@@ -1,0 +1,23 @@
+import emptyInsightsImg from "../../zero-page/assets/empty-insights.webp";
+
+export function UsageInsightEmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 gap-3">
+      <img
+        src={emptyInsightsImg}
+        alt=""
+        role="presentation"
+        loading="lazy"
+        className="h-24 w-24 object-contain opacity-80"
+      />
+      <div className="text-center">
+        <p className="text-sm font-medium text-foreground">
+          No usage data yet
+        </p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Start a chat or run a schedule to see your insights here.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-view.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-view.tsx
@@ -28,6 +28,7 @@ import { UsageInsightBarChart } from "./usage-insight-bar-chart.tsx";
 import { UsageInsightSchedulesTable } from "./usage-insight-schedules-table.tsx";
 import { UsageInsightChatsTable } from "./usage-insight-chats-table.tsx";
 import { UsageInsightTotalsBar } from "./usage-insight-totals-bar.tsx";
+import emptyInsightsImg from "../../zero-page/assets/empty-insights.webp";
 
 export function UsageInsightView() {
   const range = useGet(range$);
@@ -43,6 +44,10 @@ export function UsageInsightView() {
   const isLoading = loadable.state === "loading";
   const isError = loadable.state === "hasError";
   const data = loadable.state === "hasData" ? loadable.data : null;
+  const isEmpty =
+    data !== null &&
+    data.grandTotalCredits === 0 &&
+    data.grandTotalTokens === 0;
 
   const handleRangeChange = (val: string) => {
     setRange(val as InsightRange);
@@ -108,7 +113,7 @@ export function UsageInsightView() {
       </div>
 
       {/* Totals bar (100% stacked) */}
-      {data && (
+      {data && !isEmpty && (
         <UsageInsightTotalsBar
           data={data}
           metric={metric}
@@ -129,7 +134,26 @@ export function UsageInsightView() {
           Failed to load usage insights. Please try again later.
         </div>
       )}
-      {data && (
+      {isEmpty && (
+        <div className="flex flex-col items-center justify-center py-12 gap-3">
+          <img
+            src={emptyInsightsImg}
+            alt=""
+            role="presentation"
+            loading="lazy"
+            className="h-24 w-24 object-contain opacity-80"
+          />
+          <div className="text-center">
+            <p className="text-sm font-medium text-foreground">
+              No usage data yet
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              Start a chat or run a schedule to see your insights here.
+            </p>
+          </div>
+        </div>
+      )}
+      {data && !isEmpty && (
         <UsageInsightBarChart
           buckets={data.buckets}
           metric={metric}
@@ -139,7 +163,7 @@ export function UsageInsightView() {
       )}
 
       {/* Detail tabs: Schedules / Chats */}
-      {data && (
+      {data && !isEmpty && (
         <Tabs
           value={detailTab}
           onValueChange={handleDetailTabChange}

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-view.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-view.tsx
@@ -28,7 +28,7 @@ import { UsageInsightBarChart } from "./usage-insight-bar-chart.tsx";
 import { UsageInsightSchedulesTable } from "./usage-insight-schedules-table.tsx";
 import { UsageInsightChatsTable } from "./usage-insight-chats-table.tsx";
 import { UsageInsightTotalsBar } from "./usage-insight-totals-bar.tsx";
-import emptyInsightsImg from "../../zero-page/assets/empty-insights.webp";
+import { UsageInsightEmptyState } from "./usage-insight-empty-state.tsx";
 
 export function UsageInsightView() {
   const range = useGet(range$);
@@ -134,25 +134,7 @@ export function UsageInsightView() {
           Failed to load usage insights. Please try again later.
         </div>
       )}
-      {isEmpty && (
-        <div className="flex flex-col items-center justify-center py-12 gap-3">
-          <img
-            src={emptyInsightsImg}
-            alt=""
-            role="presentation"
-            loading="lazy"
-            className="h-24 w-24 object-contain opacity-80"
-          />
-          <div className="text-center">
-            <p className="text-sm font-medium text-foreground">
-              No usage data yet
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Start a chat or run a schedule to see your insights here.
-            </p>
-          </div>
-        </div>
-      )}
+      {isEmpty && <UsageInsightEmptyState />}
       {data && !isEmpty && (
         <UsageInsightBarChart
           buckets={data.buckets}


### PR DESCRIPTION
## Summary

- Wire up the existing `empty-insights.webp` asset (magnifying glass + data points, teal backdrop) to the Usage Insights page
- Show the illustrated empty state when `grandTotalCredits === 0 && grandTotalTokens === 0` — replaces blank charts/tables with a friendly visual + helper text
- Guard totals bar, chart, and detail tabs behind `!isEmpty` so they don't render when there's no data

## Preview

The `empty-insights.webp` illustration (already in assets from PR #11081):

![empty-insights](https://raw.githubusercontent.com/vm0-ai/vm0/main/turbo/apps/platform/src/views/zero-page/assets/empty-insights.webp)

## Test plan

- [ ] Open the Insights page with a fresh account (no usage) — verify the illustration + "No usage data yet" message appears
- [ ] Switch date range filters — empty state should persist if all ranges have zero usage
- [ ] Verify that once there is usage data, the normal charts/tables render correctly
- [ ] Check dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)