### PR TITLE
fix(org-manage): widen workspace settings dialog with side padding

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
@@ -170,7 +170,7 @@ export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="zero-app flex flex-col w-full max-w-[960px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card">
+      <DialogContent className="zero-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card">
         <DialogTitle className="sr-only">Workspace settings</DialogTitle>
         <DialogDescription className="sr-only">
           Manage your workspace profile, members, integrations, and billing.


### PR DESCRIPTION
## Summary
- Bump `OrgManageDialog` desktop cap from `max-w-[960px]` to `max-w-[1200px]` so Profile and Danger zone rows have room to breathe.
- Replace `w-full` with `w-[calc(100vw-2rem)]` so the dialog keeps a 1rem margin on either side at viewports below the cap instead of stretching edge-to-edge.

Existing responsive layers (`sm:flex-row` sidebar/dropdown switch, `sm:px-10`, `h-[92dvh] sm:h-[85vh]`) are preserved.

## Preview

![Breakpoint preview at 1440 / 1024 / 768 / 480px](https://www.vm0.ai/f/user_36PnTFtD4dBQ9zg5jj6E5r918aV/7f72b13d-ac3a-4e0e-b4c8-18ca87f5b805/preview_grid.png)

## Test plan
- [ ] Open workspace settings on a >=1280px viewport — modal centers at 1200px with visible page margin
- [ ] Resize to 1024px / 768px — modal keeps 1rem padding on each side, sidebar still visible
- [ ] Resize to <640px — sidebar collapses to dropdown, modal still has 1rem horizontal margin
- [ ] All tabs (General, Model Providers, Domains, Members, Billing, Usage, Invoices) render without layout regressions