### PR TITLE
fix(billing): include usage events in member caps

### DIFF
--- a/turbo/apps/web/app/api/cron/process-usage-events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/process-usage-events/__tests__/route.test.ts
@@ -10,8 +10,11 @@ import {
   insertTestUsageEvent,
   findTestUsageEvent,
   getOrgCredits,
+  getOrgMembersEntry,
   insertOrgCacheEntry,
+  insertOrgMembersEntry,
   setOrgCredits,
+  updateOrgStripeFields,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { reloadEnv } from "../../../../../src/env";
 
@@ -264,8 +267,39 @@ describe("GET /api/cron/process-usage-events", () => {
     expect(r2!.status).toBe("processed");
   });
 
-  // NOTE: evaluateMemberCaps currently only aggregates `credit_usage`, not
-  // `usage_event`, so spend going through this processor can still slip
-  // past a member cap. Tracked in #10734; no regression test here to avoid
-  // pinning in the current broken behaviour.
+  it("disables capped members when processed usage_event spend reaches the cap", async () => {
+    const periodEnd = new Date(Date.now() + 15 * 24 * 60 * 60 * 1000);
+    await updateOrgStripeFields(user.orgId, { currentPeriodEnd: periodEnd });
+    await insertOrgMembersEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      creditCap: 25,
+      creditEnabled: true,
+    });
+    await insertTestUsagePricing({
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      unitPrice: 10,
+      unitSize: 1,
+    });
+
+    const eventId = await insertTestUsageEvent(user.orgId, {
+      userId: user.userId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 3,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const event = await findTestUsageEvent(eventId);
+    expect(event!.status).toBe("processed");
+    expect(event!.creditsCharged).toBe(30);
+
+    const member = await getOrgMembersEntry(user.orgId, user.userId);
+    expect(member!.creditEnabled).toBe(false);
+  });
 });

--- a/turbo/apps/web/app/api/zero/org/members/credit-cap/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/members/credit-cap/__tests__/route.test.ts
@@ -32,6 +32,7 @@ describe("/api/zero/org/members/credit-cap", () => {
     orgId: string,
     userId: string,
     creditsCharged: number,
+    processedAt?: Date,
   ): Promise<void> {
     await insertTestCreditUsage(orgId, {
       userId,
@@ -39,6 +40,7 @@ describe("/api/zero/org/members/credit-cap", () => {
       modelProvider: "vm0",
       creditsCharged,
       status: "processed",
+      processedAt,
     });
   }
 
@@ -46,11 +48,13 @@ describe("/api/zero/org/members/credit-cap", () => {
     orgId: string,
     userId: string,
     creditsCharged: number,
+    processedAt?: Date,
   ): Promise<void> {
     await insertTestUsageEvent(orgId, {
       userId,
       status: "processed",
       creditsCharged,
+      processedAt,
     });
   }
 
@@ -146,6 +150,57 @@ describe("/api/zero/org/members/credit-cap", () => {
         userId: user.userId,
         creditCap: 100,
         creditEnabled: false,
+      });
+    });
+
+    it("disables member when combined spend exactly reaches cap", async () => {
+      const periodEnd = new Date(Date.now() + 15 * 24 * 60 * 60 * 1000);
+      await updateOrgStripeFields(user.orgId, { currentPeriodEnd: periodEnd });
+
+      await insertProcessedCreditUsage(user.orgId, user.userId, 60);
+      await insertProcessedUsageEvent(user.orgId, user.userId, 40);
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        body: JSON.stringify({ userId: user.userId, creditCap: 100 }),
+        headers: { "content-type": "application/json" },
+      });
+      const response = await PUT(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({
+        userId: user.userId,
+        creditCap: 100,
+        creditEnabled: false,
+      });
+    });
+
+    it("ignores processed usage at the billing period end boundary", async () => {
+      const periodEnd = new Date("2099-04-01T00:00:00Z");
+      await updateOrgStripeFields(user.orgId, { currentPeriodEnd: periodEnd });
+
+      await insertProcessedCreditUsage(
+        user.orgId,
+        user.userId,
+        40,
+        new Date("2099-03-15T00:00:00Z"),
+      );
+      await insertProcessedUsageEvent(user.orgId, user.userId, 80, periodEnd);
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        body: JSON.stringify({ userId: user.userId, creditCap: 100 }),
+        headers: { "content-type": "application/json" },
+      });
+      const response = await PUT(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({
+        userId: user.userId,
+        creditCap: 100,
+        creditEnabled: true,
       });
     });
 

--- a/turbo/apps/web/app/api/zero/org/members/credit-cap/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/members/credit-cap/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import {
   createTestRequest,
   insertOrgMembersEntry,
   insertTestCreditUsage,
+  insertTestUsageEvent,
   updateOrgStripeFields,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
@@ -38,6 +39,18 @@ describe("/api/zero/org/members/credit-cap", () => {
       modelProvider: "vm0",
       creditsCharged,
       status: "processed",
+    });
+  }
+
+  async function insertProcessedUsageEvent(
+    orgId: string,
+    userId: string,
+    creditsCharged: number,
+  ): Promise<void> {
+    await insertTestUsageEvent(orgId, {
+      userId,
+      status: "processed",
+      creditsCharged,
     });
   }
 
@@ -96,6 +109,29 @@ describe("/api/zero/org/members/credit-cap", () => {
 
       // Insert processed credit usage exceeding the cap we'll set
       await insertProcessedCreditUsage(user.orgId, user.userId, 200);
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        body: JSON.stringify({ userId: user.userId, creditCap: 100 }),
+        headers: { "content-type": "application/json" },
+      });
+      const response = await PUT(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({
+        userId: user.userId,
+        creditCap: 100,
+        creditEnabled: false,
+      });
+    });
+
+    it("disables member when combined credit_usage and usage_event spend exceeds cap", async () => {
+      const periodEnd = new Date(Date.now() + 15 * 24 * 60 * 60 * 1000);
+      await updateOrgStripeFields(user.orgId, { currentPeriodEnd: periodEnd });
+
+      await insertProcessedCreditUsage(user.orgId, user.userId, 80);
+      await insertProcessedUsageEvent(user.orgId, user.userId, 40);
 
       const request = createTestRequest(BASE_URL, {
         method: "PUT",

--- a/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
@@ -257,9 +257,17 @@ export async function insertTestUsageEvent(
     status?: string;
     creditsCharged?: number;
     idempotencyKey?: string;
+    processedAt?: Date | null;
   },
 ): Promise<string> {
   initServices();
+  const processedAt =
+    options.processedAt !== undefined
+      ? options.processedAt
+      : options.status === "processed"
+        ? new Date()
+        : null;
+
   const [record] = await globalThis.services.db
     .insert(usageEvent)
     .values({
@@ -272,6 +280,7 @@ export async function insertTestUsageEvent(
       status: options.status ?? "pending",
       creditsCharged: options.creditsCharged ?? null,
       idempotencyKey: options.idempotencyKey ?? randomUUID(),
+      processedAt,
     })
     .returning({ id: usageEvent.id });
   return record!.id;

--- a/turbo/apps/web/src/lib/zero/credit/member-credit-cap-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/member-credit-cap-service.ts
@@ -1,7 +1,18 @@
-import { eq, and, sql, gte, inArray } from "drizzle-orm";
+import { eq, and, sql, gte, lt, inArray } from "drizzle-orm";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { creditUsage } from "@vm0/db/schema/credit-usage";
+import { usageEvent } from "@vm0/db/schema/usage-event";
 import { getOrgBillingPeriod } from "../org/org-metadata-service";
+
+interface BillingPeriod {
+  start: Date;
+  end: Date;
+}
+
+interface UsageTotalRow {
+  userId: string;
+  total: number;
+}
 
 /**
  * Get a member's credit cap state.
@@ -94,7 +105,7 @@ export async function setMemberCreditCap(
 
 /**
  * Evaluate member caps for affected users after credit processing.
- * Only disables members (never re-enables). Called by processOrgCredits().
+ * Only disables members (never re-enables). Called by usage processors.
  */
 export async function evaluateMemberCaps(
   orgId: string,
@@ -130,32 +141,12 @@ export async function evaluateMemberCaps(
   });
   if (enabledCapped.length === 0) return;
 
-  // Batch: single aggregation query instead of N individual queries
-  const usageByUser = await db
-    .select({
-      userId: creditUsage.userId,
-      total: sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)`,
-    })
-    .from(creditUsage)
-    .where(
-      and(
-        eq(creditUsage.orgId, orgId),
-        inArray(
-          creditUsage.userId,
-          enabledCapped.map((m) => {
-            return m.userId;
-          }),
-        ),
-        eq(creditUsage.status, "processed"),
-        gte(creditUsage.processedAt, billingPeriod.start),
-      ),
-    )
-    .groupBy(creditUsage.userId);
-
-  const usageMap = new Map(
-    usageByUser.map((u) => {
-      return [u.userId, u.total];
+  const usageMap = await getProcessedUsageTotalsByUser(
+    orgId,
+    enabledCapped.map((m) => {
+      return m.userId;
     }),
+    billingPeriod,
   );
 
   for (const member of enabledCapped) {
@@ -173,6 +164,75 @@ export async function evaluateMemberCaps(
           ),
         );
     }
+  }
+}
+
+async function getProcessedUsageTotalsByUser(
+  orgId: string,
+  userIds: string[],
+  billingPeriod: BillingPeriod,
+): Promise<Map<string, number>> {
+  const uniqueUserIds = [...new Set(userIds)];
+  const usageMap = new Map<string, number>();
+  if (uniqueUserIds.length === 0) return usageMap;
+
+  const db = globalThis.services.db;
+
+  const creditRows = await db
+    .select({
+      userId: creditUsage.userId,
+      total:
+        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
+          "total",
+        ),
+    })
+    .from(creditUsage)
+    .where(
+      and(
+        eq(creditUsage.orgId, orgId),
+        inArray(creditUsage.userId, uniqueUserIds),
+        eq(creditUsage.status, "processed"),
+        gte(creditUsage.processedAt, billingPeriod.start),
+        lt(creditUsage.processedAt, billingPeriod.end),
+      ),
+    )
+    .groupBy(creditUsage.userId);
+
+  const eventRows = await db
+    .select({
+      userId: usageEvent.userId,
+      total:
+        sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
+          "total",
+        ),
+    })
+    .from(usageEvent)
+    .where(
+      and(
+        eq(usageEvent.orgId, orgId),
+        inArray(usageEvent.userId, uniqueUserIds),
+        eq(usageEvent.status, "processed"),
+        gte(usageEvent.processedAt, billingPeriod.start),
+        lt(usageEvent.processedAt, billingPeriod.end),
+      ),
+    )
+    .groupBy(usageEvent.userId);
+
+  addUsageRows(usageMap, creditRows);
+  addUsageRows(usageMap, eventRows);
+
+  return usageMap;
+}
+
+function addUsageRows(
+  usageMap: Map<string, number>,
+  rows: UsageTotalRow[],
+): void {
+  for (const row of rows) {
+    usageMap.set(
+      row.userId,
+      (usageMap.get(row.userId) ?? 0) + Number(row.total),
+    );
   }
 }
 
@@ -204,21 +264,10 @@ async function getMemberUsageInBillingPeriod(
   const billingPeriod = await getOrgBillingPeriod(orgId);
   if (!billingPeriod) return 0;
 
-  const db = globalThis.services.db;
+  const usageMap = await getProcessedUsageTotalsByUser(orgId, [userId], {
+    start: billingPeriod.start,
+    end: billingPeriod.end,
+  });
 
-  const [result] = await db
-    .select({
-      total: sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)`,
-    })
-    .from(creditUsage)
-    .where(
-      and(
-        eq(creditUsage.orgId, orgId),
-        eq(creditUsage.userId, userId),
-        eq(creditUsage.status, "processed"),
-        gte(creditUsage.processedAt, billingPeriod.start),
-      ),
-    );
-
-  return result?.total ?? 0;
+  return usageMap.get(userId) ?? 0;
 }

--- a/turbo/apps/web/src/lib/zero/credit/member-credit-cap-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/member-credit-cap-service.ts
@@ -161,6 +161,8 @@ export async function evaluateMemberCaps(
           and(
             eq(orgMembersMetadata.orgId, orgId),
             eq(orgMembersMetadata.userId, member.userId),
+            eq(orgMembersMetadata.creditEnabled, true),
+            eq(orgMembersMetadata.creditCap, cap),
           ),
         );
     }


### PR DESCRIPTION
## Summary
- Aggregate processed credit_usage and usage_event spend when evaluating member caps.
- Reuse the combined total for cap updates and usage-event processing enforcement.
- Add regression coverage for usage_event-only and mixed credit_usage/usage_event cap enforcement.

Fixes #10734

## Tests
- pnpm test app/api/cron/process-usage-events/__tests__/route.test.ts
- pnpm test app/api/zero/org/members/credit-cap/__tests__/route.test.ts
- pnpm test src/lib/zero/credit/__tests__/member-credit-cap-service.test.ts
- pnpm check-types
- pnpm lint
- pnpm test (fails on unrelated schedule-dialog timezone assertion; cleanup-sandboxes timed out in full run)
- pnpm test app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
- pnpm test src/views/zero-page/__tests__/schedule-dialog.test.tsx (still fails standalone on unrelated timezone assertion)