### PR TITLE
feat(api): add auth-route wrapper, lazy-singleton helpers, and lint rules

### DIFF
--- a/turbo/apps/api/.oxlintrc.json
+++ b/turbo/apps/api/.oxlintrc.json
@@ -21,6 +21,23 @@
     }
   ],
   "rules": {
-    "no-console": "deny"
+    "no-console": "deny",
+    "no-restricted-imports": [
+      "deny",
+      {
+        "paths": [
+          {
+            "name": "@vercel/functions",
+            "importNames": ["waitUntil"],
+            "message": "Use waitUntil from signals/context/wait-until instead so detached promises stay tracked."
+          },
+          {
+            "name": "hono",
+            "allowTypeImports": true,
+            "message": "Only signals/context/hono.ts may import hono. Other signals files must use the wrappers from signals/context/hono."
+          }
+        ]
+      }
+    ]
   }
 }

--- a/turbo/apps/api/custom-eslint/__tests__/no-fn-dollar-suffix.test.ts
+++ b/turbo/apps/api/custom-eslint/__tests__/no-fn-dollar-suffix.test.ts
@@ -1,0 +1,40 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+import { noFnDollarSuffix } from "../rules/no-fn-dollar-suffix.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-fn-dollar-suffix", noFnDollarSuffix, {
+  valid: [
+    { code: "const counter$ = state(0)" },
+    { code: "const double$ = computed((get) => get(counter$) * 2)" },
+    { code: "const reset$ = command(({ set }) => set(counter$, 0))" },
+    { code: "function helper(arg) { return arg + 1 }" },
+    { code: "const helper = (arg) => arg + 1" },
+    { code: "function makeSignal() { return state(0) }" },
+    { code: "const alias$ = otherSignal$" },
+  ],
+  invalid: [
+    {
+      code: "function fetchUser$(id) { return computed(() => null) }",
+      errors: [{ messageId: "functionDeclaration" }],
+    },
+    {
+      code: "const fetchUser$ = (id) => computed(() => null)",
+      errors: [{ messageId: "arrowOrFunctionExpression" }],
+    },
+    {
+      code: "const reset$ = () => 1",
+      errors: [{ messageId: "arrowOrFunctionExpression" }],
+    },
+    {
+      code: "const fn$ = function() { return 1 }",
+      errors: [{ messageId: "arrowOrFunctionExpression" }],
+    },
+  ],
+});

--- a/turbo/apps/api/custom-eslint/__tests__/no-package-variable.test.ts
+++ b/turbo/apps/api/custom-eslint/__tests__/no-package-variable.test.ts
@@ -1,0 +1,70 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+import { noPackageVariable } from "../rules/no-package-variable.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-package-variable", noPackageVariable, {
+  valid: [
+    { code: "const MAX = 42;" },
+    { code: "const NAME = 'hello';" },
+    { code: "const count$ = state(0);" },
+    { code: "const doubled$ = computed((get) => get(count$) * 2);" },
+    { code: "const load$ = command(async () => {});" },
+    { code: "const config = Object.freeze({ key: 'value' });" },
+    { code: "const items: Readonly<Record<string, number>> = {};" },
+    { code: "const list: readonly string[] = [];" },
+    { code: "function init() { let x = 0; }" },
+    { code: "function init() { const cache = new Map(); }" },
+    { code: "const { a, b } = getConfig();" },
+    { code: "const [first, second] = getItems();" },
+    {
+      code: "const registry = new LoggerRegistry();",
+      options: [{ allowedConstructors: ["LoggerRegistry"] }],
+    },
+    {
+      code: "const tracker = new PromiseTracker();",
+      options: [{ allowedConstructors: ["PromiseTracker", "LoggerRegistry"] }],
+    },
+  ],
+  invalid: [
+    {
+      code: "let counter = 0;",
+      errors: [{ messageId: "noPackageVariable" }],
+    },
+    {
+      code: "var counter = 0;",
+      errors: [{ messageId: "noPackageVariable" }],
+    },
+    {
+      code: "const items = [];",
+      errors: [{ messageId: "noPackageVariable" }],
+    },
+    {
+      code: "const cache = {};",
+      errors: [{ messageId: "noPackageVariable" }],
+    },
+    {
+      code: "const cache = new Map();",
+      errors: [{ messageId: "noPackageVariable" }],
+    },
+    {
+      code: "const set = new Set();",
+      errors: [{ messageId: "noPackageVariable" }],
+    },
+    {
+      code: "const inst = new lib.Registry();",
+      errors: [{ messageId: "noPackageVariable" }],
+    },
+    {
+      code: "const cache = new Map();",
+      options: [{ allowedConstructors: ["LoggerRegistry"] }],
+      errors: [{ messageId: "noPackageVariable" }],
+    },
+  ],
+});

--- a/turbo/apps/api/custom-eslint/index.ts
+++ b/turbo/apps/api/custom-eslint/index.ts
@@ -1,6 +1,8 @@
 import { noCatchAbort } from "./rules/no-catch-abort.ts";
+import { noFnDollarSuffix } from "./rules/no-fn-dollar-suffix.ts";
 import { noGetterSetterParams } from "./rules/no-getter-setter-params.ts";
 import { noLoggerInfo } from "./rules/no-logger-info.ts";
+import { noPackageVariable } from "./rules/no-package-variable.ts";
 import { noTestViMocks } from "./rules/no-test-vi-mocks.ts";
 
 export const apiLintPlugin = {
@@ -10,8 +12,10 @@ export const apiLintPlugin = {
   },
   rules: {
     "no-catch-abort": noCatchAbort,
+    "no-fn-dollar-suffix": noFnDollarSuffix,
     "no-getter-setter-params": noGetterSetterParams,
     "no-logger-info": noLoggerInfo,
+    "no-package-variable": noPackageVariable,
     "no-test-vi-mocks": noTestViMocks,
   },
 };

--- a/turbo/apps/api/custom-eslint/rules/no-fn-dollar-suffix.ts
+++ b/turbo/apps/api/custom-eslint/rules/no-fn-dollar-suffix.ts
@@ -1,0 +1,83 @@
+/**
+ * ESLint rule: no-fn-dollar-suffix
+ *
+ * The `$` suffix is reserved for ccstate signals (state/computed/command).
+ * Plain functions and function expressions must not end with `$` — if you
+ * need a parameterised signal, use `command()` directly so it accepts its
+ * arguments natively, instead of wrapping a `computed()`/`command()` in a
+ * factory function.
+ *
+ * Good:
+ *   const counter$ = state(0)
+ *   const double$ = computed((get) => get(counter$) * 2)
+ *   const reset$ = command(({ set }) => set(counter$, 0))
+ *   function helper(arg: string) { ... }
+ *
+ * Bad:
+ *   function fetchUser$(id: string): Computed<User> { ... }
+ *   const fetchUser$ = (id: string): Computed<User> => computed(...)
+ *   const reset$ = () => store.set(counter$, 0)
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../utils.ts";
+
+export const noFnDollarSuffix = createRule({
+  name: "no-fn-dollar-suffix",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Functions must not end with $ — only state/computed/command results may use the $ suffix",
+      requiresTypeChecking: false,
+    },
+    schema: [],
+    messages: {
+      functionDeclaration:
+        "Function '{{name}}' must not end with $. The $ suffix is reserved for state/computed/command. Use command() with arguments directly instead of a factory function.",
+      arrowOrFunctionExpression:
+        "Variable '{{name}}' is bound to a function but ends with $. The $ suffix is reserved for state/computed/command results.",
+    },
+  },
+  create(context) {
+    function endsWithDollar(name: string): boolean {
+      return name.endsWith("$");
+    }
+
+    return {
+      FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+        const name = node.id?.name;
+        if (name && endsWithDollar(name)) {
+          context.report({
+            node: node.id ?? node,
+            messageId: "functionDeclaration",
+            data: { name },
+          });
+        }
+      },
+      VariableDeclarator(node: TSESTree.VariableDeclarator) {
+        if (node.id.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+        const name = node.id.name;
+        if (!endsWithDollar(name)) {
+          return;
+        }
+        const init = node.init;
+        if (
+          init &&
+          (init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+            init.type === AST_NODE_TYPES.FunctionExpression)
+        ) {
+          context.report({
+            node: node.id,
+            messageId: "arrowOrFunctionExpression",
+            data: { name },
+          });
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/api/custom-eslint/rules/no-package-variable.ts
+++ b/turbo/apps/api/custom-eslint/rules/no-package-variable.ts
@@ -1,0 +1,163 @@
+/**
+ * ESLint rule: no-package-variable
+ *
+ * Prevents mutable variables at package (module) scope.
+ * Use signals (state/computed) for module-level state instead.
+ *
+ * Good:
+ *   const count$ = state(0);
+ *   const config = Object.freeze({ key: 'value' });
+ *
+ * Bad:
+ *   let counter = 0;
+ *   const items = [];
+ *   const cache = new Map();
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../utils.ts";
+
+export interface NoPackageVariableOptions {
+  allowedConstructors?: string[];
+}
+
+function isPackageScope(node: TSESTree.Node): boolean {
+  let parent = node.parent;
+  while (parent) {
+    if (
+      parent.type === AST_NODE_TYPES.FunctionDeclaration ||
+      parent.type === AST_NODE_TYPES.FunctionExpression ||
+      parent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      parent.type === AST_NODE_TYPES.BlockStatement ||
+      parent.type === AST_NODE_TYPES.ClassDeclaration
+    ) {
+      return false;
+    }
+    parent = parent.parent;
+  }
+  return true;
+}
+
+function isReadonlyAnnotated(declarator: TSESTree.VariableDeclarator): boolean {
+  if (
+    declarator.id.type !== AST_NODE_TYPES.Identifier ||
+    declarator.id.typeAnnotation === null ||
+    declarator.id.typeAnnotation === undefined
+  ) {
+    return false;
+  }
+  const typeNode = declarator.id.typeAnnotation.typeAnnotation;
+  if (
+    typeNode.type === AST_NODE_TYPES.TSTypeOperator &&
+    typeNode.operator === "readonly"
+  ) {
+    return true;
+  }
+  if (
+    typeNode.type === AST_NODE_TYPES.TSTypeReference &&
+    typeNode.typeName.type === AST_NODE_TYPES.Identifier &&
+    typeNode.typeName.name === "Readonly"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function isMutableInit(
+  init: TSESTree.Expression,
+  allowedConstructors: ReadonlySet<string>,
+): boolean {
+  if (init.type === AST_NODE_TYPES.NewExpression) {
+    const callee = init.callee;
+    if (callee.type === AST_NODE_TYPES.Identifier) {
+      return !allowedConstructors.has(callee.name);
+    }
+    return true;
+  }
+  if (init.type === AST_NODE_TYPES.ArrayExpression) {
+    return true;
+  }
+  if (init.type === AST_NODE_TYPES.ObjectExpression) {
+    return true;
+  }
+  return false;
+}
+
+export const noPackageVariable = createRule<
+  [NoPackageVariableOptions] | [],
+  "noPackageVariable"
+>({
+  name: "no-package-variable",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Prevent using package scope variables",
+      recommended: true,
+      requiresTypeChecking: false,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowedConstructors: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noPackageVariable:
+        "Variable & mutable object is not allowed in package scope, use signals instead.",
+    },
+  },
+  create(context) {
+    const options = context.options[0];
+    const allowedConstructors = new Set<string>(
+      options?.allowedConstructors ?? [],
+    );
+
+    return {
+      VariableDeclaration(node: TSESTree.VariableDeclaration) {
+        if (!isPackageScope(node)) {
+          return;
+        }
+
+        if (node.kind !== "const") {
+          context.report({
+            node,
+            messageId: "noPackageVariable",
+          });
+          return;
+        }
+
+        for (const declarator of node.declarations) {
+          if (!declarator.init) {
+            continue;
+          }
+
+          if (
+            declarator.id.type === AST_NODE_TYPES.ObjectPattern ||
+            declarator.id.type === AST_NODE_TYPES.ArrayPattern
+          ) {
+            continue;
+          }
+
+          if (isReadonlyAnnotated(declarator)) {
+            continue;
+          }
+
+          if (isMutableInit(declarator.init, allowedConstructors)) {
+            context.report({
+              node: declarator,
+              messageId: "noPackageVariable",
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -1,188 +1,81 @@
 import { config, oxlint } from "@vm0/eslint-config/base";
 import { apiLintPlugin } from "./custom-eslint/index.ts";
 
+const restrictedSyntax = [
+  {
+    selector: "MemberExpression[object.name='process'][property.name='env']",
+    message:
+      "Use env(name) from lib/env (or signals/external/env) instead of process.env. process.env is only allowed in lib/env.ts.",
+  },
+  {
+    selector:
+      "CallExpression[callee.object.name='vi'][callee.property.name='stubEnv']",
+    message:
+      "Use mockEnv(name, value) from lib/env instead of vi.stubEnv. vi.stubEnv is only allowed in __tests__/env-stub.ts for module-load-time bootstrap.",
+  },
+  {
+    selector:
+      "CallExpression[callee.object.name='Date'][callee.property.name='now']",
+    message:
+      "Use now() from lib/time instead of Date.now() so tests can mock time.",
+  },
+  {
+    selector: "NewExpression[callee.name='Date'][arguments.length=0]",
+    message:
+      "Use nowDate() from lib/time instead of new Date() so tests can mock time.",
+  },
+  {
+    selector: "CallExpression[callee.name='setTimeout']",
+    message:
+      "Use delay() from the signal-timers package instead of setTimeout, and pass the correct AbortSignal.",
+  },
+  {
+    selector: "CallExpression[callee.name='setInterval']",
+    message:
+      "Use delay() from the signal-timers package instead of setInterval, and pass the correct AbortSignal.",
+  },
+  {
+    selector: "CallExpression[callee.property.name='setTimeout']",
+    message:
+      "Use delay() from the signal-timers package instead of setTimeout, and pass the correct AbortSignal.",
+  },
+  {
+    selector: "CallExpression[callee.property.name='setInterval']",
+    message:
+      "Use delay() from the signal-timers package instead of setInterval, and pass the correct AbortSignal.",
+  },
+  {
+    selector: "TryStatement",
+    message:
+      "try/catch is not allowed. Centralize guarded operations in signals/utils.ts (e.g. safeJsonParse).",
+  },
+];
+
 export default [
   ...config,
   {
+    files: ["src/**/*.ts", "custom-eslint/**/*.ts"],
     plugins: {
       api: apiLintPlugin,
     },
     rules: {
       "api/no-catch-abort": "error",
+      "api/no-fn-dollar-suffix": "error",
       "api/no-getter-setter-params": "error",
       "api/no-logger-info": "error",
     },
   },
   {
-    files: ["src/signals/**/*.ts"],
+    files: ["src/**/*.ts"],
     rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [
-            {
-              group: ["**/lib/**"],
-              message:
-                "lib/ singletons must be re-exported through signals/external/. Do not import lib/ from other signals files.",
-            },
-            {
-              regex: "^hono(/|$)",
-              allowTypeImports: true,
-              message:
-                "Only signals/**/hono.ts may import hono. Other signals files must use the wrappers from signals/context/hono.",
-            },
-          ],
-        },
-      ],
-    },
-  },
-  {
-    files: ["src/signals/external/**/*.ts"],
-    rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [
-            {
-              regex: "^hono(/|$)",
-              allowTypeImports: true,
-              message:
-                "Only signals/**/hono.ts may import hono. Other signals files must use the wrappers from signals/context/hono.",
-            },
-          ],
-        },
-      ],
-    },
-  },
-  {
-    files: ["src/signals/**/hono.ts"],
-    rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [
-            {
-              group: ["**/lib/**"],
-              message:
-                "lib/ singletons must be re-exported through signals/external/. Do not import lib/ from other signals files.",
-            },
-          ],
-        },
-      ],
-    },
-  },
-  {
-    files: ["src/signals/**/__tests__/**/*.ts", "src/signals/**/*.test.ts"],
-    rules: {
-      "no-restricted-imports": "off",
+      "api/no-package-variable": "error",
     },
   },
   {
     files: ["src/**/*.ts"],
     ignores: ["src/lib/env.ts", "src/lib/time.ts", "src/__tests__/env-stub.ts"],
     rules: {
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector:
-            "MemberExpression[object.name='process'][property.name='env']",
-          message:
-            "Use env(name) from lib/env (or signals/external/env) instead of process.env. process.env is only allowed in lib/env.ts.",
-        },
-        {
-          selector:
-            "CallExpression[callee.object.name='vi'][callee.property.name='stubEnv']",
-          message:
-            "Use mockEnv(name, value) from lib/env instead of vi.stubEnv. vi.stubEnv is only allowed in __tests__/env-stub.ts for module-load-time bootstrap.",
-        },
-        {
-          selector:
-            "CallExpression[callee.object.name='Date'][callee.property.name='now']",
-          message:
-            "Use now() from lib/time instead of Date.now() so tests can mock time.",
-        },
-        {
-          selector: "NewExpression[callee.name='Date'][arguments.length=0]",
-          message:
-            "Use nowDate() from lib/time instead of new Date() so tests can mock time.",
-        },
-        {
-          selector: "CallExpression[callee.name='setTimeout']",
-          message:
-            "Use delay() from the signal-timers package instead of setTimeout, and pass the correct AbortSignal.",
-        },
-        {
-          selector: "CallExpression[callee.name='setInterval']",
-          message:
-            "Use delay() from the signal-timers package instead of setInterval, and pass the correct AbortSignal.",
-        },
-        {
-          selector: "CallExpression[callee.property.name='setTimeout']",
-          message:
-            "Use delay() from the signal-timers package instead of setTimeout, and pass the correct AbortSignal.",
-        },
-        {
-          selector: "CallExpression[callee.property.name='setInterval']",
-          message:
-            "Use delay() from the signal-timers package instead of setInterval, and pass the correct AbortSignal.",
-        },
-        {
-          selector: "TryStatement",
-          message:
-            "try/catch is not allowed. Centralize guarded operations in signals/utils.ts (e.g. safeJsonParse).",
-        },
-      ],
-    },
-  },
-  {
-    files: ["src/signals/utils.ts"],
-    rules: {
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector:
-            "MemberExpression[object.name='process'][property.name='env']",
-          message:
-            "Use env(name) from lib/env (or signals/external/env) instead of process.env. process.env is only allowed in lib/env.ts.",
-        },
-        {
-          selector:
-            "CallExpression[callee.object.name='vi'][callee.property.name='stubEnv']",
-          message:
-            "Use mockEnv(name, value) from lib/env instead of vi.stubEnv. vi.stubEnv is only allowed in __tests__/env-stub.ts for module-load-time bootstrap.",
-        },
-        {
-          selector:
-            "CallExpression[callee.object.name='Date'][callee.property.name='now']",
-          message:
-            "Use now() from lib/time instead of Date.now() so tests can mock time.",
-        },
-        {
-          selector: "NewExpression[callee.name='Date'][arguments.length=0]",
-          message:
-            "Use nowDate() from lib/time instead of new Date() so tests can mock time.",
-        },
-        {
-          selector: "CallExpression[callee.name='setTimeout']",
-          message:
-            "Use delay() from the signal-timers package instead of setTimeout, and pass the correct AbortSignal.",
-        },
-        {
-          selector: "CallExpression[callee.name='setInterval']",
-          message:
-            "Use delay() from the signal-timers package instead of setInterval, and pass the correct AbortSignal.",
-        },
-        {
-          selector: "CallExpression[callee.property.name='setTimeout']",
-          message:
-            "Use delay() from the signal-timers package instead of setTimeout, and pass the correct AbortSignal.",
-        },
-        {
-          selector: "CallExpression[callee.property.name='setInterval']",
-          message:
-            "Use delay() from the signal-timers package instead of setInterval, and pass the correct AbortSignal.",
-        },
-      ],
+      "no-restricted-syntax": ["error", ...restrictedSyntax],
     },
   },
   {
@@ -190,52 +83,6 @@ export default [
     ignores: ["src/__tests__/env-stub.ts", "src/__tests__/mocks.ts"],
     rules: {
       "api/no-test-vi-mocks": "error",
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector:
-            "MemberExpression[object.name='process'][property.name='env']",
-          message:
-            "Use env(name) from lib/env (or signals/external/env) instead of process.env. process.env is only allowed in lib/env.ts.",
-        },
-        {
-          selector:
-            "CallExpression[callee.object.name='vi'][callee.property.name='stubEnv']",
-          message:
-            "Use mockEnv(name, value) from lib/env instead of vi.stubEnv. vi.stubEnv is only allowed in __tests__/env-stub.ts for module-load-time bootstrap.",
-        },
-        {
-          selector:
-            "CallExpression[callee.object.name='Date'][callee.property.name='now']",
-          message:
-            "Use now() from lib/time instead of Date.now() so tests can mock time.",
-        },
-        {
-          selector: "NewExpression[callee.name='Date'][arguments.length=0]",
-          message:
-            "Use nowDate() from lib/time instead of new Date() so tests can mock time.",
-        },
-        {
-          selector: "CallExpression[callee.name='setTimeout']",
-          message:
-            "Use delay() from the signal-timers package instead of setTimeout, and pass the correct AbortSignal.",
-        },
-        {
-          selector: "CallExpression[callee.name='setInterval']",
-          message:
-            "Use delay() from the signal-timers package instead of setInterval, and pass the correct AbortSignal.",
-        },
-        {
-          selector: "CallExpression[callee.property.name='setTimeout']",
-          message:
-            "Use delay() from the signal-timers package instead of setTimeout, and pass the correct AbortSignal.",
-        },
-        {
-          selector: "CallExpression[callee.property.name='setInterval']",
-          message:
-            "Use delay() from the signal-timers package instead of setInterval, and pass the correct AbortSignal.",
-        },
-      ],
     },
   },
   {

--- a/turbo/apps/api/src/__tests__/test-helpers.ts
+++ b/turbo/apps/api/src/__tests__/test-helpers.ts
@@ -11,7 +11,11 @@ import { afterEach, expect } from "vitest";
 
 import { createApp } from "../app-factory";
 import { clearMockedEnv } from "../lib/env";
-import { ROUTES, type SignalRouteHandler } from "../signals/route";
+import {
+  ROUTES,
+  type RouteEntry,
+  type SignalRouteHandler,
+} from "../signals/route";
 import { clearAllDetached } from "../signals/utils";
 import { getApiTestMocks, type ApiTestMocks } from "./mocks";
 
@@ -94,22 +98,21 @@ async function requestApp(
 function buildRoutesExtend(
   handlers: Record<string, SignalRouteHandler<unknown>>,
   contract: Record<string, AppRoute>,
-): Map<AppRoute, SignalRouteHandler<unknown>> {
-  const map = new Map<AppRoute, SignalRouteHandler<unknown>>();
+): RouteEntry[] {
+  const entries: RouteEntry[] = [];
   for (const [key, handler] of Object.entries(handlers)) {
     if (handler !== undefined) {
-      map.set(contract[key]!, handler!);
+      entries.push({ route: contract[key]!, handler });
     }
   }
-
-  return map;
+  return entries;
 }
 
 function createAppFetcher(
   context: TestContext,
-  routesExtend: ReadonlyMap<AppRoute, SignalRouteHandler<unknown>>,
+  routesExtend: readonly RouteEntry[],
 ): ApiFetcher {
-  const routes = new Map([...ROUTES, ...routesExtend]);
+  const routes = [...ROUTES, ...routesExtend];
   const app = createApp({ signal: context.signal, routes });
 
   return (args) => {

--- a/turbo/apps/api/src/app-factory.ts
+++ b/turbo/apps/api/src/app-factory.ts
@@ -1,11 +1,11 @@
 import * as Sentry from "@sentry/node";
-import type { AppRoute } from "@ts-rest/core";
+// oxlint-disable-next-line no-restricted-imports -- app-factory owns the Hono instance, confirmed by ethan@vm0.ai
 import { type Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 
 import { logger } from "./lib/log";
 import { honoSignalHandler } from "./signals/context/route";
-import { ROUTES, type SignalRouteHandler } from "./signals/route";
+import { ROUTES, type RouteEntry } from "./signals/route";
 import { isAbortError } from "./signals/utils";
 
 const L = logger("App");
@@ -37,19 +37,15 @@ function handleError(error: Error, context: Context): Response {
 
 interface CreateAppOptions {
   readonly signal: AbortSignal;
-  readonly routes?: ReadonlyMap<AppRoute, SignalRouteHandler<unknown>>;
+  readonly routes?: readonly RouteEntry[];
 }
 
 export function createApp({ routes = ROUTES, signal }: CreateAppOptions): Hono {
   const app = new Hono();
   app.onError(handleError);
 
-  for (const [contract, handler] of routes) {
-    app.on(
-      contract.method,
-      contract.path,
-      honoSignalHandler(handler, contract, signal),
-    );
+  for (const { route, handler } of routes) {
+    app.on(route.method, route.path, honoSignalHandler(handler, route, signal));
   }
 
   return app;

--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -1,13 +1,16 @@
 import "./instrument";
 import { createApp } from "./app-factory";
 
-const instanceAbortController = new AbortController();
+const app = (() => {
+  const instanceAbortController = new AbortController();
 
-process.once("SIGTERM", () => {
-  const error = new Error("Aborted due to terminated function instance");
-  error.name = "AbortError";
-  instanceAbortController.abort(error);
-});
+  process.once("SIGTERM", () => {
+    const error = new Error("Aborted due to terminated function instance");
+    error.name = "AbortError";
+    instanceAbortController.abort(error);
+  });
 
-const app = createApp({ signal: instanceAbortController.signal });
+  return createApp({ signal: instanceAbortController.signal });
+})();
+
 export default app;

--- a/turbo/apps/api/src/lib/clerk.ts
+++ b/turbo/apps/api/src/lib/clerk.ts
@@ -1,13 +1,11 @@
 import { createClerkClient } from "@clerk/backend";
 
 import { env } from "./env";
+import { lazySingleton } from "./lazy-singleton";
 
-let _client: ReturnType<typeof createClerkClient> | undefined;
-
-export function clerk(): ReturnType<typeof createClerkClient> {
-  _client ??= createClerkClient({
+export const clerk = lazySingleton((): ReturnType<typeof createClerkClient> => {
+  return createClerkClient({
     secretKey: env("CLERK_SECRET_KEY"),
     publishableKey: env("CLERK_PUBLISHABLE_KEY"),
   });
-  return _client;
-}
+});

--- a/turbo/apps/api/src/lib/db.ts
+++ b/turbo/apps/api/src/lib/db.ts
@@ -3,27 +3,25 @@ import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 
 import { env } from "./env";
+import { lazySingleton } from "./lazy-singleton";
 
-let _pool: Pool | undefined;
-let _db: NodePgDatabase<typeof schema> | undefined;
-
-function pool(): Pool {
-  _pool ??= new Pool({
+const pool = lazySingleton((): Pool => {
+  return new Pool({
     allowExitOnIdle: true,
     connectionString: env("DATABASE_URL"),
     max: 5,
   });
+});
 
-  return _pool;
-}
-
-export function db(): NodePgDatabase<typeof schema> {
-  _db ??= drizzle(pool(), { schema });
-  return _db;
-}
+export const db = lazySingleton((): NodePgDatabase<typeof schema> => {
+  return drizzle(pool(), { schema });
+});
 
 export async function closeDbPool(): Promise<void> {
-  await _pool?.end();
-  _pool = undefined;
-  _db = undefined;
+  const current = pool.peek();
+  if (current) {
+    await current.end();
+    pool.reset();
+    db.reset();
+  }
 }

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -1,6 +1,8 @@
 import { createEnv } from "@t3-oss/env-core";
 import { z, type ZodType } from "zod";
 
+import { testOverride } from "./lazy-singleton";
+
 const SCHEMA = {
   DATABASE_URL: z.string().min(1),
   CLERK_SECRET_KEY: z.string().min(1),
@@ -23,9 +25,16 @@ const baseEnv = createEnv<undefined, typeof SCHEMA>({
 type EnvShape = typeof baseEnv;
 export type EnvKey = keyof EnvShape;
 
-const overrideEnv: Partial<EnvShape> = {};
+const {
+  get: getOverrideEnv,
+  set: setOverrideEnv,
+  clear: clearOverrideEnv,
+} = testOverride<Partial<EnvShape>>(() => {
+  return {};
+});
 
 export function env<K extends EnvKey>(name: K): EnvShape[K] {
+  const overrideEnv = getOverrideEnv();
   if (Object.prototype.hasOwnProperty.call(overrideEnv, name)) {
     return overrideEnv[name] as EnvShape[K];
   }
@@ -34,11 +43,12 @@ export function env<K extends EnvKey>(name: K): EnvShape[K] {
 
 export function mockEnv<K extends EnvKey>(name: K, value: EnvShape[K]): void {
   const schema = SCHEMA[name] as ZodType;
-  overrideEnv[name] = schema.parse(value) as EnvShape[K];
+  setOverrideEnv({
+    ...getOverrideEnv(),
+    [name]: schema.parse(value) as EnvShape[K],
+  });
 }
 
 export function clearMockedEnv(): void {
-  for (const key of Object.keys(overrideEnv)) {
-    delete (overrideEnv as Record<string, unknown>)[key];
-  }
+  clearOverrideEnv();
 }

--- a/turbo/apps/api/src/lib/lazy-singleton.ts
+++ b/turbo/apps/api/src/lib/lazy-singleton.ts
@@ -1,0 +1,41 @@
+export function lazySingleton<T>(factory: () => T): {
+  (): T;
+  readonly peek: () => T | undefined;
+  readonly reset: () => void;
+} {
+  let instance: T | undefined;
+
+  const get = (): T => {
+    instance ??= factory();
+    return instance;
+  };
+
+  return Object.assign(get, {
+    peek: (): T | undefined => {
+      return instance;
+    },
+    reset: (): void => {
+      instance = undefined;
+    },
+  });
+}
+
+export function testOverride<T>(factory: () => T): {
+  readonly get: () => T;
+  readonly set: (value: T) => void;
+  readonly clear: () => void;
+} {
+  let init = factory();
+
+  return {
+    get: () => {
+      return init;
+    },
+    set: (value: T) => {
+      init = value;
+    },
+    clear: () => {
+      init = factory();
+    },
+  };
+}

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -1,4 +1,5 @@
 import { env } from "./env";
+import { lazySingleton } from "./lazy-singleton";
 
 type LogMethod = (...args: unknown[]) => void;
 
@@ -40,7 +41,9 @@ class LoggerRegistry {
   }
 }
 
-const loggerRegistry = new LoggerRegistry();
+const loggerRegistry = lazySingleton(() => {
+  return new LoggerRegistry();
+});
 
 function getDebugPatterns(): string[] {
   const value = env("VM0_DEBUG");
@@ -144,12 +147,13 @@ function createLogger(name: string): Logger {
 }
 
 export function logger(name: string): Logger {
-  const existing = loggerRegistry.get(name);
+  const registry = loggerRegistry();
+  const existing = registry.get(name);
   if (existing) {
     return existing;
   }
 
   const loggerInstance = createLogger(name);
-  loggerRegistry.set(name, loggerInstance);
+  registry.set(name, loggerInstance);
   return loggerInstance;
 }

--- a/turbo/apps/api/src/lib/time.ts
+++ b/turbo/apps/api/src/lib/time.ts
@@ -1,7 +1,15 @@
-let mockedNow: number | undefined;
+import { testOverride } from "./lazy-singleton";
+
+const {
+  get: getMockedNow,
+  set: setMockedNow,
+  clear: clearMockedNow,
+} = testOverride<number | undefined>(() => {
+  return undefined;
+});
 
 export function now(): number {
-  return mockedNow ?? Date.now();
+  return getMockedNow() ?? Date.now();
 }
 
 export function nowDate(): Date {
@@ -9,9 +17,9 @@ export function nowDate(): Date {
 }
 
 export function mockNow(value: Date | number): void {
-  mockedNow = value instanceof Date ? value.getTime() : value;
+  setMockedNow(value instanceof Date ? value.getTime() : value);
 }
 
 export function clearMockNow(): void {
-  mockedNow = undefined;
+  clearMockedNow();
 }

--- a/turbo/apps/api/src/signals/auth/__tests__/auth-context.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/auth-context.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { initContract } from "@ts-rest/core";
 import { cliTokens } from "@vm0/db/schema/cli-tokens";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
-import { computed, createStore, type Computed } from "ccstate";
+import { command, createStore, type Command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -14,7 +14,8 @@ import { now, nowDate } from "../../external/time";
 import {
   apiKeyAuthContext$,
   createAuthContext$,
-  createRequiredAuthContext$,
+  requiredAuthContext$,
+  type AuthOptions,
 } from "../auth-context";
 import { signPatJwtForTests, signSandboxJwtForTests } from "../tokens";
 
@@ -93,18 +94,39 @@ function currentSecond(): number {
   return Math.floor(now() / 1000);
 }
 
-function createAuthClient(result$: Computed<unknown>) {
+function createAuthClient(resolver$: Command<Promise<unknown>, [AbortSignal]>) {
   return setupApp({
     context,
     contract: authContextTestContract,
     handlers: {
-      get: computed(async (get): Promise<AuthContextTestRouteResponse> => {
-        const result = await get(result$);
-        return isAuthErrorResponse(result)
-          ? result
-          : { status: 200 as const, body: result };
-      }),
+      get: command(
+        async (
+          { set },
+          signal: AbortSignal,
+        ): Promise<AuthContextTestRouteResponse> => {
+          const result = await set(resolver$, signal);
+          return isAuthErrorResponse(result)
+            ? result
+            : { status: 200 as const, body: result };
+        },
+      ),
     },
+  });
+}
+
+function authContextResolver(
+  options: AuthOptions = {},
+): Command<Promise<unknown>, [AbortSignal]> {
+  return command(async ({ set }, signal: AbortSignal) => {
+    return set(createAuthContext$, options, signal);
+  });
+}
+
+function requiredAuthContextResolver(
+  options: AuthOptions,
+): Command<Promise<unknown>, [AbortSignal]> {
+  return command(async ({ set }, signal: AbortSignal) => {
+    return set(requiredAuthContext$, options, signal);
   });
 }
 
@@ -175,7 +197,7 @@ describe("auth context", () => {
     const fixture = await seedPatFixture("admin");
     fixtures.push(fixture);
 
-    const client = createAuthClient(createAuthContext$());
+    const client = createAuthClient(authContextResolver());
     const response = await accept(
       client.get({
         headers: { authorization: `Bearer ${fixture.token}` },
@@ -230,7 +252,7 @@ describe("auth context", () => {
         ),
       );
 
-    const client = createAuthClient(createAuthContext$());
+    const client = createAuthClient(authContextResolver());
     const response = await accept(
       client.get({
         headers: { authorization: `Bearer ${fixture.token}` },
@@ -252,7 +274,7 @@ describe("auth context", () => {
     });
 
     const client = createAuthClient(
-      createAuthContext$({ acceptAnySandboxCapability: true }),
+      authContextResolver({ acceptAnySandboxCapability: true }),
     );
     const response = await accept(
       client.get({
@@ -284,7 +306,7 @@ describe("auth context", () => {
     });
 
     const client = createAuthClient(
-      createAuthContext$({ requiredCapability: "file:read" }),
+      authContextResolver({ requiredCapability: "file:read" }),
     );
     const response = await accept(
       client.get({
@@ -316,7 +338,7 @@ describe("auth context", () => {
     });
 
     const client = createAuthClient(
-      createRequiredAuthContext$({ requiredCapability: "file:write" }),
+      requiredAuthContextResolver({ requiredCapability: "file:write" }),
     );
     const response = await accept(
       client.get({

--- a/turbo/apps/api/src/signals/auth/__tests__/auth-route.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/auth-route.test.ts
@@ -1,0 +1,284 @@
+import { randomUUID } from "node:crypto";
+
+import { initContract } from "@ts-rest/core";
+import { cliTokens } from "@vm0/db/schema/cli-tokens";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { command, computed, createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { closeFixtureDbPool } from "../../../__tests__/db.fixture";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { now, nowDate } from "../../external/time";
+import { clearAllDetached } from "../../utils";
+import { authContext$ } from "../auth-context";
+import { authRoute } from "../auth-route";
+import { signPatJwtForTests, signSandboxJwtForTests } from "../tokens";
+
+interface TestTokenFixture {
+  readonly token: string;
+  readonly tokenId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}
+
+const store = createStore();
+const context = testContext();
+const c = initContract();
+
+const authRouteTestContract = c.router({
+  get: {
+    method: "GET",
+    path: "/__test/auth-route",
+    headers: z.object({
+      authorization: z.string().optional(),
+    }),
+    responses: {
+      200: z.unknown(),
+      401: z.object({
+        error: z.object({
+          message: z.string(),
+          code: z.literal("UNAUTHORIZED"),
+        }),
+      }),
+      403: z.object({
+        error: z.object({
+          message: z.string(),
+          code: z.literal("FORBIDDEN"),
+        }),
+      }),
+    },
+  },
+});
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+async function seedPatFixture(
+  role: "admin" | "member",
+): Promise<TestTokenFixture> {
+  const tokenId = randomUUID();
+  const userId = `user_${randomUUID()}`;
+  const orgId = `org_${randomUUID()}`;
+  const nowSeconds = currentSecond();
+  const token = signPatJwtForTests({
+    scope: "cli",
+    userId,
+    orgId,
+    tokenId,
+    iat: nowSeconds,
+    exp: nowSeconds + 60,
+  });
+  const writeDb = store.set(writeDb$);
+
+  await writeDb.insert(cliTokens).values({
+    id: tokenId,
+    token,
+    userId,
+    name: "test token",
+    expiresAt: new Date(now() + 60_000),
+  });
+  await writeDb.insert(orgMembersCache).values({
+    orgId,
+    userId,
+    role,
+    cachedAt: nowDate(),
+  });
+
+  return { token, tokenId, userId, orgId };
+}
+
+async function deletePatFixture(fixture: TestTokenFixture): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(orgMembersCache)
+    .where(
+      and(
+        eq(orgMembersCache.orgId, fixture.orgId),
+        eq(orgMembersCache.userId, fixture.userId),
+      ),
+    );
+  await writeDb.delete(cliTokens).where(eq(cliTokens.id, fixture.tokenId));
+}
+
+async function loadCliToken(
+  tokenId: string,
+): Promise<{ lastUsedAt: Date | null } | undefined> {
+  const writeDb = store.set(writeDb$);
+  const [record] = await writeDb
+    .select({ lastUsedAt: cliTokens.lastUsedAt })
+    .from(cliTokens)
+    .where(eq(cliTokens.id, tokenId))
+    .limit(1);
+  return record;
+}
+
+describe("authRoute", () => {
+  const fixtures: TestTokenFixture[] = [];
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await deletePatFixture(fixture);
+      }
+    }
+  });
+
+  afterAll(async () => {
+    await closeFixtureDbPool();
+  });
+
+  it("invokes the inner handler with authContext$ accessible", async () => {
+    const fixture = await seedPatFixture("admin");
+    fixtures.push(fixture);
+
+    const handler$ = computed((get) => {
+      const ctx = get(authContext$);
+      return { status: 200 as const, body: ctx };
+    });
+
+    const client = setupApp({
+      context,
+      contract: authRouteTestContract,
+      handlers: { get: authRoute({}, handler$) },
+    });
+    const response = await accept(
+      client.get({
+        headers: { authorization: `Bearer ${fixture.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body).toEqual({
+      tokenType: "pat",
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      orgRole: "admin",
+    });
+  });
+
+  it("returns 401 when no credentials are presented", async () => {
+    const handler$ = computed(() => {
+      return { status: 200 as const, body: { ok: true } };
+    });
+
+    const client = setupApp({
+      context,
+      contract: authRouteTestContract,
+      handlers: { get: authRoute({}, handler$) },
+    });
+    const response = await accept(client.get(), [401]);
+
+    expect(response.body).toEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 when sandbox token lacks the required capability", async () => {
+    const token = signSandboxJwtForTests({
+      scope: "sandbox",
+      userId: "user_sandbox",
+      orgId: "org_sandbox",
+      runId: "run_sandbox",
+      iat: currentSecond(),
+      exp: currentSecond() + 60,
+    });
+
+    const handler$ = computed(() => {
+      return { status: 200 as const, body: { ok: true } };
+    });
+
+    const client = setupApp({
+      context,
+      contract: authRouteTestContract,
+      handlers: {
+        get: authRoute({ requiredCapability: "file:read" }, handler$),
+      },
+    });
+    const response = await accept(
+      client.get({ headers: { authorization: `Bearer ${token}` } }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("rejects credential types not in accept list with 403", async () => {
+    const fixture = await seedPatFixture("member");
+    fixtures.push(fixture);
+
+    const handler$ = computed(() => {
+      return { status: 200 as const, body: { ok: true } };
+    });
+
+    const client = setupApp({
+      context,
+      contract: authRouteTestContract,
+      handlers: {
+        get: authRoute({ accept: ["session"] }, handler$),
+      },
+    });
+    const response = await accept(
+      client.get({
+        headers: { authorization: `Bearer ${fixture.token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("supports a Command inner handler with the abort signal", async () => {
+    const fixture = await seedPatFixture("member");
+    fixtures.push(fixture);
+
+    const handler$ = command((_visitor, _signal: AbortSignal) => {
+      return { status: 200 as const, body: { resolved: true } };
+    });
+
+    const client = setupApp({
+      context,
+      contract: authRouteTestContract,
+      handlers: { get: authRoute({}, handler$) },
+    });
+    const response = await accept(
+      client.get({
+        headers: { authorization: `Bearer ${fixture.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body).toEqual({ resolved: true });
+  });
+
+  it("updates lastUsedAt on the cli token after PAT auth", async () => {
+    const fixture = await seedPatFixture("member");
+    fixtures.push(fixture);
+
+    expect((await loadCliToken(fixture.tokenId))?.lastUsedAt).toBeNull();
+
+    const handler$ = computed(() => {
+      return { status: 200 as const, body: { ok: true } };
+    });
+
+    const client = setupApp({
+      context,
+      contract: authRouteTestContract,
+      handlers: { get: authRoute({}, handler$) },
+    });
+    await accept(
+      client.get({
+        headers: { authorization: `Bearer ${fixture.token}` },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    const after = await loadCliToken(fixture.tokenId);
+    expect(after?.lastUsedAt).not.toBeNull();
+  });
+});

--- a/turbo/apps/api/src/signals/auth/__tests__/runner-auth.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/runner-auth.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { initContract } from "@ts-rest/core";
 import { cliTokens } from "@vm0/db/schema/cli-tokens";
-import { computed, createStore } from "ccstate";
+import { command, createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -43,8 +43,8 @@ function createClient() {
     context,
     contract: runnerAuthTestContract,
     handlers: {
-      get: computed(async (get) => {
-        return { status: 200 as const, body: await get(runnerAuth$) };
+      get: command(async ({ set }, signal: AbortSignal) => {
+        return { status: 200 as const, body: await set(runnerAuth$, signal) };
       }),
     },
   });

--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -1,171 +1,63 @@
-import { cliTokens } from "@vm0/db/schema/cli-tokens";
-import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
-import { and, eq, gt } from "drizzle-orm";
-import { computed, type Computed } from "ccstate";
+import { command, computed, state, type Computed } from "ccstate";
 
-import { request$ } from "../context/hono";
-import { db$ } from "../external/db";
-import { membershipsByUserId } from "../external/clerk";
-import { now, nowDate } from "../external/time";
+import { waitUntil } from "../context/wait-until";
 import {
   isPatToken,
   isSandboxToken,
   verifyCliToken,
   verifySandboxToken,
   verifyZeroToken,
-  type CliAuth,
-  type ZeroCapability,
 } from "./tokens";
-import { clerkSessionAuth$, type ApiOrgRole } from "./clerk-session";
+import { clerkSessionAuth$ } from "./clerk-session";
+import { ZeroCapability } from "@vm0/api-contracts";
+import { AuthContext, CliAuth, ZeroAuthContext } from "../../types/auth";
+import {
+  cliTokenRecord,
+  memberRole,
+  updateCliTokenLastUsedAt$,
+} from "../services/auth.service";
+import { authorization$, cookie$ } from "../context/hono";
 
-type SessionAuthContext =
-  | {
-      readonly tokenType: "session";
-      readonly userId: string;
-      readonly orgId: string;
-      readonly orgRole: ApiOrgRole;
-    }
-  | {
-      readonly tokenType: "session";
-      readonly userId: string;
-      readonly orgId?: undefined;
-      readonly orgRole?: undefined;
-    };
-
-interface PatAuthContext {
-  readonly tokenType: "pat";
-  readonly userId: string;
-  readonly orgId: string;
-  readonly orgRole: ApiOrgRole;
-}
-
-interface SandboxAuthContext {
-  readonly tokenType: "sandbox";
-  readonly userId: string;
-  readonly orgId: string;
-  readonly runId: string;
-}
-
-interface ZeroAuthContext {
-  readonly tokenType: "zero";
-  readonly userId: string;
-  readonly orgId: string;
-  readonly orgRole?: ApiOrgRole;
-  readonly runId: string;
-  readonly capabilities: readonly ZeroCapability[];
-}
-
-type AuthContext =
-  | SessionAuthContext
-  | PatAuthContext
-  | SandboxAuthContext
-  | ZeroAuthContext;
-
-interface AuthOptions {
+export interface AuthOptions {
   readonly requiredCapability?: ZeroCapability;
   readonly acceptAnySandboxCapability?: boolean;
 }
 
-type AuthErrorResponse = {
+export type AuthErrorResponse = {
   readonly status: 401 | 403;
   readonly body: {
     readonly error: { readonly message: string; readonly code: string };
   };
 };
 
-interface CliTokenRecord {
-  readonly userId: string;
-  readonly orgId: string;
-}
+const innerAuthContext$ = state<AuthContext | null>(null);
 
-export const authorizationHeader$ = computed((get) => {
-  return get(request$).header("authorization");
+export const authContext$: Computed<AuthContext> = computed((get) => {
+  const ctx = get(innerAuthContext$);
+  if (ctx === null) {
+    throw new Error("authContext$ accessed outside an authRoute scope");
+  }
+  return ctx;
 });
 
-function mapClerkRole(role: string): ApiOrgRole {
-  return role === "org:admin" ? "admin" : "member";
-}
+export const setAuthContext$ = command(({ set }, ctx: AuthContext): void => {
+  set(innerAuthContext$, ctx);
+});
 
-function createMemberRole$(
-  orgId: string,
-  userId: string,
-): Computed<Promise<{ role: ApiOrgRole } | null>> {
-  return computed(async (get): Promise<{ role: ApiOrgRole } | null> => {
-    const db = get(db$);
-    const [cached] = await db
-      .select({
-        role: orgMembersCache.role,
-        cachedAt: orgMembersCache.cachedAt,
-      })
-      .from(orgMembersCache)
-      .where(
-        and(
-          eq(orgMembersCache.orgId, orgId),
-          eq(orgMembersCache.userId, userId),
-        ),
-      )
-      .limit(1);
-
-    const currentTime = now();
-    if (cached && currentTime - cached.cachedAt.getTime() < 60_000) {
-      const role: ApiOrgRole = cached.role === "admin" ? "admin" : "member";
-      return { role };
-    }
-
-    const memberships = await get(membershipsByUserId(userId));
-    const membership = memberships.data.find((candidate) => {
-      return candidate.organization.id === orgId;
-    });
-
-    if (!membership) {
-      return null;
-    }
-
-    const role = mapClerkRole(membership.role);
-    return { role };
-  });
-}
-
-export function createCliTokenRecord$(
-  cliAuth: CliAuth,
-): Computed<Promise<CliTokenRecord | null>> {
-  return computed(async (get): Promise<CliTokenRecord | null> => {
-    const db = get(db$);
-    const currentDate = nowDate();
-    const [record] = await db
-      .select()
-      .from(cliTokens)
-      .where(
-        and(
-          eq(cliTokens.id, cliAuth.tokenId),
-          gt(cliTokens.expiresAt, currentDate),
-        ),
-      )
-      .limit(1);
-
-    if (!record) {
-      return null;
-    }
-
-    return {
-      userId: cliAuth.userId,
-      orgId: cliAuth.orgId,
-    };
-  });
-}
-
-function createCliAuth$(
-  cliAuth: CliAuth,
-): Computed<Promise<AuthContext | null>> {
-  return computed(async (get): Promise<AuthContext | null> => {
-    const resolved = await get(createCliTokenRecord$(cliAuth));
+const cliAuth$ = command(
+  async (
+    { get, set },
+    cliAuth: CliAuth,
+    signal: AbortSignal,
+  ): Promise<AuthContext | null> => {
+    const resolved = await get(cliTokenRecord(cliAuth));
     if (!resolved) {
       return null;
     }
 
-    const membership = await get(
-      createMemberRole$(resolved.orgId, resolved.userId),
-    );
+    waitUntil(set(updateCliTokenLastUsedAt$, cliAuth.tokenId, signal));
+
+    const membership = await get(memberRole(resolved.orgId, resolved.userId));
     if (!membership) {
       return null;
     }
@@ -176,8 +68,8 @@ function createCliAuth$(
       orgId: resolved.orgId,
       orgRole: membership.role,
     };
-  });
-}
+  },
+);
 
 function resolveSandboxAuth(
   token: string,
@@ -200,7 +92,7 @@ function resolveSandboxAuth(
   return null;
 }
 
-function createZeroAuth$(
+function zeroAuth(
   token: string,
   options: AuthOptions,
 ): Computed<Promise<AuthContext | null>> {
@@ -227,9 +119,7 @@ function createZeroAuth$(
       capabilities: [...zeroAuth.capabilities],
     };
 
-    const membership = await get(
-      createMemberRole$(zeroAuth.orgId, zeroAuth.userId),
-    );
+    const membership = await get(memberRole(zeroAuth.orgId, zeroAuth.userId));
     if (!membership) {
       return result;
     }
@@ -238,7 +128,7 @@ function createZeroAuth$(
   });
 }
 
-function createSandboxTokenAuth$(
+function sandboxTokenAuth(
   token: string,
   options: AuthOptions,
 ): Computed<Promise<AuthContext | null>> {
@@ -249,45 +139,59 @@ function createSandboxTokenAuth$(
 
     return (
       resolveSandboxAuth(token, options) ??
-      (await get(createZeroAuth$(token, options)))
+      (await get(zeroAuth(token, options)))
     );
   });
 }
 
-function createResolvedAuthContext$(
-  authHeader: string | undefined,
-  options: AuthOptions,
-): Computed<Promise<AuthContext | null>> {
-  return computed(async (get): Promise<AuthContext | null> => {
-    if (authHeader?.startsWith("Bearer ")) {
-      const token = authHeader.substring(7);
+const resolvedAuthContext$ = command(
+  async (
+    { get, set },
+    options: AuthOptions,
+    signal: AbortSignal,
+  ): Promise<AuthContext | null> => {
+    const authHeader = get(authorization$);
 
-      if (isPatToken(token)) {
-        const cliAuth = verifyCliToken(token);
-        return cliAuth ? get(createCliAuth$(cliAuth)) : null;
+    if (!authHeader?.startsWith("Bearer ")) {
+      if (!get(cookie$)) {
+        return null;
       }
-
-      if (isSandboxToken(token)) {
-        const cliAuth = verifyCliToken(token);
-        if (cliAuth) {
-          return get(createCliAuth$(cliAuth));
-        }
-
-        return get(createSandboxTokenAuth$(token, options));
-      }
+      return await get(clerkSessionAuth$);
     }
 
-    return get(clerkSessionAuth$);
-  });
-}
+    const token = authHeader.substring(7);
 
-export function createAuthContext$(
-  options: AuthOptions = {},
-): Computed<Promise<AuthContext | null>> {
-  return computed(async (get) => {
-    return get(createResolvedAuthContext$(get(authorizationHeader$), options));
-  });
-}
+    if (isPatToken(token)) {
+      const cliAuth = verifyCliToken(token);
+      if (!cliAuth) {
+        return null;
+      }
+
+      return await set(cliAuth$, cliAuth, signal);
+    }
+
+    if (isSandboxToken(token)) {
+      const cliAuth = verifyCliToken(token);
+      if (!cliAuth) {
+        return await get(sandboxTokenAuth(token, options));
+      }
+
+      return await set(cliAuth$, cliAuth, signal);
+    }
+
+    return null;
+  },
+);
+
+export const createAuthContext$ = command(
+  async (
+    { set },
+    options: AuthOptions,
+    signal: AbortSignal,
+  ): Promise<AuthContext | null> => {
+    return await set(resolvedAuthContext$, options, signal);
+  },
+);
 
 function missingCapabilityError(capability: ZeroCapability): AuthErrorResponse {
   return {
@@ -330,14 +234,14 @@ function sandboxTokenAuthError(
   };
 }
 
-export function createRequiredAuthContext$(
-  options: AuthOptions = {},
-): Computed<Promise<AuthContext | AuthErrorResponse>> {
-  return computed(async (get): Promise<AuthContext | AuthErrorResponse> => {
-    const authHeader = get(authorizationHeader$);
-    const authContext = await get(
-      createResolvedAuthContext$(authHeader, options),
-    );
+export const requiredAuthContext$ = command(
+  async (
+    { get, set },
+    options: AuthOptions,
+    signal: AbortSignal,
+  ): Promise<AuthContext | AuthErrorResponse> => {
+    const authHeader = get(authorization$);
+    const authContext = await set(resolvedAuthContext$, options, signal);
     if (authContext) {
       return authContext;
     }
@@ -355,33 +259,36 @@ export function createRequiredAuthContext$(
         error: { message: "Not authenticated", code: "UNAUTHORIZED" },
       },
     };
-  });
-}
+  },
+);
 
-export const apiKeyAuthContext$: Computed<
-  Promise<AuthContext | AuthErrorResponse>
-> = computed(async (get) => {
-  const unauthorized: AuthErrorResponse = {
-    status: 401,
-    body: {
-      error: { message: "API key required", code: "UNAUTHORIZED" },
-    },
-  };
+export const apiKeyAuthContext$ = command(
+  async (
+    { get, set },
+    signal: AbortSignal,
+  ): Promise<AuthContext | AuthErrorResponse> => {
+    const UNAUTHORIZED: AuthErrorResponse = {
+      status: 401,
+      body: {
+        error: { message: "API key required", code: "UNAUTHORIZED" },
+      },
+    };
 
-  const authHeader = get(authorizationHeader$);
-  if (!authHeader?.startsWith("Bearer ")) {
-    return unauthorized;
-  }
+    const authHeader = get(authorization$);
+    if (!authHeader?.startsWith("Bearer ")) {
+      return UNAUTHORIZED;
+    }
 
-  const token = authHeader.substring(7);
-  if (!isPatToken(token)) {
-    return unauthorized;
-  }
+    const token = authHeader.substring(7);
+    if (!isPatToken(token)) {
+      return UNAUTHORIZED;
+    }
 
-  const authContext = await get(createResolvedAuthContext$(authHeader, {}));
-  if (!authContext || authContext.tokenType !== "pat") {
-    return unauthorized;
-  }
+    const authContext = await set(resolvedAuthContext$, {}, signal);
+    if (!authContext || authContext.tokenType !== "pat") {
+      return UNAUTHORIZED;
+    }
 
-  return authContext;
-});
+    return authContext;
+  },
+);

--- a/turbo/apps/api/src/signals/auth/auth-route.ts
+++ b/turbo/apps/api/src/signals/auth/auth-route.ts
@@ -1,0 +1,57 @@
+import { command, type Command } from "ccstate";
+
+import type { SignalRouteHandler } from "../context/route";
+import type { AuthTokenType } from "../../types/auth";
+import {
+  requiredAuthContext$,
+  setAuthContext$,
+  type AuthErrorResponse,
+  type AuthOptions,
+} from "./auth-context";
+
+interface AuthRouteOptions extends AuthOptions {
+  readonly accept?: readonly AuthTokenType[];
+}
+
+const FORBIDDEN_TOKEN_TYPE: AuthErrorResponse = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "This endpoint does not accept the provided credential type",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+function isCommand<T>(
+  handler$: SignalRouteHandler<T>,
+): handler$ is Command<T, [AbortSignal]> {
+  return "write" in handler$;
+}
+
+export function authRoute<T>(
+  options: AuthRouteOptions,
+  handler$: SignalRouteHandler<T>,
+): Command<Promise<T | AuthErrorResponse>, [AbortSignal]> {
+  return command(
+    async (
+      { get, set },
+      signal: AbortSignal,
+    ): Promise<T | AuthErrorResponse> => {
+      const result = await set(requiredAuthContext$, options, signal);
+      if ("status" in result) {
+        return result;
+      }
+
+      if (options.accept && !options.accept.includes(result.tokenType)) {
+        return FORBIDDEN_TOKEN_TYPE;
+      }
+
+      set(setAuthContext$, result);
+
+      return isCommand(handler$)
+        ? await set(handler$, signal)
+        : await get(handler$);
+    },
+  );
+}

--- a/turbo/apps/api/src/signals/auth/clerk-session.ts
+++ b/turbo/apps/api/src/signals/auth/clerk-session.ts
@@ -3,13 +3,12 @@ import { computed, type Computed } from "ccstate";
 
 import { request$ } from "../context/hono";
 import { clerk$ } from "../external/clerk";
+import { ApiOrgRole } from "../../types/auth";
 
 type SignedInSessionAuthObject = Extract<
   SessionAuthObject,
   { isAuthenticated: true }
 >;
-
-export type ApiOrgRole = "admin" | "member";
 
 type ClerkSessionAuthContext =
   | {

--- a/turbo/apps/api/src/signals/auth/runner-auth.ts
+++ b/turbo/apps/api/src/signals/auth/runner-auth.ts
@@ -1,9 +1,14 @@
 import { timingSafeEqual } from "node:crypto";
 
-import { computed, type Computed } from "ccstate";
+import { command } from "ccstate";
 
+import { authorization$ } from "../context/hono";
+import { waitUntil } from "../context/wait-until";
 import { env } from "../external/env";
-import { authorizationHeader$, createCliTokenRecord$ } from "./auth-context";
+import {
+  cliTokenRecord,
+  updateCliTokenLastUsedAt$,
+} from "../services/auth.service";
 import { isPatToken, isSandboxToken, verifyCliToken } from "./tokens";
 
 const OFFICIAL_RUNNER_TOKEN_PREFIX = "vm0_official_";
@@ -27,9 +32,12 @@ function validateOfficialRunnerSecret(providedSecret: string): boolean {
   return timingSafeEqual(providedBuffer, expectedBuffer);
 }
 
-export const runnerAuth$: Computed<Promise<RunnerAuthContext | null>> =
-  computed(async (get): Promise<RunnerAuthContext | null> => {
-    const authHeader = get(authorizationHeader$);
+export const runnerAuth$ = command(
+  async (
+    { get, set },
+    signal: AbortSignal,
+  ): Promise<RunnerAuthContext | null> => {
+    const authHeader = get(authorization$);
     if (!authHeader?.startsWith("Bearer ")) {
       return null;
     }
@@ -42,10 +50,14 @@ export const runnerAuth$: Computed<Promise<RunnerAuthContext | null>> =
         return null;
       }
 
-      const resolved = await get(createCliTokenRecord$(cliAuth));
-      return resolved
-        ? { type: "user" as const, userId: resolved.userId }
-        : null;
+      const resolved = await get(cliTokenRecord(cliAuth));
+      if (!resolved) {
+        return null;
+      }
+
+      waitUntil(set(updateCliTokenLastUsedAt$, cliAuth.tokenId, signal));
+
+      return { type: "user" as const, userId: resolved.userId };
     }
 
     if (token.startsWith(OFFICIAL_RUNNER_TOKEN_PREFIX)) {
@@ -56,4 +68,5 @@ export const runnerAuth$: Computed<Promise<RunnerAuthContext | null>> =
     }
 
     return null;
-  });
+  },
+);

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -2,15 +2,20 @@ import { createHmac, hkdfSync } from "node:crypto";
 
 import {
   ZERO_CAPABILITIES,
-  type ZeroCapability,
+  ZeroCapability,
 } from "@vm0/api-contracts/contracts/composes";
 import { z } from "zod";
 
 import { env } from "../external/env";
+import { lazySingleton } from "../external/lazy-singleton";
 import { now } from "../external/time";
 import { safeJsonParse } from "../utils";
-
-export type { ZeroCapability };
+import {
+  CliAuth,
+  ComposeJobAuth,
+  SandboxAuth,
+  ZeroAuth,
+} from "../../types/auth";
 
 const SANDBOX_TOKEN_PREFIX = "vm0_sandbox_";
 const PAT_TOKEN_PREFIX = "vm0_pat_";
@@ -61,30 +66,6 @@ type JwtPayload =
   | z.infer<typeof cliTokenPayloadSchema>
   | z.infer<typeof composeJobTokenPayloadSchema>;
 
-interface SandboxAuth {
-  readonly userId: string;
-  readonly runId: string;
-  readonly orgId: string;
-}
-
-interface ZeroAuth {
-  readonly userId: string;
-  readonly runId: string;
-  readonly orgId: string;
-  readonly capabilities: readonly ZeroCapability[];
-}
-
-export interface CliAuth {
-  readonly userId: string;
-  readonly orgId: string;
-  readonly tokenId: string;
-}
-
-interface ComposeJobAuth {
-  readonly userId: string;
-  readonly jobId: string;
-}
-
 function base64UrlEncode(data: Buffer | string): string {
   const buffer = typeof data === "string" ? Buffer.from(data) : data;
   return buffer.toString("base64url");
@@ -101,12 +82,9 @@ function deriveJwtKey(): Buffer {
   );
 }
 
-let cachedJwtKey: Buffer | undefined;
-
-function getJwtKey(): Buffer {
-  cachedJwtKey ??= deriveJwtKey();
-  return cachedJwtKey;
-}
+const getJwtKey = lazySingleton((): Buffer => {
+  return deriveJwtKey();
+});
 
 function signJwt(payload: JwtPayload): string {
   const header = { alg: "HS256", typ: "JWT" };

--- a/turbo/apps/api/src/signals/context/hono.ts
+++ b/turbo/apps/api/src/signals/context/hono.ts
@@ -17,15 +17,18 @@ function header(name: string) {
 }
 
 export const userAgent$ = header("User-Agent");
+export const authorization$ = header("authorization");
+export const cookie$ = header("cookie");
 
 // Response Headers
-export const resUserAgent$ = resHeader("User-Agent");
 function resHeader(name: string) {
   return computed((get) => {
     const context = get(innerHonoContext$);
     return context.res.headers.get(name);
   });
 }
+
+export const resUserAgent$ = resHeader("User-Agent");
 
 // Request
 export const request$ = computed((get) => {

--- a/turbo/apps/api/src/signals/context/wait-until.ts
+++ b/turbo/apps/api/src/signals/context/wait-until.ts
@@ -1,3 +1,4 @@
+// oxlint-disable-next-line no-restricted-imports -- this file is the wrapper around @vercel/functions waitUntil, confirmed by ethan@vm0.ai
 import { waitUntil as vercelWaitUntil } from "@vercel/functions";
 
 import { detach, Mechanism } from "../utils";

--- a/turbo/apps/api/src/signals/external/lazy-singleton.ts
+++ b/turbo/apps/api/src/signals/external/lazy-singleton.ts
@@ -1,0 +1,1 @@
+export { lazySingleton } from "../../lib/lazy-singleton";

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -9,7 +9,18 @@ import { apiHealth$, apiHealthAuth$ } from "./routes/health";
 
 export type { SignalRouteHandler };
 
-export const ROUTES = new Map<AppRoute, SignalRouteHandler<unknown>>([
-  [healthContract.check, apiHealth$],
-  [healthAuthContract.check, apiHealthAuth$],
-]);
+export interface RouteEntry {
+  readonly route: AppRoute;
+  readonly handler: SignalRouteHandler<unknown>;
+}
+
+export const ROUTES: readonly RouteEntry[] = [
+  {
+    route: healthContract.check,
+    handler: apiHealth$,
+  },
+  {
+    route: healthAuthContract.check,
+    handler: apiHealthAuth$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/health.ts
+++ b/turbo/apps/api/src/signals/routes/health.ts
@@ -4,39 +4,16 @@ import {
   type HealthRouteResponse,
 } from "@vm0/api-contracts/contracts";
 
-import { createAuthContext$ } from "../auth/auth-context";
-import { request$ } from "../context/hono";
+import { authRoute } from "../auth/auth-route";
 
 export const apiHealth$ = computed<Promise<HealthRouteResponse>>(async () => {
   await Promise.resolve();
   return { status: 200, body: { status: "ok" } };
 });
 
-export const apiHealthAuth$ = computed(
-  async (get): Promise<HealthAuthRouteResponse> => {
-    const request = get(request$);
-    const hasCredentials =
-      request.header("authorization") || request.header("cookie");
-
-    if (!hasCredentials) {
-      return {
-        status: 401,
-        body: {
-          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
-        },
-      };
-    }
-
-    const authContext = await get(createAuthContext$());
-    if (!authContext) {
-      return {
-        status: 401,
-        body: {
-          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
-        },
-      };
-    }
-
-    return { status: 200, body: { status: "ok" } };
-  },
+export const apiHealthAuth$ = authRoute(
+  {},
+  computed((): HealthAuthRouteResponse => {
+    return { status: 200 as const, body: { status: "ok" } };
+  }),
 );

--- a/turbo/apps/api/src/signals/services/auth.service.ts
+++ b/turbo/apps/api/src/signals/services/auth.service.ts
@@ -1,0 +1,95 @@
+import { command, computed, type Computed } from "ccstate";
+import { cliTokens } from "@vm0/db/schema/cli-tokens";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { and, eq, gt } from "drizzle-orm";
+
+import { membershipsByUserId } from "../external/clerk";
+import { db$, writeDb$ } from "../external/db";
+import { now, nowDate } from "../external/time";
+import {
+  type ApiOrgRole,
+  type CliAuth,
+  type CliTokenRecord,
+} from "../../types/auth";
+
+function mapClerkRole(role: string): ApiOrgRole {
+  return role === "org:admin" ? "admin" : "member";
+}
+
+export const updateCliTokenLastUsedAt$ = command(
+  async ({ set }, tokenId: string, _signal: AbortSignal): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .update(cliTokens)
+      .set({ lastUsedAt: nowDate() })
+      .where(eq(cliTokens.id, tokenId));
+  },
+);
+
+export function memberRole(
+  orgId: string,
+  userId: string,
+): Computed<Promise<{ role: ApiOrgRole } | null>> {
+  return computed(async (get): Promise<{ role: ApiOrgRole } | null> => {
+    const db = get(db$);
+    const [cached] = await db
+      .select({
+        role: orgMembersCache.role,
+        cachedAt: orgMembersCache.cachedAt,
+      })
+      .from(orgMembersCache)
+      .where(
+        and(
+          eq(orgMembersCache.orgId, orgId),
+          eq(orgMembersCache.userId, userId),
+        ),
+      )
+      .limit(1);
+
+    const currentTime = now();
+    if (cached && currentTime - cached.cachedAt.getTime() < 60_000) {
+      const role: ApiOrgRole = cached.role === "admin" ? "admin" : "member";
+      return { role };
+    }
+
+    const memberships = await get(membershipsByUserId(userId));
+    const membership = memberships.data.find((candidate) => {
+      return candidate.organization.id === orgId;
+    });
+
+    if (!membership) {
+      return null;
+    }
+
+    const role = mapClerkRole(membership.role);
+    return { role };
+  });
+}
+
+export function cliTokenRecord(
+  cliAuth: CliAuth,
+): Computed<Promise<CliTokenRecord | null>> {
+  return computed(async (get): Promise<CliTokenRecord | null> => {
+    const db = get(db$);
+    const currentDate = nowDate();
+    const [record] = await db
+      .select()
+      .from(cliTokens)
+      .where(
+        and(
+          eq(cliTokens.id, cliAuth.tokenId),
+          gt(cliTokens.expiresAt, currentDate),
+        ),
+      )
+      .limit(1);
+
+    if (!record) {
+      return null;
+    }
+
+    return {
+      userId: cliAuth.userId,
+      orgId: cliAuth.orgId,
+    };
+  });
+}

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -1,4 +1,5 @@
 import { env } from "./external/env";
+import { lazySingleton } from "./external/lazy-singleton";
 import { logger } from "./external/log";
 
 export enum Mechanism {
@@ -14,7 +15,9 @@ class PromiseTracker {
   descriptions = new Map<Promise<unknown>, string>();
 }
 
-const tracker = new PromiseTracker();
+const tracker = lazySingleton(() => {
+  return new PromiseTracker();
+});
 
 export function isAbortError(error: unknown): boolean {
   return (
@@ -30,6 +33,7 @@ function throwIfAbort(error: unknown): void {
 }
 
 export function safeJsonParse(input: string): unknown {
+  // eslint-disable-next-line no-restricted-syntax -- this is the centralized guarded JSON.parse
   try {
     return JSON.parse(input);
   } catch (error) {
@@ -53,26 +57,26 @@ export function detach(
   );
 
   if (IN_VITEST) {
-    tracker.collected.add(silenced);
-    tracker.mechanisms.set(silenced, mechanism);
+    tracker().collected.add(silenced);
+    tracker().mechanisms.set(silenced, mechanism);
     if (description) {
-      tracker.descriptions.set(silenced, description);
+      tracker().descriptions.set(silenced, description);
     }
   }
 }
 
 export async function clearAllDetached(): Promise<void> {
   if (!IN_VITEST) {
-    tracker.collected.clear();
-    tracker.mechanisms.clear();
-    tracker.descriptions.clear();
+    tracker().collected.clear();
+    tracker().mechanisms.clear();
+    tracker().descriptions.clear();
     return;
   }
 
-  for (const promise of tracker.collected) {
+  for (const promise of tracker().collected) {
     await promise;
   }
-  tracker.collected.clear();
-  tracker.mechanisms.clear();
-  tracker.descriptions.clear();
+  tracker().collected.clear();
+  tracker().mechanisms.clear();
+  tracker().descriptions.clear();
 }

--- a/turbo/apps/api/src/types/auth.ts
+++ b/turbo/apps/api/src/types/auth.ts
@@ -1,0 +1,77 @@
+import { ZeroCapability } from "@vm0/api-contracts";
+
+export type ApiOrgRole = "admin" | "member";
+
+type SessionAuthContext =
+  | {
+      readonly tokenType: "session";
+      readonly userId: string;
+      readonly orgId: string;
+      readonly orgRole: ApiOrgRole;
+    }
+  | {
+      readonly tokenType: "session";
+      readonly userId: string;
+      readonly orgId?: undefined;
+      readonly orgRole?: undefined;
+    };
+
+interface PatAuthContext {
+  readonly tokenType: "pat";
+  readonly userId: string;
+  readonly orgId: string;
+  readonly orgRole: ApiOrgRole;
+}
+
+interface SandboxAuthContext {
+  readonly tokenType: "sandbox";
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+}
+
+export interface ZeroAuthContext {
+  readonly tokenType: "zero";
+  readonly userId: string;
+  readonly orgId: string;
+  readonly orgRole?: ApiOrgRole;
+  readonly runId: string;
+  readonly capabilities: readonly ZeroCapability[];
+}
+
+export type AuthContext =
+  | SessionAuthContext
+  | PatAuthContext
+  | SandboxAuthContext
+  | ZeroAuthContext;
+
+export type AuthTokenType = AuthContext["tokenType"];
+
+export interface CliTokenRecord {
+  readonly userId: string;
+  readonly orgId: string;
+}
+
+export interface SandboxAuth {
+  readonly userId: string;
+  readonly runId: string;
+  readonly orgId: string;
+}
+
+export interface ZeroAuth {
+  readonly userId: string;
+  readonly runId: string;
+  readonly orgId: string;
+  readonly capabilities: readonly ZeroCapability[];
+}
+
+export interface CliAuth {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly tokenId: string;
+}
+
+export interface ComposeJobAuth {
+  readonly userId: string;
+  readonly jobId: string;
+}


### PR DESCRIPTION
## Summary

Build on the existing auth-context to provide a route-level wrapper, a shared service module, and helpers for lazy singletons / test overrides. Add custom lint rules so future code follows the same conventions.

## Auth refactor

- Add `authRoute(options, handler)` wrapper that resolves required auth via `createRequiredAuthContext`, short-circuits 401/403, narrows by `options.accept` (returning 403 on tokenType mismatch), exposes the resolved AuthContext via ambient `authContext` atom, and forwards the signal to the inner Computed/Command.
- Convert the auth resolution chain (`cliAuth`, `resolvedAuthContext`, `createAuthContext`, `requiredAuthContext`, `apiKeyAuthContext`, `runnerAuth`) to direct Commands taking `signal: AbortSignal` as the last arg.
- Extract reusable auth helpers (`memberRole`, `cliTokenRecord`, `updateCliTokenLastUsedAt`) into `signals/services/auth.service.ts` and shared types into `types/auth.ts`.
- Restore the `lastUsedAt` fire-and-forget update at the CLI token verification site via `waitUntil`.
- Fix `authorization` and `cookie` helpers in `signals/context/hono.ts` that were reading response headers instead of request headers.
- Rewrite `apiHealthAuth` to `authRoute({}, computed(...))`.

## Lazy singletons

- Add `lib/lazy-singleton.ts` exposing `lazySingleton` and `testOverride`.
- Re-export `lazySingleton` through `signals/external/lazy-singleton.ts`.
- Rewrite `db`, `clerk`, `log`, `tokens` (JWT key cache), `env`, `time`, and `signals/utils` `PromiseTracker` to use the new helpers.

## Lint rules

- Add `api/no-fn-dollar-suffix` forbidding function declarations and arrow/function expressions assigned to a `$`-suffixed variable; the `$` suffix is reserved for `state/computed/command` results.
- Add `api/no-package-variable` (migrated from platform) forbidding mutable module-scope state; allowed constructors are specified in `eslint.config.mjs`.
- Migrate the hono import restriction to oxlint's `no-restricted-imports` alongside the existing `waitUntil` block. Use line-level `oxlint-disable` in `app-factory` and `signals/context/wait-until` for the legitimate exceptions.
- Consolidate the `no-restricted-syntax` blocks in `eslint.config.mjs` into a single shared list with an inline disable for the centralized `safeJsonParse` try/catch.

## Other

- ROUTES is now a `readonly RouteEntry[]` (instead of a Map) so `app-factory` and test helpers iterate by destructuring `{ route, handler }`.

## Test plan
- [ ] \`pnpm -F api lint\`
- [ ] \`pnpm -F api check-types\`
- [ ] \`pnpm -F api exec vitest run\`
- [ ] \`pnpm knip\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)