### PR TITLE
fix(ci): run deploy-web in merge queue without github deployment

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -660,9 +660,10 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     needs: [prepare]
-    # Deploy if job-ref is set (PR or main), not a release-please commit, not a merge queue run, and web, API, CLI, runner, or platform changed
+    # Deploy if job-ref is set (PR or main), not a release-please commit, and web, API, CLI, runner, or platform changed.
+    # Runs in merge queue too, but skips GitHub Deployment creation (the bobheadxi/deployments action
+    # cannot resolve the temporary `gh-readonly-queue/*` ref via the GitHub API).
     if: |
-      github.event_name != 'merge_group' &&
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
@@ -802,6 +803,7 @@ jobs:
       # Step 4: Deploy prebuilt artifacts with database URL
       - name: Start deployment
         id: deployment
+        if: github.event_name != 'merge_group'
         uses: bobheadxi/deployments@v1
         with:
           step: start
@@ -837,7 +839,7 @@ jobs:
 
       - name: Finish deployment
         uses: bobheadxi/deployments@v1
-        if: always() && !(github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '')
+        if: always() && github.event_name != 'merge_group' && !(github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '')
         with:
           step: finish
           token: ${{ github.token }}
@@ -895,7 +897,8 @@ jobs:
           environment-file: ${{ steps.api-deploy-env.outputs.file }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
-          skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}
+          skip-start: ${{ github.event_name == 'merge_group' }}
+          skip-finish: ${{ github.event_name == 'merge_group' || (github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '') }}
 
       - name: Check API health
         if: needs.prepare.outputs.api-changed == 'true' || needs.prepare.outputs.ci-changed == 'true'


### PR DESCRIPTION
## Summary

Reverses the workaround from #10865. Instead of skipping the entire `deploy-web` job in the merge queue, we now run it and only skip the GitHub Deployment API calls — those are the actual source of `HttpError: No ref found for: refs/heads/gh-readonly-queue/...`.

This means the merge queue actually validates the web/API build + Vercel deploy path (and unblocks the downstream E2E jobs that consume `deploy-web.outputs.preview-url`), while still avoiding the `bobheadxi/deployments@v1` API failure.

### Changes (.github/workflows/turbo.yml)

- `deploy-web` job: drop `github.event_name != 'merge_group'` gate
- Inline web "Start deployment" step: add `if: github.event_name != 'merge_group'`
- Inline web "Finish deployment" step: extend existing `if` with the same guard
- Inline API `vercel-deploy` call: pass `skip-start` / `skip-finish` in `merge_group`

### Why each piece is safe

- `vercel-alias` action already gracefully tolerates an empty `deployment-id` (skips only its inner finish-deployment step), so the alias creation still works without a GitHub deployment record.
- `vercel-deploy` action already exposes `skip-start` / `skip-finish` inputs that gate its internal bobheadxi calls — no changes needed inside the action.
- `ci-gate-turbo` requires `deploy-web` to either succeed or be skipped; running successfully without a deployment record satisfies the same contract as the previous skipped state.

### Note

`deploy-app` (separate job) does **not** currently have a `merge_group` guard. Its `platform-changed / e2e-changed / ci-changed` filter likely keeps it dormant in most queue runs, so I left it alone in this PR. If we observe similar `bobheadxi` failures from `deploy-app`, the same `skip-start` / `skip-finish` pattern can be applied.

## Test plan

- [ ] Next merge queue run: `deploy-web` runs to completion (not skipped, not failed); no `HttpError: No ref found` in logs
- [ ] Downstream E2E jobs (`cli-e2e-02-browser`, runner, etc.) consume `deploy-web.outputs.preview-url` correctly in the queue
- [ ] PR CI behavior unchanged — `deploy-web` still creates and finishes a GitHub deployment record on `pull_request` events
- [ ] `ci-gate-turbo` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)