### PR TITLE
fix(slack): align home action buttons

### DIFF
--- a/turbo/apps/web/src/lib/zero/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/zero/slack/__tests__/blocks.test.ts
@@ -222,6 +222,42 @@ describe("buildAppHomeView", () => {
     expect(blockTexts.join(" ")).toContain("MyAgent");
   });
 
+  it("should show switch and settings side by side when switching is available", () => {
+    const view = buildAppHomeView({
+      isLinked: true,
+      agentName: "MyAgent",
+      vm0UserId: "user-123",
+      canSwitch: true,
+    });
+
+    const actionsBlock = view.blocks
+      .filter((b): b is ActionsBlock => {
+        return b.type === "actions" && "elements" in b;
+      })
+      .find((block) => {
+        return block.elements.some((element) => {
+          return (
+            "action_id" in element && element.action_id === "home_switch_agent"
+          );
+        });
+      });
+
+    expect(actionsBlock).toBeDefined();
+    expect(actionsBlock!.elements).toMatchObject([
+      {
+        type: "button",
+        text: { type: "plain_text", text: "Switch" },
+        action_id: "home_switch_agent",
+        style: "primary",
+      },
+      {
+        type: "button",
+        text: { type: "plain_text", text: "Settings" },
+        action_id: "home_environment_setup",
+      },
+    ]);
+  });
+
   it("should not include agent/commands sections for not-installed state", () => {
     const view = buildAppHomeView({ isLinked: false, isInstalled: false });
 

--- a/turbo/apps/web/src/lib/zero/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/zero/slack/blocks.ts
@@ -128,18 +128,19 @@ export function buildAppHomeView(options: {
   });
 
   if (options.agentName) {
+    const settingsButton = {
+      type: "button" as const,
+      text: { type: "plain_text" as const, text: "Settings" },
+      url: `${getAppUrl()}/works`,
+      action_id: "home_environment_setup",
+    };
     const agentBlock: KnownBlock = {
       type: "section",
       text: {
         type: "mrkdwn",
         text: `AgentName: *${options.agentName}*`,
       },
-      accessory: {
-        type: "button",
-        text: { type: "plain_text", text: "Settings" },
-        url: `${getAppUrl()}/works`,
-        action_id: "home_environment_setup",
-      },
+      ...(options.canSwitch ? {} : { accessory: settingsButton }),
     };
     blocks.push(agentBlock);
     if (options.canSwitch) {
@@ -150,7 +151,9 @@ export function buildAppHomeView(options: {
             type: "button",
             text: { type: "plain_text", text: "Switch" },
             action_id: "home_switch_agent",
+            style: "primary",
           },
+          settingsButton,
         ],
       });
     }


### PR DESCRIPTION
## Summary
- Put Slack App Home Switch and Settings buttons in the same actions block when switching is available
- Style the Switch button as primary
- Add Slack block regression coverage

## Tests
- pnpm --filter web test src/lib/zero/slack/__tests__/blocks.test.ts
- pnpm --filter web exec oxlint src/lib/zero/slack/blocks.ts src/lib/zero/slack/__tests__/blocks.test.ts
- pnpm --filter web check-types (fails on existing unrelated web type errors)
- pre-commit check-types (fails on existing unrelated apps/platform type errors)