### PR TITLE
feat: align daily insights with processed usage ledger

### DIFF
--- a/turbo/apps/web/app/api/cron/aggregate-insights/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-insights/__tests__/route.test.ts
@@ -8,10 +8,13 @@ import {
   createTestCompose,
   ensureOrgRow,
   findInsightsDaily,
+  insertTestUsageEvent,
   seedCreditUsageRecord,
+  seedInsightsDaily,
   seedUserCacheEntry,
   setOrgCredits,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
 import { seedCompletedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 import { reloadEnv } from "../../../../../src/env";
 
@@ -35,7 +38,10 @@ function cronRequest(secret?: string) {
  */
 function recentDate(): { date: Date; dateStr: string } {
   const now = new Date();
-  const date = new Date(now.getTime() - 120_000);
+  const dayStart = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const date = new Date(Math.max(dayStart.getTime(), now.getTime() - 120_000));
   return { date, dateStr: todayDateStr() };
 }
 
@@ -51,6 +57,7 @@ function todayDateStr(): string {
 
 describe("GET /api/cron/aggregate-insights", () => {
   let composeVersionId: string;
+  let composeName: string;
   let userId: string;
   let orgId: string;
 
@@ -61,8 +68,11 @@ describe("GET /api/cron/aggregate-insights", () => {
     const user = await context.setupUser();
     userId = user.userId;
     orgId = user.orgId;
-    const { versionId } = await createTestCompose(uniqueId("insights-agent"));
+    const { versionId, name } = await createTestCompose(
+      uniqueId("insights-agent"),
+    );
     composeVersionId = versionId;
+    composeName = name;
 
     // Ensure org has metadata row for credit balance lookup
     await ensureOrgRow(orgId);
@@ -103,17 +113,15 @@ describe("GET /api/cron/aggregate-insights", () => {
       userId,
       createdAt: date,
       startedAt: date,
-      completedAt: new Date(date.getTime() + 5000),
+      completedAt: date,
     });
 
-    // Second run
-    const run2Start = new Date(date.getTime() + 60000);
     await seedCompletedTestRun({
       composeVersionId,
       userId,
-      createdAt: run2Start,
-      startedAt: run2Start,
-      completedAt: new Date(run2Start.getTime() + 8000),
+      createdAt: date,
+      startedAt: date,
+      completedAt: date,
     });
 
     const response = await GET(cronRequest("test-cron-secret"));
@@ -140,7 +148,7 @@ describe("GET /api/cron/aggregate-insights", () => {
       userId,
       createdAt: date,
       startedAt: date,
-      completedAt: new Date(date.getTime() + 5000),
+      completedAt: date,
     });
 
     await seedUserCacheEntry(userId, "test@example.com");
@@ -170,6 +178,233 @@ describe("GET /api/cron/aggregate-insights", () => {
     expect(teamUsage[0]!.credits).toBe(500);
   });
 
+  it("should count credits by processedAt when the run finished on an earlier day", async () => {
+    const { date } = recentDate();
+    const previousDay = new Date(date.getTime() - 48 * 60 * 60_000);
+
+    const runId = await seedCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: previousDay,
+      startedAt: previousDay,
+      completedAt: new Date(previousDay.getTime() + 5000),
+    });
+
+    await seedUserCacheEntry(userId, "test@example.com");
+    await seedCreditUsageRecord({
+      runId,
+      orgId,
+      userId,
+      creditsCharged: 600,
+      createdAt: previousDay,
+      processedAt: date,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+    expect(row!.data.creditsUsed).toBe(600);
+
+    const agents = row!.data.agents as Array<{
+      agentName: string;
+      runs: number;
+      credits: number;
+    }>;
+    expect(agents).toHaveLength(1);
+    expect(agents[0]!.runs).toBe(0);
+    expect(agents[0]!.credits).toBe(600);
+  });
+
+  it("should count runs by completedAt when the run was created earlier", async () => {
+    const { date } = recentDate();
+    const previousDay = new Date(date.getTime() - 48 * 60 * 60_000);
+
+    await seedCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: previousDay,
+      startedAt: previousDay,
+      completedAt: date,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+
+    const agents = row!.data.agents as Array<{ runs: number; credits: number }>;
+    expect(agents).toHaveLength(1);
+    expect(agents[0]!.runs).toBe(1);
+    expect(agents[0]!.credits).toBe(0);
+  });
+
+  it("should include runless usage events as Other usage", async () => {
+    const { date } = recentDate();
+    await seedUserCacheEntry(userId, "test@example.com");
+
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId: null,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 333,
+      status: "processed",
+      processedAt: date,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+    expect(row!.data.creditsUsed).toBe(333);
+
+    const agents = row!.data.agents as Array<{
+      agentName: string;
+      runs: number;
+      credits: number;
+    }>;
+    expect(agents).toEqual([
+      { agentId: null, agentName: "Other usage", runs: 0, credits: 333 },
+    ]);
+
+    const teamUsage = row!.data.teamUsage as Array<{
+      agentNames: string[];
+      agentCredits: Record<string, number>;
+      credits: number;
+    }>;
+    expect(teamUsage).toHaveLength(1);
+    expect(teamUsage[0]!.credits).toBe(333);
+    expect(teamUsage[0]!.agentNames).toEqual(["Other usage"]);
+    expect(teamUsage[0]!.agentCredits).toEqual({ "Other usage": 333 });
+  });
+
+  it("should reprocess activity at the previous aggregation watermark", async () => {
+    const { date } = recentDate();
+    await seedUserCacheEntry(userId, "test@example.com");
+    await seedInsightsDaily(
+      orgId,
+      todayDateStr(),
+      {
+        agents: [],
+        creditsUsed: 0,
+        creditBalance: 0,
+        teamUsage: [],
+        topTask: null,
+        services: [],
+        permissions: [],
+      },
+      userId,
+      { updatedAt: date },
+    );
+
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId: null,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 444,
+      status: "processed",
+      processedAt: date,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+    expect(row!.data.creditsUsed).toBe(444);
+  });
+
+  it("should keep agents with the same display name separate", async () => {
+    const { date } = recentDate();
+    const secondAgent = await createTestCompose(uniqueId("insights-agent"));
+
+    await createTestZeroAgent(orgId, composeName, {
+      displayName: "Shared display",
+    });
+    await createTestZeroAgent(orgId, secondAgent.name, {
+      displayName: "Shared display",
+    });
+
+    const run1Id = await seedCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: date,
+    });
+    const run2Id = await seedCompletedTestRun({
+      composeVersionId: secondAgent.versionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: date,
+    });
+
+    await seedCreditUsageRecord({
+      runId: run1Id,
+      orgId,
+      userId,
+      creditsCharged: 100,
+      createdAt: date,
+    });
+    await seedCreditUsageRecord({
+      runId: run2Id,
+      orgId,
+      userId,
+      creditsCharged: 200,
+      createdAt: date,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+
+    const agents = row!.data.agents as Array<{
+      agentId: string | null;
+      agentName: string;
+      runs: number;
+      credits: number;
+    }>;
+    expect(agents).toHaveLength(2);
+    expect(
+      agents.map((agent) => {
+        return agent.agentName;
+      }),
+    ).toEqual(["Shared display", "Shared display"]);
+    expect(
+      new Set(
+        agents.map((agent) => {
+          return agent.agentId;
+        }),
+      ).size,
+    ).toBe(2);
+    expect(
+      agents.map((agent) => {
+        return agent.runs;
+      }),
+    ).toEqual([1, 1]);
+    expect(
+      agents
+        .map((agent) => {
+          return agent.credits;
+        })
+        .sort((a, b) => {
+          return a - b;
+        }),
+    ).toEqual([100, 200]);
+  });
+
   it("should include credit balance from org metadata", async () => {
     const { date } = recentDate();
 
@@ -178,7 +413,7 @@ describe("GET /api/cron/aggregate-insights", () => {
       userId,
       createdAt: date,
       startedAt: date,
-      completedAt: new Date(date.getTime() + 5000),
+      completedAt: date,
     });
 
     const response = await GET(cronRequest("test-cron-secret"));
@@ -198,7 +433,7 @@ describe("GET /api/cron/aggregate-insights", () => {
       userId,
       createdAt: date,
       startedAt: date,
-      completedAt: new Date(date.getTime() + 5000),
+      completedAt: date,
     });
 
     // Mock Axiom to return network logs referencing this run
@@ -270,6 +505,67 @@ describe("GET /api/cron/aggregate-insights", () => {
     expect(slackPerm!.denied).toBe(1);
   });
 
+  it("should attribute current-day network logs for older runs by runId", async () => {
+    const { date } = recentDate();
+    const previousDay = new Date(date.getTime() - 48 * 60 * 60_000);
+
+    const runId = await seedCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: previousDay,
+      startedAt: previousDay,
+      completedAt: new Date(previousDay.getTime() + 5000),
+    });
+
+    await insertTestUsageEvent(orgId, {
+      userId,
+      runId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 25,
+      status: "processed",
+      processedAt: date,
+    });
+
+    context.mocks.axiom.queryAxiom.mockResolvedValue([
+      {
+        _time: date.toISOString(),
+        runId,
+        host: "api.slack.com",
+        firewall_name: "slack",
+        firewall_permission: "send_message",
+        action: "ALLOW",
+      },
+    ]);
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+    expect(row!.data.creditsUsed).toBe(25);
+
+    const agents = row!.data.agents as Array<{
+      agentName: string;
+      runs: number;
+      credits: number;
+    }>;
+    expect(agents).toHaveLength(1);
+    expect(agents[0]!.runs).toBe(0);
+    expect(agents[0]!.credits).toBe(25);
+
+    const services = row!.data.services as Array<{
+      domain: string;
+      calls: number;
+      agentNames: string[];
+    }>;
+    expect(services).toEqual([
+      { domain: "slack", calls: 1, agentNames: [expect.any(String)] },
+    ]);
+  });
+
   it("should record denied requests with empty firewall_permission", async () => {
     const { date } = recentDate();
 
@@ -278,7 +574,7 @@ describe("GET /api/cron/aggregate-insights", () => {
       userId,
       createdAt: date,
       startedAt: date,
-      completedAt: new Date(date.getTime() + 5000),
+      completedAt: date,
     });
 
     context.mocks.axiom.queryAxiom.mockResolvedValue([
@@ -346,7 +642,7 @@ describe("GET /api/cron/aggregate-insights", () => {
       userId,
       createdAt: date,
       startedAt: date,
-      completedAt: new Date(date.getTime() + 5000),
+      completedAt: date,
     });
 
     context.mocks.axiom.queryAxiom.mockRejectedValue(
@@ -377,7 +673,7 @@ describe("GET /api/cron/aggregate-insights", () => {
       userId,
       createdAt: date,
       startedAt: date,
-      completedAt: new Date(date.getTime() + 5000),
+      completedAt: date,
     });
 
     await seedUserCacheEntry(userId, "test@example.com");
@@ -413,7 +709,7 @@ describe("GET /api/cron/aggregate-insights", () => {
       userId,
       createdAt: date,
       startedAt: date,
-      completedAt: new Date(date.getTime() + 5000),
+      completedAt: date,
     });
 
     await seedUserCacheEntry(userId, "alice@example.com", "Alice");
@@ -448,7 +744,7 @@ describe("GET /api/cron/aggregate-insights", () => {
       userId,
       createdAt: date,
       startedAt: date,
-      completedAt: new Date(date.getTime() + 5000),
+      completedAt: date,
     });
 
     // Seed cache entry without name (name=null)
@@ -484,7 +780,7 @@ describe("GET /api/cron/aggregate-insights", () => {
       userId,
       createdAt: date,
       startedAt: date,
-      completedAt: new Date(date.getTime() + 5000),
+      completedAt: date,
     });
 
     // First run

--- a/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
@@ -7,6 +7,7 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { creditUsage } from "@vm0/db/schema/credit-usage";
+import { usageEvent } from "@vm0/db/schema/usage-event";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { userCache } from "@vm0/db/schema/user-cache";
@@ -23,13 +24,16 @@ import {
 import { clerkClient } from "@clerk/nextjs/server";
 
 const log = logger("cron:aggregate-insights");
+const OTHER_USAGE_AGENT_NAME = "Other usage";
+const NETWORK_RUN_ATTRIBUTION_BATCH_SIZE = 10_000;
+const AGGREGATION_REPROCESS_OVERLAP_MS = 5 * 60_000;
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 interface AgentInfo {
-  agentId: string;
+  agentId: string | null;
   agentName: string;
   runs: number;
   credits: number;
@@ -118,6 +122,10 @@ function getLocalToday(
     day: "2-digit",
   }).format(now);
   return { targetDate, dayStart, dayEnd };
+}
+
+function normalizeDbDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value);
 }
 
 // ---------------------------------------------------------------------------
@@ -298,7 +306,7 @@ function aggregateNetworkDataPerUser(
 interface InsightData {
   agents: {
     agentName: string;
-    agentId: string;
+    agentId: string | null;
     runs: number;
     credits: number;
   }[];
@@ -412,6 +420,35 @@ interface OrgCreditsInfo {
   teamUsage: TeamUsageEntry[];
 }
 
+interface LedgerCreditRow {
+  orgId: string;
+  userId: string;
+  agentId: string | null;
+  agentName: string;
+  credits: number;
+}
+
+interface RunCountRow {
+  orgId: string;
+  userId: string;
+  agentId: string;
+  agentName: string;
+  runs: number;
+}
+
+interface ActiveUserRow {
+  orgId: string;
+  userId: string;
+  lastActivity: Date;
+}
+
+interface NetworkRunAgentRow {
+  runId: string;
+  orgId: string;
+  userId: string;
+  agentName: string;
+}
+
 function aggregateOrgCredits(
   memberRows: {
     orgId: string;
@@ -476,6 +513,364 @@ function aggregateOrgCredits(
   return orgCreditsMap;
 }
 
+function mergeActiveUserRows(rows: ActiveUserRow[]): ActiveUserRow[] {
+  const byUser = new Map<string, ActiveUserRow>();
+  for (const row of rows) {
+    const normalizedRow = {
+      ...row,
+      lastActivity: normalizeDbDate(row.lastActivity),
+    };
+    const key = `${row.orgId}:${row.userId}`;
+    const existing = byUser.get(key);
+    if (!existing || normalizedRow.lastActivity > existing.lastActivity) {
+      byUser.set(key, normalizedRow);
+    }
+  }
+  return [...byUser.values()];
+}
+
+async function queryActiveUsers(lookbackStart: Date): Promise<ActiveUserRow[]> {
+  const db = globalThis.services.db;
+  const [completedRuns, legacyUsage, eventUsage] = await Promise.all([
+    db
+      .select({
+        orgId: agentRuns.orgId,
+        userId: agentRuns.userId,
+        lastActivity: sql<Date>`MAX(${agentRuns.completedAt})`.as(
+          "last_activity",
+        ),
+      })
+      .from(agentRuns)
+      .where(
+        and(
+          gte(agentRuns.completedAt, lookbackStart),
+          isNotNull(agentRuns.completedAt),
+        ),
+      )
+      .groupBy(agentRuns.orgId, agentRuns.userId),
+    db
+      .select({
+        orgId: creditUsage.orgId,
+        userId: creditUsage.userId,
+        lastActivity: sql<Date>`MAX(${creditUsage.processedAt})`.as(
+          "last_activity",
+        ),
+      })
+      .from(creditUsage)
+      .where(
+        and(
+          eq(creditUsage.status, "processed"),
+          gte(creditUsage.processedAt, lookbackStart),
+          isNotNull(creditUsage.processedAt),
+        ),
+      )
+      .groupBy(creditUsage.orgId, creditUsage.userId),
+    db
+      .select({
+        orgId: usageEvent.orgId,
+        userId: usageEvent.userId,
+        lastActivity: sql<Date>`MAX(${usageEvent.processedAt})`.as(
+          "last_activity",
+        ),
+      })
+      .from(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.status, "processed"),
+          gte(usageEvent.processedAt, lookbackStart),
+          isNotNull(usageEvent.processedAt),
+        ),
+      )
+      .groupBy(usageEvent.orgId, usageEvent.userId),
+  ]);
+
+  return mergeActiveUserRows([...completedRuns, ...legacyUsage, ...eventUsage]);
+}
+
+function mergeAgentRows(
+  runRows: RunCountRow[],
+  creditRows: LedgerCreditRow[],
+  users: Array<{ orgId: string; userId: string }>,
+): Map<string, AgentInfo[]> {
+  const wantedUsers = new Set(
+    users.map((user) => {
+      return `${user.orgId}:${user.userId}`;
+    }),
+  );
+  const byUser = new Map<string, Map<string, AgentInfo>>();
+
+  const add = (
+    orgId: string,
+    userId: string,
+    agentName: string,
+    agentId: string | null,
+    runs: number,
+    credits: number,
+  ) => {
+    const userKey = `${orgId}:${userId}`;
+    if (!wantedUsers.has(userKey)) return;
+
+    const userAgents = byUser.get(userKey) ?? new Map<string, AgentInfo>();
+    const agentKey = agentId ?? `unattributed:${agentName}`;
+    const existing = userAgents.get(agentKey) ?? {
+      agentId,
+      agentName,
+      runs: 0,
+      credits: 0,
+    };
+    existing.agentId = existing.agentId ?? agentId;
+    existing.runs += runs;
+    existing.credits += credits;
+    userAgents.set(agentKey, existing);
+    byUser.set(userKey, userAgents);
+  };
+
+  for (const row of runRows) {
+    add(row.orgId, row.userId, row.agentName, row.agentId, row.runs, 0);
+  }
+  for (const row of creditRows) {
+    add(
+      row.orgId,
+      row.userId,
+      row.agentName,
+      row.agentId,
+      0,
+      Number(row.credits),
+    );
+  }
+
+  const result = new Map<string, AgentInfo[]>();
+  for (const [userKey, agents] of byUser) {
+    const list = [...agents.values()];
+    list.sort((a, b) => {
+      return (
+        b.credits - a.credits ||
+        b.runs - a.runs ||
+        a.agentName.localeCompare(b.agentName)
+      );
+    });
+    result.set(userKey, list);
+  }
+
+  return result;
+}
+
+async function queryCompletedRunCounts(
+  db: typeof globalThis.services.db,
+  orgIds: string[],
+  userIds: string[],
+  dayStart: Date,
+  dayEnd: Date,
+): Promise<RunCountRow[]> {
+  const rows = await db
+    .select({
+      orgId: agentRuns.orgId,
+      userId: agentRuns.userId,
+      agentId: zeroAgents.id,
+      agentName:
+        sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
+          "agent_name",
+        ),
+      runs: sql<number>`COUNT(DISTINCT ${agentRuns.id})::int`.as("runs"),
+    })
+    .from(agentRuns)
+    .innerJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .innerJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
+    .where(
+      and(
+        inArray(agentRuns.orgId, orgIds),
+        inArray(agentRuns.userId, userIds),
+        gte(agentRuns.completedAt, dayStart),
+        lt(agentRuns.completedAt, dayEnd),
+        isNotNull(agentRuns.completedAt),
+      ),
+    )
+    .groupBy(
+      agentRuns.orgId,
+      agentRuns.userId,
+      zeroAgents.id,
+      zeroAgents.displayName,
+      zeroAgents.name,
+    );
+
+  return rows.map((row) => {
+    return {
+      orgId: row.orgId,
+      userId: row.userId,
+      agentId: row.agentId,
+      agentName: row.agentName,
+      runs: Number(row.runs),
+    };
+  });
+}
+
+async function queryLegacyCreditRows(
+  db: typeof globalThis.services.db,
+  orgIds: string[],
+  dayStart: Date,
+  dayEnd: Date,
+): Promise<LedgerCreditRow[]> {
+  const isRunless = sql`${creditUsage.runId} IS NULL`;
+  const rows = await db
+    .select({
+      orgId: creditUsage.orgId,
+      userId: creditUsage.userId,
+      agentId: sql<
+        string | null
+      >`CASE WHEN ${isRunless} THEN NULL ELSE ${zeroAgents.id}::text END`.as(
+        "agent_id",
+      ),
+      agentName:
+        sql<string>`CASE WHEN ${isRunless} THEN ${OTHER_USAGE_AGENT_NAME} ELSE COALESCE(${zeroAgents.displayName}, ${zeroAgents.name}, 'Unknown agent') END`.as(
+          "agent_name",
+        ),
+      credits:
+        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
+          "credits",
+        ),
+    })
+    .from(creditUsage)
+    .leftJoin(agentRuns, eq(creditUsage.runId, agentRuns.id))
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .leftJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
+    .where(
+      and(
+        inArray(creditUsage.orgId, orgIds),
+        eq(creditUsage.status, "processed"),
+        gte(creditUsage.processedAt, dayStart),
+        lt(creditUsage.processedAt, dayEnd),
+        isNotNull(creditUsage.processedAt),
+      ),
+    )
+    .groupBy(
+      creditUsage.orgId,
+      creditUsage.userId,
+      isRunless,
+      zeroAgents.id,
+      zeroAgents.displayName,
+      zeroAgents.name,
+    );
+
+  return rows.map((row) => {
+    return { ...row, credits: Number(row.credits) };
+  });
+}
+
+async function queryUsageEventCreditRows(
+  db: typeof globalThis.services.db,
+  orgIds: string[],
+  dayStart: Date,
+  dayEnd: Date,
+): Promise<LedgerCreditRow[]> {
+  const isRunless = sql`${usageEvent.runId} IS NULL`;
+  const rows = await db
+    .select({
+      orgId: usageEvent.orgId,
+      userId: usageEvent.userId,
+      agentId: sql<
+        string | null
+      >`CASE WHEN ${isRunless} THEN NULL ELSE ${zeroAgents.id}::text END`.as(
+        "agent_id",
+      ),
+      agentName:
+        sql<string>`CASE WHEN ${isRunless} THEN ${OTHER_USAGE_AGENT_NAME} ELSE COALESCE(${zeroAgents.displayName}, ${zeroAgents.name}, 'Unknown agent') END`.as(
+          "agent_name",
+        ),
+      credits:
+        sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
+          "credits",
+        ),
+    })
+    .from(usageEvent)
+    .leftJoin(agentRuns, eq(usageEvent.runId, agentRuns.id))
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .leftJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
+    .where(
+      and(
+        inArray(usageEvent.orgId, orgIds),
+        eq(usageEvent.status, "processed"),
+        gte(usageEvent.processedAt, dayStart),
+        lt(usageEvent.processedAt, dayEnd),
+        isNotNull(usageEvent.processedAt),
+      ),
+    )
+    .groupBy(
+      usageEvent.orgId,
+      usageEvent.userId,
+      isRunless,
+      zeroAgents.id,
+      zeroAgents.displayName,
+      zeroAgents.name,
+    );
+
+  return rows.map((row) => {
+    return { ...row, credits: Number(row.credits) };
+  });
+}
+
+async function queryLedgerCreditRows(
+  db: typeof globalThis.services.db,
+  orgIds: string[],
+  dayStart: Date,
+  dayEnd: Date,
+): Promise<LedgerCreditRow[]> {
+  const [legacyRows, eventRows] = await Promise.all([
+    queryLegacyCreditRows(db, orgIds, dayStart, dayEnd),
+    queryUsageEventCreditRows(db, orgIds, dayStart, dayEnd),
+  ]);
+  return [...legacyRows, ...eventRows];
+}
+
+async function queryNetworkRunAgentRows(
+  db: typeof globalThis.services.db,
+  orgIds: string[],
+  userIds: string[],
+  runIds: string[],
+): Promise<NetworkRunAgentRow[]> {
+  const rows: NetworkRunAgentRow[] = [];
+  for (let i = 0; i < runIds.length; i += NETWORK_RUN_ATTRIBUTION_BATCH_SIZE) {
+    const batch = runIds.slice(i, i + NETWORK_RUN_ATTRIBUTION_BATCH_SIZE);
+    rows.push(
+      ...(await db
+        .select({
+          runId: agentRuns.id,
+          orgId: agentRuns.orgId,
+          userId: agentRuns.userId,
+          agentName:
+            sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
+              "agent_name",
+            ),
+        })
+        .from(agentRuns)
+        .innerJoin(
+          agentComposeVersions,
+          eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+        )
+        .innerJoin(
+          zeroAgents,
+          eq(agentComposeVersions.composeId, zeroAgents.id),
+        )
+        .where(
+          and(
+            inArray(agentRuns.orgId, orgIds),
+            inArray(agentRuns.userId, userIds),
+            inArray(agentRuns.id, batch),
+          ),
+        )),
+    );
+  }
+  return rows;
+}
+
 // ---------------------------------------------------------------------------
 // Window group processing
 // ---------------------------------------------------------------------------
@@ -507,154 +902,23 @@ async function processWindowGroup(
     ),
   ];
 
-  // ── Agent runs per user ────────────────────────────────────────────
+  // ── Completed runs and processed ledger credits ─────────────────────
 
-  const agentRows = await db
-    .select({
-      orgId: agentRuns.orgId,
-      userId: agentRuns.userId,
-      agentId: zeroAgents.id,
-      agentName:
-        sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
-          "agent_name",
-        ),
-      runCount: sql<number>`COUNT(DISTINCT ${agentRuns.id})::int`.as(
-        "run_count",
-      ),
-      credits:
-        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
-          "credits",
-        ),
-    })
-    .from(agentRuns)
-    .innerJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .innerJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
-    .leftJoin(
-      creditUsage,
-      and(
-        eq(creditUsage.runId, agentRuns.id),
-        eq(creditUsage.status, "processed"),
-      ),
-    )
-    .where(
-      and(
-        inArray(agentRuns.orgId, orgIds),
-        inArray(agentRuns.userId, userIds),
-        gte(agentRuns.createdAt, dayStart),
-        lt(agentRuns.createdAt, dayEnd),
-        isNotNull(agentRuns.completedAt),
-      ),
-    )
-    .groupBy(
-      agentRuns.orgId,
-      agentRuns.userId,
-      zeroAgents.id,
-      zeroAgents.displayName,
-      zeroAgents.name,
-    );
-
-  // key: `orgId:userId`
-  const userAgentMap = new Map<string, AgentInfo[]>();
-  for (const row of agentRows) {
-    const key = `${row.orgId}:${row.userId}`;
-    const list = userAgentMap.get(key) ?? [];
-    list.push({
-      agentId: row.agentId,
-      agentName: row.agentName,
-      runs: row.runCount,
-      credits: Number(row.credits),
-    });
-    userAgentMap.set(key, list);
-  }
-
-  // ── runId → user mapping for Axiom cross-reference ─────────────────
-
-  const runAgentRows = await db
-    .select({
-      runId: agentRuns.id,
-      orgId: agentRuns.orgId,
-      userId: agentRuns.userId,
-      agentName:
-        sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
-          "agent_name",
-        ),
-    })
-    .from(agentRuns)
-    .innerJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .innerJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
-    .where(
-      and(
-        inArray(agentRuns.orgId, orgIds),
-        inArray(agentRuns.userId, userIds),
-        gte(agentRuns.createdAt, dayStart),
-        lt(agentRuns.createdAt, dayEnd),
-      ),
-    );
-
-  const runIdToInfo = new Map<
-    string,
-    { orgId: string; userId: string; agentName: string }
-  >();
-  for (const row of runAgentRows) {
-    runIdToInfo.set(row.runId, {
-      orgId: row.orgId,
-      userId: row.userId,
-      agentName: row.agentName,
-    });
-  }
-
-  // ── Org-wide credits with agent breakdown ────────────────────────────
-
-  const memberRows = await db
-    .select({
-      orgId: creditUsage.orgId,
-      userId: creditUsage.userId,
-      agentName:
-        sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
-          "agent_name",
-        ),
-      credits:
-        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
-          "credits",
-        ),
-    })
-    .from(creditUsage)
-    .innerJoin(agentRuns, eq(creditUsage.runId, agentRuns.id))
-    .innerJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .innerJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
-    .where(
-      and(
-        inArray(creditUsage.orgId, orgIds),
-        eq(creditUsage.status, "processed"),
-        gte(creditUsage.createdAt, dayStart),
-        lt(creditUsage.createdAt, dayEnd),
-      ),
-    )
-    .groupBy(
-      creditUsage.orgId,
-      creditUsage.userId,
-      zeroAgents.displayName,
-      zeroAgents.name,
-    );
+  const [runRows, ledgerCreditRows] = await Promise.all([
+    queryCompletedRunCounts(db, orgIds, userIds, dayStart, dayEnd),
+    queryLedgerCreditRows(db, orgIds, dayStart, dayEnd),
+  ]);
+  const userAgentMap = mergeAgentRows(runRows, ledgerCreditRows, users);
 
   const allCreditUserIds = [
     ...new Set(
-      memberRows.map((r) => {
+      ledgerCreditRows.map((r) => {
         return r.userId;
       }),
     ),
   ];
   const userNameMap = await resolveUserNames(allCreditUserIds);
-  const orgCreditsMap = aggregateOrgCredits(memberRows, userNameMap);
+  const orgCreditsMap = aggregateOrgCredits(ledgerCreditRows, userNameMap);
 
   // ── Credit balances ────────────────────────────────────────────────
 
@@ -695,6 +959,34 @@ async function processWindowGroup(
     });
   }
 
+  // Network rows are already time-windowed by Axiom `_time`; use `runId` only
+  // for attribution so old runs with current-day network activity still map.
+  const networkRunIds = [
+    ...new Set(
+      networkRows
+        .map((row) => {
+          return row.runId;
+        })
+        .filter(Boolean),
+    ),
+  ];
+  const runAgentRows =
+    networkRunIds.length > 0
+      ? await queryNetworkRunAgentRows(db, orgIds, userIds, networkRunIds)
+      : [];
+
+  const runIdToInfo = new Map<
+    string,
+    { orgId: string; userId: string; agentName: string }
+  >();
+  for (const row of runAgentRows) {
+    runIdToInfo.set(row.runId, {
+      orgId: row.orgId,
+      userId: row.userId,
+      agentName: row.agentName,
+    });
+  }
+
   const userNetworkMap = aggregateNetworkDataPerUser(networkRows, runIdToInfo);
 
   // ── Upsert per user ────────────────────────────────────────────────
@@ -715,12 +1007,14 @@ async function processWindowGroup(
       axiomDegraded,
     );
 
+    // `updatedAt` is the aggregation watermark. Keep it at the window end so
+    // rows landing after this snapshot are picked up by the next cron run.
     await db
       .insert(insightsDaily)
-      .values({ orgId, userId, date: targetDate, data })
+      .values({ orgId, userId, date: targetDate, data, updatedAt: dayEnd })
       .onConflictDoUpdate({
         target: [insightsDaily.orgId, insightsDaily.userId, insightsDaily.date],
-        set: { data, updatedAt: new Date() },
+        set: { data, updatedAt: dayEnd },
       });
 
     upserted++;
@@ -749,34 +1043,19 @@ export async function GET(request: Request): Promise<Response> {
   const db = globalThis.services.db;
   const now = new Date();
 
-  // ── Step 1: Find (org, user) pairs with new completed runs ─────────────
+  // ── Step 1: Find (org, user) pairs with new completed runs or ledger usage
   // 25h lookback covers "today" in all timezones (UTC-12 to UTC+14)
 
   const lookbackStart = new Date(now.getTime() - 25 * 3600_000);
 
-  const activeUsers = await db
-    .select({
-      orgId: agentRuns.orgId,
-      userId: agentRuns.userId,
-      lastCompleted: sql<Date>`MAX(${agentRuns.completedAt})`.as(
-        "last_completed",
-      ),
-    })
-    .from(agentRuns)
-    .where(
-      and(
-        gte(agentRuns.completedAt, lookbackStart),
-        isNotNull(agentRuns.completedAt),
-      ),
-    )
-    .groupBy(agentRuns.orgId, agentRuns.userId);
+  const activeUsers = await queryActiveUsers(lookbackStart);
 
   if (activeUsers.length === 0) {
-    log.info("No users with new runs, skipping aggregation");
+    log.info("No users with new runs or ledger usage, skipping aggregation");
     return NextResponse.json({ users: 0, skipped: true });
   }
 
-  // ── Step 1b: Filter out users whose last run is older than last aggregation
+  // ── Step 1b: Filter out users whose latest activity predates aggregation
 
   const activeOrgIds = [
     ...new Set(
@@ -812,14 +1091,19 @@ export async function GET(request: Request): Promise<Response> {
 
   const lastAggMap = new Map(
     lastAggRows.map((r) => {
-      return [`${r.orgId}:${r.userId}`, r.lastUpdated];
+      return [`${r.orgId}:${r.userId}`, normalizeDbDate(r.lastUpdated)];
     }),
   );
 
   const usersToAggregate = activeUsers.filter((u) => {
     const lastAgg = lastAggMap.get(`${u.orgId}:${u.userId}`);
     if (!lastAgg) return true;
-    return u.lastCompleted > lastAgg;
+    // Reprocess a small overlap around the previous watermark so rows committed
+    // near the snapshot boundary are not skipped by the activity prefilter.
+    const lastCovered = new Date(
+      lastAgg.getTime() - AGGREGATION_REPROCESS_OVERLAP_MS,
+    );
+    return u.lastActivity >= lastCovered;
   });
 
   if (usersToAggregate.length === 0) {

--- a/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
@@ -460,9 +460,9 @@ export async function setTestCreditUsageCreatedAt(
 /**
  * Seed a credit_usage record for testing insights aggregation.
  *
- * @why-db-direct Seeds credit usage with specific createdAt for insights
- * aggregation tests. Normally created by agent webhooks, but tests need
- * controlled timestamps.
+ * @why-db-direct Seeds credit usage with specific createdAt/processedAt
+ * timestamps for insights aggregation tests. Normally created by agent
+ * webhooks, but tests need controlled timestamps.
  */
 export async function seedCreditUsageRecord(options: {
   runId: string;
@@ -470,6 +470,7 @@ export async function seedCreditUsageRecord(options: {
   userId: string;
   creditsCharged: number;
   createdAt: Date;
+  processedAt?: Date;
 }): Promise<void> {
   initServices();
   await globalThis.services.db.insert(creditUsage).values({
@@ -483,6 +484,7 @@ export async function seedCreditUsageRecord(options: {
     creditsCharged: options.creditsCharged,
     status: "processed",
     createdAt: options.createdAt,
+    processedAt: options.processedAt ?? options.createdAt,
   });
 }
 
@@ -498,14 +500,22 @@ export async function seedInsightsDaily(
   date: string,
   data: Record<string, unknown>,
   userId?: string,
+  options: { updatedAt?: Date } = {},
 ): Promise<void> {
   initServices();
+  const values = {
+    orgId,
+    userId: userId ?? "user_test_default",
+    date,
+    data,
+    ...(options.updatedAt ? { updatedAt: options.updatedAt } : {}),
+  };
   await globalThis.services.db
     .insert(insightsDaily)
-    .values({ orgId, userId: userId ?? "user_test_default", date, data })
+    .values(values)
     .onConflictDoUpdate({
       target: [insightsDaily.orgId, insightsDaily.userId, insightsDaily.date],
-      set: { data, updatedAt: new Date() },
+      set: { data, updatedAt: options.updatedAt ?? new Date() },
     });
 }
 


### PR DESCRIPTION
## Summary

- Count daily insight run totals by `agent_runs.completed_at` while counting credit totals by processed ledger time
- Include processed `usage_event` rows in daily credit, team, and agent breakdowns, with runless events shown as `Other usage`
- Use Axiom log time for network windows and runId-only lookup for agent attribution
- Add coverage for completed-run timing, cross-day processed usage, runless usage events, and old-run network attribution

Related: #11198
Closes #11263

## Test plan

- [x] `pnpm --dir turbo --filter web test app/api/cron/aggregate-insights/__tests__/route.test.ts`
- [x] `pnpm --dir turbo --filter web check-types`
- [x] `pnpm --dir turbo --filter web lint`
- [x] `git diff --check`
- [x] pre-commit: prettier, knip, turbo check-types