### PR TITLE
feat: support batched usage event webhooks

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -33,6 +33,7 @@ from .x_billing import (
 # ambiguity of an ``OK_MAX`` that is itself excluded from the OK range.
 _HTTP_STATUS_OK_MIN = 200
 _HTTP_STATUS_REDIRECT_MIN = 300
+_USAGE_EVENT_BATCH_SIZE = 100
 
 # X v2 NDJSON streaming endpoint paths (exact match — ``/2/tweets/search/stream/rules``
 # is a regular request/response endpoint for rules management, NOT a stream).
@@ -484,6 +485,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
         )
         return
     url = f"{api_url}/api/webhooks/agent/usage-event"
+    events = []
     for category, qty in billable_counts.items():
         # UUIDv5 from stable inputs — retries produce the same key, so the
         # server-side UNIQUE(idempotency_key) dedups duplicate deliveries
@@ -494,16 +496,22 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
                 f"{run_id}:{flow.id}:{category}",
             )
         )
-        _enqueue_webhook(
-            url,
-            sandbox_token,
+        events.append(
             {
-                "runId": run_id,
                 "idempotencyKey": idempotency_key,
                 "kind": "connector",
                 "provider": firewall_name,
                 "category": category,
                 "quantity": qty,
+            }
+        )
+    for start in range(0, len(events), _USAGE_EVENT_BATCH_SIZE):
+        _enqueue_webhook(
+            url,
+            sandbox_token,
+            {
+                "runId": run_id,
+                "events": events[start : start + _USAGE_EVENT_BATCH_SIZE],
             },
             proxy_log_path,
             "usage_event",

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -20,6 +20,16 @@ import usage
 from usage import create_sse_usage_extractor
 
 
+def _request_bodies_from_calls(call_args_list):
+    return [json.loads(call[0][0].data) for call in call_args_list]
+
+
+def _usage_event_events_from_calls(call_args_list):
+    return [
+        event for body in _request_bodies_from_calls(call_args_list) for event in body["events"]
+    ]
+
+
 class TestRequestHandler:
     async def test_allowed_domain_passes_through(self, registry_file, real_flow, mitm_ctx):
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -1772,7 +1782,7 @@ class TestErrorHandler:
 
         # Connector billing webhook should have been posted to _opener.
         assert mock_opener.open.called
-        payloads = [json.loads(call[0][0].data) for call in mock_opener.open.call_args_list]
+        payloads = _usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat["posts.read"] == 23
         assert by_cat["user.read"] == 5
@@ -1827,7 +1837,7 @@ class TestErrorHandler:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Billing must reflect the 2 complete tweets (partial 3rd is dropped)
-        payloads = [json.loads(call[0][0].data) for call in mock_opener.open.call_args_list]
+        payloads = _usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat["posts.read"] == 2  # not 3 — partial trailing dropped
         assert by_cat["user.read"] == 1
@@ -2058,7 +2068,11 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_connector_usage(flow, run_id)
-        return [json.loads(call[0][0].data) for call in mock_opener.open.call_args_list]
+        return [
+            event
+            for body in _request_bodies_from_calls(mock_opener.open.call_args_list)
+            for event in body["events"]
+        ]
 
     def _call_and_get_single_billing(self, flow, run_id="run-abc-123"):
         """Call report_connector_usage and return the single webhook payload."""
@@ -2114,6 +2128,73 @@ class TestReportConnectorUsage:
         payloads = self._call_and_get_billing(flow)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat == {"posts.read": 1, "user.read": 1, "media.read": 2}
+
+    def test_posts_usage_events_as_one_batch(self, tmp_path, real_flow):
+        """One X response with multiple categories sends one batched webhook."""
+        body = json.dumps(
+            {
+                "data": [{"id": "1", "author_id": "99"}],
+                "includes": {"users": [{"id": "99"}]},
+            }
+        ).encode()
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            query="expansions=author_id",
+            body=body,
+        )
+
+        with (
+            patch.object(
+                usage.providers.connectors.x, "get_api_url", return_value="https://app.test"
+            ),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            usage.report_connector_usage(flow, "run-abc-123")
+
+        mock_opener.open.assert_called_once()
+        [payload] = _request_bodies_from_calls(mock_opener.open.call_args_list)
+        assert payload["runId"] == "run-abc-123"
+        assert "idempotencyKey" not in payload
+        by_cat = {event["category"]: event for event in payload["events"]}
+        assert set(by_cat) == {"posts.read", "user.read"}
+        assert by_cat["posts.read"]["kind"] == "connector"
+        assert by_cat["posts.read"]["provider"] == "x"
+        assert by_cat["posts.read"]["quantity"] == 1
+        assert by_cat["user.read"]["quantity"] == 1
+
+    def test_splits_usage_event_batches_at_server_limit(self, tmp_path, real_flow):
+        """Large synthetic category sets are chunked to match the webhook contract."""
+        body = json.dumps(
+            {
+                "data": [],
+                "includes": {f"future_{index}": [{"id": str(index)}] for index in range(101)},
+            }
+        ).encode()
+        flow = self._make_x_flow(real_flow, tmp_path, query="expansions=future", body=body)
+
+        with (
+            patch.object(
+                usage.providers.connectors.x, "get_api_url", return_value="https://app.test"
+            ),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            usage.report_connector_usage(flow, "run-abc-123")
+
+        bodies = _request_bodies_from_calls(mock_opener.open.call_args_list)
+        assert [len(body["events"]) for body in bodies] == [100, 1]
+        assert {body["runId"] for body in bodies} == {"run-abc-123"}
+        assert all(
+            event["kind"] == "connector" and event["provider"] == "x"
+            for body in bodies
+            for event in body["events"]
+        )
+        categories = {event["category"] for body in bodies for event in body["events"]}
+        assert len(categories) == 101
+        assert "includes.future_0" in categories
+        assert "includes.future_100" in categories
 
     def test_empty_search_emits_no_billing(self, tmp_path, real_flow):
         """Search returning zero results emits no usage_event row."""
@@ -2780,7 +2861,7 @@ class TestReportConnectorUsage:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Verify billing payloads
-        payloads = [json.loads(call[0][0].data) for call in mock_opener.open.call_args_list]
+        payloads = _usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         # 3 tweets primary + 0 from includes.tweets (none here) = 3
         assert by_cat["posts.read"] == 3

--- a/turbo/apps/web/app/api/webhooks/agent/usage-event/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/usage-event/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import {
   createTestRun,
   createTestSandboxToken,
   findTestConnectorBillingByRunId,
+  findTestUsageEventsByRunId,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -82,6 +83,29 @@ describe("POST /api/webhooks/agent/usage-event", () => {
       const token = await createTestSandboxToken(user.userId, missingRunId);
       const response = await POST(
         makeRequest({ ...validBody(), runId: missingRunId }, token),
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it("returns 404 for a batch when the run does not exist", async () => {
+      const missingRunId = randomUUID();
+      const token = await createTestSandboxToken(user.userId, missingRunId);
+      const response = await POST(
+        makeRequest(
+          {
+            runId: missingRunId,
+            events: [
+              {
+                idempotencyKey: randomUUID(),
+                kind: "connector",
+                provider: "x",
+                category: "tweet.read",
+                quantity: 1,
+              },
+            ],
+          },
+          token,
+        ),
       );
       expect(response.status).toBe(404);
     });
@@ -162,6 +186,184 @@ describe("POST /api/webhooks/agent/usage-event", () => {
       expect(rows).toHaveLength(1);
       expect(rows[0]!.quantity).toBe(0);
     });
+
+    it("accepts a batch with model and image usage events", async () => {
+      const modelEventId = randomUUID();
+      const imageEventId = randomUUID();
+      const response = await POST(
+        makeRequest(
+          {
+            runId: testRunId,
+            events: [
+              {
+                idempotencyKey: modelEventId,
+                kind: "model",
+                provider: "claude-sonnet-4-6",
+                category: "tokens.input",
+                quantity: 123,
+              },
+              {
+                idempotencyKey: imageEventId,
+                kind: "image",
+                provider: "gpt-image-1",
+                category: "output_image",
+                quantity: 1,
+              },
+            ],
+          },
+          testToken,
+        ),
+      );
+      expect(response.status).toBe(200);
+
+      const rows = await findTestUsageEventsByRunId(testRunId);
+      expect(rows).toHaveLength(2);
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            idempotencyKey: modelEventId,
+            kind: "model",
+            provider: "claude-sonnet-4-6",
+            category: "tokens.input",
+            quantity: 123,
+            status: "pending",
+          }),
+          expect.objectContaining({
+            idempotencyKey: imageEventId,
+            kind: "image",
+            provider: "gpt-image-1",
+            category: "output_image",
+            quantity: 1,
+            status: "pending",
+          }),
+        ]),
+      );
+    });
+
+    it("deduplicates duplicate idempotency keys inside a batch", async () => {
+      const sharedKey = randomUUID();
+      const response = await POST(
+        makeRequest(
+          {
+            runId: testRunId,
+            events: [
+              {
+                idempotencyKey: sharedKey,
+                kind: "connector",
+                provider: "x",
+                category: "tweet.read",
+                quantity: 3,
+              },
+              {
+                idempotencyKey: sharedKey,
+                kind: "connector",
+                provider: "x",
+                category: "users.read",
+                quantity: 7,
+              },
+            ],
+          },
+          testToken,
+        ),
+      );
+      expect(response.status).toBe(200);
+
+      const rows = await findTestUsageEventsByRunId(testRunId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        idempotencyKey: sharedKey,
+        provider: "x",
+        category: "tweet.read",
+        quantity: 3,
+      });
+    });
+
+    it("deduplicates a retried batch by idempotencyKey", async () => {
+      const firstEventId = randomUUID();
+      const secondEventId = randomUUID();
+      const body = {
+        runId: testRunId,
+        events: [
+          {
+            idempotencyKey: firstEventId,
+            kind: "model",
+            provider: "claude-sonnet-4-6",
+            category: "tokens.input",
+            quantity: 10,
+          },
+          {
+            idempotencyKey: secondEventId,
+            kind: "model",
+            provider: "claude-sonnet-4-6",
+            category: "tokens.output",
+            quantity: 20,
+          },
+        ],
+      };
+
+      expect((await POST(makeRequest(body, testToken))).status).toBe(200);
+      expect((await POST(makeRequest(body, testToken))).status).toBe(200);
+
+      const rows = await findTestUsageEventsByRunId(testRunId);
+      expect(rows).toHaveLength(2);
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            idempotencyKey: firstEventId,
+            category: "tokens.input",
+            quantity: 10,
+          }),
+          expect.objectContaining({
+            idempotencyKey: secondEventId,
+            category: "tokens.output",
+            quantity: 20,
+          }),
+        ]),
+      );
+    });
+
+    it("accepts batches at the 100-event limit", async () => {
+      const firstEventId = randomUUID();
+      const lastEventId = randomUUID();
+      const response = await POST(
+        makeRequest(
+          {
+            runId: testRunId,
+            events: Array.from({ length: 100 }, (_, index) => {
+              return {
+                idempotencyKey:
+                  index === 0
+                    ? firstEventId
+                    : index === 99
+                      ? lastEventId
+                      : randomUUID(),
+                kind: "model",
+                provider: "claude-sonnet-4-6",
+                category: index % 2 === 0 ? "tokens.input" : "tokens.output",
+                quantity: index + 1,
+              };
+            }),
+          },
+          testToken,
+        ),
+      );
+      expect(response.status).toBe(200);
+
+      const rows = await findTestUsageEventsByRunId(testRunId);
+      expect(rows).toHaveLength(100);
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            idempotencyKey: firstEventId,
+            quantity: 1,
+          }),
+          expect.objectContaining({
+            idempotencyKey: lastEventId,
+            quantity: 100,
+          }),
+        ]),
+      );
+    });
   });
 
   // ── Validation ─────────────────────────────────────────────────────
@@ -194,6 +396,47 @@ describe("POST /api/webhooks/agent/usage-event", () => {
     it("rejects non-UUID idempotencyKey", async () => {
       const body = { ...validBody(), idempotencyKey: "not-a-uuid" };
       const response = await POST(makeRequest(body, testToken));
+      expect(response.status).toBe(400);
+    });
+
+    it("rejects empty batches", async () => {
+      const response = await POST(
+        makeRequest({ runId: testRunId, events: [] }, testToken),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it("rejects a mixed legacy and invalid batch body", async () => {
+      const response = await POST(
+        makeRequest(
+          {
+            ...validBody(),
+            events: [],
+          },
+          testToken,
+        ),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it("rejects batches with more than 100 events", async () => {
+      const response = await POST(
+        makeRequest(
+          {
+            runId: testRunId,
+            events: Array.from({ length: 101 }, (_, index) => {
+              return {
+                idempotencyKey: randomUUID(),
+                kind: "model",
+                provider: "claude-sonnet-4-6",
+                category: index % 2 === 0 ? "tokens.input" : "tokens.output",
+                quantity: index,
+              };
+            }),
+          },
+          testToken,
+        ),
+      );
       expect(response.status).toBe(400);
     });
   });

--- a/turbo/apps/web/app/api/webhooks/agent/usage-event/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/usage-event/route.ts
@@ -16,6 +16,7 @@ const router = tsr.router(webhookUsageEventContract, {
   send: async ({ body, headers }) => {
     initServices();
 
+    const events = "events" in body ? body.events : [body];
     const auth = getSandboxAuthForRun(body.runId, headers.authorization);
     if (!auth) {
       return {
@@ -42,22 +43,26 @@ const router = tsr.router(webhookUsageEventContract, {
     try {
       await globalThis.services.db
         .insert(usageEvent)
-        .values({
-          runId: body.runId,
-          orgId,
-          userId,
-          kind: body.kind,
-          provider: body.provider,
-          category: body.category,
-          quantity: body.quantity,
-          idempotencyKey: body.idempotencyKey,
-        })
+        .values(
+          events.map((event) => {
+            return {
+              runId: body.runId,
+              orgId,
+              userId,
+              kind: event.kind,
+              provider: event.provider,
+              category: event.category,
+              quantity: event.quantity,
+              idempotencyKey: event.idempotencyKey,
+            };
+          }),
+        )
         .onConflictDoNothing({ target: [usageEvent.idempotencyKey] });
     } catch (err) {
       if (isForeignKeyViolation(err)) {
         log.info("Run not found for usage event, dropping", {
           runId: body.runId,
-          idempotencyKey: body.idempotencyKey,
+          eventCount: events.length,
         });
         return {
           status: 404 as const,
@@ -72,12 +77,9 @@ const router = tsr.router(webhookUsageEventContract, {
       throw err;
     }
 
-    log.debug("Usage event recorded", {
+    log.debug("Usage events recorded", {
       runId: body.runId,
-      kind: body.kind,
-      provider: body.provider,
-      category: body.category,
-      quantity: body.quantity,
+      eventCount: events.length,
     });
 
     return {
@@ -92,7 +94,9 @@ const router = tsr.router(webhookUsageEventContract, {
 function errorHandler(err: unknown): TsRestResponse | void {
   if (err && typeof err === "object" && "bodyError" in err) {
     const validationError = err as {
-      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+      bodyError: {
+        issues: Array<{ path: Array<string | number>; message: string }>;
+      } | null;
     };
     if (validationError.bodyError) {
       const issue = validationError.bodyError.issues[0];

--- a/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
@@ -40,6 +40,7 @@ export {
   findTestCreditUsage,
   findTestCreditUsagesByRunId,
   findTestUsageEvent,
+  findTestUsageEventsByRunId,
   findTestClientCreditUsagesByRunId,
   findUsageDaily,
   findInsightsDaily,

--- a/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
@@ -188,6 +188,7 @@ export {
   findTestCreditUsage,
   findTestCreditUsagesByRunId,
   findTestUsageEvent,
+  findTestUsageEventsByRunId,
   findTestClientCreditUsagesByRunId,
   findUsageDaily,
   findInsightsDaily,

--- a/turbo/apps/web/src/__tests__/db-test-assertions/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/credits.ts
@@ -302,3 +302,31 @@ export async function findTestUsageEvent(id: string): Promise<
     .limit(1);
   return record;
 }
+
+/**
+ * Find all usage_event records by runId.
+ */
+export async function findTestUsageEventsByRunId(runId: string): Promise<
+  Array<{
+    idempotencyKey: string;
+    kind: string;
+    provider: string;
+    category: string;
+    quantity: number;
+    status: string;
+  }>
+> {
+  initServices();
+  return globalThis.services.db
+    .select({
+      idempotencyKey: usageEvent.idempotencyKey,
+      kind: usageEvent.kind,
+      provider: usageEvent.provider,
+      category: usageEvent.category,
+      quantity: usageEvent.quantity,
+      status: usageEvent.status,
+    })
+    .from(usageEvent)
+    .where(eq(usageEvent.runId, runId))
+    .orderBy(usageEvent.kind, usageEvent.provider, usageEvent.category);
+}

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -528,23 +528,38 @@ export type WebhookUsageContract = typeof webhookUsageContract;
 /**
  * Webhook usage event contract for /api/webhooks/agent/usage-event
  *
- * Receives per-event billable usage records (connector API calls, and
- * future sandbox-reported billable events) from the mitmproxy addon
- * for persistence in the `usage_event` table.
+ * Receives billable usage records from the sandbox for persistence in the
+ * `usage_event` table. The legacy single-event body remains supported for
+ * connector billing; new reporters should send `{ runId, events }` batches.
  */
+const webhookUsageEventItemSchema = z
+  .object({
+    idempotencyKey: z.uuid(),
+    kind: z.enum(["connector", "model", "image"]),
+    provider: z.string().min(1).max(100),
+    category: z.string().min(1).max(100),
+    quantity: z.number().int().min(0),
+  })
+  .strict();
+
 export const webhookUsageEventContract = c.router({
   send: {
     method: "POST",
     path: "/api/webhooks/agent/usage-event",
     headers: authHeadersSchema,
-    body: z.object({
-      runId: z.string().min(1, "runId is required"),
-      idempotencyKey: z.uuid(),
-      kind: z.enum(["connector"]),
-      provider: z.string().min(1).max(100),
-      category: z.string().min(1).max(100),
-      quantity: z.number().int().min(0),
-    }),
+    body: z.union([
+      z
+        .object({
+          runId: z.string().min(1, "runId is required"),
+          events: z.array(webhookUsageEventItemSchema).min(1).max(100),
+        })
+        .strict(),
+      webhookUsageEventItemSchema
+        .extend({
+          runId: z.string().min(1, "runId is required"),
+        })
+        .strict(),
+    ]),
     responses: {
       200: z.object({
         success: z.boolean(),


### PR DESCRIPTION
## Summary
- extend the usage-event webhook contract to accept both legacy single-event bodies and new batched events
- normalize requests in the handler and insert all events with existing idempotency conflict handling
- cover legacy, batch, expanded kinds, duplicate idempotency, invalid sizes, and missing-run behavior

## Tests
- pnpm --dir turbo/apps/web test app/api/webhooks/agent/usage-event/__tests__/route.test.ts
- pnpm --dir turbo/apps/web test
- pnpm --dir turbo/apps/web check-types
- pnpm --dir turbo/packages/api-contracts lint
- pnpm --dir turbo/packages/api-contracts check-types
- pre-commit hook: prettier, knip, turbo check-types

Closes #11203