### PR TITLE
feat(sidebar): unify session indicator (running / unread / draft)

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -343,3 +343,24 @@ export const canSendZeroChat$ = computed((get) => {
     get(zeroChatInput$).trim() !== "" || get(zeroChatAttachments$).length > 0
   );
 });
+
+/**
+ * Map of threadId → true when that thread's draft has unsent content
+ * (non-empty text or ≥1 attachment). Drives the sidebar draft indicator.
+ *
+ * Threads that the user has not opened this session simply absent from the map
+ * — sidebar treats `undefined` as "no draft". Server-persisted drafts surface
+ * here once the thread is opened and seeded into the map.
+ */
+export const draftPresenceMap$ = computed((get) => {
+  const map = get(internalDraftMap$);
+  const result: Record<string, boolean> = {};
+  for (const [threadId, draft] of Object.entries(map)) {
+    const hasText = get(draft.input$).trim() !== "";
+    const hasAttachment = get(draft.attachments$).length > 0;
+    if (hasText || hasAttachment) {
+      result[threadId] = true;
+    }
+  }
+  return result;
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/session-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/session-indicator.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Tests for SessionIndicator — the chat sidebar status indicator.
+ *
+ * Each state must render a distinct element so callers/tests can assert on
+ * shape, not on color (color alone is not accessible).
+ */
+
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { SessionIndicator } from "../session-indicator.tsx";
+
+describe("SessionIndicator", () => {
+  it("renders nothing for state 'none'", () => {
+    const { container } = render(<SessionIndicator state="none" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the running spinner with role=status and aria-label", () => {
+    const { getByRole } = render(<SessionIndicator state="running" />);
+    const el = getByRole("status", { name: "Running" });
+    expect(el).toHaveClass("animate-spin");
+  });
+
+  it("renders an unread dot when state='unread' and no count is given", () => {
+    const { getByLabelText, queryByText } = render(
+      <SessionIndicator state="unread" />,
+    );
+    expect(getByLabelText("Unread")).toBeInTheDocument();
+    // Dot variant has no text content
+    expect(queryByText(/\d+/)).not.toBeInTheDocument();
+  });
+
+  it("renders an unread badge with the count when state='unread' and count>0", () => {
+    const { getByLabelText, getByText } = render(
+      <SessionIndicator state="unread" unreadCount={3} />,
+    );
+    expect(getByLabelText("3 unread")).toBeInTheDocument();
+    expect(getByText("3")).toBeInTheDocument();
+  });
+
+  it("clamps unread count overflow to '99+'", () => {
+    const { getByText } = render(
+      <SessionIndicator state="unread" unreadCount={120} />,
+    );
+    expect(getByText("99+")).toBeInTheDocument();
+  });
+
+  it("falls back to the dot variant when unreadCount is 0", () => {
+    const { getByLabelText, queryByText } = render(
+      <SessionIndicator state="unread" unreadCount={0} />,
+    );
+    expect(getByLabelText("Unread")).toBeInTheDocument();
+    expect(queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("renders the pencil icon for state='draft'", () => {
+    const { getByLabelText } = render(<SessionIndicator state="draft" />);
+    // Tabler icons render as <svg> and forward aria-label to the root element.
+    const el = getByLabelText("Draft");
+    expect(el.tagName.toLowerCase()).toBe("svg");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/session-indicator.tsx
+++ b/turbo/apps/platform/src/views/zero-page/session-indicator.tsx
@@ -1,0 +1,67 @@
+import { IconPencil } from "@tabler/icons-react";
+
+export type SessionIndicatorState = "running" | "unread" | "draft" | "none";
+
+/**
+ * Visual indicator for chat session state in the sidebar.
+ *
+ * Three states differentiated by *shape* (not just color) so they remain
+ * distinguishable for color-blind users and in static screenshots:
+ * - running: spinning arc — open shape, conveys in-progress
+ * - unread:  solid filled dot, optional count badge
+ * - draft:   pencil outline icon
+ *
+ * Stacking priority: running > unread > draft. Callers resolve to a single
+ * state before rendering — the component itself only renders the one passed in.
+ */
+export function SessionIndicator({
+  state,
+  unreadCount,
+}: {
+  state: SessionIndicatorState;
+  unreadCount?: number;
+}) {
+  if (state === "running") {
+    return (
+      <span
+        className="shrink-0 h-3.5 w-3.5 rounded-full border-[1.8px] border-emerald-500/25 border-t-emerald-500 border-r-emerald-500 animate-spin"
+        style={{ boxShadow: "0 0 6px rgba(16, 185, 129, 0.25)" }}
+        role="status"
+        aria-label="Running"
+      />
+    );
+  }
+
+  if (state === "unread") {
+    if (unreadCount && unreadCount > 0) {
+      const label = unreadCount > 99 ? "99+" : String(unreadCount);
+      return (
+        <span
+          className="shrink-0 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-primary px-1.5 text-[11px] font-semibold leading-none text-primary-foreground"
+          aria-label={`${unreadCount} unread`}
+        >
+          {label}
+        </span>
+      );
+    }
+    return (
+      <span
+        className="shrink-0 h-2 w-2 rounded-full bg-primary"
+        aria-label="Unread"
+      />
+    );
+  }
+
+  if (state === "draft") {
+    return (
+      <IconPencil
+        size={14}
+        stroke={2.2}
+        className="shrink-0 text-muted-foreground"
+        aria-label="Draft"
+      />
+    );
+  }
+
+  return null;
+}

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -37,6 +37,11 @@ import {
   chatThreads$,
   deleteChatThread$,
 } from "../../signals/chat-page/chat-message.ts";
+import { draftPresenceMap$ } from "../../signals/zero-page/chat-draft.ts";
+import {
+  SessionIndicator,
+  type SessionIndicatorState,
+} from "./session-indicator.tsx";
 import {
   createNewChatThreadOptimistically$,
   optimisticChatThread$,
@@ -63,15 +68,28 @@ function ChatThreadItem({
   isSelected,
   onSelect,
   showReadIndicator,
+  hasDraft,
 }: {
   session: ChatThreadListItem;
   isSelected: boolean;
   onSelect?: () => void;
   showReadIndicator: boolean;
+  hasDraft: boolean;
 }) {
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
   const isUnread = showReadIndicator && !session.isRead;
   const isRunning = showReadIndicator && session.running;
+
+  // Priority: running > unread > draft. Selected rows suppress unread because
+  // the selection itself signals "you are looking at this thread".
+  let indicatorState: SessionIndicatorState = "none";
+  if (isRunning) {
+    indicatorState = "running";
+  } else if (isUnread && !isSelected) {
+    indicatorState = "unread";
+  } else if (hasDraft && !isSelected) {
+    indicatorState = "draft";
+  }
 
   function handleDeleteClick(e: React.MouseEvent) {
     e.preventDefault();
@@ -100,18 +118,7 @@ function ChatThreadItem({
               : "text-sidebar-foreground hover:bg-sidebar-accent"
         }`}
       >
-        {isRunning && (
-          <span
-            className="shrink-0 h-2 w-2 rounded-full bg-sky-600 animate-pulse"
-            aria-label="Running"
-          />
-        )}
-        {!isRunning && !isSelected && isUnread && (
-          <span
-            className="shrink-0 h-2 w-2 rounded-full bg-primary"
-            aria-label="Unread"
-          />
-        )}
+        <SessionIndicator state={indicatorState} />
         <span className="truncate min-w-0 flex-1">
           {session.title ?? "New chat"}
         </span>
@@ -159,6 +166,7 @@ function ChatThreads() {
   const features = useLastResolved(featureSwitch$);
   const showReadIndicator =
     features?.[FeatureSwitchKey.ChatThreadReadIndicator] ?? false;
+  const draftPresence = useGet(draftPresenceMap$);
   const searchTerm = useGet(sidebarSearchTerm$);
   const trimmedTerm = searchTerm.trim().toLowerCase();
   const filteredChatThreads = trimmedTerm
@@ -207,6 +215,7 @@ function ChatThreads() {
             isSelected={selectedThreadId === session.id}
             onSelect={onRecentSelect}
             showReadIndicator={showReadIndicator}
+            hasDraft={draftPresence[session.id] ?? false}
           />
         );
       })}
@@ -218,6 +227,7 @@ function ChatThreads() {
             isSelected={selectedThreadId === session.id}
             onSelect={onRecentSelect}
             showReadIndicator={showReadIndicator}
+            hasDraft={draftPresence[session.id] ?? false}
           />
         );
       })}


### PR DESCRIPTION
## Summary

- Replaces the inline running/unread dots in the chat sidebar with a single `SessionIndicator` component that distinguishes states by **shape**, not just color — so the three states stay distinguishable for color-blind users and in static screenshots.
- Adds the new **draft** state (a gray pencil icon), surfaced through a new `draftPresenceMap$` signal derived from the existing per-thread `internalDraftMap$`.
- Priority unchanged: `running > unread > draft`. Only the highest-priority state renders.

## Visual

| State | Visual | Driven by |
|------|------|-------------|
| Running | Green spinning arc (`animate-spin`) | `session.running` (server) |
| Unread | Blue dot, optional `99+` count badge | `!session.isRead` (server) |
| Draft | Gray pencil | `draftPresenceMap$` (client, in-memory) |

Existing `ChatThreadReadIndicator` feature gate continues to gate running + unread. Draft is not gated since it is purely client-side and informational.

Animated reference: https://www.vm0.ai/f/user_36PnTFtD4dBQ9zg5jj6E5r918aV/246a9f60-a87c-470f-9354-39ee99d77fd3/chat-indicator.gif

## Notes

- `draftPresenceMap$` only sees threads the user has opened this session. Server-persisted drafts (`draftContent` on `ChatThreadDetail`) seed into the map when the thread is opened, so the indicator appears as the user navigates. Adding `hasDraft` to the list contract would make it visible from first paint — left out for YAGNI; can follow up if needed.
- Existing `sidebar-running-indicator.test.tsx` continues to pass: `aria-label="Running"` / `aria-label="Unread"` are preserved.

## Test plan

- [x] \`pnpm vitest run src/views/zero-page/__tests__/session-indicator.test.tsx\` (7 new unit tests)
- [x] \`pnpm vitest run src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx\` (existing 6 tests still pass)
- [x] \`pnpm vitest run src/views/zero-page/__tests__/sidebar-chat-{navigation,delete}.test.tsx\` (regression)
- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean on changed files
- [ ] Verify in PR preview: hover/select states, dark mode, draft surfacing after composer typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)