### PR TITLE
fix: show all connectors in chat composer dropdown

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -382,7 +382,7 @@ function ConnectorsPopoverButton({
       ? sorted.filter((c) => {
           return matchesConnectorSearch(search, c);
         })
-      : sorted.slice(0, 20);
+      : sorted;
 
   const handleOpenChange = (open: boolean) => {
     if (open) {


### PR DESCRIPTION
## Summary

Removed the `slice(0, 20)` limit on the connector list rendered in the chat composer's connector popover so users can see and select every connector their agent has, not just the first 20.

## Changes

- `turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx`: when no search query is active, render the full sorted list instead of the first 20 entries.

## Test plan

- [ ] Open the chat composer for an agent with more than 20 connectors and verify all connectors appear in the dropdown
- [ ] Confirm search filtering still narrows the list as expected