### PR TITLE
refactor(insights): restructure header with caption divider

### DIFF
--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -1096,8 +1096,8 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
             <div>
               <h1 className="text-xl font-semibold">Insights</h1>
               <p className="text-sm text-muted-foreground mt-1">
-                Monitor what your agents access, which permissions they use,
-                and spot anything unusual.
+                Monitor what your agents access, which permissions they use, and
+                spot anything unusual.
               </p>
             </div>
             {data.days.length > 0 && (

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -1091,30 +1091,33 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
     <div className="h-full overflow-auto">
       <div className="mx-auto w-full max-w-[960px] px-4 sm:px-8 py-8 flex flex-col gap-10">
         {/* Header */}
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <div className="flex items-baseline gap-2">
+        <div>
+          <div className="flex items-start justify-between gap-4">
+            <div>
               <h1 className="text-xl font-semibold">Insights</h1>
-              {data.lastUpdated && (
-                <span className="text-xs text-muted-foreground">
-                  Last updated {formatAbsoluteTime(data.lastUpdated)}
-                </span>
-              )}
+              <p className="text-sm text-muted-foreground mt-1">
+                Monitor what your agents access, which permissions they use,
+                and spot anything unusual.
+              </p>
             </div>
-            <p className="text-sm text-muted-foreground mt-1">
-              Monitor what your agents access, which permissions they use, and
-              spot anything unusual.
-            </p>
+            {data.days.length > 0 && (
+              <DateRangeFilter
+                value={dateRange}
+                onChange={setRange}
+                availableDates={data.days.map((d) => {
+                  return d.date;
+                })}
+                timezone={timezone}
+              />
+            )}
           </div>
-          {data.days.length > 0 && (
-            <DateRangeFilter
-              value={dateRange}
-              onChange={setRange}
-              availableDates={data.days.map((d) => {
-                return d.date;
-              })}
-              timezone={timezone}
-            />
+          {data.lastUpdated && (
+            <div className="mt-6 flex items-center gap-4">
+              <span className="text-xs italic text-muted-foreground whitespace-nowrap">
+                Last updated — {formatAbsoluteTime(data.lastUpdated)}
+              </span>
+              <span className="flex-1 h-px bg-border" />
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
## Summary

The Insights page header had three competing font sizes in tight vertical proximity — the bold title, the inline \"Last updated\" timestamp on the same baseline, and the description below. The timestamp visually fought with the title even though it's just metadata.

This change:
- Removes the inline timestamp from the title row, leaving the title and description as a clean two-tier hierarchy.
- Introduces an italic caption divider — `Last updated — {time}` followed by a flex-1 hairline — between the header and the day cards. The divider visually separates the header from the cards while labelling the freshness of the data below.

### Before / after

Before — three sizes competing on one row:
![before](https://www.vm0.ai/f/user_36PnTFtD4dBQ9zg5jj6E5r918aV/1303aa19-f15f-470f-9ea1-50da388775f8/image.png)

After — title + description as a unit, divider with caption between header and content:
![after](https://www.vm0.ai/f/user_36PnTFtD4dBQ9zg5jj6E5r918aV/af4f4985-39f4-4242-9c0b-4691b101526d/option_b_v2.png)

## Test plan

- [x] `pnpm vitest run src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx` — 36/36 passing locally
- [x] `pnpm lint` — clean
- [x] `pnpm check-types` — clean
- [ ] Visual review of the Insights page in the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)