### PR TITLE
refactor: centralize guest system log path

### DIFF
--- a/crates/guest-agent/src/artifact.rs
+++ b/crates/guest-agent/src/artifact.rs
@@ -827,6 +827,10 @@ mod tests {
         server
     });
 
+    fn disable_system_log() {
+        guest_common::log::clear_system_log_file();
+    }
+
     #[test]
     fn walk_dir_skips_symlinks() {
         let dir = tempfile::tempdir().unwrap();
@@ -1197,6 +1201,7 @@ mod tests {
 
     #[tokio::test]
     async fn dedup_snapshot_validation_failure_does_not_commit() {
+        disable_system_log();
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         std::fs::write(root.join("target.txt"), "before").unwrap();
@@ -1412,6 +1417,7 @@ mod tests {
 
     #[test]
     fn collect_file_metadata_nonexistent_dir() {
+        disable_system_log();
         let files = collect_file_metadata("/nonexistent/path/that/does/not/exist");
         assert!(files.is_empty());
     }

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -579,6 +579,34 @@ pub async fn execute_cli(
 mod tests {
     use super::*;
 
+    fn disable_system_log() {
+        guest_common::log::clear_system_log_file();
+    }
+
+    fn build_claude_args_for_test(
+        resume_id: &str,
+        append_system_prompt: &str,
+        disallowed_tools: &str,
+        tools: &str,
+        settings: &str,
+        prompt: &str,
+    ) -> Vec<String> {
+        disable_system_log();
+        build_claude_args(
+            resume_id,
+            append_system_prompt,
+            disallowed_tools,
+            tools,
+            settings,
+            prompt,
+        )
+    }
+
+    fn build_claude_command_for_test(use_mock: bool) -> Vec<String> {
+        disable_system_log();
+        build_claude_command(use_mock)
+    }
+
     /// Assert prompt is last and preceded by "--" separator.
     fn assert_prompt_with_separator(args: &[String], expected_prompt: &str) {
         let len = args.len();
@@ -593,7 +621,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_basic() {
-        let args = build_claude_args("", "", "", "", "", "hello world");
+        let args = build_claude_args_for_test("", "", "", "", "", "hello world");
         assert!(args.contains(&"--print".to_string()));
         assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
         assert_prompt_with_separator(&args, "hello world");
@@ -603,7 +631,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_with_append_system_prompt() {
-        let args = build_claude_args("", "Your name is Aria.", "", "", "", "analyze this");
+        let args = build_claude_args_for_test("", "Your name is Aria.", "", "", "", "analyze this");
         let asp_idx = args
             .iter()
             .position(|a| a == "--append-system-prompt")
@@ -614,13 +642,13 @@ mod tests {
 
     #[test]
     fn build_claude_args_empty_append_system_prompt_omitted() {
-        let args = build_claude_args("", "", "", "", "", "test");
+        let args = build_claude_args_for_test("", "", "", "", "", "test");
         assert!(!args.contains(&"--append-system-prompt".to_string()));
     }
 
     #[test]
     fn build_claude_args_with_resume_and_append() {
-        let args = build_claude_args("sess-123", "Be helpful.", "", "", "", "prompt");
+        let args = build_claude_args_for_test("sess-123", "Be helpful.", "", "", "", "prompt");
         assert!(args.contains(&"--resume".to_string()));
         assert!(args.contains(&"--append-system-prompt".to_string()));
         assert_prompt_with_separator(&args, "prompt");
@@ -628,7 +656,7 @@ mod tests {
 
     #[test]
     fn build_claude_command_uses_claude_binary() {
-        let cmd = build_claude_command(false);
+        let cmd = build_claude_command_for_test(false);
         assert_eq!(cmd[0], "claude");
     }
 
@@ -640,13 +668,14 @@ mod tests {
         // against the const (not the accessor) catches regressions in
         // the default path itself — the previous form compared the
         // accessor against itself and was tautological.
-        let cmd = build_claude_command(true);
+        let cmd = build_claude_command_for_test(true);
         assert_eq!(cmd[0], env::DEFAULT_MOCK_CLAUDE_PATH);
     }
 
     #[test]
     fn build_claude_args_with_disallowed_tools() {
-        let args = build_claude_args("", "", "CronCreate,CronDelete,CronList", "", "", "hello");
+        let args =
+            build_claude_args_for_test("", "", "CronCreate,CronDelete,CronList", "", "", "hello");
         let dt_idx = args.iter().position(|a| a == "--disallowed-tools").unwrap();
         assert_eq!(args[dt_idx + 1], "CronCreate");
         assert_eq!(args[dt_idx + 2], "CronDelete");
@@ -657,13 +686,13 @@ mod tests {
 
     #[test]
     fn build_claude_args_empty_disallowed_tools_omitted() {
-        let args = build_claude_args("", "", "", "", "", "test");
+        let args = build_claude_args_for_test("", "", "", "", "", "test");
         assert!(!args.contains(&"--disallowed-tools".to_string()));
     }
 
     #[test]
     fn build_claude_args_with_tools() {
-        let args = build_claude_args("", "", "", "Bash,Edit,Read", "", "hello");
+        let args = build_claude_args_for_test("", "", "", "Bash,Edit,Read", "", "hello");
         let t_idx = args.iter().position(|a| a == "--tools").unwrap();
         assert_eq!(args[t_idx + 1], "Bash");
         assert_eq!(args[t_idx + 2], "Edit");
@@ -674,13 +703,13 @@ mod tests {
 
     #[test]
     fn build_claude_args_empty_tools_omitted() {
-        let args = build_claude_args("", "", "", "", "", "test");
+        let args = build_claude_args_for_test("", "", "", "", "", "test");
         assert!(!args.contains(&"--tools".to_string()));
     }
 
     #[test]
     fn build_claude_args_with_settings() {
-        let args = build_claude_args("", "", "", "", r#"{"hooks":{}}"#, "hello");
+        let args = build_claude_args_for_test("", "", "", "", r#"{"hooks":{}}"#, "hello");
         let s_idx = args.iter().position(|a| a == "--settings").unwrap();
         assert_eq!(args[s_idx + 1], r#"{"hooks":{}}"#);
         assert_prompt_with_separator(&args, "hello");
@@ -688,13 +717,13 @@ mod tests {
 
     #[test]
     fn build_claude_args_empty_settings_omitted() {
-        let args = build_claude_args("", "", "", "", "", "test");
+        let args = build_claude_args_for_test("", "", "", "", "", "test");
         assert!(!args.contains(&"--settings".to_string()));
     }
 
     #[test]
     fn build_claude_args_all_options_combined() {
-        let args = build_claude_args(
+        let args = build_claude_args_for_test(
             "sess-abc",
             "Be concise.",
             "CronCreate,CronDelete",
@@ -723,7 +752,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_disallowed_tools_whitespace_trimmed() {
-        let args = build_claude_args("", "", " CronCreate , CronDelete ", "", "", "test");
+        let args = build_claude_args_for_test("", "", " CronCreate , CronDelete ", "", "", "test");
         let dt_idx = args.iter().position(|a| a == "--disallowed-tools").unwrap();
         assert_eq!(args[dt_idx + 1], "CronCreate");
         assert_eq!(args[dt_idx + 2], "CronDelete");
@@ -731,7 +760,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_tools_whitespace_trimmed() {
-        let args = build_claude_args("", "", "", " Bash , Read ", "", "test");
+        let args = build_claude_args_for_test("", "", "", " Bash , Read ", "", "test");
         let t_idx = args.iter().position(|a| a == "--tools").unwrap();
         assert_eq!(args[t_idx + 1], "Bash");
         assert_eq!(args[t_idx + 2], "Read");
@@ -740,7 +769,7 @@ mod tests {
     #[test]
     fn build_claude_args_disallowed_tools_empty_items_skipped() {
         // Trailing comma produces an empty token that should be skipped
-        let args = build_claude_args("", "", "CronCreate,,CronDelete,", "", "", "test");
+        let args = build_claude_args_for_test("", "", "CronCreate,,CronDelete,", "", "", "test");
         let dt_idx = args.iter().position(|a| a == "--disallowed-tools").unwrap();
         // Only non-empty tools should be present
         let tool_args: Vec<&str> = args[dt_idx + 1..]
@@ -753,7 +782,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_prompt_always_last() {
-        let args = build_claude_args("", "", "", "", "", "my prompt");
+        let args = build_claude_args_for_test("", "", "", "", "", "my prompt");
         assert_eq!(args.last().unwrap(), "my prompt");
     }
 

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -22,7 +22,6 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 
 #[tokio::main]
 async fn main() {
-    guest_common::log::set_system_log_file(paths::system_log_file());
     let exit_code = run().await;
     std::process::exit(exit_code);
 }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -22,6 +22,7 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 
 #[tokio::main]
 async fn main() {
+    guest_common::log::enable_system_log_file();
     let exit_code = run().await;
     std::process::exit(exit_code);
 }

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -33,8 +33,6 @@ static EVENT_ERROR_FLAG: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-event-error-{}", env::run_id()));
 static CHECKPOINT_ERROR_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-checkpoint-error-{}", env::run_id()));
-static SYSTEM_LOG_FILE: LazyLock<String> =
-    LazyLock::new(|| format!("/tmp/vm0-system-{}.log", env::run_id()));
 static AGENT_LOG_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-agent-{}.log", env::run_id()));
 static METRICS_LOG_FILE: LazyLock<String> =
@@ -47,7 +45,7 @@ pub fn checkpoint_error_file() -> &'static str {
     &CHECKPOINT_ERROR_FILE
 }
 pub fn system_log_file() -> &'static str {
-    &SYSTEM_LOG_FILE
+    guest_common::log::system_log_file()
 }
 pub fn agent_log_file() -> &'static str {
     &AGENT_LOG_FILE

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -33,6 +33,8 @@ static EVENT_ERROR_FLAG: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-event-error-{}", env::run_id()));
 static CHECKPOINT_ERROR_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-checkpoint-error-{}", env::run_id()));
+static SYSTEM_LOG_FILE: LazyLock<String> =
+    LazyLock::new(|| format!("/tmp/vm0-system-{}.log", env::run_id()));
 static AGENT_LOG_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-agent-{}.log", env::run_id()));
 static METRICS_LOG_FILE: LazyLock<String> =
@@ -45,7 +47,7 @@ pub fn checkpoint_error_file() -> &'static str {
     &CHECKPOINT_ERROR_FILE
 }
 pub fn system_log_file() -> &'static str {
-    guest_common::log::system_log_file()
+    &SYSTEM_LOG_FILE
 }
 pub fn agent_log_file() -> &'static str {
     &AGENT_LOG_FILE

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -33,6 +33,21 @@ static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
 /// Serialize all tests — they share one mock server and process-wide env vars.
 static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
+struct SystemLogOverrideGuard;
+
+impl SystemLogOverrideGuard {
+    fn set(path: &str) -> Self {
+        guest_common::log::set_system_log_file(path);
+        Self
+    }
+}
+
+impl Drop for SystemLogOverrideGuard {
+    fn drop(&mut self) {
+        guest_common::log::clear_system_log_file();
+    }
+}
+
 // =========================================================================
 // Group 1: post_json core
 // =========================================================================
@@ -1076,7 +1091,7 @@ async fn final_flush_uploads_log_emitted_immediately_before_it() {
         then.status(200);
     });
 
-    guest_common::log::set_system_log_file(system_log);
+    let system_log_guard = SystemLogOverrideGuard::set(system_log);
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
     let telemetry = guest_agent::telemetry::Telemetry::spawn(masker);
 
@@ -1087,7 +1102,7 @@ async fn final_flush_uploads_log_emitted_immediately_before_it() {
         .expect("final flush should upload just-emitted log");
 
     telemetry.shutdown().await;
-    guest_common::log::clear_system_log_file();
+    drop(system_log_guard);
 
     upload_mock.assert_calls_async(1).await;
     upload_mock.delete_async().await;

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -10,7 +10,7 @@ static RUN_ID: LazyLock<String> = LazyLock::new(|| match std::env::var("VM0_RUN_
 });
 static DEFAULT_SYSTEM_LOG_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-system-{}.log", &*RUN_ID));
-static SYSTEM_LOG_FILE: Mutex<SystemLogFile> = Mutex::new(SystemLogFile::Default);
+static SYSTEM_LOG_FILE: Mutex<SystemLogFile> = Mutex::new(SystemLogFile::Disabled);
 
 enum SystemLogFile {
     Default,
@@ -23,8 +23,14 @@ pub fn timestamp() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
-/// Guest-side system log path for the current run.
-pub fn system_log_file() -> &'static str {
+/// Enable writes to the guest-side system log file for the current run.
+pub fn enable_system_log_file() {
+    default_system_log_file();
+    let mut guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
+    *guard = SystemLogFile::Default;
+}
+
+fn default_system_log_file() -> &'static str {
     &DEFAULT_SYSTEM_LOG_FILE
 }
 
@@ -47,7 +53,7 @@ pub fn clear_system_log_file() {
 fn append_system_log_line(line: &str) -> std::io::Result<()> {
     let guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
     let path = match &*guard {
-        SystemLogFile::Default => PathBuf::from(system_log_file()),
+        SystemLogFile::Default => PathBuf::from(default_system_log_file()),
         SystemLogFile::Override(path) => path.clone(),
         SystemLogFile::Disabled => return Ok(()),
     };
@@ -71,7 +77,8 @@ fn write_stderr_line(line: &str) {
     let _ = stderr.flush();
 }
 
-/// Emit one formatted log line to stderr and the guest-side system log file.
+/// Emit one formatted log line to stderr and, when enabled, the guest-side
+/// system log file.
 pub fn emit(level: &str, tag: &str, args: std::fmt::Arguments<'_>) {
     let line = format!("[{}] [{level}] [{tag}] {args}", timestamp());
     if let Err(e) = append_system_log_line(&line) {
@@ -124,6 +131,18 @@ mod tests {
         assert!(
             chrono::DateTime::parse_from_rfc3339(&ts).is_ok(),
             "not a valid RFC3339: {ts}"
+        );
+    }
+
+    #[test]
+    fn emit_does_not_require_system_log_when_file_logging_is_disabled() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        clear_system_log_file();
+
+        emit(
+            "INFO",
+            "sandbox:guest-agent",
+            format_args!("stderr-only log line"),
         );
     }
 

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -120,6 +120,21 @@ mod tests {
 
     static LOG_TEST_MUTEX: Mutex<()> = Mutex::new(());
 
+    struct SystemLogFileGuard;
+
+    impl SystemLogFileGuard {
+        fn set(path: impl AsRef<Path>) -> Self {
+            set_system_log_file(path);
+            Self
+        }
+    }
+
+    impl Drop for SystemLogFileGuard {
+        fn drop(&mut self) {
+            clear_system_log_file();
+        }
+    }
+
     #[test]
     fn timestamp_is_rfc3339() {
         let ts = timestamp();
@@ -151,7 +166,7 @@ mod tests {
         let _guard = LOG_TEST_MUTEX.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("system.log");
-        set_system_log_file(&path);
+        let _system_log = SystemLogFileGuard::set(&path);
         clear_system_log_file();
 
         emit(
@@ -171,7 +186,7 @@ mod tests {
         let _guard = LOG_TEST_MUTEX.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("system.log");
-        set_system_log_file(&path);
+        let _system_log = SystemLogFileGuard::set(&path);
 
         emit(
             "WARN",
@@ -179,7 +194,6 @@ mod tests {
             format_args!("Tool timeout {}", "WebFetch"),
         );
 
-        clear_system_log_file();
         let content = std::fs::read_to_string(path).unwrap();
         assert!(
             content.contains("[WARN] [sandbox:guest-agent] Tool timeout WebFetch"),
@@ -193,7 +207,7 @@ mod tests {
         let _guard = LOG_TEST_MUTEX.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("missing-parent").join("system.log");
-        set_system_log_file(&path);
+        let _system_log = SystemLogFileGuard::set(&path);
 
         emit(
             "WARN",
@@ -201,7 +215,6 @@ mod tests {
             format_args!("system log path is not writable"),
         );
 
-        clear_system_log_file();
         assert!(
             !path.exists(),
             "test setup expected append to fail for missing parent dir",
@@ -213,7 +226,7 @@ mod tests {
         let _guard = LOG_TEST_MUTEX.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("system.log");
-        set_system_log_file(&path);
+        let _system_log = SystemLogFileGuard::set(&path);
 
         let handles: Vec<_> = (0..8)
             .map(|thread_id| {
@@ -231,7 +244,6 @@ mod tests {
         for handle in handles {
             handle.join().unwrap();
         }
-        clear_system_log_file();
 
         let content = std::fs::read_to_string(path).unwrap();
         let lines: Vec<_> = content.lines().collect();

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -10,13 +10,7 @@ static RUN_ID: LazyLock<String> = LazyLock::new(|| match std::env::var("VM0_RUN_
 });
 static DEFAULT_SYSTEM_LOG_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-system-{}.log", &*RUN_ID));
-static SYSTEM_LOG_FILE: Mutex<SystemLogFile> = Mutex::new(SystemLogFile::Disabled);
-
-enum SystemLogFile {
-    Default,
-    Override(PathBuf),
-    Disabled,
-}
+static SYSTEM_LOG_FILE: Mutex<Option<PathBuf>> = Mutex::new(None);
 
 /// Get current timestamp in RFC3339 format with milliseconds.
 pub fn timestamp() -> String {
@@ -24,10 +18,13 @@ pub fn timestamp() -> String {
 }
 
 /// Enable writes to the guest-side system log file for the current run.
+///
+/// # Panics
+///
+/// Panics when `VM0_RUN_ID` is missing or empty. Guest binaries require a run
+/// ID before writing run-scoped logs.
 pub fn enable_system_log_file() {
-    default_system_log_file();
-    let mut guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
-    *guard = SystemLogFile::Default;
+    set_system_log_file(default_system_log_file());
 }
 
 fn default_system_log_file() -> &'static str {
@@ -41,26 +38,24 @@ fn default_system_log_file() -> &'static str {
 /// same file immediately after some fatal-path log lines are emitted.
 pub fn set_system_log_file(path: impl AsRef<Path>) {
     let mut guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
-    *guard = SystemLogFile::Override(path.as_ref().to_path_buf());
+    *guard = Some(path.as_ref().to_path_buf());
 }
 
 #[doc(hidden)]
 pub fn clear_system_log_file() {
     let mut guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
-    *guard = SystemLogFile::Disabled;
+    *guard = None;
 }
 
 fn append_system_log_line(line: &str) -> std::io::Result<()> {
     let guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
-    let path = match &*guard {
-        SystemLogFile::Default => PathBuf::from(default_system_log_file()),
-        SystemLogFile::Override(path) => path.clone(),
-        SystemLogFile::Disabled => return Ok(()),
+    let Some(path) = guard.as_ref() else {
+        return Ok(());
     };
     let mut file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(&path)
+        .open(path)
         .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {e}", path.display())))?;
     use std::io::Write;
     let mut line = line.as_bytes().to_vec();

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -147,6 +147,26 @@ mod tests {
     }
 
     #[test]
+    fn emit_does_not_write_previous_path_when_file_logging_is_disabled() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.log");
+        set_system_log_file(&path);
+        clear_system_log_file();
+
+        emit(
+            "INFO",
+            "sandbox:guest-agent",
+            format_args!("stderr-only after clearing system log"),
+        );
+
+        assert!(
+            !path.exists(),
+            "disabled system log should not write to previous path",
+        );
+    }
+
+    #[test]
     fn emit_appends_to_configured_system_log_file() {
         let _guard = LOG_TEST_MUTEX.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -1,40 +1,60 @@
 //! Logging utilities for VM scripts.
 
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
-static SYSTEM_LOG_FILE: Mutex<Option<PathBuf>> = Mutex::new(None);
+#[allow(clippy::panic)]
+static RUN_ID: LazyLock<String> = LazyLock::new(|| match std::env::var("VM0_RUN_ID") {
+    Ok(run_id) if !run_id.is_empty() => run_id,
+    _ => panic!("VM0_RUN_ID is required for guest system logging"),
+});
+static DEFAULT_SYSTEM_LOG_FILE: LazyLock<String> =
+    LazyLock::new(|| format!("/tmp/vm0-system-{}.log", &*RUN_ID));
+static SYSTEM_LOG_FILE: Mutex<SystemLogFile> = Mutex::new(SystemLogFile::Default);
+
+enum SystemLogFile {
+    Default,
+    Override(PathBuf),
+    Disabled,
+}
 
 /// Get current timestamp in RFC3339 format with milliseconds.
 pub fn timestamp() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
-/// Also append future log lines to a system log file.
+/// Guest-side system log path for the current run.
+pub fn system_log_file() -> &'static str {
+    &DEFAULT_SYSTEM_LOG_FILE
+}
+
+/// Override the system log file used by future log lines.
 ///
 /// The write is synchronous and completes before the logging macro returns.
 /// This matters for guest-agent's final telemetry upload, which reads the
 /// same file immediately after some fatal-path log lines are emitted.
 pub fn set_system_log_file(path: impl AsRef<Path>) {
     let mut guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
-    *guard = Some(path.as_ref().to_path_buf());
+    *guard = SystemLogFile::Override(path.as_ref().to_path_buf());
 }
 
 #[doc(hidden)]
 pub fn clear_system_log_file() {
     let mut guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
-    *guard = None;
+    *guard = SystemLogFile::Disabled;
 }
 
 fn append_system_log_line(line: &str) -> std::io::Result<()> {
     let guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
-    let Some(path) = guard.as_ref() else {
-        return Ok(());
+    let path = match &*guard {
+        SystemLogFile::Default => PathBuf::from(system_log_file()),
+        SystemLogFile::Override(path) => path.clone(),
+        SystemLogFile::Disabled => return Ok(()),
     };
     let mut file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(path)
+        .open(&path)
         .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {e}", path.display())))?;
     use std::io::Write;
     let mut line = line.as_bytes().to_vec();
@@ -51,8 +71,7 @@ fn write_stderr_line(line: &str) {
     let _ = stderr.flush();
 }
 
-/// Emit one formatted log line to stderr and, when configured, to the
-/// guest-side system log file.
+/// Emit one formatted log line to stderr and the guest-side system log file.
 pub fn emit(level: &str, tag: &str, args: std::fmt::Arguments<'_>) {
     let line = format!("[{}] [{level}] [{tag}] {args}", timestamp());
     if let Err(e) = append_system_log_line(&line) {

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -588,6 +588,10 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
 mod tests {
     use super::*;
 
+    fn disable_system_log() {
+        guest_common::log::clear_system_log_file();
+    }
+
     // -- normalize_path tests --
 
     #[test]
@@ -733,6 +737,7 @@ mod tests {
 
     #[test]
     fn cleanup_removes_path_without_preserved_children() {
+        disable_system_log();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("mount");
         fs::create_dir_all(&path).unwrap();
@@ -744,6 +749,7 @@ mod tests {
 
     #[test]
     fn cleanup_preserves_unchanged_children() {
+        disable_system_log();
         let dir = tempfile::tempdir().unwrap();
         let parent = dir.path().join("claude");
         let child = parent.join("skills").join("foo");
@@ -766,6 +772,7 @@ mod tests {
 
     #[test]
     fn cleanup_handles_nonexistent_path() {
+        disable_system_log();
         // Should not panic
         cleanup_stale_paths(&["/nonexistent/path/12345".into()], &[]);
     }

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -4,6 +4,8 @@ use std::time::Instant;
 const LOG_TAG: &str = "sandbox:download";
 
 fn main() {
+    guest_common::log::enable_system_log_file();
+
     let args: Vec<String> = std::env::args().collect();
     let manifest_path = match args.get(1) {
         Some(p) => p,

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -241,6 +241,25 @@ fn binary_panics_without_run_id_for_default_system_log() {
     );
 }
 
+#[test]
+fn binary_panics_with_empty_run_id_for_default_system_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_manifest(&dir, &[], None).unwrap();
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg(&manifest_path)
+        .env("VM0_RUN_ID", "")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("VM0_RUN_ID is required for guest system logging"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Test 1: single storage download succeeds
 // ---------------------------------------------------------------------------

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -162,6 +162,27 @@ fn run_guest_download(manifest_path: &str) -> bool {
     guest_download::run(manifest_path)
 }
 
+struct RunFileCleanup {
+    paths: Vec<String>,
+}
+
+impl RunFileCleanup {
+    fn new(paths: Vec<String>) -> Self {
+        for path in &paths {
+            let _ = std::fs::remove_file(path);
+        }
+        Self { paths }
+    }
+}
+
+impl Drop for RunFileCleanup {
+    fn drop(&mut self) {
+        for path in &self.paths {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
 #[test]
 fn binary_writes_system_log_to_guest_common_default_path() {
     let dir = tempfile::tempdir().unwrap();
@@ -176,8 +197,7 @@ fn binary_writes_system_log_to_guest_common_default_path() {
     );
     let system_log = format!("/tmp/vm0-system-{run_id}.log");
     let ops_log = format!("/tmp/vm0-sandbox-ops-{run_id}.jsonl");
-    let _ = std::fs::remove_file(&system_log);
-    let _ = std::fs::remove_file(&ops_log);
+    let _cleanup = RunFileCleanup::new(vec![system_log.clone(), ops_log]);
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
         .arg(&manifest_path)
@@ -200,9 +220,6 @@ fn binary_writes_system_log_to_guest_common_default_path() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("[INFO] [sandbox:download] Download completed"));
-
-    let _ = std::fs::remove_file(system_log);
-    let _ = std::fs::remove_file(ops_log);
 }
 
 #[test]

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -3,7 +3,10 @@ use flate2::write::GzEncoder;
 use httpmock::prelude::*;
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tempfile::TempDir;
+
+static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 enum TarEntry<'a> {
     File(&'a str, &'a [u8]),
@@ -162,6 +165,14 @@ fn run_guest_download(manifest_path: &str) -> bool {
     guest_download::run(manifest_path)
 }
 
+fn unique_run_id(test_name: &str) -> String {
+    format!(
+        "guest-download-{test_name}-{}-{}",
+        std::process::id(),
+        RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
 struct RunFileCleanup {
     paths: Vec<String>,
 }
@@ -187,14 +198,7 @@ impl Drop for RunFileCleanup {
 fn binary_writes_system_log_to_guest_common_default_path() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_manifest(&dir, &[], None).unwrap();
-    let run_id = format!(
-        "guest-download-test-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    );
+    let run_id = unique_run_id("success");
     let system_log = format!("/tmp/vm0-system-{run_id}.log");
     let ops_log = format!("/tmp/vm0-sandbox-ops-{run_id}.jsonl");
     let _cleanup = RunFileCleanup::new(vec![system_log.clone(), ops_log]);
@@ -220,6 +224,32 @@ fn binary_writes_system_log_to_guest_common_default_path() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("[INFO] [sandbox:download] Download completed"));
+}
+
+#[test]
+fn binary_writes_system_log_on_manifest_read_failure() {
+    let run_id = unique_run_id("missing-manifest");
+    let system_log = format!("/tmp/vm0-system-{run_id}.log");
+    let ops_log = format!("/tmp/vm0-sandbox-ops-{run_id}.jsonl");
+    let _cleanup = RunFileCleanup::new(vec![system_log.clone(), ops_log]);
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg("/tmp/nonexistent-guest-download-manifest.json")
+        .env("VM0_RUN_ID", &run_id)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+
+    let content = std::fs::read_to_string(&system_log).unwrap();
+    assert!(
+        content.contains("[ERROR] [sandbox:download] Failed to read manifest"),
+        "unexpected system log: {content:?}"
+    );
+    assert!(
+        content.contains("[ERROR] [sandbox:download] Download failed"),
+        "unexpected system log: {content:?}"
+    );
 }
 
 #[test]

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -157,6 +157,73 @@ fn write_manifest(
     Ok(manifest_path)
 }
 
+fn run_guest_download(manifest_path: &str) -> bool {
+    guest_common::log::clear_system_log_file();
+    guest_download::run(manifest_path)
+}
+
+#[test]
+fn binary_writes_system_log_to_guest_common_default_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_manifest(&dir, &[], None).unwrap();
+    let run_id = format!(
+        "guest-download-test-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let system_log = format!("/tmp/vm0-system-{run_id}.log");
+    let ops_log = format!("/tmp/vm0-sandbox-ops-{run_id}.jsonl");
+    let _ = std::fs::remove_file(&system_log);
+    let _ = std::fs::remove_file(&ops_log);
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg(&manifest_path)
+        .env("VM0_RUN_ID", &run_id)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = std::fs::read_to_string(&system_log).unwrap();
+    assert!(
+        content.contains("[INFO] [sandbox:download] Download completed"),
+        "unexpected system log: {content:?}"
+    );
+    assert_eq!(content.matches("Download completed").count(), 1);
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("[INFO] [sandbox:download] Download completed"));
+
+    let _ = std::fs::remove_file(system_log);
+    let _ = std::fs::remove_file(ops_log);
+}
+
+#[test]
+fn binary_panics_without_run_id_for_default_system_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_manifest(&dir, &[], None).unwrap();
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg(&manifest_path)
+        .env_remove("VM0_RUN_ID")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("VM0_RUN_ID is required for guest system logging"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Test 1: single storage download succeeds
 // ---------------------------------------------------------------------------
@@ -177,7 +244,7 @@ fn single_storage_download() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     assert_eq!(
@@ -224,7 +291,7 @@ fn six_storages_parallel() {
         .collect();
 
     let manifest = write_manifest(&dir, &storage_refs, None).unwrap();
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
 
@@ -296,7 +363,7 @@ fn parent_child_mount_paths_parallel() {
     ];
 
     let manifest = write_manifest(&dir, &storages, None).unwrap();
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     m_parent.assert();
@@ -342,7 +409,7 @@ fn artifact_download_success() {
     let url = server.url("/artifact.tar.gz");
     let manifest = write_manifest(&dir, &[], Some((mount.to_str().unwrap(), Some(&url)))).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     assert_eq!(
@@ -368,7 +435,7 @@ fn artifact_404_non_fatal() {
     let url = server.url("/artifact.tar.gz");
     let manifest = write_manifest(&dir, &[], Some((mount.to_str().unwrap(), Some(&url)))).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
     assert!(result);
 }
 
@@ -389,7 +456,7 @@ fn storage_404_fatal() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
     assert!(!result);
 }
 
@@ -410,7 +477,7 @@ fn server_error_exhausts_retries() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(!result);
     mock.assert_calls(3);
@@ -433,7 +500,7 @@ fn rate_limit_exhausts_retries() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(!result);
     mock.assert_calls(3);
@@ -458,7 +525,7 @@ fn invalid_tar_gz_non_retriable() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(!result);
     mock.assert_calls(1);
@@ -483,7 +550,7 @@ fn null_and_missing_urls_skip_download() {
     )
     .unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
     assert!(result);
 }
 
@@ -492,7 +559,7 @@ fn null_and_missing_urls_skip_download() {
 // ---------------------------------------------------------------------------
 #[test]
 fn manifest_file_not_found() {
-    let result = guest_download::run("/tmp/nonexistent-manifest-path.json");
+    let result = run_guest_download("/tmp/nonexistent-manifest-path.json");
     assert!(!result);
 }
 
@@ -505,7 +572,7 @@ fn manifest_json_invalid() {
     let manifest_path = dir.path().join("manifest.json");
     std::fs::write(&manifest_path, "{{not valid json").unwrap();
 
-    let result = guest_download::run(manifest_path.to_str().unwrap());
+    let result = run_guest_download(manifest_path.to_str().unwrap());
     assert!(!result);
 }
 
@@ -526,7 +593,7 @@ fn artifact_500_fatal() {
     let url = server.url("/artifact.tar.gz");
     let manifest = write_manifest(&dir, &[], Some((mount.to_str().unwrap(), Some(&url)))).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(!result);
     mock.assert_calls(3); // exhausts all retries
@@ -553,7 +620,7 @@ fn retry_then_succeed() {
     let manifest_str = manifest.to_str().unwrap().to_string();
 
     // Run in background thread so we can swap the mock during RETRY_DELAY
-    let handle = std::thread::spawn(move || guest_download::run(&manifest_str));
+    let handle = std::thread::spawn(move || run_guest_download(&manifest_str));
 
     // Poll until the first request has been made, then swap mock before retry fires (RETRY_DELAY = 1s).
     // Timeout after 5s to avoid infinite loop if the spawned thread panics before making a request.
@@ -617,7 +684,7 @@ fn storages_partial_failure() {
     )
     .unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(!result);
     // The successful storage should still have extracted its file
@@ -638,12 +705,12 @@ fn artifact_null_url_skipped() {
     // archiveUrl is the string "null" — should be treated as missing
     let manifest =
         write_manifest(&dir, &[], Some((mount.to_str().unwrap(), Some("null")))).unwrap();
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
     assert!(result);
 
     // archiveUrl is absent entirely
     let manifest = write_manifest(&dir, &[], Some((mount.to_str().unwrap(), None))).unwrap();
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
     assert!(result);
 }
 
@@ -677,7 +744,7 @@ fn symlink_path_traversal_blocked() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     // Legitimate file should be extracted
@@ -714,7 +781,7 @@ fn symlink_within_target_allowed() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     assert_eq!(
@@ -763,7 +830,7 @@ fn path_traversal_via_dotdot_blocked() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     // Legit file should be extracted
@@ -806,7 +873,7 @@ fn two_step_symlink_attack_blocked() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     // Safe file should be extracted
@@ -842,7 +909,7 @@ fn hardlink_escaping_target_blocked() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     assert_eq!(
@@ -883,7 +950,7 @@ fn symlink_relative_dotdot_escape_blocked() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     assert_eq!(
@@ -925,7 +992,7 @@ fn two_step_attack_deep_nested_blocked() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     // Payload should NOT be written to the evil target
@@ -957,7 +1024,7 @@ fn hardlink_relative_dotdot_escape_blocked() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     assert_eq!(
@@ -998,7 +1065,7 @@ fn absolute_path_entry_blocked() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     assert_eq!(
@@ -1041,7 +1108,7 @@ fn symlink_missing_link_target_skipped() {
     let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     assert_eq!(
@@ -1072,7 +1139,7 @@ fn file_scheme_extraction_success() {
     let url = format!("file://{}", staged.display());
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
 
     assert!(result);
     assert_eq!(
@@ -1096,7 +1163,7 @@ fn file_scheme_missing_storage_fatal() {
     let url = format!("file://{}", missing.display());
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
     assert!(!result);
 }
 
@@ -1114,6 +1181,6 @@ fn file_scheme_missing_artifact_fatal() {
     let url = format!("file://{}", missing.display());
     let manifest = write_manifest(&dir, &[], Some((mount.to_str().unwrap(), Some(&url)))).unwrap();
 
-    let result = guest_download::run(manifest.to_str().unwrap());
+    let result = run_guest_download(manifest.to_str().unwrap());
     assert!(!result);
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -428,13 +428,6 @@ async fn run_in_sandbox(
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
 ) -> RunnerResult<(i32, Option<String>)> {
-    // Guest-side system log file. Setup commands append directly here before
-    // guest-agent starts; guest-agent owns the file during the agent phase.
-    let log_file = format!(
-        "{GUEST_SYSTEM_LOG_PREFIX}{}{GUEST_SYSTEM_LOG_SUFFIX}",
-        context.run_id
-    );
-
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
     if start.restore_guest_state {
@@ -472,7 +465,7 @@ async fn run_in_sandbox(
                     telemetry,
                 )
                 .await?;
-                download_storages(sandbox, context, &effective, &log_file).await
+                download_storages(sandbox, context, &effective).await
             }
             .await
         } else {
@@ -1072,11 +1065,18 @@ fn filter_unchanged_storages(
 }
 
 /// Download storage volumes into the guest.
+fn guest_download_command(manifest_path: &str) -> String {
+    format!("{} {}", guest::DOWNLOAD_BIN, manifest_path)
+}
+
+fn guest_download_env(run_id: &str) -> [(&'static str, &str); 1] {
+    [("VM0_RUN_ID", run_id)]
+}
+
 async fn download_storages(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     manifest: &StorageManifest,
-    log_file: &str,
 ) -> RunnerResult<()> {
     let manifest_json = serde_json::to_vec(manifest)
         .map_err(|e| RunnerError::Internal(format!("manifest json: {e}")))?;
@@ -1084,17 +1084,15 @@ async fn download_storages(
         .write_file(guest::STORAGE_MANIFEST, &manifest_json)
         .await?;
 
-    let download_cmd = format!(
-        "{} {} >> {log_file} 2>&1",
-        guest::DOWNLOAD_BIN,
-        guest::STORAGE_MANIFEST
-    );
+    let download_cmd = guest_download_command(guest::STORAGE_MANIFEST);
+    let run_id = context.run_id.to_string();
+    let download_env = guest_download_env(&run_id);
     info!(run_id = %context.run_id, "downloading storages");
     let result = sandbox
         .exec(&ExecRequest {
             cmd: &download_cmd,
             timeout: DEFAULT_EXEC_TIMEOUT,
-            env: &[],
+            env: &download_env,
             sudo: false,
         })
         .await?;
@@ -2198,9 +2196,30 @@ mod tests {
             artifacts: vec![],
             cleanup_paths: vec![],
         };
-        download_storages(&sandbox, &ctx, &manifest, "/tmp/log")
-            .await
-            .unwrap();
+        download_storages(&sandbox, &ctx, &manifest).await.unwrap();
+    }
+
+    #[test]
+    fn guest_download_command_uses_guest_common_system_log_without_shell_redirect() {
+        let cmd = guest_download_command("/tmp/storage-manifest.json");
+
+        assert_eq!(
+            cmd,
+            "/usr/local/bin/guest-download /tmp/storage-manifest.json"
+        );
+        assert!(!cmd.contains(">>"));
+        assert!(!cmd.contains("2>&1"));
+        assert!(!cmd.contains("--system-log"));
+    }
+
+    #[test]
+    fn guest_download_env_includes_run_id_for_guest_common_logs() {
+        let ctx = minimal_context();
+        let run_id = ctx.run_id.to_string();
+        let env = guest_download_env(&run_id);
+
+        assert_eq!(env[0].0, "VM0_RUN_ID");
+        assert_eq!(env[0].1, run_id);
     }
 
     #[tokio::test]
@@ -2218,7 +2237,7 @@ mod tests {
             artifacts: vec![],
             cleanup_paths: vec![],
         };
-        let err = download_storages(&sandbox, &ctx, &manifest, "/tmp/log")
+        let err = download_storages(&sandbox, &ctx, &manifest)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("storage download failed"));
@@ -2446,7 +2465,7 @@ mod tests {
             artifacts: vec![],
             cleanup_paths: vec![],
         };
-        let err = download_storages(&sandbox, &ctx, &manifest, "/tmp/log")
+        let err = download_storages(&sandbox, &ctx, &manifest)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("vsock write failed"), "got: {err}");

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1065,8 +1065,8 @@ fn filter_unchanged_storages(
 }
 
 /// Download storage volumes into the guest.
-fn guest_download_command(manifest_path: &str) -> String {
-    format!("{} {}", guest::DOWNLOAD_BIN, manifest_path)
+fn guest_download_command() -> String {
+    format!("{} {}", guest::DOWNLOAD_BIN, guest::STORAGE_MANIFEST)
 }
 
 fn guest_download_env(run_id: &str) -> [(&'static str, &str); 1] {
@@ -1084,7 +1084,7 @@ async fn download_storages(
         .write_file(guest::STORAGE_MANIFEST, &manifest_json)
         .await?;
 
-    let download_cmd = guest_download_command(guest::STORAGE_MANIFEST);
+    let download_cmd = guest_download_command();
     let run_id = context.run_id.to_string();
     let download_env = guest_download_env(&run_id);
     info!(run_id = %context.run_id, "downloading storages");
@@ -2201,7 +2201,7 @@ mod tests {
 
     #[test]
     fn guest_download_command_uses_guest_common_system_log_without_shell_redirect() {
-        let cmd = guest_download_command("/tmp/storage-manifest.json");
+        let cmd = guest_download_command();
 
         assert_eq!(
             cmd,


### PR DESCRIPTION
## Summary
- centralize the default guest system log path in guest-common
- remove runner shell redirection for guest-download and pass VM0_RUN_ID through exec env
- add binary coverage for guest-download system log writes and missing run id panic

Note: the issue originally mentioned passing an explicit system log path. This PR follows the later review direction to derive /tmp/vm0-system-{run_id}.log inside guest-common instead.

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features
- cargo test --manifest-path crates/Cargo.toml -j1 -p guest-common -p guest-download
- cargo test --manifest-path crates/Cargo.toml -j1 -p runner download_storages
- cargo test --manifest-path crates/Cargo.toml -j1 -p runner guest_download
- cargo test --manifest-path crates/Cargo.toml -j1 -p guest-agent final_flush_uploads_log_emitted_immediately_before_it

Closes #11240