### PR TITLE
fix(runner): cap storage cache downloads

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1182,7 +1182,7 @@ async fn gc_storage_cache_with_cap(
                 continue;
             }
 
-            let lock_path = home.storage_lock(name_str, version_str);
+            let lock_path = home.storage_lock_for_cache_key(name_str, version_str);
             let lock = match probe_lock(&lock_path) {
                 LockProbe::Free(l) => l,
                 LockProbe::Held => {
@@ -2670,14 +2670,7 @@ mod tests {
     // gc_storage_cache tests
     // -----------------------------------------------------------------------
 
-    fn make_storage_entry(
-        home: &HomePaths,
-        name: &str,
-        version: &str,
-        archive_bytes: &[u8],
-        mtime: SystemTime,
-    ) -> PathBuf {
-        let dir = home.storages_dir().join(name).join(version);
+    fn make_storage_entry_at(dir: PathBuf, archive_bytes: &[u8], mtime: SystemTime) -> PathBuf {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("archive.tar.gz"), archive_bytes).unwrap();
         std::fs::File::open(&dir)
@@ -2685,6 +2678,16 @@ mod tests {
             .set_times(std::fs::FileTimes::new().set_modified(mtime))
             .unwrap();
         dir
+    }
+
+    fn make_storage_entry(
+        home: &HomePaths,
+        name: &str,
+        version: &str,
+        archive_bytes: &[u8],
+        mtime: SystemTime,
+    ) -> PathBuf {
+        make_storage_entry_at(home.storage_cache_dir(name, version), archive_bytes, mtime)
     }
 
     #[tokio::test]
@@ -2846,7 +2849,12 @@ mod tests {
         // not be counted toward `total_size`.
         let t_old = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
         let real = make_storage_entry(&home, "foo", "v1", &[0u8; 128], t_old);
-        let tmp = make_storage_entry(&home, "foo", "v1.tmp", &[0u8; 128], t_old);
+        let tmp_final_dir = home.storage_cache_dir("foo", "v2");
+        let tmp_name = format!(
+            "{}.tmp",
+            tmp_final_dir.file_name().and_then(|n| n.to_str()).unwrap()
+        );
+        let tmp = make_storage_entry_at(tmp_final_dir.with_file_name(tmp_name), &[0u8; 128], t_old);
 
         // Cap well above the real entry alone — if the walker counted the
         // `.tmp` sibling, total_size would exceed the cap and the real

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -2967,6 +2967,27 @@ mod tests {
         assert!(tmp.exists(), "locked .tmp staging dir must survive");
     }
 
+    #[tokio::test]
+    async fn gc_storage_cache_dry_run_reports_stale_tmp_without_deleting() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+        let t_old = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let tmp = make_storage_staging_entry(&home, "foo", "v1", &[0u8; 128], t_old);
+        let (tmp_size, _) = dir_stats(&tmp).await;
+
+        let freed = gc_storage_cache_with_cap(&home, 1 << 20, true)
+            .await
+            .unwrap();
+
+        assert_eq!(freed, tmp_size);
+        assert!(
+            tmp.exists(),
+            "dry-run must not delete stale .tmp staging dir"
+        );
+    }
+
     #[test]
     fn discover_dead_runner_base_dirs_skips_whitespace_only() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1116,10 +1116,9 @@ struct StorageCandidate {
 ///
 /// Entries younger than [`GC_MIN_AGE`] or whose per-version flock is held
 /// are always protected — the former prevents races with a writer's
-/// atomic rename-in, the latter protects an in-flight cache read. The
-/// walker also skips `<version>.tmp/` staging directories by name: a
-/// crashed writer may leave one past lock drop, and the naming
-/// convention is the only reliable signal.
+/// atomic rename-in, the latter protects an in-flight cache read. Stale
+/// `<version>.tmp/` staging directories are removed under the final
+/// version's flock so crashed writers do not leak disk indefinitely.
 ///
 /// Missing `storages_dir` is a no-op (cold host before the cache writer
 /// in #10808 lands).
@@ -1145,6 +1144,7 @@ async fn gc_storage_cache_with_cap(
     // without racing the writer, and counting them would evict eligible
     // entries to make room for unmeasurable ones.
     let mut total_size: u64 = 0;
+    let mut freed: u64 = 0;
 
     while let Some(name_entry) =
         next_entry_warn(&mut name_entries, "gc_storage_cache", &storages_dir).await
@@ -1175,10 +1175,18 @@ async fn gc_storage_cache_with_cap(
             if !version_path.is_dir() {
                 continue;
             }
-            // Writer stages to `<version>.tmp/` and atomic-renames into place.
-            // A crashed writer may leave the staging dir behind after its
-            // flock is dropped, so filter by naming convention.
-            if version_str.ends_with(".tmp") {
+            if let Some(final_version_hash) = version_str.strip_suffix(".tmp") {
+                freed = freed.saturating_add(
+                    gc_storage_staging_dir(
+                        home,
+                        name_str,
+                        final_version_hash,
+                        &version_path,
+                        now,
+                        dry_run,
+                    )
+                    .await,
+                );
                 continue;
             }
 
@@ -1220,13 +1228,12 @@ async fn gc_storage_cache_with_cap(
     }
 
     if total_size <= max_bytes {
-        return Ok(0);
+        return Ok(freed);
     }
 
     // LRU: evict oldest first until within cap.
     candidates.sort_by_key(|c| c.mtime);
 
-    let mut freed: u64 = 0;
     for c in candidates {
         if total_size <= max_bytes {
             break;
@@ -1254,6 +1261,57 @@ async fn gc_storage_cache_with_cap(
     }
 
     Ok(freed)
+}
+
+async fn gc_storage_staging_dir(
+    home: &HomePaths,
+    name_hash: &str,
+    version_hash: &str,
+    path: &Path,
+    now: SystemTime,
+    dry_run: bool,
+) -> u64 {
+    let lock_path = home.storage_lock_for_cache_key(name_hash, version_hash);
+    let _lock = match probe_lock(&lock_path) {
+        LockProbe::Free(l) => l,
+        LockProbe::Held => {
+            info!("storages/{name_hash}/{version_hash}.tmp: in use, skipping");
+            return 0;
+        }
+        LockProbe::Error(e) => {
+            info!("storages/{name_hash}/{version_hash}.tmp: lock probe failed ({e}), skipping");
+            return 0;
+        }
+    };
+
+    let (size, mtime) = dir_stats(path).await;
+    let age = now.duration_since(mtime).unwrap_or_default();
+    if age < GC_MIN_AGE {
+        info!(
+            "storages/{name_hash}/{version_hash}.tmp: too recent ({}s), keeping",
+            age.as_secs()
+        );
+        return 0;
+    }
+
+    if dry_run {
+        info!(
+            "[dry-run] would remove stale storage staging storages/{name_hash}/{version_hash}.tmp ({})",
+            human_bytes(size)
+        );
+    } else if let Err(e) = tokio::fs::remove_dir_all(path).await {
+        warn!(
+            "failed to remove stale storage staging storages/{name_hash}/{version_hash}.tmp: {e}"
+        );
+        return 0;
+    } else {
+        info!(
+            "removed stale storage staging storages/{name_hash}/{version_hash}.tmp ({})",
+            human_bytes(size)
+        );
+    }
+
+    size
 }
 
 fn human_bytes(bytes: u64) -> String {
@@ -2690,6 +2748,21 @@ mod tests {
         make_storage_entry_at(home.storage_cache_dir(name, version), archive_bytes, mtime)
     }
 
+    fn make_storage_staging_entry(
+        home: &HomePaths,
+        name: &str,
+        version: &str,
+        archive_bytes: &[u8],
+        mtime: SystemTime,
+    ) -> PathBuf {
+        let final_dir = home.storage_cache_dir(name, version);
+        let tmp_name = format!(
+            "{}.tmp",
+            final_dir.file_name().and_then(|n| n.to_str()).unwrap()
+        );
+        make_storage_entry_at(final_dir.with_file_name(tmp_name), archive_bytes, mtime)
+    }
+
     #[tokio::test]
     async fn gc_storage_cache_missing_dir_returns_zero() {
         let dir = tempfile::tempdir().unwrap();
@@ -2834,38 +2907,64 @@ mod tests {
         );
     }
 
-    /// `<version>.tmp/` staging directories must be skipped by the walker:
-    /// a writer may crash leaving one behind after its flock is dropped,
-    /// and we must not evict it as if it were a complete cache entry.
+    /// Stale `<version>.tmp/` staging directories are crash residue and
+    /// should be cleaned even when completed cache entries are under cap.
     #[tokio::test]
-    async fn gc_storage_cache_skips_tmp_staging_dir() {
+    async fn gc_storage_cache_removes_stale_tmp_staging_dir() {
         let dir = tempfile::tempdir().unwrap();
         let home = test_home(dir.path());
         std::fs::create_dir_all(home.locks_dir()).unwrap();
 
-        // One fully-staged entry (eligible by mtime) and one `.tmp` sibling
-        // that is equally old. Even with the cap set below both entries'
-        // combined footprint, the `.tmp` dir must not be touched and must
-        // not be counted toward `total_size`.
         let t_old = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
         let real = make_storage_entry(&home, "foo", "v1", &[0u8; 128], t_old);
-        let tmp_final_dir = home.storage_cache_dir("foo", "v2");
-        let tmp_name = format!(
-            "{}.tmp",
-            tmp_final_dir.file_name().and_then(|n| n.to_str()).unwrap()
-        );
-        let tmp = make_storage_entry_at(tmp_final_dir.with_file_name(tmp_name), &[0u8; 128], t_old);
+        let tmp = make_storage_staging_entry(&home, "foo", "v2", &[0u8; 128], t_old);
+        let (tmp_size, _) = dir_stats(&tmp).await;
 
-        // Cap well above the real entry alone — if the walker counted the
-        // `.tmp` sibling, total_size would exceed the cap and the real
-        // entry would be evicted.
         let freed = gc_storage_cache_with_cap(&home, 1 << 20, false)
             .await
             .unwrap();
 
-        assert_eq!(freed, 0, "under-cap when .tmp is correctly skipped");
+        assert_eq!(freed, tmp_size, "stale .tmp bytes must be reported");
         assert!(real.exists(), "real entry must survive");
-        assert!(tmp.exists(), ".tmp staging dir must not be touched");
+        assert!(!tmp.exists(), "stale .tmp staging dir must be removed");
+    }
+
+    #[tokio::test]
+    async fn gc_storage_cache_keeps_recent_tmp_staging_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+        let tmp = make_storage_staging_entry(&home, "foo", "v1", &[0u8; 128], SystemTime::now());
+
+        let freed = gc_storage_cache_with_cap(&home, 1 << 20, false)
+            .await
+            .unwrap();
+
+        assert_eq!(freed, 0);
+        assert!(
+            tmp.exists(),
+            "recent .tmp staging dir must survive grace window"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_storage_cache_keeps_locked_tmp_staging_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+        let t_old = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let tmp = make_storage_staging_entry(&home, "foo", "v1", &[0u8; 128], t_old);
+        let lock_file = lock::open_lock_file(&home.storage_lock("foo", "v1")).unwrap();
+        let _held = Flock::lock(lock_file, FlockArg::LockShared).unwrap();
+
+        let freed = gc_storage_cache_with_cap(&home, 1 << 20, false)
+            .await
+            .unwrap();
+
+        assert_eq!(freed, 0);
+        assert!(tmp.exists(), "locked .tmp staging dir must survive");
     }
 
     #[test]

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -190,6 +190,15 @@ impl HomePaths {
     /// be injective in `(name, version)` and safe to embed in a path segment.
     pub fn storage_lock(&self, name: &str, version: &str) -> PathBuf {
         let (name_hash, version_hash) = storage_key_hashes(name, version);
+        self.storage_lock_for_cache_key(&name_hash, &version_hash)
+    }
+
+    /// Per-version flock path from already-hashed cache directory components.
+    ///
+    /// This is for disk walkers such as `runner gc`, which discover
+    /// `<storages>/<name_hash>/<version_hash>/` and must use the exact same
+    /// lock as `storage_lock(name, version)`, not hash those components again.
+    pub fn storage_lock_for_cache_key(&self, name_hash: &str, version_hash: &str) -> PathBuf {
         self.locks_dir()
             .join(format!("storage-{name_hash}-{version_hash}.lock"))
     }
@@ -554,6 +563,16 @@ mod tests {
         assert!(a.starts_with(&locks));
         assert!(b.starts_with(&locks));
         assert!(a.to_string_lossy().ends_with(".lock"));
+
+        let cache_dir = home.storage_cache_dir("foo", "bar-v1");
+        let cache_tail: Vec<_> = cache_dir
+            .strip_prefix(home.storages_dir())
+            .unwrap()
+            .components()
+            .collect();
+        let name_hash = cache_tail[0].as_os_str().to_str().unwrap();
+        let version_hash = cache_tail[1].as_os_str().to_str().unwrap();
+        assert_eq!(a, home.storage_lock_for_cache_key(name_hash, version_hash));
     }
 
     #[test]

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -166,7 +166,7 @@ impl HomePaths {
 
     /// Root directory for the runner-side storage archive cache.
     ///
-    /// Layout: `<storages_dir>/<vasStorageName>/<vasVersionId>/archive.tar.gz`.
+    /// Layout: `<storages_dir>/<hash(vasStorageName)>/<hash(vasVersionId)>/archive.tar.gz`.
     /// Populated by the cache writer (#10808) and reaped by `gc_storage_cache`.
     pub fn storages_dir(&self) -> PathBuf {
         self.root.join("storages")

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -350,7 +350,7 @@ async fn probe_size(http: &Client, url: &str) -> RunnerResult<Option<u64>> {
         .timeout(HEAD_TIMEOUT)
         .send()
         .await
-        .map_err(|e| RunnerError::Internal(format!("probe GET {url}: {e}")))?;
+        .map_err(|e| RunnerError::Internal(format!("probe GET: {}", reqwest_error(e))))?;
 
     let status = resp.status();
     if status == StatusCode::PARTIAL_CONTENT {
@@ -380,9 +380,13 @@ async fn probe_size(http: &Client, url: &str) -> RunnerResult<Option<u64>> {
     let err = resp
         .error_for_status()
         .err()
-        .map(|e| e.to_string())
+        .map(reqwest_error)
         .unwrap_or_else(|| format!("unexpected status {status}"));
-    Err(RunnerError::Internal(format!("probe GET {url}: {err}")))
+    Err(RunnerError::Internal(format!("probe GET: {err}")))
+}
+
+fn reqwest_error(e: reqwest::Error) -> String {
+    e.without_url().to_string()
 }
 
 /// Parse the total size out of a `Content-Range` header value such as
@@ -402,9 +406,9 @@ async fn download_tarball(http: &Client, url: &str, max_size: u64) -> RunnerResu
         .timeout(DOWNLOAD_TIMEOUT)
         .send()
         .await
-        .map_err(|e| RunnerError::Internal(format!("GET {url}: {e}")))?
+        .map_err(|e| RunnerError::Internal(format!("GET: {}", reqwest_error(e))))?
         .error_for_status()
-        .map_err(|e| RunnerError::Internal(format!("GET status {url}: {e}")))?;
+        .map_err(|e| RunnerError::Internal(format!("GET status: {}", reqwest_error(e))))?;
 
     if let Some(content_length) = resp.content_length()
         && content_length > max_size
@@ -420,7 +424,7 @@ async fn download_tarball(http: &Client, url: &str, max_size: u64) -> RunnerResu
     while let Some(chunk) = resp
         .chunk()
         .await
-        .map_err(|e| RunnerError::Internal(format!("read body {url}: {e}")))?
+        .map_err(|e| RunnerError::Internal(format!("read body: {}", reqwest_error(e))))?
     {
         if let Some(observed_size) =
             append_limited_chunk(&mut bytes, &mut downloaded, &chunk, max_size)?
@@ -1144,7 +1148,10 @@ mod tests {
             })
             .await;
 
-        let original = server.url("/broken.tar.gz");
+        let original = format!(
+            "{}?X-Amz-Signature=secret&X-Amz-Credential=credential",
+            server.url("/broken.tar.gz")
+        );
         let mut manifest = manifest_single_storage(original.clone(), "broken-skill", "v1");
 
         populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
@@ -1162,6 +1169,18 @@ mod tests {
         assert!(
             ops.iter()
                 .any(|(k, _, _)| k == "storage_cache_skipped_head_failed")
+        );
+        let (_, _, error) = ops
+            .iter()
+            .find(|(k, _, _)| k == "storage_cache_skipped_head_failed")
+            .expect("expected skipped head telemetry");
+        let error = error.as_deref().expect("expected telemetry error reason");
+        assert!(
+            !error.contains("X-Amz-Signature")
+                && !error.contains("secret")
+                && !error.contains("credential")
+                && !error.contains("/broken.tar.gz"),
+            "telemetry error must not include presigned URL details: {error}"
         );
     }
 

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1200,6 +1200,44 @@ mod tests {
         assert_eq!(result, Some(advertised_size));
     }
 
+    #[tokio::test]
+    async fn probe_206_uses_content_range_without_reading_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let total_size = CACHE_MAX_SIZE;
+
+        let server_task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await?;
+            let mut request = [0u8; 1024];
+            let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-0/{total_size}\r\nContent-Length: {}\r\n\r\n",
+                        CACHE_MAX_SIZE + 1
+                    )
+                    .as_bytes(),
+                )
+                .await?;
+            let _ = release_rx.await;
+            Ok::<(), std::io::Error>(())
+        });
+
+        let http = Client::builder().build().unwrap();
+        let result = tokio::time::timeout(
+            HEAD_TIMEOUT + Duration::from_secs(1),
+            probe_size(&http, &format!("http://{addr}/partial.tar.gz")),
+        )
+        .await
+        .expect("probe must return after Content-Range without waiting for the body")
+        .unwrap();
+
+        let _ = release_tx.send(());
+        server_task.await.unwrap().unwrap();
+        assert_eq!(result, Some(total_size));
+    }
+
     #[test]
     fn staging_dir_is_sibling() {
         let d = PathBuf::from("/var/lib/vm0-runner/storages/foo/v1");

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -15,6 +15,9 @@
 //! Entries above [`CACHE_MAX_SIZE`], entries without a content key, and
 //! entries already marked `cached = true` (reuse-in-place from
 //! `filter_unchanged_storages`) pass through untouched.
+//! If the probe says an entry is cache-eligible but the full response exceeds
+//! [`CACHE_MAX_SIZE`], the cache fails closed instead of handing the same
+//! inconsistent URL to the guest.
 //!
 //! Merge-order contract: this module produces `file://` URLs, which only
 //! `guest-download` understands after #10805. The PR adding this module
@@ -94,6 +97,11 @@ enum TargetOutcome {
     SkippedHeadFailed {
         reason: String,
     },
+}
+
+enum DownloadBody {
+    Complete(Bytes),
+    OverSize { observed_size: u64 },
 }
 
 /// Populate the runner-side cache for eligible entries in `manifest`.
@@ -238,14 +246,40 @@ async fn process_one(
 
     // 1. Fast path: disk hit. Read the bytes directly and skip the network.
     //    This also makes the hit path resilient to transient HEAD failures.
-    if fs::metadata(&archive_path).await.is_ok() {
-        let bytes = fs::read(&archive_path).await.map_err(|e| {
-            RunnerError::Internal(format!("read cached {}: {e}", archive_path.display()))
-        })?;
-        touch_mtime(&cache_dir);
-        let guest_path = guest_archive_path(&target.name, &target.version);
-        sandbox.write_file(&guest_path, &bytes).await?;
-        return Ok(TargetOutcome::Hit);
+    match fs::metadata(&archive_path).await {
+        Ok(metadata) if metadata.len() <= CACHE_MAX_SIZE => {
+            let bytes = fs::read(&archive_path).await.map_err(|e| {
+                RunnerError::Internal(format!("read cached {}: {e}", archive_path.display()))
+            })?;
+            touch_mtime(&cache_dir);
+            let guest_path = guest_archive_path(&target.name, &target.version);
+            sandbox.write_file(&guest_path, &bytes).await?;
+            return Ok(TargetOutcome::Hit);
+        }
+        Ok(metadata) => {
+            warn!(
+                name = %target.name,
+                version = %target.version,
+                size = metadata.len(),
+                limit = CACHE_MAX_SIZE,
+                "storage_cache: cached archive exceeds size limit, evicting"
+            );
+            if let Err(e) = fs::remove_dir_all(&cache_dir).await
+                && e.kind() != io::ErrorKind::NotFound
+            {
+                return Err(RunnerError::Internal(format!(
+                    "remove oversized cache {}: {e}",
+                    cache_dir.display()
+                )));
+            }
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "stat cached {}: {e}",
+                archive_path.display()
+            )));
+        }
     }
 
     // 2. Miss path: probe size via `GET` + `Range: bytes=0-0`. A probe
@@ -291,7 +325,23 @@ async fn process_one(
     //    writer and the sandbox `write_file` costs zero extra allocation
     //    over the single response body.
     let t = Instant::now();
-    let bytes = download_tarball(http, &target.archive_url).await?;
+    let bytes = match download_tarball(http, &target.archive_url, CACHE_MAX_SIZE).await? {
+        DownloadBody::Complete(bytes) => bytes,
+        DownloadBody::OverSize { observed_size } => {
+            warn!(
+                name = %target.name,
+                version = %target.version,
+                probe_size = size,
+                observed_size,
+                limit = CACHE_MAX_SIZE,
+                "storage_cache: full download exceeded probed size limit, failing closed"
+            );
+            return Err(RunnerError::Internal(format!(
+                "storage cache download size mismatch for {}@{}: probe reported {size} bytes within {CACHE_MAX_SIZE} byte limit, but full GET reached {observed_size} bytes",
+                target.name, target.version
+            )));
+        }
+    };
     write_to_cache(&cache_dir, &bytes).await?;
     let guest_path = guest_archive_path(&target.name, &target.version);
     sandbox.write_file(&guest_path, &bytes).await?;
@@ -353,8 +403,8 @@ fn parse_content_range_total(value: &str) -> Option<u64> {
     total.trim().parse::<u64>().ok()
 }
 
-async fn download_tarball(http: &Client, url: &str) -> RunnerResult<Bytes> {
-    let resp = http
+async fn download_tarball(http: &Client, url: &str, max_size: u64) -> RunnerResult<DownloadBody> {
+    let mut resp = http
         .get(url)
         .timeout(DOWNLOAD_TIMEOUT)
         .send()
@@ -362,9 +412,50 @@ async fn download_tarball(http: &Client, url: &str) -> RunnerResult<Bytes> {
         .map_err(|e| RunnerError::Internal(format!("GET {url}: {e}")))?
         .error_for_status()
         .map_err(|e| RunnerError::Internal(format!("GET status {url}: {e}")))?;
-    resp.bytes()
+
+    if let Some(content_length) = resp.content_length()
+        && content_length > max_size
+    {
+        return Ok(DownloadBody::OverSize {
+            observed_size: content_length,
+        });
+    }
+
+    let mut bytes = Vec::with_capacity(max_size.min(64 * 1024) as usize);
+    let mut downloaded = 0u64;
+
+    while let Some(chunk) = resp
+        .chunk()
         .await
-        .map_err(|e| RunnerError::Internal(format!("read body {url}: {e}")))
+        .map_err(|e| RunnerError::Internal(format!("read body {url}: {e}")))?
+    {
+        if let Some(observed_size) =
+            append_limited_chunk(&mut bytes, &mut downloaded, &chunk, max_size)?
+        {
+            return Ok(DownloadBody::OverSize { observed_size });
+        }
+    }
+
+    Ok(DownloadBody::Complete(Bytes::from(bytes)))
+}
+
+fn append_limited_chunk(
+    bytes: &mut Vec<u8>,
+    downloaded: &mut u64,
+    chunk: &[u8],
+    max_size: u64,
+) -> RunnerResult<Option<u64>> {
+    let chunk_len = u64::try_from(chunk.len())
+        .map_err(|_| RunnerError::Internal("body chunk length overflow".to_string()))?;
+    let Some(next_downloaded) = downloaded.checked_add(chunk_len) else {
+        return Ok(Some(u64::MAX));
+    };
+    if next_downloaded > max_size {
+        return Ok(Some(next_downloaded));
+    }
+    bytes.extend_from_slice(chunk);
+    *downloaded = next_downloaded;
+    Ok(None)
 }
 
 async fn write_to_cache(cache_dir: &Path, bytes: &[u8]) -> RunnerResult<()> {
@@ -526,6 +617,7 @@ mod tests {
 
     use httpmock::Method::{GET, HEAD};
     use httpmock::prelude::*;
+    use sandbox::{SandboxError, SandboxOperation, SandboxOperationReason};
     use sandbox_mock::MockSandbox;
 
     use crate::http::HttpClient;
@@ -558,6 +650,14 @@ mod tests {
     fn tarball_bytes() -> Vec<u8> {
         // A small payload is enough — the cache treats it as opaque bytes.
         b"pretend-tar-gz-bytes".to_vec()
+    }
+
+    fn sandbox_write_file_error(message: impl Into<String>) -> SandboxError {
+        SandboxError::Operation {
+            operation: SandboxOperation::WriteFile,
+            reason: SandboxOperationReason::Guest,
+            message: message.into(),
+        }
     }
 
     #[tokio::test]
@@ -698,6 +798,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn full_download_over_probe_limit_fails_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_write_file_result(Err(sandbox_write_file_error("unexpected archive write")));
+        let mut telemetry = new_telemetry();
+        let server = MockServer::start_async().await;
+
+        let probe = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/lying-body.tar.gz")
+                    .header("range", "bytes=0-0");
+                then.status(206)
+                    .header("content-range", format!("bytes 0-0/{CACHE_MAX_SIZE}"))
+                    .body(b"x");
+            })
+            .await;
+        let get = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/lying-body.tar.gz")
+                    .header_missing("range");
+                then.status(200)
+                    .body(vec![b'x'; (CACHE_MAX_SIZE + 1) as usize]);
+            })
+            .await;
+
+        let original = server.url("/lying-body.tar.gz");
+        let name = "lying-body";
+        let version = "v1";
+        let mut manifest = manifest_single_storage(original.clone(), name, version);
+
+        let err = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap_err();
+
+        probe.assert_async().await;
+        get.assert_async().await;
+        assert!(
+            err.to_string().contains("download size mismatch"),
+            "got: {err}"
+        );
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(original.as_str())
+        );
+        assert!(
+            !home
+                .storage_cache_dir(name, version)
+                .join("archive.tar.gz")
+                .exists()
+        );
+        assert!(
+            !telemetry
+                .pending_ops_snapshot()
+                .iter()
+                .any(|(k, _, _)| k == "storage_cache_miss")
+        );
+        assert!(
+            sandbox.write_file("/tmp/sentinel", b"x").await.is_err(),
+            "queued write_file error should remain if archive write was not attempted"
+        );
+    }
+
+    #[tokio::test]
     async fn cached_true_entry_is_not_touched() {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
@@ -798,6 +964,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn oversized_disk_hit_is_evicted_and_revalidated() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+        let server = MockServer::start_async().await;
+        let body = tarball_bytes();
+
+        let name = "oversized-hit";
+        let version = "v1";
+        let cache_dir = home.storage_cache_dir(name, version);
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let archive = std::fs::File::create(cache_dir.join("archive.tar.gz")).unwrap();
+        archive.set_len(CACHE_MAX_SIZE + 1).unwrap();
+
+        let probe = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/revalidated.tar.gz")
+                    .header("range", "bytes=0-0");
+                then.status(206)
+                    .header("content-range", format!("bytes 0-0/{}", body.len()))
+                    .body(b"x");
+            })
+            .await;
+        let get = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/revalidated.tar.gz")
+                    .header_missing("range");
+                then.status(200).body(body.clone());
+            })
+            .await;
+
+        let url = server.url("/revalidated.tar.gz");
+        let mut manifest = manifest_single_storage(url, name, version);
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        probe.assert_async().await;
+        get.assert_async().await;
+        assert_eq!(
+            std::fs::read(home.storage_cache_dir(name, version).join("archive.tar.gz")).unwrap(),
+            body
+        );
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(format!("file://{}", guest_archive_path(name, version)).as_str())
+        );
+        let ops = telemetry.pending_ops_snapshot();
+        assert!(
+            ops.iter().any(|(k, _, _)| k == "storage_cache_miss"),
+            "expected revalidation miss in {ops:?}"
+        );
+        assert!(
+            !ops.iter().any(|(k, _, _)| k == "storage_cache_hit"),
+            "oversized cache file must not be treated as a hit: {ops:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn artifacts_are_cached_too() {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
@@ -878,6 +1107,64 @@ mod tests {
         assert_eq!(s, PathBuf::from("/var/lib/vm0-runner/storages/foo/v1.tmp"));
         // Same parent → atomic rename.
         assert_eq!(s.parent(), d.parent());
+    }
+
+    #[test]
+    fn limited_body_allows_exact_limit() {
+        let mut bytes = Vec::new();
+        let mut downloaded = 0u64;
+
+        let first = append_limited_chunk(&mut bytes, &mut downloaded, b"abcd", 6).unwrap();
+        let second = append_limited_chunk(&mut bytes, &mut downloaded, b"ef", 6).unwrap();
+
+        assert_eq!(first, None);
+        assert_eq!(second, None);
+        assert_eq!(downloaded, 6);
+        assert_eq!(bytes, b"abcdef");
+    }
+
+    #[test]
+    fn limited_body_rejects_one_byte_over_limit() {
+        let mut bytes = Vec::new();
+        let mut downloaded = 0u64;
+
+        let first = append_limited_chunk(&mut bytes, &mut downloaded, b"abcd", 6).unwrap();
+        let second = append_limited_chunk(&mut bytes, &mut downloaded, b"efg", 6).unwrap();
+
+        assert_eq!(first, None);
+        assert_eq!(second, Some(7));
+        assert_eq!(
+            downloaded, 4,
+            "over-limit chunk must not advance downloaded size"
+        );
+        assert_eq!(bytes, b"abcd", "over-limit chunk must not be appended");
+    }
+
+    #[tokio::test]
+    async fn download_rejects_advertised_content_length_over_limit() {
+        let server = MockServer::start_async().await;
+        let get = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/too-long.tar.gz");
+                then.status(200).body(vec![0u8; 7]);
+            })
+            .await;
+        let http = Client::builder().build().unwrap();
+
+        let result = download_tarball(&http, &server.url("/too-long.tar.gz"), 6)
+            .await
+            .unwrap();
+
+        get.assert_async().await;
+        match result {
+            DownloadBody::Complete(bytes) => {
+                panic!(
+                    "content-length over limit should be rejected, read {} bytes",
+                    bytes.len()
+                )
+            }
+            DownloadBody::OverSize { observed_size } => assert_eq!(observed_size, 7),
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -32,6 +32,7 @@ use futures_util::stream::{self, StreamExt};
 use reqwest::Client;
 use sandbox::{ExecRequest, Sandbox};
 use tokio::fs;
+use tokio::io::AsyncReadExt as _;
 use tracing::{debug, warn};
 
 use crate::error::{RunnerError, RunnerResult};
@@ -43,7 +44,7 @@ use crate::types::StorageManifest;
 /// Archive sizes strictly larger than this are passthrough.
 const CACHE_MAX_SIZE: u64 = 8 * 1024 * 1024;
 
-/// Parallel (HEAD / GET / flock / vsock) operations per `populate_cache` call.
+/// Parallel (probe GET / full GET / flock / vsock) operations per `populate_cache` call.
 const CONCURRENCY: usize = 4;
 
 /// Guest stage directory for `file://` archives.
@@ -245,33 +246,23 @@ async fn process_one(
     let archive_path = cache_dir.join("archive.tar.gz");
 
     // 1. Fast path: disk hit. Read the bytes directly and skip the network.
-    //    This also makes the hit path resilient to transient HEAD failures.
+    //    This also makes the hit path resilient to transient probe failures.
     match fs::metadata(&archive_path).await {
         Ok(metadata) if metadata.len() <= CACHE_MAX_SIZE => {
-            let bytes = fs::read(&archive_path).await.map_err(|e| {
-                RunnerError::Internal(format!("read cached {}: {e}", archive_path.display()))
-            })?;
-            touch_mtime(&cache_dir);
-            let guest_path = guest_archive_path(&target.name, &target.version);
-            sandbox.write_file(&guest_path, &bytes).await?;
-            return Ok(TargetOutcome::Hit);
+            match read_cached_archive(&archive_path, CACHE_MAX_SIZE).await? {
+                DownloadBody::Complete(bytes) => {
+                    touch_mtime(&cache_dir);
+                    let guest_path = guest_archive_path(&target.name, &target.version);
+                    sandbox.write_file(&guest_path, &bytes).await?;
+                    return Ok(TargetOutcome::Hit);
+                }
+                DownloadBody::OverSize { observed_size } => {
+                    evict_oversized_cache(target, &cache_dir, observed_size).await?;
+                }
+            }
         }
         Ok(metadata) => {
-            warn!(
-                name = %target.name,
-                version = %target.version,
-                size = metadata.len(),
-                limit = CACHE_MAX_SIZE,
-                "storage_cache: cached archive exceeds size limit, evicting"
-            );
-            if let Err(e) = fs::remove_dir_all(&cache_dir).await
-                && e.kind() != io::ErrorKind::NotFound
-            {
-                return Err(RunnerError::Internal(format!(
-                    "remove oversized cache {}: {e}",
-                    cache_dir.display()
-                )));
-            }
+            evict_oversized_cache(target, &cache_dir, metadata.len()).await?;
         }
         Err(e) if e.kind() == io::ErrorKind::NotFound => {}
         Err(e) => {
@@ -369,8 +360,9 @@ async fn probe_size(http: &Client, url: &str) -> RunnerResult<Option<u64>> {
             .get(header::CONTENT_RANGE)
             .and_then(|v| v.to_str().ok())
             .and_then(parse_content_range_total);
-        // Consume the 1-byte body so the connection returns to the pool.
-        let _ = resp.bytes().await;
+        // Do not drain the body here. Some origins ignore Range while still
+        // returning large bodies, and probe safety matters more than reusing
+        // this connection.
         return Ok(total);
     }
     if status.is_success() {
@@ -380,7 +372,8 @@ async fn probe_size(http: &Client, url: &str) -> RunnerResult<Option<u64>> {
             .get(header::CONTENT_LENGTH)
             .and_then(|v| v.to_str().ok())
             .and_then(|s| s.parse::<u64>().ok());
-        let _ = resp.bytes().await;
+        // Drop the response after headers instead of buffering an ignored
+        // Range response into memory.
         return Ok(total);
     }
     // 4xx / 5xx / 416 / anything else — treat as probe failure.
@@ -439,6 +432,38 @@ async fn download_tarball(http: &Client, url: &str, max_size: u64) -> RunnerResu
     Ok(DownloadBody::Complete(Bytes::from(bytes)))
 }
 
+async fn read_cached_archive(path: &Path, max_size: u64) -> RunnerResult<DownloadBody> {
+    let mut file = fs::File::open(path)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("open cached {}: {e}", path.display())))?;
+    let mut bytes = Vec::with_capacity(max_size.min(64 * 1024) as usize);
+    let mut downloaded = 0u64;
+    let mut buf = [0u8; 64 * 1024];
+
+    loop {
+        let n = file
+            .read(&mut buf)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("read cached {}: {e}", path.display())))?;
+        if n == 0 {
+            break;
+        }
+        let chunk = buf.get(..n).ok_or_else(|| {
+            RunnerError::Internal(format!(
+                "read cached {} produced invalid chunk length {n}",
+                path.display()
+            ))
+        })?;
+        if let Some(observed_size) =
+            append_limited_chunk(&mut bytes, &mut downloaded, chunk, max_size)?
+        {
+            return Ok(DownloadBody::OverSize { observed_size });
+        }
+    }
+
+    Ok(DownloadBody::Complete(Bytes::from(bytes)))
+}
+
 fn append_limited_chunk(
     bytes: &mut Vec<u8>,
     downloaded: &mut u64,
@@ -456,6 +481,29 @@ fn append_limited_chunk(
     bytes.extend_from_slice(chunk);
     *downloaded = next_downloaded;
     Ok(None)
+}
+
+async fn evict_oversized_cache(
+    target: &CacheTarget,
+    cache_dir: &Path,
+    observed_size: u64,
+) -> RunnerResult<()> {
+    warn!(
+        name = %target.name,
+        version = %target.version,
+        size = observed_size,
+        limit = CACHE_MAX_SIZE,
+        "storage_cache: cached archive exceeds size limit, evicting"
+    );
+    if let Err(e) = fs::remove_dir_all(cache_dir).await
+        && e.kind() != io::ErrorKind::NotFound
+    {
+        return Err(RunnerError::Internal(format!(
+            "remove oversized cache {}: {e}",
+            cache_dir.display()
+        )));
+    }
+    Ok(())
 }
 
 async fn write_to_cache(cache_dir: &Path, bytes: &[u8]) -> RunnerResult<()> {
@@ -619,6 +667,8 @@ mod tests {
     use httpmock::prelude::*;
     use sandbox::{SandboxError, SandboxOperation, SandboxOperationReason};
     use sandbox_mock::MockSandbox;
+    use tokio::io::AsyncWriteExt as _;
+    use tokio::net::TcpListener;
 
     use crate::http::HttpClient;
     use crate::ids::RunId;
@@ -658,6 +708,21 @@ mod tests {
             reason: SandboxOperationReason::Guest,
             message: message.into(),
         }
+    }
+
+    async fn raw_http_url(
+        response: Vec<u8>,
+    ) -> (String, tokio::task::JoinHandle<std::io::Result<()>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await?;
+            let mut request = [0u8; 1024];
+            let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
+            socket.write_all(&response).await?;
+            Ok(())
+        });
+        (format!("http://{addr}/archive.tar.gz"), handle)
     }
 
     #[tokio::test]
@@ -1100,6 +1165,41 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn probe_200_ignored_range_uses_content_length_without_reading_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let advertised_size = CACHE_MAX_SIZE + 1;
+
+        let server_task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await?;
+            let mut request = [0u8; 1024];
+            let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
+            socket
+                .write_all(
+                    format!("HTTP/1.1 200 OK\r\nContent-Length: {advertised_size}\r\n\r\n")
+                        .as_bytes(),
+                )
+                .await?;
+            let _ = release_rx.await;
+            Ok::<(), std::io::Error>(())
+        });
+
+        let http = Client::builder().build().unwrap();
+        let result = tokio::time::timeout(
+            HEAD_TIMEOUT + Duration::from_secs(1),
+            probe_size(&http, &format!("http://{addr}/range-ignored.tar.gz")),
+        )
+        .await
+        .expect("probe must return after headers without waiting for the body")
+        .unwrap();
+
+        let _ = release_tx.send(());
+        server_task.await.unwrap().unwrap();
+        assert_eq!(result, Some(advertised_size));
+    }
+
     #[test]
     fn staging_dir_is_sibling() {
         let d = PathBuf::from("/var/lib/vm0-runner/storages/foo/v1");
@@ -1160,6 +1260,48 @@ mod tests {
             DownloadBody::Complete(bytes) => {
                 panic!(
                     "content-length over limit should be rejected, read {} bytes",
+                    bytes.len()
+                )
+            }
+            DownloadBody::OverSize { observed_size } => assert_eq!(observed_size, 7),
+        }
+    }
+
+    #[tokio::test]
+    async fn download_rejects_stream_without_content_length_over_limit() {
+        let (url, server_task) = raw_http_url(
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n4\r\nabcd\r\n3\r\nefg\r\n0\r\n\r\n"
+                .to_vec(),
+        )
+        .await;
+        let http = Client::builder().build().unwrap();
+
+        let result = download_tarball(&http, &url, 6).await.unwrap();
+        server_task.await.unwrap().unwrap();
+
+        match result {
+            DownloadBody::Complete(bytes) => {
+                panic!(
+                    "stream over limit should be rejected, read {} bytes",
+                    bytes.len()
+                )
+            }
+            DownloadBody::OverSize { observed_size } => assert_eq!(observed_size, 7),
+        }
+    }
+
+    #[tokio::test]
+    async fn cached_archive_read_rejects_one_byte_over_limit() {
+        let temp = tempfile::tempdir().unwrap();
+        let archive_path = temp.path().join("archive.tar.gz");
+        fs::write(&archive_path, b"abcdefg").await.unwrap();
+
+        let result = read_cached_archive(&archive_path, 6).await.unwrap();
+
+        match result {
+            DownloadBody::Complete(bytes) => {
+                panic!(
+                    "cached file over limit should be rejected, read {} bytes",
                     bytes.len()
                 )
             }


### PR DESCRIPTION
## Summary

- stream runner storage cache downloads with a hard size cap instead of buffering full responses
- fail closed when a cache-eligible probe is contradicted by an oversized full GET
- evict oversized existing cache files before reading them into memory
- add regression coverage for mismatch, content-length, chunk boundaries, and oversized disk hits

Fixes #10993

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner storage_cache`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
