### PR TITLE
chore: disable r2 cache for dev runner

### DIFF
--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -87,15 +87,10 @@ cmd_deploy() {
   log "Running setup..."
   ssh_cmd "$RUNNER_BIN setup"
 
-  # R2 creds passed as sudo args so they survive sudo's env scrub. Empty
-  # values are treated as "unset" by r2_cache.rs, matching
-  # ansible/playbooks/build-runner.yml's R2 env block. Applied to both
-  # `gc` (sweeps shared R2 objects older than 7d) and `build` (pulls
-  # cached rootfs instead of rebuilding ~3-5min locally).
-  R2_ENV="R2_ACCOUNT_ID='${R2_ACCOUNT_ID:-}' R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID:-}' R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY:-}' R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME:-}'"
-
-  # Clean up old images (keep 3 most recent deploys)
-  ssh_cmd "sudo $R2_ENV $REMOTE_BIN_DIR/runner gc --keep-latest 3"
+  # Clean up old local images (keep 3 most recent deploys). Dev runner builds
+  # guest binaries locally, so its rootfs hash does not reliably match CI's
+  # x64-built artifacts; keep R2 disabled here to avoid misleading cache misses.
+  ssh_cmd "sudo $REMOTE_BIN_DIR/runner gc --keep-latest 3"
 
   # Build unified image (rootfs + snapshot)
   PROFILES=("vm0/default")
@@ -104,7 +99,7 @@ cmd_deploy() {
   for PROFILE in "${PROFILES[@]}"; do
     log "Building $PROFILE..."
     BUILD_LOG=$(mktemp)
-    ssh_cmd "sudo $R2_ENV $REMOTE_BIN_DIR/runner build --profile $PROFILE" | tee "$BUILD_LOG"
+    ssh_cmd "sudo $REMOTE_BIN_DIR/runner build --profile $PROFILE" | tee "$BUILD_LOG"
     ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG" | cut -d= -f2)
     SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG" | cut -d= -f2)
     rm -f "$BUILD_LOG"


### PR DESCRIPTION
## Summary
- stop passing R2 credentials to dev-runner gc/build
- keep dev-runner image cleanup/build local because locally built guest binaries do not reliably match CI x64 artifacts

## Test
- bash -n scripts/dev-runner.sh