### PR TITLE
fix: route PostHog SDK through Vercel reverse proxy to avoid ad-blocker data loss

### DIFF
--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -9,7 +9,7 @@ export function initPostHog(): void {
   }
 
   posthog.init(POSTHOG_KEY, {
-    api_host: "https://us.posthog.com",
+    api_host: "/ingest",
     autocapture: false,
     capture_pageview: false,
     disable_session_recording: true,

--- a/turbo/apps/platform/vercel.json
+++ b/turbo/apps/platform/vercel.json
@@ -45,6 +45,10 @@
   ],
   "rewrites": [
     {
+      "source": "/ingest/(.*)",
+      "destination": "https://us.posthog.com/$1"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary

PostHog's client-side SDK sends events directly to `us.posthog.com`, which is blocked by 10-30% of users with ad blockers or privacy-focused proxy rules. This causes undercounting of critical performance metrics like `chat_navigation_timing`.

## Changes

- **`vercel.json`**: Added a rewrite rule `/ingest/(.*)` → `https://us.posthog.com/$1` before the catch-all SPA rewrite. This proxies PostHog SDK requests through `app.vm0.ai/ingest/*`, making them same-origin and bypassing third-party domain blocklists.
- **`posthog.ts`**: Changed `api_host` from `"https://us.posthog.com"` to `"/ingest"` (relative path), so the SDK sends requests to the same origin.

## Impact

- **Zero cost**: No additional infrastructure needed — Vercel's free tier includes 100GB/month bandwidth, and PostHog events are ~1KB each
- **Two lines changed**
- **No CSP or security impact**: The rewrite is transparent forwarding; same HTTPS origin

## Test plan

- [ ] Deploy preview and verify PostHog events flow correctly via `/ingest/e/` path
- [ ] Confirm `chat_navigation_timing` events appear in PostHog dashboard
- [ ] Verify no CORS errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)