### PR TITLE
fix(guest-agent): delay initial telemetry tick

### DIFF
--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -284,6 +284,10 @@ async fn run(mut rx: mpsc::Receiver<Cmd>, masker: Arc<SecretMasker>) {
     let mut interval =
         tokio::time::interval(Duration::from_secs(constants::TELEMETRY_INTERVAL_SECS));
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    // `interval`'s first tick is immediately ready. Consume it so periodic
+    // uploads start after the first full interval instead of racing explicit
+    // startup/final flushes.
+    interval.tick().await;
 
     loop {
         tokio::select! {


### PR DESCRIPTION
## Summary
- prevent the guest-agent telemetry interval from firing immediately after spawn
- avoid a race where the background tick can upload the same delta before an explicit flush
- fixes the merge-queue CI failure pattern after #11216 where telemetry tests saw duplicate POSTs and poisoned TEST_MUTEX

## Tests
- cargo fmt --check
- cargo test -p guest-agent