### PR TITLE
fix(api): tighten bearer auth fallthrough and adopt platform's lint rules

### DIFF
--- a/turbo/apps/api/.oxlintrc.json
+++ b/turbo/apps/api/.oxlintrc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxlint/main/npm/oxlint/configuration_schema.json",
   "extends": ["../../.oxlintrc.json"],
+  "plugins": ["import", "promise", "typescript", "unicorn", "eslint", "oxc"],
   "overrides": [
     {
       "files": ["src/lib/log.ts"],
@@ -17,6 +18,64 @@
       ],
       "rules": {
         "import/no-default-export": "off"
+      }
+    },
+    {
+      "files": ["**/__tests__/**/*.ts", "src/test/mocks/**/*.ts"],
+      "plugins": ["jest", "vitest"],
+      "rules": {
+        "no-restricted-imports": "allow",
+        "valid-expect": ["deny", { "maxArgs": 2 }],
+        "consistent-test-it": "deny",
+        "eslint/max-nested-callbacks": ["allow"],
+        "expect-expect": "allow",
+        "max-lines-per-function": ["allow"],
+        "no-alias-methods": "deny",
+        "no-confusing-set-timeout": "deny",
+        "no-deprecated-functions": "deny",
+        "no-disabled-tests": "allow",
+        "no-done-callback": "deny",
+        "no-duplicate-hooks": "deny",
+        "no-identical-title": "deny",
+        "no-jasmine-globals": "deny",
+        "no-mocks-import": "deny",
+        "no-standalone-expect": "allow",
+        "no-test-return-statement": "deny",
+        "no-untyped-mock-factory": "allow",
+        "prefer-called-with": "deny",
+        "prefer-comparison-matcher": "deny",
+        "prefer-each": "deny",
+        "prefer-equality-matcher": "deny",
+        "prefer-expect-resolves": "deny",
+        "prefer-hooks-in-order": "deny",
+        "prefer-hooks-on-top": "deny",
+        "prefer-jest-mocked": "deny",
+        "prefer-lowercase-title": [
+          "deny",
+          {
+            "ignore": ["describe"]
+          }
+        ],
+        "prefer-mock-promise-shorthand": "deny",
+        "prefer-spy-on": "deny",
+        "prefer-strict-equal": "deny",
+        "prefer-to-be": "deny",
+        "prefer-to-contain": "deny",
+        "prefer-to-have-length": "deny",
+        "vitest/no-import-node-tests": "deny",
+        "vitest/prefer-to-be-falsy": "deny",
+        "vitest/prefer-to-be-object": "deny",
+        "vitest/prefer-to-be-truthy": "deny",
+        "jest/require-to-throw-message": "allow",
+        "jest/no-conditional-expect": "allow"
+      }
+    },
+    {
+      "files": ["custom-eslint/**/*.*"],
+      "rules": {
+        "new-cap": "allow",
+        "max-lines-per-function": ["allow"],
+        "complexity": "allow"
       }
     }
   ],
@@ -38,6 +97,149 @@
           }
         ]
       }
-    ]
+    ],
+    "adjacent-overload-signatures": "deny",
+    "array-callback-return": "deny",
+    "array-type": "deny",
+    "catch-error-name": "deny",
+    "catch-or-return": "deny",
+    "consistent-date-clone": "deny",
+    "consistent-existence-index-check": "deny",
+    "consistent-generic-constructors": "deny",
+    "consistent-indexed-object-style": "deny",
+    "curly": "deny",
+    "default": "deny",
+    "default-param-last": "deny",
+    "empty-brace-spaces": "deny",
+    "eqeqeq": "deny",
+    "error-message": "deny",
+    "export": "deny",
+    "filename-case": [
+      "deny",
+      {
+        "case": "kebabCase"
+      }
+    ],
+    "first": "deny",
+    "guard-for-in": "deny",
+    "max-depth": "deny",
+    "max-lines-per-function": [
+      "deny",
+      {
+        "max": 128,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-nested-callbacks": [
+      "deny",
+      {
+        "max": 4
+      }
+    ],
+    "max-params": [
+      "deny",
+      {
+        "max": 5
+      }
+    ],
+    "named": "deny",
+    "namespace": "deny",
+    "new-cap": "deny",
+    "new-for-builtins": "deny",
+    "no-abusive-eslint-disable": "deny",
+    "no-alert": "deny",
+    "no-amd": "deny",
+    "no-array-constructor": "deny",
+    "no-array-for-each": "deny",
+    "no-array-index-key": "deny",
+    "no-commonjs": "deny",
+    "no-console-spaces": "deny",
+    "no-cycle": "deny",
+    "no-duplicate-imports": "deny",
+    "no-duplicates": "deny",
+    "no-dynamic-require": "deny",
+    "no-else-return": "deny",
+    "no-empty": "deny",
+    "no-empty-interface": "deny",
+    "no-empty-named-blocks": "deny",
+    "no-empty-object-types": "deny",
+    "no-eq-null": "deny",
+    "no-explicit-any": "deny",
+    "no-extend-native": "deny",
+    "no-fallthrough": "deny",
+    "no-import-type-side-effects": "deny",
+    "no-inferrable-types": "deny",
+    "no-lonely-if": "deny",
+    "no-multi-assign": "deny",
+    "no-multi-string": "deny",
+    "no-mutable-exports": "deny",
+    "no-named-as-default": "deny",
+    "no-named-as-default-member": "deny",
+    "no-nesting": "deny",
+    "no-promise-in-callback": "deny",
+    "no-proto": "deny",
+    "no-redeclare": "deny",
+    "no-return-in-finally": "deny",
+    "no-return-wrap": "deny",
+    "no-self-import": "deny",
+    "no-template-curly-in-string": "deny",
+    "no-unexpected-multiline": "deny",
+    "no-unneeded-ternary": "deny",
+    "no-unreadable-array-destructuring": "deny",
+    "no-unresolved": "deny",
+    "no-new-buffer": "deny",
+    "no-negation-in-equality-check": "deny",
+    "no-unreadable-iife": "deny",
+    "no-unsafe-function-types": "deny",
+    "no-unused-modules": "deny",
+    "no-useless-concat": "deny",
+    "no-zero-fractions": "deny",
+    "numeric-separators-style": "deny",
+    "param-names": "deny",
+    "prefer-array-flat": "deny",
+    "prefer-array-flat-map": "deny",
+    "prefer-regexp-test": "deny",
+    "prefer-array-some": "deny",
+    "prefer-catch": "deny",
+    "prefer-enum-initializers": "deny",
+    "prefer-for-of": "deny",
+    "prefer-function-type": "deny",
+    "prefer-includes": "deny",
+    "prefer-logical-operator-over-ternary": "deny",
+    "prefer-modern-math-apis": "deny",
+    "prefer-negative-index": "deny",
+    "prefer-number-properties": "deny",
+    "prefer-object-spread": "deny",
+    "prefer-optional-catch-binding": "deny",
+    "prefer-promise-reject-errors": "deny",
+    "prefer-reflect-apply": "deny",
+    "prefer-rest-params": "deny",
+    "prefer-set-has": "deny",
+    "prefer-spread": "deny",
+    "prefer-string-raw": "deny",
+    "prefer-string-trim-start-end": "deny",
+    "prefer-structured-clone": "deny",
+    "@typescript-eslint/ban-ts-comment": "error",
+    "@typescript-eslint/no-array-constructor": "error",
+    "@typescript-eslint/no-empty-object-type": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-namespace": "error",
+    "@typescript-eslint/no-require-imports": "error",
+    "@typescript-eslint/no-unnecessary-type-constraint": "error",
+    "@typescript-eslint/no-unsafe-function-type": "error",
+    "complexity": "error",
+    "no-case-declarations": "error",
+    "no-prototype-builtins": "error",
+    "no-regex-spaces": "error",
+    "no-var": "error",
+    "prefer-const": "error",
+    "require-array-join-separator": "deny",
+    "require-await": "deny",
+    "spec-only": "deny",
+    "switch-case-braces": "deny",
+    "text-encoding-identifier-case": "deny",
+    "typescript/no-namespace": "deny",
+    "extensions": "allow"
   }
 }

--- a/turbo/apps/api/custom-eslint/index.ts
+++ b/turbo/apps/api/custom-eslint/index.ts
@@ -4,6 +4,7 @@ import { noGetterSetterParams } from "./rules/no-getter-setter-params.ts";
 import { noLoggerInfo } from "./rules/no-logger-info.ts";
 import { noPackageVariable } from "./rules/no-package-variable.ts";
 import { noTestViMocks } from "./rules/no-test-vi-mocks.ts";
+import { signalCheckAwait } from "./rules/signal-check-await.ts";
 
 export const apiLintPlugin = {
   meta: {
@@ -17,5 +18,6 @@ export const apiLintPlugin = {
     "no-logger-info": noLoggerInfo,
     "no-package-variable": noPackageVariable,
     "no-test-vi-mocks": noTestViMocks,
+    "signal-check-await": signalCheckAwait,
   },
 };

--- a/turbo/apps/api/custom-eslint/rules/signal-check-await.ts
+++ b/turbo/apps/api/custom-eslint/rules/signal-check-await.ts
@@ -1,0 +1,294 @@
+/**
+ * ESLint rule: signal-check-await
+ *
+ * Enforces that commands check AbortSignal after await expressions
+ * to properly handle cancellation.
+ *
+ * Good:
+ *   command(async ({ signal }) => {
+ *     const data = await fetch(url);
+ *     signal.throwIfAborted();
+ *     // process data
+ *   })
+ *
+ * Bad:
+ *   command(async ({ signal }) => {
+ *     const data = await fetch(url);
+ *     // missing signal check after await
+ *     processData(data);
+ *   })
+ */
+
+import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator((name) => {
+  return `https://github.com/anthropics/vm0/blob/main/docs/eslint/${name}.md`;
+});
+
+type MessageIds = "missingSignalCheck";
+
+export const signalCheckAwait = createRule<[], MessageIds>({
+  name: "signal-check-await",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforce AbortSignal check after await expressions in commands",
+    },
+    schema: [],
+    messages: {
+      missingSignalCheck:
+        "Consider checking signal.throwIfAborted() after await to handle cancellation",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    let signalParamName: string | null = null;
+    let inCommand = false;
+    let functionDepth = 0;
+    let commandCallback: TSESTree.Node | null = null;
+
+    function isCommandCall(node: TSESTree.CallExpression): boolean {
+      const callee = node.callee;
+      return callee.type === "Identifier" && callee.name === "command";
+    }
+
+    function getSignalParamName(
+      node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+    ): string | null {
+      // Iterate all parameters, not just the first one
+      for (const param of node.params) {
+        // Case 1: standalone parameter signal: AbortSignal
+        if (param.type === "Identifier" && param.name === "signal") {
+          return "signal";
+        }
+
+        // Case 2: destructured parameter { signal } or { signal: customName }
+        if (param.type !== "ObjectPattern") {
+          continue;
+        }
+
+        for (const prop of param.properties) {
+          if (prop.type !== "Property") {
+            continue;
+          }
+          if (prop.key.type !== "Identifier" || prop.key.name !== "signal") {
+            continue;
+          }
+
+          // Found the signal property
+          if (prop.value.type === "Identifier") {
+            return prop.value.name;
+          }
+          return "signal";
+        }
+      }
+
+      return null;
+    }
+
+    function isSignalCheck(node: TSESTree.Node): boolean {
+      if (!signalParamName) {
+        return false;
+      }
+
+      if (node.type === "ExpressionStatement") {
+        const expr = node.expression;
+        if (expr.type === "CallExpression") {
+          const callee = expr.callee;
+          if (
+            callee.type === "MemberExpression" &&
+            callee.object.type === "Identifier" &&
+            callee.object.name === signalParamName &&
+            callee.property.type === "Identifier" &&
+            callee.property.name === "throwIfAborted"
+          ) {
+            return true;
+          }
+        }
+      }
+
+      if (node.type === "IfStatement") {
+        const test = node.test;
+        if (
+          test.type === "MemberExpression" &&
+          test.object.type === "Identifier" &&
+          test.object.name === signalParamName &&
+          test.property.type === "Identifier" &&
+          test.property.name === "aborted"
+        ) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    function objectContainsSignal(node: TSESTree.ObjectExpression): boolean {
+      return node.properties.some((prop) => {
+        if (prop.type !== "Property") {
+          return false;
+        }
+        // { signal } or { signal: signal }
+        if (prop.key.type === "Identifier" && prop.key.name === "signal") {
+          if (prop.value.type === "Identifier") {
+            return prop.value.name === signalParamName;
+          }
+          return prop.key.name === signalParamName;
+        }
+        // Nested object: { fetchOptions: { signal } }
+        if (prop.value.type === "ObjectExpression") {
+          return objectContainsSignal(prop.value);
+        }
+        return false;
+      });
+    }
+
+    function hasSignalInArguments(
+      awaitExpr: TSESTree.AwaitExpression,
+    ): boolean {
+      if (!signalParamName) {
+        return false;
+      }
+
+      const arg = awaitExpr.argument;
+      if (arg.type !== "CallExpression") {
+        return false;
+      }
+
+      // Check all arguments of the call expression
+      return arg.arguments.some((argNode) => {
+        // Case 1: Direct pass - someFunc(signal)
+        if (argNode.type === "Identifier" && argNode.name === signalParamName) {
+          return true;
+        }
+
+        // Case 2: In object literal (recursive) - someFunc({ signal }) or someFunc({ opts: { signal } })
+        if (argNode.type === "ObjectExpression") {
+          return objectContainsSignal(argNode);
+        }
+
+        return false;
+      });
+    }
+
+    function checkAwaitInBlock(statements: TSESTree.Statement[]): void {
+      for (let i = 0; i < statements.length; i++) {
+        const stmt = statements[i];
+        if (!stmt) {
+          continue;
+        }
+
+        let awaitExpr: TSESTree.AwaitExpression | null = null;
+
+        // Extract await expression from statement
+        if (stmt.type === "ExpressionStatement") {
+          if (stmt.expression.type === "AwaitExpression") {
+            awaitExpr = stmt.expression;
+          }
+        } else if (stmt.type === "VariableDeclaration") {
+          // Find the first await expression in declarations
+          for (const decl of stmt.declarations) {
+            if (decl.init?.type === "AwaitExpression") {
+              awaitExpr = decl.init;
+              break;
+            }
+          }
+        }
+
+        if (awaitExpr) {
+          // If signal is already passed to the awaited function, no check needed
+          if (hasSignalInArguments(awaitExpr)) {
+            continue;
+          }
+
+          // Otherwise, require signal check after await
+          const nextStmt = statements[i + 1];
+          if (nextStmt && !isSignalCheck(nextStmt)) {
+            context.report({
+              node: stmt,
+              messageId: "missingSignalCheck",
+            });
+          }
+        }
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        if (isCommandCall(node) && node.arguments[0]) {
+          const callback = node.arguments[0];
+          if (
+            callback.type === "ArrowFunctionExpression" ||
+            callback.type === "FunctionExpression"
+          ) {
+            if (callback.async) {
+              inCommand = true;
+              signalParamName = getSignalParamName(callback);
+              functionDepth = 0;
+              commandCallback = callback; // Save reference to command callback
+            }
+          }
+        }
+      },
+      "CallExpression:exit"(node: TSESTree.CallExpression) {
+        if (isCommandCall(node)) {
+          inCommand = false;
+          signalParamName = null;
+          functionDepth = 0;
+          commandCallback = null;
+        }
+      },
+      ArrowFunctionExpression(node) {
+        // Track nested async functions inside command (but not the command callback itself)
+        if (
+          inCommand &&
+          signalParamName &&
+          node.async &&
+          node !== commandCallback
+        ) {
+          functionDepth++;
+        }
+      },
+      "ArrowFunctionExpression:exit"(node: TSESTree.ArrowFunctionExpression) {
+        if (
+          inCommand &&
+          signalParamName &&
+          node.async &&
+          node !== commandCallback &&
+          functionDepth > 0
+        ) {
+          functionDepth--;
+        }
+      },
+      FunctionExpression(node) {
+        // Track nested async functions inside command (but not the command callback itself)
+        if (
+          inCommand &&
+          signalParamName &&
+          node.async &&
+          node !== commandCallback
+        ) {
+          functionDepth++;
+        }
+      },
+      "FunctionExpression:exit"(node: TSESTree.FunctionExpression) {
+        if (
+          inCommand &&
+          signalParamName &&
+          node.async &&
+          node !== commandCallback &&
+          functionDepth > 0
+        ) {
+          functionDepth--;
+        }
+      },
+      BlockStatement(node) {
+        // Only check await in the command's direct block, not nested functions
+        if (inCommand && signalParamName && functionDepth === 0) {
+          checkAwaitInBlock(node.body);
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -63,6 +63,7 @@ export default [
       "api/no-fn-dollar-suffix": "error",
       "api/no-getter-setter-params": "error",
       "api/no-logger-info": "error",
+      "api/signal-check-await": "error",
     },
   },
   {

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -54,7 +54,7 @@ describe("createApp", () => {
 
     const response = await accept(client.boom(), [500]);
 
-    expect(response.body).toEqual({ error: "Internal server error" });
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
     expect(context.mocks.sentry.captureException).toHaveBeenCalledWith(error);
   });
 

--- a/turbo/apps/api/src/__tests__/test-helpers.ts
+++ b/turbo/apps/api/src/__tests__/test-helpers.ts
@@ -53,7 +53,7 @@ export async function accept<
   return result as Extract<TResponse, { status: TStatus }>;
 }
 
-async function parseResponseBody(response: Response): Promise<unknown> {
+function parseResponseBody(response: Response): Promise<unknown> | undefined {
   if (response.status === 204 || response.status === 205) {
     return undefined;
   }

--- a/turbo/apps/api/src/lib/__tests__/time.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/time.test.ts
@@ -21,7 +21,7 @@ describe("time", () => {
     const timestamp = 1_700_000_000_000;
     mockNow(timestamp);
 
-    expect(nowDate()).toEqual(new Date(timestamp));
+    expect(nowDate()).toStrictEqual(new Date(timestamp));
   });
 
   it("clears mocked time", () => {

--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -19,7 +19,7 @@ export function notFound(message: string) {
 }
 
 interface ZodLikeIssue {
-  readonly path: ReadonlyArray<PropertyKey>;
+  readonly path: readonly PropertyKey[];
   readonly message: string;
 }
 

--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -51,6 +51,7 @@ const cliAuth$ = command(
     signal: AbortSignal,
   ): Promise<AuthContext | null> => {
     const resolved = await get(cliTokenRecord(cliAuth));
+    signal.throwIfAborted();
     if (!resolved) {
       return null;
     }
@@ -188,7 +189,14 @@ const resolvedAuthContext$ = command(
           return result;
         }
       }
-    } else if (isSandboxToken(token)) {
+      // Recognized PAT prefix that failed verification or DB lookup must not
+      // fall through to Clerk session auth — match web's `requireApiKeyAuth`
+      // semantics so a bogus/expired PAT alongside a valid Clerk cookie is
+      // still rejected.
+      return null;
+    }
+
+    if (isSandboxToken(token)) {
       const cliAuth = verifyCliToken(token);
       if (!cliAuth) {
         const result = await set(sandboxTokenAuth$, token, options, signal);
@@ -201,9 +209,12 @@ const resolvedAuthContext$ = command(
           return result;
         }
       }
+      return null;
     }
 
-    // Bearer token verification failed — fall through to Clerk session auth
+    // Unrecognized Bearer shape (e.g. a Clerk session JWT forwarded by the
+    // platform api-client) — defer to Clerk session auth, which validates
+    // both the Authorization header and the cookie.
     return await get(clerkSessionAuth$);
   },
 );

--- a/turbo/apps/api/src/signals/auth/auth-route.ts
+++ b/turbo/apps/api/src/signals/auth/auth-route.ts
@@ -39,7 +39,9 @@ function isPatOnly(accept: readonly AuthTokenType[] | undefined): boolean {
 function rewriteUnauthorizedForPat(
   result: AuthErrorResponse,
 ): AuthErrorResponse {
-  if (result.status !== 401) return result;
+  if (result.status !== 401) {
+    return result;
+  }
   return {
     status: 401,
     body: {

--- a/turbo/apps/api/src/signals/auth/clerk-session.ts
+++ b/turbo/apps/api/src/signals/auth/clerk-session.ts
@@ -34,7 +34,7 @@ function mapClerkOrgRole(
   return orgRole === "org:admin" ? "admin" : "member";
 }
 
-const requestState$ = computed(async (get) => {
+const requestState$ = computed((get) => {
   const request = get(request$);
   const clerk = get(clerk$);
   return clerk.authenticateRequest(request.raw, {

--- a/turbo/apps/api/src/signals/context/__tests__/route.test.ts
+++ b/turbo/apps/api/src/signals/context/__tests__/route.test.ts
@@ -56,7 +56,7 @@ describe("honoSignalHandler", () => {
 
     const response = await accept(client.computed(), [200]);
 
-    expect(response.body).toEqual({ ok: true });
+    expect(response.body).toStrictEqual({ ok: true });
   });
 
   it("sets command handlers with the instance signal", async () => {
@@ -79,7 +79,7 @@ describe("honoSignalHandler", () => {
 
     const response = await accept(client.command(), [200]);
 
-    expect(response.body).toEqual({ aborted: false, sameSignal: true });
+    expect(response.body).toStrictEqual({ aborted: false, sameSignal: true });
   });
 
   it("registers non-GET handlers", async () => {
@@ -96,6 +96,6 @@ describe("honoSignalHandler", () => {
       [200],
     );
 
-    expect(response.body).toEqual({ ok: true });
+    expect(response.body).toStrictEqual({ ok: true });
   });
 });

--- a/turbo/apps/api/src/signals/context/hono.ts
+++ b/turbo/apps/api/src/signals/context/hono.ts
@@ -1,10 +1,7 @@
 import type { AppRoute } from "@ts-rest/core";
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import type { Context } from "hono";
 import { RedirectStatusCode } from "hono/utils/http-status";
-import type { z } from "zod";
-
-import { badRequest } from "../../lib/error";
 
 const innerHonoContext$ = state<Context>({} as Context);
 const innerRoute$ = state<AppRoute | null>(null);
@@ -49,6 +46,24 @@ export const requestSignal$ = computed((get) => {
   return context.req.raw.signal;
 });
 
+export const route$ = computed((get): AppRoute => {
+  const route = get(innerRoute$);
+  if (!route) {
+    throw new Error("route accessed outside a request scope");
+  }
+  return route;
+});
+
+export const rawPathParams$ = computed((get) => {
+  const context = get(innerHonoContext$);
+  return context.req.param();
+});
+
+export const rawQuery$ = computed((get) => {
+  const context = get(innerHonoContext$);
+  return context.req.query();
+});
+
 // Response
 export const setResHeader$ = command(
   ({ get }, name: string, value?: string, options?: { append?: boolean }) => {
@@ -63,125 +78,3 @@ export const redirect$ = command(
     context.redirect(url, status);
   },
 );
-
-// Path/query validation derived from the active route's contract. The
-// validation runs as a computed off the hono request rather than being pushed
-// in via a setter — there is no source of truth other than the request itself,
-// and computeds keep the cache invalidation semantics ccstate already gives us.
-
-interface ZodLikeIssue {
-  readonly path: ReadonlyArray<PropertyKey>;
-  readonly message: string;
-}
-
-interface ZodLikeResult {
-  readonly success: boolean;
-  readonly data?: unknown;
-  readonly error?: { readonly issues: readonly ZodLikeIssue[] };
-}
-
-interface ZodLikeSchema {
-  readonly safeParse: (input: unknown) => ZodLikeResult;
-}
-
-function isZodLikeSchema(value: unknown): value is ZodLikeSchema {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "safeParse" in value &&
-    typeof (value as { safeParse: unknown }).safeParse === "function"
-  );
-}
-
-const FALLBACK_ISSUE: ZodLikeIssue = Object.freeze({
-  path: [],
-  message: "Bad request",
-});
-
-type ValidationResult =
-  | { readonly ok: true; readonly data: unknown }
-  | { readonly ok: false; readonly issue: ZodLikeIssue };
-
-const route$ = computed((get): AppRoute => {
-  const route = get(innerRoute$);
-  if (!route) {
-    throw new Error("route accessed outside a request scope");
-  }
-  return route;
-});
-
-const pathParamsResult$ = computed((get): ValidationResult => {
-  const schema = get(route$).pathParams;
-  if (!isZodLikeSchema(schema)) return { ok: true, data: {} };
-  const ctx = get(innerHonoContext$);
-  const result = schema.safeParse(ctx.req.param());
-  if (!result.success) {
-    return { ok: false, issue: result.error?.issues[0] ?? FALLBACK_ISSUE };
-  }
-  return { ok: true, data: result.data };
-});
-
-const queryResult$ = computed((get): ValidationResult => {
-  const schema = get(route$).query;
-  if (!isZodLikeSchema(schema)) return { ok: true, data: {} };
-  const ctx = get(innerHonoContext$);
-  const result = schema.safeParse(ctx.req.query());
-  if (!result.success) {
-    return { ok: false, issue: result.error?.issues[0] ?? FALLBACK_ISSUE };
-  }
-  return { ok: true, data: result.data };
-});
-
-interface BadRequestResponse {
-  readonly status: 400;
-  readonly body: {
-    readonly error: { readonly message: string; readonly code: string };
-  };
-}
-
-/**
- * Run path and query validation in declared order, returning the first 400
- * response that fails. The hono adapter consumes this to short-circuit
- * malformed requests before invoking the route handler.
- */
-export const requestValidation$: Computed<BadRequestResponse | null> = computed(
-  (get): BadRequestResponse | null => {
-    const path = get(pathParamsResult$);
-    if (!path.ok) return badRequest(path.issue);
-    const query = get(queryResult$);
-    if (!query.ok) return badRequest(query.issue);
-    return null;
-  },
-);
-
-const validatedPathParams$ = computed((get): unknown => {
-  const result = get(pathParamsResult$);
-  if (!result.ok) {
-    throw new Error("pathParamsOf accessed but path validation failed");
-  }
-  return result.data;
-});
-
-const validatedQuery$ = computed((get): unknown => {
-  const result = get(queryResult$);
-  if (!result.ok) {
-    throw new Error("queryOf accessed but query validation failed");
-  }
-  return result.data;
-});
-
-type RouteWithPathParams<T> = AppRoute & { readonly pathParams: z.ZodType<T> };
-type RouteWithQuery<T> = AppRoute & { readonly query: z.ZodType<T> };
-
-/**
- * Type-narrowed accessor for the validated path params of `route`. The
- * underlying value is the same `validatedPathParams$` computed for every
- * route — the route argument exists only so TypeScript can infer the shape.
- */
-export function pathParamsOf<T>(_route: RouteWithPathParams<T>): Computed<T> {
-  return validatedPathParams$ as Computed<T>;
-}
-
-export function queryOf<T>(_route: RouteWithQuery<T>): Computed<T> {
-  return validatedQuery$ as Computed<T>;
-}

--- a/turbo/apps/api/src/signals/context/request.ts
+++ b/turbo/apps/api/src/signals/context/request.ts
@@ -1,0 +1,111 @@
+import type { AppRoute } from "@ts-rest/core";
+import { computed, type Computed } from "ccstate";
+import type { z } from "zod";
+
+import { badRequest } from "../../lib/error";
+import { rawPathParams$, rawQuery$, route$ } from "./hono";
+
+interface ZodLikeIssue {
+  readonly path: readonly PropertyKey[];
+  readonly message: string;
+}
+
+interface ZodLikeResult {
+  readonly success: boolean;
+  readonly data?: unknown;
+  readonly error?: { readonly issues: readonly ZodLikeIssue[] };
+}
+
+interface ZodLikeSchema {
+  readonly safeParse: (input: unknown) => ZodLikeResult;
+}
+
+function isZodLikeSchema(value: unknown): value is ZodLikeSchema {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "safeParse" in value &&
+    typeof (value as { safeParse: unknown }).safeParse === "function"
+  );
+}
+
+const FALLBACK_ISSUE: ZodLikeIssue = Object.freeze({
+  path: [],
+  message: "Bad request",
+});
+
+type ValidationResult =
+  | { readonly ok: true; readonly data: unknown }
+  | { readonly ok: false; readonly issue: ZodLikeIssue };
+
+const pathParamsResult$ = computed((get): ValidationResult => {
+  const schema = get(route$).pathParams;
+  if (!isZodLikeSchema(schema)) {
+    return { ok: true, data: {} };
+  }
+  const result = schema.safeParse(get(rawPathParams$));
+  if (!result.success) {
+    return { ok: false, issue: result.error?.issues[0] ?? FALLBACK_ISSUE };
+  }
+  return { ok: true, data: result.data };
+});
+
+const queryResult$ = computed((get): ValidationResult => {
+  const schema = get(route$).query;
+  if (!isZodLikeSchema(schema)) {
+    return { ok: true, data: {} };
+  }
+  const result = schema.safeParse(get(rawQuery$));
+  if (!result.success) {
+    return { ok: false, issue: result.error?.issues[0] ?? FALLBACK_ISSUE };
+  }
+  return { ok: true, data: result.data };
+});
+
+interface BadRequestResponse {
+  readonly status: 400;
+  readonly body: {
+    readonly error: { readonly message: string; readonly code: string };
+  };
+}
+
+export const requestValidation$: Computed<BadRequestResponse | null> = computed(
+  (get): BadRequestResponse | null => {
+    const path = get(pathParamsResult$);
+    if (!path.ok) {
+      return badRequest(path.issue);
+    }
+    const query = get(queryResult$);
+    if (!query.ok) {
+      return badRequest(query.issue);
+    }
+    return null;
+  },
+);
+
+const validatedPathParams$ = computed((get): unknown => {
+  const result = get(pathParamsResult$);
+  if (!result.ok) {
+    throw new Error("pathParamsOf accessed but path validation failed");
+  }
+  return result.data;
+});
+
+const validatedQuery$ = computed((get): unknown => {
+  const result = get(queryResult$);
+  if (!result.ok) {
+    throw new Error("queryOf accessed but query validation failed");
+  }
+  return result.data;
+});
+
+type RouteWithPathParams<T> = AppRoute & { readonly pathParams: z.ZodType<T> };
+type RouteWithQuery<T> = AppRoute & { readonly query: z.ZodType<T> };
+
+export function pathParamsOf<T>(_route: RouteWithPathParams<T>): Computed<T> {
+  return validatedPathParams$ as Computed<T>;
+}
+
+export function queryOf<T>(_route: RouteWithQuery<T>): Computed<T> {
+  return validatedQuery$ as Computed<T>;
+}

--- a/turbo/apps/api/src/signals/context/route.ts
+++ b/turbo/apps/api/src/signals/context/route.ts
@@ -3,7 +3,8 @@ import { createStore, type Command, type Computed } from "ccstate";
 import type { Handler } from "hono";
 import type { ContentfulStatusCode, StatusCode } from "hono/utils/http-status";
 
-import { initHono$, requestValidation$ } from "./hono";
+import { initHono$ } from "./hono";
+import { requestValidation$ } from "./request";
 import { setRootSignal$ } from "./root";
 
 export type SignalRouteHandler<T> = Computed<T> | Command<T, [AbortSignal]>;

--- a/turbo/apps/api/src/signals/external/clerk.ts
+++ b/turbo/apps/api/src/signals/external/clerk.ts
@@ -14,7 +14,7 @@ export function membershipsByUserId(
   userId: string,
   limit = 100,
 ): Computed<Promise<OrganizationMembershipList>> {
-  return computed(async (get) => {
+  return computed((get) => {
     return get(clerk$).users.getOrganizationMembershipList({
       userId,
       limit,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
@@ -159,11 +159,15 @@ describe("GET /api/v1/chat-threads/:threadId", () => {
   afterEach(async () => {
     while (threads.length > 0) {
       const t = threads.pop();
-      if (t) await deleteThreadFixture(t);
+      if (t) {
+        await deleteThreadFixture(t);
+      }
     }
     while (pats.length > 0) {
       const p = pats.pop();
-      if (p) await deletePatFixture(p);
+      if (p) {
+        await deletePatFixture(p);
+      }
     }
   });
 
@@ -182,7 +186,7 @@ describe("GET /api/v1/chat-threads/:threadId", () => {
       [200],
     );
 
-    expect(response.body).toEqual({
+    expect(response.body).toStrictEqual({
       id: thread.threadId,
       title: "hello",
       createdAt: expect.any(String),
@@ -252,7 +256,7 @@ describe("GET /api/v1/chat-threads/:threadId", () => {
       [401],
     );
 
-    expect(response.body.error).toEqual({
+    expect(response.body.error).toStrictEqual({
       message: "API key required",
       code: "UNAUTHORIZED",
     });
@@ -299,11 +303,15 @@ describe("GET /api/v1/chat-threads/:threadId/messages", () => {
   afterEach(async () => {
     while (threads.length > 0) {
       const t = threads.pop();
-      if (t) await deleteThreadFixture(t);
+      if (t) {
+        await deleteThreadFixture(t);
+      }
     }
     while (pats.length > 0) {
       const p = pats.pop();
-      if (p) await deletePatFixture(p);
+      if (p) {
+        await deletePatFixture(p);
+      }
     }
   });
 
@@ -339,7 +347,7 @@ describe("GET /api/v1/chat-threads/:threadId/messages", () => {
       response.body.messages.map((m) => {
         return m.id;
       }),
-    ).toEqual([m1, m2]);
+    ).toStrictEqual([m1, m2]);
     expect(response.body.messages[0]?.content).toBe("first");
     expect(response.body.messages[1]?.role).toBe("assistant");
   });
@@ -381,7 +389,7 @@ describe("GET /api/v1/chat-threads/:threadId/messages", () => {
       response.body.messages.map((m) => {
         return m.id;
       }),
-    ).toEqual([m2, m3]);
+    ).toStrictEqual([m2, m3]);
   });
 
   it("paginates backward with beforeId", async () => {
@@ -421,7 +429,7 @@ describe("GET /api/v1/chat-threads/:threadId/messages", () => {
       response.body.messages.map((m) => {
         return m.id;
       }),
-    ).toEqual([m1, m2]);
+    ).toStrictEqual([m1, m2]);
   });
 
   it("returns 404 when the thread is owned by a different user", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
@@ -121,15 +121,6 @@ const capabilityProbe$ = authRoute(
 describe("GET /health/auth", () => {
   const fixtures: PatFixture[] = [];
 
-  afterEach(async () => {
-    while (fixtures.length > 0) {
-      const fixture = fixtures.pop();
-      if (fixture) {
-        await deletePatFixture(fixture);
-      }
-    }
-  });
-
   beforeEach(() => {
     // Default: Clerk session not authenticated, no org memberships
     context.mocks.clerk.authenticateRequest.mockReset();
@@ -137,6 +128,15 @@ describe("GET /health/auth", () => {
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
     });
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await deletePatFixture(fixture);
+      }
+    }
   });
 
   describe("Clerk session", () => {
@@ -158,7 +158,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         tokenType: "session",
         userId: "user_admin",
         orgId: "org_admin",
@@ -184,7 +184,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         tokenType: "session",
         userId: "user_member",
         orgId: "org_member",
@@ -206,7 +206,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         tokenType: "session",
         userId: "user_solo",
       });
@@ -240,7 +240,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         userId: fixture.userId,
         orgId: fixture.orgId,
         orgRole: "admin",
@@ -260,7 +260,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         userId: fixture.userId,
         orgId: fixture.orgId,
         orgRole: "member",
@@ -322,7 +322,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         tokenType: "pat",
         userId: fixture.userId,
       });
@@ -347,7 +347,7 @@ describe("GET /health/auth", () => {
         }),
         [200],
       );
-      expect(first.body).toEqual({
+      expect(first.body).toStrictEqual({
         tokenType: "pat",
         userId: fixture.userId,
         orgId: fixture.orgId,
@@ -364,11 +364,10 @@ describe("GET /health/auth", () => {
         }),
         [200],
       );
-      expect(second.body).toEqual(first.body);
+      expect(second.body).toStrictEqual(first.body);
       expect(
-        context.mocks.clerk.users.getOrganizationMembershipList.mock.calls
-          .length,
-      ).toBe(callsBefore);
+        context.mocks.clerk.users.getOrganizationMembershipList.mock.calls,
+      ).toHaveLength(callsBefore);
     });
 
     it("refreshes the cached role when Clerk reports a different role", async () => {
@@ -390,7 +389,7 @@ describe("GET /health/auth", () => {
         }),
         [200],
       );
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         tokenType: "pat",
         userId: fixture.userId,
         orgId: fixture.orgId,
@@ -430,7 +429,7 @@ describe("GET /health/auth", () => {
         }),
         [200],
       );
-      expect(first.body).toEqual({
+      expect(first.body).toStrictEqual({
         tokenType: "pat",
         userId: fixture.userId,
       });
@@ -466,7 +465,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         tokenType: "sandbox",
         userId: "user_sandbox",
         orgId: "org_sandbox",
@@ -496,7 +495,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         userId: fixture.userId,
         orgId: fixture.orgId,
         orgRole: "member",
@@ -526,7 +525,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         userId: fixture.userId,
         orgId: fixture.orgId,
         orgRole: "admin",
@@ -559,7 +558,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         userId,
         orgId,
         runId: "run_zero",
@@ -570,7 +569,12 @@ describe("GET /health/auth", () => {
   });
 
   describe("Clerk session fallback for Bearer requests", () => {
-    it("falls through to Clerk session when PAT tokenId is not in DB but cookie is present", async () => {
+    // A `Bearer <pat>` whose tokenId is missing from the DB (revoked, expired,
+    // or simply forged) must NOT fall through to Clerk session auth even when
+    // a valid cookie rides along — web's `requireApiKeyAuth` rejects that
+    // shape with 401, and the API mirror has to agree or shadow comparison
+    // produces an `outcome` mismatch.
+    it("rejects a PAT whose tokenId is not in DB even when a valid Clerk cookie is present", async () => {
       const tokenId = randomUUID();
       const userId = `user_${randomUUID()}`;
       const nowSeconds = currentSecond();
@@ -601,15 +605,36 @@ describe("GET /health/auth", () => {
             cookie: "__session=valid-session",
           },
         }),
-        [200],
+        [401],
       );
 
-      expect(response.body).toEqual({
-        tokenType: "session",
-        userId: "user_cookie_fallback",
-        orgId: "org_cookie_fallback",
-        orgRole: "admin",
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("rejects a sandbox-prefixed token with a bad signature even when a valid Clerk cookie is present", async () => {
+      context.mocks.clerk.authenticateRequest.mockResolvedValue({
+        isAuthenticated: true,
+        toAuth: () => {
+          return {
+            userId: "user_cookie_fallback",
+            orgId: "org_cookie_fallback",
+            orgRole: "org:admin",
+          };
+        },
       });
+
+      const client = setupApp({ context })(healthAuthProbeContract);
+      const response = await accept(
+        client.check({
+          headers: {
+            authorization: "Bearer vm0_sandbox_not-a-real-token",
+            cookie: "__session=valid-session",
+          },
+        }),
+        [401],
+      );
+
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
     });
 
     it("falls through to Clerk session for unknown Bearer shapes when cookie is present", async () => {
@@ -635,7 +660,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         tokenType: "session",
         userId: "user_unknown_shape",
         orgId: "org_unknown_shape",
@@ -763,7 +788,7 @@ describe("GET /health/auth", () => {
         [200],
       );
 
-      expect(response.body).toEqual({
+      expect(response.body).toStrictEqual({
         tokenType: "zero",
         userId: fixture.userId,
         orgId: fixture.orgId,

--- a/turbo/apps/api/src/signals/routes/__tests__/health.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/health.test.ts
@@ -14,14 +14,14 @@ describe("api health routes", () => {
     const client = createClient(healthContract);
     const response = await accept(client.check(), [200]);
 
-    expect(response.body).toEqual({ status: "ok" });
+    expect(response.body).toStrictEqual({ status: "ok" });
   });
 
   it("requires auth for the authenticated health check", async () => {
     const client = createClient(healthAuthContract);
     const response = await accept(client.check(), [401]);
 
-    expect(response.body).toEqual({
+    expect(response.body).toStrictEqual({
       error: { message: "Not authenticated", code: "UNAUTHORIZED" },
     });
   });

--- a/turbo/apps/api/src/signals/routes/chat-threads-v1.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-v1.ts
@@ -6,7 +6,7 @@ import {
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { pathParamsOf, queryOf } from "../context/hono";
+import { pathParamsOf, queryOf } from "../context/request";
 import { notFound } from "../../lib/error";
 import {
   chatThreadMessagesV1,

--- a/turbo/apps/api/src/signals/routes/health.ts
+++ b/turbo/apps/api/src/signals/routes/health.ts
@@ -1,5 +1,5 @@
 import { computed } from "ccstate";
-import { type HealthRouteResponse } from "@vm0/api-contracts/contracts";
+import type { HealthRouteResponse } from "@vm0/api-contracts/contracts";
 
 export const apiHealth$ = computed<Promise<HealthRouteResponse>>(async () => {
   await Promise.resolve();

--- a/turbo/apps/api/src/signals/services/auth.service.ts
+++ b/turbo/apps/api/src/signals/services/auth.service.ts
@@ -6,11 +6,7 @@ import { and, eq, gt } from "drizzle-orm";
 import { membershipsByUserId } from "../external/clerk";
 import { db$, writeDb$ } from "../external/db";
 import { now, nowDate } from "../external/time";
-import {
-  type ApiOrgRole,
-  type CliAuth,
-  type CliTokenRecord,
-} from "../../types/auth";
+import type { ApiOrgRole, CliAuth, CliTokenRecord } from "../../types/auth";
 
 const MEMBER_ROLE_CACHE_TTL_MS = 60_000;
 
@@ -87,6 +83,7 @@ export const getMemberRoleAndUpdateCache$ = command(
         ),
       )
       .limit(1);
+    signal.throwIfAborted();
 
     const currentTime = now();
     if (
@@ -98,6 +95,7 @@ export const getMemberRoleAndUpdateCache$ = command(
     }
 
     const memberships = await get(membershipsByUserId(userId));
+    signal.throwIfAborted();
     const membership = memberships.data.find((candidate) => {
       return candidate.organization.id === orgId;
     });

--- a/turbo/apps/api/src/signals/services/chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread.service.ts
@@ -2,9 +2,9 @@ import { computed, type Computed } from "ccstate";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import {
-  type ChatMessageV1,
-  type ChatThreadV1,
+import type {
+  ChatMessageV1,
+  ChatThreadV1,
 } from "@vm0/api-contracts/contracts/chat-threads-v1";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { z } from "zod";


### PR DESCRIPTION
## Summary

- **Auth fix (the production [outcome] mismatch)**: API's Bearer auth no longer falls through to Clerk session when a recognized PAT/sandbox token fails verification or DB lookup. This matches web's `requireApiKeyAuth` semantics — an invalid PAT alongside a valid Clerk cookie now consistently returns 401 on both sides. Only genuinely unrecognized Bearer shapes (e.g. Clerk session JWTs forwarded via the platform api-client) still fall through.
- **Refactor**: extracted path/query validation out of `signals/context/hono.ts` into a new `signals/context/request.ts`. The new file consumes `route$` / `rawPathParams$` / `rawQuery$` computeds exposed by hono.ts, so it doesn't import the `hono` package directly.
- **Lint**: migrated platform's strict oxlint config to api (curly, array-type, prefer-strict-equal, prefer-lowercase-title, no-import-type-side-effects, require-await, max-lines-per-function, eqeqeq, etc.) so this app is at least as strict as platform. Fixed all resulting violations.
- **Custom rule**: ported the `signal-check-await` ESLint rule from platform — it surfaced 3 missing `signal.throwIfAborted()` checks in `auth-context.ts` and `auth.service.ts`, all patched.

## Test plan

- [ ] CI green (lint, typecheck, vitest, knip)
- [ ] New regression tests in `health-auth-probe.test.ts`:
  - `Bearer <PAT not in DB>` + valid Clerk cookie → 401 (was 200 before this change)
  - `Bearer vm0_sandbox_<bad-sig>` + valid Clerk cookie → 401 (was 200 before)
  - `Bearer some-unknown-token-format` + valid cookie → still 200 (Clerk session, fallthrough preserved for unknown shapes)
- [ ] Confirm the `[outcome]` count on the shadow-mismatch dashboard drops after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)