### PR TITLE
feat: include usage events in usage insight reporting

### DIFF
--- a/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   createTestRequest,
   insertTestCreditUsageForRun,
+  insertTestUsageEvent,
   setTestCreditUsageCreatedAt,
   seedTestSchedule,
 } from "../../../../../../src/__tests__/api-test-helpers";
@@ -30,6 +31,21 @@ function makeRequest(params: Record<string, string>) {
   return createTestRequest(
     `http://localhost:3000/api/zero/usage/insight?${qs}`,
   );
+}
+
+function sumBucketSeries(
+  buckets: UsageInsightBucket[],
+): Record<string, { credits: number; tokens: number }> {
+  const totals: Record<string, { credits: number; tokens: number }> = {};
+  for (const bucket of buckets) {
+    for (const [key, credits] of Object.entries(bucket.series)) {
+      const current = totals[key] ?? { credits: 0, tokens: 0 };
+      current.credits += credits;
+      current.tokens += bucket.tokens[key] ?? 0;
+      totals[key] = current;
+    }
+  }
+  return totals;
 }
 
 describe("GET /api/zero/usage/insight", () => {
@@ -462,6 +478,7 @@ describe("GET /api/zero/usage/insight", () => {
       name: uniqueId("compose"),
       orgId,
     });
+    let eventBoostedScheduleId = "";
 
     // Seed 105 schedules in parallel, each with one run + credit usage
     await Promise.all(
@@ -485,6 +502,20 @@ describe("GET /api/zero/usage/insight", () => {
           creditsCharged: i + 1,
           status: "processed",
         });
+
+        if (i === 0) {
+          eventBoostedScheduleId = scheduleId;
+          await insertTestUsageEvent(orgId, {
+            userId,
+            runId,
+            kind: "connector",
+            provider: "x",
+            category: "tweet.read",
+            quantity: 1,
+            creditsCharged: 10_000,
+            status: "processed",
+          });
+        }
       }),
     );
 
@@ -496,6 +527,10 @@ describe("GET /api/zero/usage/insight", () => {
 
     expect(data.schedules.length).toBe(100);
     expect(data.scheduleOtherCount).toBe(5);
+    expect(data.schedules[0]).toMatchObject({
+      scheduleId: eventBoostedScheduleId,
+      credits: 10_001,
+    });
   });
 
   it("scope isolation — other user's activity in same org is invisible", async () => {
@@ -541,6 +576,16 @@ describe("GET /api/zero/usage/insight", () => {
       creditsCharged: 999,
       status: "processed",
     });
+    await insertTestUsageEvent(orgId, {
+      userId: otherUserId,
+      runId: otherRunId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 999,
+      status: "processed",
+    });
 
     const response = await GET(
       makeRequest({ range: "7d", groupBy: "source", tz: "UTC" }),
@@ -550,6 +595,156 @@ describe("GET /api/zero/usage/insight", () => {
 
     // grandTotalCredits should only include the main user's 100 credits, not other user's 999
     expect(data.grandTotalCredits).toBe(100);
+  });
+
+  it("includes usage_event rows in grand totals and source buckets", async () => {
+    const { userId, orgId } = await context.user;
+    const { composeId } = await seedTestCompose({
+      userId,
+      name: uniqueId("compose"),
+      orgId,
+    });
+    const { runId } = await seedTestRun(userId, composeId, {
+      triggerSource: "web",
+      status: "completed",
+    });
+
+    await insertTestCreditUsageForRun({
+      runId,
+      orgId,
+      userId,
+      inputTokens: 100,
+      outputTokens: 50,
+      creditsCharged: 10,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.input",
+      quantity: 30,
+      creditsCharged: 3,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.output",
+      quantity: 20,
+      creditsCharged: 2,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.cache_read",
+      quantity: 5,
+      creditsCharged: 1,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.cache_creation",
+      quantity: 10,
+      creditsCharged: 4,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 7,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.input",
+      quantity: 999,
+      creditsCharged: 999,
+      status: "pending",
+    });
+
+    const response = await GET(
+      makeRequest({ range: "7d", groupBy: "source", tz: "UTC" }),
+    );
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as UsageInsightResponse;
+    const totals = sumBucketSeries(data.buckets);
+
+    expect(data.grandTotalCredits).toBe(27);
+    expect(data.grandTotalTokens).toBe(215);
+    expect(totals["chat"]).toEqual({ credits: 20, tokens: 215 });
+    expect(totals["others"]).toEqual({ credits: 7, tokens: 0 });
+  });
+
+  it("includes run-linked usage_event rows in agent buckets and channel totals", async () => {
+    const { userId, orgId } = await context.user;
+    const agentName = uniqueId("usage-event-agent");
+    const { composeId } = await seedTestCompose({
+      userId,
+      name: agentName,
+      orgId,
+    });
+    const { runId } = await seedTestRun(userId, composeId, {
+      triggerSource: "slack",
+      status: "completed",
+    });
+
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 40,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.output",
+      quantity: 15,
+      creditsCharged: 5,
+      status: "processed",
+    });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 8,
+      status: "processed",
+    });
+
+    const response = await GET(
+      makeRequest({ range: "7d", groupBy: "agent", tz: "UTC" }),
+    );
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as UsageInsightResponse;
+    const totals = sumBucketSeries(data.buckets);
+
+    expect(totals[agentName]).toEqual({ credits: 45, tokens: 15 });
+    expect(totals["others"]).toEqual({ credits: 8, tokens: 0 });
+    expect(data.slackCredits).toBe(45);
+    expect(data.slackTokens).toBe(15);
   });
 
   it("returns chat rows when groupBy=source and there are chat runs", async () => {
@@ -581,6 +776,16 @@ describe("GET /api/zero/usage/insight", () => {
       creditsCharged: 200,
       status: "processed",
     });
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.input",
+      quantity: 12,
+      creditsCharged: 25,
+      status: "processed",
+    });
 
     const response = await GET(
       makeRequest({ range: "7d", groupBy: "source", tz: "UTC" }),
@@ -594,7 +799,8 @@ describe("GET /api/zero/usage/insight", () => {
     });
     expect(chat).toBeDefined();
     expect(chat?.threadTitle).toBe("Test Chat Thread");
-    expect(chat?.credits).toBe(200);
+    expect(chat?.credits).toBe(225);
+    expect(chat?.tokens).toBe(162);
   });
 
   it("top-100 truncation — overflow with creditsCharged=0 still reports correct otherCount", async () => {

--- a/turbo/apps/web/src/lib/zero/billing/model-usage-categories.ts
+++ b/turbo/apps/web/src/lib/zero/billing/model-usage-categories.ts
@@ -1,0 +1,12 @@
+export const MODEL_USAGE_KIND = "model";
+export const TOKEN_CATEGORY_INPUT = "tokens.input";
+export const TOKEN_CATEGORY_OUTPUT = "tokens.output";
+export const TOKEN_CATEGORY_CACHE_READ = "tokens.cache_read";
+export const TOKEN_CATEGORY_CACHE_CREATION = "tokens.cache_creation";
+
+export const MODEL_TOKEN_CATEGORIES = [
+  TOKEN_CATEGORY_INPUT,
+  TOKEN_CATEGORY_OUTPUT,
+  TOKEN_CATEGORY_CACHE_READ,
+  TOKEN_CATEGORY_CACHE_CREATION,
+] as const;

--- a/turbo/apps/web/src/lib/zero/billing/usage-insight-ledger.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-insight-ledger.ts
@@ -1,6 +1,10 @@
 import { sql } from "drizzle-orm";
 import type { UsageInsightResponse } from "@vm0/api-contracts/contracts/zero-usage-insight";
 import type { Database } from "../../../types/global";
+import {
+  MODEL_TOKEN_CATEGORIES,
+  MODEL_USAGE_KIND,
+} from "./model-usage-categories";
 
 export interface UsageInsightSqlParams {
   userIdLit: string;
@@ -18,27 +22,82 @@ export interface UsageInsightBucketRow extends Record<string, unknown> {
   tokens: string;
 }
 
-const LEGACY_USAGE_TIME_COLUMN = "cu.created_at";
+const USAGE_ROW_ALIAS = "ur";
+
+function pgLit(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
 
 function usageBucketExpr(p: UsageInsightSqlParams): string {
-  return `date_trunc(${p.truncLit}, ${LEGACY_USAGE_TIME_COLUMN}::timestamptz AT TIME ZONE ${p.tzLit})`;
+  return `date_trunc(${p.truncLit}, ${USAGE_ROW_ALIAS}.usage_time::timestamptz AT TIME ZONE ${p.tzLit})`;
 }
 
-function usageWindowPredicate(p: UsageInsightSqlParams): string {
-  return `${LEGACY_USAGE_TIME_COLUMN} >= ${p.startTsLit}::timestamptz
-        AND ${LEGACY_USAGE_TIME_COLUMN} < ${p.endTsLit}::timestamptz`;
+function createdAtWindowPredicate(
+  alias: string,
+  p: UsageInsightSqlParams,
+): string {
+  return `${alias}.created_at >= ${p.startTsLit}::timestamptz
+        AND ${alias}.created_at < ${p.endTsLit}::timestamptz`;
 }
 
-function totalTokensExpr(alias: string): string {
-  return `COALESCE(SUM(cu.input_tokens + cu.output_tokens + cu.cache_read_input_tokens + cu.cache_creation_input_tokens), 0)::bigint AS ${alias}`;
+function usageRowTokenExpr(): string {
+  const tokenCategoryList = MODEL_TOKEN_CATEGORIES.map(pgLit).join(", ");
+  return `CASE WHEN ue.kind = ${pgLit(MODEL_USAGE_KIND)} AND ue.category IN (${tokenCategoryList}) THEN ue.quantity ELSE 0 END`;
 }
 
-export async function queryLegacySourceBuckets(
+function usageRowsCte(p: UsageInsightSqlParams): string {
+  return `
+    usage_rows AS (
+      SELECT
+        'legacy' AS ledger,
+        cu.created_at AS usage_time,
+        cu.run_id,
+        cu.user_id,
+        cu.org_id,
+        COALESCE(cu.credits_charged, 0)::bigint AS credits_charged,
+        (cu.input_tokens + cu.output_tokens + cu.cache_read_input_tokens + cu.cache_creation_input_tokens)::bigint AS tokens
+      FROM credit_usage cu
+      WHERE cu.user_id = ${p.userIdLit}
+        AND cu.org_id = ${p.orgIdLit}
+        AND cu.status = 'processed'
+        AND ${createdAtWindowPredicate("cu", p)}
+
+      UNION ALL
+
+      SELECT
+        'event' AS ledger,
+        ue.created_at AS usage_time,
+        ue.run_id,
+        ue.user_id,
+        ue.org_id,
+        COALESCE(ue.credits_charged, 0)::bigint AS credits_charged,
+        ${usageRowTokenExpr()}::bigint AS tokens
+      FROM usage_event ue
+      WHERE ue.user_id = ${p.userIdLit}
+        AND ue.org_id = ${p.orgIdLit}
+        AND ue.status = 'processed'
+        AND ${createdAtWindowPredicate("ue", p)}
+    )`;
+}
+
+function usageRowsWith(p: UsageInsightSqlParams): string {
+  return `WITH ${usageRowsCte(p)}`;
+}
+
+function agentNameExpr(): string {
+  return `CASE
+    WHEN ${USAGE_ROW_ALIAS}.ledger = 'event' AND ar.id IS NULL THEN 'others'
+    ELSE COALESCE(za.display_name, za.name, acv_compose.name, 'unknown')
+  END`;
+}
+
+export async function queryUsageInsightSourceBuckets(
   db: Database,
   p: UsageInsightSqlParams,
 ) {
   return db.execute<UsageInsightBucketRow>(
     sql.raw(`
+      ${usageRowsWith(p)}
       SELECT
         ${usageBucketExpr(p)} AS ts,
         CASE
@@ -48,39 +107,35 @@ export async function queryLegacySourceBuckets(
           WHEN zr.trigger_source = 'schedule' THEN 'schedule'
           ELSE 'others'
         END AS bucket,
-        COALESCE(SUM(cu.credits_charged), 0)::bigint AS credits,
-        ${totalTokensExpr("tokens")}
-      FROM credit_usage cu
-      LEFT JOIN zero_runs zr ON zr.id = cu.run_id
-      WHERE cu.user_id = ${p.userIdLit}
-        AND cu.org_id = ${p.orgIdLit}
-        AND cu.status = 'processed'
-        AND ${usageWindowPredicate(p)}
+        COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
+        COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS tokens
+      FROM usage_rows ${USAGE_ROW_ALIAS}
+      LEFT JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
       GROUP BY 1, 2
       ORDER BY 1
     `),
   );
 }
 
-export async function queryLegacyAgentBuckets(
+export async function queryUsageInsightAgentBuckets(
   db: Database,
   p: UsageInsightSqlParams,
 ) {
+  const agentName = agentNameExpr();
+
   return db.execute<UsageInsightBucketRow>(
     sql.raw(`
-      WITH agent_totals AS (
+      ${usageRowsWith(p)},
+      agent_totals AS (
         SELECT
-          COALESCE(za.display_name, za.name, acv_compose.name, 'unknown') AS agent_name,
-          COALESCE(SUM(cu.credits_charged), 0)::bigint AS total_credits
-        FROM credit_usage cu
-        INNER JOIN agent_runs ar ON ar.id = cu.run_id
-        INNER JOIN agent_compose_versions acv ON acv.id = ar.agent_compose_version_id
-        INNER JOIN agent_composes acv_compose ON acv_compose.id = acv.compose_id
+          ${agentName} AS agent_name,
+          COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS total_credits
+        FROM usage_rows ${USAGE_ROW_ALIAS}
+        LEFT JOIN agent_runs ar ON ar.id = ${USAGE_ROW_ALIAS}.run_id
+        LEFT JOIN agent_compose_versions acv ON acv.id = ar.agent_compose_version_id
+        LEFT JOIN agent_composes acv_compose ON acv_compose.id = acv.compose_id
         LEFT JOIN zero_agents za ON za.id = acv_compose.id
-        WHERE cu.user_id = ${p.userIdLit}
-          AND cu.org_id = ${p.orgIdLit}
-          AND cu.status = 'processed'
-          AND ${usageWindowPredicate(p)}
+        WHERE ${USAGE_ROW_ALIAS}.ledger = 'event' OR ar.id IS NOT NULL
         GROUP BY 1
         ORDER BY 2 DESC
       ),
@@ -88,28 +143,25 @@ export async function queryLegacyAgentBuckets(
       SELECT
         ${usageBucketExpr(p)} AS ts,
         CASE
-          WHEN COALESCE(za.display_name, za.name, acv_compose.name, 'unknown') IN (SELECT agent_name FROM top7)
-          THEN COALESCE(za.display_name, za.name, acv_compose.name, 'unknown')
+          WHEN ${agentName} IN (SELECT agent_name FROM top7)
+          THEN ${agentName}
           ELSE 'others'
         END AS bucket,
-        COALESCE(SUM(cu.credits_charged), 0)::bigint AS credits,
-        ${totalTokensExpr("tokens")}
-      FROM credit_usage cu
-      INNER JOIN agent_runs ar ON ar.id = cu.run_id
-      INNER JOIN agent_compose_versions acv ON acv.id = ar.agent_compose_version_id
-      INNER JOIN agent_composes acv_compose ON acv_compose.id = acv.compose_id
+        COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
+        COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS tokens
+      FROM usage_rows ${USAGE_ROW_ALIAS}
+      LEFT JOIN agent_runs ar ON ar.id = ${USAGE_ROW_ALIAS}.run_id
+      LEFT JOIN agent_compose_versions acv ON acv.id = ar.agent_compose_version_id
+      LEFT JOIN agent_composes acv_compose ON acv_compose.id = acv.compose_id
       LEFT JOIN zero_agents za ON za.id = acv_compose.id
-      WHERE cu.user_id = ${p.userIdLit}
-        AND cu.org_id = ${p.orgIdLit}
-        AND cu.status = 'processed'
-        AND ${usageWindowPredicate(p)}
+      WHERE ${USAGE_ROW_ALIAS}.ledger = 'event' OR ar.id IS NOT NULL
       GROUP BY 1, 2
       ORDER BY 1
     `),
   );
 }
 
-export async function queryLegacyGrandTotal(
+export async function queryUsageInsightGrandTotal(
   db: Database,
   p: UsageInsightSqlParams,
 ): Promise<{ grandTotalCredits: number; grandTotalTokens: number }> {
@@ -118,14 +170,11 @@ export async function queryLegacyGrandTotal(
     grand_tokens: string;
   }>(
     sql.raw(`
+      ${usageRowsWith(p)}
       SELECT
-        COALESCE(SUM(cu.credits_charged), 0)::bigint AS grand_credits,
-        ${totalTokensExpr("grand_tokens")}
-      FROM credit_usage cu
-      WHERE cu.user_id = ${p.userIdLit}
-        AND cu.org_id = ${p.orgIdLit}
-        AND cu.status = 'processed'
-        AND ${usageWindowPredicate(p)}
+        COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS grand_credits,
+        COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS grand_tokens
+      FROM usage_rows ${USAGE_ROW_ALIAS}
     `),
   );
   return {
@@ -134,7 +183,7 @@ export async function queryLegacyGrandTotal(
   };
 }
 
-export async function queryLegacyChannelTotals(
+export async function queryUsageInsightChannelTotals(
   db: Database,
   p: UsageInsightSqlParams,
 ): Promise<{
@@ -149,17 +198,14 @@ export async function queryLegacyChannelTotals(
     tokens: string;
   }>(
     sql.raw(`
+      ${usageRowsWith(p)}
       SELECT
         zr.trigger_source AS source,
-        COALESCE(SUM(cu.credits_charged), 0)::bigint AS credits,
-        COALESCE(SUM(cu.input_tokens + cu.output_tokens + cu.cache_read_input_tokens + cu.cache_creation_input_tokens), 0)::bigint AS tokens
-      FROM credit_usage cu
-      LEFT JOIN zero_runs zr ON zr.id = cu.run_id
-      WHERE cu.user_id = ${p.userIdLit}
-        AND cu.org_id = ${p.orgIdLit}
-        AND cu.status = 'processed'
-        AND ${usageWindowPredicate(p)}
-        AND zr.trigger_source IN ('email', 'slack')
+        COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
+        COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS tokens
+      FROM usage_rows ${USAGE_ROW_ALIAS}
+      LEFT JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
+      WHERE zr.trigger_source IN ('email', 'slack')
       GROUP BY 1
     `),
   );
@@ -179,7 +225,7 @@ export async function queryLegacyChannelTotals(
   return { emailCredits, emailTokens, slackCredits, slackTokens };
 }
 
-export async function queryLegacyTopSchedules(
+export async function queryUsageInsightTopSchedules(
   db: Database,
   p: UsageInsightSqlParams,
 ): Promise<{
@@ -195,21 +241,18 @@ export async function queryLegacyTopSchedules(
     rn: string;
   }>(
     sql.raw(`
-      WITH agg AS (
+      ${usageRowsWith(p)},
+      agg AS (
         SELECT
           zr.schedule_id,
           COALESCE(zas.name, 'Unnamed schedule') AS schedule_name,
-          COALESCE(SUM(cu.credits_charged), 0)::bigint AS credits,
-          COALESCE(SUM(cu.input_tokens + cu.output_tokens + cu.cache_read_input_tokens + cu.cache_creation_input_tokens), 0)::bigint AS tokens,
-          ROW_NUMBER() OVER (ORDER BY SUM(cu.credits_charged) DESC NULLS LAST) AS rn
-        FROM credit_usage cu
-        INNER JOIN zero_runs zr ON zr.id = cu.run_id
+          COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
+          COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS tokens,
+          ROW_NUMBER() OVER (ORDER BY SUM(${USAGE_ROW_ALIAS}.credits_charged) DESC NULLS LAST) AS rn
+        FROM usage_rows ${USAGE_ROW_ALIAS}
+        INNER JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
         LEFT JOIN zero_agent_schedules zas ON zas.id = zr.schedule_id
-        WHERE cu.user_id = ${p.userIdLit}
-          AND cu.org_id = ${p.orgIdLit}
-          AND cu.status = 'processed'
-          AND ${usageWindowPredicate(p)}
-          AND zr.schedule_id IS NOT NULL
+        WHERE zr.schedule_id IS NOT NULL
         GROUP BY zr.schedule_id, zas.name
       )
       SELECT * FROM agg WHERE rn <= 100
@@ -246,16 +289,13 @@ export async function queryLegacyTopSchedules(
   if (hasScheduleOverflow) {
     const countRows = await db.execute<{ cnt: string }>(
       sql.raw(`
-        WITH agg AS (
+        ${usageRowsWith(p)},
+        agg AS (
           SELECT zr.schedule_id,
-            ROW_NUMBER() OVER (ORDER BY SUM(cu.credits_charged) DESC NULLS LAST) AS rn
-          FROM credit_usage cu
-          INNER JOIN zero_runs zr ON zr.id = cu.run_id
-          WHERE cu.user_id = ${p.userIdLit}
-            AND cu.org_id = ${p.orgIdLit}
-            AND cu.status = 'processed'
-            AND ${usageWindowPredicate(p)}
-            AND zr.schedule_id IS NOT NULL
+            ROW_NUMBER() OVER (ORDER BY SUM(${USAGE_ROW_ALIAS}.credits_charged) DESC NULLS LAST) AS rn
+          FROM usage_rows ${USAGE_ROW_ALIAS}
+          INNER JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
+          WHERE zr.schedule_id IS NOT NULL
           GROUP BY zr.schedule_id
         )
         SELECT COUNT(*)::bigint AS cnt FROM agg WHERE rn > 100
@@ -267,7 +307,7 @@ export async function queryLegacyTopSchedules(
   return { schedules, scheduleOtherCount, scheduleOtherCredits };
 }
 
-export async function queryLegacyTopChats(
+export async function queryUsageInsightTopChats(
   db: Database,
   p: UsageInsightSqlParams,
 ): Promise<{
@@ -283,21 +323,18 @@ export async function queryLegacyTopChats(
     rn: string;
   }>(
     sql.raw(`
-      WITH agg AS (
+      ${usageRowsWith(p)},
+      agg AS (
         SELECT
           zr.chat_thread_id,
           ct.title AS thread_title,
-          COALESCE(SUM(cu.credits_charged), 0)::bigint AS credits,
-          COALESCE(SUM(cu.input_tokens + cu.output_tokens + cu.cache_read_input_tokens + cu.cache_creation_input_tokens), 0)::bigint AS tokens,
-          ROW_NUMBER() OVER (ORDER BY SUM(cu.credits_charged) DESC NULLS LAST) AS rn
-        FROM credit_usage cu
-        INNER JOIN zero_runs zr ON zr.id = cu.run_id
+          COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
+          COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS tokens,
+          ROW_NUMBER() OVER (ORDER BY SUM(${USAGE_ROW_ALIAS}.credits_charged) DESC NULLS LAST) AS rn
+        FROM usage_rows ${USAGE_ROW_ALIAS}
+        INNER JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
         LEFT JOIN chat_threads ct ON ct.id = zr.chat_thread_id
-        WHERE cu.user_id = ${p.userIdLit}
-          AND cu.org_id = ${p.orgIdLit}
-          AND cu.status = 'processed'
-          AND ${usageWindowPredicate(p)}
-          AND zr.chat_thread_id IS NOT NULL
+        WHERE zr.chat_thread_id IS NOT NULL
         GROUP BY zr.chat_thread_id, ct.title
       )
       SELECT chat_thread_id AS thread_id, thread_title, credits, tokens, rn
@@ -335,16 +372,13 @@ export async function queryLegacyTopChats(
   if (hasChatOverflow) {
     const countRows = await db.execute<{ cnt: string }>(
       sql.raw(`
-        WITH agg AS (
+        ${usageRowsWith(p)},
+        agg AS (
           SELECT zr.chat_thread_id,
-            ROW_NUMBER() OVER (ORDER BY SUM(cu.credits_charged) DESC NULLS LAST) AS rn
-          FROM credit_usage cu
-          INNER JOIN zero_runs zr ON zr.id = cu.run_id
-          WHERE cu.user_id = ${p.userIdLit}
-            AND cu.org_id = ${p.orgIdLit}
-            AND cu.status = 'processed'
-            AND ${usageWindowPredicate(p)}
-            AND zr.chat_thread_id IS NOT NULL
+            ROW_NUMBER() OVER (ORDER BY SUM(${USAGE_ROW_ALIAS}.credits_charged) DESC NULLS LAST) AS rn
+          FROM usage_rows ${USAGE_ROW_ALIAS}
+          INNER JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
+          WHERE zr.chat_thread_id IS NOT NULL
           GROUP BY zr.chat_thread_id
         )
         SELECT COUNT(*)::bigint AS cnt FROM agg WHERE rn > 100

--- a/turbo/apps/web/src/lib/zero/billing/usage-insight-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-insight-service.ts
@@ -1,14 +1,14 @@
 import type { UsageInsightResponse } from "@vm0/api-contracts/contracts/zero-usage-insight";
 import {
-  queryLegacyAgentBuckets,
-  queryLegacyChannelTotals,
-  queryLegacyGrandTotal,
-  queryLegacySourceBuckets,
-  queryLegacyTopChats,
-  queryLegacyTopSchedules,
+  queryUsageInsightAgentBuckets,
+  queryUsageInsightChannelTotals,
+  queryUsageInsightGrandTotal,
+  queryUsageInsightSourceBuckets,
+  queryUsageInsightTopChats,
+  queryUsageInsightTopSchedules,
   type UsageInsightBucketRow,
   type UsageInsightSqlParams,
-} from "./usage-insight-legacy-ledger";
+} from "./usage-insight-ledger";
 
 interface UsageInsightOptions {
   range: "today" | "yesterday" | "7d" | "28d";
@@ -212,22 +212,18 @@ export async function getUsageInsight(
 
   const bucketsResult =
     options.groupBy === "source"
-      ? await queryLegacySourceBuckets(db, p)
-      : await queryLegacyAgentBuckets(db, p);
+      ? await queryUsageInsightSourceBuckets(db, p)
+      : await queryUsageInsightAgentBuckets(db, p);
 
   const buckets = pivotBucketRows(bucketsResult.rows);
-  const { grandTotalCredits, grandTotalTokens } = await queryLegacyGrandTotal(
-    db,
-    p,
-  );
+  const { grandTotalCredits, grandTotalTokens } =
+    await queryUsageInsightGrandTotal(db, p);
   const { emailCredits, emailTokens, slackCredits, slackTokens } =
-    await queryLegacyChannelTotals(db, p);
+    await queryUsageInsightChannelTotals(db, p);
   const { schedules, scheduleOtherCount, scheduleOtherCredits } =
-    await queryLegacyTopSchedules(db, p);
-  const { chats, chatOtherCount, chatOtherCredits } = await queryLegacyTopChats(
-    db,
-    p,
-  );
+    await queryUsageInsightTopSchedules(db, p);
+  const { chats, chatOtherCount, chatOtherCredits } =
+    await queryUsageInsightTopChats(db, p);
 
   return {
     buckets,

--- a/turbo/apps/web/src/lib/zero/billing/usage-reporting-ledger.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-reporting-ledger.ts
@@ -2,12 +2,13 @@ import { and, eq, gte, isNotNull, lt, or, sql } from "drizzle-orm";
 import { creditUsage } from "@vm0/db/schema/credit-usage";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import type { Database } from "../../../types/global";
-
-const MODEL_USAGE_KIND = "model";
-const TOKEN_CATEGORY_INPUT = "tokens.input";
-const TOKEN_CATEGORY_OUTPUT = "tokens.output";
-const TOKEN_CATEGORY_CACHE_READ = "tokens.cache_read";
-const TOKEN_CATEGORY_CACHE_CREATION = "tokens.cache_creation";
+import {
+  MODEL_USAGE_KIND,
+  TOKEN_CATEGORY_CACHE_CREATION,
+  TOKEN_CATEGORY_CACHE_READ,
+  TOKEN_CATEGORY_INPUT,
+  TOKEN_CATEGORY_OUTPUT,
+} from "./model-usage-categories";
 
 interface UsagePeriod {
   start: Date;


### PR DESCRIPTION
## Summary

- Include processed `usage_event` rows in `/api/zero/usage/insight` through a normalized usage ledger CTE
- Share model token usage category constants with existing usage reporting code
- Count model token usage event quantities as tokens while keeping connector usage credit-only
- Include run-linked usage events in source, agent, channel, schedule, and chat insight summaries; map runless usage events to `others` buckets

Related: #11198
Closes #11262

## Test plan

- [x] `pnpm --dir turbo --filter web test app/api/zero/usage/insight/__tests__/route.test.ts src/lib/zero/billing/__tests__/usage-insight-service.test.ts`
- [x] `pnpm --dir turbo --filter web check-types`
- [x] `pnpm --dir turbo --filter web lint`
- [x] `git diff --cached --check`
- [x] pre-commit: prettier, knip, turbo check-types
- [x] `pnpm db:migrate` from `turbo/apps/web`

Note: full `pnpm --dir turbo --filter web test` hit an existing unrelated timeout in `app/api/cron/cleanup-sandboxes/__tests__/route.test.ts` with unmocked callback HTTP requests; the same file passes when run directly.