### PR TITLE
fix(web): preserve org id on sandbox auth context

### DIFF
--- a/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
@@ -130,6 +130,7 @@ describe("getAuthContext with acceptAnySandboxCapability", () => {
     expect(result).not.toBeNull();
     expect(result?.userId).toBe("user-123");
     expect(result?.runId).toBe("run-456");
+    expect(result?.orgId).toBe("org-test");
   });
 
   it("should accept sandbox token without capabilities via acceptAnySandboxCapability", async () => {
@@ -217,14 +218,14 @@ describe("getAuthContext org fields from Clerk session", () => {
     expect(result?.sessionClaims?.custom_field).toBeUndefined();
   });
 
-  it("should not populate org fields for sandbox tokens", async () => {
+  it("should populate orgId from sandbox token but leave orgRole/sessionClaims unset", async () => {
     const token = await generateSandboxToken("user-123", "run-456", "org-test");
     const result = await getAuthContext(`Bearer ${token}`, {
       acceptAnySandboxCapability: true,
     });
 
     expect(result?.userId).toBe("user-123");
-    expect(result?.orgId).toBeUndefined();
+    expect(result?.orgId).toBe("org-test");
     expect(result?.orgRole).toBeUndefined();
     expect(result?.sessionClaims).toBeUndefined();
   });

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -176,6 +176,7 @@ async function authenticateSandboxToken(
 function resolveSandboxAuth(
   sandboxAuth: {
     userId: string;
+    orgId: string;
     runId: string;
   },
   options: {
@@ -186,6 +187,7 @@ function resolveSandboxAuth(
   if (options.acceptAnySandboxCapability) {
     return {
       userId: sandboxAuth.userId,
+      orgId: sandboxAuth.orgId,
       runId: sandboxAuth.runId,
       tokenType: "sandbox",
     };


### PR DESCRIPTION
## Summary
- `resolveSandboxAuth` was dropping `orgId` because the parameter type didn't include it, even though `verifySandboxToken` extracts it from the JWT payload.
- The shadow check against the new api app surfaced the divergence: api keeps `orgId` on the sandbox `AuthContext`, web silently returned `undefined` for the same token.
- Plumb `orgId` through the resolver so consumers of the sandbox `tokenType` see the same fields as the underlying JWT and as the api implementation.

## Test plan
- [x] `pnpm -F web exec vitest run src/lib/auth` — 146 passed
- [x] `pnpm -F web lint`
- [x] `pnpm -F web run check-types`
- [x] Verified end-to-end with a sandbox JWT against the local dev server: `auth shadow check mismatch` warning no longer fires for the sandbox path

🤖 Generated with [Claude Code](https://claude.com/claude-code)