### PR TITLE
fix(mitm-addon): harden static firewall host matching

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -4,6 +4,7 @@ Pure functions with no module-level state or I/O.
 """
 
 from typing import NamedTuple
+from urllib.parse import urlsplit
 
 _SEGMENT_ERROR_HINT = 'use "{name}", "prefix{name}", "{name}suffix", or "prefix{name}suffix"'
 
@@ -34,31 +35,16 @@ def _split_base_match_url(
     excludes query and fragment so callers can apply base-path prefix semantics
     without accidentally comparing query strings.
     """
-    scheme_end = value.find("://")
-    if scheme_end == -1:
+    parts = urlsplit(value)
+    if not parts.scheme or not parts.netloc:
         return None
-
-    rest = value[scheme_end + 3 :]
-    authority_end = len(rest)
-    for sep in ("/", "?", "#"):
-        idx = rest.find(sep)
-        if idx != -1:
-            authority_end = min(authority_end, idx)
-
-    suffix = rest[authority_end:]
-    if not allow_query_fragment and ("?" in suffix or "#" in suffix):
+    if not allow_query_fragment and (parts.query or parts.fragment):
         return None
-
-    path_end = len(suffix)
-    for sep in ("?", "#"):
-        idx = suffix.find(sep)
-        if idx != -1:
-            path_end = min(path_end, idx)
 
     return _BaseUrlParts(
-        scheme=value[:scheme_end],
-        authority=rest[:authority_end],
-        path=suffix[:path_end],
+        scheme=parts.scheme,
+        authority=parts.netloc,
+        path=parts.path,
     )
 
 

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -17,6 +17,51 @@ _MULTI_PARAM_BRACE_COUNT = 2
 _RULE_TOKEN_COUNT = 2
 
 
+class _BaseUrlParts(NamedTuple):
+    scheme: str
+    authority: str
+    path: str
+
+
+def _split_base_match_url(
+    value: str,
+    *,
+    allow_query_fragment: bool = True,
+) -> _BaseUrlParts | None:
+    """Split a URL-like string for firewall base matching.
+
+    Keeps the raw authority, including any explicit port. The returned path
+    excludes query and fragment so callers can apply base-path prefix semantics
+    without accidentally comparing query strings.
+    """
+    scheme_end = value.find("://")
+    if scheme_end == -1:
+        return None
+
+    rest = value[scheme_end + 3 :]
+    authority_end = len(rest)
+    for sep in ("/", "?", "#"):
+        idx = rest.find(sep)
+        if idx != -1:
+            authority_end = min(authority_end, idx)
+
+    suffix = rest[authority_end:]
+    if not allow_query_fragment and ("?" in suffix or "#" in suffix):
+        return None
+
+    path_end = len(suffix)
+    for sep in ("?", "#"):
+        idx = suffix.find(sep)
+        if idx != -1:
+            path_end = min(path_end, idx)
+
+    return _BaseUrlParts(
+        scheme=value[:scheme_end],
+        authority=rest[:authority_end],
+        path=suffix[:path_end],
+    )
+
+
 def parse_segment(seg: str) -> dict:
     """Parse a single host or path segment into literal / param / error.
 
@@ -233,52 +278,52 @@ def match_base_url(url: str, base: str) -> tuple[str, dict] | None:
     - rel_path: the path after the base (for permission rule matching)
     - params: extracted parameters from the base URL
     """
-    # Fast path: no parameters — use simple prefix matching
+    url_parts = _split_base_match_url(url)
+    if url_parts is None:
+        return None
+
+    # Fast path: no parameters - compare scheme/authority independently so
+    # host casing cannot bypass static firewall bases, while paths remain
+    # case-sensitive.
     if "{" not in base:
-        base_stripped = base.rstrip("/")
-        if not url.startswith(base_stripped):
+        base_parts = _split_base_match_url(base.rstrip("/"), allow_query_fragment=False)
+        if base_parts is None:
             return None
-        rest = url[len(base_stripped) :]
-        if rest and rest[0] not in ("/", "?", "#"):
+        if url_parts.scheme.lower() != base_parts.scheme.lower():
             return None
-        rel_path = rest.split("?")[0].split("#")[0] or "/"
+        if url_parts.authority.lower() != base_parts.authority.lower():
+            return None
+
+        base_path = base_parts.path
+        if base_path and not url_parts.path.startswith(base_path):
+            return None
+        rest = url_parts.path[len(base_path) :] if base_path else url_parts.path
+        if rest and rest[0] != "/":
+            return None
+        rel_path = rest or "/"
         return rel_path, {}
 
     # Parameterized base URL: parse into scheme, host pattern, path pattern
-    scheme_end = base.find("://")
-    if scheme_end == -1:
+    base_parts = _split_base_match_url(base, allow_query_fragment=False)
+    if base_parts is None:
         return None
-    scheme = base[: scheme_end + 3]  # e.g., "https://"
 
     # Request must start with same scheme
-    if not url.lower().startswith(scheme.lower()):
+    if url_parts.scheme.lower() != base_parts.scheme.lower():
         return None
-
-    base_rest = base[scheme_end + 3 :]  # after "://"
-    url_rest = url[scheme_end + 3 :]
-
-    # Split host from path
-    base_slash = base_rest.find("/")
-    base_host = base_rest if base_slash == -1 else base_rest[:base_slash]
-    base_path = "" if base_slash == -1 else base_rest[base_slash:]
-
-    url_slash = url_rest.find("/")
-    url_host_with_port = url_rest if url_slash == -1 else url_rest[:url_slash]
-    url_path = "" if url_slash == -1 else url_rest[url_slash:]
 
     # Match host directly — do NOT strip port. Non-standard ports (e.g., :8443)
     # are included in URLs by get_original_url() and must NOT match base patterns
     # without an explicit port, otherwise auth headers could leak to rogue servers.
     # Standard ports (443 for https, 80 for http) are omitted from URLs by
     # get_original_url(), so they match naturally.
-    host_params = match_host(url_host_with_port, base_host)
+    host_params = match_host(url_parts.authority, base_parts.authority)
     if host_params is None:
         return None
 
-    # Strip query/fragment from URL path
-    clean_url_path = url_path.split("?")[0].split("#")[0]
-
     # Match base path prefix
+    base_path = base_parts.path
+    clean_url_path = url_parts.path
     if base_path and base_path != "/":
         base_path_segs = [s for s in base_path.split("/") if s]
         url_path_segs = [s for s in clean_url_path.split("/") if s]

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -35,7 +35,10 @@ def _split_base_match_url(
     excludes query and fragment so callers can apply base-path prefix semantics
     without accidentally comparing query strings.
     """
-    parts = urlsplit(value)
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return None
     if not parts.scheme or not parts.netloc:
         return None
     if not allow_query_fragment and (parts.query or parts.fragment):

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -927,6 +927,10 @@ class TestMatchBaseUrl:
         result = match_base_url("https://API.GitHub.com/repos", "https://api.github.com")
         assert result == ("/repos", {})
 
+    def test_static_base_case_insensitive_scheme(self):
+        result = match_base_url("HTTPS://API.GitHub.com/repos", "https://api.github.com")
+        assert result == ("/repos", {})
+
     def test_static_base_preserves_path_case(self):
         result = match_base_url("https://API.GitHub.com/REPOS", "https://api.github.com")
         assert result == ("/REPOS", {})
@@ -942,6 +946,13 @@ class TestMatchBaseUrl:
     def test_static_base_query_only_case_insensitive_authority(self):
         result = match_base_url("https://API.GitHub.com?tab=repos", "https://api.github.com")
         assert result == ("/", {})
+
+    def test_static_base_strips_query_and_fragment_from_rel_path(self):
+        result = match_base_url(
+            "https://API.GitHub.com/repos?tab=code#readme",
+            "https://api.github.com",
+        )
+        assert result == ("/repos", {})
 
     def test_static_base_evil_domain(self):
         result = match_base_url("https://api.github.com.evil.com/steal", "https://api.github.com")
@@ -959,8 +970,16 @@ class TestMatchBaseUrl:
         result = match_base_url("https://api.github.com/repos", "https://api.github.com?token=1")
         assert result is None
 
+    def test_static_base_with_fragment_is_rejected(self):
+        result = match_base_url("https://api.github.com/repos", "https://api.github.com#token")
+        assert result is None
+
     def test_malformed_request_url_returns_none(self):
         result = match_base_url("https://[::1", "https://api.github.com")
+        assert result is None
+
+    def test_malformed_base_url_returns_none(self):
+        result = match_base_url("https://api.github.com/repos", "https://[::1")
         assert result is None
 
     def test_parameterized_host(self):
@@ -977,6 +996,13 @@ class TestMatchBaseUrl:
         result = match_base_url(
             "https://acme.zendesk.com/api/v2/tickets",
             "https://{subdomain}.zendesk.com?token=1",
+        )
+        assert result is None
+
+    def test_parameterized_base_with_fragment_is_rejected(self):
+        result = match_base_url(
+            "https://acme.zendesk.com/api/v2/tickets",
+            "https://{subdomain}.zendesk.com#token",
         )
         assert result is None
 

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -923,12 +923,40 @@ class TestMatchBaseUrl:
         result = match_base_url("https://api.github.com/repos", "https://api.github.com")
         assert result == ("/repos", {})
 
+    def test_static_base_case_insensitive_authority(self):
+        result = match_base_url("https://API.GitHub.com/repos", "https://api.github.com")
+        assert result == ("/repos", {})
+
+    def test_static_base_preserves_path_case(self):
+        result = match_base_url("https://API.GitHub.com/REPOS", "https://api.github.com")
+        assert result == ("/REPOS", {})
+
+    def test_static_base_path_is_case_sensitive(self):
+        result = match_base_url("https://api.github.com/V1/repos", "https://api.github.com/v1")
+        assert result is None
+
     def test_static_base_exact(self):
         result = match_base_url("https://api.github.com", "https://api.github.com")
         assert result == ("/", {})
 
+    def test_static_base_query_only_case_insensitive_authority(self):
+        result = match_base_url("https://API.GitHub.com?tab=repos", "https://api.github.com")
+        assert result == ("/", {})
+
     def test_static_base_evil_domain(self):
         result = match_base_url("https://api.github.com.evil.com/steal", "https://api.github.com")
+        assert result is None
+
+    def test_static_base_case_mixed_evil_domain(self):
+        result = match_base_url("https://API.GitHub.com.evil.com/steal", "https://api.github.com")
+        assert result is None
+
+    def test_static_base_rejects_nonstandard_port(self):
+        result = match_base_url("https://API.GitHub.com:8443/repos", "https://api.github.com")
+        assert result is None
+
+    def test_static_base_with_query_is_rejected(self):
+        result = match_base_url("https://api.github.com/repos", "https://api.github.com?token=1")
         assert result is None
 
     def test_parameterized_host(self):
@@ -940,6 +968,13 @@ class TestMatchBaseUrl:
         rel_path, params = result
         assert rel_path == "/api/v2/tickets"
         assert params == {"subdomain": "acme"}
+
+    def test_parameterized_base_with_query_is_rejected(self):
+        result = match_base_url(
+            "https://acme.zendesk.com/api/v2/tickets",
+            "https://{subdomain}.zendesk.com?token=1",
+        )
+        assert result is None
 
     def test_parameterized_path(self):
         result = match_base_url(
@@ -2753,6 +2788,19 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
+
+    def test_denied_permission_blocked_with_case_mixed_static_host(self):
+        policies = {
+            "github": {"allow": [], "deny": ["repo-read"], "ask": [], "unknownPolicy": "deny"}
+        }
+        result = matching.match_firewall_request(
+            "https://API.GitHub.COM/repos/org/repo",
+            "GET",
+            self._firewalls(),
+            network_policies=policies,
+        )
+        assert isinstance(result, FirewallBlock)
+        assert result.permissions == ("repo-read",)
 
     def test_uncategorized_permission_allowed(self):
         """Permission not in allow/deny/ask defaults to allowed."""

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -959,6 +959,10 @@ class TestMatchBaseUrl:
         result = match_base_url("https://api.github.com/repos", "https://api.github.com?token=1")
         assert result is None
 
+    def test_malformed_request_url_returns_none(self):
+        result = match_base_url("https://[::1", "https://api.github.com")
+        assert result is None
+
     def test_parameterized_host(self):
         result = match_base_url(
             "https://acme.zendesk.com/api/v2/tickets",


### PR DESCRIPTION
## Summary
- make static firewall base matching compare scheme/authority case-insensitively while preserving case-sensitive path matching
- parse request/base URLs with urlsplit and preserve netloc so explicit ports remain part of matching
- reject invalid base query/fragment and tolerate malformed URL input as no-match
- add regression and edge-case coverage for mixed-case Host bypass, ports, query/fragment, malformed URLs, and path case sensitivity

Closes #11215

## Tests
- PYTHONPATH=src python3 -m pytest tests/test_connectors.py::TestMatchBaseUrl tests/test_connectors.py::TestThreeLevelMatching::test_denied_permission_blocked_with_case_mixed_static_host -q
- PYTHONPATH=src python3 -m pytest tests/test_connectors.py -q
- python3 -m ruff check src/matching.py tests/test_connectors.py
- python3 -m ruff format --check src/matching.py tests/test_connectors.py
- git diff --check

## Notes
- Full local mitm-addon suite was also run; unrelated local failures require gitignored turbo/packages/connectors/src/firewalls/x.generated.ts, generated by cd turbo && pnpm install.