### PR TITLE
feat: add chat artifacts drawer

### DIFF
--- a/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
@@ -171,6 +171,56 @@ describe("zero web upload-file command", () => {
       const parsed = JSON.parse(stdout) as Record<string, unknown>;
       expect(parsed.contentType).toBe("text/csv");
     });
+
+    it("should infer text/html for html files", async () => {
+      const filePath = join(tmpDir, "preview.html");
+      writeFileSync(filePath, "<!doctype html><title>Preview</title>");
+
+      let putReceivedContentType: string | null = null;
+
+      server.use(
+        http.post(PREPARE_URL, async ({ request }) => {
+          const body = (await request.json()) as {
+            filename: string;
+            contentType: string;
+          };
+          expect(body.filename).toBe("preview.html");
+          expect(body.contentType).toBe("text/html");
+
+          return HttpResponse.json(
+            {
+              id: "html-uuid",
+              filename: "preview.html",
+              contentType: "text/html",
+              size: 37,
+              uploadUrl: PUT_URL,
+              url: "https://presigned.example.com/html-uuid/preview.html",
+            },
+            { status: 200 },
+          );
+        }),
+        http.put(PUT_URL, ({ request }) => {
+          putReceivedContentType = request.headers.get("content-type");
+          return new HttpResponse(null, { status: 200 });
+        }),
+        http.post(COMPLETE_URL, () => {
+          return HttpResponse.json({
+            id: "html-uuid",
+            filename: "preview.html",
+            contentType: "text/html",
+            size: 37,
+            url: "https://presigned.example.com/html-uuid/preview.html",
+          });
+        }),
+      );
+
+      await uploadFileCommand.parseAsync(["node", "cli", "-f", filePath]);
+
+      expect(putReceivedContentType).toBe("text/html");
+      const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+      const parsed = JSON.parse(stdout) as Record<string, unknown>;
+      expect(parsed.contentType).toBe("text/html");
+    });
   });
 
   describe("validation errors", () => {

--- a/turbo/apps/cli/src/commands/zero/web/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/web/upload-file.ts
@@ -23,7 +23,7 @@ Notes:
   - Returned URL is permanent (serves a short-lived signed redirect on access)
   - Safe to persist in chat messages or share over external channels
   - Max file size: 1 GB
-  - Allowed types: png / jpeg / gif / webp / svg / mp4 / webm / mov / pdf / txt / csv / md / json`,
+  - Allowed types: png / jpeg / gif / webp / svg / mp4 / webm / mov / pdf / txt / csv / md / html / json`,
   )
   .action(
     withErrorHandler(

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -24,6 +24,8 @@ const MIME_BY_EXTENSION: Record<string, string> = {
   ".txt": "text/plain",
   ".csv": "text/csv",
   ".md": "text/markdown",
+  ".html": "text/html",
+  ".htm": "text/html",
   ".json": "application/json",
 };
 

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -16,6 +16,7 @@ import {
   chatThreadByIdContract,
   chatThreadMarkReadContract,
   chatThreadMessagesContract,
+  chatThreadArtifactsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ComposeListItem } from "@vm0/api-contracts/contracts/composes";
 import { mockApi } from "../msw-contract.ts";
@@ -141,6 +142,11 @@ export const apiAgentsHandlers = [
   // GET /api/zero/chat-threads/:threadId/messages (paged messages)
   mockApi(chatThreadMessagesContract.list, ({ respond }) => {
     return respond(200, { messages: [] });
+  }),
+
+  // GET /api/zero/chat-threads/:threadId/artifacts
+  mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+    return respond(200, { runs: [] });
   }),
 
   // GET /api/zero/chat-threads/:id (thread detail)

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -885,9 +885,9 @@ function createArtifacts(
     await get(groupedChatMessages$);
     get(internalArtifactsReload$);
     const client = get(zeroClient$)(chatThreadArtifactsContract);
-    const result = (await accept(client.list({ params: { threadId } }), [200], {
+    const result = await accept(client.list({ params: { threadId } }), [200], {
       toast: false,
-    })) as { body: { runs: ChatThreadArtifactRun[] } };
+    });
     return result.body.runs;
   });
 

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -24,9 +24,11 @@ import { prepareUserMessageFromDraft$ } from "./resolve-draft-attachments.ts";
 import { reloadChatThreads$, type ChatThread } from "../agent-chat.ts";
 import {
   chatMessagesContract,
+  chatThreadArtifactsContract,
   chatThreadByIdContract,
   chatThreadMarkReadContract,
   chatThreadMessagesContract,
+  type ChatThreadArtifactRun,
   type ModelSelectionRequest,
   type PersistedAttachment,
   type PagedChatMessage,
@@ -194,6 +196,12 @@ export interface ChatThreadSignals {
   rotatingPhrase$: Computed<string>;
   donePhrase$: Computed<string>;
   runPhraseLoop$: Command<Promise<void>, [AbortSignal]>;
+  // ── Artifacts drawer ─────────────────────────────────────────────────────
+  artifacts$: Computed<Promise<ChatThreadArtifactRun[]>>;
+  artifactsDrawerOpen$: Computed<boolean>;
+  setArtifactsDrawerOpen$: Command<void, [boolean]>;
+  artifactPreviewKey$: Computed<string | null>;
+  setArtifactPreviewKey$: Command<void, [string | null]>;
 }
 
 export interface LocalChatThreadSnapshot {
@@ -868,6 +876,44 @@ function createLoadHistoryCommand({
   });
 }
 
+function createArtifacts(
+  threadId: string,
+  groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>,
+) {
+  const artifacts$ = computed(async (get): Promise<ChatThreadArtifactRun[]> => {
+    await get(groupedChatMessages$);
+    const client = get(zeroClient$)(chatThreadArtifactsContract);
+    const result = (await accept(client.list({ params: { threadId } }), [200], {
+      toast: false,
+    })) as { body: { runs: ChatThreadArtifactRun[] } };
+    return result.body.runs;
+  });
+
+  const internalDrawerOpen$ = state(false);
+  const artifactsDrawerOpen$ = computed((get) => {
+    return get(internalDrawerOpen$);
+  });
+  const setArtifactsDrawerOpen$ = command(({ set }, open: boolean) => {
+    set(internalDrawerOpen$, open);
+  });
+
+  const internalPreviewKey$ = state<string | null>(null);
+  const artifactPreviewKey$ = computed((get) => {
+    return get(internalPreviewKey$);
+  });
+  const setArtifactPreviewKey$ = command(({ set }, key: string | null) => {
+    set(internalPreviewKey$, key);
+  });
+
+  return {
+    artifacts$,
+    artifactsDrawerOpen$,
+    setArtifactsDrawerOpen$,
+    artifactPreviewKey$,
+    setArtifactPreviewKey$,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Draft cache
 // ---------------------------------------------------------------------------
@@ -1359,6 +1405,13 @@ export function createChatThreadSignals(
   const { setInputRef$, focusInput$ } = createInputRef();
   const { blockColors$, rotatingPhrase$, donePhrase$, runPhraseLoop$ } =
     createPhraseLoop(groupedChatMessages$, allFinished$);
+  const {
+    artifacts$,
+    artifactsDrawerOpen$,
+    setArtifactsDrawerOpen$,
+    artifactPreviewKey$,
+    setArtifactPreviewKey$,
+  } = createArtifacts(threadId, groupedChatMessages$);
 
   // Status of the currently-active run, sourced from threadData$.activeRuns.
   // `chatThreadRunUpdated` Ably events trigger reloadThread$, so this signal
@@ -1408,5 +1461,10 @@ export function createChatThreadSignals(
     rotatingPhrase$,
     donePhrase$,
     runPhraseLoop$,
+    artifacts$,
+    artifactsDrawerOpen$,
+    setArtifactsDrawerOpen$,
+    artifactPreviewKey$,
+    setArtifactPreviewKey$,
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -880,8 +880,10 @@ function createArtifacts(
   threadId: string,
   groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>,
 ) {
+  const internalArtifactsReload$ = state(0);
   const artifacts$ = computed(async (get): Promise<ChatThreadArtifactRun[]> => {
     await get(groupedChatMessages$);
+    get(internalArtifactsReload$);
     const client = get(zeroClient$)(chatThreadArtifactsContract);
     const result = (await accept(client.list({ params: { threadId } }), [200], {
       toast: false,
@@ -894,6 +896,11 @@ function createArtifacts(
     return get(internalDrawerOpen$);
   });
   const setArtifactsDrawerOpen$ = command(({ set }, open: boolean) => {
+    if (open) {
+      set(internalArtifactsReload$, (version) => {
+        return version + 1;
+      });
+    }
     set(internalDrawerOpen$, open);
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { http, HttpResponse } from "msw";
@@ -618,6 +618,8 @@ describe("zero chat thread page display - header agent avatar flicker fix", () =
 
 describe("zero chat thread page display - artifacts drawer", () => {
   it("opens a drawer with uploaded files grouped by run when enabled", async () => {
+    const user = userEvent.setup();
+    let artifactsRequests = 0;
     mockChatLifecycle({
       chatMessages: [
         {
@@ -629,7 +631,18 @@ describe("zero chat thread page display - artifacts drawer", () => {
       ],
     });
     server.use(
+      http.get("https://example.com/chart.png", () => {
+        return new HttpResponse(new Blob(["img"], { type: "image/png" }), {
+          headers: { "Content-Type": "image/png" },
+        });
+      }),
+      http.get("https://example.com/data.csv", () => {
+        return new HttpResponse("label,value\nalpha,1\n", {
+          headers: { "Content-Type": "text/csv" },
+        });
+      }),
       mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        artifactsRequests += 1;
         return respond(200, {
           runs: [
             {
@@ -641,7 +654,6 @@ describe("zero chat thread page display - artifacts drawer", () => {
                   contentType: "image/png",
                   size: 4096,
                   url: "https://example.com/chart.png",
-                  messageId: "msg-1",
                   createdAt: "2026-03-10T00:00:00Z",
                 },
                 {
@@ -650,7 +662,6 @@ describe("zero chat thread page display - artifacts drawer", () => {
                   contentType: "text/csv",
                   size: 2048,
                   url: "https://example.com/data.csv",
-                  messageId: "msg-1",
                   createdAt: "2026-03-10T00:00:00Z",
                 },
               ],
@@ -659,6 +670,13 @@ describe("zero chat thread page display - artifacts drawer", () => {
         });
       }),
     );
+    const createObjectURLSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:artifact-download");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
 
     detachedSetupPage({
       context,
@@ -669,6 +687,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
     const button = await waitFor(() => {
       return screen.getByRole("button", { name: "Open artifacts" });
     });
+    expect(artifactsRequests).toBe(0);
     click(button);
 
     await waitFor(() => {
@@ -676,15 +695,50 @@ describe("zero chat thread page display - artifacts drawer", () => {
         screen.getByRole("heading", { name: "Artifacts" }),
       ).toBeInTheDocument();
     });
+    expect(artifactsRequests).toBeGreaterThan(0);
     expect(
       screen.getByRole("img", { name: "Preview chart.png" }),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByRole("link", { name: "Download chart.png" })[0],
-    ).toHaveAttribute("href", "https://example.com/chart.png?download=1");
+      screen.queryByRole("link", { name: "Download chart.png" }),
+    ).not.toBeInTheDocument();
+    await user.click(
+      screen.getAllByRole("button", { name: "Download chart.png" })[0]!,
+    );
+    await waitFor(() => {
+      expect(createObjectURLSpy).toHaveBeenCalledOnce();
+      expect(anchorClickSpy).toHaveBeenCalledOnce();
+    });
     expect(screen.getAllByText("chart.png").length).toBeGreaterThan(0);
     expect(screen.getByText("data.csv")).toBeInTheDocument();
-    expect(screen.getAllByText(/Run run-art/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/2 runs/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Run run-art/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "View run" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Show preview for chart.png" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Open chart.png" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Preview chart.png" }));
+
+    const lightbox = await screen.findByTestId("attachment-lightbox");
+    await user.click(within(lightbox).getByRole("button", { name: "Close" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("attachment-lightbox"),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("heading", { name: "Artifacts" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Select data.csv" }));
+    expect(screen.getByTitle("Preview data.csv")).toBeInTheDocument();
   });
 
   it("hides the artifacts button when the feature switch is off", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -685,59 +685,39 @@ describe("zero chat thread page display - artifacts drawer", () => {
     });
 
     const button = await waitFor(() => {
-      return screen.getByRole("button", { name: "Open artifacts" });
+      return screen.getByLabelText("Open artifacts");
     });
     expect(artifactsRequests).toBe(0);
     click(button);
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "Artifacts" }),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Artifacts")).toBeInTheDocument();
     });
     expect(artifactsRequests).toBeGreaterThan(0);
-    expect(
-      screen.getByRole("img", { name: "Preview chart.png" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "Download chart.png" }),
-    ).not.toBeInTheDocument();
-    await user.click(
-      screen.getAllByRole("button", { name: "Download chart.png" })[0]!,
-    );
+    expect(screen.getByLabelText("Preview chart.png")).toBeInTheDocument();
+    const downloadButtons = screen.getAllByLabelText("Download chart.png");
+    expect(downloadButtons[0]!.tagName).toBe("BUTTON");
+    await user.click(downloadButtons[0]!);
     await waitFor(() => {
       expect(createObjectURLSpy).toHaveBeenCalledOnce();
       expect(anchorClickSpy).toHaveBeenCalledOnce();
     });
     expect(screen.getAllByText("chart.png").length).toBeGreaterThan(0);
     expect(screen.getByText("data.csv")).toBeInTheDocument();
-    expect(screen.queryByText(/2 runs/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Run run-art/i)).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "View run" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Show preview for chart.png" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "Open chart.png" }),
-    ).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Preview chart.png" }));
+    await user.click(screen.getByLabelText("Preview chart.png"));
 
     const lightbox = await screen.findByTestId("attachment-lightbox");
-    await user.click(within(lightbox).getByRole("button", { name: "Close" }));
+    await user.click(within(lightbox).getByLabelText("Close"));
 
     await waitFor(() => {
       expect(
         screen.queryByTestId("attachment-lightbox"),
       ).not.toBeInTheDocument();
     });
-    expect(
-      screen.getByRole("heading", { name: "Artifacts" }),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Artifacts")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Select data.csv" }));
+    await user.click(screen.getByLabelText("Select data.csv"));
     expect(screen.getByTitle("Preview data.csv")).toBeInTheDocument();
   });
 
@@ -755,9 +735,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
         screen.getByText("Send a message to start the conversation"),
       ).toBeInTheDocument();
     });
-    expect(
-      screen.queryByRole("button", { name: "Open artifacts" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Open artifacts")).not.toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -5,8 +5,10 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   mockChatLifecycle,
   mockSubagentThread,
@@ -611,6 +613,97 @@ describe("zero chat thread page display - header agent avatar flicker fix", () =
       'a[aria-label="View agent profile"]',
     );
     expect(avatarLinks).toHaveLength(1);
+  });
+});
+
+describe("zero chat thread page display - artifacts drawer", () => {
+  it("opens a drawer with uploaded files grouped by run when enabled", async () => {
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "See attached",
+          runId: "run-artifacts-1",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-artifacts-1",
+              files: [
+                {
+                  id: "file-1",
+                  filename: "chart.png",
+                  contentType: "image/png",
+                  size: 4096,
+                  url: "https://example.com/chart.png",
+                  messageId: "msg-1",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+                {
+                  id: "file-2",
+                  filename: "data.csv",
+                  contentType: "text/csv",
+                  size: 2048,
+                  url: "https://example.com/data.csv",
+                  messageId: "msg-1",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.ChatArtifactsDrawer]: true },
+    });
+
+    const button = await waitFor(() => {
+      return screen.getByRole("button", { name: "Open artifacts" });
+    });
+    click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Artifacts" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("img", { name: "Preview chart.png" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("link", { name: "Download chart.png" })[0],
+    ).toHaveAttribute("href", "https://example.com/chart.png?download=1");
+    expect(screen.getAllByText("chart.png").length).toBeGreaterThan(0);
+    expect(screen.getByText("data.csv")).toBeInTheDocument();
+    expect(screen.getAllByText(/Run run-art/i).length).toBeGreaterThan(0);
+  });
+
+  it("hides the artifacts button when the feature switch is off", async () => {
+    mockChatLifecycle();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.ChatArtifactsDrawer]: false },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Send a message to start the conversation"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: "Open artifacts" }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -303,11 +303,11 @@ function fetchBlobOrOpen(
     });
 }
 
-function downloadAttachmentUrl(
+export function downloadAttachmentUrl(
   url: string,
   signal: AbortSignal,
+  filename = filenameFromUrl(url),
 ): Promise<void> {
-  const filename = filenameFromUrl(url);
   return fetchBlobOrOpen(url, signal).then((blob) => {
     if (blob !== null) {
       triggerBlobDownload(blob, filename);
@@ -330,7 +330,8 @@ function ImageLightbox({ url }: { url: string }) {
     <div
       ref={dialogRef}
       tabIndex={-1}
-      className="fixed inset-0 z-[9999] isolate flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-200 outline-none"
+      className="pointer-events-auto fixed inset-0 z-[9999] isolate flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-200 outline-none"
+      style={{ pointerEvents: "auto" }}
       onClick={handleBackdropClick}
       role="dialog"
       aria-modal="true"
@@ -398,7 +399,8 @@ export function AttachmentLightbox() {
     <div
       ref={dialogRef}
       tabIndex={-1}
-      className="fixed inset-0 z-[9999] isolate flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-200 outline-none"
+      className="pointer-events-auto fixed inset-0 z-[9999] isolate flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-200 outline-none"
+      style={{ pointerEvents: "auto" }}
       onClick={handleBackdropClick}
       role="dialog"
       aria-modal="true"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -18,9 +18,20 @@ import {
   IconPin,
   IconVolume2,
   IconArrowBarToUp,
+  IconDownload,
+  IconEye,
+  IconExternalLink,
+  IconFile,
+  IconFiles,
+  IconVideo,
 } from "@tabler/icons-react";
 import {
   cn,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
   Skeleton,
   Tooltip,
   TooltipContent,
@@ -71,6 +82,7 @@ import type {
   GroupedChatMessageGroup,
   PagedChatMessage,
 } from "../../signals/chat-page/chat-message.ts";
+import type { ChatThreadArtifactFile } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
 import type { ChatThread } from "../../signals/agent-chat.ts";
 import { ATTACH_ONLY_PLACEHOLDER } from "../../signals/chat-page/resolve-draft-attachments.ts";
@@ -186,6 +198,65 @@ function PinPillButton({ thread }: { thread: ChatThreadSignals }) {
   );
 }
 
+function useArtifactCount(thread: ChatThreadSignals): number | null {
+  const runs = useLastResolved(thread.artifacts$);
+  if (!runs) {
+    return null;
+  }
+  return runs.reduce((sum, run) => {
+    return sum + run.files.length;
+  }, 0);
+}
+
+function ArtifactsButton({ thread }: { thread: ChatThreadSignals }) {
+  const features = useLastResolved(featureSwitch$);
+  const enabled = features?.[FeatureSwitchKey.ChatArtifactsDrawer] ?? false;
+
+  if (!enabled) {
+    return null;
+  }
+
+  return <ArtifactsButtonInner thread={thread} />;
+}
+
+function ArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
+  const open = useGet(thread.artifactsDrawerOpen$);
+  const setOpen = useSet(thread.setArtifactsDrawerOpen$);
+  const count = useArtifactCount(thread);
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(true);
+            }}
+            className={cn(
+              "inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-sm transition-colors duration-150",
+              open
+                ? "bg-primary/10 text-primary"
+                : "text-muted-foreground/70 hover:bg-accent hover:text-foreground",
+            )}
+            aria-label="Open artifacts"
+            aria-pressed={open}
+          >
+            <IconFiles size={17} stroke={1.5} />
+            <span>Artifacts</span>
+            {count !== null && count > 0 && (
+              <span className="rounded-full bg-muted px-1.5 py-0.5 text-[11px] leading-none text-muted-foreground">
+                {count}
+              </span>
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Open artifacts</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   const displayName = useLastResolved(thread.agentDisplayName$);
   const autoRead = useGet(autoReadEnabled$);
@@ -207,6 +278,7 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
         )}
       </div>
       <div className="hidden sm:flex items-center gap-0.5">
+        <ArtifactsButton thread={thread} />
         {audioOutputEnabled && (
           <TooltipProvider delayDuration={300}>
             <Tooltip>
@@ -243,6 +315,501 @@ interface ZeroChatThreadPageProps {
   thread: ChatThreadSignals;
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ["KB", "MB", "GB"] as const;
+  let value = bytes / 1024;
+  for (let i = 0; i < units.length; i++) {
+    const unit = units[i]!;
+    if (value < 1024 || i === units.length - 1) {
+      return `${value.toFixed(value >= 10 ? 0 : 1)} ${unit}`;
+    }
+    value = value / 1024;
+  }
+  return `${bytes} B`;
+}
+
+function formatArtifactTime(value: string): string {
+  return new Date(value).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function withDownloadParam(url: string): string {
+  return `${url}${url.includes("?") ? "&" : "?"}download=1`;
+}
+
+type ChatArtifactItem = {
+  runId: string;
+  file: ChatThreadArtifactFile;
+};
+
+type ArtifactPreviewKind = "image" | "video" | "document" | "file";
+
+function artifactItemKey(item: ChatArtifactItem): string {
+  return `${item.runId}:${item.file.messageId}:${item.file.id}`;
+}
+
+function getFileExtension(filename: string): string {
+  const ext = filename.split(".").pop();
+  return ext && ext !== filename ? ext.toUpperCase() : "FILE";
+}
+
+function getArtifactPreviewKind(
+  file: ChatThreadArtifactFile,
+): ArtifactPreviewKind {
+  const contentType = file.contentType.toLowerCase();
+  const filename = file.filename.toLowerCase();
+
+  if (contentType.startsWith("image/") || isImageFilename(filename)) {
+    return "image";
+  }
+  if (contentType.startsWith("video/") || isVideoFilename(filename)) {
+    return "video";
+  }
+  if (
+    contentType === "application/pdf" ||
+    contentType === "application/json" ||
+    contentType === "text/csv" ||
+    (contentType.startsWith("text/") && contentType !== "text/html") ||
+    /\.(pdf|txt|md|csv|json|log)$/i.test(filename)
+  ) {
+    return "document";
+  }
+  return "file";
+}
+
+function flattenArtifactRuns(
+  runs: { runId: string; files: ChatThreadArtifactFile[] }[],
+): ChatArtifactItem[] {
+  return runs.flatMap((run) => {
+    return run.files.map((file) => {
+      return { runId: run.runId, file };
+    });
+  });
+}
+
+function ArtifactFileIcon({ file }: { file: ChatThreadArtifactFile }) {
+  const previewKind = getArtifactPreviewKind(file);
+  if (previewKind === "image") {
+    return <IconPhoto size={18} stroke={1.5} />;
+  }
+  if (previewKind === "video") {
+    return <IconVideo size={18} stroke={1.5} />;
+  }
+  return <IconFile size={18} stroke={1.5} />;
+}
+
+function ArtifactPreviewOpenAction({
+  file,
+  className,
+}: {
+  file: ChatThreadArtifactFile;
+  className: string;
+}) {
+  const openImageLightbox = useSet(openAttachmentImageLightbox$);
+  const previewKind = getArtifactPreviewKind(file);
+
+  if (previewKind === "image") {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          openImageLightbox(file.url);
+        }}
+        className={className}
+        aria-label={`Preview ${file.filename}`}
+      >
+        <IconEye size={16} stroke={1.5} />
+      </button>
+    );
+  }
+
+  return (
+    <a
+      href={file.url}
+      target="_blank"
+      rel="noreferrer"
+      className={className}
+      aria-label={`Preview ${file.filename}`}
+    >
+      <IconEye size={16} stroke={1.5} />
+    </a>
+  );
+}
+
+function ArtifactDownloadAction({
+  file,
+  className,
+}: {
+  file: ChatThreadArtifactFile;
+  className: string;
+}) {
+  return (
+    <a
+      href={withDownloadParam(file.url)}
+      download={file.filename}
+      className={className}
+      aria-label={`Download ${file.filename}`}
+    >
+      <IconDownload size={16} stroke={1.5} />
+    </a>
+  );
+}
+
+function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
+  const openImageLightbox = useSet(openAttachmentImageLightbox$);
+  const previewKind = getArtifactPreviewKind(file);
+
+  if (previewKind === "image") {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          openImageLightbox(file.url);
+        }}
+        className="group relative flex h-full w-full items-center justify-center overflow-hidden bg-muted"
+        aria-label={`Preview ${file.filename}`}
+      >
+        <img
+          src={file.url}
+          alt={`Preview ${file.filename}`}
+          className="h-full w-full object-contain"
+        />
+        <span className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-150 group-hover:bg-black/25 group-hover:opacity-100">
+          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-black/50 text-white shadow-lg">
+            <IconEye size={18} stroke={1.8} />
+          </span>
+        </span>
+      </button>
+    );
+  }
+
+  if (previewKind === "video") {
+    return (
+      <video
+        src={file.url}
+        controls
+        preload="metadata"
+        className="h-full w-full bg-black object-contain"
+      />
+    );
+  }
+
+  if (previewKind === "document") {
+    return (
+      <iframe
+        src={file.url}
+        title={`Preview ${file.filename}`}
+        className="h-full w-full bg-background"
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-muted/40 p-8 text-center">
+      <span className="flex h-16 w-16 items-center justify-center rounded-lg border border-border/70 bg-background text-muted-foreground shadow-sm">
+        <IconFile size={30} stroke={1.4} />
+      </span>
+      <div className="min-w-0">
+        <p className="text-xs font-medium uppercase text-muted-foreground">
+          {getFileExtension(file.filename)}
+        </p>
+        <p className="mt-1 max-w-[260px] truncate text-sm text-foreground">
+          {file.filename}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ArtifactPreviewPanel({ item }: { item: ChatArtifactItem }) {
+  const { file, runId } = item;
+  const actionClass =
+    "flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground";
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/70 bg-background shadow-sm">
+      <div className="h-[260px] border-b border-border/60 bg-muted/30">
+        <ArtifactPreviewFrame file={file} />
+      </div>
+      <div className="flex items-start gap-3 px-3 py-3">
+        <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          <ArtifactFileIcon file={file} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-foreground">
+            {file.filename}
+          </p>
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+            <span>{formatBytes(file.size)}</span>
+            <span aria-hidden>·</span>
+            <span>{getFileExtension(file.filename)}</span>
+            <span aria-hidden>·</span>
+            <span>Run {runId.slice(0, 8)}</span>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <ArtifactPreviewOpenAction file={file} className={actionClass} />
+          <ArtifactDownloadAction file={file} className={actionClass} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ArtifactThumbnail({
+  file,
+  selected,
+  onPreview,
+}: {
+  file: ChatThreadArtifactFile;
+  selected: boolean;
+  onPreview: () => void;
+}) {
+  const previewKind = getArtifactPreviewKind(file);
+
+  return (
+    <button
+      type="button"
+      onClick={onPreview}
+      className={cn(
+        "group relative flex h-14 w-20 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-muted/60 transition-colors",
+        selected
+          ? "border-primary/60 ring-2 ring-primary/15"
+          : "border-border/70 hover:border-foreground/25",
+      )}
+      aria-label={`Show preview for ${file.filename}`}
+    >
+      {previewKind === "image" ? (
+        <img
+          src={file.url}
+          alt=""
+          className="h-full w-full object-cover"
+          aria-hidden="true"
+        />
+      ) : (
+        <span className="flex flex-col items-center gap-0.5 text-muted-foreground">
+          <ArtifactFileIcon file={file} />
+          <span className="max-w-14 truncate text-[10px] font-medium">
+            {getFileExtension(file.filename)}
+          </span>
+        </span>
+      )}
+      <span className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-150 group-hover:bg-black/25 group-hover:opacity-100">
+        <IconEye size={17} className="text-white drop-shadow" />
+      </span>
+    </button>
+  );
+}
+
+function ArtifactFileRow({
+  item,
+  selected,
+  onPreview,
+}: {
+  item: ChatArtifactItem;
+  selected: boolean;
+  onPreview: () => void;
+}) {
+  const { file } = item;
+  const actionClass =
+    "flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground";
+
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-3 rounded-lg border px-3 py-2.5 transition-colors",
+        selected
+          ? "border-primary/40 bg-primary/5"
+          : "border-border/60 bg-background/70 hover:bg-muted/25",
+      )}
+    >
+      <ArtifactThumbnail
+        file={file}
+        selected={selected}
+        onPreview={onPreview}
+      />
+      <div className="min-w-0 flex-1">
+        <button
+          type="button"
+          onClick={onPreview}
+          className="block max-w-full truncate text-left text-sm font-medium text-foreground underline-offset-2 hover:underline"
+          title={file.filename}
+        >
+          {file.filename}
+        </button>
+        <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+          <span>{formatBytes(file.size)}</span>
+          <span aria-hidden>·</span>
+          <span>{getFileExtension(file.filename)}</span>
+          <span aria-hidden>·</span>
+          <span>{formatArtifactTime(file.createdAt)}</span>
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          onClick={onPreview}
+          className={actionClass}
+          aria-label={`Show preview for ${file.filename}`}
+        >
+          <IconEye size={16} stroke={1.5} />
+        </button>
+        <a
+          href={file.url}
+          target="_blank"
+          rel="noreferrer"
+          className={actionClass}
+          aria-label={`Open ${file.filename}`}
+        >
+          <IconExternalLink size={16} stroke={1.5} />
+        </a>
+        <ArtifactDownloadAction file={file} className={actionClass} />
+      </div>
+    </div>
+  );
+}
+
+function ChatArtifactsDrawerContent({ thread }: { thread: ChatThreadSignals }) {
+  const loadable = useLastLoadable(thread.artifacts$);
+  const selectedArtifactKey = useGet(thread.artifactPreviewKey$);
+  const setSelectedArtifactKey = useSet(thread.setArtifactPreviewKey$);
+
+  if (loadable.state === "loading") {
+    return (
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 4 }, (_, i) => {
+          return <Skeleton key={i} className="h-16 rounded-lg" />;
+        })}
+      </div>
+    );
+  }
+
+  if (loadable.state === "hasError") {
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+        Failed to load artifacts
+      </div>
+    );
+  }
+
+  if (loadable.state !== "hasData") {
+    return null;
+  }
+
+  const runs = loadable.data;
+  const items = flattenArtifactRuns(runs);
+  const selectedItem =
+    items.find((item) => {
+      return artifactItemKey(item) === selectedArtifactKey;
+    }) ?? items[0];
+  const totalFiles = runs.reduce((sum, run) => {
+    return sum + run.files.length;
+  }, 0);
+
+  if (totalFiles === 0) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-dashed border-border/70 p-8 text-center text-sm text-muted-foreground">
+        No uploaded files in this chat yet.
+      </div>
+    );
+  }
+
+  const selectedKey = selectedItem ? artifactItemKey(selectedItem) : null;
+
+  return (
+    <div className="flex flex-col gap-5">
+      {selectedItem && <ArtifactPreviewPanel item={selectedItem} />}
+      <div className="flex items-center justify-between border-b border-border/60 pb-3 text-xs text-muted-foreground">
+        <span>
+          {totalFiles} file{totalFiles === 1 ? "" : "s"}
+        </span>
+        <span>
+          {runs.length} run{runs.length === 1 ? "" : "s"}
+        </span>
+      </div>
+      {runs.map((run) => {
+        return (
+          <section key={run.runId} className="flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <h3 className="truncate font-mono text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Run {run.runId.slice(0, 8)}
+                </h3>
+              </div>
+              <Link
+                pathname="/activities/:activityRunId"
+                options={{ pathParams: { activityRunId: run.runId } }}
+                className="shrink-0 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+              >
+                View run
+              </Link>
+            </div>
+            <div className="flex flex-col gap-2">
+              {run.files.map((file) => {
+                const item = { runId: run.runId, file };
+                const itemKey = artifactItemKey(item);
+                return (
+                  <ArtifactFileRow
+                    key={itemKey}
+                    item={item}
+                    selected={selectedKey === itemKey}
+                    onPreview={() => {
+                      setSelectedArtifactKey(itemKey);
+                    }}
+                  />
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function ChatArtifactsDrawer({ thread }: { thread: ChatThreadSignals }) {
+  const open = useGet(thread.artifactsDrawerOpen$);
+  const setOpen = useSet(thread.setArtifactsDrawerOpen$);
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(value) => {
+        setOpen(value);
+      }}
+    >
+      <SheetContent
+        side="right"
+        className="w-[420px] sm:max-w-[420px] flex flex-col"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+        }}
+      >
+        <SheetHeader className="shrink-0">
+          <SheetTitle>Artifacts</SheetTitle>
+          <SheetDescription>
+            Uploaded files from runs in this chat thread.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="flex-1 min-h-0 overflow-y-auto -mx-6 px-6 -mb-6 pb-6">
+          {open && <ChatArtifactsDrawerContent thread={thread} />}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ZeroSessionChatPage — real conversation backed by agent runs
+// ---------------------------------------------------------------------------
+
 export function ZeroChatThreadPage({ thread }: ZeroChatThreadPageProps) {
   const shortcutHelpOpen = useGet(chatShortcutHelpOpen$);
   const setShortcutHelpOpen = useSet(setChatShortcutHelpOpen$);
@@ -250,6 +817,7 @@ export function ZeroChatThreadPage({ thread }: ZeroChatThreadPageProps) {
   return (
     <>
       <ZeroChatThreadPageInner thread={thread} />
+      <ChatArtifactsDrawer thread={thread} />
       <ShortcutHelpDialog
         open={shortcutHelpOpen}
         onOpenChange={setShortcutHelpOpen}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -20,7 +20,6 @@ import {
   IconArrowBarToUp,
   IconDownload,
   IconEye,
-  IconExternalLink,
   IconFile,
   IconFiles,
   IconVideo,
@@ -40,6 +39,12 @@ import {
 } from "@vm0/ui";
 import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
 import emptyChatImg from "./assets/empty-chat.webp";
+import docCsvIcon from "./assets/doc-csv.svg";
+import docDocIcon from "./assets/doc-doc.svg";
+import docHtmlIcon from "./assets/doc-html.svg";
+import docJsonIcon from "./assets/doc-json.svg";
+import docPdfIcon from "./assets/doc-pdf.svg";
+import docTxtIcon from "./assets/doc-txt.svg";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
@@ -55,6 +60,7 @@ import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason, onDomEventFn } from "../../signals/utils.ts";
 import {
   AttachmentLightbox,
+  downloadAttachmentUrl,
   FileAttachmentChip,
   PreviewableFileAttachmentChip,
 } from "./zero-attachment-chips.tsx";
@@ -198,16 +204,6 @@ function PinPillButton({ thread }: { thread: ChatThreadSignals }) {
   );
 }
 
-function useArtifactCount(thread: ChatThreadSignals): number | null {
-  const runs = useLastResolved(thread.artifacts$);
-  if (!runs) {
-    return null;
-  }
-  return runs.reduce((sum, run) => {
-    return sum + run.files.length;
-  }, 0);
-}
-
 function ArtifactsButton({ thread }: { thread: ChatThreadSignals }) {
   const features = useLastResolved(featureSwitch$);
   const enabled = features?.[FeatureSwitchKey.ChatArtifactsDrawer] ?? false;
@@ -222,7 +218,6 @@ function ArtifactsButton({ thread }: { thread: ChatThreadSignals }) {
 function ArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
   const open = useGet(thread.artifactsDrawerOpen$);
   const setOpen = useSet(thread.setArtifactsDrawerOpen$);
-  const count = useArtifactCount(thread);
 
   return (
     <TooltipProvider delayDuration={300}>
@@ -234,7 +229,7 @@ function ArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
               setOpen(true);
             }}
             className={cn(
-              "inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-sm transition-colors duration-150",
+              "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors duration-150",
               open
                 ? "bg-primary/10 text-primary"
                 : "text-muted-foreground/70 hover:bg-accent hover:text-foreground",
@@ -243,12 +238,6 @@ function ArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
             aria-pressed={open}
           >
             <IconFiles size={17} stroke={1.5} />
-            <span>Artifacts</span>
-            {count !== null && count > 0 && (
-              <span className="rounded-full bg-muted px-1.5 py-0.5 text-[11px] leading-none text-muted-foreground">
-                {count}
-              </span>
-            )}
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">Open artifacts</TooltipContent>
@@ -340,10 +329,6 @@ function formatArtifactTime(value: string): string {
   });
 }
 
-function withDownloadParam(url: string): string {
-  return `${url}${url.includes("?") ? "&" : "?"}download=1`;
-}
-
 type ChatArtifactItem = {
   runId: string;
   file: ChatThreadArtifactFile;
@@ -352,7 +337,7 @@ type ChatArtifactItem = {
 type ArtifactPreviewKind = "image" | "video" | "document" | "file";
 
 function artifactItemKey(item: ChatArtifactItem): string {
-  return `${item.runId}:${item.file.messageId}:${item.file.id}`;
+  return `${item.runId}:${item.file.id}:${item.file.url}`;
 }
 
 function getFileExtension(filename: string): string {
@@ -394,7 +379,53 @@ function flattenArtifactRuns(
   });
 }
 
-function ArtifactFileIcon({ file }: { file: ChatThreadArtifactFile }) {
+function getArtifactFileIconSrc(file: ChatThreadArtifactFile): string | null {
+  const kind = classifyChatAttachment({
+    filename: file.filename,
+    url: file.url,
+    contentType: file.contentType,
+  });
+
+  if (kind === "pdf") {
+    return docPdfIcon;
+  }
+  if (kind === "html") {
+    return docHtmlIcon;
+  }
+  if (kind === "csv") {
+    return docCsvIcon;
+  }
+  if (kind === "json") {
+    return docJsonIcon;
+  }
+  if (kind === "text") {
+    return docTxtIcon;
+  }
+  if (kind === "markdown") {
+    return docDocIcon;
+  }
+  return null;
+}
+
+function ArtifactFileIcon({
+  file,
+  className,
+}: {
+  file: ChatThreadArtifactFile;
+  className?: string;
+}) {
+  const iconSrc = getArtifactFileIconSrc(file);
+  if (iconSrc) {
+    return (
+      <img
+        alt=""
+        aria-hidden="true"
+        src={iconSrc}
+        className={cn("h-5 w-5 object-contain opacity-90", className)}
+      />
+    );
+  }
+
   const previewKind = getArtifactPreviewKind(file);
   if (previewKind === "image") {
     return <IconPhoto size={18} stroke={1.5} />;
@@ -405,44 +436,6 @@ function ArtifactFileIcon({ file }: { file: ChatThreadArtifactFile }) {
   return <IconFile size={18} stroke={1.5} />;
 }
 
-function ArtifactPreviewOpenAction({
-  file,
-  className,
-}: {
-  file: ChatThreadArtifactFile;
-  className: string;
-}) {
-  const openImageLightbox = useSet(openAttachmentImageLightbox$);
-  const previewKind = getArtifactPreviewKind(file);
-
-  if (previewKind === "image") {
-    return (
-      <button
-        type="button"
-        onClick={() => {
-          openImageLightbox(file.url);
-        }}
-        className={className}
-        aria-label={`Preview ${file.filename}`}
-      >
-        <IconEye size={16} stroke={1.5} />
-      </button>
-    );
-  }
-
-  return (
-    <a
-      href={file.url}
-      target="_blank"
-      rel="noreferrer"
-      className={className}
-      aria-label={`Preview ${file.filename}`}
-    >
-      <IconEye size={16} stroke={1.5} />
-    </a>
-  );
-}
-
 function ArtifactDownloadAction({
   file,
   className,
@@ -450,15 +443,23 @@ function ArtifactDownloadAction({
   file: ChatThreadArtifactFile;
   className: string;
 }) {
+  const pageSignal = useGet(pageSignal$);
+
   return (
-    <a
-      href={withDownloadParam(file.url)}
-      download={file.filename}
+    <button
+      type="button"
+      onClick={() => {
+        detach(
+          downloadAttachmentUrl(file.url, pageSignal, file.filename),
+          Reason.DomCallback,
+          "artifact download",
+        );
+      }}
       className={className}
       aria-label={`Download ${file.filename}`}
     >
       <IconDownload size={16} stroke={1.5} />
-    </a>
+    </button>
   );
 }
 
@@ -514,7 +515,7 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-muted/40 p-8 text-center">
       <span className="flex h-16 w-16 items-center justify-center rounded-lg border border-border/70 bg-background text-muted-foreground shadow-sm">
-        <IconFile size={30} stroke={1.4} />
+        <ArtifactFileIcon file={file} className="h-10 w-10" />
       </span>
       <div className="min-w-0">
         <p className="text-xs font-medium uppercase text-muted-foreground">
@@ -529,7 +530,7 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
 }
 
 function ArtifactPreviewPanel({ item }: { item: ChatArtifactItem }) {
-  const { file, runId } = item;
+  const { file } = item;
   const actionClass =
     "flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground";
 
@@ -550,12 +551,9 @@ function ArtifactPreviewPanel({ item }: { item: ChatArtifactItem }) {
             <span>{formatBytes(file.size)}</span>
             <span aria-hidden>·</span>
             <span>{getFileExtension(file.filename)}</span>
-            <span aria-hidden>·</span>
-            <span>Run {runId.slice(0, 8)}</span>
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          <ArtifactPreviewOpenAction file={file} className={actionClass} />
           <ArtifactDownloadAction file={file} className={actionClass} />
         </div>
       </div>
@@ -566,25 +564,21 @@ function ArtifactPreviewPanel({ item }: { item: ChatArtifactItem }) {
 function ArtifactThumbnail({
   file,
   selected,
-  onPreview,
 }: {
   file: ChatThreadArtifactFile;
   selected: boolean;
-  onPreview: () => void;
 }) {
   const previewKind = getArtifactPreviewKind(file);
 
   return (
-    <button
-      type="button"
-      onClick={onPreview}
+    <div
       className={cn(
-        "group relative flex h-14 w-20 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-muted/60 transition-colors",
+        "relative flex h-14 w-20 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-muted/60 transition-colors",
         selected
           ? "border-primary/60 ring-2 ring-primary/15"
           : "border-border/70 hover:border-foreground/25",
       )}
-      aria-label={`Show preview for ${file.filename}`}
+      aria-hidden="true"
     >
       {previewKind === "image" ? (
         <img
@@ -601,10 +595,7 @@ function ArtifactThumbnail({
           </span>
         </span>
       )}
-      <span className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-150 group-hover:bg-black/25 group-hover:opacity-100">
-        <IconEye size={17} className="text-white drop-shadow" />
-      </span>
-    </button>
+    </div>
   );
 }
 
@@ -624,52 +615,36 @@ function ArtifactFileRow({
   return (
     <div
       className={cn(
-        "flex items-start gap-3 rounded-lg border px-3 py-2.5 transition-colors",
+        "flex rounded-lg border transition-colors",
         selected
           ? "border-primary/40 bg-primary/5"
           : "border-border/60 bg-background/70 hover:bg-muted/25",
       )}
     >
-      <ArtifactThumbnail
-        file={file}
-        selected={selected}
-        onPreview={onPreview}
-      />
-      <div className="min-w-0 flex-1">
-        <button
-          type="button"
-          onClick={onPreview}
-          className="block max-w-full truncate text-left text-sm font-medium text-foreground underline-offset-2 hover:underline"
-          title={file.filename}
-        >
-          {file.filename}
-        </button>
-        <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-          <span>{formatBytes(file.size)}</span>
-          <span aria-hidden>·</span>
-          <span>{getFileExtension(file.filename)}</span>
-          <span aria-hidden>·</span>
-          <span>{formatArtifactTime(file.createdAt)}</span>
+      <button
+        type="button"
+        onClick={onPreview}
+        className="flex min-w-0 flex-1 items-start gap-3 rounded-l-lg px-3 py-2.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        aria-label={`Select ${file.filename}`}
+      >
+        <ArtifactThumbnail file={file} selected={selected} />
+        <div className="min-w-0 flex-1">
+          <span
+            className="block max-w-full truncate text-sm font-medium text-foreground"
+            title={file.filename}
+          >
+            {file.filename}
+          </span>
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+            <span>{formatBytes(file.size)}</span>
+            <span aria-hidden>·</span>
+            <span>{getFileExtension(file.filename)}</span>
+            <span aria-hidden>·</span>
+            <span>{formatArtifactTime(file.createdAt)}</span>
+          </div>
         </div>
-      </div>
-      <div className="flex shrink-0 items-center gap-1">
-        <button
-          type="button"
-          onClick={onPreview}
-          className={actionClass}
-          aria-label={`Show preview for ${file.filename}`}
-        >
-          <IconEye size={16} stroke={1.5} />
-        </button>
-        <a
-          href={file.url}
-          target="_blank"
-          rel="noreferrer"
-          className={actionClass}
-          aria-label={`Open ${file.filename}`}
-        >
-          <IconExternalLink size={16} stroke={1.5} />
-        </a>
+      </button>
+      <div className="flex shrink-0 items-center pr-3">
         <ArtifactDownloadAction file={file} className={actionClass} />
       </div>
     </div>
@@ -730,46 +705,22 @@ function ChatArtifactsDrawerContent({ thread }: { thread: ChatThreadSignals }) {
         <span>
           {totalFiles} file{totalFiles === 1 ? "" : "s"}
         </span>
-        <span>
-          {runs.length} run{runs.length === 1 ? "" : "s"}
-        </span>
       </div>
-      {runs.map((run) => {
-        return (
-          <section key={run.runId} className="flex flex-col gap-2">
-            <div className="flex items-center justify-between gap-3">
-              <div className="min-w-0">
-                <h3 className="truncate font-mono text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  Run {run.runId.slice(0, 8)}
-                </h3>
-              </div>
-              <Link
-                pathname="/activities/:activityRunId"
-                options={{ pathParams: { activityRunId: run.runId } }}
-                className="shrink-0 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
-              >
-                View run
-              </Link>
-            </div>
-            <div className="flex flex-col gap-2">
-              {run.files.map((file) => {
-                const item = { runId: run.runId, file };
-                const itemKey = artifactItemKey(item);
-                return (
-                  <ArtifactFileRow
-                    key={itemKey}
-                    item={item}
-                    selected={selectedKey === itemKey}
-                    onPreview={() => {
-                      setSelectedArtifactKey(itemKey);
-                    }}
-                  />
-                );
-              })}
-            </div>
-          </section>
-        );
-      })}
+      <div className="flex flex-col gap-2">
+        {items.map((item) => {
+          const itemKey = artifactItemKey(item);
+          return (
+            <ArtifactFileRow
+              key={itemKey}
+              item={item}
+              selected={selectedKey === itemKey}
+              onPreview={() => {
+                setSelectedArtifactKey(itemKey);
+              }}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -777,6 +728,7 @@ function ChatArtifactsDrawerContent({ thread }: { thread: ChatThreadSignals }) {
 function ChatArtifactsDrawer({ thread }: { thread: ChatThreadSignals }) {
   const open = useGet(thread.artifactsDrawerOpen$);
   const setOpen = useSet(thread.setArtifactsDrawerOpen$);
+  const lightboxUrl = useGet(attachmentLightboxUrl$);
 
   return (
     <Sheet
@@ -790,6 +742,16 @@ function ChatArtifactsDrawer({ thread }: { thread: ChatThreadSignals }) {
         className="w-[420px] sm:max-w-[420px] flex flex-col"
         onOpenAutoFocus={(event) => {
           event.preventDefault();
+        }}
+        onEscapeKeyDown={(event) => {
+          if (lightboxUrl) {
+            event.preventDefault();
+          }
+        }}
+        onInteractOutside={(event) => {
+          if (lightboxUrl) {
+            event.preventDefault();
+          }
         }}
       >
         <SheetHeader className="shrink-0">

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
@@ -14,6 +14,7 @@ import {
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 import { updateUserFeatureSwitches } from "../../../../../../../src/lib/zero/user/feature-switches-service";
+import { recordRunUploadedFile } from "../../../../../../../src/lib/zero/uploads/run-uploaded-files";
 
 const context = testContext();
 
@@ -54,18 +55,10 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
     expect(response.status).toBe(403);
   });
 
-  it("returns uploaded files grouped by run", async () => {
+  it("returns run uploaded files grouped by run", async () => {
     await updateUserFeatureSwitches(testOrgId, testUserId, {
       [FeatureSwitchKey.ChatArtifactsDrawer]: true,
     });
-    context.mocks.s3.listS3Objects.mockImplementation(
-      async (_bucket, prefix) => {
-        if (prefix.endsWith("/file-1/")) {
-          return [{ key: `${prefix}data.csv`, size: 2048 }];
-        }
-        return [];
-      },
-    );
 
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {
@@ -78,15 +71,19 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
     const { runId } = await seedTestRun(testUserId, testComposeId, {
       status: "completed",
       prompt: "Use the attached file",
+      chatThreadId: threadId,
     });
 
-    await insertTestChatMessage({
-      chatThreadId: threadId,
-      userId: testUserId,
-      role: "user",
-      content: "Use the attached file",
+    await recordRunUploadedFile({
       runId,
-      attachFiles: ["file-1"],
+      source: "web",
+      externalId: "file-1",
+      userId: testUserId,
+      orgId: testOrgId,
+      filename: "data.csv",
+      contentType: "text/csv",
+      sizeBytes: 2048,
+      url: `http://localhost:3000/f/${testUserId}/file-1/data.csv`,
     });
 
     const response = await GET(
@@ -106,5 +103,60 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
       size: 2048,
     });
     expect(data.runs[0].files[0].url).toContain("/f/");
+  });
+
+  it("uses chat message run ownership when zero run chat thread is missing", async () => {
+    await updateUserFeatureSwitches(testOrgId, testUserId, {
+      [FeatureSwitchKey.ChatArtifactsDrawer]: true,
+    });
+
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
+      status: "completed",
+      prompt: "Uploaded during the run",
+    });
+
+    await insertTestChatMessage({
+      chatThreadId: threadId,
+      userId: testUserId,
+      role: "user",
+      content: "Uploaded during the run",
+      runId,
+    });
+    await recordRunUploadedFile({
+      runId,
+      source: "web",
+      externalId: "file-fallback",
+      userId: testUserId,
+      orgId: testOrgId,
+      filename: "preview.html",
+      contentType: "text/html",
+      sizeBytes: 512,
+      url: `http://localhost:3000/f/${testUserId}/file-fallback/preview.html`,
+    });
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/artifacts`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.runs).toHaveLength(1);
+    expect(data.runs[0].runId).toBe(runId);
+    expect(data.runs[0].files[0]).toMatchObject({
+      id: "file-fallback",
+      filename: "preview.html",
+      contentType: "text/html",
+      size: 512,
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
-import { updateUserFeatureSwitches } from "../../../../../../../src/lib/zero/user/feature-switches-service";
+import { seedUserFeatureSwitches } from "../../../../../../../src/__tests__/db-test-seeders/feature-switches";
 import { recordRunUploadedFile } from "../../../../../../../src/lib/zero/uploads/run-uploaded-files";
 
 const context = testContext();
@@ -56,7 +56,7 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
   });
 
   it("returns run uploaded files grouped by run", async () => {
-    await updateUserFeatureSwitches(testOrgId, testUserId, {
+    await seedUserFeatureSwitches(testOrgId, testUserId, {
       [FeatureSwitchKey.ChatArtifactsDrawer]: true,
     });
 
@@ -106,7 +106,7 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
   });
 
   it("uses chat message run ownership when zero run chat thread is missing", async () => {
-    await updateUserFeatureSwitches(testOrgId, testUserId, {
+    await seedUserFeatureSwitches(testOrgId, testUserId, {
       [FeatureSwitchKey.ChatArtifactsDrawer]: true,
     });
 

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { GET } from "../route";
+import { POST } from "../../../route";
+import {
+  createTestCompose,
+  createTestRequest,
+  insertTestChatMessage,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
+import { updateUserFeatureSwitches } from "../../../../../../../src/lib/zero/user/feature-switches-service";
+
+const context = testContext();
+
+describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
+  let testComposeId: string;
+  let testUserId: string;
+  let testOrgId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    testUserId = user.userId;
+    testOrgId = user.orgId;
+
+    const { composeId } = await createTestCompose(uniqueId("artifacts"));
+    testComposeId = composeId;
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(
+      createTestRequest(
+        "http://localhost:3000/api/zero/chat-threads/thread-id/artifacts",
+      ),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 when the feature switch is disabled", async () => {
+    const response = await GET(
+      createTestRequest(
+        "http://localhost:3000/api/zero/chat-threads/thread-id/artifacts",
+      ),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns uploaded files grouped by run", async () => {
+    await updateUserFeatureSwitches(testOrgId, testUserId, {
+      [FeatureSwitchKey.ChatArtifactsDrawer]: true,
+    });
+    context.mocks.s3.listS3Objects.mockImplementation(
+      async (_bucket, prefix) => {
+        if (prefix.endsWith("/file-1/")) {
+          return [{ key: `${prefix}data.csv`, size: 2048 }];
+        }
+        return [];
+      },
+    );
+
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
+      status: "completed",
+      prompt: "Use the attached file",
+    });
+
+    await insertTestChatMessage({
+      chatThreadId: threadId,
+      userId: testUserId,
+      role: "user",
+      content: "Use the attached file",
+      runId,
+      attachFiles: ["file-1"],
+    });
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/artifacts`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.runs).toHaveLength(1);
+    expect(data.runs[0].runId).toBe(runId);
+    expect(data.runs[0].files[0]).toMatchObject({
+      id: "file-1",
+      filename: "data.csv",
+      contentType: "text/csv",
+      size: 2048,
+    });
+    expect(data.runs[0].files[0].url).toContain("/f/");
+  });
+});

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/route.ts
@@ -1,0 +1,53 @@
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
+import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
+import { getChatThreadArtifacts } from "../../../../../../src/lib/zero/chat-thread";
+import { loadFeatureSwitchOverrides } from "../../../../../../src/lib/zero/user/feature-switches-service";
+import { isNotFound } from "@vm0/api-services/errors";
+
+const router = tsr.router(chatThreadArtifactsContract, {
+  list: async ({ params, headers }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
+    const overrides = await loadFeatureSwitchOverrides(
+      authCtx.orgId,
+      authCtx.userId,
+    );
+    const enabled = isFeatureEnabled(FeatureSwitchKey.ChatArtifactsDrawer, {
+      orgId: authCtx.orgId,
+      userId: authCtx.userId,
+      overrides,
+    });
+    if (!enabled) {
+      return createErrorResponse("FORBIDDEN", "Chat artifacts are not enabled");
+    }
+
+    try {
+      const runs = await getChatThreadArtifacts(
+        params.threadId,
+        authCtx.userId,
+      );
+      return { status: 200 as const, body: { runs } };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return createErrorResponse("NOT_FOUND", "Chat thread not found");
+      }
+      throw error;
+    }
+  },
+});
+
+const handler = createHandler(chatThreadArtifactsContract, router, {
+  routeName: "zero.chat-threads.artifacts",
+});
+
+export { handler as GET };

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -1,18 +1,10 @@
-import {
-  eq,
-  and,
-  desc,
-  inArray,
-  isNull,
-  isNotNull,
-  asc,
-  sql,
-} from "drizzle-orm";
+import { eq, and, desc, inArray, isNull, asc, or, sql } from "drizzle-orm";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { notFound } from "@vm0/api-services/errors";
 import {
   getMessagesByThreadId,
@@ -342,54 +334,54 @@ export async function getChatThreadArtifacts(
 
   const rows = await globalThis.services.db
     .select({
-      messageId: chatMessages.id,
-      runId: chatMessages.runId,
-      attachFiles: chatMessages.attachFiles,
-      createdAt: chatMessages.createdAt,
+      runId: runUploadedFiles.runId,
+      externalId: runUploadedFiles.externalId,
+      filename: runUploadedFiles.filename,
+      contentType: runUploadedFiles.contentType,
+      sizeBytes: runUploadedFiles.sizeBytes,
+      url: runUploadedFiles.url,
+      createdAt: runUploadedFiles.createdAt,
     })
-    .from(chatMessages)
+    .from(runUploadedFiles)
+    .innerJoin(zeroRuns, eq(zeroRuns.id, runUploadedFiles.runId))
+    .innerJoin(agentRuns, eq(agentRuns.id, runUploadedFiles.runId))
     .where(
       and(
-        eq(chatMessages.chatThreadId, threadId),
-        isNotNull(chatMessages.runId),
-        isNotNull(chatMessages.attachFiles),
+        eq(runUploadedFiles.userId, userId),
+        or(
+          eq(zeroRuns.chatThreadId, threadId),
+          sql`EXISTS (
+            SELECT 1
+            FROM ${chatMessages}
+            WHERE ${chatMessages.runId} = ${runUploadedFiles.runId}
+              AND ${chatMessages.chatThreadId} = ${threadId}
+          )`,
+        ),
       ),
     )
-    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));
-
-  const resolvedRows = await Promise.all(
-    rows.map(async (row) => {
-      if (!row.runId || !row.attachFiles || row.attachFiles.length === 0) {
-        return null;
-      }
-      const files = await resolveAttachFileUrls(userId, row.attachFiles);
-      if (files.length === 0) {
-        return null;
-      }
-      return { row, files };
-    }),
-  );
+    .orderBy(asc(agentRuns.createdAt), asc(runUploadedFiles.createdAt));
 
   const byRun = new Map<string, ChatThreadArtifactRun>();
 
-  for (const item of resolvedRows) {
-    if (!item) {
+  for (const row of rows) {
+    if (!row.url) {
       continue;
     }
-    const { row, files } = item;
-    if (row.runId) {
-      const existing = byRun.get(row.runId) ?? { runId: row.runId, files: [] };
-      existing.files.push(
-        ...files.map((file) => {
-          return {
-            ...file,
-            messageId: row.messageId,
-            createdAt: row.createdAt.toISOString(),
-          };
-        }),
-      );
-      byRun.set(row.runId, existing);
-    }
+    const filename = row.filename ?? row.externalId;
+    const ext = filename.split(".").pop()?.toLowerCase();
+    const existing = byRun.get(row.runId) ?? { runId: row.runId, files: [] };
+    existing.files.push({
+      id: row.externalId,
+      filename,
+      contentType:
+        row.contentType ??
+        (ext ? EXT_MIMETYPE_MAP[ext] : undefined) ??
+        "application/octet-stream",
+      size: row.sizeBytes ?? 0,
+      url: row.url,
+      createdAt: row.createdAt.toISOString(),
+    });
+    byRun.set(row.runId, existing);
   }
 
   return Array.from(byRun.values()).filter((run) => {

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -1,4 +1,13 @@
-import { eq, and, desc, inArray, isNull, sql } from "drizzle-orm";
+import {
+  eq,
+  and,
+  desc,
+  inArray,
+  isNull,
+  isNotNull,
+  asc,
+  sql,
+} from "drizzle-orm";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -12,6 +21,7 @@ import {
 } from "./chat-message-service";
 import { formatChatRunErrorMessage } from "./chat-run-error-message";
 import {
+  type ChatThreadArtifactRun,
   type PersistedAttachment,
   type ResolvedAttachFile,
   persistedAttachmentSchema,
@@ -321,6 +331,69 @@ export async function resolveAttachFileUrls(
   );
   return results.filter((r): r is ResolvedAttachFile => {
     return r !== null;
+  });
+}
+
+export async function getChatThreadArtifacts(
+  threadId: string,
+  userId: string,
+): Promise<ChatThreadArtifactRun[]> {
+  await getChatThread(threadId, userId);
+
+  const rows = await globalThis.services.db
+    .select({
+      messageId: chatMessages.id,
+      runId: chatMessages.runId,
+      attachFiles: chatMessages.attachFiles,
+      createdAt: chatMessages.createdAt,
+    })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        isNotNull(chatMessages.runId),
+        isNotNull(chatMessages.attachFiles),
+      ),
+    )
+    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));
+
+  const resolvedRows = await Promise.all(
+    rows.map(async (row) => {
+      if (!row.runId || !row.attachFiles || row.attachFiles.length === 0) {
+        return null;
+      }
+      const files = await resolveAttachFileUrls(userId, row.attachFiles);
+      if (files.length === 0) {
+        return null;
+      }
+      return { row, files };
+    }),
+  );
+
+  const byRun = new Map<string, ChatThreadArtifactRun>();
+
+  for (const item of resolvedRows) {
+    if (!item) {
+      continue;
+    }
+    const { row, files } = item;
+    if (row.runId) {
+      const existing = byRun.get(row.runId) ?? { runId: row.runId, files: [] };
+      existing.files.push(
+        ...files.map((file) => {
+          return {
+            ...file,
+            messageId: row.messageId,
+            createdAt: row.createdAt.toISOString(),
+          };
+        }),
+      );
+      byRun.set(row.runId, existing);
+    }
+  }
+
+  return Array.from(byRun.values()).filter((run) => {
+    return run.files.length > 0;
   });
 }
 

--- a/turbo/apps/web/src/lib/zero/chat-thread/index.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/index.ts
@@ -9,5 +9,6 @@ export {
   deleteChatThread,
   markThreadRead,
   resolveAttachFileUrls,
+  getChatThreadArtifacts,
 } from "./chat-thread-service";
 export { getPagedMessages } from "./chat-message-service";

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -29,7 +29,6 @@ const resolvedAttachFileSchema = attachFileSchema.extend({
 });
 
 const chatThreadArtifactFileSchema = resolvedAttachFileSchema.extend({
-  messageId: z.string(),
   createdAt: z.string(),
 });
 

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -28,6 +28,16 @@ const resolvedAttachFileSchema = attachFileSchema.extend({
   url: z.string(),
 });
 
+const chatThreadArtifactFileSchema = resolvedAttachFileSchema.extend({
+  messageId: z.string(),
+  createdAt: z.string(),
+});
+
+const chatThreadArtifactRunSchema = z.object({
+  runId: z.string(),
+  files: z.array(chatThreadArtifactFileSchema),
+});
+
 /**
  * Attachment metadata persisted in chat_threads.draft_attachments.
  *
@@ -422,11 +432,30 @@ export const chatThreadMessagesContract = c.router({
   },
 });
 
+export const chatThreadArtifactsContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/chat-threads/:threadId/artifacts",
+    headers: authHeadersSchema,
+    pathParams: z.object({ threadId: z.string() }),
+    responses: {
+      200: z.object({
+        runs: z.array(chatThreadArtifactRunSchema),
+      }),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "List uploaded files associated with every run in a chat thread",
+  },
+});
+
 export type ChatThreadsContract = typeof chatThreadsContract;
 export type ChatThreadByIdContract = typeof chatThreadByIdContract;
 export type ChatThreadMarkReadContract = typeof chatThreadMarkReadContract;
 export type ChatMessagesContract = typeof chatMessagesContract;
 export type ChatThreadMessagesContract = typeof chatThreadMessagesContract;
+export type ChatThreadArtifactsContract = typeof chatThreadArtifactsContract;
 export type ChatSearchContract = typeof chatSearchContract;
 export type ChatSearchResponse = z.infer<typeof chatSearchResponseSchema>;
 export type ChatSearchResult = z.infer<typeof chatSearchResultSchema>;
@@ -441,6 +470,8 @@ export {
   persistedAttachmentSchema,
   attachFileSchema,
   resolvedAttachFileSchema,
+  chatThreadArtifactFileSchema,
+  chatThreadArtifactRunSchema,
 };
 
 export type ModelSelectionRequest = z.infer<typeof modelSelectionRequestSchema>;
@@ -452,3 +483,7 @@ export type PagedChatMessage = z.infer<typeof pagedChatMessageSchema>;
 export type PersistedAttachment = z.infer<typeof persistedAttachmentSchema>;
 export type AttachFile = z.infer<typeof attachFileSchema>;
 export type ResolvedAttachFile = z.infer<typeof resolvedAttachFileSchema>;
+export type ChatThreadArtifactFile = z.infer<
+  typeof chatThreadArtifactFileSchema
+>;
+export type ChatThreadArtifactRun = z.infer<typeof chatThreadArtifactRunSchema>;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -304,6 +304,7 @@ export {
   chatThreadMarkReadContract,
   chatMessagesContract,
   chatThreadMessagesContract,
+  chatThreadArtifactsContract,
   chatSearchContract,
   chatThreadListItemSchema,
   chatThreadDetailSchema,
@@ -313,6 +314,8 @@ export {
   persistedAttachmentSchema,
   attachFileSchema,
   resolvedAttachFileSchema,
+  chatThreadArtifactFileSchema,
+  chatThreadArtifactRunSchema,
   type ModelSelectionRequest,
   type SummaryEntry,
   type ChatThreadsContract,
@@ -320,6 +323,7 @@ export {
   type ChatThreadMarkReadContract,
   type ChatMessagesContract,
   type ChatThreadMessagesContract,
+  type ChatThreadArtifactsContract,
   type ChatSearchContract,
   type ChatSearchResponse,
   type ChatSearchResult,
@@ -330,6 +334,8 @@ export {
   type PersistedAttachment,
   type AttachFile,
   type ResolvedAttachFile,
+  type ChatThreadArtifactFile,
+  type ChatThreadArtifactRun,
 } from "./chat-threads";
 export {
   chatThreadV1GetContract,

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -39,6 +39,7 @@ export enum FeatureSwitchKey {
   AutoSkill = "autoSkill",
   TestOauthConnector = "testOauthConnector",
   ChatHeaderNewButton = "chatHeaderNewButton",
+  ChatArtifactsDrawer = "chatArtifactsDrawer",
   ChatThreadReadIndicator = "chatThreadReadIndicator",
   ChatManualHistory = "chatManualHistory",
   ChatMessageStartButton = "chatMessageStartButton",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -216,6 +216,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Replace the Invite people button in the agent chat page header with a New button that creates a new chat thread",
     enabled: false,
   },
+  [FeatureSwitchKey.ChatArtifactsDrawer]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Show an artifacts button in the chat header that opens a drawer listing uploaded files grouped by run",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatThreadReadIndicator]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- add a chat-thread artifacts API contract and route that groups uploaded files by run
- gate the chat header Artifacts button/drawer behind `chatArtifactsDrawer`
- render artifact previews with image/video/document/file handling plus open and download actions

## Testing
- `pnpm --filter @vm0/app test src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx`
- targeted `oxlint` for changed platform, web, api-contracts, connectors, and core files
- `pnpm --filter @vm0/api-contracts check-types`
- `pnpm --filter @vm0/connectors check-types`
- `pnpm --filter @vm0/core check-types`

## Local blockers
- `pnpm --filter web test 'app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts'` is blocked by the local test DB missing main migrations; `pnpm --filter web db:migrate` is currently blocked by the existing storage memory/artifact collision guard.
- pre-commit full `pnpm check-types` is blocked by existing `apps/api` type errors in `clerk-session.test.ts`, `route.test.ts`, and `health.test.ts`.
