### PR TITLE
fix(runner): harden usage drain on shutdown

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -529,7 +529,7 @@ def response(flow: http.HTTPFlow) -> None:
 
     # Report proxy-extracted usage for model provider responses.
     # For non-streaming responses, fall back to extracting usage from the
-    # buffered JSON body (buffer is never truncated for model providers).
+    # buffered JSON body (buffer is never truncated for billable model providers).
     if not flow.metadata.get("model_provider_usage") and stream_buf:
         firewall_name = flow.metadata.get("firewall_name", "")
         if firewall_name.startswith("model-provider:") and flow.metadata.get(

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -79,11 +79,22 @@ def load(loader: Loader) -> None:
         default=str(Path(tempfile.gettempdir()) / "proxy-registry.json"),
         help="Path to proxy registry file",
     )
+    loader.add_option(
+        name="vm0_usage_state_id",
+        typespec=str,
+        default="",
+        help="Runner-generated usage-pending state id",
+    )
 
-    # Initialize the usage pending-count file so the runner can poll it
-    # before sending SIGTERM.  The file lives next to the addon script,
-    # which is written to addon_dir by the runner.
-    usage.set_pending_path(str(Path(__file__).resolve().parent / "usage-pending"))
+
+def configure(updated: set[str]) -> None:
+    if "vm0_usage_state_id" in updated:
+        # Custom --set options are deferred until after load() registers them,
+        # so initialize this file here where ctx.options has the runner value.
+        usage.set_pending_path(
+            str(Path(__file__).resolve().parent / "usage-pending"),
+            usage_state_id=ctx.options.vm0_usage_state_id or None,
+        )
 
 
 def get_api_url() -> str:
@@ -290,10 +301,29 @@ async def request(flow: http.HTTPFlow) -> None:
             return
         if isinstance(result, FirewallAllow):
             await handle_firewall_request(flow, result.api_entry, vm_info, result.match_info)
+            _maybe_track_usage_flow(flow)
             return
 
     # No firewall match — pass through directly
     flow.metadata["firewall_action"] = "ALLOW"
+
+
+def _maybe_track_usage_flow(flow: http.HTTPFlow) -> None:
+    """Track billable flows before upstream response headers.
+
+    This closes the shutdown drain gap where the request has already been
+    sent upstream, but mitmproxy has not yet reached responseheaders().
+    The response/error decorator pops the metadata flag so decrement runs
+    exactly once.
+    """
+    if flow.metadata.get("_usage_flow_tracked"):
+        return
+    # Local firewall/auth errors synthesize a response but never enqueue usage.
+    if flow.response is not None and not flow.metadata.get("auth_url_rewrite"):
+        return
+    if flow.metadata.get("firewall_billable", False):
+        usage.increment_flows()
+        flow.metadata["_usage_flow_tracked"] = True
 
 
 # ============================================================================
@@ -317,9 +347,9 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     buf = bytearray()
     state = {"truncated": False}
 
-    # Set up SSE usage extraction for model provider streaming responses.
-    # For non-SSE model provider responses, disable buffer truncation so the
-    # full JSON body is available for usage extraction in response().
+    # Set up usage extraction only for billable model-provider responses.
+    # For non-SSE billable model-provider responses, disable buffer truncation
+    # so the full JSON body is available for usage extraction in response().
     sse_parser = None
     sse_decompressor = None
     ndjson_parser = None
@@ -330,6 +360,7 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     # via auth.handle_firewall_request.  Gates report_connector_usage (in response())
     # and the full-body response buffering that billing payload extraction needs.
     is_billable_flow = flow.metadata.get("firewall_billable", False)
+    is_billable_model_provider = is_model_provider and is_billable_flow
     # X-specific NDJSON stream classification — tied to the x firewall itself,
     # not to billing.  Kept separate so a future non-x billable connector
     # doesn't accidentally inherit X stream parsing.
@@ -356,13 +387,7 @@ def responseheaders(flow: http.HTTPFlow) -> None:
         stream_path = urllib.parse.urlparse(flow.metadata.get("original_url", "")).path
         is_x_stream = usage.x.is_stream_path(stream_path)
 
-    # Track flows that will generate webhook POSTs (usage or connector billing)
-    # so the runner can wait for them to reach response()/error() before stopping.
-    if is_model_provider or is_billable_flow:
-        usage.increment_flows()
-        flow.metadata["_usage_flow_tracked"] = True
-
-    if is_model_provider:
+    if is_billable_model_provider:
         content_type = flow.response.headers.get("content-type", "")
         if "text/event-stream" in content_type:
             parser_fn, usage_dict = usage.create_sse_usage_extractor()
@@ -378,18 +403,12 @@ def responseheaders(flow: http.HTTPFlow) -> None:
         flow.metadata["x_ndjson_state"] = ndjson_state
         ndjson_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
 
-    # Buffer cap policy (coupled to billability by design — every billable
-    # connector today needs json.loads on the full body to build the webhook
-    # payload; if that ever diverges, add a separate flag):
-    # - Model providers: unbounded — need full body for non-SSE JSON usage extraction.
-    # - Billable non-stream connectors: unbounded — full body feeds json.loads.
-    # - X stream endpoints: STREAM_BUFFER_LIMIT (64 KB) — parser handles bytes
-    #   incrementally; the buffer is kept only for forensic network logging.
-    # - Everything else: STREAM_BUFFER_LIMIT (default 64 KB).
-    if is_model_provider or (is_billable_flow and not is_x_stream):
-        buf_limit = None
-    else:
-        buf_limit = body_utils.STREAM_BUFFER_LIMIT
+    # Buffer cap policy:
+    # - Billable flows keep the full body for billing extraction.
+    # - X stream endpoints are the exception: the incremental parser handles
+    #   bytes as they arrive, so the buffer is only for forensic logging.
+    # - Everything else uses STREAM_BUFFER_LIMIT (default 64 KB).
+    buf_limit = None if is_billable_flow and not is_x_stream else body_utils.STREAM_BUFFER_LIMIT
 
     def stream_and_buffer(chunk: bytes) -> bytes:
         if not state["truncated"]:
@@ -418,9 +437,9 @@ def responseheaders(flow: http.HTTPFlow) -> None:
 def _track_usage_flow(fn):
     """Decorator ensuring decrement_flows runs after response/error handlers.
 
-    Pairs with ``increment_flows()`` in ``responseheaders()``.  Uses
-    ``pop`` so that even if both ``response()`` and ``error()`` fire for
-    the same flow, the decrement only happens once.
+    Pairs with ``increment_flows()`` in ``request()``.  Uses ``pop`` so
+    that even if both ``response()`` and ``error()`` fire for the same
+    flow, the decrement only happens once.
     """
 
     @functools.wraps(fn)
@@ -513,7 +532,9 @@ def response(flow: http.HTTPFlow) -> None:
     # buffered JSON body (buffer is never truncated for model providers).
     if not flow.metadata.get("model_provider_usage") and stream_buf:
         firewall_name = flow.metadata.get("firewall_name", "")
-        if firewall_name.startswith("model-provider:"):
+        if firewall_name.startswith("model-provider:") and flow.metadata.get(
+            "firewall_billable", False
+        ):
             json_usage = usage.extract_usage_from_json(
                 bytes(stream_buf),
                 flow.response.headers if flow.response else None,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -226,100 +226,102 @@ async def request(flow: http.HTTPFlow) -> None:
     # Track request start time (after early returns to avoid leaking entries)
     _request_start_times[flow.id] = time.time()
 
-    original_url = get_original_url(flow)
+    try:
+        original_url = get_original_url(flow)
 
-    # Store info for response handler
-    flow.metadata["original_url"] = original_url
-    flow.metadata["vm_run_id"] = run_id
-    flow.metadata["vm_client_ip"] = client_ip
-    flow.metadata["vm_network_log_path"] = vm_info.get("networkLogPath", "")
-    flow.metadata["vm_proxy_log_path"] = vm_info.get("proxyLogPath", "")
-    flow.metadata["capture_body"] = vm_info.get("captureNetworkBodies", False)
-    flow.metadata["vm_sandbox_token"] = vm_info.get("sandboxToken", "")
+        # Store info for response handler
+        flow.metadata["original_url"] = original_url
+        flow.metadata["vm_run_id"] = run_id
+        flow.metadata["vm_client_ip"] = client_ip
+        flow.metadata["vm_network_log_path"] = vm_info.get("networkLogPath", "")
+        flow.metadata["vm_proxy_log_path"] = vm_info.get("proxyLogPath", "")
+        flow.metadata["capture_body"] = vm_info.get("captureNetworkBodies", False)
+        flow.metadata["vm_sandbox_token"] = vm_info.get("sandboxToken", "")
 
-    # Get target hostname
-    hostname = flow.request.pretty_host.lower()
+        # Get target hostname
+        hostname = flow.request.pretty_host.lower()
 
-    # --- Step 1: Auto-allow VM0 API requests ---
-    # The agent MUST be able to communicate with the platform (heartbeat,
-    # logs, CLI auth, etc.). Exception: `/api/test/*` routes exist only to
-    # exercise the firewall pipeline itself (e.g. the test-oauth provider),
-    # so they must go through Step 2 and get their auth injected by the
-    # matching firewall — otherwise the E2E tests that back them would
-    # auto-allow past the thing they're supposed to exercise.
-    api_url = get_api_url()
-    if api_url:
-        parsed_api = urllib.parse.urlparse(api_url)
-        api_hostname = parsed_api.hostname.lower() if parsed_api.hostname else ""
-        if (
-            api_hostname
-            and (hostname == api_hostname or hostname.endswith(f".{api_hostname}"))
-            and not flow.request.path.startswith("/api/test/")
-        ):
-            flow.metadata["firewall_action"] = "ALLOW"
-            return
+        # --- Step 1: Auto-allow VM0 API requests ---
+        # The agent MUST be able to communicate with the platform (heartbeat,
+        # logs, CLI auth, etc.). Exception: `/api/test/*` routes exist only to
+        # exercise the firewall pipeline itself (e.g. the test-oauth provider),
+        # so they must go through Step 2 and get their auth injected by the
+        # matching firewall — otherwise the E2E tests that back them would
+        # auto-allow past the thing they're supposed to exercise.
+        api_url = get_api_url()
+        if api_url:
+            parsed_api = urllib.parse.urlparse(api_url)
+            api_hostname = parsed_api.hostname.lower() if parsed_api.hostname else ""
+            if (
+                api_hostname
+                and (hostname == api_hostname or hostname.endswith(f".{api_hostname}"))
+                and not flow.request.path.startswith("/api/test/")
+            ):
+                flow.metadata["firewall_action"] = "ALLOW"
+                return
 
-    # --- Step 2: Firewall match with permission check ---
-    # Match base URL, then check permission rules before injecting auth headers.
-    vm_firewalls = vm_info.get("firewalls")
-    if vm_firewalls:
-        network_policies = vm_info.get("networkPolicies") or {}
-        result = match_firewall_request(
-            original_url,
-            flow.request.method,
-            vm_firewalls,
-            network_policies,
-        )
-        if isinstance(result, FirewallBlock):
-            proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
-            log_proxy_entry(
-                proxy_log_path,
-                "warn",
-                f"Firewall {result.name}: no matching permission for {result.method} {result.path}",
-                type="firewall_block",
-                name=result.name,
+        # --- Step 2: Firewall match with permission check ---
+        # Match base URL, then check permission rules before injecting auth headers.
+        vm_firewalls = vm_info.get("firewalls")
+        if vm_firewalls:
+            network_policies = vm_info.get("networkPolicies") or {}
+            result = match_firewall_request(
+                original_url,
+                flow.request.method,
+                vm_firewalls,
+                network_policies,
             )
-            flow.metadata["firewall_action"] = "DENY"
-            flow.metadata["firewall_base"] = result.base
-            flow.metadata["firewall_name"] = result.name
-            error_body = json.dumps(
-                {
-                    "error": "permission_denied",
-                    "message": "Request blocked: no matching permission rule",
-                    "method": result.method,
-                    "path": result.path,
-                    "name": result.name,
-                    "permissions": list(result.permissions),
-                    "base": result.base,
-                }
-            )
-            flow.response = http.Response.make(
-                403,
-                error_body.encode(),
-                {"Content-Type": "application/json"},
-            )
-            return
-        if isinstance(result, FirewallAllow):
-            flow.metadata["firewall_billable"] = result.match_info.get("name", "") in (
-                vm_info.get("billableFirewalls") or []
-            )
-            _maybe_track_usage_flow(flow)
-            try:
-                await handle_firewall_request(flow, result.api_entry, vm_info, result.match_info)
-            except Exception:
-                _release_tracked_usage_flow(flow)
-                raise
-            if flow.response is not None and not flow.metadata.get("auth_url_rewrite"):
-                # Local firewall/auth errors never reach a provider. They only
-                # need pre-tracking to keep shutdown from racing while auth is
-                # resolving, so release as soon as the local response exists.
-                _release_tracked_usage_flow(flow)
-            else:
+            if isinstance(result, FirewallBlock):
+                proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+                log_proxy_entry(
+                    proxy_log_path,
+                    "warn",
+                    "Firewall "
+                    f"{result.name}: no matching permission for {result.method} {result.path}",
+                    type="firewall_block",
+                    name=result.name,
+                )
+                flow.metadata["firewall_action"] = "DENY"
+                flow.metadata["firewall_base"] = result.base
+                flow.metadata["firewall_name"] = result.name
+                error_body = json.dumps(
+                    {
+                        "error": "permission_denied",
+                        "message": "Request blocked: no matching permission rule",
+                        "method": result.method,
+                        "path": result.path,
+                        "name": result.name,
+                        "permissions": list(result.permissions),
+                        "base": result.base,
+                    }
+                )
+                flow.response = http.Response.make(
+                    403,
+                    error_body.encode(),
+                    {"Content-Type": "application/json"},
+                )
+                return
+            if isinstance(result, FirewallAllow):
+                flow.metadata["firewall_billable"] = result.match_info.get("name", "") in (
+                    vm_info.get("billableFirewalls") or []
+                )
                 _maybe_track_usage_flow(flow)
-            return
+                await handle_firewall_request(flow, result.api_entry, vm_info, result.match_info)
+                if flow.response is not None and not flow.metadata.get("auth_url_rewrite"):
+                    # Local firewall/auth errors never reach a provider. They only
+                    # need pre-tracking to keep shutdown from racing while auth is
+                    # resolving, so release as soon as the local response exists.
+                    _release_tracked_usage_flow(flow)
+                else:
+                    _maybe_track_usage_flow(flow)
+                return
 
-    # No firewall match — pass through directly
-    flow.metadata["firewall_action"] = "ALLOW"
+        # No firewall match — pass through directly
+        flow.metadata["firewall_action"] = "ALLOW"
+    except Exception:
+        _request_start_times.pop(flow.id, None)
+        _release_tracked_usage_flow(flow)
+        raise
 
 
 def _maybe_track_usage_flow(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -300,8 +300,22 @@ async def request(flow: http.HTTPFlow) -> None:
             )
             return
         if isinstance(result, FirewallAllow):
-            await handle_firewall_request(flow, result.api_entry, vm_info, result.match_info)
+            flow.metadata["firewall_billable"] = result.match_info.get("name", "") in (
+                vm_info.get("billableFirewalls") or []
+            )
             _maybe_track_usage_flow(flow)
+            try:
+                await handle_firewall_request(flow, result.api_entry, vm_info, result.match_info)
+            except Exception:
+                _release_tracked_usage_flow(flow)
+                raise
+            if flow.response is not None and not flow.metadata.get("auth_url_rewrite"):
+                # Local firewall/auth errors never reach a provider. They only
+                # need pre-tracking to keep shutdown from racing while auth is
+                # resolving, so release as soon as the local response exists.
+                _release_tracked_usage_flow(flow)
+            else:
+                _maybe_track_usage_flow(flow)
             return
 
     # No firewall match — pass through directly
@@ -309,21 +323,23 @@ async def request(flow: http.HTTPFlow) -> None:
 
 
 def _maybe_track_usage_flow(flow: http.HTTPFlow) -> None:
-    """Track billable flows before upstream response headers.
+    """Track billable flows before provider work can outlive shutdown.
 
-    This closes the shutdown drain gap where the request has already been
-    sent upstream, but mitmproxy has not yet reached responseheaders().
+    This closes the shutdown drain gap before standard upstream dispatch and
+    before auth.base URL rewrites, where the addon itself forwards upstream.
     The response/error decorator pops the metadata flag so decrement runs
     exactly once.
     """
     if flow.metadata.get("_usage_flow_tracked"):
         return
-    # Local firewall/auth errors synthesize a response but never enqueue usage.
-    if flow.response is not None and not flow.metadata.get("auth_url_rewrite"):
-        return
     if flow.metadata.get("firewall_billable", False):
         usage.increment_flows()
         flow.metadata["_usage_flow_tracked"] = True
+
+
+def _release_tracked_usage_flow(flow: http.HTTPFlow) -> None:
+    if flow.metadata.pop("_usage_flow_tracked", False):
+        usage.decrement_flows()
 
 
 # ============================================================================
@@ -444,12 +460,10 @@ def _track_usage_flow(fn):
 
     @functools.wraps(fn)
     def wrapper(flow: http.HTTPFlow, *args, **kwargs):
-        tracked = flow.metadata.pop("_usage_flow_tracked", False)
         try:
             return fn(flow, *args, **kwargs)
         finally:
-            if tracked:
-                usage.decrement_flows()
+            _release_tracked_usage_flow(flow)
 
     return wrapper
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -673,9 +673,9 @@ def error(flow: http.HTTPFlow) -> None:
 def done():
     """Flush pending usage reports before mitmproxy exits.
 
-    The runner sends SIGTERM then waits 15 seconds before SIGKILL.
-    ``shutdown(wait=True)`` blocks until all submitted futures complete;
-    SIGKILL is the hard stop if any report takes too long.
+    The runner waits for pending flow/report counters before stopping the
+    proxy. ``shutdown(wait=True)`` is the final mitmproxy-side drain for
+    already-submitted futures during graceful stop.
     """
     usage.webhook.usage_executor.shutdown(wait=True)
 

--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -21,14 +21,14 @@ _in_flight_flows = 0
 _pending_reports = 0
 _pending_path = ""
 _usage_state_id = str(uuid.uuid4())
-# One-shot guard: the symptom of sustained ``_write_pending`` failure is
-# the runner always hitting its 15s SIGKILL on graceful shutdown without
-# any local signal pointing at FS trouble.  Emit one warn per addon
-# process on first failure — enough to seed the operator investigation
-# without spamming logs under persistent FS pressure.  Deliberately goes
-# through mitmproxy's own stderr logger (not ``log_proxy_entry``) because
-# the per-job proxy log shares the same filesystem we just failed to
-# write and is likely affected by the same root cause.
+# One-shot guard: sustained ``_write_pending`` failure makes the runner
+# hit the bounded usage-drain timeout without any local signal pointing at
+# filesystem trouble.  Emit one warn per addon process on first failure —
+# enough to seed the operator investigation without spamming logs under
+# persistent FS pressure.  Deliberately goes through mitmproxy's own
+# stderr logger (not ``log_proxy_entry``) because the per-job proxy log
+# shares the same filesystem we just failed to write and is likely
+# affected by the same root cause.
 _pending_write_error_logged = False
 
 

--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -2,19 +2,25 @@
 
 The runner reads the pending-count file before sending SIGTERM so it can
 wait until both counters reach zero (all flows processed, all reports
-delivered).  File format: ``"<flows>:<reports>"`` written atomically
-(tmp + ``Path.replace``).
+delivered).  File format is JSON written atomically (tmp + ``Path.replace``)
+so the runner can reject stale state from an old mitmproxy process.
 """
 
+import json
+import os
 import threading
+import time
+import uuid
 from pathlib import Path
 
 from mitmproxy import ctx
 
+_STATE_VERSION = 1
 _counter_lock = threading.Lock()
 _in_flight_flows = 0
 _pending_reports = 0
 _pending_path = ""
+_usage_state_id = str(uuid.uuid4())
 # One-shot guard: the symptom of sustained ``_write_pending`` failure is
 # the runner always hitting its 15s SIGKILL on graceful shutdown without
 # any local signal pointing at FS trouble.  Emit one warn per addon
@@ -26,11 +32,24 @@ _pending_path = ""
 _pending_write_error_logged = False
 
 
-def set_pending_path(path: str) -> None:
-    """Set the path for the pending-count file.  Called once at addon init."""
-    global _pending_path
+def set_pending_path(path: str, usage_state_id: str | None = None) -> None:
+    """Set the path/state id for the pending-count file and write current state."""
+    global _pending_path, _usage_state_id
     _pending_path = path
+    if usage_state_id:
+        _usage_state_id = usage_state_id
     _write_pending()
+
+
+def _pending_state() -> dict:
+    return {
+        "version": _STATE_VERSION,
+        "pid": os.getpid(),
+        "usageStateId": _usage_state_id,
+        "updatedAtMs": int(time.time() * 1000),
+        "flows": _in_flight_flows,
+        "reports": _pending_reports,
+    }
 
 
 def _write_pending() -> None:
@@ -41,29 +60,29 @@ def _write_pending() -> None:
     tmp = Path(_pending_path + ".tmp")
     try:
         with tmp.open("w") as f:
-            f.write(f"{_in_flight_flows}:{_pending_reports}")
+            json.dump(_pending_state(), f, separators=(",", ":"))
         tmp.replace(_pending_path)
     except OSError as exc:
         # Best-effort: this file is observability (runner polls it to
         # wait for in-flight flows + pending reports to drain before
         # SIGTERM).  Transient write failures are upper-bounded by the
-        # runner's 15s SIGKILL hard stop — in the worst case the runner
-        # proceeds to SIGKILL with possible in-flight webhooks lost,
+        # runner's drain timeout and mitmdump stop timeout — in the worst
+        # case the runner proceeds with possible in-flight webhooks lost,
         # which is the same outcome as a genuinely stalled flow.
         if not _pending_write_error_logged:
             _pending_write_error_logged = True
             ctx.log.warn(
                 f"Failed to write pending count to {_pending_path!r}: {exc}.  "
                 "Subsequent failures in this process will be silent; runner "
-                "shutdown may hit the 15s SIGKILL hard stop."
+                "shutdown may hit the bounded proxy stop timeout."
             )
 
 
 def increment_flows() -> None:
-    """Track a new in-flight billable flow (call from responseheaders).
+    """Track a new in-flight billable flow (call from request).
 
-    Covers both model-provider flows and billable connector flows — any
-    flow that may enqueue a webhook POST before response/error runs.
+    Covers billable model-provider and connector flows — any flow that may
+    enqueue a webhook POST before response/error runs.
     """
     global _in_flight_flows
     with _counter_lock:

--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -35,10 +35,11 @@ _pending_write_error_logged = False
 def set_pending_path(path: str, usage_state_id: str | None = None) -> None:
     """Set the path/state id for the pending-count file and write current state."""
     global _pending_path, _usage_state_id
-    _pending_path = path
-    if usage_state_id:
-        _usage_state_id = usage_state_id
-    _write_pending()
+    with _counter_lock:
+        _pending_path = path
+        if usage_state_id:
+            _usage_state_id = usage_state_id
+        _write_pending()
 
 
 def _pending_state() -> dict:

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -1,9 +1,10 @@
 """Webhook delivery (HTTP + thread pool).
 
-Background thread pool processes usage reports in parallel; ``done()``
-flushes pending items before mitmproxy exits (SIGKILL at 15 s is the
-hard stop).  Falls back to synchronous delivery if the executor has been
-shut down (drain/shutdown race) so reports are not silently lost.
+Background thread pool processes usage reports in parallel; the runner
+first waits for the pending counters to drain, then ``done()`` flushes
+submitted futures during mitmproxy shutdown.  Falls back to synchronous
+delivery if the executor has been shut down (drain/shutdown race) so
+reports are not silently lost.
 """
 
 import json

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -661,6 +661,12 @@ class TestRequestHandler:
             "cache_hit": False,
         }
 
+        async def forward_request(*_args):
+            assert flow.metadata["_usage_flow_tracked"] is True
+            assert usage.counters._in_flight_flows == 1
+            _assert_pending(pending_path, flows=1, reports=0)
+            return (200, b'{"delivered":true}', {"Content-Type": "application/json"})
+
         try:
             with (
                 mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -672,13 +678,7 @@ class TestRequestHandler:
                 patch.object(
                     auth,
                     "forward_request",
-                    AsyncMock(
-                        return_value=(
-                            200,
-                            b'{"delivered":true}',
-                            {"Content-Type": "application/json"},
-                        )
-                    ),
+                    AsyncMock(side_effect=forward_request),
                 ),
             ):
                 await mitm_addon.request(flow)

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -3,6 +3,7 @@
 import asyncio
 import gzip
 import json
+import os
 import time
 import urllib.error
 from pathlib import Path
@@ -28,6 +29,55 @@ def _usage_event_events_from_calls(call_args_list):
     return [
         event for body in _request_bodies_from_calls(call_args_list) for event in body["events"]
     ]
+
+
+def _pending_state(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _assert_pending(path: Path, flows: int, reports: int) -> dict:
+    state = _pending_state(path)
+    assert set(state) == {
+        "version",
+        "pid",
+        "usageStateId",
+        "updatedAtMs",
+        "flows",
+        "reports",
+    }
+    assert state["version"] == 1
+    assert state["pid"] == os.getpid()
+    assert state["usageStateId"]
+    assert isinstance(state["updatedAtMs"], int)
+    assert state["flows"] == flows
+    assert state["reports"] == reports
+    return state
+
+
+class TestAddonConfiguration:
+    def test_load_registers_usage_state_id_without_pending_write(self):
+        loader = MagicMock()
+
+        with patch.object(usage, "set_pending_path") as set_pending_path:
+            mitm_addon.load(loader)
+
+        option_names = [call.kwargs["name"] for call in loader.add_option.call_args_list]
+        assert "vm0_usage_state_id" in option_names
+        set_pending_path.assert_not_called()
+
+    def test_configure_initializes_pending_path_with_usage_state_id(self):
+        options = MagicMock(vm0_usage_state_id="runner-usage-state-id")
+        pending_path = str(Path(mitm_addon.__file__).resolve().parent / "usage-pending")
+
+        with (
+            patch.object(mitm_addon.ctx, "options", options, create=True),
+            patch.object(usage, "set_pending_path") as set_pending_path,
+        ):
+            mitm_addon.configure({"vm0_usage_state_id"})
+
+        set_pending_path.assert_called_once_with(
+            pending_path, usage_state_id="runner-usage-state-id"
+        )
 
 
 class TestRequestHandler:
@@ -330,6 +380,202 @@ class TestRequestHandler:
         assert flow.metadata["firewall_permission"] == "read-repos"
         assert flow.metadata["firewall_rule_match"] == "GET /repos/{owner}/{repo}"
         assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
+
+    async def test_billable_flow_is_tracked_before_responseheaders(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        """Drain sees billable requests after request() even before responseheaders()."""
+        pending_path = tmp_path / "usage-pending"
+        usage.counters._in_flight_flows = 0
+        usage.counters._pending_reports = 0
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+
+        registry = {
+            "vms": {
+                "10.200.0.5": {
+                    "runId": "run-conn-1",
+                    "billableFirewalls": ["x"],
+                    "sandboxToken": "tok-conn",
+                    "networkLogPath": str(tmp_path / "net.jsonl"),
+                    "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+                    "firewalls": [
+                        {
+                            "name": "x",
+                            "apis": [
+                                {
+                                    "base": "https://api.x.com",
+                                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                                    "permissions": [
+                                        {"name": "read-posts", "rules": ["GET /2/users/by"]}
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    "networkPolicies": {
+                        "x": {
+                            "allow": ["read-posts"],
+                            "deny": [],
+                            "ask": [],
+                            "unknownPolicy": "deny",
+                        },
+                    },
+                    "encryptedSecrets": "iv:tag:data",
+                }
+            }
+        }
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(json.dumps(registry))
+
+        flow = real_flow(
+            with_response=False, client_ip="10.200.0.5", host="api.x.com", path="/2/users/by"
+        )
+
+        try:
+            with (
+                mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+                fake_firewall_headers(),
+            ):
+                await mitm_addon.request(flow)
+
+            assert flow.metadata["_usage_flow_tracked"] is True
+            assert usage.counters._in_flight_flows == 1
+            _assert_pending(pending_path, flows=1, reports=0)
+        finally:
+            if usage.counters._in_flight_flows:
+                usage.decrement_flows()
+            usage.set_pending_path("")
+
+    async def test_local_firewall_error_does_not_track_usage_flow(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
+        """Local auth failures do not enqueue usage and must not leak drain counters."""
+        pending_path = tmp_path / "usage-pending"
+        usage.counters._in_flight_flows = 0
+        usage.counters._pending_reports = 0
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+
+        registry = {
+            "vms": {
+                "10.200.0.5": {
+                    "runId": "run-conn-1",
+                    "billableFirewalls": ["x"],
+                    "sandboxToken": "tok-conn",
+                    "networkLogPath": str(tmp_path / "net.jsonl"),
+                    "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+                    "firewalls": [
+                        {
+                            "name": "x",
+                            "apis": [
+                                {
+                                    "base": "https://api.x.com",
+                                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                                    "permissions": [
+                                        {"name": "read-posts", "rules": ["GET /2/users/by"]}
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    "networkPolicies": {
+                        "x": {
+                            "allow": ["read-posts"],
+                            "deny": [],
+                            "ask": [],
+                            "unknownPolicy": "deny",
+                        },
+                    },
+                }
+            }
+        }
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(json.dumps(registry))
+
+        flow = real_flow(
+            with_response=False, client_ip="10.200.0.5", host="api.x.com", path="/2/users/by"
+        )
+
+        try:
+            with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+                await mitm_addon.request(flow)
+
+            assert flow.response is not None
+            assert flow.response.status_code == 502
+            assert flow.metadata["firewall_error"] == "auth_unavailable"
+            assert "_usage_flow_tracked" not in flow.metadata
+            assert usage.counters._in_flight_flows == 0
+            _assert_pending(pending_path, flows=0, reports=0)
+        finally:
+            usage.set_pending_path("")
+
+    async def test_non_billable_model_provider_is_not_tracked_before_responseheaders(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        """Model-provider usage only reports when the firewall is billable."""
+        pending_path = tmp_path / "usage-pending"
+        usage.counters._in_flight_flows = 0
+        usage.counters._pending_reports = 0
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+
+        registry = {
+            "vms": {
+                "10.200.0.5": {
+                    "runId": "run-model-1",
+                    "billableFirewalls": [],
+                    "sandboxToken": "tok-model",
+                    "networkLogPath": str(tmp_path / "net.jsonl"),
+                    "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+                    "firewalls": [
+                        {
+                            "name": "model-provider:anthropic-api-key",
+                            "apis": [
+                                {
+                                    "base": "https://api.anthropic.com",
+                                    "auth": {"headers": {"x-api-key": "test-key"}},
+                                    "permissions": [
+                                        {"name": "messages", "rules": ["POST /v1/messages"]}
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    "networkPolicies": {
+                        "model-provider:anthropic-api-key": {
+                            "allow": ["messages"],
+                            "deny": [],
+                            "ask": [],
+                            "unknownPolicy": "deny",
+                        },
+                    },
+                    "encryptedSecrets": "iv:tag:data",
+                }
+            }
+        }
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(json.dumps(registry))
+
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
+
+        try:
+            with (
+                mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+                fake_firewall_headers(),
+            ):
+                await mitm_addon.request(flow)
+
+            assert flow.metadata["firewall_name"] == "model-provider:anthropic-api-key"
+            assert flow.metadata["firewall_billable"] is False
+            assert "_usage_flow_tracked" not in flow.metadata
+            assert usage.counters._in_flight_flows == 0
+            _assert_pending(pending_path, flows=0, reports=0)
+        finally:
+            usage.set_pending_path("")
 
     async def test_firewall_no_base_match_passes_through(
         self, tmp_path, real_flow, mitm_ctx, headers
@@ -1241,6 +1487,7 @@ class TestResponseHeadersSseParser:
             status_code=200, headers=http.Headers(**{"content-type": "text/event-stream"})
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
 
         mitm_addon.responseheaders(flow)
 
@@ -1270,6 +1517,7 @@ class TestResponseHeadersSseParser:
             ),
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
 
         mitm_addon.responseheaders(flow)
 
@@ -1311,6 +1559,18 @@ class TestResponseHeadersSseParser:
 
         assert "model_provider_usage" not in flow.metadata
 
+    def test_no_sse_parser_for_non_billable_model_provider(self, real_flow, headers):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "text/event-stream"})
+        )
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = False
+
+        mitm_addon.responseheaders(flow)
+
+        assert "model_provider_usage" not in flow.metadata
+
     def test_no_sse_parser_without_firewall_name(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
@@ -1338,6 +1598,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         # No model_provider_usage set (no SSE parser) — JSON body in buffer
         body = json.dumps(
@@ -1375,12 +1636,13 @@ class TestResponseUsageReporting:
         assert extracted["output_tokens"] == 200
 
     def test_model_provider_buffer_not_truncated(self, real_flow, headers):
-        """Model provider responses should buffer without truncation."""
+        """Billable model provider responses should buffer without truncation."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
             status_code=200, headers=http.Headers(**{"content-type": "application/json"})
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
 
         mitm_addon.responseheaders(flow)
 
@@ -1393,6 +1655,26 @@ class TestResponseUsageReporting:
         state = flow.metadata["stream_buffer_state"]
         assert len(buf) == len(large_chunk)
         assert not state["truncated"]
+
+    def test_non_billable_model_provider_buffer_truncated(self, real_flow, headers):
+        """Non-billable model providers should use the normal bounded buffer."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.response = tutils.tresp(
+            status_code=200, headers=http.Headers(**{"content-type": "application/json"})
+        )
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = False
+
+        mitm_addon.responseheaders(flow)
+
+        callback = flow.response.stream
+        large_chunk = b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
+        callback(large_chunk)
+
+        buf = flow.metadata["stream_buffer"]
+        state = flow.metadata["stream_buffer_state"]
+        assert len(buf) == body_utils.STREAM_BUFFER_LIMIT
+        assert state["truncated"]
 
     def test_non_model_provider_buffer_truncated(self, real_flow, headers):
         """Non-model-provider responses should truncate at 64KB."""
@@ -3328,33 +3610,38 @@ class TestUsagePendingCounter:
         usage.counters._in_flight_flows = 0
         usage.counters._pending_reports = 0
         usage.counters._pending_path = ""
+        usage.counters._usage_state_id = "test-usage-state-id"
+        usage.counters._pending_write_error_logged = False
 
     def test_increment_decrement_flows(self, tmp_path):
-        usage.set_pending_path(str(tmp_path / "usage-pending"))
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
         usage.increment_flows()
         usage.increment_flows()
         assert usage.counters._in_flight_flows == 2
-        content = (tmp_path / "usage-pending").read_text()
-        assert content == "2:0"
+        _assert_pending(pending_path, flows=2, reports=0)
 
         usage.decrement_flows()
-        content = (tmp_path / "usage-pending").read_text()
-        assert content == "1:0"
+        _assert_pending(pending_path, flows=1, reports=0)
 
         usage.decrement_flows()
-        content = (tmp_path / "usage-pending").read_text()
-        assert content == "0:0"
+        _assert_pending(pending_path, flows=0, reports=0)
 
     def test_increment_decrement_reports(self, tmp_path):
-        usage.set_pending_path(str(tmp_path / "usage-pending"))
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
         usage.counters._increment_reports()
         assert usage.counters._pending_reports == 1
-        content = (tmp_path / "usage-pending").read_text()
-        assert content == "0:1"
+        _assert_pending(pending_path, flows=0, reports=1)
 
         usage.counters._decrement_reports()
-        content = (tmp_path / "usage-pending").read_text()
-        assert content == "0:0"
+        _assert_pending(pending_path, flows=0, reports=0)
+
+    def test_set_pending_path_accepts_explicit_usage_state_id(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path), usage_state_id="explicit-usage-state-id")
+        state = _assert_pending(pending_path, flows=0, reports=0)
+        assert state["usageStateId"] == "explicit-usage-state-id"
 
     def test_decrement_does_not_go_negative(self, tmp_path):
         usage.set_pending_path(str(tmp_path / "usage-pending"))
@@ -3407,10 +3694,12 @@ class TestUsagePendingCounter:
 
     def test_report_decrements_after_completion(self, tmp_path, real_flow, fresh_usage_executor):
         """Retry exhaustion still runs the decrement finally-block."""
-        usage.set_pending_path(str(tmp_path / "usage-pending"))
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
 
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok"
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["model_provider_usage"] = {"input_tokens": 1}
@@ -3426,15 +3715,16 @@ class TestUsagePendingCounter:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
-        content = (tmp_path / "usage-pending").read_text()
-        assert content == "0:0"
+        _assert_pending(pending_path, flows=0, reports=0)
 
     def test_enqueue_increments_and_drains_reports(self, tmp_path, real_flow, fresh_usage_executor):
         """Public entry increments pending on enqueue; executor drain decrements to 0."""
-        usage.set_pending_path(str(tmp_path / "usage-pending"))
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
 
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok"
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["model_provider_usage"] = {"input_tokens": 1}
@@ -3450,8 +3740,7 @@ class TestUsagePendingCounter:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
-        content = (tmp_path / "usage-pending").read_text()
-        assert content == "0:0"
+        _assert_pending(pending_path, flows=0, reports=0)
 
     def test_decorator_pop_prevents_double_decrement(self, tmp_path, real_flow):
         """If both response() and error() fire for the same flow, decrement only once."""
@@ -3490,12 +3779,14 @@ class TestUsagePendingCounter:
 
     def test_sync_fallback_decrements_reports(self, tmp_path, real_flow, fresh_usage_executor):
         """When the executor is already shut down, the sync fallback still decrements."""
-        usage.set_pending_path(str(tmp_path / "usage-pending"))
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
         # Shut down the executor so _enqueue_webhook takes the sync fallback.
         usage.webhook.usage_executor.shutdown(wait=True)
 
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok"
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["model_provider_usage"] = {"input_tokens": 1}
@@ -3510,5 +3801,4 @@ class TestUsagePendingCounter:
             usage.report_model_provider_usage(flow, "run-1")
 
         assert usage.counters._pending_reports == 0
-        content = (tmp_path / "usage-pending").read_text()
-        assert content == "0:0"
+        _assert_pending(pending_path, flows=0, reports=0)

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -7,7 +7,7 @@ import os
 import time
 import urllib.error
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from mitmproxy import http
@@ -598,6 +598,105 @@ class TestRequestHandler:
             assert usage.counters._in_flight_flows == 0
             _assert_pending(pending_path, flows=0, reports=0)
         finally:
+            usage.set_pending_path("")
+
+    async def test_billable_auth_url_rewrite_flow_drains_after_response(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """Inline auth.base responses still pair request-time tracking with response()."""
+        pending_path = tmp_path / "usage-pending"
+        usage.counters._in_flight_flows = 0
+        usage.counters._pending_reports = 0
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+
+        registry = {
+            "vms": {
+                "10.200.0.5": {
+                    "runId": "run-rewrite-1",
+                    "billableFirewalls": ["webhook"],
+                    "sandboxToken": "tok-rewrite",
+                    "networkLogPath": str(tmp_path / "net.jsonl"),
+                    "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+                    "firewalls": [
+                        {
+                            "name": "webhook",
+                            "apis": [
+                                {
+                                    "base": "https://placeholder.example.com",
+                                    "auth": {"base": "${{ secrets.WEBHOOK_URL }}"},
+                                    "permissions": [{"name": "send", "rules": ["POST /"]}],
+                                },
+                            ],
+                        },
+                    ],
+                    "networkPolicies": {
+                        "webhook": {
+                            "allow": ["send"],
+                            "deny": [],
+                            "ask": [],
+                            "unknownPolicy": "deny",
+                        },
+                    },
+                    "encryptedSecrets": "iv:tag:data",
+                }
+            }
+        }
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(json.dumps(registry))
+
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="placeholder.example.com",
+            path="/",
+            method="POST",
+            request_body=b'{"ok":true}',
+        )
+        token_meta = {
+            "headers": {},
+            "base": "https://real.example.com/webhook",
+            "resolved_secrets": ["WEBHOOK_URL"],
+            "refreshed_connectors": [],
+            "refreshed_secrets": [],
+            "cache_hit": False,
+        }
+
+        try:
+            with (
+                mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+                patch.object(
+                    auth,
+                    "get_firewall_headers",
+                    AsyncMock(return_value=token_meta),
+                ),
+                patch.object(
+                    auth,
+                    "forward_request",
+                    AsyncMock(
+                        return_value=(
+                            200,
+                            b'{"delivered":true}',
+                            {"Content-Type": "application/json"},
+                        )
+                    ),
+                ),
+            ):
+                await mitm_addon.request(flow)
+
+                assert flow.response is not None
+                assert flow.metadata["auth_url_rewrite"] is True
+                assert flow.metadata["_usage_flow_tracked"] is True
+                assert usage.counters._in_flight_flows == 1
+                _assert_pending(pending_path, flows=1, reports=0)
+
+                mitm_addon.response(flow)
+
+            assert "_usage_flow_tracked" not in flow.metadata
+            assert usage.counters._in_flight_flows == 0
+            _assert_pending(pending_path, flows=0, reports=0)
+        finally:
+            if usage.counters._in_flight_flows:
+                usage.decrement_flows()
             usage.set_pending_path("")
 
     async def test_firewall_no_base_match_passes_through(

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -79,6 +79,29 @@ class TestAddonConfiguration:
             pending_path, usage_state_id="runner-usage-state-id"
         )
 
+    def test_configure_passes_none_when_usage_state_id_is_empty(self):
+        options = MagicMock(vm0_usage_state_id="")
+        pending_path = str(Path(mitm_addon.__file__).resolve().parent / "usage-pending")
+
+        with (
+            patch.object(mitm_addon.ctx, "options", options, create=True),
+            patch.object(usage, "set_pending_path") as set_pending_path,
+        ):
+            mitm_addon.configure({"vm0_usage_state_id"})
+
+        set_pending_path.assert_called_once_with(pending_path, usage_state_id=None)
+
+    def test_configure_ignores_unrelated_option_updates(self):
+        options = MagicMock(vm0_usage_state_id="runner-usage-state-id")
+
+        with (
+            patch.object(mitm_addon.ctx, "options", options, create=True),
+            patch.object(usage, "set_pending_path") as set_pending_path,
+        ):
+            mitm_addon.configure({"vm0_api_url"})
+
+        set_pending_path.assert_not_called()
+
 
 class TestRequestHandler:
     async def test_allowed_domain_passes_through(self, registry_file, real_flow, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -766,6 +766,101 @@ class TestRequestHandler:
                 usage.decrement_flows()
             usage.set_pending_path("")
 
+    async def test_billable_auth_url_rewrite_forward_failure_releases_tracking(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """Failed inline auth.base forwarding is a local response and drains immediately."""
+        pending_path = tmp_path / "usage-pending"
+        usage.counters._in_flight_flows = 0
+        usage.counters._pending_reports = 0
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+
+        registry = {
+            "vms": {
+                "10.200.0.5": {
+                    "runId": "run-rewrite-1",
+                    "billableFirewalls": ["webhook"],
+                    "sandboxToken": "tok-rewrite",
+                    "networkLogPath": str(tmp_path / "net.jsonl"),
+                    "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+                    "firewalls": [
+                        {
+                            "name": "webhook",
+                            "apis": [
+                                {
+                                    "base": "https://placeholder.example.com",
+                                    "auth": {"base": "${{ secrets.WEBHOOK_URL }}"},
+                                    "permissions": [{"name": "send", "rules": ["POST /"]}],
+                                },
+                            ],
+                        },
+                    ],
+                    "networkPolicies": {
+                        "webhook": {
+                            "allow": ["send"],
+                            "deny": [],
+                            "ask": [],
+                            "unknownPolicy": "deny",
+                        },
+                    },
+                    "encryptedSecrets": "iv:tag:data",
+                }
+            }
+        }
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(json.dumps(registry))
+
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="placeholder.example.com",
+            path="/",
+            method="POST",
+            request_body=b'{"ok":true}',
+        )
+        token_meta = {
+            "headers": {},
+            "base": "https://real.example.com/webhook",
+            "resolved_secrets": ["WEBHOOK_URL"],
+            "refreshed_connectors": [],
+            "refreshed_secrets": [],
+            "cache_hit": False,
+        }
+
+        async def fail_forward_request(*_args):
+            assert flow.metadata["_usage_flow_tracked"] is True
+            assert usage.counters._in_flight_flows == 1
+            _assert_pending(pending_path, flows=1, reports=0)
+            raise RuntimeError("upstream unavailable")
+
+        try:
+            with (
+                mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+                patch.object(
+                    auth,
+                    "get_firewall_headers",
+                    AsyncMock(return_value=token_meta),
+                ),
+                patch.object(
+                    auth,
+                    "forward_request",
+                    AsyncMock(side_effect=fail_forward_request),
+                ),
+            ):
+                await mitm_addon.request(flow)
+
+            assert flow.response is not None
+            assert flow.response.status_code == 502
+            assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
+            assert "auth_url_rewrite" not in flow.metadata
+            assert "_usage_flow_tracked" not in flow.metadata
+            assert usage.counters._in_flight_flows == 0
+            _assert_pending(pending_path, flows=0, reports=0)
+        finally:
+            if usage.counters._in_flight_flows:
+                usage.decrement_flows()
+            usage.set_pending_path("")
+
     async def test_firewall_no_base_match_passes_through(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -531,6 +531,73 @@ class TestRequestHandler:
         finally:
             usage.set_pending_path("")
 
+    async def test_unexpected_request_exception_releases_tracking(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """Unexpected request-hook failures must not leak start-time or usage counters."""
+        pending_path = tmp_path / "usage-pending"
+        usage.counters._in_flight_flows = 0
+        usage.counters._pending_reports = 0
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+
+        registry = {
+            "vms": {
+                "10.200.0.5": {
+                    "runId": "run-conn-1",
+                    "billableFirewalls": ["x"],
+                    "sandboxToken": "tok-conn",
+                    "networkLogPath": str(tmp_path / "net.jsonl"),
+                    "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+                    "firewalls": [
+                        {
+                            "name": "x",
+                            "apis": [
+                                {
+                                    "base": "https://api.x.com",
+                                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                                    "permissions": [
+                                        {"name": "read-posts", "rules": ["GET /2/users/by"]}
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    "networkPolicies": {
+                        "x": {
+                            "allow": ["read-posts"],
+                            "deny": [],
+                            "ask": [],
+                            "unknownPolicy": "deny",
+                        },
+                    },
+                    "encryptedSecrets": "iv:tag:data",
+                }
+            }
+        }
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(json.dumps(registry))
+
+        flow = real_flow(
+            with_response=False, client_ip="10.200.0.5", host="api.x.com", path="/2/users/by"
+        )
+
+        try:
+            with (
+                mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+                patch.object(auth, "get_firewall_headers", AsyncMock(return_value={})),
+                pytest.raises(KeyError),
+            ):
+                await mitm_addon.request(flow)
+
+            assert flow.id not in mitm_addon._request_start_times
+            assert "_usage_flow_tracked" not in flow.metadata
+            assert usage.counters._in_flight_flows == 0
+            _assert_pending(pending_path, flows=0, reports=0)
+        finally:
+            if usage.counters._in_flight_flows:
+                usage.decrement_flows()
+            usage.set_pending_path("")
+
     async def test_non_billable_model_provider_is_not_tracked_before_responseheaders(
         self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
     ):

--- a/crates/runner/src/cmd/start/mitm_restart.rs
+++ b/crates/runner/src/cmd/start/mitm_restart.rs
@@ -223,7 +223,8 @@ mod tests {
             Some(MITM_MAX_CONSECUTIVE_FAILURES),
         );
 
-        let child = tokio::process::Command::new("true")
+        let child = tokio::process::Command::new("sleep")
+            .arg("60")
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())

--- a/crates/runner/src/cmd/start/mitm_restart.rs
+++ b/crates/runner/src/cmd/start/mitm_restart.rs
@@ -85,6 +85,32 @@ pub(super) fn handle_mitm_restart_result(
     }
 }
 
+/// During shutdown, preserve a restart task that has already produced a child
+/// so the normal usage-flush and proxy-stop path can still own it.
+pub(super) async fn finish_mitm_restart_before_shutdown(
+    mitm: &mut proxy::MitmProxy,
+    retry: &mut RetryState<MitmRestartHandle>,
+) {
+    let Some(handle) = retry.handle.take() else {
+        return;
+    };
+
+    info!("waiting for in-flight mitmproxy restart before shutdown");
+    match handle.await {
+        Ok(Ok(child)) => {
+            info!("mitmproxy restart completed during shutdown");
+            mitm.complete_restart(child);
+            retry.on_success();
+        }
+        Ok(Err(e)) => {
+            warn!(error = %e, "mitmproxy restart failed during shutdown");
+        }
+        Err(e) => {
+            warn!(error = %e, "mitmproxy restart task failed during shutdown");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -186,5 +212,50 @@ mod tests {
             retry.restart_at.is_none(),
             "circuit breaker should prevent further retries"
         );
+    }
+
+    #[tokio::test]
+    async fn finish_mitm_restart_before_shutdown_captures_child() {
+        let (mut mitm, _rx, _dir) = test_mitm().await;
+        let mut retry: RetryState<MitmRestartHandle> = RetryState::new(
+            MITM_BACKOFF_INITIAL,
+            MITM_BACKOFF_MAX,
+            Some(MITM_MAX_CONSECUTIVE_FAILURES),
+        );
+
+        let child = tokio::process::Command::new("true")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        retry.handle = Some(tokio::spawn(async move { Ok(child) }));
+
+        finish_mitm_restart_before_shutdown(&mut mitm, &mut retry).await;
+
+        assert!(retry.handle.is_none());
+        assert!(
+            mitm.usage_flush_target().is_some(),
+            "completed restart child should remain owned for shutdown flush"
+        );
+        mitm.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn finish_mitm_restart_before_shutdown_drops_failed_handle() {
+        let (mut mitm, _rx, _dir) = test_mitm().await;
+        let mut retry: RetryState<MitmRestartHandle> = RetryState::new(
+            MITM_BACKOFF_INITIAL,
+            MITM_BACKOFF_MAX,
+            Some(MITM_MAX_CONSECUTIVE_FAILURES),
+        );
+        retry.handle = Some(tokio::spawn(async {
+            Err(crate::error::RunnerError::Internal("spawn failed".into()))
+        }));
+
+        finish_mitm_restart_before_shutdown(&mut mitm, &mut retry).await;
+
+        assert!(retry.handle.is_none());
+        assert!(mitm.usage_flush_target().is_none());
     }
 }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -43,7 +43,7 @@ mod signals;
 use identity::load_or_generate_runner_id;
 use mitm_restart::{
     MITM_BACKOFF_INITIAL, MITM_BACKOFF_MAX, MITM_MAX_CONSECUTIVE_FAILURES, MitmRestartHandle,
-    handle_mitm_restart_result, maybe_spawn_mitm_restart,
+    finish_mitm_restart_before_shutdown, handle_mitm_restart_result, maybe_spawn_mitm_restart,
 };
 use signals::{EarlySignals, SignalController};
 
@@ -798,9 +798,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             warn!(error = %e, "destroy task panicked during shutdown");
         }
     }
-    if let Some(h) = mitm_retry.handle {
-        h.abort();
-    }
+    finish_mitm_restart_before_shutdown(&mut mitm, &mut mitm_retry).await;
     if let Some(abort) = signal_handler_abort {
         abort.abort();
     }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -809,15 +809,24 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     shutdown_factories(&mut factories, runtime.as_mut()).await;
 
     // Wait for pending usage reports to flush before stopping the proxy.
-    // The addon writes in-flight flow and pending report counts to a file;
-    // we poll until both reach zero so no usage data is lost on shutdown.
-    info!("waiting for proxy usage reports to flush");
-    let flushed =
-        proxy::wait_usage_flush(&base_dir.join("mitm-addon"), proxy::USAGE_FLUSH_TIMEOUT).await;
-    if flushed {
-        info!("all usage reports flushed");
+    // The addon writes the current mitmdump identity plus in-flight flow
+    // and pending report counts; this remains bounded best-effort and
+    // falls back to stopping the proxy on timeout.
+    if let Some(usage_flush_target) = mitm.usage_flush_target() {
+        info!("waiting for proxy usage reports to flush");
+        let flushed = proxy::wait_usage_flush(
+            &base_dir.join("mitm-addon"),
+            proxy::USAGE_FLUSH_TIMEOUT,
+            &usage_flush_target,
+        )
+        .await;
+        if flushed {
+            info!("all usage reports flushed");
+        } else {
+            warn!("usage flush timed out, some reports may be lost");
+        }
     } else {
-        warn!("usage flush timed out, some reports may be lost");
+        info!("proxy is not running; skipping usage flush wait");
     }
 
     // Stop proxy after all jobs have drained and factory is shut down.

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1541,6 +1541,23 @@ PY
     }
 
     #[tokio::test]
+    async fn wait_usage_flush_waits_for_state_file_to_appear() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let path = dir.path().join("usage-pending");
+
+        let p = path.clone();
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            std::fs::write(&p, usage_state(0, 0)).unwrap();
+        });
+
+        let d = dir.path().to_path_buf();
+        assert!(wait_usage_flush(&d, Duration::from_secs(5), &target).await);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn wait_usage_flush_waits_until_zero() {
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
@@ -1595,6 +1612,37 @@ PY
             "flows": 0,
             "reports": 0,
             "extraField": "unexpected",
+        });
+        std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
+    }
+
+    #[tokio::test]
+    async fn wait_usage_flush_rejects_unsupported_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let state = serde_json::json!({
+            "version": 2,
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flows": 0,
+            "reports": 0,
+        });
+        std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
+    }
+
+    #[tokio::test]
+    async fn wait_usage_flush_rejects_missing_required_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let state = serde_json::json!({
+            "version": 1,
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flows": 0,
         });
         std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
         assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -567,6 +567,7 @@ pub(crate) async fn spawn_mitmdump(
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
+    cmd.kill_on_drop(true);
 
     // SAFETY: `set_pdeathsig` calls `prctl(PR_SET_PDEATHSIG)` which is
     // async-signal-safe. This ensures the kernel sends SIGKILL to the
@@ -798,6 +799,60 @@ mod tests {
     use super::*;
     use crate::types::{FirewallApi, FirewallAuth, FirewallPermission};
     use std::os::unix::fs::PermissionsExt;
+
+    fn write_fake_listening_mitmdump(path: &Path) {
+        std::fs::write(
+            path,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$0.args"
+port=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--listen-port" ]; then
+    port="$arg"
+    break
+  fi
+  prev="$arg"
+done
+exec python3 - "$port" <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+sock = socket.socket()
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", port))
+sock.listen(1)
+while True:
+    conn, _ = sock.accept()
+    conn.close()
+PY
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    async fn wait_for_reaped_pid(pid: nix::unistd::Pid) -> bool {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            match nix::sys::wait::waitpid(pid, Some(nix::sys::wait::WaitPidFlag::WNOHANG)) {
+                Ok(nix::sys::wait::WaitStatus::StillAlive) => {}
+                Ok(_) => return true,
+                Err(nix::errno::Errno::ECHILD) => {
+                    return nix::sys::signal::kill(pid, None).is_err();
+                }
+                Err(_) => {}
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
 
     #[test]
     fn find_port_returns_nonzero() {
@@ -1391,39 +1446,7 @@ mod tests {
     async fn spawn_mitmdump_passes_usage_state_id_option() {
         let dir = tempfile::tempdir().unwrap();
         let fake_mitmdump = dir.path().join("fake-mitmdump");
-        std::fs::write(
-            &fake_mitmdump,
-            r#"#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "$@" > "$0.args"
-port=""
-prev=""
-for arg in "$@"; do
-  if [ "$prev" = "--listen-port" ]; then
-    port="$arg"
-    break
-  fi
-  prev="$arg"
-done
-python3 - "$port" <<'PY'
-import socket
-import sys
-
-port = int(sys.argv[1])
-sock = socket.socket()
-sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-sock.bind(("127.0.0.1", port))
-sock.listen(1)
-while True:
-    conn, _ = sock.accept()
-    conn.close()
-PY
-"#,
-        )
-        .unwrap();
-        let mut perms = std::fs::metadata(&fake_mitmdump).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&fake_mitmdump, perms).unwrap();
+        write_fake_listening_mitmdump(&fake_mitmdump);
 
         let config = ProxyConfig {
             mitmdump_bin: fake_mitmdump.clone(),
@@ -1448,6 +1471,37 @@ PY
             args.lines()
                 .any(|arg| arg == "vm0_usage_state_id=usage-state-test"),
             "mitmdump args should include vm0_usage_state_id option; got:\n{args}",
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_mitmdump_kills_child_when_handle_is_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let fake_mitmdump = dir.path().join("fake-mitmdump");
+        write_fake_listening_mitmdump(&fake_mitmdump);
+
+        let config = ProxyConfig {
+            mitmdump_bin: fake_mitmdump,
+            ca_dir: dir.path().join("ca"),
+            addon_dir: dir.path().join("addon"),
+            registry_path: dir.path().join("proxy-registry.json"),
+            registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            api_url: None,
+        };
+        let (crash_tx, _crash_rx) = mpsc::channel(1);
+        let stopping = Arc::new(AtomicBool::new(false));
+        let port = find_available_port().unwrap();
+
+        let child = spawn_mitmdump(&config, port, &crash_tx, &stopping, "usage-state-test")
+            .await
+            .unwrap();
+        let pid = nix::unistd::Pid::from_raw(child.id().unwrap() as i32);
+        stopping.store(true, Ordering::Release);
+        drop(child);
+
+        assert!(
+            wait_for_reaped_pid(pid).await,
+            "dropping mitmdump Child should kill and reap the process"
         );
     }
 

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -260,7 +260,23 @@ impl MitmProxy {
     }
 
     /// Current mitmdump identity expected in the usage-pending state file.
-    pub fn usage_flush_target(&self) -> Option<UsageFlushTarget> {
+    pub fn usage_flush_target(&mut self) -> Option<UsageFlushTarget> {
+        let child_exited = match self.child.as_mut()?.try_wait() {
+            Ok(Some(status)) => {
+                warn!(code = status.code(), "mitmdump exited before usage flush");
+                true
+            }
+            Ok(None) => false,
+            Err(e) => {
+                warn!(error = %e, "failed to query mitmdump status before usage flush");
+                false
+            }
+        };
+        if child_exited {
+            self.child = None;
+            return None;
+        }
+
         let expected_pid = self.child.as_ref().and_then(|child| child.id())?;
         Some(UsageFlushTarget {
             expected_pid,
@@ -1503,6 +1519,39 @@ PY
             wait_for_reaped_pid(pid).await,
             "dropping mitmdump Child should kill and reap the process"
         );
+    }
+
+    #[tokio::test]
+    async fn usage_flush_target_returns_target_for_running_child() {
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+        let child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        proxy.child = Some(child);
+
+        assert!(proxy.usage_flush_target().is_some());
+
+        proxy.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn usage_flush_target_skips_exited_child() {
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+        let mut child = tokio::process::Command::new("true")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        child.wait().await.unwrap();
+        proxy.child = Some(child);
+
+        assert!(proxy.usage_flush_target().is_none());
+        assert!(proxy.child.is_none());
     }
 
     fn usage_target() -> UsageFlushTarget {

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -797,6 +797,7 @@ fn send_sigterm(child: &tokio::process::Child) {
 mod tests {
     use super::*;
     use crate::types::{FirewallApi, FirewallAuth, FirewallPermission};
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn find_port_returns_nonzero() {
@@ -1384,6 +1385,70 @@ mod tests {
         let port = find_available_port().unwrap();
         let result = wait_for_ready(&mut child, port, Duration::from_secs(5)).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn spawn_mitmdump_passes_usage_state_id_option() {
+        let dir = tempfile::tempdir().unwrap();
+        let fake_mitmdump = dir.path().join("fake-mitmdump");
+        std::fs::write(
+            &fake_mitmdump,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$0.args"
+port=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--listen-port" ]; then
+    port="$arg"
+    break
+  fi
+  prev="$arg"
+done
+python3 - "$port" <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+sock = socket.socket()
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", port))
+sock.listen(1)
+while True:
+    conn, _ = sock.accept()
+    conn.close()
+PY
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&fake_mitmdump).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_mitmdump, perms).unwrap();
+
+        let config = ProxyConfig {
+            mitmdump_bin: fake_mitmdump.clone(),
+            ca_dir: dir.path().join("ca"),
+            addon_dir: dir.path().join("addon"),
+            registry_path: dir.path().join("proxy-registry.json"),
+            registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            api_url: None,
+        };
+        let (crash_tx, _crash_rx) = mpsc::channel(1);
+        let stopping = Arc::new(AtomicBool::new(false));
+        let port = find_available_port().unwrap();
+
+        let mut child = spawn_mitmdump(&config, port, &crash_tx, &stopping, "usage-state-test")
+            .await
+            .unwrap();
+        stopping.store(true, Ordering::Release);
+        let _ = child.kill().await;
+
+        let args = std::fs::read_to_string(fake_mitmdump.with_extension("args")).unwrap();
+        assert!(
+            args.lines()
+                .any(|arg| arg == "vm0_usage_state_id=usage-state-test"),
+            "mitmdump args should include vm0_usage_state_id option; got:\n{args}",
+        );
     }
 
     fn usage_target() -> UsageFlushTarget {

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -2,12 +2,13 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncBufReadExt;
 use tokio::sync::mpsc;
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
@@ -77,6 +78,51 @@ pub const USAGE_FLUSH_TIMEOUT: Duration = Duration::from_secs(30);
 /// Poll interval when waiting for usage flush.
 const USAGE_FLUSH_POLL: Duration = Duration::from_millis(200);
 
+/// Current JSON schema version for `{addon_dir}/usage-pending`.
+const USAGE_PENDING_VERSION: u32 = 1;
+
+/// Tolerated wall-clock skew when validating addon timestamps.
+const USAGE_PENDING_CLOCK_SKEW: Duration = Duration::from_secs(300);
+
+#[derive(Debug, Clone)]
+pub struct UsageFlushTarget {
+    expected_pid: u32,
+    expected_usage_state_id: String,
+    usage_state_started_at_ms: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct UsagePendingState {
+    version: u32,
+    pid: u32,
+    usage_state_id: String,
+    updated_at_ms: u64,
+    flows: u32,
+    reports: u32,
+}
+
+#[derive(Debug, Clone)]
+struct UsagePendingSnapshot {
+    pid: u32,
+    usage_state_id: String,
+    updated_at_ms: u64,
+    flows: u32,
+    reports: u32,
+}
+
+impl From<&UsagePendingState> for UsagePendingSnapshot {
+    fn from(state: &UsagePendingState) -> Self {
+        Self {
+            pid: state.pid,
+            usage_state_id: state.usage_state_id.clone(),
+            updated_at_ms: state.updated_at_ms,
+            flows: state.flows,
+            reports: state.reports,
+        }
+    }
+}
+
 /// Configuration for starting the proxy.
 #[derive(Clone)]
 pub struct ProxyConfig {
@@ -103,6 +149,10 @@ pub struct MitmProxy {
     crash_tx: mpsc::Sender<()>,
     /// Set to `true` during graceful `stop()` / `Drop` to suppress crash notifications.
     stopping: Arc<AtomicBool>,
+    /// Per-mitmdump-process token written by the addon to `usage-pending`.
+    usage_state_id: String,
+    /// Host timestamp from when `usage_state_id` was minted.
+    usage_state_started_at_ms: u64,
 }
 
 impl MitmProxy {
@@ -146,6 +196,7 @@ impl MitmProxy {
         write_registry(&config.registry_path, &empty_registry).await?;
 
         let (crash_tx, crash_rx) = mpsc::channel(1);
+        let (usage_state_id, usage_state_started_at_ms) = new_usage_state_id();
 
         Ok((
             Self {
@@ -154,6 +205,8 @@ impl MitmProxy {
                 child: None,
                 crash_tx,
                 stopping: Arc::new(AtomicBool::new(false)),
+                usage_state_id,
+                usage_state_started_at_ms,
             },
             crash_rx,
         ))
@@ -161,7 +214,14 @@ impl MitmProxy {
 
     /// Spawn the mitmdump process.
     pub async fn start(&mut self) -> RunnerResult<()> {
-        let child = spawn_mitmdump(&self.config, self.port, &self.crash_tx, &self.stopping).await?;
+        let child = spawn_mitmdump(
+            &self.config,
+            self.port,
+            &self.crash_tx,
+            &self.stopping,
+            &self.usage_state_id,
+        )
+        .await?;
         self.child = Some(child);
         info!(port = self.port, "mitmdump started");
         Ok(())
@@ -199,6 +259,16 @@ impl MitmProxy {
         self.registry_handle().unregister_vm(source_ip).await
     }
 
+    /// Current mitmdump identity expected in the usage-pending state file.
+    pub fn usage_flush_target(&self) -> Option<UsageFlushTarget> {
+        let expected_pid = self.child.as_ref().and_then(|child| child.id())?;
+        Some(UsageFlushTarget {
+            expected_pid,
+            expected_usage_state_id: self.usage_state_id.clone(),
+            usage_state_started_at_ms: self.usage_state_started_at_ms,
+        })
+    }
+
     /// Prepare for restart: kill any lingering child, permanently silence
     /// its stdout monitor, and return fresh parameters for
     /// [`spawn_mitmdump`].
@@ -227,11 +297,15 @@ impl MitmProxy {
         // Fresh flag for the incoming process's monitor.
         let new_stopping = Arc::new(AtomicBool::new(false));
         self.stopping = Arc::clone(&new_stopping);
+        let (usage_state_id, usage_state_started_at_ms) = new_usage_state_id();
+        self.usage_state_id = usage_state_id.clone();
+        self.usage_state_started_at_ms = usage_state_started_at_ms;
         MitmRestartParams {
             config: self.config.clone(),
             port: self.port,
             crash_tx: self.crash_tx.clone(),
             stopping: new_stopping,
+            usage_state_id,
         }
     }
 
@@ -266,52 +340,123 @@ impl MitmProxy {
     }
 }
 
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+fn new_usage_state_id() -> (String, u64) {
+    (Uuid::new_v4().to_string(), now_millis())
+}
+
+fn parse_usage_pending_state(content: &str) -> Result<UsagePendingState, String> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Err("state file is empty".to_string());
+    }
+    serde_json::from_str::<UsagePendingState>(trimmed)
+        .map_err(|e| format!("state file is not valid usage-pending JSON: {e}"))
+}
+
+fn validate_usage_pending_state(
+    state: &UsagePendingState,
+    target: &UsageFlushTarget,
+    now_ms: u64,
+) -> Result<(), String> {
+    if state.version != USAGE_PENDING_VERSION {
+        return Err(format!(
+            "unsupported version {}, expected {}",
+            state.version, USAGE_PENDING_VERSION
+        ));
+    }
+    if state.pid != target.expected_pid {
+        return Err(format!(
+            "pid {} does not match current mitmdump pid {}",
+            state.pid, target.expected_pid
+        ));
+    }
+    if state.usage_state_id != target.expected_usage_state_id {
+        return Err("usage state id does not match current mitmdump process".to_string());
+    }
+
+    let skew_ms = USAGE_PENDING_CLOCK_SKEW.as_millis() as u64;
+    let min_updated_at = target.usage_state_started_at_ms.saturating_sub(skew_ms);
+    if state.updated_at_ms < min_updated_at {
+        return Err(format!(
+            "updatedAtMs {} predates current usage state id start {}",
+            state.updated_at_ms, target.usage_state_started_at_ms
+        ));
+    }
+    if state.updated_at_ms > now_ms.saturating_add(skew_ms) {
+        return Err(format!(
+            "updatedAtMs {} is too far in the future",
+            state.updated_at_ms
+        ));
+    }
+
+    Ok(())
+}
+
 /// Wait for all pending proxy usage reports to be delivered.
 ///
-/// The Python addon writes `<flows>:<reports>` to `{addon_dir}/usage-pending`
-/// where `flows` is the number of in-flight model-provider HTTP flows and
-/// `reports` is the number of usage webhook POSTs in the thread pool.
-///
-/// Returns `true` if both counters reached zero, `false` on timeout.
-/// Missing or unreadable file is treated as zero (old addon version or
-/// no reports were ever submitted).
-pub async fn wait_usage_flush(addon_dir: &Path, timeout: Duration) -> bool {
+/// The Python addon writes JSON to `{addon_dir}/usage-pending` with the
+/// mitmdump process identity plus in-flight flow and report counters.
+/// A successful drain requires current valid state with `flows == 0` and
+/// `reports == 0`. Missing, unreadable, stale, wrong state id, or invalid
+/// state is treated as not ready and waits until timeout.
+pub async fn wait_usage_flush(
+    addon_dir: &Path,
+    timeout: Duration,
+    target: &UsageFlushTarget,
+) -> bool {
     let path = addon_dir.join("usage-pending");
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
-        match tokio::fs::read_to_string(&path).await {
-            Ok(s) => {
-                let trimmed = s.trim();
-                if trimmed == "0:0" || trimmed == "0" {
-                    return true;
+        let (not_ready, snapshot) = match tokio::fs::read_to_string(&path).await {
+            Ok(content) => match parse_usage_pending_state(&content) {
+                Ok(state) => {
+                    let snapshot = Some(UsagePendingSnapshot::from(&state));
+                    match validate_usage_pending_state(&state, target, now_millis()) {
+                        Ok(()) => {
+                            if state.flows == 0 && state.reports == 0 {
+                                return true;
+                            }
+                            (
+                                format!("pending flows={} reports={}", state.flows, state.reports),
+                                snapshot,
+                            )
+                        }
+                        Err(reason) => (reason, snapshot),
+                    }
                 }
-                // Verify the file contains a valid "<flows>:<reports>" pair.
-                // If unparseable (corrupt file, future format change), treat
-                // as zero to avoid blocking shutdown for 30 s on stale data.
-                let parseable = if let Some((flows, reports)) = trimmed.split_once(':') {
-                    flows.parse::<u32>().is_ok() && reports.parse::<u32>().is_ok()
-                } else {
-                    trimmed.parse::<u32>().is_ok()
-                };
-                if !parseable {
-                    warn!(
-                        content = trimmed,
-                        "usage-pending file has unparseable content, treating as flushed"
-                    );
-                    return true;
-                }
+                Err(reason) => (reason, None),
+            },
+            Err(e) => (format!("cannot read {}: {e}", path.display()), None),
+        };
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            match snapshot {
+                Some(snapshot) => warn!(
+                    timeout_secs = timeout.as_secs(),
+                    reason = %not_ready,
+                    pid = snapshot.pid,
+                    usage_state_id = %snapshot.usage_state_id,
+                    updated_at_ms = snapshot.updated_at_ms,
+                    flows = snapshot.flows,
+                    reports = snapshot.reports,
+                    "usage flush timed out, proceeding with proxy stop"
+                ),
+                None => warn!(
+                    timeout_secs = timeout.as_secs(),
+                    reason = %not_ready,
+                    "usage flush timed out, proceeding with proxy stop"
+                ),
             }
-            // File missing = no reports were ever submitted (or old addon).
-            Err(_) => return true,
-        }
-        if tokio::time::Instant::now() >= deadline {
-            warn!(
-                timeout_secs = timeout.as_secs(),
-                "usage flush timed out, proceeding with proxy stop"
-            );
             return false;
         }
-        tokio::time::sleep(USAGE_FLUSH_POLL).await;
+        tokio::time::sleep(std::cmp::min(USAGE_FLUSH_POLL, deadline - now)).await;
     }
 }
 
@@ -338,6 +483,8 @@ impl MitmProxy {
                 child: None,
                 crash_tx,
                 stopping: Arc::new(AtomicBool::new(false)),
+                usage_state_id: "test-usage-state-id".to_string(),
+                usage_state_started_at_ms: now_millis(),
             },
             crash_rx,
         )
@@ -362,12 +509,20 @@ pub(crate) struct MitmRestartParams {
     port: u16,
     crash_tx: mpsc::Sender<()>,
     stopping: Arc<AtomicBool>,
+    usage_state_id: String,
 }
 
 impl MitmRestartParams {
     /// Spawn mitmdump using these parameters. Suitable for `tokio::spawn`.
     pub(crate) async fn spawn(self) -> RunnerResult<tokio::process::Child> {
-        spawn_mitmdump(&self.config, self.port, &self.crash_tx, &self.stopping).await
+        spawn_mitmdump(
+            &self.config,
+            self.port,
+            &self.crash_tx,
+            &self.stopping,
+            &self.usage_state_id,
+        )
+        .await
     }
 }
 
@@ -379,6 +534,7 @@ pub(crate) async fn spawn_mitmdump(
     port: u16,
     crash_tx: &mpsc::Sender<()>,
     stopping: &Arc<AtomicBool>,
+    usage_state_id: &str,
 ) -> RunnerResult<tokio::process::Child> {
     let mut cmd = tokio::process::Command::new(&config.mitmdump_bin);
     cmd.arg("--mode")
@@ -392,6 +548,8 @@ pub(crate) async fn spawn_mitmdump(
             "vm0_proxy_registry_path={}",
             config.registry_path.display()
         ))
+        .arg("--set")
+        .arg(format!("vm0_usage_state_id={usage_state_id}"))
         .arg("--scripts")
         .arg(config.addon_dir.join("mitm_addon.py"))
         .arg("--set")
@@ -1228,65 +1386,163 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[tokio::test]
-    async fn wait_usage_flush_returns_true_when_zero() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("usage-pending"), "0:0").unwrap();
-        assert!(wait_usage_flush(dir.path(), Duration::from_secs(1)).await);
+    fn usage_target() -> UsageFlushTarget {
+        UsageFlushTarget {
+            expected_pid: 1234,
+            expected_usage_state_id: "state-test".to_string(),
+            usage_state_started_at_ms: 1_770_000_000_000,
+        }
+    }
+
+    fn usage_state(flows: u32, reports: u32) -> String {
+        serde_json::json!({
+            "version": 1,
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flows": flows,
+            "reports": reports,
+        })
+        .to_string()
     }
 
     #[tokio::test]
-    async fn wait_usage_flush_returns_true_when_file_missing() {
+    async fn wait_usage_flush_returns_true_when_zero() {
         let dir = tempfile::tempdir().unwrap();
-        // No file written — should return true immediately.
-        assert!(wait_usage_flush(dir.path(), Duration::from_secs(1)).await);
+        let target = usage_target();
+        std::fs::write(dir.path().join("usage-pending"), usage_state(0, 0)).unwrap();
+        assert!(wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
+    }
+
+    #[tokio::test]
+    async fn wait_usage_flush_times_out_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
     }
 
     #[tokio::test]
     async fn wait_usage_flush_waits_until_zero() {
         let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
         let path = dir.path().join("usage-pending");
-        std::fs::write(&path, "2:1").unwrap();
+        std::fs::write(&path, usage_state(2, 1)).unwrap();
 
         let p = path.clone();
         let handle = tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            std::fs::write(&p, "0:0").unwrap();
+            std::fs::write(&p, usage_state(0, 0)).unwrap();
         });
 
         let d = dir.path().to_path_buf();
-        assert!(wait_usage_flush(&d, Duration::from_secs(5)).await);
+        assert!(wait_usage_flush(&d, Duration::from_secs(5), &target).await);
         handle.await.unwrap();
     }
 
     #[tokio::test]
     async fn wait_usage_flush_timeout() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("usage-pending"), "1:3").unwrap();
+        let target = usage_target();
+        std::fs::write(dir.path().join("usage-pending"), usage_state(1, 3)).unwrap();
         // Very short timeout — should return false.
-        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(300)).await);
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
     }
 
     #[tokio::test]
-    async fn wait_usage_flush_returns_true_on_corrupt_file() {
+    async fn wait_usage_flush_times_out_on_corrupt_file() {
         let dir = tempfile::tempdir().unwrap();
-        // Corrupt / unparseable content should not block shutdown.
+        let target = usage_target();
         std::fs::write(dir.path().join("usage-pending"), "garbage").unwrap();
-        assert!(wait_usage_flush(dir.path(), Duration::from_secs(1)).await);
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
     }
 
     #[tokio::test]
-    async fn wait_usage_flush_returns_true_on_empty_file() {
+    async fn wait_usage_flush_times_out_on_empty_file() {
         let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
         std::fs::write(dir.path().join("usage-pending"), "").unwrap();
-        assert!(wait_usage_flush(dir.path(), Duration::from_secs(1)).await);
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
     }
 
     #[tokio::test]
-    async fn wait_usage_flush_accepts_plain_zero() {
+    async fn wait_usage_flush_rejects_unknown_field() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("usage-pending"), "0").unwrap();
-        assert!(wait_usage_flush(dir.path(), Duration::from_secs(1)).await);
+        let target = usage_target();
+        let state = serde_json::json!({
+            "version": 1,
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flows": 0,
+            "reports": 0,
+            "extraField": "unexpected",
+        });
+        std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
+    }
+
+    #[tokio::test]
+    async fn wait_usage_flush_rejects_wrong_usage_state_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let state = serde_json::json!({
+            "version": 1,
+            "pid": 1234,
+            "usageStateId": "old-state",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flows": 0,
+            "reports": 0,
+        });
+        std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
+    }
+
+    #[tokio::test]
+    async fn wait_usage_flush_rejects_wrong_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let state = serde_json::json!({
+            "version": 1,
+            "pid": 5678,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flows": 0,
+            "reports": 0,
+        });
+        std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
+    }
+
+    #[tokio::test]
+    async fn wait_usage_flush_rejects_stale_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let state = serde_json::json!({
+            "version": 1,
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_769_000_000_000u64,
+            "flows": 0,
+            "reports": 0,
+        });
+        std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
+    }
+
+    #[tokio::test]
+    async fn wait_usage_flush_rejects_future_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let state = serde_json::json!({
+            "version": 1,
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": now_millis() + USAGE_PENDING_CLOCK_SKEW.as_millis() as u64 + 60_000,
+            "flows": 0,
+            "reports": 0,
+        });
+        std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
     }
 
     /// Regression for #10624: `begin_restart` must lock the old

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -86,7 +86,6 @@ const USAGE_PENDING_CLOCK_SKEW: Duration = Duration::from_secs(300);
 
 #[derive(Debug, Clone)]
 pub struct UsageFlushTarget {
-    expected_pid: u32,
     expected_usage_state_id: String,
     usage_state_started_at_ms: u64,
 }
@@ -259,7 +258,7 @@ impl MitmProxy {
         self.registry_handle().unregister_vm(source_ip).await
     }
 
-    /// Current mitmdump identity expected in the usage-pending state file.
+    /// Current mitmdump usage state expected in the usage-pending state file.
     pub fn usage_flush_target(&mut self) -> Option<UsageFlushTarget> {
         let child_exited = match self.child.as_mut()?.try_wait() {
             Ok(Some(status)) => {
@@ -277,9 +276,8 @@ impl MitmProxy {
             return None;
         }
 
-        let expected_pid = self.child.as_ref().and_then(|child| child.id())?;
+        let _child_pid = self.child.as_ref().and_then(|child| child.id())?;
         Some(UsageFlushTarget {
-            expected_pid,
             expected_usage_state_id: self.usage_state_id.clone(),
             usage_state_started_at_ms: self.usage_state_started_at_ms,
         })
@@ -387,12 +385,6 @@ fn validate_usage_pending_state(
             state.version, USAGE_PENDING_VERSION
         ));
     }
-    if state.pid != target.expected_pid {
-        return Err(format!(
-            "pid {} does not match current mitmdump pid {}",
-            state.pid, target.expected_pid
-        ));
-    }
     if state.usage_state_id != target.expected_usage_state_id {
         return Err("usage state id does not match current mitmdump process".to_string());
     }
@@ -418,10 +410,12 @@ fn validate_usage_pending_state(
 /// Wait for all pending proxy usage reports to be delivered.
 ///
 /// The Python addon writes JSON to `{addon_dir}/usage-pending` with the
-/// mitmdump process identity plus in-flight flow and report counters.
+/// mitmdump usage-state identity plus in-flight flow and report counters.
 /// A successful drain requires current valid state with `flows == 0` and
 /// `reports == 0`. Missing, unreadable, stale, wrong state id, or invalid
-/// state is treated as not ready and waits until timeout.
+/// state is treated as not ready and waits until timeout. The JSON `pid`
+/// is diagnostic only: mitmdump launchers can keep the runner's direct
+/// child as a wrapper while the Python addon runs in a child process.
 pub async fn wait_usage_flush(
     addon_dir: &Path,
     timeout: Duration,
@@ -1556,7 +1550,6 @@ PY
 
     fn usage_target() -> UsageFlushTarget {
         UsageFlushTarget {
-            expected_pid: 1234,
             expected_usage_state_id: "state-test".to_string(),
             usage_state_started_at_ms: 1_770_000_000_000,
         }
@@ -1714,7 +1707,7 @@ PY
     }
 
     #[tokio::test]
-    async fn wait_usage_flush_rejects_wrong_pid() {
+    async fn wait_usage_flush_allows_wrapper_pid_mismatch() {
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
         let state = serde_json::json!({
@@ -1726,7 +1719,7 @@ PY
             "reports": 0,
         });
         std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
-        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
+        assert!(wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- wait for usage drain only against the current mitmdump process using pid + usageStateId + timestamp validation
- make mitm-addon pending counters write JSON state and initialize from the real mitmproxy option in configure()
- track billable flows before response headers and keep billing buffers gated on firewall_billable, with X stream incremental parsing preserved

## Tests
- python3 -m ruff check . && python3 -m ruff format --check .
- python3 -m pytest tests/test_handlers.py -q
- cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features
- git diff --check

Closes #11227