### PR TITLE
feat: include usage events in usage reporting

### DIFF
--- a/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   createTestRequest,
   insertTestCreditUsage,
+  insertTestUsageEvent,
   updateOrgStripeFields,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
@@ -224,5 +225,181 @@ describe("GET /api/zero/usage/members", () => {
     expect(data.members).toHaveLength(1);
     expect(data.members[0].inputTokens).toBe(1000);
     expect(data.members[0].creditsCharged).toBe(50);
+  });
+
+  it("includes processed usage_event records in member totals", async () => {
+    const { userId, orgId } = await context.user;
+    const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus"),
+      stripeSubscriptionId: uniqueId("sub"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+      tier: "pro",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheReadInputTokens: 200,
+      cacheCreationInputTokens: 100,
+      creditsCharged: 50,
+      status: "processed",
+    });
+
+    await insertTestUsageEvent(orgId, {
+      userId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.input",
+      quantity: 300,
+      creditsCharged: 30,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.output",
+      quantity: 120,
+      creditsCharged: 12,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.cache_read",
+      quantity: 80,
+      creditsCharged: 8,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.cache_creation",
+      quantity: 40,
+      creditsCharged: 4,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 20,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.input",
+      quantity: 9999,
+      creditsCharged: 999,
+      status: "pending",
+    });
+
+    const eventOnlyUserId = uniqueId("event-only-user");
+    await insertTestUsageEvent(orgId, {
+      userId: eventOnlyUserId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 200,
+      status: "processed",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/members",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.members).toHaveLength(2);
+
+    const mixedMember = data.members.find((member: { userId: string }) => {
+      return member.userId === userId;
+    });
+    expect(mixedMember).toMatchObject({
+      inputTokens: 1300,
+      outputTokens: 620,
+      cacheReadInputTokens: 280,
+      cacheCreationInputTokens: 140,
+      creditsCharged: 124,
+    });
+
+    const eventOnlyMember = data.members.find((member: { userId: string }) => {
+      return member.userId === eventOnlyUserId;
+    });
+    expect(eventOnlyMember).toMatchObject({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      creditsCharged: 200,
+    });
+  });
+
+  it("uses processedAt for billing-period membership", async () => {
+    const { userId, orgId } = await context.user;
+    const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const periodStart = new Date(periodEnd);
+    periodStart.setMonth(periodStart.getMonth() - 1);
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus"),
+      stripeSubscriptionId: uniqueId("sub"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+      tier: "pro",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      inputTokens: 10,
+      outputTokens: 5,
+      creditsCharged: 10,
+      status: "processed",
+      processedAt: periodStart,
+    });
+    await insertTestCreditUsage(orgId, {
+      userId,
+      inputTokens: 999,
+      outputTokens: 999,
+      creditsCharged: 999,
+      status: "processed",
+      processedAt: periodEnd,
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.input",
+      quantity: 999,
+      creditsCharged: 999,
+      status: "processed",
+      processedAt: periodEnd,
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/members",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.members).toHaveLength(1);
+    expect(data.members[0]).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 5,
+      creditsCharged: 10,
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/usage/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/runs/__tests__/route.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
+  createCompletedRun,
   createTestRequest,
   insertTestCreditUsage,
+  insertTestCreditUsageForRun,
+  insertTestUsageEvent,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -199,5 +202,142 @@ describe("GET /api/zero/usage/runs", () => {
     // Only the processed run should appear
     expect(data.runs).toHaveLength(1);
     expect(data.runs[0].creditsCharged).toBe(50);
+  });
+
+  it("returns run-linked usage_event records and excludes runless events", async () => {
+    const { userId, orgId } = await context.user;
+    const runId = await createCompletedRun(orgId, userId, new Date());
+
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.input",
+      quantity: 300,
+      creditsCharged: 30,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 20,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 999,
+      status: "processed",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/runs",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.runs).toHaveLength(1);
+    expect(data.pagination.total).toBe(1);
+    expect(data.runs[0]).toMatchObject({
+      runId,
+      model: "claude-sonnet-4-6",
+      inputTokens: 300,
+      outputTokens: 0,
+      cacheTokens: 0,
+      creditsCharged: 50,
+    });
+  });
+
+  it("combines credit_usage and usage_event totals for the same run", async () => {
+    const { userId, orgId } = await context.user;
+    const runId = await createCompletedRun(orgId, userId, new Date());
+
+    await insertTestCreditUsageForRun({
+      runId,
+      orgId,
+      userId,
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadInputTokens: 20,
+      cacheCreationInputTokens: 10,
+      creditsCharged: 40,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.input",
+      quantity: 30,
+      creditsCharged: 3,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.output",
+      quantity: 70,
+      creditsCharged: 7,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.cache_read",
+      quantity: 11,
+      creditsCharged: 1,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.cache_creation",
+      quantity: 13,
+      creditsCharged: 2,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.input",
+      quantity: 9999,
+      creditsCharged: 999,
+      status: "pending",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/runs",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.runs).toHaveLength(1);
+    expect(data.pagination.total).toBe(1);
+    expect(data.runs[0]).toMatchObject({
+      runId,
+      inputTokens: 130,
+      outputTokens: 120,
+      cacheTokens: 54,
+      creditsCharged: 53,
+    });
   });
 });

--- a/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
@@ -256,6 +256,7 @@ export async function insertTestUsageEvent(
     quantity?: number;
     status?: string;
     creditsCharged?: number;
+    runId?: string | null;
     idempotencyKey?: string;
     processedAt?: Date | null;
   },
@@ -271,6 +272,7 @@ export async function insertTestUsageEvent(
   const [record] = await globalThis.services.db
     .insert(usageEvent)
     .values({
+      runId: options.runId ?? null,
       orgId,
       userId: options.userId ?? "test-user",
       kind: options.kind ?? "connector",

--- a/turbo/apps/web/src/lib/zero/billing/usage-reporting-ledger.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-reporting-ledger.ts
@@ -1,6 +1,13 @@
-import { and, eq, gte, lt, sql } from "drizzle-orm";
+import { and, eq, gte, isNotNull, lt, or, sql } from "drizzle-orm";
 import { creditUsage } from "@vm0/db/schema/credit-usage";
+import { usageEvent } from "@vm0/db/schema/usage-event";
 import type { Database } from "../../../types/global";
+
+const MODEL_USAGE_KIND = "model";
+const TOKEN_CATEGORY_INPUT = "tokens.input";
+const TOKEN_CATEGORY_OUTPUT = "tokens.output";
+const TOKEN_CATEGORY_CACHE_READ = "tokens.cache_read";
+const TOKEN_CATEGORY_CACHE_CREATION = "tokens.cache_creation";
 
 interface UsagePeriod {
   start: Date;
@@ -20,6 +27,8 @@ interface UsageRunTotalsRow {
   runId: string | null;
   inputTokens: number;
   outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
   cacheTokens: number;
   creditsCharged: number;
   model: string | null;
@@ -27,12 +36,23 @@ interface UsageRunTotalsRow {
 }
 
 /**
- * Legacy reporting aggregate for member usage.
- *
- * Uses credit_usage.created_at to preserve current reporting semantics. The
- * usage_event follow-up should extend this boundary without changing callers.
+ * Reporting aggregate for member usage across the legacy and usage_event
+ * ledgers. Uses processed_at so reporting follows the posted ledger time.
  */
-export async function getLegacyMemberUsageTotals(
+export async function getMemberUsageTotals(
+  db: Database,
+  orgId: string,
+  period: UsagePeriod,
+): Promise<UsageMemberTotalsRow[]> {
+  const [creditRows, eventRows] = await Promise.all([
+    getLegacyMemberUsageTotals(db, orgId, period),
+    getUsageEventMemberUsageTotals(db, orgId, period),
+  ]);
+
+  return mergeMemberTotals([...creditRows, ...eventRows]);
+}
+
+function getLegacyMemberUsageTotals(
   db: Database,
   orgId: string,
   period: UsagePeriod,
@@ -68,11 +88,77 @@ export async function getLegacyMemberUsageTotals(
       and(
         eq(creditUsage.orgId, orgId),
         eq(creditUsage.status, "processed"),
-        gte(creditUsage.createdAt, period.start),
-        lt(creditUsage.createdAt, period.end),
+        gte(creditUsage.processedAt, period.start),
+        lt(creditUsage.processedAt, period.end),
       ),
     )
     .groupBy(creditUsage.userId);
+}
+
+function getUsageEventMemberUsageTotals(
+  db: Database,
+  orgId: string,
+  period: UsagePeriod,
+): Promise<UsageMemberTotalsRow[]> {
+  const totalsSelect = {
+    userId: usageEvent.userId,
+    inputTokens: usageEventTokenSum(TOKEN_CATEGORY_INPUT, "input_tokens"),
+    outputTokens: usageEventTokenSum(TOKEN_CATEGORY_OUTPUT, "output_tokens"),
+    cacheReadInputTokens: usageEventTokenSum(
+      TOKEN_CATEGORY_CACHE_READ,
+      "cache_read_input_tokens",
+    ),
+    cacheCreationInputTokens: usageEventTokenSum(
+      TOKEN_CATEGORY_CACHE_CREATION,
+      "cache_creation_input_tokens",
+    ),
+    creditsCharged:
+      sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
+        "credits_charged",
+      ),
+  } satisfies Record<keyof UsageMemberTotalsRow, unknown>;
+
+  return db
+    .select(totalsSelect)
+    .from(usageEvent)
+    .where(
+      and(
+        eq(usageEvent.orgId, orgId),
+        eq(usageEvent.status, "processed"),
+        gte(usageEvent.processedAt, period.start),
+        lt(usageEvent.processedAt, period.end),
+      ),
+    )
+    .groupBy(usageEvent.userId);
+}
+
+function mergeMemberTotals(
+  rows: UsageMemberTotalsRow[],
+): UsageMemberTotalsRow[] {
+  const totalsByUser = new Map<string, UsageMemberTotalsRow>();
+
+  for (const row of rows) {
+    const current = totalsByUser.get(row.userId);
+    if (!current) {
+      totalsByUser.set(row.userId, {
+        userId: row.userId,
+        inputTokens: Number(row.inputTokens),
+        outputTokens: Number(row.outputTokens),
+        cacheReadInputTokens: Number(row.cacheReadInputTokens),
+        cacheCreationInputTokens: Number(row.cacheCreationInputTokens),
+        creditsCharged: Number(row.creditsCharged),
+      });
+      continue;
+    }
+
+    current.inputTokens += Number(row.inputTokens);
+    current.outputTokens += Number(row.outputTokens);
+    current.cacheReadInputTokens += Number(row.cacheReadInputTokens);
+    current.cacheCreationInputTokens += Number(row.cacheCreationInputTokens);
+    current.creditsCharged += Number(row.creditsCharged);
+  }
+
+  return [...totalsByUser.values()];
 }
 
 /**
@@ -86,21 +172,29 @@ export function buildLegacyRunUsageTotalsSubquery(db: Database, orgId: string) {
     runId: creditUsage.runId,
     inputTokens:
       sql<number>`COALESCE(SUM(${creditUsage.inputTokens}), 0)::bigint`.as(
-        "input_tokens_sum",
+        "legacy_input_tokens_sum",
       ),
     outputTokens:
       sql<number>`COALESCE(SUM(${creditUsage.outputTokens}), 0)::bigint`.as(
-        "output_tokens_sum",
+        "legacy_output_tokens_sum",
+      ),
+    cacheReadInputTokens:
+      sql<number>`COALESCE(SUM(${creditUsage.cacheReadInputTokens}), 0)::bigint`.as(
+        "legacy_cache_read_input_tokens_sum",
+      ),
+    cacheCreationInputTokens:
+      sql<number>`COALESCE(SUM(${creditUsage.cacheCreationInputTokens}), 0)::bigint`.as(
+        "legacy_cache_creation_input_tokens_sum",
       ),
     cacheTokens:
       sql<number>`COALESCE(SUM(${creditUsage.cacheReadInputTokens}) + SUM(${creditUsage.cacheCreationInputTokens}), 0)::bigint`.as(
-        "cache_tokens_sum",
+        "legacy_cache_tokens_sum",
       ),
     creditsCharged:
       sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
-        "credits_sum",
+        "legacy_credits_sum",
       ),
-    model: sql<string>`MAX(${creditUsage.model})`.as("model"),
+    model: sql<string>`MAX(${creditUsage.model})`.as("legacy_model"),
     userId: sql<string>`MAX(${creditUsage.userId})`.as("cu_user_id"),
   } satisfies Record<keyof UsageRunTotalsRow, unknown>;
 
@@ -112,4 +206,122 @@ export function buildLegacyRunUsageTotalsSubquery(db: Database, orgId: string) {
     )
     .groupBy(creditUsage.runId)
     .as("legacy_run_usage_totals");
+}
+
+export function buildUsageEventRunUsageTotalsSubquery(
+  db: Database,
+  orgId: string,
+) {
+  const totalsSelect = {
+    runId: usageEvent.runId,
+    inputTokens: usageEventTokenSum(
+      TOKEN_CATEGORY_INPUT,
+      "event_input_tokens_sum",
+    ),
+    outputTokens: usageEventTokenSum(
+      TOKEN_CATEGORY_OUTPUT,
+      "event_output_tokens_sum",
+    ),
+    cacheReadInputTokens: usageEventTokenSum(
+      TOKEN_CATEGORY_CACHE_READ,
+      "event_cache_read_input_tokens_sum",
+    ),
+    cacheCreationInputTokens: usageEventTokenSum(
+      TOKEN_CATEGORY_CACHE_CREATION,
+      "event_cache_creation_input_tokens_sum",
+    ),
+    cacheTokens:
+      sql<number>`COALESCE(SUM(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} AND ${usageEvent.category} IN (${TOKEN_CATEGORY_CACHE_READ}, ${TOKEN_CATEGORY_CACHE_CREATION}) THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`.as(
+        "event_cache_tokens_sum",
+      ),
+    creditsCharged:
+      sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
+        "event_credits_sum",
+      ),
+    model: sql<
+      string | null
+    >`MAX(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} THEN ${usageEvent.provider} ELSE NULL END)`.as(
+      "event_model",
+    ),
+    userId: sql<string>`MAX(${usageEvent.userId})`.as("ue_user_id"),
+  } satisfies Record<keyof UsageRunTotalsRow, unknown>;
+
+  return db
+    .select(totalsSelect)
+    .from(usageEvent)
+    .where(
+      and(
+        eq(usageEvent.orgId, orgId),
+        eq(usageEvent.status, "processed"),
+        isNotNull(usageEvent.runId),
+      ),
+    )
+    .groupBy(usageEvent.runId)
+    .as("usage_event_run_usage_totals");
+}
+
+export function hasRunUsageTotals(
+  legacy: ReturnType<typeof buildLegacyRunUsageTotalsSubquery>,
+  events: ReturnType<typeof buildUsageEventRunUsageTotalsSubquery>,
+) {
+  return or(isNotNull(legacy.runId), isNotNull(events.runId));
+}
+
+export function mergedRunInputTokens(
+  legacy: ReturnType<typeof buildLegacyRunUsageTotalsSubquery>,
+  events: ReturnType<typeof buildUsageEventRunUsageTotalsSubquery>,
+) {
+  return sumNullableLedgerColumns(legacy.inputTokens, events.inputTokens).as(
+    "input_tokens",
+  );
+}
+
+export function mergedRunOutputTokens(
+  legacy: ReturnType<typeof buildLegacyRunUsageTotalsSubquery>,
+  events: ReturnType<typeof buildUsageEventRunUsageTotalsSubquery>,
+) {
+  return sumNullableLedgerColumns(legacy.outputTokens, events.outputTokens).as(
+    "output_tokens",
+  );
+}
+
+export function mergedRunCacheTokens(
+  legacy: ReturnType<typeof buildLegacyRunUsageTotalsSubquery>,
+  events: ReturnType<typeof buildUsageEventRunUsageTotalsSubquery>,
+) {
+  return sumNullableLedgerColumns(legacy.cacheTokens, events.cacheTokens).as(
+    "cache_tokens",
+  );
+}
+
+export function mergedRunCreditsCharged(
+  legacy: ReturnType<typeof buildLegacyRunUsageTotalsSubquery>,
+  events: ReturnType<typeof buildUsageEventRunUsageTotalsSubquery>,
+) {
+  return sumNullableLedgerColumns(
+    legacy.creditsCharged,
+    events.creditsCharged,
+  ).as("credits_charged");
+}
+
+export function mergedRunModel(
+  legacy: ReturnType<typeof buildLegacyRunUsageTotalsSubquery>,
+  events: ReturnType<typeof buildUsageEventRunUsageTotalsSubquery>,
+) {
+  return sql<string | null>`COALESCE(${legacy.model}, ${events.model})`.as(
+    "model",
+  );
+}
+
+function usageEventTokenSum(category: string, alias: string) {
+  return sql<number>`COALESCE(SUM(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} AND ${usageEvent.category} = ${category} THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`.as(
+    alias,
+  );
+}
+
+function sumNullableLedgerColumns(
+  left: unknown,
+  right: unknown,
+): ReturnType<typeof sql<number>> {
+  return sql<number>`COALESCE(${left}, 0) + COALESCE(${right}, 0)`;
 }

--- a/turbo/apps/web/src/lib/zero/billing/usage-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-service.ts
@@ -17,12 +17,19 @@ import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { clerkClient } from "@clerk/nextjs/server";
 import {
   buildLegacyRunUsageTotalsSubquery,
-  getLegacyMemberUsageTotals,
+  buildUsageEventRunUsageTotalsSubquery,
+  getMemberUsageTotals,
+  hasRunUsageTotals,
+  mergedRunCacheTokens,
+  mergedRunCreditsCharged,
+  mergedRunInputTokens,
+  mergedRunModel,
+  mergedRunOutputTokens,
 } from "./usage-reporting-ledger";
 
 /**
  * Get per-member token usage aggregation for the current billing period.
- * Only includes credit_usage records with status = 'processed'.
+ * Includes processed credit_usage and usage_event records.
  * Free tier orgs (no billing period) get { period: null, members: [] }.
  */
 export async function getUsageMembers(
@@ -36,7 +43,7 @@ export async function getUsageMembers(
 
   const db = globalThis.services.db;
 
-  const rows = await getLegacyMemberUsageTotals(db, orgId, billingPeriod);
+  const rows = await getMemberUsageTotals(db, orgId, billingPeriod);
 
   if (rows.length === 0) {
     return {
@@ -161,8 +168,8 @@ interface UsageRunsOptions {
 }
 
 /**
- * Get per-run credit usage records for an org with pagination and filtering.
- * Only includes runs that have processed credit_usage records.
+ * Get per-run usage records for an org with pagination and filtering.
+ * Includes runs with processed credit_usage or run-linked usage_event records.
  */
 export async function getUsageRuns(
   orgId: string,
@@ -170,7 +177,8 @@ export async function getUsageRuns(
 ): Promise<UsageRunsResponse> {
   const db = globalThis.services.db;
 
-  const creditSub = buildLegacyRunUsageTotalsSubquery(db, orgId);
+  const legacyUsage = buildLegacyRunUsageTotalsSubquery(db, orgId);
+  const eventUsage = buildUsageEventRunUsageTotalsSubquery(db, orgId);
 
   // Build filter conditions
   const conditions = [eq(agentRuns.orgId, orgId)];
@@ -192,7 +200,8 @@ export async function getUsageRuns(
   const [countResult] = await db
     .select({ total: count() })
     .from(agentRuns)
-    .innerJoin(creditSub, eq(agentRuns.id, creditSub.runId))
+    .leftJoin(legacyUsage, eq(agentRuns.id, legacyUsage.runId))
+    .leftJoin(eventUsage, eq(agentRuns.id, eventUsage.runId))
     .leftJoin(
       agentComposeVersions,
       eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
@@ -201,7 +210,7 @@ export async function getUsageRuns(
       agentComposes,
       eq(agentComposeVersions.composeId, agentComposes.id),
     )
-    .where(and(...conditions));
+    .where(and(...conditions, hasRunUsageTotals(legacyUsage, eventUsage)));
 
   const total = countResult?.total ?? 0;
 
@@ -219,14 +228,15 @@ export async function getUsageRuns(
       prompt: agentRuns.prompt,
       triggerSource: zeroRuns.triggerSource,
       agentName: zeroAgents.displayName,
-      inputTokens: creditSub.inputTokens,
-      outputTokens: creditSub.outputTokens,
-      cacheTokens: creditSub.cacheTokens,
-      creditsCharged: creditSub.creditsCharged,
-      model: creditSub.model,
+      inputTokens: mergedRunInputTokens(legacyUsage, eventUsage),
+      outputTokens: mergedRunOutputTokens(legacyUsage, eventUsage),
+      cacheTokens: mergedRunCacheTokens(legacyUsage, eventUsage),
+      creditsCharged: mergedRunCreditsCharged(legacyUsage, eventUsage),
+      model: mergedRunModel(legacyUsage, eventUsage),
     })
     .from(agentRuns)
-    .innerJoin(creditSub, eq(agentRuns.id, creditSub.runId))
+    .leftJoin(legacyUsage, eq(agentRuns.id, legacyUsage.runId))
+    .leftJoin(eventUsage, eq(agentRuns.id, eventUsage.runId))
     .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
     .leftJoin(
       agentComposeVersions,
@@ -237,7 +247,7 @@ export async function getUsageRuns(
       eq(agentComposeVersions.composeId, agentComposes.id),
     )
     .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
-    .where(and(...conditions))
+    .where(and(...conditions, hasRunUsageTotals(legacyUsage, eventUsage)))
     .orderBy(desc(agentRuns.createdAt))
     .limit(options.pageSize)
     .offset(offset);


### PR DESCRIPTION
## Summary

- Include processed `usage_event` rows in `/api/zero/usage/members` totals
- Include run-linked processed `usage_event` rows in `/api/zero/usage/runs`
- Map model token event categories into existing token counters while keeping connector/image events credit-only
- Use `processedAt` for member billing-period ledger windows

Related: #11198
Closes #11260

## Test plan

- [x] `pnpm --dir turbo --filter web test app/api/zero/usage/members/__tests__/route.test.ts app/api/zero/usage/runs/__tests__/route.test.ts`
- [x] `pnpm --dir turbo --filter web check-types`
- [x] `pnpm --dir turbo --filter web lint`
- [x] `git diff --check`
- [x] pre-commit: prettier, knip, turbo check-types