### PR TITLE
fix: increase release-please commit batch size from 10 to 100

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,7 @@
         {"type": "build", "hidden": true},
         {"type": "revert", "hidden": true}
     ],
+    "commit-batch-size": 100,
     "packages": {
         "turbo/packages/core": {
             "release-type": "node"


### PR DESCRIPTION
## Summary
- Adds `"commit-batch-size": 100` to `release-please-config.json`
- Reduces GraphQL API calls during release diffing by **10x** (from 29+ to 3)
- The upstream default of 10 puts unnecessary load on GitHub's API and increases the chance of hitting rate limits or transient errors

## Why
`release-please` uses a GraphQL query to walk the main branch history and find commits since the last release. The default `commitBatchSize` is **10**, meaning each API call fetches only 10 commits. GitHub's GraphQL API supports up to **100** nodes per page.

With 21 monorepo components, the oldest release can be ~290 commits behind HEAD, resulting in 29+ serial API calls instead of 3. This caused [run 24992258231](https://github.com/vm0-ai/vm0/actions/runs/24992258231) to fail when the GitHub API returned an internal error after 279+ pagination requests.

## Test plan
- [x] Valid JSON syntax
- [ ] Verify next release-please run completes with fewer API calls (cursor log should show jumps of ~100 instead of ~10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)