### PR TITLE
fix(runner): gate parking during soft drain transitions

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -3831,7 +3831,9 @@ mod tests {
         assert!(matches!(result, ParkResult::Parked));
     }
 
-    async fn status_idle_sessions(status_path: &std::path::Path) -> Vec<String> {
+    async fn status_idle_sessions_and_active_runs(
+        status_path: &std::path::Path,
+    ) -> (Vec<String>, Vec<String>) {
         let raw = tokio::fs::read_to_string(status_path).await.unwrap();
         let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
         let mut sessions: Vec<String> = status
@@ -3849,23 +3851,49 @@ mod tests {
             })
             .unwrap_or_default();
         sessions.sort_unstable();
-        sessions
+        let mut run_ids: Vec<String> = status["active_runs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|run| {
+                run.get("run_id")
+                    .and_then(|run_id| run_id.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+        run_ids.sort_unstable();
+        (sessions, run_ids)
     }
 
-    async fn wait_status_idle_sessions(
+    async fn status_idle_sessions(status_path: &std::path::Path) -> Vec<String> {
+        status_idle_sessions_and_active_runs(status_path).await.0
+    }
+
+    async fn publish_idle_status(pool: &SharedIdlePool, status: &StatusTracker) {
+        let snapshot = pool.lock().await.status_snapshot();
+        assert!(
+            status
+                .set_idle_info_at_revision(snapshot.revision, snapshot.idle_vms)
+                .await
+        );
+    }
+
+    async fn wait_status_idle_empty_with_active_run(
         status_path: &std::path::Path,
-        expected: Vec<String>,
+        run_id: RunId,
         timeout: Duration,
     ) {
+        let expected = run_id.to_string();
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            let actual = status_idle_sessions(status_path).await;
-            if actual == expected {
+            let (idle_sessions, active_runs) =
+                status_idle_sessions_and_active_runs(status_path).await;
+            if idle_sessions.is_empty() && active_runs.iter().any(|id| id == &expected) {
                 return;
             }
             assert!(
                 tokio::time::Instant::now() < deadline,
-                "status idle sessions did not reach {expected:?} within {timeout:?} (actual: {actual:?})",
+                "status did not atomically clear idle_vms and add active run {expected} within {timeout:?} (idle: {idle_sessions:?}, active: {active_runs:?})",
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
@@ -4127,17 +4155,7 @@ mod tests {
         );
 
         wait_idle_pool_len(&idle_pool, 0, Duration::from_secs(5)).await;
-        wait_status_idle_sessions(&status_path, Vec::new(), Duration::from_secs(5)).await;
-        let raw = tokio::fs::read_to_string(&status_path).await.unwrap();
-        let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        let active_runs = status["active_runs"].as_array().unwrap();
-        let run_id_text = run_id.to_string();
-        assert!(
-            active_runs
-                .iter()
-                .any(|run| run["run_id"].as_str() == Some(run_id_text.as_str())),
-            "reuse status update must add active run in the same write that clears idle_vms",
-        );
+        wait_status_idle_empty_with_active_run(&status_path, run_id, Duration::from_secs(5)).await;
 
         gate.notify_one();
         let completion = env
@@ -4240,6 +4258,60 @@ mod tests {
         assert_eq!(alloc_count, 1, "only new VM should hold budget");
         assert_eq!(alloc_vcpu, 4, "new VM is vm0/large (4 vcpu)");
         assert_eq!(alloc_mem, 8192, "new VM is vm0/large (8192 MB)");
+
+        shutdown(&env, run_handle).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn profile_mismatch_status_switches_from_idle_to_active_while_job_runs() {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+            Arc::clone(&gate),
+        ));
+        let (config, env) = mock_run_config_with_overrides(two_profiles(), 16, 32768, 4, overrides);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let budget = Arc::clone(&config.budget);
+        let status = Arc::clone(&config.status);
+        let status_path = env._temp_dir.path().join("status.json");
+
+        seed_idle_pool(
+            &idle_pool,
+            &budget,
+            "sess-mm-status",
+            "vm0/default",
+            2,
+            4096,
+        )
+        .await;
+        publish_idle_status(&idle_pool, &status).await;
+        assert_eq!(
+            status_idle_sessions(&status_path).await,
+            vec!["sess-mm-status".to_string()],
+            "pre-run status should list the stale idle VM",
+        );
+
+        let run_handle = tokio::spawn(run(config));
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/large",
+            Some(context_with_session(run_id, "sess-mm-status")),
+        );
+
+        wait_idle_pool_len(&idle_pool, 0, Duration::from_secs(5)).await;
+        wait_status_idle_empty_with_active_run(&status_path, run_id, Duration::from_secs(5)).await;
+
+        gate.notify_one();
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .expect("fresh-create job should still complete");
+        assert_eq!(
+            completion.reuse_result,
+            Some(SandboxReuseResult::ProfileMismatch),
+        );
 
         shutdown(&env, run_handle).await;
     }
@@ -5327,6 +5399,66 @@ mod tests {
             counter.park_call_count(),
             1,
             "expected exactly one park (the fresh-create's)"
+        );
+
+        shutdown(&env, run_handle).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unpark_failure_status_switches_from_idle_to_active_while_job_runs() {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+            Arc::clone(&gate),
+        ));
+        let counter = Arc::clone(&overrides);
+        overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+            transition: sandbox::SandboxIdleTransition::Unpark,
+            message: "simulated unpark failure".into(),
+        }));
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+        let budget = Arc::clone(&config.budget);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let status = Arc::clone(&config.status);
+        let status_path = env._temp_dir.path().join("status.json");
+
+        seed_idle_pool_with_overrides(
+            &idle_pool,
+            &budget,
+            &counter,
+            "sess-unpark-status",
+            "vm0/default",
+            2,
+            4096,
+        )
+        .await;
+        publish_idle_status(&idle_pool, &status).await;
+        assert_eq!(
+            status_idle_sessions(&status_path).await,
+            vec!["sess-unpark-status".to_string()],
+            "pre-run status should list the idle VM",
+        );
+
+        let run_handle = tokio::spawn(run(config));
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-unpark-status")),
+        );
+
+        wait_idle_pool_len(&idle_pool, 0, Duration::from_secs(5)).await;
+        wait_status_idle_empty_with_active_run(&status_path, run_id, Duration::from_secs(5)).await;
+
+        gate.notify_one();
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .expect("fresh-create job should still complete");
+        assert_eq!(
+            completion.reuse_result,
+            Some(SandboxReuseResult::UnparkFailed),
         );
 
         shutdown(&env, run_handle).await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -4406,7 +4406,12 @@ mod tests {
         // Enter Draining. The Draining path drains an empty pool and waits for the
         // gated job.
         env.drain();
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        wait_parking_state(
+            &idle_pool,
+            ParkingState::SoftDraining,
+            Duration::from_secs(5),
+        )
+        .await;
         assert_eq!(
             idle_pool.lock().await.len(),
             0,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -21,8 +21,8 @@ use crate::executor::{self, ExecutorConfig};
 use crate::host;
 use crate::http::HttpClient;
 use crate::idle_pool::{
-    IdleDestroyPayload, IdleEntry, IdlePool, IdlePoolConfig, ParkResult, ParkingGate,
-    ReusableIdleSandbox,
+    IdleDestroyPayload, IdleEntry, IdlePool, IdlePoolConfig, IdlePoolSnapshot, ParkResult,
+    ParkingGate, ReusableIdleSandbox,
 };
 use crate::kmsg_log;
 use crate::lock;
@@ -711,9 +711,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     );
                 }
                 // Update status with current idle pool state
-                let idle_vms = pool.held_snapshot();
+                let snapshot = pool.status_snapshot();
                 drop(pool);
-                status.set_idle_info(idle_vms).await;
+                set_idle_status_snapshot(&status, snapshot).await;
                 for entry in expired {
                     spawn_destroy_idle_entry(&mut destroy_tasks, entry, "idle_expired");
                 }
@@ -968,10 +968,15 @@ async fn try_reuse_from_pool(
 
     // Take the entry under the pool lock, then drop the lock before any awaits
     // so unpark does not block other take/park operations.
-    let taken = {
+    let (taken, snapshot) = {
         let mut pool = ctx.idle_pool.lock().await;
-        pool.take(session_id)
+        let taken = pool.take(session_id);
+        let snapshot = taken.as_ref().map(|_| pool.status_snapshot());
+        (taken, snapshot)
     };
+    if let Some(snapshot) = snapshot {
+        set_idle_status_snapshot(ctx.status, snapshot).await;
+    }
     match taken {
         Some(mut entry) if entry.profile_name == profile_name => {
             match unpark_sandbox_panic_safe(entry.sandbox.as_mut()).await {
@@ -1260,17 +1265,17 @@ fn spawn_job(
                                     // nor idle) until the next idle_cleanup tick
                                     // (~10s), producing transient false-positive
                                     // FirecrackerNotInStatus warnings.
-                                    let idle_vms = pool.held_snapshot();
+                                    let snapshot = pool.status_snapshot();
                                     drop(pool);
-                                    status.set_idle_info(idle_vms).await;
+                                    set_idle_status_snapshot(&status, snapshot).await;
                                     park_notify.notify_one();
                                     true
                                 }
                                 ParkResult::Evicted(evicted) => {
                                     info!(run_id = %run_id, session_id, "VM parked, evicting previous");
-                                    let idle_vms = pool.held_snapshot();
+                                    let snapshot = pool.status_snapshot();
                                     drop(pool);
-                                    status.set_idle_info(idle_vms).await;
+                                    set_idle_status_snapshot(&status, snapshot).await;
                                     // Notify immediately — session is already in pool.
                                     // Don't wait for stop_and_destroy which can be slow.
                                     park_notify.notify_one();
@@ -1435,13 +1440,12 @@ async fn drain_idle_pool(
     context: &'static str,
 ) {
     let entries = idle_pool.lock().await.drain();
-    if entries.is_empty() {
-        return;
+    if !entries.is_empty() {
+        info!(count = entries.len(), context, "destroying idle VMs");
+        destroy_idle_entries_and_wait(entries, context).await;
     }
-    info!(count = entries.len(), context, "destroying idle VMs");
-    destroy_idle_entries_and_wait(entries, context).await;
-    let idle_vms = idle_pool.lock().await.held_snapshot();
-    status.set_idle_info(idle_vms).await;
+    let snapshot = idle_pool.lock().await.status_snapshot();
+    set_idle_status_snapshot(status, snapshot).await;
 }
 
 /// Remove expired idle entries and update status to match the new pool state.
@@ -1454,9 +1458,9 @@ async fn evict_expired_idle_entries(
     if expired.is_empty() {
         return expired;
     }
-    let idle_vms = pool.held_snapshot();
+    let snapshot = pool.status_snapshot();
     drop(pool);
-    status.set_idle_info(idle_vms).await;
+    set_idle_status_snapshot(status, snapshot).await;
     expired
 }
 
@@ -1467,10 +1471,22 @@ async fn evict_oldest_idle_entry(
 ) -> Option<IdleEntry> {
     let mut pool = idle_pool.lock().await;
     let evicted = pool.evict_oldest()?;
-    let idle_vms = pool.held_snapshot();
+    let snapshot = pool.status_snapshot();
     drop(pool);
-    status.set_idle_info(idle_vms).await;
+    set_idle_status_snapshot(status, snapshot).await;
     Some(evicted)
+}
+
+async fn set_idle_status_snapshot(status: &StatusTracker, snapshot: IdlePoolSnapshot) {
+    let applied = status
+        .set_idle_info_at_revision(snapshot.revision, snapshot.idle_vms)
+        .await;
+    if !applied {
+        debug!(
+            revision = snapshot.revision,
+            "ignored stale idle pool status snapshot"
+        );
+    }
 }
 
 fn spawn_destroy_idle_entry(
@@ -3696,6 +3712,21 @@ mod tests {
         }
     }
 
+    async fn wait_idle_pool_len(pool: &SharedIdlePool, expected: usize, timeout: Duration) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let actual = pool.lock().await.len();
+            if actual == expected {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "idle pool length did not reach {expected} within {timeout:?} (actual: {actual})",
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
     /// Poll until the idle pool parking state reaches `expected`.
     async fn wait_parking_state(pool: &SharedIdlePool, expected: ParkingState, timeout: Duration) {
         let deadline = tokio::time::Instant::now() + timeout;
@@ -3989,6 +4020,70 @@ mod tests {
             budget.allocated().2,
             1,
             "budget should remain at 1 (reused, not additive)"
+        );
+
+        shutdown(&env, run_handle).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reuse_take_clears_idle_status_while_job_is_active() {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+            Arc::clone(&gate),
+        ));
+        let (config, env) =
+            mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let budget = Arc::clone(&config.budget);
+        let status = Arc::clone(&config.status);
+        let status_path = env._temp_dir.path().join("status.json");
+
+        let _seeded_sandbox_id = seed_idle_pool_with_overrides(
+            &idle_pool,
+            &budget,
+            &overrides,
+            "sess-reuse-status",
+            "vm0/default",
+            2,
+            4096,
+        )
+        .await;
+        let snapshot = idle_pool.lock().await.status_snapshot();
+        assert!(
+            status
+                .set_idle_info_at_revision(snapshot.revision, snapshot.idle_vms)
+                .await
+        );
+        assert_eq!(
+            status_idle_sessions(&status_path).await,
+            vec!["sess-reuse-status".to_string()],
+            "pre-run status should list the seeded idle VM",
+        );
+
+        let run_handle = tokio::spawn(run(config));
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-reuse-status")),
+        );
+
+        wait_idle_pool_len(&idle_pool, 0, Duration::from_secs(5)).await;
+        assert!(
+            status_idle_sessions(&status_path).await.is_empty(),
+            "taking an idle VM for reuse must remove it from status.json before the job completes",
+        );
+
+        gate.notify_one();
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(completion.is_some(), "reused job should complete");
+        assert_eq!(
+            completion.unwrap().reuse_result,
+            Some(SandboxReuseResult::Reused),
         );
 
         shutdown(&env, run_handle).await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -923,7 +923,7 @@ async fn handle_discovered_job(job: DiscoveredJob, mut ctx: DiscoveredJobContext
     };
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
 
-    let (reuse_entry, active_lease, reuse_result) =
+    let (reuse_entry, active_lease, reuse_result, idle_snapshot) =
         try_reuse_from_pool(run_id, &profile_name, &context, job_lease, &mut ctx).await;
 
     // Determine sandbox_id after the reuse decision. On reuse, the sandbox keeps
@@ -933,7 +933,11 @@ async fn handle_discovered_job(job: DiscoveredJob, mut ctx: DiscoveredJobContext
         Some(entry) => entry.sandbox_id,
         None => SandboxId::new_v4(),
     };
-    ctx.status.add_run(run_id, sandbox_id).await;
+    if let Some(snapshot) = idle_snapshot {
+        add_run_with_idle_status_snapshot(ctx.status, run_id, sandbox_id, snapshot).await;
+    } else {
+        ctx.status.add_run(run_id, sandbox_id).await;
+    }
 
     let job_profile = JobProfile {
         profile_name,
@@ -961,9 +965,14 @@ async fn try_reuse_from_pool(
     context: &ExecutionContext,
     job_lease: BudgetLease,
     ctx: &mut DiscoveredJobContext<'_>,
-) -> (Option<ReusableIdleSandbox>, BudgetLease, SandboxReuseResult) {
+) -> (
+    Option<ReusableIdleSandbox>,
+    BudgetLease,
+    SandboxReuseResult,
+    Option<IdlePoolSnapshot>,
+) {
     let Some(session_id) = context.session_id() else {
-        return (None, job_lease, SandboxReuseResult::NoSessionId);
+        return (None, job_lease, SandboxReuseResult::NoSessionId, None);
     };
 
     // Take the entry under the pool lock, then drop the lock before any awaits
@@ -974,9 +983,6 @@ async fn try_reuse_from_pool(
         let snapshot = taken.as_ref().map(|_| pool.status_snapshot());
         (taken, snapshot)
     };
-    if let Some(snapshot) = snapshot {
-        set_idle_status_snapshot(ctx.status, snapshot).await;
-    }
     match taken {
         Some(mut entry) if entry.profile_name == profile_name => {
             match unpark_sandbox_panic_safe(entry.sandbox.as_mut()).await {
@@ -991,7 +997,12 @@ async fn try_reuse_from_pool(
                     // task before handing the sandbox to the executor.
                     drop(job_lease);
                     let (idle_sandbox, idle_lease) = entry.into_reuse_parts();
-                    (Some(idle_sandbox), idle_lease, SandboxReuseResult::Reused)
+                    (
+                        Some(idle_sandbox),
+                        idle_lease,
+                        SandboxReuseResult::Reused,
+                        snapshot,
+                    )
                 }
                 Err(e) => {
                     warn!(
@@ -1001,7 +1012,7 @@ async fn try_reuse_from_pool(
                         "unpark failed, destroying idle VM and falling through to fresh create"
                     );
                     spawn_destroy_idle_entry(ctx.destroy_tasks, entry, "reuse_unpark_failed");
-                    (None, job_lease, SandboxReuseResult::UnparkFailed)
+                    (None, job_lease, SandboxReuseResult::UnparkFailed, snapshot)
                 }
             }
         }
@@ -1014,7 +1025,12 @@ async fn try_reuse_from_pool(
                 "idle VM profile mismatch, destroying"
             );
             spawn_destroy_idle_entry(ctx.destroy_tasks, stale, "reuse_profile_mismatch");
-            (None, job_lease, SandboxReuseResult::ProfileMismatch)
+            (
+                None,
+                job_lease,
+                SandboxReuseResult::ProfileMismatch,
+                snapshot,
+            )
         }
         None => {
             info!(
@@ -1022,7 +1038,7 @@ async fn try_reuse_from_pool(
                 session_id,
                 "no idle VM found for session"
             );
-            (None, job_lease, SandboxReuseResult::PoolMiss)
+            (None, job_lease, SandboxReuseResult::PoolMiss, None)
         }
     }
 }
@@ -1485,6 +1501,28 @@ async fn set_idle_status_snapshot(status: &StatusTracker, snapshot: IdlePoolSnap
         debug!(
             revision = snapshot.revision,
             "ignored stale idle pool status snapshot"
+        );
+    }
+}
+
+async fn add_run_with_idle_status_snapshot(
+    status: &StatusTracker,
+    run_id: RunId,
+    sandbox_id: SandboxId,
+    snapshot: IdlePoolSnapshot,
+) {
+    let applied = status
+        .add_run_with_idle_info_at_revision(
+            run_id,
+            sandbox_id,
+            snapshot.revision,
+            snapshot.idle_vms,
+        )
+        .await;
+    if !applied {
+        debug!(
+            revision = snapshot.revision,
+            "ignored stale idle pool status snapshot while adding active run"
         );
     }
 }
@@ -3814,6 +3852,25 @@ mod tests {
         sessions
     }
 
+    async fn wait_status_idle_sessions(
+        status_path: &std::path::Path,
+        expected: Vec<String>,
+        timeout: Duration,
+    ) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let actual = status_idle_sessions(status_path).await;
+            if actual == expected {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "status idle sessions did not reach {expected:?} within {timeout:?} (actual: {actual:?})",
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Test 10: Successful job parks VM in idle pool
     // -----------------------------------------------------------------------
@@ -4070,9 +4127,16 @@ mod tests {
         );
 
         wait_idle_pool_len(&idle_pool, 0, Duration::from_secs(5)).await;
+        wait_status_idle_sessions(&status_path, Vec::new(), Duration::from_secs(5)).await;
+        let raw = tokio::fs::read_to_string(&status_path).await.unwrap();
+        let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let active_runs = status["active_runs"].as_array().unwrap();
+        let run_id_text = run_id.to_string();
         assert!(
-            status_idle_sessions(&status_path).await.is_empty(),
-            "taking an idle VM for reuse must remove it from status.json before the job completes",
+            active_runs
+                .iter()
+                .any(|run| run["run_id"].as_str() == Some(run_id_text.as_str())),
+            "reuse status update must add active run in the same write that clears idle_vms",
         );
 
         gate.notify_one();

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -48,11 +48,6 @@ use mitm_restart::{
 };
 use signals::{EarlySignals, SignalController};
 
-#[cfg(test)]
-use signals::LifecycleController;
-#[cfg(test)]
-use signals::{handle_drain_signal, handle_resume_signal, handle_stopping_signal};
-
 /// Period between routine heartbeat ticks sent to the server. First
 /// tick is deferred by one period via `interval_at` — see the comment
 /// at the interval construction in `run()`.
@@ -1719,6 +1714,9 @@ fn collect_heartbeat_state(
 
 #[cfg(test)]
 mod tests {
+    use super::signals::{
+        LifecycleController, handle_drain_signal, handle_resume_signal, handle_stopping_signal,
+    };
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -21,7 +21,8 @@ use crate::executor::{self, ExecutorConfig};
 use crate::host;
 use crate::http::HttpClient;
 use crate::idle_pool::{
-    IdleDestroyPayload, IdleEntry, IdlePool, IdlePoolConfig, ParkResult, ReusableIdleSandbox,
+    IdleDestroyPayload, IdleEntry, IdlePool, IdlePoolConfig, ParkResult, ParkingGate,
+    ReusableIdleSandbox,
 };
 use crate::kmsg_log;
 use crate::lock;
@@ -47,6 +48,8 @@ use mitm_restart::{
 };
 use signals::{EarlySignals, SignalController};
 
+#[cfg(test)]
+use signals::LifecycleController;
 #[cfg(test)]
 use signals::{handle_drain_signal, handle_resume_signal, handle_stopping_signal};
 
@@ -260,10 +263,14 @@ pub async fn run_start(
     );
 
     // Idle sandbox pool for VM reuse across conversation turns.
-    let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-        default_timeout: Duration::from_secs(idle_timeout_secs),
-        max_idle,
-    })));
+    let parking_gate = ParkingGate::new_open();
+    let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
+        IdlePoolConfig {
+            default_timeout: Duration::from_secs(idle_timeout_secs),
+            max_idle,
+        },
+        parking_gate.clone(),
+    )));
 
     // Estimated capacity for status reporting.
     // Derived from the smallest profile to cover the worst case.
@@ -346,6 +353,7 @@ pub async fn run_start(
         home,
         budget,
         idle_pool,
+        parking_gate,
         status,
         mitm,
         mitm_crash_rx,
@@ -374,6 +382,7 @@ struct RunConfig {
     home: HomePaths,
     budget: Arc<ResourceBudget>,
     idle_pool: SharedIdlePool,
+    parking_gate: ParkingGate,
     status: Arc<StatusTracker>,
     mitm: proxy::MitmProxy,
     mitm_crash_rx: tokio::sync::mpsc::Receiver<()>,
@@ -392,7 +401,7 @@ struct RunConfig {
     /// How the run's mode channel is driven. Production supplies the signal
     /// streams registered at the top of `run_start`; tests supply a
     /// pre-built `SignalController` so they can drive mode transitions
-    /// directly.
+    /// through the lifecycle controller.
     signal_source: SignalSource,
 }
 
@@ -417,6 +426,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         home,
         budget,
         idle_pool,
+        parking_gate,
         status,
         mut mitm,
         mut mitm_crash_rx,
@@ -488,13 +498,16 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Signal handling / mode channel
     // -----------------------------------------------------------------------
     let signal = match signal_source {
-        SignalSource::Real(signals) => {
-            SignalController::spawn(cancel.clone(), Arc::clone(&cancel_tokens), signals)
-        }
+        SignalSource::Real(signals) => SignalController::spawn(
+            cancel.clone(),
+            Arc::clone(&cancel_tokens),
+            signals,
+            parking_gate.clone(),
+        ),
         SignalSource::Override(controller) => controller,
     };
     let mut mode_rx = signal.mode_rx;
-    let mode_tx = signal.mode_tx;
+    let lifecycle = signal.lifecycle;
     let signal_handler_abort = signal.handler_abort;
 
     // -----------------------------------------------------------------------
@@ -551,12 +564,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let mut discover_fut = Box::pin(provider.discover());
 
     let mut current_mode = RunnerMode::Running;
-    let mut spawn_ctx = SpawnContext {
+    let spawn_ctx = SpawnContext {
         provider: Arc::clone(&provider),
         exec_config: Arc::clone(&exec_config),
         idle_pool: Arc::clone(&idle_pool),
         status: Arc::clone(&status),
-        mode: current_mode,
+        parking_gate: parking_gate.clone(),
         park_notify: Arc::clone(&park_notify),
     };
     let mut draining_idle_pool_drained = false;
@@ -564,7 +577,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         let mode = *mode_rx.borrow_and_update();
         if mode != current_mode {
             current_mode = mode;
-            spawn_ctx.mode = mode;
             status.set_mode(mode).await;
         }
         match mode {
@@ -588,15 +600,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     // transition on `mode == Draining` so a concurrent SIGUSR2
                     // resume wins instead of being overwritten.
                     info!("draining: jobs drained, transitioning to Stopping");
-                    let transitioned = mode_tx.send_if_modified(|v| {
-                        if *v == RunnerMode::Draining {
-                            *v = RunnerMode::Stopping;
-                            true
-                        } else {
-                            // SIGUSR2 raced us to Running — keep that.
-                            false
-                        }
-                    });
+                    let transitioned = lifecycle.stop_after_natural_drain();
                     if transitioned {
                         // Live observability: fire an immediate "stopping"
                         // heartbeat before teardown removes the runner.
@@ -606,9 +610,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 }
             }
             RunnerMode::Running => {
-                if draining_idle_pool_drained {
-                    idle_pool.lock().await.resume_after_soft_drain();
-                }
                 draining_idle_pool_drained = false;
             }
         }
@@ -743,6 +744,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Drain idle pool first — these VMs hold budget reservations. This
     // also clears `idle_vms` in status.json so the final snapshot is
     // consistent with the empty pool.
+    lifecycle.close_parking();
     drain_idle_pool(&idle_pool, &status, "shutdown").await;
 
     provider.shutdown().await;
@@ -1054,17 +1056,10 @@ struct SpawnContext {
     exec_config: Arc<ExecutorConfig>,
     idle_pool: SharedIdlePool,
     status: Arc<StatusTracker>,
-    /// Snapshot of [`RunnerMode`] at spawn time. Each `jobs.spawn` captures
-    /// this value, so the post-exec park decision uses the mode that was
-    /// current **when the job was claimed**, not when it finished. Only
-    /// jobs spawned in `Running` are eligible for parking.
-    ///
-    /// Consequence: a job spawned in `Running` that completes during
-    /// `Draining` may park — the entry is cleaned up by the teardown
-    /// drain, so this wastes work rather than leaking. On `Stopping` the
-    /// per-job cancel token fires, taking the cancelled branch and skipping
-    /// park entirely.
-    mode: RunnerMode,
+    /// Current lifecycle parking permission. This is checked at job
+    /// completion so soft-drain/resume races do not depend on a stale
+    /// spawn-time mode snapshot.
+    parking_gate: ParkingGate,
     /// Notifies the main loop to send an immediate heartbeat after parking a VM.
     /// This eliminates the up-to-10s blind spot where the server doesn't know
     /// which runner holds a newly-parked session.
@@ -1116,7 +1111,7 @@ fn spawn_job(
     let status = Arc::clone(&ctx.status);
     let idle_pool = Arc::clone(&ctx.idle_pool);
     let park_notify = Arc::clone(&ctx.park_notify);
-    let mode = ctx.mode;
+    let parking_gate = ctx.parking_gate.clone();
     let factory_for_cleanup = Arc::clone(&factory);
 
     // Captured for the post-complete deferred work below: the panic-arm
@@ -1206,7 +1201,7 @@ fn spawn_job(
         // Decide: park sandbox for reuse, or stop + destroy.
         let parked = if let Some(mut sandbox) = sandbox {
             let parkable_session =
-                if exit_code == 0 && !job_cancel.is_cancelled() && mode == RunnerMode::Running {
+                if exit_code == 0 && !job_cancel.is_cancelled() && parking_gate.is_open() {
                     // Prefer context session_id (from resume_session), fall back to
                     // guest-reported session ID (first run — CLI generated it).
                     session_id.as_deref().or(guest_session_id.as_deref())
@@ -1336,7 +1331,7 @@ fn spawn_job(
                         reason: active_cleanup_reason(
                             exit_code,
                             job_cancel.is_cancelled(),
-                            mode,
+                            parking_gate.is_open(),
                             session_id.as_deref(),
                             guest_session_id.as_deref(),
                         ),
@@ -1407,7 +1402,7 @@ async fn unpark_sandbox_panic_safe(sandbox: &mut dyn Sandbox) -> Result<(), Stri
 fn active_cleanup_reason(
     exit_code: i32,
     cancelled: bool,
-    mode: RunnerMode,
+    parking_open: bool,
     context_session_id: Option<&str>,
     guest_session_id: Option<&str>,
 ) -> &'static str {
@@ -1415,8 +1410,8 @@ fn active_cleanup_reason(
         "cancelled"
     } else if exit_code != 0 {
         "nonzero_exit"
-    } else if mode != RunnerMode::Running {
-        "runner_not_running"
+    } else if !parking_open {
+        "parking_closed"
     } else if context_session_id.is_none() && guest_session_id.is_none() {
         "no_session"
     } else {
@@ -1424,11 +1419,13 @@ fn active_cleanup_reason(
     }
 }
 
-/// Drain the idle pool: destroy every entry in parallel and wait for all
-/// destroys to complete before returning (budgets released, `status.json`
-/// `idle_vms` cleared). Called from both the Draining mode (soft-drain
-/// entry) and teardown — both need the final state consistent with an
-/// empty pool before proceeding.
+/// Drain the idle pool: destroy every entry captured at drain start in parallel
+/// and wait for all destroys to complete before returning (budgets released).
+/// Called from both Draining mode (soft-drain entry) and teardown.
+///
+/// A SIGUSR2 resume can reopen parking while a soft-drain destroy is still in
+/// progress, so write the current post-destroy pool snapshot rather than
+/// blindly clearing `idle_vms`.
 ///
 /// `context` is logged alongside the destroyed count for operator clarity
 /// (e.g. "draining" vs "shutdown").
@@ -1443,7 +1440,8 @@ async fn drain_idle_pool(
     }
     info!(count = entries.len(), context, "destroying idle VMs");
     destroy_idle_entries_and_wait(entries, context).await;
-    status.set_idle_info(Vec::new()).await;
+    let idle_vms = idle_pool.lock().await.held_snapshot();
+    status.set_idle_info(idle_vms).await;
 }
 
 /// Remove expired idle entries and update status to match the new pool state.
@@ -1674,7 +1672,7 @@ mod tests {
     // collect_heartbeat_state: running_count excludes idle VMs
     // -----------------------------------------------------------------------
 
-    use crate::idle_pool::{IdleEntry, IdlePool, IdlePoolConfig, ParkResult};
+    use crate::idle_pool::{IdleEntry, IdlePool, IdlePoolConfig, ParkResult, ParkingState};
     use async_trait::async_trait;
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
@@ -2035,6 +2033,8 @@ mod tests {
         handle: MockProviderHandle,
         provider: Arc<MockJobProvider>,
         idle_pool: SharedIdlePool,
+        lifecycle: LifecycleController,
+        parking_gate: ParkingGate,
         mode_tx: tokio::sync::watch::Sender<RunnerMode>,
         cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
         cancel: CancellationToken,
@@ -2046,19 +2046,20 @@ mod tests {
         /// tests exercise the same state-guard path production does
         /// (ignored unless current mode is Running).
         fn drain(&self) {
-            handle_drain_signal(&self.mode_tx);
+            handle_drain_signal(&self.lifecycle);
         }
 
         /// Simulate SIGUSR2 via the real `handle_resume_signal` — only
         /// transitions when current mode is Draining.
         fn resume(&self) {
-            handle_resume_signal(&self.mode_tx);
+            handle_resume_signal(&self.lifecycle);
         }
 
         /// Simulate SIGTERM by driving the real `handle_stopping_signal`.
         /// Keeps the test path in sync with production.
         async fn trigger_stopping(&self) {
-            handle_stopping_signal("TEST", &self.cancel, &self.cancel_tokens, &self.mode_tx).await;
+            handle_stopping_signal("TEST", &self.cancel, &self.cancel_tokens, &self.lifecycle)
+                .await;
         }
     }
 
@@ -2148,6 +2149,8 @@ mod tests {
         let provider_ref = Arc::clone(&provider);
 
         let (mode_tx, mode_rx) = tokio::sync::watch::channel(RunnerMode::Running);
+        let parking_gate = ParkingGate::new_open();
+        let lifecycle = LifecycleController::new(mode_tx, parking_gate.clone());
         let cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
             Arc::new(tokio::sync::Mutex::new(HashMap::new()));
 
@@ -2165,10 +2168,13 @@ mod tests {
         let min_vcpu = profiles_min_vcpu(&profiles);
         let min_memory_mb = profiles_min_memory(&profiles);
         let idle_pool: SharedIdlePool =
-            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-                default_timeout: Duration::from_secs(300),
-                max_idle: 10,
-            })));
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
+                IdlePoolConfig {
+                    default_timeout: Duration::from_secs(300),
+                    max_idle: 10,
+                },
+                parking_gate.clone(),
+            )));
 
         let config = RunConfig {
             id: "test-runner".into(),
@@ -2184,6 +2190,7 @@ mod tests {
                 max_concurrent,
             )),
             idle_pool: Arc::clone(&idle_pool),
+            parking_gate: parking_gate.clone(),
             status: Arc::new(StatusTracker::new(
                 temp_dir.path().join("status.json"),
                 max_concurrent,
@@ -2214,7 +2221,7 @@ mod tests {
             dns_handle: crate::dns::DnsProxy::noop(),
             signal_source: SignalSource::Override(SignalController {
                 mode_rx,
-                mode_tx: mode_tx.clone(),
+                lifecycle: lifecycle.clone(),
                 handler_abort: None,
             }),
         };
@@ -2223,7 +2230,9 @@ mod tests {
             handle,
             provider: provider_ref,
             idle_pool,
-            mode_tx,
+            lifecycle: lifecycle.clone(),
+            parking_gate,
+            mode_tx: lifecycle.mode_tx().clone(),
             cancel_tokens,
             cancel,
             _temp_dir: temp_dir,
@@ -2287,7 +2296,7 @@ mod tests {
 
     /// Trigger graceful shutdown and wait for run() to exit.
     async fn shutdown(env: &MockRunEnv, run_handle: tokio::task::JoinHandle<RunnerResult<()>>) {
-        let _ = env.mode_tx.send(RunnerMode::Draining);
+        env.drain();
         env.cancel.cancel();
         let result = tokio::time::timeout(Duration::from_secs(10), run_handle)
             .await
@@ -2607,11 +2616,16 @@ mod tests {
         let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
 
         env.drain();
-        wait_idle_pool_drained(&idle_pool, true, Duration::from_secs(5)).await;
+        wait_parking_state(
+            &idle_pool,
+            ParkingState::SoftDraining,
+            Duration::from_secs(5),
+        )
+        .await;
         assert_eq!(*env.mode_tx.borrow(), RunnerMode::Draining);
 
         env.resume();
-        wait_idle_pool_drained(&idle_pool, false, Duration::from_secs(5)).await;
+        wait_parking_state(&idle_pool, ParkingState::Open, Duration::from_secs(5)).await;
         assert_eq!(*env.mode_tx.borrow(), RunnerMode::Running);
 
         gate.notify_one();
@@ -2893,6 +2907,7 @@ mod tests {
         .expect("run() did not enter discover_fut select! within 2s");
 
         // Flip the watch value to Stopping without firing changed().
+        env.parking_gate.close();
         env.mode_tx.send_if_modified(|v| {
             *v = RunnerMode::Stopping;
             false
@@ -2917,6 +2932,7 @@ mod tests {
 
         // Let run() exit — fire changed() now so the main loop observes
         // Stopping at loop top and breaks to teardown.
+        env.parking_gate.close();
         env.mode_tx.send_modify(|v| {
             *v = RunnerMode::Stopping;
         });
@@ -2949,7 +2965,7 @@ mod tests {
         env.trigger_stopping().await;
 
         // handle_resume_signal refuses any transition except from Draining.
-        handle_resume_signal(&env.mode_tx);
+        handle_resume_signal(&env.lifecycle);
         assert_eq!(
             *env.mode_tx.borrow(),
             RunnerMode::Stopping,
@@ -3013,7 +3029,7 @@ mod tests {
     }
 
     /// Draining auto-transitions to Stopping when jobs drain naturally.
-    /// Verifies the internal `mode_tx.send(Stopping)` in Draining mode.
+    /// Verifies the internal lifecycle transition from Draining to Stopping.
     #[tokio::test]
     async fn drain_with_jobs_transitions_to_stopping_when_empty() {
         let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
@@ -3045,6 +3061,7 @@ mod tests {
             RunnerMode::Stopping,
             "mode_tx must reflect Stopping after natural drain transition"
         );
+        assert_eq!(env.parking_gate.state(), ParkingState::Closed);
 
         // Observability pin: the Draining → Stopping auto-transition must
         // emit a one-shot heartbeat with mode="stopping" before teardown,
@@ -3105,6 +3122,7 @@ mod tests {
         // `changed()`, so the arm does not wake on a mode transition. The
         // guard will only observe the new value on its next iteration's
         // send_if_modified closure.
+        env.parking_gate.open_after_soft_drain();
         env.mode_tx.send_if_modified(|v| {
             *v = RunnerMode::Running;
             false
@@ -3678,17 +3696,17 @@ mod tests {
         }
     }
 
-    /// Poll until the idle pool drain flag reaches `expected`.
-    async fn wait_idle_pool_drained(pool: &SharedIdlePool, expected: bool, timeout: Duration) {
+    /// Poll until the idle pool parking state reaches `expected`.
+    async fn wait_parking_state(pool: &SharedIdlePool, expected: ParkingState, timeout: Duration) {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            let actual = pool.lock().await.is_drained();
+            let actual = pool.lock().await.parking_state();
             if actual == expected {
                 return;
             }
             assert!(
                 tokio::time::Instant::now() < deadline,
-                "idle pool drained flag did not reach {expected} within {timeout:?} (actual: {actual})",
+                "idle pool parking state did not reach {expected:?} within {timeout:?} (actual: {actual:?})",
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
@@ -4361,15 +4379,11 @@ mod tests {
         assert_eq!(count, 0, "all budget should be released after drain");
     }
 
-    /// Regression (G1): a job spawned in Running but completing during
-    /// Draining captures `mode = Running` in its spawn snapshot, so the
-    /// post-exec path still calls `park()`. The resulting pool entry
-    /// lands *after* Draining mode's initial drain — teardown's final
-    /// `drain_idle_pool` is the only safety net that prevents a VM leak.
-    /// Without it, the late-parked VM would remain in the pool and its
-    /// budget would never be released.
+    /// Active soft drain closes parking for successful jobs that complete
+    /// before SIGUSR2 resume. The sandbox is destroyed and budget is released
+    /// instead of late-parking into an already-drained pool.
     #[tokio::test]
-    async fn late_park_during_draining_cleaned_by_teardown() {
+    async fn job_completing_during_active_draining_is_not_parked() {
         let gate = Arc::new(tokio::sync::Notify::new());
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
             Arc::clone(&gate),
@@ -4379,8 +4393,7 @@ mod tests {
         let budget = Arc::clone(&config.budget);
         let run_handle = tokio::spawn(run(config));
 
-        // Claim a gated job with session + reuse — the spawn-time snapshot
-        // captures `mode = Running`.
+        // Claim a gated job with a reusable session while Running.
         let run_id = RunId::new_v4();
         push_job(
             &env,
@@ -4400,9 +4413,8 @@ mod tests {
             "Draining mode should have drained an empty pool",
         );
 
-        // Release the gate: the job completes, post-exec parks the sandbox
-        // (snapshot says Running), and the entry lands in the already-
-        // drained pool.
+        // Release the gate while still Draining: parking is closed, so the
+        // successful job destroys its sandbox instead of parking it.
         gate.notify_one();
         let c = env
             .handle
@@ -4411,26 +4423,101 @@ mod tests {
         assert!(c.is_some(), "job should complete");
         assert_eq!(c.unwrap().exit_code, 0);
 
-        // Draining mode observes jobs.is_empty → auto-Stop → teardown → the second
-        // `drain_idle_pool` call cleans the late-parked VM.
+        assert_eq!(
+            idle_pool.lock().await.len(),
+            0,
+            "active draining must reject post-job parking",
+        );
+
+        // Draining mode observes jobs.is_empty → auto-Stop → teardown.
         match tokio::time::timeout(Duration::from_secs(5), run_handle).await {
             Ok(Ok(Ok(()))) => {}
             Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
             Ok(Err(e)) => panic!("task panicked: {e}"),
-            Err(_) => panic!("natural drain + late park should exit within 5s"),
+            Err(_) => panic!("natural drain should exit within 5s"),
         }
 
         // Leak proof: pool empty, budget fully released.
         assert_eq!(
             idle_pool.lock().await.len(),
             0,
-            "teardown must clean the late-parked VM",
+            "teardown must leave no idle VM",
         );
         assert_eq!(
             budget.allocated().2,
             0,
             "budget must be fully released (no held entries, no stray reservations)",
         );
+    }
+
+    /// Regression for #11162: once SIGUSR2 has logically resumed the runner,
+    /// parking is open even if the main loop has not yet processed the Running
+    /// tick. The silent mode flip keeps the main loop in the pre-ack window
+    /// deterministically.
+    #[tokio::test]
+    async fn soft_drain_resume_opens_parking_before_running_ack() {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+            Arc::clone(&gate),
+        ));
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let budget = Arc::clone(&config.budget);
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-soft-resume-race")),
+        );
+        let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+
+        env.drain();
+        wait_parking_state(
+            &idle_pool,
+            ParkingState::SoftDraining,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        // Simulate SIGUSR2's ordering while suppressing the watch wake: open
+        // parking first, then make Running visible without letting the main
+        // loop run its top-of-loop Running branch.
+        env.parking_gate.open_after_soft_drain();
+        env.mode_tx.send_if_modified(|mode| {
+            *mode = RunnerMode::Running;
+            false
+        });
+        assert_eq!(*env.mode_tx.borrow(), RunnerMode::Running);
+
+        gate.notify_one();
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "job should complete after logical resume");
+        assert_eq!(c.unwrap().exit_code, 0);
+
+        assert_eq!(
+            idle_pool.lock().await.len(),
+            1,
+            "job should park even before the main loop acknowledges Running",
+        );
+        assert_eq!(
+            budget.allocated().2,
+            1,
+            "parked VM should retain its budget lease",
+        );
+
+        env.trigger_stopping().await;
+        match tokio::time::timeout(Duration::from_secs(5), run_handle).await {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
+            Ok(Err(e)) => panic!("task panicked: {e}"),
+            Err(_) => panic!("hard shutdown should exit within 5s"),
+        }
     }
 
     /// Regression (G2): on SIGTERM from Running, teardown's

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -90,8 +90,7 @@ impl LifecycleController {
         let gate = self.parking_gate.clone();
         let mut transitioned = false;
         let _ = self.mode_tx.send_if_modified(|mode| {
-            if *mode == RunnerMode::Running {
-                gate.soft_drain();
+            if *mode == RunnerMode::Running && gate.soft_drain() {
                 *mode = RunnerMode::Draining;
                 transitioned = true;
                 true
@@ -106,8 +105,7 @@ impl LifecycleController {
         let gate = self.parking_gate.clone();
         let mut transitioned = false;
         let _ = self.mode_tx.send_if_modified(|mode| {
-            if *mode == RunnerMode::Draining {
-                gate.open_after_soft_drain();
+            if *mode == RunnerMode::Draining && gate.open_after_soft_drain() {
                 *mode = RunnerMode::Running;
                 transitioned = true;
                 true

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::idle_pool::ParkingGate;
 use crate::ids::RunId;
 use crate::status::RunnerMode;
 
@@ -54,16 +55,111 @@ impl EarlySignals {
     }
 }
 
+/// Ordered lifecycle transition handle shared between signal handlers, tests,
+/// and the main run loop's internal Draining -> Stopping transition.
+///
+/// Parking state is updated before publishing the externally visible mode so a
+/// task that observes `Running` can also rely on parking already being open.
+#[derive(Clone)]
+pub(crate) struct LifecycleController {
+    mode_tx: tokio::sync::watch::Sender<RunnerMode>,
+    parking_gate: ParkingGate,
+}
+
+impl LifecycleController {
+    pub(crate) fn new(
+        mode_tx: tokio::sync::watch::Sender<RunnerMode>,
+        parking_gate: ParkingGate,
+    ) -> Self {
+        Self {
+            mode_tx,
+            parking_gate,
+        }
+    }
+
+    pub(crate) fn current_mode(&self) -> RunnerMode {
+        *self.mode_tx.borrow()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn mode_tx(&self) -> &tokio::sync::watch::Sender<RunnerMode> {
+        &self.mode_tx
+    }
+
+    pub(crate) fn enter_soft_drain(&self) -> bool {
+        let gate = self.parking_gate.clone();
+        let mut transitioned = false;
+        let _ = self.mode_tx.send_if_modified(|mode| {
+            if *mode == RunnerMode::Running {
+                gate.soft_drain();
+                *mode = RunnerMode::Draining;
+                transitioned = true;
+                true
+            } else {
+                false
+            }
+        });
+        transitioned
+    }
+
+    pub(crate) fn resume_from_soft_drain(&self) -> bool {
+        let gate = self.parking_gate.clone();
+        let mut transitioned = false;
+        let _ = self.mode_tx.send_if_modified(|mode| {
+            if *mode == RunnerMode::Draining {
+                gate.open_after_soft_drain();
+                *mode = RunnerMode::Running;
+                transitioned = true;
+                true
+            } else {
+                false
+            }
+        });
+        transitioned
+    }
+
+    pub(crate) fn hard_stop(&self) -> bool {
+        let gate = self.parking_gate.clone();
+        let mut transitioned = false;
+        let _ = self.mode_tx.send_if_modified(|mode| {
+            if *mode != RunnerMode::Stopping {
+                gate.close();
+                *mode = RunnerMode::Stopping;
+                transitioned = true;
+                true
+            } else {
+                false
+            }
+        });
+        transitioned
+    }
+
+    pub(crate) fn stop_after_natural_drain(&self) -> bool {
+        let gate = self.parking_gate.clone();
+        let mut transitioned = false;
+        let _ = self.mode_tx.send_if_modified(|mode| {
+            if *mode == RunnerMode::Draining {
+                gate.close();
+                *mode = RunnerMode::Stopping;
+                transitioned = true;
+                true
+            } else {
+                false
+            }
+        });
+        transitioned
+    }
+
+    pub(crate) fn close_parking(&self) {
+        self.parking_gate.close();
+    }
+}
+
 /// Signal-driven mode channel shared between the signal handler task and
 /// the main run loop.
-///
-/// The `RunnerMode` enum is the single source of truth for runner lifecycle
-/// state — `mode_tx` has two writers (the handler for external signals,
-/// and the main loop for the internal Draining → Stopping transition when
-/// `jobs.is_empty()`).
 pub(crate) struct SignalController {
     pub mode_rx: tokio::sync::watch::Receiver<RunnerMode>,
-    pub mode_tx: tokio::sync::watch::Sender<RunnerMode>,
+    pub lifecycle: LifecycleController,
     /// Abort handle for the spawned signal-handler task. `None` for test
     /// overrides where no task was spawned. Teardown calls `.abort()` to
     /// reap the task symmetrically with `mitm_retry.handle.abort()` — the
@@ -77,22 +173,23 @@ impl SignalController {
     /// Spawn the signal-handler task and return a controller handle.
     ///
     /// Signal semantics:
-    /// - **SIGUSR1** (drain): from `Running`, send `Draining` (soft,
-    ///   resumable). Ignored from any other state.
-    /// - **SIGUSR2** (resume): from `Draining`, send `Running` (resume normal
-    ///   discovery). Ignored from `Running` / `Stopping` / `Stopped`.
-    /// - **SIGTERM / SIGINT** (hard): send `Stopping`, cancel every in-flight
-    ///   job's token, cancel the discovery token. Bypasses the soft drain
-    ///   so `systemctl stop` exits promptly rather than waiting up to
-    ///   `JOB_TIMEOUT = 2h` for jobs to finish naturally.
+    /// - **SIGUSR1** (drain): from `Running`, close parking for soft drain,
+    ///   then send `Draining`. Ignored from any other state.
+    /// - **SIGUSR2** (resume): from `Draining`, reopen parking, then send
+    ///   `Running` (resume normal discovery). Ignored from `Running` /
+    ///   `Stopping` / `Stopped`.
+    /// - **SIGTERM / SIGINT** (hard): close parking, send `Stopping`, cancel
+    ///   every in-flight job's token, cancel the discovery token. Bypasses the
+    ///   soft drain so `systemctl stop` exits promptly rather than waiting up
+    ///   to `JOB_TIMEOUT = 2h` for jobs to finish naturally.
     ///
     /// ## Race handling
     ///
-    /// `handle_stopping_signal` sends Stopping **before** locking
-    /// `cancel_tokens`. This ordering lets the main loop close the TOCTOU
-    /// window where a new job is claimed between the handler's iteration
-    /// and its own token insert: the main loop re-reads `mode_rx` after
-    /// insert and sees Stopping via watch's write/read fence.
+    /// `handle_stopping_signal` closes parking and sends Stopping **before**
+    /// locking `cancel_tokens`. This ordering lets the main loop close the
+    /// TOCTOU window where a new job is claimed between the handler's
+    /// iteration and its own token insert: the main loop re-reads `mode_rx`
+    /// after insert and sees Stopping via watch's write/read fence.
     ///
     /// ## Lifetime
     ///
@@ -103,9 +200,11 @@ impl SignalController {
         cancel: CancellationToken,
         cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
         signals: EarlySignals,
+        parking_gate: ParkingGate,
     ) -> Self {
         let (mode_tx, mode_rx) = tokio::sync::watch::channel(RunnerMode::Running);
-        let tx_for_task = mode_tx.clone();
+        let lifecycle = LifecycleController::new(mode_tx, parking_gate);
+        let lifecycle_for_task = lifecycle.clone();
         let EarlySignals {
             mut sigterm,
             mut sigint,
@@ -116,63 +215,63 @@ impl SignalController {
             loop {
                 tokio::select! {
                     _ = sigterm.recv() => {
-                        handle_stopping_signal("SIGTERM", &cancel, &cancel_tokens, &tx_for_task).await;
+                        handle_stopping_signal("SIGTERM", &cancel, &cancel_tokens, &lifecycle_for_task).await;
                     }
                     _ = sigint.recv() => {
-                        handle_stopping_signal("SIGINT", &cancel, &cancel_tokens, &tx_for_task).await;
+                        handle_stopping_signal("SIGINT", &cancel, &cancel_tokens, &lifecycle_for_task).await;
                     }
                     _ = sigusr1.recv() => {
-                        handle_drain_signal(&tx_for_task);
+                        handle_drain_signal(&lifecycle_for_task);
                     }
                     _ = sigusr2.recv() => {
-                        handle_resume_signal(&tx_for_task);
+                        handle_resume_signal(&lifecycle_for_task);
                     }
                 }
             }
         });
         Self {
             mode_rx,
-            mode_tx,
+            lifecycle,
             handler_abort: Some(handle.abort_handle()),
         }
     }
 }
 
-pub(super) fn handle_drain_signal(mode_tx: &tokio::sync::watch::Sender<RunnerMode>) {
-    let current = *mode_tx.borrow();
-    if current != RunnerMode::Running {
+pub(super) fn handle_drain_signal(lifecycle: &LifecycleController) {
+    let current = lifecycle.current_mode();
+    if !lifecycle.enter_soft_drain() {
         warn!(mode = ?current, "SIGUSR1 ignored — only valid from Running");
         return;
     }
     info!("received SIGUSR1, entering Draining (soft drain)");
-    let _ = mode_tx.send(RunnerMode::Draining);
 }
 
-pub(super) fn handle_resume_signal(mode_tx: &tokio::sync::watch::Sender<RunnerMode>) {
-    let current = *mode_tx.borrow();
-    if current != RunnerMode::Draining {
+pub(super) fn handle_resume_signal(lifecycle: &LifecycleController) {
+    let current = lifecycle.current_mode();
+    if !lifecycle.resume_from_soft_drain() {
         warn!(mode = ?current, "SIGUSR2 ignored — only valid from Draining");
         return;
     }
     info!("received SIGUSR2, resuming to Running");
-    let _ = mode_tx.send(RunnerMode::Running);
 }
 
 pub(super) async fn handle_stopping_signal(
     name: &str,
     cancel: &CancellationToken,
     cancel_tokens: &Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
-    mode_tx: &tokio::sync::watch::Sender<RunnerMode>,
+    lifecycle: &LifecycleController,
 ) {
-    if *mode_tx.borrow() == RunnerMode::Stopping {
+    if lifecycle.current_mode() == RunnerMode::Stopping {
+        lifecycle.close_parking();
         warn!(signal = name, "already Stopping, ignoring repeat");
         return;
     }
     info!(signal = name, "initiating hard shutdown");
-    // Send Stopping *before* locking cancel_tokens so that the main loop's
+    // Close parking and send Stopping *before* locking cancel_tokens so that
+    // the main loop's
     // post-insert `mode_rx.borrow()` check catches any job claimed after
     // our iteration but before send would otherwise publish the state.
-    let _ = mode_tx.send(RunnerMode::Stopping);
+    lifecycle.hard_stop();
     let tokens = cancel_tokens.lock().await;
     let count = tokens.len();
     for (run_id, token) in tokens.iter() {
@@ -216,6 +315,7 @@ mod tests {
             CancellationToken::new(),
             Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             signals,
+            ParkingGate::new_open(),
         );
         let mut mode_rx = controller.mode_rx;
 
@@ -236,25 +336,42 @@ mod tests {
     /// Running. Mirrors `handle_resume_signal`'s Draining-only guard.
     #[test]
     fn drain_signal_state_guards() {
+        use crate::idle_pool::ParkingState;
+
         // Running → Draining (sanity: the one legal transition).
+        let gate = ParkingGate::new_open();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Running);
-        handle_drain_signal(&tx);
-        assert_eq!(*tx.borrow(), RunnerMode::Draining);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        handle_drain_signal(&lifecycle);
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
+        assert_eq!(gate.state(), ParkingState::SoftDraining);
 
         // Draining → ignored (no self-transition).
+        let gate = ParkingGate::new_open();
+        gate.soft_drain();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Draining);
-        handle_drain_signal(&tx);
-        assert_eq!(*tx.borrow(), RunnerMode::Draining);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        handle_drain_signal(&lifecycle);
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
+        assert_eq!(gate.state(), ParkingState::SoftDraining);
 
         // Stopping → ignored (cannot reverse teardown).
+        let gate = ParkingGate::new_open();
+        gate.close();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopping);
-        handle_drain_signal(&tx);
-        assert_eq!(*tx.borrow(), RunnerMode::Stopping);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        handle_drain_signal(&lifecycle);
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopping);
+        assert_eq!(gate.state(), ParkingState::Closed);
 
         // Stopped → ignored (runner has exited its loop).
+        let gate = ParkingGate::new_open();
+        gate.close();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopped);
-        handle_drain_signal(&tx);
-        assert_eq!(*tx.borrow(), RunnerMode::Stopped);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        handle_drain_signal(&lifecycle);
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopped);
+        assert_eq!(gate.state(), ParkingState::Closed);
     }
 
     /// `handle_resume_signal` state guard: SIGUSR2 is honored only from
@@ -262,25 +379,42 @@ mod tests {
     /// covers the Stopping case; this pins the full matrix as a unit test.
     #[test]
     fn resume_signal_state_guards() {
+        use crate::idle_pool::ParkingState;
+
         // Draining → Running (sanity: the one legal transition).
+        let gate = ParkingGate::new_open();
+        gate.soft_drain();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Draining);
-        handle_resume_signal(&tx);
-        assert_eq!(*tx.borrow(), RunnerMode::Running);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        handle_resume_signal(&lifecycle);
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Running);
+        assert_eq!(gate.state(), ParkingState::Open);
 
         // Running → ignored (nothing to resume from).
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Running);
-        handle_resume_signal(&tx);
-        assert_eq!(*tx.borrow(), RunnerMode::Running);
+        let gate = ParkingGate::new_open();
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        handle_resume_signal(&lifecycle);
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Running);
+        assert_eq!(gate.state(), ParkingState::Open);
 
         // Stopping → ignored (too late).
+        let gate = ParkingGate::new_open();
+        gate.close();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopping);
-        handle_resume_signal(&tx);
-        assert_eq!(*tx.borrow(), RunnerMode::Stopping);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        handle_resume_signal(&lifecycle);
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopping);
+        assert_eq!(gate.state(), ParkingState::Closed);
 
         // Stopped → ignored.
+        let gate = ParkingGate::new_open();
+        gate.close();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopped);
-        handle_resume_signal(&tx);
-        assert_eq!(*tx.borrow(), RunnerMode::Stopped);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        handle_resume_signal(&lifecycle);
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopped);
+        assert_eq!(gate.state(), ParkingState::Closed);
     }
 
     /// `handle_stopping_signal` idempotency: a repeat invocation takes the
@@ -288,14 +422,19 @@ mod tests {
     /// `cancel_tokens` or re-cancelling `cancel`.
     #[tokio::test]
     async fn stopping_signal_repeat_is_idempotent() {
+        use crate::idle_pool::ParkingState;
+
+        let gate = ParkingGate::new_open();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Running);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
         let cancel = CancellationToken::new();
         let tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
             Arc::new(tokio::sync::Mutex::new(HashMap::new()));
 
         // First call: transitions, cancels main cancel.
-        handle_stopping_signal("SIGTERM", &cancel, &tokens, &tx).await;
-        assert_eq!(*tx.borrow(), RunnerMode::Stopping);
+        handle_stopping_signal("SIGTERM", &cancel, &tokens, &lifecycle).await;
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopping);
+        assert_eq!(gate.state(), ParkingState::Closed);
         assert!(cancel.is_cancelled());
 
         // Insert a sentinel token *after* the first call so we can prove
@@ -307,8 +446,9 @@ mod tests {
             .insert(RunId::new_v4(), sentinel.clone());
 
         // Repeat call: must early-return on the already-Stopping guard.
-        handle_stopping_signal("SIGTERM", &cancel, &tokens, &tx).await;
-        assert_eq!(*tx.borrow(), RunnerMode::Stopping);
+        handle_stopping_signal("SIGTERM", &cancel, &tokens, &lifecycle).await;
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopping);
+        assert_eq!(gate.state(), ParkingState::Closed);
         assert!(
             !sentinel.is_cancelled(),
             "repeat must not re-iterate cancel_tokens and cancel late-inserted sentinel",

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -113,13 +113,28 @@ impl ParkingGate {
         self.state() == ParkingState::Open
     }
 
-    pub(crate) fn soft_drain(&self) {
-        self.state
-            .store(ParkingState::SoftDraining as u8, Ordering::SeqCst);
+    pub(crate) fn soft_drain(&self) -> bool {
+        match self.state.compare_exchange(
+            ParkingState::Open as u8,
+            ParkingState::SoftDraining as u8,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => true,
+            Err(state) => ParkingState::from_u8(state) == ParkingState::SoftDraining,
+        }
     }
 
-    pub(crate) fn open_after_soft_drain(&self) {
-        self.state.store(ParkingState::Open as u8, Ordering::SeqCst);
+    pub(crate) fn open_after_soft_drain(&self) -> bool {
+        match self.state.compare_exchange(
+            ParkingState::SoftDraining as u8,
+            ParkingState::Open as u8,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => true,
+            Err(state) => ParkingState::from_u8(state) == ParkingState::Open,
+        }
     }
 
     pub(crate) fn close(&self) {

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -168,6 +168,17 @@ pub struct IdleEntry {
     pub storage_fingerprints: StorageFingerprints,
 }
 
+/// Idle pool status snapshot paired with a monotonic mutation revision.
+///
+/// Status writes happen after dropping the pool lock, so an older snapshot can
+/// otherwise complete after a newer drain/evict write and reintroduce stale
+/// `idle_vms` in status.json.
+#[derive(Clone, Debug)]
+pub struct IdlePoolSnapshot {
+    pub revision: u64,
+    pub idle_vms: Vec<IdleVm>,
+}
+
 /// Reusable sandbox state handed to the executor after a successful unpark.
 ///
 /// The budget lease is intentionally not part of this payload. The outer job
@@ -253,6 +264,7 @@ impl IdleEntry {
 pub struct IdlePool {
     entries: HashMap<String, IdleEntry>,
     config: IdlePoolConfig,
+    revision: u64,
     /// Shared lifecycle gate. The signal/main-loop lifecycle controller updates
     /// this before publishing externally visible mode transitions.
     parking_gate: ParkingGate,
@@ -268,6 +280,7 @@ impl IdlePool {
         Self {
             entries: HashMap::new(),
             config,
+            revision: 0,
             parking_gate,
         }
     }
@@ -286,16 +299,22 @@ impl IdlePool {
                 return ParkResult::PoolFull(entry);
             }
         }
-        match self.entries.insert(session_id, entry) {
+        let result = match self.entries.insert(session_id, entry) {
             Some(evicted) => ParkResult::Evicted(evicted),
             None => ParkResult::Parked,
-        }
+        };
+        self.bump_revision();
+        result
     }
 
     /// Take a sandbox from the pool for reuse. Returns `None` if no
     /// sandbox is parked for this session.
     pub fn take(&mut self, session_id: &str) -> Option<IdleEntry> {
-        self.entries.remove(session_id)
+        let entry = self.entries.remove(session_id);
+        if entry.is_some() {
+            self.bump_revision();
+        }
+        entry
     }
 
     /// Remove and return all entries that have exceeded their idle timeout.
@@ -308,10 +327,14 @@ impl IdlePool {
             .map(|(k, _)| k.clone())
             .collect();
 
-        expired_keys
+        let expired: Vec<IdleEntry> = expired_keys
             .into_iter()
             .filter_map(|k| self.entries.remove(&k))
-            .collect()
+            .collect();
+        if !expired.is_empty() {
+            self.bump_revision();
+        }
+        expired
     }
 
     /// Evict the oldest idle entry (by park time). Used for resource
@@ -322,13 +345,18 @@ impl IdlePool {
             .iter()
             .min_by_key(|(_, e)| e.parked_at)
             .map(|(k, _)| k.clone())?;
-        self.entries.remove(&oldest_key)
+        let entry = self.entries.remove(&oldest_key);
+        if entry.is_some() {
+            self.bump_revision();
+        }
+        entry
     }
 
-    /// Return a sorted-by-session_id snapshot of the idle pool suitable
-    /// for status.json. Produced in a single iteration so `session_id` and
-    /// `sandbox_id` can never drift out of pairing.
-    pub fn held_snapshot(&self) -> Vec<IdleVm> {
+    /// Return a revisioned sorted-by-session_id snapshot suitable for status.json.
+    ///
+    /// Produced in a single iteration so `session_id` and `sandbox_id` can never
+    /// drift out of pairing.
+    pub fn status_snapshot(&self) -> IdlePoolSnapshot {
         let mut vms: Vec<IdleVm> = self
             .entries
             .iter()
@@ -338,13 +366,24 @@ impl IdlePool {
             })
             .collect();
         vms.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
-        vms
+        IdlePoolSnapshot {
+            revision: self.revision,
+            idle_vms: vms,
+        }
+    }
+
+    /// Return a sorted-by-session_id snapshot of the idle pool suitable
+    /// for status.json. Produced in a single iteration so `session_id` and
+    /// `sandbox_id` can never drift out of pairing.
+    #[cfg(test)]
+    pub fn held_snapshot(&self) -> Vec<IdleVm> {
+        self.status_snapshot().idle_vms
     }
 
     /// Return the list of session IDs currently held in the pool, sorted
     /// lexicographically for deterministic heartbeat output.
     ///
-    /// Prefer [`held_snapshot`](Self::held_snapshot) when pairing with
+    /// Prefer [`status_snapshot`](Self::status_snapshot) when pairing with
     /// sandbox IDs — it produces both views from a single iteration.
     pub fn held_sessions(&self) -> Vec<String> {
         let mut sessions: Vec<String> = self.entries.keys().cloned().collect();
@@ -378,7 +417,15 @@ impl IdlePool {
     /// [`ParkingGate`] so soft-drain resume can reopen parking before
     /// `RunnerMode::Running` becomes visible.
     pub fn drain(&mut self) -> Vec<IdleEntry> {
-        self.entries.drain().map(|(_, v)| v).collect()
+        let entries: Vec<IdleEntry> = self.entries.drain().map(|(_, v)| v).collect();
+        if !entries.is_empty() {
+            self.bump_revision();
+        }
+        entries
+    }
+
+    fn bump_revision(&mut self) {
+        self.revision = self.revision.saturating_add(1);
     }
 }
 
@@ -600,6 +647,33 @@ mod tests {
     fn held_snapshot_empty_pool() {
         let pool = IdlePool::new(pool_config(0));
         assert!(pool.held_snapshot().is_empty());
+    }
+
+    #[test]
+    fn status_snapshot_revision_tracks_idle_vm_mutations() {
+        let mut pool = IdlePool::new(pool_config(0));
+        assert_eq!(pool.status_snapshot().revision, 0);
+
+        let _ = pool.park("s1".into(), make_entry(2, 2048));
+        assert_eq!(pool.status_snapshot().revision, 1);
+
+        assert!(pool.take("s1").is_some());
+        assert_eq!(pool.status_snapshot().revision, 2);
+
+        let drained = pool.drain();
+        assert!(drained.is_empty());
+        assert_eq!(
+            pool.status_snapshot().revision,
+            2,
+            "empty drain must not create a fake idle_vms mutation",
+        );
+
+        let _ = pool.park("s2".into(), make_entry(2, 2048));
+        assert_eq!(pool.status_snapshot().revision, 3);
+
+        let drained = pool.drain();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(pool.status_snapshot().revision, 4);
     }
 
     #[test]

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU8, Ordering},
+};
 use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
@@ -67,6 +70,67 @@ impl Default for IdlePoolConfig {
             default_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS),
             max_idle: 0,
         }
+    }
+}
+
+/// Lifecycle-owned gate for whether completed jobs may enter the idle pool.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ParkingState {
+    Open = 0,
+    SoftDraining = 1,
+    Closed = 2,
+}
+
+impl ParkingState {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Open,
+            1 => Self::SoftDraining,
+            2 => Self::Closed,
+            _ => Self::Closed,
+        }
+    }
+}
+
+/// Shared parking permission updated before publishing runner mode transitions.
+#[derive(Clone, Debug)]
+pub(crate) struct ParkingGate {
+    state: Arc<AtomicU8>,
+}
+
+impl ParkingGate {
+    pub(crate) fn new_open() -> Self {
+        Self {
+            state: Arc::new(AtomicU8::new(ParkingState::Open as u8)),
+        }
+    }
+
+    pub(crate) fn state(&self) -> ParkingState {
+        ParkingState::from_u8(self.state.load(Ordering::SeqCst))
+    }
+
+    pub(crate) fn is_open(&self) -> bool {
+        self.state() == ParkingState::Open
+    }
+
+    pub(crate) fn soft_drain(&self) {
+        self.state
+            .store(ParkingState::SoftDraining as u8, Ordering::SeqCst);
+    }
+
+    pub(crate) fn open_after_soft_drain(&self) {
+        self.state.store(ParkingState::Open as u8, Ordering::SeqCst);
+    }
+
+    pub(crate) fn close(&self) {
+        self.state
+            .store(ParkingState::Closed as u8, Ordering::SeqCst);
+    }
+}
+
+impl Default for ParkingGate {
+    fn default() -> Self {
+        Self::new_open()
     }
 }
 
@@ -174,25 +238,31 @@ impl IdleEntry {
 pub struct IdlePool {
     entries: HashMap<String, IdleEntry>,
     config: IdlePoolConfig,
-    /// Set by `drain()` to reject park attempts after shutdown.
-    drained: bool,
+    /// Shared lifecycle gate. The signal/main-loop lifecycle controller updates
+    /// this before publishing externally visible mode transitions.
+    parking_gate: ParkingGate,
 }
 
 impl IdlePool {
+    #[cfg(test)]
     pub fn new(config: IdlePoolConfig) -> Self {
+        Self::new_with_parking_gate(config, ParkingGate::new_open())
+    }
+
+    pub(crate) fn new_with_parking_gate(config: IdlePoolConfig, parking_gate: ParkingGate) -> Self {
         Self {
             entries: HashMap::new(),
             config,
-            drained: false,
+            parking_gate,
         }
     }
 
     /// Park a sandbox in the pool. Returns the previously parked entry
     /// for this session if one existed (caller must destroy it).
     ///
-    /// Returns `PoolFull(entry)` if the pool is drained or at capacity.
+    /// Returns `PoolFull(entry)` if parking is closed/soft-draining or at capacity.
     pub fn park(&mut self, session_id: String, entry: IdleEntry) -> ParkResult {
-        if self.drained {
+        if !self.parking_gate.is_open() {
             return ParkResult::PoolFull(entry);
         }
         if self.config.max_idle > 0 && self.entries.len() >= self.config.max_idle {
@@ -272,19 +342,16 @@ impl IdlePool {
         self.entries.len()
     }
 
-    /// Whether the pool has been drained (rejects new park calls).
+    /// Current lifecycle parking state.
     #[cfg(test)]
-    pub fn is_drained(&self) -> bool {
-        self.drained
+    pub fn parking_state(&self) -> ParkingState {
+        self.parking_gate.state()
     }
 
-    /// Re-enable parking after a resumable soft drain returns to Running.
-    ///
-    /// This is only valid for SIGUSR1 -> SIGUSR2 soft-drain resume. Hard
-    /// shutdown paths must leave the pool drained so stale job tasks cannot
-    /// park new entries while teardown is in progress.
-    pub(crate) fn resume_after_soft_drain(&mut self) {
-        self.drained = false;
+    /// Shared lifecycle parking gate.
+    #[cfg(test)]
+    pub fn parking_gate(&self) -> ParkingGate {
+        self.parking_gate.clone()
     }
 
     /// The default idle timeout.
@@ -292,12 +359,10 @@ impl IdlePool {
         self.config.default_timeout
     }
 
-    /// Drain all entries from the pool (for shutdown).
-    ///
-    /// Also disables the pool so that concurrent job tasks that still hold
-    /// a stale `mode == Running` snapshot cannot park new entries after drain.
+    /// Drain all entries from the pool. Parking permission is controlled by
+    /// [`ParkingGate`] so soft-drain resume can reopen parking before
+    /// `RunnerMode::Running` becomes visible.
     pub fn drain(&mut self) -> Vec<IdleEntry> {
-        self.drained = true;
         self.entries.drain().map(|(_, v)| v).collect()
     }
 }
@@ -531,21 +596,47 @@ mod tests {
         let drained = pool.drain();
         assert_eq!(drained.len(), 2);
         assert_eq!(pool.len(), 0);
-        // drain marks the pool as drained to prevent post-shutdown parking
-        assert!(pool.is_drained());
+        assert_eq!(pool.parking_state(), ParkingState::Open);
     }
 
     #[test]
-    fn park_after_drain_rejected() {
-        // drain() marks pool as drained — subsequent park() calls are rejected.
+    fn park_rejected_while_soft_draining() {
         let mut pool = IdlePool::new(pool_config(0));
+        let gate = pool.parking_gate();
         let _ = pool.park("s1".into(), make_entry(2, 2048));
-        pool.drain();
-        assert!(pool.is_drained());
+        gate.soft_drain();
+        assert_eq!(pool.parking_state(), ParkingState::SoftDraining);
 
         let result = pool.park("s2".into(), make_entry(4, 4096));
         assert!(matches!(result, ParkResult::PoolFull(_)));
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn park_rejected_when_closed() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let gate = pool.parking_gate();
+        gate.close();
+
+        let result = pool.park("s1".into(), make_entry(2, 2048));
+        assert!(matches!(result, ParkResult::PoolFull(_)));
         assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn soft_drain_can_reopen_parking() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let gate = pool.parking_gate();
+        gate.soft_drain();
+        assert!(matches!(
+            pool.park("s1".into(), make_entry(2, 2048)),
+            ParkResult::PoolFull(_)
+        ));
+
+        gate.open_after_soft_drain();
+        let result = pool.park("s1".into(), make_entry(2, 2048));
+        assert!(matches!(result, ParkResult::Parked));
+        assert_eq!(pool.len(), 1);
     }
 
     #[test]
@@ -566,7 +657,7 @@ mod tests {
         let mut pool = IdlePool::new(pool_config(0));
         let drained = pool.drain();
         assert!(drained.is_empty());
-        assert!(pool.is_drained());
+        assert_eq!(pool.parking_state(), ParkingState::Open);
     }
 
     #[test]

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -92,6 +92,12 @@ struct MutableState {
     /// BTreeMap (not HashMap) for deterministic iteration order — status.json
     /// output should be stable across runs for readability and diffing.
     active_runs: BTreeMap<RunId, SandboxId>,
+    /// Monotonic idle pool mutation revision last reflected in `idle_vms`.
+    ///
+    /// Idle pool callers snapshot under the pool lock, drop it, then write
+    /// status asynchronously. The revision prevents an older delayed snapshot
+    /// from overwriting a newer drain/evict state.
+    idle_revision: u64,
     idle_vms: Vec<IdleVm>,
 }
 
@@ -119,6 +125,7 @@ impl StatusTracker {
             state: Mutex::new(MutableState {
                 mode: RunnerMode::Running,
                 active_runs: BTreeMap::new(),
+                idle_revision: 0,
                 idle_vms: Vec::new(),
             }),
         }
@@ -149,10 +156,27 @@ impl StatusTracker {
     }
 
     /// Replace the idle VM list in the status file with `idle_vms`.
+    #[cfg(test)]
     pub async fn set_idle_info(&self, idle_vms: Vec<IdleVm>) {
         let mut state = self.state.lock().await;
         state.idle_vms = idle_vms;
         self.write_status(&state).await;
+    }
+
+    /// Replace the idle VM list only if the snapshot is at least as new as the
+    /// last applied idle-pool mutation revision.
+    ///
+    /// Returns `false` when a stale async writer lost the race to a newer
+    /// snapshot and was intentionally ignored.
+    pub async fn set_idle_info_at_revision(&self, revision: u64, idle_vms: Vec<IdleVm>) -> bool {
+        let mut state = self.state.lock().await;
+        if revision < state.idle_revision {
+            return false;
+        }
+        state.idle_revision = revision;
+        state.idle_vms = idle_vms;
+        self.write_status(&state).await;
+        true
     }
 
     /// Write the initial status file.
@@ -358,6 +382,45 @@ mod tests {
         assert_eq!(vms[0]["sandbox_id"], sb1.to_string());
         assert_eq!(vms[1]["session_id"], "sess-2");
         assert_eq!(vms[1]["sandbox_id"], sb2.to_string());
+    }
+
+    #[tokio::test]
+    async fn stale_idle_info_revision_does_not_overwrite_newer_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4, None, None);
+        let stale_id = SandboxId::new_v4();
+        let fresh_id = SandboxId::new_v4();
+
+        tracker.write_initial().await;
+        assert!(
+            tracker
+                .set_idle_info_at_revision(
+                    2,
+                    vec![IdleVm {
+                        session_id: "fresh".into(),
+                        sandbox_id: fresh_id,
+                    }],
+                )
+                .await
+        );
+        assert!(
+            !tracker
+                .set_idle_info_at_revision(
+                    1,
+                    vec![IdleVm {
+                        session_id: "stale".into(),
+                        sandbox_id: stale_id,
+                    }],
+                )
+                .await
+        );
+
+        let status = read_status(&path);
+        let vms = status["idle_vms"].as_array().unwrap();
+        assert_eq!(vms.len(), 1);
+        assert_eq!(vms[0]["session_id"], "fresh");
+        assert_eq!(vms[0]["sandbox_id"], fresh_id.to_string());
     }
 
     #[tokio::test]

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -147,6 +147,26 @@ impl StatusTracker {
         self.write_status(&state).await;
     }
 
+    /// Register an active run and replace the idle VM list in the same status
+    /// write if the idle snapshot is current.
+    ///
+    /// This avoids a transient status.json gap during idle reuse where a sandbox
+    /// has been removed from `idle_vms` but has not yet appeared in
+    /// `active_runs`.
+    pub async fn add_run_with_idle_info_at_revision(
+        &self,
+        run_id: RunId,
+        sandbox_id: SandboxId,
+        revision: u64,
+        idle_vms: Vec<IdleVm>,
+    ) -> bool {
+        let mut state = self.state.lock().await;
+        state.active_runs.insert(run_id, sandbox_id);
+        let applied = apply_idle_info_at_revision(&mut state, revision, idle_vms);
+        self.write_status(&state).await;
+        applied
+    }
+
     /// Drop an active run from the status file. Silently succeeds if
     /// `run_id` was not present.
     pub async fn remove_run(&self, run_id: RunId) {
@@ -170,11 +190,10 @@ impl StatusTracker {
     /// snapshot and was intentionally ignored.
     pub async fn set_idle_info_at_revision(&self, revision: u64, idle_vms: Vec<IdleVm>) -> bool {
         let mut state = self.state.lock().await;
-        if revision < state.idle_revision {
+        let applied = apply_idle_info_at_revision(&mut state, revision, idle_vms);
+        if !applied {
             return false;
         }
-        state.idle_revision = revision;
-        state.idle_vms = idle_vms;
         self.write_status(&state).await;
         true
     }
@@ -224,6 +243,19 @@ impl StatusTracker {
             warn!(error = %e, "failed to rename status file");
         }
     }
+}
+
+fn apply_idle_info_at_revision(
+    state: &mut MutableState,
+    revision: u64,
+    idle_vms: Vec<IdleVm>,
+) -> bool {
+    if revision < state.idle_revision {
+        return false;
+    }
+    state.idle_revision = revision;
+    state.idle_vms = idle_vms;
+    true
 }
 
 #[cfg(test)]
@@ -421,6 +453,53 @@ mod tests {
         assert_eq!(vms.len(), 1);
         assert_eq!(vms[0]["session_id"], "fresh");
         assert_eq!(vms[0]["sandbox_id"], fresh_id.to_string());
+    }
+
+    #[tokio::test]
+    async fn add_run_with_idle_info_revision_preserves_newer_idle_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4, None, None);
+        let idle_id = SandboxId::new_v4();
+        let stale_id = SandboxId::new_v4();
+        let run_id = RunId::new_v4();
+        let active_id = SandboxId::new_v4();
+
+        tracker.write_initial().await;
+        assert!(
+            tracker
+                .set_idle_info_at_revision(
+                    2,
+                    vec![IdleVm {
+                        session_id: "fresh".into(),
+                        sandbox_id: idle_id,
+                    }],
+                )
+                .await
+        );
+        assert!(
+            !tracker
+                .add_run_with_idle_info_at_revision(
+                    run_id,
+                    active_id,
+                    1,
+                    vec![IdleVm {
+                        session_id: "stale".into(),
+                        sandbox_id: stale_id,
+                    }],
+                )
+                .await
+        );
+
+        let status = read_status(&path);
+        let runs = status["active_runs"].as_array().unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0]["run_id"], run_id.to_string());
+        assert_eq!(runs[0]["sandbox_id"], active_id.to_string());
+        let vms = status["idle_vms"].as_array().unwrap();
+        assert_eq!(vms.len(), 1);
+        assert_eq!(vms[0]["session_id"], "fresh");
+        assert_eq!(vms[0]["sandbox_id"], idle_id.to_string());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add a lifecycle-owned parking gate for idle VM parking state
- update drain/resume/stop transitions to change parking permission before publishing runner mode
- switch job completion parking decisions from spawn-time mode snapshots to current parking state
- add regression coverage for #11162 soft-drain resume race and active-drain rejection

Fixes #11162

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p runner idle_pool
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::signals
- cargo test --manifest-path crates/Cargo.toml -p runner drain
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings