### PR TITLE
fix(api): refresh and prune org-members-cache after clerk lookups

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -3,6 +3,7 @@ import { computed } from "ccstate";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { ROUTES } from "../signals/route";
 import { accept, setupApp, testContext } from "./test-helpers";
 
 const c = initContract();
@@ -43,15 +44,13 @@ describe("createApp", () => {
 
   it("captures unhandled errors and returns a sanitized response", async () => {
     const error = new Error("boom");
+    const handler$ = computed((): never => {
+      throw error;
+    });
     const client = setupApp({
       context,
-      contract: errorTestContract,
-      handlers: {
-        boom: computed((): never => {
-          throw error;
-        }),
-      },
-    });
+      routes: [...ROUTES, { route: errorTestContract.boom, handler: handler$ }],
+    })(errorTestContract);
 
     const response = await accept(client.boom(), [500]);
 
@@ -61,15 +60,16 @@ describe("createApp", () => {
 
   it("passes through expected HTTP client errors without capturing them", async () => {
     const error = new HTTPException(404, { message: "Missing" });
+    const handler$ = computed((): never => {
+      throw error;
+    });
     const client = setupApp({
       context,
-      contract: errorTestContract,
-      handlers: {
-        missing: computed((): never => {
-          throw error;
-        }),
-      },
-    });
+      routes: [
+        ...ROUTES,
+        { route: errorTestContract.missing, handler: handler$ },
+      ],
+    })(errorTestContract);
 
     await accept(client.missing(), [404]);
 
@@ -79,15 +79,16 @@ describe("createApp", () => {
   it("does not capture AbortError", async () => {
     const error = new Error("aborted");
     error.name = "AbortError";
+    const handler$ = computed((): never => {
+      throw error;
+    });
     const client = setupApp({
       context,
-      contract: errorTestContract,
-      handlers: {
-        aborted: computed((): never => {
-          throw error;
-        }),
-      },
-    });
+      routes: [
+        ...ROUTES,
+        { route: errorTestContract.aborted, handler: handler$ },
+      ],
+    })(errorTestContract);
 
     await accept(client.aborted(), [500]);
 
@@ -96,15 +97,16 @@ describe("createApp", () => {
 
   it("captures HTTP server errors while preserving their response", async () => {
     const error = new HTTPException(503, { message: "Unavailable" });
+    const handler$ = computed((): never => {
+      throw error;
+    });
     const client = setupApp({
       context,
-      contract: errorTestContract,
-      handlers: {
-        unavailable: computed((): never => {
-          throw error;
-        }),
-      },
-    });
+      routes: [
+        ...ROUTES,
+        { route: errorTestContract.unavailable, handler: handler$ },
+      ],
+    })(errorTestContract);
 
     await accept(client.unavailable(), [503]);
 

--- a/turbo/apps/api/src/__tests__/test-helpers.ts
+++ b/turbo/apps/api/src/__tests__/test-helpers.ts
@@ -2,7 +2,6 @@ import {
   initClient,
   type ApiFetcher,
   type ApiFetcherArgs,
-  type AppRoute,
   type AppRouter,
   type InitClientArgs,
   type InitClientReturn,
@@ -12,11 +11,7 @@ import { afterAll, afterEach, expect } from "vitest";
 import { createApp } from "../app-factory";
 import { closeDbPool } from "../lib/db";
 import { clearMockedEnv } from "../lib/env";
-import {
-  ROUTES,
-  type RouteEntry,
-  type SignalRouteHandler,
-} from "../signals/route";
+import { ROUTES, type RouteEntry } from "../signals/route";
 import { clearAllDetached } from "../signals/utils";
 import { getApiTestMocks, type ApiTestMocks } from "./mocks";
 
@@ -25,12 +20,9 @@ interface TestContext {
   readonly mocks: ApiTestMocks;
 }
 
-interface SetupAppOptions<TContract extends AppRouter> {
+interface SetupAppOptions {
   readonly context: TestContext;
-  readonly contract: TContract;
-  readonly handlers?: {
-    readonly [K in keyof TContract & string]?: SignalRouteHandler<unknown>;
-  };
+  readonly routes?: readonly RouteEntry[];
 }
 
 function formatBody(body: unknown): string {
@@ -96,24 +88,10 @@ async function requestApp(
   };
 }
 
-function buildRoutesExtend(
-  handlers: Record<string, SignalRouteHandler<unknown>>,
-  contract: Record<string, AppRoute>,
-): RouteEntry[] {
-  const entries: RouteEntry[] = [];
-  for (const [key, handler] of Object.entries(handlers)) {
-    if (handler !== undefined) {
-      entries.push({ route: contract[key]!, handler });
-    }
-  }
-  return entries;
-}
-
 function createAppFetcher(
   context: TestContext,
-  routesExtend: readonly RouteEntry[],
+  routes: readonly RouteEntry[],
 ): ApiFetcher {
-  const routes = [...ROUTES, ...routesExtend];
   const app = createApp({ signal: context.signal, routes });
 
   return (args) => {
@@ -121,23 +99,20 @@ function createAppFetcher(
   };
 }
 
-export function setupApp<TContract extends AppRouter>({
-  context,
-  contract,
-  handlers = {},
-}: SetupAppOptions<TContract>): InitClientReturn<TContract, InitClientArgs> {
-  const routesExtend = buildRoutesExtend(
-    handlers as Record<string, SignalRouteHandler<unknown>>,
-    contract as Record<string, AppRoute>,
-  );
+export function setupApp({ context, routes = ROUTES }: SetupAppOptions) {
+  const app = createAppFetcher(context, routes);
 
-  return initClient(contract, {
-    baseUrl: "http://api.test",
-    jsonQuery: false,
-    throwOnUnknownStatus: true,
-    validateResponse: false,
-    api: createAppFetcher(context, routesExtend),
-  });
+  return <TContract extends AppRouter>(
+    contract: TContract,
+  ): InitClientReturn<TContract, InitClientArgs> => {
+    return initClient(contract, {
+      baseUrl: "http://api.test",
+      jsonQuery: false,
+      throwOnUnknownStatus: true,
+      validateResponse: true,
+      api: app,
+    });
+  };
 }
 
 export function testContext(): TestContext {

--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -13,7 +13,7 @@ import { ZeroCapability } from "@vm0/api-contracts";
 import { AuthContext, CliAuth, ZeroAuthContext } from "../../types/auth";
 import {
   cliTokenRecord,
-  memberRole,
+  memberRole$,
   updateCliTokenLastUsedAt$,
 } from "../services/auth.service";
 import { authorization$, cookie$ } from "../context/hono";
@@ -57,7 +57,12 @@ const cliAuth$ = command(
 
     waitUntil(set(updateCliTokenLastUsedAt$, cliAuth.tokenId, signal));
 
-    const membership = await get(memberRole(resolved.orgId, resolved.userId));
+    const membership = await set(
+      memberRole$,
+      resolved.orgId,
+      resolved.userId,
+      signal,
+    );
     if (!membership) {
       return null;
     }
@@ -92,11 +97,13 @@ function resolveSandboxAuth(
   return null;
 }
 
-function zeroAuth(
-  token: string,
-  options: AuthOptions,
-): Computed<Promise<AuthContext | null>> {
-  return computed(async (get): Promise<AuthContext | null> => {
+const zeroAuth$ = command(
+  async (
+    { set },
+    token: string,
+    options: AuthOptions,
+    signal: AbortSignal,
+  ): Promise<AuthContext | null> => {
     const zeroAuth = verifyZeroToken(token);
     if (!zeroAuth) {
       return null;
@@ -119,30 +126,37 @@ function zeroAuth(
       capabilities: [...zeroAuth.capabilities],
     };
 
-    const membership = await get(memberRole(zeroAuth.orgId, zeroAuth.userId));
+    const membership = await set(
+      memberRole$,
+      zeroAuth.orgId,
+      zeroAuth.userId,
+      signal,
+    );
     if (!membership) {
       return result;
     }
 
     return { ...result, orgRole: membership.role };
-  });
-}
+  },
+);
 
-function sandboxTokenAuth(
-  token: string,
-  options: AuthOptions,
-): Computed<Promise<AuthContext | null>> {
-  return computed(async (get): Promise<AuthContext | null> => {
+const sandboxTokenAuth$ = command(
+  async (
+    { set },
+    token: string,
+    options: AuthOptions,
+    signal: AbortSignal,
+  ): Promise<AuthContext | null> => {
     if (!options.requiredCapability && !options.acceptAnySandboxCapability) {
       return null;
     }
 
     return (
       resolveSandboxAuth(token, options) ??
-      (await get(zeroAuth(token, options)))
+      (await set(zeroAuth$, token, options, signal))
     );
-  });
-}
+  },
+);
 
 const resolvedAuthContext$ = command(
   async (
@@ -173,7 +187,7 @@ const resolvedAuthContext$ = command(
     if (isSandboxToken(token)) {
       const cliAuth = verifyCliToken(token);
       if (!cliAuth) {
-        return await get(sandboxTokenAuth(token, options));
+        return await set(sandboxTokenAuth$, token, options, signal);
       }
 
       return await set(cliAuth$, cliAuth, signal);

--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -13,7 +13,7 @@ import { ZeroCapability } from "@vm0/api-contracts";
 import { AuthContext, CliAuth, ZeroAuthContext } from "../../types/auth";
 import {
   cliTokenRecord,
-  memberRole$,
+  getMemberRoleAndUpdateCache$,
   updateCliTokenLastUsedAt$,
 } from "../services/auth.service";
 import { authorization$, cookie$ } from "../context/hono";
@@ -58,7 +58,7 @@ const cliAuth$ = command(
     waitUntil(set(updateCliTokenLastUsedAt$, cliAuth.tokenId, signal));
 
     const membership = await set(
-      memberRole$,
+      getMemberRoleAndUpdateCache$,
       resolved.orgId,
       resolved.userId,
       signal,
@@ -127,7 +127,7 @@ const zeroAuth$ = command(
     };
 
     const membership = await set(
-      memberRole$,
+      getMemberRoleAndUpdateCache$,
       zeroAuth.orgId,
       zeroAuth.userId,
       signal,
@@ -151,10 +151,12 @@ const sandboxTokenAuth$ = command(
       return null;
     }
 
-    return (
-      resolveSandboxAuth(token, options) ??
-      (await set(zeroAuth$, token, options, signal))
-    );
+    const sandboxAuth = resolveSandboxAuth(token, options);
+    if (sandboxAuth) {
+      return sandboxAuth;
+    }
+
+    return await set(zeroAuth$, token, options, signal);
   },
 );
 

--- a/turbo/apps/api/src/signals/context/__tests__/route.test.ts
+++ b/turbo/apps/api/src/signals/context/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { ROUTES } from "../../route";
 
 const context = testContext();
 const c = initContract();
@@ -47,9 +48,11 @@ describe("honoSignalHandler", () => {
     });
     const client = setupApp({
       context,
-      contract: routeTestContract,
-      handlers: { computed: handler$ },
-    });
+      routes: [
+        ...ROUTES,
+        { route: routeTestContract.computed, handler: handler$ },
+      ],
+    })(routeTestContract);
 
     const response = await accept(client.computed(), [200]);
 
@@ -68,9 +71,11 @@ describe("honoSignalHandler", () => {
     });
     const client = setupApp({
       context,
-      contract: routeTestContract,
-      handlers: { command: handler$ },
-    });
+      routes: [
+        ...ROUTES,
+        { route: routeTestContract.command, handler: handler$ },
+      ],
+    })(routeTestContract);
 
     const response = await accept(client.command(), [200]);
 
@@ -83,9 +88,8 @@ describe("honoSignalHandler", () => {
     });
     const client = setupApp({
       context,
-      contract: routeTestContract,
-      handlers: { post: handler$ },
-    });
+      routes: [...ROUTES, { route: routeTestContract.post, handler: handler$ }],
+    })(routeTestContract);
 
     const response = await accept(
       client.post({ body: { enabled: true } }),

--- a/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
@@ -1,11 +1,15 @@
 import { randomUUID } from "node:crypto";
 
+import { initContract } from "@ts-rest/core";
 import { cliTokens } from "@vm0/db/schema/cli-tokens";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
-import { createStore } from "ccstate";
+import { computed, createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
+import { z } from "zod";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { authContext$ } from "../../auth/auth-context";
+import { authRoute } from "../../auth/auth-route";
 import { writeDb$ } from "../../external/db";
 import { now } from "../../external/time";
 import { signPatJwtForTests, signSandboxJwtForTests } from "../../auth/tokens";
@@ -84,6 +88,34 @@ async function deletePatFixture(fixture: PatFixture): Promise<void> {
     );
   await writeDb.delete(cliTokens).where(eq(cliTokens.id, fixture.tokenId));
 }
+
+const c = initContract();
+
+const capabilityProbeContract = c.router({
+  check: {
+    method: "GET" as const,
+    path: "/__test/cap",
+    headers: z.object({ authorization: z.string().optional() }),
+    responses: {
+      200: z.unknown(),
+      401: z.object({
+        error: z.object({ message: z.string(), code: z.string() }),
+      }),
+      403: z.object({
+        error: z.object({ message: z.string(), code: z.string() }),
+      }),
+    },
+  },
+});
+
+const capabilityProbeHandler$ = computed((get) => {
+  return { status: 200 as const, body: get(authContext$) };
+});
+
+const capabilityProbe$ = authRoute(
+  { requiredCapability: "agent:read" },
+  capabilityProbeHandler$,
+);
 
 describe("GET /health/auth", () => {
   const fixtures: PatFixture[] = [];
@@ -326,6 +358,48 @@ describe("GET /health/auth", () => {
       ).toBe(callsBefore);
     });
 
+    it("refreshes the cached role when Clerk reports a different role", async () => {
+      const fixture = await seedPatFixture({
+        role: "member",
+        cachedAtMs: now() - 5 * 60_000,
+      });
+      fixtures.push(fixture);
+      context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue(
+        {
+          data: [{ organization: { id: fixture.orgId }, role: "org:admin" }],
+        },
+      );
+
+      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const response = await accept(
+        client.check({
+          headers: { authorization: `Bearer ${fixture.token}` },
+        }),
+        [200],
+      );
+      expect(response.body).toEqual({
+        tokenType: "pat",
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        orgRole: "admin",
+      });
+
+      const writeDb = store.set(writeDb$);
+      const [cached] = await writeDb
+        .select({
+          role: orgMembersCache.role,
+          cachedAt: orgMembersCache.cachedAt,
+        })
+        .from(orgMembersCache)
+        .where(
+          and(
+            eq(orgMembersCache.orgId, fixture.orgId),
+            eq(orgMembersCache.userId, fixture.userId),
+          ),
+        );
+      expect(cached?.role).toBe("admin");
+    });
+
     it("removes a stale cache row when Clerk reports no membership", async () => {
       const fixture = await seedPatFixture({
         role: "admin",
@@ -509,6 +583,101 @@ describe("GET /health/auth", () => {
       );
 
       expect(response.body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 401 when the bearer token has no recognized prefix", async () => {
+      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const response = await accept(
+        client.check({ headers: { authorization: "Bearer foobar123" } }),
+        [401],
+      );
+
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 401 for a sandbox-prefixed bearer with an invalid signature", async () => {
+      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const response = await accept(
+        client.check({
+          headers: { authorization: "Bearer vm0_sandbox_not-a-real-token" },
+        }),
+        [401],
+      );
+
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 401 when the Bearer header carries an empty token", async () => {
+      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const response = await accept(
+        client.check({ headers: { authorization: "Bearer " } }),
+        [401],
+      );
+
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  describe("zero capability check", () => {
+    it("accepts a zero token whose capabilities include the required one", async () => {
+      const fixture = await seedPatFixture({ role: "admin" });
+      fixtures.push(fixture);
+      const nowSeconds = currentSecond();
+      const token = signSandboxJwtForTests({
+        scope: "zero",
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        runId: "run_zero",
+        capabilities: ["agent:read"],
+        iat: nowSeconds,
+        exp: nowSeconds + 60,
+      });
+
+      const client = setupApp({
+        context,
+        contract: capabilityProbeContract,
+        handlers: { check: capabilityProbe$ },
+      });
+      const response = await accept(
+        client.check({ headers: { authorization: `Bearer ${token}` } }),
+        [200],
+      );
+
+      expect(response.body).toEqual({
+        tokenType: "zero",
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        orgRole: "admin",
+        runId: "run_zero",
+        capabilities: ["agent:read"],
+      });
+    });
+
+    it("rejects a zero token whose capabilities omit the required one", async () => {
+      const fixture = await seedPatFixture({ role: "admin" });
+      fixtures.push(fixture);
+      const nowSeconds = currentSecond();
+      const token = signSandboxJwtForTests({
+        scope: "zero",
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        runId: "run_zero",
+        capabilities: ["agent:write"],
+        iat: nowSeconds,
+        exp: nowSeconds + 60,
+      });
+
+      const client = setupApp({
+        context,
+        contract: capabilityProbeContract,
+        handlers: { check: capabilityProbe$ },
+      });
+      const response = await accept(
+        client.check({ headers: { authorization: `Bearer ${token}` } }),
+        [403],
+      );
+
+      expect(response.body.error.code).toBe("FORBIDDEN");
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
@@ -7,7 +7,7 @@ import { and, eq } from "drizzle-orm";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { writeDb$ } from "../../external/db";
-import { now, nowDate } from "../../external/time";
+import { now } from "../../external/time";
 import { signPatJwtForTests, signSandboxJwtForTests } from "../../auth/tokens";
 import { healthAuthProbeContract } from "../health-auth-probe";
 
@@ -28,6 +28,7 @@ function currentSecond(): number {
 interface PatFixtureOptions {
   readonly role?: "admin" | "member";
   readonly seedMembership?: boolean;
+  readonly cachedAtMs?: number;
   readonly tokenExpiresAtMs?: number;
 }
 
@@ -64,7 +65,7 @@ async function seedPatFixture(
       orgId,
       userId,
       role,
-      cachedAt: nowDate(),
+      cachedAt: new Date(options.cachedAtMs ?? now()),
     });
   }
 
@@ -280,6 +281,81 @@ describe("GET /health/auth", () => {
       );
 
       expect(response.body.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  describe("org membership cache", () => {
+    it("populates the cache from Clerk on cache miss and serves the next request from cache", async () => {
+      const fixture = await seedPatFixture({ seedMembership: false });
+      fixtures.push(fixture);
+      context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue(
+        {
+          data: [{ organization: { id: fixture.orgId }, role: "org:admin" }],
+        },
+      );
+
+      const client = setupApp({ context, contract: healthAuthProbeContract });
+
+      const first = await accept(
+        client.check({
+          headers: { authorization: `Bearer ${fixture.token}` },
+        }),
+        [200],
+      );
+      expect(first.body).toEqual({
+        tokenType: "pat",
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        orgRole: "admin",
+      });
+
+      const callsBefore =
+        context.mocks.clerk.users.getOrganizationMembershipList.mock.calls
+          .length;
+
+      const second = await accept(
+        client.check({
+          headers: { authorization: `Bearer ${fixture.token}` },
+        }),
+        [200],
+      );
+      expect(second.body).toEqual(first.body);
+      expect(
+        context.mocks.clerk.users.getOrganizationMembershipList.mock.calls
+          .length,
+      ).toBe(callsBefore);
+    });
+
+    it("removes a stale cache row when Clerk reports no membership", async () => {
+      const fixture = await seedPatFixture({
+        role: "admin",
+        cachedAtMs: now() - 5 * 60_000,
+      });
+      fixtures.push(fixture);
+      context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue(
+        { data: [] },
+      );
+
+      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const first = await accept(
+        client.check({
+          headers: { authorization: `Bearer ${fixture.token}` },
+        }),
+        [401],
+      );
+      expect(first.body.error.code).toBe("UNAUTHORIZED");
+
+      const writeDb = store.set(writeDb$);
+      const remaining = await writeDb
+        .select({ orgId: orgMembersCache.orgId })
+        .from(orgMembersCache)
+        .where(
+          and(
+            eq(orgMembersCache.orgId, fixture.orgId),
+            eq(orgMembersCache.userId, fixture.userId),
+          ),
+        );
+      expect(remaining).toHaveLength(0);
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
@@ -13,6 +13,7 @@ import { authRoute } from "../../auth/auth-route";
 import { writeDb$ } from "../../external/db";
 import { now } from "../../external/time";
 import { signPatJwtForTests, signSandboxJwtForTests } from "../../auth/tokens";
+import { ROUTES } from "../../route";
 import { healthAuthProbeContract } from "../health-auth-probe";
 
 interface PatFixture {
@@ -142,7 +143,7 @@ describe("GET /health/auth", () => {
         },
       });
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { cookie: "__session=opaque" } }),
         [200],
@@ -168,7 +169,7 @@ describe("GET /health/auth", () => {
         },
       });
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { cookie: "__session=opaque" } }),
         [200],
@@ -190,7 +191,7 @@ describe("GET /health/auth", () => {
         },
       });
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { cookie: "__session=opaque" } }),
         [200],
@@ -207,7 +208,7 @@ describe("GET /health/auth", () => {
         isAuthenticated: false,
       });
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { cookie: "__session=opaque" } }),
         [401],
@@ -222,7 +223,7 @@ describe("GET /health/auth", () => {
       const fixture = await seedPatFixture({ role: "admin" });
       fixtures.push(fixture);
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({
           headers: { authorization: `Bearer ${fixture.token}` },
@@ -242,7 +243,7 @@ describe("GET /health/auth", () => {
       const fixture = await seedPatFixture({ role: "member" });
       fixtures.push(fixture);
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({
           headers: { authorization: `Bearer ${fixture.token}` },
@@ -271,7 +272,7 @@ describe("GET /health/auth", () => {
         exp: nowSeconds + 60,
       });
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { authorization: `Bearer ${token}` } }),
         [401],
@@ -286,7 +287,7 @@ describe("GET /health/auth", () => {
       });
       fixtures.push(fixture);
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({
           headers: { authorization: `Bearer ${fixture.token}` },
@@ -304,7 +305,7 @@ describe("GET /health/auth", () => {
         { data: [] },
       );
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({
           headers: { authorization: `Bearer ${fixture.token}` },
@@ -326,7 +327,7 @@ describe("GET /health/auth", () => {
         },
       );
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
 
       const first = await accept(
         client.check({
@@ -370,7 +371,7 @@ describe("GET /health/auth", () => {
         },
       );
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({
           headers: { authorization: `Bearer ${fixture.token}` },
@@ -410,7 +411,7 @@ describe("GET /health/auth", () => {
         { data: [] },
       );
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const first = await accept(
         client.check({
           headers: { authorization: `Bearer ${fixture.token}` },
@@ -444,7 +445,7 @@ describe("GET /health/auth", () => {
         exp: currentSecond() + 60,
       });
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { authorization: `Bearer ${token}` } }),
         [200],
@@ -474,7 +475,7 @@ describe("GET /health/auth", () => {
         exp: nowSeconds + 60,
       });
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { authorization: `Bearer ${token}` } }),
         [200],
@@ -504,7 +505,7 @@ describe("GET /health/auth", () => {
         exp: nowSeconds + 60,
       });
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { authorization: `Bearer ${token}` } }),
         [200],
@@ -537,7 +538,7 @@ describe("GET /health/auth", () => {
         { data: [] },
       );
 
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { authorization: `Bearer ${token}` } }),
         [200],
@@ -555,14 +556,14 @@ describe("GET /health/auth", () => {
 
   describe("rejected requests", () => {
     it("returns 401 when no credentials are presented", async () => {
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(client.check(), [401]);
 
       expect(response.body.error.code).toBe("UNAUTHORIZED");
     });
 
     it("returns 401 when the bearer token has an unknown shape", async () => {
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({
           headers: { authorization: "Bearer vm0_pat_not-a-real-token" },
@@ -574,7 +575,7 @@ describe("GET /health/auth", () => {
     });
 
     it("returns 401 for a non-Bearer Authorization header without cookie", async () => {
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({
           headers: { authorization: "Basic dXNlcjpwYXNz" },
@@ -586,7 +587,7 @@ describe("GET /health/auth", () => {
     });
 
     it("returns 401 when the bearer token has no recognized prefix", async () => {
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { authorization: "Bearer foobar123" } }),
         [401],
@@ -596,7 +597,7 @@ describe("GET /health/auth", () => {
     });
 
     it("returns 401 for a sandbox-prefixed bearer with an invalid signature", async () => {
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({
           headers: { authorization: "Bearer vm0_sandbox_not-a-real-token" },
@@ -608,7 +609,7 @@ describe("GET /health/auth", () => {
     });
 
     it("returns 401 when the Bearer header carries an empty token", async () => {
-      const client = setupApp({ context, contract: healthAuthProbeContract });
+      const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { authorization: "Bearer " } }),
         [401],
@@ -635,9 +636,11 @@ describe("GET /health/auth", () => {
 
       const client = setupApp({
         context,
-        contract: capabilityProbeContract,
-        handlers: { check: capabilityProbe$ },
-      });
+        routes: [
+          ...ROUTES,
+          { route: capabilityProbeContract.check, handler: capabilityProbe$ },
+        ],
+      })(capabilityProbeContract);
       const response = await accept(
         client.check({ headers: { authorization: `Bearer ${token}` } }),
         [200],
@@ -669,9 +672,11 @@ describe("GET /health/auth", () => {
 
       const client = setupApp({
         context,
-        contract: capabilityProbeContract,
-        handlers: { check: capabilityProbe$ },
-      });
+        routes: [
+          ...ROUTES,
+          { route: capabilityProbeContract.check, handler: capabilityProbe$ },
+        ],
+      })(capabilityProbeContract);
       const response = await accept(
         client.check({ headers: { authorization: `Bearer ${token}` } }),
         [403],

--- a/turbo/apps/api/src/signals/routes/__tests__/health.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/health.test.ts
@@ -8,15 +8,17 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 const context = testContext();
 
 describe("api health routes", () => {
+  const createClient = setupApp({ context });
+
   it("serves a lightweight health check", async () => {
-    const client = setupApp({ context, contract: healthContract });
+    const client = createClient(healthContract);
     const response = await accept(client.check(), [200]);
 
     expect(response.body).toEqual({ status: "ok" });
   });
 
   it("requires auth for the authenticated health check", async () => {
-    const client = setupApp({ context, contract: healthAuthContract });
+    const client = createClient(healthAuthContract);
     const response = await accept(client.check(), [401]);
 
     expect(response.body).toEqual({

--- a/turbo/apps/api/src/signals/services/auth.service.ts
+++ b/turbo/apps/api/src/signals/services/auth.service.ts
@@ -66,7 +66,7 @@ const deleteMemberRoleCache$ = command(
   },
 );
 
-export const memberRole$ = command(
+export const getMemberRoleAndUpdateCache$ = command(
   async (
     { get, set },
     orgId: string,

--- a/turbo/apps/api/src/signals/services/auth.service.ts
+++ b/turbo/apps/api/src/signals/services/auth.service.ts
@@ -12,6 +12,8 @@ import {
   type CliTokenRecord,
 } from "../../types/auth";
 
+const MEMBER_ROLE_CACHE_TTL_MS = 60_000;
+
 function mapClerkRole(role: string): ApiOrgRole {
   return role === "org:admin" ? "admin" : "member";
 }
@@ -26,11 +28,51 @@ export const updateCliTokenLastUsedAt$ = command(
   },
 );
 
-export function memberRole(
-  orgId: string,
-  userId: string,
-): Computed<Promise<{ role: ApiOrgRole } | null>> {
-  return computed(async (get): Promise<{ role: ApiOrgRole } | null> => {
+const upsertMemberRoleCache$ = command(
+  async (
+    { set },
+    orgId: string,
+    userId: string,
+    role: ApiOrgRole,
+    _signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .insert(orgMembersCache)
+      .values({ orgId, userId, role, cachedAt: nowDate() })
+      .onConflictDoUpdate({
+        target: [orgMembersCache.orgId, orgMembersCache.userId],
+        set: { role, cachedAt: nowDate() },
+      });
+  },
+);
+
+const deleteMemberRoleCache$ = command(
+  async (
+    { set },
+    orgId: string,
+    userId: string,
+    _signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(orgMembersCache)
+      .where(
+        and(
+          eq(orgMembersCache.orgId, orgId),
+          eq(orgMembersCache.userId, userId),
+        ),
+      );
+  },
+);
+
+export const memberRole$ = command(
+  async (
+    { get, set },
+    orgId: string,
+    userId: string,
+    signal: AbortSignal,
+  ): Promise<{ role: ApiOrgRole } | null> => {
     const db = get(db$);
     const [cached] = await db
       .select({
@@ -47,7 +89,10 @@ export function memberRole(
       .limit(1);
 
     const currentTime = now();
-    if (cached && currentTime - cached.cachedAt.getTime() < 60_000) {
+    if (
+      cached &&
+      currentTime - cached.cachedAt.getTime() < MEMBER_ROLE_CACHE_TTL_MS
+    ) {
       const role: ApiOrgRole = cached.role === "admin" ? "admin" : "member";
       return { role };
     }
@@ -58,13 +103,19 @@ export function memberRole(
     });
 
     if (!membership) {
+      // Drop the stale row so the next call doesn't keep falling back to Clerk
+      // for a user that's no longer a member.
+      if (cached) {
+        await set(deleteMemberRoleCache$, orgId, userId, signal);
+      }
       return null;
     }
 
     const role = mapClerkRole(membership.role);
+    await set(upsertMemberRoleCache$, orgId, userId, role, signal);
     return { role };
-  });
-}
+  },
+);
 
 export function cliTokenRecord(
   cliAuth: CliAuth,


### PR DESCRIPTION
## Summary

When the cache is stale and we fall back to Clerk, write the result back so subsequent calls don't repeat the round trip, and drop the stale row when Clerk reports the user is no longer a member of the org. This brings the api app's behavior in line with web's `getMemberRole` helper.

## Why

The shadow-auth check (#11244) flagged this as a behavioral divergence between web and api:

| | web (`getMemberRole`) | api (`memberRole`) before |
| --- | --- | --- |
| Clerk hit + membership | refreshes cache | leaves cache untouched (next call falls back to Clerk again) |
| Clerk hit + no membership | deletes stale cache row | leaves stale row in place |
| Clerk 404 (user gone) | propagates (route 500) | propagates (route 500) — same behavior |

Both sides have the same Clerk-404-throw behavior; this PR fixes the cache divergence. The 404 propagation is a separate follow-up.

## Implementation

- Add `upsertMemberRoleCache` and `deleteMemberRoleCache` write-side commands and call them inline (not `waitUntil`) so completion is observable on the next request without test-side draining.
- Rename `memberRole$` → `getMemberRoleAndUpdateCache$` so the side effect is obvious at the call site.
- Convert `memberRole`, `zeroAuth`, `sandboxTokenAuth` from Computed factories to direct Commands so they can issue cache writes; update `resolvedAuthContext` and `cliAuth` to call them via `set`.
- Pull the 60s cache TTL into a named constant.

## Tests

Added route-level tests on `/health/auth` covering the branches the consolidated probe alone can't reach:

1. **Cache miss → Clerk hit → cached** — first request populates the cache; second request with the same PAT does not call Clerk again.
2. **Stale cache + Clerk no membership → 401 + cache row removed** — verified via DB read since deletion has no request/response observable.
3. **Stale cache + Clerk reports a different role → cache refreshed** — exercises the `onConflictDoUpdate` path of `upsertMemberRoleCache`.
4. **Zero capability check (positive + 403)** — synthetic route with `requiredCapability: "agent:read"` for the path the probe (which uses `acceptAnySandboxCapability: true`) skips.
5. **Bearer edge cases** — unrecognized prefix, sandbox prefix with bad signature, empty token after `Bearer ` — three branches that previously fell through silently.

## Stacked on

Builds on https://github.com/vm0-ai/vm0/pull/11233.

## Test plan
- [ ] `pnpm -F api lint`
- [ ] `pnpm -F api check-types`
- [ ] `pnpm -F api exec vitest run`
- [ ] `pnpm knip`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)