### PR TITLE
fix: make guest-agent system logs deterministic

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1268,6 +1268,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -3,6 +3,9 @@
 use std::sync::LazyLock;
 
 use crate::constants;
+use guest_common::log_warn;
+
+const LOG_TAG: &str = "sandbox:guest-agent";
 
 fn env_or_empty(name: &str) -> String {
     std::env::var(name).unwrap_or_default()
@@ -52,7 +55,10 @@ static MOCK_CLAUDE_PATH: LazyLock<String> = LazyLock::new(|| {
 fn u64_env_or(name: &str, default: u64) -> u64 {
     match std::env::var(name) {
         Ok(v) => v.parse().unwrap_or_else(|_| {
-            eprintln!("[WARN] {name}={v:?} is not a valid u64, using default {default}s");
+            log_warn!(
+                LOG_TAG,
+                "{name}={v:?} is not a valid u64, using default {default}s"
+            );
             default
         }),
         Err(_) => default,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -22,6 +22,7 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 
 #[tokio::main]
 async fn main() {
+    guest_common::log::set_system_log_file(paths::system_log_file());
     let exit_code = run().await;
     std::process::exit(exit_code);
 }

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -1058,6 +1058,43 @@ async fn flush_is_incremental_between_calls() {
     let _ = std::fs::remove_file(pos_file);
 }
 
+#[tokio::test]
+async fn final_flush_uploads_log_emitted_immediately_before_it() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let system_log = guest_agent::paths::system_log_file();
+    let pos_file = guest_agent::paths::telemetry_system_log_pos_file();
+    let _ = std::fs::remove_file(system_log);
+    let _ = std::fs::remove_file(pos_file);
+
+    let marker = "fatal-tail-before-final-telemetry";
+    let upload_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/telemetry")
+            .body_includes(marker);
+        then.status(200);
+    });
+
+    guest_common::log::set_system_log_file(system_log);
+    let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker);
+
+    guest_common::log_warn!("sandbox:guest-agent", "{marker}");
+    telemetry
+        .flush(guest_agent::telemetry::UploadMode::Final)
+        .await
+        .expect("final flush should upload just-emitted log");
+
+    telemetry.shutdown().await;
+    guest_common::log::clear_system_log_file();
+
+    upload_mock.assert_calls_async(1).await;
+    upload_mock.delete_async().await;
+    let _ = std::fs::remove_file(system_log);
+    let _ = std::fs::remove_file(pos_file);
+}
+
 /// Regression for #11008. Combines two distinct guarantees that
 /// together produce the "exactly one HTTP POST" assertion:
 ///

--- a/crates/guest-common/Cargo.toml
+++ b/crates/guest-common/Cargo.toml
@@ -8,5 +8,8 @@ chrono = { workspace = true, features = ["std", "clock"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -1,15 +1,74 @@
 //! Logging utilities for VM scripts.
 
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+static SYSTEM_LOG_FILE: Mutex<Option<PathBuf>> = Mutex::new(None);
+
 /// Get current timestamp in RFC3339 format with milliseconds.
 pub fn timestamp() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+/// Also append future log lines to a system log file.
+///
+/// The write is synchronous and completes before the logging macro returns.
+/// This matters for guest-agent's final telemetry upload, which reads the
+/// same file immediately after some fatal-path log lines are emitted.
+pub fn set_system_log_file(path: impl AsRef<Path>) {
+    let mut guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
+    *guard = Some(path.as_ref().to_path_buf());
+}
+
+#[doc(hidden)]
+pub fn clear_system_log_file() {
+    let mut guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
+    *guard = None;
+}
+
+fn append_system_log_line(line: &str) -> std::io::Result<()> {
+    let guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(path) = guard.as_ref() else {
+        return Ok(());
+    };
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {e}", path.display())))?;
+    use std::io::Write;
+    let mut line = line.as_bytes().to_vec();
+    line.push(b'\n');
+    file.write_all(&line)?;
+    file.flush()
+}
+
+fn write_stderr_line(line: &str) {
+    use std::io::Write;
+    let mut stderr = std::io::stderr().lock();
+    let _ = stderr.write_all(line.as_bytes());
+    let _ = stderr.write_all(b"\n");
+    let _ = stderr.flush();
+}
+
+/// Emit one formatted log line to stderr and, when configured, to the
+/// guest-side system log file.
+pub fn emit(level: &str, tag: &str, args: std::fmt::Arguments<'_>) {
+    let line = format!("[{}] [{level}] [{tag}] {args}", timestamp());
+    if let Err(e) = append_system_log_line(&line) {
+        write_stderr_line(&format!(
+            "[{}] [WARN] [sandbox:guest-common] failed to append system log: {e}",
+            timestamp()
+        ));
+    }
+    write_stderr_line(&line);
 }
 
 /// Log an info message to stderr.
 #[macro_export]
 macro_rules! log_info {
     ($tag:expr, $($arg:tt)*) => {
-        eprintln!("[{}] [INFO] [{}] {}", $crate::log::timestamp(), $tag, format!($($arg)*));
+        $crate::log::emit("INFO", $tag, format_args!($($arg)*));
     };
 }
 
@@ -17,7 +76,7 @@ macro_rules! log_info {
 #[macro_export]
 macro_rules! log_warn {
     ($tag:expr, $($arg:tt)*) => {
-        eprintln!("[{}] [WARN] [{}] {}", $crate::log::timestamp(), $tag, format!($($arg)*));
+        $crate::log::emit("WARN", $tag, format_args!($($arg)*));
     };
 }
 
@@ -25,13 +84,15 @@ macro_rules! log_warn {
 #[macro_export]
 macro_rules! log_error {
     ($tag:expr, $($arg:tt)*) => {
-        eprintln!("[{}] [ERROR] [{}] {}", $crate::log::timestamp(), $tag, format!($($arg)*));
+        $crate::log::emit("ERROR", $tag, format_args!($($arg)*));
     };
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    static LOG_TEST_MUTEX: Mutex<()> = Mutex::new(());
 
     #[test]
     fn timestamp_is_rfc3339() {
@@ -44,6 +105,84 @@ mod tests {
         assert!(
             chrono::DateTime::parse_from_rfc3339(&ts).is_ok(),
             "not a valid RFC3339: {ts}"
+        );
+    }
+
+    #[test]
+    fn emit_appends_to_configured_system_log_file() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.log");
+        set_system_log_file(&path);
+
+        emit(
+            "WARN",
+            "sandbox:guest-agent",
+            format_args!("Tool timeout {}", "WebFetch"),
+        );
+
+        clear_system_log_file();
+        let content = std::fs::read_to_string(path).unwrap();
+        assert!(
+            content.contains("[WARN] [sandbox:guest-agent] Tool timeout WebFetch"),
+            "unexpected content: {content:?}"
+        );
+        assert!(content.ends_with('\n'));
+    }
+
+    #[test]
+    fn emit_continues_when_system_log_append_fails() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing-parent").join("system.log");
+        set_system_log_file(&path);
+
+        emit(
+            "WARN",
+            "sandbox:guest-agent",
+            format_args!("system log path is not writable"),
+        );
+
+        clear_system_log_file();
+        assert!(
+            !path.exists(),
+            "test setup expected append to fail for missing parent dir",
+        );
+    }
+
+    #[test]
+    fn emit_appends_complete_lines_concurrently() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.log");
+        set_system_log_file(&path);
+
+        let handles: Vec<_> = (0..8)
+            .map(|thread_id| {
+                std::thread::spawn(move || {
+                    for line_id in 0..20 {
+                        append_system_log_line(&format!(
+                            "[timestamp] [INFO] [sandbox:guest-agent] concurrent {thread_id}-{line_id}"
+                        ))
+                        .unwrap();
+                    }
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        clear_system_log_file();
+
+        let content = std::fs::read_to_string(path).unwrap();
+        let lines: Vec<_> = content.lines().collect();
+        assert_eq!(lines.len(), 160);
+        assert!(content.ends_with('\n'));
+        assert!(
+            lines
+                .iter()
+                .all(|line| { line.contains("[INFO] [sandbox:guest-agent] concurrent ") })
         );
     }
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -3,7 +3,7 @@ use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
-use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory, SandboxId};
+use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory, SandboxId, SpawnOutputMode};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -428,7 +428,8 @@ async fn run_in_sandbox(
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
 ) -> RunnerResult<(i32, Option<String>)> {
-    // System log file — all guest process output goes here for telemetry upload.
+    // Guest-side system log file. Setup commands append directly here before
+    // guest-agent starts; guest-agent owns the file during the agent phase.
     let log_file = format!(
         "{GUEST_SYSTEM_LOG_PREFIX}{}{GUEST_SYSTEM_LOG_SUFFIX}",
         context.run_id
@@ -511,8 +512,8 @@ async fn run_in_sandbox(
     info!(run_id = %context.run_id, count = env_refs.len(), "passing env vars via vsock");
 
     // 6. Spawn agent — stdout streamed to host via vsock, stderr merged into stdout.
-    //    vsock-guest writes stdout to the guest log file (for telemetry) AND streams
-    //    chunks to the host where we write them to the host log file in real-time.
+    //    guest-agent owns the guest-side system log for telemetry; the runner
+    //    separately writes streamed chunks to the host log file in real time.
     let agent_cmd = format!("{} 2>&1", guest::RUN_AGENT);
     info!(run_id = %context.run_id, "spawning agent");
 
@@ -527,7 +528,9 @@ async fn run_in_sandbox(
                 env: &env_refs,
                 sudo: false,
             },
-            Some(&log_file),
+            SpawnOutputMode::Stream {
+                guest_log_path: None,
+            },
         )
         .await;
 
@@ -808,10 +811,11 @@ const GUEST_METRICS_LOG_SUFFIX: &str = ".jsonl";
 
 /// Copy guest log files to host (best-effort, post-job).
 ///
-/// The system log is also streamed to the host in real-time via vsock stdout
-/// streaming during the agent phase, but the final copy here overwrites with
-/// the complete file (includes download/restore output written before streaming
-/// started).
+/// The agent phase is streamed to the host in real time via vsock stdout
+/// chunks. The final copy here overwrites with the complete guest-side file,
+/// including setup output written before agent streaming starts. Agent stdout
+/// that is not written by guest-agent's logger is intentionally not part of
+/// the final system log.
 async fn copy_guest_logs(sandbox: &dyn Sandbox, context: &ExecutionContext, log_paths: &LogPaths) {
     let run_id = context.run_id;
     let files = [
@@ -2311,6 +2315,13 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         let ctx = minimal_context();
 
+        tokio::fs::write(
+            log_paths.system_log(ctx.run_id),
+            b"transient host-streamed stdout\n",
+        )
+        .await
+        .unwrap();
+
         // Queue two exec results: system log + metrics log
         sandbox.push_exec_result(Ok(ExecResult {
             exit_code: 0,
@@ -2329,6 +2340,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(system_log, "system log line 1\nsystem log line 2\n");
+        assert!(!system_log.contains("transient host-streamed stdout"));
 
         let metrics_log = tokio::fs::read_to_string(log_paths.metrics_log(ctx.run_id))
             .await
@@ -2550,6 +2562,27 @@ mod tests {
                 .unwrap();
         assert_eq!(exit_code, 0);
         assert!(error_msg.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_inner_launches_agent_stream_only_without_guest_log_tee() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let mut factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides.clone());
+        factory.startup().await.unwrap();
+
+        let (exit_code, error_msg) =
+            run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+                .await
+                .unwrap();
+        assert_eq!(exit_code, 0);
+        assert!(error_msg.is_none());
+
+        let calls = overrides.spawn_watch_calls();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].streams_stdout);
+        assert!(calls[0].guest_log_path.is_none());
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1151,15 +1151,25 @@ impl Sandbox for FirecrackerSandbox {
     async fn spawn_watch(
         &self,
         request: &ExecRequest<'_>,
-        stdout_log_path: Option<&str>,
+        output: sandbox::SpawnOutputMode<'_>,
     ) -> sandbox::Result<SpawnHandle> {
         let operation = SandboxOperation::SpawnWatch;
         let guest = self.operation_guest(operation).await?;
 
         tokio::select! {
-            result = guest.spawn_watch(request.cmd, request.timeout_ms(), request.env, request.sudo, stdout_log_path) => {
+            result = guest.spawn_watch(
+                request.cmd,
+                request.timeout_ms(),
+                request.env,
+                request.sudo,
+                output.streams_stdout(),
+                output.guest_log_path(),
+            ) => {
                 let (pid, stdout_rx) = result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))?;
-                Ok(SpawnHandle { pid, stdout_rx: Some(stdout_rx) })
+                Ok(SpawnHandle {
+                    pid,
+                    stdout_rx: output.streams_stdout().then_some(stdout_rx),
+                })
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
                 Err(Self::backend_crashed_error(operation))

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -50,6 +50,12 @@ pub struct ExecMatcher {
     pub stderr: Vec<u8>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SpawnWatchCall {
+    pub streams_stdout: bool,
+    pub guest_log_path: Option<String>,
+}
+
 enum LifecycleBehavior {
     Result(Result<()>),
     Panic(String),
@@ -85,6 +91,9 @@ pub struct MockSandboxOverrides {
     /// FIFO queue of unpark results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     unpark_behaviors: Mutex<VecDeque<LifecycleBehavior>>,
+    /// Recorded spawn_watch output modes across all sandboxes built from
+    /// this override set.
+    spawn_watch_calls: Mutex<Vec<SpawnWatchCall>>,
     /// Total `park()` calls across all sandboxes built from this override set.
     park_calls: Mutex<u32>,
     /// Total `unpark()` calls across all sandboxes built from this override set.
@@ -102,6 +111,7 @@ impl MockSandboxOverrides {
             stop_behaviors: Mutex::new(VecDeque::new()),
             park_behaviors: Mutex::new(VecDeque::new()),
             unpark_behaviors: Mutex::new(VecDeque::new()),
+            spawn_watch_calls: Mutex::new(Vec::new()),
             park_calls: Mutex::new(0),
             unpark_calls: Mutex::new(0),
         }
@@ -200,6 +210,12 @@ impl MockSandboxOverrides {
     /// Total `unpark()` calls across all sandboxes built from this override set.
     pub fn unpark_call_count(&self) -> u32 {
         *self.unpark_calls.lock_ignoring_poison()
+    }
+
+    /// Recorded spawn_watch calls across all sandboxes built from this
+    /// override set, in call order.
+    pub fn spawn_watch_calls(&self) -> Vec<SpawnWatchCall> {
+        self.spawn_watch_calls.lock_ignoring_poison().clone()
     }
 }
 
@@ -384,8 +400,17 @@ impl Sandbox for MockSandbox {
     async fn spawn_watch(
         &self,
         _request: &ExecRequest<'_>,
-        _stdout_log_path: Option<&str>,
+        output: sandbox::SpawnOutputMode<'_>,
     ) -> Result<SpawnHandle> {
+        if let Some(overrides) = &self.overrides {
+            overrides
+                .spawn_watch_calls
+                .lock_ignoring_poison()
+                .push(SpawnWatchCall {
+                    streams_stdout: output.streams_stdout(),
+                    guest_log_path: output.guest_log_path().map(str::to_owned),
+                });
+        }
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         // When simulating wait_exit error (timeout/crash), keep the sender
         // alive so the stdout channel never closes — reproducing the real bug.
@@ -398,7 +423,7 @@ impl Sandbox for MockSandbox {
         }
         Ok(SpawnHandle {
             pid: 1,
-            stdout_rx: Some(rx),
+            stdout_rx: output.streams_stdout().then_some(rx),
         })
     }
 

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -19,4 +19,4 @@ pub use factory::SandboxFactory;
 pub use runtime::{RuntimeProvider, SandboxRuntime};
 pub use sandbox::Sandbox;
 pub use snapshot::{SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider};
-pub use types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};
+pub use types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle, SpawnOutputMode};

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -182,15 +182,14 @@ pub trait Sandbox: Send + Sync + Any {
     /// Spawn `request.cmd` in the guest and return a handle for later
     /// supervision via [`wait_exit`](Self::wait_exit).
     ///
-    /// If `stdout_log_path` is `Some`, guest stdout is also mirrored
-    /// into that file on the guest side; the returned handle's
-    /// `stdout_rx` receives the same stream in real time when the
-    /// backend supports streaming (see
-    /// [`SpawnHandle::stdout_rx`](crate::SpawnHandle::stdout_rx)).
+    /// `output` controls whether stdout is buffered into the final
+    /// [`ProcessExit`](crate::ProcessExit) or streamed in real time through
+    /// [`SpawnHandle::stdout_rx`](crate::SpawnHandle::stdout_rx), optionally
+    /// teeing streamed chunks into a guest-side file.
     async fn spawn_watch(
         &self,
         request: &ExecRequest<'_>,
-        stdout_log_path: Option<&str>,
+        output: crate::SpawnOutputMode<'_>,
     ) -> Result<SpawnHandle>;
     /// Wait for the process behind `handle` to exit, up to `timeout`.
     ///

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -27,6 +27,25 @@ pub struct SpawnHandle {
     pub stdout_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SpawnOutputMode<'a> {
+    Buffered,
+    Stream { guest_log_path: Option<&'a str> },
+}
+
+impl<'a> SpawnOutputMode<'a> {
+    pub fn streams_stdout(self) -> bool {
+        matches!(self, Self::Stream { .. })
+    }
+
+    pub fn guest_log_path(self) -> Option<&'a str> {
+        match self {
+            Self::Buffered => None,
+            Self::Stream { guest_log_path } => guest_log_path,
+        }
+    }
+}
+
 pub struct ProcessExit {
     pub pid: u32,
     pub exit_code: i32,

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -702,12 +702,22 @@ fn handle_shutdown(seq: u32) -> io::Result<Vec<u8>> {
     vsock_proto::encode(MSG_SHUTDOWN_ACK, seq, &[]).map_err(to_io_error)
 }
 
+struct SpawnWatchRequest<'a> {
+    timeout_ms: u32,
+    command: &'a str,
+    env: &'a [(&'a str, &'a str)],
+    sudo: bool,
+    stream_stdout: bool,
+    stdout_log_path: Option<&'a str>,
+}
+
 /// Handle spawn_watch: spawn the child, write `MSG_SPAWN_WATCH_RESULT` over
 /// the wire, THEN start the background monitor. Returns immediately; exit is
 /// later reported via `MSG_PROCESS_EXIT`.
 ///
-/// When `stdout_log_path` is `Some`, stdout is streamed to the host via
-/// `MSG_STDOUT_CHUNK` messages AND teed to the file path inside the VM.
+/// When `stream_stdout` is true, stdout is streamed to the host via
+/// `MSG_STDOUT_CHUNK` messages. `stdout_log_path`, when present, additionally
+/// tees those chunks to a file path inside the VM.
 ///
 /// The result-before-monitor ordering is critical: the streaming monitor
 /// thread also writes to the same socket (via the shared `writer` mutex),
@@ -716,11 +726,7 @@ fn handle_shutdown(seq: u32) -> io::Result<Vec<u8>> {
 /// stdout channel when it processes the result, so earlier chunks would
 /// be dropped.
 fn handle_spawn_watch(
-    timeout_ms: u32,
-    command: &str,
-    env: &[(&str, &str)],
-    sudo: bool,
-    stdout_log_path: Option<&str>,
+    request: SpawnWatchRequest<'_>,
     seq: u32,
     writer: Arc<Mutex<UnixStream>>,
 ) -> io::Result<()> {
@@ -728,16 +734,16 @@ fn handle_spawn_watch(
         "INFO",
         &format!(
             "spawn_watch: {} (timeout={}ms, sudo={}, env_count={}, stream={})",
-            truncate_preview(command),
-            timeout_ms,
-            sudo,
-            env.len(),
-            stdout_log_path.is_some(),
+            truncate_preview(request.command),
+            request.timeout_ms,
+            request.sudo,
+            request.env.len(),
+            request.stream_stdout,
         ),
     );
-    let command = prepend_env(command, env);
+    let command = prepend_env(request.command, request.env);
 
-    let mut child = match spawn_with_pipes(&command, sudo) {
+    let mut child = match spawn_with_pipes(&command, request.sudo) {
         Ok(c) => c,
         Err(e) => {
             let payload = vsock_proto::encode_error(&format!("Failed to spawn: {e}"));
@@ -779,29 +785,30 @@ fn handle_spawn_watch(
         }
     }
 
-    if let Some(log_path) = stdout_log_path {
-        // Streaming mode: tee stdout to log file + vsock chunks.
+    if request.stream_stdout {
+        // Streaming mode: stream stdout to vsock chunks, optionally teeing to a guest file.
         // Take stdout from child so we can read it in a separate thread.
         let stdout_pipe = child.stdout.take();
         spawn_streaming_monitor(
             pid,
             child,
-            timeout_ms,
+            request.timeout_ms,
             stdout_pipe,
-            log_path.to_owned(),
+            request.stdout_log_path.map(str::to_owned),
             writer,
         );
     } else {
         // Buffered mode: stdout/stderr drained via cancellable helper, sent
         // in a single MSG_PROCESS_EXIT after wait.
-        spawn_buffered_monitor(pid, child, timeout_ms, writer);
+        spawn_buffered_monitor(pid, child, request.timeout_ms, writer);
     }
 
     Ok(())
 }
 
-/// Streaming monitor: tees stdout chunks to a log file + vsock, drains stderr
-/// into a buffer, and races both against `child.wait()`.
+/// Streaming monitor: streams stdout chunks to vsock, optionally tees stdout
+/// chunks to a guest file, drains stderr into a buffer, and races both
+/// against `child.wait()`.
 ///
 /// Architecture:
 /// - Timeout killer thread: kills process group after deadline
@@ -820,7 +827,7 @@ fn spawn_streaming_monitor(
     mut child: std::process::Child,
     timeout_ms: u32,
     stdout_pipe: Option<std::process::ChildStdout>,
-    log_path: String,
+    log_path: Option<String>,
     writer: Arc<Mutex<UnixStream>>,
 ) {
     thread::spawn(move || {
@@ -870,19 +877,22 @@ fn spawn_streaming_monitor(
             let tx = drain_done_tx.clone();
             let stdout_writer = Arc::clone(&writer);
             Some(thread::spawn(move || {
-                let log_file = std::fs::OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&log_path);
-                let mut log_file = match log_file {
-                    Ok(f) => Some(f),
-                    Err(e) => {
-                        log(
-                            "WARN",
-                            &format!("spawn_watch: failed to open log file {log_path}: {e}"),
-                        );
-                        None
-                    }
+                let mut log_file = match log_path.as_deref() {
+                    Some(path) => match std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(path)
+                    {
+                        Ok(f) => Some(f),
+                        Err(e) => {
+                            log(
+                                "WARN",
+                                &format!("spawn_watch: failed to open log file {path}: {e}"),
+                            );
+                            None
+                        }
+                    },
+                    None => None,
                 };
 
                 drain_until_eof_or_cancelled(stdout, &cancel, |chunk| {
@@ -1176,11 +1186,14 @@ pub fn handle_connection(stream: UnixStream) -> io::Result<()> {
                 // spawning the streaming thread) to prevent a race where
                 // stdout chunks could arrive at the host before the result.
                 handle_spawn_watch(
-                    d.exec.timeout_ms,
-                    d.exec.command,
-                    &d.exec.env,
-                    d.exec.sudo,
-                    d.stdout_log_path,
+                    SpawnWatchRequest {
+                        timeout_ms: d.exec.timeout_ms,
+                        command: d.exec.command,
+                        env: &d.exec.env,
+                        sudo: d.exec.sudo,
+                        stream_stdout: d.stream_stdout,
+                        stdout_log_path: d.stdout_log_path,
+                    },
                     msg.seq,
                     Arc::clone(&writer),
                 )?;
@@ -1705,11 +1718,12 @@ mod tests {
         stream: &mut impl std::io::Write,
         seq: u32,
         command: &str,
-        log_path: &str,
+        log_path: Option<&str>,
         timeout_ms: u32,
     ) {
         let payload =
-            vsock_proto::encode_spawn_watch(timeout_ms, command, &[], false, Some(log_path));
+            vsock_proto::encode_spawn_watch(timeout_ms, command, &[], false, true, log_path)
+                .unwrap();
         let msg = vsock_proto::encode(MSG_SPAWN_WATCH, seq, &payload).unwrap();
         stream.write_all(&msg).unwrap();
     }
@@ -1773,7 +1787,7 @@ mod tests {
         read_and_discard_message(&mut host_stream);
 
         let log_path = format!("/tmp/vsock-test-normal-{}.log", std::process::id());
-        send_spawn_watch(&mut host_stream, 1, "echo hello", &log_path, 5000);
+        send_spawn_watch(&mut host_stream, 1, "echo hello", Some(&log_path), 5000);
 
         host_stream
             .set_read_timeout(Some(Duration::from_secs(10)))
@@ -1788,6 +1802,40 @@ mod tests {
         let _ = std::fs::remove_file(&log_path);
         drop(host_stream);
         let _ = handle.join();
+    }
+
+    /// Stream-only mode sends stdout chunks to the host without creating a
+    /// guest-side tee file.
+    #[test]
+    fn streaming_monitor_stream_only_does_not_write_guest_log() {
+        use std::os::unix::net::UnixStream as StdUnixStream;
+
+        let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+        let handle = thread::spawn(move || {
+            let _ = handle_connection(guest_stream);
+        });
+
+        // Discard MSG_READY
+        read_and_discard_message(&mut host_stream);
+
+        let log_path = format!("/tmp/vsock-test-stream-only-{}.log", std::process::id());
+        std::fs::write(&log_path, "preexisting\n").unwrap();
+        send_spawn_watch(&mut host_stream, 1, "echo stream-only", None, 5000);
+
+        host_stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let (pid, stdout_data, exit_code, _stderr) = read_streaming_result(&mut host_stream, 1);
+
+        assert!(pid > 0);
+        assert_eq!(exit_code, 0);
+        assert_eq!(String::from_utf8_lossy(&stdout_data).trim(), "stream-only");
+        let log_content = std::fs::read_to_string(&log_path).unwrap();
+        assert_eq!(log_content, "preexisting\n");
+
+        drop(host_stream);
+        let _ = handle.join();
+        let _ = std::fs::remove_file(&log_path);
     }
 
     /// Regression test: if the main child exits but an orphaned background
@@ -1816,7 +1864,7 @@ mod tests {
             &mut host_stream,
             1,
             "echo orphan-test; sleep 30 &",
-            &log_path,
+            Some(&log_path),
             0, // no timeout — relies entirely on drain deadline
         );
 
@@ -1869,7 +1917,7 @@ mod tests {
             &mut host_stream,
             1,
             "echo timeout-test; sleep 60",
-            &log_path,
+            Some(&log_path),
             1000, // 1 second timeout
         );
 
@@ -1905,7 +1953,8 @@ mod tests {
         command: &str,
         timeout_ms: u32,
     ) {
-        let payload = vsock_proto::encode_spawn_watch(timeout_ms, command, &[], false, None);
+        let payload =
+            vsock_proto::encode_spawn_watch(timeout_ms, command, &[], false, false, None).unwrap();
         let msg = vsock_proto::encode(MSG_SPAWN_WATCH, seq, &payload).unwrap();
         stream.write_all(&msg).unwrap();
     }
@@ -2036,7 +2085,7 @@ mod tests {
             &mut host_stream,
             1,
             "while true; do echo tick; sleep 0.05; done",
-            &log_path,
+            Some(&log_path),
             0, // no timeout — we want SIGPIPE, not the kill watchdog, to terminate
         );
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -125,6 +125,40 @@ impl Drop for ListenerSocketGuard {
     }
 }
 
+struct PendingRequestGuard {
+    shared: Arc<Shared>,
+    seq: u32,
+}
+
+impl PendingRequestGuard {
+    fn new(shared: Arc<Shared>, seq: u32) -> Self {
+        Self { shared, seq }
+    }
+}
+
+impl Drop for PendingRequestGuard {
+    fn drop(&mut self) {
+        self.shared.remove_pending(self.seq);
+    }
+}
+
+struct PendingStdoutGuard {
+    shared: Arc<Shared>,
+    seq: u32,
+}
+
+impl PendingStdoutGuard {
+    fn new(shared: Arc<Shared>, seq: u32) -> Self {
+        Self { shared, seq }
+    }
+}
+
+impl Drop for PendingStdoutGuard {
+    fn drop(&mut self) {
+        self.shared.remove_pending_stdout(self.seq);
+    }
+}
+
 impl Shared {
     /// Get next sequence number, skipping 0 (reserved for unsolicited messages).
     fn next_seq(&self) -> u32 {
@@ -178,6 +212,20 @@ impl Shared {
         if let Some(maps) = maps_to_drop {
             drop(maps);
             self.exit_notify.notify_waiters();
+        }
+    }
+
+    fn remove_pending(&self, seq: u32) {
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let ConnectionState::Connected { pending, .. } = &mut *guard {
+            pending.remove(&seq);
+        }
+    }
+
+    fn remove_pending_stdout(&self, seq: u32) {
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let ConnectionState::Connected { pending_stdout, .. } = &mut *guard {
+            pending_stdout.remove(&seq);
         }
     }
 }
@@ -500,15 +548,11 @@ impl VsockHost {
                 }
             }
         }
+        let _pending_guard = PendingRequestGuard::new(Arc::clone(&self.shared), seq);
 
-        // Write to stream; clean up pending entry on failure.
-        if let Err(e) = self.shared.writer.lock().await.write_all(&data).await {
-            let mut guard = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
-            if let ConnectionState::Connected { pending, .. } = &mut *guard {
-                pending.remove(&seq);
-            }
-            return Err(e);
-        }
+        // The guard removes the pending entry on write failure, timeout, or
+        // cancellation before reader_loop dispatches a response.
+        self.shared.writer.lock().await.write_all(&data).await?;
 
         // `rx` returns `Ok(msg)` when the reader dispatches a response and
         // `Err(RecvError)` when `close()` drops the `Connected` variant. The
@@ -522,10 +566,6 @@ impl VsockHost {
                 ))
             }
             _ = tokio::time::sleep(timeout) => {
-                let mut guard = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
-                if let ConnectionState::Connected { pending, .. } = &mut *guard {
-                    pending.remove(&seq);
-                }
                 Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))
             }
         }
@@ -596,7 +636,7 @@ impl VsockHost {
     /// Write a file on the guest.
     ///
     /// Content larger than 15 MB is automatically split into multiple
-    /// messages using the `FLAG_APPEND` protocol flag.  Chunks are written
+    /// messages using the `WRITE_FILE_FLAG_APPEND` protocol flag. Chunks are written
     /// to a temporary file and atomically renamed to the target path after
     /// the last chunk succeeds, so a partial transfer never leaves a
     /// truncated file at the destination.
@@ -694,25 +734,34 @@ impl VsockHost {
     /// Returns immediately with `(pid, stdout_rx)`. Use [`wait_for_exit`](Self::wait_for_exit)
     /// to wait for completion.
     ///
-    /// When `stdout_log_path` is `Some`, the guest tees stdout to the given
-    /// file path AND streams chunks to the host via `MSG_STDOUT_CHUNK`.
-    /// The `stdout_rx` channel is closed when the process exits or the
-    /// connection drops.
+    /// When `stream_stdout` is true, stdout chunks are streamed to the host via
+    /// `MSG_STDOUT_CHUNK`. `stdout_log_path`, when present, additionally asks
+    /// the guest to tee those chunks into the given guest-side file.
+    /// The returned `stdout_rx` channel receives streamed chunks when enabled
+    /// and is closed when the process exits or the connection drops.
     pub async fn spawn_watch(
         &self,
         command: &str,
         timeout_ms: u32,
         env: &[(&str, &str)],
         sudo: bool,
+        stream_stdout: bool,
         stdout_log_path: Option<&str>,
     ) -> io::Result<(u32, tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>)> {
-        let payload =
-            vsock_proto::encode_spawn_watch(timeout_ms, command, env, sudo, stdout_log_path);
+        let payload = vsock_proto::encode_spawn_watch(
+            timeout_ms,
+            command,
+            env,
+            sudo,
+            stream_stdout,
+            stdout_log_path,
+        )
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 
-        // Pre-create the stdout channel and register it by seq number BEFORE
-        // sending the request. reader_loop will atomically move it from
-        // pending_stdout[seq] to stdout_senders[pid] when it processes the
-        // spawn_watch_result — before any stdout_chunk for that pid.
+        // Pre-create the stdout channel. In streaming mode, register it by seq
+        // number BEFORE sending the request. reader_loop will atomically move
+        // it from pending_stdout[seq] to stdout_senders[pid] when it processes
+        // the spawn_watch_result — before any stdout_chunk for that pid.
         let (stdout_tx, stdout_rx) = mpsc::unbounded_channel();
         let seq = self.shared.next_seq();
         {
@@ -724,21 +773,14 @@ impl VsockHost {
                         "connection closed",
                     ));
                 }
-                ConnectionState::Connected { pending_stdout, .. } => {
+                ConnectionState::Connected { pending_stdout, .. } if stream_stdout => {
                     pending_stdout.insert(seq, stdout_tx);
                 }
+                ConnectionState::Connected { .. } => {}
             }
         }
-
-        // Cleanup helper: remove the pending_stdout entry if it's still there.
-        // If `close()` already ran, the map is gone and the Closed branch is a
-        // no-op; the stdout_tx inside the map was already dropped.
-        let drop_pending_stdout = || {
-            let mut guard = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
-            if let ConnectionState::Connected { pending_stdout, .. } = &mut *guard {
-                pending_stdout.remove(&seq);
-            }
-        };
+        let _pending_stdout_guard =
+            stream_stdout.then(|| PendingStdoutGuard::new(Arc::clone(&self.shared), seq));
 
         let resp = match self
             .request_raw(MSG_SPAWN_WATCH, seq, &payload, Duration::from_secs(30))
@@ -746,21 +788,18 @@ impl VsockHost {
         {
             Ok(resp) => resp,
             Err(e) => {
-                drop_pending_stdout();
                 return Err(e);
             }
         };
 
         if resp.msg_type == MSG_ERROR {
             // No pid assigned — clean up pending stdout sender.
-            drop_pending_stdout();
             let msg = vsock_proto::decode_error(&resp.payload)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
             return Err(io::Error::other(msg));
         }
 
         if resp.msg_type != MSG_SPAWN_WATCH_RESULT {
-            drop_pending_stdout();
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("unexpected response type: 0x{:02X}", resp.msg_type),
@@ -775,7 +814,6 @@ impl VsockHost {
         let pid = match vsock_proto::decode_spawn_watch_result(&resp.payload) {
             Ok(pid) => pid,
             Err(e) => {
-                drop_pending_stdout();
                 return Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string()));
             }
         };
@@ -911,6 +949,19 @@ mod tests {
     async fn host_from_stream(stream: UnixStream) -> io::Result<VsockHost> {
         let deadline = Instant::now() + Duration::from_secs(5);
         VsockHost::from_stream(stream, deadline).await
+    }
+
+    fn registration_counts(host: &VsockHost) -> (usize, usize, usize) {
+        let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &*guard {
+            ConnectionState::Connected {
+                pending,
+                pending_stdout,
+                stdout_senders,
+                ..
+            } => (pending.len(), pending_stdout.len(), stdout_senders.len()),
+            ConnectionState::Closed { .. } => (0, 0, 0),
+        }
     }
 
     #[tokio::test]
@@ -1279,11 +1330,15 @@ mod tests {
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
-        let (pid, _stdout_rx) = host
-            .spawn_watch("sleep 1", 0, &[], false, None)
+        let (pid, mut stdout_rx) = host
+            .spawn_watch("sleep 1", 0, &[], false, false, None)
             .await
             .unwrap();
         assert_eq!(pid, 42);
+        assert!(
+            stdout_rx.recv().await.is_none(),
+            "buffered spawn_watch must not keep a stdout stream registered",
+        );
 
         let event = host
             .wait_for_exit(42, Duration::from_secs(5))
@@ -1326,7 +1381,7 @@ mod tests {
 
         let host = host_from_stream(host_stream).await.unwrap();
         let (pid, _stdout_rx) = host
-            .spawn_watch("false", 0, &[], false, None)
+            .spawn_watch("false", 0, &[], false, false, None)
             .await
             .unwrap();
         assert_eq!(pid, 99);
@@ -1340,8 +1395,8 @@ mod tests {
     }
 
     /// When a `spawn_watch` request is answered with `MSG_ERROR`, the
-    /// pre-registered `pending_stdout` entry must be removed via the
-    /// `drop_pending_stdout` closure. Assert the error surfaces with the
+    /// pre-registered `pending_stdout` entry must be removed by the
+    /// registration guard. Assert the error surfaces with the
     /// guest-provided message AND that a follow-up successful `spawn_watch`
     /// can still run — proving no stale state lingers.
     #[tokio::test]
@@ -1377,13 +1432,13 @@ mod tests {
         let host = host_from_stream(host_stream).await.unwrap();
 
         let err = host
-            .spawn_watch("bad-cmd", 0, &[], false, None)
+            .spawn_watch("bad-cmd", 0, &[], false, false, None)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("no such command"));
 
         let (pid, _stdout_rx) = host
-            .spawn_watch("good-cmd", 0, &[], false, None)
+            .spawn_watch("good-cmd", 0, &[], false, false, None)
             .await
             .unwrap();
         assert_eq!(pid, 222);
@@ -1429,16 +1484,63 @@ mod tests {
         let host = host_from_stream(host_stream).await.unwrap();
 
         let err = host
-            .spawn_watch("bad-payload-cmd", 0, &[], false, None)
+            .spawn_watch("bad-payload-cmd", 0, &[], false, false, None)
             .await
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
 
         let (pid, _stdout_rx) = host
-            .spawn_watch("good-cmd", 0, &[], false, None)
+            .spawn_watch("good-cmd", 0, &[], false, false, None)
             .await
             .unwrap();
         assert_eq!(pid, 333);
+    }
+
+    #[tokio::test]
+    async fn test_spawn_watch_cancel_cleans_up_registrations() {
+        let (host_stream, mut guest) = make_pair();
+        let request_seen = std::sync::Arc::new(Notify::new());
+        let release_guest = std::sync::Arc::new(Notify::new());
+
+        {
+            let request_seen = std::sync::Arc::clone(&request_seen);
+            let release_guest = std::sync::Arc::clone(&release_guest);
+            tokio::spawn(async move {
+                let mut decoder = Decoder::new();
+                mock_handshake(&mut guest, &mut decoder).await;
+
+                let mut buf = [0u8; 4096];
+                let n = guest.read(&mut buf).await.unwrap();
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+                request_seen.notify_one();
+
+                release_guest.notified().await;
+            });
+        }
+
+        let host = std::sync::Arc::new(host_from_stream(host_stream).await.unwrap());
+        let task_host = std::sync::Arc::clone(&host);
+        let task = tokio::spawn(async move {
+            task_host
+                .spawn_watch("long-running", 0, &[], false, true, None)
+                .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), request_seen.notified())
+            .await
+            .expect("guest should receive spawn_watch request");
+        assert_eq!(registration_counts(&host), (1, 1, 0));
+
+        task.abort();
+        let _ = task.await;
+        assert_eq!(
+            registration_counts(&host),
+            (0, 0, 0),
+            "aborted spawn_watch future must clean pending registrations",
+        );
+
+        release_guest.notify_one();
     }
 
     #[tokio::test]
@@ -1546,7 +1648,7 @@ mod tests {
 
         let start = Instant::now();
         let err = host
-            .spawn_watch("long-running", 0, &[], false, None)
+            .spawn_watch("long-running", 0, &[], false, false, None)
             .await
             .unwrap_err();
         assert!(
@@ -1678,7 +1780,7 @@ mod tests {
 
         let host = host_from_stream(host_stream).await.unwrap();
         let (pid, _stdout_rx) = host
-            .spawn_watch("quick-exit", 0, &[], false, None)
+            .spawn_watch("quick-exit", 0, &[], false, false, None)
             .await
             .unwrap();
         assert_eq!(pid, 88);
@@ -1721,7 +1823,7 @@ mod tests {
 
         let host = host_from_stream(host_stream).await.unwrap();
         let (pid, _stdout_rx) = host
-            .spawn_watch("long-running", 0, &[], false, None)
+            .spawn_watch("long-running", 0, &[], false, false, None)
             .await
             .unwrap();
         assert_eq!(pid, 77);
@@ -1770,7 +1872,7 @@ mod tests {
 
         let host = host_from_stream(host_stream).await.unwrap();
         let (pid, _stdout_rx) = host
-            .spawn_watch("quick-exit", 0, &[], false, None)
+            .spawn_watch("quick-exit", 0, &[], false, false, None)
             .await
             .unwrap();
         assert_eq!(pid, 111);
@@ -1820,7 +1922,7 @@ mod tests {
 
         let host = host_from_stream(host_stream).await.unwrap();
         let (pid, _stdout_rx) = host
-            .spawn_watch("long-running", 0, &[], false, None)
+            .spawn_watch("long-running", 0, &[], false, false, None)
             .await
             .unwrap();
         assert_eq!(pid, 55);
@@ -1919,7 +2021,7 @@ mod tests {
 
         let host = Arc::new(host_from_stream(host_stream).await.unwrap());
         let (pid, _stdout_rx) = host
-            .spawn_watch("long-running", 0, &[], false, None)
+            .spawn_watch("long-running", 0, &[], false, false, None)
             .await
             .unwrap();
         assert_eq!(pid, 50);

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -22,7 +22,7 @@
 //! | 0x04 | G→H       | exec_result       | `[4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` |
 //! | 0x05 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
 //! | 0x06 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
-//! | 0x07 | H→G       | spawn_watch       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` |
+//! | 0x07 | H→G       | spawn_watch       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`) |
 //! | 0x08 | G→H       | spawn_watch_result| `[4B pid]` |
 //! | 0x09 | G→H       | process_exit      | `[4B pid][4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` |
 //! | 0x0A | H→G       | shutdown          | (empty) |
@@ -58,10 +58,16 @@ pub const MSG_ERROR: u8 = 0xFF;
 /// Default vsock port for host-guest communication.
 pub const VSOCK_PORT: u32 = 1000;
 
-/// Flag: execute with root privileges (used in exec, spawn_watch, and write_file).
-pub const FLAG_SUDO: u8 = 0x01;
-/// Flag: append to existing file instead of truncating (used in write_file).
-pub const FLAG_APPEND: u8 = 0x02;
+// Exec payload flags.
+pub const EXEC_FLAG_SUDO: u8 = 0x01;
+
+// Spawn-watch payload flags.
+pub const SPAWN_WATCH_FLAG_SUDO: u8 = 0x01;
+pub const SPAWN_WATCH_FLAG_STREAM_STDOUT: u8 = 0x02;
+
+// Write-file payload flags.
+pub const WRITE_FILE_FLAG_SUDO: u8 = 0x01;
+pub const WRITE_FILE_FLAG_APPEND: u8 = 0x02;
 
 /// Protocol error.
 #[derive(Debug, Clone)]
@@ -152,7 +158,7 @@ pub fn encode_exec(timeout_ms: u32, command: &str, env: &[(&str, &str)], sudo: b
     };
     let mut p = Vec::with_capacity(9 + cmd.len() + env_size);
     p.extend_from_slice(&timeout_ms.to_be_bytes());
-    p.push(if sudo { FLAG_SUDO } else { 0 });
+    p.push(if sudo { EXEC_FLAG_SUDO } else { 0 });
     p.extend_from_slice(&(cmd.len() as u32).to_be_bytes());
     p.extend_from_slice(cmd);
     if !env.is_empty() {
@@ -171,8 +177,9 @@ pub fn encode_exec(timeout_ms: u32, command: &str, env: &[(&str, &str)], sudo: b
 
 /// Encode spawn_watch payload: exec fields + optional `[2B log_path_len][log_path]`.
 ///
-/// When `stdout_log_path` is `Some`, the guest tees stdout to this file path
-/// AND streams chunks to the host via `MSG_STDOUT_CHUNK`.
+/// `stream_stdout` controls whether stdout is streamed to the host via
+/// `MSG_STDOUT_CHUNK`. `stdout_log_path`, when present, additionally asks
+/// the guest to tee streamed stdout to that file.
 ///
 /// Unlike `encode_exec`, this always writes the env section (even when empty)
 /// so `decode_spawn_watch` can unambiguously find the log_path boundary.
@@ -181,20 +188,37 @@ pub fn encode_spawn_watch(
     command: &str,
     env: &[(&str, &str)],
     sudo: bool,
+    stream_stdout: bool,
     stdout_log_path: Option<&str>,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, ProtocolError> {
+    if !stream_stdout && stdout_log_path.is_some() {
+        return Err(ProtocolError::InvalidPayload(
+            "spawn_watch log_path requires stream flag",
+        ));
+    }
     let cmd = command.as_bytes();
     let env_size: usize = 4 + env
         .iter()
         .map(|(k, v)| 8 + k.len() + v.len())
         .sum::<usize>();
-    let log_size: usize = match stdout_log_path {
-        Some(p) => 2 + p.len().min(u16::MAX as usize),
-        None => 0,
+    let log_path = match stdout_log_path {
+        Some("") => {
+            return Err(ProtocolError::InvalidPayload("spawn_watch log_path empty"));
+        }
+        Some(path) if path.len() > u16::MAX as usize => {
+            return Err(ProtocolError::PayloadTooLarge("log_path", path.len()));
+        }
+        Some(path) => Some((path.as_bytes(), path.len() as u16)),
+        None => None,
     };
+    let log_size = log_path.map_or(0, |(_, len)| 2 + len as usize);
     let mut p = Vec::with_capacity(9 + cmd.len() + env_size + log_size);
     p.extend_from_slice(&timeout_ms.to_be_bytes());
-    p.push(if sudo { FLAG_SUDO } else { 0 });
+    let mut flags = if sudo { SPAWN_WATCH_FLAG_SUDO } else { 0 };
+    if stream_stdout {
+        flags |= SPAWN_WATCH_FLAG_STREAM_STDOUT;
+    }
+    p.push(flags);
     p.extend_from_slice(&(cmd.len() as u32).to_be_bytes());
     p.extend_from_slice(cmd);
     // Always write env_count so the decoder knows where env ends.
@@ -207,14 +231,11 @@ pub fn encode_spawn_watch(
         p.extend_from_slice(&(vb.len() as u32).to_be_bytes());
         p.extend_from_slice(vb);
     }
-    if let Some(path) = stdout_log_path {
-        let path_bytes = path.as_bytes();
-        let path_len = path_bytes.len().min(u16::MAX as usize) as u16;
+    if let Some((path_bytes, path_len)) = log_path {
         p.extend_from_slice(&path_len.to_be_bytes());
-        // path_len <= path_bytes.len() is guaranteed by .min() above
-        p.extend_from_slice(path_bytes.get(..path_len as usize).unwrap_or(path_bytes));
+        p.extend_from_slice(path_bytes);
     }
-    p
+    Ok(p)
 }
 
 /// Encode exec_result payload: `[4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]`.
@@ -245,10 +266,10 @@ pub fn encode_write_file(
     let path_len = path_bytes.len() as u16;
     let mut flags = 0u8;
     if sudo {
-        flags |= FLAG_SUDO;
+        flags |= WRITE_FILE_FLAG_SUDO;
     }
     if append {
-        flags |= FLAG_APPEND;
+        flags |= WRITE_FILE_FLAG_APPEND;
     }
     let mut p = Vec::with_capacity(7 + path_len as usize + content.len());
     p.extend_from_slice(&path_len.to_be_bytes());
@@ -319,12 +340,15 @@ pub fn encode_error(message: &str) -> Vec<u8> {
 ///
 /// The env section is optional: if the payload ends right after the command,
 /// an empty vec is returned (backward-compatible with old encoders).
-fn decode_exec_inner(payload: &[u8]) -> Result<(DecodedExec<'_>, usize), ProtocolError> {
+fn decode_exec_inner(
+    payload: &[u8],
+    sudo_flag: u8,
+) -> Result<(DecodedExec<'_>, usize), ProtocolError> {
     let timeout_ms =
         read_u32_at(payload, 0).ok_or(ProtocolError::InvalidPayload("exec payload too short"))?;
     let flags =
         read_u8_at(payload, 4).ok_or(ProtocolError::InvalidPayload("exec payload too short"))?;
-    let sudo = (flags & FLAG_SUDO) != 0;
+    let sudo = (flags & sudo_flag) != 0;
     let cmd_len = read_u32_at(payload, 5)
         .ok_or(ProtocolError::InvalidPayload("exec payload too short"))? as usize;
     let command = std::str::from_utf8(
@@ -396,35 +420,52 @@ fn decode_exec_inner(payload: &[u8]) -> Result<(DecodedExec<'_>, usize), Protoco
 
 /// Decode exec payload. Returns `(timeout_ms, command, env, sudo)`.
 pub fn decode_exec(payload: &[u8]) -> Result<DecodedExec<'_>, ProtocolError> {
-    decode_exec_inner(payload).map(|(d, _)| d)
+    decode_exec_inner(payload, EXEC_FLAG_SUDO).map(|(d, _)| d)
 }
 
-/// Decode spawn_watch payload. Extends exec fields with an optional `stdout_log_path`.
+/// Decode spawn_watch payload. Extends exec fields with streaming metadata.
 ///
 /// Wire format: `[exec fields...]([2B log_path_len][log_path])`.
 /// The log_path section is optional — if the payload ends after the exec
-/// fields, `stdout_log_path` is `None` (backward-compatible with old encoders).
+/// fields, `stdout_log_path` is `None`.
 pub fn decode_spawn_watch(payload: &[u8]) -> Result<DecodedSpawnWatch<'_>, ProtocolError> {
-    let (exec, offset) = decode_exec_inner(payload)?;
-    let stdout_log_path = if offset + 2 <= payload.len() {
+    let (exec, offset) = decode_exec_inner(payload, SPAWN_WATCH_FLAG_SUDO)?;
+    let flags =
+        read_u8_at(payload, 4).ok_or(ProtocolError::InvalidPayload("exec payload too short"))?;
+    let stream_flag = (flags & SPAWN_WATCH_FLAG_STREAM_STDOUT) != 0;
+    let stdout_log_path = if offset == payload.len() {
+        None
+    } else if offset + 2 <= payload.len() {
         let path_len = read_u16_at(payload, offset).ok_or(ProtocolError::InvalidPayload(
             "spawn_watch log_path_len truncated",
         ))? as usize;
         if path_len == 0 {
-            None
+            return Err(ProtocolError::InvalidPayload("spawn_watch log_path empty"));
         } else {
+            let path_end = offset + 2 + path_len;
+            if path_end != payload.len() {
+                return Err(ProtocolError::InvalidPayload("spawn_watch trailing bytes"));
+            }
             Some(
-                std::str::from_utf8(payload.get(offset + 2..offset + 2 + path_len).ok_or(
+                std::str::from_utf8(payload.get(offset + 2..path_end).ok_or(
                     ProtocolError::InvalidPayload("spawn_watch log_path truncated"),
                 )?)
                 .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in log_path"))?,
             )
         }
     } else {
-        None
+        return Err(ProtocolError::InvalidPayload(
+            "spawn_watch trailing byte after env",
+        ));
     };
+    if !stream_flag && stdout_log_path.is_some() {
+        return Err(ProtocolError::InvalidPayload(
+            "spawn_watch log_path requires stream flag",
+        ));
+    }
     Ok(DecodedSpawnWatch {
         exec,
+        stream_stdout: stream_flag,
         stdout_log_path,
     })
 }
@@ -476,8 +517,8 @@ pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool), Pr
     Ok((
         path,
         content,
-        (flags & FLAG_SUDO) != 0,
-        (flags & FLAG_APPEND) != 0,
+        (flags & WRITE_FILE_FLAG_SUDO) != 0,
+        (flags & WRITE_FILE_FLAG_APPEND) != 0,
     ))
 }
 
@@ -511,11 +552,12 @@ pub struct DecodedExec<'a> {
     pub sudo: bool,
 }
 
-/// Decoded spawn_watch fields: exec fields + optional stdout log path.
+/// Decoded spawn_watch fields: exec fields + stdout streaming options.
 pub struct DecodedSpawnWatch<'a> {
     pub exec: DecodedExec<'a>,
-    /// Guest-side file path where vsock-guest tees stdout while streaming
-    /// chunks to the host. `None` disables streaming (legacy mode).
+    /// Whether vsock-guest should stream stdout chunks to the host.
+    pub stream_stdout: bool,
+    /// Optional guest-side file path where vsock-guest also tees stdout.
     pub stdout_log_path: Option<&'a str>,
 }
 
@@ -851,34 +893,112 @@ mod tests {
             "echo hello",
             &[("FOO", "bar")],
             false,
+            true,
             Some("/tmp/vm0-system-123.log"),
-        );
+        )
+        .unwrap();
         let d = decode_spawn_watch(&payload).unwrap();
         assert_eq!(d.exec.timeout_ms, 5000);
         assert_eq!(d.exec.command, "echo hello");
         assert_eq!(d.exec.env, vec![("FOO", "bar")]);
         assert!(!d.exec.sudo);
+        assert!(d.stream_stdout);
         assert_eq!(d.stdout_log_path.unwrap(), "/tmp/vm0-system-123.log");
     }
 
     #[test]
-    fn spawn_watch_payload_roundtrip_no_log_path() {
-        let payload = encode_spawn_watch(3000, "ls", &[], true, None);
+    fn spawn_watch_payload_roundtrip_stream_only() {
+        let payload = encode_spawn_watch(3000, "ls", &[], true, true, None).unwrap();
         let d = decode_spawn_watch(&payload).unwrap();
         assert_eq!(d.exec.timeout_ms, 3000);
         assert_eq!(d.exec.command, "ls");
         assert!(d.exec.env.is_empty());
         assert!(d.exec.sudo);
+        assert!(d.stream_stdout);
         assert!(d.stdout_log_path.is_none());
     }
 
     #[test]
-    fn spawn_watch_backward_compat_old_encoder() {
-        // Old-style payload (no log_path) decoded as spawn_watch → log_path is None
-        let payload = encode_exec(1000, "cmd", &[], false);
+    fn spawn_watch_payload_roundtrip_buffered() {
+        let payload = encode_spawn_watch(1000, "cmd", &[], false, false, None).unwrap();
         let d = decode_spawn_watch(&payload).unwrap();
         assert_eq!(d.exec.command, "cmd");
+        assert!(!d.stream_stdout);
         assert!(d.stdout_log_path.is_none());
+    }
+
+    #[test]
+    fn spawn_watch_log_path_requires_streaming() {
+        let err = encode_spawn_watch(1000, "cmd", &[], false, false, Some("/tmp/log")).unwrap_err();
+        assert!(matches!(err, ProtocolError::InvalidPayload(_)));
+    }
+
+    #[test]
+    fn spawn_watch_log_path_too_long() {
+        let long_path = "x".repeat(u16::MAX as usize + 1);
+        let err = encode_spawn_watch(1000, "cmd", &[], false, true, Some(&long_path)).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::PayloadTooLarge("log_path", size) if size == long_path.len()
+        ));
+    }
+
+    fn decode_spawn_watch_error(payload: &[u8]) -> ProtocolError {
+        match decode_spawn_watch(payload) {
+            Ok(_) => panic!("expected spawn_watch payload to be rejected"),
+            Err(e) => e,
+        }
+    }
+
+    #[test]
+    fn decode_spawn_watch_rejects_empty_log_path() {
+        let mut payload = encode_spawn_watch(1000, "cmd", &[], false, true, None).unwrap();
+        payload.extend_from_slice(&0u16.to_be_bytes());
+
+        let err = decode_spawn_watch_error(&payload);
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("spawn_watch log_path empty")
+        ));
+    }
+
+    #[test]
+    fn decode_spawn_watch_rejects_trailing_byte_after_env() {
+        let mut payload = encode_spawn_watch(1000, "cmd", &[], false, true, None).unwrap();
+        payload.push(0xFF);
+
+        let err = decode_spawn_watch_error(&payload);
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("spawn_watch trailing byte after env")
+        ));
+    }
+
+    #[test]
+    fn decode_spawn_watch_rejects_trailing_bytes_after_log_path() {
+        let mut payload =
+            encode_spawn_watch(1000, "cmd", &[], false, true, Some("/tmp/log")).unwrap();
+        payload.push(0xFF);
+
+        let err = decode_spawn_watch_error(&payload);
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("spawn_watch trailing bytes")
+        ));
+    }
+
+    #[test]
+    fn decode_spawn_watch_rejects_log_path_without_stream_flag() {
+        let mut payload = encode_spawn_watch(1000, "cmd", &[], false, false, None).unwrap();
+        let path = b"/tmp/log";
+        payload.extend_from_slice(&(path.len() as u16).to_be_bytes());
+        payload.extend_from_slice(path);
+
+        let err = decode_spawn_watch_error(&payload);
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("spawn_watch log_path requires stream flag")
+        ));
     }
 
     #[test]

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -291,7 +291,7 @@ async fn test_spawn_watch() {
     let h = Harness::new().await;
 
     let (pid, _stdout_rx) = h
-        .spawn_watch("echo done", 5000, &[], false, None)
+        .spawn_watch("echo done", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
     assert!(pid > 0);
@@ -312,7 +312,7 @@ async fn test_spawn_watch_exit_code() {
     let h = Harness::new().await;
 
     let (pid, _stdout_rx) = h
-        .spawn_watch("exit 42", 5000, &[], false, None)
+        .spawn_watch("exit 42", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -330,7 +330,7 @@ async fn test_spawn_watch_stderr() {
     let h = Harness::new().await;
 
     let (pid, _stdout_rx) = h
-        .spawn_watch("echo error >&2 && exit 1", 5000, &[], false, None)
+        .spawn_watch("echo error >&2 && exit 1", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -349,7 +349,14 @@ async fn test_spawn_watch_both_stdout_stderr() {
     let h = Harness::new().await;
 
     let (pid, _stdout_rx) = h
-        .spawn_watch("echo out && echo err >&2 && exit 2", 5000, &[], false, None)
+        .spawn_watch(
+            "echo out && echo err >&2 && exit 2",
+            5000,
+            &[],
+            false,
+            false,
+            None,
+        )
         .await
         .expect("spawn_watch failed");
 
@@ -369,7 +376,7 @@ async fn test_spawn_watch_no_output() {
     let h = Harness::new().await;
 
     let (pid, _stdout_rx) = h
-        .spawn_watch("true", 5000, &[], false, None)
+        .spawn_watch("true", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -390,11 +397,11 @@ async fn test_spawn_watch_concurrent() {
 
     // Spawn two processes — second finishes first
     let (pid1, _rx1) = h
-        .spawn_watch("sleep 0.1 && echo first", 5000, &[], false, None)
+        .spawn_watch("sleep 0.1 && echo first", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch 1 failed");
     let (pid2, _rx2) = h
-        .spawn_watch("echo second", 5000, &[], false, None)
+        .spawn_watch("echo second", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch 2 failed");
 
@@ -429,7 +436,7 @@ async fn test_exec_while_waiting_for_exit() {
     // Spawn a long-running process. Use `exec` to replace the shell so the
     // PID we get is the actual sleep process (same pattern as sigterm/sigkill tests).
     let (pid, _stdout_rx) = h
-        .spawn_watch("exec sleep 60", 0, &[], false, None)
+        .spawn_watch("exec sleep 60", 0, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -471,7 +478,7 @@ async fn test_spawn_watch_timeout() {
     let h = Harness::new().await;
 
     let (pid, _stdout_rx) = h
-        .spawn_watch("sleep 10", 100, &[], false, None)
+        .spawn_watch("sleep 10", 100, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -490,7 +497,7 @@ async fn test_spawn_watch_cached_exit() {
     let h = Harness::new().await;
 
     let (pid, _stdout_rx) = h
-        .spawn_watch("echo cached", 5000, &[], false, None)
+        .spawn_watch("echo cached", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -516,7 +523,14 @@ async fn test_spawn_watch_multiline() {
     let h = Harness::new().await;
 
     let (pid, _stdout_rx) = h
-        .spawn_watch("printf 'line1\\nline2\\nline3\\n'", 5000, &[], false, None)
+        .spawn_watch(
+            "printf 'line1\\nline2\\nline3\\n'",
+            5000,
+            &[],
+            false,
+            false,
+            None,
+        )
         .await
         .expect("spawn_watch failed");
 
@@ -540,6 +554,7 @@ async fn test_spawn_watch_large_output() {
             5000,
             &[],
             false,
+            false,
             None,
         )
         .await
@@ -560,7 +575,7 @@ async fn test_spawn_watch_delayed_output() {
     let h = Harness::new().await;
 
     let (pid, _stdout_rx) = h
-        .spawn_watch("sleep 0.2 && echo delayed", 5000, &[], false, None)
+        .spawn_watch("sleep 0.2 && echo delayed", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -580,7 +595,7 @@ async fn test_spawn_watch_sigterm() {
 
     // Use `exec` to replace shell so the PID we get is the actual sleep process
     let (pid, _stdout_rx) = h
-        .spawn_watch("exec sleep 60", 0, &[], false, None)
+        .spawn_watch("exec sleep 60", 0, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -608,7 +623,7 @@ async fn test_spawn_watch_sigkill() {
     let h = Harness::new().await;
 
     let (pid, _stdout_rx) = h
-        .spawn_watch("exec sleep 60", 0, &[], false, None)
+        .spawn_watch("exec sleep 60", 0, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -637,7 +652,7 @@ async fn test_spawn_watch_rapid_multiple() {
     let mut pids = Vec::new();
     for i in 0..5 {
         let (pid, _rx) = h
-            .spawn_watch(&format!("echo p{i}"), 5000, &[], false, None)
+            .spawn_watch(&format!("echo p{i}"), 5000, &[], false, false, None)
             .await
             .expect("spawn_watch failed");
         pids.push(pid);
@@ -664,7 +679,14 @@ async fn test_spawn_watch_nonexistent_command() {
     let h = Harness::new().await;
 
     let (pid, _stdout_rx) = h
-        .spawn_watch("nonexistent_command_12345 2>&1", 5000, &[], false, None)
+        .spawn_watch(
+            "nonexistent_command_12345 2>&1",
+            5000,
+            &[],
+            false,
+            false,
+            None,
+        )
         .await
         .expect("spawn_watch failed");
 
@@ -694,6 +716,7 @@ async fn test_spawn_watch_unicode() {
             5000,
             &[],
             false,
+            false,
             None,
         )
         .await
@@ -721,6 +744,7 @@ async fn test_spawn_watch_interleaved_output() {
             "echo out1 && echo err1 >&2 && echo out2 && echo err2 >&2",
             5000,
             &[],
+            false,
             false,
             None,
         )
@@ -913,6 +937,7 @@ async fn test_spawn_watch_with_env() {
             5000,
             &[("GREETING", "hi_from_env")],
             false,
+            false,
             None,
         )
         .await
@@ -940,7 +965,7 @@ async fn test_spawn_watch_stdout_streaming() {
     let log_path = log_file.to_string_lossy().to_string();
 
     let (pid, mut stdout_rx) = h
-        .spawn_watch("echo hello_stream", 5000, &[], false, Some(&log_path))
+        .spawn_watch("echo hello_stream", 5000, &[], false, true, Some(&log_path))
         .await
         .expect("spawn_watch failed");
 
@@ -979,6 +1004,47 @@ async fn test_spawn_watch_stdout_streaming() {
     h.finish();
 }
 
+/// Streaming can be enabled without a guest-side tee file.
+#[tokio::test]
+async fn test_spawn_watch_stdout_stream_only() {
+    let h = Harness::new().await;
+
+    let existing_guest_log = h.dir.join("stream_only_guest.log");
+    std::fs::write(&existing_guest_log, "preexisting\n").unwrap();
+
+    let (pid, mut stdout_rx) = h
+        .spawn_watch("echo stream_only", 5000, &[], false, true, None)
+        .await
+        .expect("spawn_watch failed");
+
+    let mut streamed = Vec::new();
+    let event = loop {
+        tokio::select! {
+            biased;
+            chunk = stdout_rx.recv() => {
+                match chunk {
+                    Some(data) => streamed.extend_from_slice(&data),
+                    None => break h.wait_for_exit(pid, Duration::from_secs(5)).await.expect("wait failed"),
+                }
+            }
+            event = h.wait_for_exit(pid, Duration::from_secs(5)) => {
+                while let Ok(data) = stdout_rx.try_recv() {
+                    streamed.extend_from_slice(&data);
+                }
+                break event.expect("wait failed");
+            }
+        }
+    };
+
+    assert_eq!(event.exit_code, 0);
+    assert!(event.stdout.is_empty());
+    assert_eq!(String::from_utf8_lossy(&streamed).trim(), "stream_only");
+    let log_content = std::fs::read_to_string(&existing_guest_log).unwrap();
+    assert_eq!(log_content, "preexisting\n");
+
+    h.finish();
+}
+
 /// Streaming with multiple chunks (large output).
 #[tokio::test]
 async fn test_spawn_watch_stdout_streaming_large() {
@@ -994,6 +1060,7 @@ async fn test_spawn_watch_stdout_streaming_large() {
             5000,
             &[],
             false,
+            true,
             Some(&log_path),
         )
         .await
@@ -1045,7 +1112,7 @@ async fn test_spawn_watch_stdout_log_path_not_in_env() {
     // The child prints its own env — stdout_log_path is a protocol parameter,
     // not an env var, so it should never appear in the child's environment.
     let (pid, _stdout_rx) = h
-        .spawn_watch("env", 5000, &[], false, Some(&log_path))
+        .spawn_watch("env", 5000, &[], false, true, Some(&log_path))
         .await
         .expect("spawn_watch failed");
 
@@ -1081,6 +1148,7 @@ async fn test_spawn_watch_stdout_streaming_timeout() {
             100,
             &[],
             false,
+            true,
             Some(&log_path),
         )
         .await

--- a/e2e/tests/03-runner/t43-stuck-tool-watchdog.bats
+++ b/e2e/tests/03-runner/t43-stuck-tool-watchdog.bats
@@ -62,22 +62,5 @@ EOF
     }
 
     echo "# Step 4: Verify system logs contain tool timeout error..."
-    local log_output=""
-    local log_status=1
-    local found=false
-    for _ in {1..15}; do
-        log_output="$($VM0_CLI logs "$RUN_ID" --system 2>&1)"
-        log_status=$?
-        if [[ "$log_status" -eq 0 && "$log_output" == *"Tool timeout"* && "$log_output" == *"WebFetch"* ]]; then
-            found=true
-            break
-        fi
-        sleep 2
-    done
-
-    if [[ "$found" != "true" ]]; then
-        echo "# Timed out waiting for system log containing: Tool timeout WebFetch"
-        echo "# Last output: $log_output"
-        return 1
-    fi
+    wait_for_log "$RUN_ID" --system -- "Tool timeout" "WebFetch"
 }


### PR DESCRIPTION
Closes #11236

## Summary
- make guest-agent log macros synchronously append to the guest-side system log file
- split spawn_watch stdout streaming from optional guest-side tee output mode
- launch guest-agent in stream-only mode so vsock does not race or duplicate guest system log writes
- add unit/integration coverage for final telemetry tail logs and stream-only spawn_watch behavior

## Tests
- cargo test --manifest-path crates/Cargo.toml -j1 -p vsock-proto -p guest-common
- cargo test --manifest-path crates/Cargo.toml -j1 -p vsock-guest -p vsock-host -p vsock-test
- cargo test --manifest-path crates/Cargo.toml -j1 -p guest-agent final_flush_uploads_log_emitted_immediately_before_it
- cargo test --manifest-path crates/Cargo.toml -j1 -p guest-agent -- --test-threads=1
- cargo check --manifest-path crates/Cargo.toml -j1 -p sandbox -p sandbox-mock -p sandbox-fc -p runner
- cargo clippy --manifest-path crates/Cargo.toml -j1 -p guest-common -p guest-agent -p vsock-proto -p vsock-guest -p vsock-host -p vsock-test -p sandbox -p sandbox-mock -p sandbox-fc -p runner --all-targets -- -D warnings
- cargo fmt --manifest-path crates/Cargo.toml --all --check

Note: the first broad cargo test attempt hit a linker OOM in this workspace, so I reran the same affected crates in smaller -j1 batches.