### PR TITLE
fix(api): align auth resolution with web app for shadow comparison

### DIFF
--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -64,7 +64,10 @@ const cliAuth$ = command(
       signal,
     );
     if (!membership) {
-      return null;
+      return {
+        tokenType: "pat",
+        userId: resolved.userId,
+      };
     }
 
     return {
@@ -179,23 +182,23 @@ const resolvedAuthContext$ = command(
 
     if (isPatToken(token)) {
       const cliAuth = verifyCliToken(token);
-      if (!cliAuth) {
-        return null;
+      if (cliAuth) {
+        return await set(cliAuth$, cliAuth, signal);
       }
-
-      return await set(cliAuth$, cliAuth, signal);
-    }
-
-    if (isSandboxToken(token)) {
+    } else if (isSandboxToken(token)) {
       const cliAuth = verifyCliToken(token);
       if (!cliAuth) {
-        return await set(sandboxTokenAuth$, token, options, signal);
+        const result = await set(sandboxTokenAuth$, token, options, signal);
+        if (result) {
+          return result;
+        }
+      } else {
+        return await set(cliAuth$, cliAuth, signal);
       }
-
-      return await set(cliAuth$, cliAuth, signal);
     }
 
-    return null;
+    // Bearer token verification failed — fall through to Clerk session auth
+    return await get(clerkSessionAuth$);
   },
 );
 

--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -183,7 +183,10 @@ const resolvedAuthContext$ = command(
     if (isPatToken(token)) {
       const cliAuth = verifyCliToken(token);
       if (cliAuth) {
-        return await set(cliAuth$, cliAuth, signal);
+        const result = await set(cliAuth$, cliAuth, signal);
+        if (result) {
+          return result;
+        }
       }
     } else if (isSandboxToken(token)) {
       const cliAuth = verifyCliToken(token);
@@ -193,7 +196,10 @@ const resolvedAuthContext$ = command(
           return result;
         }
       } else {
-        return await set(cliAuth$, cliAuth, signal);
+        const result = await set(cliAuth$, cliAuth, signal);
+        if (result) {
+          return result;
+        }
       }
     }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
@@ -130,6 +130,15 @@ describe("GET /health/auth", () => {
     }
   });
 
+  beforeEach(() => {
+    // Default: Clerk session not authenticated, no org memberships
+    context.mocks.clerk.authenticateRequest.mockReset();
+    context.mocks.clerk.users.getOrganizationMembershipList.mockReset();
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+  });
+
   describe("Clerk session", () => {
     it("resolves admin Clerk session from a cookie", async () => {
       context.mocks.clerk.authenticateRequest.mockResolvedValue({
@@ -298,7 +307,7 @@ describe("GET /health/auth", () => {
       expect(response.body.error.code).toBe("UNAUTHORIZED");
     });
 
-    it("returns 401 when the PAT user is not a member of the org", async () => {
+    it("resolves PAT without orgRole when the user is not a member of the org", async () => {
       const fixture = await seedPatFixture({ seedMembership: false });
       fixtures.push(fixture);
       context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue(
@@ -310,10 +319,13 @@ describe("GET /health/auth", () => {
         client.check({
           headers: { authorization: `Bearer ${fixture.token}` },
         }),
-        [401],
+        [200],
       );
 
-      expect(response.body.error.code).toBe("UNAUTHORIZED");
+      expect(response.body).toEqual({
+        tokenType: "pat",
+        userId: fixture.userId,
+      });
     });
   });
 
@@ -401,7 +413,7 @@ describe("GET /health/auth", () => {
       expect(cached?.role).toBe("admin");
     });
 
-    it("removes a stale cache row when Clerk reports no membership", async () => {
+    it("removes a stale cache row when Clerk reports no membership and resolves without orgRole", async () => {
       const fixture = await seedPatFixture({
         role: "admin",
         cachedAtMs: now() - 5 * 60_000,
@@ -416,9 +428,12 @@ describe("GET /health/auth", () => {
         client.check({
           headers: { authorization: `Bearer ${fixture.token}` },
         }),
-        [401],
+        [200],
       );
-      expect(first.body.error.code).toBe("UNAUTHORIZED");
+      expect(first.body).toEqual({
+        tokenType: "pat",
+        userId: fixture.userId,
+      });
 
       const writeDb = store.set(writeDb$);
       const remaining = await writeDb
@@ -551,6 +566,108 @@ describe("GET /health/auth", () => {
         capabilities: ["file:read"],
         tokenType: "zero",
       });
+    });
+  });
+
+  describe("Clerk session fallback for Bearer requests", () => {
+    it("falls through to Clerk session when PAT tokenId is not in DB but cookie is present", async () => {
+      const tokenId = randomUUID();
+      const userId = `user_${randomUUID()}`;
+      const nowSeconds = currentSecond();
+      const token = signPatJwtForTests({
+        scope: "cli",
+        userId,
+        orgId: `org_${randomUUID()}`,
+        tokenId,
+        iat: nowSeconds,
+        exp: nowSeconds + 60,
+      });
+      context.mocks.clerk.authenticateRequest.mockResolvedValue({
+        isAuthenticated: true,
+        toAuth: () => {
+          return {
+            userId: "user_cookie_fallback",
+            orgId: "org_cookie_fallback",
+            orgRole: "org:admin",
+          };
+        },
+      });
+
+      const client = setupApp({ context })(healthAuthProbeContract);
+      const response = await accept(
+        client.check({
+          headers: {
+            authorization: `Bearer ${token}`,
+            cookie: "__session=valid-session",
+          },
+        }),
+        [200],
+      );
+
+      expect(response.body).toEqual({
+        tokenType: "session",
+        userId: "user_cookie_fallback",
+        orgId: "org_cookie_fallback",
+        orgRole: "admin",
+      });
+    });
+
+    it("falls through to Clerk session for unknown Bearer shapes when cookie is present", async () => {
+      context.mocks.clerk.authenticateRequest.mockResolvedValue({
+        isAuthenticated: true,
+        toAuth: () => {
+          return {
+            userId: "user_unknown_shape",
+            orgId: "org_unknown_shape",
+            orgRole: "org:member",
+          };
+        },
+      });
+
+      const client = setupApp({ context })(healthAuthProbeContract);
+      const response = await accept(
+        client.check({
+          headers: {
+            authorization: "Bearer some-unknown-token-format",
+            cookie: "__session=valid-session",
+          },
+        }),
+        [200],
+      );
+
+      expect(response.body).toEqual({
+        tokenType: "session",
+        userId: "user_unknown_shape",
+        orgId: "org_unknown_shape",
+        orgRole: "member",
+      });
+    });
+
+    it("returns 401 when invalid PAT and no cookie", async () => {
+      const tokenId = randomUUID();
+      const userId = `user_${randomUUID()}`;
+      const nowSeconds = currentSecond();
+      const token = signPatJwtForTests({
+        scope: "cli",
+        userId,
+        orgId: `org_${randomUUID()}`,
+        tokenId,
+        iat: nowSeconds,
+        exp: nowSeconds + 60,
+      });
+      context.mocks.clerk.authenticateRequest.mockResolvedValue({
+        isAuthenticated: false,
+      });
+
+      const client = setupApp({ context })(healthAuthProbeContract);
+      const response = await accept(
+        client.check({
+          headers: { authorization: `Bearer ${token}` },
+        }),
+        [401],
+      );
+
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
     });
   });
 

--- a/turbo/apps/api/src/types/auth.ts
+++ b/turbo/apps/api/src/types/auth.ts
@@ -16,12 +16,19 @@ type SessionAuthContext =
       readonly orgRole?: undefined;
     };
 
-interface PatAuthContext {
-  readonly tokenType: "pat";
-  readonly userId: string;
-  readonly orgId: string;
-  readonly orgRole: ApiOrgRole;
-}
+type PatAuthContext =
+  | {
+      readonly tokenType: "pat";
+      readonly userId: string;
+      readonly orgId: string;
+      readonly orgRole: ApiOrgRole;
+    }
+  | {
+      readonly tokenType: "pat";
+      readonly userId: string;
+      readonly orgId?: undefined;
+      readonly orgRole?: undefined;
+    };
 
 interface SandboxAuthContext {
   readonly tokenType: "sandbox";

--- a/turbo/apps/web/src/lib/auth/require-auth.ts
+++ b/turbo/apps/web/src/lib/auth/require-auth.ts
@@ -19,10 +19,11 @@ type AuthErrorResponse = {
 function scheduleShadowCheck(
   result: AuthContext | AuthErrorResponse,
   authHeader: string | undefined,
+  cookieHeader?: string,
 ): void {
   try {
     after(async () => {
-      await shadowCompareAuth(result, { authHeader });
+      await shadowCompareAuth(result, { authHeader, cookieHeader });
     });
   } catch {
     // Outside a Next.js request scope (e.g. unit tests) — skip silently.
@@ -40,12 +41,14 @@ export async function requireAuth(
   options?: {
     requiredCapability?: ZeroCapability;
     acceptAnySandboxCapability?: boolean;
+    cookieHeader?: string;
   },
 ): Promise<AuthContext | AuthErrorResponse> {
+  const cookieHeader = options?.cookieHeader;
   const authCtx = await getAuthContext(authHeader, options);
 
   if (authCtx) {
-    scheduleShadowCheck(authCtx, authHeader);
+    scheduleShadowCheck(authCtx, authHeader, cookieHeader);
     return authCtx;
   }
 
@@ -73,7 +76,7 @@ export async function requireAuth(
                 },
               },
             };
-        scheduleShadowCheck(capabilityErr, authHeader);
+        scheduleShadowCheck(capabilityErr, authHeader, cookieHeader);
         return capabilityErr;
       }
     }
@@ -86,7 +89,7 @@ export async function requireAuth(
       error: { message: "Not authenticated", code: "UNAUTHORIZED" },
     },
   };
-  scheduleShadowCheck(unauthorized, authHeader);
+  scheduleShadowCheck(unauthorized, authHeader, cookieHeader);
   return unauthorized;
 }
 
@@ -116,6 +119,7 @@ export function isAuthError(
  */
 export async function requireApiKeyAuth(
   authHeader: string | undefined,
+  cookieHeader?: string,
 ): Promise<AuthContext | AuthErrorResponse> {
   const unauthorized: AuthErrorResponse = {
     status: 401 as const,
@@ -124,19 +128,19 @@ export async function requireApiKeyAuth(
     },
   };
   if (!authHeader?.startsWith("Bearer ")) {
-    scheduleShadowCheck(unauthorized, authHeader);
+    scheduleShadowCheck(unauthorized, authHeader, cookieHeader);
     return unauthorized;
   }
   const token = authHeader.substring(7);
   if (!isPatToken(token)) {
-    scheduleShadowCheck(unauthorized, authHeader);
+    scheduleShadowCheck(unauthorized, authHeader, cookieHeader);
     return unauthorized;
   }
   const authCtx = await getAuthContext(authHeader);
   if (!authCtx || authCtx.tokenType !== "pat" || !authCtx.orgId) {
-    scheduleShadowCheck(unauthorized, authHeader);
+    scheduleShadowCheck(unauthorized, authHeader, cookieHeader);
     return unauthorized;
   }
-  scheduleShadowCheck(authCtx, authHeader);
+  scheduleShadowCheck(authCtx, authHeader, cookieHeader);
   return authCtx;
 }

--- a/turbo/apps/web/src/lib/auth/shadow-check.ts
+++ b/turbo/apps/web/src/lib/auth/shadow-check.ts
@@ -1,6 +1,5 @@
 import { env } from "../../env";
 import { logger } from "../shared/logger";
-import { DATASETS, getDatasetName, ingestToAxiom } from "../shared/axiom";
 
 import type { AuthContext } from "./get-auth-context";
 
@@ -217,7 +216,7 @@ function compare(
 
 /**
  * Shadow-call the new `/health/auth` probe with the same Bearer credential
- * the caller already presented and report any divergence to Axiom.
+ * the caller already presented and log a warning on any divergence.
  *
  * When a cookie is available, it is forwarded to the API so the probe can
  * fall through to Clerk session auth for requests where the Bearer token
@@ -235,7 +234,11 @@ export async function shadowCompareAuth(
     return;
   }
 
-  const apiResponse = await probeApi(apiUrl, options.authHeader, options.cookieHeader);
+  const apiResponse = await probeApi(
+    apiUrl,
+    options.authHeader,
+    options.cookieHeader,
+  );
   const event = compare(webResult, apiResponse, options.route);
 
   if (!event.consistent) {
@@ -244,8 +247,4 @@ export async function shadowCompareAuth(
       differences: event.differences,
     });
   }
-
-  ingestToAxiom(getDatasetName(DATASETS.AUTH_SHADOW), [
-    event as unknown as Record<string, unknown>,
-  ]);
 }

--- a/turbo/apps/web/src/lib/auth/shadow-check.ts
+++ b/turbo/apps/web/src/lib/auth/shadow-check.ts
@@ -15,6 +15,7 @@ type WebResult = AuthContext | AuthErrorResponse;
 
 interface ShadowOptions {
   readonly authHeader: string | undefined;
+  readonly cookieHeader?: string;
   readonly route?: string;
 }
 
@@ -51,11 +52,16 @@ type ApiResponse = ApiResponseSuccess | ApiResponseError | ApiResponseNetwork;
 async function probeApi(
   apiUrl: string,
   authHeader: string,
+  cookieHeader?: string,
 ): Promise<ApiResponse> {
   const target = new URL("/health/auth", apiUrl).toString();
+  const headers: Record<string, string> = { authorization: authHeader };
+  if (cookieHeader) {
+    headers.cookie = cookieHeader;
+  }
   const response = await fetch(target, {
     method: "GET",
-    headers: { authorization: authHeader },
+    headers,
     signal: AbortSignal.timeout(2000),
   }).catch((err: unknown) => {
     return err instanceof Error ? err : new Error(String(err));
@@ -213,11 +219,9 @@ function compare(
  * Shadow-call the new `/health/auth` probe with the same Bearer credential
  * the caller already presented and report any divergence to Axiom.
  *
- * Session-cookie auth is intentionally not shadowed: forwarding the
- * Clerk session cookie would require reading `next/headers` (banned by
- * `no-restricted-imports`) or threading the cookie through every caller.
- * Bearer auth (PAT / sandbox / zero) covers the surface that the new
- * api app is meant to take over.
+ * When a cookie is available, it is forwarded to the API so the probe can
+ * fall through to Clerk session auth for requests where the Bearer token
+ * is not self-sufficient.
  */
 export async function shadowCompareAuth(
   webResult: WebResult,
@@ -231,7 +235,7 @@ export async function shadowCompareAuth(
     return;
   }
 
-  const apiResponse = await probeApi(apiUrl, options.authHeader);
+  const apiResponse = await probeApi(apiUrl, options.authHeader, options.cookieHeader);
   const event = compare(webResult, apiResponse, options.route);
 
   if (!event.consistent) {

--- a/turbo/apps/web/src/lib/shared/axiom/datasets.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/datasets.ts
@@ -24,7 +24,6 @@ export const DATASETS = {
   REQUEST_LOG: "request-log",
   SANDBOX_OP_LOG: "sandbox-op-log",
   RUN_CONTEXT: "run-context",
-  AUTH_SHADOW: "auth-shadow",
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

PR #11244's auth shadow probe found 578 outcome mismatches in 3 hours — every mismatch was `differences: ["outcome"]` (web says success, API says 401). This PR fixes three root causes.

## Root Causes

1. **`cliAuth$` returned null when PAT user is not an org member** — Web returns success without `orgId`/`orgRole`. API returned 401.
2. **`resolvedAuthContext$` had no Clerk session fallback for Bearer requests** — Web falls through to Clerk after Bearer verification fails. API returned hard 401.
3. **Shadow probe didn't forward cookies** — API's `/health/auth` never had a chance to fall back to Clerk session even after fix #2.

## Changes

### API (`turbo/apps/api`)

- `cliAuth$`: return `{ tokenType: "pat", userId }` (no orgId/orgRole) when membership is null, matching web's `get-auth-context.ts`
- `resolvedAuthContext$`: fall through to `clerkSessionAuth$` when Bearer token verification fails
- `PatAuthContext`: split into union type for with/without orgId variants
- Tests: PAT-no-member → 200, 3 new Clerk-fallback tests, `beforeEach` Clerk mock reset

### Web (`turbo/apps/web`)

- `shadow-check.ts`: forward `cookieHeader` when available in shadow probe
- `requireAuth` / `requireApiKeyAuth`: accept optional `cookieHeader` parameter
- Stop ingesting shadow events to Axiom (`vm0-auth-shadow-*`); keep the in-process compare + `log.warn` on mismatch. Drops the now-unused `AUTH_SHADOW` dataset constant.

## Test plan

- [ ] `pnpm -F @vm0/api exec vitest run src/signals/routes/__tests__/health-auth-probe.test.ts`
- [ ] `pnpm -F web check-types`
- [ ] `pnpm -F web lint`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)