### PR TITLE
ci: retry transient curl downloads

### DIFF
--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -24,7 +24,13 @@ runs:
       env:
         CLOUDFLARED_VERSION: ${{ inputs.cloudflared-version }}
       run: |
-        curl -sfL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64.deb" -o /tmp/cloudflared.deb
+        curl -sfL \
+          --retry 5 \
+          --retry-delay 2 \
+          --retry-max-time 60 \
+          --retry-all-errors \
+          "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64.deb" \
+          -o /tmp/cloudflared.deb
         if command -v sudo &>/dev/null; then
           sudo dpkg -i /tmp/cloudflared.deb
         else

--- a/.github/actions/vercel-dashboard-url/action.yml
+++ b/.github/actions/vercel-dashboard-url/action.yml
@@ -28,7 +28,12 @@ runs:
         HOSTNAME=$(echo "$DEPLOYMENT_URL" | sed 's|https://||')
 
         # Query Vercel API to get deployment details
-        RESPONSE=$(curl -sf -H "Authorization: Bearer $VERCEL_TOKEN" \
+        RESPONSE=$(curl -sf \
+          --retry 5 \
+          --retry-delay 2 \
+          --retry-max-time 60 \
+          --retry-all-errors \
+          -H "Authorization: Bearer $VERCEL_TOKEN" \
           "https://api.vercel.com/v13/deployments/$HOSTNAME" 2>/dev/null) || true
 
         if [ -n "$RESPONSE" ]; then

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -51,7 +51,12 @@ jobs:
             if [ -n "$PR_NUMBER" ]; then
 
               # Check PR state via GitHub API
-              PR_STATE=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+              PR_STATE=$(curl -sf \
+                --retry 5 \
+                --retry-delay 2 \
+                --retry-max-time 60 \
+                --retry-all-errors \
+                -H "Authorization: token $GH_TOKEN" \
                 "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" | jq -r '.state')
 
               if [ "$PR_STATE" = "open" ]; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1404,6 +1404,10 @@ jobs:
 
           # Get the release ID from the tag
           RELEASE_ID=$(curl -sfL \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-max-time 60 \
+            --retry-all-errors \
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
@@ -1411,6 +1415,10 @@ jobs:
 
           # Delete existing asset with the same name (--clobber equivalent)
           EXISTING=$(curl -sfL \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-max-time 60 \
+            --retry-all-errors \
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" \

--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -126,6 +126,10 @@ jobs:
           # `curl -f` turns HTTP 404 on a missing tag into a non-zero exit
           # so set -e halts before grep runs.
           ASSETS=$(curl -sfL \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-max-time 60 \
+            --retry-all-errors \
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install actionlint
-        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        run: bash <(curl -fsSL --retry 5 --retry-delay 2 --retry-max-time 60 --retry-all-errors https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
 
       - name: Run actionlint
         run: ./actionlint
@@ -201,7 +201,13 @@ jobs:
       - name: Install Gitleaks
         run: |
           GITLEAKS_VERSION=8.30.1
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz -C /usr/local/bin gitleaks
+          curl -sSfL \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-max-time 60 \
+            --retry-all-errors \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar xz -C /usr/local/bin gitleaks
 
       - name: Run Gitleaks
         run: |

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1867,7 +1867,7 @@ jobs:
           vm0 --help
           zero --help
       - name: Install GNU parallel for bats
-        run: sudo curl -sL https://raw.githubusercontent.com/martinda/gnu-parallel/master/src/parallel -o /usr/local/bin/parallel && sudo chmod +x /usr/local/bin/parallel
+        run: sudo curl -fsSL --retry 5 --retry-delay 2 --retry-max-time 60 --retry-all-errors https://raw.githubusercontent.com/martinda/gnu-parallel/master/src/parallel -o /usr/local/bin/parallel && sudo chmod +x /usr/local/bin/parallel
       - name: Download E2E test tokens
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Summary
- add retry options to CI curl downloads for cloudflared, actionlint, gitleaks, and GNU parallel
- add retry options to read-only metadata GET calls against GitHub and Vercel APIs
- leave non-idempotent DELETE, upload, POST, and local health-check curl calls unchanged

## Tests
- git diff --check
- parsed changed action/workflow YAML files with PyYAML